### PR TITLE
fix(web): pin OAuth redirect_uri to registered /login callback

### DIFF
--- a/web/src/auth/github-oauth-api.ts
+++ b/web/src/auth/github-oauth-api.ts
@@ -1,8 +1,13 @@
 import { GITHUB_OAUTH_WORKER_BASE } from "./constants"
 import type { GithubDeviceCodeResponse, GithubTokenResponse } from "./types"
 
+// Must exactly match the OAuth App's registered callback URL (.../login).
+// Deriving it from the live pathname breaks the web flow when launched from
+// any other route (e.g. the re-authorize banner). See issue #57.
+const OAUTH_CALLBACK_PATH = "/login"
+
 function redirectUri() {
-  return window.location.origin + window.location.pathname
+  return window.location.origin + OAUTH_CALLBACK_PATH
 }
 
 function assertOAuthSuccess(


### PR DESCRIPTION
## Summary
- Closes #57: clicking **Re-authorize** on the missing-scopes banner failed with GitHub's "the `redirect_uri` is not associated with this application" error.
- Root cause: `redirectUri()` derived the OAuth `redirect_uri` from the live `window.location.pathname`. The banner renders on every route, so launching the web flow from a deep page (e.g. a classroom/roster page) sent that page's path as the `redirect_uri`. GitHub only accepts the registered callback URL (`.../login`), so it rejected the mismatched value.
- Fix: pin `redirect_uri` to the fixed `/login` callback. The same value is used by both `buildGithubAuthorizeUrl` and `exchangeWebCode`, so authorize and token exchange stay consistent.

## Why it's safe
- The `?code=`/`state` callback effect lives in `GitHubAuthProvider`, which wraps the `RouterProvider`, so it runs on mount regardless of route and strips the query via `history.replaceState` before the `/login` route guard applies.
- Device flow is unaffected (it never uses a `redirect_uri`).

## Test plan
- [ ] Sign in via web flow from `/login` (unchanged happy path).
- [ ] Trigger the missing-scope banner on a deep route, click **Re-authorize**, and confirm GitHub shows the consent screen (no `redirect_uri` error) and returns successfully.
- [ ] Confirm device flow still works.

## Note
After re-authorizing from a deep page, GitHub now returns the user to `/login`, which forwards authenticated users to `/` rather than back to the original route. Preserving the origin route (via `state` or a stored return path) can be a follow-up if desired.