### PR TITLE
feat(locales): add translation prompt and integrity checker

### DIFF
--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -14,11 +14,35 @@ file or pasting a URL to it.
    the JSON structure exactly as they are.
 3. Save it as `<code>.json` (e.g. `de.json`, `pt-BR.json`).
 
-An LLM does this well. A prompt that works:
+An LLM does this well. Use the ready-made prompt in
+[`TRANSLATION_PROMPT.md`](./TRANSLATION_PROMPT.md) — it is language-agnostic and
+encodes the rules that matter here (keys/placeholders preserved, concatenated
+`_prefix`/`_suffix` fragments reassembled for the target word order, GitHub UI
+labels kept findable, consistent terminology).
 
-> Translate the JSON values in this file to German. Keep every key and the
-> nesting structure unchanged. Keep `{{placeholders}}` exactly as written.
-> Return only the JSON.
+### Example: translating with an agent
+
+Point the agent at the prompt and name a target language, e.g.:
+
+> Follow @src/locales/TRANSLATION_PROMPT.md and produce a Korean translation.
+
+The agent should then:
+
+1. Read [`TRANSLATION_PROMPT.md`](./TRANSLATION_PROMPT.md) and translate
+   [`en.json`](./en.json) into the target language.
+2. Save the result as `<code>.json` in this folder (e.g. `ko.json`).
+3. Verify integrity against the base before finishing:
+
+   ```bash
+   cd src/locales
+   python verify_locale.py ko.json
+   ```
+
+   Do not ship a pack that does not print `RESULT: PASS`. The checker
+   ([`verify_locale.py`](./verify_locale.py)) flags any dropped/added/renamed
+   key, non-string value, or placeholder mismatch — the failure modes that
+   silently break a pack. It mirrors the installer's own validation, so a
+   passing pack also installs cleanly.
 
 ### Rules the installer enforces
 

--- a/web/src/locales/TRANSLATION_PROMPT.md
+++ b/web/src/locales/TRANSLATION_PROMPT.md
@@ -1,0 +1,120 @@
+# Translation prompt
+
+Use this prompt to translate the base locale (`en.json`) into a new language
+pack with an LLM. It is written to be applicable to **any** target language.
+After translating, always run the integrity check in
+[`verify_locale.py`](./verify_locale.py) before shipping the pack.
+
+Replace `<CODE>` with the target BCP-47 locale code (e.g. `es`, `hi`, `zh-CN`).
+
+---
+
+You are translating the UI language pack for **Classroom 50**, a GitHub-based
+assignment-management and autograding platform (a self-hosted GitHub Classroom).
+Translate the JSON **values** in `en.json` into the target language (locale code
+`<CODE>`).
+
+## Audience & register
+
+- Two audiences: **instructors/TAs** (comfortable with GitHub jargon) and
+  **students**. Use a clear, professional, friendly register.
+- **Audience-appropriate vocabulary.** The product is used across a wide range of
+  educational settings, from K-12 through higher education. Prefer **neutral,
+  widely-applicable** terms for words like "student," "instructor,"
+  "class/classroom," and "term" — wording that reads naturally to teachers and
+  learners at any level, rather than terms that lock the text to one specific
+  level of schooling. If your language forces a choice, pick the most inclusive
+  general-purpose option.
+- **Follow the target language's own conventions.** Every language has its own
+  norms for punctuation, quotation marks, ellipsis, spacing (e.g. around Latin
+  words/numbers), word order, honorific/politeness level, measure words, and
+  pluralization. Apply the conventions that a native reader expects — do not carry
+  over English punctuation, spacing, or sentence structure just because the source
+  uses it.
+
+## Hard rules (violating these breaks the app)
+
+1. **Never drop, add, rename, or reorder keys.** Keep every key and the full
+   nesting structure exactly as in the source. The output must contain the **same
+   set of keys** as the input — no omissions, even for values you leave in English.
+   Translate only the string values. Return valid JSON with the same shape; every
+   leaf value must be a string.
+2. **Never drop, add, rename, or reorder placeholders.** Keep every
+   `{{placeholder}}` **verbatim** — identical name, identical count per value. They
+   are substituted at runtime (usernames, org/repo/classroom names, counts, dates).
+   Never translate or alter text inside `{{ }}`.
+3. **Do not translate** GitHub-sourced identifiers or code: usernames,
+   org/repo/classroom names, slugs, `classroom50`, branch names like `main`, tokens
+   like `github_pat_...`, `ubuntu-latest`, language/tool names, `pytest`,
+   `stdin`/`stdout`, `re.search`, file names, CLI commands, and anything that looks
+   like code.
+4. **Plurals:** keys ending in `_one` / `_other` are i18next plural forms. If your
+   language has no plural distinction, give both the same translation. If your
+   language needs other forms (`_zero`, `_few`, `_many`, …), add those sibling keys
+   for the same base key — but still never remove the existing ones.
+
+## Concatenated sentence fragments — MOST IMPORTANT
+
+Some sentences are **split across sibling keys** and joined at runtime with an
+interpolated value **in between**. Keys ending in `_prefix`, `_from`, `_middle`,
+`_suffix`, `_emphasis`, `_link`, and numbered parts (`_1`, `_2`, `_3`, …) are
+assembled **in order**, with a value (org name, `{{classroom}}`, `classroom50`, a
+link, etc.) inserted at each join.
+
+For each such group:
+
+1. **Reconstruct the full English sentence**, using a marker for each injected
+   value, e.g. `prefix` + `[VALUE]` + `from` + `[VALUE]` + `suffix`.
+2. **Translate the whole sentence naturally** in the target language.
+3. **Split it back** into the same fragments so that, when rejoined with the value
+   at each boundary, it reads grammatically. The value's position is **fixed by the
+   code** and cannot be moved — choose fragment wording that works with the value
+   where it lands.
+4. **Do not repeat a word/verb** across the prefix and suffix (a common error), and
+   don't leave a fragment that only parses in English word order.
+5. If your language would naturally reorder the injected value, adapt the
+   surrounding fragments (particles, prepositions, measure words) so the fixed
+   position still reads correctly. If a clean split is impossible, put the whole
+   phrase in one fragment and leave the other fragment as an empty string (`""`)
+   rather than emit a broken sentence.
+
+Read each reassembled group aloud with a sample value substituted to confirm it is
+grammatical.
+
+## GitHub UI label consistency
+
+Some strings (e.g. under `orgSettings`) reference **buttons/fields the user must
+click on GitHub**. Render these to **match GitHub's own official UI in the target
+language** so users can locate the control; if GitHub does not localize a given
+label, keep it in English. Be consistent — one policy per label, applied
+everywhere.
+
+## Terminology consistency
+
+Pick one translation per recurring domain term (assignment, submission, classroom
+vs class, roster, onboarding, autograder, runner, template, repository, service
+token, organization, unenroll, regrade, collect, …) and use it consistently across
+the entire file.
+
+## Output
+
+Return **only** the translated JSON — no explanations, no markdown fences.
+Translate **every** value; if something is genuinely untranslatable, keep the
+English rather than omit the key.
+
+---
+
+## Verify integrity after translation (required)
+
+After producing `<CODE>.json`, run the integrity check from the `src/locales`
+folder:
+
+```bash
+python verify_locale.py <CODE>.json
+```
+
+It compares the pack against `en.json` and fails loudly on any missing/extra key,
+non-string value, or placeholder mismatch. Do not ship a pack that does not
+`PASS`. This mirrors the app's own `missingKeys` / `coverage` validation in
+[`../i18n/customLocale.ts`](../i18n/customLocale.ts), so a passing pack also
+installs cleanly.

--- a/web/src/locales/verify_locale.py
+++ b/web/src/locales/verify_locale.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Verify a translated language pack against the base en.json.
+
+Fails loudly on any dropped/added/renamed key, non-string leaf value, or
+placeholder mismatch. Run from the src/locales folder:
+
+    python verify_locale.py <CODE>.json      # e.g. python verify_locale.py de.json
+
+Exit code is 0 on PASS and 1 on FAIL, so it can gate CI or a shipping step.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+BASE_FILE = "en.json"
+PLURAL_SUFFIXES = ("_zero", "_one", "_two", "_few", "_many", "_other")
+
+
+def flatten(obj, prefix=""):
+    """Flatten nested dicts to dotted keys, matching the app's internal shape."""
+    out = {}
+    for key, value in obj.items():
+        dotted = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            out.update(flatten(value, dotted))
+        else:
+            out[dotted] = value
+    return out
+
+
+def placeholders(value):
+    """Sorted list of {{...}} placeholders in a string (empty for non-strings)."""
+    if not isinstance(value, str):
+        return []
+    return sorted(re.findall(r"\{\{.*?\}\}", value))
+
+
+def is_allowed_plural_variant(key, base_keys):
+    """Allow extra keys only when they are i18next plural variants of a base key."""
+    if not any(key.endswith(suffix) for suffix in PLURAL_SUFFIXES):
+        return False
+    stem = key.rsplit("_", 1)[0]
+    return any(f"{stem}_{p}" in base_keys for p in ("one", "other"))
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: python verify_locale.py <CODE>.json", file=sys.stderr)
+        return 2
+
+    base_path = Path(BASE_FILE)
+    trans_path = Path(sys.argv[1])
+    if not base_path.exists():
+        print(f"error: base file {BASE_FILE} not found (run from src/locales)", file=sys.stderr)
+        return 2
+    if not trans_path.exists():
+        print(f"error: translation file {trans_path} not found", file=sys.stderr)
+        return 2
+
+    base = flatten(json.loads(base_path.read_text(encoding="utf-8")))
+    trans = flatten(json.loads(trans_path.read_text(encoding="utf-8")))
+
+    base_keys, trans_keys = set(base), set(trans)
+
+    missing = sorted(base_keys - trans_keys)
+    extra = sorted(
+        k for k in (trans_keys - base_keys) if not is_allowed_plural_variant(k, base_keys)
+    )
+    bad_type = sorted(k for k, v in trans.items() if not isinstance(v, str))
+
+    ph_mismatch = []
+    for key in sorted(base_keys & trans_keys):
+        if placeholders(base[key]) != placeholders(trans[key]):
+            ph_mismatch.append((key, placeholders(base[key]), placeholders(trans[key])))
+
+    passed = not (missing or extra or bad_type or ph_mismatch)
+
+    print(f"base keys: {len(base_keys)} | translated keys: {len(trans_keys)}")
+    print(f"MISSING keys ({len(missing)}): {missing or '(none)'}")
+    print(f"UNEXPECTED extra keys ({len(extra)}): {extra or '(none)'}")
+    print(f"NON-STRING values ({len(bad_type)}): {bad_type or '(none)'}")
+    print(f"PLACEHOLDER mismatches ({len(ph_mismatch)}):")
+    for key, base_ph, trans_ph in ph_mismatch:
+        print(f"  {key}: base={base_ph} translated={trans_ph}")
+    if not ph_mismatch:
+        print("  (none)")
+
+    print("\nRESULT:", "PASS" if passed else "FAIL")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds reusable tooling for producing language packs so future translations avoid the failure modes that silently break a pack (dropped/renamed keys, non-string values, placeholder mismatches).

- **`web/src/locales/TRANSLATION_PROMPT.md`** — a language-agnostic translation prompt. Covers placeholder/key preservation, reassembly of concatenated `_prefix`/`_suffix` fragments for the target language's word order, GitHub UI label consistency, and audience-neutral vocabulary (K-12 through higher ed).
- **`web/src/locales/verify_locale.py`** — a dependency-free checker that compares a pack against `en.json` and fails on any missing/unexpected key, non-string value, or placeholder mismatch (allowing legitimate i18next plural variants). Mirrors the installer's own validation.
- **`web/src/locales/README.md`** — points to the new prompt, adds an agent-driven example workflow, and documents the verification step.

Note: this PR intentionally contains only the tooling/docs. Actual language pack JSON files are not included.

## Test plan

- [ ] `cd web/src/locales && python3 verify_locale.py en.json` prints `RESULT: PASS`.
- [ ] Running the checker against a pack with a removed key / altered placeholder prints `RESULT: FAIL` and lists the offending keys.
- [ ] README renders correctly and its links resolve (`TRANSLATION_PROMPT.md`, `verify_locale.py`, `../i18n/customLocale.ts`).