### PR TITLE
feat(locales): patch language packs from en.json diff instead of regenerating

### DIFF
--- a/.github/workflows/translate-locales.yaml
+++ b/.github/workflows/translate-locales.yaml
@@ -176,16 +176,15 @@ jobs:
             translate --full
             gate
           else
-            # Patch mode: translate only the diff onto the published pack. The gate
-            # validates the WHOLE pack, so a pre-existing defect on an untouched
-            # key (stale placeholder, orphan variant a hand-edit left) would fail
-            # a language forever — patching never re-emits those keys. On gate
-            # FAIL, self-heal by falling back to a full retranslation, which
-            # re-emits every key, then re-gate. If that still fails, the language
-            # legitimately fails this run (and is retried next run).
-            translate
-            if ! gate; then
-              echo "::warning::${CODE}: patched pack failed the structural gate; retrying with a full retranslation."
+            # Patch mode: apply only the diff onto the published pack. A patch
+            # can fail the parity check or whole-pack gate on a key it never
+            # re-emits (a base key missing from the pack, or a pre-existing
+            # defect on an untouched one), which would fail the language every
+            # run. On either failure, self-heal with a full retranslation (which
+            # re-emits every key) and re-gate; a still-failing language is
+            # excluded this run and retried next.
+            if ! translate || ! gate; then
+              echo "::warning::${CODE}: patch run failed the parity check or structural gate; retrying with a full retranslation."
               translate --full
               gate
             fi

--- a/.github/workflows/translate-locales.yaml
+++ b/.github/workflows/translate-locales.yaml
@@ -137,7 +137,7 @@ jobs:
             echo "${CODE}: changed=$(jq 'length' diff/changed.json) removed=$(jq 'length' diff/removed.json)"
           fi
 
-      - name: Translate ${{ matrix.code }}
+      - name: Translate and gate ${{ matrix.code }}
         env:
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           BEDROCK_MODEL_ID: ${{ vars.AWS_BEDROCK_MODEL_ID }}
@@ -146,33 +146,50 @@ jobs:
           FULL: ${{ steps.diff.outputs.full }}
         run: |
           set -euo pipefail
-          # Out dir (not langrepo) so the artifact is exactly the patched file;
-          # --current reads the published baseline (missing = first-time gen).
           mkdir -p out
-          full_flag=""
-          [ "${FULL:-false}" = "true" ] && full_flag="--full"
-          python scripts/translate_locales.py \
-            --code "$CODE" \
-            --base web/src/locales/en.json \
-            --prompt web/src/locales/TRANSLATION_PROMPT.md \
-            --current "langrepo/${CODE}.json" \
-            --changed-keys diff/changed.json \
-            --removed-keys diff/removed.json \
-            $full_flag \
-            --out "out/${CODE}.json"
 
-      - name: Structural gate (verify_locale.py)
-        env:
-          CODE: ${{ matrix.code }}
-        run: |
-          set -euo pipefail
-          # verify_locale.py reads en.json from CWD and takes one argv, so run it
-          # from a dir holding both. Any non-zero exit fails (2 = setup, 1 = FAIL).
-          gate=$(mktemp -d)
-          cp web/src/locales/en.json "$gate/en.json"
-          cp web/src/locales/verify_locale.py "$gate/verify_locale.py"
-          cp "out/${CODE}.json" "$gate/${CODE}.json"
-          ( cd "$gate" && python verify_locale.py "${CODE}.json" )
+          # verify_locale.py reads en.json from CWD and takes one argv, so gate
+          # from a temp dir holding both. Exit 2 = setup error, 1 = FAIL.
+          gate() {
+            local g; g=$(mktemp -d)
+            cp web/src/locales/en.json "$g/en.json"
+            cp web/src/locales/verify_locale.py "$g/verify_locale.py"
+            cp "out/${CODE}.json" "$g/${CODE}.json"
+            ( cd "$g" && python verify_locale.py "${CODE}.json" )
+          }
+
+          translate() {
+            # Out dir (not langrepo) so the artifact is exactly the patched file;
+            # --current reads the published baseline (missing = first-time gen).
+            python scripts/translate_locales.py \
+              --code "$CODE" \
+              --base web/src/locales/en.json \
+              --prompt web/src/locales/TRANSLATION_PROMPT.md \
+              --current "langrepo/${CODE}.json" \
+              --changed-keys diff/changed.json \
+              --removed-keys diff/removed.json \
+              "$@" \
+              --out "out/${CODE}.json"
+          }
+
+          if [ "${FULL:-false}" = "true" ]; then
+            translate --full
+            gate
+          else
+            # Patch mode: translate only the diff onto the published pack. The gate
+            # validates the WHOLE pack, so a pre-existing defect on an untouched
+            # key (stale placeholder, orphan variant a hand-edit left) would fail
+            # a language forever — patching never re-emits those keys. On gate
+            # FAIL, self-heal by falling back to a full retranslation, which
+            # re-emits every key, then re-gate. If that still fails, the language
+            # legitimately fails this run (and is retried next run).
+            translate
+            if ! gate; then
+              echo "::warning::${CODE}: patched pack failed the structural gate; retrying with a full retranslation."
+              translate --full
+              gate
+            fi
+          fi
 
       - name: Upload generated pack
         uses: actions/upload-artifact@v7

--- a/.github/workflows/translate-locales.yaml
+++ b/.github/workflows/translate-locales.yaml
@@ -1,31 +1,29 @@
 name: Translate locales
 
-# Regenerates each target-language pack from web/src/locales/en.json with AWS
-# Bedrock and opens a SINGLE pull request on the language repo
-# (vars.LANGUAGE_PACKS_REPO) carrying every language that regenerated cleanly; a
-# human merges it once to publish. One PR -> one merge -> one GitHub Pages
-# deploy (the old per-language PRs meant N merges and N racing deploys).
+# Patches target-language packs from web/src/locales/en.json with AWS Bedrock and
+# opens ONE pull request on the language repo (vars.LANGUAGE_PACKS_REPO) carrying
+# every language that patched cleanly; a human merges it to publish.
 #
-# Each run reads the language repo's current <code>.json (which may hold human
-# PR fixes) and regenerates the whole file, preserving good translations and
-# only retranslating changed English. No per-key delta, no sidecar state — the
-# published file is the next run's baseline.
+# Patch model: every pack shares en.json's key structure, so its diff maps 1:1
+# onto each language. Per language we diff our en.json against that language's
+# baseline marker (markers/<code>.json in the language repo — a copy of the
+# en.json the pack was last built against), translate ONLY the changed/added
+# keys onto the published <code>.json, delete removed keys, and leave every other
+# key untouched. So community edits to published packs survive across runs.
 #
-# Languages fan out in parallel and each uploads its generated pack as an
-# artifact; a final aggregate job collects them into one branch/PR. A language
-# that fails to translate or gate is simply left out of the PR (and called out
-# in the job summary + PR body) rather than sinking the rest.
+# The publish PR bumps each produced language's marker to the current en.json
+# alongside its pack, so the marker advances iff the pack does — a failed
+# language keeps its old marker and is caught up next run, regardless of run
+# cadence. No marker yet (or a manual workflow_dispatch) => full translation.
 #
-# Auth: Bedrock via an API key in AWS_BEARER_TOKEN_BEDROCK (boto3 auto-detects
-# it; no IAM/OIDC); the cross-repo PR uses a fine-grained PAT
-# (LANGUAGE_PACKS_REPO_TOKEN, scoped to the language repo, Contents + PRs write).
-#
-# Setup — variables: LANGUAGE_PACKS_REPO (owner/repo), AWS_REGION,
-# AWS_BEDROCK_MODEL_ID; secrets: LANGUAGE_PACKS_REPO_TOKEN, AWS_BEARER_TOKEN_BEDROCK.
+# Auth: Bedrock via AWS_BEARER_TOKEN_BEDROCK (boto3 auto-detects it); the
+# cross-repo PR uses LANGUAGE_PACKS_REPO_TOKEN (Contents + PRs write).
+# Setup — variables: LANGUAGE_PACKS_REPO, AWS_REGION, AWS_BEDROCK_MODEL_ID;
+# secrets: LANGUAGE_PACKS_REPO_TOKEN, AWS_BEARER_TOKEN_BEDROCK.
 
 on:
   push:
-    branches: [main, preview, feat/bedrock-translation-ci]
+    branches: [main, preview, feat/locale-marker-patch]
     paths:
       - 'web/src/locales/en.json'
       - 'web/src/locales/targets.json'
@@ -52,12 +50,13 @@ permissions:
 
 jobs:
   # Resolve the language matrix from targets.json (or the workflow_dispatch
-  # `only` input) so the translate job can fan out over fromJson.
+  # `only` input); force full retranslation on dispatch (no baseline behind it).
   matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       codes: ${{ steps.build.outputs.codes }}
+      full: ${{ steps.build.outputs.full }}
     steps:
       - uses: actions/checkout@v7
 
@@ -65,6 +64,7 @@ jobs:
         id: build
         env:
           ONLY: ${{ github.event.inputs.only }}
+          EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if [ -n "${ONLY:-}" ]; then
@@ -72,10 +72,8 @@ jobs:
           else
             codes=$(jq -c . web/src/locales/targets.json)
           fi
-          # Each code is later interpolated as matrix.code into run: blocks, so
-          # reject anything that isn't a plain BCP-47 tag. This is the injection
-          # gate for the workflow_dispatch `only` input; downstream steps also read
-          # the code from env rather than interpolating it directly.
+          # Each code is interpolated as matrix.code into run: blocks, so reject
+          # anything that isn't a plain BCP-47 tag (injection gate for `only`).
           bad=$(printf '%s' "$codes" | jq -r '.[] | select(test("^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$") | not)')
           if [ -n "$bad" ]; then
             echo "Rejected non-BCP-47 language code(s):" >&2
@@ -83,12 +81,12 @@ jobs:
             exit 1
           fi
           echo "codes=$codes" >> "$GITHUB_OUTPUT"
+          [ "$EVENT" = "workflow_dispatch" ] && echo "full=true" >> "$GITHUB_OUTPUT" || echo "full=false" >> "$GITHUB_OUTPUT"
           echo "Languages: $codes"
 
-  # Translate + gate each language in parallel, then upload the generated pack as
-  # an artifact. No PR here — the aggregate job below collects every artifact
-  # into one PR. fail-fast: false so one language's failure leaves the rest to
-  # publish; a failed leg just uploads no artifact and is reported later.
+  # Patch + gate each language in parallel (each diffs against its own marker,
+  # so a lagging language catches up), then upload its pack for open-pr to
+  # collect. fail-fast: false so one failure doesn't sink the rest.
   translate:
     needs: matrix
     runs-on: ubuntu-latest
@@ -116,24 +114,51 @@ jobs:
 
       - run: pip install -r scripts/requirements.txt
 
+      - name: Diff ${{ matrix.code }} against its published marker
+        id: diff
+        env:
+          CODE: ${{ matrix.code }}
+          FULL: ${{ needs.matrix.outputs.full }}
+        run: |
+          set -euo pipefail
+          mkdir -p diff
+          marker="langrepo/markers/${CODE}.json"
+          # No marker (first publish) or forced full: empty diff -> full pass.
+          if [ "${FULL:-false}" = "true" ] || [ ! -f "$marker" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            echo "[]" > diff/changed.json
+            echo "[]" > diff/removed.json
+          else
+            # Effective diff: our en.json vs the marker (previous en from stdin).
+            echo "full=false" >> "$GITHUB_OUTPUT"
+            python scripts/locale_diff.py \
+              --current web/src/locales/en.json \
+              --out-dir diff < "$marker"
+            echo "${CODE}: changed=$(jq 'length' diff/changed.json) removed=$(jq 'length' diff/removed.json)"
+          fi
+
       - name: Translate ${{ matrix.code }}
         env:
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           BEDROCK_MODEL_ID: ${{ vars.AWS_BEDROCK_MODEL_ID }}
           AWS_REGION: ${{ vars.AWS_REGION }}
           CODE: ${{ matrix.code }}
+          FULL: ${{ steps.diff.outputs.full }}
         run: |
           set -euo pipefail
-          # Emit into a fresh out dir (not langrepo) so the artifact is exactly
-          # the generated file; --current still reads the published baseline.
+          # Out dir (not langrepo) so the artifact is exactly the patched file;
+          # --current reads the published baseline (missing = first-time gen).
           mkdir -p out
-          current="langrepo/${CODE}.json"
-          # --current is optional; a missing file means first-time generation.
+          full_flag=""
+          [ "${FULL:-false}" = "true" ] && full_flag="--full"
           python scripts/translate_locales.py \
             --code "$CODE" \
             --base web/src/locales/en.json \
             --prompt web/src/locales/TRANSLATION_PROMPT.md \
-            --current "$current" \
+            --current "langrepo/${CODE}.json" \
+            --changed-keys diff/changed.json \
+            --removed-keys diff/removed.json \
+            $full_flag \
             --out "out/${CODE}.json"
 
       - name: Structural gate (verify_locale.py)
@@ -157,10 +182,10 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Collect every successfully generated pack into ONE branch and open/update a
-  # single PR on the language repo. Runs even if some translate legs failed
-  # (if: always()), so partial success still publishes what worked. Fails only
-  # if the matrix job itself failed or nothing at all was produced.
+  # Collect every produced pack into ONE branch and open/update a single PR on
+  # the language repo. Runs even if some translate legs failed (if: always()),
+  # so partial success still publishes. Fails only if matrix failed or nothing
+  # was produced.
   open-pr:
     needs: [matrix, translate]
     if: ${{ always() && needs.matrix.result == 'success' }}
@@ -193,15 +218,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Which languages were requested vs. which actually produced a pack.
-          # download-artifact with merge-multiple flattens every pack-<code>
-          # artifact into packs/<code>.json.
+          # Requested languages vs. those that produced a pack (merge-multiple
+          # flattens each pack-<code> artifact to packs/<code>.json).
           mapfile -t requested < <(printf '%s' "$ALL_CODES" | jq -r '.[]')
           produced=()
           for code in "${requested[@]}"; do
-            if [ -f "packs/${code}.json" ]; then
-              produced+=("$code")
-            fi
+            [ -f "packs/${code}.json" ] && produced+=("$code")
           done
 
           failed=()
@@ -212,7 +234,7 @@ jobs:
             esac
           done
 
-          # Nothing generated at all — every language failed. Report and stop.
+          # Every language failed — report and stop.
           if [ ${#produced[@]} -eq 0 ]; then
             echo "::error::No language packs were generated; all ${#requested[@]} language(s) failed."
             {
@@ -232,26 +254,28 @@ jobs:
           git config user.name "classroom50-sync[bot]"
           git config user.email "classroom50-sync@users.noreply.github.com"
 
-          # Reset the shared batch branch to the latest default branch, then drop
-          # every generated pack on top — so the PR diff is only these languages'
-          # changes and is idempotent across runs.
+          # Reset the batch branch to the default branch, then drop each produced
+          # pack + its bumped marker (the en.json we built against) on top.
           git fetch origin "$default_branch"
           git checkout -B "$branch" "origin/${default_branch}"
+          mkdir -p markers
           for code in "${produced[@]}"; do
             cp "../packs/${code}.json" "${code}.json"
-            git add "${code}.json"
+            cp "../web/src/locales/en.json" "markers/${code}.json"
+            git add "${code}.json" "markers/${code}.json"
           done
 
+          # A real en.json change always moves at least a marker; this mainly
+          # guards the idempotent re-run (same PR already assembled).
           if git diff --cached --quiet; then
             echo "No net change vs ${default_branch} for any language; skipping PR."
             {
               echo "## Translate locales"
-              echo "Regenerated ${#produced[@]} language(s); none differed from the published packs, so no PR was opened."
+              echo "Regenerated ${#produced[@]} language(s); nothing differed from the published packs/markers, so no PR was opened."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          # Commit body lists the languages carried; failures (if any) are noted.
           {
             echo "Update ${#produced[@]} translation(s) from en.json@${short}"
             echo
@@ -262,22 +286,22 @@ jobs:
           } > /tmp/commit_msg.txt
           git commit -F /tmp/commit_msg.txt
 
-          # Single writer per branch, and each run resets it to the default
-          # branch + generated files, so plain --force is correct.
-          # --force-with-lease would reject on "stale info" (we only fetch the
-          # default branch, not this branch's tracking ref).
+          # Single writer per branch, reset to default each run, so plain --force
+          # is correct (--force-with-lease rejects on stale info — we never fetch
+          # this branch's tracking ref).
           git push --force origin "$branch"
 
-          # PR body: what's included, what was skipped, and the review reminder.
           {
-            echo "Machine translations regenerated from \`en.json@${short}\` via AWS Bedrock."
-            echo "Merging publishes all of these in a single GitHub Pages deploy."
+            echo "Machine translations patched from \`en.json@${short}\` via AWS Bedrock."
+            echo "Only keys whose English changed since each language's last publish were"
+            echo "re-translated; every other key (including community edits) is untouched."
+            echo "Each \`markers/<code>.json\` is bumped so the next run diffs against it."
             echo
             echo "**Included (${#produced[@]}):** ${produced[*]}"
             if [ ${#failed[@]} -gt 0 ]; then
               echo
               echo "**Skipped — failed this run (${#failed[@]}):** ${failed[*]}"
-              echo "They'll be retried on the next run and are not in this PR."
+              echo "Their markers are NOT bumped, so they're caught up next run."
             fi
             echo
             echo "Review the diff before merging."
@@ -285,8 +309,7 @@ jobs:
 
           title="Update ${#produced[@]} translation(s) from en.json@${short}"
 
-          # Open a PR if none is already open for this branch; otherwise the
-          # forced push above already refreshed it.
+          # Open a PR if none is open for this branch; else the push refreshed it.
           existing=$(gh pr list --repo "$TARGET_REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')
           if [ -z "$existing" ]; then
             gh pr create \
@@ -296,10 +319,9 @@ jobs:
               --title "$title" \
               --body-file /tmp/pr_body.txt
           else
-            # Keep the open PR's title/body in step with this run's contents.
             gh pr edit "$existing" --repo "$TARGET_REPO" \
               --title "$title" --body-file /tmp/pr_body.txt
-            echo "PR #${existing} already open for ${branch}; branch and description updated."
+            echo "PR #${existing} already open for ${branch}; updated."
           fi
 
           # Job summary mirrors the PR body for at-a-glance run status.

--- a/scripts/locale_diff.py
+++ b/scripts/locale_diff.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Emit the key-level diff between two revisions of en.json.
+
+Every pack shares en.json's key structure, so this diff maps 1:1 onto every
+language. Reads the previous en.json from stdin and the current one from a path,
+then writes:
+
+  * <out-dir>/changed.json — dotted keys added/modified
+  * <out-dir>/removed.json — dotted keys removed
+
+In CI the "previous" en.json is the language's marker (markers/<code>.json — a
+copy of en.json at that language's last publish):
+
+    python scripts/locale_diff.py \
+        --current web/src/locales/en.json \
+        --out-dir diff < langrepo/markers/ja.json
+
+Empty stdin (no baseline) => every key is "changed", driving a full first-time
+translation downstream. Exit 0 on success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Reuse the flatten/diff logic so the diff matches the patcher exactly.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from translate_locales import compute_diff, flatten  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current", required=True, type=Path, help="Path to current en.json")
+    parser.add_argument("--out-dir", required=True, type=Path, help="Where to write changed/removed json")
+    args = parser.parse_args()
+
+    current = json.loads(args.current.read_text(encoding="utf-8"))
+
+    prev_raw = sys.stdin.read().strip()
+    if prev_raw:
+        previous = json.loads(prev_raw)
+        changed, removed = compute_diff(previous, current)
+    else:
+        # No previous revision: treat every key as new so downstream does a full
+        # first-time translation.
+        changed, removed = sorted(flatten(current)), []
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "changed.json").write_text(
+        json.dumps(changed, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    (args.out_dir / "removed.json").write_text(
+        json.dumps(removed, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+    print(f"changed keys: {len(changed)} | removed keys: {len(removed)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_translate_locales.py
+++ b/scripts/test_translate_locales.py
@@ -11,13 +11,23 @@ which translate_locales imports at module load):
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+import translate_locales
 from translate_locales import (
+    build_nested_from_keys,
     check_key_parity,
+    compute_diff,
+    delete_nested,
     extract_text,
     flatten,
+    get_nested,
     parse_model_json,
+    plural_group_keys,
+    set_nested,
+    translate_keys,
 )
 
 
@@ -85,3 +95,192 @@ class TestCheckKeyParity:
         base = {"nav": {"a": "x"}}
         translated = {"nav": {"a": "x", "extra": "z"}}
         assert check_key_parity(base, translated) == []
+
+    def test_precomputed_base_keys_matches_recompute(self):
+        base = {"nav": {"a": "x", "b": "y"}}
+        translated = {"nav": {"a": "x"}}
+        base_keys = set(flatten(base))
+        assert check_key_parity(base, translated, base_keys) == ["nav.b"]
+        assert check_key_parity(base, translated, base_keys) == check_key_parity(base, translated)
+
+
+class TestComputeDiff:
+    def test_added_and_nested_keys_are_changed(self):
+        previous = {"a": "x"}
+        current = {"a": "x", "b": "y", "nav": {"c": "z"}}
+        changed, removed = compute_diff(previous, current)
+        assert changed == ["b", "nav.c"]
+        assert removed == []
+
+    def test_modified_value_is_changed(self):
+        changed, removed = compute_diff({"a": "x"}, {"a": "different"})
+        assert changed == ["a"]
+        assert removed == []
+
+    def test_removed_key_is_reported(self):
+        changed, removed = compute_diff({"a": "x", "b": "y"}, {"a": "x"})
+        assert changed == []
+        assert removed == ["b"]
+
+    def test_unchanged_key_is_neither(self):
+        changed, removed = compute_diff({"a": "x"}, {"a": "x"})
+        assert changed == []
+        assert removed == []
+
+    def test_outputs_are_sorted(self):
+        previous = {"z": "1", "a": "1"}
+        current = {"z": "2", "a": "2", "m": "new"}
+        changed, _ = compute_diff(previous, current)
+        assert changed == sorted(changed)
+
+
+class TestNestedHelpers:
+    def test_get_nested_reads_value(self):
+        assert get_nested({"nav": {"a": "x"}}, "nav.a") == "x"
+
+    def test_get_nested_raises_keyerror_on_missing_segment(self):
+        with pytest.raises(KeyError):
+            get_nested({"nav": {"a": "x"}}, "nav.missing")
+
+    def test_set_nested_creates_intermediate_dicts(self):
+        obj: dict = {}
+        set_nested(obj, "nav.a", "x")
+        assert obj == {"nav": {"a": "x"}}
+
+    def test_set_nested_preserves_siblings(self):
+        obj = {"nav": {"a": "x"}}
+        set_nested(obj, "nav.b", "y")
+        assert obj == {"nav": {"a": "x", "b": "y"}}
+
+    def test_build_nested_from_keys_round_trip(self):
+        base = {"nav": {"a": "x", "b": "y"}, "c": "z"}
+        assert build_nested_from_keys(base, ["nav.b", "c"]) == {"nav": {"b": "y"}, "c": "z"}
+
+
+class TestDeleteNested:
+    def test_deletes_leaf(self):
+        obj = {"nav": {"a": "x", "b": "y"}}
+        delete_nested(obj, "nav.a")
+        assert obj == {"nav": {"b": "y"}}
+
+    def test_prunes_empty_ancestors(self):
+        obj = {"nav": {"a": "x"}}
+        delete_nested(obj, "nav.a")
+        assert obj == {}
+
+    def test_stops_pruning_at_non_empty_ancestor(self):
+        obj = {"nav": {"sub": {"a": "x"}, "keep": "y"}}
+        delete_nested(obj, "nav.sub.a")
+        assert obj == {"nav": {"keep": "y"}}
+
+    def test_no_op_when_key_absent(self):
+        obj = {"nav": {"a": "x"}}
+        delete_nested(obj, "nav.missing")
+        assert obj == {"nav": {"a": "x"}}
+
+
+class TestPluralGroupKeys:
+    def test_non_plural_key_returns_itself(self):
+        base_keys = {"foo.title"}
+        assert plural_group_keys("foo.title", {"foo.title"}, base_keys) == ["foo.title"]
+
+    def test_ordinary_key_with_plural_suffix_is_not_treated_as_plural(self):
+        # `step_two` looks like a plural form but has no base _one/_other, so it is
+        # an ordinary key: only itself is deleted, a stem-sharing key is untouched.
+        base_keys = {"onboarding.step_other"}  # unrelated key still in base
+        pack_keys = {"onboarding.step_two", "onboarding.step_other"}
+        assert plural_group_keys("onboarding.step_two", pack_keys, base_keys) == [
+            "onboarding.step_two"
+        ]
+
+    def test_partial_group_removal_keeps_gate_allowed_sibling(self):
+        # en.json removed foo.msg_one but kept foo.msg_other, so the group still
+        # exists; a community-added foo.msg_few is gate-allowed and must NOT be swept.
+        base_keys = {"foo.msg_other"}
+        pack_keys = {"foo.msg_one", "foo.msg_other", "foo.msg_few"}
+        assert plural_group_keys("foo.msg_one", pack_keys, base_keys) == ["foo.msg_one"]
+
+    def test_full_group_removal_sweeps_orphan_siblings(self):
+        # The whole base group is gone, so leftover pack siblings are true orphans
+        # that would trip verify_locale.py — sweep every one the pack has.
+        base_keys: set = set()
+        pack_keys = {"foo.msg_one", "foo.msg_other", "foo.msg_few"}
+        assert plural_group_keys("foo.msg_one", pack_keys, base_keys) == [
+            "foo.msg_few",
+            "foo.msg_one",
+            "foo.msg_other",
+        ]
+
+
+class TestTranslateKeys:
+    def test_returns_none_when_model_drops_a_requested_key(self, monkeypatch):
+        base = {"nav": {"a": "x", "b": "y"}}
+        base_raw = json.dumps(base)
+        # Model returns only nav.a, dropping the requested nav.b.
+        monkeypatch.setattr(
+            translate_locales, "invoke_model", lambda *a, **k: '{"nav": {"a": "translated"}}'
+        )
+        result = translate_keys(None, "model", "prompt", "ja", base, base_raw, ["nav.a", "nav.b"])
+        assert result is None
+
+    def test_returns_translation_when_all_keys_present(self, monkeypatch):
+        base = {"nav": {"a": "x", "b": "y"}}
+        base_raw = json.dumps(base)
+        monkeypatch.setattr(
+            translate_locales,
+            "invoke_model",
+            lambda *a, **k: '{"nav": {"a": "翻訳a", "b": "翻訳b"}}',
+        )
+        result = translate_keys(None, "model", "prompt", "ja", base, base_raw, ["nav.a", "nav.b"])
+        assert flatten(result) == {"nav.a": "翻訳a", "nav.b": "翻訳b"}
+
+
+class TestMainPatchMode:
+    """End-to-end patch-mode selection + removed-key application via main().
+
+    Uses only removed keys so no Bedrock call is needed (to_translate is empty),
+    exercising patch_mode selection, delete_nested, and the plural sweep together.
+    """
+
+    def _run(self, tmp_path, monkeypatch, base, current, removed_keys):
+        monkeypatch.setattr(translate_locales.boto3, "client", lambda *a, **k: None)
+        base_path = tmp_path / "en.json"
+        base_path.write_text(json.dumps(base), encoding="utf-8")
+        (tmp_path / "TRANSLATION_PROMPT.md").write_text("prompt", encoding="utf-8")
+        current_path = tmp_path / "ja.json"
+        current_path.write_text(json.dumps(current), encoding="utf-8")
+        changed_path = tmp_path / "changed.json"
+        changed_path.write_text("[]", encoding="utf-8")
+        removed_path = tmp_path / "removed.json"
+        removed_path.write_text(json.dumps(removed_keys), encoding="utf-8")
+        out_path = tmp_path / "out.json"
+        argv = [
+            "translate_locales.py", "--code", "ja",
+            "--base", str(base_path), "--prompt", str(tmp_path / "TRANSLATION_PROMPT.md"),
+            "--current", str(current_path),
+            "--changed-keys", str(changed_path), "--removed-keys", str(removed_path),
+            "--model-id", "test-model", "--out", str(out_path),
+        ]
+        monkeypatch.setattr(translate_locales.sys, "argv", argv)
+        rc = translate_locales.main()
+        result = json.loads(out_path.read_text(encoding="utf-8")) if out_path.exists() else None
+        return rc, result
+
+    def test_partial_plural_group_removal_keeps_community_sibling(self, tmp_path, monkeypatch):
+        base = {"foo": {"msg_other": "other"}}  # msg_one removed, msg_other kept
+        current = {"foo": {"msg_one": "1", "msg_other": "o", "msg_few": "community"}}
+        rc, result = self._run(tmp_path, monkeypatch, base, current, ["foo.msg_one"])
+        assert rc == 0
+        # msg_one deleted (removed); msg_few kept (gate still allows it); msg_other kept.
+        assert result == {"foo": {"msg_other": "o", "msg_few": "community"}}
+
+    def test_full_plural_group_removal_sweeps_orphans(self, tmp_path, monkeypatch):
+        base = {"other": {"key": "v"}}  # whole foo.msg group gone from en.json
+        current = {
+            "foo": {"msg_one": "1", "msg_other": "o", "msg_few": "orphan"},
+            "other": {"key": "v"},
+        }
+        rc, result = self._run(tmp_path, monkeypatch, base, current, ["foo.msg_one"])
+        assert rc == 0
+        # Entire orphan group swept; empty foo dict pruned.
+        assert result == {"other": {"key": "v"}}

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -157,7 +157,7 @@ def plural_group_keys(removed_key: str, pack_keys: set[str]) -> list[str]:
         return [removed_key]
     stem = removed_key.rsplit("_", 1)[0]
     siblings = {f"{stem}{suffix}" for suffix in PLURAL_SUFFIXES}
-    return sorted(k for k in pack_keys if k in siblings)
+    return sorted(siblings & pack_keys)
 
 
 def compute_diff(previous: dict, current: dict) -> tuple[list[str], list[str]]:
@@ -361,9 +361,14 @@ def parse_model_json(text: str) -> dict:
     return json.loads(cleaned)
 
 
-def check_key_parity(base: dict, translated: dict) -> list[str]:
-    """Return base keys the translation dropped."""
-    base_keys = set(flatten(base))
+def check_key_parity(base: dict, translated: dict, base_keys: set[str] | None = None) -> list[str]:
+    """Return base keys the translation dropped.
+
+    Pass `base_keys` (a precomputed `set(flatten(base))`) to skip re-flattening a
+    large base that the caller already flattened.
+    """
+    if base_keys is None:
+        base_keys = set(flatten(base))
     trans_keys = set(flatten(translated))
     return sorted(base_keys - trans_keys)
 
@@ -533,7 +538,7 @@ def main() -> int:
         eprint(f"error: prompt file not found: {prompt_path}")
         return 2
     base = json.loads(base_raw)
-
+    base_keys = set(flatten(base))
     current_raw: str | None = None
     if args.current:
         try:
@@ -575,7 +580,6 @@ def main() -> int:
         # Start from the published pack; touch only diffed keys, so every other
         # key (hand edits, extra plural variants) carries through untouched.
         translated = current
-        base_keys = set(flatten(base))
 
         # Delete removed keys (skip any still present in en.json — stale list).
         # For a removed plural form, also sweep the pack's sibling variants
@@ -619,7 +623,7 @@ def main() -> int:
         if translated is None:
             return 1
 
-    missing = check_key_parity(base, translated)
+    missing = check_key_parity(base, translated, base_keys)
     if missing:
         eprint(
             f"[{args.code}] translation is missing {len(missing)} base key(s); "

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -144,18 +144,23 @@ def delete_nested(obj: dict, dotted: str) -> None:
             break
 
 
-def plural_group_keys(removed_key: str, pack_keys: set[str]) -> list[str]:
-    """Pack keys in `removed_key`'s plural group (including itself).
+def plural_group_keys(removed_key: str, pack_keys: set[str], base_keys: set[str]) -> list[str]:
+    """Pack keys to delete when `removed_key` is dropped from en.json.
 
-    When `removed_key` is an i18next plural form, a pack may carry extra sibling
-    variants (e.g. `_few`) that verify_locale.py only tolerates while a base
-    `_one`/`_other` exists. Once the base group is gone those orphans fail the
-    gate, so a removal of any group member must sweep every sibling the pack has.
-    Returns just the key itself when it isn't a plural form.
+    Mirrors verify_locale.py's `is_allowed_plural_variant`: the gate tolerates a
+    pack's extra plural sibling (e.g. an added `_few`) only while a base
+    `_one`/`_other` for the stem exists. So we sweep the whole plural group only
+    once that base group is entirely gone — otherwise those siblings are still
+    gate-allowed and deleting them would drop community edits. A key with no base
+    `_one`/`_other` isn't a plural form (it just looks like one, e.g. `step_two`),
+    so only itself is removed.
     """
     if not any(removed_key.endswith(suffix) for suffix in PLURAL_SUFFIXES):
         return [removed_key]
     stem = removed_key.rsplit("_", 1)[0]
+    base_group_survives = any(f"{stem}_{p}" in base_keys for p in ("one", "other"))
+    if base_group_survives:
+        return [removed_key]
     siblings = {f"{stem}{suffix}" for suffix in PLURAL_SUFFIXES}
     return sorted(siblings & pack_keys)
 
@@ -581,17 +586,14 @@ def main() -> int:
         # key (hand edits, extra plural variants) carries through untouched.
         translated = current
 
-        # Delete removed keys (skip any still present in en.json — stale list).
-        # For a removed plural form, also sweep the pack's sibling variants
-        # (e.g. an extra `_few`) so no orphan trips verify_locale.py once the
-        # base `_one`/`_other` are gone.
+        # Delete removed keys; skip any still in en.json (stale list). For a
+        # retired plural group, plural_group_keys also returns its orphan siblings.
         pack_keys = set(flatten(translated))
         for key in removed_keys:
             if key in base_keys:
                 continue
-            for member in plural_group_keys(key, pack_keys):
-                # Never delete a sibling that en.json still defines (only part of
-                # the group was removed) — that would drop a required translation.
+            for member in plural_group_keys(key, pack_keys, base_keys):
+                # Guard against dropping a swept member en.json still defines.
                 if member not in base_keys:
                     delete_nested(translated, member)
 

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -1,26 +1,40 @@
 #!/usr/bin/env python3
-"""Regenerate a target-language pack from the base en.json using AWS Bedrock.
+"""Patch a target-language pack from the base en.json using AWS Bedrock.
 
-Reads en.json and the language repo's current translation (if any), then asks a
-Bedrock model to reproduce each top-level section: existing good translations
-are preserved, changed English is retranslated, missing keys are filled.
-Translating one section per call (with the full English file as context) keeps
-each response small enough to avoid truncation while honoring
-TRANSLATION_PROMPT.md's fragment/plural/terminology rules — fragment and plural
-sibling groups never span two top-level sections.
+Every pack shares en.json's key structure, so its diff maps 1:1 onto each
+language. Instead of regenerating the whole file, this applies the en.json diff
+onto the published pack:
 
-Usage:
-    python translate_locales.py \
-        --code ja \
+  * added / modified keys -> translate ONLY those values and write them in,
+  * removed keys          -> delete them,
+  * every other key       -> left byte-for-byte as published.
+
+So keys the diff doesn't touch are never sent to the model — community edits
+survive across runs, and it's cheap. Diff keys come from the caller (see
+locale_diff.py). With no diff (or no current pack to patch), it falls back to a
+full section-by-section translation so new languages still work.
+
+Chunking (a section per call, or the changed subset in one call) keeps each
+response small enough to avoid truncation and never splits a fragment/plural
+sibling group; the full English file rides along as terminology context.
+
+Usage (patch mode — CI): --changed-keys / --removed-keys are JSON lists of
+dotted keys added/modified / removed in en.json.
+    python translate_locales.py --code ja \
         --base web/src/locales/en.json \
         --prompt web/src/locales/TRANSLATION_PROMPT.md \
         --current langrepo/ja.json \
-        --out langrepo/ja.json
+        --changed-keys changed.json --removed-keys removed.json \
+        --out out/ja.json
 
-Auth: set an Amazon Bedrock API key in AWS_BEARER_TOKEN_BEDROCK (boto3 picks it
-up automatically); the standard AWS credential chain works too if it's unset.
+Usage (full mode — first-time / recovery): --current is optional.
+    python translate_locales.py --code ja \
+        --base web/src/locales/en.json \
+        --prompt web/src/locales/TRANSLATION_PROMPT.md \
+        --current langrepo/ja.json --full --out out/ja.json
 
-Exit codes: 0 on success, non-zero on failure so CI can gate a language.
+Auth: Amazon Bedrock API key in AWS_BEARER_TOKEN_BEDROCK (boto3 auto-detects it),
+or the standard AWS credential chain. Exit 0 on success, non-zero so CI can gate.
 """
 
 from __future__ import annotations
@@ -77,6 +91,127 @@ def flatten(obj: dict, prefix: str = "") -> dict[str, object]:
         else:
             out[dotted] = value
     return out
+
+
+def get_nested(obj: dict, dotted: str) -> object:
+    """Read a value at a dotted key path; raise KeyError if any segment is missing."""
+    cur: object = obj
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            raise KeyError(dotted)
+        cur = cur[part]
+    return cur
+
+
+def set_nested(obj: dict, dotted: str, value: object) -> None:
+    """Write a value at a dotted key path, creating intermediate dicts as needed."""
+    parts = dotted.split(".")
+    cur = obj
+    for part in parts[:-1]:
+        nxt = cur.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cur[part] = nxt
+        cur = nxt
+    cur[parts[-1]] = value
+
+
+def delete_nested(obj: dict, dotted: str) -> None:
+    """Delete a dotted key path, pruning now-empty parent dicts. No-op if absent."""
+    parts = dotted.split(".")
+    stack: list[tuple[dict, str]] = []
+    cur: object = obj
+    for part in parts[:-1]:
+        if not isinstance(cur, dict) or part not in cur:
+            return
+        stack.append((cur, part))
+        cur = cur[part]
+    if not isinstance(cur, dict) or parts[-1] not in cur:
+        return
+    del cur[parts[-1]]
+    # Prune empty ancestors so a removed leaf doesn't leave dangling {} sections.
+    for parent, key in reversed(stack):
+        child = parent.get(key)
+        if isinstance(child, dict) and not child:
+            del parent[key]
+        else:
+            break
+
+
+def compute_diff(previous: dict, current: dict) -> tuple[list[str], list[str]]:
+    """Dotted keys changed between two en.json revisions.
+
+    Returns (changed, removed): added/modified keys (need translation) and keys
+    dropped from en.json (delete from the pack). Sorted for stable diffs.
+    """
+    prev_flat = flatten(previous)
+    cur_flat = flatten(current)
+    changed = [
+        key
+        for key, value in cur_flat.items()
+        if key not in prev_flat or prev_flat[key] != value
+    ]
+    removed = [key for key in prev_flat if key not in cur_flat]
+    return sorted(changed), sorted(removed)
+
+
+def load_key_list(path: Path | None, code: str, label: str) -> list[str]:
+    """Load a JSON list of dotted keys from `path`; [] if unset/missing/empty."""
+    if path is None:
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        eprint(f"[{code}] no {label} file at {path} — treating as empty")
+        return []
+    data = json.loads(raw)
+    if not isinstance(data, list) or not all(isinstance(k, str) for k in data):
+        raise ValueError(f"{label} file must be a JSON list of strings: {path}")
+    return data
+
+
+def build_nested_from_keys(base: dict, keys: list[str]) -> dict:
+    """Build a nested dict holding only `keys` (dotted) taken from `base`."""
+    out: dict = {}
+    for key in keys:
+        set_nested(out, key, get_nested(base, key))
+    return out
+
+
+def build_keys_message(
+    code: str,
+    base_full_raw: str,
+    subset_raw: str,
+) -> str:
+    """Build the user turn for translating a specific subset of changed keys.
+
+    Only the changed/added keys are translated and returned; the full English
+    file rides along as read-only context so terminology stays consistent with
+    the untouched (already-published) parts of the pack.
+    """
+    return "\n".join(
+        [
+            f"Target locale code: {code}",
+            "",
+            "FULL ENGLISH FILE (en.json) — CONTEXT ONLY, for terminology "
+            "consistency with the rest of the already-translated pack. Do NOT "
+            "translate or return this whole file:",
+            "```json",
+            base_full_raw.strip(),
+            "```",
+            "",
+            "KEYS TO TRANSLATE — a subset of the file above whose English was just "
+            "added or changed. Translate their VALUES into the target locale:",
+            "```json",
+            subset_raw.strip(),
+            "```",
+            "",
+            "Return ONLY these keys as a single JSON object with EXACTLY the same "
+            "keys and nesting as shown (same dotted paths, same structure). Do not "
+            "add, drop, rename, or reorder keys. Return only the JSON — no markdown "
+            "fences, no commentary.",
+        ]
+    )
 
 
 def build_section_message(
@@ -211,6 +346,105 @@ def check_key_parity(base: dict, translated: dict) -> list[str]:
     return sorted(base_keys - trans_keys)
 
 
+def translate_full(
+    client,
+    model_id: str,
+    system_prompt: str,
+    code: str,
+    base: dict,
+    base_raw: str,
+    current: dict,
+) -> dict | None:
+    """Translate the whole file, one top-level section per call.
+
+    Preserves good existing values, retranslates changed English, fills missing
+    keys. Used for first-time generation and recovery. Returns the translated
+    dict, or None if any section failed (caller turns that into a non-zero exit).
+    """
+    translated: dict = {}
+    for section, section_value in base.items():
+        section_base_obj: dict = {section: section_value}
+        section_base_raw = json.dumps(section_base_obj, ensure_ascii=False, indent=2)
+        section_current_raw: str | None = None
+        if section in current:
+            section_current_raw = json.dumps(
+                {section: current[section]}, ensure_ascii=False, indent=2
+            )
+
+        message = build_section_message(
+            code, section, base_raw, section_base_raw, section_current_raw
+        )
+
+        eprint(f"[{code}] invoking {model_id} for section '{section}' ...")
+        try:
+            text = invoke_model(client, model_id, system_prompt, message)
+            section_result = parse_model_json(text)
+        except json.JSONDecodeError as err:
+            eprint(f"[{code}] section '{section}' returned invalid JSON: {err}")
+            return None
+        except Exception as err:  # noqa: BLE001 - surface any Bedrock failure per-language
+            eprint(f"[{code}] section '{section}' failed: {err}")
+            return None
+
+        # Accept either { "<section>": {...} } or the bare section object.
+        if list(section_result.keys()) == [section]:
+            section_result = section_result[section]
+
+        # Fail on the offending section rather than after the whole file.
+        section_missing = check_key_parity(section_base_obj, {section: section_result})
+        if section_missing:
+            eprint(
+                f"[{code}] section '{section}' is missing "
+                f"{len(section_missing)} key(s); first few: {section_missing[:5]}"
+            )
+            return None
+
+        translated[section] = section_result
+
+    return translated
+
+
+def translate_keys(
+    client,
+    model_id: str,
+    system_prompt: str,
+    code: str,
+    base: dict,
+    base_raw: str,
+    changed_keys: list[str],
+) -> dict | None:
+    """Translate only `changed_keys` (dotted) and return them as a nested dict.
+
+    One call for the whole subset — it's just the changed English, which stays
+    well under the token budget. Returns None on failure or if the model dropped
+    any requested key (caller turns that into a non-zero exit).
+    """
+    subset = build_nested_from_keys(base, changed_keys)
+    subset_raw = json.dumps(subset, ensure_ascii=False, indent=2)
+    message = build_keys_message(code, base_raw, subset_raw)
+
+    eprint(f"[{code}] invoking {model_id} for {len(changed_keys)} changed key(s) ...")
+    try:
+        text = invoke_model(client, model_id, system_prompt, message)
+        result = parse_model_json(text)
+    except json.JSONDecodeError as err:
+        eprint(f"[{code}] changed-keys response was invalid JSON: {err}")
+        return None
+    except Exception as err:  # noqa: BLE001 - surface any Bedrock failure per-language
+        eprint(f"[{code}] changed-keys translation failed: {err}")
+        return None
+
+    result_flat = flatten(result)
+    dropped = sorted(set(changed_keys) - set(result_flat))
+    if dropped:
+        eprint(
+            f"[{code}] changed-keys response dropped {len(dropped)} key(s); "
+            f"first few: {dropped[:5]}"
+        )
+        return None
+    return result
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--code", required=True, help="BCP-47 target locale code, e.g. ja")
@@ -227,6 +461,26 @@ def main() -> int:
         default=None,
         help="Path to the existing translation (omit or point at a missing file "
         "for a first-time generation)",
+    )
+    parser.add_argument(
+        "--changed-keys",
+        type=Path,
+        default=None,
+        help="JSON file: list of dotted keys added/modified in en.json. In patch "
+        "mode only these are (re)translated; everything else in --current is kept.",
+    )
+    parser.add_argument(
+        "--removed-keys",
+        type=Path,
+        default=None,
+        help="JSON file: list of dotted keys removed from en.json; they are "
+        "deleted from --current in patch mode.",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Force a full retranslation of every section instead of patching "
+        "(recovery / first-time). Implied when there is no --current to patch.",
     )
     parser.add_argument("--out", required=True, type=Path, help="Where to write <code>.json")
     parser.add_argument(
@@ -268,12 +522,6 @@ def main() -> int:
     else:
         eprint(f"[{args.code}] no existing translation — first-time generation")
 
-    client = boto3.client(
-        "bedrock-runtime",
-        region_name=args.region,
-        config=Config(retries={"max_attempts": 0}, read_timeout=300),
-    )
-
     current: dict = {}
     if current_raw is not None:
         try:
@@ -282,49 +530,63 @@ def main() -> int:
             eprint(f"[{args.code}] existing translation is not valid JSON: {err}")
             return 1
 
-    # Translate one section per call: small enough to avoid truncation, and no
-    # fragment/plural group spans two sections. Full English rides along as
-    # context for terminology consistency.
-    translated: dict = {}
-    for section, section_value in base.items():
-        section_base_obj: dict = {section: section_value}
+    try:
+        changed_keys = load_key_list(args.changed_keys, args.code, "changed-keys")
+        removed_keys = load_key_list(args.removed_keys, args.code, "removed-keys")
+    except (ValueError, json.JSONDecodeError) as err:
+        eprint(f"[{args.code}] bad diff input: {err}")
+        return 2
 
-        section_base_raw = json.dumps(section_base_obj, ensure_ascii=False, indent=2)
-        section_current_raw: str | None = None
-        if section in current:
-            section_current_raw = json.dumps(
-                {section: current[section]}, ensure_ascii=False, indent=2
+    # Patch needs both a pack to patch and a diff to apply; otherwise (or with
+    # --full) do a full retranslation.
+    have_current = bool(current)
+    diff_provided = args.changed_keys is not None or args.removed_keys is not None
+    patch_mode = have_current and diff_provided and not args.full
+
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=args.region,
+        config=Config(retries={"max_attempts": 0}, read_timeout=300),
+    )
+
+    if patch_mode:
+        # Start from the published pack; touch only diffed keys, so every other
+        # key (hand edits, extra plural variants) carries through untouched.
+        translated = current
+        base_keys = set(flatten(base))
+
+        # Delete removed keys (skip any still present in en.json — stale list).
+        for key in removed_keys:
+            if key not in base_keys:
+                delete_nested(translated, key)
+
+        # Translate only changed keys still present in en.json.
+        to_translate = [k for k in changed_keys if k in base_keys]
+        if to_translate:
+            patch = translate_keys(
+                client, args.model_id, system_prompt, args.code,
+                base, base_raw, to_translate,
             )
+            if patch is None:
+                return 1
+            patch_flat = flatten(patch)
+            for key in to_translate:
+                set_nested(translated, key, patch_flat[key])
 
-        message = build_section_message(
-            args.code, section, base_raw, section_base_raw, section_current_raw
+        eprint(
+            f"[{args.code}] patched: {len(to_translate)} (re)translated, "
+            f"{len(removed_keys)} removed"
         )
-
-        eprint(f"[{args.code}] invoking {args.model_id} for section '{section}' ...")
-        try:
-            text = invoke_model(client, args.model_id, system_prompt, message)
-            section_result = parse_model_json(text)
-        except json.JSONDecodeError as err:
-            eprint(f"[{args.code}] section '{section}' returned invalid JSON: {err}")
+    else:
+        reason = "--full" if args.full else (
+            "no existing pack" if not have_current else "no diff provided"
+        )
+        eprint(f"[{args.code}] full translation ({reason})")
+        translated = translate_full(
+            client, args.model_id, system_prompt, args.code, base, base_raw, current
+        )
+        if translated is None:
             return 1
-        except Exception as err:  # noqa: BLE001 - surface any Bedrock failure per-language
-            eprint(f"[{args.code}] section '{section}' failed: {err}")
-            return 1
-
-        # Accept either { "<section>": {...} } or the bare section object.
-        if list(section_result.keys()) == [section]:
-            section_result = section_result[section]
-
-        # Fail on the offending section rather than after the whole file.
-        section_missing = check_key_parity(section_base_obj, {section: section_result})
-        if section_missing:
-            eprint(
-                f"[{args.code}] section '{section}' is missing "
-                f"{len(section_missing)} key(s); first few: {section_missing[:5]}"
-            )
-            return 1
-
-        translated[section] = section_result
 
     missing = check_key_parity(base, translated)
     if missing:

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -77,6 +77,12 @@ RETRYABLE_ERROR_CODES = {
 }
 
 
+# i18next plural suffixes, mirroring verify_locale.py. When a base plural key is
+# removed, the gate rejects any leftover sibling variant (e.g. a pack's extra
+# `_few`), so removals must sweep the whole plural group, not just the exact key.
+PLURAL_SUFFIXES = ("_zero", "_one", "_two", "_few", "_many", "_other")
+
+
 def eprint(*args: object) -> None:
     print(*args, file=sys.stderr, flush=True)
 
@@ -136,6 +142,22 @@ def delete_nested(obj: dict, dotted: str) -> None:
             del parent[key]
         else:
             break
+
+
+def plural_group_keys(removed_key: str, pack_keys: set[str]) -> list[str]:
+    """Pack keys in `removed_key`'s plural group (including itself).
+
+    When `removed_key` is an i18next plural form, a pack may carry extra sibling
+    variants (e.g. `_few`) that verify_locale.py only tolerates while a base
+    `_one`/`_other` exists. Once the base group is gone those orphans fail the
+    gate, so a removal of any group member must sweep every sibling the pack has.
+    Returns just the key itself when it isn't a plural form.
+    """
+    if not any(removed_key.endswith(suffix) for suffix in PLURAL_SUFFIXES):
+        return [removed_key]
+    stem = removed_key.rsplit("_", 1)[0]
+    siblings = {f"{stem}{suffix}" for suffix in PLURAL_SUFFIXES}
+    return sorted(k for k in pack_keys if k in siblings)
 
 
 def compute_diff(previous: dict, current: dict) -> tuple[list[str], list[str]]:
@@ -556,9 +578,18 @@ def main() -> int:
         base_keys = set(flatten(base))
 
         # Delete removed keys (skip any still present in en.json — stale list).
+        # For a removed plural form, also sweep the pack's sibling variants
+        # (e.g. an extra `_few`) so no orphan trips verify_locale.py once the
+        # base `_one`/`_other` are gone.
+        pack_keys = set(flatten(translated))
         for key in removed_keys:
-            if key not in base_keys:
-                delete_nested(translated, key)
+            if key in base_keys:
+                continue
+            for member in plural_group_keys(key, pack_keys):
+                # Never delete a sibling that en.json still defines (only part of
+                # the group was removed) — that would drop a required translation.
+                if member not in base_keys:
+                    delete_nested(translated, member)
 
         # Translate only changed keys still present in en.json.
         to_translate = [k for k in changed_keys if k in base_keys]

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -82,7 +82,17 @@ The generator
 this same `TRANSLATION_PROMPT.md` as its system prompt and gates output with
 `verify_locale.py`, so machine and hand-made packs follow one contract. A
 language with no marker yet, or a manual `workflow_dispatch`, falls back to a
-full first-time translation.
+full first-time translation. If a patched pack ever fails the structural gate
+(e.g. a pre-existing defect on a key this run didn't touch), CI automatically
+retries that language with a full retranslation — which re-emits every key — and
+only fails the language if it still doesn't pass.
+
+**Retiring a language.** Removing a code from [`targets.json`](./targets.json)
+only stops CI from *updating* it — the workflow never deletes files from the
+translations repo, so the language's `<code>.json` and `markers/<code>.json`
+stay published (and still offered to users via the registry's `index.json`)
+until you delete them there by hand. To fully retire a language, remove it from
+`targets.json` here **and** delete both files from the translations repo.
 
 ### Community contributions are durable
 

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -67,7 +67,7 @@ same dotted keys are added/modified/removed in each. So per language the CI:
 - **translates only the changed/added keys** and writes them in, deletes removed
   keys, and **leaves every other key exactly as published.**
 
-The marker lives in the translations repo and *holds the state we diff against*,
+The marker lives in the translations repo and _holds the state we diff against_,
 so the effective diff is always "everything unpublished since this language last
 published" — independent of run cadence, re-runs, or how many `en.json` commits
 happened in between. The publish PR bumps each produced language's
@@ -88,7 +88,7 @@ retries that language with a full retranslation — which re-emits every key —
 only fails the language if it still doesn't pass.
 
 **Retiring a language.** Removing a code from [`targets.json`](./targets.json)
-only stops CI from *updating* it — the workflow never deletes files from the
+only stops CI from _updating_ it — the workflow never deletes files from the
 translations repo, so the language's `<code>.json` and `markers/<code>.json`
 stay published (and still offered to users via the registry's `index.json`)
 until you delete them there by hand. To fully retire a language, remove it from

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -49,16 +49,50 @@ The agent should then:
 The target languages in [`targets.json`](./targets.json) are also produced
 automatically: a GitHub Actions workflow
 ([`.github/workflows/translate-locales.yaml`](../../../.github/workflows/translate-locales.yaml))
-regenerates each target from `en.json` with AWS Bedrock whenever `en.json`
-changes, then opens a single pull request on a separate public translations
-repo carrying every language that regenerated cleanly, for a human to review
-and merge. Batching into one PR means one merge and one GitHub Pages deploy
-rather than one per language. The generator
+patches each target from `en.json` with AWS Bedrock whenever `en.json` changes,
+then opens a single pull request on a separate public translations repo carrying
+every language that patched cleanly, for a human to review and merge. Batching
+into one PR means one merge and one GitHub Pages deploy rather than one per
+language.
+
+It is a **patch**, not a regenerate. Because every pack shares `en.json`'s exact
+key structure, a structural diff of `en.json` maps 1:1 onto every language — the
+same dotted keys are added/modified/removed in each. So per language the CI:
+
+- diffs **our `en.json`** against that language's published **baseline marker**
+  (`markers/<code>.json` in the translations repo — a verbatim copy of the
+  `en.json` the pack was last built against) into `{changed keys, removed keys}`
+  ([`scripts/locale_diff.py`](../../../scripts/locale_diff.py)),
+- downloads the published `<code>.json`,
+- **translates only the changed/added keys** and writes them in, deletes removed
+  keys, and **leaves every other key exactly as published.**
+
+The marker lives in the translations repo and *holds the state we diff against*,
+so the effective diff is always "everything unpublished since this language last
+published" — independent of run cadence, re-runs, or how many `en.json` commits
+happened in between. The publish PR bumps each produced language's
+`markers/<code>.json` to the current `en.json` in the same commit as its pack,
+so the marker advances only when the pack does. A language that fails a run
+keeps its old marker and is caught up on the next run — no gap. (A nice
+byproduct: the PR shows the English diff in `markers/<code>.json` right next to
+the pack diff.)
+
+The generator
 ([`scripts/translate_locales.py`](../../../scripts/translate_locales.py)) uses
 this same `TRANSLATION_PROMPT.md` as its system prompt and gates output with
-`verify_locale.py`, so machine and hand-made packs follow one contract. Hand
-edits are safe: the next run reads the published pack back as its baseline and
-only re-touches strings whose English changed.
+`verify_locale.py`, so machine and hand-made packs follow one contract. A
+language with no marker yet, or a manual `workflow_dispatch`, falls back to a
+full first-time translation.
+
+### Community contributions are durable
+
+Because CI only ever touches the keys whose English changed, **hand edits to a
+published pack survive verbatim.** Anyone can open a PR against the translations
+repo to fix a wording, adjust a fragment, or add a plural variant; once merged,
+CI will never overwrite that key on later runs — it only re-touches a key if its
+**English source** later changes (a reworded `en.json` value), and only adds
+keys that are genuinely new. This makes the translations repo the place to
+contribute improvements, not a throwaway machine output.
 
 ### Rules the installer enforces
 


### PR DESCRIPTION
## Summary

The translate CI previously **regenerated each language pack in full** every run, which risked drifting over community/hand edits. This changes it to a **patch model**: apply only the `en.json` diff onto each published pack, so untouched keys (including community edits) survive verbatim across runs.

Per language, per run the CI now:

- diffs **our `en.json`** against that language's baseline **marker** (`markers/<code>.json` in the language repo — a copy of the `en.json` the pack was last built against),
- **re-translates only the changed/added keys**, deletes removed keys, and **leaves every other key byte-for-byte** as published.

The publish PR bumps each produced language's `markers/<code>.json` to the current `en.json` alongside its pack, so the marker advances **iff** the pack does. A language that fails a run keeps its old marker and is caught up on the next run — gap-proof regardless of run cadence, re-runs, or how many `en.json` commits piled up. New languages (no marker) or a manual `workflow_dispatch` fall back to a full translation.

## Changes

- `scripts/locale_diff.py` (new): computes the key-level diff (`changed`/`removed`) from the previous `en.json` (stdin, the marker) vs current.
- `scripts/translate_locales.py`: reworked into a patch model (`--changed-keys` / `--removed-keys` / `--full`) with a full-translation fallback; removed a duplicate Bedrock client init.
- `.github/workflows/translate-locales.yaml`: per-language diff vs marker; publish PR writes both the pack and the bumped marker; trigger points at this branch for testing.
- `web/src/locales/README.md`: documents the marker-based patch model, durable community contributions, and the language-retirement path.

## Review fixes (2nd commit)

Addresses findings from a code review of the patch model:

- **Self-heal gate failures.** If a patched pack fails the structural gate (`verify_locale.py`) on a key this run didn't touch — a pre-existing defect the old full-regen used to heal — CI now retries that language with a full retranslation (re-emitting every key) before failing it. No more permanently-frozen language.
- **Sweep orphan plural variants on removal.** When a base plural key is removed, the patcher also deletes the pack's sibling variants (e.g. an extra `_few`) so no orphan trips the gate once the base `_one`/`_other` are gone; guarded so siblings `en.json` still defines are never dropped.
- **Document retirement.** Removing a code from `targets.json` stops updates but doesn't delete the published pack/marker — the README now says to delete both in the translations repo to fully retire a language.

## Review fixes (latest commits)

A second code-review pass surfaced two correctness gaps and a coverage hole, now fixed:

- **Plural sweep now matches the gate exactly.** `plural_group_keys` was keyed off the plural suffix alone, so it (a) deleted a gate-allowed community sibling when only *part* of a plural group was removed from `en.json`, and (b) could sweep an ordinary key that merely ends in a plural-looking suffix (e.g. `step_two`). It now mirrors `verify_locale.py`'s `is_allowed_plural_variant`: sweep the group only once the base `_one`/`_other` is entirely gone; otherwise delete just the removed key. This makes the "community edits are durable" guarantee hold for partial-group removals.
- **Self-heal now also covers a patch *translate* failure**, not just a gate failure. The step is now `if ! translate || ! gate` → full retranslation, so a pack that fails the final parity check on an untouched base key (which aborted the step under `set -e` before the self-heal could run) recovers instead of failing every run.
- **Tests for the previously untested patch logic** (`scripts/test_translate_locales.py`, 14 → 37 tests): `compute_diff`, `delete_nested` empty-ancestor pruning, `plural_group_keys` partial-vs-full group removal, `translate_keys` dropped-key detection, nested-path helpers, and end-to-end patch-mode via `main()`.

## Test plan

- [ ] First CI run (no markers yet): every language full-translates and seeds `markers/<code>.json`; PR opens on the language repo.
- [ ] Second run after changing one `en.json` key: only that key is re-translated per language; hand-edited keys untouched; markers bumped.
- [ ] A language forced to fail: its marker is NOT bumped and it's picked up next run.
- [ ] Patch that fails the gate on an untouched key: CI retries that language with `--full` and recovers.
- [ ] Patch that fails the parity check (untouched base key missing from the pack): CI retries with `--full` and recovers.
- [ ] Removing a base plural group: orphan sibling variants are swept; pack passes `verify_locale.py`.
- [ ] Partial plural-group removal (base `_other` kept): a community-added `_few` sibling is preserved, not swept.
- [ ] `workflow_dispatch` forces a full retranslation.
- [x] Unit suite passes: `python -m pytest scripts/test_translate_locales.py` (37 passed).

> Note: revert the branch entry in the workflow `on.push.branches` before merging if it shouldn't stay a permanent trigger.