### PR TITLE
fix(web): SSO-aware, fail-open org-membership gate on assignment accept (#66)

### DIFF
--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1721,6 +1721,13 @@ export async function acceptAssignment(params: {
 
   // Best-effort: auto-accept a pending org invite. Failures are ignored (the
   // student may already be a member), so this isn't a tracked step.
+  //
+  // TODO(#66 follow-up): a SAML-SSO-gated 403 here (org enforces SSO and this
+  // token has no live SSO session) surfaces later as a generic step failure
+  // (repo/access), not the SSO-aware screen the accept gate now renders. The
+  // gate covers the common case (initial membership read); routing this
+  // mutation-side SSO 403 to the same "Authorize single sign-on" affordance is
+  // still open.
   await acceptPendingOrgInvite(client, org)
 
   const assignment = await withAcceptStep(

--- a/web/src/hooks/github/client.ts
+++ b/web/src/hooks/github/client.ts
@@ -103,6 +103,7 @@ export function createGitHubClient(args: {
         message,
         body,
         rateLimit,
+        ssoHeader: res.headers.get("x-github-sso"),
       })
     }
 

--- a/web/src/hooks/github/errors.test.ts
+++ b/web/src/hooks/github/errors.test.ts
@@ -40,7 +40,8 @@ describe("isDefinitiveGitHubStatus", () => {
 })
 
 describe("retryTransientNotFoundForbidden", () => {
-  it("does not retry a definitive 404 / 403", () => {
+  it("does not retry a definitive 401 / 403 / 404", () => {
+    expect(retryTransientNotFoundForbidden(0, apiError(401))).toBe(false)
     expect(retryTransientNotFoundForbidden(0, apiError(404))).toBe(false)
     expect(retryTransientNotFoundForbidden(0, apiError(403))).toBe(false)
   })
@@ -63,10 +64,20 @@ describe("SAML SSO detection", () => {
   const entSsoUrl =
     "https://github.com/enterprises/acme-inc/sso?authorization_request=ABC123"
 
-  it("isSsoRequired reflects presence of the X-GitHub-SSO header", () => {
+  it("isSsoRequired requires a 403 carrying the X-GitHub-SSO header", () => {
     expect(apiError(403, `required; url=${orgSsoUrl}`).isSsoRequired).toBe(true)
     expect(apiError(403, null).isSsoRequired).toBe(false)
     expect(apiError(403).isSsoRequired).toBe(false)
+  })
+
+  it("isSsoRequired is false when the header rides a non-403 status", () => {
+    // GitHub only emits X-GitHub-SSO on a 403; a header echoed onto a dead-token
+    // 401 or a transient 5xx/429 (e.g. copied by a proxy) must NOT be read as an
+    // SSO gate, or it would mask a re-auth / outage as "authorize SSO".
+    const header = `required; url=${orgSsoUrl}`
+    expect(apiError(401, header).isSsoRequired).toBe(false)
+    expect(apiError(500, header).isSsoRequired).toBe(false)
+    expect(apiError(429, header).isSsoRequired).toBe(false)
   })
 
   it("extracts the authorization URL from a `required; url=…` header", () => {
@@ -87,6 +98,37 @@ describe("SAML SSO detection", () => {
   it("rejects a non-github.com URL (defensive against a spoofed redirect)", () => {
     expect(
       parseSsoAuthorizationUrl("required; url=https://evil.example.com/sso"),
+    ).toBeNull()
+  })
+
+  it("rejects github.com spoofs that shift the real host (userinfo / subdomain)", () => {
+    // The `hostname === "github.com"` guard is the security-relevant sentinel;
+    // these are the classic ways a naive substring/`includes` check would be
+    // fooled. `new URL()` puts `github.com` in the userinfo (host = evil.com)
+    // for the `@` form, and the trailing-domain form has host github.com.evil.com.
+    expect(
+      parseSsoAuthorizationUrl("required; url=https://github.com@evil.com/sso"),
+    ).toBeNull()
+    expect(
+      parseSsoAuthorizationUrl("required; url=https://github.com.evil.com/sso"),
+    ).toBeNull()
+  })
+
+  it("rejects non-https schemes even when the host is github.com", () => {
+    // Script schemes parse to an empty host (already rejected), but the explicit
+    // https: allowlist also blocks any benign non-http scheme and makes the
+    // intent durable against a future refactor of the host check.
+    expect(
+      parseSsoAuthorizationUrl("required; url=javascript:alert(1)"),
+    ).toBeNull()
+    expect(
+      parseSsoAuthorizationUrl("required; url=data:text/html,<script>x</script>"),
+    ).toBeNull()
+    expect(
+      parseSsoAuthorizationUrl("required; url=http://github.com/orgs/acme/sso"),
+    ).toBeNull()
+    expect(
+      parseSsoAuthorizationUrl("required; url=ftp://github.com/x"),
     ).toBeNull()
   })
 

--- a/web/src/hooks/github/errors.test.ts
+++ b/web/src/hooks/github/errors.test.ts
@@ -81,11 +81,15 @@ describe("SAML SSO detection", () => {
   })
 
   it("extracts the authorization URL from a `required; url=…` header", () => {
-    expect(parseSsoAuthorizationUrl(`required; url=${orgSsoUrl}`)).toBe(orgSsoUrl)
-    expect(parseSsoAuthorizationUrl(`required; url=${entSsoUrl}`)).toBe(entSsoUrl)
-    expect(apiError(403, `required; url=${entSsoUrl}`).ssoAuthorizationUrl).toBe(
+    expect(parseSsoAuthorizationUrl(`required; url=${orgSsoUrl}`)).toBe(
+      orgSsoUrl,
+    )
+    expect(parseSsoAuthorizationUrl(`required; url=${entSsoUrl}`)).toBe(
       entSsoUrl,
     )
+    expect(
+      apiError(403, `required; url=${entSsoUrl}`).ssoAuthorizationUrl,
+    ).toBe(entSsoUrl)
   })
 
   it("returns null for the multi-org `partial-results` shape (no URL)", () => {
@@ -122,7 +126,9 @@ describe("SAML SSO detection", () => {
       parseSsoAuthorizationUrl("required; url=javascript:alert(1)"),
     ).toBeNull()
     expect(
-      parseSsoAuthorizationUrl("required; url=data:text/html,<script>x</script>"),
+      parseSsoAuthorizationUrl(
+        "required; url=data:text/html,<script>x</script>",
+      ),
     ).toBeNull()
     expect(
       parseSsoAuthorizationUrl("required; url=http://github.com/orgs/acme/sso"),

--- a/web/src/hooks/github/errors.test.ts
+++ b/web/src/hooks/github/errors.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from "vitest"
 import {
   GitHubAPIError,
   isDefinitiveGitHubStatus,
+  parseSsoAuthorizationUrl,
   retryTransientNotFoundForbidden,
 } from "./errors"
 
-const apiError = (status: number) =>
+const apiError = (status: number, ssoHeader?: string | null) =>
   new GitHubAPIError({
     status,
     url: "https://api.github.com/x",
@@ -20,6 +21,7 @@ const apiError = (status: number) =>
       resource: null,
       retryAfter: null,
     },
+    ssoHeader,
   })
 
 describe("isDefinitiveGitHubStatus", () => {
@@ -52,5 +54,45 @@ describe("retryTransientNotFoundForbidden", () => {
   it("retries non-GitHubAPIError (network) failures within the bound", () => {
     expect(retryTransientNotFoundForbidden(0, new Error("network"))).toBe(true)
     expect(retryTransientNotFoundForbidden(2, new Error("network"))).toBe(false)
+  })
+})
+
+describe("SAML SSO detection", () => {
+  const orgSsoUrl =
+    "https://github.com/orgs/acme/sso?authorization_request=ABC123"
+  const entSsoUrl =
+    "https://github.com/enterprises/acme-inc/sso?authorization_request=ABC123"
+
+  it("isSsoRequired reflects presence of the X-GitHub-SSO header", () => {
+    expect(apiError(403, `required; url=${orgSsoUrl}`).isSsoRequired).toBe(true)
+    expect(apiError(403, null).isSsoRequired).toBe(false)
+    expect(apiError(403).isSsoRequired).toBe(false)
+  })
+
+  it("extracts the authorization URL from a `required; url=…` header", () => {
+    expect(parseSsoAuthorizationUrl(`required; url=${orgSsoUrl}`)).toBe(orgSsoUrl)
+    expect(parseSsoAuthorizationUrl(`required; url=${entSsoUrl}`)).toBe(entSsoUrl)
+    expect(apiError(403, `required; url=${entSsoUrl}`).ssoAuthorizationUrl).toBe(
+      entSsoUrl,
+    )
+  })
+
+  it("returns null for the multi-org `partial-results` shape (no URL)", () => {
+    const header = "partial-results; organizations=21955855,20582480"
+    expect(parseSsoAuthorizationUrl(header)).toBeNull()
+    expect(apiError(403, header).isSsoRequired).toBe(true)
+    expect(apiError(403, header).ssoAuthorizationUrl).toBeNull()
+  })
+
+  it("rejects a non-github.com URL (defensive against a spoofed redirect)", () => {
+    expect(
+      parseSsoAuthorizationUrl("required; url=https://evil.example.com/sso"),
+    ).toBeNull()
+  })
+
+  it("returns null for absent / malformed headers", () => {
+    expect(parseSsoAuthorizationUrl(null)).toBeNull()
+    expect(parseSsoAuthorizationUrl(undefined)).toBeNull()
+    expect(parseSsoAuthorizationUrl("required; url=not-a-url")).toBeNull()
   })
 })

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -12,6 +12,11 @@ export class GitHubAPIError extends Error {
   url: string
   body: unknown
   rateLimit: GitHubRateLimit
+  // Raw X-GitHub-SSO response header, when present. GitHub sets this on a
+  // 403 (and omits SSO-gated orgs from multi-org reads) when the token lacks a
+  // live SAML SSO session for the org/enterprise. `null` when the header was
+  // absent. See parseSsoAuthorizationUrl for extracting the authorization URL.
+  ssoHeader: string | null
 
   constructor(args: {
     status: number
@@ -19,6 +24,7 @@ export class GitHubAPIError extends Error {
     message: string
     body: unknown
     rateLimit: GitHubRateLimit
+    ssoHeader?: string | null
   }) {
     super(args.message)
     this.name = "GitHubAPIError"
@@ -26,6 +32,7 @@ export class GitHubAPIError extends Error {
     this.url = args.url
     this.body = args.body
     this.rateLimit = args.rateLimit
+    this.ssoHeader = args.ssoHeader ?? null
   }
 
   get isNotFound() {
@@ -46,6 +53,44 @@ export class GitHubAPIError extends Error {
       (this.status === 403 &&
         (this.rateLimit.remaining === 0 || this.rateLimit.retryAfter !== null))
     )
+  }
+
+  // The org/enterprise enforces SAML SSO and this token has no live SSO session
+  // for it. GitHub signals this with the X-GitHub-SSO header (a 403 carrying
+  // `required; url=…`, or `partial-results; organizations=…` on multi-org reads).
+  get isSsoRequired() {
+    return this.ssoHeader !== null
+  }
+
+  // The GitHub SSO authorization URL to send the user to, if the header carried
+  // one (`required; url=…`). Returns null for the `partial-results` shape or
+  // when no header is present.
+  get ssoAuthorizationUrl() {
+    return parseSsoAuthorizationUrl(this.ssoHeader)
+  }
+}
+
+// Extract the authorization URL from an X-GitHub-SSO header value. GitHub uses
+// two shapes:
+//   - `required; url=https://github.com/orgs/<org>/sso?authorization_request=…`
+//     (or `enterprises/<ent>/sso`) — a single-org read the token can't see.
+//   - `partial-results; organizations=21955855,20582480` — a multi-org read
+//     that silently omitted SSO-gated orgs; carries org IDs, not a URL.
+// Returns the URL for the first shape, or null otherwise.
+export function parseSsoAuthorizationUrl(
+  ssoHeader: string | null | undefined,
+): string | null {
+  if (!ssoHeader) return null
+  const match = ssoHeader.match(/url=(\S+)/)
+  if (!match) return null
+  try {
+    const url = new URL(match[1])
+    // Only ever hand back a github.com SSO URL, never an attacker-influenced
+    // origin (the header is from GitHub, but stay defensive since we redirect).
+    if (url.hostname !== "github.com") return null
+    return url.toString()
+  } catch {
+    return null
   }
 }
 

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -109,7 +109,10 @@ export function retryTransientNotFoundForbidden(
   failureCount: number,
   error: unknown,
 ): boolean {
-  if (error instanceof GitHubAPIError && isDefinitiveGitHubStatus(error.status)) {
+  if (
+    error instanceof GitHubAPIError &&
+    isDefinitiveGitHubStatus(error.status)
+  ) {
     return false
   }
   return failureCount < 2

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -58,8 +58,11 @@ export class GitHubAPIError extends Error {
   // The org/enterprise enforces SAML SSO and this token has no live SSO session
   // for it. GitHub signals this with the X-GitHub-SSO header (a 403 carrying
   // `required; url=…`, or `partial-results; organizations=…` on multi-org reads).
+  // Scoped to 403: GitHub only emits X-GitHub-SSO on a forbidden response, so a
+  // header echoed on any other status (a 401 dead token, a 5xx/429 that a proxy
+  // copied the header onto) is NOT an SSO gate and must not misroute the user.
   get isSsoRequired() {
-    return this.ssoHeader !== null
+    return this.status === 403 && this.ssoHeader !== null
   }
 
   // The GitHub SSO authorization URL to send the user to, if the header carried
@@ -85,8 +88,12 @@ export function parseSsoAuthorizationUrl(
   if (!match) return null
   try {
     const url = new URL(match[1])
-    // Only ever hand back a github.com SSO URL, never an attacker-influenced
-    // origin (the header is from GitHub, but stay defensive since we redirect).
+    // Only ever hand back an https://github.com SSO URL, never an
+    // attacker-influenced origin or scheme (the header is from GitHub, but stay
+    // defensive since we render this as a clickable redirect). The explicit
+    // https: check makes the intent durable rather than relying on the
+    // incidental fact that javascript:/data: URLs parse to an empty hostname.
+    if (url.protocol !== "https:") return null
     if (url.hostname !== "github.com") return null
     return url.toString()
   } catch {
@@ -95,16 +102,14 @@ export function parseSsoAuthorizationUrl(
 }
 
 // Shared React Query `retry` predicate for fail-closed role/permission reads: a
-// 404 (not found / not a member) or 403 (blocked) is DEFINITIVE and must NOT
-// retry, while a transient 5xx/429/network blip self-heals (bounded to 2).
+// definitive status (401 revoked/expired, 403 blocked, 404 not found / not a
+// member — see isDefinitiveGitHubStatus) must NOT retry, while a transient
+// 5xx/429/network blip self-heals (bounded to 2).
 export function retryTransientNotFoundForbidden(
   failureCount: number,
   error: unknown,
 ): boolean {
-  if (
-    error instanceof GitHubAPIError &&
-    (error.status === 404 || error.status === 403)
-  ) {
+  if (error instanceof GitHubAPIError && isDefinitiveGitHubStatus(error.status)) {
     return false
   }
   return failureCount < 2

--- a/web/src/hooks/useGetOwnOrgMembership.ts
+++ b/web/src/hooks/useGetOwnOrgMembership.ts
@@ -1,7 +1,16 @@
 import { useQuery } from "@tanstack/react-query"
 import { getPendingOrgInvite } from "./github/mutations"
+import { retryTransientNotFoundForbidden } from "./github/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
+// Reads the authenticated user's OWN membership in `org` (GET
+// /user/memberships/orgs/{org}). A definitive 404 (no membership) or 403
+// (blocked / SAML SSO gated) does NOT retry — callers must inspect the error to
+// tell "genuinely not a member" (404) from "SSO/authorization" (403, see
+// GitHubAPIError.isSsoRequired) — while a transient 5xx/429/network blip
+// self-heals (bounded). The query is intentionally allowed to error (rather
+// than swallowing to `undefined`) so the accept/onboarding gate can render a
+// cause-specific screen instead of a blanket "not a member".
 const useGetOwnOrgMembership = (org: string | undefined) => {
   const client = useGitHubClient()
 
@@ -9,7 +18,7 @@ const useGetOwnOrgMembership = (org: string | undefined) => {
     queryKey: ["github", "memberships", "orgs", org],
     queryFn: () => getPendingOrgInvite(client, org ?? ""),
     staleTime: 10 * 60 * 1000,
-    retry: false,
+    retry: retryTransientNotFoundForbidden,
     enabled: Boolean(org),
   })
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1072,6 +1072,14 @@
       "inviteBody_suffix": "class roster before you can accept this assignment.",
       "afterAccepting": "After accepting the GitHub organization invite, return to this page and try again."
     },
+    "ssoRequired": {
+      "badge": "Single sign-on required",
+      "title": "Authorize single sign-on",
+      "body_prefix": "The",
+      "body_suffix": "organization requires SAML single sign-on (SSO), and your current session isn't authorized for it yet. You may already be a member — you just need to authorize SSO before continuing.",
+      "instructions": "Open this assignment link from within your school's learning management system (LMS) so you're signed in through single sign-on first, or use the button below to authorize single sign-on for this organization, then reload this page.",
+      "authorizeButton": "Authorize single sign-on"
+    },
     "steps": {
       "account": "Checking your GitHub account",
       "assignment": "Looking up the assignment",

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -16,6 +16,7 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubUser } from "@/hooks/github/types"
 import { Link, Navigate, useParams, useSearch } from "@tanstack/react-router"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { GitHubAPIError } from "@/hooks/github/errors"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useMutation } from "@tanstack/react-query"
 import { useState } from "react"
@@ -258,6 +259,73 @@ const NotOrgMember = ({
   )
 }
 
+// Shown when GitHub reports the org/enterprise enforces SAML SSO and the
+// student's token has no live SSO session (403 + X-GitHub-SSO). Distinct from
+// NotOrgMember: the student may well BE a member — they just need to authorize
+// SSO for this org. When GitHub handed us an authorization URL, offer it as the
+// primary action; otherwise explain that opening the link from the SSO-gated
+// LMS (or re-authenticating) is required.
+const SsoRequired = ({
+  user,
+  org,
+  ssoUrl,
+}: {
+  user: GitHubUser | null
+  org?: string
+  ssoUrl: string | null
+}) => {
+  const { t } = useTranslation()
+  return (
+    <div className="min-h-screen bg-base-100">
+      <AcceptNavbar />
+      <AcceptCard>
+        <div className="card-body gap-8">
+          <div>
+            <span className="badge badge-warning badge-soft gap-2">
+              <AlertTriangle aria-hidden="true" className="size-4" />
+              {t("accept.ssoRequired.badge")}
+            </span>
+
+            <h1 className="mt-6 text-2xl font-bold">
+              {t("accept.ssoRequired.title")}
+            </h1>
+
+            <p className="mt-2 text-base text-base-content/70">
+              {t("accept.ssoRequired.body_prefix")}{" "}
+              <span className="font-bold">{org}</span>{" "}
+              {t("accept.ssoRequired.body_suffix")}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-info/20 bg-info/5 p-5">
+            <p className="text-sm leading-5 text-base-content/70">
+              {t("accept.ssoRequired.instructions")}
+            </p>
+            {ssoUrl && (
+              <a
+                href={ssoUrl}
+                className="btn btn-primary btn-sm mt-4"
+                rel="noopener noreferrer"
+              >
+                {t("accept.ssoRequired.authorizeButton")}
+              </a>
+            )}
+          </div>
+
+          <div className="divider my-0" />
+
+          <div className="space-y-3">
+            <label className="label p-0 text-base font-semibold">
+              {t("accept.signedInAs")}
+            </label>
+            <UserInfo user={user} />
+          </div>
+        </div>
+      </AcceptCard>
+    </div>
+  )
+}
+
 const modeLabelKey: Record<string, string> = {
   individual: "accept.modeIndividual",
   group: "accept.modeGroup",
@@ -477,8 +545,11 @@ const AcceptAssignmentPage = () => {
 
   const { data: assignmentsData, isLoading: loadingAssignments } =
     usePagesAssignments(org, classroom, secret)
-  const { data: orgInvite, isLoading: loadingOrgMembership } =
-    useGetOwnOrgMembership(org)
+  const {
+    data: orgInvite,
+    isLoading: loadingOrgMembership,
+    error: orgMembershipError,
+  } = useGetOwnOrgMembership(org)
 
   const assignmentData = assignmentsData?.find((a) => a.slug === assignment)
 
@@ -542,6 +613,28 @@ const AcceptAssignmentPage = () => {
         </AcceptCard>
       </div>
     )
+  }
+
+  // Membership read failed. Distinguish causes rather than blanket "not a
+  // member": a 403 carrying X-GitHub-SSO means the org/enterprise enforces SAML
+  // SSO and this token has no live SSO session (the student may well be a
+  // member) — route them to authorize instead. Any other definitive failure
+  // (404 / non-SSO 403) falls through to the not-a-member screen. (Transient
+  // 5xx/429 are retried by the query, so they don't reach here as errors.)
+  if (orgMembershipError) {
+    if (
+      orgMembershipError instanceof GitHubAPIError &&
+      orgMembershipError.isSsoRequired
+    ) {
+      return (
+        <SsoRequired
+          user={user}
+          org={org}
+          ssoUrl={orgMembershipError.ssoAuthorizationUrl}
+        />
+      )
+    }
+    return <NotOrgMember classroom={classroom} user={user} org={org} />
   }
 
   if (!orgInvite) {

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -618,13 +618,21 @@ const AcceptAssignmentPage = () => {
   // Membership read failed. Distinguish causes rather than blanket "not a
   // member": a 403 carrying X-GitHub-SSO means the org/enterprise enforces SAML
   // SSO and this token has no live SSO session (the student may well be a
-  // member) — route them to authorize instead. Any other definitive failure
-  // (404 / non-SSO 403) falls through to the not-a-member screen. (Transient
-  // 5xx/429 are retried by the query, so they don't reach here as errors.)
+  // member) — route them to authorize instead. We only take the SSO detour when
+  // GitHub gave us an actionable authorization URL; the header-only
+  // `partial-results` shape (ssoAuthorizationUrl === null) has no button to
+  // offer, so it falls through to the not-a-member screen (which at least points
+  // the student at their instructor / re-opening from the LMS) rather than
+  // dead-ending them on a button-less SSO screen. Any other definitive failure
+  // (404 / non-SSO 403) also renders not-a-member. (Transient 5xx/429 are
+  // retried by the query, so they don't reach here as errors — and on any error
+  // the query's `data` is undefined, so the pending-invite onboarding redirect
+  // below is only reachable from a successful read.)
   if (orgMembershipError) {
     if (
       orgMembershipError instanceof GitHubAPIError &&
-      orgMembershipError.isSsoRequired
+      orgMembershipError.isSsoRequired &&
+      orgMembershipError.ssoAuthorizationUrl
     ) {
       return (
         <SsoRequired


### PR DESCRIPTION
## Summary

Fixes #66. The assignment **accept** gate read the student's own org membership (`GET /user/memberships/orgs/{org}`) and treated **any** failure as "not a member of the Org." For **SAML-SSO-enforced** orgs this misfires: GitHub returns **403 + `X-GitHub-SSO`** when the token has no live SSO session — even for a legitimate, active member — so students hit a dead-end that points them at the wrong fix. Transient `5xx`/`429` blips (`retry: false`) also surfaced the same screen.

This makes the gate **cause-aware and fail-open**:

- **Capture `X-GitHub-SSO`** on `GitHubAPIError`, with `isSsoRequired` and `ssoAuthorizationUrl` (parses the `required; url=…` shape, **restricted to `github.com`**; returns `null` for the multi-org `partial-results; organizations=…` shape).
- **`useGetOwnOrgMembership`** now retries transient failures via the existing `retryTransientNotFoundForbidden` predicate instead of failing closed, and surfaces the error so the gate can classify the cause.
- **`AcceptAssignmentPage`** renders a dedicated **"Authorize single sign-on"** screen (with a CTA to the GitHub SSO URL when provided, plus guidance to open the link from the SSO-gated LMS) on an SSO-gated 403, and keeps the existing not-a-member screen for a genuine 404 / non-SSO failure.
- Adds `accept.ssoRequired.*` strings and unit tests for the header parsing.

## Why

A real member on a SAML-SSO org was blocked with "not a member" (confirmed via `403 + x-github-sso: required; url=…enterprises/…/sso`). The self-view read is SSO-gated per token/session; the fix routes the student to authorize SSO instead of mislabeling them.

## Scope / not included

- The onboarding-repo 403 message and the `NotOrgMember` copy rewrite (also listed in #66) are intentionally left for a follow-up to keep this focused on the accept-gate + SSO detection.
- **Mutation-side SSO 403 is not yet SSO-aware.** This PR routes the *initial* membership read (the accept gate) to the new "Authorize single sign-on" screen — the reported symptom. If the read succeeds but a later step in `acceptAssignment` (`acceptPendingOrgInvite` / repo creation) hits a SAML-SSO 403, it still surfaces as a generic step failure. Tracked with a `TODO(#66 follow-up)` at the call site.
- #71 (post-auth redirect drops the deep link) is a separate, stacked follow-up.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on all changed files
- [x] `verify_locale.py en.json` → PASS
- [x] New unit tests in `errors.test.ts` (org/enterprise URL, `partial-results`, non-github.com rejection, malformed/absent)
- [x] Full web suite: 576/576 passing
- [ ] Manual: SSO-gated 403 shows the Authorize SSO screen; genuine non-member still shows not-a-member; transient error retries
