### PR TITLE
fix(web): return to the deep link after a forced sign-in (#71)

### DIFF
--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -9,6 +9,10 @@ export const GITHUB_AUTH_SESSION = {
   STATE: "gh_oauth_state",
   CLIENT_ID: "gh_oauth_client_id",
   SCOPE: "gh_oauth_scope",
+  // Same-origin relative path to return to after a successful sign-in, captured
+  // before leaving for GitHub (the OAuth redirect_uri is pinned to /login, so
+  // the original deep link can't ride the URL round-trip — see issue #71).
+  RETURN_TO: "gh_oauth_return_to",
 } as const
 
 // Scopes: admin:org enables org-invite management + team writes; repo covers

--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -9,9 +9,8 @@ export const GITHUB_AUTH_SESSION = {
   STATE: "gh_oauth_state",
   CLIENT_ID: "gh_oauth_client_id",
   SCOPE: "gh_oauth_scope",
-  // Same-origin relative path to return to after a successful sign-in, captured
-  // before leaving for GitHub (the OAuth redirect_uri is pinned to /login, so
-  // the original deep link can't ride the URL round-trip — see issue #71).
+  // Deep link to return to after sign-in; the /login redirect_uri can't carry
+  // it across the GitHub round-trip, so it rides the session instead (#71).
   RETURN_TO: "gh_oauth_return_to",
 } as const
 

--- a/web/src/auth/returnTo.navigation.test.ts
+++ b/web/src/auth/returnTo.navigation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router"
+
+// Regression guard for #71: a query-bearing returnTo (e.g. the ?k= accept key)
+// must survive navigation. navigate({ to: returnTo }) folds "?k=..." into the
+// pathname; history.push preserves it. Pins the behavior useGithubAuth and the
+// /login guard rely on.
+function buildTestRouter() {
+  const rootRoute = createRootRoute()
+  const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: "/" })
+  const acceptRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/org/cls/assignments/a1/accept",
+    validateSearch: (search: Record<string, unknown>): { k?: string } => ({
+      k: typeof search.k === "string" ? search.k : undefined,
+    }),
+  })
+  const routeTree = rootRoute.addChildren([indexRoute, acceptRoute])
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  })
+}
+
+describe("returnTo navigation (query preservation)", () => {
+  it("preserves the query string when pushing a deep link via history.push", async () => {
+    const router = buildTestRouter()
+    await router.load()
+
+    router.history.push("/org/cls/assignments/a1/accept?k=SECRET")
+    await router.load()
+
+    expect(router.state.location.pathname).toBe(
+      "/org/cls/assignments/a1/accept",
+    )
+    expect(router.state.location.search).toEqual({ k: "SECRET" })
+  })
+
+  it("documents that navigate({ to }) would fold the query into the pathname", () => {
+    const router = buildTestRouter()
+
+    const built = router.buildLocation({
+      // Cast: the point of this test is passing a raw path+query string, which
+      // is not a literal member of the typed route union.
+      to: "/org/cls/assignments/a1/accept?k=SECRET" as never,
+    })
+
+    // The regression this suite guards against: the query is NOT parsed out.
+    expect(built.pathname).toBe("/org/cls/assignments/a1/accept?k=SECRET")
+    expect(built.search).toEqual({})
+  })
+})

--- a/web/src/auth/returnTo.test.ts
+++ b/web/src/auth/returnTo.test.ts
@@ -9,6 +9,8 @@ describe("isSafeReturnTo", () => {
     expect(isSafeReturnTo("/acme/cs101/assignments/a1/accept?k=secret")).toBe(
       true,
     )
+    // A leading "@" is a same-origin path segment, not a host.
+    expect(isSafeReturnTo("/@acme")).toBe(true)
   })
 
   it("rejects protocol-relative // paths (open-redirect to another host)", () => {
@@ -21,6 +23,24 @@ describe("isSafeReturnTo", () => {
     expect(isSafeReturnTo("http://github.com/x")).toBe(false)
     expect(isSafeReturnTo("evil.com")).toBe(false)
     expect(isSafeReturnTo("acme/cs101")).toBe(false)
+  })
+
+  it("rejects backslash protocol-relative payloads (browsers treat \\ as /)", () => {
+    expect(isSafeReturnTo("/\\evil.com")).toBe(false)
+    expect(isSafeReturnTo("/\\\\evil.com")).toBe(false)
+    expect(isSafeReturnTo("/\\/evil.com")).toBe(false)
+  })
+
+  it("rejects percent-encoded slashes/backslashes (decoded downstream)", () => {
+    expect(isSafeReturnTo("/%2f%2fevil.com")).toBe(false)
+    expect(isSafeReturnTo("/%2F%2Fevil.com")).toBe(false)
+    expect(isSafeReturnTo("/%5cevil.com")).toBe(false)
+  })
+
+  it("rejects leading control / whitespace characters", () => {
+    expect(isSafeReturnTo("/\tevil.com")).toBe(false)
+    expect(isSafeReturnTo("/\revil.com")).toBe(false)
+    expect(isSafeReturnTo("/\nevil.com")).toBe(false)
   })
 
   it("rejects non-string values", () => {

--- a/web/src/auth/returnTo.test.ts
+++ b/web/src/auth/returnTo.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { isSafeReturnTo } from "./returnTo"
+
+describe("isSafeReturnTo", () => {
+  it("accepts a same-origin relative path", () => {
+    expect(isSafeReturnTo("/")).toBe(true)
+    expect(isSafeReturnTo("/acme/cs101/assignments/a1/accept")).toBe(true)
+    expect(isSafeReturnTo("/acme/cs101/assignments/a1/accept?k=secret")).toBe(
+      true,
+    )
+  })
+
+  it("rejects protocol-relative // paths (open-redirect to another host)", () => {
+    expect(isSafeReturnTo("//evil.com")).toBe(false)
+    expect(isSafeReturnTo("//evil.com/acme")).toBe(false)
+  })
+
+  it("rejects absolute URLs and non-leading-slash values", () => {
+    expect(isSafeReturnTo("https://evil.com")).toBe(false)
+    expect(isSafeReturnTo("http://github.com/x")).toBe(false)
+    expect(isSafeReturnTo("evil.com")).toBe(false)
+    expect(isSafeReturnTo("acme/cs101")).toBe(false)
+  })
+
+  it("rejects non-string values", () => {
+    expect(isSafeReturnTo(undefined)).toBe(false)
+    expect(isSafeReturnTo(null)).toBe(false)
+    expect(isSafeReturnTo(42)).toBe(false)
+    expect(isSafeReturnTo({})).toBe(false)
+  })
+})

--- a/web/src/auth/returnTo.ts
+++ b/web/src/auth/returnTo.ts
@@ -1,10 +1,42 @@
-// Open-redirect guard for post-auth / post-onboarding return targets: only a
-// same-origin relative path ("/" but not "//", which is a protocol-relative
-// absolute URL). Shared by the login redirect and the onboarding returnTo.
+// Open-redirect guard for post-auth / post-onboarding return targets: accept
+// only a same-origin relative path. Beyond the leading-single-slash checks
+// (which reject "//host" and absolute URLs), we also reject vectors that a
+// naive startsWith("/") misses and then confirm same-origin via the URL parser
+// so the guard owns its property rather than relying on a browser quirk:
+//   - "\": URL parsers treat it as "/", so "/\evil.com" resolves cross-origin.
+//   - Encoded slashes/backslashes (%2F, %5C): a downstream decode can restore "//".
+//   - ASCII control chars: parsers strip some, shifting how the value resolves.
+const SAME_ORIGIN_FALLBACK = "http://localhost"
+
 export function isSafeReturnTo(value: unknown): value is string {
-  return (
-    typeof value === "string" &&
-    value.startsWith("/") &&
-    !value.startsWith("//")
-  )
+  if (
+    typeof value !== "string" ||
+    !value.startsWith("/") ||
+    value.startsWith("//")
+  ) {
+    return false
+  }
+
+  if (value.includes("\\") || /%2f|%5c/i.test(value)) {
+    return false
+  }
+
+  // Reject ASCII control chars (tab/CR/LF, DEL); URL parsers strip some.
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i)
+    if (code <= 0x1f || code === 0x7f) {
+      return false
+    }
+  }
+
+  const origin =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : SAME_ORIGIN_FALLBACK
+
+  try {
+    return new URL(value, origin).origin === origin
+  } catch {
+    return false
+  }
 }

--- a/web/src/auth/returnTo.ts
+++ b/web/src/auth/returnTo.ts
@@ -1,0 +1,14 @@
+// A post-auth / post-onboarding return target is only ever a SAME-ORIGIN
+// relative path: it must start with a single "/" and not "//" (which the
+// browser treats as a protocol-relative absolute URL to another host). This is
+// the open-redirect guard shared by the login redirect (#71) and the onboarding
+// returnTo. Anything else — an absolute URL, a "//evil.com" path, a non-string
+// — is rejected so a crafted link can't bounce a freshly authenticated user to
+// an attacker origin.
+export function isSafeReturnTo(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.startsWith("/") &&
+    !value.startsWith("//")
+  )
+}

--- a/web/src/auth/returnTo.ts
+++ b/web/src/auth/returnTo.ts
@@ -1,10 +1,6 @@
-// A post-auth / post-onboarding return target is only ever a SAME-ORIGIN
-// relative path: it must start with a single "/" and not "//" (which the
-// browser treats as a protocol-relative absolute URL to another host). This is
-// the open-redirect guard shared by the login redirect (#71) and the onboarding
-// returnTo. Anything else — an absolute URL, a "//evil.com" path, a non-string
-// — is rejected so a crafted link can't bounce a freshly authenticated user to
-// an attacker origin.
+// Open-redirect guard for post-auth / post-onboarding return targets: only a
+// same-origin relative path ("/" but not "//", which is a protocol-relative
+// absolute URL). Shared by the login redirect and the onboarding returnTo.
 export function isSafeReturnTo(value: unknown): value is string {
   return (
     typeof value === "string" &&

--- a/web/src/auth/storage.ts
+++ b/web/src/auth/storage.ts
@@ -1,4 +1,5 @@
 import { GITHUB_AUTH_SESSION, GITHUB_AUTH_STORAGE } from "./constants"
+import { isSafeReturnTo } from "./returnTo"
 
 function canUseBrowserStorage() {
   return typeof window !== "undefined"
@@ -41,6 +42,10 @@ export function saveOAuthSession(input: {
   state: string
   clientId: string
   scope: string
+  // Optional same-origin deep link to return to after sign-in (#71). Only a
+  // value passing isSafeReturnTo is stored; anything else is dropped so a bad
+  // value can't linger and misroute the next sign-in.
+  returnTo?: string | null
 }) {
   if (!canUseBrowserStorage()) return
 
@@ -48,6 +53,12 @@ export function saveOAuthSession(input: {
   sessionStorage.setItem(GITHUB_AUTH_SESSION.STATE, input.state)
   sessionStorage.setItem(GITHUB_AUTH_SESSION.CLIENT_ID, input.clientId)
   sessionStorage.setItem(GITHUB_AUTH_SESSION.SCOPE, input.scope)
+
+  if (isSafeReturnTo(input.returnTo)) {
+    sessionStorage.setItem(GITHUB_AUTH_SESSION.RETURN_TO, input.returnTo)
+  } else {
+    sessionStorage.removeItem(GITHUB_AUTH_SESSION.RETURN_TO)
+  }
 }
 
 export function consumeOAuthSession() {
@@ -57,6 +68,7 @@ export function consumeOAuthSession() {
       expectedState: null,
       clientId: null,
       scope: null,
+      returnTo: null,
     }
   }
 
@@ -64,16 +76,23 @@ export function consumeOAuthSession() {
   const expectedState = sessionStorage.getItem(GITHUB_AUTH_SESSION.STATE)
   const clientId = sessionStorage.getItem(GITHUB_AUTH_SESSION.CLIENT_ID)
   const scope = sessionStorage.getItem(GITHUB_AUTH_SESSION.SCOPE)
+  const storedReturnTo = sessionStorage.getItem(GITHUB_AUTH_SESSION.RETURN_TO)
 
   sessionStorage.removeItem(GITHUB_AUTH_SESSION.VERIFIER)
   sessionStorage.removeItem(GITHUB_AUTH_SESSION.STATE)
   sessionStorage.removeItem(GITHUB_AUTH_SESSION.CLIENT_ID)
   sessionStorage.removeItem(GITHUB_AUTH_SESSION.SCOPE)
+  sessionStorage.removeItem(GITHUB_AUTH_SESSION.RETURN_TO)
+
+  // Re-validate on read: sessionStorage is user-writable, so never trust a
+  // stored path without re-checking the open-redirect guard.
+  const returnTo = isSafeReturnTo(storedReturnTo) ? storedReturnTo : null
 
   return {
     verifier,
     expectedState,
     clientId,
     scope,
+    returnTo,
   }
 }

--- a/web/src/auth/storage.ts
+++ b/web/src/auth/storage.ts
@@ -42,9 +42,8 @@ export function saveOAuthSession(input: {
   state: string
   clientId: string
   scope: string
-  // Optional same-origin deep link to return to after sign-in (#71). Only a
-  // value passing isSafeReturnTo is stored; anything else is dropped so a bad
-  // value can't linger and misroute the next sign-in.
+  // Same-origin deep link to return to after sign-in (#71); only a value
+  // passing isSafeReturnTo is kept.
   returnTo?: string | null
 }) {
   if (!canUseBrowserStorage()) return
@@ -84,8 +83,7 @@ export function consumeOAuthSession() {
   sessionStorage.removeItem(GITHUB_AUTH_SESSION.SCOPE)
   sessionStorage.removeItem(GITHUB_AUTH_SESSION.RETURN_TO)
 
-  // Re-validate on read: sessionStorage is user-writable, so never trust a
-  // stored path without re-checking the open-redirect guard.
+  // Re-validate on read: sessionStorage is user-writable.
   const returnTo = isSafeReturnTo(storedReturnTo) ? storedReturnTo : null
 
   return {

--- a/web/src/auth/storage.ts
+++ b/web/src/auth/storage.ts
@@ -42,8 +42,11 @@ export function saveOAuthSession(input: {
   state: string
   clientId: string
   scope: string
-  // Same-origin deep link to return to after sign-in (#71); only a value
-  // passing isSafeReturnTo is kept.
+  // Same-origin deep link to return to after sign-in (#71); kept only if it
+  // passes isSafeReturnTo. May carry the accept ?k= key (needed to land on the
+  // right link), so it is briefly persisted — acceptable since sessionStorage
+  // is same-origin and per-tab, cleared on consume, and the same secret is
+  // already in the URL the user arrived from.
   returnTo?: string | null
 }) {
   if (!canUseBrowserStorage()) return

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -67,6 +67,9 @@ function useGithubAuthState() {
   const queryClient = useQueryClient()
   const abortRef = useRef<AbortController | null>(null)
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Deep link (#71) stashed at code-exchange, consumed by the status-driven
+  // effect below so navigation runs against an authenticated router context.
+  const pendingReturnToRef = useRef<string | null>(null)
 
   const [screen, setScreen] = useState<GithubAuthScreen>("config")
   const [clientId, setClientId] = useState(GITHUB_OAUTH_CLIENT_ID)
@@ -221,11 +224,10 @@ function useGithubAuthState() {
       {
         onSuccess: (data) => {
           completeSignIn(data)
-          // Return to the originally requested deep link instead of the
-          // homepage (#71); already re-validated by consumeOAuthSession.
-          if (returnTo) {
-            router.navigate({ to: returnTo })
-          }
+          // Defer the return until status is "authenticated" (effect below);
+          // navigating now would race the router context and bounce through
+          // the _authed guard (#71).
+          pendingReturnToRef.current = returnTo
         },
         onError: (err) => {
           setError(formatError(err))
@@ -553,6 +555,23 @@ function useGithubAuthState() {
     githubUserQuery.isError,
     githubUserQuery.data,
   ])
+
+  // Navigate to the stashed deep link once status is "authenticated", so the
+  // target _authed guard sees an authenticated context instead of bouncing
+  // through /login (#71). history.push (not navigate({ to })) preserves the
+  // query — e.g. the ?k= accept key — which navigate({ to }) would fold into
+  // the pathname. A bad path degrades to the homepage.
+  useEffect(() => {
+    if (status !== "authenticated") return
+    const returnTo = pendingReturnToRef.current
+    if (!returnTo) return
+    pendingReturnToRef.current = null
+    try {
+      router.history.push(returnTo)
+    } catch {
+      router.history.push("/")
+    }
+  }, [status])
 
   return {
     screen,

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -221,10 +221,8 @@ function useGithubAuthState() {
       {
         onSuccess: (data) => {
           completeSignIn(data)
-          // Return the user to the deep link they originally requested (e.g. an
-          // assignment accept link) instead of the homepage (#71). The value was
-          // re-validated as a safe relative path by consumeOAuthSession; absent
-          // it, the /login guard falls back to "/" as before.
+          // Return to the originally requested deep link instead of the
+          // homepage (#71); already re-validated by consumeOAuthSession.
           if (returnTo) {
             router.navigate({ to: returnTo })
           }
@@ -266,12 +264,8 @@ function useGithubAuthState() {
     const challenge = await deriveChallenge(verifier)
     const oauthState = randomBase64Url(16)
 
-    // Capture where to return after sign-in. The _authed guard (and App's
-    // session-expiry redirect) bounce here as /login?redirect=<deep-link>; that
-    // param can't survive the GitHub round-trip (redirect_uri is pinned to
-    // /login), so stash it in the OAuth session now and restore it after the
-    // code exchange (#71). saveOAuthSession re-validates it as a safe relative
-    // path.
+    // Stash the deep link (from /login?redirect=) in the OAuth session so it
+    // survives the GitHub round-trip; restored after the code exchange (#71).
     const returnTo = new URLSearchParams(window.location.search).get("redirect")
 
     saveOAuthSession({

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -18,6 +18,7 @@ import {
 } from "./github-oauth-api"
 import { fetchGithubUser, GitHubUserFetchError } from "./github-user-api"
 import { isDefinitiveGitHubStatus } from "@/hooks/github/errors"
+import router from "@/router"
 import { deriveChallenge, generateVerifier, randomBase64Url } from "./pkce"
 import {
   clearGithubToken,
@@ -188,6 +189,7 @@ function useGithubAuthState() {
       verifier,
       expectedState,
       clientId: callbackClientId,
+      returnTo,
     } = consumeOAuthSession()
 
     if (!returnedState || returnedState !== expectedState) {
@@ -219,6 +221,13 @@ function useGithubAuthState() {
       {
         onSuccess: (data) => {
           completeSignIn(data)
+          // Return the user to the deep link they originally requested (e.g. an
+          // assignment accept link) instead of the homepage (#71). The value was
+          // re-validated as a safe relative path by consumeOAuthSession; absent
+          // it, the /login guard falls back to "/" as before.
+          if (returnTo) {
+            router.navigate({ to: returnTo })
+          }
         },
         onError: (err) => {
           setError(formatError(err))
@@ -257,11 +266,20 @@ function useGithubAuthState() {
     const challenge = await deriveChallenge(verifier)
     const oauthState = randomBase64Url(16)
 
+    // Capture where to return after sign-in. The _authed guard (and App's
+    // session-expiry redirect) bounce here as /login?redirect=<deep-link>; that
+    // param can't survive the GitHub round-trip (redirect_uri is pinned to
+    // /login), so stash it in the OAuth session now and restore it after the
+    // code exchange (#71). saveOAuthSession re-validates it as a safe relative
+    // path.
+    const returnTo = new URLSearchParams(window.location.search).get("redirect")
+
     saveOAuthSession({
       verifier,
       state: oauthState,
       clientId: config.clientId,
       scope: config.scope,
+      returnTo,
     })
 
     window.location.href = buildGithubAuthorizeUrl({

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -8,9 +8,9 @@ export const Route = createFileRoute("/_authed")({
       throw redirect({
         to: "/login",
         search: {
-          // Same-origin relative path only (see /login's isSafeRedirect), so
-          // the destination survives the round-trip without an open-redirect
-          // risk. Consuming it post-auth is tracked in issue #71.
+          // Same-origin relative path only (see isSafeReturnTo), so the
+          // destination survives the round-trip without open-redirect risk.
+          // Consumed post-auth in useGithubAuth and login.tsx's guard (#71).
           redirect: location.pathname + location.searchStr,
         },
       })

--- a/web/src/routes/_authed/$org/$classroom/onboard/index.tsx
+++ b/web/src/routes/_authed/$org/$classroom/onboard/index.tsx
@@ -10,8 +10,8 @@ import { isSafeReturnTo } from "@/auth/returnTo"
 // flow (github_id, else email).
 //
 // `returnTo`: where to send the student after they become an active member (the
-// accept page sets it). Only a same-origin relative path (leading "/", not "//")
-// is kept, so it can't become an open redirect (see isSafeReturnTo).
+// accept page sets it). Kept only when it passes isSafeReturnTo (open-redirect
+// guard).
 
 export const Route = createFileRoute("/_authed/$org/$classroom/onboard/")({
   validateSearch: (

--- a/web/src/routes/_authed/$org/$classroom/onboard/index.tsx
+++ b/web/src/routes/_authed/$org/$classroom/onboard/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import OnboardingPage from "@/pages/OnboardingPage"
 import { isValidInviteToken } from "@/util/onboarding"
+import { isSafeReturnTo } from "@/auth/returnTo"
 
 // `email`: untrusted prefill only; session authorizes.
 //
@@ -10,9 +11,7 @@ import { isValidInviteToken } from "@/util/onboarding"
 //
 // `returnTo`: where to send the student after they become an active member (the
 // accept page sets it). Only a same-origin relative path (leading "/", not "//")
-// is kept, so it can't become an open redirect.
-const isSafeReturnTo = (value: unknown): value is string =>
-  typeof value === "string" && value.startsWith("/") && !value.startsWith("//")
+// is kept, so it can't become an open redirect (see isSafeReturnTo).
 
 export const Route = createFileRoute("/_authed/$org/$classroom/onboard/")({
   validateSearch: (

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -1,24 +1,25 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { GitHubAuthCard } from "@/auth/GitHubAuthCard"
+import { isSafeReturnTo } from "@/auth/returnTo"
 
 // `redirect`: where to send the user after a successful sign-in — set when the
 // _authed guard (or App's session-expiry redirect) bounces an unauthenticated
 // user here. Only a same-origin relative path (leading "/", not "//") is kept,
-// so it can't become an open redirect. Consuming it post-auth is tracked in
-// issue #71; validating it here reserves the param and keeps it safe now.
-const isSafeRedirect = (value: unknown): value is string =>
-  typeof value === "string" && value.startsWith("/") && !value.startsWith("//")
+// so it can't become an open redirect (#71). The unauthenticated → sign-in →
+// return path is handled in useGithubAuth (the param can't survive the GitHub
+// round-trip, so it's stashed in the OAuth session); this guard covers the
+// already-authenticated case — landing on /login?redirect=X while signed in.
 
 export const Route = createFileRoute("/login")({
   component: GitHubAuthCard,
   validateSearch: (search: Record<string, unknown>): { redirect?: string } => ({
-    redirect: isSafeRedirect(search.redirect) ? search.redirect : undefined,
+    redirect: isSafeReturnTo(search.redirect) ? search.redirect : undefined,
   }),
-  beforeLoad: ({ context }) => {
+  beforeLoad: ({ context, search }) => {
     const { auth } = context
     if (auth.status === "authenticated") {
       throw redirect({
-        to: "/",
+        to: search.redirect ?? "/",
       })
     }
   },

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -2,13 +2,10 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 import { GitHubAuthCard } from "@/auth/GitHubAuthCard"
 import { isSafeReturnTo } from "@/auth/returnTo"
 
-// `redirect`: where to send the user after a successful sign-in — set when the
-// _authed guard (or App's session-expiry redirect) bounces an unauthenticated
-// user here. Only a same-origin relative path (leading "/", not "//") is kept,
-// so it can't become an open redirect (#71). The unauthenticated → sign-in →
-// return path is handled in useGithubAuth (the param can't survive the GitHub
-// round-trip, so it's stashed in the OAuth session); this guard covers the
-// already-authenticated case — landing on /login?redirect=X while signed in.
+// `redirect`: same-origin path to return to after sign-in, set when the _authed
+// guard (or App's session-expiry redirect) bounces an unauthenticated user
+// here (#71). The sign-in round-trip is handled in useGithubAuth (stashed in
+// the OAuth session); this guard covers the already-authenticated case.
 
 export const Route = createFileRoute("/login")({
   component: GitHubAuthCard,

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -3,21 +3,44 @@ import { GitHubAuthCard } from "@/auth/GitHubAuthCard"
 import { isSafeReturnTo } from "@/auth/returnTo"
 
 // `redirect`: same-origin path to return to after sign-in, set when the _authed
-// guard (or App's session-expiry redirect) bounces an unauthenticated user
-// here (#71). The sign-in round-trip is handled in useGithubAuth (stashed in
-// the OAuth session); this guard covers the already-authenticated case.
+// guard (or App's session-expiry redirect) bounces an unauthenticated user here
+// (#71). useGithubAuth handles the sign-in round-trip; this guard covers the
+// already-authenticated case.
+//
+// The value is built as pathname + search (see _authed.tsx / App.tsx), so it may
+// carry a query (e.g. the ?k= accept capability key). Passing it whole as
+// `redirect({ to })` folds the query into the pathname, so split it into
+// { to, search } first. /login itself is rejected to avoid a self-redirect hop.
+function toRedirectTarget(value: string): {
+  to: string
+  search: Record<string, string>
+} {
+  const queryIndex = value.indexOf("?")
+  const to = queryIndex === -1 ? value : value.slice(0, queryIndex)
+  const search =
+    queryIndex === -1
+      ? {}
+      : Object.fromEntries(new URLSearchParams(value.slice(queryIndex + 1)))
+  return { to, search }
+}
+
+function safeRedirect(value: unknown): string | undefined {
+  if (!isSafeReturnTo(value)) return undefined
+  const { to } = toRedirectTarget(value)
+  return to === "/login" ? undefined : value
+}
 
 export const Route = createFileRoute("/login")({
   component: GitHubAuthCard,
   validateSearch: (search: Record<string, unknown>): { redirect?: string } => ({
-    redirect: isSafeReturnTo(search.redirect) ? search.redirect : undefined,
+    redirect: safeRedirect(search.redirect),
   }),
   beforeLoad: ({ context, search }) => {
     const { auth } = context
     if (auth.status === "authenticated") {
-      throw redirect({
-        to: search.redirect ?? "/",
-      })
+      throw redirect(
+        search.redirect ? toRedirectTarget(search.redirect) : { to: "/" },
+      )
     }
   },
 })


### PR DESCRIPTION
## Summary

Fixes #71. Opening an auth-gated deep link (most importantly an **assignment accept link**) while signed out bounced the user to `/login?redirect=<link>`, but after signing in / authorizing they landed on the **homepage** instead of the link they requested.

Two reasons the destination was lost:
- The OAuth `redirect_uri` is pinned to `/login` (see #57), so the `?redirect=` param can't survive the GitHub round-trip on the URL.
- The `/login` guard unconditionally redirected authenticated users to `/`.

This threads the destination through the OAuth session instead:

- **`startWebFlow`** captures the current `?redirect=` and stashes it in the OAuth session; **the code-exchange `onSuccess`** stashes the restored destination in a ref, and a **`status === "authenticated"` effect** navigates there once sign-in is fully committed (falls back to `/` when absent). Deferring the navigation until the router context is authenticated stops the target `_authed` guard from bouncing the user back through `/login`.
- The navigation uses **`router.history.push`** (not `navigate({ to })`), which preserves the deep link's query string — e.g. the accept **`?k=` capability key**. `navigate({ to })` folds `?k=...` into the pathname, which would drop the key.
- **`login.tsx`** guard now honors `?redirect=` for the already-authenticated case, splitting the value into `{ to, search }` (same query-preservation reason) and rejecting `/login` as a self-redirect target.
- Extracts the open-redirect guard into a shared **`auth/returnTo.ts` `isSafeReturnTo`**, reused by `storage.ts`, the login route, and the onboarding route (dedupes the two previously inlined copies).

## Security

`returnTo` is only ever a **same-origin relative path**. `isSafeReturnTo` requires a single leading `/` (not `//`), rejects **backslash** payloads (`/\evil.com`), **percent-encoded** slashes/backslashes (`%2F`/`%5C`), and **ASCII control chars**, then confirms **same-origin via the URL parser** — so the guard owns its property rather than relying on `pushState` throwing on a cross-origin URL. It's validated on write (`saveOAuthSession`), re-validated on read (`consumeOAuthSession`, since sessionStorage is user-writable), and validated in the route `validateSearch` — so a crafted link can't turn this into an open redirect. Unit tests cover relative paths, `//host`, absolute URLs, backslash / `%2F` / control-char vectors, and non-strings.

The login `returnTo` may carry the accept `?k=` capability key, so it is briefly persisted in sessionStorage — acceptable since it is same-origin and per-tab, cleared on consume, and the same secret already lives in the URL the user arrived from.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint .` — 0 errors (pre-existing warnings only)
- [x] `prettier --check .` clean
- [x] `vitest run` — 588/588 passing (`returnTo.test.ts` hardened-guard vectors + new `returnTo.navigation.test.ts` query round-trip)
- [x] `vite build` succeeds (no circular-import / chunk regressions)
- [ ] Manual: signed-out → open an accept link → sign in/authorize → lands on the assignment (not the homepage); `?k=` preserved
- [ ] Manual: already signed in → hitting `/login?redirect=/x` forwards to `/x`

## Related

- Completes the student accept-link happy path alongside #66 (SSO-aware gate), already merged.
- Constrained by #57 (redirect_uri must stay `/login`).