### PR TITLE
ci: pin CI workflows to least-privilege contents:read token

### DIFF
--- a/.github/workflows/cli-shared-ci.yaml
+++ b/.github/workflows/cli-shared-ci.yaml
@@ -11,6 +11,9 @@ on:
       - 'cli/shared/**'
       - '.github/workflows/cli-shared-ci.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-student-ci.yaml
+++ b/.github/workflows/gh-student-ci.yaml
@@ -13,6 +13,9 @@ on:
       - 'cli/shared/**'
       - '.github/workflows/gh-student-ci.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-teacher-ci.yaml
+++ b/.github/workflows/gh-teacher-ci.yaml
@@ -13,6 +13,9 @@ on:
       - 'cli/shared/**'
       - '.github/workflows/gh-teacher-ci.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-ci.yaml
+++ b/.github/workflows/lint-ci.yaml
@@ -34,6 +34,9 @@ on:
       - 'cli/gh-teacher/embed/**'
       - 'cli/gh-student/embed/**'
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/skeleton-scripts-ci.yaml
+++ b/.github/workflows/skeleton-scripts-ci.yaml
@@ -47,6 +47,9 @@ on:
       - 'examples/declarative-tests/tests.json'
       - '.github/workflows/skeleton-scripts-ci.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The 5 CI/lint workflows had no top-level `permissions:` block, so they inherited the repo/org default `GITHUB_TOKEN` scope. They only build/test/lint and never write to the repo, so pin each to `contents: read`.

Defense-in-depth: today the org default is read-only, but this ensures these jobs can't silently gain write access if the default token level is ever widened. The workflows that legitimately need write (deploy, release-please, etc.) already declare their own explicit `permissions:` blocks and are unaffected.

## Files

- `cli-shared-ci.yaml`
- `gh-student-ci.yaml`
- `gh-teacher-ci.yaml`
- `skeleton-scripts-ci.yaml`
- `lint-ci.yaml`

Each adds only:

```yaml
permissions:
  contents: read
```

## Test plan

- [x] All 5 parse as valid YAML with `permissions: {contents: read}`
- [x] `actionlint` clean on all 5
- [x] No behavior change — these jobs never wrote to the repo