### PR TITLE
fix(web): resolve code-review P2/P3 findings from PR #77

### DIFF
--- a/scripts/test_translate_locales.py
+++ b/scripts/test_translate_locales.py
@@ -284,3 +284,58 @@ class TestMainPatchMode:
         assert rc == 0
         # Entire orphan group swept; empty foo dict pruned.
         assert result == {"other": {"key": "v"}}
+
+
+class TestFlattenParityWithVerifyLocale:
+    """`flatten()` is duplicated in verify_locale.py (which ships standalone next
+    to en.json) and here. The duplication is intentional for portability, so
+    guard the two copies against silent drift with a behavioral parity test
+    rather than merging them. If either implementation changes shape, this fails.
+    """
+
+    @staticmethod
+    def _load_verify_locale():
+        import importlib.util
+        from pathlib import Path
+
+        verify_path = (
+            Path(__file__).resolve().parent.parent
+            / "web"
+            / "src"
+            / "locales"
+            / "verify_locale.py"
+        )
+        spec = importlib.util.spec_from_file_location("verify_locale", verify_path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            {},
+            {"a": "1"},
+            {"a": {"b": "2", "c": {"d": "3"}}},
+            {"nav": {"appName": "x"}, "accept": {"title": "t", "body": "b"}},
+            {"a": {"b": {"c": {"deep": "leaf"}}}, "top": "value"},
+            {"count_one": "one", "count_other": "many"},
+        ],
+    )
+    def test_flatten_matches_verify_locale(self, obj):
+        verify_locale = self._load_verify_locale()
+        assert flatten(obj) == verify_locale.flatten(obj)
+
+    def test_flatten_matches_on_real_base_locale(self):
+        from pathlib import Path
+
+        verify_locale = self._load_verify_locale()
+        base_path = (
+            Path(__file__).resolve().parent.parent
+            / "web"
+            / "src"
+            / "locales"
+            / "en.json"
+        )
+        base = json.loads(base_path.read_text(encoding="utf-8"))
+        assert flatten(base) == verify_locale.flatten(base)

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -94,7 +94,7 @@ function useGithubAuthState() {
     // the session settles. Transient failures (5xx / network) still self-heal
     // with a bounded retry so a momentary GitHub blip doesn't eject a signed-in
     // user. Shares the definitive-status policy with the GitHub-client reads
-    // (see retryTransientNotFoundForbidden / isDefinitiveGitHubStatus).
+    // (see retryTransientGitHubError / isDefinitiveGitHubStatus).
     retry: (failureCount, error) => {
       if (
         error instanceof GitHubUserFetchError &&

--- a/web/src/components/LanguageDialog.tsx
+++ b/web/src/components/LanguageDialog.tsx
@@ -1,0 +1,49 @@
+import { forwardRef } from "react"
+import { useTranslation } from "react-i18next"
+import { X } from "lucide-react"
+
+import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
+
+// Language-pack modal shown from the sidebar footer. Extracted alongside
+// AboutDialog (same forwardRef<HTMLDialogElement> shape) so the sidebar footer
+// wires two consistent portalled dialogs rather than inlining one and importing
+// the other. Closing on apply is driven by the same ref the caller opens with.
+export const LanguageDialog = forwardRef<HTMLDialogElement, { titleId: string }>(
+  function LanguageDialog({ titleId }, ref) {
+    const { t } = useTranslation()
+
+    // Close via the forwarded ref once a pack is applied. The ref is a
+    // MutableRefObject here (the caller passes useRef), so read .current; guard
+    // the RefCallback shape defensively.
+    const close = () => {
+      if (typeof ref === "object" && ref !== null) {
+        ref.current?.close()
+      }
+    }
+
+    return (
+      <dialog ref={ref} className="modal" aria-labelledby={titleId}>
+        <div className="modal-box flex max-h-[85vh] max-w-lg flex-col overflow-y-auto text-base-content">
+          <form method="dialog">
+            <button
+              className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
+              aria-label={t("common.close")}
+            >
+              <X className="size-4" aria-hidden="true" />
+            </button>
+          </form>
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("nav.languageDialogTitle")}
+          </h3>
+          <p className="mt-1 mb-4 text-sm text-base-content/70">
+            {t("nav.languageDialogDescription")}
+          </p>
+          <LanguageSwitcher onApplied={close} />
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button>{t("common.close")}</button>
+        </form>
+      </dialog>
+    )
+  },
+)

--- a/web/src/components/LanguageDialog.tsx
+++ b/web/src/components/LanguageDialog.tsx
@@ -8,42 +8,43 @@ import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 // AboutDialog (same forwardRef<HTMLDialogElement> shape) so the sidebar footer
 // wires two consistent portalled dialogs rather than inlining one and importing
 // the other. Closing on apply is driven by the same ref the caller opens with.
-export const LanguageDialog = forwardRef<HTMLDialogElement, { titleId: string }>(
-  function LanguageDialog({ titleId }, ref) {
-    const { t } = useTranslation()
+export const LanguageDialog = forwardRef<
+  HTMLDialogElement,
+  { titleId: string }
+>(function LanguageDialog({ titleId }, ref) {
+  const { t } = useTranslation()
 
-    // Close via the forwarded ref once a pack is applied. The ref is a
-    // MutableRefObject here (the caller passes useRef), so read .current; guard
-    // the RefCallback shape defensively.
-    const close = () => {
-      if (typeof ref === "object" && ref !== null) {
-        ref.current?.close()
-      }
+  // Close via the forwarded ref once a pack is applied. The ref is a
+  // MutableRefObject here (the caller passes useRef), so read .current; guard
+  // the RefCallback shape defensively.
+  const close = () => {
+    if (typeof ref === "object" && ref !== null) {
+      ref.current?.close()
     }
+  }
 
-    return (
-      <dialog ref={ref} className="modal" aria-labelledby={titleId}>
-        <div className="modal-box flex max-h-[85vh] max-w-lg flex-col overflow-y-auto text-base-content">
-          <form method="dialog">
-            <button
-              className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
-              aria-label={t("common.close")}
-            >
-              <X className="size-4" aria-hidden="true" />
-            </button>
-          </form>
-          <h3 id={titleId} className="text-lg font-bold">
-            {t("nav.languageDialogTitle")}
-          </h3>
-          <p className="mt-1 mb-4 text-sm text-base-content/70">
-            {t("nav.languageDialogDescription")}
-          </p>
-          <LanguageSwitcher onApplied={close} />
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>{t("common.close")}</button>
+  return (
+    <dialog ref={ref} className="modal" aria-labelledby={titleId}>
+      <div className="modal-box flex max-h-[85vh] max-w-lg flex-col overflow-y-auto text-base-content">
+        <form method="dialog">
+          <button
+            className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
+            aria-label={t("common.close")}
+          >
+            <X className="size-4" aria-hidden="true" />
+          </button>
         </form>
-      </dialog>
-    )
-  },
-)
+        <h3 id={titleId} className="text-lg font-bold">
+          {t("nav.languageDialogTitle")}
+        </h3>
+        <p className="mt-1 mb-4 text-sm text-base-content/70">
+          {t("nav.languageDialogDescription")}
+        </p>
+        <LanguageSwitcher onApplied={close} />
+      </div>
+      <form method="dialog" className="modal-backdrop">
+        <button>{t("common.close")}</button>
+      </form>
+    </dialog>
+  )
+})

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -16,7 +16,6 @@ import {
   Sun,
   Moon,
   Languages,
-  X,
   Info,
 } from "lucide-react"
 import {
@@ -45,7 +44,7 @@ import useDotClassroom50 from "@/hooks/useDotClassroom50"
 import { studentRepoName } from "@/util/studentRepo"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import { useTheme } from "@/hooks/useTheme"
-import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
+import { LanguageDialog } from "@/components/LanguageDialog"
 import { AboutDialog } from "@/components/AboutDialog"
 import type { Classroom } from "@/types/classroom"
 import {
@@ -920,34 +919,7 @@ export const SidebarFooter = () => {
       </div>
 
       {createPortal(
-        <dialog
-          ref={langDialogRef}
-          className="modal"
-          aria-labelledby={langDialogTitleId}
-        >
-          <div className="modal-box flex max-h-[85vh] max-w-lg flex-col overflow-y-auto text-base-content">
-            <form method="dialog">
-              <button
-                className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
-                aria-label={t("common.close")}
-              >
-                <X className="size-4" aria-hidden="true" />
-              </button>
-            </form>
-            <h3 id={langDialogTitleId} className="text-lg font-bold">
-              {t("nav.languageDialogTitle")}
-            </h3>
-            <p className="mt-1 mb-4 text-sm text-base-content/70">
-              {t("nav.languageDialogDescription")}
-            </p>
-            <LanguageSwitcher
-              onApplied={() => langDialogRef.current?.close()}
-            />
-          </div>
-          <form method="dialog" className="modal-backdrop">
-            <button>{t("common.close")}</button>
-          </form>
-        </dialog>,
+        <LanguageDialog ref={langDialogRef} titleId={langDialogTitleId} />,
         document.body,
       )}
 

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -64,8 +64,9 @@ export const LanguageSwitcher = ({
   const [shareCodeOverride, setShareCodeOverride] = useState<string | null>(
     null,
   )
-  // Synchronous re-entry lock for prepares: `busy` is async React state, so a
-  // fast second click can fire before it re-renders. A ref flips immediately.
+  // Synchronous re-entry lock shared by all prepare entry points (file, URL,
+  // built-in): `busy` is async React state, so a fast second click can fire
+  // before it re-renders. A ref flips immediately. Owned by runPrepare.
   const preparingRef = useRef(false)
 
   const showError = (err: unknown) => {
@@ -86,6 +87,13 @@ export const LanguageSwitcher = ({
     // (the cards render below all sections; a detached preview is confusing).
     section: "add" | "install",
   ) => {
+    // Synchronous re-entry lock shared by all prepare entry points (file, URL,
+    // built-in). `busy` is async React state, so a fast second click or an
+    // overlapping URL/file prepare would otherwise race two fetches over the
+    // shared preview and let the last fetch to resolve win — installing a pack
+    // that isn't the one the user last chose. The ref flips immediately.
+    if (preparingRef.current) return
+    preparingRef.current = true
     setError(null)
     setPreview(null)
     setBusy(true)
@@ -97,6 +105,7 @@ export const LanguageSwitcher = ({
       setOpenSection(section)
     } finally {
       setBusy(false)
+      preparingRef.current = false
     }
   }
 
@@ -154,17 +163,15 @@ export const LanguageSwitcher = ({
   }
 
   const handleBuiltIn = async (builtInCode: string) => {
-    // Guard synchronously: two fast clicks would otherwise race two prepares
-    // over the shared preview/preparingCode, letting the last fetch to resolve
-    // win and install a pack that isn't the one last clicked.
+    // The re-entry lock now lives in runPrepare (shared across all entry
+    // points), so a second concurrent click is a no-op there. Set preparingCode
+    // for the per-row spinner; runPrepare's guard prevents the racing install.
     if (preparingRef.current) return
-    preparingRef.current = true
     setPreparingCode(builtInCode)
     try {
       await runPrepare(() => prepareFromBuiltIn(builtInCode), "add")
     } finally {
       setPreparingCode(null)
-      preparingRef.current = false
     }
   }
 

--- a/web/src/hooks/github/errors.test.ts
+++ b/web/src/hooks/github/errors.test.ts
@@ -4,7 +4,7 @@ import {
   GitHubAPIError,
   isDefinitiveGitHubStatus,
   parseSsoAuthorizationUrl,
-  retryTransientNotFoundForbidden,
+  retryTransientGitHubError,
 } from "./errors"
 
 const apiError = (status: number, ssoHeader?: string | null) =>
@@ -39,22 +39,22 @@ describe("isDefinitiveGitHubStatus", () => {
   })
 })
 
-describe("retryTransientNotFoundForbidden", () => {
+describe("retryTransientGitHubError", () => {
   it("does not retry a definitive 401 / 403 / 404", () => {
-    expect(retryTransientNotFoundForbidden(0, apiError(401))).toBe(false)
-    expect(retryTransientNotFoundForbidden(0, apiError(404))).toBe(false)
-    expect(retryTransientNotFoundForbidden(0, apiError(403))).toBe(false)
+    expect(retryTransientGitHubError(0, apiError(401))).toBe(false)
+    expect(retryTransientGitHubError(0, apiError(404))).toBe(false)
+    expect(retryTransientGitHubError(0, apiError(403))).toBe(false)
   })
 
   it("retries transient failures up to a bounded count", () => {
-    expect(retryTransientNotFoundForbidden(0, apiError(500))).toBe(true)
-    expect(retryTransientNotFoundForbidden(1, apiError(500))).toBe(true)
-    expect(retryTransientNotFoundForbidden(2, apiError(500))).toBe(false)
+    expect(retryTransientGitHubError(0, apiError(500))).toBe(true)
+    expect(retryTransientGitHubError(1, apiError(500))).toBe(true)
+    expect(retryTransientGitHubError(2, apiError(500))).toBe(false)
   })
 
   it("retries non-GitHubAPIError (network) failures within the bound", () => {
-    expect(retryTransientNotFoundForbidden(0, new Error("network"))).toBe(true)
-    expect(retryTransientNotFoundForbidden(2, new Error("network"))).toBe(false)
+    expect(retryTransientGitHubError(0, new Error("network"))).toBe(true)
+    expect(retryTransientGitHubError(2, new Error("network"))).toBe(false)
   })
 })
 

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -104,8 +104,9 @@ export function parseSsoAuthorizationUrl(
 // Shared React Query `retry` predicate for fail-closed role/permission reads: a
 // definitive status (401 revoked/expired, 403 blocked, 404 not found / not a
 // member — see isDefinitiveGitHubStatus) must NOT retry, while a transient
-// 5xx/429/network blip self-heals (bounded to 2).
-export function retryTransientNotFoundForbidden(
+// 5xx/429/network blip self-heals (bounded to 2). Named for its behavior (retry
+// only transient errors); the definitive set includes 401 as well as 403/404.
+export function retryTransientGitHubError(
   failureCount: number,
   error: unknown,
 ): boolean {

--- a/web/src/hooks/useClassroomRole.ts
+++ b/web/src/hooks/useClassroomRole.ts
@@ -4,7 +4,7 @@ import { orgMembershipQuery } from "./github/queries"
 import { useGitHubRepo } from "./github/hooks"
 import {
   GitHubAPIError,
-  retryTransientNotFoundForbidden,
+  retryTransientGitHubError,
 } from "./github/errors"
 import { resolveTeacherVerdict } from "./useCourseTeacherAccess"
 import { staffTeamName } from "./github/mutations"
@@ -225,11 +225,11 @@ export function useClassroomRole(
     // orgMembershipQuery defaults to retry:false, but a transient blip on the
     // membership read must self-heal rather than pin isOwner at `undefined`
     // (which would silently demote a real owner). A 404/403 is definitive.
-    retry: retryTransientNotFoundForbidden,
+    retry: retryTransientGitHubError,
   })
 
   const staffRepoQuery = useGitHubRepo(org, "classroom50", {
-    retry: retryTransientNotFoundForbidden,
+    retry: retryTransientGitHubError,
   })
   const staff = resolveTeacherVerdict({
     org,

--- a/web/src/hooks/useClassroomRole.ts
+++ b/web/src/hooks/useClassroomRole.ts
@@ -2,10 +2,7 @@ import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { orgMembershipQuery } from "./github/queries"
 import { useGitHubRepo } from "./github/hooks"
-import {
-  GitHubAPIError,
-  retryTransientGitHubError,
-} from "./github/errors"
+import { GitHubAPIError, retryTransientGitHubError } from "./github/errors"
 import { resolveTeacherVerdict } from "./useCourseTeacherAccess"
 import { staffTeamName } from "./github/mutations"
 import { useRoleView } from "@/context/roleView/RoleViewProvider"

--- a/web/src/hooks/useCourseTeacherAccess.ts
+++ b/web/src/hooks/useCourseTeacherAccess.ts
@@ -1,9 +1,6 @@
 import { useGitHubRepo } from "./github/hooks"
 import { useParams } from "@tanstack/react-router"
-import {
-  GitHubAPIError,
-  retryTransientGitHubError,
-} from "./github/errors"
+import { GitHubAPIError, retryTransientGitHubError } from "./github/errors"
 import { useRoleView } from "@/context/roleView/RoleViewProvider"
 import type { ViewAsRole } from "./useClassroomRole"
 

--- a/web/src/hooks/useCourseTeacherAccess.ts
+++ b/web/src/hooks/useCourseTeacherAccess.ts
@@ -2,7 +2,7 @@ import { useGitHubRepo } from "./github/hooks"
 import { useParams } from "@tanstack/react-router"
 import {
   GitHubAPIError,
-  retryTransientNotFoundForbidden,
+  retryTransientGitHubError,
 } from "./github/errors"
 import { useRoleView } from "@/context/roleView/RoleViewProvider"
 import type { ViewAsRole } from "./useClassroomRole"
@@ -98,7 +98,7 @@ export function useCourseTeacherAccess(org: string | undefined) {
   // a definitive verdict and must not be retried, but a 5xx/429/network blip
   // should self-heal instead of stranding the role unresolved.
   const repoQuery = useGitHubRepo(org, teacherRepo, {
-    retry: retryTransientNotFoundForbidden,
+    retry: retryTransientGitHubError,
   })
 
   const verdict = resolveTeacherVerdict({

--- a/web/src/hooks/useGetOwnOrgMembership.ts
+++ b/web/src/hooks/useGetOwnOrgMembership.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { getPendingOrgInvite } from "./github/mutations"
-import { retryTransientNotFoundForbidden } from "./github/errors"
+import { retryTransientGitHubError } from "./github/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
 // Reads the authenticated user's OWN membership in `org` (GET
@@ -18,7 +18,7 @@ const useGetOwnOrgMembership = (org: string | undefined) => {
     queryKey: ["github", "memberships", "orgs", org],
     queryFn: () => getPendingOrgInvite(client, org ?? ""),
     staleTime: 10 * 60 * 1000,
-    retry: retryTransientNotFoundForbidden,
+    retry: retryTransientGitHubError,
     enabled: Boolean(org),
   })
 }

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -31,14 +31,20 @@ void i18n.use(initReactI18next).init({
 // Runs after init so addResourceBundle has an instance to attach to.
 const installed = hydratePacks()
 const stored = getStoredLang()
-if (stored !== BASE_LANG && installed.includes(stored)) {
-  void i18n.changeLanguage(stored)
-}
 
-// A `?lang=<code>` deep link sets the active language and persists it (it
-// overrides the stored choice going forward, not just for this visit).
-// Fire-and-forget so startup isn't blocked; it activates when it resolves and
-// swallows errors, so a shared link is always safe.
-void applyLangFromQuery()
+// Activate the stored language, THEN apply any `?lang=<code>` deep link, in that
+// order. A `?lang=` deep link sets the active language and persists it (it
+// overrides the stored choice going forward, not just for this visit), so it
+// must be the last write to both i18n.language and the persisted lang. Chaining
+// (rather than firing both unawaited) prevents a startup race where the stored
+// activation resolves after applyLangFromQuery and clobbers the deep link,
+// leaving the screen and localStorage disagreeing. Fire-and-forget the chain so
+// startup isn't blocked; both steps swallow errors, so a shared link is safe.
+void (async () => {
+  if (stored !== BASE_LANG && installed.includes(stored)) {
+    await i18n.changeLanguage(stored)
+  }
+  await applyLangFromQuery()
+})()
 
 export default i18n


### PR DESCRIPTION
## Summary

Addresses the validated **P2** and **P3** findings from the code review of #77 (the `preview → main` promotion). No new features; behavior is unchanged except for one startup race fix. Based on `preview` so these land ahead of the next promotion.

**P2 — moderate**
- **i18n startup race** (`web/src/i18n/index.ts`): chain the stored-language activation to `await` before `applyLangFromQuery()`, so a `?lang=` deep link is always the last write to both `i18n.language` and the persisted lang. Previously both fired unawaited — the stored activation could resolve last and clobber the deep link, leaving the rendered language and `localStorage` disagreeing.
- **Prepare re-entry lock** (`web/src/components/settings/LanguageSwitcher.tsx`): move the synchronous `preparingRef` lock into `runPrepare` so the file / URL / built-in prepare paths all share it. Previously only the built-in path held the lock, so two rapid URL/file prepares could race and let the last fetch to resolve win the preview.
- **Extract `LanguageDialog`** (`web/src/components/LanguageDialog.tsx` + `drawer/index.tsx`): pull the language `<dialog>` inlined in `SidebarFooter` into a `forwardRef` component mirroring `AboutDialog`. The sidebar footer now wires two consistent portalled dialogs, and the >1k `drawer/index.tsx` drops from 1121 → 1093 lines instead of growing.

**P3 — low**
- **Rename `retryTransientNotFoundForbidden` → `retryTransientGitHubError`** across `errors.ts` and its consumers/tests. The old name stopped describing the behavior once `401` joined the definitive (non-retried) set alongside `403`/`404`. Pure rename, no behavior change.
- **`flatten()` parity test** (`scripts/test_translate_locales.py`): guard the intentionally-duplicated `flatten()` in `verify_locale.py` (which ships standalone next to `en.json`) against silent drift with a behavioral parity test, rather than merging the two copies.

The P3 `roleLabel → roleLabelKey` finding needed no change — the rename was already complete with no dangling consumers.

The three **P1** test-gap findings (assignment-accept gate, revoked-token teardown, `invoke_model` retry) are intentionally **not** in this PR.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` on all changed files — 0 errors (pre-existing warnings only)
- [x] `ruff check` on the Python test — clean
- [x] Full web suite: **588/588 tests pass** (incl. `customLocale.test.ts` 40, `errors.test.ts` 13)
- [x] `scripts/test_translate_locales.py`: **44/44 pass** (incl. 7 new parity tests)
- [ ] Manual: open a `?lang=<code>` deep link with a different stored language and confirm the deep link wins and persists
- [ ] Manual: open the sidebar language dialog, confirm apply/close still works after the extraction