### PR TITLE
ci(web): single-trunk model — deploy preview from main

### DIFF
--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -2,13 +2,15 @@ name: web Deploy to Preview (preview.classroom50.org)
 
 # Builds the web app (web/) and publishes the built dist/ to the preview repo
 # (foundation50/classroom50-web-preview), whose GitHub Pages serves
-# preview.classroom50.org. Runs on every push to `preview` (scoped to web/**),
-# so day-to-day work merged into the preview branch is continuously deployed.
+# preview.classroom50.org. Runs on every push to `main` (scoped to web/**), so
+# day-to-day work merged into main is continuously deployed to the preview site.
 # Manual runs available via the Actions tab.
 #
-# Branch model: `preview` is the rapid-dev integration branch; a release PR
-# merges preview -> main, and main deploys production (classroom50.org) via
-# web-deploy.yaml.
+# Branch model: single trunk. `main` is the default/integration branch — feature
+# PRs merge into it (squash) and each merge deploys here to preview. Production
+# (classroom50.org) is cut only by merging the release-please Release PR, which
+# tags `web-v*` and deploys via web-release-please.yaml. A release-PR merge is
+# also a push to main, so it redeploys preview too (harmless, same content).
 #
 # Why a separate repo: GitHub Pages allows only one custom domain per repo, so
 # production (classroom50.org) and preview must live in different repos. Source
@@ -16,7 +18,7 @@ name: web Deploy to Preview (preview.classroom50.org)
 
 on:
   push:
-    branches: [preview]
+    branches: [main]
     paths:
       - 'web/**'
       - '.github/workflows/web-deploy-preview.yaml'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,37 +133,38 @@ provenance attestation on a private repo.
 
 ## Releasing the web app (maintainers)
 
-The web app (classroom50.org) uses a two-branch promotion model. Day-to-day
-work lands on `preview`, which continuously deploys to
+The web app uses a **single-trunk** model. `main` is the default and
+integration branch: feature PRs merge into `main` (squash), and every merge
+continuously deploys to
 [preview.classroom50.org](https://preview.classroom50.org) via
-[`web-deploy-preview`](.github/workflows/web-deploy-preview.yaml). A release is
-a PR merging `preview` -> `main`.
+[`web-deploy-preview`](.github/workflows/web-deploy-preview.yaml). There is no
+separate long-lived `preview` branch to promote from.
 
-Releases are automated with
+Releases to production (classroom50.org) are automated with
 [release-please](https://github.com/googleapis/release-please)
 ([`web-release-please`](.github/workflows/web-release-please.yaml),
 [`release-please-config.json`](release-please-config.json)). You do not tag or
 edit the changelog by hand:
 
-1. Merge `preview` -> `main` as usual. release-please reads the
-   [Conventional Commits](https://www.conventionalcommits.org/) since the last
-   release and maintains a **release PR** on `main` that bumps
+1. Merge feature PRs into `main` as usual (each deploys to preview).
+   release-please reads the [Conventional Commits](https://www.conventionalcommits.org/)
+   since the last release and maintains a **release PR** on `main` that bumps
    `web/package.json` and [`web/CHANGELOG.md`](web/CHANGELOG.md) (`feat:` ->
    minor, `fix:` -> patch, `feat!:`/`fix!:` -> major).
 2. When ready to release, merge that release PR. release-please then tags the
    commit `web-vX.Y.Z` (namespaced apart from the CLI's `cli-v*` tags) and
    publishes the GitHub Release from the changelog.
 3. The same workflow builds the tagged commit and deploys it to
-   classroom50.org — gated on the release actually being created, so a plain
-   merge to `main` never deploys. The version is stamped into the build via
-   `VITE_APP_VERSION` and the running app reports it in the browser console.
+   **classroom50.org** — gated on the release actually being created, so a plain
+   merge to `main` only touches preview, never production. The version is
+   stamped into the build via `VITE_APP_VERSION` and the running app reports it.
 
 To force a specific version (e.g. a first `1.0.0` or a jump), land a commit on
 `main` whose body contains `Release-As: X.Y.Z`.
 
 [`web-deploy`](.github/workflows/web-deploy.yaml) is retained only as a manual
 escape hatch (`workflow_dispatch` with an optional `ref`) to re-publish a chosen
-tag/branch/SHA without cutting a release.
+tag/branch/SHA to production without cutting a release.
 
 Requirement (repo/org Settings, one-time): enable "Allow GitHub Actions to
 create and approve pull requests" so release-please can open its release PR with

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Releases are automated with
-[release-please](https://github.com/googleapis/release-please): merges to `main`
-(via the `preview -> main` release PR) maintain a release PR that bumps
+[release-please](https://github.com/googleapis/release-please): feature PRs
+merge into `main` and release-please maintains a release PR that bumps
 `web/package.json` and this file from [Conventional Commits](https://www.conventionalcommits.org/)
 (`feat:` -> minor, `fix:` -> patch, `feat!:`/`fix!:` -> major). Merging that
 release PR tags `web-vX.Y.Z`, publishes the GitHub Release, and deploys to


### PR DESCRIPTION
## Summary

Completes the move to a **single-trunk** branch model now that `main` is the repo's default/integration branch.

- Feature PRs merge into `main` (squash) and each merge deploys to **preview.classroom50.org**.
- Production (**classroom50.org**) is still cut only by merging the release-please Release PR (tag-gated) — unchanged.
- The old `preview` branch is retired to idle (kept, no workflow triggers on it).

This removes the two-long-lived-branch (`preview` vs `main`) divergence that required manual reconciliation.

## Changes

- **`.github/workflows/web-deploy-preview.yaml`**: trigger on push to `main` instead of `preview`; refresh the header + branch-model comments. Everything else (cross-repo publish to `classroom50-web-preview` via `PREVIEW_DEPLOY_KEY`, CNAME, `force_orphan`) unchanged.
- **`CONTRIBUTING.md`** / **`web/CHANGELOG.md`**: describe the single-trunk model; drop the `preview -> main` promotion wording.

## Repo settings already applied (outside this PR)

- Default branch switched to `main`.
- Branch protection re-established on `main` (PR required + linear history + no force-push); `allow_merge_commit` reverted to false (squash-only). `main` is now protected like the old `preview`.
- `preview` branch kept, still PR-gated, idle.

## Note

A release-PR merge is also a push to `main`, so it redeploys preview (harmless, same content) in addition to the tag-gated production deploy. Documented in the workflow header; a skip-guard can be added later if undesired.

## Test plan

- [x] `web-deploy-preview.yaml` valid YAML + `actionlint` clean
- [x] `web/CHANGELOG.md` passes `prettier --check`
- [ ] After merge: confirm a push to `main` triggers `web Deploy to Preview` and preview.classroom50.org updates