### PR TITLE
ci: bump all GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -101,7 +101,7 @@ jobs:
           - { os: linux, arch: arm64 }
           - { os: windows, arch: amd64 }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:
@@ -136,7 +136,7 @@ jobs:
           ls -l "$out"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.extension }}-${{ matrix.target.os }}-${{ matrix.target.arch }}
           path: dist/*
@@ -158,7 +158,7 @@ jobs:
         extension: [gh-teacher, gh-student]
     steps:
       - name: Download this extension's binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-${{ matrix.extension }}-*
           merge-multiple: true
@@ -176,7 +176,7 @@ jobs:
       # dispatch run forces it; otherwise skip so testing still publishes.
       - name: Attest build provenance
         if: ${{ !github.event.repository.private || github.event.inputs.attest == 'true' }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: 'dist/gh-*'
 

--- a/.github/workflows/cli-shared-ci.yaml
+++ b/.github/workflows/cli-shared-ci.yaml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: cli/shared
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,7 +54,7 @@ jobs:
       E2E_COLLECT_TOKEN: ${{ secrets.E2E_COLLECT_TOKEN }}
       GOWORK: "off" # the e2e module is standalone; the CLIs build via their replace directives
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/gh-student-ci.yaml
+++ b/.github/workflows/gh-student-ci.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         working-directory: cli/gh-student
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/gh-teacher-ci.yaml
+++ b/.github/workflows/gh-teacher-ci.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         working-directory: cli/gh-teacher
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/lint-ci.yaml
+++ b/.github/workflows/lint-ci.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install actionlint + shellcheck
         # Both pinned to specific releases so the lint result is
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/publish-wiki.yaml
+++ b/.github/workflows/publish-wiki.yaml
@@ -48,7 +48,7 @@ jobs:
       # authored by this identity is treated as an unreconciled upstream edit.
       SYNC_BOT_EMAIL: classroom50-sync@users.noreply.github.com
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/skeleton-scripts-ci.yaml
+++ b/.github/workflows/skeleton-scripts-ci.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -40,7 +40,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/web-deploy.yaml
+++ b/.github/workflows/web-deploy.yaml
@@ -37,7 +37,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Build the ref the operator chose (a tag to redeploy a release, or a
           # branch/SHA); empty falls back to the ref the run was dispatched on.

--- a/.github/workflows/web-release-please.yaml
+++ b/.github/workflows/web-release-please.yaml
@@ -40,7 +40,7 @@ jobs:
       release_created: ${{ steps.release.outputs['web--release_created'] }}
       tag_name: ${{ steps.release.outputs['web--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Check out the tag release-please just created so the build stamps
           # the released commit + version, not a later main tip.


### PR DESCRIPTION
## Summary

Audited every `uses:` across all workflows (skeleton files excluded) against the GitHub releases API and bumped each to its current latest major. Also unifies versions that had drifted (`actions/checkout` was a mix of v4/v6/v7; artifact actions differed between `cli-release` and `translate-locales`).

## Bumps

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 / v6 / v7 (mixed) | **v7** (all 18) |
| `actions/upload-artifact` | v4 (cli-release) | **v7** |
| `actions/download-artifact` | v4 (cli-release) | **v8** |
| `actions/attest-build-provenance` | v2 | **v4** |
| `googleapis/release-please-action` | v4 | **v5** |

## Already latest (unchanged)

`setup-go@v6`, `setup-node@v6`, `setup-python@v6`, `configure-pages@v6`, `deploy-pages@v5`, `upload-pages-artifact@v5`, `golangci-lint-action@v9`, and `peaceiris/actions-gh-pages` (kept SHA-pinned to v4.1.0 — pinning a third-party action by SHA is intentional supply-chain hardening).

## Risk notes

- **`release-please-action` v4 -> v5**: the only breaking change is the Node 20 -> 24 runtime (per the v5 migration notes). No config, YAML, or output-name changes — our `web--release_created` / `web--tag_name` outputs and `release-please-config.json` are unaffected.
- **`attest-build-provenance` v2 -> v4**: runtime/dependency major; the `subject-path` input we use is stable.
- Artifact v7/v8 majors: `cli-release` uses only stable inputs (`name`, `path`, `pattern`, `merge-multiple`), already proven at these majors in `translate-locales`.

## Test plan

- [x] `actionlint` clean on all workflows
- [x] All `uses:` verified against the latest release tag via the GitHub API
- [ ] release-please run on merge still opens/updates the Release PR (v5)
- [ ] Next `cli-v*` tag still builds/attests (v7/v8/v4 artifact + provenance)