### PR TITLE
feat(web): surface skeleton drift and bump skeleton action pins

### DIFF
--- a/cli/gh-teacher/init_skeleton_test.go
+++ b/cli/gh-teacher/init_skeleton_test.go
@@ -294,11 +294,11 @@ func TestSkeletonFiles_AutogradeRunner(t *testing.T) {
 		"if: needs.setup.outputs.python != ''",
 		"actions/setup-python@v6",
 		"if: needs.setup.outputs.node != ''",
-		"actions/setup-node@v4",
+		"actions/setup-node@v6",
 		"if: needs.setup.outputs.java != ''",
-		"actions/setup-java@v4",
+		"actions/setup-java@v5",
 		"if: needs.setup.outputs.go != ''",
-		"actions/setup-go@v5",
+		"actions/setup-go@v6",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("autograde-runner.yaml missing toolchain dispatch %q", want)

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -56,7 +56,7 @@ jobs:
       mode:           ${{ steps.read.outputs.mode }}
       allowed-files:  ${{ steps.read.outputs.allowed-files }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Full history -- the acceptance check walks back to the commit
           # that added .classroom50.yaml; a shallow clone hides it.
@@ -540,7 +540,7 @@ jobs:
       # runner.py removes disallowed files before grading. "[]" = allow all.
       ALLOWED_FILES:  ${{ needs.setup.outputs.allowed-files }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.setup.outputs.submission-tag }}
           # Full history -- runner.py needs the student's baseline
@@ -554,18 +554,18 @@ jobs:
           python-version: ${{ needs.setup.outputs.python }}
 
       - if: needs.setup.outputs.node != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ needs.setup.outputs.node }}
 
       - if: needs.setup.outputs.java != ''
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ needs.setup.outputs.java }}
 
       - if: needs.setup.outputs.go != ''
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ needs.setup.outputs.go }}
 

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
@@ -30,7 +30,7 @@ jobs:
   collect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/publish-pages.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/publish-pages.yaml
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Assemble Pages artifact (allow-list)
         run: |

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/regrade.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/regrade.yaml
@@ -72,7 +72,7 @@ jobs:
     # just be run again.
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react"
+import { Link, useParams } from "@tanstack/react-router"
+import { FileWarning } from "lucide-react"
+import { AnimatePresence } from "motion/react"
+import { useTranslation } from "react-i18next"
+
+import { AppBanner } from "@/components/AppBanner"
+import { useSkeletonDrift } from "@/hooks/useSkeletonDrift"
+import { RERUN_ONBOARDING_ANCHOR } from "@/pages/orgSettings/RerunOnboarding"
+
+// Global warning banner shown to a teacher when the org's `classroom50` config
+// repo has scaffolded workflow files that drifted from the current bundled
+// skeleton (e.g. after an action-pin bump). Routes to the existing "Re-run
+// onboarding" Org Settings section, which performs the overwrite.
+//
+// The copy states plainly that updating REPLACES any customized workflow files
+// with the defaults — the overwrite is byte-for-byte from the skeleton, so a
+// teacher who hand-edited collect-scores/regrade/publish-pages/autograde-runner
+// loses those edits. The re-run flow's overwrite-confirmation modal gates it
+// per file, but the banner warns up front so nobody is surprised.
+//
+// Dismiss is per-session (component-local state, like ScopeWarningBanner): it
+// reappears on reload until the drift is actually resolved.
+export function SkeletonDriftBanner() {
+  // Org-level and classroom routes both live under /_authed/$org, so read the
+  // param loosely; org-less routes (the org picker) yield undefined and the
+  // teacher-gated hook stays disabled.
+  const { org } = useParams({ strict: false })
+  const { hasDrift } = useSkeletonDrift(org)
+  const [dismissed, setDismissed] = useState(false)
+  const { t } = useTranslation()
+
+  const show = Boolean(org) && hasDrift && !dismissed
+
+  return (
+    <AnimatePresence initial={false}>
+      {show ? (
+        <AppBanner
+          key="skeleton-drift"
+          tone="warning"
+          icon={<FileWarning className="size-5" aria-hidden="true" />}
+          title={t("skeletonDrift.title")}
+          onDismiss={() => setDismissed(true)}
+        >
+          <p className="text-base-content/70">{t("skeletonDrift.body")}</p>
+          <p className="text-base-content/70">
+            <span className="font-semibold text-base-content">
+              {t("skeletonDrift.overwriteWarning_label")}
+            </span>{" "}
+            {t("skeletonDrift.overwriteWarning")}
+          </p>
+          <Link
+            to="/$org/settings"
+            params={{ org: org as string }}
+            hash={RERUN_ONBOARDING_ANCHOR}
+            className="btn btn-sm btn-warning self-start"
+          >
+            {t("skeletonDrift.action")}
+          </Link>
+        </AppBanner>
+      ) : null}
+    </AnimatePresence>
+  )
+}
+
+export default SkeletonDriftBanner

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -8,29 +8,27 @@ import { AppBanner } from "@/components/AppBanner"
 import { useSkeletonDrift } from "@/hooks/useSkeletonDrift"
 import { RERUN_ONBOARDING_ANCHOR } from "@/pages/orgSettings/RerunOnboarding"
 
-// Global warning banner shown to a teacher when the org's `classroom50` config
-// repo has scaffolded workflow files that drifted from the current bundled
-// skeleton (e.g. after an action-pin bump). Routes to the existing "Re-run
-// onboarding" Org Settings section, which performs the overwrite.
+// Global warning banner shown to an org owner when the `classroom50` config
+// repo's scaffolded workflows have drifted from the current bundled skeleton
+// (e.g. after an action-pin bump). Routes to the owner-only "Re-run onboarding"
+// Org Settings section, which performs the overwrite.
 //
-// The copy states plainly that updating REPLACES any customized workflow files
-// with the defaults — the overwrite is byte-for-byte from the skeleton, so a
-// teacher who hand-edited collect-scores/regrade/publish-pages/autograde-runner
-// loses those edits. The re-run flow's overwrite-confirmation modal gates it
-// per file, but the banner warns up front so nobody is surprised.
+// The copy warns that re-running overwrites customized workflow files with the
+// skeleton defaults (the re-run flow's modal still confirms per file).
 //
-// Dismiss is per-session (component-local state, like ScopeWarningBanner): it
-// reappears on reload until the drift is actually resolved.
+// Dismiss is per-session and per-org: the banner is mounted once in the stable
+// _authed layout and never remounts on org navigation, so dismissal is tracked
+// by org — dismissing org A must not suppress org B's drift. Reappears on
+// reload until resolved.
 export function SkeletonDriftBanner() {
-  // Org-level and classroom routes both live under /_authed/$org, so read the
-  // param loosely; org-less routes (the org picker) yield undefined and the
-  // teacher-gated hook stays disabled.
+  // Loose param read: org-less routes (the org picker) yield undefined and the
+  // owner-gated hook stays disabled.
   const { org } = useParams({ strict: false })
   const { hasDrift } = useSkeletonDrift(org)
-  const [dismissed, setDismissed] = useState(false)
+  const [dismissedOrg, setDismissedOrg] = useState<string>()
   const { t } = useTranslation()
 
-  const show = Boolean(org) && hasDrift && !dismissed
+  const show = Boolean(org) && hasDrift && dismissedOrg !== org
 
   return (
     <AnimatePresence initial={false}>
@@ -40,7 +38,7 @@ export function SkeletonDriftBanner() {
           tone="warning"
           icon={<FileWarning className="size-5" aria-hidden="true" />}
           title={t("skeletonDrift.title")}
-          onDismiss={() => setDismissed(true)}
+          onDismiss={() => setDismissedOrg(org)}
         >
           <p className="text-base-content/70">{t("skeletonDrift.body")}</p>
           <p className="text-base-content/70">

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -128,6 +128,9 @@ export const githubKeys = {
   serviceToken: (owner: string) =>
     [...githubKeys.all, "serviceToken", owner] as const,
 
+  skeletonDrift: (owner: string) =>
+    [...githubKeys.all, "skeletonDrift", owner] as const,
+
   orgAudit: (owner: string, plan?: string) =>
     [...githubKeys.all, "orgAudit", owner, plan ?? null] as const,
 

--- a/web/src/hooks/useSkeletonDrift.test.ts
+++ b/web/src/hooks/useSkeletonDrift.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveSkeletonDrift } from "./useSkeletonDrift"
+
+describe("resolveSkeletonDrift", () => {
+  it("shows the banner when a successful check found drifted/missing files", () => {
+    expect(
+      resolveSkeletonDrift({
+        isSuccess: true,
+        driftedCount: 2,
+        isError: false,
+      }),
+    ).toBe(true)
+  })
+
+  it("stays quiet when a successful check found no drift (clean repo)", () => {
+    expect(
+      resolveSkeletonDrift({
+        isSuccess: true,
+        driftedCount: 0,
+        isError: false,
+      }),
+    ).toBe(false)
+  })
+
+  it("fails open on a read error — never nag on a failed/forbidden read", () => {
+    expect(
+      resolveSkeletonDrift({
+        isSuccess: false,
+        driftedCount: undefined,
+        isError: true,
+      }),
+    ).toBe(false)
+  })
+
+  it("fails open when a stale error state still reports a drifted count", () => {
+    // A React Query error retaining the previous successful data must not
+    // resurrect the banner: isError dominates.
+    expect(
+      resolveSkeletonDrift({
+        isSuccess: false,
+        driftedCount: 3,
+        isError: true,
+      }),
+    ).toBe(false)
+  })
+
+  it("stays quiet while the check is in flight (no definitive success yet)", () => {
+    expect(
+      resolveSkeletonDrift({
+        isSuccess: false,
+        driftedCount: undefined,
+        isError: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/web/src/hooks/useSkeletonDrift.ts
+++ b/web/src/hooks/useSkeletonDrift.ts
@@ -1,0 +1,56 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { findStaleSkeletonFiles } from "./github/mutations"
+import { githubKeys } from "./github/queries"
+import { useCourseTeacherAccess } from "./useCourseTeacherAccess"
+
+// The subset of the drift query's state the verdict depends on. Structural so
+// the fail-open logic stays a pure, unit-testable function (no React Query).
+export type SkeletonDriftInput = {
+  isSuccess: boolean
+  driftedCount: number | undefined
+  isError: boolean
+}
+
+// Fail-open drift verdict: a banner shows ONLY on a definitive success that
+// found at least one drifted/missing skeleton file. A read error (network,
+// 5xx, a repo the teacher can't see) or an in-flight query resolves to "no
+// drift" so we never nag on incomplete information — mirrors the issue's
+// "on any read error, show nothing".
+export function resolveSkeletonDrift(input: SkeletonDriftInput): boolean {
+  const { isSuccess, driftedCount, isError } = input
+  if (isError || !isSuccess) return false
+  return (driftedCount ?? 0) > 0
+}
+
+// Teacher-gated, cached check for whether the org's `classroom50` config repo
+// has scaffolded workflow files that drifted from the bundled skeleton (e.g.
+// after a skeleton bump like #88's action-pin update). Reuses the existing
+// content-based diff (findStaleSkeletonFiles) read-only — no version marker.
+//
+// Gated on teacher/owner access so a student never triggers the config-repo
+// tree read, cached with a generous staleTime so it doesn't refetch on every
+// render, and fail-open: any read error surfaces as "no drift".
+export function useSkeletonDrift(org: string | undefined) {
+  const client = useGitHubClient()
+  const { showTeacherUi } = useCourseTeacherAccess(org)
+
+  const query = useQuery({
+    queryKey: githubKeys.skeletonDrift(org ?? ""),
+    queryFn: () => findStaleSkeletonFiles(client, org as string),
+    enabled: Boolean(org) && showTeacherUi,
+    staleTime: 30 * 60 * 1000,
+    // Fail-open on read errors (see resolveSkeletonDrift); no point burning
+    // retries on a check whose failure mode is "stay quiet".
+    retry: false,
+  })
+
+  const hasDrift = resolveSkeletonDrift({
+    isSuccess: query.isSuccess,
+    driftedCount: query.data?.length,
+    isError: query.isError,
+  })
+
+  return { ...query, hasDrift }
+}

--- a/web/src/hooks/useSkeletonDrift.ts
+++ b/web/src/hooks/useSkeletonDrift.ts
@@ -3,46 +3,45 @@ import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { findStaleSkeletonFiles } from "./github/mutations"
 import { githubKeys } from "./github/queries"
-import { useCourseTeacherAccess } from "./useCourseTeacherAccess"
+import useGetOrgMembership from "./useGetOrgMembership"
 
-// The subset of the drift query's state the verdict depends on. Structural so
-// the fail-open logic stays a pure, unit-testable function (no React Query).
+// State subset the verdict depends on — kept structural so the fail-open logic
+// stays a pure, unit-testable function.
 export type SkeletonDriftInput = {
   isSuccess: boolean
   driftedCount: number | undefined
   isError: boolean
 }
 
-// Fail-open drift verdict: a banner shows ONLY on a definitive success that
-// found at least one drifted/missing skeleton file. A read error (network,
-// 5xx, a repo the teacher can't see) or an in-flight query resolves to "no
-// drift" so we never nag on incomplete information — mirrors the issue's
-// "on any read error, show nothing".
+// Fail-open verdict: show only on a definitive success that found drift. A read
+// error or in-flight query resolves to "no drift" so we never nag on incomplete
+// info (the issue's "on any read error, show nothing").
 export function resolveSkeletonDrift(input: SkeletonDriftInput): boolean {
   const { isSuccess, driftedCount, isError } = input
   if (isError || !isSuccess) return false
   return (driftedCount ?? 0) > 0
 }
 
-// Teacher-gated, cached check for whether the org's `classroom50` config repo
-// has scaffolded workflow files that drifted from the bundled skeleton (e.g.
-// after a skeleton bump like #88's action-pin update). Reuses the existing
-// content-based diff (findStaleSkeletonFiles) read-only — no version marker.
+// Owner-gated, cached, fail-open check for whether the org's `classroom50`
+// config repo has drifted from the bundled skeleton (e.g. after #88's pin
+// bump). Reuses findStaleSkeletonFiles read-only — no version marker.
 //
-// Gated on teacher/owner access so a student never triggers the config-repo
-// tree read, cached with a generous staleTime so it doesn't refetch on every
-// render, and fail-open: any read error surfaces as "no drift".
+// Gated on org owner (admin), not any staff: the banner routes to the
+// owner-only Re-run onboarding section, so surfacing it to a TA/non-owner
+// instructor would dead-end their CTA on a NotFound — and only an owner should
+// trigger the config-repo read.
 export function useSkeletonDrift(org: string | undefined) {
   const client = useGitHubClient()
-  const { showTeacherUi } = useCourseTeacherAccess(org)
+  const { data: membership } = useGetOrgMembership(org)
+  const isOwner = membership?.role === "admin"
 
   const query = useQuery({
     queryKey: githubKeys.skeletonDrift(org ?? ""),
     queryFn: () => findStaleSkeletonFiles(client, org as string),
-    enabled: Boolean(org) && showTeacherUi,
+    enabled: Boolean(org) && isOwner,
     staleTime: 30 * 60 * 1000,
-    // Fail-open on read errors (see resolveSkeletonDrift); no point burning
-    // retries on a check whose failure mode is "stay quiet".
+    // Fail-open (see resolveSkeletonDrift); no point retrying a check whose
+    // failure mode is "stay quiet".
     retry: false,
   })
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -912,6 +912,13 @@
       }
     }
   },
+  "skeletonDrift": {
+    "title": "Classroom workflow files are out of date",
+    "body": "The GitHub Actions workflows scaffolded into this organization's classroom50 configuration repository have drifted from the current version. Re-run onboarding to update them so grading, score collection, and Pages publishing keep working.",
+    "overwriteWarning_label": "Heads up:",
+    "overwriteWarning": "Updating replaces the scaffolded workflow files (collect-scores, regrade, publish-pages, autograde-runner) with the defaults. Any manual edits you made to those files will be overwritten — you'll confirm each replacement first.",
+    "action": "Update workflows"
+  },
   "classes": {
     "createTitle": "Create Classroom",
     "missingOrg": "Missing organization.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -914,9 +914,9 @@
   },
   "skeletonDrift": {
     "title": "Classroom workflow files are out of date",
-    "body": "The GitHub Actions workflows scaffolded into this organization's classroom50 configuration repository have drifted from the current version. Re-run onboarding to update them so grading, score collection, and Pages publishing keep working.",
+    "body": "The GitHub Actions workflows in this org's classroom50 config repo are out of date. Re-run onboarding to update them and keep grading, score collection, and Pages publishing working.",
     "overwriteWarning_label": "Heads up:",
-    "overwriteWarning": "Updating replaces the scaffolded workflow files (collect-scores, regrade, publish-pages, autograde-runner) with the defaults. Any manual edits you made to those files will be overwritten — you'll confirm each replacement first.",
+    "overwriteWarning": "Updating overwrites the scaffolded workflow files (collect-scores, regrade, publish-pages, autograde-runner) with the defaults, replacing any manual edits — you'll confirm each one first.",
     "action": "Update workflows"
   },
   "classes": {

--- a/web/src/pages/orgSettings/RerunOnboarding.tsx
+++ b/web/src/pages/orgSettings/RerunOnboarding.tsx
@@ -49,6 +49,11 @@ const SummaryBanner = ({
   </CalloutDiv>
 )
 
+// DOM anchor for the Re-run onboarding section, shared with the global
+// skeleton-drift banner (SkeletonDriftBanner) so its "Update workflows" action
+// can scroll the teacher straight to this section.
+export const RERUN_ONBOARDING_ANCHOR = "rerun-onboarding"
+
 // Re-run onboarding from Org Settings: re-invokes the idempotent
 // initClassroom50 to re-apply the full lockdown, rulesets, and repo settings.
 // Owner-gated; shows the same badge board the wizard uses. This is the
@@ -123,6 +128,7 @@ const RerunOnboarding = ({ org }: { org: string }) => {
 
   return (
     <SettingsSection
+      id={RERUN_ONBOARDING_ANCHOR}
       title={t("orgSettings.rerun.title")}
       description={t("orgSettings.rerun.description")}
       action={

--- a/web/src/pages/orgSettings/RerunOnboarding.tsx
+++ b/web/src/pages/orgSettings/RerunOnboarding.tsx
@@ -49,9 +49,8 @@ const SummaryBanner = ({
   </CalloutDiv>
 )
 
-// DOM anchor for the Re-run onboarding section, shared with the global
-// skeleton-drift banner (SkeletonDriftBanner) so its "Update workflows" action
-// can scroll the teacher straight to this section.
+// DOM anchor shared with SkeletonDriftBanner so its "Update workflows" action
+// scrolls straight to this section.
 export const RERUN_ONBOARDING_ANCHOR = "rerun-onboarding"
 
 // Re-run onboarding from Org Settings: re-invokes the idempotent

--- a/web/src/pages/orgSettings/SettingsSection.tsx
+++ b/web/src/pages/orgSettings/SettingsSection.tsx
@@ -12,6 +12,7 @@ const SettingsSection = ({
   action,
   titleAdornment,
   tone = "default",
+  id,
   children,
 }: PropsWithChildren<{
   title: string
@@ -19,13 +20,15 @@ const SettingsSection = ({
   action?: ReactNode
   titleAdornment?: ReactNode
   tone?: "default" | "danger"
+  id?: string
 }>) => {
   const isDanger = tone === "danger"
 
   return (
     <section
+      id={id}
       className={[
-        "rounded-2xl border p-6",
+        "scroll-mt-24 rounded-2xl border p-6",
         isDanger ? "border-error/30 bg-error/5" : "border-base-300 bg-base-100",
       ].join(" ")}
     >

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
+import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
 
 export const Route = createFileRoute("/_authed")({
   beforeLoad: ({ context, location }) => {
@@ -24,6 +25,7 @@ function AuthedLayout() {
   return (
     <>
       <ScopeWarningBanner />
+      <SkeletonDriftBanner />
       <Outlet />
     </>
   )


### PR DESCRIPTION
Closes #88.

Follow-up to #65 / #85. Two parts, folded together.

## Part 1 — Bump skeleton action pins

Bumps the `gh teacher` skeleton workflow action pins (`cli/gh-teacher/skeleton/dotgithub/workflows/`) that ship into end-user classroom50 config repos, keeping them off the deprecated Node 20 runner path:

| File | Action | Old → New |
| --- | --- | --- |
| `collect-scores.yaml`, `regrade.yaml`, `publish-pages.yaml`, `autograde-runner.yaml` (x2) | `actions/checkout` | v6 → **v7** |
| `autograde-runner.yaml` | `actions/setup-node` | v4 → **v6** |
| `autograde-runner.yaml` | `actions/setup-java` | v4 → **v5** |
| `autograde-runner.yaml` | `actions/setup-go` | v5 → **v6** |

Already current, unchanged: `setup-python@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`. Updated the pin assertions in `init_skeleton_test.go` to match.

> **Note:** `checkout@v7` requires Actions Runner ≥ 2.327.1 (GitHub-hosted runners are fine).

## Part 2 — Proactive skeleton-drift banner (no version marker)

Reuses the existing content-based drift check (`findStaleSkeletonFiles`, git-blob-SHA byte-for-byte diff) read-only — no version marker/manifest.

- **`useSkeletonDrift(org)`** — **owner-gated** (org admin via `useGetOrgMembership`), cached (React Query, 30m `staleTime`), **fail-open** (any read error → show nothing). Exposes a pure `resolveSkeletonDrift` verdict. Owner-gated because the banner routes to the owner-only Re-run onboarding section — surfacing it to a TA/non-owner instructor would dead-end their CTA on a NotFound.
- **`SkeletonDriftBanner`** — global warning banner modeled on `ScopeWarningBanner` + `AppBanner`: warning tone, **dismissible per session and per org** (dismissing one org doesn't suppress another org's drift; reappears on reload until resolved), i18n. Mounted in `_authed.tsx`. Its action routes to the existing **Re-run onboarding** Org Settings section via a hash anchor.
- **Overwrite warning in the copy** — re-running onboarding overwrites the scaffolded workflow files (`collect-scores` / `regrade` / `publish-pages` / `autograde-runner`) with the defaults; the banner states plainly that manual edits to those files will be replaced (the existing per-file overwrite-confirmation modal still gates it).

**Scope boundaries:** config repo only (student assignment repos out of scope); detection only (routes to the existing re-run flow, no auto-apply); no version marker (deliberately deferred).

## Test plan

- [x] `actionlint` clean on all four changed skeleton workflows
- [x] `go test` (gh-teacher skeleton/init) green — `skeleton.test.ts` parity holds
- [x] `npm run check` in `web/`: tsc + eslint + prettier clean, 593 tests pass
- [x] New unit test for the drift verdict (drifted / clean / read-error fail-open / in-flight)
- [ ] Manual: on an org with stale scaffolded workflows, the banner appears for an **owner**, routes to Re-run onboarding, and the overwrite modal + banner copy both warn that customized workflows are replaced
- [ ] Ideally exercise the bumped skeleton via a manual `gh teacher init` / e2e against a throwaway org

## Optional follow-up

Dependabot (`package-ecosystem: github-actions`) to keep pins current, and a real version marker to distinguish "stale from our bump" vs "intentional teacher edit" — both deliberately deferred here.