### PR TITLE
fix(web): match ConfirmModal cancel button to its description copy

### DIFF
--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -34,6 +34,10 @@ export function ConfirmModal({
   const resolvedConfirmLabel =
     confirmLabel ?? t("components.confirmModal.confirm")
   const resolvedCancelLabel = cancelLabel ?? t("common.cancel")
+  // Honor a caller's cancelLabel here too (not just the type-to-confirm step),
+  // since the description copy may refer to it; default to "No".
+  const acknowledgeCancelLabel =
+    cancelLabel ?? t("components.confirmModal.no")
   const [hasAcknowledged, setHasAcknowledged] = useState(false)
   const [typedText, setTypedText] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -179,7 +183,7 @@ export function ConfirmModal({
                 disabled={isSubmitting}
                 onClick={handleClose}
               >
-                {t("components.confirmModal.no")}
+                {acknowledgeCancelLabel}
               </button>
 
               <button

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -36,8 +36,7 @@ export function ConfirmModal({
   const resolvedCancelLabel = cancelLabel ?? t("common.cancel")
   // Honor a caller's cancelLabel here too (not just the type-to-confirm step),
   // since the description copy may refer to it; default to "No".
-  const acknowledgeCancelLabel =
-    cancelLabel ?? t("components.confirmModal.no")
+  const acknowledgeCancelLabel = cancelLabel ?? t("components.confirmModal.no")
   const [hasAcknowledged, setHasAcknowledged] = useState(false)
   const [typedText, setTypedText] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)


### PR DESCRIPTION
## Summary
- The skeleton-overwrite modal's description told users to "choose **Keep mine**", but the button rendered "No" — the copy and button disagreed.
- Root cause: `ConfirmModal` only applied the caller's `cancelLabel` on the type-to-confirm step. The overwrite flow uses `needsConfirm={false}`, so it renders the acknowledge step, whose cancel button was hardcoded to `components.confirmModal.no`.
- Fix: the acknowledge-step cancel button now honors the supplied `cancelLabel` (falling back to "No"), so the overwrite modal shows "Keep mine" as the description promises.

Side benefit: other two-button modals that pass `cancelLabel={t("common.cancel")}` (regrade, resend invites, archive) now correctly show "Cancel" instead of the mismatched "No". No tests relied on the old "No" text.

## Test plan
- [ ] Open the "Re-run onboarding" overwrite modal with drifted files; confirm the cancel button reads **Keep mine**, matching the description.
- [ ] Verify regrade/resend/archive modals show **Cancel**.
- [ ] Verify modals with no `cancelLabel` still show **No**.