### PR TITLE
feat(web): add docs link to logged-in account menu

### DIFF
--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -8,6 +8,7 @@ import { GitHubAuthedPanel } from "./GitHubAuthedPanel"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
 import { LoginLanguageMenu } from "./LoginLanguageMenu"
 import { AppVersionBadge } from "@/components/AppVersionBadge"
+import { WIKI_URL } from "@/version"
 
 function LoadingScreen({ label }: { label: string }) {
   return (
@@ -147,7 +148,7 @@ export function GitHubAuthCard() {
             <AppVersionBadge className="tabular-nums text-base-content/50" />
             <a
               className="link link-info link-hover"
-              href="https://github.com/foundation50/classroom50/wiki"
+              href={WIKI_URL}
               target="_blank"
               rel="noreferrer"
             >

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -17,6 +17,7 @@ import {
   Moon,
   Languages,
   Info,
+  BookOpen,
 } from "lucide-react"
 import {
   Link,
@@ -46,6 +47,7 @@ import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import { useTheme } from "@/hooks/useTheme"
 import { LanguageDialog } from "@/components/LanguageDialog"
 import { AboutDialog } from "@/components/AboutDialog"
+import { WIKI_URL } from "@/version"
 import type { Classroom } from "@/types/classroom"
 import {
   createContext,
@@ -852,6 +854,20 @@ export const SidebarFooter = () => {
               </button>
             </li>
             <div className="divider my-1" />
+            <li>
+              <a
+                href={WIKI_URL}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setMenuOpen(false)
+                }}
+              >
+                <BookOpen aria-hidden="true" className="size-4" />
+                <span className="flex-1 text-left">{t("nav.docs")}</span>
+              </a>
+            </li>
             <li>
               <button
                 type="button"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -67,6 +67,7 @@
     "languageDialogDescription": "Switch languages or install a translated language pack.",
     "signOut": "Sign Out",
     "about": "About",
+    "docs": "Docs",
     "aboutDialogTitle": "Classroom 50",
     "aboutDialogDescription": "Build and version information for this app.",
     "aboutVersion": "Version",

--- a/web/src/version.ts
+++ b/web/src/version.ts
@@ -28,6 +28,8 @@ export const ISSUES_URL = `${REPO_URL}/issues`
 
 export const DISCUSSIONS_URL = `${REPO_URL}/discussions`
 
+export const WIKI_URL = `${REPO_URL}/wiki`
+
 /** e.g. "1.0.0 (a1b2c3d4e5f6)" — for footers, logs, and bug reports. */
 export function formatAppVersion(v: AppVersion = appVersion): string {
   return `${v.version} (${v.commit})`


### PR DESCRIPTION
## Summary
- Closes #91.
- The wiki/docs link previously appeared only on the pre-login landing page. This adds the same link to the sidebar account menu (on the user avatar popover) so logged-in users can reach the docs too.
- Centralizes the docs URL in a shared `WIKI_URL` constant in `web/src/version.ts`, reused by both the login page (`GitHubAuthCard`) and the account menu, so the two stay in sync.
- Adds a `nav.docs` string to the source locale (`en.json`); target locales are machine-generated.

## Notes
- The menu entry sits just above **About** and opens the wiki in a new tab.
- Available across all authed views (students and staff, at org/classroom/assignment scopes) since the account menu is shared.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` — 593 tests pass
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [ ] Manually verify the **Docs** item appears in the account menu when logged in and opens the wiki