### PR TITLE
docs: add training session information

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -4,6 +4,17 @@ Classroom 50 is a free and open-source tool for managing and grading programming
 
 Classroom 50 exists both as a web application (available at [https://classroom50.org](https://classroom50.org/)) and as a command-line tool.
 
+## Training Sessions
+
+The Fifty Foundation will host two online training sessions to teach you how to use Classroom 50 and to answer your questions live. The sessions will take place at the following times:
+
+- [Friday, July 24, 1pm-2pm EDT](https://time.cs50.io/20260724T1300-0400/PT1H?title=Classroom+50+Training+Session)
+- [Friday, August 14, 1pm-2pm EDT](https://time.cs50.io/20260814T1300-0400/PT1H?title=Classroom+50+Training+Session)
+
+To sign up to attend one of the training sessions, [complete the registration form here](https://docs.google.com/forms/d/e/1FAIpQLSdSZzOUOtSExmldFOsdlePWGZkJELHnZBpH3NPhXAJMDG9eXA/viewform?usp=dialog).
+
+A recorded training session will also be made available for those who cannot attend live.
+
 ## Features
 
 Classroom 50 supports:


### PR DESCRIPTION
## Summary

Updates Wiki to include training session information.

DEV-220

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(web): ...`, `fix(gh-teacher): ...`).
