### PR TITLE
feat(web): localize relative timestamps to the active language

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,6 @@
         "@tanstack/react-query": "^5.100.10",
         "@tanstack/react-router": "^1.168.25",
         "canvas-confetti": "^1.9.4",
-        "date-fns": "^4.4.0",
         "i18next": "^26.3.4",
         "libsodium-wrappers": "^0.8.4",
         "lucide-react": "^1.12.0",
@@ -2916,16 +2915,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,6 @@
     "@tanstack/react-query": "^5.100.10",
     "@tanstack/react-router": "^1.168.25",
     "canvas-confetti": "^1.9.4",
-    "date-fns": "^4.4.0",
     "i18next": "^26.3.4",
     "libsodium-wrappers": "^0.8.4",
     "lucide-react": "^1.12.0",

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -179,8 +179,5 @@ validation/installation API lives in
 
 ## Known limitations
 
-- Relative timestamps ("3 days ago") are English-only for now (date-fns
-  locales are not sideloaded). Absolute dates follow the active language via
-  `Intl`.
 - A handful of strings asserted by unit tests in the `orgMembers` logic files
   remain English.

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -61,8 +61,7 @@ import {
   COLLECT_SCORES_WORKFLOW,
   REGRADE_WORKFLOW,
 } from "@/hooks/github/mutations"
-import { formatDueDateTime } from "@/util/formatDate"
-import { formatDistanceToNow } from "date-fns"
+import { formatDueDateTime, formatRelativeToNow } from "@/util/formatDate"
 
 // Re-renders on an interval to keep relative timestamps fresh; returns nothing.
 const usePeriodicRerender = (intervalMs = 30_000) => {
@@ -146,7 +145,7 @@ const SubmissionsPageContent = () => {
   const secret = classroomMeta?.secret
   const scoresLastUpdated =
     scoresUpdatedAt > 0
-      ? formatDistanceToNow(scoresUpdatedAt, { addSuffix: true })
+      ? formatRelativeToNow(scoresUpdatedAt)
       : t("submissions.dashboard.never")
 
   const assignmentSubmitUrl =
@@ -376,7 +375,7 @@ const SubmissionsPageContent = () => {
 
   const lastCollectedLabel =
     lastRun?.status === "completed" && lastRun.created_at
-      ? formatDistanceToNow(new Date(lastRun.created_at), { addSuffix: true })
+      ? formatRelativeToNow(new Date(lastRun.created_at))
       : null
 
   // Refresh scores and the last-run timestamp once a manual collection finishes.

--- a/web/src/util/formatDate.test.ts
+++ b/web/src/util/formatDate.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import i18n from "@/i18n"
+
 import {
   buildDueFields,
   formatDueDate,
   formatDueDateTime,
+  formatInvitedAt,
+  formatRelativeToNow,
   isPastDue,
 } from "./formatDate"
 
@@ -75,6 +80,98 @@ describe("isPastDue", () => {
     vi.setSystemTime(new Date("2026-06-23T12:00:00Z"))
     expect(isPastDue("not-a-date")).toBe(false)
     expect(isPastDue("2026-13-45")).toBe(false)
+  })
+})
+
+describe("formatRelativeToNow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-23T12:00:00Z"))
+  })
+  afterEach(async () => {
+    vi.useRealTimers()
+    await i18n.changeLanguage("en")
+  })
+
+  it("renders the largest whole unit that fits", () => {
+    expect(formatRelativeToNow(new Date("2026-06-23T11:59:30Z"))).toBe(
+      "30 seconds ago",
+    )
+    expect(formatRelativeToNow(new Date("2026-06-23T11:55:00Z"))).toBe(
+      "5 minutes ago",
+    )
+    expect(formatRelativeToNow(new Date("2026-06-23T09:00:00Z"))).toBe(
+      "3 hours ago",
+    )
+    expect(formatRelativeToNow(new Date("2026-06-20T12:00:00Z"))).toBe(
+      "3 days ago",
+    )
+    expect(formatRelativeToNow(new Date("2026-04-24T12:00:00Z"))).toBe(
+      "2 months ago",
+    )
+    expect(formatRelativeToNow(new Date("2024-06-23T12:00:00Z"))).toBe(
+      "2 years ago",
+    )
+  })
+
+  it("renders a zero/sub-second difference as past, not future", () => {
+    expect(formatRelativeToNow(new Date("2026-06-23T12:00:00Z"))).toBe(
+      "0 seconds ago",
+    )
+  })
+
+  it("renders a future instant with an 'in' prefix", () => {
+    expect(formatRelativeToNow(new Date("2026-06-23T12:05:00Z"))).toBe(
+      "in 5 minutes",
+    )
+  })
+
+  it("accepts an epoch-milliseconds timestamp", () => {
+    expect(formatRelativeToNow(Date.now() - 5 * 60_000)).toBe("5 minutes ago")
+  })
+
+  it("renders in the active UI language", async () => {
+    await i18n.changeLanguage("de")
+    expect(formatRelativeToNow(new Date("2026-06-20T12:00:00Z"))).toBe(
+      "vor 3 Tagen",
+    )
+  })
+
+  it("falls back to English when the language has no locale data", async () => {
+    // Well-formed BCP-47 tag with no CLDR data behind it.
+    await i18n.changeLanguage("xq")
+    expect(formatRelativeToNow(new Date("2026-06-20T12:00:00Z"))).toBe(
+      "3 days ago",
+    )
+  })
+
+  it("falls back to English for a malformed language code", async () => {
+    // A sideloaded pack code that Intl rejects must not make rendering throw.
+    await i18n.changeLanguage("123")
+    expect(formatRelativeToNow(new Date("2026-06-20T12:00:00Z"))).toBe(
+      "3 days ago",
+    )
+  })
+})
+
+describe("formatInvitedAt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-23T12:00:00Z"))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("renders a relative timestamp", () => {
+    expect(formatInvitedAt("2026-06-20T12:00:00Z")).toBe("3 days ago")
+  })
+
+  it("returns null for missing or unparseable input", () => {
+    expect(formatInvitedAt(undefined)).toBeNull()
+    expect(formatInvitedAt(null)).toBeNull()
+    expect(formatInvitedAt("")).toBeNull()
+    expect(formatInvitedAt("not-a-date")).toBeNull()
   })
 })
 

--- a/web/src/util/formatDate.ts
+++ b/web/src/util/formatDate.ts
@@ -1,5 +1,4 @@
 import type { DueMeta } from "@/types/classroom"
-import { formatDistanceToNow } from "date-fns"
 
 import i18n from "@/i18n"
 import { BASE_LANG } from "@/i18n/customLocale"
@@ -76,14 +75,46 @@ export const formatDueDateTime = (dateString: string): string => {
   return dueDateTimeFormatter().format(date)
 }
 
+// Unlike DateTimeFormat above, an unsupported-but-well-formed tag must fall
+// back to English, not to the browser's default locale — hence the extra
+// supportedLocalesOf check.
+const relativeTimeFormatter = () => {
+  const supported = Intl.RelativeTimeFormat.supportedLocalesOf([
+    resolveLocale(),
+  ])
+  return new Intl.RelativeTimeFormat(supported[0] ?? "en-US", {
+    numeric: "always",
+  })
+}
+
+// Largest whole unit wins. No weeks — day counts up to a month read more
+// naturally on a dashboard; month/year lengths are approximations.
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ["year", 365 * 24 * 3600],
+  ["month", 30 * 24 * 3600],
+  ["day", 24 * 3600],
+  ["hour", 3600],
+  ["minute", 60],
+]
+
+// Relative "x ago" / "in x" in the active UI language, via the platform's
+// Intl locale data — sideloaded languages need no per-language bundles.
+export const formatRelativeToNow = (date: Date | number): string => {
+  const diffSeconds = Math.round((new Date(date).getTime() - Date.now()) / 1000)
+  const abs = Math.abs(diffSeconds)
+  const found = RELATIVE_UNITS.find(([, size]) => abs >= size)
+  const [unit, size] = found ?? ["second", 1]
+  const value = Math.trunc(diffSeconds / size)
+  // -0 keeps a zero diff on the past side ("0 seconds ago", not "in 0 seconds").
+  return relativeTimeFormatter().format(value === 0 ? -0 : value, unit)
+}
+
 // Relative "x ago" for an invitation timestamp. Returns null on missing/invalid.
 export const formatInvitedAt = (dateString?: string | null): string | null => {
   if (!dateString) return null
   const date = new Date(dateString)
   if (Number.isNaN(date.getTime())) return null
-  // TODO(i18n): relative-time output is English-only. Localizing needs per-
-  // language date-fns locales (deferred — bundles are heavy).
-  return formatDistanceToNow(date, { addSuffix: true })
+  return formatRelativeToNow(date)
 }
 
 export const isPastDue = (dateString: string): boolean => {


### PR DESCRIPTION
## Summary

`date-fns`' `formatDistanceToNow` was called without a `locale` at all three relative-time call sites, so "3 days ago" and "2 hours ago" stayed English even after the UI language was switched, while absolute dates (via `Intl`) already followed it. One view could show both at once.

The fix is a single `formatRelativeToNow` helper backed by `Intl.RelativeTimeFormat`. The three call sites now route through it.

- `formatInvitedAt` — "Invited N ago" on the Students page
- `SubmissionsPage` — "Last updated N ago" and "Last collected N ago"

`Intl` reads its locale data from the platform, which is what makes this work here, because the app's languages are sideloaded at runtime as arbitrary BCP-47 codes and there's no fixed list to bundle `date-fns` locales for. Unknown or malformed codes fall back to English. `date-fns` is gone now, since these three were its only uses.

Tested in the browser in English and with the real `pt-BR` and `ja` packs from the registry. Timestamps localize and lay out fine, and a bogus language code falls back to English.

One behavior change is worth flagging. `Intl` phrasing isn't byte-identical to `date-fns` in the sub-minute range, where it now reads "0 seconds ago" instead of the old "less than a minute ago", and it drops the "about" on hours and months. Nothing pinned those strings. I can add a flat "just now" for the sub-minute case if we'd prefer.

Closes #54

## Type of change

- [x] New feature

## Checklist

- [x] Ran `cd web && npm run check` for the web app (602 tests pass, no new lint warnings)
- [ ] Cross-binary contract — n/a, web-only
- [ ] CLI command/flag docs — n/a
- [x] Commits follow Conventional Commits