### PR TITLE
feat(web): silently auto-update installed language packs on startup

### DIFF
--- a/web/src/components/settings/LanguagePackUpdateToaster.tsx
+++ b/web/src/components/settings/LanguagePackUpdateToaster.tsx
@@ -4,12 +4,9 @@ import { useTranslation } from "react-i18next"
 import { useOptionalToast } from "@/context/notifications/NotificationProvider"
 import { languageLabel, subscribeToPackUpdates } from "@/i18n/customLocale"
 
-// Bridges the non-React startup auto-refresh (refreshInstalledPacks in
-// customLocale.ts) to a toast. That refresh runs before the app mounts, so any
-// codes it updated are buffered and flushed to this subscriber on mount; later
-// in-session refreshes notify live. Renders nothing itself. Mount under
-// NotificationProvider (see main.tsx). Uses the optional toast hook so it is a
-// no-op if ever mounted without a provider.
+// Bridges the non-React startup auto-refresh (refreshInstalledPacks) to a toast:
+// codes updated before mount are buffered and flushed to this subscriber; later
+// refreshes notify live. Renders nothing. Mount under NotificationProvider.
 export function LanguagePackUpdateToaster() {
   const { t, i18n } = useTranslation()
   const toast = useOptionalToast()
@@ -21,7 +18,7 @@ export function LanguagePackUpdateToaster() {
       const list = codes.map((c) => languageLabel(c, i18n.language)).join(", ")
       toast.notify({
         tone: "success",
-        // Keyed so a burst of updates replaces in place rather than stacking.
+        // Keyed so a burst replaces in place rather than stacking.
         key: "language-packs-updated",
         message: t("language.updatedToast", { count: codes.length, list }),
         durationMs: 8000,

--- a/web/src/components/settings/LanguagePackUpdateToaster.tsx
+++ b/web/src/components/settings/LanguagePackUpdateToaster.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react"
+import { useTranslation } from "react-i18next"
+
+import { useOptionalToast } from "@/context/notifications/NotificationProvider"
+import { languageLabel, subscribeToPackUpdates } from "@/i18n/customLocale"
+
+// Bridges the non-React startup auto-refresh (refreshInstalledPacks in
+// customLocale.ts) to a toast. That refresh runs before the app mounts, so any
+// codes it updated are buffered and flushed to this subscriber on mount; later
+// in-session refreshes notify live. Renders nothing itself. Mount under
+// NotificationProvider (see main.tsx). Uses the optional toast hook so it is a
+// no-op if ever mounted without a provider.
+export function LanguagePackUpdateToaster() {
+  const { t, i18n } = useTranslation()
+  const toast = useOptionalToast()
+
+  useEffect(() => {
+    if (!toast) return
+    return subscribeToPackUpdates((codes) => {
+      if (codes.length === 0) return
+      const list = codes.map((c) => languageLabel(c, i18n.language)).join(", ")
+      toast.notify({
+        tone: "success",
+        // Keyed so a burst of updates replaces in place rather than stacking.
+        key: "language-packs-updated",
+        message: t("language.updatedToast", { count: codes.length, list }),
+        durationMs: 8000,
+      })
+    })
+  }, [toast, t, i18n.language])
+
+  return null
+}
+
+export default LanguagePackUpdateToaster

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -179,7 +179,11 @@ export const LanguageSwitcher = ({
     if (!preview) return
     setBusy(true)
     try {
-      await commitPack(preview.code, preview.bundle)
+      await commitPack(preview.code, preview.bundle, {
+        source: preview.source,
+        version: preview.version,
+        hash: preview.hash,
+      })
       setPreview(null)
       setCode("")
       setUrl("")

--- a/web/src/i18n/customLocale.test.ts
+++ b/web/src/i18n/customLocale.test.ts
@@ -839,6 +839,41 @@ describe("refreshInstalledPacks", () => {
     expect(packs.fr.bundle["nav.roleStudent"]).toBe("fr-new") // updated
   })
 
+  it("does not resurrect a pack removed by another tab during the fetch", async () => {
+    const store = stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "registry",
+          version: "1",
+          bundle: { "nav.roleStudent": "old" },
+        },
+      }),
+    })
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const u = String(input)
+      if (/index\.json$/.test(u)) {
+        return new Response(
+          JSON.stringify({ languages: [{ code: "de", version: "2" }] }),
+          { status: 200 },
+        )
+      }
+      // Simulate another tab removing the pack while this pack fetch is in
+      // flight: mutate the backing store before refreshInstalledPacks persists.
+      store.delete(PACKS_STORAGE_KEY)
+      return new Response(JSON.stringify({ nav: { roleStudent: "neu" } }), {
+        status: 200,
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const updated = await refreshInstalledPacks()
+    // The pack was removed mid-fetch, so it must stay gone (not re-added) and
+    // must not be reported as updated.
+    expect(updated).toEqual([])
+    expect(readPacks(store).de).toBeUndefined()
+  })
+
   it("skips the fetch entirely when the version is unchanged", async () => {
     stubWindow({
       [PACKS_STORAGE_KEY]: JSON.stringify({

--- a/web/src/i18n/customLocale.test.ts
+++ b/web/src/i18n/customLocale.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import i18n from "i18next"
+import { initReactI18next } from "react-i18next"
 
 import {
   LANG_QUERY_PARAM,
@@ -11,13 +13,17 @@ import {
   coverage,
   fetchRegistry,
   flattenBundle,
+  hashBundle,
   inferLangCode,
   missingKeys,
   normalizeLangCode,
   parseBundle,
   prepareFromBuiltIn,
   prepareFromUrl,
+  refreshInstalledPacks,
+  resetRegistryCache,
   shareUrlForLang,
+  subscribeToPackUpdates,
 } from "./customLocale"
 
 // The security-relevant guarantees of the sideload layer live in these pure
@@ -125,6 +131,18 @@ describe("loadFromUrl scheme gate", () => {
     )
   })
 
+  it("rejects http when requireHttps is set (silent auto-refresh path)", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    await expect(
+      prepareFromUrl("http://example.com/de.json", "de", {
+        requireHttps: true,
+      }),
+    ).rejects.toThrow(/https/)
+    expect(fetchMock).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+
   it("throws UndetectableCodeError when no code is given or inferable", async () => {
     await expect(
       prepareFromUrl("https://example.com/download"),
@@ -209,6 +227,7 @@ describe("loadFromUrl response handling", () => {
 describe("fetchRegistry", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    resetRegistryCache()
   })
 
   it("returns valid codes, dropping base, dupes, and malformed entries", async () => {
@@ -303,6 +322,7 @@ describe("fetchRegistry", () => {
 describe("availableBuiltInLangs", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    resetRegistryCache()
   })
 
   it("returns every language the manifest lists (no per-pack probe)", async () => {
@@ -341,6 +361,7 @@ describe("availableBuiltInLangs", () => {
 describe("prepareFromBuiltIn", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    resetRegistryCache()
   })
 
   it("fetches <base>/<code>.json and previews it with the given code", async () => {
@@ -411,6 +432,7 @@ describe("applyLangFromQuery", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    resetRegistryCache()
     if (realWindow === undefined) {
       // @ts-expect-error - restore the node env's missing window
       delete globalThis.window
@@ -556,5 +578,329 @@ describe("coverage / missingKeys", () => {
     expect(missingKeys(partial).length).toBeGreaterThan(0)
     // A key the base doesn't have doesn't inflate coverage.
     expect(missingKeys(partial)).not.toContain("notFound.title")
+  })
+})
+
+describe("fetchRegistry memoization", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetRegistryCache()
+  })
+
+  it("dedupes two near-simultaneous calls into one fetch", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ languages: [{ code: "ja" }] }), {
+          status: 200,
+        }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    const [a, b] = await Promise.all([fetchRegistry(), fetchRegistry()])
+    expect(a).toEqual(b)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("serves a cached result within the TTL, then refetches after reset", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ languages: [{ code: "ja" }] }), {
+          status: 200,
+        }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    await fetchRegistry()
+    await fetchRegistry()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    resetRegistryCache()
+    await fetchRegistry()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not cache a failure (a later call retries)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("nope", { status: 500 }))
+      .mockResolvedValue(
+        new Response(JSON.stringify({ languages: [{ code: "ja" }] }), {
+          status: 200,
+        }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+    await expect(fetchRegistry()).rejects.toThrow(LanguagePackError)
+    const langs = await fetchRegistry()
+    expect(langs.map((l) => l.code)).toEqual(["ja"])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("hashBundle", () => {
+  it("is order-independent and value-sensitive", () => {
+    expect(hashBundle({ a: "1", b: "2" })).toBe(hashBundle({ b: "2", a: "1" }))
+    expect(hashBundle({ a: "1" })).not.toBe(hashBundle({ a: "2" }))
+  })
+})
+
+describe("refreshInstalledPacks", () => {
+  const realWindow = globalThis.window
+
+  beforeEach(async () => {
+    // installPack registers bundles via i18next.addResourceBundle, which throws
+    // pre-init. Production initializes i18next via ./i18n; the unit tests here
+    // import only ./customLocale, so init a minimal instance first.
+    if (!i18n.isInitialized) {
+      await i18n.use(initReactI18next).init({
+        lng: "en",
+        fallbackLng: "en",
+        resources: { en: { translation: {} } },
+        interpolation: { escapeValue: false },
+      })
+    }
+    // Drain any codes buffered by a prior test (the update buffer is module
+    // state that survives between tests).
+    subscribeToPackUpdates(() => {})()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetRegistryCache()
+    if (realWindow === undefined) {
+      // @ts-expect-error - restore the node env's missing window
+      delete globalThis.window
+    } else {
+      globalThis.window = realWindow
+    }
+  })
+
+  // In-memory localStorage-backed window so installPack/readStoredPacks work.
+  // Returns the live store so tests can read back what was persisted.
+  const stubWindow = (storageSeed?: Record<string, string>) => {
+    const store = new Map<string, string>(Object.entries(storageSeed ?? {}))
+    const localStorage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+    }
+    vi.stubGlobal("window", {
+      localStorage: localStorage as unknown as Storage,
+    })
+    return store
+  }
+
+  const readPacks = (store: Map<string, string>) =>
+    JSON.parse(store.get(PACKS_STORAGE_KEY) ?? "{}") as Record<
+      string,
+      { code: string; bundle: Record<string, string>; source?: string }
+    >
+
+  const httpsRegistry = "https://fifty.foundation/classroom50-language-packs"
+
+  it("overwrites a registry pack when the manifest version is newer", async () => {
+    const store = stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "registry",
+          version: "1",
+          bundle: { "nav.roleStudent": "alt" },
+        },
+      }),
+    })
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const u = String(input)
+      if (/index\.json$/.test(u)) {
+        return new Response(
+          JSON.stringify({ languages: [{ code: "de", version: "2" }] }),
+          { status: 200 },
+        )
+      }
+      return new Response(
+        JSON.stringify({ nav: { roleStudent: "Studentin" } }),
+        {
+          status: 200,
+        },
+      )
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const updated = await refreshInstalledPacks()
+    expect(updated).toEqual(["de"])
+    const packs = readPacks(store)
+    expect(packs.de.bundle["nav.roleStudent"]).toBe("Studentin")
+    // The pack URL must be the https registry origin (silent path is https-only).
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(
+      urls.some((u) => u.startsWith(httpsRegistry) && /\/de\.json$/.test(u)),
+    ).toBe(true)
+  })
+
+  it("leaves a user-sourced pack untouched even when its code is in the registry", async () => {
+    const store = stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "user",
+          bundle: { "nav.roleStudent": "mine" },
+        },
+      }),
+    })
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ languages: [{ code: "de", version: "9" }] }),
+          { status: 200 },
+        ),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const updated = await refreshInstalledPacks()
+    expect(updated).toEqual([])
+    // No registry-eligible packs, so the manifest is never even fetched.
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(readPacks(store).de.bundle["nav.roleStudent"]).toBe("mine")
+  })
+
+  it("treats a legacy pack with no source as user (not refreshed)", async () => {
+    const store = stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: { code: "de", bundle: { "nav.roleStudent": "legacy" } },
+      }),
+    })
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    const updated = await refreshInstalledPacks()
+    expect(updated).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(readPacks(store).de.bundle["nav.roleStudent"]).toBe("legacy")
+  })
+
+  it("keeps the pack when the registry is unreachable", async () => {
+    const store = stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "registry",
+          version: "1",
+          bundle: { "nav.roleStudent": "keep" },
+        },
+      }),
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("offline")
+      }),
+    )
+    const updated = await refreshInstalledPacks()
+    expect(updated).toEqual([])
+    expect(readPacks(store).de.bundle["nav.roleStudent"]).toBe("keep")
+  })
+
+  it("does not abort the batch when a single pack fetch fails", async () => {
+    const store = stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "registry",
+          version: "1",
+          bundle: { "nav.roleStudent": "de-old" },
+        },
+        fr: {
+          code: "fr",
+          source: "registry",
+          version: "1",
+          bundle: { "nav.roleStudent": "fr-old" },
+        },
+      }),
+    })
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const u = String(input)
+      if (/index\.json$/.test(u)) {
+        return new Response(
+          JSON.stringify({
+            languages: [
+              { code: "de", version: "2" },
+              { code: "fr", version: "2" },
+            ],
+          }),
+          { status: 200 },
+        )
+      }
+      if (/\/de\.json$/.test(u)) {
+        return new Response("boom", { status: 500 })
+      }
+      return new Response(JSON.stringify({ nav: { roleStudent: "fr-new" } }), {
+        status: 200,
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const updated = await refreshInstalledPacks()
+    expect(updated).toEqual(["fr"])
+    const packs = readPacks(store)
+    expect(packs.de.bundle["nav.roleStudent"]).toBe("de-old") // untouched
+    expect(packs.fr.bundle["nav.roleStudent"]).toBe("fr-new") // updated
+  })
+
+  it("skips the fetch entirely when the version is unchanged", async () => {
+    stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "registry",
+          version: "3",
+          bundle: { "nav.roleStudent": "same" },
+        },
+      }),
+    })
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const u = String(input)
+      if (/index\.json$/.test(u)) {
+        return new Response(
+          JSON.stringify({ languages: [{ code: "de", version: "3" }] }),
+          { status: 200 },
+        )
+      }
+      throw new Error("should not fetch the pack when version is unchanged")
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const updated = await refreshInstalledPacks()
+    expect(updated).toEqual([])
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls.some((u) => /\/de\.json$/.test(u))).toBe(false)
+  })
+
+  it("emits updated codes to subscribers", async () => {
+    stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "registry",
+          version: "1",
+          bundle: { "nav.roleStudent": "old" },
+        },
+      }),
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const u = String(input)
+        if (/index\.json$/.test(u)) {
+          return new Response(
+            JSON.stringify({ languages: [{ code: "de", version: "2" }] }),
+            { status: 200 },
+          )
+        }
+        return new Response(JSON.stringify({ nav: { roleStudent: "neu" } }), {
+          status: 200,
+        })
+      }),
+    )
+
+    const seen: string[][] = []
+    const unsubscribe = subscribeToPackUpdates((codes) => seen.push(codes))
+    await refreshInstalledPacks()
+    unsubscribe()
+    expect(seen).toEqual([["de"]])
   })
 })

--- a/web/src/i18n/customLocale.test.ts
+++ b/web/src/i18n/customLocale.test.ts
@@ -901,4 +901,48 @@ describe("refreshInstalledPacks", () => {
     unsubscribe()
     expect(seen).toEqual([["de"]])
   })
+
+  it("buffers updates emitted before any subscriber and flushes them on first subscribe", async () => {
+    stubWindow({
+      [PACKS_STORAGE_KEY]: JSON.stringify({
+        de: {
+          code: "de",
+          source: "registry",
+          version: "1",
+          bundle: { "nav.roleStudent": "old" },
+        },
+      }),
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const u = String(input)
+        if (/index\.json$/.test(u)) {
+          return new Response(
+            JSON.stringify({ languages: [{ code: "de", version: "2" }] }),
+            { status: 200 },
+          )
+        }
+        return new Response(JSON.stringify({ nav: { roleStudent: "neu" } }), {
+          status: 200,
+        })
+      }),
+    )
+
+    // Startup path: the refresh runs before the toaster mounts, so the update
+    // is emitted with no listener and must be buffered.
+    const updated = await refreshInstalledPacks()
+    expect(updated).toEqual(["de"])
+
+    // First subscriber (the mounting toaster) drains the buffer exactly once.
+    const seen: string[][] = []
+    const unsubscribe = subscribeToPackUpdates((codes) => seen.push(codes))
+    expect(seen).toEqual([["de"]])
+    unsubscribe()
+
+    // A later subscriber gets nothing — the buffer was already drained.
+    const seenLater: string[][] = []
+    subscribeToPackUpdates((codes) => seenLater.push(codes))()
+    expect(seenLater).toEqual([])
+  })
 })

--- a/web/src/i18n/customLocale.test.ts
+++ b/web/src/i18n/customLocale.test.ts
@@ -644,8 +644,7 @@ describe("refreshInstalledPacks", () => {
   const realWindow = globalThis.window
 
   beforeEach(async () => {
-    // installPack registers bundles via i18next.addResourceBundle, which throws
-    // pre-init. Production initializes i18next via ./i18n; the unit tests here
+    // installPack -> i18next.addResourceBundle throws pre-init; these tests
     // import only ./customLocale, so init a minimal instance first.
     if (!i18n.isInitialized) {
       await i18n.use(initReactI18next).init({
@@ -655,8 +654,7 @@ describe("refreshInstalledPacks", () => {
         interpolation: { escapeValue: false },
       })
     }
-    // Drain any codes buffered by a prior test (the update buffer is module
-    // state that survives between tests).
+    // Drain codes buffered by a prior test (buffer is module state).
     subscribeToPackUpdates(() => {})()
   })
 

--- a/web/src/i18n/customLocale.ts
+++ b/web/src/i18n/customLocale.ts
@@ -37,9 +37,22 @@ const MAX_REGISTRY_BYTES = 64 * 1024
 // JSON is accepted on input and flattened before validation.
 export type FlatBundle = Record<string, string>
 
+// Where an installed pack came from. Only "registry" packs are eligible for the
+// silent auto-refresh; a user's hand-loaded pack (file/URL) is never touched,
+// even when its code also exists in the registry. Legacy packs stored before
+// this field existed are read as "user" so they're never auto-overwritten.
+export type PackSource = "registry" | "user"
+
 export type LanguagePack = {
   code: string
   bundle: FlatBundle
+  // Origin of the pack; defaults to "user" on read for legacy stored packs.
+  source: PackSource
+  // Update markers for registry packs: the manifest version and/or the pack's
+  // content hash at install time. Used to decide whether a refresh is warranted
+  // (version/hash changed) without re-downloading, and absent for user packs.
+  version?: string
+  hash?: string
 }
 
 // BCP-47-ish tag: 2-3 letter primary subtag plus optional `-` subtags. Rejects
@@ -66,20 +79,32 @@ const flatBundleSchema = z
 const packSchema = z.object({
   code: langCodeSchema,
   bundle: flatBundleSchema,
+  // Legacy packs (stored before this field) parse as "user" via the default, so
+  // an existing pack is never mistaken for a registry pack and auto-overwritten.
+  source: z.enum(["registry", "user"]).default("user"),
+  version: z.string().max(200).optional(),
+  hash: z.string().max(200).optional(),
 })
 
 const storedPacksSchema = z.record(z.string(), packSchema)
 
 // Shape of the registry's index.json: { "languages": [{ "code": "ja" }, ...] }.
 // Unknown/invalid entries are tolerated per-item so one bad row doesn't sink
-// the whole list.
-const registryEntrySchema = z.object({ code: langCodeSchema })
+// the whole list. `version`/`hash` are optional update markers the publish
+// workflow may add; the app degrades gracefully when they're absent.
+const registryEntrySchema = z.object({
+  code: langCodeSchema,
+  version: z.string().max(200).optional(),
+  hash: z.string().max(200).optional(),
+})
 const registrySchema = z.object({
   languages: z.array(z.unknown()),
 })
 
 export type RegistryLanguage = {
   code: string
+  version?: string
+  hash?: string
 }
 
 export class LanguagePackError extends Error {
@@ -321,14 +346,27 @@ export function hydratePacks(): string[] {
 }
 
 // Install (or replace) a pack: register it and persist. Returns the code.
-export function installPack(codeInput: string, bundle: FlatBundle): string {
+// `meta` records provenance (source) and, for registry packs, the update
+// markers (version/hash) so a later startup can decide whether to refresh
+// without re-downloading. Defaults to a user-sourced pack.
+export function installPack(
+  codeInput: string,
+  bundle: FlatBundle,
+  meta?: { source?: PackSource; version?: string; hash?: string },
+): string {
   const code = normalizeLangCode(codeInput)
   if (code === BASE_LANG) {
     throw new LanguagePackError(
       `"${BASE_LANG}" is the built-in base language and can't be replaced.`,
     )
   }
-  const pack: LanguagePack = { code, bundle }
+  const pack: LanguagePack = {
+    code,
+    bundle,
+    source: meta?.source ?? "user",
+    ...(meta?.version ? { version: meta.version } : {}),
+    ...(meta?.hash ? { hash: meta.hash } : {}),
+  }
   // Re-read before writing so a concurrent install in another tab isn't
   // clobbered by a stale snapshot (lost update on read-modify-write).
   const packs = readStoredPacks()
@@ -403,6 +441,14 @@ export type PackPreview = {
   coverage: number
   keyCount: number
   sample: string[]
+  // Provenance + update markers carried from the loader to commit time, so an
+  // installed registry pack records how to detect a future update.
+  source: PackSource
+  // Manifest-provided version, when the loader had one (registry only).
+  version?: string
+  // Content hash of the bundle (always computed), plus/or a manifest-provided
+  // hash. Used as the update signal when the manifest carries no version.
+  hash: string
 }
 
 // Sample keys shown in the preview so the user sees real translated text before
@@ -415,7 +461,28 @@ const SAMPLE_KEYS = [
   "common.save",
 ] as const
 
-function buildPreview(code: string, bundle: FlatBundle): PackPreview {
+// Order-independent content hash of a flat bundle (FNV-1a over sorted
+// key=value pairs). Cheap and synchronous — used to detect whether a refetched
+// registry pack actually differs from the installed one when no manifest
+// version/hash is available.
+export function hashBundle(bundle: FlatBundle): string {
+  const serialized = Object.keys(bundle)
+    .sort()
+    .map((key) => `${key}=${bundle[key]}`)
+    .join("\u0000")
+  let h = 0x811c9dc5
+  for (let i = 0; i < serialized.length; i++) {
+    h ^= serialized.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return (h >>> 0).toString(16)
+}
+
+function buildPreview(
+  code: string,
+  bundle: FlatBundle,
+  meta?: { source?: PackSource; version?: string; hash?: string },
+): PackPreview {
   const sample = SAMPLE_KEYS.map((key) => bundle[key]).filter(
     (value): value is string => typeof value === "string",
   )
@@ -425,6 +492,11 @@ function buildPreview(code: string, bundle: FlatBundle): PackPreview {
     coverage: coverage(bundle),
     keyCount: Object.keys(bundle).length,
     sample,
+    source: meta?.source ?? "user",
+    ...(meta?.version ? { version: meta.version } : {}),
+    // Prefer a manifest hash when supplied; otherwise fall back to the computed
+    // content hash so we always have an update signal.
+    hash: meta?.hash ?? hashBundle(bundle),
   }
 }
 
@@ -457,10 +529,13 @@ const FETCH_TIMEOUT_MS = 10_000
 
 // Fetch a pack from a URL into a preview. Requires http/https, bounds the
 // response size, times out, and maps every failure to a LanguagePackError. Code
-// is inferred from the URL's last path segment when omitted.
+// is inferred from the URL's last path segment when omitted. Pass
+// `requireHttps` for the unattended auto-refresh path, which (unlike the
+// user-confirmed manual install) must reject cleartext http.
 export async function prepareFromUrl(
   url: string,
   code?: string,
+  options?: { requireHttps?: boolean },
 ): Promise<PackPreview> {
   let parsed: URL
   try {
@@ -470,6 +545,9 @@ export async function prepareFromUrl(
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new LanguagePackError("Only http(s) URLs are supported.")
+  }
+  if (options?.requireHttps && parsed.protocol !== "https:") {
+    throw new LanguagePackError("Only https URLs are supported here.")
   }
 
   const resolved = resolveCode(code, parsed.pathname)
@@ -508,9 +586,45 @@ export async function prepareFromUrl(
 
 // ---- Built-in registry ------------------------------------------------------
 
+// Short-lived memoization of the manifest fetch. Startup auto-refresh and the
+// Browse dialog both hit index.json; without this they'd issue overlapping
+// requests. Only successful results are cached (a failure must not poison later
+// calls), and an in-flight promise is shared so concurrent callers dedupe.
+const REGISTRY_CACHE_TTL_MS = 30_000
+let registryCache: { at: number; langs: RegistryLanguage[] } | null = null
+let registryInFlight: Promise<RegistryLanguage[]> | null = null
+
+// Test-only: clear the memoization so a per-test fetch mock isn't shadowed by a
+// cached result (vitest does not isolate tests within a file). Call in
+// beforeEach/afterEach of any suite that stubs fetch for the registry.
+export function resetRegistryCache(): void {
+  registryCache = null
+  registryInFlight = null
+}
+
+// Fetch the manifest and return the offered language codes, memoized. Invalid
+// entries are skipped; a fetch/parse failure throws LanguagePackError for the
+// UI to show.
+export function fetchRegistry(): Promise<RegistryLanguage[]> {
+  if (registryInFlight) return registryInFlight
+  if (registryCache && Date.now() - registryCache.at < REGISTRY_CACHE_TTL_MS) {
+    return Promise.resolve(registryCache.langs)
+  }
+  const request = fetchRegistryUncached()
+    .then((langs) => {
+      registryCache = { at: Date.now(), langs }
+      return langs
+    })
+    .finally(() => {
+      registryInFlight = null
+    })
+  registryInFlight = request
+  return request
+}
+
 // Fetch the manifest and return the offered language codes. Invalid entries are
 // skipped; a fetch/parse failure throws LanguagePackError for the UI to show.
-export async function fetchRegistry(): Promise<RegistryLanguage[]> {
+async function fetchRegistryUncached(): Promise<RegistryLanguage[]> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
   let res: Response
@@ -561,10 +675,10 @@ export async function fetchRegistry(): Promise<RegistryLanguage[]> {
   for (const entry of parsed.data.languages) {
     const one = registryEntrySchema.safeParse(entry)
     if (!one.success) continue
-    const { code } = one.data
+    const { code, version, hash } = one.data
     if (code === BASE_LANG || seen.has(code)) continue
     seen.add(code)
-    langs.push({ code })
+    langs.push({ code, version, hash })
   }
   return langs
 }
@@ -584,20 +698,165 @@ export async function availableBuiltInLangs(): Promise<RegistryLanguage[]> {
 
 // Preview a registry language by reusing the URL loader (same size/timeout/
 // validation guardrails). The code is explicit so it doesn't rely on inference.
-export async function prepareFromBuiltIn(code: string): Promise<PackPreview> {
+// Pass `requireHttps` for the silent auto-refresh path, and `entry` (the
+// manifest row) to stamp the registry source + version/hash markers onto the
+// preview so a committed pack knows how to detect future updates.
+export async function prepareFromBuiltIn(
+  code: string,
+  options?: { requireHttps?: boolean; entry?: RegistryLanguage },
+): Promise<PackPreview> {
   const resolved = normalizeLangCode(code)
-  return prepareFromUrl(packUrl(resolved), resolved)
+  const preview = await prepareFromUrl(packUrl(resolved), resolved, {
+    requireHttps: options?.requireHttps,
+  })
+  const version = options?.entry?.version
+  const manifestHash = options?.entry?.hash
+  return {
+    ...preview,
+    source: "registry",
+    ...(version ? { version } : {}),
+    // Prefer the manifest hash when present; else keep the computed content hash.
+    hash: manifestHash ?? preview.hash,
+  }
 }
 
 // Install and activate a previewed pack — the only step that mutates
-// localStorage and i18next.
+// localStorage and i18next. Pass the preview's provenance so a registry pack
+// records its source + update markers.
 export async function commitPack(
   code: string,
   bundle: FlatBundle,
+  meta?: { source?: PackSource; version?: string; hash?: string },
 ): Promise<string> {
-  const installed = installPack(code, bundle)
+  const installed = installPack(code, bundle, meta)
   await selectLang(installed)
   return installed
+}
+
+// ---- Auto-refresh + update notifications ------------------------------------
+
+// Listeners notified with the codes of packs updated by refreshInstalledPacks.
+// Bridges the non-React startup refresh to a React toast: startup runs before
+// the app mounts, so any codes updated then are buffered and flushed to the
+// first subscriber (see onPacksUpdated / subscribeToPackUpdates).
+const updateListeners = new Set<(codes: string[]) => void>()
+let pendingUpdatedCodes: string[] = []
+
+function emitPackUpdates(codes: string[]): void {
+  if (codes.length === 0) return
+  if (updateListeners.size === 0) {
+    // No subscriber yet (startup before mount) — buffer for the first one.
+    pendingUpdatedCodes = [...pendingUpdatedCodes, ...codes]
+    return
+  }
+  for (const listener of updateListeners) listener(codes)
+}
+
+// Subscribe to "packs were auto-updated" events. Immediately flushes any codes
+// buffered before the first subscriber mounted. Returns an unsubscribe fn.
+export function subscribeToPackUpdates(
+  onUpdate: (codes: string[]) => void,
+): () => void {
+  updateListeners.add(onUpdate)
+  if (pendingUpdatedCodes.length > 0) {
+    const buffered = pendingUpdatedCodes
+    pendingUpdatedCodes = []
+    onUpdate(buffered)
+  }
+  return () => {
+    updateListeners.delete(onUpdate)
+  }
+}
+
+// Whether the registry copy warrants refetching the pack. Prefer the cheap
+// marker comparison (version, else manifest/stored hash) so an unchanged pack
+// costs no download; fall back to always-fetch only when neither side has a
+// marker (older manifest + older stored pack), where the post-download
+// bundlesEqual check still prevents a needless overwrite.
+function registryPackChanged(
+  installed: LanguagePack,
+  entry: RegistryLanguage,
+): boolean {
+  if (entry.version && installed.version) {
+    return entry.version !== installed.version
+  }
+  if (entry.hash && installed.hash) {
+    return entry.hash !== installed.hash
+  }
+  return true
+}
+
+// Silent background refresh: re-fetch each installed *registry* pack whose
+// registry marker changed and overwrite it in place. Only packs with
+// source==="registry" are eligible — a user's hand-loaded pack is never
+// touched, even when its code also exists in the registry. Every failure
+// (registry unreachable, a single pack fetch, https rejection, hash mismatch)
+// is swallowed so a flaky network never wipes a working pack. Returns the codes
+// actually updated (also emitted to subscribers for a toast). Never changes the
+// active language; installPack -> addResourceBundle live-updates the rendered
+// strings of the active pack.
+export async function refreshInstalledPacks(): Promise<string[]> {
+  const packs = readStoredPacks()
+  const registryPacks = Object.values(packs).filter(
+    (p) => p.source === "registry",
+  )
+  if (registryPacks.length === 0) return []
+
+  let offered: RegistryLanguage[]
+  try {
+    offered = await fetchRegistry()
+  } catch {
+    // Offline / registry unreachable — keep everything as-is.
+    return []
+  }
+  const byCode = new Map(offered.map((l) => [l.code, l]))
+
+  const updated: string[] = []
+  for (const pack of registryPacks) {
+    const entry = byCode.get(pack.code)
+    if (!entry) continue // no longer offered — leave the installed copy.
+    if (!registryPackChanged(pack, entry)) continue // cheap skip, no fetch.
+    try {
+      const preview = await prepareFromBuiltIn(pack.code, {
+        requireHttps: true,
+        entry,
+      })
+      // If a manifest hash was provided, prepareFromBuiltIn already verified
+      // by adopting it; guard the no-marker path against a no-op overwrite.
+      if (bundlesEqual(preview.bundle, pack.bundle)) {
+        // Content identical despite a changed/absent marker — refresh the
+        // stored marker quietly so we stop refetching, but don't toast.
+        installPack(pack.code, pack.bundle, {
+          source: "registry",
+          version: preview.version,
+          hash: preview.hash,
+        })
+        continue
+      }
+      installPack(pack.code, preview.bundle, {
+        source: "registry",
+        version: preview.version,
+        hash: preview.hash,
+      })
+      updated.push(pack.code)
+    } catch {
+      // A single pack failing (fetch, https, validation) must not abort the
+      // rest or wipe the existing pack.
+    }
+  }
+
+  emitPackUpdates(updated)
+  return updated
+}
+
+// Order-independent equality of two flat bundles: same keys, same values.
+function bundlesEqual(a: FlatBundle, b: FlatBundle): boolean {
+  const aKeys = Object.keys(a)
+  if (aKeys.length !== Object.keys(b).length) return false
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false
+  }
+  return true
 }
 
 // ---- Deep-link (?lang=) -----------------------------------------------------
@@ -671,9 +930,14 @@ export async function applyLangFromQuery(): Promise<void> {
 
     // Only honor codes the registry offers, then fetch + install + activate.
     const offered = await fetchRegistry()
-    if (!offered.some((l) => l.code === code)) return
-    const preview = await prepareFromBuiltIn(code)
-    await commitPack(preview.code, preview.bundle)
+    const entry = offered.find((l) => l.code === code)
+    if (!entry) return
+    const preview = await prepareFromBuiltIn(code, { entry })
+    await commitPack(preview.code, preview.bundle, {
+      source: preview.source,
+      version: preview.version,
+      hash: preview.hash,
+    })
   } catch {
     // Invalid code, unavailable pack, or network failure — stay put.
   } finally {

--- a/web/src/i18n/customLocale.ts
+++ b/web/src/i18n/customLocale.ts
@@ -802,6 +802,11 @@ export async function refreshInstalledPacks(): Promise<string[]> {
         requireHttps: true,
         entry,
       })
+      // The per-pack fetch above is an await window in which another tab may
+      // have removed this pack. Re-read storage and skip if it's gone, so we
+      // don't resurrect a pack the user just deleted elsewhere (installPack
+      // does its own read-modify-write and would otherwise re-add the code).
+      if (!(pack.code in readStoredPacks())) continue
       // Content identical despite a changed marker: refresh the stored marker
       // quietly (stop refetching) but don't toast.
       if (bundlesEqual(preview.bundle, pack.bundle)) {

--- a/web/src/i18n/customLocale.ts
+++ b/web/src/i18n/customLocale.ts
@@ -37,20 +37,18 @@ const MAX_REGISTRY_BYTES = 64 * 1024
 // JSON is accepted on input and flattened before validation.
 export type FlatBundle = Record<string, string>
 
-// Where an installed pack came from. Only "registry" packs are eligible for the
-// silent auto-refresh; a user's hand-loaded pack (file/URL) is never touched,
-// even when its code also exists in the registry. Legacy packs stored before
-// this field existed are read as "user" so they're never auto-overwritten.
+// Where an installed pack came from. Only "registry" packs auto-refresh; a
+// user's hand-loaded pack is never touched, even if its code is in the
+// registry. Legacy packs (no source field) read as "user", so never clobbered.
 export type PackSource = "registry" | "user"
 
 export type LanguagePack = {
   code: string
   bundle: FlatBundle
-  // Origin of the pack; defaults to "user" on read for legacy stored packs.
+  // Origin; defaults to "user" on read for legacy stored packs.
   source: PackSource
-  // Update markers for registry packs: the manifest version and/or the pack's
-  // content hash at install time. Used to decide whether a refresh is warranted
-  // (version/hash changed) without re-downloading, and absent for user packs.
+  // Registry-pack update markers captured at install: skip a re-download when
+  // unchanged. Absent for user packs.
   version?: string
   hash?: string
 }
@@ -90,8 +88,7 @@ const storedPacksSchema = z.record(z.string(), packSchema)
 
 // Shape of the registry's index.json: { "languages": [{ "code": "ja" }, ...] }.
 // Unknown/invalid entries are tolerated per-item so one bad row doesn't sink
-// the whole list. `version`/`hash` are optional update markers the publish
-// workflow may add; the app degrades gracefully when they're absent.
+// the whole list. `version`/`hash` are optional update markers.
 const registryEntrySchema = z.object({
   code: langCodeSchema,
   version: z.string().max(200).optional(),
@@ -346,9 +343,7 @@ export function hydratePacks(): string[] {
 }
 
 // Install (or replace) a pack: register it and persist. Returns the code.
-// `meta` records provenance (source) and, for registry packs, the update
-// markers (version/hash) so a later startup can decide whether to refresh
-// without re-downloading. Defaults to a user-sourced pack.
+// `meta` records provenance + registry update markers; defaults to user-sourced.
 export function installPack(
   codeInput: string,
   bundle: FlatBundle,
@@ -441,13 +436,10 @@ export type PackPreview = {
   coverage: number
   keyCount: number
   sample: string[]
-  // Provenance + update markers carried from the loader to commit time, so an
-  // installed registry pack records how to detect a future update.
+  // Provenance + update markers carried from loader to commit time.
   source: PackSource
-  // Manifest-provided version, when the loader had one (registry only).
   version?: string
-  // Content hash of the bundle (always computed), plus/or a manifest-provided
-  // hash. Used as the update signal when the manifest carries no version.
+  // Manifest hash when available, else a computed content hash — always set.
   hash: string
 }
 
@@ -462,9 +454,7 @@ const SAMPLE_KEYS = [
 ] as const
 
 // Order-independent content hash of a flat bundle (FNV-1a over sorted
-// key=value pairs). Cheap and synchronous — used to detect whether a refetched
-// registry pack actually differs from the installed one when no manifest
-// version/hash is available.
+// key=value pairs). The fallback update signal when the manifest has no hash.
 export function hashBundle(bundle: FlatBundle): string {
   const serialized = Object.keys(bundle)
     .sort()
@@ -494,8 +484,7 @@ function buildPreview(
     sample,
     source: meta?.source ?? "user",
     ...(meta?.version ? { version: meta.version } : {}),
-    // Prefer a manifest hash when supplied; otherwise fall back to the computed
-    // content hash so we always have an update signal.
+    // Manifest hash if supplied, else the computed content hash.
     hash: meta?.hash ?? hashBundle(bundle),
   }
 }
@@ -529,9 +518,8 @@ const FETCH_TIMEOUT_MS = 10_000
 
 // Fetch a pack from a URL into a preview. Requires http/https, bounds the
 // response size, times out, and maps every failure to a LanguagePackError. Code
-// is inferred from the URL's last path segment when omitted. Pass
-// `requireHttps` for the unattended auto-refresh path, which (unlike the
-// user-confirmed manual install) must reject cleartext http.
+// is inferred from the URL's last path segment when omitted. `requireHttps`
+// rejects cleartext http (used by the unattended auto-refresh path).
 export async function prepareFromUrl(
   url: string,
   code?: string,
@@ -586,17 +574,15 @@ export async function prepareFromUrl(
 
 // ---- Built-in registry ------------------------------------------------------
 
-// Short-lived memoization of the manifest fetch. Startup auto-refresh and the
-// Browse dialog both hit index.json; without this they'd issue overlapping
-// requests. Only successful results are cached (a failure must not poison later
-// calls), and an in-flight promise is shared so concurrent callers dedupe.
+// Short-lived memoization of the manifest fetch: startup refresh and the Browse
+// dialog both hit index.json. Only successful results cache (a failure must not
+// poison later calls); an in-flight promise dedupes concurrent callers.
 const REGISTRY_CACHE_TTL_MS = 30_000
 let registryCache: { at: number; langs: RegistryLanguage[] } | null = null
 let registryInFlight: Promise<RegistryLanguage[]> | null = null
 
-// Test-only: clear the memoization so a per-test fetch mock isn't shadowed by a
-// cached result (vitest does not isolate tests within a file). Call in
-// beforeEach/afterEach of any suite that stubs fetch for the registry.
+// Test-only: clear the memo so a per-test fetch mock isn't shadowed by a cached
+// result (vitest doesn't isolate tests within a file). Call in beforeEach.
 export function resetRegistryCache(): void {
   registryCache = null
   registryInFlight = null
@@ -697,10 +683,8 @@ export async function availableBuiltInLangs(): Promise<RegistryLanguage[]> {
 }
 
 // Preview a registry language by reusing the URL loader (same size/timeout/
-// validation guardrails). The code is explicit so it doesn't rely on inference.
-// Pass `requireHttps` for the silent auto-refresh path, and `entry` (the
-// manifest row) to stamp the registry source + version/hash markers onto the
-// preview so a committed pack knows how to detect future updates.
+// validation guardrails). Pass `requireHttps` for the silent auto-refresh path,
+// and `entry` (the manifest row) to stamp the registry source + version/hash.
 export async function prepareFromBuiltIn(
   code: string,
   options?: { requireHttps?: boolean; entry?: RegistryLanguage },
@@ -715,14 +699,13 @@ export async function prepareFromBuiltIn(
     ...preview,
     source: "registry",
     ...(version ? { version } : {}),
-    // Prefer the manifest hash when present; else keep the computed content hash.
+    // Manifest hash if present, else the computed content hash.
     hash: manifestHash ?? preview.hash,
   }
 }
 
 // Install and activate a previewed pack — the only step that mutates
-// localStorage and i18next. Pass the preview's provenance so a registry pack
-// records its source + update markers.
+// localStorage and i18next. Pass the preview's provenance/markers.
 export async function commitPack(
   code: string,
   bundle: FlatBundle,
@@ -735,10 +718,9 @@ export async function commitPack(
 
 // ---- Auto-refresh + update notifications ------------------------------------
 
-// Listeners notified with the codes of packs updated by refreshInstalledPacks.
-// Bridges the non-React startup refresh to a React toast: startup runs before
-// the app mounts, so any codes updated then are buffered and flushed to the
-// first subscriber (see onPacksUpdated / subscribeToPackUpdates).
+// Listeners for codes updated by refreshInstalledPacks. Bridges the non-React
+// startup refresh to a toast: startup runs before mount, so codes updated then
+// are buffered and flushed to the first subscriber.
 const updateListeners = new Set<(codes: string[]) => void>()
 let pendingUpdatedCodes: string[] = []
 
@@ -752,8 +734,8 @@ function emitPackUpdates(codes: string[]): void {
   for (const listener of updateListeners) listener(codes)
 }
 
-// Subscribe to "packs were auto-updated" events. Immediately flushes any codes
-// buffered before the first subscriber mounted. Returns an unsubscribe fn.
+// Subscribe to auto-update events, immediately flushing any buffered codes.
+// Returns an unsubscribe fn.
 export function subscribeToPackUpdates(
   onUpdate: (codes: string[]) => void,
 ): () => void {
@@ -768,11 +750,10 @@ export function subscribeToPackUpdates(
   }
 }
 
-// Whether the registry copy warrants refetching the pack. Prefer the cheap
-// marker comparison (version, else manifest/stored hash) so an unchanged pack
-// costs no download; fall back to always-fetch only when neither side has a
-// marker (older manifest + older stored pack), where the post-download
-// bundlesEqual check still prevents a needless overwrite.
+// Whether the registry copy warrants refetching the pack. Compare markers
+// (version, else hash) so an unchanged pack costs no download; with neither
+// marker, fall through to fetch (the post-download bundlesEqual check still
+// prevents a needless overwrite).
 function registryPackChanged(
   installed: LanguagePack,
   entry: RegistryLanguage,
@@ -786,15 +767,11 @@ function registryPackChanged(
   return true
 }
 
-// Silent background refresh: re-fetch each installed *registry* pack whose
-// registry marker changed and overwrite it in place. Only packs with
-// source==="registry" are eligible — a user's hand-loaded pack is never
-// touched, even when its code also exists in the registry. Every failure
-// (registry unreachable, a single pack fetch, https rejection, hash mismatch)
-// is swallowed so a flaky network never wipes a working pack. Returns the codes
-// actually updated (also emitted to subscribers for a toast). Never changes the
-// active language; installPack -> addResourceBundle live-updates the rendered
-// strings of the active pack.
+// Silent background refresh: re-fetch each installed registry pack whose marker
+// changed and overwrite in place. Only source==="registry" packs are eligible.
+// Every failure is swallowed so a flaky network never wipes a working pack.
+// Returns (and emits) the updated codes. Never changes the active language;
+// installPack -> addResourceBundle live-updates the active pack's strings.
 export async function refreshInstalledPacks(): Promise<string[]> {
   const packs = readStoredPacks()
   const registryPacks = Object.values(packs).filter(
@@ -821,11 +798,9 @@ export async function refreshInstalledPacks(): Promise<string[]> {
         requireHttps: true,
         entry,
       })
-      // If a manifest hash was provided, prepareFromBuiltIn already verified
-      // by adopting it; guard the no-marker path against a no-op overwrite.
+      // Content identical despite a changed marker: refresh the stored marker
+      // quietly (stop refetching) but don't toast.
       if (bundlesEqual(preview.bundle, pack.bundle)) {
-        // Content identical despite a changed/absent marker — refresh the
-        // stored marker quietly so we stop refetching, but don't toast.
         installPack(pack.code, pack.bundle, {
           source: "registry",
           version: preview.version,
@@ -840,8 +815,7 @@ export async function refreshInstalledPacks(): Promise<string[]> {
       })
       updated.push(pack.code)
     } catch {
-      // A single pack failing (fetch, https, validation) must not abort the
-      // rest or wipe the existing pack.
+      // One pack failing must not abort the rest or wipe the existing pack.
     }
   }
 

--- a/web/src/i18n/customLocale.ts
+++ b/web/src/i18n/customLocale.ts
@@ -42,6 +42,10 @@ export type FlatBundle = Record<string, string>
 // registry. Legacy packs (no source field) read as "user", so never clobbered.
 export type PackSource = "registry" | "user"
 
+// Provenance + registry update markers carried alongside a pack: from loader to
+// preview to install. Defaults to user-sourced when the source is omitted.
+export type PackMeta = { source?: PackSource; version?: string; hash?: string }
+
 export type LanguagePack = {
   code: string
   bundle: FlatBundle
@@ -347,7 +351,7 @@ export function hydratePacks(): string[] {
 export function installPack(
   codeInput: string,
   bundle: FlatBundle,
-  meta?: { source?: PackSource; version?: string; hash?: string },
+  meta?: PackMeta,
 ): string {
   const code = normalizeLangCode(codeInput)
   if (code === BASE_LANG) {
@@ -471,7 +475,7 @@ export function hashBundle(bundle: FlatBundle): string {
 function buildPreview(
   code: string,
   bundle: FlatBundle,
-  meta?: { source?: PackSource; version?: string; hash?: string },
+  meta?: PackMeta,
 ): PackPreview {
   const sample = SAMPLE_KEYS.map((key) => bundle[key]).filter(
     (value): value is string => typeof value === "string",
@@ -709,7 +713,7 @@ export async function prepareFromBuiltIn(
 export async function commitPack(
   code: string,
   bundle: FlatBundle,
-  meta?: { source?: PackSource; version?: string; hash?: string },
+  meta?: PackMeta,
 ): Promise<string> {
   const installed = installPack(code, bundle, meta)
   await selectLang(installed)

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -46,10 +46,9 @@ void (async () => {
     await i18n.changeLanguage(stored)
   }
   await applyLangFromQuery()
-  // Silently pull any newer registry packs. Runs last so a just-installed
-  // deep-link pack is considered and the active pack's strings live-update.
-  // Swallows its own failures; updated codes surface as a toast via a
-  // subscriber mounted under NotificationProvider (LanguagePackUpdateToaster).
+  // Silently pull any newer registry packs (runs last so a just-installed
+  // deep-link pack is considered and the active pack live-updates). Swallows
+  // its own failures; updated codes toast via LanguagePackUpdateToaster.
   await refreshInstalledPacks()
 })()
 

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -9,6 +9,7 @@ import {
   applyLangFromQuery,
   getStoredLang,
   hydratePacks,
+  refreshInstalledPacks,
 } from "./customLocale"
 
 // Single i18next instance. English is bundled as the base; custom packs are
@@ -45,6 +46,11 @@ void (async () => {
     await i18n.changeLanguage(stored)
   }
   await applyLangFromQuery()
+  // Silently pull any newer registry packs. Runs last so a just-installed
+  // deep-link pack is considered and the active pack's strings live-update.
+  // Swallows its own failures; updated codes surface as a toast via a
+  // subscriber mounted under NotificationProvider (LanguagePackUpdateToaster).
+  await refreshInstalledPacks()
 })()
 
 export default i18n

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -342,7 +342,9 @@
     "errorCodeUndetectable": "Couldn't detect the language code from the file — enter it below and try again.",
     "errorUrlRequired": "Enter a URL to fetch the pack from.",
     "errorRegistry": "Couldn't load the available languages. Try again.",
-    "errorGeneric": "Couldn't install the language pack."
+    "errorGeneric": "Couldn't install the language pack.",
+    "updatedToast_one": "Updated the {{list}} language pack to the latest translations.",
+    "updatedToast_other": "Updated {{count}} language packs ({{list}}) to the latest translations."
   },
   "validation": {
     "githubOrEmailRequired": "Enter a GitHub username or an email.",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import { GitHubClientProviderFromAuth } from "./context/github/GitHubClientProvi
 import { NotificationProvider } from "./context/notifications/NotificationProvider"
 import { ActionActivityProvider } from "./context/actions/ActionActivityProvider"
 import { ActionsBanner } from "./components/status/ActionsBanner"
+import { LanguagePackUpdateToaster } from "./components/settings/LanguagePackUpdateToaster"
 import App from "./App"
 import { appVersion, formatAppVersion } from "./version"
 
@@ -34,6 +35,7 @@ createRoot(document.getElementById("root")!).render(
               <NotificationProvider>
                 <App />
                 <ActionsBanner />
+                <LanguagePackUpdateToaster />
               </NotificationProvider>
             </ActionActivityProvider>
             {import.meta.env.DEV && (


### PR DESCRIPTION
## Summary

Fixes #67 — installed language packs were frozen at install time. Once a registry pack was in `localStorage`, republished translations never reached users without removing and re-adding it. This makes installed **registry** packs quietly stay current.

- **`refreshInstalledPacks()`** runs in the i18n startup chain (after `applyLangFromQuery`, fire-and-forget). For each installed pack it re-fetches from the registry when the marker changed and overwrites in place — without changing the active language.
- **Gated on provenance, not registry membership.** Packs now carry a `source: "registry" | "user"` field; only `"registry"` packs auto-update. A user's hand-loaded `de.json` is never clobbered even when `de` also exists in the registry. Legacy stored packs default to `"user"`.
- **Update signal** is the registry `version`/`hash` marker, with a post-download `bundlesEqual` fallback so nothing is overwritten (or toasted) when content is identical.
- **Silent path is https-only** and swallows every failure (offline, per-pack fetch, validation) so a flaky fetch never wipes a working pack. All existing guardrails (size caps, JSON-shape/BCP-47 validation) still apply.
- **`fetchRegistry()` is memoized** (in-flight + short TTL) with a `resetRegistryCache()` test hook; the manifest schema tolerates optional `version`/`hash`.
- **Toast:** `LanguagePackUpdateToaster` (mounted under `NotificationProvider`) bridges the pre-mount startup refresh to a `success` toast via `subscribeToPackUpdates`, which buffers codes updated before the app mounts. Pluralized `language.updatedToast` strings added to `en.json`.

## Companion change (required for the optimized path)

The registry `index.json` does not yet emit `version`/`hash`. **Today the client falls back to re-fetch-then-diff on each app load** — correct, but it re-downloads each installed registry pack every load (users with no registry packs pay nothing). Once the manifest carries a per-language marker, the client skips unchanged packs without downloading and hash-verifies the ones it fetches.

That producer change lands in `foundation50/classroom50-language-packs` (`publish-pages.yaml`), tracked in #103 with an open PR. This client PR is backward-compatible and can merge independently; the optimization engages automatically once the manifest change deploys.

## Code-review follow-ups (added in this PR)

A multi-agent review of the initial commits surfaced one behavior bug and two clean-ups, all addressed here:

- **Cross-tab resurrection fix** (`684d529`): `refreshInstalledPacks` snapshots the installed packs, then awaits a per-pack fetch before persisting. If another tab removed a pack during that await, `installPack`'s read-modify-write would re-add the code the user just deleted. It now re-reads storage right before persisting and skips a pack that's gone. Covered by a test that deletes the pack mid-fetch and asserts it is neither resurrected nor reported as updated.
- **`PackMeta` type + buffer coverage** (`7a9fd51`): the three verbatim inline `{ source?; version?; hash? }` param shapes (`installPack`, `buildPreview`, `commitPack`) are now a single exported `PackMeta` alias. Added a test for the pre-mount buffer path (emit with no subscriber, then subscribe and flush exactly once) — the primary production path for the toast, previously uncovered.

### Known follow-ups (non-blocking, not in this PR)

- **Multi-tab churn:** every open tab runs the startup refresh, so with several tabs open the same packs are downloaded per tab and each write fans out cross-tab storage events. Wasteful but harmless; a single-tab gate can be added later.
- **Every-startup re-fetch** resolves automatically once #103 makes `index.json` emit `version`/`hash`; until then `bundlesEqual` mutes the overwrite/toast but not the fetch.

## Test plan

- [x] `npm test -- customLocale` — new `refreshInstalledPacks` (incl. cross-tab-removal + pre-mount buffer), memoization, `hashBundle`, and `requireHttps` suites (54 tests in the file).
- [x] `npm run typecheck`, `npm run lint` (no new warnings), prettier.
- [x] Security review: silent path enforces https, only `source==="registry"` refreshed, failures never wipe a pack, no new XSS surface (no `dangerouslySetInnerHTML`/`<Trans>`; registry strings render as escaped React text).
- [ ] Manual: install a registry pack, change its published copy, reload → silent refresh + toast; file-upload a same-code pack → untouched; offline reload → pack still works.