### PR TITLE
ci(web): publish preview to build branch for Actions-based Pages

### DIFF
--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -16,11 +16,9 @@ name: web Deploy to Preview (preview.classroom50.org)
 # production (classroom50.org) and preview must live in different repos. Source
 # stays here; the preview repo holds only the built artifact + its own CNAME.
 #
-# Deploy mechanism: the preview repo uses Actions-based Pages. This workflow
-# force-pushes the built dist/ to the preview repo's `build` branch; a workflow
-# on the preview repo's `main` (deploy-pages.yaml) then publishes it via
-# actions/deploy-pages. (Previously this pushed to the preview repo's `main`,
-# which used legacy branch-based Pages.)
+# Deploy mechanism: the preview repo uses Actions-based Pages. This force-pushes
+# dist/ to the preview repo's `build` branch, and its deploy-pages.yaml (on
+# `main`) publishes it.
 
 on:
   push:
@@ -80,14 +78,11 @@ jobs:
       - name: Write CNAME for preview domain
         run: echo "preview.classroom50.org" > dist/CNAME
 
-      # Publish the built site to the preview repo's `build` branch. The preview
-      # repo uses Actions-based GitHub Pages (build_type: workflow): its
-      # deploy-pages.yaml lives on `main` and triggers on pushes to `build`,
-      # then runs upload-pages-artifact + deploy-pages. Publishing to a separate
-      # branch (not `main`) is required because force_orphan recreates the
-      # branch with ONLY these files — pushing to `main` would delete the
-      # preview repo's deploy workflow. Uses an SSH deploy key (least privilege,
-      # no expiry) with write access to ONLY the preview repo.
+      # Publish dist/ to the preview repo's `build` branch, which triggers its
+      # Actions-based Pages deploy. A separate branch (not `main`) is required:
+      # force_orphan recreates the branch with only these files, which would
+      # delete the preview repo's deploy workflow. Uses an SSH deploy key scoped
+      # to only the preview repo.
       - name: Publish to preview repo
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:

--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -15,6 +15,12 @@ name: web Deploy to Preview (preview.classroom50.org)
 # Why a separate repo: GitHub Pages allows only one custom domain per repo, so
 # production (classroom50.org) and preview must live in different repos. Source
 # stays here; the preview repo holds only the built artifact + its own CNAME.
+#
+# Deploy mechanism: the preview repo uses Actions-based Pages. This workflow
+# force-pushes the built dist/ to the preview repo's `build` branch; a workflow
+# on the preview repo's `main` (deploy-pages.yaml) then publishes it via
+# actions/deploy-pages. (Previously this pushed to the preview repo's `main`,
+# which used legacy branch-based Pages.)
 
 on:
   push:
@@ -74,15 +80,20 @@ jobs:
       - name: Write CNAME for preview domain
         run: echo "preview.classroom50.org" > dist/CNAME
 
-      # Publish the built site to the preview repo's `main` branch (its Pages
-      # source). Uses an SSH deploy key (least privilege, no expiry) that has
-      # write access to ONLY the preview repo.
+      # Publish the built site to the preview repo's `build` branch. The preview
+      # repo uses Actions-based GitHub Pages (build_type: workflow): its
+      # deploy-pages.yaml lives on `main` and triggers on pushes to `build`,
+      # then runs upload-pages-artifact + deploy-pages. Publishing to a separate
+      # branch (not `main`) is required because force_orphan recreates the
+      # branch with ONLY these files — pushing to `main` would delete the
+      # preview repo's deploy workflow. Uses an SSH deploy key (least privilege,
+      # no expiry) with write access to ONLY the preview repo.
       - name: Publish to preview repo
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           deploy_key: ${{ secrets.PREVIEW_DEPLOY_KEY }}
           external_repository: foundation50/classroom50-web-preview
-          publish_branch: main
+          publish_branch: build
           # Repo-root-relative; the build wrote to web/dist.
           publish_dir: ./web/dist
           # Replace the branch contents wholesale each deploy (the preview repo


### PR DESCRIPTION
## Summary

Migrates the preview site (`preview.classroom50.org`) off **legacy branch-based GitHub Pages** and onto an **Actions-based deploy**, then points this repo's preview publish step at the new layout.

- **This repo** (`web-deploy-preview.yaml`): publish the built `dist/` to the preview repo's new **`build`** branch instead of `main`.
- **Preview repo** (`classroom50-web-preview`, changed separately): `main` now holds only a `deploy-pages.yaml` workflow (`actions/checkout@v7` → `configure-pages@v6` → `upload-pages-artifact@v5` → `deploy-pages@v5`) that triggers on pushes to `build`. Pages Source switched to **GitHub Actions**.

### Why
The legacy Pages build spawned auto `pages-build-deployment` runs that could get **stuck/queued indefinitely** and block *all* deployments sharing the account's Pages backend — including the production `classroom50.org` v1.1.0 release, which failed with `Deployment failed, try again later.` Actions-based Pages stops these auto-runs from ever being created.

### Why a separate `build` branch
The publish step uses `force_orphan: true`, which recreates the target branch with **only** the built files. Pushing to `main` would delete the preview repo's `deploy-pages.yaml`. Keeping the workflow on `main` and the artifact on `build` keeps them independent. The preview workflow also sets `include-hidden-files: true` so `.nojekyll` ships (otherwise Jekyll strips the app's underscore-prefixed JS chunks).

## Test plan
- [x] Preview deploy workflow runs green end-to-end (`deploy-pages` succeeds).
- [x] `https://preview.classroom50.org/` serves the app (`<title>Classroom 50</title>`, Vite `assets/index-*.js` + CSS load `200`).
- [x] Underscore-prefixed chunk (`assets/_assignment-*.js`) returns `200` (confirms `.nojekyll` shipped / Jekyll not applied).
- [ ] Next merge to `main` force-pushes to `build` and auto-deploys preview.