### PR TITLE
ci(web): audit i18n keys against en.json in CI

### DIFF
--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -2,6 +2,8 @@ name: web CI
 
 # Quality gate for the web app (web/): type-check, lint, format, tests, and an
 # i18n key audit (missing t() keys fail; dead/hardcoded strings are advisory).
+# The audit tool has its own pytest suite (i18n audit tests) that runs first so
+# a regex regression can't silently turn the audit into a permanent PASS.
 # Blocks merge and can't be bypassed like a local hook. Scoped to web/** so
 # it only runs when the frontend changes, independent of the Go/Python CI.
 #
@@ -66,6 +68,25 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # Unit tests for the i18n audit tool itself. Its detection logic is
+      # entirely regex-driven, so these lock down the source-of-truth behavior
+      # (missing-key hard-fail, --strict flip, key-form capture, plural base,
+      # flatten/PLURAL_SUFFIXES parity with verify_locale.py) on inline
+      # fixtures -- a regex regression that silently stops catching a missing
+      # key fails here before it can turn the gate below into a permanent PASS.
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install audit test deps
+        working-directory: ${{ github.workspace }}
+        run: python -m pip install --quiet pytest
+
+      - name: i18n audit tests
+        working-directory: ${{ github.workspace }}
+        run: python -m pytest web/src/locales/test_audit_i18n.py -v
 
       # i18n coverage gate: fails if any t("...") in the source references a key
       # missing from en.json (those render as a raw key / English fallback in

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -1,6 +1,7 @@
 name: web CI
 
-# Quality gate for the web app (web/): type-check, lint, format, and tests.
+# Quality gate for the web app (web/): type-check, lint, format, tests, and an
+# i18n key audit (missing t() keys fail; dead/hardcoded strings are advisory).
 # Blocks merge and can't be bypassed like a local hook. Scoped to web/** so
 # it only runs when the frontend changes, independent of the Go/Python CI.
 #
@@ -65,3 +66,14 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # i18n coverage gate: fails if any t("...") in the source references a key
+      # missing from en.json (those render as a raw key / English fallback in
+      # every language). Dead keys and hardcoded user-facing strings are printed
+      # as advisory warnings only (default mode, not --strict), so they don't
+      # block merges. Uses the runner's preinstalled python3; the audit has no
+      # third-party deps. Run from the repo root since the script resolves web/src
+      # relative to itself.
+      - name: i18n key audit
+        working-directory: ${{ github.workspace }}
+        run: python3 web/src/locales/audit_i18n.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,11 @@ npm run check   # tsc -b + eslint + prettier + vitest
 npm run dev     # local dev server
 ```
 
+User-facing strings go through `t()` so language packs can translate them, and
+CI audits coverage against `en.json` — see
+[`web/src/locales/README.md`](web/src/locales/README.md) for the `t()`
+conventions the audit expects.
+
 Skeleton scripts (Python):
 
 ```

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -44,6 +44,35 @@ The agent should then:
    silently break a pack. It mirrors the installer's own validation, so a
    passing pack also installs cleanly.
 
+### Auditing coverage in our own code
+
+[`verify_locale.py`](./verify_locale.py) checks a *pack* against `en.json`.
+The complementary direction — checking that **our source code and `en.json`
+agree** — is [`audit_i18n.py`](./audit_i18n.py). Run it to sweep the whole web
+app for coverage problems:
+
+```bash
+python web/src/locales/audit_i18n.py            # report
+python web/src/locales/audit_i18n.py --strict   # also fail on dead/hardcoded
+```
+
+It reports three things:
+
+- **MISSING keys** — a `t("...")` in code whose key isn't in `en.json` (renders
+  the raw key; always a bug). Fails the run.
+- **DEAD keys** — keys in `en.json` no code references, directly or via a bare
+  string constant (`labelKey`/`titleKey`/`what`/`why`/…) or a dynamic
+  `` t(`prefix.${x}`) `` prefix. These waste translator effort — every pack
+  translates a string that never renders. Warning; fails only under `--strict`.
+- **HARDCODED strings** — user-facing literals that bypass i18n entirely
+  (prose in `aria-label`/`alt`/`title`/`placeholder`, or `setError`/`toast`
+  calls), so **no pack can ever translate them.** Heuristic; warning, fails
+  only under `--strict`.
+
+The dead/hardcoded checks are heuristic (indirect references and prose
+detection aren't exact), so they're warnings by default — skim them rather than
+treating every line as a defect.
+
 ### Automated packs (CI)
 
 The target languages in [`targets.json`](./targets.json) are also produced

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -46,7 +46,7 @@ The agent should then:
 
 ### Auditing coverage in our own code
 
-[`verify_locale.py`](./verify_locale.py) checks a *pack* against `en.json`.
+[`verify_locale.py`](./verify_locale.py) checks a _pack_ against `en.json`.
 The complementary direction — checking that **our source code and `en.json`
 agree** — is [`audit_i18n.py`](./audit_i18n.py). Run it to sweep the whole web
 app for coverage problems:
@@ -62,7 +62,7 @@ It reports three things:
   the raw key; always a bug). Fails the run.
 - **DEAD keys** — keys in `en.json` no code references, directly or via a bare
   string constant (`labelKey`/`titleKey`/`what`/`why`/…) or a dynamic
-  `` t(`prefix.${x}`) `` prefix. These waste translator effort — every pack
+  ``t(`prefix.${x}`)`` prefix. These waste translator effort — every pack
   translates a string that never renders. Warning; fails only under `--strict`.
 - **HARDCODED strings** — user-facing literals that bypass i18n entirely
   (prose in `aria-label`/`alt`/`title`/`placeholder`, or `setError`/`toast`

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -44,6 +44,22 @@ The agent should then:
    silently break a pack. It mirrors the installer's own validation, so a
    passing pack also installs cleanly.
 
+### Writing translatable strings
+
+Every user-facing string goes through `t()` so a language pack can translate
+it. The CI audit below is a gate, but it can only see a key when the reference
+is statically analyzable, so keep to these conventions:
+
+- **Reference keys with a literal**, not a fully dynamic variable. The audit
+  sees `t("a.b")`, `t('a.b')`, ``t(`a.b`)``, and literal-prefixed dynamic
+  keys (``t(`a.${x}`)`` or `t("a." + x)`). A fully dynamic `t(someVar)` is
+  **invisible** to the gate — a key referenced only that way can go missing and
+  ship silently. If you must build a key dynamically, keep a literal prefix.
+- **Key segments use `[A-Za-z0-9_.:-]`** (dotted paths, optionally an i18next
+  `ns:` namespace). A key with any other character in a segment won't be seen.
+- **Don't hardcode prose** in `aria-label`/`alt`/`title`/`placeholder` or in
+  `setError`/`toast` calls — those bypass i18n and no pack can translate them.
+
 ### Auditing coverage in our own code
 
 [`verify_locale.py`](./verify_locale.py) checks a _pack_ against `en.json`.

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -59,7 +59,12 @@ python web/src/locales/audit_i18n.py --strict   # also fail on dead/hardcoded
 It reports three things:
 
 - **MISSING keys** — a `t("...")` in code whose key isn't in `en.json` (renders
-  the raw key; always a bug). Fails the run.
+  the raw key; always a bug). Fails the run. Recognizes double/single-quoted and
+  no-interpolation backtick (``t(`foo.bar`)``) keys, hyphenated segments, and
+  `ns:key` namespaces (the namespace is stripped before comparing); a
+  concatenated `t("prefix." + x)` is treated as a dynamic prefix, not a miss.
+  Runs over `.ts`/`.tsx`/`.mts`/`.cts` files. The tool has a pytest suite
+  ([`test_audit_i18n.py`](./test_audit_i18n.py)) that pins this detection logic.
 - **DEAD keys** — keys in `en.json` no code references, directly or via a bare
   string constant (`labelKey`/`titleKey`/`what`/`why`/…) or a dynamic
   ``t(`prefix.${x}`)`` prefix. These waste translator effort — every pack

--- a/web/src/locales/audit_i18n.py
+++ b/web/src/locales/audit_i18n.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Sweep the web app source for i18n coverage problems against en.json.
+
+This is the inverse of verify_locale.py: verify_locale.py checks a *translated
+pack* against en.json, whereas this checks that the *source code* and en.json
+agree. It is meant to be run over the whole codebase to answer "are we missing
+any translation coverage?".
+
+Run from the repo root (or anywhere -- it locates web/src relative to itself):
+
+    python web/src/locales/audit_i18n.py            # human-readable report
+    python web/src/locales/audit_i18n.py --strict   # also exit 1 on dead/hardcoded
+
+It reports three independent things:
+
+  1. MISSING keys  -- a t("...") / i18n.t("...") reference in code whose key is
+     absent from en.json. These render as the raw key (or English fallback) and
+     are always a bug. Fails the run (exit 1).
+
+  2. DEAD keys     -- keys in en.json that no source string literal references,
+     directly or indirectly. "Indirectly" matters: many keys are stored as bare
+     string constants (labelKey/titleKey/what/why/...) and passed to t() later,
+     so we count a key as used if its exact dotted string appears anywhere in the
+     source, and also honour dynamic t(`prefix.${x}`) prefixes. Reported as a
+     warning; only fails under --strict.
+
+  3. HARDCODED strings -- user-facing string literals that bypass i18n entirely
+     (so no language pack can ever translate them): prose in translatable JSX
+     attributes (aria-label/alt/title/placeholder) and plain-string error/toast
+     calls. Heuristic; reported as a warning, only fails under --strict.
+
+Exit code: 0 when clean (no MISSING, and under --strict no DEAD/HARDCODED), else 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# --- locate web/src relative to this file (web/src/locales/audit_i18n.py) ---
+LOCALES_DIR = Path(__file__).resolve().parent
+SRC_DIR = LOCALES_DIR.parent
+EN_FILE = LOCALES_DIR / "en.json"
+
+PLURAL_SUFFIXES = ("_zero", "_one", "_two", "_few", "_many", "_other")
+
+# t("key") / t('key') / i18n.t("key") with a static dotted key
+STATIC_KEY_RE = re.compile(r'\b(?:i18n\.)?t\(\s*["\']([A-Za-z0-9_.]+)["\']')
+# dynamic: t(`prefix.${...}`) -> record the literal prefix so we don't flag its keys
+DYNAMIC_PREFIX_RE = re.compile(r'\b(?:i18n\.)?t\(\s*`([A-Za-z0-9_.]*)\$\{')
+# any dotted string literal in source (catches labelKey/titleKey/what/why consts)
+STRING_LITERAL_RE = re.compile(r'["\']([A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)["\']')
+
+# user-visible attributes whose literal (prose) values bypass i18n
+ATTR_RE = re.compile(
+    r'(?:aria-label|alt|title|placeholder)\s*=\s*"([^"]*[A-Za-z]{2}[^"]*)"'
+)
+# error/toast style calls taking a raw string first arg the user may see
+USERFACING_CALL_RE = re.compile(
+    r'\b(toast(?:\.\w+)?|setError|failDeviceFlow)\s*\(\s*"([^"]*[A-Za-z]{3}[^"]*)"'
+)
+
+# literals that look like code/config, not prose worth translating
+CODEISH_RE = re.compile(r"^[a-z0-9]+(?:[-_/][a-z0-9]+)*$")  # ubuntu-latest, foo_bar
+
+
+def flatten(obj: dict, prefix: str = "") -> dict[str, object]:
+    out: dict[str, object] = {}
+    for key, value in obj.items():
+        dotted = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            out.update(flatten(value, dotted))
+        else:
+            out[dotted] = value
+    return out
+
+
+def base_stem(key: str) -> str:
+    for suffix in PLURAL_SUFFIXES:
+        if key.endswith(suffix):
+            return key[: -len(suffix)]
+    return key
+
+
+def iter_source_files() -> list[Path]:
+    files: list[Path] = []
+    for path in SRC_DIR.rglob("*.ts*"):
+        if path.suffix not in (".ts", ".tsx"):
+            continue
+        if path.name.endswith((".test.ts", ".test.tsx")):
+            continue
+        if "node_modules" in path.parts:
+            continue
+        files.append(path)
+    return files
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(SRC_DIR.parent.parent))
+    except ValueError:
+        return str(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="also fail (exit 1) on dead keys and hardcoded strings",
+    )
+    args = parser.parse_args()
+
+    if not EN_FILE.exists():
+        print(f"error: {EN_FILE} not found", file=sys.stderr)
+        return 2
+
+    en = flatten(json.loads(EN_FILE.read_text(encoding="utf-8")))
+    en_keys = set(en)
+
+    static_keys: set[str] = set()
+    dynamic_prefixes: set[str] = set()
+    literal_strings: set[str] = set()
+    hardcoded: list[tuple[str, int, str]] = []
+
+    for path in iter_source_files():
+        text = path.read_text(encoding="utf-8")
+        for m in STATIC_KEY_RE.finditer(text):
+            static_keys.add(m.group(1))
+        for m in DYNAMIC_PREFIX_RE.finditer(text):
+            if m.group(1):
+                dynamic_prefixes.add(m.group(1))
+        for m in STRING_LITERAL_RE.finditer(text):
+            literal_strings.add(m.group(1))
+        # hardcoded-string heuristics only apply to component files
+        if path.suffix == ".tsx":
+            for i, line in enumerate(text.splitlines(), 1):
+                for m in ATTR_RE.finditer(line):
+                    val = m.group(1).strip()
+                    if CODEISH_RE.match(val):
+                        continue
+                    hardcoded.append((rel(path), i, val))
+        for i, line in enumerate(text.splitlines(), 1):
+            for m in USERFACING_CALL_RE.finditer(line):
+                val = m.group(2)
+                # skip developer-only "must be used within" invariants
+                if "must be used" in val:
+                    continue
+                hardcoded.append((rel(path), i, val))
+
+    # 1) MISSING: statically referenced but absent from en.json (allow plural base)
+    missing = sorted(
+        k
+        for k in static_keys
+        if k not in en_keys
+        and not any(f"{k}{p}" in en_keys for p in PLURAL_SUFFIXES)
+    )
+
+    # 2) DEAD: en.json key whose stem/full form appears in no source literal and
+    #    isn't covered by a dynamic prefix.
+    def is_used(key: str) -> bool:
+        stem = base_stem(key)
+        if key in literal_strings or stem in literal_strings:
+            return True
+        if key in static_keys or stem in static_keys:
+            return True
+        return any(pfx and key.startswith(pfx) for pfx in dynamic_prefixes)
+
+    dead = sorted(k for k in en_keys if not is_used(k))
+
+    # 3) HARDCODED already collected
+    hardcoded.sort()
+
+    print(f"en.json flat keys:          {len(en_keys)}")
+    print(f"static t() keys referenced: {len(static_keys)}")
+    print(f"dynamic t(`prefix`) prefixes: {sorted(dynamic_prefixes) or '(none)'}")
+
+    print(f"\n=== MISSING keys ({len(missing)}) — referenced in code, absent from en.json ===")
+    for k in missing:
+        print(f"  {k}")
+    if not missing:
+        print("  (none)")
+
+    print(f"\n=== DEAD keys ({len(dead)}) — in en.json, no source reference found ===")
+    for k in dead:
+        print(f"  {k}")
+    if not dead:
+        print("  (none)")
+
+    print(f"\n=== HARDCODED user-facing strings ({len(hardcoded)}) — bypass i18n ===")
+    for p, i, s in hardcoded:
+        print(f"  {p}:{i}: {s!r}")
+    if not hardcoded:
+        print("  (none)")
+
+    failed = bool(missing) or (args.strict and (dead or hardcoded))
+    print("\nRESULT:", "FAIL" if failed else "PASS")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/src/locales/audit_i18n.py
+++ b/web/src/locales/audit_i18n.py
@@ -15,7 +15,11 @@ It reports three independent things:
 
   1. MISSING keys  -- a t("...") / i18n.t("...") reference in code whose key is
      absent from en.json. These render as the raw key (or English fallback) and
-     are always a bug. Fails the run (exit 1).
+     are always a bug. Fails the run (exit 1). Quoted, single-quoted, and
+     no-interpolation backtick keys (t(`foo.bar`)) are all recognized, as are
+     hyphenated segments and i18next namespaces (the "ns:" prefix is stripped
+     before comparing, since en.json is flattened without it). A concatenated
+     key (t("prefix." + x)) is treated as a dynamic prefix, not a missing key.
 
   2. DEAD keys     -- keys in en.json that no source string literal references,
      directly or indirectly. "Indirectly" matters: many keys are stored as bare
@@ -45,12 +49,23 @@ LOCALES_DIR = Path(__file__).resolve().parent
 SRC_DIR = LOCALES_DIR.parent
 EN_FILE = LOCALES_DIR / "en.json"
 
+# keep in sync with verify_locale.py
 PLURAL_SUFFIXES = ("_zero", "_one", "_two", "_few", "_many", "_other")
 
-# t("key") / t('key') / i18n.t("key") with a static dotted key
-STATIC_KEY_RE = re.compile(r'\b(?:i18n\.)?t\(\s*["\']([A-Za-z0-9_.]+)["\']')
+# Legal characters in an i18next key: dotted segments, plus '-' (JSON keys allow
+# hyphens) and ':' (the i18next namespace separator, e.g. "common:foo.bar").
+_KEY_CHARS = r"[A-Za-z0-9_.:-]+"
+# The translator call, matched for both quoted and backtick-static keys below.
+# The (?<![.\w]) look-behind rejects any object method named `t` (e.g.
+# `builder.t("a.b")`) so only a bare `t(` or `i18n.t(` translator call matches.
+_T_CALL = r"(?<![.\w])(?:i18n\.)?t\("
+# t("key") / t('key') / i18n.t("key") with a static dotted key.
+STATIC_KEY_RE = re.compile(_T_CALL + r'\s*["\'](' + _KEY_CHARS + r')["\']')
+# t(`key`) with a static dotted key and NO interpolation (a no-${} template
+# literal is idiomatic i18next and must be caught by the MISSING gate too).
+STATIC_BACKTICK_RE = re.compile(_T_CALL + r"\s*`(" + _KEY_CHARS + r")`")
 # dynamic: t(`prefix.${...}`) -> record the literal prefix so we don't flag its keys
-DYNAMIC_PREFIX_RE = re.compile(r'\b(?:i18n\.)?t\(\s*`([A-Za-z0-9_.]*)\$\{')
+DYNAMIC_PREFIX_RE = re.compile(_T_CALL + r"\s*`([A-Za-z0-9_.]*)\$\{")
 # any dotted string literal in source (catches labelKey/titleKey/what/why consts)
 STRING_LITERAL_RE = re.compile(r'["\']([A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)["\']')
 
@@ -85,12 +100,41 @@ def base_stem(key: str) -> str:
     return key
 
 
+def strip_namespace(key: str) -> str:
+    """Drop an i18next namespace prefix (`common:foo.bar` -> `foo.bar`).
+
+    en.json is flattened without a namespace prefix, so a namespaced reference
+    must be compared against the bare key. Only the first ':' separates the
+    namespace; anything after is the key path.
+    """
+    return key.split(":", 1)[1] if ":" in key else key
+
+
+def collect_static_key(raw: str, static_keys: set[str], dynamic_prefixes: set[str]) -> None:
+    """Route a captured static-key token to the right bucket.
+
+    A concatenated key like `t("prefix." + x)` captures the partial token
+    `prefix.` (trailing dot). That is not a real key -- treat it as a dynamic
+    prefix so it neither fires a spurious MISSING nor flags its own keys DEAD.
+    """
+    key = strip_namespace(raw)
+    if key.endswith("."):
+        dynamic_prefixes.add(key)
+    else:
+        static_keys.add(key)
+
+
+SOURCE_SUFFIXES = ("ts", "tsx", "mts", "cts")
+TEST_SUFFIXES = tuple(f".test.{ext}" for ext in SOURCE_SUFFIXES)
+
+
 def iter_source_files() -> list[Path]:
     files: list[Path] = []
-    for path in SRC_DIR.rglob("*.ts*"):
-        if path.suffix not in (".ts", ".tsx"):
-            continue
-        if path.name.endswith((".test.ts", ".test.tsx")):
+    # Glob per suffix so the filesystem walk prunes by name -- rglob("*") would
+    # descend into (and stat) the whole node_modules tree before the guard below
+    # could skip it.
+    for path in (p for ext in SOURCE_SUFFIXES for p in SRC_DIR.rglob(f"*.{ext}")):
+        if path.name.endswith(TEST_SUFFIXES):
             continue
         if "node_modules" in path.parts:
             continue
@@ -128,28 +172,32 @@ def main() -> int:
 
     for path in iter_source_files():
         text = path.read_text(encoding="utf-8")
+        relpath = rel(path)
         for m in STATIC_KEY_RE.finditer(text):
-            static_keys.add(m.group(1))
+            collect_static_key(m.group(1), static_keys, dynamic_prefixes)
+        for m in STATIC_BACKTICK_RE.finditer(text):
+            collect_static_key(m.group(1), static_keys, dynamic_prefixes)
         for m in DYNAMIC_PREFIX_RE.finditer(text):
             if m.group(1):
                 dynamic_prefixes.add(m.group(1))
         for m in STRING_LITERAL_RE.finditer(text):
             literal_strings.add(m.group(1))
-        # hardcoded-string heuristics only apply to component files
-        if path.suffix == ".tsx":
-            for i, line in enumerate(text.splitlines(), 1):
-                for m in ATTR_RE.finditer(line):
-                    val = m.group(1).strip()
-                    if CODEISH_RE.match(val):
-                        continue
-                    hardcoded.append((rel(path), i, val))
+        # Hardcoded JSX-attribute prose can appear in any component-bearing file
+        # (a .ts helper returning JSX via createElement, not just .tsx), so scan
+        # every source file; ATTR_RE is specific enough that non-JSX files match
+        # nothing.
         for i, line in enumerate(text.splitlines(), 1):
+            for m in ATTR_RE.finditer(line):
+                val = m.group(1).strip()
+                if CODEISH_RE.match(val):
+                    continue
+                hardcoded.append((relpath, i, val))
             for m in USERFACING_CALL_RE.finditer(line):
                 val = m.group(2)
                 # skip developer-only "must be used within" invariants
                 if "must be used" in val:
                     continue
-                hardcoded.append((rel(path), i, val))
+                hardcoded.append((relpath, i, val))
 
     # 1) MISSING: statically referenced but absent from en.json (allow plural base)
     missing = sorted(

--- a/web/src/locales/test_audit_i18n.py
+++ b/web/src/locales/test_audit_i18n.py
@@ -1,0 +1,260 @@
+"""Unit tests for audit_i18n.py -- the source-vs-en.json i18n coverage gate.
+
+audit_i18n.py is wired into web CI as a build-blocking check: a t("...") key
+absent from en.json fails the build. Its correctness rests entirely on
+hand-written regexes and set arithmetic, so these tests lock down the
+detection behavior on tiny inline fixtures (rather than the live web/src tree)
+so a future regex tweak that silently stops catching a real missing key --
+turning the gate into a permanent PASS -- fails here first.
+
+Run from the repo root:
+
+    python -m pytest web/src/locales/test_audit_i18n.py
+
+The module is loaded via importlib (not a plain import) because it lives
+outside any package and resolves its paths relative to its own __file__; the
+tests monkeypatch EN_FILE / SRC_DIR onto tmp fixtures so nothing touches the
+real tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+AUDIT_PATH = Path(__file__).resolve().parent / "audit_i18n.py"
+
+
+def _load_audit():
+    spec = importlib.util.spec_from_file_location("audit_i18n", AUDIT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+audit = _load_module("audit_i18n", AUDIT_PATH)
+verify_locale = _load_module("verify_locale", AUDIT_PATH.parent / "verify_locale.py")
+
+
+def _capture(text: str) -> tuple[set[str], set[str]]:
+    """Run the static-key + backtick + dynamic-prefix regexes over `text`,
+    returning (static_keys, dynamic_prefixes) exactly as main() collects them."""
+    static_keys: set[str] = set()
+    dynamic_prefixes: set[str] = set()
+    for m in audit.STATIC_KEY_RE.finditer(text):
+        audit.collect_static_key(m.group(1), static_keys, dynamic_prefixes)
+    for m in audit.STATIC_BACKTICK_RE.finditer(text):
+        audit.collect_static_key(m.group(1), static_keys, dynamic_prefixes)
+    for m in audit.DYNAMIC_PREFIX_RE.finditer(text):
+        if m.group(1):
+            dynamic_prefixes.add(m.group(1))
+    return static_keys, dynamic_prefixes
+
+
+def _run(monkeypatch, tmp_path, en: dict, sources: dict[str, str], *, strict=False):
+    """Point the module at a fixture en.json + src tree and run main().
+
+    `sources` maps a relative path under the fake web/src to file contents.
+    Returns main()'s exit code (0 pass / 1 fail / 2 missing en.json).
+    """
+    src_dir = tmp_path / "web" / "src"
+    locales = src_dir / "locales"
+    locales.mkdir(parents=True)
+    en_file = locales / "en.json"
+    en_file.write_text(json.dumps(en), encoding="utf-8")
+    for relpath, contents in sources.items():
+        p = src_dir / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents, encoding="utf-8")
+
+    monkeypatch.setattr(audit, "SRC_DIR", src_dir)
+    monkeypatch.setattr(audit, "EN_FILE", en_file)
+    monkeypatch.setattr("sys.argv", ["audit_i18n.py"] + (["--strict"] if strict else []))
+    return audit.main()
+
+
+# --------------------------------------------------------------------------
+# STATIC_KEY_RE / STATIC_BACKTICK_RE capture across every supported t() form
+# --------------------------------------------------------------------------
+
+
+class TestKeyCapture:
+    def test_double_quoted(self):
+        assert _capture('t("nav.home")')[0] == {"nav.home"}
+
+    def test_single_quoted(self):
+        assert _capture("t('nav.home')")[0] == {"nav.home"}
+
+    def test_i18n_namespaced_call(self):
+        assert _capture('i18n.t("nav.home")')[0] == {"nav.home"}
+
+    def test_backtick_no_interpolation(self):
+        # A no-${} template literal is idiomatic i18next and MUST be caught.
+        assert _capture("t(`nav.home`)")[0] == {"nav.home"}
+
+    def test_hyphenated_segment(self):
+        assert _capture('t("new-feature.title")')[0] == {"new-feature.title"}
+
+    def test_namespace_prefix_stripped(self):
+        # en.json is flattened without a namespace, so "common:" is stripped.
+        assert _capture('t("common:nav.home")')[0] == {"nav.home"}
+
+    def test_method_call_not_matched(self):
+        # A method named `t` on some other object is NOT the translator.
+        assert _capture('builder.t("a.b")') == (set(), set())
+
+    def test_concatenation_routed_to_dynamic_prefix(self):
+        # t("prefix." + x) captures the partial "prefix." -- treat as a prefix,
+        # never a (spuriously) missing key.
+        static, dynamic = _capture('t("assignments.dynamic." + name)')
+        assert static == set()
+        assert "assignments.dynamic." in dynamic
+
+    def test_interpolated_backtick_is_a_prefix(self):
+        static, dynamic = _capture("t(`classes.filter.${f}`)")
+        assert static == set()
+        assert "classes.filter." in dynamic
+
+    def test_multiline_call(self):
+        # Python \s spans newlines, so a multi-line t() call is captured.
+        assert _capture('t(\n  "nav.home",\n)')[0] == {"nav.home"}
+
+
+# --------------------------------------------------------------------------
+# The build-blocking behavior: a referenced-but-absent key fails the run
+# --------------------------------------------------------------------------
+
+
+class TestMissingGate:
+    def test_missing_key_fails(self, monkeypatch, tmp_path):
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"nav": {"home": "Home"}},
+            sources={"App.tsx": 't("nav.absent")'},
+        )
+        assert code == 1
+
+    def test_present_key_passes(self, monkeypatch, tmp_path):
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"nav": {"home": "Home"}},
+            sources={"App.tsx": 't("nav.home")'},
+        )
+        assert code == 0
+
+    def test_backtick_missing_key_fails(self, monkeypatch, tmp_path):
+        # Regression guard for the false-green backtick escape.
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"nav": {"home": "Home"}},
+            sources={"App.tsx": "t(`nav.absent`)"},
+        )
+        assert code == 1
+
+    def test_concatenation_does_not_false_red(self, monkeypatch, tmp_path):
+        # t("prefix." + x) must NOT be reported as a missing key.
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"nav": {"home": "Home"}},
+            sources={"App.tsx": 't("nav." + which)'},
+        )
+        assert code == 0
+
+    def test_mts_file_is_scanned(self, monkeypatch, tmp_path):
+        # A missing key referenced only from a .mts file must still fail.
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"nav": {"home": "Home"}},
+            sources={"helper.mts": 't("nav.absent")'},
+        )
+        assert code == 1
+
+
+# --------------------------------------------------------------------------
+# Plural-base allowance: t("x.count") is satisfied by x.count_one/_other
+# --------------------------------------------------------------------------
+
+
+class TestPluralBase:
+    def test_plural_base_reference_not_missing(self, monkeypatch, tmp_path):
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"students": {"count_one": "1", "count_other": "{{n}}"}},
+            sources={"App.tsx": 't("students.count")'},
+        )
+        assert code == 0
+
+
+# --------------------------------------------------------------------------
+# --strict flips the exit code for DEAD/HARDCODED-only findings
+# --------------------------------------------------------------------------
+
+
+class TestStrictFlag:
+    def test_dead_key_advisory_by_default(self, monkeypatch, tmp_path):
+        # en.json has an unused key; no MISSING -> PASS without --strict.
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"nav": {"home": "Home", "unused": "x"}},
+            sources={"App.tsx": 't("nav.home")'},
+        )
+        assert code == 0
+
+    def test_dead_key_fails_under_strict(self, monkeypatch, tmp_path):
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            en={"nav": {"home": "Home", "unused": "x"}},
+            sources={"App.tsx": 't("nav.home")'},
+            strict=True,
+        )
+        assert code == 1
+
+
+# --------------------------------------------------------------------------
+# flatten() / PLURAL_SUFFIXES parity with the sibling verify_locale.py.
+# The two copies are intentionally duplicated (both scripts are standalone,
+# zero-import), so guard against silent drift the way translate_locales does.
+# --------------------------------------------------------------------------
+
+
+class TestParityWithVerifyLocale:
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            {},
+            {"a": "1"},
+            {"a": {"b": "2", "c": {"d": "3"}}},
+            {"count_one": "one", "count_other": "many"},
+            {"a": {"b": {"c": {"deep": "leaf"}}}, "top": "value"},
+        ],
+    )
+    def test_flatten_matches_verify_locale(self, obj):
+        assert audit.flatten(obj) == verify_locale.flatten(obj)
+
+    def test_plural_suffixes_match_verify_locale(self):
+        assert audit.PLURAL_SUFFIXES == verify_locale.PLURAL_SUFFIXES
+
+    def test_flatten_matches_on_real_base_locale(self):
+        en_file = AUDIT_PATH.parent / "en.json"
+        raw = json.loads(en_file.read_text(encoding="utf-8"))
+        assert audit.flatten(raw) == verify_locale.flatten(raw)

--- a/web/src/locales/verify_locale.py
+++ b/web/src/locales/verify_locale.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 BASE_FILE = "en.json"
+# keep in sync with audit_i18n.py
 PLURAL_SUFFIXES = ("_zero", "_one", "_two", "_few", "_many", "_other")
 
 


### PR DESCRIPTION
## Summary

- Adds `web/src/locales/audit_i18n.py` — the inverse of the existing `verify_locale.py`. Where `verify_locale.py` checks a *translated pack* against `en.json`, this checks that the **source code and `en.json` agree**, sweeping the whole web app for i18n coverage problems.
- Wires it into the existing **web CI** job (runs on `web/**` changes, uses the runner's preinstalled `python3`, no third-party deps).
- Documents the tool alongside `verify_locale.py` in `web/src/locales/README.md`.

## What it reports

- **MISSING keys** — a `t("...")` in code whose key is absent from `en.json` (renders as a raw key / English fallback in every language). **Blocks the build.**
- **DEAD keys** — keys in `en.json` no code references (directly, via a bare string constant like `labelKey`/`titleKey`, or a dynamic `` t(`prefix.${x}`) `` prefix). These waste translator effort. **Advisory only.**
- **HARDCODED strings** — user-facing literals that bypass i18n entirely (`aria-label`/`alt`/`title`/`placeholder`, `setError`/`toast` calls), which no pack can translate. **Advisory only.**

## Not strict (for now)

CI runs the audit in default mode, so only **MISSING keys fail the build**; dead keys and hardcoded strings print as advisory warnings in the log without blocking merges. Flipping to `--strict` (block on all three) is a one-word change once the current advisory findings are cleaned up.

Current state: **0 missing keys** (green). The run also surfaces 9 dead keys and 5 hardcoded auth strings as warnings — good follow-up cleanup, tracked separately.

## Test plan

- [x] `actionlint .github/workflows/web-ci.yaml` passes
- [x] `python3 web/src/locales/audit_i18n.py` exits 0 on current `main` (no missing keys)
- [x] `--strict` exits 1 (confirms the gate can fail when warranted)
- [ ] Confirm the new **i18n key audit** step is green on this PR's CI run