### PR TITLE
ci: drop the retired preview branch from workflow triggers

### DIFF
--- a/.github/workflows/cli-shared-ci.yaml
+++ b/.github/workflows/cli-shared-ci.yaml
@@ -2,7 +2,7 @@ name: cli-shared CI
 
 on:
   push:
-    branches: [main, preview]
+    branches: [main]
     paths:
       - 'cli/shared/**'
       - '.github/workflows/cli-shared-ci.yaml'

--- a/.github/workflows/gh-student-ci.yaml
+++ b/.github/workflows/gh-student-ci.yaml
@@ -2,7 +2,7 @@ name: gh-student CI
 
 on:
   push:
-    branches: [main, preview]
+    branches: [main]
     paths:
       - 'cli/gh-student/**'
       - 'cli/shared/**'

--- a/.github/workflows/gh-teacher-ci.yaml
+++ b/.github/workflows/gh-teacher-ci.yaml
@@ -2,7 +2,7 @@ name: gh-teacher CI
 
 on:
   push:
-    branches: [main, preview]
+    branches: [main]
     paths:
       - 'cli/gh-teacher/**'
       - 'cli/shared/**'

--- a/.github/workflows/lint-ci.yaml
+++ b/.github/workflows/lint-ci.yaml
@@ -19,7 +19,7 @@ name: lint CI
 
 on:
   push:
-    branches: [main, preview]
+    branches: [main]
     paths:
       - '.github/workflows/**'
       - 'cli/gh-teacher/skeleton/dotgithub/workflows/**'

--- a/.github/workflows/skeleton-scripts-ci.yaml
+++ b/.github/workflows/skeleton-scripts-ci.yaml
@@ -20,7 +20,7 @@ name: embedded-python CI
 
 on:
   push:
-    branches: [main, preview]
+    branches: [main]
     paths:
       - 'cli/gh-teacher/skeleton/dotgithub/scripts/**'
       - 'cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml'

--- a/.github/workflows/translate-locales.yaml
+++ b/.github/workflows/translate-locales.yaml
@@ -23,7 +23,7 @@ name: Translate locales
 
 on:
   push:
-    branches: [main, preview, feat/locale-marker-patch]
+    branches: [main, feat/locale-marker-patch]
     paths:
       - 'web/src/locales/en.json'
       - 'web/src/locales/targets.json'

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -15,7 +15,7 @@ name: web CI
 
 on:
   push:
-    branches: [main, preview]
+    branches: [main]
     paths:
       - 'web/**'
       - 'cli/gh-teacher/skeleton/dotgithub/**'

--- a/.github/workflows/web-release-please.yaml
+++ b/.github/workflows/web-release-please.yaml
@@ -1,7 +1,7 @@
 name: web Release Please
 
 # Automates web-app releases with googleapis/release-please. Day-to-day work
-# lands on `preview`; a release PR merges `preview` -> `main`. This workflow
+# lands on `main` (all PRs merge straight into main). This workflow
 # watches `main` and maintains a *Release PR* that bumps web/package.json +
 # web/CHANGELOG.md from Conventional Commits. Merging that Release PR creates
 # the `web-vX.Y.Z` tag + GitHub Release, which is the single production-release


### PR DESCRIPTION
## Summary
- The `preview` branch has been retired: all PRs now merge straight into `main`, and merging the release-please PR is what cuts a web release.
- Removed `preview` from the push triggers of every workflow that still listed it, so CI no longer references a branch that no longer exists.
- Fixed the stale `preview -> main` release-flow note in the `web-release-please.yaml` header.

### Changed workflows
- `web-ci.yaml`, `skeleton-scripts-ci.yaml`, `lint-ci.yaml`, `gh-teacher-ci.yaml`, `gh-student-ci.yaml`, `cli-shared-ci.yaml`: `branches: [main, preview]` -> `[main]`
- `translate-locales.yaml`: dropped `preview`, kept the unrelated `feat/locale-marker-patch`
- `web-release-please.yaml`: header comment only (no trigger/logic change; already `main`-only)

### Intentionally untouched
- `web-deploy-preview.yaml`: every "preview" there refers to the preview **site** (`preview.classroom50.org`), which already deploys on push to `main`. Behavior is correct as-is.
- `pull_request` triggers were never branch-scoped, so PRs into `main` run CI exactly as before.

## Test plan
- [ ] Confirm each changed workflow still parses (actionlint runs in `lint-ci`).
- [ ] Verify pushes to `main` still trigger the expected workflows.
- [ ] Confirm no workflow is expected to run on a `preview` branch anymore.