### PR TITLE
fix(web): bound GitHub client requests with a default timeout

### DIFF
--- a/web/src/hooks/github/client.test.ts
+++ b/web/src/hooks/github/client.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { DEFAULT_REQUEST_TIMEOUT_MS, createGitHubClient } from "./client"
+
+// Drive aborts with REAL short timeouts, not vitest fake timers: @sinonjs
+// fake-timers doesn't mock AbortSignal.timeout, so advancing would never abort.
+
+// Never settles until its signal aborts — the half-open connection to bound.
+function stubHangingFetch(): void {
+  vi.stubGlobal("fetch", (_url: string, init?: RequestInit) => {
+    const signal = init?.signal
+    return new Promise<Response>((_resolve, reject) => {
+      if (!signal) return
+      if (signal.aborted) {
+        reject(signal.reason)
+        return
+      }
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      })
+    })
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("createGitHubClient request timeout", () => {
+  it("aborts a hung request once the per-request timeout elapses", async () => {
+    stubHangingFetch()
+    const client = createGitHubClient({ token: "t" })
+
+    // A tiny override exercises the real AbortSignal.timeout path fast.
+    await expect(
+      client.request("/rate_limit", { method: "GET", timeoutMs: 20 }),
+    ).rejects.toThrow()
+  })
+
+  it("still aborts when the caller's own signal fires (composition)", async () => {
+    stubHangingFetch()
+    const client = createGitHubClient({ token: "t" })
+    const controller = new AbortController()
+
+    const pending = client.request("/rate_limit", {
+      method: "GET",
+      signal: controller.signal,
+    })
+    controller.abort()
+
+    await expect(pending).rejects.toThrow()
+  })
+
+  it("does not abort when the default timeout is opted out with timeoutMs: 0", async () => {
+    stubHangingFetch()
+    const client = createGitHubClient({ token: "t" })
+
+    let settled = false
+    const pending = client
+      .request("/rate_limit", { method: "GET", timeoutMs: 0 })
+      .then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        },
+      )
+
+    // Opted out and no caller signal, so nothing aborts it.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(settled).toBe(false)
+
+    void pending
+  })
+
+  it("exposes a sane default timeout constant", () => {
+    expect(DEFAULT_REQUEST_TIMEOUT_MS).toBe(15000)
+  })
+})

--- a/web/src/hooks/github/client.ts
+++ b/web/src/hooks/github/client.ts
@@ -1,5 +1,11 @@
 import { GitHubAPIError, readGitHubRateLimitHeaders } from "./errors"
 
+// Bound every request so a half-open GitHub connection can't pin a poll or
+// mutation forever (React Query imposes no request timeout; the banner uses
+// retry:false). Wider than the 5s github.io probes since these are authed API
+// calls.
+export const DEFAULT_REQUEST_TIMEOUT_MS = 15000
+
 export type GitHubClient = {
   request: <T = unknown>(
     path: string,
@@ -15,6 +21,9 @@ export type GitHubRequestOptions = {
   accept?: string
   signal?: AbortSignal
   headers?: Record<string, string>
+  // Composed with `signal`; defaults to DEFAULT_REQUEST_TIMEOUT_MS. Pass a
+  // larger value for a legitimately long call, or `0` to opt out.
+  timeoutMs?: number
 }
 
 // A per-response signal about the token's live state, reported to the provider
@@ -51,12 +60,22 @@ export function createGitHubClient(args: {
       headers["Content-Type"] = "application/json"
     }
 
+    // Abort on whichever fires first: the caller's signal or the timeout. A
+    // timeout surfaces as a rejected fetch, handled like any other rejection.
+    const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    const timeoutSignal =
+      timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined
+    const signal =
+      options.signal && timeoutSignal
+        ? AbortSignal.any([options.signal, timeoutSignal])
+        : (options.signal ?? timeoutSignal)
+
     const res = await fetch(url, {
       method: options.method ?? "GET",
       headers,
       body:
         options.body === undefined ? undefined : JSON.stringify(options.body),
-      signal: options.signal,
+      signal,
       cache: options.method === "GET" ? "no-store" : undefined,
     })
 


### PR DESCRIPTION
## Summary

The shared GitHub REST client (`web/src/hooks/github/client.ts`) issued every `fetch` with no request timeout — only the caller's `AbortSignal`. React Query imposes none either, and the activity-banner poll (`listActiveAndRecentRuns`) and retry POST (`rerunFailedRun`) use `retry: false`, so a slow/half-open connection left a request pending indefinitely with no abort and no retry.

- Add `DEFAULT_REQUEST_TIMEOUT_MS = 15000` and compose it into `requestInternal` via `AbortSignal.timeout(...)` + `AbortSignal.any([...])`, so a hung request aborts on its own while the caller's signal still cancels as before.
- Add an optional `timeoutMs` to `GitHubRequestOptions` to override (larger) or opt out (`0`) for any legitimately long call.
- A timed-out request now rejects, so the banner's retry `onSettled` clears the spinner/disabled state instead of waiting on the optimistic safety timer.

Closes #99.

## Test plan

- [x] New `client.test.ts` covers: hung request aborts at the timeout, caller signal still aborts when composed, `timeoutMs: 0` opts out (stays pending), and the default constant.
  - Drives aborts with real short timeouts rather than fake timers, since vitest/`@sinonjs/fake-timers` does not mock `AbortSignal.timeout` (vitest #3088).
- [x] `tsc -b` clean, `eslint` clean, `vitest run` 676/676 pass.