### PR TITLE
refactor: tighten and clean up source comments across the repo

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -24,37 +24,33 @@ import (
 	"github.com/foundation50/gh-student/internal/ui"
 )
 
-// embeddedShimContent is the universal autograder shim — the same
-// body for every student repo across every classroom and org. The
-// `{{ORG}}` placeholder is substituted at accept time so the
-// reusable-workflow `uses:` line points at the calling org's
-// classroom50 repo.
+// embeddedShimContent is the universal autograder shim — the same body for
+// every student repo across every org. The `{{ORG}}` placeholder is
+// substituted at accept time so the reusable-workflow `uses:` line points at
+// the calling org's classroom50 repo.
 //
-// Source-of-truth lives at cli/gh-student/embed/autograde-shim.yaml
-// so it's a real, lintable YAML file rather than a Go string
-// literal.
+// Source-of-truth lives at cli/gh-student/embed/autograde-shim.yaml so it's a
+// real, lintable YAML file rather than a Go string literal.
 //
-// NOTE: this asset is filesystem-pinned. //go:embed cannot cross
-// directories (no ../) and package main is unimportable, so the accept
-// command (which embeds and writes this shim) must stay at the module
-// root — it is the principled terminus of the gh-student package
-// extraction, not unfinished work. Do NOT "finish" the refactor by
-// moving the embed tree into internal/*. See
+// NOTE: this asset is filesystem-pinned. //go:embed can't cross directories
+// (no ../) and package main is unimportable, so the accept command (which
+// embeds and writes this shim) must stay at the module root — the principled
+// terminus of the package extraction, not unfinished work. Do NOT "finish"
+// the refactor by moving the embed tree into internal/*. See
 // docs/solutions/architecture-patterns/embed-terminus-and-build-as-oracle-in-go-package-extraction.md
 //
 //go:embed embed/autograde-shim.yaml
 var embeddedShimContent string
 
-// shimOrgPlaceholder: substituted in embeddedShimContent at accept
-// time so each student repo's shim references the correct org's
-// reusable autograde-runner workflow.
+// shimOrgPlaceholder is substituted in embeddedShimContent at accept time so
+// each student repo's shim references the correct org's reusable
+// autograde-runner workflow.
 const shimOrgPlaceholder = "{{ORG}}"
 
-// renderEmbeddedShim returns the embedded shim with the org
-// placeholder substituted. The shim never changes after accept —
-// runtime customization, runner edits, and teacher overrides all
-// flow through the runner workflow + assignments.json on the
-// teacher's side.
+// renderEmbeddedShim returns the embedded shim with the org placeholder
+// substituted. The shim never changes after accept — runtime customization,
+// runner edits, and teacher overrides all flow through the runner workflow +
+// assignments.json on the teacher's side.
 func renderEmbeddedShim(org string) string {
 	return strings.ReplaceAll(embeddedShimContent, shimOrgPlaceholder, org)
 }
@@ -115,7 +111,7 @@ func acceptCmd() *cobra.Command {
 			}
 
 			// The --key access key is the classroom's optional capability-URL
-			// secret. Validate it before any network call so a typo fails fast
+			// secret. Validate before any network call so a typo fails fast
 			// instead of surfacing as a confusing 404.
 			secret := strings.TrimSpace(key)
 			if secret != "" {
@@ -226,10 +222,9 @@ func acceptOrgInvite(client githubapi.Client, org string) (AcceptStatus, error) 
 	return AcceptStatus{StatusCode: http.StatusOK}, nil
 }
 
-// checkAcceptableMode gates `gh student accept` by assignment mode.
-// Both individual and group are accepted (and an empty mode defaults to
-// individual); only an unrecognized mode is rejected. Pure helper so the
-// lifted group seam is unit-testable.
+// checkAcceptableMode gates `gh student accept` by assignment mode: individual
+// and group (and empty, defaulting to individual) are accepted; only an
+// unrecognized mode is rejected. Pure helper so the group seam is unit-testable.
 func checkAcceptableMode(assignment, mode string) error {
 	if mode != "" && mode != contract.ModeIndividual && mode != contract.ModeGroup {
 		return fmt.Errorf("assignment %q has unsupported mode %q", assignment, mode)
@@ -248,11 +243,11 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	}
 	acceptedAt := time.Now().UTC().Format(time.RFC3339)
 
-	// 1) Look up the assignment entry on the published Pages site (no token;
-	//    publish-pages keeps the JSON public). The entry carries the template
-	//    ref, mode, and autograder ref. `secret` (the --key value) selects the
-	//    `<classroom>/<secret>/...` path for a protected classroom, else "";
-	//    it must arrive via --key since students can't read the config repo.
+	// 1) Look up the assignment entry on the public Pages site (no token).
+	//    The entry carries the template ref, mode, and autograder ref.
+	//    `secret` (the --key value) selects the `<classroom>/<secret>/...`
+	//    path for a protected classroom, else "" — it must arrive via --key
+	//    since students can't read the config repo.
 	lookup := u.Spinner(fmt.Sprintf("Looking up %s in %s/%s", assignment, org, classroom))
 	lookup.Start()
 	entry, err := assignments.FetchEntry(cmd.Context(), org, classroom, secret, assignment)
@@ -261,27 +256,25 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 		return err
 	}
 	lookup.Stop(fmt.Sprintf("Found assignment %s", assignment))
-	// Group assignments are accepted normally by the first accepter:
-	// the repo is created under their name and they add teammates with
-	// `gh student invite <org>/<repo> <teammate>`. Only an unknown mode
-	// is rejected.
+	// The first accepter accepts a group assignment normally: the repo is
+	// created under their name and they add teammates via
+	// `gh student invite <org>/<repo> <teammate>`. Only an unknown mode errors.
 	if err := checkAcceptableMode(assignment, entry.Mode); err != nil {
 		return err
 	}
-	// A template, when present, must be complete. A template-less
-	// assignment (no template block) is accepted as an empty repo
-	// carrying only the autograder shim — see the hasTemplate fork below.
+	// A template, when present, must be complete. A template-less assignment
+	// (no template block) is accepted as an empty repo carrying only the
+	// autograder shim — see the hasTemplate fork below.
 	hasTemplate := entry.HasTemplate()
 	if entry.Template != nil && !hasTemplate {
 		return fmt.Errorf("assignment %q has an incomplete template ref (owner=%q repo=%q branch=%q) — ask your instructor to re-run `gh teacher assignment add`",
 			assignment, entry.Template.Owner, entry.Template.Repo, entry.Template.Branch)
 	}
 
-	// 2) Resolve the autograder shim *before* creating the
-	//    assignment repo so a non-default-autograder fetch failure
-	//    doesn't leave a half-baked repo on the teacher's org. The
-	//    default autograder uses the embedded shim (no Pages
-	//    fetch); other names fetch from Pages.
+	// 2) Resolve the autograder shim *before* creating the repo so a
+	//    non-default-autograder fetch failure doesn't leave a half-baked repo
+	//    on the teacher's org. The default autograder uses the embedded shim
+	//    (no Pages fetch); other names fetch from Pages.
 	autograderName := entry.ResolveAutograder()
 	var shim string
 	if autograderName == contract.DefaultAutograderName {
@@ -294,12 +287,12 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 		shim = workflow.Content
 	}
 
-	// 3) Create the assignment repo (templated → generate; template-less
-	//    → empty auto-init'd). Already-exists is NOT a terminal
-	//    short-circuit: a prior accept may have created the repo but died
-	//    before landing the control files (seeding lag, transient 5xx,
-	//    Ctrl-C), leaving a repo that looks accepted but never autogrades.
-	//    The probe below heals that. Mirrors the GUI's accept.
+	// 3) Create the assignment repo (templated → generate; template-less →
+	//    empty auto-init'd). Already-exists is NOT a terminal short-circuit: a
+	//    prior accept may have created the repo but died before landing the
+	//    control files (seeding lag, transient 5xx, Ctrl-C), leaving a repo
+	//    that looks accepted but never autogrades. The probe below heals that.
+	//    Mirrors the GUI's accept.
 	var (
 		htmlURL        string
 		fullName       string
@@ -313,10 +306,9 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	if hasTemplate {
 		htmlURL, fullName, alreadyExisted, err = createTemplatedPrivateAssignmentRepoInOrg(client, u, verbose, username, classroom, assignment, org, *entry.Template)
 		commitBranch = entry.Template.Branch
-		// Resolve the template owner's immutable id best-effort: a rename of
-		// the template org/user shouldn't break submit's instructor-file
-		// re-fetch. A failed lookup is non-fatal — leave owner_id null rather
-		// than abort the accept.
+		// Resolve the template owner's immutable id best-effort so a rename
+		// of the template org/user doesn't break submit's instructor-file
+		// re-fetch. A failed lookup is non-fatal — leave owner_id null.
 		templateOwnerID := lookupUserID(client, entry.Template.Owner)
 		if templateOwnerID == nil && verbose {
 			u.Detail("could not resolve template owner id for %q; recording source.owner_id as null", entry.Template.Owner)
@@ -361,8 +353,8 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 
 // acceptRepoParams carries the post-create inputs acceptIntoRepo needs.
 // Splitting this tail out of acceptAssignment makes the self-heal fork
-// testable end-to-end against an httptest GitHub server, without the
-// Pages fetch acceptAssignment does up front.
+// testable end-to-end against an httptest GitHub server, without the up-front
+// Pages fetch.
 type acceptRepoParams struct {
 	org, classroom, assignment string
 	secret                     string
@@ -378,18 +370,17 @@ type acceptRepoParams struct {
 }
 
 // acceptIntoRepo decides whether a just-created-or-existing repo needs
-// provisioning, runs the idempotent provisioning when it does, and emits
-// the final report. It is the self-healing fork:
+// provisioning, runs the idempotent provisioning when it does, and emits the
+// final report. It is the self-healing fork:
 //
-//   - alreadyExisted + marker present → genuinely already accepted, leave
-//     untouched and short-circuit.
-//   - alreadyExisted + marker missing → a half-finished prior accept;
-//     re-run the idempotent provisioning to repair it.
+//   - alreadyExisted + marker present → already accepted, leave untouched.
+//   - alreadyExisted + marker missing → half-finished prior accept; re-run
+//     the idempotent provisioning to repair it.
 //   - freshly created → provision normally.
 func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writer, p acceptRepoParams) error {
-	// An existing repo with its .classroom50.yaml present is genuinely
-	// already accepted — leave it untouched. A missing marker means a
-	// half-finished prior accept; fall through to re-provision and repair.
+	// An existing repo with .classroom50.yaml present is already accepted —
+	// leave it untouched. A missing marker means a half-finished prior
+	// accept; fall through to re-provision and repair.
 	if p.alreadyExisted {
 		provisioned, perr := repoFileExists(client, p.org, p.repoName, classroomcfg.MetadataPath)
 		if perr != nil {
@@ -400,10 +391,9 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
 			return reportAlreadyAccepted(u, out, p.fullName, p.htmlURL)
 		}
-		// The ✓ here marks the completed probe (setup found incomplete),
-		// not the repair — the following setup spinner reports that with
-		// its own ✓/✗, so a failed re-provision isn't preceded by a
-		// success glyph for work that hadn't happened yet.
+		// The ✓ here marks the completed probe (setup found incomplete), not
+		// the repair — the following setup spinner reports that with its own
+		// ✓/✗, so a failed re-provision isn't preceded by a success glyph.
 		p.createSp.Stop(fmt.Sprintf("Found incomplete setup: %s", p.fullName))
 	} else {
 		p.createSp.Stop(fmt.Sprintf("Created %s", p.fullName))
@@ -442,22 +432,21 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 //  3. Verify the accept marker is readable before declaring success, so
 //     "accepted" always means "will autograde".
 //
-// It reads its inputs from the caller's acceptRepoParams plus the built
-// config; the single caller (acceptIntoRepo) covers both the fresh-create
-// and heal paths. Mirrors the GUI's provisionAcceptedRepo so the CLI and
-// GUI heal a half-finished accept identically.
+// The single caller (acceptIntoRepo) covers both the fresh-create and heal
+// paths. Mirrors the GUI's provisionAcceptedRepo so CLI and GUI heal a
+// half-finished accept identically.
 func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p acceptRepoParams, cfg classroomcfg.Config) error {
-	// Founder stays repo `admin` (upsert) so they can manage collaborators
-	// — a group founder adds teammates via `gh student invite`, which only
-	// an admin can do. The org-level lockdown in `gh teacher init`
-	// defangs the admin's delete/transfer/visibility powers org-wide.
+	// Founder stays repo `admin` (upsert) so they can manage collaborators —
+	// a group founder adds teammates via `gh student invite`, which only an
+	// admin can do. The org-level lockdown in `gh teacher init` defangs the
+	// admin's delete/transfer/visibility powers org-wide.
 	if err := inviteUserAsAdmin(client, u, verbose, p.username, p.org, p.repoName); err != nil {
 		return err
 	}
 
 	// DropFiles lands both control files in one Tree commit, waiting out
-	// GitHub's post-create replication lag; the spinner animates
-	// throughout (no numeric counter — the wait has no guaranteed bound).
+	// GitHub's post-create replication lag; the spinner animates throughout
+	// (no numeric counter — the wait has no guaranteed bound).
 	const setupMsg = "Setting up autograder and metadata"
 	setupSp := u.Spinner(setupMsg)
 	setupSp.Start()
@@ -471,24 +460,23 @@ func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p ac
 			classroomcfg.MetadataPath, classroomcfg.AutogradeWorkflowPath, p.org, p.repoName, p.autograderName)
 	}
 
-	// Read-back: a successful commit PATCH isn't proof the repo is
-	// readable yet, so confirm the marker before reporting accepted.
+	// Read-back: a successful commit PATCH isn't proof the repo is readable
+	// yet, so confirm the marker before reporting accepted.
 	if err := verifyProvisioned(client, p.org, p.repoName); err != nil {
 		return err
 	}
 	return nil
 }
 
-// verifyProvisioned confirms the repo is autogradable before accept
-// reports success. DropFiles lands both control files in ONE atomic Tree
-// commit, so checking the accept marker (.classroom50.yaml) alone is
-// sufficient.
+// verifyProvisioned confirms the repo is autogradable before accept reports
+// success. DropFiles lands both control files in ONE atomic Tree commit, so
+// checking the accept marker (.classroom50.yaml) alone is sufficient.
 //
-// The read-back uses the CONTENTS API, which can briefly lag the
-// just-landed git-data commit (the same eventual-consistency window
-// WaitForStableBranch absorbs on the branches API). So a single 404 is
-// not definitive: poll with a short backoff and only fail — with an
-// actionable, idempotent-re-run hint — when the marker is still missing.
+// The read-back uses the CONTENTS API, which can briefly lag the just-landed
+// git-data commit (the eventual-consistency window WaitForStableBranch
+// absorbs on the branches API). So a single 404 isn't definitive: poll with a
+// short backoff and only fail — with an actionable re-run hint — when the
+// marker is still missing.
 func verifyProvisioned(client githubapi.Client, org, repoName string) error {
 	var lastErr error
 	for attempt := range verifyProvisionAttempts {
@@ -508,16 +496,16 @@ func verifyProvisioned(client githubapi.Client, org, repoName string) error {
 	return lastErr
 }
 
-// verifyProvisionAttempts / verifyProvisionBackoff bound the read-back
-// poll (~4s total). Vars, not consts, so tests can shrink the backoff.
+// verifyProvisionAttempts / verifyProvisionBackoff bound the read-back poll
+// (~4s total). Vars, not consts, so tests can shrink the backoff.
 var (
 	verifyProvisionAttempts = 5
 	verifyProvisionBackoff  = 400 * time.Millisecond
 )
 
-// repoFileExists reports whether `path` is readable on org/repoName via
-// the contents API. 404 → false; other errors propagate so a transient
-// failure isn't misread as "missing".
+// repoFileExists reports whether `path` is readable on org/repoName via the
+// contents API. 404 → false; other errors propagate so a transient failure
+// isn't misread as "missing".
 func repoFileExists(client githubapi.Client, org, repoName, path string) (bool, error) {
 	apiPath := fmt.Sprintf("repos/%s/%s/contents/%s",
 		url.PathEscape(org), url.PathEscape(repoName), classroomcfg.EscapeContentPath(path))
@@ -531,9 +519,8 @@ func repoFileExists(client githubapi.Client, org, repoName, path string) (bool, 
 }
 
 // classroomFromRepo recovers the classroom slug from a derived repo name
-// (<classroom>-<assignment>-<username>) for the re-run hint. Best-effort:
-// the hint is advisory, so a non-conforming name just yields the repo
-// name's leading segment.
+// (<classroom>-<assignment>-<username>) for the re-run hint. Best-effort: the
+// hint is advisory, so a non-conforming name yields the leading segment.
 func classroomFromRepo(repoName string) string {
 	if i := strings.IndexByte(repoName, '-'); i > 0 {
 		return repoName[:i]
@@ -555,17 +542,16 @@ func is422AlreadyExists(httpErr *githubapi.HTTPError) bool {
 	return false
 }
 
-// reportAccepted: success header + clone instructions on stdout
+// reportAccepted writes the success header + clone instructions on stdout
 // (machine-stable, scriptable). The per-step spinners already rendered
-// the human-channel progress, so this doesn't duplicate the headline
-// onto stderr.
+// human-channel progress, so this doesn't duplicate the headline onto stderr.
 func reportAccepted(u *ui.UI, out io.Writer, fullName, htmlURL string) error {
 	_, _ = fmt.Fprintf(out, "Assignment accepted: %s\n\n", fullName)
 	return printCloneInstructions(u, out, htmlURL)
 }
 
-// reportAlreadyAccepted: re-run message; the existing repo is
-// never touched.
+// reportAlreadyAccepted writes the re-run message; the existing repo is never
+// touched.
 func reportAlreadyAccepted(u *ui.UI, out io.Writer, fullName, htmlURL string) error {
 	_, _ = fmt.Fprintf(out, "Assignment already accepted: %s\n\n", fullName)
 	_, _ = fmt.Fprintln(out, "Your existing repository contains your latest submissions and commits.")
@@ -573,8 +559,8 @@ func reportAlreadyAccepted(u *ui.UI, out io.Writer, fullName, htmlURL string) er
 	return printCloneInstructions(u, out, htmlURL)
 }
 
-// printCloneInstructions: clone block on stdout (scriptable); warns on
-// the human channel if cwd is inside a Git repo (nested clones are
+// printCloneInstructions writes the clone block on stdout (scriptable) and
+// warns on the human channel if cwd is inside a Git repo (nested clones are
 // confusing).
 func printCloneInstructions(u *ui.UI, out io.Writer, htmlURL string) error {
 	root, insideRepo, err := localgit.CurrentGitRoot()
@@ -594,8 +580,8 @@ func printCloneInstructions(u *ui.UI, out io.Writer, htmlURL string) error {
 
 // lookupUserID resolves a GitHub login to its immutable numeric id via
 // GET /users/{username}, best-effort: any failure (404, transient 5xx,
-// rate-limit) returns nil so the caller records owner_id as null rather
-// than aborting the accept.
+// rate-limit) returns nil so the caller records owner_id as null rather than
+// aborting the accept.
 func lookupUserID(client githubapi.Client, username string) *int64 {
 	var user struct {
 		ID int64 `json:"id"`
@@ -618,12 +604,11 @@ type GeneratedRepo struct {
 	HasWiki     bool `json:"has_wiki"`
 }
 
-// createTemplatedPrivateAssignmentRepoInOrg generates a private
-// repo from the entry's template and disables
-// issues/projects/wiki. 404 on generate → cross-org visibility
-// message (template not readable by the student).
-// 422-already-exists → alreadyExisted=true and the PATCH is skipped
-// so re-runs don't disturb an existing repo.
+// createTemplatedPrivateAssignmentRepoInOrg generates a private repo from the
+// entry's template and disables issues/projects/wiki. 404 on generate →
+// cross-org visibility message (template not readable by the student).
+// 422-already-exists → alreadyExisted=true and the PATCH is skipped so
+// re-runs don't disturb an existing repo.
 func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, verbose bool, username, classroom, assignment, org string, tmpl assignments.TemplateRef) (htmlURL, fullName string, alreadyExisted bool, err error) {
 	newRepoName := reponame.Name(classroom, assignment, username)
 	createBody, err := json.Marshal(map[string]any{
@@ -681,16 +666,15 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 	return updated.HTMLURL, updated.FullName, false, nil
 }
 
-// createEmptyPrivateAssignmentRepoInOrg creates an empty private repo for
-// a template-less assignment via POST /orgs/{org}/repos with
-// auto_init:true (mirroring gh-teacher's ensureConfigRepo). auto_init is
-// load-bearing: it gives the repo an initial commit + default branch so
-// the shared WaitForStableBranch poll and the fresh-repo Tree-commit
-// retry both work unchanged. Returns the repo's default_branch so the
-// caller commits the shim onto the right ref. issues/projects/wiki are
-// disabled like the templated path. 422-already-exists →
-// alreadyExisted=true and the PATCH is skipped so re-runs don't disturb
-// an existing repo.
+// createEmptyPrivateAssignmentRepoInOrg creates an empty private repo for a
+// template-less assignment via POST /orgs/{org}/repos with auto_init:true
+// (mirroring gh-teacher's ensureConfigRepo). auto_init is load-bearing: it
+// gives the repo an initial commit + default branch so the shared
+// WaitForStableBranch poll and the fresh-repo Tree-commit retry both work
+// unchanged. Returns the repo's default_branch so the caller commits the shim
+// onto the right ref. issues/projects/wiki are disabled like the templated
+// path. 422-already-exists → alreadyExisted=true and the PATCH is skipped so
+// re-runs don't disturb an existing repo.
 func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, verbose bool, username, classroom, assignment, org string) (htmlURL, fullName, defaultBranch string, alreadyExisted bool, err error) {
 	newRepoName := reponame.Name(classroom, assignment, username)
 	createBody, err := json.Marshal(map[string]any{
@@ -742,12 +726,11 @@ func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, ve
 
 // defaultBranchOrMain guards against an empty default_branch in the
 // create/GET response. The templated path takes its branch from the
-// (HasTemplate-guaranteed non-empty) template ref; the empty-repo path
-// has no such guarantee, so an empty value here would flow into
-// WaitForStableBranch("") and 404-loop to an opaque "did not stabilize"
-// failure, leaving a created-but-shimless repo. "main" is GitHub's
-// default for an auto_init repo and matches what `gh student submit`
-// pushes to.
+// (HasTemplate-guaranteed non-empty) template ref; the empty-repo path has no
+// such guarantee, so an empty value would flow into WaitForStableBranch("")
+// and 404-loop to an opaque "did not stabilize" failure, leaving a
+// created-but-shimless repo. "main" is GitHub's default for an auto_init repo
+// and matches what `gh student submit` pushes to.
 func defaultBranchOrMain(branch string) string {
 	if branch == "" {
 		return "main"
@@ -760,8 +743,8 @@ func defaultBranchOrMain(branch string) string {
 // Admin (not maintain) is required because only an admin can manage
 // collaborator access — a group founder uses `gh student invite` to add
 // teammates. The org-level member-privilege lockdown in `gh teacher init`
-// removes the org-wide danger of repo-admin (no delete/transfer/
-// visibility change), so admin-on-own-repo is safe.
+// removes the org-wide danger of repo-admin (no delete/transfer/visibility
+// change), so admin-on-own-repo is safe.
 func inviteUserAsAdmin(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName string) error {
 	if _, err := githubapi.SetCollaborator(client, org, repoName, username, "admin"); err != nil {
 		return err

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -233,9 +233,9 @@ func TestCreateEmptyPrivateAssignmentRepoInOrg(t *testing.T) {
 	})
 }
 
-// repoFileExists underpins the self-healing branch (probe
-// .classroom50.yaml on an already-existing repo) and the post-provision
-// verification. 200 -> true, 404 -> false, other statuses -> error.
+// repoFileExists underpins the self-healing branch (probe .classroom50.yaml on
+// an already-existing repo) and the post-provision verification. 200 → true,
+// 404 → false, other statuses → error.
 func TestRepoFileExists(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -279,12 +279,11 @@ func TestRepoFileExists(t *testing.T) {
 }
 
 // verifyProvisioned passes when the accept marker (.classroom50.yaml) is
-// readable. DropFiles lands it and the autograde workflow in one atomic
-// Tree commit, so the marker's presence implies the workflow's; checking
-// the marker alone is the contract. The read-back polls through the
-// contents API's post-commit consistency lag, so a marker that is missing
-// on the first read but present on a retry succeeds; a persistently
-// missing marker fails with an actionable re-run hint.
+// readable. DropFiles lands it and the autograde workflow in one atomic Tree
+// commit, so the marker's presence implies the workflow's. The read-back polls
+// through the contents API's post-commit consistency lag: a marker missing on
+// the first read but present on a retry succeeds; a persistently missing one
+// fails with an actionable re-run hint.
 func TestVerifyProvisioned(t *testing.T) {
 	const repo = "cs-principles-hello-alice"
 
@@ -343,14 +342,12 @@ func TestVerifyProvisioned(t *testing.T) {
 	})
 }
 
-// TestAcceptIntoRepo_SelfHealFork is the end-to-end test of accept's
-// headline self-healing behavior — the fork the code review flagged as
-// uncovered. It exercises acceptIntoRepo (the post-create tail of
-// acceptAssignment, split out so it can be driven without the up-front
-// Pages fetch) against an httptest GitHub server, asserting both
-// branches: an already-provisioned repo is left untouched, and a
-// half-provisioned one is repaired by re-running the idempotent
-// provisioning.
+// TestAcceptIntoRepo_SelfHealFork is the end-to-end test of accept's headline
+// self-healing behavior. It drives acceptIntoRepo (the post-create tail of
+// acceptAssignment, split out so it runs without the up-front Pages fetch)
+// against an httptest GitHub server, asserting both branches: an
+// already-provisioned repo is left untouched, and a half-provisioned one is
+// repaired by re-running the idempotent provisioning.
 func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 	const (
 		org      = "o"
@@ -482,8 +479,7 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 			t.Errorf("heal path must re-provision (collaboratorPut=%v treeWrite=%v refPatched=%v)", collaboratorPut, treeWrite, refPatched)
 		}
 		// The marker is probed for the fork decision (1) and again by the
-		// post-provision verifyProvisioned (>=1), so it must be read more
-		// than once.
+		// post-provision verifyProvisioned (>=1), so it must be read >1 time.
 		if markerReads < 2 {
 			t.Errorf("expected the marker to be re-read after provisioning, got %d read(s)", markerReads)
 		}

--- a/cli/gh-student/accept_shim_test.go
+++ b/cli/gh-student/accept_shim_test.go
@@ -6,15 +6,13 @@ import (
 )
 
 func TestRenderEmbeddedShim(t *testing.T) {
-	// The embedded shim is the universal one-body-fits-all that
-	// gh student accept drops into every student repo. {{ORG}} is
-	// the only piece of per-classroom customization; everything
-	// else is fixed.
+	// The embedded shim is the universal one-body-fits-all that gh student
+	// accept drops into every student repo. {{ORG}} is the only per-classroom
+	// customization; everything else is fixed.
 	got := renderEmbeddedShim("cs50-fall-2026")
 
-	// Trigger contract: branch pushes auto-grade; manual submit/*
-	// tag pushes still work (the runner detects which trigger
-	// fired and either creates the tag or reuses it).
+	// Trigger contract: branch pushes auto-grade; manual submit/* tag pushes
+	// still work (the runner detects which fired and creates or reuses the tag).
 	for _, want := range []string{
 		"branches: [main]",
 		`tags: ["submit/*"]`,
@@ -24,10 +22,9 @@ func TestRenderEmbeddedShim(t *testing.T) {
 		}
 	}
 
-	// Org-substituted reusable-workflow `uses:` line. Quoted in
-	// the embed so the unsubstituted placeholder doesn't trip
-	// YAML's flow-mapping parser; the quotes survive substitution
-	// and remain valid in Actions `uses:`.
+	// Org-substituted reusable-workflow `uses:` line. Quoted in the embed so
+	// the unsubstituted placeholder doesn't trip YAML's flow-mapping parser;
+	// the quotes survive substitution and stay valid in Actions `uses:`.
 	wantUses := `uses: "cs50-fall-2026/classroom50/.github/workflows/autograde-runner.yaml@main"`
 	if !strings.Contains(got, wantUses) {
 		t.Errorf("embedded shim missing %q\nfull:\n%s", wantUses, got)
@@ -38,18 +35,18 @@ func TestRenderEmbeddedShim(t *testing.T) {
 		t.Errorf("embedded shim still contains unsubstituted {{ORG}}:\n%s", got)
 	}
 
-	// Caller's job-level permissions must include both writes the
-	// runner downstream-steps need.
+	// Caller's job-level permissions must include both writes the runner's
+	// downstream steps need.
 	for _, perm := range []string{"contents: write", "statuses: write"} {
 		if !strings.Contains(got, perm) {
 			t.Errorf("embedded shim missing required permission %q\nfull:\n%s", perm, got)
 		}
 	}
 
-	// Shim must NOT contain any of the bootstrap / status / release
-	// logic — those live in autograde-runner.yaml. A regression that
-	// re-inlines them would put substantive logic in every student's
-	// repo, which is what this whole architecture exists to avoid.
+	// Shim must NOT contain any bootstrap / status / release logic — that
+	// lives in autograde-runner.yaml. A regression that re-inlines it would
+	// put substantive logic in every student repo, which this architecture
+	// exists to avoid.
 	for _, mustNotContain := range []string{
 		"PAGES_BASE_URL",
 		"shell: python3",
@@ -66,10 +63,9 @@ func TestRenderEmbeddedShim(t *testing.T) {
 }
 
 func TestRenderEmbeddedShim_OrgSubstitution(t *testing.T) {
-	// `{{ORG}}` substitution is the only piece of per-classroom
-	// customization in the shim — exercise across hyphenated and
-	// plain shapes to confirm ReplaceAll isn't matching anything
-	// else.
+	// `{{ORG}}` substitution is the only per-classroom customization in the
+	// shim — exercise hyphenated and plain shapes to confirm ReplaceAll isn't
+	// matching anything else.
 	for _, org := range []string{"cs50-fall-2026", "foundation50", "very-long-org-name-2026"} {
 		t.Run(org, func(t *testing.T) {
 			got := renderEmbeddedShim(org)

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/foundation50/gh-student/internal/ui"
 )
 
-// TestCheckAcceptableMode pins the lifted accept seam: group is now
-// accepted (previously rejected), individual and empty are accepted, and
-// only an unrecognized mode errors.
+// TestCheckAcceptableMode pins the lifted accept seam: group is now accepted
+// (previously rejected), individual and empty are accepted, and only an
+// unrecognized mode errors.
 func TestCheckAcceptableMode(t *testing.T) {
 	cases := []struct {
 		mode    string
@@ -38,11 +38,11 @@ func TestCheckAcceptableMode(t *testing.T) {
 	}
 }
 
-// TestInviteUserAsAdmin pins the founder-admin grant: accept must
-// keep the student as an `admin` collaborator (not the old `maintain`),
-// because only an admin can manage collaborators for the founder-driven
-// group-invite flow. A regression to a weaker permission silently breaks
-// `gh student invite`, so assert the exact PUT path and request body.
+// TestInviteUserAsAdmin pins the founder-admin grant: accept must keep the
+// student as an `admin` collaborator (not the old `maintain`), because only an
+// admin can manage collaborators for the founder-driven group-invite flow. A
+// regression to a weaker permission silently breaks `gh student invite`, so
+// assert the exact PUT path and request body.
 func TestInviteUserAsAdmin(t *testing.T) {
 	const (
 		org      = "cs50"

--- a/cli/gh-student/internal/assignments/assignments.go
+++ b/cli/gh-student/internal/assignments/assignments.go
@@ -1,10 +1,10 @@
-// Package assignments owns the read side of the published classroom
-// manifest: the token-less GitHub Pages fetch of `assignments.json` and
-// the autograder workflow shim, plus the typed manifest shapes the
-// student CLI consumes. The Pages site is public by design, so this
-// package uses a plain net/http client (no go-gh, no token) and depends
-// only on the shared contract package + stdlib. Consumed by accept (entry
-// + autograder fetch) and invite (entry, for the group-size cap).
+// Package assignments owns the read side of the published classroom manifest:
+// the token-less GitHub Pages fetch of `assignments.json` and the autograder
+// workflow shim, plus the typed manifest shapes the student CLI consumes. The
+// Pages site is public by design, so this uses a plain net/http client (no
+// go-gh, no token) and depends only on the shared contract package + stdlib.
+// Consumed by accept (entry + autograder fetch) and invite (entry, for the
+// group-size cap).
 package assignments
 
 import (
@@ -22,19 +22,19 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/contract"
 )
 
-// configRepoName: the fixed per-org classroom config repo created by
-// `gh teacher init`. Hardcoded so the Pages URL builder stays aligned
-// with the teacher CLI. Single-sourced in the shared contract package.
+// configRepoName is the fixed per-org classroom config repo created by
+// `gh teacher init`. Hardcoded so the Pages URL builder stays aligned with the
+// teacher CLI. Single-sourced in the shared contract package.
 const configRepoName = contract.ConfigRepoName
 
-// PagesFetchTimeout bounds Pages GETs. Without it, http.Client would hang
-// indefinitely on a slow CDN. Exported so callers that run their own
-// context-bounded work (e.g. invite's group-size check) can match it.
+// PagesFetchTimeout bounds Pages GETs; without it http.Client would hang on a
+// slow CDN. Exported so callers running their own context-bounded work (e.g.
+// invite's group-size check) can match it.
 const PagesFetchTimeout = 15 * time.Second
 
-// Entry mirrors `gh teacher assignment add`'s on-disk shape. Only the
-// fields the student CLI needs are typed; unrecognized fields decode
-// silently so future shape additions work without a flag day.
+// Entry mirrors `gh teacher assignment add`'s on-disk shape. Only the fields
+// the student CLI needs are typed; unrecognized fields decode silently so
+// future shape additions work without a flag day.
 type Entry struct {
 	Slug         string       `json:"slug"`
 	Name         string       `json:"name"`
@@ -66,25 +66,25 @@ func (e Entry) HasTemplate() bool {
 		e.Template.Owner != "" && e.Template.Repo != "" && e.Template.Branch != ""
 }
 
-// TemplateRef: assignment starter-code source. All three fields are
-// populated by `gh teacher assignment add` when a template is supplied;
-// a template-less assignment omits the block entirely (Template is nil).
+// TemplateRef is the assignment's starter-code source. All three fields are
+// populated by `gh teacher assignment add` when a template is supplied; a
+// template-less assignment omits the block (Template is nil).
 type TemplateRef struct {
 	Owner  string `json:"owner"`
 	Repo   string `json:"repo"`
 	Branch string `json:"branch"`
 }
 
-// assignmentsFile: top-level shape of assignments.json. Schema is checked
-// first so a future v2 file surfaces "this CLI handles only v1" rather
+// assignmentsFile is the top-level shape of assignments.json. Schema is
+// checked first so a future v2 file surfaces "this CLI handles only v1" rather
 // than silently dropping unknown entries.
 type assignmentsFile struct {
 	Schema      string  `json:"schema"`
 	Assignments []Entry `json:"assignments"`
 }
 
-// assignmentsSchemaV1: the only sentinel this CLI accepts. Single-sourced
-// in the shared contract package.
+// assignmentsSchemaV1 is the only sentinel this CLI accepts. Single-sourced in
+// the shared contract package.
 const assignmentsSchemaV1 = contract.AssignmentsSchemaV1
 
 // classroomPathSegment returns the per-classroom Pages path prefix:
@@ -97,29 +97,28 @@ func classroomPathSegment(classroom, secret string) string {
 	return classroom + "/" + secret
 }
 
-// pagesAssignmentsURL: Pages URL for a classroom's assignments.json, served
-// under `<org>.github.io/classroom50/` per publish-pages.yaml. secret-aware.
+// pagesAssignmentsURL builds the Pages URL for a classroom's
+// assignments.json, served under `<org>.github.io/classroom50/` per
+// publish-pages.yaml. Secret-aware.
 func pagesAssignmentsURL(org, classroom, secret string) string {
 	return fmt.Sprintf("https://%s.github.io/%s/%s/assignments.json", org, configRepoName, classroomPathSegment(classroom, secret))
 }
 
-// pagesAutograderURL: Pages URL for a classroom's autograder workflow.
-// Mirrors publish-pages.yaml's allow-list pattern (secret-aware).
+// pagesAutograderURL builds the Pages URL for a classroom's autograder
+// workflow. Mirrors publish-pages.yaml's allow-list pattern (secret-aware).
 func pagesAutograderURL(org, classroom, secret, name string) string {
 	return fmt.Sprintf("https://%s.github.io/%s/%s/autograders/%s.yaml", org, configRepoName, classroomPathSegment(classroom, secret), name)
 }
 
-// FetchEntry: find the entry by slug from the Pages `assignments.json`.
-// No auth — the Pages site is public by design. secret is the optional
-// capability-URL segment (empty for an unprotected classroom). Thin
-// wrapper around fetchEntryFromURL so tests can inject an httptest URL.
+// FetchEntry finds the entry by slug in the Pages `assignments.json`. No auth
+// — the Pages site is public. secret is the optional capability-URL segment
+// (empty for an unprotected classroom). Thin wrapper around fetchEntryFromURL
+// so tests can inject an httptest URL.
 func FetchEntry(ctx context.Context, org, classroom, secret, assignment string) (Entry, error) {
 	entry, err := fetchEntryFromURL(ctx, pagesAssignmentsURL(org, classroom, secret), assignment)
 	if nf := new(NotFoundError); errors.As(err, &nf) {
-		// Fill the org/classroom hints — the inner function can't
-		// include them in its
-		// "ask your instructor to run `gh teacher assignment add ...`"
-		// message.
+		// Fill the org/classroom hints the inner function can't include in
+		// its "run `gh teacher assignment add ...`" message.
 		nf.Org = org
 		nf.Classroom = classroom
 		return entry, nf
@@ -127,7 +126,7 @@ func FetchEntry(ctx context.Context, org, classroom, secret, assignment string) 
 	// A whole-manifest 404 on a protected classroom is usually a wrong or
 	// missing --key (the manifest lives at <classroom>/<secret>/), not a Pages
 	// problem. The inner 404 can't tell; augment it here where the key is in
-	// scope so the student debugs the key.
+	// scope.
 	if errors.Is(err, errManifestNotFound) {
 		if secret != "" {
 			return entry, fmt.Errorf("%w; the access key (--key) may be wrong — double-check the key your instructor gave you", err)
@@ -137,9 +136,9 @@ func FetchEntry(ctx context.Context, org, classroom, secret, assignment string) 
 	return entry, err
 }
 
-// fetchEntryFromURL is the HTTP-bearing core. Returns actionable messages
-// for network failures, 404, and schema mismatches; a missing slug
-// returns a typed NotFoundError. Mode rejection happens at the call site.
+// fetchEntryFromURL is the HTTP-bearing core. Returns actionable messages for
+// network failures, 404, and schema mismatches; a missing slug returns a typed
+// NotFoundError. Mode rejection happens at the call site.
 func fetchEntryFromURL(ctx context.Context, rawURL, assignment string) (Entry, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
@@ -191,8 +190,8 @@ func fetchEntryFromURL(ctx context.Context, rawURL, assignment string) (Entry, e
 // key-aware hint. Matched via errors.Is.
 var errManifestNotFound = errors.New("assignments manifest not found (404)")
 
-// NotFoundError: Pages fetch succeeded but the requested slug isn't in
-// the manifest. Typed so callers can branch without matching error text.
+// NotFoundError means the Pages fetch succeeded but the requested slug isn't
+// in the manifest. Typed so callers can branch without matching error text.
 type NotFoundError struct {
 	Org        string
 	Classroom  string
@@ -215,30 +214,27 @@ func IsNotFound(err error) bool {
 	return errors.As(err, &nf)
 }
 
-// AutogradeWorkflow is the result of a Pages autograder fetch. Content is
-// the raw workflow shim body dropped at
-// `.github/workflows/autograde.yaml`. The shim is intentionally stable —
-// it `uses:` the reusable autograde-runner workflow in the config repo,
-// which fetches the runner-side bootstrap (runner.py) and the autograder
-// fresh on every submission, so a stale shim still grades against the
-// latest teacher-side logic.
+// AutogradeWorkflow is the result of a Pages autograder fetch. Content is the
+// raw workflow shim body dropped at `.github/workflows/autograde.yaml`. The
+// shim is intentionally stable — it `uses:` the reusable autograde-runner
+// workflow in the config repo, which fetches the runner-side bootstrap
+// (runner.py) and the autograder fresh on every submission, so a stale shim
+// still grades against the latest teacher-side logic.
 type AutogradeWorkflow struct {
 	Content string
 }
 
-// FetchAutograderWorkflow fetches `<classroom>/autograders/<name>.yaml`
-// from Pages. Unauth — the publish-pages allow-list keeps the directory
-// public. Thin wrapper around fetchAutograderWorkflowFromURL for
-// testability.
+// FetchAutograderWorkflow fetches `<classroom>/autograders/<name>.yaml` from
+// Pages. Unauth — the publish-pages allow-list keeps the directory public.
+// Thin wrapper around fetchAutograderWorkflowFromURL for testability.
 func FetchAutograderWorkflow(ctx context.Context, org, classroom, secret, name string) (AutogradeWorkflow, error) {
 	return fetchAutograderWorkflowFromURL(ctx, pagesAutograderURL(org, classroom, secret, name), name)
 }
 
-// fetchAutograderWorkflowFromURL is the HTTP-bearing core. Actionable
-// shapes: 404 → "not published yet", network/unexpected status →
-// wrapped, empty body → "deployment still in flight, retry". YAML is
-// validated before returning so malformed bodies fail at fetch time
-// instead of inside Actions logs.
+// fetchAutograderWorkflowFromURL is the HTTP-bearing core. Actionable shapes:
+// 404 → "not published yet", network/unexpected status → wrapped, empty body →
+// "deployment still in flight, retry". YAML is validated before returning so
+// malformed bodies fail at fetch time instead of inside Actions logs.
 func fetchAutograderWorkflowFromURL(ctx context.Context, rawURL, name string) (AutogradeWorkflow, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
@@ -268,10 +264,10 @@ func fetchAutograderWorkflowFromURL(ctx context.Context, rawURL, name string) (A
 		return AutogradeWorkflow{}, fmt.Errorf("GET %s: empty body — the Pages deployment may still be in flight; retry in a minute", rawURL)
 	}
 
-	// Decode into `any` to validate YAML well-formedness without
-	// imposing schema on the workflow body. Teachers can write any shape
-	// that satisfies the autograder contract (submit-tag trigger,
-	// `result.json` release asset, `classroom50/autograde` commit status).
+	// Decode into `any` to validate YAML well-formedness without imposing
+	// schema on the workflow body. Teachers can write any shape that
+	// satisfies the autograder contract (submit-tag trigger, `result.json`
+	// release asset, `classroom50/autograde` commit status).
 	var sink any
 	if err := yaml.Unmarshal(body, &sink); err != nil {
 		return AutogradeWorkflow{}, fmt.Errorf("autograder %q is malformed YAML (parsed from %s) — ask your instructor to check the file in the config repo: %w", name, rawURL, err)

--- a/cli/gh-student/internal/assignments/assignments_test.go
+++ b/cli/gh-student/internal/assignments/assignments_test.go
@@ -264,7 +264,7 @@ func TestFetchAssignmentEntry_404Surfaces_PagesGuidance(t *testing.T) {
 }
 
 // fetchOneTestEntry serves `body` at /cs-principles/assignments.json
-// and runs fetchAssignmentEntry against it.
+// and runs fetchEntryFromURL against it.
 func fetchOneTestEntry(t *testing.T, body, slug string) (Entry, func()) {
 	t.Helper()
 	server, cleanup := newPagesServer(t, body, http.StatusOK)

--- a/cli/gh-student/internal/assignments/assignments_test.go
+++ b/cli/gh-student/internal/assignments/assignments_test.go
@@ -31,10 +31,9 @@ func TestHasTemplate(t *testing.T) {
 }
 
 func TestPagesAssignmentsURL(t *testing.T) {
-	// Public contract: publish-pages publishes
-	// `<classroom>/assignments.json` at
-	// `https://<org>.github.io/classroom50/...`. A typo here would
-	// 404 every accept.
+	// Public contract: publish-pages publishes `<classroom>/assignments.json`
+	// at `https://<org>.github.io/classroom50/...`. A typo here 404s every
+	// accept.
 	got := pagesAssignmentsURL("cs50-fall-2026", "cs-principles", "")
 	want := "https://cs50-fall-2026.github.io/classroom50/cs-principles/assignments.json"
 	if got != want {
@@ -43,9 +42,9 @@ func TestPagesAssignmentsURL(t *testing.T) {
 }
 
 func TestPagesAssignmentsURL_WithSecret(t *testing.T) {
-	// A protected classroom inserts the capability-URL segment between
-	// the classroom and the resource. Must match publish-pages.yaml and
-	// runner.py's layout exactly or a protected accept 404s.
+	// A protected classroom inserts the capability-URL segment between the
+	// classroom and the resource. Must match publish-pages.yaml and runner.py
+	// exactly or a protected accept 404s.
 	got := pagesAssignmentsURL("cs50-fall-2026", "cs-principles", "abc123")
 	want := "https://cs50-fall-2026.github.io/classroom50/cs-principles/abc123/assignments.json"
 	if got != want {
@@ -63,8 +62,7 @@ func TestPagesAutograderURL(t *testing.T) {
 }
 
 func TestAssignmentEntryResolveAutograder(t *testing.T) {
-	// Empty Autograder resolves to "default"; explicit values
-	// round-trip verbatim.
+	// Empty Autograder resolves to "default"; explicit values round-trip.
 	cases := []struct {
 		in   Entry
 		want string
@@ -82,8 +80,8 @@ func TestAssignmentEntryResolveAutograder(t *testing.T) {
 }
 
 func TestFetchAutograderWorkflow_HappyPath(t *testing.T) {
-	// Fetched bytes round-trip verbatim into the student repo so
-	// the shim's commit-time content matches Pages' published copy.
+	// Fetched bytes round-trip verbatim into the student repo so the shim's
+	// commit-time content matches Pages' published copy.
 	body := "name: Autograde\n" +
 		"on:\n" +
 		"  push:\n" +
@@ -110,8 +108,8 @@ func TestFetchAutograderWorkflow_HappyPath(t *testing.T) {
 }
 
 func TestFetchAutograderWorkflow_404SurfacesActionableGuidance(t *testing.T) {
-	// 404 is the most likely failure (Pages not deployed yet or
-	// file deleted). Error must name the autograder, URL, and fix.
+	// 404 is the most likely failure (Pages not deployed yet or file deleted).
+	// Error must name the autograder, URL, and fix.
 	server, cleanup := newAutograderServer(t, "not found", http.StatusNotFound)
 	defer cleanup()
 
@@ -127,9 +125,8 @@ func TestFetchAutograderWorkflow_404SurfacesActionableGuidance(t *testing.T) {
 }
 
 func TestFetchAutograderWorkflow_RejectsMalformedYAML(t *testing.T) {
-	// Malformed YAML must fail at fetch time, before landing in
-	// the student repo. Error is the signal the student forwards
-	// to the instructor.
+	// Malformed YAML must fail at fetch time, before landing in the student
+	// repo. The error is the signal the student forwards to the instructor.
 	server, cleanup := newAutograderServer(t, "name: Autograde\non: { invalid: [\n", http.StatusOK)
 	defer cleanup()
 
@@ -146,8 +143,8 @@ func TestFetchAutograderWorkflow_RejectsMalformedYAML(t *testing.T) {
 }
 
 func TestFetchAutograderWorkflow_RejectsEmptyBody(t *testing.T) {
-	// Pages occasionally serves a stub during deployment.
-	// Empty body → "retry" rather than empty workflow on disk.
+	// Pages occasionally serves a stub during deployment. Empty body →
+	// "retry" rather than an empty workflow on disk.
 	server, cleanup := newAutograderServer(t, "   \n   \n", http.StatusOK)
 	defer cleanup()
 
@@ -160,8 +157,7 @@ func TestFetchAutograderWorkflow_RejectsEmptyBody(t *testing.T) {
 	}
 }
 
-// newAutograderServer: same pattern as newPagesServer below,
-// mounted at the autograders path.
+// newAutograderServer mirrors newPagesServer, mounted at the autograders path.
 func newAutograderServer(t *testing.T, body string, status int) (*httptest.Server, func()) {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -246,8 +242,8 @@ func TestFetchAssignmentEntry_ReturnsTypedNotFound(t *testing.T) {
 }
 
 func TestFetchAssignmentEntry_404Surfaces_PagesGuidance(t *testing.T) {
-	// 404 → publish-pages hasn't run or the classroom arg is
-	// typo'd. Error must give the student something to ask for.
+	// 404 → publish-pages hasn't run or the classroom arg is typo'd. Error
+	// must give the student something to ask for.
 	server, cleanup := newPagesServer(t, "not found", http.StatusNotFound)
 	defer cleanup()
 

--- a/cli/gh-student/internal/auth/auth.go
+++ b/cli/gh-student/internal/auth/auth.go
@@ -1,7 +1,7 @@
-// Package auth implements the gh-student authentication commands:
-// whoami, login, and logout. It mirrors cli/gh-teacher/internal/auth —
-// thin cobra wrappers over the shared classroom50-cli-shared/ghauth
-// scaffolding and the internal/githubapi client seam.
+// Package auth implements the gh-student authentication commands: whoami,
+// login, and logout. Mirrors cli/gh-teacher/internal/auth — thin cobra
+// wrappers over the shared classroom50-cli-shared/ghauth scaffolding and the
+// internal/githubapi client seam.
 package auth
 
 import (

--- a/cli/gh-student/internal/classroomcfg/commit.go
+++ b/cli/gh-student/internal/classroomcfg/commit.go
@@ -9,21 +9,21 @@ import (
 	"github.com/foundation50/gh-student/internal/githubapi"
 )
 
-// commitFilesAttempts: read-parent + build-tree retries at 200ms × 2^n backoff
-// (~3s), to ride out a freshly-templated repo's git-data lag. DropFiles
-// already calls WaitForStableBranch first; this absorbs any lag that slips past
-// the poll budget.
+// commitFilesAttempts bounds read-parent + build-tree retries at 200ms × 2^n
+// backoff (~3s) to ride out a freshly-templated repo's git-data lag. DropFiles
+// already calls WaitForStableBranch first; this absorbs any lag past that poll.
 const commitFilesAttempts = 5
 
-// errRefNotReady: RefAndTree returned 200 but an empty SHA — the ref isn't
-// readable yet and the Tree API would 404 on the blank base_tree. Retryable.
+// errRefNotReady means RefAndTree returned 200 but an empty SHA — the ref
+// isn't readable yet and the Tree API would 404 on the blank base_tree.
+// Retryable.
 var errRefNotReady = errors.New("branch ref not fully propagated")
 
 // CommitFiles lands `files` (path → UTF-8 content) on `branch` as one Tree
 // commit, retrying the read+build while a freshly-templated repo's git-data
-// APIs lag. No rebase loop: this writes to the student's own just-accepted repo,
-// which has no concurrent writers (the teacher-side configwrite.CommitTree
-// handles the contended config repo).
+// APIs lag. No rebase loop: this writes to the student's own just-accepted
+// repo, which has no concurrent writers (the teacher-side
+// configwrite.CommitTree handles the contended config repo).
 func CommitFiles(client githubapi.Client, owner, repo, branch, message string, files map[string]string) error {
 	if len(files) == 0 {
 		return nil
@@ -47,9 +47,9 @@ func CommitFiles(client githubapi.Client, owner, repo, branch, message string, f
 	return err
 }
 
-// isFreshRepoRetryable: the transient fresh-repo conditions worth a retry —
-// 404 (reads), 409 "Git Repository is empty" (writes), or an empty parent SHA
-// (errRefNotReady).
+// isFreshRepoRetryable reports the transient fresh-repo conditions worth a
+// retry — 404 (reads), 409 "Git Repository is empty" (writes), or an empty
+// parent SHA (errRefNotReady).
 func isFreshRepoRetryable(err error) bool {
 	return ghutil.IsHTTPStatus(err, http.StatusNotFound) ||
 		ghutil.IsHTTPStatus(err, http.StatusConflict) ||

--- a/cli/gh-student/internal/classroomcfg/commit_test.go
+++ b/cli/gh-student/internal/classroomcfg/commit_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/foundation50/gh-student/internal/githubtest"
 )
 
-// TestCommitFiles_RetriesOnFreshRepoLag pins the behavioral change introduced
-// when CommitFiles moved onto the shared fresh-repo-retry loop: a just-templated
+// TestCommitFiles_RetriesOnFreshRepoLag pins the behavioral change when
+// CommitFiles moved onto the shared fresh-repo-retry loop: a just-templated
 // student repo whose first Tree write 409s "Git Repository is empty" must be
 // retried, not surfaced as a failure. Before the refactor CommitFiles did a
-// single attempt and would have errored here.
+// single attempt and would have errored.
 func TestCommitFiles_RetriesOnFreshRepoLag(t *testing.T) {
 	var (
 		mu          sync.Mutex
@@ -86,8 +86,8 @@ func TestCommitFiles_RetriesOnFreshRepoLag(t *testing.T) {
 	}
 }
 
-// TestCommitFiles_EmptyIsNoop pins that an empty file set short-circuits before
-// any API call.
+// TestCommitFiles_EmptyIsNoop pins that an empty file set short-circuits
+// before any API call.
 func TestCommitFiles_EmptyIsNoop(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/cli/gh-student/internal/classroomcfg/metadata.go
+++ b/cli/gh-student/internal/classroomcfg/metadata.go
@@ -1,10 +1,10 @@
-// Package classroomcfg owns the `.classroom50.yaml` on-disk contract and
-// the write path that drops a freshly-accepted assignment repo's initial
-// files. The config types (Config/Source) are read by every gh-student
-// command; the write helpers (DropFiles/CommitFiles/WaitForStableBranch)
-// are the accept-side seam that lands `.classroom50.yaml` + the autograde
-// workflow in one Tree commit. Depends on internal/githubapi and the
-// shared gittree/ghutil helpers, never on package main.
+// Package classroomcfg owns the `.classroom50.yaml` on-disk contract and the
+// write path that drops a freshly-accepted assignment repo's initial files.
+// The config types (Config/Source) are read by every gh-student command; the
+// write helpers (DropFiles/CommitFiles/WaitForStableBranch) are the
+// accept-side seam that lands `.classroom50.yaml` + the autograde workflow in
+// one Tree commit. Depends on internal/githubapi and the shared gittree/ghutil
+// helpers, never on package main.
 package classroomcfg
 
 import (
@@ -22,41 +22,38 @@ import (
 	"github.com/foundation50/gh-student/internal/githubapi"
 )
 
-// MetadataPath: in-repo path read by both the student CLI and the
+// MetadataPath is the in-repo path read by both the student CLI and the
 // autograde-runner workflow's bootstrap step.
 //
-// It also serves as the runner's accept-commit marker: the runner
-// resolves the Feedback-PR baseline as "the commit that introduced
-// .classroom50.yaml", not by matching the commit subject. Every accept
-// client (this CLI, the web GUI, any future client) MUST create this
-// file in its accept commit; the commit subject carries no contract.
-// Mirrored runner-side as runner.ACCEPT_MARKER_PATH
-// (cli/gh-teacher/skeleton/dotgithub/scripts/runner.py).
+// It also serves as the runner's accept-commit marker: the runner resolves the
+// Feedback-PR baseline as "the commit that introduced .classroom50.yaml", not
+// by matching the commit subject. Every accept client (this CLI, the web GUI,
+// any future client) MUST create this file in its accept commit; the commit
+// subject carries no contract. Mirrored runner-side as
+// runner.ACCEPT_MARKER_PATH (cli/gh-teacher/skeleton/dotgithub/scripts/runner.py).
 const MetadataPath = ".classroom50.yaml"
 
-// AutogradeWorkflowPath: in-repo destination for the autograde shim
+// AutogradeWorkflowPath is the in-repo destination for the autograde shim
 // written at accept time.
 const AutogradeWorkflowPath = ".github/workflows/autograde.yaml"
 
-// SchemaRepoConfigV1: versioned sentinel stamped into `.classroom50.yaml`
-// at accept time. Readers treat it as optional —
-// pre-v1 files predate it — but new accepts always write it so future
-// shape changes are detectable. Mirrors the web GUI's emitted value.
+// SchemaRepoConfigV1 is the versioned sentinel stamped into `.classroom50.yaml`
+// at accept time. Readers treat it as optional — pre-v1 files predate it — but
+// new accepts always write it so future shape changes are detectable. Mirrors
+// the web GUI's emitted value.
 const SchemaRepoConfigV1 = "classroom50/repo-config/v1"
 
-// Config is the on-disk shape of `.classroom50.yaml`. classroom +
-// assignment identify the submission; source.* records the template repo
-// so `gh student submit` can re-fetch the latest instructor `.gitignore`
-// / `.github/` on each push. source is omitted for a template-less
-// assignment (nothing to re-fetch).
+// Config is the on-disk shape of `.classroom50.yaml`. classroom + assignment
+// identify the submission; source.* records the template repo so
+// `gh student submit` can re-fetch the latest instructor `.gitignore` /
+// `.github/` on each push. source is omitted for a template-less assignment.
 //
-// Secret is the optional capability-URL path segment, written here at accept
-// so submit and the autograde runner can rebuild the `<classroom>/<secret>/...`
-// Pages URLs without an org read. Omitted (plain path) for an unprotected
-// classroom.
+// Secret is the optional capability-URL path segment, written here at accept so
+// submit and the runner can rebuild the `<classroom>/<secret>/...` Pages URLs
+// without an org read. Omitted (plain path) for an unprotected classroom.
 //
-// The runner derives its config-repo coordinates from the calling repo's
-// org (security-pinned at workflow runtime) and the classroom slug, so no
+// The runner derives its config-repo coordinates from the calling repo's org
+// (security-pinned at workflow runtime) and the classroom slug, so no
 // `config:` block is needed on disk.
 type Config struct {
 	Schema     string    `yaml:"schema,omitempty"`
@@ -68,21 +65,20 @@ type Config struct {
 }
 
 // Identity records a GitHub account by both its mutable login and its
-// immutable numeric id, so a username rename never
-// breaks the repo<->student binding. ID is a pointer so it renders as a
-// YAML number (or null when unresolved), never a quoted string. AcceptedAt
-// is the UTC instant of the accept commit; the owner is the acceptor, so it
-// lives here rather than in a separate accepted_by block.
+// immutable numeric id, so a username rename never breaks the repo<->student
+// binding. ID is a pointer so it renders as a YAML number (or null when
+// unresolved), never a quoted string. AcceptedAt is the UTC instant of the
+// accept commit; the owner is the acceptor, so it lives here.
 type Identity struct {
 	Username   string `yaml:"username"`
 	ID         *int64 `yaml:"id"`
 	AcceptedAt string `yaml:"accepted_at,omitempty"`
 }
 
-// Source: source.* block (template repo). Submit reads instructor-side
-// `.gitignore` / `.github/` from here. Absent for a template-less
-// assignment. OwnerID is the template owner's immutable id (org or user),
-// resolved best-effort at accept time and null when the lookup failed.
+// Source is the source.* block (template repo). Submit reads instructor-side
+// `.gitignore` / `.github/` from here. Absent for a template-less assignment.
+// OwnerID is the template owner's immutable id (org or user), resolved
+// best-effort at accept time and null when the lookup failed.
 type Source struct {
 	Owner   string `yaml:"owner"`
 	OwnerID *int64 `yaml:"owner_id,omitempty"`
@@ -91,8 +87,7 @@ type Source struct {
 }
 
 // Render serializes cfg as double-quoted YAML. Used by accept to drop the
-// initial file; submit doesn't re-render since the shape is stable across
-// the assignment's lifetime.
+// initial file; submit doesn't re-render since the shape is stable.
 func Render(cfg Config) ([]byte, error) {
 	yamlBytes, err := marshalQuotedYAML(cfg)
 	if err != nil {
@@ -101,14 +96,13 @@ func Render(cfg Config) ([]byte, error) {
 	return yamlBytes, nil
 }
 
-// DropFiles commits `.classroom50.yaml` + the autograde workflow in one
-// Tree commit so the repo's initial shape lands atomically. This is the
-// accept commit; creating `.classroom50.yaml` here is what the runner
-// uses to resolve the Feedback-PR baseline (see MetadataPath). The
-// commit message is human-readable only and can be reworded freely.
-// WaitForStableBranch polls first because GitHub doesn't propagate the
-// post-templated-repo commit ref synchronously (the contents API briefly
-// returns 409 "Git Repository is empty" otherwise).
+// DropFiles commits `.classroom50.yaml` + the autograde workflow in one Tree
+// commit so the repo's initial shape lands atomically. This is the accept
+// commit; creating `.classroom50.yaml` here is what the runner uses to resolve
+// the Feedback-PR baseline (see MetadataPath). The commit message is
+// human-readable only. WaitForStableBranch polls first because GitHub doesn't
+// propagate the post-templated-repo commit ref synchronously (the contents API
+// briefly returns 409 "Git Repository is empty" otherwise).
 func DropFiles(client githubapi.Client, owner, repo, branch string, cfg Config, workflowContent string) error {
 	if err := WaitForStableBranch(client, owner, repo, branch); err != nil {
 		return err
@@ -143,8 +137,8 @@ func EscapeContentPath(path string) string {
 	return strings.Join(parts, "/")
 }
 
-// marshalQuotedYAML: double-quoted string scalars, 2-space indent.
-// Defends against auto-typing of slugs like "yes" or "2026".
+// marshalQuotedYAML renders double-quoted string scalars at 2-space indent,
+// defending against auto-typing of slugs like "yes" or "2026".
 func marshalQuotedYAML(v any) ([]byte, error) {
 	var node yaml.Node
 	if err := node.Encode(v); err != nil {
@@ -196,12 +190,10 @@ func IsHTTPNotFound(err error) bool {
 
 // ReadConfig reads and validates a `.classroom50.yaml` at path. The
 // classroom/assignment identity is always required. The source.* template
-// block is optional (a template-less assignment has none); when present,
-// only source.owner is required — this matches the published
-// repo-config-v1 JSON Schema and the web GUI reader, which mark
-// source.repo/source.branch optional. submit guards on Source != nil and
-// degrades gracefully (a 404 on the instructor-file fetch is tolerated) if
-// repo/branch are absent, so the reader need not reject such a file.
+// block is optional (a template-less assignment has none); when present, only
+// source.owner is required — matching the published repo-config-v1 JSON Schema
+// and the web GUI reader. submit guards on Source != nil and degrades
+// gracefully if repo/branch are absent, so the reader need not reject such a file.
 func ReadConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -223,8 +215,8 @@ func ReadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("source block present but missing source.owner (omit the whole source block for a template-less assignment): %s", path)
 	}
 	// Re-validate the optional secret in lockstep with every other consumer
-	// (the same ^[a-z0-9]{4,64}$ rule) before submit/invite compose it into a
-	// URL: empty = unprotected, a present-but-malformed value fails fast here
+	// (same ^[a-z0-9]{4,64}$ rule) before submit/invite compose it into a URL:
+	// empty = unprotected; a present-but-malformed value fails fast here
 	// instead of building a 404-ing path.
 	if config.Secret != "" {
 		if err := ValidateSecret(config.Secret); err != nil {

--- a/cli/gh-student/internal/classroomcfg/metadata_test.go
+++ b/cli/gh-student/internal/classroomcfg/metadata_test.go
@@ -16,11 +16,10 @@ import (
 )
 
 func TestRenderClassroomMetadata_Shape(t *testing.T) {
-	// `.classroom50.yaml` carries identity (classroom + assignment)
-	// plus a `source:` block (template repo). The runner derives
-	// the config-repo coordinates from the calling repo's org and
-	// the classroom slug at workflow time, so no `config:` block is
-	// written here.
+	// `.classroom50.yaml` carries identity (classroom + assignment) plus a
+	// `source:` block (template repo). The runner derives config-repo
+	// coordinates from the calling repo's org and the classroom slug at
+	// workflow time, so no `config:` block is written here.
 	cfg := Config{
 		Classroom:  "cs-principles",
 		Assignment: "hello",
@@ -35,8 +34,8 @@ func TestRenderClassroomMetadata_Shape(t *testing.T) {
 		t.Fatalf("Render: %v", err)
 	}
 
-	// String scalars must be double-quoted so YAML doesn't
-	// auto-type slugs like "yes" or "2026".
+	// String scalars must be double-quoted so YAML doesn't auto-type slugs
+	// like "yes" or "2026".
 	wantSubs := []string{
 		`classroom: "cs-principles"`,
 		`assignment: "hello"`,
@@ -57,8 +56,8 @@ func TestRenderClassroomMetadata_Shape(t *testing.T) {
 		}
 	}
 
-	// `config:` and `autograde:` blocks are dropped; the runner no
-	// longer reads them.
+	// `config:` and `autograde:` blocks are dropped; the runner no longer
+	// reads them.
 	for _, removed := range []string{"config:", "autograde:"} {
 		if strings.Contains(string(out), removed) {
 			t.Errorf("legacy key %q must not appear in rendered metadata, got:\n%s", removed, out)
@@ -77,8 +76,8 @@ func TestRenderClassroomMetadata_Shape(t *testing.T) {
 
 func TestRenderClassroomMetadata_TemplateLessOmitsSource(t *testing.T) {
 	// A template-less assignment carries no Source: the rendered
-	// `.classroom50.yaml` must omit the `source:` block entirely
-	// (the feature's on-disk shape), and round-trip back to nil Source.
+	// `.classroom50.yaml` must omit the `source:` block entirely and
+	// round-trip back to nil Source.
 	cfg := Config{Classroom: "cs-principles", Assignment: "solo"}
 	out, err := Render(cfg)
 	if err != nil {
@@ -97,9 +96,8 @@ func TestRenderClassroomMetadata_TemplateLessOmitsSource(t *testing.T) {
 }
 
 func TestRenderClassroomMetadata_PreservesNumericLookingSlugs(t *testing.T) {
-	// Pins double-quoting: a numeric-looking classroom slug must
-	// not encode as a YAML integer — downstream string compares
-	// against args would break.
+	// Pins double-quoting: a numeric-looking classroom slug must not encode as
+	// a YAML integer — downstream string compares against args would break.
 	cfg := Config{
 		Classroom:  "2026",
 		Assignment: "hello",

--- a/cli/gh-student/internal/githubapi/auth.go
+++ b/cli/gh-student/internal/githubapi/auth.go
@@ -10,25 +10,24 @@ import (
 // requiredScopes is the unified OAuth scope set shared with gh-teacher
 // (contract.RequiredOAuthScopes, issue #246) so authenticating for one CLI
 // covers the other. gh-student itself only needs read:org + repo + workflow,
-// but the two binaries deliberately request an identical set (it also gains
-// admin:org, which supersedes read:org). Single source of truth for the login
-// command and RequireAuthClient's auto-login.
+// but both binaries request an identical set (it also gains admin:org, which
+// supersedes read:org). Single source of truth for the login command and
+// RequireAuthClient's auto-login.
 var requiredScopes = contract.RequiredOAuthScopes()
 
 // RequiredScopes returns the OAuth scopes gh-student requests beyond gh's
-// defaults. Exposed for the login command, which requests the same set
-// when it triggers an interactive `gh auth login`.
+// defaults. Exposed for the login command, which requests the same set when it
+// triggers an interactive `gh auth login`.
 func RequiredScopes() []string { return append([]string(nil), requiredScopes...) }
 
-// authOptions binds gh-student's scopes + command name to the shared
-// auth scaffolding.
+// authOptions binds gh-student's scopes + command name to the shared auth
+// scaffolding.
 var authOptions = ghauth.Options{RequiredScopes: requiredScopes, CommandName: "gh student"}
 
-// RequireAuthClient returns a REST client, auto-running `gh auth login`
-// when no token is set for the default host. Thin wrapper over the shared
-// auth helper, owned by githubapi because it constructs a go-gh client;
-// returned as the Client seam so domain code never names the concrete
-// go-gh type.
+// RequireAuthClient returns a REST client, auto-running `gh auth login` when no
+// token is set for the default host. Thin wrapper over the shared auth helper,
+// owned by githubapi because it constructs a go-gh client; returned as the
+// Client seam so domain code never names the concrete go-gh type.
 func RequireAuthClient(cmd *cobra.Command) (Client, error) {
 	return ghauth.RequireClient(cmd.OutOrStdout(), cmd.ErrOrStderr(), authOptions)
 }

--- a/cli/gh-student/internal/githubapi/client.go
+++ b/cli/gh-student/internal/githubapi/client.go
@@ -6,33 +6,31 @@ import (
 	"net/http"
 )
 
-// Client is the transport-verb seam over the GitHub REST API. It exposes
-// the four verbs gh-student uses against go-gh's *api.RESTClient — Get,
-// Post, Patch, and the context-bound RequestWithContext (which carries
-// the Link-header-returning GET that group-membership pagination needs,
+// Client is the transport-verb seam over the GitHub REST API. It exposes the
+// four verbs gh-student uses against go-gh's *api.RESTClient — Get, Post,
+// Patch, and the context-bound RequestWithContext (which carries the
+// Link-header-returning GET that group-membership pagination needs,
 // deadline-bounded because go-gh's default client has no HTTP timeout).
 //
-// It is deliberately NOT a per-operation domain interface: domain shaping
-// lives in the command layer, not in this seam, which keeps the interface
-// narrow. The concrete implementation is go-gh's *api.RESTClient, which
-// satisfies this interface structurally — RequireAuthClient returns one.
-// Tests use the in-memory fake in internal/githubtest.
+// Deliberately NOT a per-operation domain interface: domain shaping lives in
+// the command layer, keeping this interface narrow. The concrete impl is
+// go-gh's *api.RESTClient (satisfies it structurally; RequireAuthClient returns
+// one). Tests use the in-memory fake in internal/githubtest.
 type Client interface {
-	// Get issues a GET and decodes the JSON body into resp (resp may be
-	// nil for existence-only checks).
+	// Get issues a GET and decodes the JSON body into resp (resp may be nil
+	// for existence-only checks).
 	Get(path string, resp interface{}) error
-	// Post issues a POST with body and decodes the JSON response into
-	// resp (resp may be nil).
+	// Post issues a POST with body and decodes the JSON response into resp
+	// (resp may be nil).
 	Post(path string, body io.Reader, resp interface{}) error
-	// Patch issues a PATCH with body and decodes the JSON response into
-	// resp (resp may be nil).
+	// Patch issues a PATCH with body and decodes the JSON response into resp
+	// (resp may be nil).
 	Patch(path string, body io.Reader, resp interface{}) error
-	// RequestWithContext issues an arbitrary-method request bound to a
-	// context and returns the raw response, so callers can read headers
-	// (e.g. Link for pagination) or status codes the decode-and-discard
-	// verbs hide, and cancel / deadline an in-flight request (the
-	// group-membership collaborators walk uses this — go-gh's default
-	// client has no HTTP timeout, so the enumeration needs an external
-	// deadline).
+	// RequestWithContext issues an arbitrary-method request bound to a context
+	// and returns the raw response, so callers can read headers (e.g. Link for
+	// pagination) or status codes the decode-and-discard verbs hide, and
+	// cancel / deadline an in-flight request (the group-membership
+	// collaborators walk uses this — go-gh's default client has no HTTP
+	// timeout, so the enumeration needs an external deadline).
 	RequestWithContext(ctx context.Context, method string, path string, body io.Reader) (*http.Response, error)
 }

--- a/cli/gh-student/internal/githubapi/doc.go
+++ b/cli/gh-student/internal/githubapi/doc.go
@@ -1,12 +1,12 @@
-// Package githubapi is the single seam between gh-student and the
-// GitHub REST API. It is the ONLY package permitted to import
-// github.com/cli/go-gh/v2/pkg/api (enforced by a CI guard, not the
-// compiler); every domain talks to GitHub through the transport-verb
-// Client interface defined here.
+// Package githubapi is the single seam between gh-student and the GitHub REST
+// API. It is the ONLY package permitted to import
+// github.com/cli/go-gh/v2/pkg/api (enforced by a CI guard, not the compiler);
+// every domain talks to GitHub through the transport-verb Client interface
+// defined here.
 //
-// The interface is intentionally transport-verb-level
-// (Get/Post/Patch/Request), not a per-operation domain interface —
-// domain shaping belongs in the command/service layer, not in this
-// seam. This mirrors cli/gh-teacher/internal/githubapi (the two CLIs
-// are separate Go modules, so the seam can't be shared, only paralleled).
+// The interface is intentionally transport-verb-level (Get/Post/Patch/Request),
+// not a per-operation domain interface — domain shaping belongs in the
+// command/service layer, not this seam. Mirrors
+// cli/gh-teacher/internal/githubapi (separate Go modules, so the seam can't be
+// shared, only paralleled).
 package githubapi

--- a/cli/gh-student/internal/githubapi/errors.go
+++ b/cli/gh-student/internal/githubapi/errors.go
@@ -2,8 +2,8 @@ package githubapi
 
 import "github.com/cli/go-gh/v2/pkg/api"
 
-// HTTPError aliases go-gh's api.HTTPError so domain packages can branch
-// on status codes and OAuth-scope headers without importing go-gh
-// directly. As a type alias it carries every field and method of the
-// underlying type transparently (StatusCode, Message, Errors, Error(), …).
+// HTTPError aliases go-gh's api.HTTPError so domain packages can branch on
+// status codes and OAuth-scope headers without importing go-gh directly. As a
+// type alias it carries every field and method of the underlying type
+// (StatusCode, Message, Errors, Error(), …).
 type HTTPError = api.HTTPError

--- a/cli/gh-student/internal/githubapi/shared.go
+++ b/cli/gh-student/internal/githubapi/shared.go
@@ -7,12 +7,11 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/gittree"
 )
 
-// rest recovers the concrete *api.RESTClient backing a Client. Every
-// Client in this binary is the go-gh client returned by RequireAuthClient
-// / NewClient (or the test fake in internal/githubtest, which embeds one),
-// so the assertion holds. It panics otherwise — a programming error, since
-// the shared-module helpers below genuinely require the concrete type and
-// no other implementation can satisfy them.
+// rest recovers the concrete *api.RESTClient backing a Client. Every Client in
+// this binary is the go-gh client from RequireAuthClient / NewClient (or the
+// test fake in internal/githubtest, which embeds one), so the assertion holds.
+// It panics otherwise — a programming error, since the shared-module helpers
+// below require the concrete type and no other impl can satisfy them.
 func rest(c Client) *api.RESTClient {
 	rc, ok := c.(*api.RESTClient)
 	if !ok {

--- a/cli/gh-student/internal/githubtest/client.go
+++ b/cli/gh-student/internal/githubtest/client.go
@@ -11,10 +11,10 @@ import (
 	"github.com/foundation50/gh-student/internal/githubapi"
 )
 
-// hostRewriteTransport redirects every request to a single test server
-// while preserving the path so the handler can dispatch on it. This is
-// the seam go-gh's docs recommend for tests (ClientOptions.Transport
-// "should be reserved for testing").
+// hostRewriteTransport redirects every request to a single test server while
+// preserving the path so the handler can dispatch on it. This is the seam
+// go-gh's docs recommend for tests (ClientOptions.Transport "should be
+// reserved for testing").
 type hostRewriteTransport struct {
 	target *url.URL
 }
@@ -25,15 +25,15 @@ func (h *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return http.DefaultTransport.RoundTrip(req)
 }
 
-// NewTestClient wires a real go-gh client at the given test server,
-// returned as the githubapi.Client seam. AuthToken must be non-empty so
-// go-gh's header-injection layer leaves Authorization alone.
+// NewTestClient wires a real go-gh client at the given test server, returned as
+// the githubapi.Client seam. AuthToken must be non-empty so go-gh's
+// header-injection layer leaves Authorization alone.
 //
 // This is the shared white-box test helper for gh-student: domain tests
 // construct a Client here instead of reaching into the concrete go-gh
-// constructor, so the go-gh dependency stays confined to githubapi and
-// this package. Mirrors cli/gh-teacher/internal/githubtest (the two CLIs
-// are separate Go modules, so the helper can't be shared).
+// constructor, so the go-gh dependency stays confined to githubapi and this
+// package. Mirrors cli/gh-teacher/internal/githubtest (separate Go modules, so
+// the helper can't be shared).
 func NewTestClient(t *testing.T, server *httptest.Server) githubapi.Client {
 	t.Helper()
 	u, err := url.Parse(server.URL)

--- a/cli/gh-student/internal/ignorematch/ignorematch.go
+++ b/cli/gh-student/internal/ignorematch/ignorematch.go
@@ -1,7 +1,7 @@
-// Package ignorematch classifies repository paths against an ordered
-// list of .gitignore-style patterns (the assignment's allowed_files),
-// delegating to `git check-ignore` so negation, ordering, and directory
-// rules match .gitignore exactly.
+// Package ignorematch classifies repository paths against an ordered list of
+// .gitignore-style patterns (the assignment's allowed_files), delegating to
+// `git check-ignore` so negation, ordering, and directory rules match
+// .gitignore exactly.
 //
 // allowed_files is an allowlist in gitignore syntax: `*` then `!hello.py`
 // allows only hello.py. A path is ALLOWED when git would NOT ignore it.
@@ -23,10 +23,9 @@ import (
 // `gh student submit` hot path; the caller degrades safely on error.
 const gitTimeout = 30 * time.Second
 
-// Disallowed returns the subset of paths the patterns do NOT allow (the
-// paths git would ignore under an allowlist built from patterns). Empty
-// patterns or paths returns an empty set. Paths are forward-slash
-// relative, as git emits them.
+// Disallowed returns the subset of paths the patterns do NOT allow (the paths
+// git would ignore under an allowlist built from patterns). Empty patterns or
+// paths returns an empty set. Paths are forward-slash relative, as git emits.
 func Disallowed(patterns []string, paths []string) (map[string]bool, error) {
 	disallowed := make(map[string]bool)
 	if len(patterns) == 0 || len(paths) == 0 {
@@ -40,8 +39,8 @@ func Disallowed(patterns []string, paths []string) (map[string]bool, error) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// check-ignore needs a repo context even with --no-index, so use a
-	// throwaway repo whose .gitignore is the pattern list, isolated from
-	// the host's git config (see isolatedGitEnv). Mirrors runner.py.
+	// throwaway repo whose .gitignore is the pattern list, isolated from the
+	// host's git config (see isolatedGitEnv). Mirrors runner.py.
 	gitEnv := isolatedGitEnv()
 	initCtx, cancelInit := context.WithTimeout(context.Background(), gitTimeout)
 	defer cancelInit()
@@ -86,9 +85,8 @@ func Disallowed(patterns []string, paths []string) (map[string]bool, error) {
 }
 
 // isolatedGitEnv neutralizes git's system/global config so the matcher
-// classifies identically regardless of the user's global gitignore.
-// Paired with `-c core.excludesFile`. Mirrors runner.py's
-// _isolated_git_env.
+// classifies identically regardless of the user's global gitignore. Paired
+// with `-c core.excludesFile`. Mirrors runner.py's _isolated_git_env.
 func isolatedGitEnv() []string {
 	return append(os.Environ(),
 		"GIT_CONFIG_NOSYSTEM=1",

--- a/cli/gh-student/internal/ignorematch/ignorematch_test.go
+++ b/cli/gh-student/internal/ignorematch/ignorematch_test.go
@@ -57,8 +57,8 @@ func TestDisallowed_SharedFixtureParity(t *testing.T) {
 }
 
 func TestDisallowed_Allowlist(t *testing.T) {
-	// `*` ignores everything, `!hello.py` re-includes it: only hello.py
-	// is allowed, the rest are disallowed.
+	// `*` ignores everything, `!hello.py` re-includes it: only hello.py is
+	// allowed, the rest disallowed.
 	paths := []string{"hello.py", "main.c", "sub/foo.txt"}
 	got, err := Disallowed([]string{"*", "!hello.py"}, paths)
 	if err != nil {
@@ -117,9 +117,9 @@ func keys(m map[string]bool) []string {
 	return out
 }
 
-// TestDisallowed_IgnoresAmbientGitConfig proves the matcher ignores the
-// host's global gitignore: patterns not matching `app.log` keep it
-// allowed even when a global excludesFile would ignore `*.log`.
+// TestDisallowed_IgnoresAmbientGitConfig proves the matcher ignores the host's
+// global gitignore: patterns not matching `app.log` keep it allowed even when
+// a global excludesFile would ignore `*.log`.
 func TestDisallowed_IgnoresAmbientGitConfig(t *testing.T) {
 	home := t.TempDir()
 	globalIgnore := filepath.Join(home, "globalignore")

--- a/cli/gh-student/internal/invitecmd/group_membership.go
+++ b/cli/gh-student/internal/invitecmd/group_membership.go
@@ -13,29 +13,26 @@ import (
 	"github.com/foundation50/gh-student/internal/githubapi"
 )
 
-// listGroupMemberLogins returns the logins of the student-level
-// collaborators on org/repo, walking pagination. The repo `owner` (the
-// founder) is always kept even though they are repo `admin` (the org
-// lockdown keeps the founder admin so they can manage collaborators). Every
-// *other* admin — the org owner and instructors, who are admins on every
-// repo, plus any admin-granted TA — is excluded so they don't consume
-// student slots against max_group_size (push collaborators count; the
-// founder and added teammates count, a non-founder admin does not).
+// listGroupMemberLogins returns the logins of student-level collaborators on
+// org/repo, walking pagination. The repo `owner` (founder) is always kept even
+// though they are repo `admin` (the org lockdown keeps them admin so they can
+// manage collaborators). Every *other* admin — org owner, instructors, any
+// admin-granted TA — is excluded so they don't consume student slots against
+// max_group_size (push collaborators count; the founder and added teammates
+// count, a non-founder admin does not).
 //
-// NOTE: this admin exclusion is for COUNTING toward max_group_size only —
-// it is a best-effort, advisory limit (a founder can bypass it via the
-// GitHub UI). It is deliberately NOT how a teammate is CREDITED a score:
-// crediting happens at collection time in collect_scores.py, which gates
-// on the teacher's roster (not on collaborator permission), so a rostered
-// teammate who happens to be a repo/org admin is still credited the shared
-// group score even though they don't count as a separate slot here. The
-// roster — available only to the teacher CLI — is the real attribution
-// boundary; the student CLI has no roster, so it counts by permission.
+// NOTE: this admin exclusion is for COUNTING toward max_group_size only — an
+// advisory limit (bypassable via the GitHub UI). It is deliberately NOT how a
+// teammate is CREDITED: crediting happens at collection time in
+// collect_scores.py, which gates on the teacher's roster (not on collaborator
+// permission), so a rostered teammate who is also a repo/org admin is still
+// credited the shared group score though they don't count as a slot here. The
+// roster — teacher-CLI only — is the real attribution boundary; the student
+// CLI has no roster, so it counts by permission.
 //
-// ctx bounds the enumeration. go-gh's default REST client has no HTTP
-// timeout, so without a deadline a stalled collaborators API would hang
-// the invite indefinitely — the caller passes a context.WithTimeout
-// matching the sibling Pages fetch's budget.
+// ctx bounds the enumeration: go-gh's default REST client has no HTTP timeout,
+// so without a deadline a stalled collaborators API would hang the invite. The
+// caller passes a context.WithTimeout matching the sibling Pages fetch budget.
 func listGroupMemberLogins(ctx context.Context, client githubapi.Client, org, repo, owner string) ([]string, error) {
 	const perPage = 100
 	const maxPages = 100
@@ -61,18 +58,18 @@ func listGroupMemberLogins(ctx context.Context, client githubapi.Client, org, re
 			return nil, fmt.Errorf("GET %s: decode body: %w", path, decodeErr)
 		}
 		for _, c := range batch {
-			// Exclude admins (org owners, instructors/TAs granted admin)
-			// so they don't count toward the student group limit — but
-			// keep the founder, who is admin on their own repo.
+			// Exclude admins (org owners, admin-granted instructors/TAs) so
+			// they don't count toward the student group limit — but keep the
+			// founder, who is admin on their own repo.
 			if strings.EqualFold(c.RoleName, "admin") && !strings.EqualFold(c.Login, owner) {
 				continue
 			}
 			logins = append(logins, c.Login)
 		}
-		// Shared termination decision (ghutil.NextPage) — identical to
-		// the teacher CLI's githubapi.PaginateAll: follow GitHub's authoritative
-		// `Link: rel="next"`, stop on a no-next Link / short no-Link page,
-		// else synthesize the next page.
+		// Shared termination decision (ghutil.NextPage), identical to the
+		// teacher CLI's githubapi.PaginateAll: follow GitHub's authoritative
+		// `Link: rel="next"`, stop on a no-next Link / short no-Link page, else
+		// synthesize the next page.
 		next, stop := ghutil.NextPage(linkHeader, len(batch), perPage)
 		if stop {
 			return logins, nil
@@ -87,11 +84,10 @@ func listGroupMemberLogins(ctx context.Context, client githubapi.Client, org, re
 	return nil, fmt.Errorf("repos/%s/%s/collaborators: too many collaborators to enumerate (hit the %d-page cap)", org, repo, maxPages)
 }
 
-// checkGroupSizeBeforeInvite enforces max_group_size for a group repo
-// before adding a new push collaborator. It counts the repo's current
-// student members (admins other than the founder excluded) and returns
-// an error when adding `invitee` would exceed `maxGroupSize`. An invitee
-// who is already a member is never blocked (re-inviting is a no-op).
+// checkGroupSizeBeforeInvite enforces max_group_size for a group repo before
+// adding a new push collaborator. It counts the repo's current student members
+// (non-founder admins excluded) and errors when adding `invitee` would exceed
+// `maxGroupSize`. An already-member invitee is never blocked (re-invite no-op).
 //
 // max <= 0 means no limit (defensive — group assignments always carry a
 // positive size). The founder (`owner`) counts toward the total.

--- a/cli/gh-student/internal/invitecmd/group_membership_test.go
+++ b/cli/gh-student/internal/invitecmd/group_membership_test.go
@@ -34,9 +34,9 @@ func TestGroupRepoOwner(t *testing.T) {
 
 // TestGroupRepoOwnerRoundTripsAssignmentRepoName pins the producer
 // (reponame.Name) and consumer (groupRepoOwner) to the same
-// `<classroom>-<assignment>-<owner>` shape. Both now derive from
-// reponame.Prefix, so a future separator/casing change can't drift
-// one side into silently returning "" (which would disable the cap).
+// `<classroom>-<assignment>-<owner>` shape. Both derive from reponame.Prefix,
+// so a future separator/casing change can't drift one side into silently
+// returning "" (which would disable the cap).
 func TestGroupRepoOwnerRoundTripsAssignmentRepoName(t *testing.T) {
 	cases := []struct {
 		classroom, assignment, owner string
@@ -91,10 +91,10 @@ func TestListGroupMemberLogins_KeepsFounderExcludesOtherAdmins(t *testing.T) {
 }
 
 // TestListGroupMemberLogins_FollowsLinkHeader exercises the authoritative
-// Link-following branch: page 1 advertises `rel="next"` via the Link
-// header (pointing at a cursor URL), page 2 omits it. The handler ignores
-// the `page` query and dispatches on the cursor, so the walk must have
-// followed the server-supplied Link rather than a synthesized page number.
+// Link-following branch: page 1 advertises `rel="next"` (a cursor URL), page 2
+// omits it. The handler ignores the `page` query and dispatches on the cursor,
+// so the walk must have followed the server-supplied Link, not a synthesized
+// page number.
 func TestListGroupMemberLogins_FollowsLinkHeader(t *testing.T) {
 	var server *httptest.Server
 	mux := http.NewServeMux()
@@ -104,10 +104,10 @@ func TestListGroupMemberLogins_FollowsLinkHeader(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{{"login": "bob", "role_name": "push"}})
 			return
 		}
-		// Page 1: advertise the next page via Link (cursor-based). The
-		// proof here is that the walk reached page 2 via the cursor URL
-		// (the handler errors on an unexpected path); the companion test
-		// FullPageNoNextLinkStops proves Link beats the length heuristic.
+		// Page 1: advertise the next page via Link (cursor-based). The proof
+		// is that the walk reached page 2 via the cursor URL (the handler
+		// errors on an unexpected path); FullPageNoNextLinkStops proves Link
+		// beats the length heuristic.
 		w.Header().Set("Link", `<`+server.URL+`/repos/o/cs-hw-alice/collaborators?cursor=two>; rel="next"`)
 		_ = json.NewEncoder(w).Encode([]map[string]any{{"login": "alice", "role_name": "admin"}})
 	})
@@ -133,9 +133,9 @@ func TestListGroupMemberLogins_FollowsLinkHeader(t *testing.T) {
 }
 
 // TestListGroupMemberLogins_FullPageNoNextLinkStops asserts a full page
-// carrying a Link header WITHOUT rel=next (the last page) terminates the
-// walk in one request, rather than the len==perPage short-page heuristic
-// forcing an extra fetch. Proves Link is authoritative over page length.
+// carrying a Link header WITHOUT rel=next (the last page) terminates the walk
+// in one request, rather than the len==perPage short-page heuristic forcing an
+// extra fetch. Proves Link is authoritative over page length.
 func TestListGroupMemberLogins_FullPageNoNextLinkStops(t *testing.T) {
 	const perPage = 100
 	var requests int
@@ -216,12 +216,11 @@ func TestCheckGroupSizeBeforeInvite(t *testing.T) {
 	})
 }
 
-// TestListGroupMemberLogins_Pagination exercises the multi-page walk:
-// a first page of exactly perPage (100) entries forces the loop to fetch
-// a second page, and both must be merged. A mock that only ever returns a
-// short batch (the other tests) never exercises this branch, so a broken
-// continuation that undercounts members — and would wrongly let an invite
-// past the cap — would otherwise pass silently.
+// TestListGroupMemberLogins_Pagination exercises the multi-page walk: a first
+// page of exactly perPage (100) entries forces a second-page fetch, and both
+// must be merged. A mock that only ever returns a short batch never exercises
+// this, so a broken continuation that undercounts members — wrongly letting an
+// invite past the cap — would otherwise pass silently.
 func TestListGroupMemberLogins_Pagination(t *testing.T) {
 	const perPage = 100
 	mux := http.NewServeMux()
@@ -260,9 +259,9 @@ func TestListGroupMemberLogins_Pagination(t *testing.T) {
 	}
 }
 
-// TestListGroupMemberLogins_PageCap asserts the enumeration fails closed
-// (no partial count) when every page stays full past the 100-page cap,
-// rather than silently returning a truncated member list.
+// TestListGroupMemberLogins_PageCap asserts the enumeration fails closed (no
+// partial count) when every page stays full past the 100-page cap, rather than
+// silently returning a truncated member list.
 func TestListGroupMemberLogins_PageCap(t *testing.T) {
 	const perPage = 100
 	mux := http.NewServeMux()

--- a/cli/gh-student/internal/invitecmd/invite.go
+++ b/cli/gh-student/internal/invitecmd/invite.go
@@ -1,9 +1,8 @@
 // Package invitecmd implements `gh student invite <org>/<repo> <username>`:
-// add a push collaborator, and (when run from inside a group repo) enforce
-// the assignment's advisory max-group-size cap. It is an extracted command
-// package; only NewCmd is exported. Consumes the internal/* seams
-// (githubapi, assignments, classroomcfg, localgit, reponame) + contract,
-// never package main.
+// add a push collaborator, and (when run from inside a group repo) enforce the
+// assignment's advisory max-group-size cap. Extracted command package; only
+// NewCmd is exported. Consumes the internal/* seams (githubapi, assignments,
+// classroomcfg, localgit, reponame) + contract, never main.
 package invitecmd
 
 import (
@@ -67,11 +66,11 @@ func NewCmd() *cobra.Command {
 
 			out := cmd.OutOrStdout()
 
-			// Enforce max_group_size when invite is run from inside the
-			// group repo (the founder's working tree carries the
-			// .classroom50.yaml that identifies the assignment). Failing
-			// to resolve the group context is non-fatal — a TA invite or
-			// an invite run outside a repo just adds the collaborator.
+			// Enforce max_group_size when invite runs from inside the group
+			// repo (the founder's tree carries the .classroom50.yaml that
+			// identifies the assignment). Failing to resolve the group context
+			// is non-fatal — a TA invite or an invite run outside a repo just
+			// adds the collaborator.
 			if err := enforceGroupSize(cmd, client, org, repo, username); err != nil {
 				return err
 			}
@@ -84,35 +83,29 @@ func NewCmd() *cobra.Command {
 }
 
 // enforceGroupSize applies the assignment's max_group_size cap before an
-// invite when (and only when) invite is run from inside the *target*
-// group-assignment repo. It reads the local .classroom50.yaml to identify
-// the classroom + assignment, fetches the published assignment entry, and
-// — if the assignment is `mode: group` — refuses to add `invitee` past the
-// cap.
+// invite when (and only when) invite runs from inside the *target*
+// group-assignment repo. It reads the local .classroom50.yaml to identify the
+// classroom + assignment, fetches the published entry, and — if the assignment
+// is `mode: group` — refuses to add `invitee` past the cap.
 //
-// TRUST MODEL — this is an ADVISORY guardrail, not a security control:
-//   - The cap VALUE is trusted: max_group_size is read from the teacher's
-//     published Pages assignments.json (assignments.FetchEntry), never from
-//     the student-writable .classroom50.yaml.
-//   - The assignment POINTER is NOT trusted: .classroom50.yaml lives in the
-//     student's repo, so a student could edit `classroom`/`assignment` to
-//     point at a more permissive entry (or an individual assignment) and
-//     dodge the check. That's acceptable because invite-time enforcement is
-//     inherently bypassable anyway (a founder can add a collaborator via the
-//     GitHub UI, or simply not run the CLI). The real attribution boundary
-//     is collection-time: collect-scores intersects collaborators with the
-//     teacher's roster, and the teacher can review each repo's collaborators.
-//     This check just keeps an honest founder from accidentally overfilling.
+// TRUST MODEL — advisory guardrail, not a security control:
+//   - The cap VALUE is trusted: max_group_size comes from the teacher's
+//     published Pages assignments.json, never from the student-writable
+//     .classroom50.yaml.
+//   - The assignment POINTER is NOT trusted: a student could edit
+//     `classroom`/`assignment` in .classroom50.yaml to point at a more
+//     permissive (or individual) entry and dodge the check. That's acceptable
+//     because invite-time enforcement is bypassable anyway (add via the GitHub
+//     UI, or don't run the CLI). The real attribution boundary is
+//     collection-time: collect-scores intersects collaborators with the
+//     teacher's roster. This just keeps an honest founder from overfilling.
 //
-// It is deliberately best-effort on *context*: not being inside a repo, a
-// missing/unreadable .classroom50.yaml, a config that describes a DIFFERENT
-// repo than the invite target, or a non-group assignment all mean "no group
-// cap applies" and invite proceeds as a plain push-invite (this keeps TA
-// invites, cross-repo invites, and individual-assignment invites working). A
-// transient failure to read the published entry warns but does not block —
-// the guardrail is advisory, so an infrastructure blip must not stop an
-// honest invite. Only a genuine "group is full" decision (or an API error
-// while counting members of the matched repo) blocks the invite.
+// Deliberately best-effort on *context*: not in a repo, a missing/unreadable
+// .classroom50.yaml, a config describing a DIFFERENT repo than the target, or
+// a non-group assignment all mean "no cap applies" and invite proceeds as a
+// plain push-invite (keeps TA, cross-repo, and individual invites working). A
+// transient failure to read the published entry warns but doesn't block. Only
+// a genuine "group is full" (or an API error counting members) blocks.
 func enforceGroupSize(cmd *cobra.Command, client githubapi.Client, org, repo, invitee string) error {
 	root, inside, err := localgit.CurrentGitRoot()
 	if err != nil || !inside {
@@ -123,11 +116,11 @@ func enforceGroupSize(cmd *cobra.Command, client githubapi.Client, org, repo, in
 		return nil // no/!readable .classroom50.yaml → not a classroom repo
 	}
 
-	// Only enforce when the local config provably describes the invite
-	// TARGET: the target repo must be the founder's own group repo for this
-	// assignment (`<classroom>-<assignment>-<owner>`). A founder standing in
-	// repo A while inviting into repo B would otherwise have A's cap applied
-	// to B — so require the repo-name prefix match and take the owner from it.
+	// Only enforce when the local config provably describes the invite TARGET:
+	// the target repo must be the founder's own group repo for this assignment
+	// (`<classroom>-<assignment>-<owner>`). A founder standing in repo A while
+	// inviting into repo B would otherwise have A's cap applied to B — so
+	// require the repo-name prefix match and take the owner from it.
 	owner := groupRepoOwner(repo, cfg)
 	if owner == "" {
 		return nil // target repo isn't this assignment's group repo → skip
@@ -135,10 +128,10 @@ func enforceGroupSize(cmd *cobra.Command, client githubapi.Client, org, repo, in
 
 	entry, err := assignments.FetchEntry(cmd.Context(), org, cfg.Classroom, cfg.Secret, cfg.Assignment)
 	if err != nil {
-		// The local config points at an assignment we can't resolve. If it's
-		// genuinely not published, that's a "not a group repo we can check"
-		// case — skip silently. Any other (transient/network) failure warns
-		// but still proceeds: the advisory cap must not block on a blip.
+		// Config points at an unresolvable assignment. If it's genuinely not
+		// published, that's a "not a group repo we can check" case — skip
+		// silently. Any other (transient/network) failure warns but proceeds:
+		// the advisory cap must not block on a blip.
 		var nf *assignments.NotFoundError
 		if !errors.As(err, &nf) {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
@@ -151,25 +144,23 @@ func enforceGroupSize(cmd *cobra.Command, client githubapi.Client, org, repo, in
 		return nil // individual assignment → no cap
 	}
 
-	// Bound the collaborator count with the same deadline budget the
-	// Pages fetch uses — go-gh's REST client has no default HTTP timeout,
-	// so an unbounded count could otherwise hang the invite.
+	// Bound the collaborator count with the same deadline the Pages fetch uses
+	// — go-gh's REST client has no default HTTP timeout, so an unbounded count
+	// could hang the invite.
 	ctx, cancel := context.WithTimeout(cmd.Context(), assignments.PagesFetchTimeout)
 	defer cancel()
 	return checkGroupSizeBeforeInvite(ctx, client, org, repo, owner, invitee, entry.MaxGroupSize)
 }
 
-// groupRepoOwner returns the founder login for a group repo, or "" when
-// `repo` is not this assignment's group repo. The repo is named
-// `<classroom>-<assignment>-<owner>` (all lowercased), so the owner is the
-// suffix after the `<classroom>-<assignment>-` prefix. A "" return is the
-// signal enforceGroupSize uses to skip the cap entirely (the invite target
-// isn't the founder's group repo for the local config's assignment), so the
-// member count is only ever taken with a real, matched owner.
+// groupRepoOwner returns the founder login for a group repo, or "" when `repo`
+// isn't this assignment's group repo. The repo is named
+// `<classroom>-<assignment>-<owner>` (lowercased), so the owner is the suffix
+// after the prefix. A "" return signals enforceGroupSize to skip the cap (the
+// target isn't the founder's group repo for the local config's assignment), so
+// the member count is only ever taken with a real, matched owner.
 //
-// The prefix is derived from reponame.Prefix — the same source
-// reponame.Name builds from — so this consumer can never drift from
-// the producer's `<classroom>-<assignment>-<owner>` shape.
+// The prefix comes from reponame.Prefix — the same source reponame.Name builds
+// from — so this consumer can't drift from the producer's shape.
 func groupRepoOwner(repo string, cfg *classroomcfg.Config) string {
 	prefix := reponame.Prefix(cfg.Classroom, cfg.Assignment)
 	lower := strings.ToLower(repo)

--- a/cli/gh-student/internal/localgit/localgit.go
+++ b/cli/gh-student/internal/localgit/localgit.go
@@ -1,7 +1,6 @@
-// Package localgit holds small helpers that inspect the caller's local
-// git working tree (not the GitHub API). Extracted so the accept/submit/
-// invite commands can share them without the helpers living in a command
-// file.
+// Package localgit holds small helpers that inspect the caller's local git
+// working tree (not the GitHub API). Extracted so the accept/submit/invite
+// commands can share them without living in a command file.
 package localgit
 
 import (
@@ -11,10 +10,10 @@ import (
 	"strings"
 )
 
-// CurrentGitRoot returns the toplevel of the git repo the process is run
-// from, and whether the cwd is inside a git tree at all. Used to warn
-// against nested clones. A non-git cwd is ("", false, nil); git-not-found
-// (or another exec failure) propagates as an error.
+// CurrentGitRoot returns the toplevel of the git repo the process runs from,
+// and whether cwd is inside a git tree at all. Used to warn against nested
+// clones. A non-git cwd is ("", false, nil); git-not-found (or another exec
+// failure) propagates as an error.
 func CurrentGitRoot() (string, bool, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 

--- a/cli/gh-student/internal/reponame/reponame.go
+++ b/cli/gh-student/internal/reponame/reponame.go
@@ -1,10 +1,10 @@
 // Package reponame owns the canonical assignment-repo naming formula, a
-// cross-binary contract shared with cli/gh-teacher (which rebuilds the
-// prefix by hand in download.go — separate go.mod, no shared symbol) and
+// cross-binary contract shared with cli/gh-teacher (which rebuilds the prefix
+// by hand in download.go — separate go.mod, no shared symbol) and
 // runner.py::username_from_repo. Changing the shape here silently makes
-// `gh teacher download` return zero repos and misidentifies every
-// submission in scores.json, so it lives in one named seam consumed by
-// every gh-student command that builds or parses a repo name.
+// `gh teacher download` return zero repos and misidentifies every submission
+// in scores.json, so it lives in one named seam consumed by every gh-student
+// command that builds or parses a repo name.
 package reponame
 
 import (
@@ -19,10 +19,10 @@ func Name(classroom, assignment, username string) string {
 }
 
 // Prefix is the single source of the group/individual repo-name prefix
-// `<classroom>-<assignment>-` (all lowercased). Both the producer (Name)
-// and the consumer (group-membership's owner recovery, which strips this
-// prefix to recover the owner login) derive from it, so the
-// `<classroom>-<assignment>-<owner>` shape can only change in one place.
+// `<classroom>-<assignment>-` (all lowercased). Both the producer (Name) and
+// the consumer (group-membership's owner recovery, which strips this prefix)
+// derive from it, so the `<classroom>-<assignment>-<owner>` shape can only
+// change in one place.
 func Prefix(classroom, assignment string) string {
 	return fmt.Sprintf("%s-%s-",
 		strings.ToLower(classroom),

--- a/cli/gh-student/internal/submitcmd/copysubmittable_test.go
+++ b/cli/gh-student/internal/submitcmd/copysubmittable_test.go
@@ -141,9 +141,9 @@ func TestCopySubmittableFiles_ControlFilesKeptEvenUnderStarIgnore(t *testing.T) 
 }
 
 func TestFetchAllowedFiles_FetchFailureReturnsNil(t *testing.T) {
-	// The best-effort guarantee: a manifest fetch failure must never
-	// block submission — fetchAllowedFiles returns nil (submit all files)
-	// because the runner enforces the allowlist authoritatively.
+	// Best-effort guarantee: a manifest fetch failure must never block
+	// submission — fetchAllowedFiles returns nil (submit all) since the
+	// runner enforces the allowlist authoritatively.
 	orig := fetchEntryFn
 	t.Cleanup(func() { fetchEntryFn = orig })
 	fetchEntryFn = func(ctx context.Context, org, classroom, secret, assignment string) (assignments.Entry, error) {
@@ -177,9 +177,9 @@ func TestFetchAllowedFiles_SuccessReturnsPatterns(t *testing.T) {
 // (also consumed by the Python runner.py test) relative to this package.
 const sharedControlPathCasesPath = "../../../shared/testdata/control_path_cases.json"
 
-// TestIsControlPath_SharedFixtureParity runs the shared golden cases so the
-// Go isControlPath and the Python _is_control_path force-keep sets stay in
-// lockstep, the same way the matcher fixture pins the two matchers.
+// TestIsControlPath_SharedFixtureParity runs the shared golden cases so the Go
+// isControlPath and the Python _is_control_path force-keep sets stay in
+// lockstep, like the matcher fixture pins the two matchers.
 func TestIsControlPath_SharedFixtureParity(t *testing.T) {
 	raw, err := os.ReadFile(filepath.Clean(sharedControlPathCasesPath))
 	if err != nil {

--- a/cli/gh-student/internal/submitcmd/orchestration_test.go
+++ b/cli/gh-student/internal/submitcmd/orchestration_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 func TestFetchRepoPath(t *testing.T) {
-	// A repo with a top-level file and a one-level subdirectory, served via
-	// the contents API: a directory listing is a JSON array; a file is a
-	// JSON object with base64 content. fetchRepoPath must recurse and write
-	// every file under dstRoot preserving paths.
+	// A repo with a top-level file and a one-level subdirectory served via the
+	// contents API: a directory listing is a JSON array; a file is a JSON
+	// object with base64 content. fetchRepoPath must recurse and write every
+	// file under dstRoot preserving paths.
 	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
 
 	mux := http.NewServeMux()

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -1,9 +1,8 @@
 // Package submitcmd implements `gh student submit`: snapshot the current
-// branch and push it as a new commit on the assignment repo's main, so
-// the autograde workflow tags and grades the submission. It is an
-// extracted command package; only NewCmd is exported. Consumes the
-// internal/* seams (githubapi, classroomcfg, identity, localgit) + the
-// shared ghutil helper, never package main.
+// branch and push it as a new commit on the assignment repo's main, so the
+// autograde workflow tags and grades the submission. Extracted command
+// package; only NewCmd is exported. Consumes the internal/* seams (githubapi,
+// classroomcfg, identity, localgit) + the shared ghutil helper, never main.
 package submitcmd
 
 import (
@@ -169,11 +168,10 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 		u.Detail("No template source recorded; skipping instructor .gitignore/.github refresh")
 	}
 
-	// The push (clone history + commit + push) is the slowest step, so
-	// drive a spinner. Non-verbose: discard git's stdout and buffer its
-	// stderr, surfacing the tail only on failure, so its "Cloning into…"
-	// chatter doesn't scroll the spinner away. Verbose: stream git
-	// directly so its own progress shows.
+	// The push (clone history + commit + push) is the slowest step, so drive a
+	// spinner. Non-verbose: discard git's stdout and buffer its stderr,
+	// surfacing the tail only on failure, so its "Cloning into…" chatter
+	// doesn't scroll the spinner away. Verbose: stream git directly.
 	const pushMsg = "Submitting"
 	var (
 		pushOut, pushErr = out, errOut
@@ -212,9 +210,9 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 		sp.Stop("Submission pushed")
 	}
 
-	// Confirmation on stdout: the assignment's full name (falls back to
-	// the slug — see resolveAssignmentName) and the local submission time,
-	// then a link to the submitted commit.
+	// Confirmation on stdout: the assignment's full name (falls back to the
+	// slug — see resolveAssignmentName), the local submission time, then a
+	// link to the submitted commit.
 	displayName := resolveAssignmentName(ctx, repoOwner, config.Classroom, config.Secret, config.Assignment)
 	localTime := time.Now().Local().Format("2006-01-02 15:04:05 MST")
 	_, _ = fmt.Fprintf(out, "Submitted assignment %q at %s\n", displayName, localTime)
@@ -247,10 +245,10 @@ func fetchAllowedFiles(ctx context.Context, org string, config *classroomcfg.Con
 	return entry.AllowedFiles
 }
 
-// resolveAssignmentName returns the assignment's full name from the
-// published manifest, falling back to the slug on any error/timeout. The
-// fetch is bounded (assignmentNameTimeout) and runs after the push has
-// already succeeded, so submit never fails — or stalls — over cosmetics.
+// resolveAssignmentName returns the assignment's full name from the published
+// manifest, falling back to the slug on any error/timeout. The fetch is
+// bounded (assignmentNameTimeout) and runs after the push succeeded, so submit
+// never fails — or stalls — over cosmetics.
 func resolveAssignmentName(ctx context.Context, org, classroom, secret, slug string) string {
 	ctx, cancel := context.WithTimeout(ctx, assignmentNameTimeout)
 	defer cancel()
@@ -368,10 +366,9 @@ func fetchRepoPath(
 	}
 }
 
-// parseGitHubRemote: extract (owner, repo) from a GitHub remote
-// URL. Accepts SSH (`git@github.com:owner/repo[.git]`), HTTPS
-// (`https://github.com/owner/repo[.git]`), and
-// `ssh://git@github.com/...` shapes.
+// parseGitHubRemote extracts (owner, repo) from a GitHub remote URL. Accepts
+// SSH (`git@github.com:owner/repo[.git]`), HTTPS
+// (`https://github.com/owner/repo[.git]`), and `ssh://git@github.com/...`.
 func parseGitHubRemote(remoteURL string) (owner, repo string, err error) {
 	remoteURL = strings.TrimSpace(remoteURL)
 	remoteURL = strings.TrimSuffix(remoteURL, ".git")
@@ -404,10 +401,9 @@ func splitOwnerRepo(s string) (owner, repo string) {
 	return parts[0], parts[1]
 }
 
-// commitWorkTreeOnRemoteBranch clones origin into a temporary bare
-// repo, stages workTree onto `branch`, commits with `identity`, and
-// pushes. Returns the new commit SHA (informational; the runner
-// workflow does the auto-tagging on its end).
+// commitWorkTreeOnRemoteBranch clones origin into a temporary bare repo,
+// stages workTree onto `branch`, commits with `identity`, and pushes. Returns
+// the new commit SHA (informational; the runner workflow auto-tags on its end).
 func commitWorkTreeOnRemoteBranch(gitDir string, workTree string, remoteURL string, branch string, message string, identity identitypkg.GitIdentity, out io.Writer, errOut io.Writer) (string, error) {
 	if err := runCmd(out, errOut, "", "git", "clone", "--bare", remoteURL, gitDir); err != nil {
 		return "", fmt.Errorf("clone remote history: %w", err)
@@ -441,8 +437,7 @@ func commitWorkTreeOnRemoteBranch(gitDir string, workTree string, remoteURL stri
 		return "", fmt.Errorf("push submission: %w", err)
 	}
 
-	// Resolve HEAD post-push so callers can log the SHA the runner
-	// workflow will tag.
+	// Resolve HEAD post-push so callers can log the SHA the runner will tag.
 	sha, err := gitOutputWithGitDir(gitDir, "rev-parse", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("resolve submission SHA: %w", err)
@@ -450,9 +445,9 @@ func commitWorkTreeOnRemoteBranch(gitDir string, workTree string, remoteURL stri
 	return strings.TrimSpace(sha), nil
 }
 
-// gitOutputWithGitDir runs `git --git-dir=<gitDir> <args>`.
-// Separate from gitOutput because rev-parsing the submitted commit
-// runs against the bare clone (no work tree).
+// gitOutputWithGitDir runs `git --git-dir=<gitDir> <args>`. Separate from
+// gitOutput because rev-parsing the submitted commit runs against the bare
+// clone (no work tree).
 func gitOutputWithGitDir(gitDir string, args ...string) (string, error) {
 	fullArgs := append([]string{"--git-dir", gitDir}, args...)
 	cmd := exec.Command("git", fullArgs...)
@@ -578,16 +573,15 @@ func copySubmittableFiles(srcRoot string, dstRoot string, allowedFiles []string,
 }
 
 // isControlPath reports whether rel is a control file always submitted
-// regardless of allowed_files. Lockstep with runner.py's
-// _is_control_path / ALLOWED_FILES_KEEP_*: the .classroom50.yaml marker,
-// the .github/ shim, the .git metadata dir, and the runner outputs
-// (result.json, release-body.md). Both sides are pinned by the shared
-// fixture cli/shared/testdata/control_path_cases.json.
+// regardless of allowed_files. Lockstep with runner.py's _is_control_path /
+// ALLOWED_FILES_KEEP_*: the .classroom50.yaml marker, the .github/ shim, the
+// .git metadata dir, and the runner outputs (result.json, release-body.md).
+// Both sides are pinned by cli/shared/testdata/control_path_cases.json.
 //
-// `.git` is included for literal parity with the Python keep-set even
-// though copySubmittableFiles already strips it upstream — keeping the two
+// `.git` is included for literal parity with the Python keep-set even though
+// copySubmittableFiles already strips it upstream — keeping the two
 // classifiers identical means the lockstep holds without relying on that
-// external precondition.
+// precondition.
 func isControlPath(rel string) bool {
 	switch rel {
 	case classroomcfg.MetadataPath, contract.ResultFilename, contract.ReleaseBodyFilename:
@@ -600,7 +594,7 @@ func isControlPath(rel string) bool {
 
 // lastNonEmptyLine returns the last non-empty trimmed line of s, used to
 // surface git's actionable error (e.g. `fatal: ...`) when its stderr was
-// captured to a buffer rather than streamed.
+// buffered rather than streamed.
 func lastNonEmptyLine(s string) string {
 	lines := strings.Split(s, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {

--- a/cli/gh-student/internal/submitcmd/submit_test.go
+++ b/cli/gh-student/internal/submitcmd/submit_test.go
@@ -13,8 +13,8 @@ func TestParseGitHubRemote(t *testing.T) {
 		wantRepo  string
 		wantErr   bool
 	}{
-		// `gh repo clone` defaults to SSH, but students that have
-		// switched gh to https-only show the alternate form.
+		// `gh repo clone` defaults to SSH; students who switched gh to
+		// https-only show the alternate form.
 		{"SSH with .git", "git@github.com:cs50-fall-2026/cs-principles-hello-alice.git", "cs50-fall-2026", "cs-principles-hello-alice", false},
 		{"SSH without .git", "git@github.com:cs50-fall-2026/cs-principles-hello-alice", "cs50-fall-2026", "cs-principles-hello-alice", false},
 		{"HTTPS with .git", "https://github.com/cs50-fall-2026/cs-principles-hello-alice.git", "cs50-fall-2026", "cs-principles-hello-alice", false},
@@ -23,8 +23,8 @@ func TestParseGitHubRemote(t *testing.T) {
 		{"with extra path", "https://github.com/cs50-fall-2026/cs-principles-hello-alice/something", "cs50-fall-2026", "cs-principles-hello-alice", false},
 		{"surrounding whitespace", "  git@github.com:cs50-fall-2026/cs-principles-hello-alice.git\n", "cs50-fall-2026", "cs-principles-hello-alice", false},
 
-		// Reject shapes — a clear error beats a malformed URL that
-		// 404s downstream.
+		// Reject shapes — a clear error beats a malformed URL that 404s
+		// downstream.
 		{"non-GitHub remote", "git@gitlab.com:foo/bar.git", "", "", true},
 		{"missing repo", "git@github.com:cs50-fall-2026/", "", "", true},
 		{"missing owner", "https://github.com//cs-principles-hello-alice.git", "", "", true},
@@ -52,9 +52,9 @@ func TestParseGitHubRemote(t *testing.T) {
 }
 
 func TestParseGitHubRemote_ErrorMentionsShape(t *testing.T) {
-	// A non-GitHub remote should surface an error the student can
-	// understand. The error text shapes the troubleshooting path
-	// (clone via gh, not bare git remote).
+	// A non-GitHub remote should surface an error the student can understand.
+	// The error text shapes the troubleshooting path (clone via gh, not bare
+	// git remote).
 	_, _, err := parseGitHubRemote("git@gitlab.com:foo/bar.git")
 	if err == nil {
 		t.Fatalf("expected error for gitlab.com remote")

--- a/cli/gh-student/internal/ui/ui.go
+++ b/cli/gh-student/internal/ui/ui.go
@@ -1,11 +1,11 @@
 // Package ui renders gh-student's human-facing output (warnings, verbose
-// detail, and the long-running spinner) to a single writer — always
-// stderr, so stdout stays machine-stable for scripts and greps.
+// detail, and the long-running spinner) to a single writer — always stderr, so
+// stdout stays machine-stable for scripts and greps.
 //
-// It mirrors gh-teacher's internal/ui tone and shares the ghui spinner +
+// Mirrors gh-teacher's internal/ui tone and shares the ghui spinner +
 // color/TTY policy so the two CLIs present a consistent experience: the
-// "Warning: " prefix is preserved in both color and plain modes, and
-// color is TTY-gated (honoring NO_COLOR / CLASSROOM50_NO_COLOR).
+// "Warning: " prefix is preserved in both color and plain modes, and color is
+// TTY-gated (honoring NO_COLOR / CLASSROOM50_NO_COLOR).
 package ui
 
 import (
@@ -28,14 +28,14 @@ type UI struct {
 }
 
 // New builds a UI writing to w, auto-detecting color via ghui.UseColor
-// (stderr-TTY-gated, honoring NO_COLOR / CLASSROOM50_NO_COLOR) so the
-// policy stays identical to the shared spinner and gh-teacher.
+// (stderr-TTY-gated, honoring NO_COLOR / CLASSROOM50_NO_COLOR) so the policy
+// stays identical to the shared spinner and gh-teacher.
 func New(w io.Writer) *UI {
 	return &UI{w: w, color: ghui.UseColor(w)}
 }
 
 // NewForced builds a UI with an explicit color setting, for deterministic
-// tests of either renderer.
+// tests.
 func NewForced(w io.Writer, color bool) *UI {
 	return &UI{w: w, color: color}
 }
@@ -47,17 +47,17 @@ func (u *UI) paint(code, s string) string {
 	return code + s + ansiReset
 }
 
-// Spinner returns a live single-line spinner for a long-running step,
-// writing to the human channel. Animates on a TTY; degrades to plain
-// lines otherwise. Backed by the shared ghui spinner so gh-student and
-// gh-teacher animate identically.
+// Spinner returns a live single-line spinner for a long-running step, writing
+// to the human channel. Animates on a TTY; degrades to plain lines otherwise.
+// Backed by the shared ghui spinner so gh-student and gh-teacher animate
+// identically.
 func (u *UI) Spinner(message string) *ghui.Spinner {
 	return ghui.NewSpinner(u.w, message)
 }
 
 // Warn prints a warning that ALWAYS contains the literal "Warning: " so
-// downstream log scrapers and existing assertions keep working; on a
-// color TTY it's additionally prefixed with a yellow ⚠.
+// downstream log scrapers and assertions keep working; on a color TTY it's
+// additionally prefixed with a yellow ⚠.
 func (u *UI) Warn(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	if u.color {
@@ -68,7 +68,7 @@ func (u *UI) Warn(format string, a ...any) {
 }
 
 // Detail prints a dimmed continuation line (dimmed on a color TTY, plain
-// otherwise) — used for verbose per-step operational detail.
+// otherwise) for verbose per-step operational detail.
 func (u *UI) Detail(format string, a ...any) {
 	_, _ = fmt.Fprintf(u.w, "%s\n", u.paint(ansiDim, fmt.Sprintf(format, a...)))
 }

--- a/cli/gh-student/main.go
+++ b/cli/gh-student/main.go
@@ -14,8 +14,7 @@ import (
 	"github.com/foundation50/gh-student/internal/submitcmd"
 )
 
-// Build metadata, injected by the release workflow via
-// -ldflags "-X main.version=… -X main.commit=… -X main.date=…". Defaults
+// Build metadata, injected by the release workflow via -ldflags. Defaults
 // identify a local (non-release) build.
 var (
 	version = "dev"
@@ -42,9 +41,9 @@ func main() {
 	root.AddCommand(invitecmd.NewCmd())
 	root.AddCommand(submitcmd.NewCmd())
 
-	// Signal-aware root context: subcommands see cmd.Context()
-	// cancel on Ctrl-C / SIGTERM so in-flight HTTP (notably the
-	// Pages fetches in accept and invite) unwinds promptly.
+	// Signal-aware root context: subcommands see cmd.Context() cancel on
+	// Ctrl-C / SIGTERM so in-flight HTTP (the Pages fetches in accept and
+	// invite) unwinds promptly.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -53,8 +52,8 @@ func main() {
 	}
 }
 
-// versionString renders cobra's --version line. A release build shows the
-// injected tag, short commit, and build date; a local build stays terse ("dev").
+// versionString renders cobra's --version line: a release build shows the
+// injected tag, short commit, and build date; a local build stays "dev".
 func versionString() string {
 	if commit == "none" && date == "unknown" {
 		return version

--- a/cli/gh-student/testhelpers_test.go
+++ b/cli/gh-student/testhelpers_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // newTestRESTClient wires a real go-gh client at the test server, as the
-// githubapi.Client seam. Thin shim over githubtest.NewTestClient so the
-// existing package-main test call sites stay unchanged.
+// githubapi.Client seam. Thin shim over githubtest.NewTestClient so existing
+// package-main call sites stay unchanged.
 func newTestRESTClient(t *testing.T, server *httptest.Server) githubapi.Client {
 	t.Helper()
 	return githubtest.NewTestClient(t, server)

--- a/cli/gh-teacher/autograder_cmd.go
+++ b/cli/gh-teacher/autograder_cmd.go
@@ -21,26 +21,21 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// classroomAutograderFilename: file name written under <classroom>/.
-// Mirrored across:
-//   - publish-pages.yaml's per-classroom publish step (`<classroom>/autograder.py`
-//     → `_site/<classroom>/autograder.py`)
-//   - skeleton/dotgithub/scripts/runner.py's classroom_default_autograder_url
+// classroomAutograderFilename: file written under <classroom>/. Mirrored in
+// publish-pages.yaml and runner.py's classroom_default_autograder_url.
 const classroomAutograderFilename = "autograder.py"
 
-// diagnosticStub is the autograder.py written to <classroom>/autograder.py
-// when `gh teacher autograder set-default` is invoked without --from.
-// Echoes runner-supplied env vars, writes a vacuous-pass result.json,
-// and exits 0 — useful for verifying the pipeline before authoring
-// real grading logic.
+// diagnosticStub is written to <classroom>/autograder.py when `autograder
+// set-default` runs without --from. Echoes runner env vars, writes a
+// vacuous-pass result.json, exits 0 — for verifying the pipeline before real
+// grading logic.
 //
 //go:embed embed/autograder.py
 var diagnosticStub []byte
 
-// autograderCmd: top-level group for managing classroom default
-// autograders. Per-assignment autograders are NOT managed here —
-// they live as files at `<classroom>/autograders/<slug>/autograder.py`
-// and are committed via ordinary git tooling.
+// autograderCmd: top-level group for classroom default autograders.
+// Per-assignment autograders live as files at
+// `<classroom>/autograders/<slug>/autograder.py` and are managed via git.
 func autograderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "autograder",
@@ -69,14 +64,9 @@ func autograderCmd() *cobra.Command {
 	return cmd
 }
 
-// autograderSetDefaultCmd: replace `<classroom>/autograder.py` in
-// `<org>/classroom50` with the contents of `--from <path>` (or
-// stdin via `--from -`). When `--from` is omitted, writes the
-// shipped diagnostic stub — useful for verifying the runner
-// pipeline before authoring real grading logic. Single Tree commit
-// through configwrite.CommitTree so concurrent edits don't silently lose each
-// other's work. No-ops when the proposed body matches the on-disk
-// body byte-for-byte.
+// autograderSetDefaultCmd: replace `<classroom>/autograder.py` with `--from
+// <path>` (or stdin via `--from -`). When --from is omitted, writes the
+// diagnostic stub. Single Tree commit; no-ops when the body is unchanged.
 func autograderSetDefaultCmd() *cobra.Command {
 	var fromPath string
 	cmd := &cobra.Command{
@@ -124,13 +114,10 @@ func autograderSetDefaultCmd() *cobra.Command {
 	return cmd
 }
 
-// readAutograderSource loads the proposed body. Empty `path` returns
-// the embedded diagnostic stub (unconditionally non-empty by build).
-// `-` reads from stdin (the cobra command's wired-in reader, so tests
-// can hand it a buffer). Any other value is a filesystem path. Empty
-// content from --from path/stdin is rejected — committing an empty
-// autograder.py would silently disable grading for every assignment
-// in the classroom.
+// readAutograderSource loads the proposed body. Empty `path` returns the
+// embedded stub; `-` reads stdin; any other value is a filesystem path. Empty
+// content from --from is rejected — an empty autograder.py would silently
+// disable grading for every assignment.
 func readAutograderSource(path string, stdin io.Reader) (content []byte, label string, err error) {
 	if path == "" {
 		return diagnosticStub, "<diagnostic stub>", nil
@@ -151,21 +138,18 @@ func readAutograderSource(path string, stdin io.Reader) (content []byte, label s
 	return content, label, nil
 }
 
-// setClassroomDefaultAutograder lands `content` as
-// `<classroom>/autograder.py` on `<org>/classroom50`'s default
-// branch. Validates the classroom exists in the config repo before
-// writing — prevents typos creating phantom-classroom files. Skips
-// the commit when the existing file is already byte-for-byte equal.
+// setClassroomDefaultAutograder lands `content` as `<classroom>/autograder.py`.
+// Validates the classroom exists before writing (prevents typos creating
+// phantom files). Skips the commit when the file is already byte-equal.
 func setClassroomDefaultAutograder(client githubapi.Client, out, errOut io.Writer, org, classroom, label string, content []byte) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
 		return err
 	}
 
-	// Validate the classroom is registered before writing — `set-default`
-	// against a typo'd classroom name would otherwise silently create a
-	// phantom directory containing only autograder.py, which then never
-	// gets graded because no assignments are registered there.
+	// Validate the classroom is registered before writing — else a typo'd name
+	// silently creates a phantom dir with only autograder.py that never grades
+	// (no assignments registered there).
 	if err := requireClassroomExists(client, org, classroom, branch); err != nil {
 		return err
 	}
@@ -177,7 +161,7 @@ func setClassroomDefaultAutograder(client githubapi.Client, out, errOut io.Write
 			return nil, err
 		}
 		if existing != nil && bytes.Equal(existing, content) {
-			return nil, nil // no-op: identical to what's already in the repo
+			return nil, nil // no-op: identical to the repo
 		}
 		return map[string]string{repoPath: string(content)}, nil
 	}
@@ -198,13 +182,10 @@ func setClassroomDefaultAutograder(client githubapi.Client, out, errOut io.Write
 	return nil
 }
 
-// fetchFileContent returns the raw bytes of `path` at `ref`. 404 →
-// (nil, nil) so the caller can treat "doesn't exist yet" the same as
-// "different from proposed". Other errors propagate.
-//
-// The contents API returns the body base64-encoded for files up to
-// ~1 MB; autograder.py is well under that ceiling. Files >100 MB
-// would need the git-blobs API, but that's out of scope.
+// fetchFileContent returns the raw bytes of `path` at `ref`. 404 → (nil, nil)
+// so the caller treats "doesn't exist yet" like "different from proposed".
+// Other errors propagate. The contents API base64-encodes files up to ~1 MB;
+// autograder.py is well under that.
 func fetchFileContent(client githubapi.Client, owner, repo, path, ref string) ([]byte, error) {
 	segs := strings.Split(path, "/")
 	for i := range segs {
@@ -227,8 +208,7 @@ func fetchFileContent(client githubapi.Client, owner, repo, path, ref string) ([
 	if body.Encoding != "base64" {
 		return nil, fmt.Errorf("GET %s: unexpected encoding %q (want base64)", apiPath, body.Encoding)
 	}
-	// GitHub wraps base64 at 76 chars per RFC 4648 §3.2; strip
-	// whitespace before decoding.
+	// GitHub wraps base64 at 76 chars; strip whitespace before decoding.
 	clean := strings.Map(func(r rune) rune {
 		if r == '\n' || r == '\r' || r == ' ' || r == '\t' {
 			return -1

--- a/cli/gh-teacher/autograder_crud.go
+++ b/cli/gh-teacher/autograder_crud.go
@@ -20,11 +20,9 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// requireClassroomExists errors unless <classroom>/classroom.json is
-// present in <org>/classroom50 at `branch`. Shared by the autograder
-// read/write commands so a typo'd classroom name surfaces as a clear
-// "run classroom add" error instead of an empty listing or a phantom
-// directory. Mirrors set-default's original inline guard.
+// requireClassroomExists errors unless <classroom>/classroom.json is present at
+// `branch`. Shared by the autograder commands so a typo surfaces as a clear
+// "run classroom add" error instead of an empty listing or phantom directory.
 func requireClassroomExists(client githubapi.Client, org, classroom, branch string) error {
 	marker := classroom + "/classroom.json"
 	exists, err := configrepo.ContentsExists(client, org, configrepo.ConfigRepoName, marker, branch)
@@ -38,10 +36,9 @@ func requireClassroomExists(client githubapi.Client, org, classroom, branch stri
 	return nil
 }
 
-// gitBlobSHA computes the git blob object id for `content` -- the same
-// 40-hex SHA-1 the contents/trees API reports for a file -- so
-// `autograder show --json` can surface it without a second API call.
-// Formula: sha1("blob <bytelen>\x00" + content).
+// gitBlobSHA computes the git blob object id for `content` — the same 40-hex
+// SHA-1 the contents/trees API reports — so `autograder show --json` can
+// surface it without a second API call. Formula: sha1("blob <len>\x00" + content).
 func gitBlobSHA(content []byte) string {
 	h := sha1.New()
 	_, _ = fmt.Fprintf(h, "blob %d\x00", len(content))
@@ -51,9 +48,8 @@ func gitBlobSHA(content []byte) string {
 
 // ---- autograder show -------------------------------------------------
 
-// autograderShowMeta is the `--json` view for `autograder show`: the
-// metadata a script or agent needs to decide what (if anything) is
-// installed without parsing the file body.
+// autograderShowMeta is the `--json` view for `autograder show`: the metadata a
+// script needs to decide what's installed without parsing the body.
 type autograderShowMeta struct {
 	Path   string `json:"path"`
 	Exists bool   `json:"exists"`
@@ -105,9 +101,9 @@ func autograderShowCmd() *cobra.Command {
 	return cmd
 }
 
-// runAutograderShow reads <classroom>/autograder.py and renders it as
-// either the raw body (default) or a metadata object (--json). A
-// missing file is a clean exit-0 "none" state, not an error.
+// runAutograderShow reads <classroom>/autograder.py and renders it as the raw
+// body (default) or a metadata object (--json). A missing file is a clean
+// exit-0 "none" state.
 func runAutograderShow(client githubapi.Client, out, errOut io.Writer, org, classroom string, asJSON, quiet bool) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -157,18 +153,16 @@ func runAutograderShow(client githubapi.Client, out, errOut io.Writer, org, clas
 	return nil
 }
 
-// bytesEqualStub reports whether content is byte-for-byte the shipped
-// diagnostic stub (what set-default writes with no --from).
+// bytesEqualStub reports whether content is byte-for-byte the shipped stub.
 func bytesEqualStub(content []byte) bool {
 	return string(content) == string(diagnosticStub)
 }
 
 // ---- autograder list -------------------------------------------------
 
-// autograderListEntry is one immediate child of <classroom>/autograders/.
-// Kind is "named-shim" for a `<name>.yaml` workflow shim (referenced by
-// `assignment add --autograder <name>`) or "per-assignment" for a
-// `<slug>/` override bundle (auto-applied to the matching assignment).
+// autograderListEntry is one immediate child of <classroom>/autograders/. Kind
+// is "named-shim" for a `<name>.yaml` shim or "per-assignment" for a `<slug>/`
+// override bundle.
 type autograderListEntry struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
@@ -226,8 +220,8 @@ func autograderListCmd() *cobra.Command {
 }
 
 // runAutograderList enumerates the immediate children of
-// <classroom>/autograders/ in one contents-API call. A missing
-// autograders/ directory (404) is a clean empty listing, not an error.
+// <classroom>/autograders/ in one contents-API call. A missing directory (404)
+// is a clean empty listing.
 func runAutograderList(client githubapi.Client, out, errOut io.Writer, org, classroom string, asJSON, quiet bool) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -259,8 +253,8 @@ func runAutograderList(client githubapi.Client, out, errOut io.Writer, org, clas
 					Kind: autograderKindNamedShim,
 					Path: dirPath + "/" + e.Name,
 				})
-				// Any other file (e.g. a stray README) is not an autograder
-				// artifact and is skipped.
+				// Any other file (e.g. a stray README) isn't an autograder
+				// artifact; skip.
 			}
 		}
 	}
@@ -350,8 +344,8 @@ func autograderRemoveCmd() *cobra.Command {
 }
 
 // removeClassroomDefaultAutograder deletes <classroom>/autograder.py via
-// configwrite.CommitTreeChange. Existence is re-probed inside the build callback so
-// a concurrent delete collapses to a clean no-op rather than an error.
+// CommitTreeChange. Existence is re-probed inside the build callback so a
+// concurrent delete collapses to a no-op.
 func removeClassroomDefaultAutograder(client githubapi.Client, in io.Reader, out, errOut io.Writer, org, classroom string, skipConfirm bool) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -363,8 +357,7 @@ func removeClassroomDefaultAutograder(client githubapi.Client, in io.Reader, out
 
 	repoPath := classroom + "/" + classroomAutograderFilename
 
-	// Preflight so a no-default classroom short-circuits before the
-	// confirmation prompt. The authoritative check happens in build.
+	// Preflight so a no-default classroom short-circuits before the prompt.
 	exists, err := configrepo.ContentsExists(client, org, configrepo.ConfigRepoName, repoPath, branch)
 	if err != nil {
 		return err
@@ -409,9 +402,8 @@ func removeClassroomDefaultAutograder(client githubapi.Client, in io.Reader, out
 	return nil
 }
 
-// confirmAutograderRemove prompts on errOut and reads one line from in.
-// Only an explicit y/yes proceeds; mismatch returns (false, nil), a read
-// error (other than EOF) propagates. Mirrors confirmSkeletonRefresh.
+// confirmAutograderRemove prompts on errOut and reads one line. Only y/yes
+// proceeds; a read error (other than EOF) propagates.
 func confirmAutograderRemove(in io.Reader, errOut io.Writer, classroom string) (bool, error) {
 	_, _ = fmt.Fprintf(errOut, "Remove the default autograder.py for %s? Assignments without a per-assignment override will grade as a vacuous pass until you set a new one. [y/N]: ", classroom)
 	line, err := bufio.NewReader(in).ReadString('\n')

--- a/cli/gh-teacher/autograders_tests/conftest.py
+++ b/cli/gh-teacher/autograders_tests/conftest.py
@@ -1,20 +1,18 @@
 """Loads the embedded scripts for the test suite.
 
-The runner-side scripts live under
-`cli/gh-teacher/skeleton/dotgithub/scripts/` because `gh teacher init`
-lands them at `.github/scripts/` in each org's `classroom50` repo:
-  - runner.py         — runner-side bootstrap (loaded as a module so
-                        its pure helpers are unit-testable)
-  - collect_scores.py — score collector (loaded so cross-binary
-                        constants like RESULT_SCHEMA_V1 can be
-                        compared, not just pinned to literals)
+The runner-side scripts live under `cli/gh-teacher/skeleton/dotgithub/scripts/`
+because `gh teacher init` lands them at `.github/scripts/` in each org's
+`classroom50` repo:
+  - runner.py         — runner-side bootstrap (loaded as a module so its pure
+                        helpers are unit-testable)
+  - collect_scores.py — score collector (loaded so cross-binary constants like
+                        RESULT_SCHEMA_V1 can be compared, not just pinned)
 
-The diagnostic-stub autograder lives under `cli/gh-teacher/embed/`
-because it's `//go:embed`-ed into the gh-teacher binary and written
-to `<classroom>/autograder.py` only when teachers run
-`gh teacher autograder set-default` without `--from`.
-test_default_autograder.py runs it as a subprocess because it does
-its work at module-execution time.
+The diagnostic-stub autograder lives under `cli/gh-teacher/embed/` because it's
+`//go:embed`-ed into the gh-teacher binary and written to
+`<classroom>/autograder.py` only when teachers run `gh teacher autograder
+set-default` without `--from`. test_default_autograder.py runs it as a
+subprocess because it does its work at module-execution time.
 """
 
 from __future__ import annotations

--- a/cli/gh-teacher/autograders_tests/test_declarative_grader.py
+++ b/cli/gh-teacher/autograders_tests/test_declarative_grader.py
@@ -1,12 +1,11 @@
 """Tests for the built-in declarative test grader in runner.py.
 
-The grader turns a materialized tests.json (input/output, run-command,
-and pytest specs -- the GitHub Classroom-style autograding model) into a
-classroom50/result/v1 result.json. These tests exercise the comparison
-modes, per-test execution (timeouts, setup, exit codes, fixtures), the
-pytest points split, and the end-to-end run_declarative wiring. Real
-shell commands run in pytest's tmp_path so the subprocess behavior is
-covered, not mocked.
+The grader turns a materialized tests.json (input/output, run-command, and
+pytest specs -- the GitHub Classroom-style autograding model) into a
+classroom50/result/v1 result.json. These exercise the comparison modes,
+per-test execution (timeouts, setup, exit codes, fixtures), the pytest points
+split, and the end-to-end run_declarative wiring. Real shell commands run in
+pytest's tmp_path so the subprocess behavior is covered, not mocked.
 """
 
 from __future__ import annotations
@@ -169,8 +168,8 @@ def _pytest_run(testfile_body: str, tmp_path, points: int) -> dict:
     (tmp_path / "test_sample.py").write_text(testfile_body)
     spec = {
         "name": "suite", "type": "python",
-        # sys.executable so the subprocess uses this interpreter (which
-        # has pytest + pytest-json-report), not whatever `python` is on PATH.
+        # sys.executable so the subprocess uses this interpreter (which has
+        # pytest + pytest-json-report), not whatever `python` is on PATH.
         "run": f"{shlex.quote(sys.executable)} -m pytest -q",
         "timeout": 60, "points": points,
     }
@@ -224,10 +223,9 @@ class TestExecutePython:
         assert o["score"] == 2 and not o["passed"]
 
     def test_teacher_supplied_json_report_flags_not_duplicated(self, tmp_path):
-        # A run command that already configures the plugin must not get
-        # the flags appended again (pytest errors on duplicates). The
-        # report then lands at the teacher's path, not ours, so scoring
-        # falls back to the exit code.
+        # A run command that already configures the plugin must not get the
+        # flags appended again (pytest errors on duplicates). The report then
+        # lands at the teacher's path, not ours, so scoring falls back to exit.
         (tmp_path / "test_sample.py").write_text("def test_a():\n    assert True\n")
         spec = {
             "name": "suite", "type": "python",

--- a/cli/gh-teacher/autograders_tests/test_default_autograder.py
+++ b/cli/gh-teacher/autograders_tests/test_default_autograder.py
@@ -1,15 +1,13 @@
-"""Subprocess-driven tests for the diagnostic-stub autograder.py
-shipped inside gh-teacher (`cli/gh-teacher/embed/autograder.py`).
+"""Subprocess-driven tests for the diagnostic-stub autograder.py shipped inside
+gh-teacher (`cli/gh-teacher/embed/autograder.py`).
 
-The stub does its work at module-execution time (no functions to
-unit-test), so we run it as a subprocess with synthesized env vars +
-a temp cwd and inspect the side effects: result.json, release-body.md,
-and $GITHUB_OUTPUT contents.
+The stub does its work at module-execution time (no functions to unit-test), so
+we run it as a subprocess with synthesized env vars + a temp cwd and inspect the
+side effects: result.json, release-body.md, and $GITHUB_OUTPUT.
 
-`gh teacher autograder set-default <org> <classroom>` writes this
-stub to `<classroom>/autograder.py` when the teacher omits `--from`,
-so the runner pipeline can be verified end-to-end before any real
-grading logic is in place.
+`gh teacher autograder set-default <org> <classroom>` writes this stub to
+`<classroom>/autograder.py` when the teacher omits `--from`, so the runner
+pipeline can be verified end-to-end before any real grading logic is in place.
 """
 
 from __future__ import annotations

--- a/cli/gh-teacher/autograders_tests/test_inline_validator.py
+++ b/cli/gh-teacher/autograders_tests/test_inline_validator.py
@@ -1,18 +1,16 @@
 """Behavioral tests for the inline Python validator embedded in
 autograde-runner.yaml's setup job.
 
-The validator runs in production on every student submission against
-a teacher-controlled assignments.json + a student-controlled
-.classroom50.yaml, and it's the last gate before runtime values flow
-into the grade job's `runs-on:`/`container:` mapping. Drift between
-this validator and `runtime.go` (CLI write-time) would let injection
-past one or the other without any test catching it.
+The validator runs in production on every submission against a
+teacher-controlled assignments.json + a student-controlled .classroom50.yaml,
+and it's the last gate before runtime values flow into the grade job's
+`runs-on:`/`container:` mapping. Drift between it and `runtime.go` (CLI
+write-time) would let injection past one or the other untested.
 
-These tests extract the YAML-embedded `shell: python3 {0}` block,
-write it to a tempfile, and exec it as a subprocess with hand-crafted
-.classroom50.yaml + assignments.json fixtures so the validator's
-allow-lists, regexes, and emit shape can be exercised independently
-of the rest of the workflow.
+These tests extract the YAML-embedded `shell: python3 {0}` block, write it to a
+tempfile, and exec it as a subprocess with hand-crafted .classroom50.yaml +
+assignments.json fixtures so the validator's allow-lists, regexes, and emit
+shape can be exercised independently of the rest of the workflow.
 """
 
 from __future__ import annotations
@@ -36,9 +34,8 @@ _RUNNER_YAML = (
 
 
 def _extract_inline_python() -> str:
-    """Pull the inline Python validator body out of the setup-job's
-    `read` step. Identifies the step by its `id: read` + `shell:
-    python3 {0}` pair and returns the text of its `run:` block."""
+    """Pull the inline Python validator body out of the setup-job's `read`
+    step, identified by its `id: read` + `shell: python3 {0}` pair."""
     doc = yaml.safe_load(_RUNNER_YAML.read_text())
     setup_steps = doc["jobs"]["setup"]["steps"]
     for step in setup_steps:
@@ -64,10 +61,10 @@ def _run_validator(
 ) -> tuple[int, str, str, dict]:
     """Run the inline validator with hand-crafted env + fixtures.
 
-    Stubs network: the validator's `get(manifest_url)` call hits a
-    file:// URL pointing at the local manifest fixture instead of
-    GitHub Pages. Manifest=None → no file written, simulating a 404
-    (the validator should fail gracefully).
+    Stubs network: the validator's `get(manifest_url)` hits a file:// URL
+    pointing at the local manifest fixture instead of GitHub Pages.
+    Manifest=None → no file written, simulating a 404 (validator should fail
+    gracefully).
 
     Returns (exit_code, stdout, stderr, parsed-GITHUB_OUTPUT-as-dict).
     """
@@ -88,20 +85,10 @@ def _run_validator(
     gh_output = tmp_path / "github-output"
     gh_output.write_text("")
 
-    # Wire the validator's Pages fetch at a local file:// URL so the
-    # `get()` helper resolves without a network round-trip. The
-    # validator hard-codes `https://{owner}.github.io/classroom50` —
-    # we monkey-patch the env-driven owner to be the literal pages
-    # root via REPO_OWNER and a small wrapper.
-
-    # Simpler: replace `f"https://{owner}.github.io/classroom50"`
-    # with a file:// URL via env-injected sed-on-source. But the
-    # script reads `REPO_OWNER` from env and composes the URL itself.
-    # We can't intercept that cleanly without rewriting the script.
-    #
-    # Pragmatic workaround: write a tiny wrapper that monkey-patches
-    # urlopen before exec'ing the validator, so the file:// URL is
-    # served from the pages_root fixture.
+    # Serve the validator's Pages fetch from a local file:// URL. The script
+    # composes `https://{REPO_OWNER}.github.io/classroom50` from env itself, so
+    # rather than intercept that, a tiny wrapper monkey-patches urlopen before
+    # exec'ing the validator to serve the URL from the pages_root fixture.
 
     wrapper = textwrap.dedent(f"""
     import urllib.request
@@ -361,10 +348,9 @@ class TestRunsOnRejection:
 
 
 class TestUnknownKeyRejection:
-    """Hand-edited assignments.json with extra keys must be rejected
-    by the runtime validator, mirroring Go's DisallowUnknownFields.
-    Without this, `container.options: --privileged` would flow through
-    to the grade job."""
+    """Hand-edited assignments.json with extra keys must be rejected by the
+    runtime validator, mirroring Go's DisallowUnknownFields. Without this,
+    `container.options: --privileged` would flow through to the grade job."""
 
     def test_unknown_runtime_key_rejected(self, inline_script, tmp_path):
         rc, _stdout, stderr, _outputs = _run_validator(
@@ -453,9 +439,9 @@ class TestFieldValidation:
 
 class TestDeclarativeTestsValidation:
     """The setup job re-validates the `tests` block (mirroring
-    cli/gh-teacher/tests.go, like the runtime block's dual validation):
-    a hand-edited assignments.json must fail at setup with a clear
-    message, and nothing from `tests` may reach the job outputs."""
+    cli/gh-teacher/tests.go, like the runtime block's dual validation): a
+    hand-edited assignments.json must fail at setup with a clear message, and
+    nothing from `tests` may reach the job outputs."""
 
     def test_valid_tests_pass_and_never_reach_outputs(self, inline_script, tmp_path):
         rc, _stdout, _stderr, outputs = _run_validator(

--- a/cli/gh-teacher/autograders_tests/test_main.py
+++ b/cli/gh-teacher/autograders_tests/test_main.py
@@ -1,16 +1,14 @@
 """Integration tests for `runner.py::main()`.
 
-The pure helpers (URL composition, validate_result, fetch_url
-retries, etc.) are unit-tested in test_runner.py. This file covers
-the orchestration glue — bundle fetch, extraction, entrypoint
-resolution (per-assignment vs classroom default vs vacuous pass),
-subprocess exec, result.json validation, and Finalizer-driven error
-synthesis.
+The pure helpers (URL composition, validate_result, fetch_url retries, etc.)
+are unit-tested in test_runner.py. This covers the orchestration glue — bundle
+fetch, extraction, entrypoint resolution (per-assignment vs classroom default
+vs vacuous pass), subprocess exec, result.json validation, and Finalizer-driven
+error synthesis.
 
-Each test stubs `runner.fetch_url` and the autograder subprocess so
-no real network or pytest invocation happens. Verifies the
-side-effects on the workspace (`result.json`, `release-body.md`) and
-on `$GITHUB_OUTPUT`.
+Each test stubs `runner.fetch_url` and the autograder subprocess so no real
+network or pytest invocation happens. Verifies side-effects on the workspace
+(`result.json`, `release-body.md`) and on `$GITHUB_OUTPUT`.
 """
 
 from __future__ import annotations

--- a/cli/gh-teacher/autograders_tests/test_runner.py
+++ b/cli/gh-teacher/autograders_tests/test_runner.py
@@ -1,15 +1,13 @@
 """Tests for the runner-side bootstrap (`runner.py`).
 
-The runner's job is to (1) download + extract the per-assignment
-bundle, (2) resolve the entrypoint (per-assignment override,
-classroom default, or vacuous-pass fallback), (3) exec it with the
-right env / cwd, and (4) validate / synthesize the autograder's
-outputs. These tests cover the data-shape invariants the rest of
-the loop depends on plus the URL helpers and HTTP retry logic.
+The runner (1) downloads + extracts the per-assignment bundle, (2) resolves the
+entrypoint (per-assignment override, classroom default, or vacuous-pass
+fallback), (3) execs it with the right env/cwd, and (4) validates/synthesizes
+the autograder's outputs. These cover the data-shape invariants the loop
+depends on plus the URL helpers and HTTP retry logic.
 
-Integration testing of the diagnostic-stub autograder.py (shipped
-inside gh-teacher) lives in test_default_autograder.py
-(subprocess-driven).
+Integration testing of the diagnostic-stub autograder.py (shipped inside
+gh-teacher) lives in test_default_autograder.py (subprocess-driven).
 """
 
 from __future__ import annotations

--- a/cli/gh-teacher/init.go
+++ b/cli/gh-teacher/init.go
@@ -94,18 +94,16 @@ func initCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			errOut := cmd.ErrOrStderr()
 
-			// --json implies --quiet so stdout stays a single
-			// machine-readable object and no human chatter interleaves.
+			// --json implies --quiet so stdout stays a single machine-readable
+			// object with no interleaved chatter.
 			if asJSON {
 				quiet = true
 			}
 			u := ui.New(errOut)
 
-			// Preflight: read-only checks before any mutation. A hard
-			// failure (missing scope, org not found, not an owner, no
-			// token + no prompt) stops here so init never leaves a
-			// half-configured org. Plan is read once and reused by the
-			// lockdown read-back's plan-aware warning.
+			// Preflight: read-only checks before any mutation. A hard failure
+			// stops here so init never leaves a half-configured org. Plan is
+			// read once and reused by the lockdown read-back's warning.
 			tok := currentTokenSource()
 			pre := runPreflight(client, org, tok)
 			renderPreflight(u, pre, quiet)
@@ -137,14 +135,11 @@ func initCmd() *cobra.Command {
 			prog := u.NewProgress(total)
 			interactive := prog.Active()
 
-			// On an interactive terminal, fold the per-step output into one
-			// self-rewriting progress line ([1/12] → [12/12] Done): route
-			// the helpers' stdout (success lines) to a discard and their
-			// stderr (warnings) to a buffer that's replayed once the
-			// progress line is finalized, so nothing scrolls the line away.
-			// On a non-TTY / piped / --quiet / --json run, keep the stable
-			// per-line output (stepOut = real stdout, stepErr = real stderr)
-			// so machine consumers and logs are unchanged.
+			// On an interactive terminal, fold per-step output into one
+			// self-rewriting progress line: route helpers' stdout to discard
+			// and stderr to a buffer replayed after the line finalizes, so
+			// nothing scrolls it away. On a non-TTY/piped/--quiet/--json run,
+			// keep stable per-line output.
 			stepOut, stepErr := out, errOut
 			var capturedErr bytes.Buffer
 			if interactive {
@@ -163,21 +158,16 @@ func initCmd() *cobra.Command {
 					u.Step(stepNum, total, label)
 				}
 			}
-			// flushStepWarnings replays any warnings the helpers buffered
-			// during the interactive progress phase (rare edge-case
-			// Warning: lines), after the progress line is done.
+			// flushStepWarnings replays warnings the helpers buffered during the
+			// interactive progress phase, after the line is done.
 			flushStepWarnings := func() {
 				if interactive && capturedErr.Len() > 0 {
 					_, _ = io.Copy(errOut, &capturedErr)
 				}
 			}
 
-			// (The org plan was already checked read-only in preflight —
-			// pre.Plan — and its advisory is surfaced there, so init no
-			// longer re-fetches /orgs/{org} for a second plan warning.)
-
-			// Tighten org-level member defaults before any repos
-			// land so the classroom starts in a known-safe state.
+			// Tighten org-level member defaults before any repos land so the
+			// classroom starts in a known-safe state.
 			step(initStepLabels[0])
 			lockdownComplete, unenforced, err := applyOrgMemberDefaults(client, stepOut, stepErr, org, pre.Plan)
 			if err != nil {
@@ -185,31 +175,25 @@ func initCmd() *cobra.Command {
 				return err
 			}
 			summary.LockdownComplete = lockdownComplete
-			// Build one consolidated, verified checklist of the settings
-			// init couldn't apply (whether plan-gated 422 or silently
-			// ignored) from the authoritative read-back. Each carries the
-			// exact GitHub-UI instruction, so the teacher gets a single
-			// "do this by hand" list instead of three overlapping warnings.
+			// Build one consolidated, verified checklist of the settings init
+			// couldn't apply (plan-gated 422 or silently ignored) from the
+			// read-back, each with its GitHub-UI instruction.
 			settingsURL := fmt.Sprintf("https://github.com/organizations/%s/settings/member_privileges", org)
 			for _, item := range unenforced {
 				summary.LockdownManualSteps = append(summary.LockdownManualSteps, orgpolicy.ManualStep{Setting: item.manualFix, URL: settingsURL})
 			}
 			if !lockdownComplete {
-				// The org-level locks are what defang the repo-admin that
-				// `gh student accept` grants each founder. Record the
-				// warning; the actionable checklist is rendered at the end
-				// (with the summary) so it isn't lost above the progress
-				// line.
+				// The org-level locks defang the repo-admin `student accept`
+				// grants each founder. Record the warning; the checklist is
+				// rendered at the end so it isn't lost above the progress line.
 				summary.addWarning("%s: org member-privilege lockdown INCOMPLETE — %d setting(s) need to be set by hand at %s (see the summary checklist). Until then, the repo-admin that `gh student accept` grants founders is not fully defanged org-wide.", org, len(unenforced), settingsURL)
 			}
 
-			// On Team/Free, "private repos only" doesn't exist: GitHub
-			// couples public+private repo creation into one switch, and the
-			// student flow REQUIRES private creation, so init can't lock
-			// public creation off (the field is enterpriseOnly and filtered
-			// out). Note it so a clean "lockdown complete" banner isn't read
-			// as "members can't create public repos" — they still can on
-			// these plans.
+			// On Team/Free, "private repos only" doesn't exist: GitHub couples
+			// public+private creation into one switch and the student flow
+			// needs private, so init can't lock public off (the field is
+			// enterpriseOnly, filtered out). Note it so a clean banner isn't
+			// read as "members can't create public repos".
 			if pre.Plan != "enterprise" {
 				planName := pre.Plan
 				if planName == "" {
@@ -218,8 +202,8 @@ func initCmd() *cobra.Command {
 				summary.addNote("Member public-repo creation stays enabled on the %s plan: GitHub couples public+private repo creation into one control and the student flow needs private creation, so \"private repos only\" (an Enterprise Cloud capability) can't be applied here.", planName)
 			}
 
-			// Enable Actions before any repo/Pages/workflow setup --
-			// the classroom workflows all depend on it.
+			// Enable Actions before any repo/Pages/workflow setup — the
+			// classroom workflows all depend on it.
 			step(initStepLabels[1])
 			if err := ensureOrgActionsEnabled(client, stepOut, stepErr, org); err != nil {
 				prog.Abort()
@@ -227,10 +211,9 @@ func initCmd() *cobra.Command {
 			}
 
 			// Allow Actions' GITHUB_TOKEN to open the opt-in Feedback PR.
-			// Org-level so student repos inherit it at
-			// creation; a maintain student can't set it per-repo. Even
-			// with pull-requests: write, PR creation is rejected unless
-			// this org toggle is on, and it defaults off.
+			// Org-level so student repos inherit it; a maintain student can't
+			// set it per-repo. Even with pull-requests: write, PR creation is
+			// rejected unless this org toggle is on, and it defaults off.
 			step(initStepLabels[2])
 			prCreateReady, err := ensureOrgCanCreatePRs(client, stepOut, stepErr, org)
 			if err != nil {
@@ -238,11 +221,9 @@ func initCmd() *cobra.Command {
 				return err
 			}
 
-			// Install the org-level rulesets that protect submission
-			// history and lock the Feedback PR base. Org-
-			// level so they auto-cover every current/future student
-			// repo; warn-and-continue if the org's plan/policy blocks
-			// them.
+			// Install the org-level rulesets protecting submission history and
+			// the Feedback PR base. Org-level so they auto-cover every
+			// current/future student repo; warn-and-continue if blocked.
 			step(initStepLabels[3])
 			rulesetsReady, err := ensureClassroomRulesets(client, stepOut, stepErr, org)
 			if err != nil {
@@ -250,8 +231,8 @@ func initCmd() *cobra.Command {
 				return err
 			}
 
-			// Default branch comes from the create/fetch response —
-			// org policy can rename it.
+			// Default branch comes from the create/fetch response (org policy
+			// can rename it).
 			step(initStepLabels[4])
 			repo, created, err := ensureConfigRepo(client, org)
 			if err != nil {
@@ -269,8 +250,8 @@ func initCmd() *cobra.Command {
 				branch = "main"
 			}
 
-			// Re-enable repo-level Actions before the skeleton push
-			// so the workflows' first run isn't blocked.
+			// Re-enable repo-level Actions before the skeleton push so the
+			// workflows' first run isn't blocked.
 			step(initStepLabels[5])
 			if err := ensureRepoActionsEnabled(client, stepOut, stepErr, org, configrepo.ConfigRepoName); err != nil {
 				prog.Abort()
@@ -279,10 +260,8 @@ func initCmd() *cobra.Command {
 
 			step(initStepLabels[6])
 			// commitSkeleton may prompt (skeleton-refresh confirmation) on
-			// stderr and read stdin. A prompt must be visible and not
-			// buffered behind the progress line, so clear the in-place line
-			// first and give it the REAL stderr (its rare warnings show
-			// too); its success chatter still goes to the discarded stepOut.
+			// stderr and read stdin, so clear the in-place line first and give
+			// it the REAL stderr; success chatter still goes to discard.
 			if interactive {
 				prog.Abort()
 			}
@@ -312,9 +291,9 @@ func initCmd() *cobra.Command {
 			}
 
 			step(initStepLabels[11])
-			// The service-token prompt (when needed) must not be hidden
-			// behind the progress line: finalize progress and flush any
-			// buffered warnings before any prompt/notice.
+			// The service-token prompt (when needed) must not hide behind the
+			// progress line: finalize progress and flush buffered warnings
+			// first.
 			prog.Done()
 			flushStepWarnings()
 			if err := provisionServiceToken(cmd, client, summary, org, pre.SecretExists); err != nil {
@@ -335,17 +314,14 @@ func initCmd() *cobra.Command {
 					org, strings.Join(missing, " and "), org)
 			}
 
-			// Pages takes a few seconds after the first publish-pages
-			// run before the URL serves.
+			// Pages takes a few seconds after the first publish-pages run
+			// before the URL serves.
 			summary.PagesURL = fmt.Sprintf("https://%s.github.io/%s/", org, configrepo.ConfigRepoName)
 			summary.finalize()
 
-			// Render the canonical summary: JSON to stdout (the only
-			// machine surface), or the human report to stderr. The human
-			// report (banner + setup status + one action checklist + next
-			// step) conveys everything the recorded warnings say, so we
-			// don't separately replay summary.Warnings to the terminal —
-			// they remain in --json for machine consumers.
+			// Render the canonical summary: JSON to stdout, or the human report
+			// to stderr. The human report conveys everything the warnings say,
+			// so we don't separately replay summary.Warnings to the terminal.
 			if asJSON {
 				return summary.renderJSON(out)
 			}

--- a/cli/gh-teacher/init_preflight.go
+++ b/cli/gh-teacher/init_preflight.go
@@ -18,10 +18,9 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// preflightStatus is the outcome of a single read-only preflight check.
-// Aliased to ui.Status so the renderer owns the canonical type (and its
-// glyph mapping) while init keeps reading naturally; the string values
-// ("ok"/"warn"/"fail") are unchanged, preserving the --json contract.
+// preflightStatus is the outcome of a single preflight check, aliased to
+// ui.Status so the renderer owns the glyph mapping. The string values
+// ("ok"/"warn"/"fail") preserve the --json contract.
 type preflightStatus = ui.Status
 
 const (
@@ -30,31 +29,28 @@ const (
 	preflightFail = ui.StatusFail
 )
 
-// preflightCheck is one read-only check run before init mutates the org.
-// JSON-serializable (no omitempty, matching the repo's --json convention)
-// so it can be embedded in the init summary for agent consumers.
+// preflightCheck is one read-only check before init mutates the org.
+// JSON-serializable (no omitempty) so it embeds in the init summary.
 type preflightCheck struct {
 	Name   string          `json:"name"`
 	Status preflightStatus `json:"status"`
 	Detail string          `json:"detail"`
 }
 
-// preflightResult bundles the checks with the org plan (read once here
-// so later steps — notably the plan-aware lockdown read-back warning —
-// don't re-fetch it) and a convenience `failed` flag.
+// preflightResult bundles the checks with the org plan (read once here so later
+// steps don't re-fetch it) and a convenience `failed` flag.
 type preflightResult struct {
 	Checks []preflightCheck
 	Plan   string
-	// SecretExists records whether the service-token secret is already
-	// provisioned, so the provisioning step can skip a duplicate GET.
+	// SecretExists records whether the token secret is already provisioned, so
+	// the provisioning step can skip a duplicate GET.
 	SecretExists bool
 	Failed       bool
 }
 
-// tokenSource describes whether a service token is already available
-// (env) or will need a prompt — preflight needs to know to catch the
-// "no token + no interactive terminal" case before any mutation, since
-// the prompt otherwise crashes only at the very end after 13 writes.
+// tokenSource describes whether a service token is available (env) or needs a
+// prompt — preflight catches the "no token + no interactive terminal" case
+// before any mutation, since the prompt otherwise crashes only at the end.
 type tokenSource struct {
 	envSet     bool
 	stdinTTY   bool
@@ -62,33 +58,31 @@ type tokenSource struct {
 	stdinPiped bool
 }
 
-// runPreflight runs every read-only check and returns the aggregate.
-// Order is deliberate: cheap local checks (token/TTY) and the single
-// org GET first, so a misconfigured run fails fast without extra calls.
+// runPreflight runs every read-only check and returns the aggregate. Order is
+// deliberate: cheap local checks and the single org GET first, so a
+// misconfigured run fails fast.
 func runPreflight(client githubapi.Client, org string, tok tokenSource) preflightResult {
 	var res preflightResult
 
-	// 1. Auth scopes — read X-OAuth-Scopes off a cheap authenticated GET.
-	// The same call yields the login, reused by the ownership check below.
+	// 1. Auth scopes — read X-OAuth-Scopes off a cheap GET; the same call
+	// yields the login reused by the ownership check.
 	scopeCheck, _, login := checkScopes(client)
 	res.Checks = append(res.Checks, scopeCheck)
 
-	// 2 & 3. Org access + plan come from a single GET /orgs/{org}.
+	// 2 & 3. Org access + plan from a single GET /orgs/{org}.
 	accessCheck, plan := checkOrgAccess(client, org)
 	res.Plan = plan
 	res.Checks = append(res.Checks, accessCheck)
 	res.Checks = append(res.Checks, planCheck(org, plan))
 
-	// 4. Org ownership — only an owner can apply the member-privilege
-	// lockdown and create the repo (reuses the login from checkScopes).
+	// 4. Org ownership — only an owner can apply the lockdown and create the
+	// repo (reuses the login from checkScopes).
 	res.Checks = append(res.Checks, checkOwnership(client, org, login))
 
-	// 5. Token availability — a token must be obtainable, UNLESS the
-	// secret is already configured (a re-run leaves it untouched). Check
-	// the secret first so a re-run on a non-interactive shell (no env, no
-	// TTY) isn't falsely blocked. A repo-not-found / error here means
-	// first-time setup, so a token is required. The result is carried on
-	// the preflight so the provisioning step doesn't re-fetch it.
+	// 5. Token availability, UNLESS the secret is already configured (a re-run
+	// leaves it untouched). Check the secret first so a re-run on a
+	// non-interactive shell isn't falsely blocked. Result carried on the
+	// preflight so provisioning doesn't re-fetch it.
 	res.SecretExists, _ = servicetoken.SecretExists(client, org, configrepo.ConfigRepoName)
 	res.Checks = append(res.Checks, checkTokenAvailability(tok, res.SecretExists))
 
@@ -100,18 +94,13 @@ func runPreflight(client githubapi.Client, org string, tok tokenSource) prefligh
 	return res
 }
 
-// checkScopes confirms the token carries the scopes gh-teacher needs
-// (githubapi.RequiredScopes()). It reads the X-OAuth-Scopes header from
-// GET /user (always present on a classic-token request) and checks each
-// required scope with validate.ScopeListSatisfies, which honors GitHub's
-// scope hierarchy — a token granted admin:org reports only admin:org in
-// the header (read:org is normalized away), and must still count as
-// having read:org. A fine-grained PAT or an unknown auth type returns no
-// scope header; we can't prove scopes there, so we warn rather than fail
-// (the real operations still fail loudly later with actionable
-// messages). Returns the check plus the raw scope string and the
-// authenticated login (decoded from the same response so the ownership
-// check doesn't have to re-fetch /user).
+// checkScopes confirms the token carries gh-teacher's required scopes, reading
+// X-OAuth-Scopes from GET /user and checking each via
+// validate.ScopeListSatisfies (honoring GitHub's scope hierarchy — admin:org
+// implies read:org). A fine-grained PAT or unknown auth type has no scope
+// header, so we warn rather than fail (real ops fail loudly later). Returns the
+// check plus the raw scope string and the login (decoded from the same
+// response).
 func checkScopes(client githubapi.Client) (check preflightCheck, scopes, login string) {
 	c := preflightCheck{Name: "auth scopes"}
 	resp, err := client.Request(http.MethodGet, "user", nil)
@@ -147,12 +136,10 @@ func checkScopes(client githubapi.Client) (check preflightCheck, scopes, login s
 	return c, scopes, user.Login
 }
 
-// checkOrgAccess confirms GET /orgs/{org} succeeds and returns the plan
-// name (empty when the caller lacks billing visibility). A 404 is a
-// hard fail (org missing or invisible to this token); any other error
-// is also a fail since every later step needs org access. The org read
-// itself lives in githubapi.OrgPlan; this wrapper adds init's preflight
-// framing and the actionable 404 message.
+// checkOrgAccess confirms GET /orgs/{org} succeeds and returns the plan name
+// (empty when the caller lacks billing visibility). Any error is a hard fail
+// since every later step needs org access. The read lives in
+// githubapi.OrgPlan; this wrapper adds preflight framing and the 404 message.
 func checkOrgAccess(client githubapi.Client, org string) (preflightCheck, string) {
 	c := preflightCheck{Name: "org access"}
 	plan, err := githubapi.OrgPlan(client, org)
@@ -170,10 +157,9 @@ func checkOrgAccess(client githubapi.Client, org string) (preflightCheck, string
 	return c, plan
 }
 
-// planCheck applies the Pages-from-private-repo advisory: a
-// non-Team/Enterprise plan can't serve Pages from a private repo.
-// Advisory (warn), never fail — init still creates the repo. An empty
-// plan (no billing visibility) is treated as OK since we can't tell.
+// planCheck applies the Pages-from-private-repo advisory: a non-Team/Enterprise
+// plan can't serve Pages from a private repo. Advisory (warn), never fail. An
+// empty plan is treated as OK (can't tell).
 func planCheck(org, plan string) preflightCheck {
 	c := preflightCheck{Name: "org plan"}
 	switch {
@@ -190,13 +176,10 @@ func planCheck(org, plan string) preflightCheck {
 	return c
 }
 
-// checkOwnership confirms the authenticated user is an owner of the org
-// (GET /orgs/{org}/memberships/{login} → role "admin"). Only owners can
-// apply the member-privilege lockdown. A member (role "member") fails
-// up front rather than collecting 403s mid-run. A read failure is a warn
-// (the operations themselves will surface the real permission error). The
-// login comes from the earlier checkScopes /user read, so this doesn't
-// re-fetch it.
+// checkOwnership confirms the authenticated user is an org owner (membership
+// role "admin"). Only owners can apply the lockdown, so a member fails up front
+// rather than collecting 403s mid-run. A read failure is a warn. The login
+// comes from checkScopes, so this doesn't re-fetch /user.
 func checkOwnership(client githubapi.Client, org, login string) preflightCheck {
 	c := preflightCheck{Name: "org ownership"}
 	if login == "" {
@@ -224,13 +207,10 @@ func checkOwnership(client githubapi.Client, org, login string) preflightCheck {
 	return c
 }
 
-// checkTokenAvailability catches the "no service token AND no way to
-// prompt for one" case before init mutates anything. servicetoken.ReadToken
-// reads the env var, else a piped stdin line, else a hidden stderr
-// prompt; if the env is unset, stdin is a TTY (so it won't read a piped
-// line), and stderr is NOT a TTY, the prompt path errors — but only
-// after init has already configured the org. Surfacing it here fails
-// fast. Env set, or a usable prompt/pipe, is OK.
+// checkTokenAvailability catches "no token AND no way to prompt" before init
+// mutates anything. ReadToken reads env, else piped stdin, else a hidden stderr
+// prompt; if env is unset, stdin is a TTY, and stderr is NOT a TTY, the prompt
+// errors — but only after the org is configured. Surfacing it here fails fast.
 func checkTokenAvailability(tok tokenSource, secretExists bool) preflightCheck {
 	c := preflightCheck{Name: "service token"}
 	switch {
@@ -253,9 +233,8 @@ func checkTokenAvailability(tok tokenSource, secretExists bool) preflightCheck {
 	return c
 }
 
-// currentTokenSource snapshots the token/TTY environment for the
-// availability check. stdinPiped means stdin is a pipe/file (readable as
-// one line), distinct from stdinTTY (interactive).
+// currentTokenSource snapshots the token/TTY environment. stdinPiped means
+// stdin is a pipe/file (readable as one line), distinct from stdinTTY.
 func currentTokenSource() tokenSource {
 	envSet := strings.TrimSpace(os.Getenv(servicetoken.EnvServiceToken)) != ""
 	stdinTTY := ghauth.IsCharDevice(os.Stdin)
@@ -267,9 +246,8 @@ func currentTokenSource() tokenSource {
 	}
 }
 
-// renderPreflight prints the preflight section to the human channel via
-// the ui helper. Quiet suppresses the per-check lines but always prints
-// a failure summary (the teacher must see why init refused to start).
+// renderPreflight prints the preflight section to the human channel. Quiet
+// suppresses per-check lines but always prints failures.
 func renderPreflight(u *ui.UI, res preflightResult, quiet bool) {
 	if !quiet {
 		u.Section("Preflight checks")
@@ -281,16 +259,15 @@ func renderPreflight(u *ui.UI, res preflightResult, quiet bool) {
 				u.Ok("%s: %s", c.Name, c.Detail)
 			}
 		case preflightWarn, preflightFail:
-			// Both warn and fail show as a warning line; a fail
-			// additionally aborts the run (see preflightFailError).
+			// Both show as a warning; a fail additionally aborts (see
+			// preflightFailError).
 			u.Warn("%s: %s", c.Name, c.Detail)
 		}
 	}
 }
 
-// preflightFailError builds the terminal error returned when a preflight
-// check fails, naming each failing check so the teacher sees all blockers
-// at once rather than one re-run at a time.
+// preflightFailError builds the terminal error when a preflight check fails,
+// naming each failing check so the teacher sees all blockers at once.
 func preflightFailError(res preflightResult) error {
 	var failed []string
 	for _, c := range res.Checks {
@@ -301,9 +278,8 @@ func preflightFailError(res preflightResult) error {
 	return fmt.Errorf("preflight failed — fix before re-running: %s", strings.Join(failed, "; "))
 }
 
-// initStepLabels are the phase labels init would execute, in order —
-// used both by --dry-run (to describe the plan) and by the progress
-// headers. Kept as one list so the count and order can't drift.
+// initStepLabels are init's phase labels in order — used by --dry-run and the
+// progress headers. One list so count and order can't drift.
 var initStepLabels = []string{
 	"Locking down org member privileges",
 	"Enabling GitHub Actions (org)",
@@ -319,8 +295,7 @@ var initStepLabels = []string{
 	"Storing the service-token secret",
 }
 
-// renderDryRunSteps prints the ordered list of steps init would perform,
-// for --dry-run. No mutation, no current-vs-desired diffing.
+// renderDryRunSteps prints the ordered steps init would perform, for --dry-run.
 func renderDryRunSteps(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Dry run — init would perform these steps (no changes made):")
 	for i, label := range initStepLabels {

--- a/cli/gh-teacher/init_repo.go
+++ b/cli/gh-teacher/init_repo.go
@@ -16,8 +16,8 @@ import (
 	"github.com/foundation50/gh-teacher/internal/orgpolicy"
 )
 
-// plansThatSupportPrivatePages: GitHub plan slugs that allow Pages
-// from a private source repo.
+// plansThatSupportPrivatePages: GitHub plan slugs that allow Pages from a
+// private source repo.
 var plansThatSupportPrivatePages = map[string]bool{
 	"team":          true,
 	"business":      true,
@@ -26,17 +26,12 @@ var plansThatSupportPrivatePages = map[string]bool{
 }
 
 // applyOrgMemberDefaults applies the policies in one combined PATCH
-// /orgs/{org}. On 403/422 (one plan-gated field fails the whole
-// PATCH) it falls back to one PATCH per policy, warning only for the
-// fields GitHub rejects. init completes either way.
+// /orgs/{org}. On 403/422 (one plan-gated field sinks the whole PATCH) it
+// falls back to one PATCH per policy. init completes either way.
 //
-// Returns complete=true only when every *critical* lockdown field
-// landed — the fields that defang the founder-admin grant org-wide.
-// A combined-PATCH success applies all fields atomically, so
-// it's always complete; the per-field fallback computes completeness
-// from which critical fields the org rejected. init surfaces an
-// explicit "lockdown INCOMPLETE" warning when complete=false so a
-// half-locked org never hides behind a clean success line.
+// complete=true only when every *critical* lockdown field landed (the fields
+// that defang the founder-admin grant org-wide). init warns "lockdown
+// INCOMPLETE" when complete=false so a half-locked org isn't hidden.
 func applyOrgMemberDefaults(client githubapi.Client, out, errOut io.Writer, org, plan string) (complete bool, unenforced []unenforcedSetting, err error) {
 	settings := orgpolicy.MemberDefaultSettings(plan)
 	combined := make(map[string]any, len(settings))
@@ -51,8 +46,8 @@ func applyOrgMemberDefaults(client githubapi.Client, out, errOut io.Writer, org,
 	resp, err := client.Request(http.MethodPatch, path, bytes.NewReader(body))
 	if err != nil {
 		// A secondary-rate-limit 403 must not drop into the per-field
-		// fallback — that fires one more PATCH per policy and amplifies
-		// the throttle. Surface it as a transient error so a re-run retries.
+		// fallback — that fires one more PATCH per policy and amplifies the
+		// throttle. Surface it as transient so a re-run retries.
 		if isSecondaryRateLimit(err) {
 			return false, nil, fmt.Errorf("PATCH %s: secondary rate limit (retry shortly): %w", path, err)
 		}
@@ -63,26 +58,21 @@ func applyOrgMemberDefaults(client githubapi.Client, out, errOut io.Writer, org,
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	// go-gh returns non-2xx as err (handled above); this only
-	// catches a stray non-200 2xx.
+	// go-gh returns non-2xx as err (handled above); this catches a stray 2xx.
 	if resp.StatusCode != http.StatusOK {
 		return false, nil, fmt.Errorf("PATCH %s: unexpected status %d", path, resp.StatusCode)
 	}
 	_, _ = fmt.Fprintf(out, "%s: org member defaults locked down (%s)\n", org, orgMemberDefaultsSummary(plan))
-	// A 200 is not proof the values stuck: enterprise-owned orgs accept
-	// the PATCH but silently keep enterprise-pinned fields at their
-	// policy value (e.g. members_can_invite_outside_collaborators). Read
-	// the org back and confirm the fields actually changed — the only
-	// way to catch a silent no-op, and the authoritative residual state.
+	// A 200 isn't proof the values stuck: enterprise-owned orgs accept the
+	// PATCH but silently keep enterprise-pinned fields. Read the org back to
+	// catch a silent no-op — the authoritative residual state.
 	ok, unenforced := verifyOrgDefaults(client, errOut, org, plan)
 	return ok, unenforced, nil
 }
 
 // unenforcedSetting is one org member-privilege policy whose live value
-// (read back from the org) does not match what init wants. It carries
-// the exact GitHub-UI instruction (manualFix) so init can render a
-// single, actionable "fix these by hand" checklist instead of a wall of
-// per-attempt warnings.
+// doesn't match what init wants. It carries the exact GitHub-UI instruction
+// (manualFix) so init can render one actionable "fix by hand" checklist.
 type unenforcedSetting struct {
 	field     string
 	manualFix string
@@ -93,15 +83,12 @@ type unenforcedSetting struct {
 // internal/orgpolicy (the shared policy/classification seam consumed by
 // both init's verifyOrgDefaults and audit's buildAuditReport).
 
-// verifyOrgDefaults reads the org back and returns every member-default
-// policy whose live value still doesn't match what init wants —
-// regardless of whether the earlier PATCH was rejected (422) or silently
-// ignored (200-but-unchanged). This single read-back is the authoritative
-// source of truth: it reflects what the teacher would actually see in the
-// settings UI, so init reports the real residual state rather than
-// replaying what it *tried* to do. ok is true when nothing critical is
-// unenforced. A read failure returns ok=true with a single warning (the
-// writes reported success; don't manufacture a false checklist).
+// verifyOrgDefaults reads the org back and returns every member-default policy
+// whose live value still doesn't match — whether the PATCH was rejected (422)
+// or silently ignored (200-but-unchanged). This read-back is the authoritative
+// source of truth (what the teacher sees in the settings UI). ok is true when
+// nothing critical is unenforced. A read failure returns ok=true with one
+// warning (the writes reported success; don't manufacture a false checklist).
 func verifyOrgDefaults(client githubapi.Client, errOut io.Writer, org, plan string) (ok bool, unenforced []unenforcedSetting) {
 	path := fmt.Sprintf("orgs/%s", url.PathEscape(org))
 	var live map[string]any
@@ -121,18 +108,15 @@ func verifyOrgDefaults(client githubapi.Client, errOut io.Writer, org, plan stri
 	return !criticalMissed, unenforced
 }
 
-// unenforcedCause renders the plan-appropriate one-line explanation for
-// why init couldn't apply some member-privilege settings.
+// unenforcedCause renders the plan-appropriate one-line reason init couldn't
+// apply some member-privilege settings.
 //
-// On Team/Free plans (the common case for teachers) GitHub doesn't expose
-// these member-privilege toggles via the org API, so init can't set them —
-// the teacher just applies them by hand. We deliberately do NOT suggest
-// "upgrade to Enterprise Cloud": the audience is overwhelmingly Team-plan
-// teachers who can't realistically switch plans, so that advice is noise.
-// (On Enterprise Cloud the same fields are settable via the API unless an
-// enterprise owner has pinned them at the enterprise layer, in which case
-// only an enterprise owner can change them.) An enterprise org therefore
-// gets a different message; an unknown plan gets a neutral note.
+// On Team/Free plans (the common teacher case) GitHub doesn't expose these
+// toggles via the org API, so the teacher applies them by hand. We
+// deliberately do NOT suggest "upgrade to Enterprise Cloud" — most teachers
+// can't switch plans, so that advice is noise. On Enterprise Cloud the fields
+// are API-settable unless an enterprise owner pinned them (only they can
+// change those). An unknown plan gets a neutral note.
 func unenforcedCause(plan string) string {
 	switch plan {
 	case "enterprise":
@@ -144,14 +128,11 @@ func unenforcedCause(plan string) string {
 	}
 }
 
-// isSecondaryRateLimit reports whether err is GitHub's secondary
-// rate-limit response. GitHub surfaces it as a 403 (occasionally 429)
-// whose message mentions a secondary rate limit / abuse detection —
-// distinct from a plan-gated field rejection, which is also a 403 but
-// means the field can't be set on this plan. Distinguishing them
-// matters: a plan-gated 403 warns "set it manually" (correct), whereas
-// a rate-limit 403 must be treated as transient (retry), not as a field
-// the teacher should go toggle by hand.
+// isSecondaryRateLimit reports whether err is GitHub's secondary rate-limit
+// response (403, occasionally 429, mentioning "secondary rate limit"/"abuse").
+// Distinct from a plan-gated field rejection (also 403): a plan-gated 403 warns
+// "set it manually", but a rate-limit 403 is transient (retry), not a field to
+// toggle by hand.
 func isSecondaryRateLimit(err error) bool {
 	httpErr, ok := errors.AsType[*githubapi.HTTPError](err)
 	if !ok {
@@ -165,10 +146,8 @@ func isSecondaryRateLimit(err error) bool {
 }
 
 // orgMemberDefaultsSummary renders the applied policies straight from
-// orgpolicy.MemberDefaultSettings(plan) so the combined-PATCH success
-// line can't drift from the canonical slice (it previously hand-listed the
-// policies in prose and silently fell out of sync). Reports the policy
-// count and joins each setting's `desc`.
+// orgpolicy.MemberDefaultSettings(plan) so the success line can't drift from
+// the canonical slice. Reports the count and joins each setting's `desc`.
 func orgMemberDefaultsSummary(plan string) string {
 	settings := orgpolicy.MemberDefaultSettings(plan)
 	descs := make([]string, 0, len(settings))
@@ -178,15 +157,12 @@ func orgMemberDefaultsSummary(plan string) string {
 	return fmt.Sprintf("%d policies: %s", len(settings), strings.Join(descs, "; "))
 }
 
-// applyOrgMemberDefaultsPerField is the 403/422 fallback: one PATCH
-// per policy so one plan-gated field can't sink the others. It does NOT
-// warn per rejection — the authoritative residual state comes from the
-// single read-back at the end (verifyOrgDefaults), which reflects what
-// the teacher would actually see in the settings UI regardless of which
-// PATCHes were rejected vs. silently ignored. A transient (non-403/422)
-// error mid-loop still aborts init, but first reports which policies were
-// already applied and which were never attempted — the org is left
-// partially mutated and the teacher needs to know exactly where.
+// applyOrgMemberDefaultsPerField is the 403/422 fallback: one PATCH per policy
+// so one plan-gated field can't sink the others. It does NOT warn per rejection
+// — the authoritative residual state comes from the read-back at the end
+// (verifyOrgDefaults). A transient (non-403/422) error mid-loop aborts init but
+// first reports which policies landed and which were never attempted, since the
+// org is left partially mutated.
 func applyOrgMemberDefaultsPerField(client githubapi.Client, out, errOut io.Writer, org, plan string) (complete bool, unenforced []unenforcedSetting, err error) {
 	path := fmt.Sprintf("orgs/%s", url.PathEscape(org))
 	settingsURL := fmt.Sprintf("https://github.com/organizations/%s/settings/member_privileges", org)
@@ -199,23 +175,21 @@ func applyOrgMemberDefaultsPerField(client githubapi.Client, out, errOut io.Writ
 		}
 		resp, reqErr := client.Request(http.MethodPatch, path, bytes.NewReader(body))
 		if reqErr != nil {
-			// A secondary-rate-limit 403 is NOT a plan-gated field
-			// rejection: retrying per-field amplifies the throttle.
-			// Treat it like any other transient error — report the
-			// partial state and abort so a re-run can finish cleanly.
+			// A secondary-rate-limit 403 isn't a plan-gated rejection:
+			// retrying per-field amplifies the throttle. Report partial state
+			// and abort so a re-run can finish cleanly.
 			if isSecondaryRateLimit(reqErr) {
 				reportPartialMemberDefaults(errOut, org, settings, applied, i, settingsURL)
 				return false, nil, fmt.Errorf("PATCH %s: secondary rate limit: %w", path, reqErr)
 			}
 			if cliutil.IsHTTPStatus(reqErr, http.StatusForbidden) || cliutil.IsHTTPStatus(reqErr, http.StatusUnprocessableEntity) {
-				// Plan-gated rejection: don't warn here. The read-back
-				// below reports the true residual state as one checklist.
+				// Plan-gated: don't warn here; the read-back reports the true
+				// residual state as one checklist.
 				continue
 			}
-			// Transient/unexpected error (429/5xx/network): the org is
-			// now partially mutated. Report what landed and what was
-			// never attempted before aborting, so the teacher can finish
-			// the lockdown manually or re-run from a known state.
+			// Transient/unexpected (429/5xx/network): the org is partially
+			// mutated. Report what landed and what wasn't attempted, so the
+			// teacher can finish manually or re-run from a known state.
 			reportPartialMemberDefaults(errOut, org, settings, applied, i, settingsURL)
 			return false, nil, fmt.Errorf("PATCH %s: %w", path, reqErr)
 		}
@@ -230,19 +204,16 @@ func applyOrgMemberDefaultsPerField(client githubapi.Client, out, errOut io.Writ
 	if len(applied) > 0 {
 		_, _ = fmt.Fprintf(out, "%s: org member defaults set (%s)\n", org, strings.Join(applied, ", "))
 	}
-	// The read-back is the single source of truth for what didn't land —
-	// covering both 422 rejections and 200-but-silently-ignored fields —
-	// so init can render one actionable checklist instead of per-field
-	// warnings.
+	// The read-back is the single source of truth for what didn't land (both
+	// 422 rejections and 200-but-silently-ignored fields), so init renders one
+	// checklist instead of per-field warnings.
 	ok, unenforced := verifyOrgDefaults(client, errOut, org, plan)
 	return ok, unenforced, nil
 }
 
 // reportPartialMemberDefaults warns that a transient error left the org
-// member-privilege lockdown half-applied, naming the policies that
-// landed and the ones at index failedIdx onward that were never
-// attempted — so a teacher (or a script parsing stderr) can reconcile
-// manually or re-run init rather than assuming a clean failure.
+// lockdown half-applied, naming the policies that landed and those at failedIdx
+// onward that weren't attempted, so a teacher can reconcile or re-run.
 func reportPartialMemberDefaults(errOut io.Writer, org string, settings []orgpolicy.MemberDefaultSetting, applied []string, failedIdx int, settingsURL string) {
 	notAttempted := make([]string, 0, len(settings)-failedIdx)
 	for _, s := range settings[failedIdx:] {
@@ -257,17 +228,16 @@ func reportPartialMemberDefaults(errOut io.Writer, org string, settings []orgpol
 		org, appliedList, strings.Join(notAttempted, ", "), settingsURL)
 }
 
-// orgActionsPermissions is the subset of GET
-// /orgs/{org}/actions/permissions that we read.
+// orgActionsPermissions is the subset of GET /orgs/{org}/actions/permissions
+// that we read.
 type orgActionsPermissions struct {
 	EnabledRepositories string `json:"enabled_repositories"`
 }
 
-// ensureOrgActionsEnabled turns Actions on for the org when it's off
-// org-wide ("none" -> PUT "all"); Classroom50's workflows run as
-// Actions and never run otherwise. "all" -> noop; "selected"/unknown
-// -> warn. Read failures and a rejected enable (403/409/422, usually
-// enterprise-locked) warn and continue so init still finishes.
+// ensureOrgActionsEnabled turns Actions on for the org when it's off org-wide
+// ("none" → PUT "all"); Classroom50's workflows never run otherwise. "all" →
+// noop; "selected"/unknown → warn. Read failures and a rejected enable
+// (403/409/422, usually enterprise-locked) warn and continue.
 func ensureOrgActionsEnabled(client githubapi.Client, out, errOut io.Writer, org string) error {
 	path := fmt.Sprintf("orgs/%s/actions/permissions", url.PathEscape(org))
 
@@ -287,9 +257,9 @@ func ensureOrgActionsEnabled(client githubapi.Client, out, errOut io.Writer, org
 			org, org)
 		return nil
 	case "none":
-		// Off org-wide -- enable it below.
+		// Off org-wide — enable below.
 	default:
-		// Empty or unknown value: warn, don't touch the policy.
+		// Empty/unknown: warn, don't touch the policy.
 		_, _ = fmt.Fprintf(errOut, "Warning: %s: unexpected Actions enabled_repositories value %q; leaving it unchanged — verify GitHub Actions is enabled for the org at https://github.com/organizations/%s/settings/actions, or Classroom50's workflows may not run.\n",
 			org, perms.EnabledRepositories, org)
 		return nil
@@ -328,28 +298,22 @@ type orgWorkflowPermissions struct {
 	CanApprovePullRequestReviews bool   `json:"can_approve_pull_request_reviews"`
 }
 
-// ensureOrgCanCreatePRs turns on the org-level "Allow GitHub Actions to
-// create and approve pull requests" setting. The opt-in Feedback PR
-// is opened by each student repo's autograde workflow using
-// GITHUB_TOKEN; even with `pull-requests: write`, GitHub rejects the
-// creation unless can_approve_pull_request_reviews is enabled -- and it
-// defaults off. Student repos inherit this from the org at creation
-// time, and a `maintain` collaborator can't set it per-repo, so the org
-// is the only place to enable it. Preserves default_workflow_permissions
-// (only the PR toggle is ours to change). 403/409 (enterprise-locked) ->
-// warn and continue, matching ensureOrgActionsEnabled.
+// ensureOrgCanCreatePRs turns on the org-level "Allow GitHub Actions to create
+// and approve pull requests". The opt-in Feedback PR is opened by each student
+// repo's workflow using GITHUB_TOKEN; even with `pull-requests: write`, GitHub
+// rejects the creation unless can_approve_pull_request_reviews is on (defaults
+// off). Student repos inherit this from the org, and a `maintain` collaborator
+// can't set it per-repo, so the org is the only lever. Preserves
+// default_workflow_permissions. 403/409 (enterprise-locked) → warn and
+// continue.
 //
-// Trade-off (no narrower lever): GitHub's single org field couples
-// "create" and "approve" -- there is no create-only toggle, so enabling
-// it also lets Actions *approve* PRs org-wide. This is safe for the
-// Classroom50 model as shipped: the config repo's default branch has no
-// required-review gate (applyBranchProtection sets
-// required_pull_request_reviews=null), and student assignment repos have
-// none either, so a self-approval grants no merge a student couldn't
-// already perform. The residual is that if a teacher *later* adds a
-// required-review rule to a repo in this org, a student-controlled
-// workflow token could satisfy it via self-approval -- documented in the
-// wiki so that choice is made knowingly.
+// Trade-off: GitHub's single field couples "create" and "approve" — no
+// create-only toggle, so this also lets Actions *approve* PRs org-wide. Safe as
+// shipped: neither the config repo's default branch nor student repos have a
+// required-review gate, so a self-approval grants no merge a student couldn't
+// already do. Residual: if a teacher later adds a required-review rule, a
+// student-controlled token could satisfy it via self-approval (documented in
+// the wiki).
 func ensureOrgCanCreatePRs(client githubapi.Client, out, errOut io.Writer, org string) (bool, error) {
 	path := fmt.Sprintf("orgs/%s/actions/permissions/workflow", url.PathEscape(org))
 
@@ -394,11 +358,10 @@ type repoActionsPermissions struct {
 	Enabled bool `json:"enabled"`
 }
 
-// ensureRepoActionsEnabled turns Actions back on for a single repo when
-// it's been disabled at the repo level (`enabled` false -> PUT true),
-// independent of the org-wide setting. A read failure or a rejected
-// enable (403/409/422, usually an org/enterprise policy) warns and
-// continues, matching init's warn-and-carry-on convention.
+// ensureRepoActionsEnabled turns Actions back on for a single repo disabled at
+// the repo level (`enabled` false → PUT true), independent of the org setting.
+// A read failure or rejected enable (403/409/422, usually org/enterprise
+// policy) warns and continues.
 func ensureRepoActionsEnabled(client githubapi.Client, out, errOut io.Writer, owner, repo string) error {
 	path := fmt.Sprintf("repos/%s/%s/actions/permissions", url.PathEscape(owner), url.PathEscape(repo))
 
@@ -439,14 +402,12 @@ func ensureRepoActionsEnabled(client githubapi.Client, out, errOut io.Writer, ow
 	return nil
 }
 
-// checkOrgPlan was removed: the org plan is read once in preflight
-// (checkOrgAccess + planCheck) and its advisory surfaced there, so init
-// no longer makes a second GET /orgs/{org} for the same warning.
+// checkOrgPlan was removed: the org plan is read once in preflight and its
+// advisory surfaced there, so init no longer makes a second GET /orgs/{org}.
 
-// ensureConfigRepo returns the classroom50 repo for <org>, creating
-// it if absent. 422 → name is taken; fall back to GET so init
-// re-runs succeed. default_branch flows through so an org policy
-// rename doesn't break the bootstrap.
+// ensureConfigRepo returns the classroom50 repo for <org>, creating it if
+// absent. 422 → name taken; fall back to GET so re-runs succeed.
+// default_branch flows through so an org policy rename doesn't break bootstrap.
 func ensureConfigRepo(client githubapi.Client, org string) (repo configrepo.ConfigRepo, created bool, err error) {
 	body, err := json.Marshal(struct {
 		Name     string `json:"name"`
@@ -475,15 +436,11 @@ func ensureConfigRepo(client githubapi.Client, org string) (repo configrepo.Conf
 	return repo, true, nil
 }
 
-// enablePages turns on Actions-built Pages and sets the site
-// visibility to public — the student CLIs fetch `assignments.json`
-// unauthenticated (plus a non-default `--autograder` shim YAML when
-// one is registered); the runner workflow fetches `assignments.json`,
-// `runner.py`, the per-classroom `<classroom>/autograder.py` (when
-// set), and per-assignment bundles.
-// 409 on create → "already enabled";
-// visibility PUT fires either way so re-runs reconcile a
-// previously-private site. Success lines land on `out`; the
+// enablePages turns on Actions-built Pages and sets the site public — the
+// student CLIs and the runner workflow fetch assignments.json, runner.py, the
+// per-classroom autograder.py, and per-assignment bundles unauthenticated.
+// 409 on create → "already enabled"; the visibility PUT fires either way so
+// re-runs reconcile a previously-private site. Success on `out`; the
 // visibility step warns to `errOut` if the API rejects it.
 func enablePages(client githubapi.Client, out, errOut io.Writer, owner, repo string) error {
 	body, err := json.Marshal(struct {
@@ -504,27 +461,22 @@ func enablePages(client githubapi.Client, out, errOut io.Writer, owner, repo str
 	return setPagesPublic(client, out, errOut, owner, repo)
 }
 
-// isPrivatePagesUnsupported reports whether err is the HTTP 400
-// GitHub returns when the org's plan has no Pages visibility control
-// at all: "Private pages is not enabled for this repository. All
-// Pages will be public." Visibility control is an Enterprise Cloud
-// feature — on every other plan (including Team, the free educator
-// tier) sites are unconditionally public, which is exactly the state
-// init wants, so this response is a success, not a warning.
+// isPrivatePagesUnsupported reports whether err is the HTTP 400 GitHub returns
+// when the plan has no Pages visibility control: "Private pages is not enabled
+// for this repository. All Pages will be public." Visibility control is
+// Enterprise-Cloud-only; every other plan is unconditionally public — exactly
+// what init wants, so this is a success, not a warning.
 func isPrivatePagesUnsupported(err error) bool {
 	httpErr, ok := errors.AsType[*githubapi.HTTPError](err)
 	return ok && httpErr.StatusCode == http.StatusBadRequest &&
 		strings.Contains(httpErr.Message, "Private pages is not enabled")
 }
 
-// setPagesPublic PUTs `{"public": true}` to /pages. The field
-// isn't in the public OpenAPI body schema but the endpoint
-// accepts it — same field the UI's Visibility radio drives. 204
-// → success on `out`; the plan-without-visibility-control 400
-// (see isPrivatePagesUnsupported) is also success — the site is
-// already public by plan default; any other status emits a
-// `Warning:` to `errOut` and returns nil so a quirky org policy
-// doesn't fail the whole init.
+// setPagesPublic PUTs `{"public": true}` to /pages. The field isn't in the
+// public OpenAPI body schema but the endpoint accepts it (same field the UI's
+// Visibility radio drives). 204 → success; the no-visibility-control 400 (see
+// isPrivatePagesUnsupported) is also success; any other status warns to
+// `errOut` and returns nil so a quirky org policy doesn't fail init.
 func setPagesPublic(client githubapi.Client, out, errOut io.Writer, owner, repo string) error {
 	body, err := json.Marshal(struct {
 		Public bool `json:"public"`
@@ -551,11 +503,10 @@ func setPagesPublic(client githubapi.Client, out, errOut io.Writer, owner, repo 
 			owner, repo, resp.StatusCode, owner, repo)
 		return nil
 	}
-	// A 204 doesn't prove the value stuck: `public` is an
-	// undocumented body field and an org/enterprise policy could pin
-	// visibility. Read it back and confirm — warn-only (non-blocking),
-	// and a read failure is silent (the PUT reported success; don't
-	// invent a false alarm), mirroring the org-lockdown read-back.
+	// A 204 doesn't prove the value stuck: `public` is undocumented and an
+	// org/enterprise policy could pin visibility. Read it back — warn-only,
+	// and a read failure is silent (the PUT reported success), mirroring the
+	// org-lockdown read-back.
 	if public, known := readPagesPublic(client, owner, repo); known && !public {
 		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: set Pages visibility to public but a read-back shows it still private — likely pinned by an org or enterprise policy. Students fetch assignments.json unauthenticated, so a private Pages site breaks `gh student accept`. Set it manually at https://github.com/%s/%s/settings/pages → Visibility.\n",
 			owner, repo, owner, repo)
@@ -565,9 +516,9 @@ func setPagesPublic(client githubapi.Client, out, errOut io.Writer, owner, repo 
 	return nil
 }
 
-// readPagesPublic GETs the repo Pages config and returns whether the
-// site is public. known=false on any read failure so the caller treats
-// an unverifiable read-back as non-blocking (no false alarm).
+// readPagesPublic GETs the repo Pages config and returns whether the site is
+// public. known=false on any read failure so the caller treats an unverifiable
+// read-back as non-blocking.
 func readPagesPublic(client githubapi.Client, owner, repo string) (public, known bool) {
 	path := fmt.Sprintf("repos/%s/%s/pages", url.PathEscape(owner), url.PathEscape(repo))
 	var resp struct {
@@ -579,16 +530,14 @@ func readPagesPublic(client githubapi.Client, owner, repo string) (public, known
 	return resp.Public, true
 }
 
-// applyBranchProtection sets minimal protection on the default
-// branch: no force-pushes, no deletions. PR-required is deliberately
-// off — collect-scores.yaml and the CLI Tree-API writes both target
-// the default branch directly, and a PR requirement would block
-// both. Force-push + delete blocking bounds the blast radius of an
-// account compromise.
+// applyBranchProtection sets minimal protection on the default branch: no
+// force-pushes, no deletions. PR-required is deliberately off —
+// collect-scores.yaml and the CLI Tree-API writes both target the default
+// branch directly and would be blocked. Force-push + delete blocking bounds the
+// blast radius of an account compromise.
 func applyBranchProtection(client githubapi.Client, out io.Writer, owner, repo, branch string) error {
-	// Classic branch protection requires the four null fields to
-	// be present (not omitted); a JSON literal is simpler than
-	// juggling pointer types.
+	// Classic branch protection requires the four null fields present (not
+	// omitted); a JSON literal beats juggling pointer types.
 	body := []byte(`{
   "required_status_checks": null,
   "enforce_admins": false,
@@ -612,14 +561,13 @@ func applyBranchProtection(client githubapi.Client, out io.Writer, owner, repo, 
 	return nil
 }
 
-// feedbackBaseBranch is the frozen PR base the Feedback PR feature
-// pins at each student repo's baseline commit. Kept in
-// lockstep with the autograde-runner workflow's BASE_BRANCH.
+// feedbackBaseBranch is the frozen PR base the Feedback PR feature pins at each
+// student repo's baseline commit. Kept in lockstep with the autograde-runner
+// workflow's BASE_BRANCH.
 const feedbackBaseBranch = "feedback"
 
 // Stable ruleset names so re-running init is idempotent —
-// ensureClassroomRulesets reconciles an existing ruleset (matched by
-// name) in place rather than creating a duplicate.
+// ensureClassroomRulesets reconciles an existing ruleset (by name) in place.
 const (
 	rulesetNameSubmissionHistory = "classroom50-protect-submission-history"
 	rulesetNameFeedbackBase      = "classroom50-feedback-base-lock"
@@ -641,18 +589,18 @@ type rulesetConditions struct {
 	RepositoryName refPatternCondition `json:"repository_name"`
 }
 
-// refPatternCondition is GitHub's include/exclude shape, reused for
-// both ref_name and repository_name. "~ALL" (repos) and
-// "~DEFAULT_BRANCH" (refs) are the documented wildcards.
+// refPatternCondition is GitHub's include/exclude shape, reused for ref_name
+// and repository_name. "~ALL" (repos) and "~DEFAULT_BRANCH" (refs) are the
+// documented wildcards.
 type refPatternCondition struct {
 	Include []string `json:"include"`
 	Exclude []string `json:"exclude"`
 }
 
 // rulesetBypassActor lets an actor skip the rules. OrganizationAdmin
-// (actor_id 1) is the org-owner role — the teacher — so they can merge
-// the Feedback PR (the grading-done signal) and force-push/delete in a
-// pinch while students (maintain, no bypass) cannot.
+// (actor_id 1) is the org-owner role — the teacher — so they can merge the
+// Feedback PR and force-push/delete in a pinch while students (maintain, no
+// bypass) cannot.
 type rulesetBypassActor struct {
 	ActorID    int    `json:"actor_id"`
 	ActorType  string `json:"actor_type"`
@@ -663,30 +611,23 @@ type rulesetRule struct {
 	Type string `json:"type"`
 }
 
-// ensureClassroomRulesets installs two org-level branch rulesets that
-// auto-cover every current and future repo in the org (the student
-// assignment repos), powering the Feedback PR feature:
+// ensureClassroomRulesets installs two org-level branch rulesets covering
+// every current and future repo (the student assignment repos), powering the
+// Feedback PR feature:
 //
-//  1. submission history — on `main`: block force-push + deletion so a
-//     student can't rewrite or erase their submission history; normal
-//     fast-forward submits still go through, so the teacher always sees
-//     the full version history.
-//  2. feedback-base lock — on the `feedback` branch: restrict
-//     updates + block deletion so students (maintain collaborators)
-//     can't merge or move the frozen PR base. Branch *creation* is left
-//     allowed so the autograde runner's GITHUB_TOKEN can create the
-//     branch once; org admins bypass, so the teacher can merge the PR.
+//  1. submission history — on the default branch: block force-push + deletion
+//     so a student can't rewrite/erase submission history; normal
+//     fast-forward submits still go through.
+//  2. feedback-base lock — on the `feedback` branch: restrict updates + block
+//     deletion so students (maintain) can't merge or move the frozen PR base.
+//     Branch *creation* stays allowed so the runner's GITHUB_TOKEN can create
+//     it once; org admins bypass, so the teacher can merge the PR.
 //
-// Org-level rulesets need an org-admin token — gh teacher authenticates
-// as the org owner — whereas the workflow GITHUB_TOKEN has no
-// administration scope, which is why this lives here, not in the
-// runner. Idempotent **and reconciling**: a ruleset that already exists
-// (by name) is updated in place to the current definition, so re-running
-// init repairs a stale ruleset left by an older CLI (e.g. one targeting
-// the wrong branch pattern) rather than skipping it. Warn-and-continue
-// on any failure (a plan without org rulesets, or a policy lock) so a
-// quirky org doesn't fail the whole init — mirrors the other org-setup
-// helpers.
+// Org-level rulesets need an org-admin token (gh teacher authenticates as org
+// owner) — the workflow GITHUB_TOKEN has no administration scope, which is why
+// this lives here, not in the runner. Idempotent AND reconciling: an existing
+// ruleset (by name) is PUT to the current definition, repairing a stale one
+// from an older CLI. Warn-and-continue on any failure.
 func ensureClassroomRulesets(client githubapi.Client, out, errOut io.Writer, org string) (bool, error) {
 	existing, err := listOrgRulesets(client, org)
 	if err != nil {
@@ -705,10 +646,9 @@ func ensureClassroomRulesets(client githubapi.Client, out, errOut io.Writer, org
 			Enforcement: "active",
 			Conditions: rulesetConditions{
 				// ~DEFAULT_BRANCH follows each repo's actual default branch
-				// rather than hardcoding `main`, so the protection still
-				// covers repos whose default branch was renamed by org
-				// policy — and matches the branch the Feedback PR opens
-				// against (the runner resolves defaultBranchRef.name).
+				// (not hardcoded `main`) so it still covers repos renamed by
+				// org policy — and matches the branch the Feedback PR opens
+				// against.
 				RefName:        refPatternCondition{Include: []string{"~DEFAULT_BRANCH"}, Exclude: []string{}},
 				RepositoryName: allRepos,
 			},
@@ -727,8 +667,8 @@ func ensureClassroomRulesets(client githubapi.Client, out, errOut io.Writer, org
 			},
 			BypassActors: adminBypass,
 			// `update` restricts pushes/merges to bypass actors (only the
-			// teacher merges); `deletion` blocks delete. Creation is left
-			// allowed so the runner can land the branch once.
+			// teacher); `deletion` blocks delete. Creation stays allowed so
+			// the runner can land the branch once.
 			Rules: []rulesetRule{{Type: "update"}, {Type: "deletion"}},
 		},
 	}
@@ -736,9 +676,8 @@ func ensureClassroomRulesets(client githubapi.Client, out, errOut io.Writer, org
 	allReady := true
 	for _, rs := range rulesets {
 		if id, ok := existing[rs.Name]; ok {
-			// Reconcile: PUT the current definition over the existing
-			// ruleset so a re-run picks up a changed branch pattern/rules
-			// (e.g. an older CLI's stale ruleset) instead of skipping it.
+			// Reconcile: PUT the current definition so a re-run picks up a
+			// changed branch pattern/rules instead of skipping it.
 			if err := updateOrgRuleset(client, org, id, rs); err != nil {
 				_, _ = fmt.Fprintf(errOut, "Warning: %s: could not update org ruleset %q (%v); review it at https://github.com/organizations/%s/settings/rules — a stale ruleset may %s.\n",
 					org, rs.Name, err, org, rulesetMissDescription(rs.Name))
@@ -760,10 +699,9 @@ func ensureClassroomRulesets(client githubapi.Client, out, errOut io.Writer, org
 }
 
 // listOrgRulesets returns existing org rulesets as a name->ID map so
-// ensureClassroomRulesets can decide between creating (POST) a new
-// ruleset and updating (PUT by ID) an existing one to reconcile drift.
-// Paginated so an org with many rulesets doesn't hide the Classroom 50
-// entries (which would make the reconcile re-POST and 422).
+// ensureClassroomRulesets can choose POST (new) vs PUT-by-ID (reconcile).
+// Paginated so a large org doesn't hide the Classroom 50 entries (which would
+// make the reconcile re-POST and 422).
 func listOrgRulesets(client githubapi.Client, org string) (map[string]int64, error) {
 	type orgRuleset struct {
 		ID   int64  `json:"id"`
@@ -796,10 +734,9 @@ func createOrgRuleset(client githubapi.Client, org string, body orgRulesetBody) 
 	return nil
 }
 
-// updateOrgRuleset PUTs the full definition over an existing ruleset by
-// ID, so re-running init reconciles a stale ruleset (e.g. one created by
-// an older CLI that targeted the wrong branch pattern) to the current
-// definition rather than leaving it as-is.
+// updateOrgRuleset PUTs the full definition over an existing ruleset by ID, so
+// a re-run reconciles a stale ruleset (e.g. an older CLI's wrong branch
+// pattern) to the current definition.
 func updateOrgRuleset(client githubapi.Client, org string, id int64, body orgRulesetBody) error {
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -818,9 +755,8 @@ func updateOrgRuleset(client githubapi.Client, org string, id int64, body orgRul
 	return nil
 }
 
-// rulesetMissDescription explains, per ruleset, what a teacher loses if
-// it couldn't be created — surfaced in the warning so the manual-fix
-// hint is actionable.
+// rulesetMissDescription explains, per ruleset, what a teacher loses if it
+// couldn't be created — surfaced in the warning so the fix hint is actionable.
 func rulesetMissDescription(name string) string {
 	switch name {
 	case rulesetNameSubmissionHistory:
@@ -832,12 +768,11 @@ func rulesetMissDescription(name string) string {
 	}
 }
 
-// setWorkflowPermissions raises the default GITHUB_TOKEN to write.
-// Each skeleton workflow already declares its own permissions; this
-// catches any teacher-added workflow that doesn't. (GitHub's
-// new-repo default flipped to read-only in 2023.) 409 → org enforces
-// a unified policy; reportOrgWorkflowPermissions logs the effective
-// setting and continues.
+// setWorkflowPermissions raises the default GITHUB_TOKEN to write. Skeleton
+// workflows declare their own permissions; this catches any teacher-added
+// workflow that doesn't. (GitHub's new-repo default flipped to read-only in
+// 2023.) 409 → org enforces a unified policy; reportOrgWorkflowPermissions
+// logs the effective setting and continues.
 func setWorkflowPermissions(client githubapi.Client, out io.Writer, owner, repo string) error {
 	body, err := json.Marshal(struct {
 		DefaultWorkflowPermissions   string `json:"default_workflow_permissions"`
@@ -867,10 +802,9 @@ func setWorkflowPermissions(client githubapi.Client, out io.Writer, owner, repo 
 	return nil
 }
 
-// reportOrgWorkflowPermissions logs the effective setting (the org
-// value under enforced policy). Always returns nil — a `read`
-// default doesn't break the bootstrap because skeleton workflows
-// declare their own permissions.
+// reportOrgWorkflowPermissions logs the effective setting (the org value under
+// enforced policy). Always returns nil — a `read` default doesn't break
+// bootstrap because skeleton workflows declare their own permissions.
 func reportOrgWorkflowPermissions(client githubapi.Client, out io.Writer, owner, repo string) error {
 	path := fmt.Sprintf("repos/%s/%s/actions/permissions/workflow",
 		url.PathEscape(owner), url.PathEscape(repo))
@@ -890,20 +824,15 @@ func reportOrgWorkflowPermissions(client githubapi.Client, out io.Writer, owner,
 	return nil
 }
 
-// enableReusableWorkflowAccess opens this private repo's workflows
-// to other repos in the same organization. The per-classroom
-// autograder shim that lands in every student repo references the
-// `autograde-runner.yaml` reusable workflow via
-// `uses: <org>/classroom50/.github/workflows/autograde-runner.yaml@main`;
-// without this access toggle, the student repo's GitHub Token gets
-// a 403 trying to resolve that `uses:` line.
+// enableReusableWorkflowAccess opens this private repo's workflows to other
+// repos in the org. The per-classroom autograder shim in every student repo
+// references the `autograde-runner.yaml` reusable workflow via `uses:
+// <org>/classroom50/...@main`; without this toggle the student repo's token
+// gets a 403 resolving that `uses:` line.
 //
-// PUT /repos/{owner}/{repo}/actions/permissions/access with
-// `access_level: organization` is the per-repo lever; idempotent —
-// safe to re-run. 403/409 (org-enforced policy) is treated as a
-// warning to errOut, since some orgs lock this at the enterprise
-// layer and the teacher's recourse is a settings change rather
-// than a CLI fix.
+// PUT .../actions/permissions/access with `access_level: organization` is the
+// per-repo lever; idempotent. 403/409 (org-enforced) → warn to errOut, since
+// some orgs lock this at the enterprise layer.
 func enableReusableWorkflowAccess(client githubapi.Client, out, errOut io.Writer, owner, repo string) error {
 	body, err := json.Marshal(struct {
 		AccessLevel string `json:"access_level"`

--- a/cli/gh-teacher/init_repo_test.go
+++ b/cli/gh-teacher/init_repo_test.go
@@ -346,11 +346,9 @@ func TestApplyOrgMemberDefaults_HappyPath(t *testing.T) {
 	if gotBody["members_can_create_private_repositories"] != true {
 		t.Errorf("members_can_create_private_repositories = %v, want true", gotBody["members_can_create_private_repositories"])
 	}
-	// The master repo-creation switch must be sent true: on Team the
-	// granular private boolean is slaved to it, so omitting it leaves
-	// BOTH public and private OFF (members can create no repos), which
-	// breaks gh student accept. This is the fix for the "both unchecked
-	// after init" symptom.
+	// The master repo-creation switch must be sent true: on Team the granular
+	// private boolean is slaved to it, so omitting it leaves BOTH options OFF,
+	// breaking gh student accept.
 	if gotBody["members_can_create_repositories"] != true {
 		t.Errorf("members_can_create_repositories = %v, want true (master switch; without it Team leaves both repo-creation options off)", gotBody["members_can_create_repositories"])
 	}
@@ -371,11 +369,8 @@ func TestApplyOrgMemberDefaults_HappyPath(t *testing.T) {
 		}
 	}
 	// Enterprise-only fields must be OMITTED on a Team plan (Team doesn't
-	// expose these toggles — sending them is wasted and confusing).
-	// members_can_create_public_repositories=false is enterpriseOnly
-	// because "private repos only" exists only on Enterprise Cloud; on
-	// Team, public/private are coupled and the student flow needs private
-	// creation, so init can't lock public off and must not attempt it.
+	// expose them). members_can_create_public_repositories=false is
+	// enterpriseOnly because "private repos only" is Enterprise-Cloud-only.
 	for _, f := range []string{
 		"members_can_create_public_repositories",
 		"members_can_create_internal_repositories",
@@ -394,10 +389,9 @@ func TestApplyOrgMemberDefaults_HappyPath(t *testing.T) {
 			t.Errorf("combined PATCH field %s = %v (present=%v), want true", f, v, ok)
 		}
 	}
-	// The success line is derived from orgpolicy.MemberDefaultSettings(plan)
-	// (orgMemberDefaultsSummary), so assert every policy's desc appears
-	// — this is what catches a hand-written prose summary drifting out
-	// of sync with the canonical slice.
+	// The success line derives from orgpolicy.MemberDefaultSettings(plan), so
+	// assert every policy's desc appears — catches a prose summary drifting
+	// from the canonical slice.
 	for _, s := range orgpolicy.MemberDefaultSettings("team") {
 		if !strings.Contains(out.String(), s.Desc) {
 			t.Errorf("success line missing policy %q, got: %q", s.Desc, out.String())
@@ -412,12 +406,10 @@ func TestApplyOrgMemberDefaults_HappyPath(t *testing.T) {
 }
 
 func TestApplyOrgMemberDefaults_ForbiddenWarnsButSucceeds(t *testing.T) {
-	// 403 on the combined PATCH (e.g. an enterprise-locked org) falls
-	// back to per-field PATCHes. When every field is rejected, the
-	// function does NOT warn per-field — it returns the authoritative
-	// read-back list of everything still unenforced (each with its
-	// manual-fix instruction) so init can render one checklist. init
-	// must still finish (no error).
+	// 403 on the combined PATCH falls back to per-field PATCHes. When every
+	// field is rejected, the function does NOT warn per-field — it returns the
+	// read-back list of everything unenforced (each with its manual fix) so
+	// init renders one checklist. init still finishes (no error).
 	var (
 		mu        sync.Mutex
 		patchCall int
@@ -509,14 +501,10 @@ func TestApplyOrgMemberDefaults_TransportFailurePropagates(t *testing.T) {
 }
 
 func TestApplyOrgMemberDefaults_UnprocessableFallsBackPerField(t *testing.T) {
-	// A 422 on the combined PATCH (one plan-gated/pinned field) must fall
-	// back to per-field PATCHes so the settable policies still apply.
-	// The function no longer warns per-field; it returns the one
-	// still-unenforced setting (from the read-back) for init to render.
-	// Uses the enterprise plan so the public-repo lockdown field is in
-	// play — on Team it's filtered out (enterpriseOnly), since "private
-	// repos only" doesn't exist there. Mirrors an enterprise org where an
-	// enterprise owner has pinned members_can_create_public_repositories.
+	// A 422 on the combined PATCH (one plan-gated/pinned field) must fall back
+	// to per-field PATCHes so the settable policies still apply; it returns the
+	// still-unenforced setting for init to render. Uses enterprise so the
+	// public-repo field is in play (filtered out on Team).
 	const rejectedField = "members_can_create_public_repositories"
 	var (
 		mu     sync.Mutex

--- a/cli/gh-teacher/init_skeleton.go
+++ b/cli/gh-teacher/init_skeleton.go
@@ -27,8 +27,8 @@ import (
 var skeletonFS embed.FS
 
 // skeletonProbePath detects "already committed" on re-runs.
-// publish-pages.yaml is unique to the config repo; README.md isn't
-// reliable because auto_init creates one.
+// publish-pages.yaml is unique to the config repo; README.md isn't reliable
+// (auto_init creates one).
 const skeletonProbePath = ".github/workflows/publish-pages.yaml"
 
 // defaultBranchPlaceholder is substituted at commit time so
@@ -77,28 +77,23 @@ func skeletonFiles(defaultBranch string) (map[string]string, error) {
 // skeletonCommitMessage is the single bootstrap commit's message.
 var skeletonCommitMessage = contract.PrefixCommit("Bootstrap classroom50 config repo (gh teacher init)")
 
-// skeletonCommitAttempts: read-parent + build-tree retries, at 200ms x
-// 2^n backoff (~3s), to ride out a fresh repo's git-data lag.
+// skeletonCommitAttempts: read-parent + build-tree retries at 200ms×2^n backoff
+// (~3s) to ride out a fresh repo's git-data lag.
 const skeletonCommitAttempts = 5
 
-// errRefNotReady: refAndTree returned 200 but an empty SHA -- the ref
-// isn't readable yet and the Tree API would 404 on the blank
-// base_tree. Retryable.
+// errRefNotReady: refAndTree returned 200 but an empty SHA — the ref isn't
+// readable yet and the Tree API would 404 on the blank base_tree. Retryable.
 var errRefNotReady = errors.New("branch ref not fully propagated")
 
-// commitSkeleton lands the embedded skeleton on defaultBranch in one
-// Tree commit. When the probe file shows a skeleton already landed, it
-// refreshes stale files instead (diff embedded vs repo, confirm, commit
-// only the changed paths) so re-running init picks up skeleton updates
-// — e.g. an org bootstrapped before declarative tests gains
-// materialize_tests.py and the updated runner/workflows.
+// commitSkeleton lands the embedded skeleton on defaultBranch in one Tree
+// commit. When the probe shows a skeleton already landed, it refreshes stale
+// files instead (diff, confirm, commit changed paths) so re-running init picks
+// up skeleton updates.
 //
-// A just-created repo (auto_init, or one a prior run made seconds ago
-// then 422'd on) serves the git-data APIs before its ref propagates:
-// reads 404, the Tree write 409s "Git Repository is empty". So wait
-// for the branch tip to settle, then retry the read+build for any lag
-// that slips through. Both run on every path -- "already exists" is
-// often a seconds-old repo.
+// A just-created repo serves the git-data APIs before its ref propagates (reads
+// 404, the Tree write 409s "Git Repository is empty"), so wait for the tip to
+// settle then retry. Both run on every path — "already exists" is often a
+// seconds-old repo.
 func commitSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Writer, owner, repo, defaultBranch string, assumeYes bool) error {
 	files, err := skeletonFiles(defaultBranch)
 	if err != nil {
@@ -113,15 +108,14 @@ func commitSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Writer
 		return refreshSkeleton(client, in, out, errOut, owner, repo, defaultBranch, files, assumeYes)
 	}
 
-	// Let auto_init's commit propagate first. Best-effort: the retry
-	// below still covers a ref slow past the poll budget.
+	// Let auto_init's commit propagate first. Best-effort: the retry still
+	// covers a ref slow past the poll budget.
 	if err := githubapi.WaitForStableBranch(client, owner, repo, defaultBranch); err != nil {
 		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: %s slow to propagate (%v); proceeding with retries\n",
 			owner, repo, defaultBranch, err)
 	}
 
-	// Blobs are content-addressed, so upload once; a retry below
-	// reuses these SHAs.
+	// Blobs are content-addressed, so upload once; a retry reuses these SHAs.
 	entries, err := githubapi.UploadBlobs(client, owner, repo, files)
 	if err != nil {
 		return err
@@ -135,12 +129,10 @@ func commitSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Writer
 	return nil
 }
 
-// refreshSkeleton brings an already-bootstrapped config repo's skeleton
-// up to date: diff the embedded files against the repo, confirm with
-// the teacher (skeleton files are documented as user-editable, so an
-// overwrite resets local customizations), then commit only the stale
-// paths through the optimistic-rebase loop. Declining is not an error
-// — init continues with the rest of its steps.
+// refreshSkeleton brings an already-bootstrapped config repo's skeleton up to
+// date: diff embedded vs repo, confirm (skeleton files are user-editable, so an
+// overwrite resets customizations), then commit only the stale paths. Declining
+// is not an error.
 func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Writer, owner, repo, branch string, files map[string]string, assumeYes bool) error {
 	stale, err := diffSkeleton(client, owner, repo, branch, files)
 	if err != nil {
@@ -166,10 +158,9 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 		}
 	}
 
-	// Re-diff inside the build closure so a rebase retry sees each
-	// attempt's parent state and never re-commits an already-current
-	// file. refreshed resets per attempt so the post-commit message
-	// reports what actually landed, not the pre-confirmation diff.
+	// Re-diff inside the build closure so a rebase retry sees each attempt's
+	// parent and never re-commits a current file. refreshed resets per attempt
+	// so the message reports what actually landed.
 	var refreshed int
 	build := func(parentSHA string) (map[string]string, error) {
 		refreshed = 0
@@ -189,8 +180,8 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 		return err
 	}
 	if commitSHA == "" {
-		// A concurrent writer refreshed the same files between the
-		// initial diff and the commit attempt; nothing left to land.
+		// A concurrent writer refreshed the same files between the diff and
+		// the commit; nothing left to land.
 		_, _ = fmt.Fprintf(out, "%s/%s: skeleton already refreshed by a concurrent writer, nothing to commit\n", owner, repo)
 		return nil
 	}
@@ -227,11 +218,9 @@ func confirmSkeletonRefresh(in io.Reader, errOut io.Writer) (bool, error) {
 	return answer == "y" || answer == "yes", nil
 }
 
-// skeletonFreshRepoRetry configures the shared fresh-repo-retry loop for the
-// skeleton commit: ride out a fresh repo's git-data lag (404 reads, 409 "Git
-// Repository is empty" writes, or an empty parent SHA), but treat a
-// missing-`workflow`-scope 404 as terminal. createTree's base_tree must
-// resolve, so the retry wraps the write, not just the ref read.
+// skeletonFreshRepoRetry configures the shared fresh-repo-retry loop: ride out
+// a fresh repo's git-data lag but treat a missing-`workflow`-scope 404 as
+// terminal. createTree's base_tree must resolve, so the retry wraps the write.
 func skeletonFreshRepoRetry() gittree.FreshRepoRetry {
 	return gittree.FreshRepoRetry{
 		Attempts: skeletonCommitAttempts,
@@ -246,9 +235,8 @@ func skeletonFreshRepoRetry() gittree.FreshRepoRetry {
 	}
 }
 
-// isSkeletonRetryable: the transient fresh-repo conditions worth a
-// retry -- 404 (reads), 409 "Git Repository is empty" (writes), or an
-// empty parent SHA (errRefNotReady).
+// isSkeletonRetryable: transient fresh-repo conditions worth a retry — 404
+// (reads), 409 "Git Repository is empty" (writes), or an empty parent SHA.
 func isSkeletonRetryable(err error) bool {
 	if errors.Is(err, configwrite.ErrMissingWorkflowScope) {
 		return false

--- a/cli/gh-teacher/init_summary.go
+++ b/cli/gh-teacher/init_summary.go
@@ -9,46 +9,33 @@ import (
 	"github.com/foundation50/gh-teacher/internal/ui"
 )
 
-// initSummary is the canonical record of what `gh teacher init` did. It
-// is the single source of truth behind all three renderers (human box,
-// plain, and --json), so the agent-readable JSON and the teacher-facing
-// summary can never drift. JSON tags follow the repo convention: no
-// omitempty (stable consumer contract) and slices always initialized so
-// they serialize as [] not null.
+// initSummary is the canonical record of what `gh teacher init` did, the single
+// source of truth behind all three renderers (human box, plain, --json) so they
+// can't drift. JSON tags follow the repo convention: no omitempty, slices
+// always initialized (serialize as [] not null).
 type initSummary struct {
 	Org    string `json:"org"`
 	DryRun bool   `json:"dry_run"`
-	// Ready is the overall go/no-go: no preflight failure, the org
-	// member-privilege lockdown invariant holds, and no fatal step. Feedback-PR readiness
-	// is reported separately (a not-ready Feedback PR doesn't make the
-	// classroom unusable, just degrades one feature).
+	// Ready is the overall go/no-go: no preflight failure, lockdown invariant
+	// holds, no fatal step. Feedback-PR readiness is reported separately.
 	Ready            bool        `json:"ready"`
 	Plan             string      `json:"plan"`
 	ConfigRepo       repoSummary `json:"config_repo"`
 	PagesURL         string      `json:"pages_url"`
 	LockdownComplete bool        `json:"lockdown_complete"`
-	// LockdownManualSteps lists the member-privilege settings init could
-	// not apply via the API (plan-gated or enterprise-pinned), each with
-	// the exact GitHub-UI instruction to set it by hand. Derived from the
-	// authoritative read-back, so it reflects the real residual state.
+	// LockdownManualSteps lists the settings init couldn't apply via the API,
+	// each with its GitHub-UI instruction. Derived from the read-back.
 	LockdownManualSteps []orgpolicy.ManualStep `json:"lockdown_manual_steps"`
 	FeedbackPRReady     bool                   `json:"feedback_pr_ready"`
-	// ServiceToken describes how the CLASSROOM50_SERVICE_TOKEN ended up
-	// configured this run ("configured from CLASSROOM50_SERVICE_TOKEN",
-	// "already configured", or "configured (prompted)") so a re-run is
-	// self-explanatory and an agent can confirm the token was handled.
+	// ServiceToken describes how the token ended up configured this run, so a
+	// re-run is self-explanatory.
 	ServiceToken string `json:"service_token"`
-	// ManualHardeningRequired is the set of org member-privilege settings
-	// GitHub exposes no REST API for, so init can neither set nor detect
-	// them. Surfaced as structured data (not just stderr prose) so an
-	// orchestrating agent can branch on "manual steps pending".
+	// ManualHardeningRequired: org settings with no REST API. Surfaced as
+	// structured data so an agent can branch on "manual steps pending".
 	ManualHardeningRequired []orgpolicy.ManualStep `json:"manual_hardening_required"`
-	// Notes are plan- or policy-specific informational caveats that are
-	// NOT action items — e.g. on Team/Free, member public-repo creation
-	// can't be locked off (it's coupled to the private-repo creation the
-	// student flow requires), so "lockdown complete" doesn't mean public
-	// creation is disabled. Surfaced so the teacher (and an agent) isn't
-	// misled by a clean "complete" banner.
+	// Notes are plan/policy caveats that are NOT action items — e.g. on
+	// Team/Free, public-repo creation can't be locked off, so "lockdown
+	// complete" doesn't mean public creation is disabled.
 	Notes     []string         `json:"notes"`
 	Preflight []preflightCheck `json:"preflight"`
 	Warnings  []string         `json:"warnings"`
@@ -60,12 +47,8 @@ type repoSummary struct {
 	Created bool   `json:"created"`
 }
 
-// manualStep moved to internal/orgpolicy (orgpolicy.ManualStep); it's
-// shared by init's summary rendering and audit's unreadable list.
-
-// newInitSummary returns a summary with all slices initialized (so JSON
-// emits [] not null) and the static manual-hardening checklist
-// pre-populated for the given org.
+// newInitSummary returns a summary with all slices initialized (JSON emits []
+// not null) and the manual-hardening checklist pre-populated.
 func newInitSummary(org string) *initSummary {
 	return &initSummary{
 		Org:                     org,
@@ -77,38 +60,27 @@ func newInitSummary(org string) *initSummary {
 	}
 }
 
-// addWarning records a warning in the summary. The same text is also
-// emitted inline at the moment it happens (for context); the summary's
-// copy is the authoritative recap and powers the JSON `warnings` array
-// and the human warning count.
+// addWarning records a warning in the summary. It powers the JSON `warnings`
+// array and the human warning count.
 func (s *initSummary) addWarning(format string, a ...any) {
 	s.Warnings = append(s.Warnings, fmt.Sprintf(format, a...))
 }
 
-// addNote records an informational, non-action caveat (see the Notes
-// field). Unlike addWarning it does not imply something went wrong — it
-// clarifies a plan/policy limitation so a clean banner isn't misread.
+// addNote records an informational, non-action caveat (see Notes). Unlike
+// addWarning it doesn't imply something went wrong.
 func (s *initSummary) addNote(format string, a ...any) {
 	s.Notes = append(s.Notes, fmt.Sprintf(format, a...))
 }
 
-// manualHardeningSteps moved to internal/orgpolicy
-// (orgpolicy.ManualHardeningSteps): the canonical API-less hardening
-// checklist, single-sourced so init's reminder and audit's unreadable
-// list can't drift.
-
-// finalize computes the overall Ready flag from the recorded state. Ready
-// means: not a dry run, the lockdown invariant holds, and a config repo
-// landed. FeedbackPRReady is intentionally NOT part of Ready (a degraded
-// Feedback PR doesn't block running a classroom).
+// finalize computes Ready: not a dry run, lockdown invariant holds, config repo
+// landed. FeedbackPRReady is intentionally NOT part of Ready.
 func (s *initSummary) finalize() {
 	s.Ready = !s.DryRun && s.LockdownComplete && s.ConfigRepo.URL != ""
 }
 
-// renderJSON writes the summary as a single indented JSON object to w
-// (stdout). This is the only thing on stdout under --json. HTML escaping
-// is disabled so `>` in setting descriptions stays readable (this is CLI
-// output, not embedded in HTML).
+// renderJSON writes the summary as a single indented JSON object to stdout
+// (the only thing on stdout under --json). HTML escaping is off so `>` stays
+// readable.
 func (s *initSummary) renderJSON(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
@@ -116,16 +88,12 @@ func (s *initSummary) renderJSON(w io.Writer) error {
 	return enc.Encode(s)
 }
 
-// renderHuman writes the end-of-run report to the human channel
-// (stderr): a one-line outcome banner, a terse setup summary, a single
-// consolidated "action required" checklist (the API-less hardening steps
-// plus any lockdown settings the plan/policy wouldn't let init apply),
-// and a prominent next command. No box — long URLs and instructions
-// would overflow it; a flat checklist is easier to scan and act on.
+// renderHuman writes the end-of-run report to stderr: an outcome banner, a
+// terse setup summary, one consolidated "action required" checklist, and the
+// next command. No box — long URLs would overflow it.
 func (s *initSummary) renderHuman(u *ui.UI) {
-	// 1. Outcome banner. A leading blank line separates the report from
-	// the progress line / step output above it (we don't hard-clear the
-	// terminal — that would wipe the teacher's scrollback).
+	// 1. Outcome banner, preceded by a blank line to separate it from the
+	// progress output above (we don't hard-clear the terminal).
 	u.Blank()
 	switch {
 	case s.Ready:
@@ -165,17 +133,14 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 		}
 	}
 
-	// 3. One consolidated manual-action checklist. The lockdown steps
-	// (settings init couldn't apply on this plan/policy) and the
-	// always-API-less hardening steps both live on the same org
-	// member-privileges page, so merge them into one checklist the
-	// teacher works top-to-bottom.
+	// 3. One consolidated manual-action checklist: the lockdown steps init
+	// couldn't apply and the always-API-less hardening steps both live on the
+	// org member-privileges page, so merge them.
 	settingsURL := manualSettingsURL(s)
 	manual := s.manualActions()
 	if len(manual) > 0 {
 		u.Heading("Action required — set these by hand (org owner)")
-		// When the lockdown is incomplete, lead with the plan-aware
-		// reason so the teacher understands why init couldn't do it.
+		// When incomplete, lead with the plan-aware reason.
 		if !s.LockdownComplete {
 			u.Detail("%s", unenforcedCause(s.Plan))
 		}
@@ -192,9 +157,9 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 	u.Next(fmt.Sprintf("gh teacher classroom add %s <short-name>", s.Org))
 }
 
-// manualActions merges the unenforced lockdown steps (only present when
-// the lockdown is incomplete) with the always-manual hardening steps
-// into one ordered checklist of GitHub-UI instructions.
+// manualActions merges the unenforced lockdown steps (present only when the
+// lockdown is incomplete) with the always-manual hardening steps into one
+// ordered checklist.
 func (s *initSummary) manualActions() []string {
 	var out []string
 	if !s.LockdownComplete {
@@ -208,8 +173,8 @@ func (s *initSummary) manualActions() []string {
 	return out
 }
 
-// manualSettingsURL returns the org member-privileges settings page URL
-// shared by every manual step (they all live on the same page).
+// manualSettingsURL returns the org member-privileges page URL shared by every
+// manual step.
 func manualSettingsURL(s *initSummary) string {
 	if len(s.LockdownManualSteps) > 0 {
 		return s.LockdownManualSteps[0].URL

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -1,19 +1,13 @@
-// Package assignment is the assignment data layer: it parses, validates,
-// and re-encodes a single assignments.json entry, including its embedded
-// tests[] and runtime{} sub-objects. It is pure data/validation logic with
-// no GitHub I/O and no commit plumbing — it depends only on internal/output,
-// internal/validate, the shared contract package, and stdlib. The assignment
-// commands (internal/assignmentcmd), the config-repo write loop
-// (configwrite.CommitTree), and the autograder-shim helpers (internal/autograder)
-// all consume this package through its exported API.
+// Package assignment is the pure data layer for a single assignments.json
+// entry (plus its tests[] and runtime{} sub-objects): parse, validate,
+// re-encode, no GitHub I/O.
 //
-// Security invariant: assignments.json is untrusted, hand-editable input, so
-// the runtime/container blocks are validated on the parse path
-// (ParseAssignments → ValidateExistingEntry → ValidateRuntime), not only at
-// write time. Callers must obtain entries through these entry points and must
-// not emit a RuntimeRef/ContainerSpec into a workflow without ValidateRuntime/
-// ValidateContainer having run — the exported validators are the trust
-// boundary for the anti-injection guards (see runtime.go).
+// Security invariant: assignments.json is untrusted, hand-editable, so the
+// runtime/container blocks are validated on the parse path (not only at write
+// time). Callers must obtain entries through these entry points and must not
+// emit a RuntimeRef/ContainerSpec into a workflow without ValidateRuntime/
+// ValidateContainer having run — the validators are the anti-injection trust
+// boundary (see runtime.go).
 package assignment
 
 import (
@@ -33,17 +27,15 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// Assignment modes accepted at the parse/write layer. Both are
-// end-to-end supported: `individual` (one repo per student) and
-// `group` (a shared repo a teammate joins, bounded by max_group_size).
-// Single-sourced in the shared contract package.
+// Assignment modes, single-sourced from the shared contract: `individual`
+// (one repo per student) and `group` (a shared repo, bounded by
+// max_group_size).
 const (
 	ModeIndividual = contract.ModeIndividual
 	ModeGroup      = contract.ModeGroup
 )
 
-// AssignmentModes is the canonical allow-list, sorted alphabetically
-// so error messages stay stable.
+// AssignmentModes is the allow-list, sorted so error messages stay stable.
 var AssignmentModes = []string{ModeGroup, ModeIndividual}
 
 func IsValidAssignmentMode(m string) bool {
@@ -55,57 +47,41 @@ func IsValidAssignmentMode(m string) bool {
 	return false
 }
 
-// LargeAssignmentsWarnBytes is the encoded-size threshold above
-// which `gh teacher assignment add` emits a stderr warning. Set
-// generously below GitHub's contents-API behavior change (~1 MiB
-// encoded → `encoding:"none"`, which would wedge every future
-// read/write on the file). Diagnostic only — no hard cap; teachers
-// hitting this should consider splitting the classroom or
-// shrinking per-entry fields before the file actually crosses the
-// API threshold.
+// LargeAssignmentsWarnBytes is the encoded-size threshold above which
+// `assignment add` warns on stderr. Set well below GitHub's ~1 MiB
+// contents-API limit (past which encoding flips to "none", wedging every
+// future read/write). Diagnostic only — no hard cap.
 const LargeAssignmentsWarnBytes = 700 * 1024
 
-// AssignmentsJSON is the typed on-disk shape of assignments.json.
-// Schema sentinel comes first so readers can branch before touching
-// the rest. Assignments always serializes as `[]` (never null) to
-// match `gh teacher classroom add`'s scaffold output.
+// AssignmentsJSON is the typed on-disk shape of assignments.json. Schema
+// sentinel first so readers can branch before the rest. Assignments always
+// serializes as `[]` (never null).
 type AssignmentsJSON struct {
 	Schema      string            `json:"schema"`
 	Assignments []AssignmentEntry `json:"assignments"`
 }
 
 // AssignmentEntry is one row in assignments.json. Field order reads
-// top-to-bottom for a teacher inspecting the file: identity ->
-// template -> schedule/mode -> autograder -> runtime -> tests ->
-// provenance. Mode and Autograder always serialize (no omitempty) so
-// consumers don't have to disambiguate "absent -> default" from
-// "explicit default". MigratedFrom omits cleanly when absent.
+// top-to-bottom for a teacher inspecting the file. Mode and Autograder always
+// serialize (no omitempty) so consumers don't disambiguate "absent → default"
+// from "explicit default".
 //
-// Tests is the optional declarative-grading layer (see tests.go):
-// publish-pages materializes it into the Pages bundle as tests.json and
-// runner.py grades it with a built-in interpreter. Entrypoint precedence
-// at grade time: per-assignment autograder.py > tests.json > classroom
-// default autograder.py > vacuous pass. See wiki/Autograders.md.
-// (An earlier `Tests` field was removed alongside the matrix
-// autograder; this is its declarative successor on runner.py.)
-// MaxGroupSize bounds the collaborators on a group repo. Required
-// (>= 2) for group-mode entries; must be 0 (unset, omitted) for
-// individual. The limit is enforced within the CLI at join time —
-// direct GitHub-UI invites can exceed it (documented limitation).
+// Tests is the optional declarative-grading layer (see tests.go), materialized
+// into the Pages bundle as tests.json. Grade-time entrypoint precedence:
+// per-assignment autograder.py > tests.json > classroom default autograder.py
+// > vacuous pass. See wiki/Autograders.md.
 //
-// FeedbackPR opts the assignment into the Feedback Pull Request: when
-// true, the autograde runner opens one long-lived PR per student repo
-// (base = a frozen branch at the baseline commit, head = the default
-// branch) for inline review of the full starter→submission diff. The
-// product default is on (--feedback-pr defaults to true; the GUI also
-// creates it enabled), but omitempty drops the field when false, so an
-// absent field reads as false. The runner re-reads it from the manifest.
+// MaxGroupSize bounds collaborators on a group repo: required (>= 2) for group
+// mode, must be 0 for individual. Enforced at join time in the CLI — direct
+// GitHub-UI invites can exceed it (documented limitation).
 //
-// AllowedFiles is an ordered list of .gitignore-style patterns defining
-// which files belong to the submission (last match wins, `!` re-includes),
-// so `["*", "!hello.py"]` allows only hello.py. Empty/absent allows every
-// file. The runner enforces it by removing disallowed files before
-// grading; `gh student submit` applies it best-effort.
+// FeedbackPR opts into one long-lived per-repo Feedback PR (base = frozen
+// baseline branch, head = default branch) for inline diff review. Product
+// default is on, but omitempty drops it when false, so absent reads as false.
+//
+// AllowedFiles is ordered .gitignore-style patterns for which files belong to
+// the submission (last match wins, `!` re-includes); empty/absent allows all.
+// The runner enforces it by removing disallowed files before grading.
 type AssignmentEntry struct {
 	Slug          string           `json:"slug"`
 	Name          string           `json:"name"`
@@ -124,15 +100,13 @@ type AssignmentEntry struct {
 	MigratedFrom  *MigratedFromRef `json:"migrated_from,omitempty"`
 
 	// Extra holds unknown top-level entry keys, re-emitted verbatim so a
-	// read-modify-write never drops a field a newer binary/web GUI added
-	// ("tolerate AND preserve"). Merged in/out by the custom (Un)MarshalJSON
-	// below, so it never appears as a literal "extra" key on the wire.
+	// read-modify-write never drops a field a newer binary/GUI added.
+	// Merged in/out by the custom (Un)MarshalJSON below.
 	Extra map[string]json.RawMessage `json:"-"`
 }
 
-// knownEntryKeys is the top-level entry keys this binary understands;
-// any other key is diverted to Extra. Keep in lockstep with the json
-// tags on AssignmentEntry above.
+// knownEntryKeys is the entry keys this binary understands; any other key is
+// diverted to Extra. Keep in lockstep with AssignmentEntry's json tags.
 var knownEntryKeys = map[string]struct{}{
 	"slug": {}, "name": {}, "description": {}, "template": {}, "due": {},
 	"due_meta": {}, "mode": {}, "autograder": {}, "max_group_size": {},
@@ -141,10 +115,10 @@ var knownEntryKeys = map[string]struct{}{
 }
 
 // UnmarshalJSON captures unknown top-level keys into Extra, then strictly
-// decodes only the known subset. The unknown keys must be stripped first:
-// DisallowUnknownFields is all-or-nothing per decoder, so it can stay
-// strict on the typed sub-objects (a typo inside tests/template/runtime/
-// due_meta is still a hard error) only if it never sees an unknown key.
+// decodes the known subset. Unknown keys must be stripped first because
+// DisallowUnknownFields is all-or-nothing per decoder — stripping lets the
+// typed sub-objects stay strict (a typo inside tests/template/runtime/due_meta
+// is still a hard error).
 func (e *AssignmentEntry) UnmarshalJSON(data []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -181,9 +155,8 @@ func (e *AssignmentEntry) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON emits the known fields via the alias, then byte-splices any
-// sorted Extra keys in before the closing brace. The splice (vs a map
-// round-trip) preserves the known fields' struct order so adding Extra
-// doesn't reorder every entry on the next write.
+// sorted Extra keys before the closing brace. The splice (vs a map round-trip)
+// preserves the known fields' struct order.
 func (e AssignmentEntry) MarshalJSON() ([]byte, error) {
 	type entryAlias AssignmentEntry
 	known, err := json.Marshal(entryAlias(e))
@@ -205,9 +178,9 @@ func (e AssignmentEntry) MarshalJSON() ([]byte, error) {
 	}
 	sort.Strings(keys) // deterministic output
 
-	// Splice the Extra members in before `known`'s closing brace. The alias
-	// always emits slug/name/mode/autograder (no omitempty), so `known` is
-	// never "{}" and the leading comma is always correct.
+	// Splice Extra members before `known`'s closing brace. The alias always
+	// emits slug/name/mode/autograder, so `known` is never "{}" and the
+	// leading comma is always correct.
 	var buf bytes.Buffer
 	trimmed := bytes.TrimSpace(known)
 	buf.Write(trimmed[:len(trimmed)-1]) // everything up to the final '}'
@@ -235,13 +208,11 @@ func ValidateMaxGroupSize(n int) error {
 	return nil
 }
 
-// PassThreshold is an opt-in, advisory passing bar: the integer percentage of
-// max score (0..100) at/above which a gradebook client shows a submission as
-// "passing". A *pointer* (not a plain int + omitempty like max_group_size)
-// because 0 is a legal threshold, so unset must stay distinct from 0 — absent
-// means the feature is OFF (no passing concept), not "0%". CLI-unenforced like
-// max_group_size: the autograder/score collection never read it; it exists so
-// clients such as the GUI can display and (optionally) enforce it client-side.
+// PassThreshold is an opt-in advisory passing bar: the integer percentage of
+// max score (0..100) at/above which a gradebook client shows "passing". A
+// pointer, not int+omitempty, because 0 is a legal threshold, so unset must
+// stay distinct from 0 (absent = feature OFF). CLI-unenforced: only clients
+// like the GUI read it.
 const (
 	PassThresholdMin = 0
 	PassThresholdMax = 100
@@ -264,9 +235,8 @@ func ValidatePassThreshold(n *int) error {
 const AllowedFilesCap = 100
 
 // ValidateAllowedFiles rejects empty/whitespace-only patterns and ones
-// containing NUL or newline (they're written one-per-line into a
-// .gitignore, where a newline would smuggle an extra rule). A nil/empty
-// list is valid (all files allowed); callers skip this check for it.
+// containing NUL or newline (they're written one-per-line into a .gitignore,
+// where a newline would smuggle an extra rule). A nil/empty list is valid.
 func ValidateAllowedFiles(patterns []string) error {
 	if len(patterns) > AllowedFilesCap {
 		return fmt.Errorf("allowed_files has %d patterns (max %d)", len(patterns), AllowedFilesCap)
@@ -282,18 +252,14 @@ func ValidateAllowedFiles(patterns []string) error {
 	return nil
 }
 
-// DueMeta is the write-side provenance for `due`. Because `due` is
-// normalized to a UTC instant (losing the teacher's wall-clock and
-// offset), this records what was actually supplied so a wrong-zone
-// deadline can be audited after the fact. Advisory only --
-// collect_scores.py reads `due`, never this.
+// DueMeta is write-side provenance for `due`. Because `due` is normalized to a
+// UTC instant (losing the teacher's wall-clock and offset), this records what
+// was supplied so a wrong-zone deadline can be audited. Advisory only.
 //
-// Input is the supplied value (--due flag or migrated source
-// deadline), whitespace-trimmed but otherwise verbatim. Offset is the
-// zone offset applied at normalization (always [+-]HH:MM). Zone is the
-// best-effort IANA/local zone name, set only when the offset was
-// auto-detected (an explicit offset carries no zone name). Source
-// records how the zone was determined.
+// Input is the supplied value, whitespace-trimmed but otherwise verbatim.
+// Offset is the zone offset applied at normalization ([+-]HH:MM). Zone is the
+// best-effort IANA/local zone name, set only when the offset was auto-detected.
+// Source records how the zone was determined.
 type DueMeta struct {
 	Input  string `json:"input"`
 	Zone   string `json:"zone,omitempty"`
@@ -310,25 +276,19 @@ const (
 	DueSourceMigrated = "migrated"
 )
 
-// dueMetaOffsetRe matches the [+-]HH:MM offset shape written into
-// due_meta.offset -- kept in lockstep with the schema's due_meta.offset
-// pattern so ValidateDueMeta and a schema-validating client agree.
+// dueMetaOffsetRe matches the [+-]HH:MM offset written into due_meta.offset,
+// kept in lockstep with the schema's pattern.
 var dueMetaOffsetRe = regexp.MustCompile(`^[+-]([01]\d|2[0-3]):[0-5]\d$`)
 
-// NewDueMeta builds the provenance block shared by the --due and
-// migrate paths: the supplied input, the offset applied (read off t's
-// zone), and how that offset was determined. Callers set Zone
-// separately when it was auto-detected.
+// NewDueMeta builds the provenance block for the --due and migrate paths.
+// Callers set Zone separately when the offset was auto-detected.
 func NewDueMeta(input string, t time.Time, source string) *DueMeta {
 	return &DueMeta{Input: input, Offset: t.Format("-07:00"), Source: source}
 }
 
-// ValidateDueMeta checks a due_meta block's fields against the same
-// shape the JSON schema enforces, so a malformed block written by a
-// GUI or hand-edit is rejected by the CLI too (the schema is documented
-// as mirroring these validators). Presence is NOT required: files
-// written before due_meta existed carry `due` alone and must still
-// validate, so callers only invoke this when the block is present.
+// ValidateDueMeta checks a due_meta block against the same shape the schema
+// enforces, so a malformed block from a GUI or hand-edit is rejected here too.
+// Presence is not required; callers only invoke this when the block exists.
 func ValidateDueMeta(m *DueMeta) error {
 	if m.Input == "" {
 		return errors.New("due_meta.input must not be empty")
@@ -345,17 +305,15 @@ func ValidateDueMeta(m *DueMeta) error {
 	return nil
 }
 
-// dueNaiveLayout is the RFC 3339 local-datetime shape with no zone.
-// When a teacher omits the offset, --due is parsed with this layout
-// in the machine's local timezone, then normalized to UTC.
+// dueNaiveLayout is the RFC 3339 local-datetime shape with no zone. A
+// zone-less --due is parsed with this layout in the machine's local zone, then
+// normalized to UTC.
 const dueNaiveLayout = "2006-01-02T15:04:05"
 
-// ParseDueTime parses a due value as either a full RFC 3339 timestamp
-// (offset present -> hadOffset true) or a zone-less local datetime
-// interpreted in loc (hadOffset false). The returned time carries the
-// applied zone; callers normalize to UTC for storage. Sub-second
-// precision is accepted but dropped on the UTC re-format -- deadlines
-// don't need it.
+// ParseDueTime parses a due value as either a full RFC 3339 timestamp (offset
+// present → hadOffset true) or a zone-less local datetime interpreted in loc
+// (hadOffset false). Callers normalize to UTC for storage. Sub-second
+// precision is accepted but dropped on the UTC re-format.
 func ParseDueTime(raw string, loc *time.Location) (parsed time.Time, hadOffset bool, err error) {
 	if parsed, err = time.Parse(time.RFC3339, raw); err == nil {
 		return parsed, true, nil
@@ -368,13 +326,11 @@ func ParseDueTime(raw string, loc *time.Location) (parsed time.Time, hadOffset b
 			"(2026-09-15T23:59:00-04:00) or a local time (2026-09-15T23:59:00)", raw)
 }
 
-// ValidateDueDate guards the *stored* form: empty (no deadline) or an
-// RFC 3339 timestamp with an offset. The CLI always writes a UTC
-// instant, so this passes on anything it produces. It stays strict on
-// read -- a hand-edited zone-less value is rejected rather than guessed
-// at, since (unlike a fresh --due) there's no knowable machine zone to
-// attach. The naive-input tolerance lives only at the --due/migrate
-// boundary (ParseDueTime), never here.
+// ValidateDueDate guards the stored form: empty (no deadline) or an RFC 3339
+// timestamp with an offset — anything the CLI produces. Stays strict on read:
+// a hand-edited zone-less value is rejected rather than guessed, since there's
+// no knowable machine zone to attach. Naive-input tolerance lives only in
+// ParseDueTime.
 func ValidateDueDate(due string) error {
 	if due == "" {
 		return nil
@@ -385,11 +341,10 @@ func ValidateDueDate(due string) error {
 	return nil
 }
 
-// MigratedFromRef records where an assignment originated when it
-// was imported by `gh teacher classroom migrate`. Hand-authored
-// entries never carry this block. OriginalSlug is set only when it
-// differs from the current Slug; StarterRepo is the legacy
-// "owner/repo" before re-templating; InviteLink is diagnostic.
+// MigratedFromRef records where an assignment originated when imported by
+// `classroom migrate`. Hand-authored entries never carry it. OriginalSlug is
+// set only when it differs from Slug; StarterRepo is the legacy "owner/repo"
+// before re-templating; InviteLink is diagnostic.
 type MigratedFromRef struct {
 	Source       string `json:"source"`
 	ClassroomID  int64  `json:"classroom_id"`
@@ -400,40 +355,33 @@ type MigratedFromRef struct {
 	MigratedAt   string `json:"migrated_at"`
 }
 
-// TemplateRef is the assignment's starter-code source. Three
-// explicit fields (not "owner/repo@branch") so consumers don't
-// re-parse. Branch is always populated when present; `assignment add`
-// resolves the template's `default_branch` when `@branch` is omitted.
-// Optional: a template-less assignment omits the block entirely
-// (AssignmentEntry.Template is nil), and `gh student accept` then
-// creates an empty repo carrying only the autograder shim.
+// TemplateRef is the assignment's starter-code source. Three explicit fields
+// (not "owner/repo@branch") so consumers don't re-parse; Branch is resolved to
+// the template's default_branch when `@branch` is omitted. Optional: a
+// template-less assignment omits the block (Template is nil), and `student
+// accept` creates an empty repo carrying only the autograder shim.
 type TemplateRef struct {
 	Owner  string `json:"owner"`
 	Repo   string `json:"repo"`
 	Branch string `json:"branch"`
 }
 
-// RuntimeRef captures the runtime environment for an assignment's
-// autograde job. Read by the runner's setup job and dispatched into
-// `runs-on` / `container` / language toolchain / apt steps.
+// RuntimeRef captures the autograde job's runtime environment, dispatched into
+// the runner's `runs-on` / `container` / toolchain / apt steps.
 //
-// Two paths, mutually exclusive:
+// Two mutually-exclusive paths:
 //
-//  1. Host runner — set RunsOn (one or more runner labels) plus
-//     optional language fields and Apt packages.
-//  2. Container image — set Container.Image; the image controls the
-//     environment, so Apt is forbidden. Language fields still apply
-//     (setup-X actions run inside the container).
+//  1. Host runner — set RunsOn plus optional language fields and Apt packages.
+//  2. Container image — set Container.Image; the image owns the environment,
+//     so Apt is forbidden. Language fields still apply (setup-X runs inside).
 //
-// RunsOn mirrors GitHub Actions' own `runs-on`: a single label
-// ("ubuntu-latest") or an array (["self-hosted", "gpu"]) for custom /
-// self-hosted runners. No value allow-list —
-// the teacher owns the label, as in a hand-written workflow; each is
-// only injection-checked (RunsOnLabelPattern) since it flows verbatim
-// into the workflow's `runs-on`.
+// RunsOn mirrors Actions' `runs-on`: a single label or an array for
+// custom/self-hosted runners. No value allow-list — the teacher owns the
+// label; each is only injection-checked (RunsOnLabelPattern) since it flows
+// verbatim into the workflow.
 //
-// All fields optional; an absent RuntimeRef means "use defaults"
-// (ubuntu-latest + Python 3.12, no extra packages).
+// All fields optional; an absent RuntimeRef means defaults (ubuntu-latest +
+// Python 3.12, no extra packages).
 type RuntimeRef struct {
 	RunsOn    RunsOn         `json:"runs-on,omitempty"`
 	Container *ContainerSpec `json:"container,omitempty"`
@@ -444,11 +392,10 @@ type RuntimeRef struct {
 	Apt       []string       `json:"apt,omitempty"`
 }
 
-// RunsOn models GitHub Actions' polymorphic `runs-on` (a single label
-// or an array of labels), normalized to a []string. An empty RunsOn
-// means "use the default" (ubuntu-latest) and is omitted from JSON.
-// MarshalJSON preserves the author's shape: one label round-trips as a
-// string (what teachers write), many as an array.
+// RunsOn models Actions' polymorphic `runs-on` (single label or array),
+// normalized to a []string. Empty means default (ubuntu-latest) and is
+// omitted. MarshalJSON preserves the author's shape: one label round-trips as
+// a string, many as an array.
 type RunsOn []string
 
 func (r RunsOn) MarshalJSON() ([]byte, error) {
@@ -458,15 +405,10 @@ func (r RunsOn) MarshalJSON() ([]byte, error) {
 	return json.Marshal([]string(r))
 }
 
-// UnmarshalJSON accepts a string, an array of strings, or null/absent
-// (meaning "use the default"). The degenerate present-but-empty shapes
-// — "" and [] — are rejected so this parser, the inline-Python
-// validator (autograde-runner.yaml), and the JSON schema (oneOf,
-// minItems:1) all agree that only an OMITTED runs-on means default,
-// upholding the invariant that a CLI-accepted value is never rejected
-// by a schema-validating client. Any other shape (number, object,
-// array-of-non-strings) is a hard error so a malformed runs-on fails
-// at parse rather than emitting a broken workflow value.
+// UnmarshalJSON accepts a string, array of strings, or null/absent (= default).
+// The present-but-empty shapes ("" and []) are rejected so this parser, the
+// runner's inline validator, and the schema all agree that only an OMITTED
+// runs-on means default. Any other shape is a hard error.
 func (r *RunsOn) UnmarshalJSON(data []byte) error {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
@@ -499,56 +441,40 @@ func (r *RunsOn) UnmarshalJSON(data []byte) error {
 	}
 }
 
-// ContainerSpec is the `runtime.container` block: the image to grade
-// in, plus an optional `User`.
+// ContainerSpec is the `runtime.container` block: the image to grade in, plus
+// an optional User.
 //
 // The image must be publicly pullable: the grade job runs inside the
-// student repo (admin'd by the student), where GitHub Actions provides
-// no way to deliver a private-registry pull secret safely, so private
-// images are out of scope. Use a public image (e.g. a public
-// ghcr.io/<org>/<name>) for grading.
+// student-admin'd repo, where Actions offers no safe way to deliver a
+// private-registry pull secret, so private images are out of scope.
 //
-// `User` is an internal field translated to `container.options:
-// --user <value>` at runtime — Actions doesn't accept
-// `container.user` directly, but a non-root container (cs50/cli,
-// most maintained images) hits EACCES when `actions/checkout`
-// writes to the runner's temp dir under `/__w/_temp/`. Setting
-// `user: root` (or `user: 0`) is the standard workaround.
+// User is translated to `container.options: --user <value>` — Actions rejects
+// `container.user` directly, but a non-root image (cs50/cli) hits EACCES when
+// actions/checkout writes under `/__w/_temp/`; `user: root` is the workaround.
 type ContainerSpec struct {
 	Image string `json:"image"`
 	User  string `json:"user,omitempty"`
 }
 
 // AssignmentsFilePath is the config-repo-relative path to a classroom's
-// assignments.json manifest. Single-sourced here so the read helpers
-// (configrepo.LoadAssignments) and the command write paths agree.
+// assignments.json. Single-sourced so read and write paths agree.
 func AssignmentsFilePath(classroom string) string {
 	return classroom + "/assignments.json"
 }
 
-// ParseAssignments decodes assignments.json with a two-pass scheme:
-// a lenient first pass reads only the schema sentinel so a future v2
-// file surfaces "this CLI handles only v1" instead of
-// "json: unknown field"; the strict pass runs only on v1.
+// ParseAssignments decodes assignments.json in two passes: a lenient pass
+// reads only the schema sentinel (so a future v2 surfaces "this CLI handles
+// only v1" instead of "json: unknown field"); the strict pass runs on v1.
 //
-// The TOP-LEVEL envelope ({schema, assignments}) stays strict
-// (DisallowUnknownFields), but each ENTRY tolerates and round-trips
-// unknown keys verbatim via AssignmentEntry.Extra — the forward-compat
-// path a newer binary / the web GUI relies on, so a read-modify-write
-// here (reuse/add) never drops a field. Known sub-objects
-// (tests/template/runtime/due_meta) stay strictly typed.
+// The top-level envelope stays strict (DisallowUnknownFields), but each entry
+// tolerates and round-trips unknown keys via Extra — the forward-compat path a
+// newer binary/GUI relies on. Known sub-objects stay strictly typed.
+// Per-entry validation still runs on every known field so a hand-edited entry
+// can't re-bless itself.
 //
-// Per-entry validation (ValidateExistingEntry) runs on every KNOWN field
-// so a hand-edited or web-inserted entry can't re-bless itself on the
-// next write; the security boundary is unchanged by the tolerance.
-//
-// No hard size cap is enforced — per-assignment tests live as files
-// in the config repo rather than being inlined, so realistic
-// manifests stay well under the ~1 MiB contents-API threshold.
-// `runAssignmentAdd` emits a stderr warning when the encoded file
-// crosses `LargeAssignmentsWarnBytes` so operators get visibility
-// before the API behavior change (encoding flips to "none" past
-// ~1 MiB, wedging future reads).
+// No hard size cap: per-assignment tests live as files, not inlined, so
+// manifests stay under the ~1 MiB contents-API threshold; `assignment add`
+// warns past LargeAssignmentsWarnBytes.
 func ParseAssignments(data []byte) (AssignmentsJSON, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return AssignmentsJSON{}, errors.New("assignments.json is empty")
@@ -565,29 +491,25 @@ func ParseAssignments(data []byte) (AssignmentsJSON, error) {
 	}
 	var file AssignmentsJSON
 	dec := json.NewDecoder(bytes.NewReader(data))
-	// Strict at the ENVELOPE level only (rejects an unknown top-level key).
-	// It does NOT recurse into entries: AssignmentEntry.UnmarshalJSON runs
-	// its own strict decode and captures unknown entry keys into Extra.
+	// Strict at the ENVELOPE level only (rejects unknown top-level keys). It
+	// doesn't recurse into entries: AssignmentEntry.UnmarshalJSON does its own
+	// strict decode and captures unknown keys into Extra.
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&file); err != nil {
 		return AssignmentsJSON{}, fmt.Errorf("parse assignments.json: %w", err)
 	}
-	// Reject trailing content; without this, the next re-encode
-	// would silently truncate it.
+	// Reject trailing content; otherwise the next re-encode silently drops it.
 	if err := expectEOF(dec); err != nil {
 		return AssignmentsJSON{}, fmt.Errorf("parse assignments.json: %w", err)
 	}
-	// An explicit `"template": null` decodes to a nil *TemplateRef, which
-	// the validators treat as "template-less" — but the JSON Schema (the
-	// GUI's contract) types `template` as an object and rejects null. Keep
-	// the two contracts in lockstep: a template-less assignment OMITS the
-	// key; explicit null is rejected on this path too.
+	// `"template": null` decodes to a nil *TemplateRef ("template-less"), but
+	// the schema types template as an object and rejects null. Keep the two
+	// contracts in lockstep: template-less OMITS the key; explicit null fails.
 	if err := rejectExplicitNullTemplates(data); err != nil {
 		return AssignmentsJSON{}, fmt.Errorf("parse assignments.json: %w", err)
 	}
-	// Callers depend on Assignments marshaling as `[]`, not `null`.
-	// Empty Autograder normalizes to "default" so downstream
-	// consumers see a uniform shape.
+	// Callers depend on Assignments marshaling as `[]`, not `null`. Empty
+	// Autograder normalizes to "default" for a uniform downstream shape.
 	if file.Assignments == nil {
 		file.Assignments = []AssignmentEntry{}
 	}
@@ -602,20 +524,17 @@ func ParseAssignments(data []byte) (AssignmentsJSON, error) {
 	return file, nil
 }
 
-// rejectExplicitNullTemplates fails when any assignment carries an
-// explicit `"template": null`. The struct decode collapses both
-// `null` and an absent key to a nil *TemplateRef, but the JSON Schema
-// types `template` as an object and rejects null — so accepting null
-// here would be a CLI/GUI divergence. A template-less assignment must
-// omit the key entirely.
+// rejectExplicitNullTemplates fails when any assignment carries an explicit
+// `"template": null`. The struct decode collapses null and absent to a nil
+// *TemplateRef, but the schema types template as an object and rejects null, so
+// accepting null would diverge CLI from GUI. Template-less must omit the key.
 func rejectExplicitNullTemplates(data []byte) error {
 	var raw struct {
 		Assignments []map[string]json.RawMessage `json:"assignments"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
-		// The strict decode already ran and succeeded; a re-parse
-		// failure here would be surprising, but surface it rather
-		// than silently skipping the check.
+		// The strict decode already succeeded, so a re-parse failure here
+		// would be surprising; surface it rather than skipping the check.
 		return fmt.Errorf("re-scan for null template: %w", err)
 	}
 	for i, entry := range raw.Assignments {
@@ -627,12 +546,10 @@ func rejectExplicitNullTemplates(data []byte) error {
 	return nil
 }
 
-// EncodeAssignments serializes via output.JSONPretty (2-space indent,
-// trailing newline) so on-disk diffs stay stable. Normalizes nil →
-// [] for Assignments and empty Autograder → contract.DefaultAutograderName so
-// the wire shape is uniform. Per-entry validation is the caller's
-// job. Normalization runs on a local copy so callers never observe
-// silent slice mutation.
+// EncodeAssignments serializes via output.JSONPretty (2-space, trailing
+// newline) so diffs stay stable. Normalizes nil → [] and empty Autograder →
+// default. Per-entry validation is the caller's job. Normalization runs on a
+// local copy so callers never observe slice mutation.
 func EncodeAssignments(file AssignmentsJSON) ([]byte, error) {
 	out := file
 	if out.Schema == "" {
@@ -641,8 +558,8 @@ func EncodeAssignments(file AssignmentsJSON) ([]byte, error) {
 	if len(out.Assignments) == 0 {
 		out.Assignments = []AssignmentEntry{}
 	} else {
-		// Copy the backing array so normalization below doesn't
-		// leak back into the caller's slice.
+		// Copy the backing array so normalization doesn't leak into the
+		// caller's slice.
 		copied := make([]AssignmentEntry, len(out.Assignments))
 		copy(copied, out.Assignments)
 		out.Assignments = copied
@@ -655,11 +572,10 @@ func EncodeAssignments(file AssignmentsJSON) ([]byte, error) {
 	return output.JSONPretty(out)
 }
 
-// UpsertAssignment replaces by Slug (case-sensitive; the slug
-// validator is lowercase-only, so case-insensitive matching would
-// just hide validator-rejected typos). Position preserved on
-// replace; new slugs append. Returns the slice and whether a row
-// was replaced.
+// UpsertAssignment replaces by Slug (case-sensitive: the slug validator is
+// lowercase-only, so case-insensitive matching would just hide typos).
+// Position preserved on replace; new slugs append. Returns the slice and
+// whether a row was replaced.
 func UpsertAssignment(entries []AssignmentEntry, entry AssignmentEntry) ([]AssignmentEntry, bool) {
 	for i := range entries {
 		if entries[i].Slug == entry.Slug {
@@ -682,9 +598,8 @@ func FindAssignment(entries []AssignmentEntry, slug string) (int, bool) {
 }
 
 // SlugExistsFold reports whether any entry's slug equals `slug`
-// case-insensitively. Slugs become GitHub repo path segments, and GitHub
-// treats repo names case-insensitively, so a target differing only in
-// case would still collide on the real repo. Mirrors the web's check.
+// case-insensitively. Slugs become GitHub repo path segments, which GitHub
+// treats case-insensitively, so a case-only difference still collides.
 func SlugExistsFold(entries []AssignmentEntry, slug string) bool {
 	for i := range entries {
 		if strings.EqualFold(entries[i].Slug, slug) {
@@ -694,24 +609,22 @@ func SlugExistsFold(entries []AssignmentEntry, slug string) bool {
 	return false
 }
 
-// slugMaxLen is the max slug length validate.ShortName accepts
-// (^[a-z0-9][a-z0-9-]{1,38}$ = 39 chars). Duplicated here (not imported
-// from validate) so the pure data layer stays free of the command seam.
+// slugMaxLen is the max slug length validate.ShortName accepts (39 chars).
+// Duplicated here (not imported) so the pure data layer stays free of the
+// command seam.
 const slugMaxLen = 39
 
 // slugSuffixRe splits a slug into base + optional trailing `-N` (N >= 1):
-// `hello` -> ("hello", 0); `hello-2` -> ("hello", 2).
+// `hello` → ("hello", 0); `hello-2` → ("hello", 2).
 var slugSuffixRe = regexp.MustCompile(`^(.*)-([1-9][0-9]*)$`)
 
-// NextAvailableSlug returns a slug that doesn't collide (case-insensitively)
-// with any existing entry, auto-suffixing `-2`, `-3`, …; a base already
-// ending in `-N` increments from N+1. Returns the input unchanged when it
-// is already free. Mirrors the web's auto-suffix algorithm.
+// NextAvailableSlug returns a slug that doesn't collide (case-insensitively),
+// auto-suffixing `-2`, `-3`, …; a base already ending in `-N` increments from
+// N+1. Returns the input unchanged when already free.
 //
-// An auto-suffixed candidate that would overflow slugMaxLen returns an
-// actionable error rather than an over-long slug a downstream validator
-// would reject with a generic pattern error. A free input that is itself
-// over-cap is returned unchanged (the caller's validation surfaces it).
+// A candidate overflowing slugMaxLen returns an actionable error rather than
+// an over-long slug. A free-but-over-cap input is returned unchanged (the
+// caller's validation surfaces it).
 func NextAvailableSlug(entries []AssignmentEntry, slug string) (string, error) {
 	if !SlugExistsFold(entries, slug) {
 		return slug, nil
@@ -720,8 +633,8 @@ func NextAvailableSlug(entries []AssignmentEntry, slug string) (string, error) {
 	start := 2
 	if m := slugSuffixRe.FindStringSubmatch(slug); m != nil {
 		base = m[1]
-		// m[2] is a non-empty digit run with no leading zero (the regex),
-		// so Atoi always succeeds; start one past it.
+		// m[2] is a non-empty digit run with no leading zero, so Atoi always
+		// succeeds; start one past it.
 		n, _ := strconv.Atoi(m[2])
 		start = n + 1
 	}
@@ -748,11 +661,9 @@ func RemoveAssignment(entries []AssignmentEntry, slug string) ([]AssignmentEntry
 	return entries, false
 }
 
-// ValidateAssignmentEntry is the write-path check. Same structural
-// bar as ValidateExistingEntry (parse-path); only error wording
-// differs — write errors reference CLI flags ("use --name"), parse
-// errors reference the file ("entry %q has..."). Field order is
-// "cheapest and most-likely-to-trip first".
+// ValidateAssignmentEntry is the write-path check. Same structural bar as
+// ValidateExistingEntry; only wording differs — write errors reference CLI
+// flags, parse errors reference the file. Field order is cheapest-first.
 func ValidateAssignmentEntry(entry AssignmentEntry) error {
 	if entry.Slug == "" {
 		return errors.New("slug must not be empty")
@@ -769,8 +680,7 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 	if !IsValidAssignmentMode(entry.Mode) {
 		return fmt.Errorf("invalid mode %q: must be one of %v", entry.Mode, AssignmentModes)
 	}
-	// Template is optional. When present (non-nil), all three fields
-	// must be set; a template-less assignment omits the block entirely.
+	// Template is optional; when present, all three fields must be set.
 	if entry.Template != nil {
 		if entry.Template.Owner == "" || entry.Template.Repo == "" {
 			return errors.New("template owner/repo must not be empty")
@@ -796,8 +706,7 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 	if err := ValidateMaxGroupSize(entry.MaxGroupSize); err != nil {
 		return err
 	}
-	// Mode/size relationship: a group assignment must carry a usable
-	// limit (>= 2); an individual one must not carry a size at all.
+	// Group must carry a usable limit (>= 2); individual must carry none.
 	switch entry.Mode {
 	case ModeGroup:
 		if entry.MaxGroupSize < 2 {
@@ -827,10 +736,9 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 	return nil
 }
 
-// ValidateExistingEntry is the parse-path twin of
-// ValidateAssignmentEntry. Same structural bar; error messages frame
-// the file context ("entry %q has..."). Schema-version drift lives in
-// the sentinel, not per-entry laxness — once v1, v1 holds strictly.
+// ValidateExistingEntry is the parse-path twin of ValidateAssignmentEntry.
+// Same structural bar; errors frame the file context. Once v1, v1 holds
+// strictly — version drift lives in the sentinel, not per-entry laxness.
 func ValidateExistingEntry(entry AssignmentEntry) error {
 	if entry.Slug == "" {
 		return errors.New("entry has empty slug")
@@ -847,8 +755,8 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 	if !IsValidAssignmentMode(entry.Mode) {
 		return fmt.Errorf("entry %q has invalid mode %q (must be one of %v)", entry.Slug, entry.Mode, AssignmentModes)
 	}
-	// Template is optional. A nil block is a valid template-less
-	// assignment; when present, all three fields must round-trip.
+	// Template is optional; a nil block is template-less. When present, all
+	// three fields must round-trip.
 	if entry.Template != nil {
 		if entry.Template.Owner == "" || entry.Template.Repo == "" {
 			return fmt.Errorf("entry %q has empty template owner/repo", entry.Slug)
@@ -865,9 +773,8 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 			return fmt.Errorf("entry %q: %w", entry.Slug, err)
 		}
 	}
-	// Empty Autograder normalizes to "default" so older entries
-	// still parse; the strict pattern check still runs because a
-	// hand-edit could otherwise round-trip a malicious name.
+	// Empty Autograder normalizes to "default" so older entries parse; the
+	// pattern check still runs so a hand-edit can't round-trip a bad name.
 	if entry.Autograder == "" {
 		entry.Autograder = contract.DefaultAutograderName
 	}
@@ -879,11 +786,8 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 	}
 	switch entry.Mode {
 	case ModeGroup:
-		// Parse and write paths share the same strict invariant: a
-		// group assignment must carry a usable size (>= 2). Pre-launch,
-		// we don't preserve older files that predate group support, so
-		// the parser rejects an unset/too-small group size rather than
-		// tolerating it.
+		// Pre-launch: no files predate group support, so the parser rejects
+		// an unset/too-small group size rather than tolerating it (>= 2).
 		if entry.MaxGroupSize < 2 {
 			return fmt.Errorf("entry %q is group mode but max_group_size is %d (must be >= 2)", entry.Slug, entry.MaxGroupSize)
 		}
@@ -911,9 +815,8 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 	return nil
 }
 
-// expectEOF rejects trailing content after the top-level Decode. A
-// second Decode returning io.EOF confirms exactly one JSON value;
-// anything else (trailing object, stray text, duplicate body) would
+// expectEOF rejects trailing content after the top-level Decode. A second
+// Decode returning io.EOF confirms exactly one JSON value; anything else would
 // be silently dropped on re-encode.
 func expectEOF(dec *json.Decoder) error {
 	var rest json.RawMessage

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -48,9 +48,8 @@ func TestParseAssignments_Canonical(t *testing.T) {
 }
 
 func TestParseAssignments_TemplateLess(t *testing.T) {
-	// An assignment with no template repo is valid: the `template`
-	// block is omitted entirely and parses to a nil Template. (At
-	// accept time gh-student creates an empty shim-only repo for it.)
+	// A template-less assignment omits the `template` block and parses to a
+	// nil Template (accept-time creates an empty shim-only repo).
 	in := []byte(`{
   "schema": "classroom50/assignments/v1",
   "assignments": [
@@ -1123,9 +1122,8 @@ func entriesWithSlugs(slugs ...string) []AssignmentEntry {
 }
 
 // TestParseAssignments_PreservesUnknownEntryField pins the "tolerate AND
-// preserve" rule: an unknown top-level entry key (e.g. one a newer binary
-// or the web GUI added) must NOT fail the parse and must round-trip
-// verbatim through a re-encode, so a read-modify-write here never drops it.
+// preserve" rule: an unknown top-level entry key must NOT fail the parse and
+// must round-trip verbatim through a re-encode.
 func TestParseAssignments_PreservesUnknownEntryField(t *testing.T) {
 	in := []byte(`{
   "schema": "classroom50/assignments/v1",
@@ -1229,10 +1227,8 @@ func TestNextAvailableSlug(t *testing.T) {
 	}
 }
 
-// TestNextAvailableSlug_OverflowsCap pins that an auto-suffix which would
-// exceed the 39-char slug cap returns an actionable error rather than a
-// too-long candidate (which a downstream validator would reject with a
-// generic pattern error).
+// TestNextAvailableSlug_OverflowsCap pins that an auto-suffix exceeding the
+// 39-char cap returns an actionable error rather than a too-long candidate.
 func TestNextAvailableSlug_OverflowsCap(t *testing.T) {
 	base := strings.Repeat("a", 39) // already at the cap; any "-N" overflows
 	entries := entriesWithSlugs(base)

--- a/cli/gh-teacher/internal/assignment/runtime.go
+++ b/cli/gh-teacher/internal/assignment/runtime.go
@@ -11,65 +11,46 @@ import (
 	"strings"
 )
 
-// RunsOnLabelPattern and the *Pattern regexes below are exported only
-// for the autograde-runner regex-parity test (init_skeleton_test.go's
-// TestRegexParity_GoVsInlinePython), which asserts these literals match
-// the inline-Python validator in autograde-runner.yaml. Production
-// callers must NOT match these directly — go through ValidateRuntime /
-// ValidateContainer, which are the trust boundary.
+// RunsOnLabelPattern and the *Pattern regexes below are exported only for the
+// regex-parity test (init_skeleton_test.go), which asserts they match the
+// inline-Python validator in autograde-runner.yaml. Production callers must NOT
+// match these directly — go through ValidateRuntime / ValidateContainer, the
+// trust boundary.
 //
-// RunsOnLabelPattern bounds each `runtime.runs-on` label. It mirrors
-// GitHub Actions' `runs-on`: any hosted label OR any custom/self-hosted
-// label. There is deliberately NO value allow-list — the teacher owns
-// the label, as in a hand-written workflow. The pattern is purely an
-// anti-injection gate: the label flows verbatim into the workflow's
-// `runs-on:`, so whitespace, quotes, and shell/YAML metacharacters are
-// rejected (alphanumerics plus `-_.`, leading alnum, length-capped).
+// RunsOnLabelPattern bounds each `runtime.runs-on` label. No value allow-list —
+// the teacher owns the label; the pattern is purely an anti-injection gate
+// (alphanumerics plus `-_.`, leading alnum, length-capped) since the label
+// flows verbatim into the workflow's `runs-on:`.
 var RunsOnLabelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`)
 
-// LanguageVersionPattern: shared shape for python/node/java/go
-// version fields. Permissive enough for `3.12`, `20`, `1.23.4`,
-// `21-ea`, `latest`; strict enough that nothing the field's value
-// might do can shell-escape into the workflow YAML.
+// LanguageVersionPattern: shared shape for python/node/java/go versions.
+// Permissive (`3.12`, `20`, `1.23.4`, `latest`) but injection-safe.
 var LanguageVersionPattern = regexp.MustCompile(`^[A-Za-z0-9._+-]{1,32}$`)
 
-// AptPackagePattern matches Debian/Ubuntu source-package naming
-// (lowercase letters/digits, `.+-`, leading alnum). Each entry in
-// `runtime.apt` is checked individually; the validated list flows
-// into `apt-get install` unquoted, so this is a hard correctness
-// gate.
+// AptPackagePattern matches Debian/Ubuntu package naming. Each `runtime.apt`
+// entry flows into `apt-get install` unquoted, so this is a hard gate.
 var AptPackagePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.+-]{0,63}$`)
 
-// ContainerImagePattern is intentionally permissive — the image
-// reference grammar is wide (registries, ports, digests, multi-arch
-// suffixes). The check is anti-injection rather than syntactic
-// validation: reject whitespace, quotes, backticks, `$`, `;`, `&`,
-// `|`, control chars. The image flows into a YAML string; GitHub
-// Actions parses the rest.
+// ContainerImagePattern is intentionally permissive (the image-ref grammar is
+// wide); the check is anti-injection, not syntactic — reject whitespace,
+// quotes, backticks, `$`, `;`, `&`, `|`, control chars. Actions parses the rest.
 var ContainerImagePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$`)
 
-// ContainerUserPattern accepts what `docker run --user` accepts:
-// "root", "0", "0:0", "1000:1000", "appuser", "appuser:appgroup".
-// The value flows into `container.options: --user <value>` in the
-// emitted workflow YAML, so it has to be tight enough that nothing
-// can shell-escape into adjacent docker options.
+// ContainerUserPattern accepts what `docker run --user` accepts ("root", "0",
+// "1000:1000", "appuser:appgroup"). It flows into `container.options: --user
+// <value>`, so it must be tight enough that nothing escapes into adjacent
+// options.
 var ContainerUserPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,31}(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,31})?$`)
 
-// ParseRuntimeFile loads `--runtime <path>` and validates it. The
-// path can be a filesystem path, or `-` to read from stdin (handy
-// for one-shot agent invocations: `gh teacher assignment add ...
-// --runtime - <<<'{"container":{"image":"..."}}'`). Empty path → no
-// runtime override (entry.Runtime stays nil and the runner uses its
-// built-in defaults). DisallowUnknownFields so a typo'd key
-// (`run-on:` for `runs-on:`) fails loudly rather than silently
-// falling through to defaults.
+// ParseRuntimeFile loads `--runtime <path>` (or `-` for stdin) and validates
+// it. Empty path → no override (Runtime stays nil, runner uses defaults).
+// DisallowUnknownFields so a typo'd key fails loudly.
 func ParseRuntimeFile(path string) (*RuntimeRef, error) {
 	return parseRuntimeFileFrom(path, os.Stdin)
 }
 
-// parseRuntimeFileFrom is the testable seam for ParseRuntimeFile.
-// Pass the reader the caller would have wired into stdin so unit
-// tests can exercise the `-` path without manipulating os.Stdin.
+// parseRuntimeFileFrom is the testable seam for ParseRuntimeFile (injectable
+// stdin for the `-` path).
 func parseRuntimeFileFrom(path string, stdin io.Reader) (*RuntimeRef, error) {
 	if path == "" {
 		return nil, nil
@@ -107,20 +88,17 @@ func parseRuntimeFileFrom(path string, stdin io.Reader) (*RuntimeRef, error) {
 	return &r, nil
 }
 
-// ValidateRuntime is the structural bar for RuntimeRef. Same checks
-// run on the write path (ParseRuntimeFile) and the parse path
-// (ValidateAssignmentEntry / ValidateExistingEntry) so a hand-edited
-// assignments.json can't smuggle a value the CLI would have
-// rejected at write time.
+// ValidateRuntime is the structural bar for RuntimeRef, run on both the write
+// and parse paths so a hand-edited assignments.json can't smuggle a value the
+// CLI would reject at write time.
 func ValidateRuntime(r RuntimeRef) error {
 	if err := ValidateRunsOn(r.RunsOn); err != nil {
 		return err
 	}
 	if r.Container != nil {
-		// GitHub-hosted containers run on Ubuntu only, so reject a
-		// recognized macOS/Windows hosted label up front; a custom /
-		// self-hosted label passes (the teacher owns OS matching). Apt
-		// is forbidden — the image owns its packages.
+		// GitHub-hosted containers run on Ubuntu only, so reject a recognized
+		// macOS/Windows hosted label (a custom label passes — the teacher owns
+		// OS matching). Apt is forbidden — the image owns its packages.
 		for _, label := range r.RunsOn {
 			if isNonUbuntuHostedLabel(label) {
 				return fmt.Errorf("runtime.runs-on %q invalid with container: GitHub Actions runs containers on Ubuntu hosts only", label)
@@ -156,11 +134,9 @@ func ValidateRuntime(r RuntimeRef) error {
 	return nil
 }
 
-// ValidateRunsOn injection-checks each label and caps the count. An
-// empty RunsOn is valid here — it means runs-on was omitted, which the
-// runner defaults to ubuntu-latest; the degenerate "" and [] forms are
-// rejected earlier by RunsOn.UnmarshalJSON. Blank labels are rejected
-// by RunsOnLabelPattern. No value allow-list (see RunsOnLabelPattern).
+// ValidateRunsOn injection-checks each label and caps the count. An empty
+// RunsOn is valid (omitted → runner defaults to ubuntu-latest); the degenerate
+// "" and [] forms are rejected earlier by RunsOn.UnmarshalJSON.
 func ValidateRunsOn(r RunsOn) error {
 	if len(r) == 0 {
 		return nil
@@ -176,19 +152,16 @@ func ValidateRunsOn(r RunsOn) error {
 	return nil
 }
 
-// isNonUbuntuHostedLabel reports whether label is a recognized
-// GitHub-hosted macOS/Windows label — the only labels we know won't run
-// a Linux container. Custom/self-hosted labels are unknown, so they
-// pass (the teacher owns OS matching).
+// isNonUbuntuHostedLabel reports whether label is a recognized GitHub-hosted
+// macOS/Windows label — the only labels we know won't run a Linux container.
+// Custom/self-hosted labels are unknown, so they pass.
 func isNonUbuntuHostedLabel(label string) bool {
 	return strings.HasPrefix(label, "macos-") || strings.HasPrefix(label, "windows-")
 }
 
-// ValidateContainer enforces image-string sanity and the `user`
-// shortcut. Image is regex-checked against a permissive but
-// injection-safe character set; user must match `docker run --user`
-// grammar. Only publicly-pullable images are supported (see
-// ContainerSpec).
+// ValidateContainer enforces image-string sanity and the `user` shortcut.
+// Image is regex-checked (permissive but injection-safe); user must match
+// `docker run --user` grammar. Only publicly-pullable images are supported.
 func ValidateContainer(c ContainerSpec) error {
 	if c.Image == "" {
 		return errors.New("runtime.container.image must not be empty")

--- a/cli/gh-teacher/internal/assignment/tests.go
+++ b/cli/gh-teacher/internal/assignment/tests.go
@@ -11,25 +11,22 @@ import (
 
 // Declarative tests: a teacher attaches small io/run/python tests to an
 // assignment in assignments.json instead of writing an autograder.py.
-// publish-pages materializes them into the Pages bundle; runner.py grades
-// them with a built-in interpreter. This file is the write/parse-time
-// validator (runtime.go's counterpart for the runtime block); the runner
-// re-validates at grade time since assignments.json is hand-editable.
+// publish-pages materializes them; runner.py grades them. This file is the
+// write/parse-time validator; the runner re-validates at grade time since
+// assignments.json is hand-editable.
 //
-// `run`/`setup` are deliberately NOT injection-checked: they are
-// teacher-authored shell by design (like an autograder.py), travel to the
-// grade job as bundle data — never interpolated into workflow YAML — and
-// students can't edit assignments.json. See wiki/Autograders.md.
+// `run`/`setup` are deliberately NOT injection-checked: they're teacher-authored
+// shell by design, travel to the grade job as bundle data (never interpolated
+// into workflow YAML), and students can't edit assignments.json.
 
-// TestSpec is one declarative test, of one of three types:
+// TestSpec is one declarative test of one of three types:
 //
-//   - "io": feed Input (or InputFile) on stdin, compare stdout against
-//     Expected (or ExpectedFile) per Comparison.
+//   - "io": feed Input (or InputFile) on stdin, compare stdout to Expected
+//     (or ExpectedFile) per Comparison.
 //   - "run": pass iff the exit code matches ExitCode (default 0).
 //   - "python": run pytest; points split across discovered cases.
 //
-// Points has no omitempty so a 0-point informational test reads
-// explicitly; io-only fields and ExitCode omit when unset.
+// Points has no omitempty so a 0-point informational test reads explicitly.
 type TestSpec struct {
 	Name         string `json:"name"`
 	Type         string `json:"type"`
@@ -51,25 +48,23 @@ const (
 	testTypePython = "python"
 )
 
-// testTypes is the canonical allow-list, sorted alphabetically so error
-// messages stay stable.
+// testTypes is the allow-list, sorted so error messages stay stable.
 var testTypes = []string{testTypeIO, testTypePython, testTypeRun}
 
-// Comparison modes for io tests, matching GitHub Classroom's
-// Included / Exact / Regex. `regex` is evaluated by Python's `re` engine
-// at grade time, not Go's RE2 — see the note in validateIOFields.
+// Comparison modes for io tests (GitHub Classroom's Included/Exact/Regex).
+// `regex` is evaluated by Python's `re` at grade time, not Go's RE2 — see
+// validateIOFields.
 const (
 	comparisonIncluded = "included"
 	comparisonExact    = "exact"
 	comparisonRegex    = "regex"
 )
 
-// comparisonModes is the canonical allow-list, sorted alphabetically.
+// comparisonModes is the allow-list, sorted.
 var comparisonModes = []string{comparisonExact, comparisonIncluded, comparisonRegex}
 
 // Bounds: generous for real assignments, tight enough that a hand-edited
-// assignments.json can't wedge the gradebook or blow past the
-// contents-API size ceiling (LargeAssignmentsWarnBytes).
+// assignments.json can't wedge the gradebook or blow the contents-API ceiling.
 const (
 	maxTestsPerAssignment = 100
 	minTimeoutSeconds     = 1
@@ -98,10 +93,9 @@ func isValidComparison(s string) bool {
 	return false
 }
 
-// ValidateTests checks an assignment's test list on both the write path
-// (ValidateAssignmentEntry) and parse path (ValidateExistingEntry):
-// count cap, per-spec validation, and unique names (a test's name is its
-// identity in result.json and the release body).
+// ValidateTests checks an assignment's test list on both paths: count cap,
+// per-spec validation, and unique names (a name is its identity in result.json
+// and the release body).
 func ValidateTests(tests []TestSpec) error {
 	if len(tests) > maxTestsPerAssignment {
 		return fmt.Errorf("too many tests: %d exceeds the per-assignment cap of %d", len(tests), maxTestsPerAssignment)
@@ -119,9 +113,9 @@ func ValidateTests(tests []TestSpec) error {
 	return nil
 }
 
-// ValidateTestSpec checks one test. Field applicability is strict
-// (io-only fields rejected on run/python tests, exit-code only on run)
-// so a mistyped spec fails loudly instead of being silently ignored.
+// ValidateTestSpec checks one test. Field applicability is strict (io-only
+// fields rejected on run/python, exit-code only on run) so a mistyped spec
+// fails loudly.
 func ValidateTestSpec(t TestSpec) error {
 	if t.Name == "" {
 		return errors.New("name must not be empty")
@@ -164,18 +158,16 @@ func validateIOFields(t TestSpec) error {
 		return errors.New("expected and expected-file are mutually exclusive")
 	}
 	// `included`/`regex` against an empty expected match everything (a
-	// silently-always-passing test), so reject at write time. `exact` is
-	// exempt: empty legitimately means "expect empty output".
+	// silently-always-passing test), so reject. `exact` is exempt: empty
+	// legitimately means "expect empty output".
 	if t.Comparison != comparisonExact && t.Expected == "" && t.ExpectedFile == "" {
 		return fmt.Errorf("an io test with comparison %q needs a non-empty expected or expected-file (an empty expected matches everything)", t.Comparison)
 	}
 	if t.ExitCode != nil {
 		return errors.New(`exit-code is not valid for an io test (use type "run")`)
 	}
-	// `regex` is intentionally NOT compile-checked here: the grader uses
-	// Python's `re`, which accepts constructs RE2 rejects (lookaround,
-	// backreferences). A bad pattern surfaces at grade time as a failing
-	// test with a clear message.
+	// `regex` is NOT compile-checked here: the grader uses Python's `re`, which
+	// accepts constructs RE2 rejects. A bad pattern surfaces at grade time.
 	return nil
 }
 
@@ -215,17 +207,14 @@ func validateNoControlChars(s, label string) error {
 	return nil
 }
 
-// ParseTestsFile loads and validates `--tests <path>` (`-` = stdin): a
-// bare JSON array of test specs, the same shape as the `tests` field in
-// assignments.json. Empty path -> (nil, nil) ("flag omitted"). Mirrors
-// ParseRuntimeFile, including DisallowUnknownFields so a typo'd key
-// fails loudly instead of being silently dropped.
+// ParseTestsFile loads and validates `--tests <path>` (`-` = stdin): a bare
+// JSON array of test specs. Empty path → (nil, nil). DisallowUnknownFields so a
+// typo'd key fails loudly.
 func ParseTestsFile(path string) ([]TestSpec, error) {
 	return parseTestsFileFrom(path, os.Stdin)
 }
 
-// parseTestsFileFrom is the testable seam for ParseTestsFile (injectable
-// stdin for the `-` path).
+// parseTestsFileFrom is the testable seam for ParseTestsFile.
 func parseTestsFileFrom(path string, stdin io.Reader) ([]TestSpec, error) {
 	if path == "" {
 		return nil, nil
@@ -286,9 +275,8 @@ func RemoveTest(tests []TestSpec, name string) ([]TestSpec, bool) {
 	return tests, false
 }
 
-// PerAssignmentAutograderPath is the config-repo path of a slug's
-// hand-written entrypoint, probed by the tests-vs-autograder.py
-// conflict check.
+// PerAssignmentAutograderPath is the config-repo path of a slug's hand-written
+// entrypoint, probed by the tests-vs-autograder.py conflict check.
 func PerAssignmentAutograderPath(classroom, slug string) string {
 	return classroom + "/autograders/" + slug + "/autograder.py"
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1,15 +1,7 @@
-// Package assignmentcmd implements the `gh teacher assignment` command
-// group: add / list / remove assignment entries in a classroom's
-// assignments.json, plus the `assignment test` subgroup for declarative
-// test specs. It is an extracted command package (mirrors internal/audit,
-// internal/teardown, internal/download): only NewCmd is exported; the
-// per-subcommand orchestration, template/due-date parsing, and the
-// configwrite build callbacks are package-private. It is distinct from
-// internal/assignment, the pure data layer it consumes for parsing and
-// validating the manifest. Depends on the internal/* substrate seams
-// (assignment data layer, autograder, cliutil, configrepo, configwrite,
-// githubapi, output, validate) plus the shared contract package, never
-// on package main.
+// Package assignmentcmd implements the `gh teacher assignment` command group:
+// add / reuse / list / remove entries in a classroom's assignments.json, plus
+// the `assignment test` subgroup for declarative test specs. Only NewCmd is
+// exported. Distinct from internal/assignment, the pure data layer it consumes.
 package assignmentcmd
 
 import (
@@ -65,10 +57,9 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-// assignmentAddCmd: `--mode` accepts `individual` (default) or
-// `group`. Group mode requires `--max-group-size` (>= 2); the size is
-// enforced within the CLI when students join a group repo (direct
-// GitHub-UI invites can bypass it — a documented limitation).
+// assignmentAddCmd: `--mode` accepts `individual` (default) or `group`. Group
+// mode requires `--max-group-size` (>= 2), enforced within the CLI when
+// students join (direct GitHub-UI invites can bypass it — documented).
 func assignmentAddCmd() *cobra.Command {
 	var (
 		name          string
@@ -169,9 +160,9 @@ func assignmentAddCmd() *cobra.Command {
 			if autograderVal == "" {
 				autograderVal = contract.DefaultAutograderName
 			}
-			// pass_threshold is opt-in: only set the pointer when the flag was
-			// passed, so an omitted flag leaves it nil (feature off) while an
-			// explicit --pass-threshold 0 is a real 0% threshold.
+			// pass_threshold is opt-in: set the pointer only when the flag was
+			// passed, so an omitted flag stays nil (off) while an explicit
+			// --pass-threshold 0 is a real 0% threshold.
 			passThresholdPtr := passThresholdFromFlag(cmd.Flags().Changed("pass-threshold"), passThreshold)
 			if err := autograderseam.ValidateName(autograderVal); err != nil {
 				return err
@@ -181,9 +172,8 @@ func assignmentAddCmd() *cobra.Command {
 				return err
 			}
 			// --template is optional. When omitted, the assignment has no
-			// starter repo and `gh student accept` creates an empty repo
-			// carrying only the autograder shim. When present, parse +
-			// (later) validate it.
+			// starter repo and `student accept` creates an empty shim-only
+			// repo. When present, parse + (later) validate it.
 			var tmplArg *templateArg
 			if templateVal != "" {
 				parsed, err := parseTemplateRef(templateVal)
@@ -242,9 +232,9 @@ func assignmentAddCmd() *cobra.Command {
 	return cmd
 }
 
-// assignmentRemoveCmd is idempotent (missing slug exits 0) and
-// leaves existing student repos untouched — only future
-// `gh student accept` calls stop finding the slug.
+// assignmentRemoveCmd is idempotent (missing slug exits 0) and leaves existing
+// student repos untouched — only future `student accept` calls stop finding the
+// slug.
 func assignmentRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove <org> <classroom> <slug>",
@@ -282,9 +272,8 @@ func assignmentRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-// assignmentListCmd: read-only. stdout = one slug per line by
-// default; `--json` emits the full entries array; `-q` suppresses
-// the stderr summary so capturing scripts see only stdout.
+// assignmentListCmd: read-only. stdout = one slug per line by default; `--json`
+// emits the full entries array; `-q` suppresses the stderr summary.
 func assignmentListCmd() *cobra.Command {
 	var (
 		asJSON bool
@@ -335,9 +324,8 @@ func assignmentListCmd() *cobra.Command {
 	return cmd
 }
 
-// runAssignmentList: one branch resolve, one file read, no commit.
-// Missing assignments.json points the teacher at
-// `gh teacher classroom add`.
+// runAssignmentList: one branch resolve, one file read, no commit. Missing
+// assignments.json points the teacher at `classroom add`.
 func runAssignmentList(client githubapi.Client, out, errOut io.Writer, org, classroom string, asJSON, quiet bool) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -366,11 +354,10 @@ func runAssignmentList(client githubapi.Client, out, errOut io.Writer, org, clas
 	return nil
 }
 
-// formatAssignmentListJSON marshals the bare entries array (no
-// `{schema, assignments}` envelope) with on-disk pretty-print +
-// trailing newline so terminal output and `jq` pipes match. Empty
-// Autograder normalizes to "default" so consumers can index
-// without nil guards.
+// formatAssignmentListJSON marshals the bare entries array (no envelope) with
+// on-disk pretty-print + trailing newline so terminal and `jq` output match.
+// Empty Autograder normalizes to "default" so consumers can index without nil
+// guards.
 func formatAssignmentListJSON(entries []assignment.AssignmentEntry) ([]byte, error) {
 	if entries == nil {
 		entries = []assignment.AssignmentEntry{}
@@ -397,25 +384,15 @@ func summarizeAssignmentList(org, classroom string, count int) string {
 	}
 }
 
-// assignmentsFilePath: on-repo path to a classroom's assignments.json
-// (matches rosterFilePath's role for students.csv).
+// assignmentsFilePath: on-repo path to a classroom's assignments.json.
 func assignmentsFilePath(classroom string) string {
 	return assignment.AssignmentsFilePath(classroom)
 }
 
-// runAssignmentAdd validates template visibility and entry shape
-// before entering the configwrite.CommitTree loop so a bad input never produces
-// a partial-state commit. The autograder existence probe runs inside
-// the build callback against each attempt's parent SHA: a concurrent
-// delete of the referenced autograder loses cleanly on retry rather
-// than landing a dangling reference. Same-slug races are
-// last-writer-wins; both commits stay in history for `git revert`.
-// validateModeAndSizeFlags normalizes/validates the --mode and
-// --max-group-size flag pair for `assignment add`. Returns the resolved
-// mode. Group mode requires --max-group-size (>= 2, within the cap);
-// individual mode must not set it (sizeProvided guards the explicit
-// case). Extracted as a pure function so the flag contract is
-// unit-testable without executing the full command.
+// validateModeAndSizeFlags normalizes/validates the --mode and --max-group-size
+// pair for `assignment add`. Group mode requires --max-group-size (2..cap);
+// individual mode must not set it. Extracted as a pure function so the flag
+// contract is unit-testable.
 func validateModeAndSizeFlags(mode string, maxGroupSize int, sizeProvided bool) (string, error) {
 	modeVal := strings.TrimSpace(mode)
 	if modeVal == "" {
@@ -440,9 +417,9 @@ func validateModeAndSizeFlags(mode string, maxGroupSize int, sizeProvided bool) 
 	return modeVal, nil
 }
 
-// passThresholdFromFlag maps the --pass-threshold flag to the optional
-// *int the entry stores: an omitted flag stays nil (off), while an explicit
-// --pass-threshold 0 is a non-nil *int(0) — a real 0% bar distinct from off.
+// passThresholdFromFlag maps --pass-threshold to the optional *int: an omitted
+// flag stays nil (off); an explicit --pass-threshold 0 is *int(0), a real 0%
+// bar distinct from off.
 func passThresholdFromFlag(changed bool, value int) *int {
 	if !changed {
 		return nil
@@ -451,11 +428,10 @@ func passThresholdFromFlag(changed bool, value int) *int {
 	return &v
 }
 
-// addAssignmentParams carries the inputs to runAssignmentAdd as named
-// fields rather than a long positional list. Several fields share types
-// (multiple strings, pointers, slices), so positional passing made arg
-// transposition a compile-clean footgun; field names make call sites
-// order-independent and self-documenting.
+// addAssignmentParams carries runAssignmentAdd's inputs as named fields. Many
+// share types (strings, pointers, slices), so positional passing made arg
+// transposition a compile-clean footgun; field names keep call sites
+// order-independent.
 type addAssignmentParams struct {
 	Org           string
 	Classroom     string
@@ -475,6 +451,11 @@ type addAssignmentParams struct {
 	PassThreshold *int
 }
 
+// runAssignmentAdd validates template visibility and entry shape before the
+// configwrite.CommitTree loop so a bad input never produces a partial-state
+// commit. The autograder existence probe runs inside the build callback against
+// each attempt's parent SHA, so a concurrent delete loses cleanly on retry.
+// Same-slug races are last-writer-wins.
 func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssignmentParams) error {
 	org, classroom, slug := p.Org, p.Classroom, p.Slug
 	name, description := p.Name, p.Description
@@ -489,8 +470,8 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	}
 
 	// Template is optional. When present, validate it and decide the
-	// private-access grant; when absent, the assignment is template-less
-	// and `gh student accept` will create an empty shim-only repo.
+	// private-access grant; when absent, `student accept` creates an empty
+	// shim-only repo.
 	var (
 		resolved        *assignment.TemplateRef
 		templatePrivate bool
@@ -504,9 +485,8 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		templatePrivate = private
 
 		// Private-template access matrix: a private template outside the org
-		// can't be shared with the
-		// classroom team, so students could never generate from it — reject
-		// up front rather than letting every `gh student accept` 404 later.
+		// can't be shared with the classroom team, so reject up front rather
+		// than letting every `student accept` 404 later.
 		inOrg = templateInOrg(ref.Owner, org)
 		if templatePrivate && !inOrg {
 			return fmt.Errorf("template `%s/%s` is private and outside the org %s — students can't be granted access to it, so `gh student accept` would fail. Copy it into %s and reference the copy, or make the template public",
@@ -548,17 +528,15 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		droppedTemplate = nil
 		droppedAllowedCnt = 0
 		droppedPassThreshold = nil
-		// Refuse on an archived classroom (active:false), mirroring the
-		// web's "archived blocks new assignments" rule. Checked at
-		// parentSHA so a concurrent unarchive is observed on retry.
+		// Refuse on an archived classroom (active:false), mirroring the web.
+		// Checked at parentSHA so a concurrent unarchive is observed on retry.
 		if err := ensureClassroomActive(client, org, classroom, parentSHA); err != nil {
 			return nil, err
 		}
-		// Verify the autograder shim exists at parent SHA before
-		// writing — otherwise the assignment lands successfully and
-		// every student's accept 404s on the Pages fetch later. The
-		// default autograder is embedded in gh-student and has no
-		// on-disk counterpart, so skip the probe in that case.
+		// Verify the autograder shim exists at parent SHA before writing —
+		// else the assignment lands and every accept 404s on the Pages fetch.
+		// The default autograder is embedded in gh-student (no on-disk
+		// counterpart), so skip the probe there.
 		if entry.Autograder != contract.DefaultAutograderName {
 			exists, err := autograderseam.Exists(client, org, configrepo.ConfigRepoName, classroom, entry.Autograder, parentSHA)
 			if err != nil {
@@ -571,11 +549,11 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			}
 		}
 
-		// Declarative tests and a hand-written per-assignment autograder.py
-		// are mutually exclusive (the runner prefers autograder.py, so the
-		// tests would silently never run). Probed at parentSHA so a
-		// concurrent autograder.py add loses cleanly on retry. The skeleton
-		// probe catches config repos that predate materialize_tests.py.
+		// Declarative tests and a per-assignment autograder.py are mutually
+		// exclusive (the runner prefers autograder.py, so the tests would
+		// silently never run). Probed at parentSHA so a concurrent
+		// autograder.py add loses cleanly on retry. The skeleton probe catches
+		// config repos predating materialize_tests.py.
 		if len(entry.Tests) > 0 {
 			if err := ensureDeclarativeTestsSupported(client, org, parentSHA); err != nil {
 				return nil, err
@@ -589,48 +567,36 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		if err != nil {
 			return nil, err
 		}
-		// One lookup of the entry this upsert replaces (if any), shared by
-		// the wholesale-replace footgun checks below and the Extra
-		// carry-forward (file.Assignments isn't mutated until UpsertAssignment).
+		// One lookup of the entry this upsert replaces, shared by the
+		// wholesale-replace footgun checks and the Extra carry-forward.
 		prevIdx, hasPrev := assignment.FindAssignment(file.Assignments, slug)
-		// Upsert replaces the whole entry, so re-running add without
-		// --tests drops tests authored via `assignment test add`. Count
-		// them here for the post-commit warning. nil means the flag was
-		// omitted; an explicit empty array (`--tests` with `[]`) is a
-		// deliberate clear and shouldn't warn.
+		// Upsert replaces the whole entry, so re-running add without --tests
+		// drops tests authored via `assignment test add`. Count them for the
+		// warning. nil = flag omitted; an explicit `[]` is a deliberate clear.
 		if hasPrev && entry.Tests == nil {
 			droppedTests = len(file.Assignments[prevIdx].Tests)
 		}
-		// Same wholesale-replace footgun for the template: re-running add
-		// without --template on a previously-templated assignment would
-		// silently drop its starter-repo binding. Detect it for a loud
-		// post-commit warning (the upsert still applies — consistent with
-		// every other field — but the teacher should know).
+		// Same footgun for the template: re-running add without --template on
+		// a templated assignment silently drops its starter-repo binding.
 		if hasPrev && entry.Template == nil && file.Assignments[prevIdx].Template != nil {
 			droppedTemplate = file.Assignments[prevIdx].Template
 		}
-		// Wholesale-replace footgun (as with tests/template): re-running
-		// add without --allowed-files drops a prior allowlist. The flag is a
-		// repeatable StringArrayVar, so via the CLI the value is either nil
-		// (flag omitted -> warn) or a non-empty list; ValidateAllowedFiles
-		// rejects an empty/whitespace pattern, so `--allowed-files ''` never
-		// yields a silent clear. A non-nil empty slice (the programmatic /
-		// non-CLI clear path) is treated as deliberate and does not warn.
+		// Same footgun for allowed_files: re-running without --allowed-files
+		// drops a prior allowlist. Via the CLI the value is nil (omitted →
+		// warn) or non-empty; a non-nil empty slice (programmatic clear) is
+		// deliberate and doesn't warn.
 		if hasPrev && entry.AllowedFiles == nil {
 			droppedAllowedCnt = len(file.Assignments[prevIdx].AllowedFiles)
 		}
-		// Wholesale-replace footgun (as with tests/template/allowed_files),
-		// sharper here because pass_threshold is usually authored by the
-		// gradebook GUI, not the CLI: re-adding without --pass-threshold
-		// silently clears it. nil = flag omitted (warn); an explicit 0 is a
-		// non-nil pointer (a real 0% bar) and not a drop.
+		// Same footgun for pass_threshold, sharper because it's usually
+		// authored by the gradebook GUI. nil = omitted (warn); an explicit 0
+		// is a non-nil pointer (real 0% bar), not a drop.
 		if hasPrev && entry.PassThreshold == nil && file.Assignments[prevIdx].PassThreshold != nil {
 			droppedPassThreshold = file.Assignments[prevIdx].PassThreshold
 		}
 		// Carry forward the existing entry's Extra (unknown/future keys):
-		// `entry` is rebuilt from CLI flags and carries none, so without
-		// this the wholesale-replace upsert would drop them. (reuse instead
-		// preserves Extra by copying the whole source entry.)
+		// `entry` is rebuilt from CLI flags and carries none, so without this
+		// the wholesale-replace upsert would drop them.
 		if hasPrev {
 			entry.Extra = file.Assignments[prevIdx].Extra
 		}
@@ -645,9 +611,8 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		if err != nil {
 			return nil, err
 		}
-		// Captured by the closure so the post-commit warning can
-		// see the final size that actually landed (after any
-		// rebase retries).
+		// Captured by the closure so the post-commit warning sees the final
+		// size that landed (after any rebase retries).
 		lastEncodedSize = len(data)
 		return map[string]string{assignmentsFilePath(classroom): string(data)}, nil
 	}
@@ -666,12 +631,8 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		templateDesc, entry.Autograder)
 
 	// In-org private template: grant the classroom team read so rostered
-	// students can generate from it (public templates need no grant; the
-	// out-of-org private case was already rejected above). Idempotent —
-	// skips the PUT when the team already has access. The team slug is
-	// read from classroom.json (authoritative); a classroom with no team
-	// (pre-feature) gets an actionable message rather than a 404 against
-	// a guessed slug.
+	// students can generate from it. Idempotent. The team slug comes from
+	// classroom.json; a classroom with no team gets an actionable message.
 	if resolved != nil && templatePrivate && inOrg {
 		if err := grantClassroomTeamTemplateRead(client, out, org, classroom, branch, slug, resolved.Owner, resolved.Repo,
 			grantContext{verb: "committed", classroomNoun: "classroom", rerunHint: ", then re-run `gh teacher assignment add`"}); err != nil {
@@ -699,11 +660,9 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			"Warning: replacing %q dropped its pass_threshold (%d%%) — `assignment add` rewrites the whole entry, and you re-ran it without --pass-threshold. The passing bar (often set in the gradebook GUI) is now off. Pass --pass-threshold %d to keep it.\n",
 			slug, *droppedPassThreshold, *droppedPassThreshold)
 	}
-	// Heads-up if the encoded file is approaching the GitHub
-	// contents-API behavior change (~1 MiB encoded → encoding:"none",
-	// which would wedge future reads/writes). Diagnostic only;
-	// no behavioral effect. See assignment.LargeAssignmentsWarnBytes in
-	// internal/assignment/assignments_json.go for the rationale.
+	// Heads-up if the encoded file nears GitHub's ~1 MiB contents-API limit
+	// (past which encoding flips to "none", wedging future reads/writes).
+	// Diagnostic only. See assignment.LargeAssignmentsWarnBytes.
 	if lastEncodedSize > assignment.LargeAssignmentsWarnBytes {
 		_, _ = fmt.Fprintf(errOut,
 			"Warning: %s/%s/%s is %d bytes — approaching GitHub's ~1 MiB contents-API ceiling. Past that, the API returns encoding:\"none\" and future `gh teacher assignment add/remove` calls will fail to read the file. Consider splitting the classroom or shrinking per-entry fields.\n",
@@ -728,8 +687,8 @@ func runAssignmentRemove(client githubapi.Client, out io.Writer, org, classroom,
 		next, ok := assignment.RemoveAssignment(file.Assignments, slug)
 		removed = ok
 		if !ok {
-			// configwrite.CommitTree treats nil-or-empty as a no-op so a missing
-			// slug doesn't produce an empty commit.
+			// configwrite.CommitTree treats nil-or-empty as a no-op so a
+			// missing slug doesn't produce an empty commit.
 			return nil, nil
 		}
 		file.Assignments = next
@@ -756,18 +715,16 @@ func runAssignmentRemove(client githubapi.Client, out io.Writer, org, classroom,
 }
 
 // loadAssignments reads assignments.json at `ref` (commit SHA for
-// rebase-consistent reads inside configwrite.CommitTree, branch name for the
-// read-only list path — the contents API accepts both). Missing
-// file → points the teacher at `gh teacher classroom add`.
+// rebase-consistent reads inside CommitTree, or a branch name for the read-only
+// list path). Missing file → points the teacher at `classroom add`.
 func loadAssignments(client githubapi.Client, org, classroom, ref string) (assignment.AssignmentsJSON, error) {
 	return configrepo.LoadAssignments(client, org, classroom, ref)
 }
 
-// ensureClassroomActive refuses a write (add / reuse) into an archived
-// classroom (classroom.json `active: false`), mirroring the web. Read at
-// `ref` inside the build callback so a concurrent archive/unarchive is
-// observed consistently. A missing/legacy classroom.json reads as active,
-// so this never blocks legacy classrooms.
+// ensureClassroomActive refuses a write into an archived classroom
+// (classroom.json `active: false`), mirroring the web. Read at `ref` inside the
+// build callback so a concurrent archive/unarchive is observed consistently. A
+// missing/legacy classroom.json reads as active.
 func ensureClassroomActive(client githubapi.Client, org, classroom, ref string) error {
 	c, ok, err := configrepo.LoadClassroom(client, org, classroom, ref)
 	if err != nil {
@@ -780,10 +737,9 @@ func ensureClassroomActive(client githubapi.Client, org, classroom, ref string) 
 	return nil
 }
 
-// templateArg is the parsed `--template` flag. Branch is empty if
-// the teacher omits `@branch`; validateTemplateRepo then fills it
-// from the template's `default_branch`. Kept distinct from
-// assignment.TemplateRef because on-disk Branch must be populated.
+// templateArg is the parsed `--template` flag. Branch is empty if `@branch` is
+// omitted; validateTemplateRepo then fills it from default_branch. Kept
+// distinct from assignment.TemplateRef because on-disk Branch must be populated.
 type templateArg struct {
 	Owner  string
 	Repo   string
@@ -814,13 +770,11 @@ func parseTemplateRef(raw string) (templateArg, error) {
 	}, nil
 }
 
-// normalizeDueDate turns a --due value into the stored UTC instant
-// plus its provenance (due_meta). Empty -> ("", nil, nil); --due is
-// optional. A value carrying an offset is converted to UTC; a
-// zone-less value is interpreted in the machine's local timezone
-// (auto-detected), then converted to UTC. The teacher's original
-// input and the applied offset/zone are preserved in due_meta so a
-// wrong-zone deadline stays auditable.
+// normalizeDueDate turns a --due value into the stored UTC instant plus its
+// provenance (due_meta). Empty → ("", nil, nil). A value with an offset is
+// converted to UTC; a zone-less value is interpreted in the machine's local
+// zone, then converted. The original input and applied offset/zone are kept in
+// due_meta so a wrong-zone deadline stays auditable.
 func normalizeDueDate(raw string) (string, *assignment.DueMeta, error) {
 	if raw == "" {
 		return "", nil, nil
@@ -831,10 +785,8 @@ func normalizeDueDate(raw string) (string, *assignment.DueMeta, error) {
 		return "", nil, fmt.Errorf("invalid --due: %w", err)
 	}
 	if !hadOffset && locErr != nil {
-		// The value is zone-less, so the result depends entirely on
-		// the local zone -- but $TZ was set to something we couldn't
-		// resolve. Fail loudly rather than silently normalizing in a
-		// fallback zone and storing the wrong instant.
+		// Zone-less value depends entirely on the local zone, but $TZ was
+		// unresolvable. Fail loudly rather than storing the wrong instant.
 		return "", nil, fmt.Errorf(
 			"invalid --due: %q has no timezone offset and the local timezone "+
 				"could not be resolved (%v); pass an explicit offset like -04:00", raw, locErr)
@@ -847,13 +799,10 @@ func normalizeDueDate(raw string) (string, *assignment.DueMeta, error) {
 	return t.UTC().Format(time.RFC3339), meta, nil
 }
 
-// localDueLocation resolves the machine's local timezone for
-// interpreting a zone-less --due. $TZ is preferred when set: it names
-// an IANA zone (e.g. "America/New_York") that round-trips a readable
-// name into due_meta.zone. When $TZ is set but unresolvable, return
-// the error (alongside time.Local) so the caller can refuse to guess
-// for a zone-less value; an empty $TZ falls back to time.Local with no
-// error (that's the legitimate auto-detect path).
+// localDueLocation resolves the machine's local timezone for a zone-less --due.
+// $TZ is preferred (its IANA name round-trips into due_meta.zone). When $TZ is
+// set but unresolvable, return the error (with time.Local) so the caller
+// refuses to guess; an empty $TZ falls back to time.Local with no error.
 func localDueLocation() (*time.Location, error) {
 	if tz := strings.TrimSpace(os.Getenv("TZ")); tz != "" {
 		loc, err := time.LoadLocation(tz)
@@ -865,11 +814,10 @@ func localDueLocation() (*time.Location, error) {
 	return time.Local, nil
 }
 
-// dueZoneName is the best-effort human-readable zone recorded in
-// due_meta when the offset was auto-detected. A named location (from
-// $TZ or a test injection) reports its IANA name; time.Local reports
-// "Local", so fall back to the abbreviation at that instant (e.g.
-// "EDT"). due_meta.offset is always exact regardless.
+// dueZoneName is the best-effort human-readable zone recorded in due_meta when
+// the offset was auto-detected. A named location reports its IANA name;
+// time.Local reports "Local", so fall back to the abbreviation at that instant
+// (e.g. "EDT"). due_meta.offset is always exact regardless.
 func dueZoneName(loc *time.Location, t time.Time) string {
 	if name := loc.String(); name != "" && name != "Local" {
 		return name
@@ -878,14 +826,11 @@ func dueZoneName(loc *time.Location, t time.Time) string {
 	return abbr
 }
 
-// validateTemplateRepo checks <owner>/<repo> exists and is a
-// template repo, then resolves missing @branch to default_branch so
-// on-disk Branch is always populated. Also returns whether the
-// template is private, so assignment add can decide whether the
-// classroom team needs a read grant (in-org private) or the
-// assignment must be rejected (out-of-org private). Post-HTTP
-// decisions live in resolveTemplateBranch so the decision table is
-// unit-testable without an httptest scaffold.
+// validateTemplateRepo checks <owner>/<repo> exists and is a template repo,
+// then resolves a missing @branch to default_branch. Also returns whether the
+// template is private, so add can decide the classroom-team read grant (in-org
+// private) or rejection (out-of-org private). Post-HTTP decisions live in
+// resolveTemplateBranch so they're unit-testable without httptest.
 func validateTemplateRepo(client githubapi.Client, t templateArg) (ref assignment.TemplateRef, private bool, err error) {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(t.Owner), url.PathEscape(t.Repo))
 	var resp struct {
@@ -908,9 +853,8 @@ func validateTemplateRepo(client githubapi.Client, t templateArg) (ref assignmen
 }
 
 // templateInOrg reports whether the template repo is owned by <org>
-// (case-insensitive, matching GitHub's login semantics). An in-org
-// private template can be shared with the classroom team; an
-// out-of-org private one cannot, so assignment add rejects it.
+// (case-insensitive). An in-org private template can be shared with the
+// classroom team; an out-of-org private one can't, so add rejects it.
 func templateInOrg(templateOwner, org string) bool {
 	return strings.EqualFold(templateOwner, org)
 }
@@ -927,8 +871,8 @@ func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string)
 		branch = defaultBranch
 	}
 	if branch == "" {
-		// Defensive: a fresh repo can return empty default_branch,
-		// and an empty Branch on disk would trip `gh student accept`.
+		// Defensive: a fresh repo can return empty default_branch, and an
+		// empty on-disk Branch would trip `student accept`.
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch — pass --template %s/%s@<branch> explicitly", t.Owner, t.Repo, t.Owner, t.Repo)
 	}
 	return assignment.TemplateRef{Owner: t.Owner, Repo: t.Repo, Branch: branch}, nil

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -21,16 +21,14 @@ import (
 )
 
 // assignmentReuseCmd copies an assignment record from one classroom's
-// assignments.json into another's in the SAME org, changing only
-// slug/name. Mirrors classroom50-web's reuse: the record is
-// copied verbatim through the typed AssignmentEntry (every v1 field
-// round-trips), and unknown/future top-level fields survive via
-// AssignmentEntry.Extra.
+// assignments.json into another's in the SAME org, changing only slug/name.
+// The record is copied verbatim through the typed AssignmentEntry, and
+// unknown/future top-level fields survive via Extra.
 //
-// In-org only (v1): a private template can only be team-granted within its
-// own org, so cross-org reuse of a private template is out of scope. The
-// only network re-derivation is re-applying the private in-org template
-// team grant for the TARGET classroom (the same grant `assignment add` does).
+// In-org only (v1): a private template can only be team-granted within its own
+// org, so cross-org reuse of a private template is out of scope. The only
+// network re-derivation is re-applying the private in-org template team grant
+// for the TARGET classroom.
 func assignmentReuseCmd() *cobra.Command {
 	var (
 		from    string
@@ -129,9 +127,8 @@ func assignmentReuseCmd() *cobra.Command {
 	return cmd
 }
 
-// reuseAssignmentParams carries the inputs to runAssignmentReuse. The
-// *WasSet flags distinguish "flag omitted (use source / auto-suffix)"
-// from an explicit value, mirroring how add treats pointer fields.
+// reuseAssignmentParams carries runAssignmentReuse's inputs. The *WasSet flags
+// distinguish "flag omitted (use source / auto-suffix)" from an explicit value.
 type reuseAssignmentParams struct {
 	Org          string
 	From         string
@@ -144,9 +141,8 @@ type reuseAssignmentParams struct {
 	AsJSON       bool
 }
 
-// reuseResult is the --json shape: the resolved copy a script/agent needs
-// to act on. `slug` is the FINAL slug (after any auto-suffix), which is the
-// reason --json exists — an auto-suffixed slug isn't knowable in advance.
+// reuseResult is the --json shape. `slug` is the FINAL slug (after any
+// auto-suffix), which is why --json exists — the suffix isn't knowable ahead.
 type reuseResult struct {
 	Org          string                  `json:"org"`
 	Classroom    string                  `json:"classroom"`
@@ -156,12 +152,10 @@ type reuseResult struct {
 	Template     *assignment.TemplateRef `json:"template,omitempty"`
 }
 
-// runAssignmentReuse reads the source entry and upserts a copy into the
-// target classroom inside one configwrite.CommitTree build callback, so
-// the source read, the collision check, and the target write all see the
-// same parent SHA (a concurrent edit loses cleanly on retry). The
-// private-in-org template team grant for the TARGET classroom runs after
-// the commit, mirroring runAssignmentAdd.
+// runAssignmentReuse reads the source entry and upserts a copy into the target
+// classroom inside one build callback, so the source read, collision check, and
+// target write all see the same parent SHA. The private-in-org template grant
+// for the TARGET runs after the commit, mirroring runAssignmentAdd.
 func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseAssignmentParams) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, p.Org)
 	if err != nil {
@@ -189,8 +183,7 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 			return nil, fmt.Errorf("assignment %q not found in source classroom %q (%s/%s/%s) — run `gh teacher assignment list %s %s` to see available slugs",
 				p.SourceSlug, p.Org, configrepo.ConfigRepoName, p.From, assignmentsFilePath(p.From), p.Org, p.From)
 		}
-		// Copy verbatim through the typed entry (every v1 field
-		// round-trips); only slug/name are overridable.
+		// Copy verbatim through the typed entry; only slug/name are overridable.
 		copied = srcFile.Assignments[idx]
 
 		dstFile, err := loadAssignments(client, p.Org, p.To, parentSHA)
@@ -199,9 +192,8 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		}
 
 		// Resolve the target slug: an explicit --slug must not collide
-		// (case-insensitive); otherwise auto-suffix off the source slug.
-		// autoSuffixed is reset each attempt because build re-runs on a
-		// rebase retry.
+		// (case-insensitive); else auto-suffix off the source slug. Reset each
+		// attempt since build re-runs on a rebase retry.
 		autoSuffixed = false
 		if p.SlugWasSet {
 			if assignment.SlugExistsFold(dstFile.Assignments, p.SlugOverride) {
@@ -239,9 +231,8 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		return err
 	}
 
-	// The copy has landed. Emit the machine-readable result (when --json)
-	// or the human summary on stdout; advisory notes always go to stderr so
-	// stdout stays a clean single value for scripted callers.
+	// Emit the machine-readable result (--json) or human summary on stdout;
+	// advisory notes go to stderr so stdout stays a clean single value.
 	if p.AsJSON {
 		data, err := output.JSONPretty(reuseResult{
 			Org:          p.Org,
@@ -267,9 +258,8 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		_, _ = fmt.Fprintf(errOut, "Note: slug %q already existed in %q, so the copy was named %q.\n", p.SourceSlug, p.To, finalSlug)
 	}
 
-	// Re-apply the target classroom's private in-org template team grant
-	// (the same grant `assignment add` performs). In --json mode the
-	// grant's "granted" line goes to stderr so stdout stays parseable.
+	// Re-apply the target classroom's private in-org template team grant. In
+	// --json mode the "granted" line goes to stderr so stdout stays parseable.
 	grantOut := out
 	if p.AsJSON {
 		grantOut = errOut
@@ -282,11 +272,10 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 	return nil
 }
 
-// grantReusedTemplateAccess re-applies the TARGET classroom team's read
-// grant on a reused assignment's private, org-owned template. Public,
-// absent, and out-of-org templates are no-ops (out-of-org with a warning —
-// it can't be granted in-org-only v1). A 404 (template gone/invisible) is
-// surfaced as a warning since the copy already landed.
+// grantReusedTemplateAccess re-applies the TARGET classroom team's read grant
+// on a reused assignment's private, org-owned template. Public/absent/out-of-org
+// templates are no-ops (out-of-org with a warning). A 404 is a warning since
+// the copy already landed.
 func grantReusedTemplateAccess(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, slug string, tmpl *assignment.TemplateRef) error {
 	if tmpl == nil {
 		return nil
@@ -311,20 +300,18 @@ func grantReusedTemplateAccess(client githubapi.Client, out, errOut io.Writer, o
 	return grantClassroomTeamTemplateRead(client, out, org, classroom, branch, slug, tmpl.Owner, tmpl.Repo, grantContext{verb: "reused", classroomNoun: "target classroom"})
 }
 
-// grantContext carries the per-caller wording for
-// grantClassroomTeamTemplateRead's error messages, so `assignment add` and
-// `assignment reuse` share the grant core while keeping distinct phrasing.
+// grantContext carries per-caller wording for grantClassroomTeamTemplateRead's
+// errors, so add and reuse share the grant core with distinct phrasing.
 type grantContext struct {
 	verb          string // past-tense action: "committed" / "reused"
 	classroomNoun string // "classroom" / "target classroom"
-	rerunHint     string // optional clause appended to the no-team error, e.g. ", then re-run `gh teacher assignment add`"
+	rerunHint     string // optional clause appended to the no-team error
 }
 
-// grantClassroomTeamTemplateRead resolves the classroom's persisted team
-// and grants it read on a private, org-owned template (idempotent via
-// GrantTeamRepoRead). Shared by `assignment add` and `assignment reuse`;
-// the caller decides WHEN to call it and supplies the wording. A classroom
-// with no team yields an actionable error, not a 404 on a guessed slug.
+// grantClassroomTeamTemplateRead resolves the classroom's persisted team and
+// grants it read on a private, org-owned template (idempotent). Shared by add
+// and reuse; the caller decides WHEN and supplies the wording. A classroom with
+// no team yields an actionable error, not a 404 on a guessed slug.
 func grantClassroomTeamTemplateRead(client githubapi.Client, out io.Writer, org, classroom, branch, slug, tmplOwner, tmplRepo string, ctx grantContext) error {
 	team, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
@@ -344,9 +331,9 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out io.Writer, org,
 	return nil
 }
 
-// templateVisibility probes a template repo for the reuse grant
-// decision: returns (private, visible, err). A 404 is the "not visible"
-// case (visible=false, err=nil); other transport errors propagate.
+// templateVisibility probes a template repo for the reuse grant decision:
+// returns (private, visible, err). A 404 is the "not visible" case; other
+// transport errors propagate.
 func templateVisibility(client githubapi.Client, owner, repo string) (private bool, visible bool, err error) {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
 	var resp struct {

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
@@ -17,11 +17,10 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// assignmentTestCmd is the `gh teacher assignment test` command group:
-// add / list / remove declarative tests on an assignment's `tests` block
-// in assignments.json (graded by runner.py's built-in interpreter, no
-// autograder.py needed). Mutually exclusive with a hand-written
-// per-assignment autograder.py — see ensureNoPerAssignmentAutograder.
+// assignmentTestCmd is the `gh teacher assignment test` command group: add /
+// list / remove declarative tests on an assignment's `tests` block (graded by
+// runner.py, no autograder.py needed). Mutually exclusive with a per-assignment
+// autograder.py — see ensureNoPerAssignmentAutograder.
 func assignmentTestCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -146,10 +145,9 @@ func assignmentTestAddCmd() *cobra.Command {
 	return cmd
 }
 
-// runAssignmentTestAdd upserts one test into an existing assignment
-// entry. The conflict check and entry lookup run inside the configwrite.CommitTree
-// build closure against each attempt's parent SHA, so concurrent edits
-// rebase cleanly. assignment.ValidateAssignmentEntry re-runs in the closure to
+// runAssignmentTestAdd upserts one test into an existing entry. The conflict
+// check and lookup run inside the build closure against each attempt's parent
+// SHA, so concurrent edits rebase cleanly. ValidateAssignmentEntry re-runs to
 // enforce the count cap + name uniqueness against the merged array.
 func runAssignmentTestAdd(client githubapi.Client, out io.Writer, org, classroom, slug string, spec assignment.TestSpec) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
@@ -329,9 +327,8 @@ func runAssignmentTestRemove(client githubapi.Client, out io.Writer, org, classr
 		return err
 	}
 
-	// removed resets at the top of build so a rebase retry never reports
-	// stale state. Missing assignment = hard error; missing test name =
-	// idempotent no-op (nil map -> no commit).
+	// removed resets at the top of build so a retry never reports stale state.
+	// Missing assignment = hard error; missing test = idempotent no-op.
 	var removed bool
 	build := func(parentSHA string) (map[string]string, error) {
 		removed = false
@@ -348,7 +345,7 @@ func runAssignmentTestRemove(client githubapi.Client, out io.Writer, org, classr
 		next, ok := assignment.RemoveTest(entry.Tests, testName)
 		removed = ok
 		if !ok {
-			return nil, nil // test already absent: no-op, no empty commit
+			return nil, nil // test already absent: no-op
 		}
 		entry.Tests = next
 		if err := assignment.ValidateAssignmentEntry(entry); err != nil {
@@ -376,15 +373,14 @@ func runAssignmentTestRemove(client githubapi.Client, out io.Writer, org, classr
 	return nil
 }
 
-// materializeScriptPath is the skeleton script publish-pages runs to
-// translate `tests` blocks into bundled tests.json files.
+// materializeScriptPath is the skeleton script publish-pages runs to translate
+// `tests` blocks into bundled tests.json files.
 const materializeScriptPath = ".github/scripts/materialize_tests.py"
 
-// ensureDeclarativeTestsSupported rejects writing declarative tests when
-// the config repo's skeleton predates materialize_tests.py. Without it,
-// the tests would land in assignments.json but never reach the Pages
-// bundle, and every submission would silently fall back (classroom
-// default or vacuous pass) while looking graded.
+// ensureDeclarativeTestsSupported rejects writing declarative tests when the
+// skeleton predates materialize_tests.py. Without it, tests would land in
+// assignments.json but never reach the Pages bundle, so submissions silently
+// fall back while looking graded.
 func ensureDeclarativeTestsSupported(client githubapi.Client, org, ref string) error {
 	exists, err := configrepo.ContentsExists(client, org, configrepo.ConfigRepoName, materializeScriptPath, ref)
 	if err != nil {
@@ -397,11 +393,9 @@ func ensureDeclarativeTestsSupported(client githubapi.Client, org, ref string) e
 	return nil
 }
 
-// ensureNoPerAssignmentAutograder rejects writing declarative tests for
-// a slug that already has a hand-written autograder.py in the config
-// repo: the runner prefers autograder.py, so the tests would silently
-// never run. Probed against `ref` so a caller inside a configwrite.CommitTree build
-// closure sees the same parent state as the rest of its read.
+// ensureNoPerAssignmentAutograder rejects writing declarative tests for a slug
+// that already has a hand-written autograder.py: the runner prefers
+// autograder.py, so the tests would silently never run. Probed against `ref`.
 func ensureNoPerAssignmentAutograder(client githubapi.Client, org, classroom, slug, ref string) error {
 	path := assignment.PerAssignmentAutograderPath(classroom, slug)
 	exists, err := configrepo.ContentsExists(client, org, configrepo.ConfigRepoName, path, ref)

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
@@ -16,15 +16,14 @@ import (
 )
 
 // testCmdFixture wires the GitHub API surface the `assignment test`
-// subcommands touch: branch resolution, the assignments.json read, the
-// per-assignment autograder.py conflict probe, and the commitTree write
-// endpoints. The captured fields record what (if anything) was committed.
+// subcommands touch (branch resolve, assignments.json read, the
+// autograder.py conflict probe, the commitTree write endpoints). Captured
+// fields record what was committed.
 type testCmdFixture struct {
 	mu sync.Mutex
-	// committed is the decoded blob content uploaded via git/blobs
-	// (the proposed assignments.json), nil if no blob was uploaded.
+	// committed is the decoded blob uploaded via git/blobs, nil if none.
 	committed []byte
-	// treePath is the path of the single entry in the proposed tree.
+	// treePath is the path of the single tree entry.
 	treePath string
 	// refPatched reports whether the branch ref was advanced.
 	refPatched bool
@@ -123,9 +122,9 @@ func newTestCmdServer(t *testing.T, assignmentsBody string, autograderExists boo
 	return server, fix
 }
 
-// helloAssignments returns an assignments.json body with one valid
-// "hello" entry carrying the given tests array (raw JSON, e.g. `[]` or
-// a populated array). Shape matches what assignment.EncodeAssignments writes.
+// helloAssignments returns an assignments.json body with one valid "hello"
+// entry carrying the given tests array (raw JSON, e.g. `[]` or a populated
+// array).
 func helloAssignments(testsJSON string) string {
 	tests := ""
 	if testsJSON != "" {
@@ -146,10 +145,8 @@ func helloAssignments(testsJSON string) string {
 }`
 }
 
-// helloAddParams returns a baseline addAssignmentParams matching the
-// `hello` fixture (individual mode, default autograder, hello-template).
-// Tests override only the fields they exercise, so call sites stay
-// field-named and order-independent.
+// helloAddParams returns a baseline addAssignmentParams matching the `hello`
+// fixture. Tests override only the fields they exercise.
 func helloAddParams() addAssignmentParams {
 	return addAssignmentParams{
 		Org:        "o",
@@ -363,9 +360,8 @@ func TestRunAssignmentAdd_AllowedFilesPersists(t *testing.T) {
 }
 
 // TestRunAssignmentAdd_TemplateLessPersists drives the headline feature:
-// `assignment add` with no --template (tmpl == nil). It must skip the
-// template-repo probe, commit an entry with a nil Template, and print
-// "no template".
+// `assignment add` with no --template (tmpl == nil) skips the template probe,
+// commits a nil Template, and prints "no template".
 func TestRunAssignmentAdd_TemplateLessPersists(t *testing.T) {
 	server, fix := newTestCmdServer(t, helloAssignments(""), false)
 	client := githubtest.NewTestClient(t, server)
@@ -638,11 +634,9 @@ func TestRunAssignmentAdd_RefusesArchivedTarget(t *testing.T) {
 }
 
 // TestRunAssignmentAdd_PreservesUnknownEntryField pins the "tolerate AND
-// preserve" rule on the add round-trip: an unknown top-level entry key (one a
-// newer binary or the web GUI wrote before this CLI models it) must survive a
-// re-run of `assignment add`, which rebuilds the entry from flags. Without the
-// Extra carry-forward the wholesale-replace upsert would silently drop it —
-// the exact silent-data-loss the cross-binary forward-compat contract forbids.
+// preserve" rule: an unknown top-level entry key (written by a newer binary/GUI)
+// must survive a re-run of `assignment add`, which rebuilds the entry from
+// flags. Without the Extra carry-forward the upsert would silently drop it.
 func TestRunAssignmentAdd_PreservesUnknownEntryField(t *testing.T) {
 	seeded := `{
   "schema": "classroom50/assignments/v1",

--- a/cli/gh-teacher/internal/audit/audit.go
+++ b/cli/gh-teacher/internal/audit/audit.go
@@ -1,13 +1,7 @@
-// Package audit implements the `gh teacher audit` command: a read-only
-// audit of an org's member-privilege lockdown. It re-reads the org and
-// reports, per setting, whether the least-privilege value `gh teacher
-// init` applies is actually in effect — the standalone confirmation
-// surface for the lockdown model. It is an extracted command package
-// (mirrors internal/teardown, internal/download, internal/invite): only
-// NewCmd is exported; the report type, classification, and the two
-// renderers are package-private. It depends on the internal/* substrate
-// seams (githubapi for the org reads, orgpolicy for the shared lockdown
-// model, ui for rendering), never on package main.
+// Package audit implements the `gh teacher audit` command: a read-only audit
+// of an org's member-privilege lockdown. It re-reads the org and reports, per
+// setting, whether the least-privilege value `init` applies is in effect. Only
+// NewCmd is exported.
 package audit
 
 import (
@@ -25,29 +19,20 @@ import (
 	"github.com/foundation50/gh-teacher/internal/ui"
 )
 
-// NewCmd implements `gh teacher audit <org>`: a read-only audit of the
-// org member-privilege lockdown. It re-reads the org and reports, per
-// setting, whether the least-privilege value `gh teacher init` applies is
-// actually in effect — the same authoritative read-back init uses,
-// exposed as a standalone command so a teacher can confirm a manual fix
-// landed without re-running the mutating init.
+// NewCmd implements `gh teacher audit <org>`: a read-only audit of the org
+// member-privilege lockdown, using the same authoritative read-back as init so
+// a teacher can confirm a manual fix landed without re-running the mutating
+// init.
 //
-// Two classes of setting are reported separately because GitHub exposes
-// them differently:
-//   - API-readable lockdown fields (PATCH /orgs/{org} fields): audit
-//     reads their live value and flags any that don't match.
-//   - The four web-UI-only hardening settings (app access requests,
-//     repo-admin GitHub App installs, Projects base permissions, branch
-//     renames): GitHub has no REST field to read them, so audit CANNOT
-//     confirm them. It lists them as "confirm by hand" rather than
-//     pretending they're fine.
+// Two setting classes are reported separately:
+//   - API-readable lockdown fields: audit reads the live value and flags any
+//     mismatch.
+//   - The four web-UI-only hardening settings: GitHub has no REST field, so
+//     audit lists them as "confirm by hand" rather than pretending they're OK.
 //
-// Exit status treats any drift as failing: non-zero when ANY API-readable
-// lockdown field is unenforced (critical or not), so the command is
-// scriptable (`gh teacher audit org && deploy`) and agrees with the web
-// GUI's verdict for the same org. The unreadable manual items do NOT fail
-// the command (they can't be read either way); they're always surfaced as
-// a reminder.
+// Exit is non-zero when ANY API-readable field is unenforced (scriptable,
+// agreeing with the web GUI's verdict). The unreadable manual items never fail
+// the command.
 func NewCmd() *cobra.Command {
 	var asJSON bool
 
@@ -86,23 +71,18 @@ func NewCmd() *cobra.Command {
 				return err
 			}
 
-			// Plan drives which fields are in scope (Team/Free don't expose
-			// the enterprise-only toggles, so they're not part of the audit).
-			// A failed plan lookup is non-fatal here: it yields an empty plan
-			// (audit then scopes to the non-enterprise set), and the
-			// authoritative org read in buildAuditReport is what sets ReadOK /
-			// the scriptable exit status if the org is truly unreadable.
+			// Plan drives which fields are in scope (Team/Free don't expose the
+			// enterprise-only toggles). A failed lookup is non-fatal: it
+			// yields an empty plan (non-enterprise scope), and the org read in
+			// buildAuditReport sets ReadOK / the exit status.
 			plan, _ := githubapi.OrgPlan(client, org)
 
 			report := buildAuditReport(client, org, plan)
 
-			// Render to the requested surface, then apply the SAME
-			// scriptable exit status on both paths: a non-zero exit when
-			// ANY API-readable field is unenforced (or the org couldn't
-			// be read). The --json branch previously returned right after
-			// rendering, so `gh teacher audit org --json && deploy` proceeded
-			// on an INCOMPLETE lockdown — the JSON's lockdown_complete:false
-			// was the only signal and the exit code lied.
+			// Render, then apply the SAME scriptable exit status on both paths
+			// (non-zero when any API-readable field is unenforced, or the org
+			// couldn't be read) so `audit --json && deploy` can't proceed on an
+			// incomplete lockdown.
 			if asJSON {
 				if err := report.renderJSON(cmd.OutOrStdout()); err != nil {
 					return err
@@ -121,31 +101,23 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-// auditReport is the canonical record behind both renderers (human and
-// --json), mirroring initSummary's single-source-of-truth pattern so the
-// two surfaces can't drift.
+// auditReport is the canonical record behind both renderers, mirroring
+// initSummary's single-source-of-truth pattern so the two surfaces can't drift.
 type auditReport struct {
 	Org  string `json:"org"`
 	Plan string `json:"plan"`
-	// ReadOK is false when the org couldn't be read back at all (network
-	// / permission). In that case Enforced is empty and the API-readable
-	// audit is inconclusive — distinct from "read fine, all enforced".
+	// ReadOK is false when the org couldn't be read (network/permission); then
+	// Enforced is empty and the audit is inconclusive.
 	ReadOK bool `json:"read_ok"`
-	// LockdownComplete is true when NO API-readable field is unenforced
-	// (any drift, critical or not, fails). This matches the web GUI's
-	// audit verdict (src/orgPolicy/audit.ts deriveVerdict), which treats
-	// any drift as "Needs attention", so both tools agree on the same
-	// org state. The unreadable manual items don't affect it.
+	// LockdownComplete is true when NO API-readable field is unenforced (any
+	// drift fails), matching the web GUI's verdict. Manual items don't affect it.
 	LockdownComplete bool `json:"lockdown_complete"`
-	// Enforced lists the API-readable lockdown settings whose live value
-	// already matches the locked-down value.
-	Enforced []auditSetting `json:"enforced"`
-	// Unenforced lists the API-readable lockdown settings whose live
-	// value does NOT match, each with the GitHub-UI fix instruction.
+	// Enforced/Unenforced: API-readable lockdown settings whose live value
+	// matches / doesn't match (the latter each with a UI fix instruction).
+	Enforced   []auditSetting `json:"enforced"`
 	Unenforced []auditSetting `json:"unenforced"`
-	// ManualUnreadable lists the web-UI-only settings GitHub exposes no
-	// REST API to read; audit can't confirm them and asks the teacher to
-	// eyeball them.
+	// ManualUnreadable: web-UI-only settings with no REST field; audit can't
+	// confirm them and asks the teacher to eyeball them.
 	ManualUnreadable []orgpolicy.ManualStep `json:"manual_unreadable"`
 	// SettingsURL is the org member-privileges page every item lives on.
 	SettingsURL string `json:"settings_url"`
@@ -161,11 +133,9 @@ type auditSetting struct {
 	Fix string `json:"fix,omitempty"`
 }
 
-// buildAuditReport reads the org back and classifies every in-scope
-// member-default setting as enforced or unenforced, plus the always-
-// unreadable manual hardening items. A read failure yields ReadOK=false
-// with LockdownComplete=false (we can't prove the lockdown holds, so the
-// scriptable exit status is conservatively a failure).
+// buildAuditReport reads the org back and classifies every in-scope setting as
+// enforced/unenforced, plus the always-unreadable manual items. A read failure
+// yields ReadOK=false with LockdownComplete=false (conservatively a failure).
 func buildAuditReport(client githubapi.Client, org, plan string) auditReport {
 	settingsURL := fmt.Sprintf("https://github.com/organizations/%s/settings/member_privileges", org)
 	report := auditReport{
@@ -195,17 +165,15 @@ func buildAuditReport(client githubapi.Client, org, plan string) auditReport {
 		as.Fix = v.Setting.ManualFix
 		report.Unenforced = append(report.Unenforced, as)
 	}
-	// Any drift fails (match the web GUI's verdict). The per-setting
-	// Critical flag is still surfaced for ordering/labeling, but it no
-	// longer gates the verdict or the scriptable exit status.
+	// Any drift fails (match the web GUI). The per-setting Critical flag is
+	// still surfaced for ordering/labeling but no longer gates the verdict.
 	report.LockdownComplete = len(report.Unenforced) == 0
 	return report
 }
 
-// readOrgMemberSettings GETs the org and returns the raw field map used
-// to compare live values against the desired lockdown. Separated from
-// init's verifyOrgDefaults (which both reads and emits warnings) so audit
-// can do a clean read without init's side effects.
+// readOrgMemberSettings GETs the org and returns the raw field map. Separated
+// from init's verifyOrgDefaults (which also emits warnings) so audit reads
+// clean.
 func readOrgMemberSettings(client githubapi.Client, org string) (map[string]any, error) {
 	path := fmt.Sprintf("orgs/%s", url.PathEscape(org))
 	var live map[string]any
@@ -215,9 +183,8 @@ func readOrgMemberSettings(client githubapi.Client, org string) (map[string]any,
 	return live, nil
 }
 
-// renderJSON writes the report as one indented JSON object to w. HTML
-// escaping is off so `>` in fix instructions stays readable (matches
-// initSummary.renderJSON).
+// renderJSON writes the report as one indented JSON object. HTML escaping is
+// off so `>` in fix instructions stays readable.
 func (r *auditReport) renderJSON(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
@@ -225,11 +192,10 @@ func (r *auditReport) renderJSON(w io.Writer) error {
 	return enc.Encode(r)
 }
 
-// renderHuman writes the audit to the human channel (stderr): an outcome
-// banner, the enforced settings (collapsed to a count + one ✓ line), an
-// "Action required" checklist for any unenforced API-readable settings,
-// and a separate "Confirm by hand" list for the web-UI-only settings
-// audit can't read.
+// renderHuman writes the audit to stderr: an outcome banner, enforced settings
+// (collapsed to ✓ lines), an "Action required" checklist for unenforced
+// API-readable settings, and a separate "Confirm by hand" list for the
+// web-UI-only settings audit can't read.
 func (r *auditReport) renderHuman(u *ui.UI) {
 	u.Blank()
 
@@ -268,11 +234,9 @@ func (r *auditReport) renderHuman(u *ui.UI) {
 		u.Detail("at %s", r.SettingsURL)
 	}
 
-	// The four web-UI-only settings can't be read back, so audit can
-	// neither confirm nor deny them. Present them as an instruction list
-	// (not checkboxes — that would imply the CLI tracks their state):
-	// lead with "open the page and confirm", then a numbered list of the
-	// items to eyeball.
+	// The four web-UI-only settings can't be read back. Present them as an
+	// instruction list (not checkboxes, which would imply the CLI tracks their
+	// state): lead with "open and confirm", then the numbered items.
 	if len(r.ManualUnreadable) > 0 {
 		u.Heading("Confirm by hand (GitHub exposes no API to read these)")
 		u.Detail("Open %s and confirm each setting below:", r.ManualUnreadable[0].URL)

--- a/cli/gh-teacher/internal/autograder/autograder.go
+++ b/cli/gh-teacher/internal/autograder/autograder.go
@@ -1,15 +1,8 @@
-// Package autograder owns the embed-independent autograder-shim helpers:
-// the in-repo path shape for a teacher-authored shim, the name validation
-// that guards that path, and the write-time existence probe the
-// assignment command uses. It is a substrate seam (like internal/scores /
-// internal/orgrepos), not a command package: the `gh teacher autograder`
-// command surface stays in package main because it is pinned to the
-// `//go:embed embed/autograder.py` asset, which cannot move out of the
-// module root (see docs/plans Phase C endgame KTD-1). These helpers
-// reference none of that embedded asset, so they extract freely and
-// unblock the assignment command. Depends only on the shared contract
-// package and the lower internal/* seams (configrepo, githubapi,
-// validate), never on package main.
+// Package autograder owns the embed-independent autograder-shim helpers: the
+// in-repo path shape for a teacher-authored shim, the name validation guarding
+// that path, and the write-time existence probe. The `gh teacher autograder`
+// command stays in package main because it's pinned to the
+// `//go:embed embed/autograder.py` asset; these helpers reference none of it.
 package autograder
 
 import (
@@ -22,26 +15,19 @@ import (
 )
 
 // defaultName is a sentinel meaning "use the universal shim embedded in
-// gh-student" — no per-classroom shim file is required (or scaffolded).
-// Other autograder names refer to a teacher-authored sibling shim at
-// `<classroom>/autograders/<name>.yaml` in the config repo, which
-// `gh student accept` fetches from Pages instead of the embedded default.
-// Single-sourced in the shared contract package; callers that need the
-// sentinel value read contract.DefaultAutograderName directly.
+// gh-student" — no per-classroom shim file is required. Other names refer to a
+// teacher-authored shim at `<classroom>/autograders/<name>.yaml`. Single-sourced
+// in the shared contract.
 const defaultName = contract.DefaultAutograderName
 
-// FilePath: in-repo path for a non-default autograder shim (e.g.
-// "c-makefile" → "cs-principles/autograders/c-makefile.yaml"). The
-// "default" sentinel resolves to the embedded gh-student shim instead
-// and never lands as a file in the config repo.
+// FilePath: in-repo path for a non-default autograder shim. The "default"
+// sentinel resolves to the embedded gh-student shim and never lands as a file.
 func FilePath(classroom, name string) string {
 	return classroom + "/autograders/" + name + ".yaml"
 }
 
-// ValidateName enforces validate.ShortNamePattern on the value that becomes
-// `<classroom>/autograders/<name>.yaml` — same regex as classroom
-// short-names and slugs, blocking traversal-style inputs from reaching
-// the contents API or the Pages URL.
+// ValidateName enforces ShortNamePattern on the value that becomes
+// `<classroom>/autograders/<name>.yaml`, blocking traversal-style inputs.
 func ValidateName(name string) error {
 	if name == "" {
 		return fmt.Errorf("--autograder must not be empty (default is %q)", defaultName)
@@ -49,14 +35,10 @@ func ValidateName(name string) error {
 	return validate.ShortName(name, "autograder")
 }
 
-// Exists probes the contents API for the named autograder shim at `ref`.
-// Catches typo'd `--autograder` values at write time so the student
-// CLI's Pages fetch doesn't 404 mid-accept. 200 → true, 404 → false;
-// other errors propagate.
-//
-// Callers SHOULD skip this probe when name == contract.DefaultAutograderName
-// — the default shim is embedded in gh-student and has no on-disk
-// counterpart in the config repo.
+// Exists probes the contents API for the named autograder shim at `ref`,
+// catching typo'd `--autograder` values at write time. 200 → true, 404 →
+// false; other errors propagate. Callers SHOULD skip this for
+// contract.DefaultAutograderName (no on-disk counterpart).
 func Exists(client githubapi.Client, owner, repo, classroom, name, ref string) (bool, error) {
 	return configrepo.ContentsExists(client, owner, repo, FilePath(classroom, name), ref)
 }

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -1,16 +1,8 @@
 // Package classroom implements the `gh teacher classroom` command group:
 // managing classroom directories inside the <org>/classroom50 config repo
-// (add/list/edit/remove) plus the `classroom migrate` subcommand that
-// imports an existing GitHub Classroom into the config repo. It is an
-// extracted command package (mirrors internal/auth, internal/remove,
-// internal/roster, internal/member, internal/invite, and
-// internal/teardown): only NewCmd is exported; the subcommand factories,
-// run* orchestration, the classroomScaffold writer, and the migrate
-// plumbing are package-private. The four-file config-repo scaffold lands
-// through the race-safe internal/configwrite seam. It depends only on the
-// internal/* substrate seams (assignment, configrepo, configwrite,
-// githubapi, output, scores, validate, cliutil) plus the shared contract
-// package, never on package main.
+// (add/list/edit/remove) plus `classroom migrate` (imports an existing GitHub
+// Classroom). Only NewCmd is exported. The four-file scaffold lands through the
+// race-safe internal/configwrite seam.
 package classroom
 
 import (
@@ -33,12 +25,10 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// Schema sentinels for the scaffolded files. Schema-aware readers MUST
-// branch on this field first so newer files don't crash older readers.
-// assignmentsSchemaV1 is single-sourced in the shared contract package
-// (it's the one shared Go<->Go); the classroom sentinel is
-// teacher-written only. The scores.json sentinel lives in
-// internal/scores (scores.SchemaV1) since the download command shares it.
+// Schema sentinels for the scaffolded files; schema-aware readers MUST branch
+// on this field first. assignmentsSchemaV1 is single-sourced in the shared
+// contract; the classroom sentinel is teacher-written only. The scores.json
+// sentinel lives in internal/scores (shared with download).
 const (
 	classroomSchemaV1   = "classroom50/classroom/v1"
 	assignmentsSchemaV1 = contract.AssignmentsSchemaV1
@@ -47,12 +37,9 @@ const (
 // studentsCSVHeader derives from configrepo.RosterColumns so they can't drift.
 var studentsCSVHeader = strings.Join(configrepo.RosterColumns, ",") + "\n"
 
-// defaultAutograderName is the sentinel meaning "use the universal
-// default autograder". Single-sourced from the shared contract package;
-// the migrate path stamps it onto imported assignments that don't name
-// their own autograder. (The internal/autograder seam keeps its own
-// package-private copy; both are single-sourced from the same contract
-// constant.)
+// defaultAutograderName is the "use the universal default autograder"
+// sentinel, single-sourced from the shared contract; the migrate path stamps
+// it onto imported assignments that don't name their own autograder.
 const defaultAutograderName = contract.DefaultAutograderName
 
 func NewCmd() *cobra.Command {
@@ -157,15 +144,11 @@ func classroomAddCmd() *cobra.Command {
 	return cmd
 }
 
-// resolveClassroomSecret turns the --unlisted / --key flags into the key
-// string to persist (empty = a normal, guessable-URL classroom). Precedence:
-//   - an explicit --key value is validated and used verbatim (opt-in);
-//   - --unlisted with no --key generates a candidate and prompts the teacher
-//     to accept it or type their own;
-//   - neither set -> empty (guessable URL, today's behavior).
-//
-// The prompt reads one line from `in`; an empty line (just Enter) accepts
-// the generated candidate, any other line is validated as a custom key.
+// resolveClassroomSecret turns --unlisted / --key into the key to persist
+// (empty = normal guessable-URL classroom). Precedence: an explicit --key is
+// validated and used (opt-in); --unlisted with no --key generates a candidate
+// and prompts; neither → empty. The prompt reads one line from `in`; an empty
+// line accepts the candidate.
 func resolveClassroomSecret(in io.Reader, errOut io.Writer, unlisted bool, keySet bool, key string) (string, error) {
 	if keySet {
 		if err := configrepo.ValidateSecret(key); err != nil {
@@ -197,24 +180,19 @@ func resolveClassroomSecret(in io.Reader, errOut io.Writer, unlisted bool, keySe
 	return entered, nil
 }
 
-// addClassroom writes the four-file scaffold in one Tree commit
-// through configwrite.CommitTree so concurrent writers don't lose each other's
-// work. The existence probe runs inside the build callback so a
-// same-classroom race surfaces as "already exists" rather than
-// silently clobbering the winner.
+// addClassroom writes the four-file scaffold in one Tree commit via
+// configwrite.CommitTree. The existence probe runs inside the build callback so
+// a same-classroom race surfaces as "already exists" rather than clobbering.
 func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName, name, term, secret string) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
 		return err
 	}
 
-	// Preflight the existence check BEFORE any GitHub side effects
-	// (team creation, config-repo grants, maintainer membership). The
-	// authoritative race guard still runs inside the build callback
-	// against the rebased parent, but doing a cheap up-front probe means
-	// the common "already exists" case fails fast with zero orphaned
-	// teams/grants — closing the window where a refused add would still
-	// have created write-granted staff teams no classroom.json records.
+	// Cheap up-front existence probe BEFORE any GitHub side effects (team
+	// creation, grants, membership). The authoritative race guard still runs
+	// in the build callback, but this fails the common "already exists" case
+	// fast with zero orphaned teams/grants.
 	if exists, err := configrepo.ContentsExists(client, org, configrepo.ConfigRepoName, shortName, branch); err != nil {
 		return err
 	} else if exists {
@@ -223,19 +201,17 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 			org, configrepo.ConfigRepoName, branch, shortName)
 	}
 
-	// Create (or adopt) the per-classroom GitHub team before scaffolding
-	// so its id/slug can be recorded in classroom.json. The team is what
-	// later lets rostered students read private, org-owned assignment
-	// templates.
+	// Create (or adopt) the per-classroom team before scaffolding so its
+	// id/slug can be recorded in classroom.json. This team later lets rostered
+	// students read private org-owned templates.
 	team, err := configrepo.EnsureClassroomTeam(client, org, shortName)
 	if err != nil {
 		return fmt.Errorf("create classroom team: %w", err)
 	}
 
-	// Create (or adopt) the per-classroom staff teams (instructor, ta),
-	// grant each write on the config repo, and seed the acting teacher as
-	// instructor maintainer, mirroring the web GUI so a CLI-created
-	// classroom carries the same role teams the web expects.
+	// Create (or adopt) the staff teams (instructor, ta), grant each write on
+	// the config repo, and seed the acting teacher as instructor maintainer,
+	// mirroring the web.
 	staffTeams, err := seedStaffTeams(client, errOut, org, shortName)
 	if err != nil {
 		return err
@@ -247,9 +223,8 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	}
 
 	build := func(parentSHA string) (map[string]string, error) {
-		// contentsExists also catches partial-state classrooms (e.g.
-		// a teacher renamed classroom.json but left other files);
-		// the directory probe is 404 only when nothing exists there.
+		// Authoritative race guard; also catches partial-state classrooms
+		// (the dir probe is 404 only when nothing exists there).
 		exists, err := configrepo.ContentsExists(client, org, configrepo.ConfigRepoName, shortName, parentSHA)
 		if err != nil {
 			return nil, err
@@ -267,8 +242,7 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 		return err
 	}
 
-	// stdout: one parseable confirmation line. stderr: advisory
-	// "View at" + "Next:" hints.
+	// stdout: parseable confirmation lines. stderr: advisory hints.
 	_, _ = fmt.Fprintf(out, "%s/%s: added classroom %s (%d files)\n", org, configrepo.ConfigRepoName, shortName, len(files))
 	_, _ = fmt.Fprintf(out, "%s: classroom team %s ready\n", org, team.Slug)
 	if staffTeams != nil && staffTeams.Instructor != nil && staffTeams.TA != nil {
@@ -282,13 +256,11 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	return nil
 }
 
-// seedStaffTeams creates (or adopts) the classroom's instructor + ta
-// teams, grants each write on the config repo, and adds the acting
-// teacher as instructor maintainer — the create-time staff-team setup
-// shared by `classroom add` and `classroom migrate` (mirrors the web's
-// single ensureStaffTeams). The maintainer add is best-effort: a
-// CurrentUser or membership failure warns to errOut but does not fail
-// the classroom creation, since the teacher can self-add via the web.
+// seedStaffTeams creates (or adopts) the instructor + ta teams, grants each
+// write on the config repo, and adds the acting teacher as instructor
+// maintainer — shared by `classroom add` and `classroom migrate`. The
+// maintainer add is best-effort: a CurrentUser/membership failure warns but
+// doesn't fail creation (the teacher can self-add via the web).
 func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName string) (*configrepo.StaffTeamsRef, error) {
 	staffTeams, err := configrepo.EnsureStaffTeams(client, org, shortName)
 	if err != nil {
@@ -299,9 +271,7 @@ func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName st
 	}
 	login, _, uerr := githubapi.CurrentUser(client)
 	if uerr != nil || login == "" {
-		// Surface the skip so a silent CurrentUser failure isn't
-		// invisible — the teacher isn't seeded and should know to
-		// self-add.
+		// Surface the skip so a silent CurrentUser failure isn't invisible.
 		_, _ = fmt.Fprintf(errOut, "Warning: created the instructor team but couldn't resolve your GitHub login to add you (%v); add yourself at https://github.com/orgs/%s/teams/%s.\n",
 			uerr, org, staffTeams.Instructor.Slug)
 		return staffTeams, nil
@@ -313,11 +283,9 @@ func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName st
 	return staffTeams, nil
 }
 
-// classroomSummary is the per-classroom view emitted by
-// `classroom list --json`: the human-relevant subset of
-// classroom.json. Active mirrors the classroom/v1 lifecycle flag
-// (omitted when active/absent, false when archived) so a JSON consumer
-// sees the same archived/active state the web does.
+// classroomSummary is the per-classroom view for `classroom list --json`: the
+// human-relevant subset of classroom.json. Active mirrors the lifecycle flag
+// (omitted when active/absent, false when archived).
 type classroomSummary struct {
 	ShortName string              `json:"short_name"`
 	Name      string              `json:"name"`
@@ -373,8 +341,8 @@ func classroomListCmd() *cobra.Command {
 }
 
 // runClassroomList: one branch resolve, one root listing, then one
-// classroom.json read per directory to recover name/term/active. No
-// commit. Archived classrooms (active:false) are dropped unless `all`.
+// classroom.json read per directory. No commit. Archived classrooms
+// (active:false) are dropped unless `all`.
 func runClassroomList(client githubapi.Client, out, errOut io.Writer, org string, asJSON, quiet, all bool) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -434,8 +402,7 @@ func runClassroomList(client githubapi.Client, out, errOut io.Writer, org string
 	return nil
 }
 
-// summarizeClassroomList: one-line stderr summary shaped
-// `<org>/<repo>: <message>` to match other list commands.
+// summarizeClassroomList: one-line stderr summary `<org>/<repo>: <message>`.
 func summarizeClassroomList(org string, count int) string {
 	path := fmt.Sprintf("%s/%s", org, configrepo.ConfigRepoName)
 	switch count {
@@ -491,11 +458,9 @@ func classroomEditCmd() *cobra.Command {
 }
 
 // commitClassroomMutation is the shared read-modify-write skeleton for the
-// classroom.json mutators (edit, archive/unarchive): it reads the file
-// inside the build callback (consistent across rebase attempts), applies
-// `mutate`, and re-commits, short-circuiting to a no-op when the body is
-// unchanged. The caller owns all output; this returns only the no-op flag
-// and the resolved branch (for the caller's "View at" line).
+// classroom.json mutators (edit, archive/unarchive): reads the file inside the
+// build callback, applies `mutate`, re-commits, short-circuiting to a no-op
+// when the body is unchanged. The caller owns all output.
 func commitClassroomMutation(client githubapi.Client, org, shortName, message string, mutate func(*configrepo.ClassroomJSON)) (noop bool, branch string, err error) {
 	branch, err = configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -533,9 +498,8 @@ func commitClassroomMutation(client githubapi.Client, org, shortName, message st
 	return noop, branch, nil
 }
 
-// editClassroom applies only the changed display name/term to
-// classroom.json. A proposed body identical to the on-disk one
-// short-circuits to a no-op.
+// editClassroom applies the changed display name/term to classroom.json. An
+// unchanged body short-circuits to a no-op.
 func editClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName string, setName bool, name string, setTerm bool, term string) error {
 	message := contract.PrefixCommit(fmt.Sprintf("Edit %s classroom (gh teacher classroom edit)", shortName))
 	noop, branch, err := commitClassroomMutation(client, org, shortName, message, func(c *configrepo.ClassroomJSON) {
@@ -558,11 +522,10 @@ func editClassroom(client githubapi.Client, out, errOut io.Writer, org, shortNam
 	return nil
 }
 
-// classroomArchiveCmd / classroomUnarchiveCmd toggle the classroom/v1
-// `active` flag (archive => active:false; unarchive => drop the field, so
-// absent = active per the web's contract). Two verbs rather than an
-// `--active` flag on `edit` so the intent is obvious in shell history and
-// `edit`'s "at least one of --name/--term" contract stays unchanged.
+// classroomArchiveCmd / classroomUnarchiveCmd toggle the `active` flag (archive
+// → active:false; unarchive → drop the field, so absent = active). Two verbs
+// rather than an `--active` flag on `edit` so the intent is obvious and edit's
+// "at least one of --name/--term" contract stays unchanged.
 func classroomArchiveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "archive <org> <short-name>",
@@ -624,8 +587,8 @@ func classroomUnarchiveCmd() *cobra.Command {
 	return cmd
 }
 
-// parseOrgShortNameArgs is the shared <org> <short-name> validation for
-// the classroom subcommands that take exactly that pair.
+// parseOrgShortNameArgs is the shared <org> <short-name> validation for the
+// classroom subcommands that take that pair.
 func parseOrgShortNameArgs(args []string) (org, shortName string, err error) {
 	org = strings.TrimSpace(args[0])
 	shortName = strings.TrimSpace(args[1])
@@ -641,9 +604,8 @@ func parseOrgShortNameArgs(args []string) (org, shortName string, err error) {
 	return org, shortName, nil
 }
 
-// setClassroomActive flips the `active` flag on classroom.json: true clears
-// the field (absent = active), false stamps `active: false`. A no-op when
-// unchanged, so re-archiving / re-activating is harmless.
+// setClassroomActive flips the `active` flag: true clears the field (absent =
+// active), false stamps `active: false`. No-op when unchanged.
 func setClassroomActive(client githubapi.Client, out, errOut io.Writer, org, shortName string, active bool) error {
 	verb, verbCap := "archive", "Archive"
 	if active {
@@ -712,10 +674,9 @@ func classroomRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-// removeClassroom deletes the whole <short-name>/ subtree in one
-// commit via configwrite.CommitTreeChange. The subtree's blob paths are
-// enumerated inside the build callback so the deletion set stays
-// consistent with the parent it commits against.
+// removeClassroom deletes the whole <short-name>/ subtree in one commit via
+// configwrite.CommitTreeChange. The subtree's blob paths are enumerated inside
+// the build callback so the deletion set stays consistent with its parent.
 func removeClassroom(client githubapi.Client, in io.Reader, out, errOut io.Writer, org, shortName string, skipConfirm bool) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -739,12 +700,10 @@ func removeClassroom(client githubapi.Client, in io.Reader, out, errOut io.Write
 	}
 
 	// Resolve the team refs BEFORE the commit deletes classroom.json.
-	// deleteClassroomTeam deletes by the persisted (authoritative) slug
-	// and verifies the id matches, so a re-slugged team is still removed
-	// and an unrelated team that merely occupies the slug is never
-	// touched. A classroom with no team block yields an empty ref
-	// (no-op delete). The staff teams (instructor, ta) are swept the same
-	// way, mirroring the web's classroom-delete team sweep.
+	// DeleteClassroomTeam deletes by the persisted slug and verifies the id,
+	// so a re-slugged team is still removed and an unrelated occupant never
+	// touched. No team block → empty ref (no-op). Staff teams swept the same
+	// way, mirroring the web.
 	var team configrepo.TeamRef
 	if t, ok, terr := configrepo.ResolveClassroomTeam(client, org, shortName, branch); terr != nil {
 		return terr
@@ -782,9 +741,9 @@ func removeClassroom(client githubapi.Client, in io.Reader, out, errOut io.Write
 	}
 	_, _ = fmt.Fprintf(out, "%s/%s: removed classroom %s (%d files)\n", org, configrepo.ConfigRepoName, shortName, deleted)
 
-	// Delete the per-classroom team (idempotent; 404 = already gone).
-	// The team's repo grants + memberships go with it. A delete failure
-	// is surfaced but doesn't undo the config removal.
+	// Delete the per-classroom team (idempotent; 404 = gone). Its grants +
+	// memberships go with it. A delete failure is surfaced but doesn't undo
+	// the config removal.
 	if team.Slug != "" {
 		if err := configrepo.DeleteClassroomTeam(client, org, team); err != nil {
 			_, _ = fmt.Fprintf(errOut, "Warning: %s: removed the classroom config but could not delete its team %q (%v); delete it by hand at https://github.com/orgs/%s/teams if it lingers.\n",
@@ -793,9 +752,8 @@ func removeClassroom(client githubapi.Client, in io.Reader, out, errOut io.Write
 		}
 		_, _ = fmt.Fprintf(out, "%s: deleted classroom team %s\n", org, team.Slug)
 	}
-	// Sweep the staff teams too (idempotent; 404 = already gone). A
-	// failure on one is surfaced but doesn't undo the config removal or
-	// block the others.
+	// Sweep the staff teams too (idempotent; 404 = gone). A failure on one is
+	// surfaced but doesn't undo the config removal or block the others.
 	for _, st := range staffTeams {
 		if err := configrepo.DeleteClassroomTeam(client, org, st); err != nil {
 			_, _ = fmt.Fprintf(errOut, "Warning: %s: removed the classroom config but could not delete its staff team %q (%v); delete it by hand at https://github.com/orgs/%s/teams if it lingers.\n",
@@ -807,10 +765,9 @@ func removeClassroom(client githubapi.Client, in io.Reader, out, errOut io.Write
 	return nil
 }
 
-// confirmClassroomRemove prompts on `out` and reads one line from
-// `in`. Returns nil iff the trimmed line equals the short-name; any
-// other input (mismatch, EOF, read error) aborts. Single read — no
-// retry (mirrors internal/teardown's confirmTeardown).
+// confirmClassroomRemove prompts on `out` and reads one line from `in`. Returns
+// nil iff the trimmed line equals the short-name; any other input (mismatch,
+// EOF, error) aborts. Single read, no retry.
 func confirmClassroomRemove(in io.Reader, out io.Writer, shortName string) error {
 	_, _ = fmt.Fprintf(out, "This will delete classroom %q and all its files. Type the short-name (%s) to confirm: ", shortName, shortName)
 	line, err := bufio.NewReader(in).ReadString('\n')
@@ -823,13 +780,10 @@ func confirmClassroomRemove(in io.Reader, out io.Writer, shortName string) error
 	return nil
 }
 
-// classroomScaffold returns destination-path → content for the
-// four-file scaffold. A nil `entries` is normalized to an empty
-// slice so assignments.json marshals as `[]` (not the `null` Go
-// would otherwise produce). `entries` populates assignments.json
-// through assignment.EncodeAssignments (same normalization as
-// `gh teacher assignment add`); `migration` populates the optional
-// `migrated_from` block on classroom.json.
+// classroomScaffold returns destination-path → content for the four-file
+// scaffold. A nil `entries` normalizes to an empty slice so assignments.json
+// marshals as `[]`. `migration` populates classroom.json's optional
+// `migrated_from` block.
 func classroomScaffold(org, shortName, name, term, secret string, entries []assignment.AssignmentEntry, migration *configrepo.MigratedFromRef, team *configrepo.TeamRef, staffTeams *configrepo.StaffTeamsRef) (map[string]string, error) {
 	classroom := configrepo.ClassroomJSON{
 		Schema:       classroomSchemaV1,

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -17,11 +17,9 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// classroomMigrateCmd implements `gh teacher classroom migrate`:
-// reads a GitHub Classroom source, copies each starter repo as a
-// fresh template in the target org, and commits the matching
-// classroom directory (classroom.json / assignments.json /
-// students.csv / scores.json) to <target>/classroom50.
+// classroomMigrateCmd implements `gh teacher classroom migrate`: reads a GitHub
+// Classroom source, copies each starter repo as a fresh template in the target
+// org, and commits the matching classroom directory to <target>/classroom50.
 func classroomMigrateCmd() *cobra.Command {
 	var (
 		source          string
@@ -109,8 +107,7 @@ func classroomMigrateCmd() *cobra.Command {
 	return cmd
 }
 
-// migrateOptions packages the CLI flags runMigrate consumes so
-// tests can call it directly without going through cobra.
+// migrateOptions packages runMigrate's flags so tests can call it directly.
 type migrateOptions struct {
 	Source          string
 	Target          string
@@ -149,8 +146,8 @@ func runMigrate(client githubapi.Client, out, errOut io.Writer, opts migrateOpti
 	return performMigration(client, out, errOut, plan, opts.TemplateSuffix)
 }
 
-// discoverMigration runs discovery: resolves --source, derives the
-// short-name, and fetches every assignment detail.
+// discoverMigration resolves --source, derives the short-name, and fetches
+// every assignment detail.
 func discoverMigration(client githubapi.Client, errOut io.Writer, opts migrateOptions) (migrationPlan, error) {
 	detail, err := resolveSource(client, errOut, opts.Source, opts.IncludeArchived)
 	if err != nil {
@@ -167,12 +164,10 @@ func discoverMigration(client githubapi.Client, errOut io.Writer, opts migrateOp
 	if err := validate.ShortName(shortNameVal, "short-name"); err != nil {
 		return migrationPlan{}, err
 	}
-	// A migrated classroom gets a GitHub team (classroom50-<short>);
-	// reject a short-name GitHub would slugify differently (consecutive
-	// or trailing hyphens) up front, before runTemplateCopy generates
-	// any repos — otherwise ensureClassroomTeam would hard-fail later
-	// and orphan the freshly-created templates. Auto-derived short-names
-	// are already canonical; this guards an explicit --short-name.
+	// A migrated classroom gets a team (classroom50-<short>); reject a
+	// short-name GitHub would slugify differently up front, before any repos
+	// are generated, so ensureClassroomTeam can't hard-fail later and orphan
+	// the templates. Auto-derived short-names are already canonical.
 	if !configrepo.CanonicalTeamSlugShortName(shortNameVal) {
 		return migrationPlan{}, fmt.Errorf("short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking membership and template grants)", shortNameVal)
 	}
@@ -192,20 +187,18 @@ func discoverMigration(client githubapi.Client, errOut io.Writer, opts migrateOp
 	}, nil
 }
 
-// performMigration runs template copy followed by a single Tree
-// commit on <target>/classroom50. Returns a non-nil error when any
-// assignment was skipped during template copy — best-effort: the
-// commit still lands with the successful entries, the non-zero
-// exit code signals partial completion.
+// performMigration runs template copy then a single Tree commit on
+// <target>/classroom50. Returns a non-nil error when any assignment was
+// skipped — best-effort: the commit lands with the successful entries and the
+// non-zero exit signals partial completion.
 func performMigration(client githubapi.Client, out, errOut io.Writer, plan migrationPlan, templateSuffix string) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, plan.TargetOrg)
 	if err != nil {
 		return err
 	}
 
-	// Fail fast on the common "already exists" case before any
-	// template repos get created. The configwrite.CommitTree build callback
-	// re-probes for race-safety against a concurrent writer.
+	// Fail fast on "already exists" before any template repos get created. The
+	// build callback re-probes for race-safety.
 	exists, err := configrepo.ContentsExists(client, plan.TargetOrg, configrepo.ConfigRepoName, plan.ShortName, branch)
 	if err != nil {
 		return err
@@ -224,16 +217,15 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	migration := classroomMigratedFromFromDetail(plan.Classroom, plan.MigratedAt)
 
 	// Create (or adopt) the per-classroom team so its ref lands in
-	// classroom.json, same as `gh teacher classroom add`.
+	// classroom.json, same as `classroom add`.
 	team, err := configrepo.EnsureClassroomTeam(client, plan.TargetOrg, plan.ShortName)
 	if err != nil {
 		return fmt.Errorf("create classroom team: %w", err)
 	}
 
-	// Preflight the existence check before seeding staff teams, so a
-	// classroom that already exists in the target fails fast without
-	// orphaning freshly-created write-granted staff teams. The in-build
-	// check below stays as the authoritative concurrent-writer guard.
+	// Re-probe existence before seeding staff teams so an already-existing
+	// classroom fails fast without orphaning write-granted staff teams. The
+	// in-build check is the authoritative concurrent-writer guard.
 	if exists, err := configrepo.ContentsExists(client, plan.TargetOrg, configrepo.ConfigRepoName, plan.ShortName, branch); err != nil {
 		return err
 	} else if exists {
@@ -241,10 +233,8 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 			plan.ShortName, plan.TargetOrg, configrepo.ConfigRepoName)
 	}
 
-	// Create (or adopt) the staff teams (instructor, ta) + config-repo
-	// write grant + instructor-maintainer seed, same as `gh teacher
-	// classroom add`, so a migrated classroom carries the role teams the
-	// web GUI expects.
+	// Create (or adopt) staff teams + config-repo write grant + instructor
+	// seed, same as `classroom add`.
 	staffTeams, err := seedStaffTeams(client, errOut, plan.TargetOrg, plan.ShortName)
 	if err != nil {
 		return err
@@ -259,9 +249,9 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 			return nil, fmt.Errorf("classroom %q appeared in %s/%s mid-commit (concurrent writer?)",
 				plan.ShortName, plan.TargetOrg, configrepo.ConfigRepoName)
 		}
-		// Migrated classrooms get a plain (guessable) URL — unlisted is an
-		// opt-in `classroom add --unlisted` concern and a bulk import can't
-		// block on its prompt, so pass an empty key.
+		// Migrated classrooms get a plain (guessable) URL — unlisted is a
+		// `classroom add --unlisted` opt-in and a bulk import can't block on
+		// its prompt, so pass an empty key.
 		return classroomScaffold(plan.TargetOrg, plan.ShortName, plan.Classroom.Name, plan.Term, "", entries, migration, &team, staffTeams)
 	}
 
@@ -274,14 +264,11 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 
 	printMigrationSummary(out, errOut, plan, resolved, entries, commitSHA, branch)
 
-	// Grant the classroom team read on any migrated template that is
-	// private. Migrated templates are copied into the target org, so a
-	// private one is the in-org-private case `assignment add` handles —
-	// without this grant, `gh student accept` would 404 generating from
-	// it (same fix, applied to the migrate path). Gate on the TARGET
-	// repo's actual visibility (correct for both Generated and Reused),
-	// use the team's authoritative slug, and track failures so the exit
-	// code reflects a template students can't yet accept.
+	// Grant the classroom team read on any private migrated template. A private
+	// template is the in-org-private case `assignment add` handles — without
+	// the grant, `student accept` 404s generating from it. Gate on the TARGET
+	// repo's visibility, use the team's authoritative slug, and track failures
+	// so the exit code reflects a template students can't yet accept.
 	var grantFailures int
 	for i := range resolved {
 		rt := resolved[i]
@@ -311,10 +298,9 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	return nil
 }
 
-// buildMigratedEntries materializes the assignment.AssignmentEntry slice for
-// the commit. A commit-time mapping failure (unreachable in normal
-// operation since copyOneTemplate pre-validates) is recorded as a
-// Skipped action so post-commit counts + exit code stay accurate.
+// buildMigratedEntries materializes the AssignmentEntry slice for the commit. A
+// commit-time mapping failure (unreachable in normal operation) is recorded as
+// a Skipped action so post-commit counts + exit code stay accurate.
 func buildMigratedEntries(errOut io.Writer, plan migrationPlan, resolved []resolvedTemplate) []assignment.AssignmentEntry {
 	out := make([]assignment.AssignmentEntry, 0, len(resolved))
 	for i := range resolved {
@@ -333,10 +319,9 @@ func buildMigratedEntries(errOut io.Writer, plan migrationPlan, resolved []resol
 	return out
 }
 
-// printMigrationSummary writes the parseable post-commit result to
-// stdout (one anchor line + per-file deltas) and follow-up advice
-// to stderr. All counts come from the committed entries so the
-// summary stays consistent with what landed on disk.
+// printMigrationSummary writes the parseable post-commit result to stdout (one
+// anchor line + per-file deltas) and follow-up advice to stderr. Counts come
+// from the committed entries.
 func printMigrationSummary(out, errOut io.Writer, plan migrationPlan, resolved []resolvedTemplate, entries []assignment.AssignmentEntry, commitSHA, branch string) {
 	generated, reused, skipped := countTemplateActions(resolved)
 	indiv, group := countEntriesByMode(entries)
@@ -367,8 +352,7 @@ func printMigrationSummary(out, errOut io.Writer, plan migrationPlan, resolved [
 }
 
 // printMigrationPlan writes the plan to stdout in source-API order
-// (deterministic so callers can pipe it). Stderr advisory output is
-// the caller's responsibility.
+// (deterministic so callers can pipe it).
 func printMigrationPlan(out io.Writer, plan migrationPlan) error {
 	indiv, group, other := plan.countsByMode()
 	noun := "assignment"

--- a/cli/gh-teacher/internal/classroom/migrate_source.go
+++ b/cli/gh-teacher/internal/classroom/migrate_source.go
@@ -20,13 +20,12 @@ const classroomAPIPerPage = 100
 // never returns an empty page can't pin migrate in a loop.
 const classroomMigrateSourcePagesMax = 100
 
-// allDigits classifies --source values: digits → classroom ID,
-// otherwise org login.
+// allDigits classifies --source: digits → classroom ID, else org login.
 var allDigits = regexp.MustCompile(`^\d+$`)
 
-// classroomListItem is one row of `GET /classrooms`. The listing
-// does NOT carry `organization`, so org-by-source resolution needs
-// a follow-up `GET /classrooms/{id}` per row.
+// classroomListItem is one row of `GET /classrooms`. The listing lacks
+// `organization`, so org-by-source resolution needs a follow-up
+// `GET /classrooms/{id}` per row.
 type classroomListItem struct {
 	ID       int64  `json:"id"`
 	Name     string `json:"name"`
@@ -53,10 +52,9 @@ type classroomDetailOrganization struct {
 	AvatarURL string  `json:"avatar_url"`
 }
 
-// classroomAssignmentListItem is one row of
-// `GET /classrooms/{id}/assignments`. The listing does NOT carry
-// `starter_code_repository`; that requires a per-row
-// `GET /assignments/{id}`.
+// classroomAssignmentListItem is one row of `GET /classrooms/{id}/assignments`.
+// The listing lacks `starter_code_repository`; that needs `GET
+// /assignments/{id}`.
 type classroomAssignmentListItem struct {
 	ID    int64  `json:"id"`
 	Title string `json:"title"`
@@ -64,10 +62,8 @@ type classroomAssignmentListItem struct {
 	Type  string `json:"type"`
 }
 
-// classroomAssignmentDetail is `GET /assignments/{id}`. Deadline
-// stays *string because the API returns JSON null when unset;
-// distinguishing null from "" matters (the latter would silently
-// land as Go's zero-value).
+// classroomAssignmentDetail is `GET /assignments/{id}`. Deadline stays *string
+// because the API returns null when unset; null vs "" matters.
 type classroomAssignmentDetail struct {
 	ID              int64                     `json:"id"`
 	PublicRepo      bool                      `json:"public_repo"`
@@ -81,8 +77,8 @@ type classroomAssignmentDetail struct {
 	Classroom       classroomListItem         `json:"classroom"`
 }
 
-// classroomStarterCodeRepo carries only the source-starter fields
-// migrate consumes — target template ref + migrated_from.starter_repo.
+// classroomStarterCodeRepo carries only the source-starter fields migrate
+// consumes.
 type classroomStarterCodeRepo struct {
 	ID            int64  `json:"id"`
 	Name          string `json:"name"`
@@ -91,8 +87,7 @@ type classroomStarterCodeRepo struct {
 	DefaultBranch string `json:"default_branch"`
 }
 
-// getClassroom calls `GET /classrooms/{id}`; 404 → an actionable
-// error pointing the teacher at `gh classroom list`.
+// getClassroom calls `GET /classrooms/{id}`; 404 → an actionable error.
 func getClassroom(client githubapi.Client, id int64) (classroomDetail, error) {
 	path := fmt.Sprintf("classrooms/%d", id)
 	var out classroomDetail
@@ -137,13 +132,11 @@ func getClassroomAssignment(client githubapi.Client, assignmentID int64) (classr
 	return out, nil
 }
 
-// resolveSource maps a --source value to a single classroom:
-// all-digits → GET /classrooms/{id} directly (archived resolves
-// with a stderr warning); otherwise → list classrooms, filter by
-// organization.login (case-insensitive), skip archived unless
-// includeArchived. Multi-match enumerates with IDs and asks for
-// re-run with --source <id>. The org-login path exists because
-// GitHub Classroom is 1:1 with orgs.
+// resolveSource maps a --source value to a single classroom: all-digits → GET
+// /classrooms/{id} (archived resolves with a warning); else list classrooms and
+// filter by organization.login (case-insensitive), skipping archived unless
+// includeArchived. Multi-match enumerates IDs and asks for --source <id>. The
+// org-login path exists because GitHub Classroom is 1:1 with orgs.
 func resolveSource(client githubapi.Client, errOut io.Writer, source string, includeArchived bool) (classroomDetail, error) {
 	source = strings.TrimSpace(source)
 	if source == "" {
@@ -181,8 +174,8 @@ func resolveSource(client githubapi.Client, errOut io.Writer, source string, inc
 		}
 		detail, err := getClassroom(client, row.ID)
 		if err != nil {
-			// A stale listing row or mid-loop access loss
-			// shouldn't kill the whole resolution.
+			// A stale listing row or mid-loop access loss shouldn't kill the
+			// whole resolution.
 			_, _ = fmt.Fprintf(errOut, "Warning: skipping classroom %d (%q) during org resolution: %v\n", row.ID, row.Name, err)
 			continue
 		}

--- a/cli/gh-teacher/internal/classroom/migrate_template.go
+++ b/cli/gh-teacher/internal/classroom/migrate_template.go
@@ -15,8 +15,7 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// templateAction classifies what the template-copy phase did for
-// one source assignment.
+// templateAction classifies what template-copy did for one source assignment.
 type templateAction string
 
 const (
@@ -25,26 +24,21 @@ const (
 	templateActionSkipped   templateAction = "skipped"
 )
 
-// resolvedTemplate is the per-assignment outcome of template copy.
-// Skipped entries record the reason on stderr; the commit phase
-// omits them from assignments.json but the rest of the migration
-// still lands.
+// resolvedTemplate is the per-assignment outcome of template copy. Skipped
+// entries are omitted from assignments.json; the rest of the migration lands.
 type resolvedTemplate struct {
 	Assignment classroomAssignmentDetail
 	Template   assignment.TemplateRef
 	Action     templateAction
 	SkipReason string
-	// TargetPrivate is the visibility of the TARGET template repo (the
-	// copy in the org), not the source. For a Generated copy it inherits
-	// the source's privacy; for a Reused pre-existing target it's read
-	// from the probe. The team read-grant gates on this so the Reused
-	// branch can't mis-decide when the target's visibility differs from
-	// the source's.
+	// TargetPrivate is the TARGET template repo's visibility (the copy in the
+	// org), not the source. The team read-grant gates on this so the Reused
+	// branch can't mis-decide when target and source visibility differ.
 	TargetPrivate bool
 }
 
-// targetRepoProbe classifies the target template repo before
-// generate runs. The default branch is populated only when Exists.
+// targetRepoProbe classifies the target template repo before generate runs.
+// Branch is populated only when Exists.
 type targetRepoProbe struct {
 	Exists     bool
 	IsTemplate bool
@@ -52,9 +46,8 @@ type targetRepoProbe struct {
 	Private    bool
 }
 
-// probeTargetRepo calls GET /repos/{owner}/{repo} and returns its
-// existence + is_template status. 404 is the safe-to-generate path;
-// any other error propagates.
+// probeTargetRepo GETs the target repo, returning existence + is_template. 404
+// is the safe-to-generate path; any other error propagates.
 func probeTargetRepo(client githubapi.Client, owner, repo string) (targetRepoProbe, error) {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
 	var resp struct {
@@ -87,12 +80,9 @@ func verifySourceIsTemplate(client githubapi.Client, owner, repo string) (bool, 
 	return resp.IsTemplate, nil
 }
 
-// generateFromTemplate calls POST /repos/{src}/{repo}/generate
-// to create a new repo from the source template. Returns the new
-// repo's default branch so the caller doesn't need a follow-up GET.
-//
-// `private` defaults to false on the API; we always pass it
-// explicitly so the target inherits the source's privacy.
+// generateFromTemplate POSTs .../generate to create a new repo from the source
+// template, returning the new default branch. `private` is always passed so the
+// target inherits the source's privacy.
 func generateFromTemplate(client githubapi.Client, srcOwner, srcRepo, targetOwner, targetName, description string, private bool) (string, error) {
 	body, err := json.Marshal(struct {
 		Owner              string `json:"owner"`
@@ -128,16 +118,16 @@ func generateFromTemplate(client githubapi.Client, srcOwner, srcRepo, targetOwne
 		return "", fmt.Errorf("decode generate response: %w", err)
 	}
 	if out.DefaultBranch == "" {
-		// Defensive: a missing default_branch would silently land
-		// an unusable assignment.TemplateRef on disk.
+		// Defensive: a missing default_branch would land an unusable
+		// TemplateRef on disk.
 		return "", fmt.Errorf("POST %s: response missing default_branch", path)
 	}
 	return out.DefaultBranch, nil
 }
 
-// markAsTemplate flips the repo's `is_template` flag via PATCH.
-// `generate` always produces a non-template repo, so this is the
-// follow-up that makes the new repo usable for `gh student accept`.
+// markAsTemplate flips the repo's `is_template` flag via PATCH. `generate`
+// always produces a non-template repo, so this makes it usable for `student
+// accept`.
 func markAsTemplate(client githubapi.Client, owner, repo string) error {
 	body, err := json.Marshal(struct {
 		IsTemplate bool `json:"is_template"`
@@ -158,9 +148,8 @@ func markAsTemplate(client githubapi.Client, owner, repo string) error {
 	return nil
 }
 
-// targetTemplateName returns the target repo name for one assignment
-// — slug, optionally with a user-supplied suffix to escape
-// collisions with existing target-org repos.
+// targetTemplateName returns the target repo name — slug, optionally with a
+// user-supplied suffix to escape collisions.
 func targetTemplateName(slug, suffix string) string {
 	if suffix == "" {
 		return slug
@@ -168,9 +157,8 @@ func targetTemplateName(slug, suffix string) string {
 	return slug + "-" + suffix
 }
 
-// runTemplateCopy walks every source assignment through validate →
-// probe → generate → mark-as-template, in plan order so downstream
-// commit + output stay deterministic. Best-effort: a per-assignment
+// runTemplateCopy walks every source assignment through validate → probe →
+// generate → mark-as-template, in plan order. Best-effort: a per-assignment
 // failure becomes a Skipped resolvedTemplate, not a hard error.
 func runTemplateCopy(client githubapi.Client, errOut io.Writer, plan migrationPlan, templateSuffix string) ([]resolvedTemplate, error) {
 	out := make([]resolvedTemplate, 0, len(plan.Assignments))
@@ -184,30 +172,25 @@ func runTemplateCopy(client githubapi.Client, errOut io.Writer, plan migrationPl
 	return out, nil
 }
 
-// copyOneTemplate handles a single source assignment. The decision
-// table:
+// copyOneTemplate handles a single source assignment:
 //
-//   - slug or mode would fail downstream assignment.AssignmentEntry validation → skip
+//   - slug/mode fails downstream validation → skip
 //   - source repo missing or not a template → skip
 //   - target name 404 → generate + mark + wait for branch to stabilize
 //   - target name exists + is_template → reuse
 //   - target name exists + !is_template → skip with collision error
 //
-// All skip reasons are recorded on `errOut` so a teacher can see
-// what didn't make it before the commit phase runs. classroomID
-// comes from the discovery context (plan.Classroom.ID), not from
-// `a.Classroom.ID`, which the Classroom API doesn't reliably
-// populate on the assignment-detail response.
+// Skip reasons are recorded on `errOut`. classroomID comes from the discovery
+// context, not `a.Classroom.ID` (unreliable on the assignment-detail response).
 func copyOneTemplate(client githubapi.Client, errOut io.Writer, targetOrg, templateSuffix string, classroomID int64, a classroomAssignmentDetail) (resolvedTemplate, error) {
 	skip := func(reason string) resolvedTemplate {
 		_, _ = fmt.Fprintf(errOut, "Skipping %q: %s\n", a.Slug, reason)
 		return resolvedTemplate{Assignment: a, Action: templateActionSkipped, SkipReason: reason}
 	}
 
-	// Validate the shape downstream assignment.AssignmentEntry needs BEFORE
-	// any API writes — otherwise a bad slug or mode would generate
-	// a template repo and then drop the entry at commit time,
-	// orphaning the generated repo.
+	// Validate the shape downstream AssignmentEntry needs BEFORE any API writes
+	// — otherwise a bad slug/mode generates a template repo, then drops the
+	// entry at commit time, orphaning the repo.
 	if err := validate.ShortName(a.Slug, "slug"); err != nil {
 		return skip(err.Error()), nil
 	}
@@ -262,16 +245,14 @@ func copyOneTemplate(client githubapi.Client, errOut io.Writer, targetOrg, templ
 			targetOrg, targetName, a.Slug, err, targetOrg, targetName)
 		return resolvedTemplate{Assignment: a, Action: templateActionSkipped, SkipReason: "is_template PATCH failed: " + err.Error()}, nil
 	}
-	// Wait for the freshly-generated branch ref to propagate
-	// before downstream `gh student accept` runs against it —
-	// otherwise students hit transient 409 "Git Repository is
-	// empty" from the contents/git-data APIs.
+	// Wait for the freshly-generated branch ref to propagate before downstream
+	// `student accept` runs against it — otherwise students hit transient 409
+	// "Git Repository is empty".
 	if err := githubapi.WaitForStableBranch(client, targetOrg, targetName, branch); err != nil {
 		_, _ = fmt.Fprintf(errOut, "Generated %s/%s for %q but branch %q did not stabilize: %v — students may need to retry `gh student accept` shortly.\n",
 			targetOrg, targetName, a.Slug, branch, err)
-		// Non-fatal: the repo exists and is marked as a template;
-		// the wait was a courtesy. Record as generated so the
-		// commit still includes the entry.
+		// Non-fatal: the repo exists and is a template; the wait was a
+		// courtesy. Record as generated so the commit includes the entry.
 	}
 
 	return resolvedTemplate{
@@ -282,9 +263,8 @@ func copyOneTemplate(client githubapi.Client, errOut io.Writer, targetOrg, templ
 	}, nil
 }
 
-// splitOwnerRepo splits a `<owner>/<repo>` full-name into its parts.
-// Empty/multi-slash inputs are rejected so a malformed source can't
-// silently mis-route the generate call.
+// splitOwnerRepo splits a `<owner>/<repo>` full-name. Empty/multi-slash inputs
+// are rejected so a malformed source can't mis-route the generate call.
 func splitOwnerRepo(fullName string) (owner, repo string, err error) {
 	parts := strings.Split(fullName, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -309,10 +289,8 @@ func countTemplateActions(resolved []resolvedTemplate) (generated, reused, skipp
 	return generated, reused, skipped
 }
 
-// countEntriesByMode tallies the committed entries' mode for the
-// post-commit summary. Computed from the entries themselves (not
-// from the pre-skip plan) so the summary can't disagree with what
-// landed in assignments.json.
+// countEntriesByMode tallies committed entries' mode. Computed from the entries
+// (not the pre-skip plan) so the summary can't disagree with what landed.
 func countEntriesByMode(entries []assignment.AssignmentEntry) (individual, group int) {
 	for _, e := range entries {
 		switch e.Mode {

--- a/cli/gh-teacher/internal/classroom/migrate_translate.go
+++ b/cli/gh-teacher/internal/classroom/migrate_translate.go
@@ -20,10 +20,9 @@ const migrateSourceGitHubClassroom = "github_classroom"
 // a hyphen before the runs-of-hyphens collapse.
 var shortNameDeriveReplace = regexp.MustCompile(`[^a-z0-9]+`)
 
-// deriveShortName slugifies a free-form classroom name into a value
-// that passes shortNamePattern: lowercase → replace non-alnum with
-// `-` → collapse runs → trim → truncate to 39 chars → validate. On
-// validation failure returns an actionable error asking for an
+// deriveShortName slugifies a free-form classroom name into a value that passes
+// ShortNamePattern (lowercase → replace non-alnum with `-` → collapse → trim →
+// truncate to 39 → validate). On failure returns an error asking for an
 // explicit --short-name.
 func deriveShortName(raw string) (string, error) {
 	lowered := strings.ToLower(strings.TrimSpace(raw))
@@ -54,11 +53,9 @@ func classroomMigratedFromFromDetail(detail classroomDetail, migratedAt time.Tim
 	}
 }
 
-// assignmentToEntry maps a source assignment + a resolved target
-// template ref into the on-disk assignment.AssignmentEntry. targetTemplate is
-// the post-copy template repo in the target org; the source
-// `starter_code_repository` lives in migrated_from.starter_repo.
-// Errors on shapes that produce an invalid on-disk entry.
+// assignmentToEntry maps a source assignment + resolved target template ref
+// into the on-disk AssignmentEntry. targetTemplate is the post-copy repo; the
+// source starter lives in migrated_from.starter_repo. Errors on invalid shapes.
 func assignmentToEntry(
 	detail classroomAssignmentDetail,
 	classroomID int64,
@@ -75,18 +72,15 @@ func assignmentToEntry(
 		return assignment.AssignmentEntry{}, fmt.Errorf("source assignment %d (%q) has unknown type %q (must be one of %v)", detail.ID, detail.Slug, detail.Type, assignment.AssignmentModes)
 	}
 
-	// Deadline is nullable in source; a non-null value is dropped
-	// unless it parses as an RFC 3339 timestamp WITH an offset --
-	// `due` is advisory and shouldn't abort the migration, and a
-	// zone-less source value has no knowable zone to normalize from,
-	// so guessing UTC would silently shift the deadline. A valid
-	// deadline is normalized to a UTC instant, with the verbatim
-	// source value preserved in due_meta for the audit trail.
+	// Deadline is nullable in source; a non-null value is dropped unless it
+	// parses as RFC 3339 WITH an offset — `due` is advisory, and a zone-less
+	// value has no knowable zone (guessing UTC would shift the deadline). A
+	// valid deadline normalizes to UTC, with the source value kept in due_meta.
 	due := ""
 	var dueProvenance *assignment.DueMeta
 	if detail.Deadline != nil {
-		// loc is unused for an offset-bearing value; the hadOffset
-		// guard below rejects the zone-less case outright.
+		// loc is unused for an offset-bearing value; the hadOffset guard
+		// rejects the zone-less case.
 		if t, hadOffset, err := assignment.ParseDueTime(*detail.Deadline, time.UTC); err == nil && hadOffset {
 			due = t.UTC().Format(time.RFC3339)
 			dueProvenance = assignment.NewDueMeta(*detail.Deadline, t, assignment.DueSourceMigrated)
@@ -104,11 +98,9 @@ func assignmentToEntry(
 		mig.StarterRepo = detail.StarterCodeRepo.FullName
 	}
 
-	// Group assignments must carry a usable max_group_size. Use the
-	// source classroom's max_teams when it reports a sane value (>= 2);
-	// otherwise fall back to the cap so a migration never fails on a
-	// missing/odd source value — the teacher can tighten it later via
-	// `gh teacher assignment add --mode group --max-group-size`.
+	// Group assignments need a usable max_group_size. Use the source's
+	// max_teams when sane (2..cap); else fall back to the cap so migration
+	// never fails on a missing/odd value (the teacher can tighten it later).
 	maxGroupSize := 0
 	if detail.Type == assignment.ModeGroup {
 		if detail.MaxTeams != nil && *detail.MaxTeams >= 2 && *detail.MaxTeams <= assignment.MaxGroupSizeCap {

--- a/cli/gh-teacher/internal/cliutil/doc.go
+++ b/cli/gh-teacher/internal/cliutil/doc.go
@@ -1,10 +1,5 @@
-// Package cliutil holds the cross-cutting CLI helpers that every domain
-// of gh-teacher reaches for but that are not themselves domain logic:
-// the HTTP-status predicate. (The authenticated-client constructor lives
-// in internal/githubapi since it builds a client.)
-//
-// It exists so the per-domain files can depend on a small, named seam
-// instead of sharing one flat package main namespace. It deliberately
-// stays free of GitHub-API types beyond what the auth scaffolding
-// returns; the API transport seam lives in internal/githubapi.
+// Package cliutil holds cross-cutting CLI helpers that aren't domain logic:
+// the HTTP-status predicate. It gives per-domain files a small named seam
+// instead of one flat package main namespace, and stays free of GitHub-API
+// types (the transport seam lives in internal/githubapi).
 package cliutil

--- a/cli/gh-teacher/internal/cliutil/httpstatus.go
+++ b/cli/gh-teacher/internal/cliutil/httpstatus.go
@@ -2,10 +2,9 @@ package cliutil
 
 import "github.com/foundation50/classroom50-cli-shared/ghutil"
 
-// IsHTTPStatus reports whether err is a *api.HTTPError with the given
-// status code. Thin wrapper over the shared ghutil helper, exposed here
-// so domain packages can branch on GitHub status codes without each
-// importing the shared package directly.
+// IsHTTPStatus reports whether err is a *api.HTTPError with the given status.
+// Thin wrapper over the shared ghutil helper so domain packages don't import
+// the shared package directly.
 func IsHTTPStatus(err error, code int) bool {
 	return ghutil.IsHTTPStatus(err, code)
 }

--- a/cli/gh-teacher/internal/configrepo/assignments.go
+++ b/cli/gh-teacher/internal/configrepo/assignments.go
@@ -7,11 +7,10 @@ import (
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 )
 
-// LoadAssignments reads and parses a classroom's assignments.json from
-// the config repo at `ref`. Mirrors LoadRoster / LoadClassroom: the
-// read substrate lives here, the typed shape + parse/validate logic
-// lives in internal/assignment. A missing file is surfaced as an
-// actionable error (it should exist once `classroom add` has run).
+// LoadAssignments reads and parses a classroom's assignments.json at `ref`.
+// Mirrors LoadRoster/LoadClassroom: the read substrate lives here, the typed
+// shape + parse logic in internal/assignment. A missing file is an actionable
+// error.
 func LoadAssignments(client githubapi.Client, org, classroom, ref string) (assignment.AssignmentsJSON, error) {
 	path := assignment.AssignmentsFilePath(classroom)
 	data, ok, err := ReadFileContents(client, org, ConfigRepoName, path, ref)

--- a/cli/gh-teacher/internal/configrepo/classroom.go
+++ b/cli/gh-teacher/internal/configrepo/classroom.go
@@ -9,9 +9,7 @@ import (
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 )
 
-// ClassroomJSON is the typed shape of a classroom's classroom.json
-// metadata record. assignments.json's typed shape lives elsewhere (the
-// assignment domain). MigratedFrom omits cleanly when absent.
+// ClassroomJSON is the typed shape of a classroom's classroom.json metadata.
 type ClassroomJSON struct {
 	Schema    string `json:"schema"`
 	Name      string `json:"name"`
@@ -19,38 +17,28 @@ type ClassroomJSON struct {
 	Term      string `json:"term"`
 	Org       string `json:"org"`
 	// Secret is the optional capability-URL path segment. When set,
-	// publish-pages serves this classroom's resources under
-	// `<classroom>/<secret>/...` (every consumer inserts it); empty = the
-	// plain path. Opt-in per classroom, so omitted on unprotected classrooms.
+	// publish-pages serves resources under `<classroom>/<secret>/...`; empty =
+	// plain path. Opt-in, so omitted on unprotected classrooms.
 	Secret string `json:"secret,omitempty"`
-	// Team is the per-classroom GitHub team that grants rostered
-	// students read on private, org-owned assignment templates.
-	// Populated by `classroom add`; omitted on classrooms created
-	// before this feature.
+	// Team is the per-classroom team granting rostered students read on
+	// private org-owned templates. Omitted on pre-feature classrooms.
 	Team *TeamRef `json:"team,omitempty"`
-	// Per-classroom staff teams (instructor, ta) backing the web GUI's in-app
-	// roles. Web-authored; the CLI only tolerates and round-trips it. Omitted
-	// on classrooms created before the feature.
+	// Teams: per-classroom staff teams backing the web GUI's in-app roles.
+	// Web-authored; the CLI tolerates and round-trips it.
 	Teams *StaffTeamsRef `json:"teams,omitempty"`
-	// Active is the classroom/v1 lifecycle flag: `false` = archived,
-	// `true` or ABSENT = active. A *pointer so "archived" stays distinct
-	// from "legacy classroom that never wrote the key" (both nil/true =
-	// active), and omitempty so it's stamped only when a teacher toggles
-	// archive/unarchive. Mirrors the web's `active === false` archival check.
+	// Active is the lifecycle flag: false = archived, true or ABSENT = active.
+	// A pointer so "archived" stays distinct from "legacy that never wrote the
+	// key"; omitempty so it's stamped only on archive/unarchive.
 	Active       *bool            `json:"active,omitempty"`
 	MigratedFrom *MigratedFromRef `json:"migrated_from,omitempty"`
 
-	// Extra holds unknown top-level keys, re-emitted verbatim so the
-	// archive/unarchive/edit read-modify-write never drops a field a newer
-	// binary/web GUI added ("tolerate AND preserve", mirroring
-	// AssignmentEntry.Extra). Merged in/out by the custom (Un)MarshalJSON
-	// below, so it never appears as a literal "extra" key on the wire.
+	// Extra holds unknown top-level keys, re-emitted verbatim so
+	// archive/unarchive/edit never drop a field a newer binary/GUI added.
 	Extra map[string]json.RawMessage `json:"-"`
 }
 
-// knownClassroomKeys is the top-level classroom.json keys this binary
-// understands; any other key is diverted to Extra. Keep in lockstep with
-// the json tags on ClassroomJSON above.
+// knownClassroomKeys is the classroom.json keys this binary understands; any
+// other key is diverted to Extra. Keep in lockstep with ClassroomJSON's tags.
 var knownClassroomKeys = map[string]struct{}{
 	"schema": {}, "name": {}, "short_name": {}, "term": {}, "org": {},
 	"secret": {}, "team": {}, "teams": {}, "active": {}, "migrated_from": {},
@@ -92,9 +80,7 @@ func (c *ClassroomJSON) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON emits the known fields via the alias, then byte-splices any
-// sorted Extra keys in before the closing brace. The splice (vs a map
-// round-trip) preserves the known fields' struct order so adding Extra
-// doesn't reorder existing classroom.json on the next write.
+// sorted Extra keys before the closing brace, preserving struct order.
 func (c ClassroomJSON) MarshalJSON() ([]byte, error) {
 	type classroomAlias ClassroomJSON
 	known, err := json.Marshal(classroomAlias(c))
@@ -116,9 +102,8 @@ func (c ClassroomJSON) MarshalJSON() ([]byte, error) {
 	}
 	sort.Strings(keys) // deterministic output
 
-	// Splice the Extra members in before `known`'s closing brace. The alias
-	// always emits schema/name/short_name/term/org (no omitempty), so
-	// `known` is never "{}" and the leading comma is always correct.
+	// Splice Extra members before `known`'s closing brace. The alias always
+	// emits schema/name/short_name/term/org, so `known` is never "{}".
 	var buf bytes.Buffer
 	trimmed := bytes.TrimSpace(known)
 	buf.Write(trimmed[:len(trimmed)-1]) // everything up to the final '}'
@@ -143,9 +128,8 @@ func (c *ClassroomJSON) IsArchived() bool {
 	return c != nil && c.Active != nil && !*c.Active
 }
 
-// MigratedFromRef records where a classroom originated when it was
-// imported by `gh teacher classroom migrate`. Hand-authored classrooms
-// never carry this block.
+// MigratedFromRef records where a classroom originated when imported by
+// `classroom migrate`. Hand-authored classrooms never carry it.
 type MigratedFromRef struct {
 	Source           string `json:"source"`
 	ClassroomID      int64  `json:"classroom_id"`

--- a/cli/gh-teacher/internal/configrepo/contents.go
+++ b/cli/gh-teacher/internal/configrepo/contents.go
@@ -1,11 +1,7 @@
-// Package configrepo is the read substrate for the per-org
-// <org>/classroom50 config repository: the contents/tree read helpers,
-// the classroom-metadata and roster record types, and the cross-domain
-// team service. It is consumed by nearly every command package. The
-// write helpers (CommitTree/CommitTreeChange + the workflow-scope
-// classifier they inject) live in internal/configwrite, the write-side
-// sibling of this package; the two are kept separate so neither imports
-// the other.
+// Package configrepo is the read substrate for the per-org <org>/classroom50
+// config repo: contents/tree read helpers, the classroom-metadata and roster
+// record types, and the team service. The write helpers live in
+// internal/configwrite; neither imports the other.
 package configrepo
 
 import (
@@ -24,10 +20,8 @@ import (
 // Thin alias for the shared contract constant — the single source of truth.
 const ConfigRepoName = contract.ConfigRepoName
 
-// ContentEntry is one immediate child returned by the GitHub contents
-// API when the requested path is a directory. Type is "file" or "dir"
-// (the API also emits "symlink"/"submodule", which classroom code
-// ignores).
+// ContentEntry is one immediate child from the contents API for a directory.
+// Type is "file" or "dir" (symlink/submodule are ignored).
 type ContentEntry struct {
 	Name string `json:"name"`
 	Path string `json:"path"`
@@ -85,12 +79,9 @@ func ContentsExists(client githubapi.Client, owner, repo, path, ref string) (boo
 	return true, nil
 }
 
-// ListDirContents lists the immediate children of directory path at ref
-// via GET /repos/{owner}/{repo}/contents/{path}. An empty path lists the
-// repo root. Returns (nil, false, nil) when the path doesn't exist (404).
-// The contents API returns a JSON array for a directory; callers must
-// only pass directory paths (a file path returns a JSON object and fails
-// to decode).
+// ListDirContents lists the immediate children of directory path at ref. Empty
+// path lists the repo root. (nil, false, nil) on 404. Callers must pass only
+// directory paths (a file path returns a JSON object and fails to decode).
 func ListDirContents(client githubapi.Client, owner, repo, path, ref string) ([]ContentEntry, bool, error) {
 	apiPath := contentsAPIPath(owner, repo, path, ref)
 	var entries []ContentEntry

--- a/cli/gh-teacher/internal/configrepo/secret.go
+++ b/cli/gh-teacher/internal/configrepo/secret.go
@@ -8,30 +8,25 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/contract"
 )
 
-// SecretAlphabet is the character set for a generated capability-URL
-// secret: lowercase letters and digits. Kept to a single safe URL path
-// segment (no uppercase, no separators) so it composes cleanly into the
-// published Pages path `<classroom>/<secret>/...`.
+// SecretAlphabet is the character set for a generated capability-URL secret:
+// lowercase letters and digits, so it composes cleanly into the Pages path
+// `<classroom>/<secret>/...`.
 const SecretAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
 
-// DefaultSecretLength is the generated length when the teacher opts in
-// without supplying their own value. 8 chars of [a-z0-9] is ~41 bits of
-// entropy — ample for anti-discovery (this is friction, not crypto).
+// DefaultSecretLength is the generated length when the teacher opts in without
+// a value. 8 chars of [a-z0-9] is ~41 bits — ample for anti-discovery friction.
 const DefaultSecretLength = 8
 
-// SecretPattern bounds a capability-URL secret to a single safe path
-// segment: 4-64 lowercase-alphanumeric chars. Compiled from the
-// single-sourced contract.SecretPattern (see that constant for the full
-// cross-language lockstep set).
+// SecretPattern bounds a capability-URL secret to one safe path segment
+// (4-64 lowercase-alnum), compiled from the single-sourced contract.SecretPattern.
 var SecretPattern = regexp.MustCompile(contract.SecretPattern)
 
 // SecretPatternDescription is the human-readable summary embedded in the
 // "invalid secret" error.
 const SecretPatternDescription = contract.SecretPatternDescription
 
-// ValidateSecret checks a teacher-supplied (or generated) secret against
-// SecretPattern. An empty secret is rejected here; callers that allow
-// "no secret" must branch on emptiness before calling this.
+// ValidateSecret checks a secret against SecretPattern. An empty secret is
+// rejected; callers allowing "no secret" must branch on emptiness first.
 func ValidateSecret(secret string) error {
 	if !SecretPattern.MatchString(secret) {
 		return fmt.Errorf("invalid secret %q: must be %s", secret, SecretPatternDescription)
@@ -39,17 +34,15 @@ func ValidateSecret(secret string) error {
 	return nil
 }
 
-// GenerateSecret returns a cryptographically random secret of n chars
-// drawn from SecretAlphabet. Uses rejection sampling so the modulo bias
-// that a naive `b % len(alphabet)` would introduce is eliminated.
+// GenerateSecret returns a cryptographically random n-char secret from
+// SecretAlphabet, using rejection sampling to avoid modulo bias.
 func GenerateSecret(n int) (string, error) {
 	if n <= 0 {
 		return "", fmt.Errorf("secret length must be positive, got %d", n)
 	}
 	out := make([]byte, n)
-	// 256 % 36 == 4, so bytes >= 252 would bias the low residues; reject
-	// them and redraw. max is the largest multiple of the alphabet size
-	// that fits in a byte.
+	// max is the largest multiple of the alphabet size that fits in a byte;
+	// bytes >= max would bias low residues, so reject and redraw.
 	max := byte(256 - (256 % len(SecretAlphabet)))
 	buf := make([]byte, 1)
 	for i := 0; i < n; {

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -12,22 +12,18 @@ import (
 )
 
 // RosterColumns: canonical required column order. github_id is CLI-managed
-// (populated from `GET /users/{username}`); the immutable numeric ID
-// defends against mid-class username changes. Email may be empty.
+// (from `GET /users/{username}`); the immutable numeric ID defends against
+// mid-class username changes. Email may be empty.
 var RosterColumns = []string{"username", "first_name", "last_name", "email", "section", "github_id"}
 
-// FullRosterHeader is the complete on-disk students.csv header the CLI writes:
-// the canonical RosterColumns, comma-joined. It is the single shared fixture
-// that both the Go and Python test suites assert against (and that
-// classroom50-web's STUDENT_CSV_FIELDS must match) so column-order drift between
-// the three codebases is caught by CI rather than surfacing as live file churn.
-// (An earlier email-first onboarding tail the web app appended was pruned — the
-// classroom GitHub team is now the source of truth for enrollment — but any such
-// legacy tail on an existing file still round-trips via RosterRow.Extra.)
+// FullRosterHeader is the on-disk students.csv header (RosterColumns,
+// comma-joined). The single shared fixture the Go, Python, and web suites
+// assert against, so column-order drift is caught by CI. A legacy trailing
+// column on an existing file still round-trips via RosterRow.Extra.
 var FullRosterHeader = strings.Join(RosterColumns, ",")
 
-// isCanonicalColumn reports whether name is one of the CLI-managed RosterColumns
-// (the rest are carried through RosterRow.Extra).
+// isCanonicalColumn reports whether name is a CLI-managed RosterColumn (the
+// rest are carried through RosterRow.Extra).
 func isCanonicalColumn(name string) bool {
 	for _, c := range RosterColumns {
 		if c == name {
@@ -37,19 +33,17 @@ func isCanonicalColumn(name string) bool {
 	return false
 }
 
-// maxFieldBytes caps each parsed cell at RFC 5321's email max so a
-// hand-edit can't push the file past the contents API's 1 MB
-// ceiling and wedge future reads with encoding:"none".
+// maxFieldBytes caps each cell at RFC 5321's email max so a hand-edit can't
+// push the file past the contents API's 1 MB ceiling.
 const maxFieldBytes = 320
 
-// utf8BOM is what Excel prepends to "CSV UTF-8" exports.
-// encoding/csv doesn't strip it, so without trimming the first
-// header field becomes "\ufeffusername" and the header check fails
-// with two identical-looking slices in the terminal.
+// utf8BOM is what Excel prepends to "CSV UTF-8" exports. encoding/csv doesn't
+// strip it, so without trimming the first header field becomes "\ufeffusername"
+// and the header check fails on two identical-looking slices.
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
-// RosterRow is one student in students.csv. GitHubID == 0 means
-// unresolved (a 5-column import row before GET /users/{username}).
+// RosterRow is one student in students.csv. GitHubID == 0 means unresolved (a
+// 5-column import row before GET /users/{username}).
 type RosterRow struct {
 	Username  string
 	FirstName string
@@ -57,30 +51,22 @@ type RosterRow struct {
 	Email     string
 	Section   string
 	GitHubID  int64
-	// Extra carries non-canonical columns (any legacy columns a prior tool
-	// appended, and any other unknown columns) keyed by header name, so a CLI
-	// read/modify/write round-trips them instead of dropping them. nil for a
-	// plain 6-column file.
+	// Extra carries non-canonical columns keyed by header name, so a
+	// read/modify/write round-trips them. nil for a plain 6-column file.
 	Extra map[string]string
-	// ExtraOrder is the on-disk order of the Extra columns, so encoding is
-	// deterministic and stable across round-trips. INVARIANT: it lists exactly
-	// the keys of Extra (recordToRow and UpsertRosterRow keep them in lockstep);
-	// collectExtraColumns relies on it as the sole enumeration of which extra
-	// columns a row has.
+	// ExtraOrder is the on-disk order of Extra columns for deterministic
+	// encoding. INVARIANT: it lists exactly the keys of Extra.
 	ExtraOrder []string
 }
 
 // ParseRoster decodes students.csv. The header MUST begin with the canonical
-// RosterColumns in order (so a hand-edit can't silently drop or shift the
-// CLI-managed data); additional trailing columns (any legacy tail, or any other
-// extras) are accepted and preserved verbatim in RosterRow.Extra. Empty input
-// is rejected.
+// RosterColumns in order; additional trailing columns are preserved verbatim in
+// RosterRow.Extra. Empty input is rejected.
 func ParseRoster(data []byte) ([]RosterRow, error) {
 	data = bytes.TrimPrefix(data, utf8BOM)
 	r := csv.NewReader(bytes.NewReader(data))
-	// Read header without field-count enforcement so a renamed or
-	// short header surfaces our message instead of csv's generic
-	// "wrong number of fields".
+	// Read header without field-count enforcement so a renamed/short header
+	// gets our message, not csv's generic "wrong number of fields".
 	r.FieldsPerRecord = -1
 
 	header, err := r.Read()
@@ -90,19 +76,18 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read header: %w", err)
 	}
-	// The header must begin with the canonical columns in order; anything after
-	// them is an extra column carried through verbatim.
+	// Header must begin with the canonical columns in order; anything after is
+	// an extra column carried through verbatim.
 	if len(header) < len(RosterColumns) || !equalSlices(header[:len(RosterColumns)], RosterColumns) {
 		return nil, fmt.Errorf("unexpected header: got %v, want %v followed by any optional columns", header, RosterColumns)
 	}
 	extraColumns := append([]string(nil), header[len(RosterColumns):]...)
-	// Reject a malformed extra-column header rather than silently mangling it on
-	// round-trip: a duplicate name clobbers on read and collapses on write (data
-	// loss); a name reusing a canonical one emits a duplicate-header file the web
-	// app's header-keyed parser mis-reads; and because EncodeRoster writes header
-	// names verbatim (no defangCSVCell), a formula-trigger name would re-inject
-	// CSV formulas into a CLI-written file opened in Excel. The web app produces
-	// none of these — this only fences off a hand-edit.
+	// Reject a malformed extra-column header rather than mangling it on
+	// round-trip: a duplicate clobbers on read and collapses on write; a name
+	// reusing a canonical one produces a file the web's header-keyed parser
+	// mis-reads; and since EncodeRoster writes header names verbatim, a
+	// formula-trigger name would re-inject CSV formulas. Only fences off a
+	// hand-edit — the web produces none of these.
 	seenExtra := make(map[string]bool, len(extraColumns))
 	for _, name := range extraColumns {
 		if isCanonicalColumn(name) {
@@ -116,7 +101,7 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 		}
 		seenExtra[name] = true
 	}
-	// Fix the field count to the full header width so a short/long data row errors.
+	// Fix the field count to the full header width so a short/long row errors.
 	r.FieldsPerRecord = len(header)
 
 	var rows []RosterRow
@@ -137,15 +122,12 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 	return rows, nil
 }
 
-// ParseImportCSV decodes a teacher-supplied import CSV. Accepts the
-// 6-column canonical shape (github_id ignored; the CLI re-resolves
-// it) or the 5-column hand-edit shape.
+// ParseImportCSV decodes a teacher-supplied import CSV: the 6-column canonical
+// shape (github_id ignored; re-resolved) or the 5-column hand-edit shape.
 //
-// Unlike ParseRoster, import deliberately rejects a wider file with extra
-// trailing columns: it re-resolves github_id and carries no extra column state,
-// so accepting a wider file would silently drop the tail (breaking
-// ParseRoster's preservation guarantee). The error points the teacher at the
-// canonical shape so they trim the tail first.
+// Unlike ParseRoster, import rejects a wider file with extra trailing columns:
+// it re-resolves github_id and carries no extra state, so a wider file would
+// silently drop the tail. The error points at the canonical shape.
 func ParseImportCSV(data []byte) ([]RosterRow, error) {
 	data = bytes.TrimPrefix(data, utf8BOM)
 	r := csv.NewReader(bytes.NewReader(data))
@@ -160,8 +142,7 @@ func ParseImportCSV(data []byte) ([]RosterRow, error) {
 	}
 
 	if !equalSlices(header, RosterColumns) && !equalSlices(header, RosterColumns[:5]) {
-		// Call out the common mistake of feeding a wider students.csv (canonical
-		// six + extra trailing columns) straight into import.
+		// Common mistake: feeding a wider students.csv straight into import.
 		if len(header) > len(RosterColumns) && equalSlices(header[:len(RosterColumns)], RosterColumns) {
 			return nil, fmt.Errorf("unexpected header: got %v — import takes only the canonical %v (or its 5-column form without github_id). "+
 				"This looks like a roster with extra columns appended; drop the columns after github_id before importing "+
@@ -197,15 +178,13 @@ func ParseImportCSV(data []byte) ([]RosterRow, error) {
 			return nil, fmt.Errorf("line %d: %w", line, err)
 		}
 		// record[5] (github_id) ignored; the CLI re-resolves it.
-		// checkFieldLengths still bounds the oversized case.
 		rows = append(rows, row)
 	}
 	return rows, nil
 }
 
 // recordToRow maps a data record onto a RosterRow. extraColumns (in header
-// order) name the values beyond the canonical 6, carried through RosterRow.Extra
-// so a round-trip preserves them.
+// order) name the values beyond the canonical 6, carried through Extra.
 func recordToRow(record, extraColumns []string, line int) (RosterRow, error) {
 	if err := checkFieldLengths(line, record); err != nil {
 		return RosterRow{}, err
@@ -228,9 +207,8 @@ func recordToRow(record, extraColumns []string, line int) (RosterRow, error) {
 		row.GitHubID = id
 	}
 	if len(extraColumns) > 0 {
-		// The row's extra-column order IS the header's extra order (same for
-		// every row), so share that slice instead of rebuilding an identical
-		// one per row. It's read-only after parse.
+		// Every row's extra order IS the header's, so share that slice instead
+		// of rebuilding an identical one per row. Read-only after parse.
 		row.Extra = make(map[string]string, len(extraColumns))
 		row.ExtraOrder = extraColumns
 		for i, name := range extraColumns {
@@ -240,10 +218,9 @@ func recordToRow(record, extraColumns []string, line int) (RosterRow, error) {
 	return row, nil
 }
 
-// EncodeRoster writes rows back as RFC 4180 students.csv (trailing
-// newline) to match the scaffold shape. The header is RosterColumns followed by
-// any extra columns present on the rows (ordered by collectExtraColumns), so the
-// CLI preserves any web-written extra columns instead of stripping them.
+// EncodeRoster writes rows back as RFC 4180 students.csv (trailing newline).
+// The header is RosterColumns followed by any extra columns present on the rows
+// (ordered by collectExtraColumns), preserving web-written extras.
 func EncodeRoster(rows []RosterRow) ([]byte, error) {
 	extraColumns := collectExtraColumns(rows)
 
@@ -259,8 +236,7 @@ func EncodeRoster(rows []RosterRow) ([]byte, error) {
 		if row.GitHubID != 0 {
 			githubID = strconv.FormatInt(row.GitHubID, 10)
 		}
-		// Defang formula-trigger cells (=/+/-/@/\t/\r prefix).
-		// github_id is numeric so it never matches.
+		// Defang formula-trigger cells; github_id is numeric so never matches.
 		record := []string{
 			defangCSVCell(row.Username),
 			defangCSVCell(row.FirstName),
@@ -284,10 +260,8 @@ func EncodeRoster(rows []RosterRow) ([]byte, error) {
 }
 
 // collectExtraColumns returns the union of non-canonical column names across
-// rows, ordered deterministically in first-seen order (across rows, then within
-// each row's ExtraOrder). This keeps the written header stable across
-// round-trips regardless of Go map iteration order. Each row's ExtraOrder is the
-// sole enumeration of its extra columns (it lists exactly the keys of Extra).
+// rows in first-seen order (across rows, then within each ExtraOrder), keeping
+// the written header stable regardless of map iteration order.
 func collectExtraColumns(rows []RosterRow) []string {
 	var ordered []string
 	seen := make(map[string]bool)
@@ -302,14 +276,12 @@ func collectExtraColumns(rows []RosterRow) []string {
 	return ordered
 }
 
-// UpsertRosterRow replaces by Username (case-insensitive, matching
-// GitHub's username rules) or appends. Position preserved on
-// replace. Returns the slice and whether a row was replaced.
+// UpsertRosterRow replaces by Username (case-insensitive) or appends. Position
+// preserved on replace. Returns the slice and whether a row was replaced.
 //
-// On replace, the existing row's Extra (any web-written extra columns) is
-// carried over to the incoming row UNLESS the incoming row supplies its own
-// Extra — so a CLI `roster add` (which only knows the canonical fields) never
-// silently wipes extra column state written by the web app.
+// On replace, the existing row's Extra is carried over UNLESS the incoming row
+// supplies its own — so a CLI `roster add` (canonical fields only) never wipes
+// web-written extra columns.
 func UpsertRosterRow(rows []RosterRow, row RosterRow) ([]RosterRow, bool) {
 	for i := range rows {
 		if strings.EqualFold(rows[i].Username, row.Username) {
@@ -324,8 +296,8 @@ func UpsertRosterRow(rows []RosterRow, row RosterRow) ([]RosterRow, bool) {
 	return append(rows, row), false
 }
 
-// RemoveRosterRow drops by Username (case-insensitive). Returns the
-// slice and whether a row was removed.
+// RemoveRosterRow drops by Username (case-insensitive). Returns the slice and
+// whether a row was removed.
 func RemoveRosterRow(rows []RosterRow, username string) ([]RosterRow, bool) {
 	for i := range rows {
 		if strings.EqualFold(rows[i].Username, username) {
@@ -344,10 +316,9 @@ type RosterPatch struct {
 	Section   *string
 }
 
-// UpdateRosterRow applies p to the row matching username (case-insensitive,
-// like UpsertRosterRow/RemoveRosterRow), leaving username and github_id
-// untouched. Returns the slice, whether a row matched, and whether any value
-// actually changed (so the caller can no-op a patch that already matches).
+// UpdateRosterRow applies p to the row matching username (case-insensitive),
+// leaving username and github_id untouched. Returns the slice, whether a row
+// matched, and whether any value changed (so the caller can no-op).
 func UpdateRosterRow(rows []RosterRow, username string, p RosterPatch) (out []RosterRow, found, changed bool) {
 	for i := range rows {
 		if !strings.EqualFold(rows[i].Username, username) {
@@ -374,11 +345,9 @@ func UpdateRosterRow(rows []RosterRow, username string, p RosterPatch) (out []Ro
 	return rows, false, false
 }
 
-// ValidateRosterEmail: empty is valid. Non-empty must parse via
-// net/mail.ParseAddress in bare `local@domain` form; the display-name
-// form (`Alice <alice@example.edu>`) is rejected so name metadata
-// doesn't sneak into the email column. No TLD requirement (internal
-// `*.local` domains are common in classrooms), no DNS check.
+// ValidateRosterEmail: empty is valid. Non-empty must parse as bare
+// `local@domain`; the display-name form is rejected so name metadata doesn't
+// sneak into the email column. No TLD requirement, no DNS check.
 func ValidateRosterEmail(email string) error {
 	if email == "" {
 		return nil
@@ -405,9 +374,8 @@ func equalSlices(a, b []string) bool {
 	return true
 }
 
-// checkFieldLengths rejects cells over maxFieldBytes so a hand-edit
-// can't push the file past the contents API's 1 MB ceiling. Errors
-// name the column from RosterColumns when possible.
+// checkFieldLengths rejects cells over maxFieldBytes. Errors name the column
+// from RosterColumns when possible.
 func checkFieldLengths(line int, record []string) error {
 	for i, v := range record {
 		if len(v) <= maxFieldBytes {
@@ -422,9 +390,9 @@ func checkFieldLengths(line int, record []string) error {
 	return nil
 }
 
-// isFormulaTrigger reports whether `b` would be parsed as a formula
-// prefix by Excel/LibreOffice. The defang/undefang pair guards
-// against CSV-injection at the disk-write boundary.
+// isFormulaTrigger reports whether `b` would be parsed as a formula prefix by
+// Excel/LibreOffice. The defang/undefang pair guards CSV injection at the
+// disk-write boundary.
 func isFormulaTrigger(b byte) bool {
 	switch b {
 	case '=', '+', '-', '@', '\t', '\r':
@@ -433,9 +401,8 @@ func isFormulaTrigger(b byte) bool {
 	return false
 }
 
-// defangCSVCell prepends `'` when the first byte is a formula
-// trigger so a roster row can't smuggle an executable payload to a
-// co-teacher who opens the file in Excel.
+// defangCSVCell prepends `'` when the first byte is a formula trigger so a
+// roster row can't smuggle a payload to a co-teacher opening it in Excel.
 func defangCSVCell(s string) string {
 	if s == "" || !isFormulaTrigger(s[0]) {
 		return s
@@ -443,9 +410,8 @@ func defangCSVCell(s string) string {
 	return "'" + s
 }
 
-// undefangCSVCell inverts defangCSVCell so parse/encode round-trips.
-// Cells without the exact `'<trigger>` pattern pass through
-// (preserves user-typed apostrophes).
+// undefangCSVCell inverts defangCSVCell. Cells without the exact `'<trigger>`
+// pattern pass through (preserving user-typed apostrophes).
 func undefangCSVCell(s string) string {
 	if len(s) >= 2 && s[0] == '\'' && isFormulaTrigger(s[1]) {
 		return s[1:]

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -13,31 +13,25 @@ import (
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 )
 
-// classroomTeamName derives the GitHub team name for a classroom from
-// its short-name: `classroom50-<short>`. The short-name is already
-// validated against validate.ShortNamePattern (lowercase alnum + hyphens), so
-// the result is a valid team name and its slug is the same string.
-// Single-sourced here so creation, membership, and grant paths can't
-// drift on the naming scheme.
+// classroomTeamName derives the GitHub team name for a classroom:
+// `classroom50-<short>`. The short-name is already validated (lowercase alnum +
+// hyphens), so the result is a valid team name whose slug equals it.
+// Single-sourced so creation/membership/grant paths can't drift.
 func classroomTeamName(shortName string) string {
 	return "classroom50-" + shortName
 }
 
-// classroomTeamSlug is the URL slug GitHub assigns the team. Because
-// classroomTeamName is already lowercase with hyphens (matching
-// GitHub's slugification), the slug equals the name; computing it
-// directly avoids a round-trip to read the team back.
+// classroomTeamSlug is the URL slug GitHub assigns the team. Since
+// classroomTeamName is already lowercase-with-hyphens, the slug equals the
+// name; deriving it directly avoids reading the team back.
 func classroomTeamSlug(shortName string) string {
 	return classroomTeamName(shortName)
 }
 
-// TeamRef is the minimal team identity the CLI persists and reuses.
-// The slug is the authoritative addressing key for all team
-// operations (GitHub may assign a slug that differs from the name on a
-// collision — e.g. `classroom50-cs-1` — so callers MUST use the
-// persisted slug rather than re-deriving `classroom50-<short>`). The
-// id is the immutable handle used for the delete so a re-slugged or
-// renamed team can't be confused with an unrelated one.
+// TeamRef is the minimal team identity the CLI persists and reuses. The slug is
+// the authoritative addressing key (GitHub may assign a slug differing from the
+// name on a collision, so callers MUST use the persisted slug, not re-derive
+// it). The id is the immutable handle used for delete verification.
 type TeamRef struct {
 	ID   int64  `json:"id"`
 	Slug string `json:"slug"`
@@ -56,10 +50,8 @@ const (
 // StaffRoles is every staff role, in a stable order (instructor first).
 var StaffRoles = []StaffRole{RoleInstructor, RoleTA}
 
-// staffTeamName derives the GitHub team name for a classroom staff role:
-// `classroom50-<short>-<role>`. Mirrors the web's staffTeamName
-// (web/src/hooks/github/mutations.ts). As with classroomTeamName the
-// short-name is canonical, so the slug equals the name.
+// staffTeamName derives the staff-role team name: `classroom50-<short>-<role>`.
+// Mirrors the web's staffTeamName. The short-name is canonical, so slug == name.
 func staffTeamName(shortName string, role StaffRole) string {
 	return "classroom50-" + shortName + "-" + string(role)
 }
@@ -71,14 +63,10 @@ type StaffTeamsRef struct {
 	TA         *TeamRef `json:"ta,omitempty"`
 }
 
-// ResolveClassroomTeam reads the persisted team ref from the
-// classroom's classroom.json at `ref`. This is the authoritative slug
-// + id for every team operation — never re-derive the slug from the
-// short-name (GitHub may have assigned a different slug on a name
-// collision). A classroom with no `team` block (created before this
-// feature, or hand-authored) yields ok=false so callers can shape an
-// actionable "run classroom add" message rather than blindly hitting a
-// 404 against a guessed slug.
+// ResolveClassroomTeam reads the persisted team ref from the classroom's
+// classroom.json at `ref` — the authoritative slug + id (never re-derive the
+// slug). A classroom with no `team` block yields ok=false so callers can shape
+// an actionable "run classroom add" message rather than 404ing on a guess.
 func ResolveClassroomTeam(client githubapi.Client, org, shortName, ref string) (TeamRef, bool, error) {
 	c, ok, err := LoadClassroom(client, org, shortName, ref)
 	if err != nil {
@@ -90,12 +78,10 @@ func ResolveClassroomTeam(client githubapi.Client, org, shortName, ref string) (
 	return *c.Team, true, nil
 }
 
-// ResolveClassroomStaffTeam reads the persisted staff-team ref for
-// `role` from the classroom's classroom.json at `ref`. Like
-// ResolveClassroomTeam, the persisted slug is authoritative — never
-// re-derive it. A classroom with no `teams` block (created before the
-// staff-teams feature, or by an older CLI) yields ok=false so callers
-// can shape an actionable "run classroom add" message.
+// ResolveClassroomStaffTeam reads the persisted staff-team ref for `role` from
+// classroom.json at `ref`. Like ResolveClassroomTeam, the persisted slug is
+// authoritative. No `teams` block yields ok=false so callers can shape an
+// actionable "run classroom add" message.
 func ResolveClassroomStaffTeam(client githubapi.Client, org, shortName, ref string, role StaffRole) (TeamRef, bool, error) {
 	c, ok, err := LoadClassroom(client, org, shortName, ref)
 	if err != nil {
@@ -117,15 +103,13 @@ func ResolveClassroomStaffTeam(client githubapi.Client, org, shortName, ref stri
 	return *team, true, nil
 }
 
-// CanonicalTeamSlugShortName reports whether shortName produces a team
-// name whose GitHub-assigned slug equals the name verbatim. GitHub
-// slugifies team names by collapsing hyphen runs and trimming trailing
-// hyphens, so a short-name with consecutive or trailing hyphens (both
-// allowed by validate.ShortNamePattern) would yield slug != name — and every
-// team path that re-derives the slug via classroomTeamSlug would then
-// 404. Requiring a canonical short-name keeps the locally-derived slug
-// authoritative without an extra API round-trip on every membership /
-// grant / delete call.
+// CanonicalTeamSlugShortName reports whether shortName yields a team whose
+// GitHub-assigned slug equals the name verbatim. GitHub slugifies by collapsing
+// hyphen runs and trimming trailing hyphens, so a short-name with
+// consecutive/trailing hyphens (both allowed by ShortNamePattern) would yield
+// slug != name and every path re-deriving the slug would 404. Requiring a
+// canonical short-name keeps the derived slug authoritative without an extra
+// round-trip.
 func CanonicalTeamSlugShortName(shortName string) bool {
 	if strings.HasSuffix(shortName, "-") || strings.Contains(shortName, "--") {
 		return false
@@ -133,31 +117,26 @@ func CanonicalTeamSlugShortName(shortName string) bool {
 	return true
 }
 
-// EnsureClassroomTeam creates the per-classroom GitHub team (privacy
-// `secret`, least-privilege: visible only to its members and org
-// owners), reconciling-and-adopting an existing team of the same name
-// rather than failing — matching the idempotent re-run style of the
-// rest of the CLI. The team is what grants rostered students read on
-// private, org-owned assignment templates so `gh student accept` can
-// generate their repo.
+// EnsureClassroomTeam creates the per-classroom `secret` GitHub team
+// (least-privilege: visible only to members and org owners), adopting an
+// existing team of the same name rather than failing. This team grants
+// rostered students read on private org-owned templates so `student accept`
+// can generate their repo.
 //
-// `members_can_create_teams: false` (set by init's lockdown) does not
-// block this — the teacher authenticates as an org owner.
+// `members_can_create_teams: false` (init's lockdown) doesn't block this — the
+// teacher authenticates as an org owner.
 func EnsureClassroomTeam(client githubapi.Client, org, shortName string) (TeamRef, error) {
-	// Guard the slug==name invariant the team paths rely on (see
-	// CanonicalTeamSlugShortName). validate.ShortNamePattern alone permits
-	// consecutive/trailing hyphens, which GitHub would slugify away.
+	// Guard the slug==name invariant (see CanonicalTeamSlugShortName):
+	// ShortNamePattern alone permits hyphens GitHub would slugify away.
 	if !CanonicalTeamSlugShortName(shortName) {
 		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking membership and template grants)", shortName)
 	}
 	return ensureSecretTeamByName(client, org, classroomTeamName(shortName))
 }
 
-// EnsureClassroomStaffTeam creates (or adopts) the per-classroom STAFF
-// team for `role` — a `secret` team named `classroom50-<short>-<role>`.
-// It mirrors the web GUI's ensureClassroomRoleTeam so a classroom
-// created/managed via the CLI carries the same staff teams the web
-// expects. Idempotent; safe as a preflight before any staff op.
+// EnsureClassroomStaffTeam creates (or adopts) the per-classroom STAFF team for
+// `role` — a `secret` team `classroom50-<short>-<role>`. Mirrors the web's
+// ensureClassroomRoleTeam. Idempotent; safe as a preflight before any staff op.
 func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, role StaffRole) (TeamRef, error) {
 	if !CanonicalTeamSlugShortName(shortName) {
 		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking staff membership and config-repo grants)", shortName)
@@ -165,11 +144,10 @@ func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, ro
 	return ensureSecretTeamByName(client, org, staffTeamName(shortName, role))
 }
 
-// EnsureStaffTeams creates (or adopts) both staff teams (instructor, ta)
-// for a classroom and grants each `push` on the org's `classroom50`
-// config repo, so staff can author assignments. Returns the persisted
-// refs to record under classroom.json `teams`. Mirrors the web's
-// ensureStaffTeams.
+// EnsureStaffTeams creates (or adopts) both staff teams (instructor, ta) and
+// grants each `push` on the org's `classroom50` config repo so staff can author
+// assignments. Returns the refs to record under classroom.json `teams`.
+// Mirrors the web's ensureStaffTeams.
 func EnsureStaffTeams(client githubapi.Client, org, shortName string) (*StaffTeamsRef, error) {
 	refs := &StaffTeamsRef{}
 	for _, role := range StaffRoles {
@@ -190,15 +168,12 @@ func EnsureStaffTeams(client githubapi.Client, org, shortName string) (*StaffTea
 	return refs, nil
 }
 
-// ensureSecretTeamByName creates a `secret` GitHub team named `name`
-// (least-privilege: visible only to its members and org owners),
-// reconciling-and-adopting an existing team of the same name rather than
-// failing — matching the idempotent re-run style of the rest of the CLI.
-// The name is a canonical short-name-derived value, so its slug equals
-// the name.
+// ensureSecretTeamByName creates a `secret` GitHub team named `name`,
+// adopting an existing team of the same name rather than failing. `name` is a
+// canonical short-name-derived value, so its slug equals the name.
 //
-// `members_can_create_teams: false` (set by init's lockdown) does not
-// block this — the teacher authenticates as an org owner.
+// `members_can_create_teams: false` (init's lockdown) doesn't block this — the
+// teacher authenticates as an org owner.
 func ensureSecretTeamByName(client githubapi.Client, org, name string) (TeamRef, error) {
 	body, err := json.Marshal(map[string]any{
 		"name":    name,
@@ -210,11 +185,10 @@ func ensureSecretTeamByName(client githubapi.Client, org, name string) (TeamRef,
 	createPath := fmt.Sprintf("orgs/%s/teams", url.PathEscape(org))
 	var created TeamRef
 	if err := client.Post(createPath, bytes.NewReader(body), &created); err != nil {
-		// 422 = a team with this name already exists. Adopt it in
-		// place (read its id/slug, ensure privacy `secret`) rather
-		// than failing, so a re-run reconciles cleanly. If the adopt
-		// read 404s, the 422 was NOT a name collision — surface the
-		// original create error, which reflects the real cause.
+		// 422 = a team with this name already exists. Adopt it in place
+		// (read id/slug, ensure privacy `secret`) so a re-run reconciles. If
+		// the adopt read 404s, the 422 wasn't a name collision — surface the
+		// original create error.
 		if cliutil.IsHTTPStatus(err, http.StatusUnprocessableEntity) {
 			adopted, adoptErr := adoptSecretTeamByName(client, org, name)
 			if adoptErr != nil {
@@ -230,10 +204,9 @@ func ensureSecretTeamByName(client githubapi.Client, org, name string) (TeamRef,
 	return created, nil
 }
 
-// adoptSecretTeamByName reads an existing team by its slug (== name,
-// given the canonical short-name guard) and reconciles its privacy to
-// `secret` (an older or hand-created team might be `closed`). Used by
-// ensureSecretTeamByName on the 422 already-exists path.
+// adoptSecretTeamByName reads an existing team by slug (== name, given the
+// canonical short-name guard) and reconciles its privacy to `secret` (an older
+// or hand-created team might be `closed`). Used on the 422 already-exists path.
 func adoptSecretTeamByName(client githubapi.Client, org, name string) (TeamRef, error) {
 	slug := name
 	getPath := fmt.Sprintf("orgs/%s/teams/%s", url.PathEscape(org), url.PathEscape(slug))
@@ -261,60 +234,41 @@ func adoptSecretTeamByName(client githubapi.Client, org, name string) (TeamRef, 
 	return TeamRef{ID: existing.ID, Slug: existing.Slug}, nil
 }
 
-// IsDeletableClassroomTeamRef reports whether a persisted team ref is
-// safe to delete: it must be `classroom50-`-namespaced AND carry a
-// positive id. This mirrors the web's isDeletableClassroomTeamRef
-// (web/src/hooks/github/mutations.ts) 1:1 — the shared fail-closed guard
-// that keeps a malformed or hand-edited classroom.json (now writable by
-// any staff team granted config-repo push) from steering a destructive
-// DELETE at an unrelated team. A ref that fails this predicate is never
-// verified-and-deleted; callers skip it.
+// IsDeletableClassroomTeamRef reports whether a persisted team ref is safe to
+// delete: it must be `classroom50-`-namespaced AND carry a positive id. Mirrors
+// the web's isDeletableClassroomTeamRef 1:1 — the fail-closed guard that keeps
+// a malformed/hand-edited classroom.json from steering a destructive DELETE at
+// an unrelated team. A ref failing this predicate is never deleted.
 func IsDeletableClassroomTeamRef(team TeamRef) bool {
 	return strings.HasPrefix(team.Slug, "classroom50-") && team.ID > 0
 }
 
-// DeleteClassroomTeam removes the classroom team identified by the
-// persisted ref. It deletes via the team SLUG — GitHub's
-// `DELETE /orgs/{org}/teams/{team_slug}` endpoint is slug-addressed;
-// the numeric id only works on the separate
-// `/organizations/{org_id}/team/{team_id}` path, so a numeric value in
-// the slug position is treated as a (non-existent) slug and 404s. The
-// persisted slug is authoritative (captured from the create response),
-// so it addresses exactly this classroom's team and never a re-derived
-// guess. As defense-in-depth against a slug later reused by an
-// unrelated team, the live team's id is confirmed to match the
-// persisted id before deletion. A 404 (already gone) is treated as
-// success so `classroom remove` is idempotent.
+// DeleteClassroomTeam removes the classroom team by its persisted ref. Deletes
+// via the SLUG — GitHub's DELETE endpoint is slug-addressed (a numeric value in
+// the slug position 404s). The persisted slug is authoritative; as
+// defense-in-depth, the live team's id is confirmed to match the persisted id
+// before deletion. A 404 (already gone) is success, so `classroom remove` is
+// idempotent.
 //
-// A ref that fails IsDeletableClassroomTeamRef is a no-op: an empty slug
-// or a zero/absent id (a classroom created before the id was persisted,
-// or a hand-edited ref) can't be verified against a live team, so the
-// CLI refuses to delete blind — matching the web's fail-closed guard.
-// The `id != 0` verification path below therefore never runs against an
-// id it can't confirm.
+// A ref failing IsDeletableClassroomTeamRef is a no-op: an empty slug or
+// zero/absent id can't be verified against a live team, so the CLI refuses to
+// delete blind (matching the web's fail-closed guard).
 func DeleteClassroomTeam(client githubapi.Client, org string, team TeamRef) error {
 	if team.Slug == "" {
 		return nil
 	}
-	// Namespace guard (mirrors the web's isDeletableClassroomTeamRef):
-	// only ever delete a `classroom50-`-prefixed team, so a malformed or
-	// hand-edited classroom.json can't point the delete at an unrelated
-	// org team.
+	// Namespace guard: only ever delete a `classroom50-`-prefixed team.
 	if !strings.HasPrefix(team.Slug, "classroom50-") {
 		return fmt.Errorf("refusing to delete team %q at %s — not a classroom50-namespaced team; remove it by hand if intended", team.Slug, org)
 	}
-	// Fail closed on a non-positive id: without a recorded id we can't
-	// confirm the live team at this slug is the one this classroom
-	// created, so we must not DELETE it. This is the load-bearing half of
-	// the web's guard the earlier port dropped — a hand-edited ref of
-	// `{"id": 0, "slug": "classroom50-<other>-instructor"}` would
-	// otherwise be deleted blind on the prefix alone.
+	// Fail closed on a non-positive id: without a recorded id we can't confirm
+	// the live team at this slug is the one this classroom created. (The
+	// load-bearing half of the web's guard an earlier port dropped.)
 	if team.ID <= 0 {
 		return fmt.Errorf("refusing to delete team %q at %s — no recorded id to verify it against; remove it by hand if intended", team.Slug, org)
 	}
-	// Defense-in-depth: confirm the team currently at this slug is the
-	// one we recorded (same id) before deleting, so we never remove an
-	// unrelated team that happens to occupy the slug now.
+	// Defense-in-depth: confirm the team at this slug is the one we recorded
+	// (same id) before deleting.
 	getPath := fmt.Sprintf("orgs/%s/teams/%s", url.PathEscape(org), url.PathEscape(team.Slug))
 	var live struct {
 		ID int64 `json:"id"`
@@ -343,9 +297,8 @@ func DeleteClassroomTeam(client githubapi.Client, org string, team TeamRef) erro
 }
 
 // TeamMemberRole is a GitHub team-membership role — distinct from the
-// per-classroom StaffRole (instructor|ta). Only these two values are
-// valid; a typed constant keeps the compiler honest at the call sites
-// instead of surfacing a typo'd literal as a 422 at runtime.
+// per-classroom StaffRole. A typed constant keeps the compiler honest at call
+// sites instead of surfacing a typo'd literal as a runtime 422.
 type TeamMemberRole string
 
 const (
@@ -353,20 +306,16 @@ const (
 	TeamMaintainer TeamMemberRole = "maintainer"
 )
 
-// AddTeamMembership adds (or updates) a user's membership in the team
-// addressed by `slug` (the authoritative persisted slug) via
-// PUT .../teams/{slug}/memberships/{username}. For an existing org
-// member the membership is active immediately; for a not-yet-member it
-// goes pending until they accept the org invite. Idempotent — re-adding
-// a member is a clean no-op.
+// AddTeamMembership adds (or updates) a user's membership in the team addressed
+// by `slug`. For an existing org member it's active immediately; for a
+// not-yet-member it stays pending until they accept the org invite. Idempotent.
 func AddTeamMembership(client githubapi.Client, org, slug, username string) error {
 	return AddTeamMembershipWithRole(client, org, slug, username, TeamMember)
 }
 
-// AddTeamMembershipWithRole is AddTeamMembership with an explicit team
-// role. Staff-team creation adds the acting teacher as an instructor
-// `TeamMaintainer` (mirroring the web), while roster/students always
-// join as `TeamMember`.
+// AddTeamMembershipWithRole is AddTeamMembership with an explicit team role.
+// Staff-team creation adds the acting teacher as a `TeamMaintainer` (mirroring
+// the web); roster/students always join as `TeamMember`.
 func AddTeamMembershipWithRole(client githubapi.Client, org, slug, username string, role TeamMemberRole) error {
 	body, err := json.Marshal(map[string]any{"role": string(role)})
 	if err != nil {
@@ -383,10 +332,9 @@ func AddTeamMembershipWithRole(client githubapi.Client, org, slug, username stri
 	return nil
 }
 
-// RemoveTeamMembership removes a user from the team addressed by
-// `slug`. A 404 (not a member, or the team is gone) is treated as
-// success so `roster remove` is idempotent. Does not affect org
-// membership.
+// RemoveTeamMembership removes a user from the team addressed by `slug`. A 404
+// (not a member, or team gone) is success so `roster remove` is idempotent.
+// Does not affect org membership.
 func RemoveTeamMembership(client githubapi.Client, org, slug, username string) error {
 	path := fmt.Sprintf("orgs/%s/teams/%s/memberships/%s",
 		url.PathEscape(org), url.PathEscape(slug), url.PathEscape(username))
@@ -402,11 +350,9 @@ func RemoveTeamMembership(client githubapi.Client, org, slug, username string) e
 	return nil
 }
 
-// teamHasRepoAccess reports whether the team addressed by `slug`
-// already has any access to <org>/<repo>. GET
-// .../teams/{slug}/repos/{owner}/{repo} returns 204 when the team has
-// access, 404 when it doesn't. Used to keep GrantTeamRepoRead
-// idempotent (skip the PUT when already granted).
+// teamHasRepoAccess reports whether the team addressed by `slug` already has
+// any access to <org>/<repo> (204 = yes, 404 = no). Keeps GrantTeamRepoRead
+// idempotent.
 func teamHasRepoAccess(client githubapi.Client, org, slug, repoOwner, repo string) (bool, error) {
 	path := fmt.Sprintf("orgs/%s/teams/%s/repos/%s/%s",
 		url.PathEscape(org), url.PathEscape(slug), url.PathEscape(repoOwner), url.PathEscape(repo))
@@ -422,29 +368,25 @@ func teamHasRepoAccess(client githubapi.Client, org, slug, repoOwner, repo strin
 	return true, nil
 }
 
-// GrantTeamRepoRead grants the team addressed by `slug` `pull` (read)
-// on <repoOwner>/<repo> — the access a base-permission-`none` student
-// needs to generate from a private, org-owned template. Idempotent:
-// skips the PUT when the team already has access. Returns whether a
-// new grant was applied.
+// GrantTeamRepoRead grants the team `pull` on <repoOwner>/<repo> — the access a
+// base-permission-`none` student needs to generate from a private org-owned
+// template. Idempotent; returns whether a new grant was applied.
 func GrantTeamRepoRead(client githubapi.Client, org, slug, repoOwner, repo string) (granted bool, err error) {
 	return grantTeamRepo(client, org, slug, repoOwner, repo, "pull")
 }
 
-// GrantTeamRepoWrite grants the team addressed by `slug` `push` (write)
-// on <repoOwner>/<repo> — the access a staff team needs on the
-// `classroom50` config repo to author assignments. Idempotent: skips
-// the PUT when the team already has access. Returns whether a new grant
-// was applied. Mirrors the web's grantTeamConfigRepoWrite.
+// GrantTeamRepoWrite grants the team `push` on <repoOwner>/<repo> — the access
+// a staff team needs on the config repo to author assignments. Idempotent;
+// returns whether a new grant was applied. Mirrors the web's
+// grantTeamConfigRepoWrite.
 func GrantTeamRepoWrite(client githubapi.Client, org, slug, repoOwner, repo string) (granted bool, err error) {
 	return grantTeamRepo(client, org, slug, repoOwner, repo, "push")
 }
 
-// grantTeamRepo PUTs a team's repo permission, skipping the write when
-// the team already has any access (keeps the grant idempotent). The
-// existing-access check is permission-agnostic; a staff-team re-run
-// after a permission change would be a no-op, which is acceptable for
-// the create-time grant this backs.
+// grantTeamRepo PUTs a team's repo permission, skipping the write when the team
+// already has any access (keeps the grant idempotent). The existing-access
+// check is permission-agnostic, acceptable for the create-time grant this
+// backs.
 func grantTeamRepo(client githubapi.Client, org, slug, repoOwner, repo, permission string) (granted bool, err error) {
 	has, err := teamHasRepoAccess(client, org, slug, repoOwner, repo)
 	if err != nil {
@@ -468,13 +410,12 @@ func grantTeamRepo(client githubapi.Client, org, slug, repoOwner, repo, permissi
 	return true, nil
 }
 
-// ResolveClassroomTeamSlug returns the classroom team's addressing slug:
-// the persisted classroom.json `team.slug` when present (authoritative —
-// GitHub may re-slug on a name collision, e.g. `classroom50-cs-1`), else the
-// derived `classroom50-<short>`. Mirrors the web app's resolveClassroomTeam and
-// the Python collector's resolve_team_slug so all three consumers target the
-// same team. A transient read failure propagates (so a caller doesn't target a
-// wrong slug); only a genuinely absent team block falls back to the derivation.
+// ResolveClassroomTeamSlug returns the classroom team's addressing slug: the
+// persisted classroom.json `team.slug` when present (authoritative — GitHub may
+// re-slug on a collision), else the derived `classroom50-<short>`. Mirrors the
+// web's resolveClassroomTeam and the Python collector's resolve_team_slug. A
+// transient read failure propagates; only a genuinely absent team block falls
+// back to derivation.
 func ResolveClassroomTeamSlug(client githubapi.Client, org, shortName, ref string) (string, error) {
 	team, ok, err := ResolveClassroomTeam(client, org, shortName, ref)
 	if err != nil {
@@ -493,11 +434,9 @@ type teamMember struct {
 }
 
 // ListTeamMembers returns the logins of every member of the classroom team
-// addressed by `slug`, walking pagination. This is the team-driven username
-// source for grade collection: the classroom GitHub team is authoritative for
-// who is enrolled (students.csv is only optional display metadata). A 404 (team
-// doesn't exist yet) returns an empty slice so a classroom whose team hasn't
-// been created reads as "no members" rather than erroring.
+// addressed by `slug`, walking pagination. The classroom GitHub team is
+// authoritative for enrollment (students.csv is optional display metadata). A
+// 404 (team doesn't exist yet) returns an empty slice rather than erroring.
 func ListTeamMembers(client githubapi.Client, org, slug string) ([]string, error) {
 	const perPage, maxPages = 100, 100
 	members, err := githubapi.PaginateAll[teamMember](
@@ -508,7 +447,7 @@ func ListTeamMembers(client githubapi.Client, org, slug string) ([]string, error
 		},
 		func(path string, err error) error {
 			if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
-				return nil // sentinel: caller treats nil error + handles empty
+				return nil // 404 sentinel: caller handles the empty result
 			}
 			return fmt.Errorf("GET %s: %w", path, err)
 		},

--- a/cli/gh-teacher/internal/configwrite/commit.go
+++ b/cli/gh-teacher/internal/configwrite/commit.go
@@ -1,12 +1,8 @@
 // Package configwrite is the config-repo write substrate: the
-// optimistic-update-with-rebase Tree-commit helpers every teacher-side
-// mutation of <org>/classroom50 goes through, plus the workflow-scope
-// classifier wired into that rebase loop. It is the write-side sibling of
-// internal/configrepo (reads); neither imports the other.
-//
-// It reaches GitHub only through internal/githubapi (via
-// githubapi.CommitWithRebase) and depends otherwise only on internal/validate,
-// the shared gittree package, and stdlib — no package main, no go-gh.
+// optimistic-update-with-rebase Tree-commit helpers every teacher-side mutation
+// of <org>/classroom50 goes through, plus the workflow-scope classifier wired
+// into that loop. Write-side sibling of internal/configrepo (reads). Reaches
+// GitHub only through internal/githubapi.
 package configwrite
 
 import (
@@ -20,21 +16,18 @@ import (
 type CommitChange = gittree.Change
 
 // CommitTree is the optimistic-update-with-rebase helper for teacher-side
-// upserts to <org>/classroom50. It covers the common upsert-only case where
-// build returns a path -> content map; for commits that also delete files, use
-// CommitTreeChange directly. The createTree workflow-scope classifier is wired
-// in so a skeleton .github/workflows write without the `workflow` scope fails
-// fast (see ClassifyWorkflowScope404).
+// upserts. Covers the common upsert-only case (build returns a path → content
+// map); for commits that also delete, use CommitTreeChange. The workflow-scope
+// classifier is wired in so a `.github/workflows` write without the `workflow`
+// scope fails fast.
 //
 // Return shape:
 //   - ("<sha>", nil) — commit landed.
 //   - ("", nil)      — build returned an empty map; no-op.
-//   - ("", err)      — failure (build can signal one via (nil, err);
-//     (nil, nil) is success/no-op).
+//   - ("", err)      — failure.
 //
-// Callers commonly close over a per-attempt accumulator (e.g.
-// `var action string`). Reset such accumulators at the top of each build call
-// so a retry doesn't see stale state.
+// Callers that close over a per-attempt accumulator must reset it at the top of
+// each build call so a retry doesn't see stale state.
 func CommitTree(
 	client githubapi.Client,
 	owner, repo, branch, message string,

--- a/cli/gh-teacher/internal/configwrite/workflowscope.go
+++ b/cli/gh-teacher/internal/configwrite/workflowscope.go
@@ -28,10 +28,8 @@ func tokenLacksWorkflowScope(err error) bool {
 }
 
 // ClassifyWorkflowScope404 maps a Tree-write 404 to ErrMissingWorkflowScope
-// when the token's X-OAuth-Scopes header shows the `workflow` scope is absent.
-// A 404 without that signal is fresh-repo lag, so it returns nil (leave the
-// original error intact). Wired into the shared CreateTree/CommitWithRebase
-// paths as their classify404 hook.
+// when X-OAuth-Scopes shows `workflow` absent. A 404 without that signal is
+// fresh-repo lag, so it returns nil. Wired into the shared paths as classify404.
 func ClassifyWorkflowScope404(err error) error {
 	if tokenLacksWorkflowScope(err) {
 		return ErrMissingWorkflowScope

--- a/cli/gh-teacher/internal/download/download.go
+++ b/cli/gh-teacher/internal/download/download.go
@@ -1,14 +1,9 @@
-// Package download implements the `gh teacher download` command: cloning
-// every student submission repo for an assignment under <org>/classroom50
-// (roster-driven by default, or --by-pattern), refreshing each repo's
+// Package download implements the `gh teacher download` command: cloning every
+// student submission repo for an assignment under <org>/classroom50
+// (roster-driven or --by-pattern), refreshing each repo's
 // result.json/results.json from its submit-tag releases, and writing a
-// scores.csv summary. It is an extracted command package (mirrors the
-// other internal/<command> packages): only NewCmd is exported; the
-// run* orchestration, the release-asset fetcher, and the scores.csv
-// writer are package-private. It is a read-only consumer of the config
-// repo. It depends only on the internal/* substrate seams (assignment,
-// configrepo, githubapi, orgrepos, scores, cliutil) plus the shared
-// contract package, never on package main.
+// scores.csv summary. Read-only consumer of the config repo; only NewCmd is
+// exported.
 package download
 
 import (
@@ -41,40 +36,36 @@ import (
 // dirTimestampFormat: filesystem-safe and lexicographically sortable.
 const dirTimestampFormat = "2006_01_02_T_15_04_05"
 
-// Cross-binary contract with collect_scores.py and
-// autograde-runner.yaml (which creates the submit-tag releases):
-// asset name, submit-tag prefix, and per-asset size cap. Keep aligned
-// with `RESULT_ASSET_NAME`, `SUBMIT_TAG_PREFIX`, and `MAX_RESULT_BYTES`
-// in skeleton/dotgithub/scripts/collect_scores.py.
+// Cross-binary contract with collect_scores.py and autograde-runner.yaml
+// (which creates the submit-tag releases): asset name, submit-tag prefix,
+// per-asset size cap. Keep aligned with RESULT_ASSET_NAME, SUBMIT_TAG_PREFIX,
+// and MAX_RESULT_BYTES in collect_scores.py.
 const (
 	resultAssetName = "result.json"
 	submitTagPrefix = "submit/"
 	maxResultBytes  = 10 * 1024 * 1024
 )
 
-// resultsAssetName: the per-repo history file written alongside the
-// clone. Holds every submit-tag submission's result.json (newest
-// first), not just the latest — `result.json` keeps the single
-// latest payload for back-compat.
+// resultsAssetName: the per-repo history file written alongside the clone.
+// Holds every submit-tag submission's result.json (newest first);
+// result.json keeps the single latest payload for back-compat.
 const resultsAssetName = "results.json"
 
-// allReleasesPerPage / allReleasesPagesMax bound the full
-// releases walk used to collect every submission. 100×100 = 10k
-// releases per repo — far beyond any plausible push history;
-// exhausting the cap errors loudly rather than silently dropping
-// older submissions.
+// allReleasesPerPage / allReleasesPagesMax bound the full releases walk.
+// 100×100 = 10k releases per repo — far beyond any push history; exhausting
+// the cap errors loudly rather than silently dropping older submissions.
 const (
 	allReleasesPerPage  = 100
 	allReleasesPagesMax = 100
 )
 
-// assetDownloadTimeout caps the asset GET. Long enough for a slow
-// CDN; short enough that a hang doesn't wedge the whole download.
+// assetDownloadTimeout caps the asset GET: long enough for a slow CDN, short
+// enough that a hang doesn't wedge the download.
 const assetDownloadTimeout = 30 * time.Second
 
 // scoresCSVHeader: stable column order. `late` and `override` are tri-state
-// ("true" / "false" / "") so spreadsheet readers can distinguish
-// an explicit flag from a non-submission or older score row.
+// ("true"/"false"/"") so readers can distinguish an explicit flag from a
+// non-submission or older row.
 var scoresCSVHeader = []string{
 	"username",
 	"first_name",
@@ -153,10 +144,9 @@ func NewCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			errOut := cmd.ErrOrStderr()
 
-			// verbose is registered as a persistent flag on the root
-			// command (main.go); read it here and thread it down rather
-			// than reaching for a package global, so this command package
-			// has no dependency on package main.
+			// verbose is a persistent flag on the root command (main.go); read
+			// it here and thread it down rather than reaching for a package
+			// global, so this package has no dependency on package main.
 			verbose, _ := cmd.Flags().GetBool("verbose")
 
 			if byPattern {
@@ -172,11 +162,10 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-// downloadByRoster: roster × assignment Cartesian, clone the
-// existing repos, refresh each repo's result.json from the latest
-// submit-tag release, write a scores.csv summary at the dir root.
-// Roster entries without a repo on the org are reported as missing
-// — not a hard failure.
+// downloadByRoster: roster × assignment Cartesian, clone the existing repos,
+// refresh each repo's result.json from the latest submit-tag release, write a
+// scores.csv summary at the dir root. Roster entries without a repo are
+// reported as missing — not a hard failure.
 func downloadByRoster(client githubapi.Client, out, errOut io.Writer, org, classroom, assignment, dir string, quiet, verbose bool) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -200,9 +189,8 @@ func downloadByRoster(client githubapi.Client, out, errOut io.Writer, org, class
 	}
 	credited := creditedUsernames(scores, assignment)
 
-	// Team-driven username source: the classroom GitHub team is authoritative
-	// for who is enrolled. Resolve the slug the same way the web view and the
-	// Python collector do (classroom.json team.slug, fallback classroom50-<c>).
+	// The classroom GitHub team is authoritative for enrollment. Resolve the
+	// slug the same way the web view and Python collector do.
 	teamSlug, err := configrepo.ResolveClassroomTeamSlug(client, org, classroom, branch)
 	if err != nil {
 		return err
@@ -219,9 +207,9 @@ func downloadByRoster(client githubapi.Client, out, errOut io.Writer, org, class
 		return nil
 	}
 
-	// students.csv is optional display metadata now — a missing/unreadable CSV
-	// yields blank metadata, never a skipped student. Load best-effort and index
-	// by github_id then login for the scores.csv join.
+	// students.csv is optional display metadata: a missing/unreadable CSV
+	// yields blank metadata, never a skipped student. Best-effort, indexed by
+	// login for the scores.csv join.
 	metaByLogin := loadRosterMetadata(client, org, classroom, branch, errOut)
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -274,16 +262,15 @@ func downloadByRoster(client githubapi.Client, out, errOut io.Writer, org, class
 		if !exists {
 			if isGroup {
 				if _, ok := credited[strings.ToLower(username)]; ok {
-					// Joined a teammate's repo: owns no derived repo,
-					// but already credited via the owner's fanned-out
-					// scores.json row. Expected — not a miss.
+					// Joined a teammate's repo: owns no derived repo but is
+					// already credited via the owner's fanned-out row.
 					if verbose && !quiet {
 						_, _ = fmt.Fprintf(out, "Credited via group repo: %s (no own repo)\n", username)
 					}
 					continue
 				}
-				// Group assignment, no own repo, and not credited in
-				// scores.json — a genuine non-participant. Still report.
+				// Group assignment, no own repo, not credited — a genuine
+				// non-participant. Still report.
 				if !quiet {
 					_, _ = fmt.Fprintf(out, "Missing: %s (group assignment — no own repo and not yet credited via a teammate)\n", username)
 				}
@@ -347,10 +334,9 @@ type RosterMeta struct {
 }
 
 // loadRosterMetadata reads students.csv best-effort and indexes it by
-// lowercased login for the scores.csv metadata join. A missing/unreadable CSV
-// is NOT fatal (the team drives enrollment; the CSV is only metadata) — it
-// warns and returns an empty map so every team member still gets a row, just
-// with blank name/section/email.
+// lowercased login for the scores.csv join. A missing/unreadable CSV is NOT
+// fatal (the team drives enrollment) — it warns and returns an empty map so
+// every team member still gets a row with blank name/section/email.
 func loadRosterMetadata(client githubapi.Client, org, classroom, branch string, errOut io.Writer) map[string]RosterMeta {
 	rows, err := configrepo.LoadRoster(client, org, classroom, branch)
 	if err != nil {
@@ -373,13 +359,12 @@ func loadRosterMetadata(client githubapi.Client, org, classroom, branch string, 
 	return byLogin
 }
 
-// downloadByPattern: page through <org>'s repos and clone every
-// one whose name starts with <classroom>-<assignment>-. Skips the
-// roster lookup, result.json refresh, and scores.csv summary —
-// those all depend on the config repo being bootstrapped.
+// downloadByPattern: page through <org>'s repos and clone every one whose
+// name starts with <classroom>-<assignment>-. Skips the roster lookup,
+// result.json refresh, and scores.csv summary (all depend on the config repo).
 func downloadByPattern(client githubapi.Client, out, errOut io.Writer, org, classroom, assignment, dir string, quiet, verbose bool) error {
-	// Deterministic head of assignmentRepoName — cross-binary
-	// contract with cli/gh-student/accept.go.
+	// Deterministic head of assignmentRepoName — cross-binary contract with
+	// cli/gh-student/accept.go.
 	prefix := strings.ToLower(classroom) + "-" + strings.ToLower(assignment) + "-"
 
 	repos, err := orgrepos.ListNames(client, org)
@@ -437,17 +422,15 @@ func downloadByPattern(client githubapi.Client, out, errOut io.Writer, org, clas
 	return nil
 }
 
-// assignmentRegistered: case-insensitive slug membership check. The
-// slug flows into repo names lowercased, so a mixed-case argument
-// still matches.
-// assignmentsPath returns the config-repo-relative assignments.json
-// path, wrapping the seam helper so call sites inside functions that
-// shadow the `assignment` package (with an `assignment` slug param) can
-// still reach it.
+// assignmentsPath returns the config-repo-relative assignments.json path,
+// wrapping the seam helper so call sites that shadow the `assignment` package
+// (with an `assignment` slug param) can still reach it.
 func assignmentsPath(classroom string) string {
 	return assignment.AssignmentsFilePath(classroom)
 }
 
+// assignmentRegistered: case-insensitive slug membership check. The slug flows
+// into repo names lowercased, so a mixed-case argument still matches.
 func assignmentRegistered(assignments assignment.AssignmentsJSON, slug string) bool {
 	for _, entry := range assignments.Assignments {
 		if strings.EqualFold(entry.Slug, slug) {
@@ -457,11 +440,10 @@ func assignmentRegistered(assignments assignment.AssignmentsJSON, slug string) b
 	return false
 }
 
-// assignmentIsGroup reports whether the registered assignment slug is a
-// group assignment. For a group assignment only the first accepter owns
-// a derived repo (`<classroom>-<assignment>-<owner>`); teammates join
-// that repo, so their own derived repo legitimately doesn't exist and a
-// 404 on it is not a "missing submission".
+// assignmentIsGroup reports whether the assignment slug is a group assignment.
+// For a group assignment only the first accepter owns a derived repo;
+// teammates join it, so their own derived repo legitimately doesn't exist and a
+// 404 on it isn't a "missing submission".
 func assignmentIsGroup(assignments assignment.AssignmentsJSON, slug string) bool {
 	for _, entry := range assignments.Assignments {
 		if strings.EqualFold(entry.Slug, slug) {
@@ -471,11 +453,10 @@ func assignmentIsGroup(assignments assignment.AssignmentsJSON, slug string) bool
 	return false
 }
 
-// assignmentRepoName: canonical lowercased
-// <classroom>-<assignment>-<username> repo name. Cross-binary
-// contract — mirrors reponame.Name in cli/gh-student/internal/reponame.
-// The two modules don't share symbols (separate go.mod); the formula's
-// shape IS the contract.
+// assignmentRepoName: canonical lowercased <classroom>-<assignment>-<username>
+// repo name. Cross-binary contract — mirrors reponame.Name in
+// cli/gh-student/internal/reponame. The two modules share no symbols; the
+// formula's shape IS the contract.
 func assignmentRepoName(classroom, assignment, username string) string {
 	return fmt.Sprintf("%s-%s-%s",
 		strings.ToLower(classroom),
@@ -497,9 +478,9 @@ func targetExists(path string) (bool, error) {
 	return false, err
 }
 
-// repoExistsOnOrg returns true iff GET /repos/{org}/{repo} returns
-// 200. 404 → false. Other errors propagate so a network or auth
-// failure doesn't get silently treated as "student didn't accept".
+// repoExistsOnOrg returns true iff GET /repos/{org}/{repo} returns 200. 404 →
+// false. Other errors propagate so a network/auth failure isn't silently
+// treated as "student didn't accept".
 func repoExistsOnOrg(client githubapi.Client, org, repo string) (bool, error) {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(repo))
 	if err := client.Get(path, nil); err != nil {
@@ -511,9 +492,8 @@ func repoExistsOnOrg(client githubapi.Client, org, repo string) (bool, error) {
 	return true, nil
 }
 
-// loadScores reads scores.json at `ref`. Absent file → empty
-// (non-nil) container so a fresh classroom still produces a
-// roster-shaped scores.csv with every row blank.
+// loadScores reads scores.json at `ref`. Absent file → empty (non-nil)
+// container so a fresh classroom still produces a roster-shaped scores.csv.
 func loadScores(client githubapi.Client, org, classroom, ref string) (scoresschema.File, error) {
 	path := scoresFilePath(classroom)
 	data, ok, err := configrepo.ReadFileContents(client, org, configrepo.ConfigRepoName, path, ref)
@@ -535,12 +515,11 @@ func scoresFilePath(classroom string) string {
 	return classroom + "/scores.json"
 }
 
-// parseScores enforces the schema sentinel before trusting any other
-// field, then decodes the root `assignments` map. Only the canonical
-// object shape is accepted; legacy shapes are not migrated (backward
-// compatibility is intentionally dropped), so a non-canonical file errors
-// loudly. Entries stay as map[string]any -- download reads only a handful
-// of well-known keys (owner, member_usernames, submissions).
+// parseScores enforces the schema sentinel before trusting other fields, then
+// decodes the root `assignments` map. Only the canonical object shape is
+// accepted (legacy shapes are not migrated), so a non-canonical file errors
+// loudly. Entries stay map[string]any — download reads only a few well-known
+// keys.
 func parseScores(data []byte) (scoresschema.File, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return scoresschema.File{Schema: scoresschema.SchemaV1, Assignments: map[string]scoresschema.AssignmentBucket{}}, nil
@@ -563,11 +542,9 @@ func parseScores(data []byte) (scoresschema.File, error) {
 }
 
 // decodeAssignments decodes the root `assignments` field as the canonical
-// slug-keyed map of `{type, entries}` buckets. Only an object (or
-// null/absent → empty) is accepted; legacy shapes are NOT migrated —
-// backward compatibility with pre-canonical scores.json is intentionally
-// dropped, so a non-canonical file errors loudly. Mirrors
-// normalize_assignments in collect_scores.py.
+// slug-keyed map of `{type, entries}` buckets. Only an object (or null/absent →
+// empty) is accepted; legacy shapes are NOT migrated, so a non-canonical file
+// errors loudly. Mirrors normalize_assignments in collect_scores.py.
 func decodeAssignments(raw json.RawMessage) (map[string]scoresschema.AssignmentBucket, error) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
@@ -583,10 +560,9 @@ func decodeAssignments(raw json.RawMessage) (map[string]scoresschema.AssignmentB
 	if m == nil {
 		m = map[string]scoresschema.AssignmentBucket{}
 	}
-	// Validate each bucket's `type` so the Go reader rejects the same
-	// non-canonical shapes Python's normalize_assignments does (parity):
-	// a bucket must declare type "individual" or "group". (A bucket whose
-	// `entries` isn't a JSON array already fails the Unmarshal above.)
+	// Validate each bucket's `type` for parity with Python's
+	// normalize_assignments: it must be "individual" or "group". (A
+	// non-array `entries` already fails the Unmarshal above.)
 	for slug, bucket := range m {
 		if bucket.Type != "individual" && bucket.Type != "group" {
 			return nil, fmt.Errorf("assignments[%q].type must be \"individual\" or \"group\", got %q", slug, bucket.Type)
@@ -595,18 +571,14 @@ func decodeAssignments(raw json.RawMessage) (map[string]scoresschema.AssignmentB
 	return m, nil
 }
 
-// writeScoresCSV writes a per-assignment summary. One CSV line per
-// submission, grouped by roster entry in roster order: a student who
-// pushed N times contributes N lines (newest first, matching the
-// stored submissions order); a non-submitter contributes a single
-// blank line so teachers see the whole class at a glance. Per-test
-// breakdowns are intentionally omitted — that detail lives in the
-// per-repo result.json / results.json.
+// writeScoresCSV writes a per-assignment summary. One CSV line per submission,
+// grouped by roster entry in roster order: a student with N pushes contributes
+// N lines (newest first); a non-submitter contributes one blank line. Per-test
+// breakdowns live in the per-repo result.json / results.json.
 func writeScoresCSV(path string, scores scoresschema.File, assignment string, teamLogins []string, metaByLogin map[string]RosterMeta) error {
 	entries := entriesForAssignment(scores, assignment)
-	// Map each credited student (lowercased) -> their gradebook entry.
-	// Group entries credit every member in member_usernames; individual
-	// entries credit the sole owner.
+	// Map each credited student (lowercased) → gradebook entry. Group entries
+	// credit every member_usernames; individual entries credit the owner.
 	byStudent := make(map[string]map[string]any, len(entries))
 	for _, entry := range entries {
 		for _, u := range entryCreditedUsernames(entry) {
@@ -634,16 +606,13 @@ func writeScoresCSV(path string, scores scoresschema.File, assignment string, te
 	return os.WriteFile(path, buf.Bytes(), 0o644)
 }
 
-// scoresCSVRows renders the CSV lines for one team student. A nil
-// `entry` (non-submitter) yields a single blank-scored line. Otherwise it
-// yields one line per submission in the entry's `submissions` list
-// (newest first), each carrying that submission's score columns; the
-// entry-level `override` flag is repeated on every line. An entry with no
-// usable `submissions` list still yields one blank-scored line so the
-// student isn't dropped from the summary. `meta` is the best-effort
-// students.csv join (blank when the CSV is absent/partial).
+// scoresCSVRows renders the CSV lines for one team student. A nil `entry`
+// (non-submitter) yields one blank-scored line. Otherwise one line per
+// submission (newest first), each with its score columns; the entry-level
+// `override` flag repeats on every line. An entry with no usable submissions
+// still yields one blank line. `meta` is the best-effort students.csv join.
 func scoresCSVRows(username string, meta RosterMeta, entry map[string]any) [][]string {
-	// Display metadata is teacher/student-controllable free text, so guard it
+	// Display metadata is teacher/student-controllable free text: guard it
 	// against spreadsheet formula injection like the other string cells.
 	firstName := csvSafeCell(meta.FirstName)
 	lastName := csvSafeCell(meta.LastName)
@@ -662,14 +631,12 @@ func scoresCSVRows(username string, meta RosterMeta, entry map[string]any) [][]s
 	}
 	out := make([][]string, 0, len(subs))
 	for _, sub := range subs {
-		// Student-controllable string cells are run through csvSafeCell to
-		// neutralize spreadsheet formula injection — a student owns their
-		// repo and can publish a result.json with e.g. review="=HYPERLINK(..)".
-		// encoding/csv quotes structural chars but does NOT defang a leading
-		// =,+,-,@. score/max-score are typed numbers (never injectable), but
-		// `late` and `override` go through stringifyOverride, which passes a
-		// hand-edited STRING through verbatim — so they're guarded too (a
-		// no-due assignment never overwrites a student-supplied `late`).
+		// Student-controllable string cells go through csvSafeCell to defang
+		// spreadsheet formula injection (a student owns their repo and can
+		// publish review="=HYPERLINK(..)"). encoding/csv quotes structural
+		// chars but not a leading =,+,-,@. score/max-score are typed numbers,
+		// but `late`/`override` pass a hand-edited STRING verbatim via
+		// stringifyOverride, so they're guarded too.
 		out = append(out, metaCells(
 			stringifyNumber(sub["score"]),
 			stringifyNumber(sub["max-score"]),
@@ -684,16 +651,12 @@ func scoresCSVRows(username string, meta RosterMeta, entry map[string]any) [][]s
 	return out
 }
 
-// csvSafeCell neutralizes CSV formula injection. A spreadsheet (Excel,
-// Sheets, LibreOffice) evaluates a cell whose first character is one of
-// = + - @ (or a leading tab / carriage return) as a formula. Several
-// scores.csv columns carry student-controlled strings (a student owns
-// their assignment repo and publishes the graded result.json), so a
-// crafted value like "=HYPERLINK(\"http://evil\",\"click\")" would execute
-// when the teacher opens the sheet. Go's encoding/csv quotes structural
-// characters (comma, quote, newline) but does nothing about formulas, so
-// we prefix a single quote to any at-risk cell. An empty cell is left
-// untouched so blank columns stay blank.
+// csvSafeCell neutralizes CSV formula injection. A spreadsheet evaluates a cell
+// whose first char is = + - @ (or a leading tab/CR) as a formula. Several
+// scores.csv columns carry student-controlled strings (a student owns their
+// repo and publishes result.json), so a crafted "=HYPERLINK(...)" would execute
+// on open. encoding/csv quotes structural chars but not formulas, so we prefix
+// a single quote to any at-risk cell. Empty cells stay blank.
 func csvSafeCell(s string) string {
 	if s == "" {
 		return s
@@ -705,10 +668,9 @@ func csvSafeCell(s string) string {
 	return s
 }
 
-// submittedByUsername returns the pusher login from a submission
-// record's `submitted_by` block, or "" when absent/malformed. For a
-// group submission the entry's `member_usernames` lists everyone
-// credited, but this column shows who actually pushed each submission.
+// submittedByUsername returns the pusher login from a submission's
+// `submitted_by` block, or "" when absent/malformed. For a group submission
+// `member_usernames` lists everyone credited; this column shows who pushed.
 func submittedByUsername(sub map[string]any) string {
 	by, ok := sub["submitted_by"].(map[string]any)
 	if !ok {
@@ -717,10 +679,9 @@ func submittedByUsername(sub map[string]any) string {
 	return stringifyString(by["username"])
 }
 
-// submissionRecords returns an entry's `submissions` history as a slice
-// of maps (newest first). Tolerant of a hand-edited file: a missing
-// or non-array `submissions`, or non-object entries, yield an empty
-// slice / are skipped rather than erroring.
+// submissionRecords returns an entry's `submissions` history (newest first).
+// Tolerant of a hand-edited file: a missing/non-array `submissions` or
+// non-object entries yield an empty slice / are skipped rather than erroring.
 func submissionRecords(entry map[string]any) []map[string]any {
 	raw, _ := entry["submissions"].([]any)
 	out := make([]map[string]any, 0, len(raw))
@@ -732,10 +693,9 @@ func submissionRecords(entry map[string]any) []map[string]any {
 	return out
 }
 
-// entriesForAssignment returns the entries for an assignment's bucket.
-// The lookup is case-insensitive -- `assignment add` lowercases slugs on
-// write and the CLI lowercases its argument, but a hand-edited scores.json
-// key might not match exactly.
+// entriesForAssignment returns the entries for an assignment's bucket. The
+// lookup is case-insensitive since a hand-edited scores.json key might not
+// match the lowercased slug exactly.
 func entriesForAssignment(scores scoresschema.File, assignment string) []map[string]any {
 	if bucket, ok := scores.Assignments[assignment]; ok {
 		return bucket.Entries
@@ -748,10 +708,9 @@ func entriesForAssignment(scores scoresschema.File, assignment string) []map[str
 	return nil
 }
 
-// creditedUsernames returns the lowercased set of usernames that already
-// have a gradebook entry for the assignment in scores.json. Used so a
-// group teammate who was fanned a score (but owns no derived repo) is not
-// mistaken for a non-participant.
+// creditedUsernames returns the lowercased set of usernames that already have a
+// gradebook entry for the assignment, so a group teammate who was fanned a
+// score (but owns no derived repo) isn't mistaken for a non-participant.
 func creditedUsernames(scores scoresschema.File, assignment string) map[string]struct{} {
 	out := make(map[string]struct{})
 	for _, entry := range entriesForAssignment(scores, assignment) {
@@ -762,9 +721,9 @@ func creditedUsernames(scores scoresschema.File, assignment string) map[string]s
 	return out
 }
 
-// entryCreditedUsernames returns every student credited by a gradebook
-// entry: a group entry's `member_usernames`, or — when that's absent
-// (an individual entry) — the sole `owner`.
+// entryCreditedUsernames returns every student credited by a gradebook entry:
+// a group entry's `member_usernames`, or — when absent (individual) — the sole
+// `owner`.
 func entryCreditedUsernames(entry map[string]any) []string {
 	if raw, ok := entry["member_usernames"].([]any); ok {
 		out := make([]string, 0, len(raw))
@@ -783,9 +742,8 @@ func entryCreditedUsernames(entry map[string]any) []string {
 	return nil
 }
 
-// stringifyNumber: integer string for whole numbers, decimal
-// otherwise. "" for nil/non-numeric so an absent or hand-typed
-// entry round-trips cleanly into the CSV.
+// stringifyNumber: integer string for whole numbers, decimal otherwise. "" for
+// nil/non-numeric so an absent or hand-typed entry round-trips into the CSV.
 func stringifyNumber(v any) string {
 	switch x := v.(type) {
 	case float64:
@@ -809,10 +767,9 @@ func stringifyString(v any) string {
 	return ""
 }
 
-// stringifyOverride collapses bool/null/missing into "true" /
-// "false" / "". A hand-edited string passes through so a teacher
-// extending the schema (e.g. `"override": "verified"`) stays
-// readable in the CSV.
+// stringifyOverride collapses bool/null/missing into "true"/"false"/"". A
+// hand-edited string passes through so a teacher extending the schema (e.g.
+// `"override": "verified"`) stays readable in the CSV.
 func stringifyOverride(v any) string {
 	switch x := v.(type) {
 	case bool:
@@ -826,25 +783,18 @@ func stringifyOverride(v any) string {
 	return ""
 }
 
-// refreshResultJSON writes the per-repo submission artifacts from the
-// repo's submit-tag releases. It writes two files into <target>:
+// refreshResultJSON writes the per-repo submission artifacts from the repo's
+// submit-tag releases into <target>:
 //
-//   - results.json: a JSON array of every submit-tag submission
-//     (newest first), each element {"submission_tag": <tag>,
-//     "result": <result.json payload, or null when the release had no
-//     result.json asset>}. This is the "collect all submissions"
-//     artifact.
-//   - result.json: the latest submission's result.json payload (the
-//     historical single-latest behavior, preserved for back-compat
-//     with anything reading <repo>/result.json directly).
+//   - results.json: a JSON array of every submit-tag submission (newest
+//     first), each {"submission_tag": <tag>, "result": <payload, or null when
+//     the release had no result.json asset>}.
+//   - result.json: the latest submission's payload (single-latest back-compat).
 //
-// Silent no-op for: no releases, or no submit-tag release at all.
-// Network/5xx/decode failures propagate so the caller can warn.
-//
-// Token and apiBase are resolved once in downloadByRoster — passing
-// them in avoids per-row keyring/env lookups, and apiBase lets
-// rewriteAssetURL retarget the asset host on GHES or test setups
-// where the asset URL doesn't match the configured API.
+// Silent no-op for no releases / no submit-tag release. Network/5xx/decode
+// failures propagate so the caller can warn. Token and apiBase are resolved
+// once in downloadByRoster; apiBase lets rewriteAssetURL retarget the asset
+// host on GHES / test setups.
 func refreshResultJSON(client githubapi.Client, token, apiBase, org, repo, target string) error {
 	releases, err := listAllSubmitReleases(client, org, repo)
 	if err != nil {
@@ -854,8 +804,8 @@ func refreshResultJSON(client githubapi.Client, token, apiBase, org, repo, targe
 		return nil
 	}
 
-	// Releases come back newest-first from the API; preserve that
-	// order so results.json[0] is the most recent submission.
+	// API returns releases newest-first; preserve that so results.json[0] is
+	// the most recent submission.
 	history := make([]submissionRecord, 0, len(releases))
 	for _, rel := range releases {
 		assetURL, err := selectResultAsset(rel)
@@ -884,8 +834,8 @@ func refreshResultJSON(client githubapi.Client, token, apiBase, org, repo, targe
 		return err
 	}
 
-	// Back-compat: keep <repo>/result.json pointed at the latest
-	// submission's payload (the first history entry with an asset).
+	// Back-compat: point <repo>/result.json at the latest submission's payload
+	// (first history entry with an asset).
 	for _, rec := range history {
 		if len(rec.Result) > 0 {
 			return os.WriteFile(filepath.Join(target, resultAssetName), rec.Result, 0o644)
@@ -894,18 +844,16 @@ func refreshResultJSON(client githubapi.Client, token, apiBase, org, repo, targe
 	return nil
 }
 
-// submissionRecord is one entry in <repo>/results.json: a submit-tag
-// release and its result.json payload (null when the release carried
-// no result.json asset). Result is held as RawMessage so the original
-// bytes round-trip verbatim — download never needs to inspect them.
+// submissionRecord is one entry in <repo>/results.json: a submit-tag release
+// and its result.json payload (null when the release carried no asset). Result
+// is RawMessage so the bytes round-trip verbatim.
 type submissionRecord struct {
 	SubmissionTag string          `json:"submission_tag"`
 	Result        json.RawMessage `json:"result"`
 }
 
-// release / releaseAsset: only the fields download consumes. Other
-// keys (name, body, etc.) are intentionally absent so a malformed
-// release doesn't fail decode for a key we don't use.
+// release / releaseAsset: only the fields download consumes. Other keys are
+// absent so a malformed release doesn't fail decode for a key we don't use.
 type release struct {
 	TagName string         `json:"tag_name"`
 	Assets  []releaseAsset `json:"assets"`
@@ -916,20 +864,18 @@ type releaseAsset struct {
 	URL  string `json:"url"`
 }
 
-// listAllSubmitReleases returns every submit-tag release for a repo,
-// newest first, walking the full /releases pagination. This is the
-// "collect all submissions" walk: a student who pushed N times has N
-// submit-tag releases, and all N are returned. Non-submit releases
-// (e.g. a student's hand-created tag) are filtered out. Mirrors
-// `all_submit_releases` in collect_scores.py.
+// listAllSubmitReleases returns every submit-tag release for a repo, newest
+// first, walking the full /releases pagination. Non-submit releases (e.g. a
+// student's hand-created tag) are filtered out. Mirrors all_submit_releases in
+// collect_scores.py.
 func listAllSubmitReleases(client githubapi.Client, owner, repo string) ([]release, error) {
 	all, err := githubapi.PaginateAll[release](client, allReleasesPerPage, allReleasesPagesMax,
 		func(page int) string {
 			return fmt.Sprintf("repos/%s/%s/releases?per_page=%d&page=%d",
 				url.PathEscape(owner), url.PathEscape(repo), allReleasesPerPage, page)
 		}, func(path string, err error) error {
-			// A repo with no releases (or not accepted yet) 404s; treat
-			// it as "no submissions" rather than a hard failure.
+			// A repo with no releases (or not accepted yet) 404s; treat as "no
+			// submissions" rather than a hard failure.
 			if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
 				return errNoReleases
 			}
@@ -950,15 +896,13 @@ func listAllSubmitReleases(client githubapi.Client, owner, repo string) ([]relea
 	return submits, nil
 }
 
-// errNoReleases signals a 404 on the releases walk (no releases yet
-// or repo not accepted) so listAllSubmitReleases can map it to an
-// empty result instead of a hard error.
+// errNoReleases signals a 404 on the releases walk so listAllSubmitReleases can
+// map it to an empty result instead of a hard error.
 var errNoReleases = errors.New("no releases")
 
-// selectResultAsset returns the result.json asset URL. Empty when
-// absent; error when the release carries more than one. Matches
-// collect_scores.py's ambiguity rejection — the library uploads
-// with --clobber, so normal releases have exactly one.
+// selectResultAsset returns the result.json asset URL. Empty when absent; error
+// when the release carries more than one (matches collect_scores.py's ambiguity
+// rejection — uploads use --clobber, so normal releases have exactly one).
 func selectResultAsset(rel release) (string, error) {
 	var matches []string
 	for _, a := range rel.Assets {
@@ -976,9 +920,9 @@ func selectResultAsset(rel release) (string, error) {
 	}
 }
 
-// apiBaseURL returns the REST base URL for `host`, matching go-gh's
-// internal routing. github.com → https://api.github.com; everything
-// else assumed to be GHES at https://<host>/api/v3.
+// apiBaseURL returns the REST base URL for `host`, matching go-gh's routing.
+// github.com → https://api.github.com; everything else assumed GHES at
+// https://<host>/api/v3.
 func apiBaseURL(host string) string {
 	host = strings.TrimSpace(host)
 	if host == "" || host == "github.com" {
@@ -987,14 +931,11 @@ func apiBaseURL(host string) string {
 	return "https://" + host + "/api/v3"
 }
 
-// rewriteAssetURL retargets an asset URL to the configured API
-// host. GitHub's release JSON returns asset URLs on api.github.com
-// even when the client is talking to a GHES box or a test server,
-// so swap scheme+host (preserving any /api/v3 path prefix on the
-// target) before downloading. Relative or otherwise-malformed
-// inputs are returned unchanged so the caller still sees the
-// original — defensive fallback for fixtures that don't include a
-// host. Mirrors `rewrite_asset_url` in collect_scores.py.
+// rewriteAssetURL retargets an asset URL to the configured API host. GitHub's
+// release JSON returns asset URLs on api.github.com even against a GHES box or
+// test server, so swap scheme+host (preserving any /api/v3 prefix) before
+// downloading. Relative/malformed inputs are returned unchanged. Mirrors
+// rewrite_asset_url in collect_scores.py.
 func rewriteAssetURL(assetURL, apiBase string) string {
 	parsedAsset, err := url.Parse(assetURL)
 	if err != nil || parsedAsset.Scheme == "" || parsedAsset.Host == "" {
@@ -1022,12 +963,10 @@ func rewriteAssetURL(assetURL, apiBase string) string {
 	return out.String()
 }
 
-// downloadAssetBytes fetches the asset body. The release-asset
-// endpoint 302s to a signed storage URL when called with
-// Accept: application/octet-stream. Go's stdlib strips
-// Authorization on cross-host redirects; the explicit CheckRedirect
-// is belt-and-suspenders defense, mirroring
-// collect_scores.py's `_AuthStrippingRedirect`.
+// downloadAssetBytes fetches the asset body. The release-asset endpoint 302s to
+// a signed storage URL under Accept: application/octet-stream. Go strips
+// Authorization on cross-host redirects; the explicit CheckRedirect is
+// belt-and-suspenders, mirroring collect_scores.py's _AuthStrippingRedirect.
 func downloadAssetBytes(token, assetURL string) ([]byte, error) {
 	if token == "" {
 		return nil, errors.New("no GitHub token available — run `gh auth login` or `gh teacher login`")
@@ -1067,24 +1006,19 @@ func downloadAssetBytes(token, assetURL string) ([]byte, error) {
 	return body, nil
 }
 
-// stderrTailCap bounds non-verbose stderr capture; the error lives
-// at the tail.
+// stderrTailCap bounds non-verbose stderr capture; the error lives at the tail.
 const stderrTailCap = 8 * 1024
 
-// cloneWithProgress clones one repo, rendering progress on the human
-// channel. Interactive: a spinner (a single large repo can take many
-// seconds). Non-TTY / --quiet: the historical stable stdout lines
-// ("Cloning X... Done"), unchanged for piped/CI readers. Verbose: streams
-// git's output with per-line "Cloning X" / "X: done".
-//
-// Returns the clone error (nil on success) so the caller records the
-// failure and continues.
+// cloneWithProgress clones one repo, rendering progress on the human channel.
+// Interactive: a spinner. Non-TTY / --quiet: stable stdout lines ("Cloning
+// X... Done") for piped/CI readers. Verbose: streams git's output. Returns the
+// clone error so the caller records the failure and continues.
 func cloneWithProgress(out, errOut io.Writer, org, repo, target string, quiet, verbose bool) error {
 	sp := ghui.NewSpinner(errOut, "Cloning "+repo)
 	interactive := sp.Active() && !quiet && !verbose
 
-	// Skip the stdout lines when animating — the spinner shows the same
-	// thing on stderr, and both would duplicate on a shared terminal.
+	// Skip the stdout lines when animating — the spinner shows the same on
+	// stderr, and both would duplicate on a shared terminal.
 	if !quiet && !interactive {
 		if verbose {
 			_, _ = fmt.Fprintf(out, "Cloning %s\n", repo)
@@ -1121,10 +1055,9 @@ func cloneWithProgress(out, errOut io.Writer, org, repo, target string, quiet, v
 	return nil
 }
 
-// cloneOrgRepo shells out to `gh repo clone`. Verbose streams git's
-// output; otherwise stdout is discarded and the tail of stderr is
-// captured so failures carry git's diagnostic, not just
-// "exit status 1".
+// cloneOrgRepo shells out to `gh repo clone`. Verbose streams git's output;
+// otherwise stdout is discarded and the stderr tail is captured so failures
+// carry git's diagnostic, not just "exit status 1".
 func cloneOrgRepo(out, errOut io.Writer, org, repo, target string, quiet, verbose bool) error {
 	args := []string{"repo", "clone", fmt.Sprintf("%s/%s", org, repo), target}
 	if quiet {
@@ -1154,8 +1087,8 @@ func cloneOrgRepo(out, errOut io.Writer, org, repo, target string, quiet, verbos
 	return nil
 }
 
-// tailWriter retains only the last `cap` bytes written, to bound
-// memory when capturing chatty stderr.
+// tailWriter retains only the last `cap` bytes written, bounding memory when
+// capturing chatty stderr.
 type tailWriter struct {
 	buf []byte
 	cap int

--- a/cli/gh-teacher/internal/githubapi/auth.go
+++ b/cli/gh-teacher/internal/githubapi/auth.go
@@ -7,28 +7,23 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/ghauth"
 )
 
-// requiredScopes is the unified OAuth scope set shared with gh-student
-// (contract.RequiredOAuthScopes, issue #246) so authenticating for one CLI
-// covers the other. gh-teacher itself only needs admin:org + workflow, but the
-// two binaries deliberately request an identical set. delete_repo stays opt-in
-// for `gh teacher teardown`. Single source of truth for the login command and
-// RequireAuthClient's auto-login.
+// requiredScopes is the unified OAuth scope set shared with gh-student so
+// authenticating for one CLI covers the other. gh-teacher itself only needs
+// admin:org + workflow, but both binaries request an identical set.
+// delete_repo stays opt-in for `teardown`.
 var requiredScopes = contract.RequiredOAuthScopes()
 
-// RequiredScopes returns the OAuth scopes gh-teacher requests beyond
-// gh's defaults. Exposed for the login command, which requests the same
-// set when it triggers an interactive `gh auth login`.
+// RequiredScopes returns the OAuth scopes gh-teacher requests beyond gh's
+// defaults. Exposed for the login command.
 func RequiredScopes() []string { return append([]string(nil), requiredScopes...) }
 
 // authOptions binds gh-teacher's scopes + command name to the shared
 // auth scaffolding.
 var authOptions = ghauth.Options{RequiredScopes: requiredScopes, CommandName: "gh teacher"}
 
-// RequireAuthClient returns a REST client, auto-running `gh auth login`
-// when no token is set for the default host. Thin wrapper over the
-// shared auth helper, owned by githubapi because it constructs a
-// go-gh client; returned as the Client seam so domain code never names
-// the concrete go-gh type.
+// RequireAuthClient returns a REST client, auto-running `gh auth login` when no
+// token is set. Returned as the Client seam so domain code never names the
+// concrete go-gh type.
 func RequireAuthClient(cmd *cobra.Command) (Client, error) {
 	return ghauth.RequireClient(cmd.OutOrStdout(), cmd.ErrOrStderr(), authOptions)
 }

--- a/cli/gh-teacher/internal/githubapi/client.go
+++ b/cli/gh-teacher/internal/githubapi/client.go
@@ -5,18 +5,13 @@ import (
 	"net/http"
 )
 
-// Client is the transport-verb seam over the GitHub REST API. It exposes
-// exactly the three verbs gh-teacher uses against go-gh's *api.RESTClient
-// — Get, Post, and the verb-agnostic Request (which carries PATCH / PUT /
-// DELETE and the Link-header-returning GET that pagination needs). It is
-// deliberately NOT a per-operation domain interface: domain shaping lives
-// in the service layer, not in this seam, which keeps the interface
-// narrow and avoids the god-interface a faithful per-endpoint mapping
-// would become.
+// Client is the transport-verb seam over the GitHub REST API, exposing the
+// three verbs gh-teacher uses: Get, Post, and the verb-agnostic Request (for
+// PATCH/PUT/DELETE and the Link-header GET pagination needs). Deliberately not
+// a per-operation domain interface — domain shaping lives in the service layer.
 //
-// The concrete implementation is go-gh's *api.RESTClient, which satisfies
-// this interface structurally — RequireAuthClient returns one. Tests use
-// the in-memory fake in internal/githubtest.
+// The concrete implementation is go-gh's *api.RESTClient (returned by
+// RequireAuthClient); tests use the in-memory fake in internal/githubtest.
 type Client interface {
 	// Get issues a GET and decodes the JSON body into resp (resp may be
 	// nil for existence-only checks).

--- a/cli/gh-teacher/internal/githubapi/doc.go
+++ b/cli/gh-teacher/internal/githubapi/doc.go
@@ -1,11 +1,8 @@
-// Package githubapi is the single seam between gh-teacher and the
-// GitHub REST API. It is the ONLY package permitted to import
-// github.com/cli/go-gh/v2/pkg/api (enforced by a CI guard, not the
-// compiler); every domain talks to GitHub through the transport-verb
-// Client interface defined here, plus the generic pagination and
-// git-tree-commit plumbing layered on top of it.
+// Package githubapi is the single seam between gh-teacher and the GitHub REST
+// API — the ONLY package permitted to import go-gh/v2/pkg/api (CI-enforced).
+// Every domain talks to GitHub through the transport-verb Client interface
+// here, plus the generic pagination and git-tree-commit plumbing on top.
 //
-// The interface is intentionally transport-verb-level (Get/Post/Request),
-// not a per-operation domain interface — domain shaping belongs in the
-// service layer, not in this seam.
+// The interface is transport-verb-level (Get/Post/Request), not per-operation —
+// domain shaping belongs in the service layer.
 package githubapi

--- a/cli/gh-teacher/internal/githubapi/errors.go
+++ b/cli/gh-teacher/internal/githubapi/errors.go
@@ -2,8 +2,6 @@ package githubapi
 
 import "github.com/cli/go-gh/v2/pkg/api"
 
-// HTTPError aliases go-gh's api.HTTPError so domain packages can branch
-// on status codes and OAuth-scope headers without importing go-gh
-// directly. As a type alias it carries every field and method of the
-// underlying type transparently (StatusCode, Headers, Error(), …).
+// HTTPError aliases go-gh's api.HTTPError so domain packages can branch on
+// status codes and OAuth-scope headers without importing go-gh directly.
 type HTTPError = api.HTTPError

--- a/cli/gh-teacher/internal/githubapi/pagination.go
+++ b/cli/gh-teacher/internal/githubapi/pagination.go
@@ -9,29 +9,18 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/ghutil"
 )
 
-// PaginateAll walks a GitHub `page`/`per_page` list endpoint, returning
-// every element across pages. It is the shared core for the teacher
-// CLI's capped list walks (org members/invitations/collaborators, the
-// GitHub Classroom imports, and the org-repos walk shared by download
-// and teardown via internal/orgrepos.ListNames), replacing those
-// per-call-site hand-rolled loops.
+// PaginateAll walks a GitHub `page`/`per_page` list endpoint, returning every
+// element across pages. The shared core for the teacher CLI's capped list
+// walks, replacing hand-rolled loops.
 //
-//   - pageURL(page) builds the request path for a 1-based page number
-//     (callers own per_page/page formatting and any query prefix). Only
-//     the first page is built from pageURL; subsequent pages follow the
-//     server's `Link: rel="next"` header (GitHub's recommended
-//     pagination contract), since page count and page size are the
-//     server's to decide. When a response carries no Link header (a test
-//     server, or an endpoint that omits it), the walk falls back to
-//     synthesizing the next page via pageURL and stopping on a short
-//     page (len < perPage, including empty).
-//   - onErr maps a failed request to a caller-specific error (e.g. a
-//     friendly 404/403 mapping); when nil, the raw error is wrapped as
+//   - pageURL(page) builds the path for a 1-based page (callers own
+//     per_page/page formatting). Only page 1 is built from pageURL; subsequent
+//     pages follow the server's `Link: rel="next"`. Without a Link header, the
+//     walk synthesizes the next page via pageURL and stops on a short page.
+//   - onErr maps a failed request to a caller-specific error; nil wraps as
 //     `GET <path>`.
-//   - Termination: the server reports no next page (no `rel="next"`
-//     Link), or — without a Link header — a short page ends the walk.
-//     Hitting maxPages without termination is a safety-cap error: a
-//     partial list would silently under-report.
+//   - Termination: no `rel="next"`, or (no Link header) a short page. Hitting
+//     maxPages is a safety-cap error, since a partial list would under-report.
 func PaginateAll[T any](
 	client Client,
 	perPage, maxPages int,
@@ -50,11 +39,9 @@ func PaginateAll[T any](
 		}
 		all = append(all, batch...)
 
-		// Centralized termination decision (shared with the student CLI's
-		// walk via ghutil.NextPage) so the error-prone predicate can't
-		// drift between call sites: follow the server's `rel="next"`;
-		// stop on a no-next Link (last page) or a short no-Link page;
-		// otherwise synthesize the next page.
+		// Centralized termination via ghutil.NextPage (shared with the student
+		// CLI) so the predicate can't drift: follow `rel="next"`; stop on a
+		// no-next Link or a short no-Link page; else synthesize the next page.
 		next, stop := ghutil.NextPage(linkHeader, len(batch), perPage)
 		if stop {
 			return all, nil
@@ -69,17 +56,15 @@ func PaginateAll[T any](
 		maxPages, maxPages*perPage)
 }
 
-// GetPage issues one list request and returns the decoded batch plus the
-// raw Link response header. It uses Request (not Get) so the Link header
-// is available for next-page resolution — Get decodes the body but
-// discards the response, hiding the header pagination depends on.
+// GetPage issues one list request and returns the decoded batch plus the raw
+// Link header. It uses Request (not Get) so the Link header is available for
+// next-page resolution.
 //
-// Following the server's absolute `rel="next"` URL relies on go-gh's
-// headerRoundTripper, which strips the Authorization token on any host
-// that isn't the configured API host or a subdomain of it — so a crafted
-// off-host next link cannot pivot the token. (On GHES a sibling subdomain
-// would retain the token; that residual is accepted, as the API host is
-// already the trust boundary.)
+// Following the server's absolute `rel="next"` relies on go-gh's
+// headerRoundTripper stripping Authorization on any host that isn't the
+// configured API host (or a subdomain), so a crafted off-host next link can't
+// pivot the token. (On GHES a sibling subdomain retains the token; accepted, as
+// the API host is already the trust boundary.)
 func GetPage[T any](client Client, path string) ([]T, string, error) {
 	resp, err := client.Request(http.MethodGet, path, nil)
 	if err != nil {

--- a/cli/gh-teacher/internal/githubapi/shared.go
+++ b/cli/gh-teacher/internal/githubapi/shared.go
@@ -10,12 +10,10 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/gittree"
 )
 
-// rest recovers the concrete *api.RESTClient backing a Client. Every
-// Client in this binary is the go-gh client returned by RequireAuthClient
-// / DefaultClient / NewClient (or a test fake that embeds one), so the
-// assertion holds. It panics otherwise — a programming error, since the
-// shared-module helpers below genuinely require the concrete type and no
-// other implementation can satisfy them.
+// rest recovers the concrete *api.RESTClient backing a Client. Every Client in
+// this binary is the go-gh client (or a test fake embedding one), so the
+// assertion holds; it panics otherwise — a programming error, since the
+// shared-module helpers below require the concrete type.
 func rest(c Client) *api.RESTClient {
 	rc, ok := c.(*api.RESTClient)
 	if !ok {
@@ -29,15 +27,10 @@ func CurrentUser(c Client) (login string, id int64, err error) {
 	return ghutil.CurrentUser(rest(c))
 }
 
-// OrgPlan reads GET /orgs/{org} and returns the org's billing plan name
-// (e.g. "free"/"team"/"enterprise"). The plan name is empty when the
-// caller's token lacks billing visibility even on a successful read.
-// This is the plan lookup both init's preflight (checkOrgAccess) and the
-// audit command need to decide which member-privilege fields are in
-// scope; it lives here, with the other org reads, so the pure
-// internal/orgpolicy model seam stays stdlib-only. The error is returned
-// raw so callers can classify it (e.g. 404 → "org not found") with
-// cliutil.IsHTTPStatus.
+// OrgPlan reads GET /orgs/{org} and returns the billing plan name
+// ("free"/"team"/"enterprise"), empty when the token lacks billing visibility.
+// Lives here (with the other org reads) so the pure internal/orgpolicy seam
+// stays stdlib-only. The error is returned raw so callers can classify it.
 func OrgPlan(c Client, org string) (string, error) {
 	path := fmt.Sprintf("orgs/%s", url.PathEscape(org))
 	var resp struct {

--- a/cli/gh-teacher/internal/githubtest/client.go
+++ b/cli/gh-teacher/internal/githubtest/client.go
@@ -25,14 +25,10 @@ func (h *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return http.DefaultTransport.RoundTrip(req)
 }
 
-// NewTestClient wires a real go-gh client at the given test server,
-// returned as the githubapi.Client seam. AuthToken must be non-empty so
-// go-gh's header-injection layer leaves Authorization alone.
-//
-// This is the shared white-box test helper for gh-teacher: domain tests
-// construct a Client here instead of reaching into the concrete go-gh
-// constructor, so the go-gh dependency stays confined to githubapi and
-// this package.
+// NewTestClient wires a real go-gh client at the given test server, returned as
+// the githubapi.Client seam. AuthToken must be non-empty so go-gh leaves
+// Authorization alone. The shared white-box helper that keeps the go-gh
+// dependency confined to githubapi and this package.
 func NewTestClient(t *testing.T, server *httptest.Server) githubapi.Client {
 	t.Helper()
 	u, err := url.Parse(server.URL)

--- a/cli/gh-teacher/internal/githubtest/doc.go
+++ b/cli/gh-teacher/internal/githubtest/doc.go
@@ -1,9 +1,4 @@
-// Package githubtest provides exported test-support helpers for
-// gh-teacher's white-box tests: a real REST client wired to an
-// httptest.Server, and an in-memory fake implementing the
-// githubapi.Client seam.
-//
-// It exists so that domain test files moving out of package main keep
-// access to the shared client-construction helpers that used to live
-// inside the flat test namespace.
+// Package githubtest provides exported test-support helpers for gh-teacher's
+// white-box tests: a real REST client wired to an httptest.Server, and an
+// in-memory fake implementing the githubapi.Client seam.
 package githubtest

--- a/cli/gh-teacher/internal/githubtest/fake.go
+++ b/cli/gh-teacher/internal/githubtest/fake.go
@@ -10,24 +10,15 @@ import (
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 )
 
-// Fake is an in-memory githubapi.Client for tests that want to exercise
-// domain logic without an httptest server. Each verb dispatches to an
-// optional func field; an unset field returns a "no handler" error so a
-// test only wires the verbs it exercises.
-//
-// Fake satisfies githubapi.Client. For tests that must exercise real
-// transport behavior (Link-header pagination, status decoding), use
-// NewTestClient with an httptest.Server instead.
+// Fake is an in-memory githubapi.Client for tests exercising domain logic
+// without an httptest server. Each verb dispatches to an optional func field;
+// an unset field returns a "no handler" error.
 //
 // WARNING: Do NOT pass a Fake into the shared-module wrappers in
-// internal/githubapi (CommitWithRebase, CommitWithFreshRepoRetry,
-// UploadBlobs, SetCollaborator, WaitForStableBranch, CurrentUser) or any
-// domain function that reaches them (e.g. commitTree, the skeleton-commit
-// path, whoami). Those wrappers type-assert the Client back to the
-// concrete go-gh *api.RESTClient and PANIC on anything else. Test those
-// paths with NewTestClient (a real client over an httptest.Server); the
-// Fake is only for the transport-verb surface (Get/Post/Request and the
-// generic PaginateAll/GetPage built on them).
+// internal/githubapi (CommitWithRebase, UploadBlobs, etc.) or any function
+// reaching them — they type-assert back to the concrete go-gh *api.RESTClient
+// and PANIC otherwise. Use NewTestClient (a real client over httptest.Server)
+// for those; the Fake is only for the transport-verb surface.
 type Fake struct {
 	GetFunc     func(path string, resp interface{}) error
 	PostFunc    func(path string, body io.Reader, resp interface{}) error
@@ -57,9 +48,9 @@ func (f *Fake) Request(method, path string, body io.Reader) (*http.Response, err
 	return f.RequestFunc(method, path, body)
 }
 
-// JSONResponse builds an *http.Response with a JSON-encoded body and the
-// given status and headers — a convenience for RequestFunc handlers that
-// need to drive pagination (the Link header) or status branching.
+// JSONResponse builds an *http.Response with a JSON body and the given status
+// and headers — a convenience for RequestFunc handlers driving pagination or
+// status branching.
 func JSONResponse(status int, body interface{}, header http.Header) (*http.Response, error) {
 	buf, err := json.Marshal(body)
 	if err != nil {

--- a/cli/gh-teacher/internal/invite/invite.go
+++ b/cli/gh-teacher/internal/invite/invite.go
@@ -1,11 +1,6 @@
-// Package invite implements the `gh teacher invite` command: inviting a
-// GitHub user to an organization (as direct_member or admin) or to a
-// specific repository (with a permission level). It is an extracted
-// command package (mirrors internal/auth, internal/remove,
-// internal/roster, and internal/member): only NewCmd is exported; the
-// validRepoPermission helper and the inviteToOrg/inviteToRepo
-// orchestration are package-private. It depends only on the internal/*
-// substrate seams (githubapi, membership), never on package main.
+// Package invite implements the `gh teacher invite` command: inviting a GitHub
+// user to an organization (direct_member or admin) or to a specific repository
+// (with a permission level). Only NewCmd is exported.
 package invite
 
 import (

--- a/cli/gh-teacher/internal/member/member_list.go
+++ b/cli/gh-teacher/internal/member/member_list.go
@@ -1,12 +1,7 @@
-// Package member implements the `gh teacher member` command: read-only
-// views of actual GitHub membership (org members + pending invitations,
-// or repo collaborators) -- the counterpart to `gh teacher invite` /
-// `gh teacher remove`, used to reconcile the intended roster against
-// real membership. It is an extracted command package (mirrors
-// internal/auth, internal/remove, and internal/roster): only NewCmd is
-// exported; the subcommand factory and run* orchestration are
-// package-private. It depends only on the internal/* substrate seams
-// (githubapi, membership, output), never on package main.
+// Package member implements the `gh teacher member` command: read-only views of
+// actual GitHub membership (org members + pending invitations, or repo
+// collaborators) — the counterpart to `invite`/`remove`, used to reconcile the
+// intended roster against real membership. Only NewCmd is exported.
 package member
 
 import (
@@ -27,23 +22,18 @@ import (
 	"github.com/foundation50/gh-teacher/internal/output"
 )
 
-// memberAPIPerPage / memberPagesMax bound the paginated membership
-// walks, mirroring listClassrooms (migrate_source.go). 100 pages x 100
-// = 10k members/collaborators, far beyond any classroom org.
+// memberAPIPerPage / memberPagesMax bound the paginated membership walks.
+// 100×100 = 10k, far beyond any classroom org.
 const (
 	memberAPIPerPage = 100
 	memberPagesMax   = 100
 )
 
-// memberListEntry is one row of `member list` output. Kind separates
-// the membership surfaces an operator reconciles against the roster:
-// an active org member, a pending org invitation, or a repo
-// collaborator. Role carries the org role (admin/member, or
-// billing_manager for an org that uses it) or the repo permission
-// level (read/triage/write/maintain/admin); it may be empty for a repo
-// collaborator whose permission GitHub didn't report. github_id is 0
-// when the source endpoint doesn't report a numeric id (pending
-// invitations key on login/email, not id).
+// memberListEntry is one row of `member list` output. Kind separates the
+// surfaces reconciled against the roster (org member, pending invitation, repo
+// collaborator). Role is the org role or repo permission level; empty when
+// GitHub didn't report it. github_id is 0 for pending invitations (keyed on
+// login/email, not id).
 type memberListEntry struct {
 	Login    string `json:"login"`
 	Kind     string `json:"kind"`
@@ -128,9 +118,8 @@ func memberListCmd() *cobra.Command {
 }
 
 // runMemberListOrg lists active org members (with role) and pending
-// invitations. Active members come from two role-filtered walks
-// (admin vs member) since GET /orgs/{org}/members does not report a
-// per-member role inline. Read-only.
+// invitations. Active members come from two role-filtered walks since GET
+// /orgs/{org}/members doesn't report a per-member role inline. Read-only.
 func runMemberListOrg(client githubapi.Client, out, errOut io.Writer, org string, asJSON, quiet bool) error {
 	entries, err := collectOrgMembers(client, org)
 	if err != nil {
@@ -150,9 +139,8 @@ func runMemberListOrg(client githubapi.Client, out, errOut io.Writer, org string
 	return renderMemberList(out, errOut, org, entries, asJSON, quiet)
 }
 
-// collectOrgMembers walks GET /orgs/{org}/members for admins then all
-// members, labeling roles. The admin set drives the role; everyone
-// else is a plain member.
+// collectOrgMembers walks org members for admins then all, labeling roles. The
+// admin set drives the role; everyone else is a plain member.
 func collectOrgMembers(client githubapi.Client, org string) ([]memberListEntry, error) {
 	adminIDs := map[int64]bool{}
 	admins, err := paginateMembers(client, fmt.Sprintf("orgs/%s/members?role=admin", url.PathEscape(org)), org+" members")
@@ -182,10 +170,9 @@ func collectOrgMembers(client githubapi.Client, org string) ([]memberListEntry, 
 	return entries, nil
 }
 
-// collectOrgInvitations walks GET /orgs/{org}/invitations (pending).
-// A 403 (no admin:org scope) is surfaced as a clear error rather than
-// silently dropping the pending set, since "no pending invites" and
-// "can't read invites" are very different operator signals.
+// collectOrgInvitations walks pending org invitations. A 403 (no admin:org
+// scope) is a clear error rather than silently dropping the set, since "no
+// pending invites" and "can't read invites" are very different signals.
 func collectOrgInvitations(client githubapi.Client, org string) ([]memberListEntry, error) {
 	base := fmt.Sprintf("orgs/%s/invitations", url.PathEscape(org))
 	subject := fmt.Sprintf("%s pending invitations", org)
@@ -209,9 +196,9 @@ func collectOrgInvitations(client githubapi.Client, org string) ([]memberListEnt
 	return entries, nil
 }
 
-// normalizeInviteRole maps the invitations API's role names
-// (admin / direct_member / billing_manager) onto the same vocabulary
-// the members listing uses, so the two org surfaces read consistently.
+// normalizeInviteRole maps the invitations API's role names onto the same
+// vocabulary the members listing uses, so the two org surfaces read
+// consistently.
 func normalizeInviteRole(role string) string {
 	switch role {
 	case "direct_member":
@@ -241,7 +228,7 @@ func runMemberListRepo(client githubapi.Client, out, errOut io.Writer, owner, re
 		entries = append(entries, memberListEntry{
 			Login:    c.Login,
 			Kind:     memberKindCollaborator,
-			Role:     c.RoleName, // raw permission level; "" rendered as "(unknown)" only in the table
+			Role:     c.RoleName, // raw permission level; "" → "-" in the table
 			GitHubID: c.ID,
 		})
 	}
@@ -271,10 +258,8 @@ type repoCollaborator struct {
 	RoleName string `json:"role_name"`
 }
 
-// paginateMembers walks a members listing endpoint (page/per_page)
-// with the shared cap. `base` already carries any role filter; this
-// appends pagination params. `subject` is a human label for error
-// messages (e.g. "<org> members").
+// paginateMembers walks a members listing endpoint with the shared cap. `base`
+// already carries any role filter; `subject` is a human label for errors.
 func paginateMembers(client githubapi.Client, base, subject string) ([]memberAccount, error) {
 	sep := "?"
 	if strings.Contains(base, "?") {
@@ -289,10 +274,8 @@ func paginateMembers(client githubapi.Client, base, subject string) ([]memberAcc
 
 // classifyMembershipReadError maps the common failure statuses of the
 // read-only membership endpoints to actionable messages, mirroring
-// membership.ClassifyOrgInviteError's 403/404 handling so `member list`
-// and `invite` stay consistent. `subject` is a human label for the thing
-// being read (e.g. "cs50/members", "cs50 pending invitations").
-// Returns the original wrapped error for statuses it doesn't special-case.
+// ClassifyOrgInviteError's 403/404 handling. `subject` is a human label for the
+// thing being read. Other statuses return the wrapped error.
 func classifyMembershipReadError(path, subject string, err error) error {
 	httpErr, ok := errors.AsType[*githubapi.HTTPError](err)
 	if !ok {
@@ -343,7 +326,7 @@ func renderMemberList(out, errOut io.Writer, target string, entries []memberList
 		}
 		role := e.Role
 		if role == "" {
-			role = "-" // an empty permission level reads as "-" in the table
+			role = "-"
 		}
 		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", e.Login, e.Kind, role, githubID)
 	}
@@ -352,10 +335,8 @@ func renderMemberList(out, errOut io.Writer, target string, entries []memberList
 	return nil
 }
 
-// summarizeMemberList: one-line stderr summary shaped
-// `<target>: <message>`, matching the other list commands. A repo
-// target (owner/repo) reports collaborators; an org target reports
-// members + pending invitations.
+// summarizeMemberList: one-line stderr summary `<target>: <message>`. A repo
+// target reports collaborators; an org target reports members + pending.
 func summarizeMemberList(target string, entries []memberListEntry) string {
 	isRepo := strings.Contains(target, "/")
 	if len(entries) == 0 {

--- a/cli/gh-teacher/internal/membership/membership.go
+++ b/cli/gh-teacher/internal/membership/membership.go
@@ -1,26 +1,14 @@
-// Package membership is the org-membership service for gh-teacher: the
-// GitHub org-level invite / user-lookup / membership-state primitives and
-// the 403-classification family shared by the invite, roster, and member
-// commands. It depends on the GitHub transport only through
-// internal/githubapi (never go-gh/v2/pkg/api directly).
+// Package membership is the org-membership service for gh-teacher: GitHub
+// org-level invite / user-lookup / membership-state primitives and the
+// 403-classification family shared by the invite, roster, and member commands.
+// Talks to GitHub only through internal/githubapi.
 //
-// Boundary vs internal/configrepo (the membership rule): if an operation
-// is keyed by or reads config-repo data (classroom.json, the roster
-// file), it lives in configrepo — that is "membership as a side-effect of
-// classroom config," e.g. AddTeamMembership/RemoveTeamMembership, which
-// act on the classroom team slug recorded in classroom.json. If it is
-// pure GitHub org-membership independent of any stored config — inviting a
-// user to the org, looking a user up, reading their org membership state —
-// it lives here. LookupUser/InviteOrgByID/MembershipState are
-// config-independent, so they belong to membership; the classroom-team
-// grants stay in configrepo.
+// Boundary vs internal/configrepo: config-repo-keyed membership (team grants
+// via the slug in classroom.json) lives in configrepo; pure org membership
+// independent of stored config (invite/lookup/state) lives here.
 //
-// This package is a deliberate primitives surface, not a fused service
-// object: the three consuming commands each need a different subset (invite
-// uses LookupUser+InviteOrgByID; member uses only the forbidden classifier;
-// roster composes the ensure-membership flow via inviteIfNotMember in
-// internal/roster), so the primitives are exported individually
-// rather than hidden behind a single operation.
+// A primitives surface, not a fused service object: each consuming command
+// needs a different subset, so the primitives are exported individually.
 package membership
 
 import (
@@ -36,10 +24,9 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// InviteOrgByID posts an org invitation by the invitee's numeric id
-// (callers that already have the id save the GET /users/{username}
-// lookup). `username` is still required so ClassifyOrgInviteError can
-// produce "already a member" / "pending invite" messages.
+// InviteOrgByID posts an org invitation by the invitee's numeric id (callers
+// with the id save the lookup). `username` is still needed so
+// ClassifyOrgInviteError can produce "already a member"/"pending" messages.
 func InviteOrgByID(client githubapi.Client, org, username string, userID int64, role string) error {
 	body, err := json.Marshal(map[string]any{
 		"invitee_id": userID,
@@ -55,9 +42,7 @@ func InviteOrgByID(client githubapi.Client, org, username string, userID int64, 
 	return nil
 }
 
-// LookupUser → (canonical login, immutable numeric ID). Roster
-// commands keep both; inviteToOrg uses only the ID. 404 →
-// "GitHub user not found".
+// LookupUser → (canonical login, immutable numeric ID). 404 → "user not found".
 func LookupUser(client githubapi.Client, username string) (login string, userID int64, err error) {
 	path := fmt.Sprintf("users/%s", url.PathEscape(username))
 	var user struct {
@@ -127,13 +112,10 @@ func ClassifyOrgInviteError(client githubapi.Client, org, username, path string,
 	return fmt.Errorf("POST %s: %w", path, err)
 }
 
-// OrgForbiddenKind classifies a 403 from an org/repo endpoint by what
-// the X-OAuth-Scopes header reveals, so callers can phrase their own
-// message without each re-inspecting the header. OrgForbiddenScopeMissing
-// means a classic PAT/OAuth token that lacks admin:org; OrgForbiddenNotAdmin
-// means the token has the scope but the caller isn't an org admin;
-// OrgForbiddenGeneric covers the absent-header case (e.g. a fine-grained
-// PAT, which doesn't emit X-OAuth-Scopes).
+// OrgForbiddenKind classifies a 403 by what X-OAuth-Scopes reveals, so callers
+// phrase their own message without re-inspecting the header. ScopeMissing: a
+// classic token lacking admin:org; NotAdmin: has the scope but isn't an admin;
+// Generic: absent header (e.g. a fine-grained PAT).
 type OrgForbiddenKind int
 
 const (
@@ -142,10 +124,9 @@ const (
 	OrgForbiddenNotAdmin
 )
 
-// ClassifyOrgForbidden inspects an *githubapi.HTTPError's X-OAuth-Scopes
-// header. Shared by ClassifyOrgInviteError (POST) and the member-read
-// classifier (GET) so the admin:org scope-vs-admin distinction stays
-// identical across the invite and read paths.
+// ClassifyOrgForbidden inspects an HTTPError's X-OAuth-Scopes. Shared by the
+// invite (POST) and member-read (GET) paths so the scope-vs-admin distinction
+// stays identical.
 func ClassifyOrgForbidden(httpErr *githubapi.HTTPError) OrgForbiddenKind {
 	scopes := httpErr.Headers.Get("X-OAuth-Scopes")
 	switch {

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -1,76 +1,49 @@
 // Package orgpolicy is the shared org-member-defaults policy seam: the
-// canonical least-privilege member-privilege model, the
-// plan-aware filtering of which settings apply, the classification of a
-// live GET /orgs/{org} response against that model, and the static
-// manual-hardening checklist for the web-UI-only settings GitHub exposes
-// no REST field for. It is a substrate seam (like internal/scores /
-// internal/configrepo / internal/orgrepos), not a command package: both
-// `gh teacher init` (apply + verify) and `gh teacher audit` (read-only
-// report) consume it so the two surfaces can't drift in what
-// "locked-down" means. It depends only on the standard library — the org
-// READ/WRITE stays with the callers (init's verifyOrgDefaults, audit's
-// readOrgMemberSettings), so this package never imports internal/githubapi
-// or package main.
+// canonical least-privilege member-privilege model, plan-aware filtering of
+// which settings apply, classification of a live GET /orgs/{org} response, and
+// the manual-hardening checklist for web-UI-only settings with no REST field.
+// Both `init` (apply + verify) and `audit` (read-only report) consume it so
+// the two can't drift. Depends only on stdlib — the org READ/WRITE stays with
+// the callers.
 package orgpolicy
 
 import "fmt"
 
-// MemberDefaultSetting is one org-level member policy, kept per-field so
-// the 403/422 fallback can retry and warn about each independently. The
-// fields are exported because both staying callers (init's
-// verifyOrgDefaults, audit's buildAuditReport) read them off the verdicts
-// this package produces.
+// MemberDefaultSetting is one org-level member policy, kept per-field so the
+// 403/422 fallback can retry and warn about each independently. Fields are
+// exported because both callers read them off the verdicts this package emits.
 type MemberDefaultSetting struct {
 	Field string // JSON field on PATCH /orgs/{org}
 	Value any    // desired value
 	Desc  string // human description for success/warning lines
-	// ManualFix: a UI state the teacher can actually reach -- plans
-	// gate the member-privileges page and some checkbox combos don't
-	// exist on every plan.
+	// ManualFix: a UI state the teacher can actually reach (plans gate the
+	// member-privileges page and some checkbox combos don't exist everywhere).
 	ManualFix string
-	// Critical marks the lockdown fields whose absence re-opens the
-	// org-wide repo-admin danger that makes the founder-admin grant in
-	// `gh student accept` safe. If any of these is rejected, the
-	// "repo-admin is defanged org-wide" invariant does NOT hold and init
-	// must say so loudly rather than reporting a clean success. The
-	// enabling fields (private-repo / Pages creation) are deliberately
-	// non-critical: a rejected `members_can_create_public_pages` on a
-	// non-Enterprise plan is expected and harmless, not a safety gap.
+	// Critical marks lockdown fields whose absence re-opens the org-wide
+	// repo-admin danger that makes the founder-admin grant in `student accept`
+	// safe. If any is rejected, the "repo-admin is defanged org-wide"
+	// invariant does NOT hold and init must say so loudly. The enabling fields
+	// (private-repo / Pages creation) are non-critical.
 	Critical bool
-	// enterpriseOnly marks settings whose member-privileges toggle only
-	// exists on GitHub Enterprise Cloud. On Team/Free orgs (the primary
-	// audience) GitHub doesn't expose these — the API silently ignores
-	// the PATCH and the settings page has no such control — so init skips
-	// them entirely on non-enterprise plans (it neither attempts, verifies,
-	// nor lists them in the manual checklist), avoiding doomed writes and
-	// noise the teacher can't act on. They stay in the canonical list so
-	// an Enterprise-Cloud org still gets them. The Enterprise-only ones:
-	//   - members_can_create_internal_repositories (internal visibility is
-	//     an Enterprise feature).
+	// enterpriseOnly marks settings whose toggle only exists on GitHub
+	// Enterprise Cloud. On Team/Free (the primary audience) the API silently
+	// ignores the PATCH and the settings page has no control, so init skips
+	// them entirely there (neither attempts, verifies, nor lists them). Kept
+	// in the canonical list so Enterprise-Cloud orgs still get them:
+	//   - members_can_create_internal_repositories (internal is Enterprise).
 	//   - members_can_view_dependency_insights (no Team control).
-	//   - members_can_invite_outside_collaborators (Team has no such
-	//     toggle; only owners invite outside collaborators).
-	//   - members_can_create_public_repositories=false ("private repos
-	//     only"): on Team/Free GitHub couples public+private into a single
-	//     "all or none" choice — the legacy members_allowed_repository_
-	//     creation_type has no Team-valid "private" value, and the UI
-	//     auto-checks Public when you check Private. Since the student flow
-	//     REQUIRES members_can_create_private_repositories=true (gh student
-	//     accept creates the private repo as the student), forcing public
-	//     off is impossible on those plans without also breaking private
-	//     creation. Restricting members to private-only is documented as a
-	//     GitHub Enterprise Cloud-only capability, so this lockdown is
-	//     attempted only there.
+	//   - members_can_invite_outside_collaborators (Team: owners only).
+	//   - members_can_create_public_repositories=false ("private only"): on
+	//     Team/Free GitHub couples public+private into one "all or none"
+	//     choice, and the student flow REQUIRES private creation, so forcing
+	//     public off is impossible there. Enterprise-Cloud-only.
 	enterpriseOnly bool
 }
 
-// MemberDefaultSettings returns the org-level member policies to apply
-// for the given plan, filtering out enterprise-only settings on
-// non-enterprise plans (Team/Free don't expose those toggles, so trying
-// to set/verify/report them is wasted effort and confusing noise). Pass
-// the org plan slug from preflight; an empty/unknown plan is treated as
-// non-enterprise (the conservative default — we only include the
-// Enterprise-only fields when we're sure the org is on Enterprise Cloud).
+// MemberDefaultSettings returns the member policies to apply for the given
+// plan, dropping enterprise-only settings on non-enterprise plans. Pass the
+// plan slug from preflight; an empty/unknown plan is treated as non-enterprise
+// (conservative — only include Enterprise-only fields when sure).
 func MemberDefaultSettings(plan string) []MemberDefaultSetting {
 	all := allMemberDefaultSettings()
 	if plan == "enterprise" {
@@ -86,45 +59,29 @@ func MemberDefaultSettings(plan string) []MemberDefaultSetting {
 	return filtered
 }
 
-// allMemberDefaultSettings: the full canonical list of org-level
-// member policies, in apply order. The intent is a
+// allMemberDefaultSettings: the full canonical list, in apply order. Intent: a
 // least-privilege org where the only member capability is private-repo
-// creation; every other member privilege and dangerous repo-admin
-// capability is locked to org owners. Because `gh student accept` now
-// keeps the founder as repo `admin` (so a group founder can add
-// teammates), these org-level locks are what defang that admin org-wide
-// (no delete/transfer/visibility-change/etc.). MemberDefaultSettings
-// filters this by plan for actual use.
+// creation; every other privilege and dangerous repo-admin power is locked to
+// owners. Because `student accept` keeps the founder as repo `admin`, these
+// org-level locks are what defang that admin org-wide. MemberDefaultSettings
+// filters this by plan.
 //
 // Notable entries:
-//   - default_repository_permission "none": new members get no implicit
-//     read access to other repos.
-//   - members_can_create_repositories true: master switch. On Team/Free
-//     the granular public/private booleans are slaved to it (true => both
-//     on, false => both off), so it must be true for the student flow to
-//     create private repos. Sending only the private boolean without this
-//     leaves BOTH off ("members can create no repositories").
-//   - members_can_create_private_repositories true: the one allowed
-//     member capability — gh student accept needs it.
-//   - members_can_create_public_repositories false (enterprise-only):
-//     "private repos only" exists only on GitHub Enterprise Cloud. On
-//     Team/Free, public and private are coupled into one "all or none"
-//     choice, and the student flow needs private creation ON — so init
-//     can't lock public off there and skips the field on those plans.
-//   - members_can_create_pages / _public_pages true: ENFORCED so the
-//     classroom50 config repo can publish its *public* Pages site (the
-//     unauthenticated assignments.json fetch the student flow depends
-//     on). init enforces, not just allows, these — re-running init
-//     resets a teacher who tightened Pages back to the working state.
-//     members_can_create_private_pages stays false (never needed).
-//   - everything else false: locks the member privilege / repo-admin
-//     power to org owners.
+//   - default_repository_permission "none": no implicit read on other repos.
+//   - members_can_create_repositories true: master switch. On Team/Free the
+//     granular public/private booleans are slaved to it (true → both on), so
+//     it must be true for the student flow; sending only the private boolean
+//     leaves BOTH off.
+//   - members_can_create_private_repositories true: the one allowed capability.
+//   - members_can_create_public_repositories false (enterprise-only): see the
+//     enterpriseOnly note above.
+//   - members_can_create_pages / _public_pages true: ENFORCED so the config
+//     repo can publish its public Pages site (the unauthenticated
+//     assignments.json fetch). init resets a tightened setting on re-run.
+//   - everything else false: locks the privilege / repo-admin power to owners.
 //
-// The four web-UI-only member privileges with no REST field (app
-// access requests, repo-admin GitHub App installs, Projects base
-// permissions, branch renames) are NOT here — they can't be PATCHed;
-// init prints a manual-hardening reminder for them instead (see
-// ManualHardeningSteps).
+// The four web-UI-only privileges with no REST field are handled by
+// ManualHardeningSteps, not here.
 func allMemberDefaultSettings() []MemberDefaultSetting {
 	return []MemberDefaultSetting{
 		{
@@ -136,15 +93,9 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 		},
 		{
 			// Master repo-creation switch. On Team/Free the granular
-			// public/private booleans are NOT independently settable —
-			// GitHub slaves them to this field: true => members may
-			// create repos (both public and private, since "private
-			// only" is Enterprise Cloud-only), false => members may
-			// create none. The student flow needs members to create
-			// their private repo (gh student accept), so this must be
-			// true. Sending only members_can_create_private_repositories
-			// without this leaves BOTH checkboxes off ("members can
-			// create no repositories"). On Enterprise Cloud the
+			// public/private booleans are slaved to this (true → both, false →
+			// none), so the student flow needs it true; sending only the
+			// private boolean leaves BOTH off. On Enterprise Cloud the
 			// public-repo lockdown below narrows this to private-only.
 			Field:     "members_can_create_repositories",
 			Value:     true,
@@ -175,21 +126,18 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 			enterpriseOnly: true,
 		},
 		{
-			// Enforced TRUE: the classroom50 config repo publishes a
-			// public Pages site (the unauthenticated assignments.json
-			// fetch). Re-running init resets this to allowed so a teacher
-			// who tightened it can't accidentally break the student flow.
+			// Enforced TRUE: the config repo publishes a public Pages site
+			// (the unauthenticated assignments.json fetch). init resets this
+			// on re-run so a teacher can't accidentally break the student flow.
 			Field:     "members_can_create_pages",
 			Value:     true,
 			Desc:      "Pages creation enabled (required for the public config-repo site)",
 			ManualFix: `check "Allow members to publish Pages sites"`,
 		},
 		{
-			// Enforced TRUE for the same reason: the config-repo Pages
-			// site must be allowed to publish *publicly*. On non-Enterprise
-			// plans this per-visibility control doesn't exist and the field
-			// is rejected (the per-field fallback warns); on Enterprise
-			// Cloud it's what keeps the public site allowed.
+			// Enforced TRUE for the same reason: the site must publish
+			// *publicly*. On non-Enterprise plans this per-visibility control
+			// doesn't exist and the field is rejected (the fallback warns).
 			Field:     "members_can_create_public_pages",
 			Value:     true,
 			Desc:      "public Pages creation enabled (required for the public config-repo site)",
@@ -264,24 +212,19 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 	}
 }
 
-// DefaultVerdict is one setting's live-classification result, produced by
-// ClassifyDefaults. It carries the source Setting (so callers can read
-// Field/Desc/ManualFix/Critical) plus whether the live org value matched
-// the desired lockdown value. Both init's read-back (verifyOrgDefaults)
-// and audit's report (buildAuditReport) derive their own output structs
-// from this single classification so the "compare live[field] to desired,
-// track critical" logic lives in one place.
+// DefaultVerdict is one setting's live-classification result from
+// ClassifyDefaults: the source Setting plus whether the live value matched the
+// desired lockdown value. Both init's read-back and audit's report derive from
+// this single classification so the compare logic lives in one place.
 type DefaultVerdict struct {
 	Setting  MemberDefaultSetting
 	Enforced bool
 }
 
-// ClassifyDefaults compares each in-scope (plan-filtered) member-default
-// setting against the live org values and reports per-setting whether it's
-// enforced, plus whether any *critical* setting is unenforced. It is the
-// single source of truth for interpreting a GET /orgs/{org} response
-// against the desired lockdown — shared by init's verifyOrgDefaults and
-// audit's buildAuditReport so the two can't drift.
+// ClassifyDefaults compares each in-scope (plan-filtered) setting against the
+// live org values and reports per-setting enforcement plus whether any critical
+// setting is unenforced. The single source of truth for interpreting a GET
+// /orgs/{org} response, shared by init and audit.
 func ClassifyDefaults(live map[string]any, plan string) (verdicts []DefaultVerdict, criticalMissed bool) {
 	settings := MemberDefaultSettings(plan)
 	verdicts = make([]DefaultVerdict, 0, len(settings))
@@ -295,30 +238,23 @@ func ClassifyDefaults(live map[string]any, plan string) (verdicts []DefaultVerdi
 	return verdicts, criticalMissed
 }
 
-// fieldMatches compares a desired lockdown value against the value GitHub
-// returned for that field. JSON decoding renders booleans as bool and
-// strings as string, so a direct compare works for both the bool toggles
-// and the one string field (default_repository_permission). Internal to
-// the seam: only ClassifyDefaults uses it.
+// fieldMatches compares a desired lockdown value against GitHub's returned
+// value. JSON decodes booleans as bool and strings as string, so a direct
+// compare works for both the bool toggles and the one string field.
 func fieldMatches(live, desired any) bool {
 	return live == desired
 }
 
 // ManualStep is one API-less org setting the teacher must apply by hand.
-// JSON tags follow the repo convention (no omitempty) so it serializes
-// stably in both init's and audit's --json reports.
 type ManualStep struct {
 	Setting string `json:"setting"`
 	URL     string `json:"url"`
 }
 
 // ManualHardeningSteps is the canonical list of the four member-privilege
-// settings with no REST API (single-sourced here so init's human reminder,
-// init's JSON array, and audit's unreadable list can't drift). Each
-// instruction is verb-first and imperative so the teacher knows the exact
-// action to take; the verb matches the GitHub control — "Uncheck" for the
-// two checkboxes, "Set" for the two dropdowns — with the section name in
-// parentheses for orientation on the Member privileges page.
+// settings with no REST API (single-sourced so init's reminder, init's JSON,
+// and audit's list can't drift). Each instruction is verb-first with the
+// section name in parentheses for orientation.
 func ManualHardeningSteps(org string) []ManualStep {
 	url := fmt.Sprintf("https://github.com/organizations/%s/settings/member_privileges", org)
 	return []ManualStep{

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -246,6 +246,8 @@ func fieldMatches(live, desired any) bool {
 }
 
 // ManualStep is one API-less org setting the teacher must apply by hand.
+// JSON tags carry no omitempty so it serializes stably in init's and audit's
+// --json reports.
 type ManualStep struct {
 	Setting string `json:"setting"`
 	URL     string `json:"url"`

--- a/cli/gh-teacher/internal/orgrepos/orgrepos.go
+++ b/cli/gh-teacher/internal/orgrepos/orgrepos.go
@@ -1,10 +1,7 @@
-// Package orgrepos is the shared org-repository lister: a thin paginated
-// walk of GET /orgs/{org}/repos returning every repo name in the org.
-// It is a substrate seam (like internal/configrepo / internal/membership),
-// not a command package: ListNames is consumed by both the download
-// command (pattern mode) and the teardown command (wildcard nuke), each of
-// which maps/filters the unfiltered name list itself. It depends only on
-// the internal/githubapi seam, never on package main.
+// Package orgrepos is the shared org-repository lister: a paginated walk of GET
+// /orgs/{org}/repos returning every repo name. Consumed by download
+// (pattern mode) and teardown (wildcard nuke), each of which filters the list
+// itself.
 package orgrepos
 
 import (
@@ -14,18 +11,15 @@ import (
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 )
 
-// perPage / pagesMax bound the org-repos walk. 100×100 = 10k repos, far
-// above classroom scale; hitting the cap errors loudly rather than
-// silently under-reporting (a partial list would make teardown miss
-// repos or download skip submissions).
+// perPage / pagesMax bound the org-repos walk. 100×100 = 10k, far above
+// classroom scale; hitting the cap errors loudly rather than under-reporting.
 const (
 	perPage  = 100
 	pagesMax = 100
 )
 
-// ListNames returns every repo name in the org. Shared by download
-// (pattern mode) and teardown (wildcard nuke); both want the unfiltered
-// name list and map/filter it themselves.
+// ListNames returns every repo name in the org. Shared by download (pattern
+// mode) and teardown (wildcard nuke), which filter it themselves.
 func ListNames(client githubapi.Client, org string) ([]string, error) {
 	repos, err := githubapi.PaginateAll[struct {
 		Name string `json:"name"`

--- a/cli/gh-teacher/internal/output/output.go
+++ b/cli/gh-teacher/internal/output/output.go
@@ -1,12 +1,6 @@
-// Package output holds the CLI-wide presentation helpers that are not
-// domain logic — currently the shared JSON encoder used for every
-// `--json` view and every config-repo file gh-teacher writes.
-//
-// It exists so the per-domain files depend on a small, named seam
-// instead of a flat package main helper, and so the JSON byte contract
-// (the agent-consumable `--json` output and the hand-editable on-disk
-// files) lives in one documented place. It depends only on the standard
-// library.
+// Package output holds CLI-wide presentation helpers that aren't domain logic —
+// currently the shared JSON encoder for every `--json` view and every
+// config-repo file gh-teacher writes. Stdlib-only.
 package output
 
 import (
@@ -14,12 +8,10 @@ import (
 	"encoding/json"
 )
 
-// JSONPretty marshals v with 2-space indent and a trailing newline so
-// teachers can inspect/hand-edit the files. EscapeHTML is off to keep
-// `<`/`>` literal in URLs. This is the single encoder behind both the
-// `--json` command output and the config-repo files written to
-// <org>/classroom50, so its byte shape is a contract: changing the
-// indent, HTML-escaping, or trailing newline is a breaking change.
+// JSONPretty marshals v with 2-space indent, trailing newline, and EscapeHTML
+// off (keeps `<`/`>` literal in URLs). The single encoder behind both `--json`
+// output and the config-repo files, so its byte shape is a contract: changing
+// indent, HTML-escaping, or the trailing newline is breaking.
 func JSONPretty(v any) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)

--- a/cli/gh-teacher/internal/roster/list.go
+++ b/cli/gh-teacher/internal/roster/list.go
@@ -16,13 +16,9 @@ import (
 	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
-// rosterListEntry is the `--json` view of one students.csv row. Field
-// names mirror the CSV column headers (configrepo.RosterColumns) so the JSON and
-// the on-disk file speak the same vocabulary. github_id is always
-// present; it is 0 for an unresolved row (a 5-column hand-import row
-// before the CLI resolves the GitHub-authoritative id) -- consumers
-// branch on `github_id == 0`, not on key presence (no omitempty, to
-// match the no-omitempty convention of the other --json record types).
+// rosterListEntry is the `--json` view of one students.csv row. Field names
+// mirror the CSV columns. github_id is always present; 0 for an unresolved row
+// — consumers branch on `github_id == 0`, not key presence.
 type rosterListEntry struct {
 	Username  string `json:"username"`
 	FirstName string `json:"first_name"`
@@ -97,9 +93,8 @@ func runRosterList(client githubapi.Client, out, errOut io.Writer, org, classroo
 	if asJSON {
 		entries := make([]rosterListEntry, 0, len(rows))
 		for _, r := range rows {
-			// Only the canonical fields are part of the documented
-			// `roster list --json` contract; the preserved extra
-			// columns (r.Extra) are internal round-trip state, not output.
+			// Only canonical fields are part of the `roster list --json`
+			// contract; r.Extra is internal round-trip state, not output.
 			entries = append(entries, rosterListEntry{
 				Username:  r.Username,
 				FirstName: r.FirstName,
@@ -157,9 +152,8 @@ func dashIfEmpty(s string) string {
 	return s
 }
 
-// summarizeRosterList: one-line stderr summary shaped
-// `<org>/<repo>/<classroom>/students.csv: <message>` to match the
-// other list commands.
+// summarizeRosterList: one-line stderr summary
+// `<org>/<repo>/<classroom>/students.csv: <message>`.
 func summarizeRosterList(org, classroom string, count int) string {
 	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom))
 	if count == 0 {

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -1,11 +1,7 @@
 // Package roster implements the `gh teacher roster` command: managing the
 // classroom roster in <org>/classroom50/<classroom>/students.csv (list, add,
-// remove, import), including resolving each student's GitHub id and inviting
-// them to the org. It is an extracted command package (mirrors internal/auth
-// and internal/remove): only NewCmd is exported; the subcommand factories and
-// run* orchestration are package-private. It depends only on the internal/*
-// substrate seams (configrepo, configwrite, membership, validate, output,
-// githubapi), never on package main.
+// update, remove, import), including resolving each student's GitHub id and
+// inviting them to the org. Only NewCmd is exported.
 package roster
 
 import (
@@ -266,12 +262,10 @@ func rosterImportCmd() *cobra.Command {
 	return cmd
 }
 
-// inviteIfNotMember invites <username> when not already active or
-// pending; returns the membership state at decision time. The
-// pre-resolved userID avoids redundant GET /users/{username} calls
-// during a bulk import. A 422 "already member/pending" from
-// membership.InviteOrgByID is recovered as success so a TOCTOU race
-// between pre-check and invite can't surface a spurious failure.
+// inviteIfNotMember invites <username> when not already active/pending, and
+// returns the membership state at decision time. The pre-resolved userID avoids
+// redundant lookups during a bulk import. A 422 "already member/pending" is
+// recovered as success so a TOCTOU race can't surface a spurious failure.
 func inviteIfNotMember(client githubapi.Client, org, username string, userID int64) (state string, err error) {
 	if s, ok := membership.MembershipState(client, org, username); ok {
 		switch s {
@@ -291,10 +285,9 @@ func inviteIfNotMember(client githubapi.Client, org, username string, userID int
 	return "invited", nil
 }
 
-// runRosterAdd commits the roster row first, then invites. If the
-// commit fails after an invite landed, the org would be ahead of the
-// roster with no clean recovery. This order leaves the roster ahead
-// of org membership, which a re-run reconciles.
+// runRosterAdd commits the roster row first, then invites. Committing first
+// leaves the roster ahead of org membership (a re-run reconciles), which is
+// safer than an invite landing before a failed commit.
 func runRosterAdd(client githubapi.Client, out, errOut io.Writer, org, classroom, username, firstName, lastName, email, section string) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -356,12 +349,9 @@ func runRosterAdd(client githubapi.Client, out, errOut io.Writer, org, classroom
 		_, _ = fmt.Fprintf(errOut, "Advise %s to sign in to https://github.com as %s, then visit https://github.com/%s to accept the invitation.\n", login, login, org)
 	}
 
-	// Add the student to the classroom team so they inherit read on the
-	// classroom's private, org-owned assignment templates. The PUT works
-	// for both an already-active member (active immediately) and a
-	// not-yet-member (pending until they accept the org invite), so one
-	// call covers both states. Idempotent. The team slug is read from
-	// classroom.json (authoritative — never re-derived).
+	// Add the student to the classroom team so they inherit read on private
+	// org-owned templates. The PUT covers both an active member (immediate) and
+	// a not-yet-member (pending). Idempotent. Slug from classroom.json.
 	team, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
 		return fmt.Errorf("roster row committed and org invite sent, but reading the classroom team failed: %w", err)
@@ -400,8 +390,7 @@ func runRosterUpdate(client githubapi.Client, out io.Writer, org, classroom, use
 				username, classroom, org, classroom, username)
 		}
 		if !changed {
-			// nil map → CommitTree skips the commit.
-			noChange = true
+			noChange = true // nil map → CommitTree skips the commit.
 			return nil, nil
 		}
 		data, err := configrepo.EncodeRoster(next)
@@ -441,9 +430,7 @@ func runRosterRemove(client githubapi.Client, out io.Writer, org, classroom, use
 		next, ok := configrepo.RemoveRosterRow(rows, username)
 		removed = ok
 		if !ok {
-			// nil → configwrite.CommitTree skips the commit (no-op when the row
-			// was already absent).
-			return nil, nil
+			return nil, nil // nil → CommitTree skips the commit (already absent)
 		}
 		data, err := configrepo.EncodeRoster(next)
 		if err != nil {
@@ -460,10 +447,9 @@ func runRosterRemove(client githubapi.Client, out io.Writer, org, classroom, use
 	if removed {
 		_, _ = fmt.Fprintf(out, "%s/%s/%s: removed %s (org membership unchanged)\n",
 			org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom), username)
-		// Symmetric with roster add: drop the student from the
-		// classroom team so they lose template read. Idempotent (404 =
-		// not a member / team gone). Org membership is untouched. The
-		// slug is read from classroom.json (authoritative).
+		// Symmetric with roster add: drop the student from the classroom team
+		// so they lose template read. Idempotent (404 = not a member/gone).
+		// Org membership untouched. Slug from classroom.json.
 		team, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 		if err != nil {
 			return fmt.Errorf("roster row removed, but reading the classroom team failed: %w", err)
@@ -474,8 +460,7 @@ func runRosterRemove(client githubapi.Client, out io.Writer, org, classroom, use
 			}
 			_, _ = fmt.Fprintf(out, "%s: removed %s from classroom team %s\n", org, username, team.Slug)
 		}
-		// Org removal is a separate, deliberate step (no cascade); point
-		// the teacher at the command that does it.
+		// Org removal is a separate, deliberate step (no cascade).
 		_, _ = fmt.Fprintf(out, "  to also remove %s from the org: gh teacher remove %s %s\n",
 			username, org, username)
 	} else {
@@ -507,9 +492,9 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 		return fmt.Errorf("%s: contains a header but no student rows", abs)
 	}
 
-	// Resolve every username up front so rebase retries don't repeat
-	// GitHub-API lookups — only the file write is retried. CSV line
-	// numbers are 1-based (header = line 1) to match parseImportCSV.
+	// Resolve every username up front so rebase retries don't repeat API
+	// lookups — only the file write is retried. CSV lines are 1-based (header =
+	// line 1) to match parseImportCSV.
 	resolved := make([]configrepo.RosterRow, 0, len(imported))
 	for i, row := range imported {
 		line := i + 2
@@ -526,8 +511,7 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 			GitHubID:  userID,
 		})
 	}
-	// Case-insensitive dedup within the batch; last occurrence wins
-	// (matching upsertRosterRow's semantics).
+	// Case-insensitive dedup within the batch; last occurrence wins.
 	resolved = configrepo.DedupeByUsername(resolved)
 
 	var (
@@ -539,8 +523,7 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 		if err != nil {
 			return nil, err
 		}
-		// Reset counters per attempt — rebase may see different
-		// new/replaced splits each time.
+		// Reset counters per attempt — rebase may split new/replaced differently.
 		added, updated = 0, 0
 		for _, row := range resolved {
 			var replaced bool
@@ -566,9 +549,8 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 	_, _ = fmt.Fprintf(out, "%s/%s/%s: imported %d row(s) (%d new, %d updated)\n",
 		org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom), len(resolved), added, updated)
 
-	// Resolve the classroom team once (authoritative slug from
-	// classroom.json). A classroom with no team is a warn-and-skip for
-	// the membership step.
+	// Resolve the classroom team once (slug from classroom.json). No team →
+	// warn-and-skip the membership step.
 	team, teamOK, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
 		return fmt.Errorf("roster rows committed, but reading the classroom team failed: %w", err)
@@ -583,10 +565,9 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 	for _, row := range resolved {
 		state, err := inviteIfNotMember(client, org, row.Username, row.GitHubID)
 		if err != nil {
-			// Warn-and-continue (not hard-fail): the commit already
-			// landed and the per-student calls are idempotent, so a
-			// transient failure on one student must not strand the
-			// rest. Collect for a summary so nothing is silently lost.
+			// Warn-and-continue (not hard-fail): the commit already landed and
+			// the per-student calls are idempotent, so a transient failure on
+			// one student mustn't strand the rest.
 			failures = append(failures, fmt.Sprintf("%s (invite: %v)", row.Username, err))
 			continue
 		}
@@ -598,8 +579,7 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 		case "invited":
 			invited++
 		}
-		// Add each student to the classroom team (idempotent; covers
-		// both active and pending members).
+		// Add each student to the classroom team (idempotent; active+pending).
 		if teamOK {
 			if err := configrepo.AddTeamMembership(client, org, team.Slug, row.Username); err != nil {
 				failures = append(failures, fmt.Sprintf("%s (team add: %v)", row.Username, err))

--- a/cli/gh-teacher/internal/scores/scores.go
+++ b/cli/gh-teacher/internal/scores/scores.go
@@ -1,33 +1,24 @@
-// Package scores is the shared scores-gradebook schema seam: the on-disk
-// shape of scores.json (`<classroom>/scores.json`), written by the
-// collect-scores workflow's collect_scores.py and read back by the
-// download command. It is a substrate seam (like internal/configrepo /
-// internal/orgrepos), not a command package: the classroom command
-// scaffolds an empty well-formed scores.json from these types, and the
-// download command parses the populated gradebook from them. It has no
-// dependencies on other internal/* packages or package main.
+// Package scores is the shared scores-gradebook schema seam: the on-disk shape
+// of scores.json, written by collect_scores.py and read by the download
+// command. The classroom command scaffolds an empty file from these types; the
+// download command parses the populated gradebook. No internal/* dependencies.
 package scores
 
-// SchemaV1 is the scores.json schema sentinel. Schema-aware readers MUST
-// branch on the schema field first so newer files don't crash older
-// readers. Teacher-written only (not shared Go<->Go), so it lives here
-// rather than in the shared contract package.
+// SchemaV1 is the scores.json schema sentinel; schema-aware readers MUST branch
+// on it first. Teacher-written only, so it lives here, not in the contract.
 const SchemaV1 = "classroom50/scores/v1"
 
-// File is the gradebook written by collect-scores.yaml's
-// collect_scores.py. The root Assignments map is keyed by assignment
-// slug; each value is an AssignmentBucket (`{type, entries}`). The map is
-// non-nil (`{}`, not null) at scaffold time so the collect script sees a
-// well-formed file on first run.
+// File is the gradebook written by collect_scores.py. Assignments is keyed by
+// slug; each value is an AssignmentBucket. Non-nil (`{}`, not null) at scaffold
+// time.
 type File struct {
 	Schema      string                      `json:"schema"`
 	Assignments map[string]AssignmentBucket `json:"assignments"`
 }
 
 // AssignmentBucket is one assignment's gradebook — its mode (`type`) plus
-// the per-repo entries. Each entry decodes as a tolerant map[string]any
-// (download reads only a handful of well-known keys: owner,
-// member_usernames, submissions).
+// per-repo entries. Each entry decodes as a tolerant map[string]any (download
+// reads only a few well-known keys).
 type AssignmentBucket struct {
 	Type    string           `json:"type"`
 	Entries []map[string]any `json:"entries"`

--- a/cli/gh-teacher/internal/servicetoken/servicetoken.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken.go
@@ -1,12 +1,7 @@
 // Package servicetoken is the service-token substrate seam: provisioning,
 // validating, and reading the CLASSROOM50_SERVICE_TOKEN repo-level Actions
-// secret that the collect-scores workflow consumes. It owns the
-// init-type-free core shared by `gh teacher init` (via package main's
-// provisionServiceToken orchestrator) and the `rotate-service-token`
-// command (NewRotateCmd). It depends only on the internal/* substrate
-// seams (cliutil, configrepo, githubapi) plus the shared ghauth helper,
-// never on package main. The *initSummary-typed init step
-// (provisionServiceToken) stays in package main and calls into this seam.
+// secret that collect-scores consumes. Shared by `init` and
+// `rotate-service-token`.
 package servicetoken
 
 import (
@@ -33,8 +28,7 @@ import (
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 )
 
-// readHiddenLine reads one line with echo off so the PAT never
-// appears on screen.
+// readHiddenLine reads one line with echo off so the PAT never appears.
 func readHiddenLine(f *os.File) (string, error) {
 	b, err := term.ReadPassword(int(f.Fd()))
 	return string(b), err
@@ -93,13 +87,11 @@ func ReadToken(cmd *cobra.Command) ([]byte, error) {
 	return []byte(v), nil
 }
 
-// SecretExists reports whether the CLASSROOM50_SERVICE_TOKEN Actions
-// secret is already provisioned on <owner>/<repo>. GitHub never returns a
-// secret's value (write-only), but GET .../secrets/{name} returns 200 when
-// it exists and 404 when not — enough to skip the interactive prompt on a
-// re-run. A non-404 error is reported as "unknown" (false, err) so callers
-// can decide; init treats unknown as "not configured" and proceeds to
-// prompt rather than silently skipping.
+// SecretExists reports whether the CLASSROOM50_SERVICE_TOKEN Actions secret is
+// provisioned on <owner>/<repo>. GitHub never returns the value, but GET
+// .../secrets/{name} is 200 when it exists, 404 when not — enough to skip the
+// prompt on a re-run. A non-404 error returns (false, err); init treats unknown
+// as "not configured" and prompts.
 func SecretExists(client githubapi.Client, owner, repo string) (bool, error) {
 	path := fmt.Sprintf("repos/%s/%s/actions/secrets/%s",
 		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(SecretName))
@@ -112,33 +104,20 @@ func SecretExists(client githubapi.Client, owner, repo string) (bool, error) {
 	return true, nil
 }
 
-// ValidateToken confirms a freshly-supplied service token can actually do
-// what the pipeline needs: read AND write repository contents in the org,
-// AND read the org's members. Reading back the gradebook (collect-scores)
-// and pushing submit/* tags to regrade (regrade.yaml) both require Contents
-// access — collect reads, regrade writes — so the one shared token must
-// hold Contents: Read and write. Collection is also TEAM-driven: it lists
-// the classroom team's members (GET /orgs/{org}/teams/{slug}/members) to
-// derive the (student, assignment) pairs, which needs the org-level
-// Members: Read permission — a permission NOT implied by any repository
-// scope. It builds a client authenticated AS the supplied token, reads the
-// config repo (catching a wrong/zeroed resource owner, a still-pending
-// fine-grained PAT, or an expired/revoked token), asserts the repo's
-// effective `permissions.push` so a read-only PAT is rejected here, and
-// probes the org members endpoint so a Members-less PAT is caught here
-// rather than surfacing months later as an opaque collect-scores 403.
-// Returns a descriptive, actionable error on failure.
+// ValidateToken confirms a service token can do what the pipeline needs:
+// Contents Read+Write in the org (collect reads, regrade pushes submit/* tags)
+// AND org Members: Read (collection is team-driven and lists the classroom
+// team's members — a scope not implied by any repository permission). Catches a
+// misconfigured PAT at provisioning time rather than as an opaque cron 403.
 func ValidateToken(token []byte, org string) error {
 	return ValidateTokenVerbose(token, org, io.Discard)
 }
 
 // ValidateTokenVerbose is ValidateToken with a writer for advisory notes. When
 // the org-members probe is INCONCLUSIVE (401/5xx/timeout after a proven-live
-// repo read), validation still passes (fail-open), but a warning is written to
-// `out` so the teacher knows the Members: Read scope wasn't positively
-// confirmed and should run the `probe-token` workflow before relying on the
-// nightly collect — otherwise a Members-less token sits latent until the cron
-// 403s and aborts the whole run.
+// repo read), validation still passes (fail-open) but warns to `out` so the
+// teacher knows Members: Read wasn't positively confirmed and should run the
+// `probe-token` workflow before relying on the nightly collect.
 func ValidateTokenVerbose(token []byte, org string, out io.Writer) error {
 	tokenClient, err := githubapi.NewClient(githubapi.ClientOptions{
 		AuthToken: string(token),
@@ -150,26 +129,19 @@ func ValidateTokenVerbose(token []byte, org string, out io.Writer) error {
 	return validateTokenWithClient(tokenClient, org, out)
 }
 
-// validateTokenWithClient is ValidateToken's testable core: it reads the
-// config repo with an already-built client (authenticated as the token
-// under test), asserts the token can write contents, then probes the org
-// members endpoint, mapping each failure mode to an actionable error.
+// validateTokenWithClient is ValidateToken's testable core: reads the config
+// repo with a client authenticated as the token, asserts it can write contents,
+// then probes org members, mapping each failure mode to an actionable error.
 //
-// GET /repos/{owner}/{repo} returns a `permissions` object reflecting the
-// AUTHENTICATED token's effective access on the repo (`push` is true only
-// when the token can write contents). We assert it so a Contents: read-only
-// PAT — which can read the gradebook but cannot push the submit/* tags a
-// regrade needs — is rejected at configuration time. The read itself also
-// exercises Contents: read (what collect-scores does on student repos).
+// GET /repos/{owner}/{repo} returns a `permissions` object for the
+// authenticated token; `push` is true only when it can write contents. We
+// assert it so a Contents read-only PAT (can read the gradebook but can't push
+// submit/* tags) is rejected here; the read itself exercises Contents: read.
 //
-// GET /orgs/{org}/members then exercises the org-level Members: Read
-// permission that team-driven collection needs (it lists the classroom
-// team's members). That permission is not implied by any Contents scope. A
-// 403/404 here is a definitive scope gap and is rejected; any other result
-// (401, 5xx, rate-limit, timeout) is treated as inconclusive and allowed to
-// proceed, since the repo read already proved the token live — blocking a
-// valid token on this second round-trip's flakiness would be worse than the
-// cron-time 403 the runtime already handles. The probe-token.yaml workflow
+// GET /orgs/{org}/members then exercises Members: Read (not implied by any
+// Contents scope). A 403/404 is a definitive scope gap and rejected; any other
+// result (401, 5xx, rate-limit, timeout) is inconclusive and allowed to
+// proceed, since the repo read already proved the token live. probe-token.yaml
 // is the exhaustive post-provision signal.
 func validateTokenWithClient(tokenClient githubapi.Client, org string, out io.Writer) error {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(configrepo.ConfigRepoName))
@@ -188,54 +160,34 @@ func validateTokenWithClient(tokenClient githubapi.Client, org string, out io.Wr
 			return fmt.Errorf("couldn't verify the token against %s/%s: %w", org, configrepo.ConfigRepoName, err)
 		}
 	}
-	// The token can read the repo, but regrade needs to push
-	// submit/* tags to student repos — Contents: write. A read-only PAT
-	// reports permissions.push == false here; reject it with the same
-	// actionable fix as a no-access token.
+	// Token can read the repo, but regrade needs Contents: write to push
+	// submit/* tags. A read-only PAT reports push == false; reject it.
 	if !repo.Permissions.Push {
 		return fmt.Errorf("the supplied token can read %s/%s but lacks write access (Contents: write) — collecting scores needs read, but regrading needs to push submit/* tags to student repos. Re-create the fine-grained PAT with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write AND Actions: Read and write (regrade re-runs student autograde workflow runs)", org, configrepo.ConfigRepoName, org)
 	}
 
-	// Contents is proven, but collection is TEAM-driven: it lists the
-	// classroom team's members to derive the (student, assignment) pairs,
-	// which needs the org-level Members: Read permission. That permission is
-	// NOT implied by any repository scope, so a token with only Contents
-	// passes every check above yet 403s on the very first API call the
-	// collect-scores workflow makes. Probe GET /orgs/{org}/members (the same
-	// Members: Read permission the team-members endpoint requires, but not
-	// dependent on a specific team existing at init time) so a Members-less
-	// PAT is rejected here instead of weeks later in a cron run.
-	// NOTE ON FAIL-OPEN: this probe is a proxy for the team-members read
-	// collection actually makes; a definitive scope gap surfaces as 403/404
-	// and is rejected here, but any OTHER result (401, 5xx, rate-limit,
-	// timeout) is treated as INCONCLUSIVE and allowed to proceed. The repo
-	// read above already proved the token is live and can write, so a 401 or
-	// transient failure on this second, independent round-trip is far more
-	// likely GitHub-side flakiness than a real problem — blocking a valid
-	// token on it would be a worse failure than the cron-time 403 the runtime
-	// already handles. The `probe-token.yaml` workflow is the exhaustive,
-	// side-effect-checked signal; this is the cheap provisioning-time guard.
+	// Contents is proven, but collection is team-driven: it lists the
+	// classroom team's members, needing org Members: Read (not implied by any
+	// repo scope). Probe GET /orgs/{org}/members (same permission, no specific
+	// team required) so a Members-less PAT is rejected here, not weeks later.
+	// Fail-open on non-definitive results (see the doc comment).
 	membersPath := fmt.Sprintf("orgs/%s/members?per_page=1", url.PathEscape(org))
 	if err := tokenClient.Get(membersPath, nil); err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) || cliutil.IsHTTPStatus(err, http.StatusForbidden) {
 			return fmt.Errorf("the supplied token can read %s/%s but can't read the org's members — collecting scores is team-driven and lists the classroom team's members, which needs the org-level Members permission. Re-create the fine-grained PAT with Resource owner = %q and add Organization permissions -> Members: Read (this is a separate section from Repository permissions; it appears only once the org is selected as Resource owner). Underlying error: %v", org, configrepo.ConfigRepoName, org, err)
 		}
 		// Inconclusive (401 after a 200 repo read, 5xx, rate-limit, timeout):
-		// proceed rather than reject a token the repo read just proved valid,
-		// but WARN — the Members: Read scope the nightly collect needs was not
-		// positively confirmed, and an unconfirmed Members-less token 403s at
-		// collect time and aborts the whole run. Point the teacher at the
-		// exhaustive probe-token workflow.
+		// proceed but WARN — Members: Read wasn't confirmed, and an
+		// unconfirmed Members-less token 403s at collect time. Point at
+		// probe-token.
 		_, _ = fmt.Fprintf(out, "Warning: couldn't confirm the token's Organization -> Members: Read scope (%v). Proceeding, since the repo read proved the token live, but if it in fact lacks Members: Read, the nightly collect will 403 and skip. Run the `probe-token` workflow to verify all scopes before the first collect.\n", err)
 	}
 	return nil
 }
 
-// ProvisionSecret sealbox-encrypts `token` against the repo's Actions
-// public key and uploads it as the repo-level CLASSROOM50_SERVICE_TOKEN
-// secret. Repo-level (not org-level) keeps the secret invisible to other
-// repos in the org. Idempotent (PUT replaces in place). Shared by `init`
-// and `rotate-service-token`.
+// ProvisionSecret sealbox-encrypts `token` against the repo's Actions public
+// key and uploads it as the repo-level CLASSROOM50_SERVICE_TOKEN secret.
+// Repo-level (not org-level) keeps it invisible to other repos. Idempotent.
 func ProvisionSecret(client githubapi.Client, out io.Writer, owner, repo string, token []byte, verb string) error {
 	keyPath := fmt.Sprintf("repos/%s/%s/actions/secrets/public-key",
 		url.PathEscape(owner), url.PathEscape(repo))
@@ -281,10 +233,8 @@ func ProvisionSecret(client githubapi.Client, out io.Writer, owner, repo string,
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	// 201 = secret created, 204 = secret updated; any other 2xx means
-	// the upload didn't land as expected. Assert it (matching the
-	// status-check convention of the sibling write helpers) so a silent
-	// non-write doesn't get reported as a stored token.
+	// 201 = created, 204 = updated; any other 2xx means the upload didn't land
+	// as expected. Assert it so a silent non-write isn't reported as stored.
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("PUT %s: unexpected status %d", putPath, resp.StatusCode)
 	}
@@ -333,8 +283,7 @@ func NewRotateCmd() *cobra.Command {
 			}
 			out := cmd.OutOrStdout()
 
-			// Refuse to rotate on an org without classroom50 — the
-			// user probably mistyped.
+			// Refuse to rotate on an org without classroom50 — likely a typo.
 			repoPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), configrepo.ConfigRepoName)
 			if err := client.Get(repoPath, nil); err != nil {
 				if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
@@ -347,9 +296,8 @@ func NewRotateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Validate before storing: catch a bad PAT now, not via a
-			// failed collect-scores workflow weeks later. Verbose so an
-			// inconclusive Members-scope probe warns the teacher.
+			// Validate before storing: catch a bad PAT now, not weeks later.
+			// Verbose so an inconclusive Members-scope probe warns.
 			if err := ValidateTokenVerbose(token, org, out); err != nil {
 				return fmt.Errorf("service token validation failed: %w", err)
 			}

--- a/cli/gh-teacher/internal/staff/staff.go
+++ b/cli/gh-teacher/internal/staff/staff.go
@@ -1,12 +1,8 @@
 // Package staff implements the `gh teacher staff` command: managing the
-// per-classroom staff teams (instructor, ta) that back the web GUI's
-// in-app roles. Membership lives entirely in the GitHub teams
-// (`classroom50-<classroom>-{instructor,ta}`), not in students.csv, so a
-// classroom's staff is the same whether managed from the CLI or the web.
-// It is an extracted command package (mirrors internal/roster): only
-// NewCmd is exported; the subcommand factories and run* orchestration are
-// package-private. It depends only on the internal/* substrate seams
-// (configrepo, membership, validate, githubapi), never on package main.
+// per-classroom staff teams (instructor, ta) that back the web GUI's in-app
+// roles. Membership lives in the GitHub teams (`classroom50-<classroom>-{...}`),
+// not students.csv, so staff is identical from CLI or web. Only NewCmd is
+// exported.
 package staff
 
 import (
@@ -50,8 +46,8 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-// parseRole maps the --role flag to a StaffRole, defaulting to
-// instructor. Accepts "instructor" or "ta" (case-insensitive).
+// parseRole maps --role to a StaffRole (default instructor). Accepts
+// "instructor" or "ta" (case-insensitive).
 func parseRole(role string) (configrepo.StaffRole, error) {
 	switch strings.ToLower(strings.TrimSpace(role)) {
 	case "", "instructor":
@@ -147,18 +143,15 @@ func staffRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-// runStaffAdd resolves the staff team from classroom.json (authoritative
-// slug — never re-derived) and adds the canonical-login user to it. The
-// team must already exist (created by `classroom add`); a classroom with
-// no `teams` block yields an actionable error rather than a silent
-// re-derive against a guessed slug.
+// runStaffAdd resolves the staff team from classroom.json and adds the
+// canonical-login user. If the `teams` block is missing/partial, it self-heals
+// (create/adopt the team, grant config-repo write, record the ref).
 func runStaffAdd(client githubapi.Client, out, errOut io.Writer, org, classroom, username string, role configrepo.StaffRole) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
 		return err
 	}
-	// Resolve the canonical login (a rename-safe, case-corrected form)
-	// and confirm the user exists before touching the team.
+	// Resolve the canonical login and confirm the user exists first.
 	login, _, err := membership.LookupUser(client, username)
 	if err != nil {
 		return err
@@ -168,13 +161,10 @@ func runStaffAdd(client githubapi.Client, out, errOut io.Writer, org, classroom,
 		return err
 	}
 	if !ok {
-		// Self-heal a missing/partial `teams` block rather than dead-ending:
-		// ensure (adopt-or-create) the staff team, grant it config-repo
-		// write, and persist its ref into classroom.json, then proceed.
-		// This makes `staff add` idempotent for classrooms created before
-		// the staff-teams feature or left with a partial `teams` block,
-		// instead of pointing the user at `classroom add` (which refuses
-		// to overwrite an existing classroom and can't repair it).
+		// Self-heal a missing/partial `teams` block: ensure the team, grant
+		// config-repo write, persist its ref, then proceed. Makes `staff add`
+		// idempotent for pre-feature classrooms rather than dead-ending at
+		// `classroom add` (which can't repair an existing classroom).
 		team, err = ensureStaffTeamRecorded(client, out, org, classroom, branch, role)
 		if err != nil {
 			return err
@@ -187,12 +177,10 @@ func runStaffAdd(client githubapi.Client, out, errOut io.Writer, org, classroom,
 	return nil
 }
 
-// ensureStaffTeamRecorded adopts-or-creates the classroom's staff team
-// for `role`, grants it config-repo write, and records its ref under
-// classroom.json `teams.<role>` in one commit. It first confirms the
-// classroom exists (so a typo'd classroom doesn't mint a stray team) and
-// is a no-op-safe read-modify-write: an already-recorded ref short-
-// circuits without a commit. Returns the resolved team ref.
+// ensureStaffTeamRecorded adopts-or-creates the classroom's staff team for
+// `role`, grants it config-repo write, and records its ref under
+// classroom.json `teams.<role>` in one commit. Confirms the classroom exists
+// first (so a typo doesn't mint a stray team); no-op-safe if already recorded.
 func ensureStaffTeamRecorded(client githubapi.Client, out io.Writer, org, classroom, branch string, role configrepo.StaffRole) (configrepo.TeamRef, error) {
 	if _, ok, err := configrepo.LoadClassroom(client, org, classroom, branch); err != nil {
 		return configrepo.TeamRef{}, err
@@ -207,8 +195,8 @@ func ensureStaffTeamRecorded(client githubapi.Client, out io.Writer, org, classr
 	if _, err := configrepo.GrantTeamRepoWrite(client, org, team.Slug, org, configrepo.ConfigRepoName); err != nil {
 		return configrepo.TeamRef{}, fmt.Errorf("grant %s staff team write on %s: %w", role, configrepo.ConfigRepoName, err)
 	}
-	// Persist the ref so future resolves (and the classroom-remove /
-	// teardown sweeps) find it. RMW classroom.json in one commit.
+	// Persist the ref so future resolves and the delete/teardown sweeps find
+	// it. RMW classroom.json in one commit.
 	path := configrepo.ClassroomFilePath(classroom)
 	message := contract.PrefixCommit(fmt.Sprintf("Record %s staff team for %s (gh teacher staff add)", role, classroom))
 	build := func(parentSHA string) (map[string]string, error) {
@@ -249,9 +237,8 @@ func ensureStaffTeamRecorded(client githubapi.Client, out io.Writer, org, classr
 	return team, nil
 }
 
-// runStaffRemove resolves the staff team from classroom.json and removes
-// the user. Idempotent — a non-member (or an already-gone team) is a
-// clean no-op.
+// runStaffRemove resolves the staff team and removes the user. Idempotent — a
+// non-member or already-gone team is a no-op.
 func runStaffRemove(client githubapi.Client, out io.Writer, org, classroom, username string, role configrepo.StaffRole) error {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {

--- a/cli/gh-teacher/internal/teardown/teardown.go
+++ b/cli/gh-teacher/internal/teardown/teardown.go
@@ -1,13 +1,6 @@
-// Package teardown implements the `gh teacher teardown` command:
-// deleting every repository in a Classroom 50 org once the org is
-// confirmed to carry the <org>/classroom50 marker repo, for resetting a
-// development org between iterations. It is an extracted command package
-// (mirrors internal/auth, internal/remove, internal/roster,
-// internal/member, and internal/invite): only NewCmd is exported; the
-// run* orchestration, the typed-confirmation prompt, and the
-// delete/order helpers are package-private. It depends only on the
-// internal/* substrate seams (cliutil, configrepo, githubapi, orgrepos),
-// never on package main.
+// Package teardown implements the `gh teacher teardown` command: deleting every
+// repo in a Classroom 50 org (confirmed by the <org>/classroom50 marker) to
+// reset a development org between iterations. Only NewCmd is exported.
 package teardown
 
 import (
@@ -28,10 +21,8 @@ import (
 	"github.com/foundation50/gh-teacher/internal/orgrepos"
 )
 
-// NewCmd implements `gh teacher teardown <org>`: deletes every
-// repo in an org once the org is confirmed to be a Classroom 50
-// setup. Intended for development scenarios where a clean reset is
-// useful between runs.
+// NewCmd implements `gh teacher teardown <org>`: deletes every repo in an org
+// once it's confirmed a Classroom 50 setup. For development resets.
 func NewCmd() *cobra.Command {
 	var skipConfirm bool
 
@@ -73,16 +64,13 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-// runTeardown enforces the precondition (classroom50 marker exists),
-// prints the deletion plan, gets confirmation, then deletes every
-// repo in the org. classroom50 is removed last so a failure leaves
-// the precondition marker intact for a safe re-run.
+// runTeardown enforces the precondition (classroom50 marker exists), prints the
+// deletion plan, gets confirmation, then deletes every repo. classroom50 is
+// removed last so a failure leaves the marker intact for a safe re-run.
 //
-// We deliberately don't preflight the `delete_repo` OAuth scope —
-// teachers who haven't opted into that scope (via
-// `gh teacher login -s delete_repo`) get a 403 on the first DELETE
-// with an actionable hint, which is the safer default for users
-// who don't realize a destructive command is about to run.
+// We deliberately don't preflight the `delete_repo` OAuth scope — a teacher who
+// hasn't opted in gets a 403 on the first DELETE with an actionable hint, the
+// safer default before a destructive command runs.
 func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, org string, skipConfirm bool) error {
 	if err := requireConfigRepo(client, org); err != nil {
 		return err
@@ -93,18 +81,15 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 		return err
 	}
 	if len(repos) == 0 {
-		// Vacuous case — should be impossible (we just verified
-		// classroom50 exists) but bail gracefully if the org was
-		// emptied mid-run.
+		// Should be impossible (classroom50 just verified) but bail
+		// gracefully if the org was emptied mid-run.
 		_, _ = fmt.Fprintf(out, "%s: nothing to delete (org appears empty)\n", org)
 		return nil
 	}
 
-	// Collect the per-classroom team refs (students + staff) BEFORE the
-	// repo deletions remove the config repo that records them, so we can
-	// sweep the teams afterward (deleting repos does not delete teams).
-	// Best-effort: a read failure here shouldn't block the destructive
-	// repo teardown the teacher asked for.
+	// Snapshot the classroom team refs (students + staff) BEFORE the repo
+	// deletions remove the config repo that records them, so we can sweep the
+	// teams afterward. Best-effort: a read failure shouldn't block teardown.
 	teams := collectClassroomTeams(client, org, errOut)
 
 	_, _ = fmt.Fprintf(out, "Found %d repo(s) in %s:\n", len(repos), org)
@@ -119,10 +104,8 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 		}
 	}
 
-	// classroom50 last — see the function doc. The per-DELETE loop is the
-	// long-running phase; drive a spinner. When animating, suppress the
-	// per-repo "deleted:" stdout lines (the summary below is always
-	// printed regardless).
+	// classroom50 last (see the function doc). The per-DELETE loop is the
+	// long phase; drive a spinner and suppress per-repo stdout when animating.
 	ordered := orderRepoDeletions(repos)
 	deleted, failed, markerPreserved := 0, 0, false
 	sp := ghui.NewSpinner(errOut, fmt.Sprintf("Deleting %d repo(s) in %s", len(ordered), org))
@@ -130,11 +113,9 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 	if animate {
 		sp.Start()
 	}
-	// The ticker goroutine rewrites the live line on errOut every frame,
-	// so writing per-repo skipped/failed lines to errOut mid-loop would
-	// be clobbered by the next \r — erasing the failure list. Buffer them
-	// while animating and flush after the spinner finalizes; on a non-TTY
-	// (no ticker) write immediately.
+	// The ticker rewrites the live line every frame, so per-repo lines written
+	// to errOut mid-loop would be clobbered. Buffer them while animating and
+	// flush after the spinner finalizes; write immediately on a non-TTY.
 	var deferredDetail []string
 	emitDetail := func(format string, a ...any) {
 		line := fmt.Sprintf(format, a...)
@@ -148,9 +129,8 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 		if animate {
 			sp.Update(fmt.Sprintf("Deleting repos in %s (%d/%d)", org, i+1, len(ordered)))
 		}
-		// Preserve the marker repo when any earlier delete
-		// failed — re-running teardown still passes
-		// requireConfigRepo and can retry the survivors.
+		// Preserve the marker when any earlier delete failed — a re-run still
+		// passes requireConfigRepo and can retry the survivors.
 		if name == configrepo.ConfigRepoName && failed > 0 {
 			markerPreserved = true
 			emitDetail("  skipped: %s/%s preserved so a re-run can retry the failed deletions above\n", org, name)
@@ -172,7 +152,7 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 		} else {
 			sp.Stop(fmt.Sprintf("Deleted %d repo(s)", deleted))
 		}
-		// Ticker stopped — safe to flush the buffered detail lines now.
+		// Ticker stopped — safe to flush buffered detail lines now.
 		for _, line := range deferredDetail {
 			_, _ = fmt.Fprint(errOut, line)
 		}
@@ -184,14 +164,11 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 	}
 	_, _ = fmt.Fprintln(out, summary+".")
 
-	// Sweep the classroom teams collected before deletion. This runs even
-	// when the marker repo was preserved after a partial repo-delete
-	// failure: the team refs were snapshotted up-front from the (still
-	// intact) classroom.json, DeleteClassroomTeam is idempotent (404 =
-	// already gone), and the deletes are independent of any surviving
-	// repos — so a re-run that re-reads the same refs harmlessly no-ops.
-	// Sweeping now avoids stranding write-granted staff teams when a
-	// stuck repo means a clean re-run never happens.
+	// Sweep the classroom teams snapshotted before deletion. Runs even when the
+	// marker was preserved: the refs were captured up-front, DeleteClassroomTeam
+	// is idempotent, and a re-run harmlessly no-ops. Sweeping now avoids
+	// stranding write-granted staff teams when a stuck repo blocks a clean
+	// re-run.
 	for _, t := range teams {
 		if err := configrepo.DeleteClassroomTeam(client, org, t); err != nil {
 			_, _ = fmt.Fprintf(errOut, "Warning: %s: could not delete classroom team %q (%v); delete it by hand at https://github.com/orgs/%s/teams if it lingers.\n",
@@ -207,12 +184,9 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 	return nil
 }
 
-// collectClassroomTeams reads every classroom.json in the config repo
-// and returns the team refs to sweep on teardown: each classroom's
-// students team plus its staff teams (instructor, ta). Best-effort — a
-// read failure is warned and skipped rather than aborting the teardown,
-// since the destructive repo deletions are the primary action. Refs are
-// deduped by slug (a hand-edited config could repeat one).
+// collectClassroomTeams reads every classroom.json and returns the team refs to
+// sweep on teardown (each classroom's student team plus staff teams).
+// Best-effort — a read failure is warned and skipped. Deduped by slug.
 func collectClassroomTeams(client githubapi.Client, org string, errOut io.Writer) []configrepo.TeamRef {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
@@ -227,10 +201,8 @@ func collectClassroomTeams(client githubapi.Client, org string, errOut io.Writer
 	bySlug := map[string]configrepo.TeamRef{}
 	add := func(t *configrepo.TeamRef) {
 		// Filter through the same fail-closed predicate the delete uses
-		// (mirrors the web's teardown, which .filter()s refs through
-		// isDeletableClassroomTeamRef before the bulk delete). A ref
-		// missing a positive id or the classroom50- prefix never enters
-		// the sweep set, defense-in-depth on top of DeleteClassroomTeam.
+		// (mirrors the web). A ref missing a positive id or the classroom50-
+		// prefix never enters the sweep set.
 		if t != nil && configrepo.IsDeletableClassroomTeamRef(*t) {
 			bySlug[t.Slug] = *t
 		}
@@ -256,9 +228,8 @@ func collectClassroomTeams(client githubapi.Client, org string, errOut io.Writer
 	return teams
 }
 
-// requireConfigRepo confirms <org>/classroom50 exists. 404 is the
-// "not a Classroom 50 org" guard — teardown refuses to touch orgs
-// that don't carry the marker. Other errors propagate.
+// requireConfigRepo confirms <org>/classroom50 exists. 404 is the "not a
+// Classroom 50 org" guard; other errors propagate.
 func requireConfigRepo(client githubapi.Client, org string) error {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), configrepo.ConfigRepoName)
 	if err := client.Get(path, nil); err != nil {
@@ -271,11 +242,9 @@ func requireConfigRepo(client githubapi.Client, org string) error {
 	return nil
 }
 
-// orderRepoDeletions returns the input slice with classroom50 moved
-// to the last position (if present). Preserves order otherwise.
-// Deleting the marker last means an interrupted run leaves
-// classroom50 behind, so re-running teardown still passes the
-// requireConfigRepo guard.
+// orderRepoDeletions moves classroom50 to last (if present), preserving order
+// otherwise, so an interrupted run leaves the marker behind and a re-run still
+// passes requireConfigRepo.
 func orderRepoDeletions(repos []string) []string {
 	out := make([]string, 0, len(repos))
 	var hasMarker bool
@@ -292,10 +261,8 @@ func orderRepoDeletions(repos []string) []string {
 	return out
 }
 
-// deleteRepo calls DELETE /repos/{owner}/{repo}. 403 → token is
-// missing the `delete_repo` scope; surface an actionable hint.
-// 204 is the success status; anything else propagates with the
-// raw HTTP code so a transient infra error is visible.
+// deleteRepo calls DELETE /repos/{owner}/{repo}. 403 → missing `delete_repo`
+// scope (actionable hint). 204 is success; anything else propagates the code.
 func deleteRepo(client githubapi.Client, owner, repo string) error {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
 	resp, err := client.Request(http.MethodDelete, path, nil)
@@ -313,10 +280,8 @@ func deleteRepo(client githubapi.Client, owner, repo string) error {
 	return nil
 }
 
-// confirmTeardown prompts on `out` and reads one line from `in`.
-// Returns nil iff the trimmed line equals the org name; any other
-// input (mismatch, EOF, read error) aborts with a typed error so
-// the caller can short-circuit cleanly. Single read — no retry.
+// confirmTeardown prompts on `out` and reads one line from `in`. Returns nil iff
+// the trimmed line equals the org name; any other input aborts. Single read.
 func confirmTeardown(in io.Reader, out io.Writer, org string) error {
 	_, _ = fmt.Fprintf(out, "This will DELETE every repo above. Type the org name (%s) to confirm: ", org)
 	reader := bufio.NewReader(in)

--- a/cli/gh-teacher/internal/ui/status.go
+++ b/cli/gh-teacher/internal/ui/status.go
@@ -1,9 +1,8 @@
 package ui
 
-// Status is the outcome of a read-only check, used to pick the
-// glyph/tag the result banner renders. Its string values ("ok"/"warn"/
-// "fail") are part of the --json contract (preflightCheck.Status), so
-// they must not change.
+// Status is the outcome of a read-only check, picking the result banner's
+// glyph/tag. Its string values ("ok"/"warn"/"fail") are part of the --json
+// contract, so they must not change.
 type Status string
 
 const (

--- a/cli/gh-teacher/internal/ui/ui.go
+++ b/cli/gh-teacher/internal/ui/ui.go
@@ -12,20 +12,18 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/ghui"
 )
 
-// UI renders the human channel. Styling (ANSI color + box-drawing) is
-// gated on color, which degrades to plain ASCII on non-TTYs and when
-// NO_COLOR / CLASSROOM50_NO_COLOR is set. The "Warning: " prefix is
-// preserved in both modes because existing tests and downstream readers
-// key on it.
+// UI renders the human channel. Styling (ANSI color + box-drawing) is gated on
+// color, which degrades to plain ASCII on non-TTYs and when NO_COLOR /
+// CLASSROOM50_NO_COLOR is set. The "Warning: " prefix survives both modes
+// because tests and downstream readers key on it.
 type UI struct {
 	w     io.Writer
 	color bool
 	tty   bool
 }
 
-// Minimal SGR codes. Hand-rolled rather than pulling in a color library
-// (muesli/termenv is only an indirect dep) — the renderer needs three
-// colors and bold, nothing more.
+// Minimal SGR codes. Hand-rolled rather than pulling in a color library — the
+// renderer needs three colors and bold, nothing more.
 const (
 	ansiReset  = "\x1b[0m"
 	ansiBold   = "\x1b[1m"
@@ -35,43 +33,35 @@ const (
 	ansiDim    = "\x1b[2m"
 )
 
-// summaryWrapWidth is the soft wrap width for long warning/summary
-// bodies so a 600-char read-back warning doesn't render as one
-// unreadable line (the Team-plan run that motivated this).
+// summaryWrapWidth is the soft-wrap width for long warning/summary bodies so a
+// 600-char read-back warning doesn't render as one unreadable line.
 const summaryWrapWidth = 76
 
-// New builds a UI writing to w, auto-detecting color: w must be a TTY
-// (we check stderr, the writer the human channel uses) and neither
-// NO_COLOR nor CLASSROOM50_NO_COLOR may be set. Callers that write
-// somewhere other than os.Stderr (tests, captured buffers) get
-// color=false, which is the safe default.
+// New builds a UI writing to w, auto-detecting color: w must be a TTY and
+// neither NO_COLOR nor CLASSROOM50_NO_COLOR set. Non-stderr callers (tests,
+// buffers) get color=false.
 func New(w io.Writer) *UI {
 	return &UI{w: w, color: detectColor(w), tty: detectTTY(w)}
 }
 
-// NewForced builds a UI with an explicit color setting, for
-// deterministic tests that must exercise the colored or plain renderer
-// regardless of where the test's output happens to go. tty follows color
-// (forced-color callers are exercising the interactive renderer).
+// NewForced builds a UI with an explicit color setting for deterministic tests.
+// tty follows color.
 func NewForced(w io.Writer, color bool) *UI {
 	return &UI{w: w, color: color, tty: color}
 }
 
-// detectTTY reports whether w is an interactive terminal, via the shared
-// ghui.IsStderrTTY. Kept separate from color so NO_COLOR still allows
-// in-place progress on a real terminal.
+// detectTTY reports whether w is an interactive terminal. Kept separate from
+// color so NO_COLOR still allows in-place progress on a real terminal.
 func detectTTY(w io.Writer) bool {
 	return ghui.IsStderrTTY(w)
 }
 
-// detectColor reports whether to emit color, via the shared ghui.UseColor
-// (so the policy stays identical across both CLIs and the spinner).
+// detectColor reports whether to emit color, via shared ghui.UseColor.
 func detectColor(w io.Writer) bool {
 	return ghui.UseColor(w)
 }
 
-// paint wraps s in an SGR code when color is on; otherwise returns s
-// unchanged.
+// paint wraps s in an SGR code when color is on; else returns s unchanged.
 func (u *UI) paint(code, s string) string {
 	if !u.color {
 		return s
@@ -79,25 +69,20 @@ func (u *UI) paint(code, s string) string {
 	return code + s + ansiReset
 }
 
-// Step prints a `[n/total] label` phase header. On a color TTY the
-// counter is dimmed and the label bold; plain otherwise.
+// Step prints a `[n/total] label` phase header (dimmed counter, bold label).
 func (u *UI) Step(n, total int, label string) {
 	counter := fmt.Sprintf("[%d/%d]", n, total)
 	_, _ = fmt.Fprintf(u.w, "%s %s\n", u.paint(ansiDim, counter), u.paint(ansiBold, label))
 }
 
-// Section prints an un-numbered phase header (e.g. "Preflight checks"),
-// bold on a color TTY. Used for phases that aren't part of the numbered
-// step sequence.
+// Section prints an un-numbered phase header, bold on a color TTY.
 func (u *UI) Section(label string) {
 	_, _ = fmt.Fprintf(u.w, "%s\n", u.paint(ansiBold, label))
 }
 
-// Progress renders a single self-rewriting status line on a TTY. Call
-// Update for each step (it rewrites the same line via carriage return),
-// then Done to finalize. On a non-TTY it's a no-op (callers fall back to
-// stable per-line output), so the machine-stable channel never sees
-// cursor-control escapes.
+// Progress renders a single self-rewriting status line on a TTY (Update per
+// step, then Done). No-op on a non-TTY, so the machine-stable channel never
+// sees cursor-control escapes.
 type Progress struct {
 	u     *UI
 	total int
@@ -108,20 +93,17 @@ func (u *UI) NewProgress(total int) *Progress {
 	return &Progress{u: u, total: total}
 }
 
-// Spinner returns a live single-line spinner for a long-running step,
-// backed by the shared ghui spinner so both CLIs animate identically.
+// Spinner returns a live single-line spinner backed by the shared ghui spinner.
 func (u *UI) Spinner(message string) *ghui.Spinner {
 	return ghui.NewSpinner(u.w, message)
 }
 
-// Active reports whether the progress line actually renders (TTY only).
-// Callers use this to decide whether to suppress the verbose per-step
-// output that would otherwise scroll the progress line away.
+// Active reports whether the progress line actually renders (TTY only). Callers
+// use it to suppress verbose per-step output that would scroll it away.
 func (p *Progress) Active() bool { return p.u.tty }
 
-// Update rewrites the in-place line to "[n/total] label". \r returns to
-// column 0 and \x1b[K clears to end of line so a shorter label can't
-// leave trailing characters from a longer previous one.
+// Update rewrites the in-place line to "[n/total] label". \r + \x1b[K clear to
+// end of line so a shorter label leaves no trailing chars.
 func (p *Progress) Update(n int, label string) {
 	if !p.u.tty {
 		return
@@ -131,8 +113,8 @@ func (p *Progress) Update(n int, label string) {
 	_, _ = fmt.Fprintf(p.u.w, "\r\x1b[K%s %s", p.u.paint(ansiDim, counter), label)
 }
 
-// Done finalizes the progress line as "[total/total] Done" and moves to
-// the next line so subsequent output (the summary) starts cleanly.
+// Done finalizes the progress line as "[total/total] Done" and moves to the
+// next line so subsequent output starts cleanly.
 func (p *Progress) Done() {
 	if !p.u.tty || !p.shown {
 		return
@@ -141,9 +123,8 @@ func (p *Progress) Done() {
 	_, _ = fmt.Fprintf(p.u.w, "\r\x1b[K%s %s\n", p.u.paint(ansiDim, counter), p.u.paint(ansiGreen, "Done"))
 }
 
-// Abort clears the in-place line without the "Done" marker, for the
-// error path so a failure message isn't appended to a half-written
-// progress line.
+// Abort clears the in-place line without the "Done" marker, so a failure
+// message isn't appended to a half-written progress line.
 func (p *Progress) Abort() {
 	if !p.u.tty || !p.shown {
 		return
@@ -151,9 +132,7 @@ func (p *Progress) Abort() {
 	_, _ = fmt.Fprint(p.u.w, "\r\x1b[K")
 }
 
-// Ok prints a success line: "✓ <msg>" on a color TTY, "[ok] <msg>"
-// plain. Used for per-step confirmations on the human channel (the
-// machine-stable stdout lines are emitted separately).
+// Ok prints a success line: "✓ <msg>" on a color TTY, "[ok] <msg>" plain.
 func (u *UI) Ok(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	if u.color {
@@ -164,17 +143,15 @@ func (u *UI) Ok(format string, a ...any) {
 }
 
 // Warn prints a warning. It ALWAYS contains the literal "Warning: " so
-// existing substring assertions and downstream log scrapers keep
-// working; on a color TTY it's additionally prefixed with a yellow ⚠
-// and the leading "Warning:" is yellowed. Long bodies are soft-wrapped
-// (continuation lines indented) so a single huge warning stays readable.
+// substring assertions and log scrapers keep working; on a color TTY it adds a
+// yellow ⚠ and yellows the leading "Warning:". Long bodies are soft-wrapped.
 func (u *UI) Warn(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	body := "Warning: " + msg
 	wrapped := softWrap(body, summaryWrapWidth, "  ")
 	if u.color {
-		// Color only the first line's "Warning:" token; the wrap keeps
-		// the rest plain so multi-line bodies don't smear escape codes.
+		// Color only the first line's "Warning:" so multi-line bodies don't
+		// smear escape codes.
 		wrapped = strings.Replace(wrapped, "Warning:", u.paint(ansiYellow, "Warning:"), 1)
 		_, _ = fmt.Fprintf(u.w, "%s %s\n", u.paint(ansiYellow, "\u26a0"), wrapped)
 		return
@@ -182,9 +159,8 @@ func (u *UI) Warn(format string, a ...any) {
 	_, _ = fmt.Fprintf(u.w, "%s\n", wrapped)
 }
 
-// Heading prints a section heading on the human channel — bold on a
-// color TTY, an ASCII-underlined label plain. A blank line precedes it
-// so sections are visually separated.
+// Heading prints a section heading (bold on a color TTY), preceded by a blank
+// line for separation.
 func (u *UI) Heading(label string) {
 	if u.color {
 		_, _ = fmt.Fprintf(u.w, "\n%s\n", u.paint(ansiBold, label))
@@ -193,9 +169,8 @@ func (u *UI) Heading(label string) {
 	_, _ = fmt.Fprintf(u.w, "\n%s\n", label)
 }
 
-// Result prints the one-line outcome banner that opens the final report:
-// a ✓ / ⚠ / ✗ glyph (green/yellow/red on a color TTY, ASCII tag plain)
-// plus the message.
+// Result prints the one-line outcome banner opening the final report: a ✓/⚠/✗
+// glyph (or ASCII tag plain) plus the message.
 func (u *UI) Result(status Status, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	if !u.color {
@@ -211,24 +186,20 @@ func (u *UI) Result(status Status, format string, a ...any) {
 	_, _ = fmt.Fprintf(u.w, "%s %s\n", glyph, u.paint(ansiBold, msg))
 }
 
-// Numbered prints an ordinal list item ("  1. <msg>") under a report
-// heading, with a hanging wrap aligned under the text. Used for a list
-// of manual steps that are NOT checkboxes — e.g. settings GitHub exposes
-// no API to read, so they're an instruction list to eyeball, not state
-// the CLI tracks.
+// Numbered prints an ordinal list item ("  1. <msg>") with a hanging wrap. Used
+// for manual steps that are NOT checkboxes (e.g. API-less settings to eyeball,
+// not state the CLI tracks).
 func (u *UI) Numbered(n int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	prefix := fmt.Sprintf("%d. ", n)
-	// Indent continuation lines past the "  N. " prefix so wrapped text
-	// lines up under the item body, not the number.
+	// Indent continuation lines past the "  N. " prefix so wrapped text lines
+	// up under the body.
 	hang := strings.Repeat(" ", 2+len(prefix))
 	_, _ = fmt.Fprintf(u.w, "  %s%s\n", prefix, softWrap(msg, summaryWrapWidth, hang))
 }
 
-// OkItem prints a checked-off list item under a report heading: "  ✓
-// <msg>" on a color TTY, "  [x] <msg>" plain. The two-space indent and
-// hanging wrap match Checkbox() so a mixed list of done (✓) and to-do
-// ([ ]) items lines up under the same heading.
+// OkItem prints a checked-off list item: "  ✓ <msg>" / "  [x] <msg>". Indent
+// and hanging wrap match Checkbox() so mixed done/to-do lists line up.
 func (u *UI) OkItem(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	if u.color {
@@ -238,16 +209,15 @@ func (u *UI) OkItem(format string, a ...any) {
 	_, _ = fmt.Fprintf(u.w, "  [x] %s\n", softWrap(msg, summaryWrapWidth, "      "))
 }
 
-// Checkbox prints an actionable to-do item as an unchecked box. The body
-// is soft-wrapped with a hanging indent so a long instruction stays
-// readable and lined up under the text (not the box).
+// Checkbox prints an actionable to-do item as an unchecked box, soft-wrapped
+// with a hanging indent so a long instruction lines up under the text.
 func (u *UI) Checkbox(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	_, _ = fmt.Fprintf(u.w, "  [ ] %s\n", softWrap(msg, summaryWrapWidth, "      "))
 }
 
-// Detail prints an indented, dimmed continuation line (e.g. a URL under
-// a checklist). Dimmed on a color TTY, plain otherwise.
+// Detail prints an indented, dimmed continuation line (e.g. a URL under a
+// checklist).
 func (u *UI) Detail(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	_, _ = fmt.Fprintf(u.w, "  %s\n", u.paint(ansiDim, msg))
@@ -273,8 +243,8 @@ func (u *UI) Blank() {
 	_, _ = fmt.Fprintln(u.w)
 }
 
-// softWrap wraps s to width columns on spaces, indenting continuation
-// lines with indent. Words longer than width are left intact (URLs).
+// softWrap wraps s to width columns on spaces, indenting continuation lines.
+// Words longer than width are left intact (URLs).
 func softWrap(s string, width int, indent string) string {
 	words := strings.Fields(s)
 	if len(words) == 0 {
@@ -301,9 +271,8 @@ func softWrap(s string, width int, indent string) string {
 	return b.String()
 }
 
-// displayLen approximates the printed width of s as its rune count,
-// ignoring ANSI escape sequences. Good enough for layout of the ASCII +
-// occasional emoji content the renderer emits.
+// displayLen approximates the printed width of s as its rune count, ignoring
+// ANSI escapes.
 func displayLen(s string) int {
 	n := 0
 	inEscape := false

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -1,8 +1,6 @@
-// Package validate holds gh-teacher's identifier validators — the
-// shape rules for org logins, classroom short-names, and assignment
-// slugs. They are pure functions shared across nearly every command,
-// with no GitHub client or domain-type dependency, so they live in
-// their own seam that command and config-repo packages can import.
+// Package validate holds gh-teacher's identifier validators (org logins,
+// classroom short-names, assignment slugs) — pure functions shared across
+// commands with no GitHub-client dependency.
 package validate
 
 import (
@@ -12,22 +10,18 @@ import (
 	"strings"
 )
 
-// ShortNamePattern: classroom short-names and assignment slugs both
-// flow into student-repo names and the contents/tree API, so both are
-// validated against this rule. Exposed for the few call sites that
-// match directly (e.g. slug derivation); most callers should use
-// ShortName for the standard error shape.
+// ShortNamePattern: classroom short-names and assignment slugs both flow into
+// student-repo names and the contents/tree API. Exposed for the few call sites
+// that match directly; most callers should use ShortName for the standard error.
 var ShortNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,38}$`)
 
-// ShortNamePatternDescription: human-readable summary of
-// ShortNamePattern, embedded in every "invalid <thing>" error (and in
-// the bespoke slug-derivation error in migrate_translate).
+// ShortNamePatternDescription: human-readable summary of ShortNamePattern,
+// embedded in every "invalid <thing>" error.
 const ShortNamePatternDescription = "^[a-z0-9][a-z0-9-]{1,38}$ (2-39 chars, lowercase letters/digits/hyphens, starting with a letter or digit)"
 
-// ShortName checks name against ShortNamePattern with a label-prefixed
-// error (e.g. "slug", "short-name"). Same rule for classroom
-// short-names and assignment slugs because both flow into student-repo
-// names; also keeps traversal-style values out of the contents/tree API.
+// ShortName checks name against ShortNamePattern with a label-prefixed error.
+// Same rule for classroom short-names and slugs (both flow into repo names) and
+// keeps traversal-style values out of the contents/tree API.
 func ShortName(name, label string) error {
 	if !ShortNamePattern.MatchString(name) {
 		return fmt.Errorf("invalid %s %q: must match %s", label, name, ShortNamePatternDescription)
@@ -35,20 +29,16 @@ func ShortName(name, label string) error {
 	return nil
 }
 
-// orgNamePattern matches a GitHub organization login: alphanumeric
-// segments joined by single hyphens, 1-39 chars, case-insensitive
-// (GitHub preserves case but treats logins case-insensitively). This
-// is intentionally laxer than ShortNamePattern — org names allow
-// uppercase and a single leading character — so a real org like
-// "CS50" or "Foundation50" validates, while traversal/garbage values
-// (slashes, dots, spaces) are rejected before they reach a
-// url.PathEscape'd API call and surface as a confusing mid-call 404.
+// orgNamePattern matches a GitHub org login: alphanumeric segments joined by
+// single hyphens, 1-39 chars, case-insensitive. Laxer than ShortNamePattern
+// (allows uppercase) so a real org like "CS50" validates, while traversal/garbage
+// (slashes, dots, spaces) is rejected before a mid-call 404.
 var orgNamePattern = regexp.MustCompile(`^[a-zA-Z0-9](-?[a-zA-Z0-9])*$`)
 
 const orgNamePatternDescription = "1-39 alphanumeric characters with non-consecutive internal hyphens (a GitHub organization login)"
 
-// OrgName checks org against orgNamePattern. Catches typos upfront with
-// a clear message rather than a 404 partway through a command.
+// OrgName checks org against orgNamePattern, catching typos with a clear
+// message rather than a mid-command 404.
 func OrgName(org string) error {
 	if len(org) > 39 || !orgNamePattern.MatchString(org) {
 		return fmt.Errorf("invalid org %q: must be %s", org, orgNamePatternDescription)
@@ -56,10 +46,8 @@ func OrgName(org string) error {
 	return nil
 }
 
-// OrgClassroom trims and validates the common `<org> <classroom>`
-// argument pair: both must be non-empty, the org must satisfy OrgName,
-// and the classroom must satisfy ShortName. Returns the trimmed values
-// or the first error.
+// OrgClassroom trims and validates the common `<org> <classroom>` pair: both
+// non-empty, org satisfies OrgName, classroom satisfies ShortName.
 func OrgClassroom(args []string) (org, classroom string, err error) {
 	org = strings.TrimSpace(args[0])
 	classroom = strings.TrimSpace(args[1])
@@ -89,27 +77,21 @@ func ScopeListContains(scopes, want string) bool {
 	return false
 }
 
-// scopeImpliedBy maps an OAuth scope to the broader scopes that include
-// it. GitHub normalizes a token's granted scopes, discarding any scope
-// implicitly covered by a broader one it was granted alongside — so a
-// token requested with `admin:org` and `read:org` comes back reporting
-// only `admin:org` in X-OAuth-Scopes. A whole-token match for the
-// narrower scope would then wrongly report it missing. Only the org
-// hierarchy is listed because it's the only implication in the scopes
-// gh-teacher requests; extend this if a new required scope has implied
-// parents. Mirrors GitHub's documented scope hierarchy
-// (admin:org -> write:org -> read:org).
+// scopeImpliedBy maps an OAuth scope to broader scopes that include it. GitHub
+// normalizes granted scopes, dropping any implied by a broader one, so a token
+// with `admin:org` reports only that and a whole-token match for `read:org`
+// would wrongly report it missing. Only the org hierarchy is listed (the only
+// implication in gh-teacher's scopes); extend if a new required scope has
+// implied parents.
 var scopeImpliedBy = map[string][]string{
 	"read:org":  {"admin:org", "write:org"},
 	"write:org": {"admin:org"},
 }
 
-// ScopeListSatisfies reports whether the X-OAuth-Scopes list satisfies
-// want, treating a broader granted scope as covering the narrower one it
-// implies (per GitHub's scope normalization). Use this — not
-// ScopeListContains — when checking whether a token can perform an
-// operation, so a normalized header that dropped an implied scope isn't
-// mistaken for a missing grant.
+// ScopeListSatisfies reports whether the X-OAuth-Scopes list satisfies want,
+// treating a broader granted scope as covering the narrower one it implies. Use
+// this (not ScopeListContains) when checking whether a token can perform an
+// operation.
 func ScopeListSatisfies(scopes, want string) bool {
 	if ScopeListContains(scopes, want) {
 		return true

--- a/cli/gh-teacher/main.go
+++ b/cli/gh-teacher/main.go
@@ -7,10 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	// Embed the IANA tz database so LoadLocation (due-date timezone
-	// detection in internal/assignmentcmd) works on hosts without system
-	// zoneinfo -- otherwise a named $TZ silently falls back to
-	// time.Local and deadlines normalize to the wrong instant.
+	// Embed the IANA tz database so LoadLocation (due-date timezone detection)
+	// works on hosts without system zoneinfo — else a named $TZ silently falls
+	// back to time.Local and deadlines normalize to the wrong instant.
 	_ "time/tzdata"
 
 	"github.com/spf13/cobra"
@@ -67,8 +66,8 @@ func main() {
 	root.AddCommand(download.NewCmd())
 	root.AddCommand(teardown.NewCmd())
 
-	// Signal-aware root context: subcommands see cmd.Context()
-	// cancel on Ctrl-C / SIGTERM so in-flight HTTP unwinds.
+	// Signal-aware root context: subcommands see cmd.Context() cancel on
+	// Ctrl-C / SIGTERM so in-flight HTTP unwinds.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/cli/gh-teacher/service_token.go
+++ b/cli/gh-teacher/service_token.go
@@ -15,21 +15,14 @@ import (
 
 // provisionServiceToken handles the service-token step of init with a
 // minimal-prompt UX:
-//   - env var set: validate it, store it, and note that it was used.
-//   - secret already exists (re-run) and no env var: skip — the token is
-//     already configured; tell the teacher how to replace it.
-//   - first-time, no env var: prompt, validate (BLOCKING — a bad token
-//     stops init rather than silently breaking collect-scores later),
-//     then store.
+//   - env var set: validate, store, note it was used.
+//   - secret exists (re-run) and no env var: skip; tell the teacher how to
+//     replace it.
+//   - first-time, no env var: prompt, validate (BLOCKING), store.
 //
-// Every non-prompt path prints a concise note of what the CLI did, so a
-// teacher re-running init understands why they weren't asked for a token.
-// secretExists is the result preflight already fetched, so the re-run
-// path doesn't repeat the secret GET.
-//
-// This is the init orchestration step (it writes *initSummary), so it
-// stays in package main; the reusable provisioning/validation/read
-// primitives live in internal/servicetoken.
+// Every non-prompt path prints a note so a re-run explains why no token was
+// asked for. secretExists is what preflight already fetched. Stays in package
+// main because it writes *initSummary.
 func provisionServiceToken(cmd *cobra.Command, client githubapi.Client, summary *initSummary, org string, secretExists bool) error {
 	errOut := cmd.ErrOrStderr()
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -2,42 +2,34 @@
 """Teacher-triggered scores collector.
 
 Walks the classroom team × assignment manifest: for each (team member,
-assignment) pair, pages through the canonical
-`<classroom>-<assignment>-<username>` repo's `submit/*` releases, validates
-each `result.json` asset, and upserts into `<classroom>/scores.json`. The
-classroom GitHub team is the source of truth for who is enrolled;
-students.csv is not read during collection.
+assignment) pair, pages the canonical `<classroom>-<assignment>-<username>`
+repo's `submit/*` releases, validates each `result.json` asset, and upserts
+into `<classroom>/scores.json`. The classroom GitHub team is the source of
+truth for enrollment; students.csv is not read during collection.
 
-`scores.json` is keyed by assignment slug under the root `assignments`
-object: each value is `{ "type": "individual"|"group", "entries": [...] }`.
-An `entry` is one student repo's gradebook record (one per repo owner):
-identity/keying at the top level (`owner`; plus `member_usernames` for a
-group entry — the credited team collaborators) and the full
-per-submission history inside a `submissions` list (newest first). Each
-`submissions` item is a validated `result.json` payload (minus the
-redundant `assignment` bucket key; it carries `owner` + `assignment_type`
-+ optional `submitted_by`, no `usernames`), so every push to `main` that
-produced a `submit/*` release is retained — not just the latest. When the
-assignment has a `due` date in assignments.json, each submission record
-carries `"late": true|false` (its `datetime` vs. `due`). Advisory only —
-nothing enforces the deadline; late submissions are still collected and
-scored.
+`scores.json` is keyed by assignment slug under root `assignments`: each value
+is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is one
+student repo's record (one per repo owner): identity/keying at the top
+(`owner`; plus `member_usernames` for group — the credited collaborators) and
+the full per-submission history in `submissions` (newest first). Each
+`submissions` item is a validated `result.json` payload minus the redundant
+`assignment` bucket key (it carries `owner` + `assignment_type` + optional
+`submitted_by`, no `usernames`). When the assignment has a `due` date, each
+record carries `"late": true|false` (its `datetime` vs. `due`) — advisory only;
+late submissions are still collected and scored.
 
-Single writer per scores.json. Re-runs are idempotent: unchanged
-submissions are no-ops, and `"override": true` entries are
-preserved verbatim so teacher corrections never get overwritten.
-
-Per-classroom writes are atomic via tmp + os.replace. A missing
-release is not an error (student hasn't accepted/submitted yet);
-the per-assignment "X of Y submitted" log shows team coverage.
+Single writer per scores.json. Re-runs are idempotent: unchanged submissions
+are no-ops, and `"override": true` entries are preserved verbatim so teacher
+corrections aren't overwritten. Per-classroom writes are atomic (tmp +
+os.replace). A missing release is not an error (student hasn't
+accepted/submitted); the per-assignment "X of Y submitted" log shows coverage.
 
 Environment (set by `collect-scores.yaml`):
   CLASSROOM50_SERVICE_TOKEN — fine-grained PAT. Needs Organization ->
-                              Members: Read (collection is team-driven and
-                              lists the classroom team) and Repository ->
-                              Contents: Read and write. Collection only
-                              reads; the write scope is shared with
-                              regrade.yaml (pushes submit/* tags).
+                              Members: Read (collection lists the classroom
+                              team) and Repository -> Contents: Read and write
+                              (read scope only used here; write scope shared
+                              with regrade.yaml).
   CLASSROOM_FILTER          — optional single-classroom limit.
   GITHUB_REPOSITORY_OWNER   — org name (auto-set by Actions).
   GITHUB_API_URL            — API URL on GHES runners.
@@ -45,9 +37,9 @@ Environment (set by `collect-scores.yaml`):
 
 Exit codes:
   0 — success.
-  1 — operational failure (missing token, malformed scores.json,
-      unrecoverable network error). The run log points the teacher
-      at `gh teacher rotate-service-token` for PAT issues.
+  1 — operational failure (missing token, malformed scores.json, unrecoverable
+      network error). The run log points at `gh teacher rotate-service-token`
+      for PAT issues.
 """
 
 from __future__ import annotations
@@ -72,8 +64,8 @@ ASSIGNMENTS_SCHEMA_V1 = "classroom50/assignments/v1"
 SCORES_SCHEMA_V1 = "classroom50/scores/v1"
 RESULT_SCHEMA_V1 = "classroom50/result/v1"
 
-# Trigger contract: only `submit/*` tag releases count as
-# submissions (created by autograde-runner.yaml on push to `main`).
+# Trigger contract: only `submit/*` tag releases count as submissions
+# (created by autograde-runner.yaml on push to `main`).
 SUBMIT_TAG_PREFIX = "submit/"
 
 RFC3339_RE = re.compile(
@@ -85,34 +77,31 @@ RFC3339_RE = re.compile(
 # contract — keep aligned with autograde-runner.yaml and download.go.
 RESULT_ASSET_NAME = "result.json"
 
-# Hard cap on result.json size. Real payloads sit well under 1 MiB;
-# 10 MiB bounds a hostile asset without rejecting any plausible
-# submission.
+# Hard cap on result.json size. Real payloads sit well under 1 MiB; 10 MiB
+# bounds a hostile asset without rejecting any plausible submission.
 MAX_RESULT_BYTES = 10 * 1024 * 1024
 
 # Required roster columns written by `gh teacher classroom add`. Mirrors
-# RosterColumns in cli/gh-teacher/internal/configrepo/students_csv.go and the web
-# app's STUDENT_CSV_FIELDS. students.csv is just these six identity/metadata
-# columns — an earlier email-first tail was pruned across all three codebases
-# (the classroom GitHub team is the source of truth for enrollment).
+# RosterColumns in cli/gh-teacher/internal/configrepo/students_csv.go and the
+# web app's STUDENT_CSV_FIELDS. Just these six identity/metadata columns — an
+# earlier email-first tail was pruned across all three codebases (the classroom
+# GitHub team is the source of truth for enrollment).
 ROSTER_REQUIRED_COLUMNS = ("username", "first_name", "last_name", "email", "section", "github_id")
 
-# FULL_ROSTER_HEADER is the exact on-disk students.csv header. Must equal
-# FullRosterHeader in the Go students_csv.go (asserted by TestFullRosterHeader)
-# and the web app's STUDENT_CSV_FIELDS header — a three-way lockstep. Any legacy
-# trailing columns on an existing file are tolerated on read (see
-# read_students_csv), not part of the written header.
+# The exact on-disk students.csv header. Must equal FullRosterHeader in the Go
+# students_csv.go (asserted by TestFullRosterHeader) and the web app's
+# STUDENT_CSV_FIELDS header — a three-way lockstep. Legacy trailing columns on
+# an existing file are tolerated on read (see read_students_csv), not written.
 FULL_ROSTER_HEADER = ",".join(ROSTER_REQUIRED_COLUMNS)
 
-# Coarse filter for obviously-bogus usernames (empty, slashes, etc.)
-# so they don't get formatted into a URL. Not a strict GitHub
-# username validator.
+# Coarse filter for obviously-bogus usernames (empty, slashes, etc.) so they
+# don't get formatted into a URL. Not a strict GitHub username validator.
 _USERNAME_BAD_CHARS = re.compile(r"[^A-Za-z0-9-]")
 
-# Leading bytes that a spreadsheet (Excel/LibreOffice) treats as a formula
-# trigger. Mirrors isFormulaTrigger in students_csv.go; used to reject a
-# hand-edited extra column whose NAME would re-introduce CSV-injection when the
-# CLI rewrites the header verbatim.
+# Leading bytes a spreadsheet (Excel/LibreOffice) treats as a formula trigger.
+# Mirrors isFormulaTrigger in students_csv.go; rejects a hand-edited extra
+# column whose NAME would re-introduce CSV-injection when the CLI rewrites the
+# header verbatim.
 _CSV_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
 
 
@@ -156,9 +145,8 @@ def main() -> int:
         except ScoresFileError as exc:
             # A malformed/hand-edited scores.json is a per-CLASSROOM data
             # problem — isolate it (like iter_classrooms does for a bad
-            # classroom.json) so one broken file can't deny collection to
-            # every other classroom in the run. The run still exits non-zero
-            # at the end so CI surfaces the failure.
+            # classroom.json) so one broken file can't deny collection to the
+            # rest. The run still exits non-zero at the end so CI surfaces it.
             emit_error(f"{classroom_short}: {exc}")
             failed_classrooms.append(classroom_short)
             continue
@@ -173,8 +161,8 @@ def main() -> int:
                 service_token=service_token,
             )
         except urllib.error.HTTPError as exc:
-            # Auth (401/403) and synthetic-network (599) failures are GLOBAL
-            # — the token is bad or GitHub is unreachable, so every remaining
+            # Auth (401/403) and synthetic-network (599) failures are GLOBAL —
+            # the token is bad or GitHub is unreachable, so every remaining
             # classroom would fail identically. Abort the whole run loudly
             # rather than warn-and-skip per classroom (which would report a
             # broken run as success that collected nothing).
@@ -193,21 +181,17 @@ def main() -> int:
                 )
             return 1
 
-        # A service token that can't read the student repos returns
-        # 404 for every repo (GitHub hides repo existence), which is
-        # indistinguishable from "not submitted" -- so collect_classroom
-        # reports the whole team as unsubmitted and the run still exits
-        # cleanly (the 401/403 hard-fail guard never trips). When a
-        # non-empty assignment set yields zero readable submissions, that
-        # often means the classroom team has no members yet OR the token
-        # lacks repo access. Warn -- but don't fail: an early-term run
-        # legitimately collects zero. (A team that is empty/unreadable also
-        # emits its own specific warning inside collect_classroom.)
+        # A service token that can't read the student repos returns 404 for
+        # every repo (GitHub hides existence), indistinguishable from "not
+        # submitted" — so collect_classroom reports the whole team as
+        # unsubmitted and the run exits cleanly (the 401/403 guard never trips).
+        # A non-empty assignment set yielding zero readable submissions often
+        # means the team has no members yet OR the token lacks repo access.
+        # Warn, don't fail: an early-term run legitimately collects zero.
         #
         # Suppress this when collect_classroom already attributed the empty
-        # result to a mode flip (releases present but all rejected by
-        # validation): that has its own loud, specific warning above, and
-        # blaming the token here would misdirect the teacher.
+        # result to a mode flip (releases present but all rejected): that has
+        # its own loud warning, and blaming the token here would misdirect.
         assignment_count = len(valid_assignment_slugs(assignments))
         if assignment_count and not updates and not mode_flip_assignments:
             emit_warning(
@@ -224,8 +208,7 @@ def main() -> int:
         try:
             save_scores(scores_path, scores)
         except ScoresFileError as exc:
-            # Per-classroom write failure — isolate like the load failure
-            # above so a single unwritable file doesn't strand the rest.
+            # Per-classroom write failure — isolate like the load failure above.
             emit_error(f"{classroom_short}: {exc}")
             failed_classrooms.append(classroom_short)
             continue
@@ -253,15 +236,13 @@ def iter_classrooms(
     base_dir: pathlib.Path, classroom_filter: str
 ) -> Iterable[tuple[str, dict[str, Any], dict[str, Any]]]:
     """Yield (short_name, classroom_meta, assignments) per classroom. Non-v1
-    schemas skip with a workflow warning (preserves forward-compat without
-    crashing the run).
+    schemas skip with a workflow warning (forward-compat without crashing).
 
-    Collection is TEAM-driven: the classroom GitHub team is the source of
-    truth for who is enrolled, so this no longer reads students.csv at all
-    (the team enumeration in collect_classroom drives the (student,
-    assignment) pairs). students.csv is optional display metadata consumed
-    elsewhere (the Go `download` scores.csv join and the web roster view),
-    not by the scorer.
+    Collection is TEAM-driven: the classroom GitHub team is the source of truth
+    for enrollment, so this no longer reads students.csv at all (the team
+    enumeration in collect_classroom drives the pairs). students.csv is optional
+    display metadata consumed elsewhere (the Go download scores.csv join and the
+    web roster view), not by the scorer.
     """
     if not base_dir.is_dir():
         return
@@ -301,29 +282,26 @@ class RosterFileError(Exception):
 
 
 def read_students_csv(path: pathlib.Path) -> list[dict[str, str]]:
-    """Parse students.csv into row dicts. Rejects a renamed/short
-    header so a hand-edit can't silently drop data. Empty-username
-    rows are skipped.
+    """Parse students.csv into row dicts. Rejects a renamed/short header so a
+    hand-edit can't silently drop data. Empty-username rows are skipped.
 
-    NOTE: score collection is TEAM-driven and no longer reads students.csv
-    (the classroom team drives the (student, assignment) pairs). This reader
-    is retained as the Python-side validator of the shared CSV contract —
-    exercised by the test suite and available to any future consumer — and
-    its header must stay in lockstep with the Go/web header (see
-    FULL_ROSTER_HEADER).
+    NOTE: score collection is TEAM-driven and no longer reads students.csv (the
+    team drives the pairs). This reader is retained as the Python-side validator
+    of the shared CSV contract — exercised by the test suite and available to
+    any future consumer — and its header must stay in lockstep with the Go/web
+    header (see FULL_ROSTER_HEADER).
     """
     try:
-        # utf-8-sig strips Excel's BOM, matching the Go-side
-        # students_csv.go reader.
+        # utf-8-sig strips Excel's BOM, matching the Go students_csv.go reader.
         with path.open(newline="", encoding="utf-8-sig") as fh:
             reader = csv.DictReader(fh)
             if reader.fieldnames is None:
                 raise RosterFileError("students.csv is empty")
             header = tuple(reader.fieldnames)
-            # Tolerate trailing extras (e.g. a legacy tail on a
-            # between-deploys file): only username + github_id are read by
-            # name. A renamed/short/shuffled required prefix is still rejected
-            # so a hand-edit can't silently drop or shift roster data.
+            # Tolerate trailing extras (e.g. a legacy tail on a between-deploys
+            # file): only username + github_id are read by name. A renamed/
+            # short/shuffled required prefix is still rejected so a hand-edit
+            # can't silently drop or shift roster data.
             if header[: len(ROSTER_REQUIRED_COLUMNS)] != ROSTER_REQUIRED_COLUMNS:
                 raise RosterFileError(
                     f"students.csv header = {header}, want it to start with "
@@ -332,10 +310,8 @@ def read_students_csv(path: pathlib.Path) -> list[dict[str, str]]:
                 )
             # Reject the same malformed extra headers the Go reader rejects so
             # both binaries agree the shared file is well-formed: a reused
-            # required name, a duplicate (csv.DictReader would silently last-wins
-            # it), or a formula-trigger name (CSV-injection on a CLI rewrite).
-            # Otherwise a hand-edit could be "broken" to the CLI yet silently
-            # graded here.
+            # required name, a duplicate (csv.DictReader silently last-wins it),
+            # or a formula-trigger name (CSV-injection on a CLI rewrite).
             extra_columns = header[len(ROSTER_REQUIRED_COLUMNS) :]
             seen_extra: set[str] = set()
             for name in extra_columns:
@@ -381,10 +357,10 @@ def read_students_csv(path: pathlib.Path) -> list[dict[str, str]]:
 
 
 def valid_assignment_slugs(assignments: dict[str, Any]) -> list[str]:
-    """Slugs worth collecting: non-empty strings, in manifest order.
-    main()'s zero-submission guard counts these; the collect loop
-    applies the same slug predicate inline (it also needs each entry's
-    `due`), so the two agree on what counts as a collectable assignment."""
+    """Slugs worth collecting: non-empty strings, in manifest order. main()'s
+    zero-submission guard counts these; the collect loop applies the same
+    predicate inline (it also needs each entry's `due`), so both agree on what
+    counts as collectable."""
     slugs: list[str] = []
     for entry in assignments.get("assignments") or []:
         slug = entry.get("slug")
@@ -402,26 +378,25 @@ def collect_classroom(
     assignments: dict[str, Any],
     service_token: str,
 ) -> tuple[list[dict[str, Any]], int]:
-    """Return (validated result payloads for every (student,
-    assignment) pair, count of assignments whose only submissions were
-    rejected by validation). Per-repo failures warn and skip; hard
-    failures (auth: 401/403; network: synthetic 599) propagate and
-    main() converts them to exit 1. The second tuple element lets main()
-    distinguish a mode-flip-induced empty result (which has its own loud
+    """Return (validated result payloads for every (student, assignment) pair,
+    count of assignments whose only submissions were rejected by validation).
+    Per-repo failures warn and skip; hard failures (auth 401/403; network 599)
+    propagate and main() converts them to exit 1. The second tuple element lets
+    main() distinguish a mode-flip-induced empty result (which has its own loud
     warning) from a token-access problem.
     """
     results: list[dict[str, Any]] = []
     group_attribution_degraded = 0
-    # Number of (assignment) buckets where every present submission was
-    # rejected by validation (the mode-flip symptom). Returned so main() can
-    # suppress its "rotate token" heuristic, which would otherwise misread a
-    # mode-flip-induced empty result as a token-access problem.
+    # (assignment) buckets where every present submission was rejected by
+    # validation (the mode-flip symptom). Returned so main() can suppress its
+    # "rotate token" heuristic, which would otherwise misread this as a
+    # token-access problem.
     mode_flip_assignments = 0
 
     # Team-driven username source: the classroom GitHub team is authoritative
-    # for who is enrolled. students.csv is only optional display metadata, so
-    # the (student, assignment) pairs come from the team member list, NOT the
-    # CSV. A 404 (team missing) or empty team yields no pairs (warn + return),
+    # for enrollment. students.csv is only optional display metadata, so the
+    # (student, assignment) pairs come from the team member list, NOT the CSV.
+    # A 404 (team missing) or empty team yields no pairs (warn + return),
     # replacing the old "students.csv missing" skip. A hard auth/network error
     # propagates so main() aborts the whole run loudly.
     team_slug = resolve_team_slug(classroom_meta, classroom_short)
@@ -462,8 +437,8 @@ def collect_classroom(
         seen_logins.add(key)
         team_usernames.append(login.strip())
 
-    # Group attribution credits a collaborator only if they are on the team
-    # (owner always credited) — same trust model as before, team-sourced set.
+    # Group attribution credits a collaborator only if on the team (owner always
+    # credited) — same trust model, team-sourced set.
     roster_logins = set(seen_logins)
     for entry in assignments.get("assignments") or []:
         slug = entry.get("slug")
@@ -502,19 +477,17 @@ def collect_classroom(
                 emit_warning(f"{org}/{repo_name}: release listing malformed ({exc}); skipping")
                 continue
             if not releases:
-                # Student hasn't submitted/accepted/finished
-                # grading. Individual misses are quiet; the
-                # per-assignment summary reports the gap.
+                # Student hasn't submitted/accepted/finished grading. Individual
+                # misses are quiet; the per-assignment summary reports the gap.
                 continue
 
-            # Collect EVERY submission, newest first. Each release's
-            # result.json is downloaded and validated independently; a
-            # single bad/missing one warns and is skipped without dropping
-            # the others. `validation_rejected` counts releases that were
-            # present and downloaded but FAILED validate_result (the
-            # mode-flip / identity-mismatch symptom) — kept distinct from a
-            # benign download error or a missing asset, so the loud
-            # "mode flipped" warning below only fires on the real symptom.
+            # Collect EVERY submission, newest first. Each release's result.json
+            # is downloaded and validated independently; a single bad/missing one
+            # warns and is skipped without dropping the others. `validation_rejected`
+            # counts releases present and downloaded but FAILED validate_result
+            # (the mode-flip / identity-mismatch symptom) — kept distinct from a
+            # benign download error or missing asset, so the "mode flipped"
+            # warning below only fires on the real symptom.
             history: list[dict[str, Any]] = []
             validation_rejected = 0
             for release in releases:
@@ -543,9 +516,9 @@ def collect_classroom(
                     continue
 
                 # validate_result enforces identity (owner == repo owner) AND
-                # that `assignment_type` matches the manifest mode (is_group),
-                # so a mode-flipped or mis-typed result is rejected here — no
-                # separate assignment_type cross-check is needed afterward.
+                # that `assignment_type` matches the manifest mode (is_group), so
+                # a mode-flipped or mis-typed result is rejected here — no
+                # separate assignment_type cross-check needed afterward.
                 try:
                     validate_result(candidate, classroom_short, slug, username, is_group=is_group)
                 except ValueError as exc:
@@ -556,32 +529,30 @@ def collect_classroom(
                     validation_rejected += 1
                     continue
 
-                # Lateness is advisory and marked per submission, on the
-                # submission record itself (each carries its own datetime).
+                # Lateness is advisory, marked per submission on the record
+                # itself (each carries its own datetime).
                 if due is not None and not mark_late(candidate, due):
                     emit_warning(
                         f"{org}/{repo_name}: result.json datetime = "
                         f"{candidate.get('datetime')!r} is not an RFC 3339 timestamp; "
                         f"cannot mark lateness"
                     )
-                # The stored submission record is the validated result payload
-                # minus the bucket-key `assignment` (it lives on the assignment
-                # bucket, not the record). Each record keeps result/v1 shape:
-                # owner + assignment_type + submitted_by, no usernames.
+                # The stored record is the validated payload minus the bucket-key
+                # `assignment`. Keeps result/v1 shape: owner + assignment_type +
+                # submitted_by, no usernames.
                 history.append({k: v for k, v in candidate.items() if k != "assignment"})
 
             if not history:
-                # The repo had submit-tag releases but produced no creditable
-                # history. When releases were rejected specifically by
-                # validation (not merely a missing asset / transient download
-                # error), that is the symptom of an assignment whose `mode` was
-                # switched individual<->group mid-term: every prior release's
-                # assignment_type now mismatches and is rejected, silently
-                # reverting graded students to "not submitted". Count it for a
-                # single consolidated, loud assignment-level warning below
-                # (rather than one per repo), and so main() can distinguish
-                # this from a token-access problem. A benign asset-missing or
-                # transient-download repo does NOT count here.
+                # The repo had submit-tag releases but no creditable history.
+                # When releases were rejected specifically by validation (not a
+                # missing asset / transient download error), that's the symptom
+                # of an assignment whose `mode` was switched individual<->group
+                # mid-term: every prior release's assignment_type now mismatches
+                # and is rejected, silently reverting graded students to "not
+                # submitted". Count it for the consolidated warning below (rather
+                # than one per repo), and so main() can distinguish this from a
+                # token-access problem. A benign asset-missing / transient repo
+                # does NOT count here.
                 if validation_rejected:
                     mode_flip_repos.append(repo_name)
                 continue
@@ -589,11 +560,10 @@ def collect_classroom(
             # Group attribution: the runner emits owner-only (it can't read
             # collaborators). Collection is authoritative — list the repo's
             # collaborators intersected with the roster and credit them all via
-            # the entry's `member_usernames`. On a read failure, force it to the
-            # owner only (never trust student-supplied data) and warn, so a
-            # scope/transient issue degrades to owner-only. Individual entries
-            # carry no member list — `owner` is the sole credited student.
-            # Resolved BEFORE building the entry so `member_usernames` can sit
+            # `member_usernames`. On a read failure, force owner-only (never
+            # trust student-supplied data) and warn, so a scope/transient issue
+            # degrades gracefully. Individual entries carry no member list.
+            # Resolved BEFORE building the entry so `member_usernames` sits
             # right after `owner` in the written JSON key order.
             members: list[str] | None = None
             if is_group:
@@ -605,11 +575,10 @@ def collect_classroom(
                     emit_warning(degraded_warning)
                 elif len(members) == 1:
                     # Read succeeded but credited only the owner — no other
-                    # rostered collaborator was found. Often expected (a solo
-                    # group submission), but it's also the symptom of a real
-                    # misconfiguration (teammates added but not on the roster,
-                    # or not added as collaborators at all), which would
-                    # otherwise be silent. Surface it so the teacher can check.
+                    # rostered collaborator found. Often expected (a solo group
+                    # submission), but also the symptom of a real misconfig
+                    # (teammates not on the roster, or not added as
+                    # collaborators), which would otherwise be silent.
                     emit_warning(
                         f"{org}/{repo_name}: group submission credited to the owner "
                         f"{username!r} only — no other team member is a collaborator "
@@ -619,14 +588,13 @@ def collect_classroom(
                     )
 
             # Build the gradebook entry: identity/keying at the top, the full
-            # per-submission detail (score, datetime, tests, ...) ONLY inside
-            # `submissions` (newest first). `owner` is the stable per-bucket
-            # key (the repo owner from the <classroom>-<assignment>-<username>
-            # formula); it is invariant across re-collects even when a group's
-            # credited member set changes, so apply_updates replaces the entry
-            # in place. For a group entry `member_usernames` sits right
-            # after `owner`. `_assignment` / `_type` are transport-only hints
-            # for apply_updates (the bucket slug + type) and are stripped on store.
+            # per-submission detail ONLY inside `submissions` (newest first).
+            # `owner` is the stable per-bucket key (repo owner from the
+            # <classroom>-<assignment>-<username> formula), invariant across
+            # re-collects even when a group's member set changes, so apply_updates
+            # replaces the entry in place. For a group entry `member_usernames`
+            # sits right after `owner`. `_assignment` / `_type` are transport-only
+            # hints for apply_updates (bucket slug + type), stripped on store.
             entry_row: dict[str, Any] = {
                 "_assignment": slug,
                 "_type": assignment_type,
@@ -666,17 +634,17 @@ def collect_classroom(
 
 def assignment_repo_name(classroom: str, assignment: str, username: str) -> str:
     """Canonical student-repo name. Cross-binary contract — mirrors
-    `assignmentRepoName` in cli/gh-student/accept.go; changing the
-    shape here without updating Go silently breaks the collect loop."""
+    `assignmentRepoName` in cli/gh-student/accept.go; changing the shape here
+    without updating Go silently breaks the collect loop."""
     return f"{classroom.lower()}-{assignment.lower()}-{username.lower()}"
 
 
 def resolve_team_slug(classroom_meta: dict[str, Any], classroom_short: str) -> str:
-    """The classroom's GitHub team slug: the persisted classroom.json
-    `team.slug` when present (authoritative — GitHub may re-slug on a name
-    collision, e.g. `classroom50-cs-1`), else the derived
-    `classroom50-<short>`. Mirrors the web app's resolveClassroomTeam and
-    Go's ResolveClassroomTeam so all three consumers target the same team."""
+    """The classroom's GitHub team slug: persisted classroom.json `team.slug`
+    when present (authoritative — GitHub may re-slug on a name collision, e.g.
+    `classroom50-cs-1`), else the derived `classroom50-<short>`. Mirrors the web
+    app's resolveClassroomTeam and Go's ResolveClassroomTeam so all three target
+    the same team."""
     team = classroom_meta.get("team")
     if isinstance(team, dict):
         slug = team.get("slug")
@@ -690,11 +658,10 @@ def resolve_team_slug(classroom_meta: dict[str, Any], classroom_short: str) -> s
 
 
 def parse_rfc3339(value: Any) -> datetime.datetime | None:
-    """Parse an RFC 3339 timestamp into an aware datetime, or None
-    when it isn't one (non-string, unparseable, or missing a
-    timezone offset). Naive timestamps are rejected rather than
-    guessed at — lateness is a cross-timezone comparison, so an
-    ambiguous wall-clock time must not silently pick one.
+    """Parse an RFC 3339 timestamp into an aware datetime, or None when it
+    isn't one (non-string, unparseable, or missing a timezone offset). Naive
+    timestamps are rejected rather than guessed — lateness is a cross-timezone
+    comparison, so an ambiguous wall-clock time must not silently pick one.
     """
     if not isinstance(value, str) or not value:
         return None
@@ -710,12 +677,10 @@ def parse_rfc3339(value: Any) -> datetime.datetime | None:
 
 
 def mark_late(payload: dict[str, Any], due: datetime.datetime) -> bool:
-    """Set payload["late"] by comparing the runner's submission
-    `datetime` (validated as a non-empty string, but not as a
-    timestamp) against the assignment's due date. Submitting exactly
-    at the deadline is on time. Returns False — leaving the payload
-    unmarked — when the timestamp doesn't parse; lateness is
-    advisory and must never drop a submission.
+    """Set payload["late"] by comparing the runner's submission `datetime`
+    against the assignment's due date. Submitting exactly at the deadline is on
+    time. Returns False — leaving the payload unmarked — when the timestamp
+    doesn't parse; lateness is advisory and must never drop a submission.
     """
     submitted = parse_rfc3339(payload.get("datetime"))
     if submitted is None:
@@ -736,9 +701,8 @@ class AssetMissingError(Exception):
 
 
 def strict_json_loads(raw: str) -> Any:
-    """Parse JSON rejecting NaN/Infinity. Python's json accepts
-    them by default but Go's encoding/json doesn't, and scores.json
-    is read by both ecosystems.
+    """Parse JSON rejecting NaN/Infinity. Python's json accepts them by default
+    but Go's encoding/json doesn't, and scores.json is read by both.
     """
 
     def reject_constant(value: str) -> None:
@@ -748,14 +712,12 @@ def strict_json_loads(raw: str) -> Any:
 
 
 def load_scores(path: pathlib.Path) -> dict[str, Any]:
-    """Read scores.json. Missing or empty returns the v1 skeleton.
-    Malformed raises so the workflow fails instead of overwriting
-    the teacher's work.
+    """Read scores.json. Missing or empty returns the v1 skeleton. Malformed
+    raises so the workflow fails instead of overwriting the teacher's work.
 
-    `assignments` must be the canonical object keyed by assignment slug,
-    each value an object `{ "type": ..., "entries": [...] }`. Legacy shapes
-    are not migrated (see normalize_assignments) — a non-canonical file
-    hard-fails.
+    `assignments` must be the canonical object keyed by slug, each value an
+    object `{ "type": ..., "entries": [...] }`. Legacy shapes are not migrated
+    (see normalize_assignments) — a non-canonical file hard-fails.
     """
     if not path.is_file():
         return {"schema": SCORES_SCHEMA_V1, "assignments": {}}
@@ -779,24 +741,20 @@ def load_scores(path: pathlib.Path) -> dict[str, Any]:
         scores["assignments"] = normalize_assignments(scores.get("assignments"))
     except ValueError as exc:
         raise ScoresFileError(f"{path}: {exc}") from exc
-    # Drop the legacy root field if a hand-edit left it around — `assignments`
-    # is authoritative.
+    # Drop the legacy root field if a hand-edit left it — `assignments` is
+    # authoritative.
     scores.pop("submissions", None)
     return scores
 
 
 def normalize_assignments(assignments: Any) -> dict[str, dict[str, Any]]:
     """Validate the `assignments` field as the canonical slug-keyed map.
-    Accepted shapes:
+    Accepted: None/missing -> {}; object -> each value an object
+    `{ "type": <"individual"|"group">, "entries": [...] }`.
 
-      - None / missing  -> {}
-      - object (dict)   -> each value must be an object
-                           `{ "type": <"individual"|"group">, "entries": [...] }`
-
-    Anything else hard-fails. Legacy shapes (a flat array, a stray "{}"
-    string wrapper, the old `submissions`-keyed map of bare entry lists) are
-    NOT migrated — backward compatibility is intentionally dropped, so a
-    non-canonical file fails the run loudly rather than being silently coerced.
+    Anything else hard-fails. Legacy shapes (flat array, "{}" string wrapper,
+    the old `submissions`-keyed map) are NOT migrated — backward compat is
+    intentionally dropped, so a non-canonical file fails loudly.
     """
     if assignments is None:
         return {}
@@ -837,8 +795,8 @@ def save_scores(path: pathlib.Path, scores: dict[str, Any]) -> None:
         payload = json.dumps(scores, indent=2, allow_nan=False) + "\n"
     except ValueError as exc:
         raise ScoresFileError(f"{path}: encode failed: {exc}") from exc
-    # Re-parse to catch silent corruption (e.g. NaN in a score)
-    # before touching the destination file.
+    # Re-parse to catch silent corruption (e.g. NaN in a score) before touching
+    # the destination file.
     strict_json_loads(payload)
     tmp_path = path.with_name(path.name + ".tmp")
     try:
@@ -858,20 +816,18 @@ def save_scores(path: pathlib.Path, scores: dict[str, Any]) -> None:
 
 def apply_updates(scores: dict[str, Any], updates: Iterable[dict[str, Any]]) -> int:
     """Merge incoming gradebook entries into the slug-keyed
-    `scores["assignments"]` map; return the number of entries added or
-    replaced. Each incoming entry carries transport hints `_assignment`
-    (the bucket slug) and `_type` (the assignment mode), plus the canonical
-    entry fields (`owner`, optional `member_usernames`, `submissions[]`).
-    The hints are stripped before storage (entry_from_result).
+    `scores["assignments"]` map; return the number of entries added or replaced.
+    Each incoming entry carries transport hints `_assignment` (bucket slug) and
+    `_type` (mode), plus the canonical fields (`owner`, optional
+    `member_usernames`, `submissions[]`). The hints are stripped before storage
+    (entry_from_result).
 
-    Each assignment bucket is `{ "type": ..., "entries": [...] }`. Existing
-    entries with `"override": true` are preserved verbatim. Entries within a
-    bucket are keyed by the repo OWNER (`row_key`), which is invariant for a
-    repo — so a group entry whose credited member set changes between collects
-    (e.g. a degraded collaborator read drops it to owner-only) REPLACES its
-    prior entry instead of orphaning it and appending a duplicate.
-    Entries without an `owner` are not keyable and are skipped — legacy
-    migration is intentionally not performed.
+    Each bucket is `{ "type": ..., "entries": [...] }`. Existing entries with
+    `"override": true` are preserved verbatim. Entries within a bucket are keyed
+    by the repo OWNER (`row_key`), invariant for a repo — so a group entry whose
+    member set changes between collects REPLACES its prior entry instead of
+    orphaning it and appending a duplicate. Entries without an `owner` are not
+    keyable and are skipped — no legacy migration.
     """
     assignments: dict[str, Any] = scores["assignments"]
     # Per-bucket index: assignment slug -> {row_key: entry index}.
@@ -891,11 +847,10 @@ def apply_updates(scores: dict[str, Any], updates: Iterable[dict[str, Any]]) -> 
         slug = update.get("_assignment")
         atype = update.get("_type")
         key = row_key(update)
-        # Require a valid slug, a valid bucket type, and a keyable owner.
-        # Validating `atype` here (not just in the re-guard below) means a
-        # missing/garbage `_type` can never be persisted as a new bucket's
-        # `type` via setdefault. Collection always supplies a valid type;
-        # this is defensive against a hand-constructed update.
+        # Require a valid slug, valid bucket type, and a keyable owner.
+        # Validating `atype` here (not just below) means a missing/garbage
+        # `_type` can never be persisted as a new bucket's `type` via
+        # setdefault. Collection always supplies a valid type; defensive.
         if (
             not isinstance(slug, str) or not slug
             or atype not in ("individual", "group")
@@ -923,12 +878,10 @@ def apply_updates(scores: dict[str, Any], updates: Iterable[dict[str, Any]]) -> 
             continue
         # A group re-collect that drops a previously-credited member (e.g. a
         # teammate who left the classroom team but is still a repo collaborator)
-        # replaces the entry in place, silently revoking that member's shared
-        # credit. The owner-only warning in collect_classroom only fires when
-        # the set collapses to just the owner; a shrink that still leaves >=2
-        # members would otherwise be invisible. Surface any dropped member so
-        # the teacher can confirm the revocation is intended, not a team/CSV
-        # divergence.
+        # replaces the entry in place, silently revoking their shared credit.
+        # The owner-only warning in collect_classroom only fires on collapse to
+        # just the owner; a shrink still leaving >=2 members would be invisible.
+        # Surface any dropped member so the teacher can confirm.
         dropped = _dropped_group_members(existing, entry)
         if dropped:
             emit_warning(
@@ -938,8 +891,8 @@ def apply_updates(scores: dict[str, Any], updates: Iterable[dict[str, Any]]) -> 
                 f"drop is intended (e.g. an unenrollment) and not a team-vs-students.csv "
                 f"divergence, since the shared score is now revoked for them."
             )
-        # Preserve an explicit "override": false on replacement —
-        # the teacher's "I reviewed this, keep refreshing" signal.
+        # Preserve an explicit "override": false on replacement — the teacher's
+        # "I reviewed this, keep refreshing" signal.
         if "override" in existing and "override" not in entry:
             entry = dict(entry)
             entry["override"] = existing["override"]
@@ -951,10 +904,10 @@ def apply_updates(scores: dict[str, Any], updates: Iterable[dict[str, Any]]) -> 
 def _dropped_group_members(
     existing: dict[str, Any], incoming: dict[str, Any]
 ) -> set[str]:
-    """Members credited on the existing group entry but absent from the
-    incoming one (case-insensitive), i.e. teammates whose shared credit a
-    re-collect would silently revoke. Empty for individual entries or when
-    the credited set did not shrink."""
+    """Members credited on the existing group entry but absent from the incoming
+    one (case-insensitive), i.e. teammates whose shared credit a re-collect
+    would silently revoke. Empty for individual entries or when the credited set
+    didn't shrink."""
     def credited(entry: dict[str, Any]) -> set[str]:
         members = entry.get("member_usernames")
         if not isinstance(members, list):
@@ -971,11 +924,10 @@ def _dropped_group_members(
 def entry_from_result(payload: dict[str, Any]) -> dict[str, Any]:
     """The stored gradebook entry, minus the transport-only hints.
 
-    An entry is the shape collection builds: identity/keying fields at the
-    top level (`owner`, optional `member_usernames` for group) and the full
-    per-submission detail inside the `submissions` list (newest first). The
-    `_assignment` (bucket slug) and `_type` (mode) hints drive bucket
-    placement in apply_updates and are dropped here so they don't persist.
+    An entry is the shape collection builds: identity/keying at the top
+    (`owner`, optional `member_usernames` for group) and the full per-submission
+    detail inside `submissions` (newest first). The `_assignment` and `_type`
+    hints drive bucket placement in apply_updates and are dropped here.
     """
     return {k: v for k, v in payload.items() if k not in ("_assignment", "_type")}
 
@@ -983,21 +935,20 @@ def entry_from_result(payload: dict[str, Any]) -> dict[str, Any]:
 def row_key(record: dict[str, Any]) -> str | None:
     """The stable per-bucket key: the repo OWNER login, lowercased.
 
-    Requires the explicit `owner` field (set by collection from the
-    repo-name formula). Returns None when `owner` is missing or not a
-    non-empty string — such a record is not keyable and `apply_updates`
-    skips it. There is no sole-username fallback and no legacy migration:
-    every canonical row carries `owner`.
+    Requires the explicit `owner` field (set by collection from the repo-name
+    formula). Returns None when `owner` is missing or not a non-empty string —
+    such a record is unkeyable and apply_updates skips it. No sole-username
+    fallback and no legacy migration: every canonical row carries `owner`.
 
-    Keying on the owner — not the credited `usernames` set — is what
-    makes a group re-collect replace its row instead of duplicating it
-    when the member set changes.
+    Keying on the owner — not the credited `usernames` set — is what makes a
+    group re-collect replace its row instead of duplicating it when the member
+    set changes.
 
-    Cross-binary tie: the owner is the `<username>` component of the
+    Cross-binary tie: the owner is the `<username>` of the
     `<classroom>-<assignment>-<username>` repo-name formula (see
     `assignment_repo_name` here and `assignmentRepoName` in
-    cli/gh-student/accept.go); it is persisted as the row `owner` field,
-    which download.go reads tolerantly (rows decode as map[string]any).
+    cli/gh-student/accept.go); persisted as the row `owner` field, which
+    download.go reads tolerantly (rows decode as map[string]any).
     """
     owner = record.get("owner")
     if isinstance(owner, str) and owner:
@@ -1027,16 +978,15 @@ def validate_result(
     is_group: bool = False,
 ) -> None:
     """Raise ValueError if the payload fails the v1 contract. The
-    classroom/assignment/owner checks defend against a hostile
-    result.json trying to land in someone else's scores.json — the
-    triple must match the source repo's expected identity.
+    classroom/assignment/owner checks defend against a hostile result.json
+    trying to land in someone else's scores.json — the triple must match the
+    source repo's expected identity.
 
-    `owner` (the repo owner, the identity anchor) must equal
-    `expected_username` (the roster/repo-name-derived owner).
-    `assignment_type` must be "individual"/"group" and match the mode
-    implied by `is_group`. There is no `usernames` field: who pushed is
-    `submitted_by`; the credited member list (group) is resolved by
-    collection after this check.
+    `owner` (repo owner, the identity anchor) must equal `expected_username`
+    (the roster/repo-name-derived owner). `assignment_type` must be
+    "individual"/"group" and match the mode implied by `is_group`. No
+    `usernames` field: who pushed is `submitted_by`; the credited member list
+    is resolved by collection after this check.
     """
     if not isinstance(payload, dict):
         raise ValueError(f"top-level value must be an object, got {type(payload).__name__}")
@@ -1103,9 +1053,8 @@ def validate_result(
                 f"tests[{i}].score ({test['score']}) > tests[{i}].max-score ({test['max-score']})"
             )
 
-    # submitted_by is optional (older results omit it). When present it
-    # records who pushed the submission; validate its shape so a
-    # hand-edited result.json can't store a malformed identity.
+    # submitted_by is optional (older results omit it). When present, validate
+    # its shape so a hand-edited result.json can't store a malformed identity.
     submitted_by = payload.get("submitted_by")
     if submitted_by is not None:
         if not isinstance(submitted_by, dict):
@@ -1122,8 +1071,8 @@ def validate_result(
 
 
 class _AuthStrippingRedirect(urllib.request.HTTPRedirectHandler):
-    """Drop Authorization on redirect so the GitHub token doesn't
-    leak to the S3-signed asset URL GitHub redirects asset reads to.
+    """Drop Authorization on redirect so the GitHub token doesn't leak to the
+    S3-signed asset URL GitHub redirects asset reads to.
     """
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
@@ -1150,19 +1099,16 @@ def _repo_url(api_url: str, owner: str, repo: str) -> str:
 def all_submit_releases(
     api_url: str, owner: str, repo: str, token: str
 ) -> list[dict[str, Any]]:
-    """Return EVERY submit-tag release for a repo, newest first, walking
-    the full /releases pagination.
+    """Every submit-tag release for a repo, newest first, walking the full
+    /releases pagination — the complete submission history (a student who pushed
+    N times has N submit/* releases, all returned). Non-submit releases (e.g. a
+    hand-created tag) are filtered out. A 404 (no releases, or repo not
+    accepted) yields an empty list.
 
-    This collects the complete submission history: a student who pushed N
-    times to `main` has N submit/* releases, and all N are returned.
-    Non-submit releases (e.g. a student's hand-created tag) are filtered
-    out. A 404 (no releases yet, or repo not accepted) yields an empty
-    list.
-
-    Pagination follows GitHub's authoritative `Link: rel="next"` header
-    (host-pinned to api_url so the bearer token can't be pivoted off-host),
-    falling back to the short-page heuristic when no Link header is present
-    — mirrors list_repo_collaborator_logins.
+    Pagination follows GitHub's `Link: rel="next"` header (host-pinned to
+    api_url so the token can't be pivoted off-host), falling back to the
+    short-page heuristic when no Link header is present — mirrors
+    list_repo_collaborator_logins.
     """
     per_page = 100
     max_pages = 100
@@ -1207,11 +1153,10 @@ def all_submit_releases(
 
 
 def _next_page_link(link_header: str | None) -> str | None:
-    """The `rel="next"` URL from a GitHub `Link` response header, or
-    None when there is no next page (or no header). GitHub's pagination
-    guidance is to follow this URL rather than to synthesize page numbers,
-    since page size and the presence of a next page are the server's to
-    decide. Mirrors NextPageLink in cli/shared/ghutil/ghutil.go.
+    """The `rel="next"` URL from a GitHub `Link` header, or None when there's no
+    next page (or no header). GitHub's guidance is to follow this URL rather
+    than synthesize page numbers, since page size and next-page presence are the
+    server's to decide. Mirrors NextPageLink in cli/shared/ghutil/ghutil.go.
     """
     if not link_header:
         return None
@@ -1220,14 +1165,12 @@ def _next_page_link(link_header: str | None) -> str | None:
 
 
 def _assert_same_host(next_url: str, api_url: str) -> str:
-    """Return next_url only if its scheme+host match api_url's; otherwise
-    raise ValueError. The pagination loop attaches `Authorization: Bearer
-    <service token>` to whatever URL it follows, so a malicious or MITM'd
-    API response whose `Link: rel="next"` points at another host would
-    otherwise pivot the token off-host. The redirect path already defends
-    this via _AuthStrippingRedirect; this is the equivalent fail-closed
-    guard on the Link-follow path. A legitimate api.github.com / GHES next
-    page stays on the same host and passes unchanged.
+    """Return next_url only if its scheme+host match api_url's; else raise
+    ValueError. The pagination loop attaches `Authorization: Bearer <token>` to
+    whatever URL it follows, so a malicious/MITM'd `Link: rel="next"` pointing
+    off-host would otherwise pivot the token. The redirect path defends this via
+    _AuthStrippingRedirect; this is the fail-closed guard on the Link-follow
+    path. A legitimate api.github.com / GHES next page passes unchanged.
     """
     api = urllib.parse.urlsplit(api_url)
     nxt = urllib.parse.urlsplit(next_url)
@@ -1246,22 +1189,21 @@ def _paginate_login_list(
     token: str,
     resource_label: str,
 ) -> list[str]:
-    """Walk a paginated GitHub list-of-accounts endpoint and return every
+    """Walk a paginated GitHub list-of-accounts endpoint, returning every
     `login`. Shared core for list_repo_collaborator_logins and
     list_team_member_logins — the only per-caller differences are the URL
     builder and the cap-error label.
 
-    `page_url(page)` builds the request URL for a 1-based page number
-    (caller owns per_page/page formatting). Only the first page is built
-    from it; subsequent pages follow GitHub's authoritative `Link: rel="next"`
-    header, host-pinned to api_url via _assert_same_host so a crafted Link
-    can't pivot the service token to a foreign host. When no Link header is
-    present, the walk falls back to synthesizing page+1 and stops on a short
-    page (len < per_page). A self/looping rel="next" is bounded by seen_next.
+    `page_url(page)` builds the request URL for a 1-based page (caller owns
+    per_page/page formatting). Only the first page uses it; subsequent pages
+    follow GitHub's `Link: rel="next"`, host-pinned via _assert_same_host so a
+    crafted Link can't pivot the token. When no Link header is present, falls
+    back to page+1 and stops on a short page (len < per_page). A self/looping
+    rel="next" is bounded by seen_next.
 
     Raises urllib.error.HTTPError on any non-2xx (including 404) so the caller
-    can decide between a soft fallback and a hard failure; raises ValueError on
-    a non-array body or on hitting the page cap.
+    can choose soft fallback vs. hard failure; raises ValueError on a non-array
+    body or on hitting the page cap.
     """
     per_page = 100
     max_pages = 100
@@ -1287,10 +1229,9 @@ def _paginate_login_list(
         next_url = _next_page_link(link_header)
         if next_url:
             next_url = _assert_same_host(next_url, api_url)
-            # Stop if the server points us back at a page we've already
-            # fetched (self/looping rel="next"): bounds a crafted or buggy
-            # Link chain to the pages actually seen instead of running out
-            # the max_pages cap.
+            # Stop if the server points back at an already-fetched page
+            # (self/looping rel="next"): bounds a crafted or buggy Link chain
+            # to the pages actually seen instead of running out the cap.
             if next_url in seen_next:
                 return logins
             seen_next.add(next_url)
@@ -1308,28 +1249,24 @@ def _paginate_login_list(
 def list_repo_collaborator_logins(
     api_url: str, owner: str, repo: str, token: str
 ) -> list[str]:
-    """Logins of every direct collaborator on owner/repo, walking
-    pagination.
+    """Logins of every direct collaborator on owner/repo, walking pagination.
 
-    This returns ALL collaborators regardless of permission level. The
-    crediting gate is NOT the permission level — it is roster membership,
-    applied by the caller (group_member_usernames intersects with the
-    classroom roster). Filtering on `role_name == "admin"` here was a bug:
-    a group teammate who is also an org owner (admin on every repo), or a
-    founder kept as repo `admin` so they can invite teammates,
-    is `admin` yet a legitimate student — the old filter silently dropped
-    them, crediting only the repo owner. Instructors/TAs/org-owners who are
-    not students are excluded downstream because they are not on the roster,
-    so dropping the admin filter here loses no protection.
+    Returns ALL collaborators regardless of permission level. The crediting gate
+    is NOT permission level — it's roster membership, applied by the caller
+    (group_member_usernames intersects with the roster). Filtering on
+    `role_name == "admin"` here was a bug: a group teammate who is also an org
+    owner (admin on every repo), or a founder kept as repo `admin` to invite
+    teammates, is `admin` yet a legitimate student — the old filter dropped
+    them, crediting only the owner. Non-student instructors/TAs/org-owners are
+    excluded downstream because they're not on the roster, so dropping the admin
+    filter here loses no protection.
 
-    Pagination follows GitHub's authoritative `Link: rel="next"` header
-    rather than guessing the next page from page length; the short-page
-    heuristic is only the fallback when no Link header is present. The
-    followed next URL is host-pinned to api_url so the bearer token can't
-    be pivoted to a foreign host by a crafted Link header.
+    Pagination follows GitHub's `Link: rel="next"` header (short-page heuristic
+    only as fallback); the followed next URL is host-pinned to api_url so the
+    token can't be pivoted off-host.
 
-    Raises urllib.error.HTTPError on any non-2xx (including 404) so the
-    caller can decide between an owner-only fallback and a hard failure.
+    Raises urllib.error.HTTPError on any non-2xx (including 404) so the caller
+    can choose owner-only fallback vs. hard failure.
     """
     per_page = 100
     base = f"{_repo_url(api_url, owner, repo)}/collaborators"
@@ -1344,15 +1281,15 @@ def list_repo_collaborator_logins(
 def list_team_member_logins(
     api_url: str, org: str, team_slug: str, token: str
 ) -> list[str]:
-    """Logins of every member of the classroom team, walking pagination.
-    This is the team-driven username source for collection: the classroom
-    GitHub team is authoritative for who is enrolled (students.csv is only
-    optional display metadata). Hits GET /orgs/{org}/teams/{slug}/members.
+    """Logins of every member of the classroom team, walking pagination. The
+    team-driven username source for collection: the classroom GitHub team is
+    authoritative for enrollment (students.csv is only optional display
+    metadata). Hits GET /orgs/{org}/teams/{slug}/members.
 
     Pagination follows GitHub's `Link: rel="next"` header, host-pinned to
     api_url (same defense as list_repo_collaborator_logins). Raises
-    urllib.error.HTTPError on any non-2xx (including 404 when the team
-    doesn't exist) so the caller can warn-and-skip vs. hard-fail."""
+    urllib.error.HTTPError on any non-2xx (including 404 when the team doesn't
+    exist) so the caller can warn-and-skip vs. hard-fail."""
     per_page = 100
     base = (
         f"{api_url}/orgs/{urllib.parse.quote(org, safe='')}/teams/"
@@ -1369,47 +1306,41 @@ def list_team_member_logins(
 def group_member_usernames(
     api_url: str, org: str, repo: str, owner_username: str, token: str, roster_logins: set[str]
 ) -> list[str]:
-    """Member list for a group submission: the repo's collaborators
-    (any permission level) **intersected with the roster**
-    (case-insensitive), sorted and deduped, with the owner guaranteed
-    present. Crediting is gated on roster membership, NOT on collaborator
-    permission: a rostered teammate is credited whether they hold push or
-    admin (an org owner is admin on every repo; a founder is kept admin so
-    they can invite). A non-rostered collaborator (instructor, TA, org
-    owner who is not a student, or an account added out-of-band via the
-    GitHub UI) is never credited. Raises on the underlying HTTP/parse error
-    so the caller can fall back to owner-only.
+    """Member list for a group submission: the repo's collaborators (any
+    permission) **intersected with the roster** (case-insensitive), sorted and
+    deduped, owner guaranteed present. Crediting is gated on roster membership,
+    NOT collaborator permission: a rostered teammate is credited whether push or
+    admin (an org owner is admin everywhere; a founder is kept admin to invite).
+    A non-rostered collaborator (instructor, TA, non-student org owner, or an
+    account added out-of-band) is never credited. Raises on the underlying
+    HTTP/parse error so the caller can fall back to owner-only.
 
-    TRUST ASSUMPTION (F6, documented residual): every rostered collaborator
-    on the repo is credited the shared score. GitHub does not record *how* a
-    collaborator was added, so collection cannot distinguish a teammate the
-    founder added via `gh student invite` from one a student added directly
-    through the GitHub UI. The roster intersection
-    bounds the blast radius to rostered classmates — a stranger can never be
-    credited — but a student could still add a rostered classmate as a
-    collaborator and credit them this assignment's score. Treating that as
-    acceptable (rostered students are mutually trusted within a classroom) is
-    the deliberate, simple model; see wiki/Autograders.md. Tightening it would
-    require a teacher-approved group manifest, deferred as out of scope.
+    TRUST ASSUMPTION (F6, documented residual): every rostered collaborator on
+    the repo is credited. GitHub doesn't record HOW a collaborator was added, so
+    collection can't distinguish a teammate the founder invited via `gh student
+    invite` from one a student added via the UI. The roster intersection bounds
+    the blast radius to rostered classmates — a stranger can never be credited —
+    but a student could add a rostered classmate and credit them this score.
+    Treating that as acceptable (rostered students are mutually trusted within a
+    classroom) is the deliberate, simple model; see wiki/Autograders.md.
+    Tightening it would require a teacher-approved group manifest, out of scope.
     """
     logins = list_repo_collaborator_logins(api_url, org, repo, token)
     seen: dict[str, str] = {}
     owner_key = owner_username.lower()
     for login in [owner_username, *logins]:
         key = login.lower()
-        # The owner is always credited; other collaborators only if
-        # they are on the roster for this classroom.
+        # Owner always credited; other collaborators only if on the roster.
         if key != owner_key and key not in roster_logins:
             continue
         if key not in seen:
-            # Store the OWNER under its own (repo-derived) casing, but
-            # normalize every other member to lowercase. GitHub's
-            # /collaborators can return a login under different casing
-            # between collects; storing that raw casing made the member
-            # list (and thus same_submission) churn and rewrite the entry
-            # every run. Lowercasing non-owner members is deterministic
-            # across collects (crediting is case-insensitive anyway), so an
-            # unchanged group submission compares equal and is left alone.
+            # Store the OWNER under its own (repo-derived) casing, but normalize
+            # every other member to lowercase. GitHub's /collaborators can return
+            # a login under different casing between collects; storing that raw
+            # casing made the member list (and same_submission) churn and rewrite
+            # the entry every run. Lowercasing non-owner members is deterministic
+            # (crediting is case-insensitive anyway), so an unchanged group
+            # submission compares equal and is left alone.
             seen[key] = owner_username if key == owner_key else key
     return [seen[k] for k in sorted(seen)]
 
@@ -1422,8 +1353,8 @@ def attribute_group_members(
     Returns (usernames, warning). On success `usernames` is the rostered
     collaborator list (owner always included) and `warning` is None. On a
     collaborator-read failure `usernames` is forced to [owner] — never the
-    runner/student-supplied list — and `warning` is a non-None message the
-    caller should emit and count as a degraded attribution.
+    runner/student-supplied list — and `warning` is a message the caller should
+    emit and count as a degraded attribution.
     """
     try:
         return group_member_usernames(api_url, org, repo, owner_username, token, roster_logins), None
@@ -1447,12 +1378,10 @@ def download_result_asset(
     """Find the `result.json` asset on `release` and return the parsed JSON.
 
     Raises:
-        urllib.error.HTTPError if the asset endpoint refuses the
-            request.
-        AssetMissingError if no `result.json` asset is found on the
-            release.
+        urllib.error.HTTPError if the asset endpoint refuses the request.
+        AssetMissingError if no `result.json` asset is found.
         json.JSONDecodeError if the bytes don't parse as JSON.
-        ValueError if the asset is too large to accept.
+        ValueError if the asset is too large.
     """
     matches = [
         c for c in (release.get("assets") or [])
@@ -1481,11 +1410,10 @@ def download_result_asset(
 
 
 def rewrite_asset_url(asset_url: str, api_url: str) -> str:
-    """Rewrite an asset API URL to the configured API host. Asset
-    records still carry api.github.com URLs even when GH_API_URL
-    points at a test server or GHES — parse and swap scheme+netloc
-    rather than string-slice a hardcoded prefix. Preserves a
-    GHES-style /api/v3 prefix when the asset URL lacks it.
+    """Rewrite an asset API URL to the configured API host. Asset records still
+    carry api.github.com URLs even when GH_API_URL points at a test server or
+    GHES — parse and swap scheme+netloc rather than string-slice a hardcoded
+    prefix. Preserves a GHES-style /api/v3 prefix when the asset URL lacks it.
     """
     parsed_asset = urllib.parse.urlsplit(asset_url)
     parsed_api = urllib.parse.urlsplit(api_url)
@@ -1512,8 +1440,8 @@ def _http_get(
     url: str, token: str, *, accept: str, max_bytes: int | None = None, _retries: int = 3
 ) -> bytes:
     """GET `url` with bearer auth; return the body. Thin wrapper over
-    `_http_get_with_headers` for the callers that don't need the
-    response headers (release/asset reads)."""
+    `_http_get_with_headers` for callers that don't need response headers
+    (release/asset reads)."""
     body, _headers = _http_get_with_headers(
         url, token, accept=accept, max_bytes=max_bytes, _retries=_retries
     )
@@ -1523,14 +1451,13 @@ def _http_get(
 def _http_get_with_headers(
     url: str, token: str, *, accept: str, max_bytes: int | None = None, _retries: int = 3
 ) -> tuple[bytes, Any]:
-    """GET `url` with bearer auth; return (body, response headers).
-    Retries 5xx/429 with exponential backoff. The custom redirect
-    handler strips Authorization before following GitHub's asset-download
-    redirect to S3 (otherwise the signed URL rejects the forwarded token).
+    """GET `url` with bearer auth; return (body, response headers). Retries
+    5xx/429 with exponential backoff. The custom redirect handler strips
+    Authorization before following GitHub's asset-download redirect to S3
+    (otherwise the signed URL rejects the forwarded token).
 
-    The headers are returned so paginated callers can follow GitHub's
-    authoritative `Link: rel="next"` rather than guessing the next page
-    from page length.
+    Headers are returned so paginated callers can follow GitHub's `Link:
+    rel="next"` rather than guessing the next page from page length.
     """
     for attempt in range(_retries):
         req = urllib.request.Request(
@@ -1556,14 +1483,12 @@ def _http_get_with_headers(
                 continue
             raise
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            # urllib wraps a connect-phase failure in URLError, but a
-            # timeout (or reset) during resp.read() raises socket.timeout
-            # (= TimeoutError, an OSError) which is NOT a URLError — so a
-            # stalled response body would otherwise escape this retry path
-            # and crash the run with a bare traceback past main()'s
-            # HTTPError handler. Catch all three so a read-phase stall
-            # retries and then wraps into the synthetic 599 that
-            # is_hard_http_error already classifies as a hard failure.
+            # A connect-phase failure is wrapped in URLError, but a timeout/reset
+            # during resp.read() raises socket.timeout (= TimeoutError, an
+            # OSError) which is NOT a URLError — so a stalled response body would
+            # otherwise escape this retry path and crash past main()'s HTTPError
+            # handler. Catch all three so a read-phase stall retries and wraps
+            # into the synthetic 599 that is_hard_http_error treats as hard.
             if attempt < _retries - 1:
                 time.sleep(2 ** attempt)
                 continue
@@ -1578,10 +1503,10 @@ def _http_get_with_headers(
 
 
 def is_hard_http_error(exc: urllib.error.HTTPError) -> bool:
-    """Hard failures that should fail the whole run: 401/403 (bad
-    or under-scoped token) and 599 (synthetic "network unavailable"
-    after retries). Treating these as per-student "not submitted"
-    would make a broken run report success while collecting nothing.
+    """Hard failures that should fail the whole run: 401/403 (bad/under-scoped
+    token) and 599 (synthetic "network unavailable" after retries). Treating
+    these as per-student "not submitted" would make a broken run report success
+    while collecting nothing.
     """
     return exc.code in (401, 403, 599)
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/ensure_feedback_pr.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/ensure_feedback_pr.py
@@ -1,33 +1,32 @@
 #!/usr/bin/env python3
 """classroom50 Feedback PR maintainer.
 
-Fetched from the teacher's GitHub Pages site by the autograde-runner
-reusable workflow's "Ensure Feedback PR" step, the same way runner.py is
-fetched and run. Lives here (not inline in the workflow) so the ~160 lines
-of control flow are unit-testable with a stubbed `gh`; the workflow step is
-a thin curl+exec shim.
+Fetched from the teacher's Pages site by the autograde-runner workflow's
+"Ensure Feedback PR" step (like runner.py). Lives here (not inline in the
+workflow) so the ~160 lines of control flow are unit-testable with a stubbed
+`gh`; the workflow step is a thin curl+exec shim.
 
-Opt-in per assignment (the workflow only invokes this when feedback-pr is
-on and there's a diff to show). Maintains ONE long-lived PR per repo:
+Opt-in per assignment (the workflow only invokes this when feedback-pr is on
+and there's a diff). Maintains ONE long-lived PR per repo:
   base = the frozen `feedback` branch at the baseline commit
   head = the repo's default branch
-so the teacher reviews the full starter->latest diff with inline comments,
-and it auto-updates on every submission. PRs opened by GITHUB_TOKEN don't
-retrigger workflows, so there's no loop.
+so the teacher reviews the full starter->latest diff with inline comments, and
+it auto-updates on every submission. PRs opened by GITHUB_TOKEN don't retrigger
+workflows, so there's no loop.
 
 Behavior (ported verbatim from the former inline bash):
   1. Freeze the base: create the `feedback` branch at BASE_SHA once, never
      advance it. If it already exists at a DIFFERENT sha, a student may have
-     pre-created it (ruleset leaves creation open) -> refuse to open/refresh
-     the PR against an unverified base, post a failure status, and stop.
-  2. Find the single PR (any state). If none, create it (labeled by mode);
-     on a create race lost to a concurrent run, re-query and treat the
-     existing PR as success. If one exists, reopen only a student's
-     *unmerged* close (a teacher merge is the grading-done signal).
+     pre-created it (ruleset leaves creation open) -> refuse to open/refresh the
+     PR against an unverified base, post a failure status, and stop.
+  2. Find the single PR (any state). If none, create it (labeled by mode); on a
+     create race lost to a concurrent run, re-query and treat the existing PR as
+     success. If one exists, reopen only a student's *unmerged* close (a teacher
+     merge is the grading-done signal).
   3. Always post a machine-readable `classroom50/feedback-pr` commit status
-     (success | failure | error), mirroring `classroom50/autograde`. The
-     status defaults to `error` and is promoted to `success` only at the
-     verified-good end, so an early failure reports error, not false success.
+     (success | failure | error), mirroring `classroom50/autograde`. It defaults
+     to `error` and is promoted to `success` only at the verified-good end, so
+     an early failure reports error, not false success.
 
 Environment (set by the autograde-runner workflow's grade job):
   GH_TOKEN            token for `gh` (Actions GITHUB_TOKEN)
@@ -39,8 +38,8 @@ Environment (set by the autograde-runner workflow's grade job):
   MODE                assignment mode (individual | group), for the PR label
 
 Exits 0 for every outcome (like runner.py): the status carries success vs
-failure vs error. Exits non-zero only on missing required env (invoked
-outside the workflow).
+failure vs error. Exits non-zero only on missing required env (invoked outside
+the workflow).
 """
 
 from __future__ import annotations
@@ -54,12 +53,12 @@ import sys
 # `classroom50-feedback-base-lock` org ruleset (pinned by a Go parity test).
 BASE_BRANCH = "feedback"
 
-# Commit-status context, mirroring classroom50/autograde so an agent can
-# poll whether the Feedback PR is in place.
+# Commit-status context, mirroring classroom50/autograde so an agent can poll
+# whether the Feedback PR is in place.
 STATUS_CONTEXT = "classroom50/feedback-pr"
 
-# Mode -> (PR label, label color). Mirrors GitHub Classroom's
-# Individual/Group feedback labels so a teacher can tell them apart.
+# Mode -> (PR label, color). Mirrors GitHub Classroom's Individual/Group
+# feedback labels so a teacher can tell them apart.
 _LABELS = {
     "group": ("Group Assignment", "5319E7"),
     "individual": ("Individual Assignment", "0E8A16"),
@@ -79,10 +78,10 @@ class GhError(Exception):
 def gh(*args: str, check: bool = True) -> str:
     """Run `gh` and return stdout (stripped). The single seam tests stub.
 
-    On a non-zero exit, raises GhError when check=True (carrying stderr for
-    legible logs), else returns "". A subprocess timeout is converted to a
-    GhError so callers (and main()'s handler) treat it uniformly rather than
-    crashing past the "always exit 0" contract. `gh` reads GH_TOKEN from env.
+    On a non-zero exit, raises GhError when check=True (carrying stderr), else
+    returns "". A subprocess timeout is converted to a GhError so callers treat
+    it uniformly rather than crashing past the "always exit 0" contract. `gh`
+    reads GH_TOKEN from env.
     """
     try:
         proc = subprocess.run(
@@ -120,18 +119,18 @@ def existing_base_sha(repo: str) -> str | None:
     Uses the API (not `git ls-remote`) so this runs without a config-repo
     checkout — the reusable workflow only checks out the student repo.
 
-    A genuine 404 (branch absent) returns None -> caller creates it. Any
-    OTHER failure (403/429/5xx/network) RAISES GhError rather than masquerading
-    as "absent": treating an unreadable base as absent would let the caller
-    fall through and open a PR over a base it could not verify, defeating the
-    poisoned-base guard (a student can pre-create the branch at a wrong SHA).
+    A genuine 404 (branch absent) returns None -> caller creates it. Any OTHER
+    failure (403/429/5xx/network) RAISES GhError rather than masquerading as
+    "absent": treating an unreadable base as absent would let the caller open a
+    PR over a base it couldn't verify, defeating the poisoned-base guard (a
+    student can pre-create the branch at a wrong SHA).
     """
     try:
         out = gh("api", f"repos/{repo}/git/ref/heads/{BASE_BRANCH}",
                  "--jq", ".object.sha")
     except GhError as exc:
-        # `gh api` exits 1 on any HTTP error; distinguish 404 (absent) from
-        # the rest via the error text gh prints (it includes "HTTP 404").
+        # `gh api` exits 1 on any HTTP error; distinguish 404 (absent) from the
+        # rest via the error text gh prints (it includes "HTTP 404").
         if "HTTP 404" in exc.output or "Not Found" in exc.output:
             return None
         raise
@@ -139,10 +138,10 @@ def existing_base_sha(repo: str) -> str | None:
 
 
 def create_base(repo: str, base_sha: str) -> bool:
-    """Create the frozen `feedback` branch at base_sha. Returns True on
-    success. A failure is non-fatal (logged as a notice) — the ruleset
-    leaves creation open to GITHUB_TOKEN, but a transient error shouldn't
-    abort; the next submission retries."""
+    """Create the frozen `feedback` branch at base_sha. Returns True on success.
+    A failure is non-fatal (logged as a notice) — the ruleset leaves creation
+    open to GITHUB_TOKEN, but a transient error shouldn't abort; the next
+    submission retries."""
     try:
         gh("api", "-X", "POST", f"repos/{repo}/git/refs",
            "-f", f"ref=refs/heads/{BASE_BRANCH}", "-f", f"sha={base_sha}")
@@ -153,14 +152,13 @@ def create_base(repo: str, base_sha: str) -> bool:
 
 
 def find_pr(repo: str, head: str) -> dict[str, str] | None:
-    """The single base<-head PR (any state) as {number, state, mergedAt},
-    or None. Matching any state means a previously closed/merged PR is
-    never duplicated.
+    """The single base<-head PR (any state) as {number, state, mergedAt}, or
+    None. Matching any state means a previously closed/merged PR is never
+    duplicated.
 
     Parses the JSON array directly (not a @tsv line): a tab-joined row is
-    fragile because an empty leading field (no PR number) survives gh's
-    output but is lost to a strip()+split, which would fabricate a phantom
-    PR. JSON is unambiguous about an empty list vs a real entry.
+    fragile because an empty leading field (no PR number) survives gh's output
+    but is lost to strip()+split, fabricating a phantom PR. JSON is unambiguous.
     """
     out = gh("pr", "list", "--repo", repo,
              "--base", BASE_BRANCH, "--head", head, "--state", "all",
@@ -225,8 +223,8 @@ def pr_body(head: str) -> str:
 
 
 def create_pr(repo: str, head: str, mode: str) -> str:
-    """Create the Feedback PR, returning its URL. Best-effort labels it
-    first. Raises GhError on a create failure (caller handles the race)."""
+    """Create the Feedback PR, returning its URL. Best-effort labels it first.
+    Raises GhError on a create failure (caller handles the race)."""
     label, color = label_for_mode(mode)
     # Best-effort label; never block PR creation on label setup.
     gh("label", "create", label, "--repo", repo, "--color", color,
@@ -302,13 +300,11 @@ def ensure_feedback_pr(repo: str, base_sha: str, mode: str, server_url: str,
     # Existing PR: reopen only a student's unmerged close.
     url = f"{server_url}/{repo}/pull/{pr['number']}"
     if pr["state"] == "CLOSED" and not pr["mergedAt"]:
-        # A failed reopen must NOT report success (review finding F8). Trust
-        # `gh pr reopen`'s own exit status: if it raises, the reopen genuinely
-        # failed -> failure. If it succeeds, the PR is open; a follow-up
-        # `pr view` only DOWNGRADES to failure when it *confirms* the PR is
-        # still CLOSED — a transient/empty view is treated as success (the
-        # reopen didn't error), so a flaky read can't flip a reopened PR to a
-        # false failure.
+        # A failed reopen must NOT report success (F8). Trust `gh pr reopen`'s
+        # own exit: if it raises, the reopen genuinely failed -> failure. If it
+        # succeeds, a follow-up `pr view` only DOWNGRADES to failure when it
+        # *confirms* the PR is still CLOSED — a transient/empty view is treated
+        # as success, so a flaky read can't flip a reopened PR to a false failure.
         try:
             gh("pr", "reopen", pr["number"], "--repo", repo)
         except GhError as exc:
@@ -337,7 +333,7 @@ def emit_status(repo: str, sha: str, state: str, description: str, url: str) -> 
            "-f", f"description={description}", "-f", f"target_url={url}")
     except (GhError, OSError) as exc:
         # Last best-effort action; never let a status-POST failure (gh error,
-        # timeout-as-GhError, or a missing gh binary) mask the real outcome.
+        # timeout-as-GhError, missing gh binary) mask the real outcome.
         print(f"::warning::could not post {STATUS_CONTEXT} status: {exc}")
 
 
@@ -355,7 +351,7 @@ def main() -> int:
               file=sys.stderr)
         return 1
 
-    # Default to error so any uncaught failure reports error (never a false
+    # Default to error so any uncaught failure reports error (never false
     # success), mirroring the former `trap emit_status EXIT` design.
     state, description = "error", "Feedback PR step did not complete"
     url = f"{server_url}/{repo}/actions/runs/{run_id}"

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 """Materialize declarative tests from each classroom's assignments.json.
 
-Run by publish-pages.yaml before the per-assignment bundles are tarred.
-For every assignment entry with a `tests` block, writes
+Run by publish-pages.yaml before the per-assignment bundles are tarred. For
+every assignment entry with a `tests` block, writes
 
     <classroom>/autograders/<slug>/tests.json   (schema classroom50/tests/v1)
 
-into the checkout so the bundle step tars it alongside any sibling
-fixtures (input-file / expected-file). runner.py grades the bundled file
-with its built-in interpreter (run_declarative).
+into the checkout so the bundle step tars it alongside any sibling fixtures
+(input-file / expected-file). runner.py grades the bundled file with its
+built-in interpreter (run_declarative).
 
-Validation lives elsewhere (tests.go at write time, runner.py at grade
-time), so this script stays deliberately forgiving: a malformed manifest
-emits a ::warning:: and is skipped rather than failing the Pages deploy.
-tests.json-vs-autograder.py precedence is resolved in ONE place —
-runner.py's entrypoint resolution — so it isn't special-cased here.
+Validation lives elsewhere (tests.go at write time, runner.py at grade time),
+so this script stays forgiving: a malformed manifest emits a ::warning:: and is
+skipped rather than failing the Pages deploy. tests.json-vs-autograder.py
+precedence is resolved in ONE place — runner.py's entrypoint resolution — so it
+isn't special-cased here.
 """
 
 from __future__ import annotations
@@ -29,16 +29,15 @@ TESTS_SCHEMA_V1 = "classroom50/tests/v1"
 TESTS_FILENAME = "tests.json"
 
 # Mirror validate.ShortNamePattern in cli/gh-teacher/internal/validate/validate.go.
-# The slug becomes a directory path here, so a hand-edited manifest with a
-# traversal-style slug must be rejected before it reaches mkdir.
+# The slug becomes a directory path here, so a traversal-style slug must be
+# rejected before it reaches mkdir.
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,38}$")
 
 
 def materialize(root: pathlib.Path) -> int:
     """Walk every <classroom>/assignments.json under `root`, writing a
-    tests.json for each assignment that declares tests. Returns the count
-    of tests.json files written. Never raises on bad manifest data -- it
-    warns and skips."""
+    tests.json for each assignment that declares tests. Returns the count of
+    files written. Never raises on bad manifest data -- warns and skips."""
     written = 0
     for manifest in sorted(root.glob("*/assignments.json")):
         classroom = manifest.parent.name

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/probe_token.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/probe_token.py
@@ -2,40 +2,36 @@
 """Teacher-triggered service-token probe.
 
 Exercises EVERY GitHub API scope the CLASSROOM50_SERVICE_TOKEN needs, so a
-teacher can run one workflow after provisioning (or after rotating) and get a
-single green/red signal that covers scopes the pre-provisioning validators
-(`gh teacher init` / the web "validate & save") cannot cheaply check — in
-particular the org-team read and the repo-level Actions permission that only
-surface at collect/regrade time otherwise.
+teacher runs one workflow after provisioning/rotating and gets a single
+green/red signal covering scopes the pre-provisioning validators (`gh teacher
+init` / the web "validate & save") can't cheaply check — the org-team read and
+the repo-level Actions permission that only surface at collect/regrade time.
 
-The probe is SIDE-EFFECT FREE by design. It never pushes a tag, re-runs a
-workflow, writes a secret, or mutates any repo. Write scopes are proven with
-read-only PROXIES that GitHub gates behind the write permission:
+SIDE-EFFECT FREE by design. Never pushes a tag, re-runs a workflow, writes a
+secret, or mutates a repo. Write scopes are proven with read-only PROXIES that
+GitHub gates behind the write permission:
 
   - Contents: write  -> GET /repos/{org}/classroom50 reports
-                        `permissions.push == true` only when the token can
-                        write contents (same signal the CLI/web validators use).
+                        `permissions.push == true` only with contents-write
+                        (same signal the CLI/web validators use).
   - Actions:  write  -> GET /repos/{org}/classroom50/actions/permissions is
-                        reachable only with the Actions permission; a fine-
-                        grained PAT's Actions permission is a single read/write
-                        pair, so reachability establishes the Actions grant
-                        regrade's rerun API needs. No run is actually re-run.
+                        reachable only with the Actions permission; a
+                        fine-grained PAT's Actions permission is a single
+                        read/write pair, so reachability establishes the grant
+                        regrade's rerun API needs. No run is re-run.
 
-What each check maps to (mirrors the wiki REST table):
+Scope -> probe (mirrors the wiki REST table):
+  Organization Members: R   -> GET /orgs/{org}/members      (+ per-team read)
+  Repository Contents: R    -> GET /repos/{org}/classroom50 (config repo)
+  Repository Contents: W    -> permissions.push on the config repo
+  Repository Actions:  R/W  -> GET /repos/{org}/classroom50/actions/permissions
+  Repository Metadata: R    -> GET /repos/{org}/classroom50/collaborators
 
-  | Scope                     | Probe (read-only)                                   |
-  | Organization Members: R   | GET /orgs/{org}/members            (+ per-team read) |
-  | Repository Contents: R    | GET /repos/{org}/classroom50 (config repo readable) |
-  | Repository Contents: W    | permissions.push on the config repo                 |
-  | Repository Actions:  R/W  | GET /repos/{org}/classroom50/actions/permissions    |
-  | Repository Metadata: R    | GET /repos/{org}/classroom50/collaborators          |
-
-Config + org scopes are ALWAYS probed. Per-classroom, the probe additionally
-reads the classroom team's members (the exact call collect-scores makes),
-which also exercises team VISIBILITY — a secret team the token can't see
-404/403s here even when the org-members proxy passes. A team that doesn't
-exist yet (404) is a PASS with a note (an early-term classroom legitimately
-has no team) — never a failure.
+Config + org scopes are ALWAYS probed. Per-classroom, the probe also reads the
+classroom team's members (the exact call collect-scores makes), which exercises
+team VISIBILITY — a secret team the token can't see 404/403s here even when the
+org-members proxy passes. A team that doesn't exist yet (404) is a PASS with a
+note (an early-term classroom legitimately has no team), never a failure.
 
 Environment (set by `probe-token.yaml`):
   CLASSROOM50_SERVICE_TOKEN — the fine-grained PAT to probe.
@@ -45,9 +41,9 @@ Environment (set by `probe-token.yaml`):
   GH_API_URL                — explicit override (test servers).
 
 Exit codes:
-  0 — every required scope is present (a per-classroom team read may be
-      skipped with a note when the team doesn't exist yet).
-  1 — at least one required scope is missing, or the token is invalid/expired.
+  0 — every required scope present (a per-classroom team read may be skipped
+      with a note when the team doesn't exist yet).
+  1 — at least one required scope missing, or the token is invalid/expired.
 """
 
 from __future__ import annotations
@@ -83,10 +79,10 @@ def _api_url() -> str:
 
 def http_get(url: str, token: str, *, _retries: int = 3) -> tuple[int, bytes]:
     """GET `url` with bearer auth. Returns (status, body) for a 2xx; raises
-    urllib.error.HTTPError for a non-2xx so callers can classify the status.
-    Retries 5xx/429 with exponential backoff (honoring Retry-After), mirroring
-    the collect/regrade transport. The token lives only in the Authorization
-    header — never logged or interpolated into output."""
+    urllib.error.HTTPError for a non-2xx so callers can classify. Retries
+    5xx/429 with exponential backoff (honoring Retry-After), mirroring the
+    collect/regrade transport. The token lives only in the Authorization header
+    — never logged or interpolated into output."""
     for attempt in range(_retries):
         req = urllib.request.Request(
             url,
@@ -131,9 +127,9 @@ def _repo_url(api_url: str, owner: str, repo: str) -> str:
 
 # Individual scope checks -----------------------------------------------------
 #
-# Each check returns a Check: ok True/False and a human message. A check that
-# can't run for a benign reason (no student repos yet) is `skipped` — counted
-# as a pass with a note, not a failure.
+# Each returns a Check: ok True/False and a human message. A check that can't
+# run for a benign reason (no student repos yet) is `skipped` — a pass with a
+# note, not a failure.
 
 
 class Check:
@@ -189,7 +185,7 @@ def check_config_contents_and_write(api_url: str, org: str, token: str) -> list[
 
 def check_actions(api_url: str, org: str, token: str) -> Check:
     """Actions: Read/Write — GET .../actions/permissions is reachable only with
-    the Actions permission (the fine-grained Actions permission is a single
+    the Actions permission (a fine-grained Actions permission is a single
     read/write pair, so reachability establishes the grant regrade's rerun API
     needs). Read-only: no run is re-run."""
     url = f"{_repo_url(api_url, org, CONFIG_REPO)}/actions/permissions"
@@ -210,7 +206,7 @@ def check_actions(api_url: str, org: str, token: str) -> Check:
 
 
 def check_metadata(api_url: str, org: str, token: str) -> Check:
-    """Metadata: Read — /collaborators is a Metadata endpoint; it is what group
+    """Metadata: Read — /collaborators is a Metadata endpoint, what group
     attribution reads. Metadata is auto-included on every fine-grained PAT, so
     this is expected to pass; a failure means the token is scoped to the wrong
     resource owner or a repo subset."""
@@ -377,7 +373,7 @@ def main() -> int:
         print_check(check)
     checks.extend(org_scope_checks)
 
-    # Per-classroom: read the exact team collect-scores reads. This catches the
+    # Per-classroom: read the exact team collect-scores reads. Catches the
     # team-visibility gap the org-members proxy can miss.
     classrooms = list(iter_classroom_meta(base_dir))
     if classrooms:

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
@@ -2,36 +2,32 @@
 """Teacher-triggered regrade fan-out.
 
 Re-runs the autograder across an assignment's student repos WITHOUT changing
-each student's submission. For every targeted repo it re-runs the repo's
-latest `autograde.yaml` workflow run via the Actions rerun API: that grades
-the SAME commit again and re-fetches the current autograder from Pages, so a
-teacher's fixed test / updated autograder takes effect. Because the runner
-stamps the submission `datetime` from the graded commit's committer date (not
-the grade time), the student's submission time and `late` flag are unchanged —
-only the score/`graded_at` move.
+each submission. For every targeted repo it re-runs the latest `autograde.yaml`
+run via the Actions rerun API: grades the SAME commit again and re-fetches the
+current autograder from Pages, so a teacher's fixed test / updated autograder
+takes effect. Because the runner stamps the submission `datetime` from the
+graded commit's committer date (not grade time), the submission time and `late`
+flag are unchanged — only the score/`graded_at` move.
 
-A re-run replays the run at ITS ORIGINAL submit/* commit, NOT the current
-`main` HEAD: regrade refreshes the score for an EXISTING submission, it does
-not grade newer un-submitted work a student may have pushed since. (Only the
-first-grade fallback below tags the current `main` HEAD.)
+A re-run replays at ITS ORIGINAL submit/* commit, NOT the current `main` HEAD:
+regrade refreshes the score for an EXISTING submission; it does not grade newer
+un-submitted work. (Only the first-grade fallback below tags the current HEAD.)
 
-A repo that has a `main` HEAD but no prior autograde run to re-run (never
-graded) is first-graded by pushing a fresh `submit/<UTC-timestamp>-<short-sha>`
-tag, which fires its autograde workflow. Repos with no `main` HEAD (student
-hasn't accepted/pushed) are skipped.
+A repo with a `main` HEAD but no prior autograde run (never graded) is
+first-graded by pushing a fresh `submit/<UTC-timestamp>-<short-sha>` tag, which
+fires its autograde workflow. Repos with no `main` HEAD (student hasn't
+accepted/pushed) are skipped.
 
-After this script re-runs/tags, grading happens ASYNCHRONOUSLY inside each
-student repo, so the refreshed releases are ingested by the next
-`collect-scores.py` run (nightly or "Collect now"). Until that next collect,
-the gradebook still shows the PRE-regrade scores — there is an
-eventual-consistency window, by design (collecting here would race the
-still-running grade jobs).
+Grading then happens ASYNCHRONOUSLY inside each student repo, so refreshed
+releases are ingested by the next `collect-scores.py` run (nightly or "Collect
+now"). Until then the gradebook shows PRE-regrade scores — an eventual-
+consistency window, by design (collecting here would race the still-running
+grade jobs).
 
-Roster-driven (unlike collect_scores.py, which is team-driven): the
-(student, assignment) pairs come from `<classroom>/students.csv` x
-`<classroom>/assignments.json`.
-A single `OWNER_FILTER` narrows the fan-out to one repo (the per-row
-"Regrade" action in the web UI); empty means the whole assignment.
+Roster-driven (unlike collect_scores.py, which is team-driven): the (student,
+assignment) pairs come from `<classroom>/students.csv` x
+`<classroom>/assignments.json`. A single `OWNER_FILTER` narrows to one repo
+(the per-row "Regrade" web action); empty means the whole assignment.
 
 Environment (set by `regrade.yaml`):
   CLASSROOM50_SERVICE_TOKEN — fine-grained PAT, Contents: Read and write AND
@@ -47,10 +43,9 @@ Environment (set by `regrade.yaml`):
   GH_API_URL                — explicit override (test servers).
 
 Exit codes:
-  0 — success (every targeted repo was re-run, first-graded, or had nothing
-      to do).
-  1 — operational failure (missing token/inputs, auth rejection,
-      unrecoverable network error). Per-repo failures warn and skip.
+  0 — success (every targeted repo re-run, first-graded, or had nothing to do).
+  1 — operational failure (missing token/inputs, auth rejection, unrecoverable
+      network error). Per-repo failures warn and skip.
 """
 
 from __future__ import annotations
@@ -72,17 +67,17 @@ import urllib.request
 CLASSROOM_SCHEMA_V1 = "classroom50/classroom/v1"
 ASSIGNMENTS_SCHEMA_V1 = "classroom50/assignments/v1"
 
-# Trigger contract: the autograde workflow fires on `submit/*` tags. Keep
-# this prefix aligned with autograde-runner.yaml and collect_scores.py.
+# Trigger contract: the autograde workflow fires on `submit/*` tags. Keep this
+# prefix aligned with autograde-runner.yaml and collect_scores.py.
 SUBMIT_TAG_PREFIX = "submit/"
 
-# Branch whose HEAD we re-tag. Submissions are graded off `main` (the
-# autograde shim's `on.push.branches`), so that's the ref we regrade.
+# Branch whose HEAD we re-tag. Submissions are graded off `main` (the autograde
+# shim's `on.push.branches`), so that's the ref we regrade.
 SUBMISSION_BRANCH = "main"
 
-# How often (every N repos) the fan-out logs an incremental progress line, so
-# a run killed by the Actions job timeout still leaves per-repo accounting in
-# the log rather than only the final summary (which prints on loop completion).
+# How often (every N repos) the fan-out logs incremental progress, so a run
+# killed by the Actions job timeout still leaves per-repo accounting in the log
+# rather than only the final summary.
 PROGRESS_EVERY = 25
 
 # Required roster columns written by `gh teacher classroom add`. Mirrors
@@ -111,9 +106,9 @@ def main() -> int:
     assignment_filter = (os.environ.get("ASSIGNMENT_FILTER") or "").strip()
     owner_filter = (os.environ.get("OWNER_FILTER") or "").strip()
 
-    # Regrade is always scoped to one classroom + assignment — unlike
-    # collect (which can sweep all classrooms), there's no "regrade
-    # everything" mode, so both inputs are required.
+    # Regrade is always scoped to one classroom + assignment — unlike collect
+    # (which can sweep all classrooms), there's no "regrade everything" mode, so
+    # both inputs are required.
     if not classroom_filter:
         emit_error("CLASSROOM_FILTER is empty — regrade requires a classroom short-name")
         return 1
@@ -148,9 +143,9 @@ def main() -> int:
         emit_error(str(exc))
         return 1
 
-    # Narrow to a single owner for the per-row regrade action. A filter that
-    # matches no rostered student is a teacher mistake (typo / stale row),
-    # so fail loudly rather than silently tagging nothing.
+    # Narrow to a single owner for the per-row regrade action. A filter matching
+    # no rostered student is a teacher mistake (typo / stale row), so fail loudly
+    # rather than silently tagging nothing.
     targets = roster
     if owner_filter:
         targets = [u for u in roster if u.lower() == owner_filter.lower()]
@@ -204,12 +199,10 @@ def main() -> int:
             skipped += 1
 
         # Incremental progress checkpoint. The final summary below only prints
-        # if the loop completes, so a job killed by the Actions timeout (a
-        # large roster is a long sequential fan-out) would otherwise leave NO
-        # per-repo accounting. Logging progress periodically means a killed run
-        # still shows how far it got; re-dispatching is safe (rerun is an
-        # idempotent replay and the tag path reuses an existing submit/* tag at
-        # HEAD), so a teacher can simply run it again to finish.
+        # if the loop completes, so a job killed by the Actions timeout (a large
+        # roster is a long sequential fan-out) would otherwise leave NO per-repo
+        # accounting. Re-dispatching is safe (rerun is idempotent and the tag
+        # path reuses an existing submit/* tag at HEAD), so a teacher can rerun.
         if index % PROGRESS_EVERY == 0 or index == total:
             print(
                 f"regrade {classroom_filter}/{assignment_filter}: progress "
@@ -245,38 +238,36 @@ AUTOGRADE_WORKFLOW = "autograde.yaml"
 
 def regrade_repo(api_url: str, org: str, repo: str, token: str) -> str:
     """Re-run grading for `repo` on its existing latest submission, without
-    creating a new submission. Returns one of:
+    creating a new one. Returns one of:
 
-      "rerun"   — re-ran the repo's latest autograde workflow run. This grades
-                  the SAME commit again (re-fetching the current autograder
-                  from Pages), and because the runner stamps the submission
-                  `datetime` from the commit's committer date, the student's
+      "rerun"   — re-ran the latest autograde run: grades the SAME commit again
+                  (re-fetching the current autograder), and because the runner
+                  stamps `datetime` from the commit's committer date, the
                   submission time / late flag DON'T change — only the score.
-      "tagged"  — the repo has a main HEAD but no prior autograde run to
-                  re-run, so a fresh submit/<ts>-<sha> tag was pushed to grade
-                  it for the first time. (Submission time is still the commit's
-                  committer date; `graded_at` records the new run.)
-      "missing" — neither a prior run nor a main HEAD (student hasn't
+      "tagged"  — no prior run, so a fresh submit/<ts>-<sha> tag was pushed to
+                  first-grade the main HEAD. (Submission time is still the
+                  commit's committer date; `graded_at` records the new run.)
+      "missing" — no prior run and no main HEAD (student hasn't
                   accepted/pushed); nothing to do.
 
     Raises urllib.error.HTTPError / ValueError on a hard failure the caller
-    classifies (auth/network abort the run; other per-repo errors warn-and-skip).
+    classifies (auth/network abort; other per-repo errors warn-and-skip).
     """
-    # Prefer re-running the existing run: that's a true "regrade the same
-    # commit" with no new tag and no new submission event.
+    # Prefer re-running the existing run: a true "regrade the same commit" with
+    # no new tag and no new submission event.
     run_id = latest_autograde_run_id(api_url, org, repo, token)
     if run_id is not None:
         rerun_workflow_run(api_url, org, repo, token, run_id)
         return "rerun"
 
-    # No prior run to re-run. If the repo has a main HEAD, kick off a first
-    # grade by tagging it; otherwise there's nothing to regrade.
+    # No prior run. If the repo has a main HEAD, kick off a first grade by
+    # tagging it; otherwise there's nothing to regrade.
     head_sha = main_head_sha(api_url, org, repo, token)
     if head_sha is None:
         return "missing"
 
     # A submit/* tag may already sit at HEAD (tagged but the run was deleted);
-    # reuse it rather than stacking a duplicate, then tag only when absent.
+    # reuse it rather than stacking a duplicate.
     if existing_submit_tag_at(api_url, org, repo, token, head_sha) is not None:
         return "tagged"
 
@@ -288,11 +279,9 @@ def regrade_repo(api_url: str, org: str, repo: str, token: str) -> str:
 def latest_autograde_run_id(
     api_url: str, org: str, repo: str, token: str
 ) -> int | None:
-    """The id of the most recent autograde workflow run on `repo`, or None
-    when the workflow has never run (or doesn't exist yet). Run ids are
-    newest-first from the API, so the first entry is the latest run — the
-    one tied to the current/latest submission, which is what a regrade
-    re-runs."""
+    """The id of the most recent autograde run on `repo`, or None when it has
+    never run (or doesn't exist yet). Run ids are newest-first from the API, so
+    the first entry is the latest run — the one a regrade re-runs."""
     url = (
         f"{_repo_url(api_url, org, repo)}/actions/workflows/"
         f"{urllib.parse.quote(AUTOGRADE_WORKFLOW)}/runs?per_page=1"
@@ -318,12 +307,12 @@ def latest_autograde_run_id(
 def rerun_workflow_run(
     api_url: str, org: str, repo: str, token: str, run_id: int
 ) -> None:
-    """Re-run a completed workflow run via the Actions rerun API. This replays
-    the run at the same commit; runtime-fetched resources (runner.py and the
-    autograder bundle, both pulled from Pages at grade time) are re-fetched,
-    so a teacher's updated autograder takes effect. A 403 (run not re-runnable
-    — e.g. still in progress) is surfaced as a per-repo skip by the caller, not
-    a hard auth failure, so a single un-rerunnable repo doesn't abort the run."""
+    """Re-run a completed workflow run via the Actions rerun API. Replays at
+    the same commit; runtime-fetched resources (runner.py and the autograder
+    bundle, both from Pages at grade time) are re-fetched, so a teacher's updated
+    autograder takes effect. A 403 (not re-runnable — e.g. still in progress) is
+    surfaced as a per-repo skip by the caller, not a hard auth failure, so one
+    un-rerunnable repo doesn't abort the run."""
     url = f"{_repo_url(api_url, org, repo)}/actions/runs/{run_id}/rerun"
     try:
         _http_request("POST", url, token, body=b"{}", accept="application/vnd.github+json")
@@ -346,8 +335,8 @@ class _SkipRepo(Exception):
 
 def build_submit_tag(sha: str) -> str:
     """submit/<UTC-timestamp>-<short-sha>. The short-SHA suffix prevents
-    collisions when two regrades land in the same UTC second. Mirrors the
-    tag format autograde-runner.yaml writes for a branch push."""
+    collisions when two regrades land in the same UTC second. Mirrors the tag
+    format autograde-runner.yaml writes for a branch push."""
     stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
     return f"{SUBMIT_TAG_PREFIX}{stamp}-{sha[:7]}"
 
@@ -375,16 +364,15 @@ def existing_submit_tag_at(
 ) -> str | None:
     """Return a submit/* tag name already pointing at `sha`, or None.
 
-    Lists the repo's submit/* tag refs and matches on the pointed-at commit.
-    A lightweight tag's ref points straight at the commit (object.type ==
+    Lists the repo's submit/* tag refs and matches on the pointed-at commit. A
+    lightweight tag's ref points straight at the commit (object.type ==
     "commit"); an ANNOTATED tag's ref points at a tag object (object.type ==
-    "tag"), so its object.sha is the tag's own sha, not the commit — that case
-    is dereferenced via git/tags/<sha> to recover the target commit before
-    comparing. Resolving both shapes keeps the first-grade fallback idempotent
-    even when a prior submit tag was annotated (autograde-runner.yaml's
-    set-latest step shows annotated submit tags occur), so a regrade reuses the
-    existing tag instead of minting a duplicate that yields two releases for
-    one commit."""
+    "tag"), so its object.sha is the tag's own sha — that case is dereferenced
+    via git/tags/<sha> to recover the target commit before comparing. Resolving
+    both keeps the first-grade fallback idempotent even when a prior submit tag
+    was annotated (autograde-runner.yaml's set-latest step shows annotated
+    submit tags occur), so a regrade reuses the existing tag instead of minting
+    a duplicate that yields two releases for one commit."""
     url = (
         f"{_repo_url(api_url, org, repo)}/git/matching-refs/"
         f"tags/{urllib.parse.quote(SUBMIT_TAG_PREFIX, safe='')}"
@@ -419,19 +407,19 @@ def _ref_points_at_commit(
 ) -> bool:
     """Whether a tag ref's `object` ultimately points at commit `sha`.
 
-    A lightweight tag's object IS the commit (object.type == "commit"); an
-    annotated tag's object is a tag object (object.type == "tag") whose
-    git/tags/<sha> target.object.sha is the commit. A failed dereference is
-    treated conservatively as a non-match (worst case: a duplicate release,
-    never a missed regrade), matching the function's original fail-safe."""
+    A lightweight tag's object IS the commit (type == "commit"); an annotated
+    tag's object is a tag object (type == "tag") whose git/tags/<sha>
+    target.object.sha is the commit. A failed dereference is treated
+    conservatively as a non-match (worst case: a duplicate release, never a
+    missed regrade)."""
     obj_sha = obj.get("sha")
     if not isinstance(obj_sha, str) or not obj_sha:
         return False
     if obj_sha == sha:
         return True
     # Annotated tag: the ref points at a tag object, so dereference it to the
-    # commit it wraps before comparing. Lightweight tags (type "commit") have
-    # already matched/failed above, so only chase the tag-object case.
+    # commit it wraps. Lightweight tags (type "commit") already matched/failed
+    # above, so only chase the tag-object case.
     if obj.get("type") != "tag":
         return False
     tag_url = f"{_repo_url(api_url, org, repo)}/git/tags/{urllib.parse.quote(obj_sha, safe='')}"
@@ -451,20 +439,19 @@ def _ref_points_at_commit(
 def create_tag_ref(
     api_url: str, org: str, repo: str, token: str, tag: str, sha: str
 ) -> None:
-    """Create a lightweight tag ref `refs/tags/<tag>` at `sha`. A 422 whose
-    body says the ref already exists is benign — a concurrent regrade won the
-    race — so it's swallowed; any OTHER 422 (e.g. an invalid sha or an
-    unprocessable payload) is a real failure and propagates, so the caller
-    records it as failed rather than mis-counting the repo as first-graded."""
+    """Create a lightweight tag ref `refs/tags/<tag>` at `sha`. A 422 whose body
+    says the ref already exists is benign — a concurrent regrade won the race —
+    so it's swallowed; any OTHER 422 (invalid sha, unprocessable payload) is a
+    real failure and propagates, so the caller records it as failed rather than
+    mis-counting the repo as first-graded."""
     url = f"{_repo_url(api_url, org, repo)}/git/refs"
     payload = json.dumps({"ref": f"refs/tags/{tag}", "sha": sha}).encode("utf-8")
     try:
         _http_request("POST", url, token, body=payload, accept="application/vnd.github+json")
     except urllib.error.HTTPError as exc:
-        # Only swallow the "reference already exists" 422 — GitHub returns
-        # that message when a concurrent regrade already created the tag.
-        # Any other 422 (invalid sha, malformed ref) must NOT be reported as
-        # a successful tagging, so re-raise it for the caller's warn-and-skip.
+        # Only swallow the "reference already exists" 422 — GitHub returns that
+        # for a duplicate ref. Any other 422 (invalid sha, malformed ref) must
+        # NOT count as a successful tagging, so re-raise for warn-and-skip.
         if exc.code == 422 and _http_error_says_ref_exists(exc):
             emit_warning(
                 f"{org}/{repo}: tag {tag} already exists (concurrent regrade?); leaving as-is"
@@ -477,10 +464,10 @@ def _http_error_says_ref_exists(exc: urllib.error.HTTPError) -> bool:
     """Whether a 422's response body reports the ref already exists.
 
     GitHub's git/refs endpoint returns `{"message": "Reference already
-    exists", ...}` for a duplicate ref. We match on that message
-    (case-insensitively) so a genuinely different 422 isn't mistaken for the
-    benign concurrent-regrade race. A body we can't read falls back to False
-    (treat as a real error) — failing safe toward surfacing the failure."""
+    exists", ...}` for a duplicate ref. Match on that (case-insensitively) so a
+    genuinely different 422 isn't mistaken for the benign race. An unreadable
+    body falls back to False (treat as a real error) — failing safe toward
+    surfacing the failure."""
     try:
         raw = exc.read()
     except (OSError, ValueError):
@@ -503,12 +490,12 @@ class RegradeInputError(Exception):
 
 
 def load_roster(classroom_dir: pathlib.Path, assignment_slug: str) -> list[str]:
-    """Rostered usernames for an assignment that exists in this classroom.
+    """Rostered usernames for an assignment registered in this classroom.
 
-    Validates the classroom's assignments.json schema and that the target
-    slug is registered (so a typo'd slug fails loudly rather than tagging
-    nothing), then returns the usernames from students.csv. Mirrors the
-    roster/manifest reads in collect_scores.py.
+    Validates the assignments.json schema and that the target slug is
+    registered (so a typo'd slug fails loudly rather than tagging nothing), then
+    returns the usernames from students.csv. Mirrors the roster/manifest reads
+    in collect_scores.py.
     """
     if not classroom_dir.is_dir():
         raise RegradeInputError(
@@ -580,9 +567,9 @@ def read_roster_usernames(path: pathlib.Path) -> list[str]:
 
 def assignment_repo_name(classroom: str, assignment: str, username: str) -> str:
     """Canonical student-repo name. Cross-binary contract — mirrors
-    `assignment_repo_name` in collect_scores.py and `assignmentRepoName`
-    in cli/gh-student/accept.go; changing the shape here without updating
-    the others silently breaks the regrade fan-out."""
+    `assignment_repo_name` in collect_scores.py and `assignmentRepoName` in
+    cli/gh-student/accept.go; changing the shape here without updating the
+    others silently breaks the regrade fan-out."""
     return f"{classroom.lower()}-{assignment.lower()}-{username.lower()}"
 
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
@@ -27,8 +27,9 @@ the gradebook still shows the PRE-regrade scores — there is an
 eventual-consistency window, by design (collecting here would race the
 still-running grade jobs).
 
-Roster-driven, mirroring `collect_scores.py`: the (student, assignment)
-pairs come from `<classroom>/students.csv` x `<classroom>/assignments.json`.
+Roster-driven (unlike collect_scores.py, which is team-driven): the
+(student, assignment) pairs come from `<classroom>/students.csv` x
+`<classroom>/assignments.json`.
 A single `OWNER_FILTER` narrows the fan-out to one repo (the per-row
 "Regrade" action in the web UI); empty means the whole assignment.
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -1,41 +1,20 @@
 #!/usr/bin/env python3
 """classroom50 runner.
 
-Fetched from the teacher's GitHub Pages site by the autograde-runner
-reusable workflow on every submission. Responsibilities:
+Fetched from the teacher's Pages site by the autograde-runner workflow on
+every submission. Reads env, resolves an entrypoint (per-assignment
+autograder.py > per-assignment tests.json > classroom-default autograder.py
+> vacuous pass), execs it in the student checkout, then reads/synthesizes
+result.json + release-body.md + $GITHUB_OUTPUT so downstream steps always
+have a v1-shaped payload. Per-assignment grading lives in autograder.py —
+see the Autograders wiki page.
 
-  1. Read env (CLASSROOM, ASSIGNMENT, SUBMISSION_TAG, etc.)
-  2. Compute helper values (USERNAME, COMMIT_URL, RELEASE_URL,
-     REVIEW_URL)
-  3. Download the per-assignment bundle from Pages, extract it
-  4. Resolve the entrypoint:
-       per-assignment <classroom>/autograders/<slug>/autograder.py
-       (extracted from the bundle), or
-       classroom default at <classroom>/autograder.py
-       (fetched from the per-classroom Pages URL).
-       When neither exists, synthesize a vacuous-pass result so the
-       workflow still publishes the submit-tag release with a clear
-       "no autograder configured" status.
-  5. Exec the entrypoint with the helper env vars and cwd at the
-     student's repo checkout
-  6. Read the autograder's outputs: ./result.json,
-     ./release-body.md, and status= / summary= entries in
-     $GITHUB_OUTPUT. Synthesize anything the autograder didn't
-     write so the workflow's downstream steps always have something
-     v1-shaped to publish.
-
-Teachers don't normally edit this file. Per-assignment grading
-logic lives in autograder.py — see the Autograders wiki page.
-
-The runner exits 0 for every grading outcome — including failures
-(bundle fetch error, malformed result.json, autograder rc != 0, etc.),
-which are reported via a synthetic error result + status=error so the
-workflow's release/commit-status steps still fire and the gradebook
-still ingests the submission. The one exception is missing required
-env vars (PAGES_BASE_URL, CLASSROOM, ASSIGNMENT, SUBMISSION_TAG):
-without those identity fields the runner can't synthesize a v1-shaped
-result.json, so it fails fast with exit 1 — this only happens when
-the script is invoked outside the autograde-runner workflow.
+Exits 0 for EVERY grading outcome, including failures (reported via a
+synthetic error result + status=error) so the release/commit-status steps
+still fire and the gradebook ingests the submission. Only missing required
+identity env (PAGES_BASE_URL, CLASSROOM, ASSIGNMENT, SUBMISSION_TAG) fails
+fast with exit 1 — those are needed to synthesize a v1 result.json, and
+this only happens when run outside the workflow.
 
 Environment (set by the autograde-runner workflow):
   PAGES_BASE_URL    org-level Pages URL of the classroom50 config repo
@@ -45,18 +24,13 @@ Environment (set by the autograde-runner workflow):
   GITHUB_REPOSITORY <owner>/<repo>
   GITHUB_SHA        commit SHA
   GITHUB_SERVER_URL https://github.com (or GHES base)
-  GITHUB_ACTOR      fallback username when the repo name doesn't
-                    follow the <classroom>-<assignment>-<username>
-                    convention
+  GITHUB_ACTOR      fallback username when the repo name doesn't follow
+                    <classroom>-<assignment>-<username>
   GITHUB_OUTPUT     workflow-step output sink
 
-Additional env vars passed through to the entrypoint:
-  USERNAME          student GitHub username (derived from repo name)
-  COMMIT_URL        link to the graded commit on github.com
-  RELEASE_URL       link to the submission release on github.com
-  REVIEW_URL        full diff (baseline...graded commit); equals
-                    COMMIT_URL when history is unavailable or there
-                    is nothing to compare (baseline == commit)
+Passed through to the entrypoint: USERNAME, COMMIT_URL, RELEASE_URL,
+REVIEW_URL (full baseline...graded diff; falls back to COMMIT_URL when
+history is unavailable or baseline == commit).
 """
 
 from __future__ import annotations
@@ -83,30 +57,27 @@ from typing import Any
 # (cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py).
 RESULT_SCHEMA_V1 = "classroom50/result/v1"
 
-# Filenames the autograder must (or may) write into the workspace.
-# release-body.md is optional; the runner synthesizes one when
-# missing. result.json is required. Keep in lockstep with the Go
-# single-source contract.ResultFilename / contract.ReleaseBodyFilename
+# result.json is required; release-body.md optional (synthesized when
+# missing). Lockstep with contract.ResultFilename / contract.ReleaseBodyFilename
 # (cli/shared/contract/contract.go); test_runner.py pins these literals.
 RESULT_FILENAME = "result.json"
 RELEASE_BODY_FILENAME = "release-body.md"
 
-# Conventional name for both the per-assignment override and the
-# classroom default entrypoint.
+# Name of both the per-assignment override and classroom-default entrypoint.
 ENTRYPOINT_FILENAME = "autograder.py"
 
-# Per-assignment declarative tests: a bundled tests.json (materialized
-# from assignments.json by publish-pages.yaml) is graded by the built-in
-# interpreter below. Schema lives in tests.go; contract in the wiki.
+# Bundled declarative tests (materialized from assignments.json by
+# publish-pages.yaml), graded by the built-in interpreter below. Schema in
+# tests.go; contract in the wiki.
 TESTS_FILENAME = "tests.json"
 TESTS_SCHEMA_V1 = "classroom50/tests/v1"
 
-# Default per-test timeout (seconds) when `timeout` is omitted/0. Setup
-# and run commands are each bounded by it independently.
+# Default per-test timeout (s) when `timeout` is omitted/0; setup and run
+# commands are each bounded by it independently.
 DEFAULT_TEST_TIMEOUT = 10
 
-# Captured stdout/stderr is truncated to this many characters in the
-# release body so a runaway program can't bloat the published release.
+# Cap captured stdout/stderr in the release body so a runaway program can't
+# bloat the published release.
 MAX_CAPTURED_CHARS = 2000
 
 # Test types and io comparison modes -- mirror the allow-lists in tests.go.
@@ -120,39 +91,34 @@ COMPARISON_EXACT = "exact"
 COMPARISON_REGEX = "regex"
 COMPARISONS = (COMPARISON_INCLUDED, COMPARISON_EXACT, COMPARISON_REGEX)
 
-# Bounded retry for Pages fetches. Fixed 1s then 2s between attempts
-# (the final attempt raises rather than sleeping) on transient network
-# errors / HTTP 5xx. 404 is NOT retried — for the bundle URL it
-# means "no per-assignment override"; for the classroom-default URL
-# it means the classroom hasn't run `gh teacher autograder
-# set-default` (the runner falls back to a vacuous-pass result).
+# Bounded retry for Pages fetches: 1s then 2s between attempts (final attempt
+# raises) on transient network errors / HTTP 5xx. 404 is NOT retried — for the
+# bundle URL it means "no per-assignment override"; for the classroom-default
+# URL it means the classroom hasn't run `gh teacher autograder set-default`
+# (falls back to a vacuous-pass result).
 FETCH_ATTEMPTS = 3
 
-# Hard cap on the bundle / classroom-default fetches. Bundles fitting
-# in 10 MB cover all realistic test suites; a single autograder.py
-# is small but the same ceiling avoids a hostile asset.
+# Hard cap on bundle / classroom-default fetches. 10 MB covers all realistic
+# test suites and bounds a hostile asset.
 MAX_FETCH_BYTES = 10 * 1024 * 1024
 
-# The accept commit is the one that creates the repo's
-# `.classroom50.yaml`. Resolving the baseline from this structural
-# marker (not the commit subject) keeps it stable across clients and
-# message rewording, and removes the subject-reuse spoof. Note the
-# baseline still can't be moved *forward* (to hide pre-baseline work)
-# only because the default-branch force-push/delete ruleset protects
-# the immutable accept commit -- on a plan that rejects org rulesets
-# that protection silently doesn't apply, so this is a robustness win
-# over subject-matching, not an unconditional guarantee. Path mirrors
-# classroomcfg.MetadataPath (cli/gh-student/internal/classroomcfg/
-# metadata.go) -- keep in lockstep.
+# The accept commit creates the repo's `.classroom50.yaml`. Resolving the
+# baseline from this structural marker (not the commit subject) is stable
+# across clients/rewording and removes the subject-reuse spoof. The baseline
+# still can't be moved *forward* (to hide pre-baseline work) only because the
+# default-branch force-push/delete ruleset protects the accept commit -- on a
+# plan that rejects org rulesets that protection silently doesn't apply, so
+# this is a robustness win over subject-matching, not a guarantee. Path mirrors
+# classroomcfg.MetadataPath (cli/gh-student/internal/classroomcfg/metadata.go)
+# -- keep in lockstep.
 ACCEPT_MARKER_PATH = ".classroom50.yaml"
 
-# The full set of paths the accept commit lands, atomically, in one Tree
-# commit. Mirrors classroomcfg.DropFiles (cli/gh-student/internal/
-# classroomcfg/metadata.go), which commits exactly MetadataPath +
-# AutogradeWorkflowPath -- keep in lockstep. is_acceptance_commit uses
-# this to fail open when the tip accept commit also adds non-setup files
-# (e.g. an amended/squashed commit carrying real work), so that work is
-# graded rather than silently skipped.
+# Full set of paths the accept commit lands atomically in one Tree commit.
+# Mirrors classroomcfg.DropFiles (cli/gh-student/internal/classroomcfg/
+# metadata.go), which commits exactly MetadataPath + AutogradeWorkflowPath --
+# keep in lockstep. is_acceptance_commit uses this to fail open when the tip
+# accept commit also adds non-setup files (e.g. amended/squashed real work),
+# so that work is graded rather than silently skipped.
 ACCEPT_COMMIT_PATHS = frozenset(
     {
         ACCEPT_MARKER_PATH,
@@ -160,7 +126,7 @@ ACCEPT_COMMIT_PATHS = frozenset(
     }
 )
 
-# `_baseline_scan` source discriminator. SOURCE_OPENABLE yield a usable
+# `_baseline_scan` source discriminator. SOURCE_OPENABLE yields a usable
 # Feedback PR base (accept commit or root fallback); the others skip.
 SOURCE_ACCEPT = "accept"
 SOURCE_ROOT = "root"
@@ -168,11 +134,10 @@ SOURCE_GIT_ERROR = "git-error"
 SOURCE_NONE = "none"
 SOURCE_OPENABLE = (SOURCE_ACCEPT, SOURCE_ROOT)
 
-# Control paths allowed_files enforcement never removes,
-# even under a bare `*`. Lockstep with submit.go's isControlPath, pinned
-# from both sides by the shared fixture
-# cli/shared/testdata/control_path_cases.json. Directory controls match by
-# prefix; file controls match exactly, so a sibling like `result.json.bak`
+# Control paths allowed_files enforcement never removes, even under a bare `*`.
+# Lockstep with submit.go's isControlPath, pinned from both sides by the shared
+# fixture cli/shared/testdata/control_path_cases.json. Directory controls match
+# by prefix; file controls match exactly, so a sibling like `result.json.bak`
 # stays subject to the allowlist.
 ALLOWED_FILES_KEEP_PREFIXES = (
     ".github/",
@@ -188,11 +153,10 @@ ALLOWED_FILES_KEEP_EXACT = (
 
 
 def runtime_root() -> pathlib.Path:
-    """Pick a writable scratch dir for bundle extraction + entrypoint
-    fetches. Prefers `$RUNNER_TEMP` (Actions cross-platform temp dir,
-    cleaned between jobs) and falls back to `tempfile.mkdtemp()` for
-    local development. Hard-coded `/tmp/` would break on Windows
-    runners (which `runtime.go`'s allow-list still admits)."""
+    """Writable scratch dir for bundle extraction + entrypoint fetches.
+    Prefers `$RUNNER_TEMP` (Actions temp, cleaned between jobs), else
+    `tempfile.mkdtemp()` for local dev. Hard-coded `/tmp/` would break on
+    Windows runners (which runtime.go's allow-list admits)."""
     base = os.environ.get("RUNNER_TEMP", "").strip()
     if base:
         return pathlib.Path(base) / "classroom50-runtime"
@@ -207,10 +171,9 @@ def runtime_root() -> pathlib.Path:
 def username_from_repo(repository: str, classroom: str, assignment: str, actor: str) -> str:
     """Derive the student username from `<owner>/<classroom>-<assignment>-<username>`.
 
-    Mirrors the `assignmentRepoName` formula in cli/gh-student/accept.go
-    (lowercased throughout). Falls back to GITHUB_ACTOR when the repo
-    name doesn't follow the convention (e.g. hand-created repos for
-    testing).
+    Mirrors `assignmentRepoName` in cli/gh-student/accept.go (lowercased
+    throughout). Falls back to GITHUB_ACTOR when the repo name doesn't follow
+    the convention (e.g. hand-created test repos).
     """
     if "/" in repository:
         _, repo = repository.split("/", 1)
@@ -235,19 +198,17 @@ def compare_url(server_url: str, repository: str, base_sha: str, head_sha: str) 
 
 
 def review_url(server_url: str, repository: str, base_sha: str | None, head_sha: str) -> str:
-    """Full diff from the student's baseline to the graded commit;
-    commit view when there's no usable baseline (history unavailable,
-    or baseline == head)."""
+    """Full baseline...graded diff; commit view when there's no usable
+    baseline (history unavailable, or baseline == head)."""
     if base_sha and head_sha and base_sha != head_sha:
         return compare_url(server_url, repository, base_sha, head_sha)
     return commit_url(server_url, repository, head_sha)
 
 
 def _classroom_segment(classroom: str, secret: str) -> str:
-    """The per-classroom Pages path segment. When the classroom opted into
-    protected resources a capability-URL secret is present and everything is
-    served under `<classroom>/<secret>`; otherwise the plain `<classroom>`.
-    Both parts are URL-quoted by the callers."""
+    """Per-classroom Pages path segment. A protected classroom carries a
+    capability-URL secret and serves everything under `<classroom>/<secret>`;
+    otherwise plain `<classroom>`. Both parts are URL-quoted by callers."""
     safe_classroom = urllib.parse.quote(classroom, safe="")
     if not secret:
         return safe_classroom
@@ -255,36 +216,30 @@ def _classroom_segment(classroom: str, secret: str) -> str:
 
 
 def bundle_url(pages_base_url: str, classroom: str, assignment: str, secret: str = "") -> str:
-    """The Pages URL for an assignment's bundle (autograder.py +
-    sibling fixtures, packaged by publish-pages.yaml). Secret-aware:
-    inserts the capability-URL segment when the classroom is protected."""
+    """Pages URL for an assignment's bundle (autograder.py + sibling fixtures,
+    packaged by publish-pages.yaml). Secret-aware."""
     safe_slug = urllib.parse.quote(assignment, safe="")
     return f"{pages_base_url}/{_classroom_segment(classroom, secret)}/autograders/{safe_slug}.tar.gz"
 
 
 def classroom_default_autograder_url(pages_base_url: str, classroom: str, secret: str = "") -> str:
-    """The Pages URL for a classroom's default autograder.py.
+    """Pages URL for a classroom's default autograder.py.
 
-    Published verbatim by publish-pages.yaml from the repo path
-    `<classroom>/autograder.py` to the Pages path
-    `<classroom>/[<secret>/]autograder.py`. Optional — classrooms that
-    haven't run `gh teacher autograder set-default` won't have one, and the
-    runner falls back to a vacuous-pass result for those.
+    Published verbatim by publish-pages.yaml from `<classroom>/autograder.py`.
+    Optional — classrooms that haven't run `gh teacher autograder set-default`
+    won't have one, and the runner falls back to a vacuous-pass result.
     """
     return f"{pages_base_url}/{_classroom_segment(classroom, secret)}/{ENTRYPOINT_FILENAME}"
 
 
 def actor_identity() -> dict[str, Any] | None:
-    """The GitHub actor who triggered this run — the person who pushed the
-    submission. Returns {"username": <login>, "id": <numeric id|None>} or
-    None when the login is unavailable.
+    """The GitHub actor who pushed this submission. Returns {"username":
+    <login>, "id": <numeric id|None>} or None when the login is unavailable.
 
-    For a GROUP submission the graded repo is the founder's, but any
-    teammate-collaborator can push; `submitted_by` records who actually
-    pushed THIS submission so the gradebook shows the submitter even though
-    the shared score is credited to every member. GITHUB_ACTOR (login) and
-    GITHUB_ACTOR_ID (numeric id) are default GitHub Actions env vars set on
-    every run; id is parsed as an int when present, else null.
+    For a GROUP submission the graded repo is the founder's but any teammate
+    can push; `submitted_by` records who actually pushed while the shared
+    score is credited to every member. From GITHUB_ACTOR / GITHUB_ACTOR_ID
+    (id parsed as int when present, else null).
     """
     login = (os.environ.get("GITHUB_ACTOR") or "").strip()
     if not login:
@@ -315,22 +270,19 @@ def make_result(
 ) -> dict[str, Any]:
     """Build a v1-shaped result.json payload. Single source of the field
     layout shared by the error/vacuous paths (empty_result) and the
-    declarative grader (which passes real score/tests). review falls
-    back to the commit view when review_link is None.
+    declarative grader. `review` falls back to the commit view when
+    review_link is None.
 
-    `username` is the repo OWNER (derived from the repo name) and is
-    emitted as the `owner` field — the identity anchor the collector
-    validates. `assignment_type` ("individual" | "group") records the
-    assignment mode. There is no `usernames` field: who pushed is
-    `submitted_by`, who owns the repo is `owner`, and the credited member
-    list (group only) is resolved by collection.
+    `username` is the repo OWNER, emitted as `owner` (the identity anchor
+    the collector validates). `assignment_type` ("individual"|"group")
+    records the mode. No `usernames` field: who pushed is `submitted_by`,
+    who owns the repo is `owner`, the credited member list is resolved by
+    collection.
 
-    `when` is the SUBMISSION instant (the graded commit's committer date),
-    emitted as `datetime`. It is invariant across regrades of the same
-    commit, so collect-scores' `late` marking (datetime vs `due`) never
-    changes when a teacher re-runs grading. `graded_at` is the wall-clock
-    instant THIS grading run produced the result (defaults to now); it
-    moves on every regrade and is purely informational ("last graded")."""
+    `when` is the SUBMISSION instant (graded commit's committer date), emitted
+    as `datetime`; invariant across regrades, so collect-scores' `late` marking
+    never changes on a re-run. `graded_at` is THIS run's wall clock (defaults
+    to now), purely informational."""
     result: dict[str, Any] = {
         "schema": RESULT_SCHEMA_V1,
         "classroom": classroom,
@@ -365,11 +317,9 @@ def empty_result(
     review_link: str | None = None,
     submitted_by: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """A v1-valid result.json payload with no tests (score 0/0).
-
-    The runner uses this for every error path — collect-scores
-    ingests it as "submitted, error"; the workflow log carries the
-    actual failure reason.
+    """A v1-valid result.json payload with no tests (score 0/0). Used for
+    every error path — collect-scores ingests it as "submitted, error"; the
+    workflow log carries the actual failure reason.
     """
     return make_result(
         classroom=classroom,
@@ -391,10 +341,9 @@ def empty_result(
 def derive_status_and_summary(result: dict[str, Any]) -> tuple[str, str]:
     """Map a result.json payload to a commit-status state + summary line.
 
-    `success` when all tests pass (or when there are zero tests —
-    vacuous pass, "submitted, no autograder configured"). `failure`
-    when any test failed. The error path is set explicitly by the
-    runner, never derived here.
+    `success` when all tests pass (or zero tests — vacuous pass, "no
+    autograder configured"). `failure` when any test failed. The error path
+    is set explicitly by the runner, never derived here.
     """
     tests = result.get("tests") or []
     score = int(result.get("score") or 0)
@@ -415,11 +364,9 @@ def derive_status_and_summary(result: dict[str, Any]) -> tuple[str, str]:
 
 
 def render_release_body(result: dict[str, Any], summary: str) -> str:
-    """Render the Markdown body for the submit-tag release.
-
-    Shows the score line, then a per-test table (or just the summary
-    when `tests` is empty). `|` characters in test names are escaped
-    so they don't break the Markdown table.
+    """Render the Markdown body for the submit-tag release: the score line,
+    then a per-test table (or just the summary when `tests` is empty). `|` in
+    test names is escaped so it can't break the Markdown table.
     """
     score = int(result.get("score") or 0)
     max_score = int(result.get("max-score") or 0)
@@ -447,23 +394,19 @@ def validate_result(
     data: Any, *, classroom: str, assignment: str, is_group: bool = False,
     owner: str | None = None,
 ) -> str | None:
-    """Return None if `data` is v1-shaped for the given identity, else
-    a human-readable error string.
+    """None if `data` is v1-shaped for the given identity, else a
+    human-readable error string.
 
-    Mirrors collect_scores.py::validate_result so a payload that
-    passes here also passes the gradebook ingest. Without the parity,
-    a malformed result.json (missing `owner`, non-int score, test entry
-    that isn't a dict, etc.) would silently pass the runner, get published
-    as a release, and only get rejected on the next collect-scores run —
-    the student appears as not-yet-submitted in the gradebook with no
-    signal in the workflow log.
+    Mirrors collect_scores.py::validate_result so a payload passing here also
+    passes gradebook ingest. Without parity, a malformed result.json (missing
+    `owner`, non-int score, non-dict test entry, ...) would silently pass the
+    runner, get published, and only be rejected on the next collect-scores run
+    — the student appears not-yet-submitted with no signal in the log.
 
-    `owner` (the repo owner login) is the identity anchor: when provided
-    it must equal `data["owner"]`. `assignment_type` must be
-    "individual"/"group" and, given `is_group`, must match the run's mode.
-    There is no `usernames` field anymore: who pushed is `submitted_by`,
-    who owns the repo is `owner`, and the credited member list (group only)
-    is resolved by collection.
+    `owner` (repo owner login) is the identity anchor: when provided it must
+    equal `data["owner"]`. `assignment_type` must be "individual"/"group" and
+    match the run's mode. No `usernames` field: who pushed is `submitted_by`,
+    who owns is `owner`, the credited member list is resolved by collection.
     """
     if not isinstance(data, dict):
         return f"{RESULT_FILENAME} is not a JSON object"
@@ -508,8 +451,7 @@ def validate_result(
 
     score = data.get("score")
     max_score = data.get("max-score")
-    # Reject bool (which is an int subclass in Python) — bool slipping
-    # past `isinstance(int)` would let `True`/`False` pass for scores.
+    # Reject bool (an int subclass in Python) so True/False can't pass as scores.
     if isinstance(score, bool) or not isinstance(score, int) or score < 0:
         return f"{RESULT_FILENAME} 'score' must be a non-negative integer"
     if isinstance(max_score, bool) or not isinstance(max_score, int) or max_score < 0:
@@ -536,9 +478,9 @@ def validate_result(
         if ts > tm:
             return f"{RESULT_FILENAME} 'tests[{i}].score' ({ts}) > 'tests[{i}].max-score' ({tm})"
 
-    # submitted_by is optional (older results omit it). When present it
-    # must be an object with a non-empty string username and an integer
-    # or null id — the runner stamps it from GITHUB_ACTOR/GITHUB_ACTOR_ID.
+    # submitted_by is optional (older results omit it). When present: object
+    # with a non-empty string username and int-or-null id — stamped by the
+    # runner from GITHUB_ACTOR/GITHUB_ACTOR_ID.
     err = validate_submitted_by(data.get("submitted_by"), RESULT_FILENAME)
     if err is not None:
         return err
@@ -546,10 +488,10 @@ def validate_result(
 
 
 def validate_submitted_by(value: Any, filename: str) -> str | None:
-    """Validate the optional `submitted_by` block (the pusher identity).
-    None/absent is allowed (older results omit it). When present it must be
-    {"username": <non-empty str>, "id": <int|null>}. Shared shape so the
-    runner and the collector agree. Returns an error string or None.
+    """Validate the optional `submitted_by` block (pusher identity). None/absent
+    is allowed (older results omit it). When present: {"username": <non-empty
+    str>, "id": <int|null>}. Shared shape so runner and collector agree. Returns
+    an error string or None.
     """
     if value is None:
         return None
@@ -575,26 +517,21 @@ def _baseline_scan(workspace: pathlib.Path) -> tuple[str | None, str]:
     Returns (sha, source) where source is one of the SOURCE_* constants:
       - SOURCE_ACCEPT:    the commit that introduced `.classroom50.yaml`
         (ACCEPT_MARKER_PATH). A trusted baseline.
-      - SOURCE_ROOT:      the repo's root commit (no commit added the
-        marker) -- a best-effort baseline.
-      - SOURCE_GIT_ERROR: git ran but failed -- e.g. the "dubious
-        ownership" guard in a container, or an un-deepenable shallow
-        clone. History might exist; we couldn't read it. Distinct from
-        SOURCE_NONE so the caller can warn accurately.
-      - SOURCE_NONE:      no history to resolve -- git is unavailable or
-        the workspace is not a git repo.
+      - SOURCE_ROOT:      the repo's root commit (no commit added the marker)
+        -- a best-effort baseline.
+      - SOURCE_GIT_ERROR: git ran but failed (e.g. "dubious ownership" in a
+        container, or an un-deepenable shallow clone). History might exist; we
+        couldn't read it. Distinct from SOURCE_NONE so the caller warns right.
+      - SOURCE_NONE:      no history to resolve -- git unavailable or not a repo.
     sha is None for everything except SOURCE_ACCEPT / SOURCE_ROOT.
     """
 
     def git(*args: str) -> subprocess.CompletedProcess[str]:
-        # `-c safe.directory=*` keeps the scan independent of the
-        # runner OS/container. In a container the checkout is owned by
-        # the host runner user but git runs as a different UID over a
-        # bind mount, tripping git's "dubious ownership" guard.
-        # actions/checkout's safe.directory exception is written under a
-        # temporary HOME that's restored before runner.py runs, so it's
-        # invisible here. Setting it per-invocation avoids relying on
-        # global config/HOME.
+        # `-c safe.directory=*` keeps the scan independent of the runner
+        # OS/container: in a container the checkout is owned by the host runner
+        # user but git runs as a different UID over a bind mount, tripping git's
+        # "dubious ownership" guard. actions/checkout's exception is under a
+        # temporary HOME restored before runner.py runs, so it's invisible here.
         return subprocess.run(
             ["git", "-c", "safe.directory=*", "-C", str(workspace), *args],
             capture_output=True, text=True, timeout=120, check=False,
@@ -608,38 +545,36 @@ def _baseline_scan(workspace: pathlib.Path) -> tuple[str | None, str]:
             low = inside.stderr.lower()
             if "not a git repository" in low or "no such file" in low:
                 return None, SOURCE_NONE
-            # Repo exists but git won't read it (dubious ownership,
-            # corruption, locked index): history may exist.
+            # Repo exists but git won't read it (dubious ownership, corruption,
+            # locked index): history may exist.
             return None, SOURCE_GIT_ERROR
         shallow = git("rev-parse", "--is-shallow-repository")
         if shallow.returncode != 0:
             return None, SOURCE_GIT_ERROR
         if shallow.stdout.strip() == "true":
-            # Depth-1 checkout (workflows predating fetch-depth: 0):
-            # deepen, or the graft boundary would pose as the root.
-            # checkout's persisted credentials authenticate the fetch.
+            # Depth-1 checkout (workflows predating fetch-depth: 0): deepen, or
+            # the graft boundary would pose as the root. checkout's persisted
+            # credentials authenticate the fetch.
             if git("fetch", "--quiet", "--unshallow", "origin").returncode != 0:
                 return None, SOURCE_GIT_ERROR
-        # Earliest commit that ADDED the marker wins so a later re-add
-        # (delete then restore) can't move the baseline forward and hide
-        # work from the review diff. --diff-filter=A selects additions,
-        # --reverse puts the oldest first, --first-parent stays on
-        # mainline. Run before the root-commit fallback.
+        # Earliest commit that ADDED the marker wins, so a later re-add (delete
+        # then restore) can't move the baseline forward and hide work from the
+        # review diff. --diff-filter=A selects additions, --reverse oldest-first,
+        # --first-parent stays on mainline. Run before the root-commit fallback.
         added = git(
             "log", "--reverse", "--first-parent", "--diff-filter=A",
             "--format=%H", "HEAD", "--", ACCEPT_MARKER_PATH,
         )
-        # A failed marker query is history-unreadable, not "marker
-        # absent" -- return SOURCE_GIT_ERROR so a transient git error
-        # doesn't silently degrade to the root fallback.
+        # A failed marker query is history-unreadable, not "marker absent" --
+        # SOURCE_GIT_ERROR so a transient git error doesn't degrade to root.
         if added.returncode != 0:
             return None, SOURCE_GIT_ERROR
         for line in added.stdout.splitlines():
             sha = line.strip()
             if sha:
                 return sha, SOURCE_ACCEPT
-        # No commit added the marker (hand-created repo): fall back to
-        # the root commit for the best-effort review link.
+        # No commit added the marker (hand-created repo): fall back to the root
+        # commit for the best-effort review link.
         log = git("log", "--reverse", "--first-parent", "--format=%H", "HEAD")
         if log.returncode != 0:
             return None, SOURCE_GIT_ERROR
@@ -653,12 +588,11 @@ def _baseline_scan(workspace: pathlib.Path) -> tuple[str | None, str]:
 
 
 def baseline_sha(workspace: pathlib.Path) -> str | None:
-    """SHA the student started from: the accept commit (the commit that
-    introduced `.classroom50.yaml`) when present, else the root commit.
-    None when history is unavailable (no git, no .git, or an
-    un-deepenable shallow clone) and the caller falls back to the commit
-    view. Used for the review compare link, which tolerates the root
-    fallback."""
+    """SHA the student started from: the accept commit (which introduced
+    `.classroom50.yaml`) when present, else the root commit. None when history
+    is unavailable (no git, no .git, or an un-deepenable shallow clone) and the
+    caller falls back to the commit view. Used for the review compare link,
+    which tolerates the root fallback."""
     return _baseline_scan(workspace)[0]
 
 
@@ -666,20 +600,17 @@ def is_acceptance_commit(workspace: pathlib.Path, head_sha: str) -> bool:
     """Whether head_sha is the bare acceptance commit: the commit that
     introduced `.classroom50.yaml` (SOURCE_ACCEPT) with nothing on top.
 
-    The setup job calls this to skip tagging + grading + the release for
-    the student's accept (no work to grade yet). True only when the
-    trusted accept commit is the tip; a submission stacks a fresh commit
-    (submit uses `--allow-empty`), so head_sha != accept_sha. Fails open
-    (False) on a root fallback, git error, empty head_sha, or no accept
-    commit, so an uncertain case grades.
+    The setup job calls this to skip tagging/grading/release for a student's
+    accept (nothing to grade yet). True only when the trusted accept commit is
+    the tip; a submission stacks a fresh commit (submit uses `--allow-empty`),
+    so head_sha != accept_sha. Fails open (False) on root fallback, git error,
+    empty head_sha, or no accept commit.
 
-    As a final guard, the tip accept commit must touch ONLY the known
-    setup paths (`ACCEPT_COMMIT_PATHS`). A student can rewrite history so
-    the marker-introducing commit is also the tip yet carries real work
-    (e.g. `git commit --amend` adding a solution then a force-push, or a
-    squash). Skipping such a commit would silently drop gradeable work,
-    so an accept commit that touches anything outside the setup set fails
-    open (False -> grade). A git error reading the commit's paths also
+    Final guard: the tip accept commit must touch ONLY the known setup paths
+    (`ACCEPT_COMMIT_PATHS`). A student can rewrite history so the marker commit
+    is the tip yet carries real work (amend + force-push, or a squash); skipping
+    it would silently drop gradeable work, so an accept commit touching anything
+    outside the setup set fails open (grade). A git error reading its paths also
     fails open.
     """
     if not head_sha:
@@ -691,10 +622,10 @@ def is_acceptance_commit(workspace: pathlib.Path, head_sha: str) -> bool:
 
 
 def _accept_commit_is_setup_only(workspace: pathlib.Path, head_sha: str) -> bool:
-    """True only when every path the commit touches is in the known
-    setup set (`ACCEPT_COMMIT_PATHS`). Fails open (False -> grade) on any
-    git error or an empty path list, so a commit we can't fully inspect
-    is treated as a submission rather than silently skipped.
+    """True only when every path the commit touches is in the known setup set
+    (`ACCEPT_COMMIT_PATHS`). Fails open (False -> grade) on any git error or an
+    empty path list, so a commit we can't fully inspect is treated as a
+    submission rather than silently skipped.
     """
 
     def git(*args: str) -> subprocess.CompletedProcess[str]:
@@ -704,9 +635,9 @@ def _accept_commit_is_setup_only(workspace: pathlib.Path, head_sha: str) -> bool
         )
 
     try:
-        # Names of every path the commit changed vs its parent (root
-        # commit: vs the empty tree). -r recurses, --no-renames keeps
-        # paths literal, -z NUL-delimits so unusual filenames survive.
+        # Names of every path the commit changed vs its parent (root commit:
+        # vs the empty tree). -r recurses, --no-renames keeps paths literal,
+        # -z NUL-delimits so unusual filenames survive.
         changed = git(
             "show", "--no-renames", "--name-only", "--format=", "-r", "-z",
             head_sha,
@@ -725,19 +656,19 @@ def feedback_base_outcome(
     workspace: pathlib.Path,
     scan: tuple[str | None, str] | None = None,
 ) -> tuple[str | None, str]:
-    """(feedback-PR-base-sha, scan-source) for `main()`, which needs both
-    the base AND the trust signal. Same (sha, source) as `_baseline_scan`,
-    but forces a null sha for non-openable sources so the caller's gate is
-    a simple `sha is not None`: SOURCE_ACCEPT / SOURCE_ROOT open (root
-    warns it's untrusted), SOURCE_GIT_ERROR / SOURCE_NONE skip.
+    """(feedback-PR-base-sha, scan-source) for `main()`, which needs both the
+    base AND the trust signal. Same (sha, source) as `_baseline_scan`, but
+    forces a null sha for non-openable sources so the caller's gate is a simple
+    `sha is not None`: SOURCE_ACCEPT / SOURCE_ROOT open (root warns it's
+    untrusted), SOURCE_GIT_ERROR / SOURCE_NONE skip.
 
-    A reviewable diff against the root commit beats no Feedback PR at all,
-    and the untrusted-baseline warning tells the teacher to verify.
+    A reviewable diff against the root commit beats no Feedback PR at all, and
+    the untrusted-baseline warning tells the teacher to verify.
 
-    `scan` lets a caller that already ran `_baseline_scan` (e.g. main(),
-    which also needs the review-link baseline) reuse that result instead
-    of re-walking history -- the scan issues several sequential git calls,
-    so a second walk doubles the worst-case time against the job ceiling.
+    `scan` lets a caller that already ran `_baseline_scan` (e.g. main(), which
+    also needs the review-link baseline) reuse it instead of re-walking history
+    -- the scan issues several sequential git calls, so a second walk doubles
+    the worst-case time against the job ceiling.
     """
     sha, source = scan if scan is not None else _baseline_scan(workspace)
     return (sha, source) if source in SOURCE_OPENABLE else (None, source)
@@ -751,8 +682,8 @@ def _is_control_path(rel: str) -> bool:
 
 
 def parse_allowed_files(raw: str | None) -> list[str]:
-    """Parse the ALLOWED_FILES env (JSON array of patterns). Empty,
-    absent, or malformed -> [] so a bad value never strips files."""
+    """Parse the ALLOWED_FILES env (JSON array of patterns). Empty, absent, or
+    malformed -> [] so a bad value never strips files."""
     if not raw or not raw.strip():
         return []
     try:
@@ -767,9 +698,9 @@ def parse_allowed_files(raw: str | None) -> list[str]:
 
 
 def _isolated_git_env() -> dict[str, str]:
-    """Environment that ignores the host's git config so allowed_files
-    patterns classify identically on every runner. Paired with
-    `-c core.excludesFile`. Mirrors Go's isolatedGitEnv."""
+    """Environment that ignores the host's git config so allowed_files patterns
+    classify identically on every runner. Paired with `-c core.excludesFile`.
+    Mirrors Go's isolatedGitEnv."""
     env = dict(os.environ)
     env["GIT_CONFIG_NOSYSTEM"] = "1"
     env["GIT_CONFIG_GLOBAL"] = os.devnull
@@ -778,9 +709,9 @@ def _isolated_git_env() -> dict[str, str]:
 
 def _walk_workspace_files(workspace: pathlib.Path) -> list[str]:
     """All regular-file relative paths (forward-slash) under `workspace`,
-    skipping `.git` at any depth. Unlike `git ls-files`, this recurses
-    into nested git repos, so files hidden inside one can't escape the
-    allowlist. Symlinks are reported as their own path."""
+    skipping `.git` at any depth. Unlike `git ls-files`, recurses into nested
+    git repos so files hidden inside one can't escape the allowlist. Symlinks
+    are reported as their own path."""
     results: list[str] = []
     for dirpath, dirnames, filenames in os.walk(workspace):
         dirnames[:] = [d for d in dirnames if d != ".git"]
@@ -793,17 +724,17 @@ def _walk_workspace_files(workspace: pathlib.Path) -> list[str]:
 
 def _classify_disallowed(patterns: list[str], paths: list[str]) -> list[str] | None:
     """Subset of `paths` the `patterns` disallow, or None when the matcher
-    couldn't run (the caller then skips enforcement — fail open). Delegates
-    to `git check-ignore` against a throwaway, config-isolated repo. Mirrors
-    Go's ignorematch.Disallowed; both pinned by the shared fixture
+    couldn't run (caller then skips enforcement — fail open). Delegates to `git
+    check-ignore` against a throwaway, config-isolated repo. Mirrors Go's
+    ignorematch.Disallowed; both pinned by the shared fixture
     cli/shared/testdata/allowed_files_matcher_cases.json."""
     if not patterns or not paths:
         return []
     git_env = _isolated_git_env()
     # A hung git raises subprocess.TimeoutExpired (a SubprocessError, not an
     # OSError); a missing git binary raises OSError. Both must surface as
-    # "matcher couldn't run" (return None) rather than escape as an uncaught
-    # traceback, mirroring _baseline_scan's SubprocessError handling.
+    # "matcher couldn't run" (return None), not an uncaught traceback —
+    # mirroring _baseline_scan's SubprocessError handling.
     try:
         with tempfile.TemporaryDirectory(prefix="classroom50-ignore-") as tmp:
             tmp_path = pathlib.Path(tmp)
@@ -833,32 +764,28 @@ def _classify_disallowed(patterns: list[str], paths: list[str]) -> list[str] | N
 
 
 def enforce_allowed_files(workspace: pathlib.Path, patterns: list[str]) -> list[str]:
-    """Remove every working-tree file the allowed_files patterns disallow
-    so the autograder only sees allowed files. Control files
-    are always kept. Working-tree-only, so the baseline and review/
-    Feedback-PR links are unaffected. Returns the sorted removed paths;
-    no-ops when patterns is empty.
+    """Remove every working-tree file the allowed_files patterns disallow so
+    the autograder only sees allowed files. Control files are always kept.
+    Working-tree-only, so the baseline and review/Feedback-PR links are
+    unaffected. Returns the sorted removed paths; no-ops when patterns is empty.
 
     Fails OPEN: if the matcher can't run for a non-empty allowlist (tree
-    enumeration failure, git init/check-ignore error, or timeout), this
-    returns [] (skip enforcement, grade the unfiltered tree) rather than
-    blocking the grade. The submit-side filter is best-effort too, so this
-    keeps the whole feature lenient under git/resource hiccups.
+    enumeration failure, git init/check-ignore error, or timeout), returns []
+    (skip enforcement, grade the unfiltered tree) rather than blocking the
+    grade. The submit-side filter is best-effort too.
 
     To fail CLOSED instead (treat the allowlist as an authoritative security
-    boundary — refuse to grade rather than risk exposing disallowed files),
-    change the two `return []` failure branches below to raise an error and
-    have main() route it through finalize.error(...) so the submission lands
-    as an `error` result that can be re-run. The decision is intentionally
-    fail-open: allowed_files is a grading-scope/hygiene tool, not a secret-
-    hiding control.
+    boundary), change the two `return []` failure branches below to raise and
+    have main() route it through finalize.error(...) so the submission lands as
+    an `error` result. The decision is intentionally fail-open: allowed_files
+    is a grading-scope/hygiene tool, not a secret-hiding control.
     """
     if not patterns:
         return []
 
-    # Walk the tree directly: `git ls-files` won't recurse into a nested
-    # repo, so a student could hide disallowed files there. The walk skips
-    # every `.git` so git metadata is never enumerated or removed.
+    # Walk the tree directly: `git ls-files` won't recurse into a nested repo,
+    # so a student could hide disallowed files there. The walk skips every
+    # `.git` so git metadata is never enumerated or removed.
     try:
         candidates = _walk_workspace_files(workspace)
     except OSError as exc:
@@ -871,7 +798,7 @@ def enforce_allowed_files(workspace: pathlib.Path, patterns: list[str]) -> list[
         return []
 
     # None = matcher couldn't run. Fail open (see docstring); to fail closed,
-    # raise here instead and surface it via finalize.error in main().
+    # raise here and surface via finalize.error in main().
     disallowed = _classify_disallowed(patterns, candidates)
     if disallowed is None:
         return []
@@ -897,8 +824,8 @@ def enforce_allowed_files(workspace: pathlib.Path, patterns: list[str]) -> list[
 
 
 def render_removed_files_note(removed: list[str]) -> str:
-    """Markdown section listing files stripped by allowed_files, appended
-    to release-body.md so a renamed/missing required file is visible."""
+    """Markdown section listing files stripped by allowed_files, appended to
+    release-body.md so a renamed/missing required file is visible."""
     lines = [
         "",
         f"### Removed {len(removed)} file(s) outside the assignment's allowed files",
@@ -926,14 +853,13 @@ def append_removed_files_note(workspace: pathlib.Path, removed: list[str]) -> No
 
 
 def no_baseline_warning(source: str = SOURCE_NONE) -> str:
-    """GitHub workflow annotation when no baseline resolves and the
-    Feedback PR step will SKIP. A pure helper so the `::warning::` prefix
-    (which routes it to GitHub's annotation stream) is unit-testable.
+    """GitHub workflow annotation when no baseline resolves and the Feedback
+    PR step will SKIP. A pure helper so the `::warning::` prefix (which routes
+    it to GitHub's annotation stream) is unit-testable.
 
     Only unopenable sources reach here (SOURCE_ROOT opens the PR with
-    `untrusted_baseline_warning` instead). `source` names the cause:
-    SOURCE_GIT_ERROR = git couldn't read history (a baseline may exist);
-    SOURCE_NONE = not a git repo / no history to anchor a base to.
+    `untrusted_baseline_warning` instead). SOURCE_GIT_ERROR = git couldn't read
+    history (a baseline may exist); SOURCE_NONE = not a git repo / no history.
     """
     prefix = "::warning title=classroom50 Feedback PR::"
     if source == SOURCE_GIT_ERROR:
@@ -951,15 +877,14 @@ def no_baseline_warning(source: str = SOURCE_NONE) -> str:
 
 
 def untrusted_baseline_warning() -> str:
-    """GitHub workflow annotation when the Feedback PR opened against the
-    repo's root commit instead of the trusted accept commit (no commit
-    detected as ADDING `.classroom50.yaml`). The PR is still useful; the
-    teacher just gets a heads-up that the frozen base may include
-    starter/plumbing work, so the diff could be larger than usual.
+    """GitHub workflow annotation when the Feedback PR opens against the repo's
+    root commit instead of the trusted accept commit (no commit detected adding
+    `.classroom50.yaml`). The PR is still useful; the teacher gets a heads-up
+    that the frozen base may include starter/plumbing work, so the diff could
+    be larger than usual.
 
-    A `::warning::` annotation (not a plain log) so the caveat shows in
-    the run summary. Pure helper for the same testability reason as
-    `no_baseline_warning`."""
+    A `::warning::` annotation (not a plain log) so it shows in the run summary.
+    Pure helper for the same testability reason as `no_baseline_warning`."""
     return (
         "::warning title=classroom50 Feedback PR::opened the Feedback PR "
         f"against the repo's root commit -- no commit was detected as adding "
@@ -999,11 +924,10 @@ def fetch_url(url: str) -> bytes | None:
 def extract_tarball(data: bytes, dest: pathlib.Path) -> None:
     """Safe-extract a gzipped tar archive into `dest`.
 
-    Prefers `tarfile.extractall(filter='data')` (Python 3.12+) to
-    block path-traversal and other unsafe member types. Falls back
-    to a manual prefix check when running on older interpreters,
-    since `runtime.python` lets teachers pin 3.10 / 3.11 and the
-    container path inherits whatever python the image ships.
+    Prefers `tarfile.extractall(filter='data')` (Python 3.12+) to block
+    path-traversal and unsafe member types. Falls back to a manual prefix
+    check on older interpreters, since `runtime.python` lets teachers pin
+    3.10/3.11 and the container path inherits the image's python.
     """
     dest.mkdir(parents=True, exist_ok=True)
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
@@ -1014,13 +938,11 @@ def extract_tarball(data: bytes, dest: pathlib.Path) -> None:
 
 
 def _safe_extractall_legacy(tar: tarfile.TarFile, dest: pathlib.Path) -> None:
-    """Path-traversal-safe extraction for Python < 3.12.
-
-    Mirrors the rejections that `filter='data'` enforces upstream:
-    no absolute paths, no `..` segments escaping `dest`, no symlinks
-    or hard links, no device / FIFO / character-special members.
-    Sane bundles produced by `git archive` / `tar -czf` extract
-    identically on both code paths.
+    """Path-traversal-safe extraction for Python < 3.12. Mirrors the
+    rejections `filter='data'` enforces upstream: no absolute paths, no `..`
+    escaping `dest`, no symlinks/hard links, no device/FIFO/char-special
+    members. Sane bundles (git archive / tar -czf) extract identically both
+    ways.
     """
     dest_real = pathlib.Path(os.path.realpath(dest))
     for m in tar.getmembers():
@@ -1056,10 +978,10 @@ def append_outputs(github_output_path: str | None, status: str, summary: str) ->
 def append_sha_outputs(
     github_output_path: str | None, base_sha: str | None, head_sha: str
 ) -> None:
-    """Write `baseline-sha` and `head-sha` to $GITHUB_OUTPUT for the
-    Feedback PR step. `baseline-sha` is omitted (left empty) when there's
-    no usable baseline, which the workflow step treats as "skip". SHAs
-    are `[0-9a-f]{40}` so they can't inject extra output lines."""
+    """Write `baseline-sha` and `head-sha` to $GITHUB_OUTPUT for the Feedback
+    PR step. `baseline-sha` is omitted (empty) when there's no usable baseline,
+    which the step treats as "skip". SHAs are `[0-9a-f]{40}` so they can't
+    inject extra output lines."""
     if not github_output_path:
         return
     with open(github_output_path, "a") as fh:
@@ -1074,16 +996,14 @@ def now_utc() -> datetime.datetime:
 
 def commit_submitted_at(sha: str, workspace: pathlib.Path) -> datetime.datetime:
     """The SUBMISSION instant for a graded commit: its committer date, read
-    from git in the (full-depth) checkout and normalized to an aware UTC
-    datetime. This is invariant for a given commit, so re-grading the same
-    commit (a teacher regrade) reproduces the identical `datetime` in
-    result.json — the submission time and the `late` flag never move.
+    from git in the (full-depth) checkout and normalized to aware UTC. Invariant
+    for a given commit, so re-grading it reproduces the identical `datetime` in
+    result.json — the submission time and `late` flag never move.
 
-    Falls back to now_utc() when the SHA is empty or git can't read the
-    committer date (shallow clone, detached state, git error): lateness is
-    advisory and a regrade must never fail or drop a submission over an
-    unreadable timestamp. The fallback only affects a freshly-graded commit
-    whose date couldn't be read; a normal full-depth checkout always resolves.
+    Falls back to now_utc() when the SHA is empty or git can't read the committer
+    date (shallow clone, detached state, git error): lateness is advisory and a
+    regrade must never fail or drop a submission over an unreadable timestamp. A
+    normal full-depth checkout always resolves.
     """
     if not sha:
         return now_utc()
@@ -1117,10 +1037,10 @@ def commit_submitted_at(sha: str, workspace: pathlib.Path) -> datetime.datetime:
 
 def mode_is_group(mode: str | None) -> bool:
     """True only when the assignment mode is exactly 'group' (case- and
-    whitespace-insensitive). Anything else — including None, '', or an
-    unrecognized value — is treated as individual, so a missing/typo'd
-    MODE env can never loosen validation (it can only require the stricter
-    individual `assignment_type`). Mirrors the setup job's mode normalization."""
+    whitespace-insensitive). Anything else — None, '', or unrecognized — is
+    individual, so a missing/typo'd MODE env can never loosen validation (only
+    require the stricter individual `assignment_type`). Mirrors the setup job's
+    mode normalization."""
     return (mode or "").strip().lower() == "group"
 
 
@@ -1130,10 +1050,10 @@ def mode_is_group(mode: str | None) -> bool:
 
 
 class Finalizer:
-    """Synthesizes a v1 result.json + release body + GITHUB_OUTPUT
-    entries on any error path. The runner calls `.error(message)`
-    instead of returning a non-zero exit code so the workflow's
-    downstream publish step still gets something to upload."""
+    """Synthesizes a v1 result.json + release body + GITHUB_OUTPUT entries on
+    any error path. The runner calls `.error(message)` instead of returning a
+    non-zero exit code so the downstream publish step still has something to
+    upload."""
 
     def __init__(
         self,
@@ -1162,9 +1082,9 @@ class Finalizer:
         self.review_link = review_link
         self.submitted_by = submitted_by
         self.assignment_type = assignment_type
-        # The graded commit's committer date — the invariant submission
-        # instant written as `datetime`. Defaults to now only when a caller
-        # didn't resolve it (keeps older call sites / tests working).
+        # The graded commit's committer date — the invariant submission instant
+        # written as `datetime`. Defaults to now only when a caller didn't
+        # resolve it (keeps older call sites / tests working).
         self.submitted_at = submitted_at or now_utc()
 
     def error(self, message: str) -> int:
@@ -1190,13 +1110,11 @@ class Finalizer:
         return 0
 
     def no_autograder(self) -> int:
-        """Vacuous-pass synthesis for classrooms that haven't configured
-        an autograder yet. Distinct from `error()` because "no autograder
-        configured" is a valid mid-setup state, not a failure: the
-        student still submitted, the workflow still tagged, and the
-        gradebook should record the submission as 0/0 success rather
-        than as an error. Reuses derive_status_and_summary's empty-tests
-        branch so the framing stays in lockstep."""
+        """Vacuous-pass synthesis for classrooms with no autograder configured
+        yet. Distinct from `error()` because "no autograder configured" is a
+        valid mid-setup state, not a failure: the student submitted, the
+        workflow tagged, and the gradebook records 0/0 success rather than an
+        error. Reuses derive_status_and_summary's empty-tests branch."""
         result = empty_result(
             classroom=self.classroom,
             assignment=self.assignment,
@@ -1221,35 +1139,33 @@ class Finalizer:
 # Declarative test grading (GitHub Classroom-style io / run / python tests)
 # ---------------------------------------------------------------------------
 #
-# Grades a bundled tests.json with a built-in interpreter. The specs are
-# DATA, never code: `run`/`setup` strings are teacher-authored shell,
-# executed in the student checkout at the same privilege as an
-# autograder.py. They arrive via the Pages bundle — never interpolated
-# into workflow YAML — and students can't edit assignments.json. The
-# interpreter re-validates spec shape because the file is hand-editable.
-# Write-time validator: tests.go; trust-boundary rationale: the
-# Autograders wiki page.
+# Grades a bundled tests.json with a built-in interpreter. The specs are DATA,
+# never code: `run`/`setup` strings are teacher-authored shell, executed in the
+# student checkout at the same privilege as an autograder.py. They arrive via
+# the Pages bundle — never interpolated into workflow YAML — and students can't
+# edit assignments.json. The interpreter re-validates spec shape because the
+# file is hand-editable. Write-time validator: tests.go; trust-boundary
+# rationale: the Autograders wiki page.
 
 
 class TestsConfigError(Exception):
-    """Raised when tests.json is missing, malformed, or fails the
-    runtime re-validation. Surfaced to the workflow via Finalizer.error."""
+    """tests.json is missing, malformed, or fails runtime re-validation.
+    Surfaced to the workflow via Finalizer.error."""
 
 
 class TestFixtureError(Exception):
-    """Raised when a test references an input-file/expected-file that is
-    missing or escapes the bundle directory."""
+    """A test references an input-file/expected-file that is missing or escapes
+    the bundle directory."""
 
 
 def compare_output(actual: str, expected: str, mode: str) -> bool:
     """Compare program stdout against expected output, GitHub Classroom-style.
 
     - included: expected appears anywhere in actual (raw substring).
-    - exact: actual equals expected, ignoring leading/trailing whitespace
-      (the trailing-newline footgun otherwise fails almost every test).
-    - regex: Python `re.search` with re.MULTILINE (so ^/$ anchor at line
-      boundaries in multi-line output). Raises re.error on a malformed
-      pattern so the caller can report it as a failing test.
+    - exact: equal ignoring leading/trailing whitespace (the trailing-newline
+      footgun otherwise fails almost every test).
+    - regex: `re.search` with re.MULTILINE (^/$ anchor at line boundaries).
+      Raises re.error on a bad pattern so the caller reports a failing test.
     """
     if mode == COMPARISON_INCLUDED:
         return expected in actual
@@ -1269,9 +1185,9 @@ def _clip(text: str | None) -> str:
 
 
 def _fence(text: str) -> str:
-    """A backtick fence longer than any backtick run inside `text`, so
-    student output containing ``` can't break out of the code block and
-    inject Markdown into the release body."""
+    """A backtick fence longer than any backtick run inside `text`, so student
+    output containing ``` can't break out of the code block and inject Markdown
+    into the release body."""
     longest = max((len(m.group(0)) for m in re.finditer(r"`+", text)), default=0)
     return "`" * max(3, longest + 1)
 
@@ -1292,9 +1208,9 @@ def _make_outcome(name: str, points: int, passed: bool, detail: str,
 
 
 def _read_fixture(rel: str, fixtures_dir: pathlib.Path) -> str:
-    """Read a bundled fixture file, rejecting any path that escapes the
-    bundle directory (a hand-edited expected-file: '../../etc/passwd'
-    must not be readable)."""
+    """Read a bundled fixture file, rejecting any path that escapes the bundle
+    directory (a hand-edited expected-file '../../etc/passwd' must not be
+    readable)."""
     base = pathlib.Path(os.path.realpath(fixtures_dir))
     target = pathlib.Path(os.path.realpath(base / rel))
     if target != base and base not in target.parents:
@@ -1307,7 +1223,7 @@ def _read_fixture(rel: str, fixtures_dir: pathlib.Path) -> str:
 def _resolve_stdin(spec: dict[str, Any], fixtures_dir: pathlib.Path) -> str:
     """stdin for an io test: the bundled input-file if set, else the inline
     `input`, else empty (always a string so the child never inherits the
-    parent's stdin and hangs waiting on a terminal)."""
+    parent's stdin and hangs on a terminal)."""
     if spec.get("input-file"):
         return _read_fixture(spec["input-file"], fixtures_dir)
     return spec.get("input") or ""
@@ -1321,8 +1237,8 @@ def _resolve_expected(spec: dict[str, Any], fixtures_dir: pathlib.Path) -> str:
 
 def _run_command(command: str, cwd: pathlib.Path, timeout: int,
                  stdin: str = "") -> subprocess.CompletedProcess[str]:
-    """Run a shell command in the student checkout with captured text
-    output and an empty-by-default stdin."""
+    """Run a shell command in the student checkout with captured text output
+    and an empty-by-default stdin."""
     return subprocess.run(
         command,
         shell=True,
@@ -1337,8 +1253,8 @@ def _run_command(command: str, cwd: pathlib.Path, timeout: int,
 
 
 def _run_setup(setup: str, cwd: pathlib.Path, timeout: int) -> str | None:
-    """Run a test's setup command. Returns an error string if it times out
-    or exits non-zero, else None."""
+    """Run a test's setup command. Returns an error string if it times out or
+    exits non-zero, else None."""
     try:
         sp = _run_command(setup, cwd, timeout)
     except subprocess.TimeoutExpired:
@@ -1352,14 +1268,14 @@ def _run_setup(setup: str, cwd: pathlib.Path, timeout: int) -> str | None:
 
 def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
                   points: int, name: str) -> dict[str, Any]:
-    """Run a pytest command and split `points` across discovered cases
-    (GitHub Classroom's points/num_tests model), reading pytest-json-report
-    output. Falls back to exit-code scoring (all-or-nothing) when no JSON
-    report is produced -- e.g. the plugin isn't installed."""
+    """Run a pytest command and split `points` across discovered cases (GitHub
+    Classroom's points/num_tests model) via pytest-json-report. Falls back to
+    all-or-nothing exit-code scoring when no JSON report is produced (e.g. the
+    plugin isn't installed)."""
     report_dir = pathlib.Path(tempfile.mkdtemp(prefix="classroom50-pytest-"))
     report = report_dir / "report.json"
-    # Skip appending when the teacher's command already configures the
-    # plugin (duplicate flags would make pytest exit with a usage error).
+    # Skip appending when the teacher's command already configures the plugin
+    # (duplicate flags make pytest exit with a usage error).
     if "--json-report" in spec["run"]:
         cmd = spec["run"]
     else:
@@ -1387,9 +1303,9 @@ def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
     if total_n:
         score = max(0, min(points, round(points * passed_n / total_n)))
         passed = passed_n == total_n
-        # Full credit is reserved for an all-pass run: with small point
-        # values, round() could otherwise award points/points to a test
-        # whose row reads FAIL (e.g. points=1, 2/3 cases passed).
+        # Full credit is reserved for an all-pass run: with small point values
+        # round() could otherwise award points/points to a FAIL row (e.g.
+        # points=1, 2/3 cases passed).
         if not passed:
             score = min(score, max(0, points - 1))
         detail = f"pytest: {passed_n}/{total_n} cases passed"
@@ -1408,9 +1324,9 @@ def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
 
 def execute_test(spec: dict[str, Any], *, cwd: pathlib.Path,
                  fixtures_dir: pathlib.Path) -> dict[str, Any]:
-    """Run one declarative test and return its outcome dict. Never raises
-    for a test failure -- a timeout, crash, bad fixture, or bad regex all
-    map to a failing outcome with a diagnostic `detail`."""
+    """Run one declarative test and return its outcome dict. Never raises for a
+    test failure -- a timeout, crash, bad fixture, or bad regex all map to a
+    failing outcome with a diagnostic `detail`."""
     name = spec["name"]
     points = int(spec.get("points") or 0)
     ttype = spec["type"]
@@ -1466,8 +1382,8 @@ def execute_test(spec: dict[str, Any], *, cwd: pathlib.Path,
 
 
 def _validate_test_spec(t: Any) -> str | None:
-    """Re-validate one spec at grade time — a lower bar than tests.go
-    that keeps a hand-edited assignments.json from crashing the grader."""
+    """Re-validate one spec at grade time — a lower bar than tests.go that
+    keeps a hand-edited assignments.json from crashing the grader."""
     if not isinstance(t, dict):
         return "not an object"
     name = t.get("name")
@@ -1483,9 +1399,8 @@ def _validate_test_spec(t: Any) -> str | None:
     timeout = t.get("timeout", 0)
     if isinstance(timeout, bool) or not isinstance(timeout, int) or timeout < 0 or timeout > 600:
         return "timeout must be an integer between 0 and 600"
-    # Type-check the optional string fields execute_test consumes, so a
-    # malformed tests.json fails with a clear message instead of a
-    # mid-run TypeError.
+    # Type-check the optional string fields execute_test consumes so a malformed
+    # tests.json fails with a clear message, not a mid-run TypeError.
     for key in ("setup", "input", "input-file", "expected", "expected-file"):
         v = t.get(key)
         if v is not None and not isinstance(v, str):
@@ -1516,8 +1431,8 @@ def load_tests(path: pathlib.Path) -> list[dict[str, Any]]:
         err = _validate_test_spec(t)
         if err:
             raise TestsConfigError(f"{TESTS_FILENAME} tests[{i}]: {err}")
-        # Names are row identities in result.json; duplicates would make
-        # the gradebook ambiguous.
+        # Names are row identities in result.json; duplicates make the
+        # gradebook ambiguous.
         if t["name"] in seen:
             raise TestsConfigError(f"{TESTS_FILENAME} tests[{i}]: duplicate test name {t['name']!r}")
         seen.add(t["name"])
@@ -1526,9 +1441,9 @@ def load_tests(path: pathlib.Path) -> list[dict[str, Any]]:
 
 def render_declarative_body(result: dict[str, Any], outcomes: list[dict[str, Any]],
                             summary: str) -> str:
-    """Release-body Markdown for a declaratively-graded submission: the
-    score line, a per-test table, and a collapsible failure-detail section
-    with captured output for any failing test."""
+    """Release-body Markdown for a declaratively-graded submission: the score
+    line, a per-test table, and a collapsible failure-detail section with
+    captured output for any failing test."""
     lines = [f"### classroom50 autograde: {result['score']}/{result['max-score']}", ""]
     lines.append("| Test | Result | Score |")
     lines.append("|---|---|---|")
@@ -1613,9 +1528,9 @@ def run_declarative(tests_path: pathlib.Path, finalize: Finalizer,
                     fixtures_dir: pathlib.Path) -> int:
     """Grade a per-assignment tests.json: load + re-validate, run each test,
     then write result.json / release-body.md / GITHUB_OUTPUT. A malformed
-    tests.json routes through Finalizer.error so the submission still
-    publishes as 'submitted, error'. Always returns 0 -- a grading outcome
-    (even all-fail) never fails the runner."""
+    tests.json routes through Finalizer.error so the submission still publishes
+    as 'submitted, error'. Always returns 0 -- a grading outcome (even all-fail)
+    never fails the runner."""
     try:
         tests = load_tests(tests_path)
     except (json.JSONDecodeError, TestsConfigError, OSError) as exc:
@@ -1635,10 +1550,9 @@ def run_declarative(tests_path: pathlib.Path, finalize: Finalizer,
         assignment_type=finalize.assignment_type,
         submitted_at=finalize.submitted_at,
     )
-    # Backstop: execute_test/load_tests handle the expected failures; the
-    # broad catch guarantees the "grading outcomes always exit 0"
-    # invariant — an unexpected exception becomes a published error
-    # result, never an uncaught crash.
+    # Backstop: execute_test/load_tests handle expected failures; the broad
+    # catch guarantees the "grading outcomes always exit 0" invariant — an
+    # unexpected exception becomes a published error result, never a crash.
     try:
         result, outcomes = grader.grade(tests)
     except Exception as exc:  # noqa: BLE001 - grading must never crash the runner
@@ -1663,20 +1577,19 @@ def run_declarative(tests_path: pathlib.Path, finalize: Finalizer,
 
 
 # ---------------------------------------------------------------------------
-# Pipeline stages (called in order by main(); each is a named step so the
-# top-level flow reads as a narrative and the precedence/early-exit rules
-# are explicit). They call the module-level fetch_url / subprocess.run so
-# the test harness's monkeypatches still apply.
+# Pipeline stages (called in order by main(); each a named step so the flow
+# reads as a narrative with explicit precedence/early-exit). They call the
+# module-level fetch_url / subprocess.run so the test harness's monkeypatches
+# still apply.
 # ---------------------------------------------------------------------------
 
 
 def fetch_bundle(finalize: Finalizer, *, pages_base_url: str, classroom: str,
                  assignment: str, runtime_dir: pathlib.Path, secret: str = "") -> int | None:
     """Download the per-assignment bundle from Pages and extract it into
-    `runtime_dir`. A 404 means "no per-assignment override" — fine, the
-    entrypoint resolver falls through to the classroom default. Returns an
-    rc (already finalized as an error) on a hard fetch/extract failure, or
-    None to continue."""
+    `runtime_dir`. A 404 means "no per-assignment override" — fine, the resolver
+    falls through to the classroom default. Returns an rc (already finalized as
+    an error) on a hard fetch/extract failure, or None to continue."""
     burl = bundle_url(pages_base_url, classroom, assignment, secret)
     print(f"runner: fetching bundle {burl}")
     try:
@@ -1702,20 +1615,18 @@ def resolve_entrypoint(
         > per-assignment tests.json (declarative, graded in-process)
         > classroom default autograder.py
         > vacuous pass.
-    A hand-written per-assignment autograder.py wins over declarative tests
-    for the same slug (it's the escape hatch).
+    A hand-written per-assignment autograder.py wins over declarative tests for
+    the same slug (it's the escape hatch).
 
     Returns exactly one of two shapes (never both-set, never both-None):
       (entrypoint, None)  — a Python entrypoint to exec; main() continues.
-      (None, rc)          — the step is already TERMINAL and rc is main()'s
-                            return value: the declarative grader ran
-                            (run_declarative), nothing was configured
-                            (no_autograder), or the default fetch failed
-                            (error).
-    A missing autograder is NOT an error: "no autograder configured" is a
-    valid mid-setup state, so finalize.no_autograder() synthesizes a
-    vacuous-pass (0/0 success) result and the gradebook records the
-    submission rather than dropping it.
+      (None, rc)          — the step is TERMINAL and rc is main()'s return
+                            value: declarative grader ran (run_declarative),
+                            nothing configured (no_autograder), or the default
+                            fetch failed (error).
+    A missing autograder is NOT an error: "no autograder configured" is a valid
+    mid-setup state, so finalize.no_autograder() synthesizes a vacuous-pass
+    (0/0 success) and the gradebook records the submission.
     """
     per_assignment = runtime_dir / assignment / ENTRYPOINT_FILENAME
     per_assignment_tests = runtime_dir / assignment / TESTS_FILENAME
@@ -1736,8 +1647,8 @@ def resolve_entrypoint(
     except (urllib.error.HTTPError, urllib.error.URLError, ValueError) as exc:
         return None, finalize.error(f"classroom default {ENTRYPOINT_FILENAME} fetch failed: {exc}")
     if content is None:
-        # "No autograder configured" is a valid mid-setup state, not an
-        # error: synthesize a vacuous-pass result (0/0 success).
+        # "No autograder configured" is a valid mid-setup state, not an error:
+        # synthesize a vacuous-pass result (0/0 success).
         return None, finalize.no_autograder()
     entrypoint = runtime_dir / ENTRYPOINT_FILENAME
     entrypoint.write_bytes(content)
@@ -1748,13 +1659,13 @@ def resolve_entrypoint(
 def run_entrypoint(
     finalize: Finalizer, entrypoint: pathlib.Path, workspace: pathlib.Path,
 ) -> int | None:
-    """Exec the entrypoint with the helper env vars and cwd at the
-    student's checkout. Returns an rc (already finalized as an error) on a
-    failed invocation or a non-zero autograder exit, else None to continue.
+    """Exec the entrypoint with the helper env vars and cwd at the student's
+    checkout. Returns an rc (already finalized as an error) on a failed
+    invocation or a non-zero autograder exit, else None to continue.
 
-    The USERNAME / *_URL helper env vars are read off `finalize` (the
-    identity carrier), matching how run_declarative pulls them, rather than
-    re-threading them through the signature."""
+    The USERNAME / *_URL helper env vars are read off `finalize` (the identity
+    carrier), matching run_declarative, rather than re-threading them through
+    the signature."""
     env = dict(os.environ)
     env["USERNAME"] = finalize.username
     env["OWNER"] = finalize.username
@@ -1777,12 +1688,11 @@ def run_entrypoint(
 
 
 def finalize_result(finalize: Finalizer, *, is_group: bool) -> int:
-    """Read + validate the autograder's result.json, then synthesize the
-    release body and status/summary outputs the autograder didn't write.
-    Returns the runner's exit code (0 on success; an error rc when the
-    result is missing/malformed/invalid). Identity/paths are read off
-    `finalize`; `is_group` is the one stage-local input (it drives the
-    `assignment_type` check in validate_result)."""
+    """Read + validate the autograder's result.json, then synthesize the release
+    body and status/summary outputs it didn't write. Returns the runner's exit
+    code (0 on success; an error rc when the result is missing/malformed/invalid).
+    Identity/paths are read off `finalize`; `is_group` is the one stage-local
+    input (it drives the `assignment_type` check in validate_result)."""
     workspace = finalize.workspace
     github_output = finalize.github_output
     result_path = workspace / RESULT_FILENAME
@@ -1793,26 +1703,23 @@ def finalize_result(finalize: Finalizer, *, is_group: bool) -> int:
     except json.JSONDecodeError as exc:
         return finalize.error(f"{RESULT_FILENAME} is not valid JSON: {exc}")
 
-    # Stamp the runner-authoritative identity fields BEFORE validation. A
-    # custom autograder builds its own result.json and can't be trusted to
-    # set `owner` (the repo owner) or `assignment_type` (the mode) — the
-    # runner knows both. Overwrite rather than trust the autograder so a
-    # student-influenced result.json can't claim a different owner/type.
+    # Stamp the runner-authoritative identity fields BEFORE validation. A custom
+    # autograder builds its own result.json and can't be trusted to set `owner`
+    # (repo owner) or `assignment_type` (mode) — the runner knows both. Overwrite
+    # so a student-influenced result.json can't claim a different owner/type.
     if isinstance(result, dict):
         result["owner"] = finalize.username
         result["assignment_type"] = finalize.assignment_type
         # Submission instant is runner-authoritative: the graded commit's
         # committer date, invariant across regrades and not student-influenced.
-        # Overwrite any autograder-written `datetime` so a custom result.json
-        # can't move its own `late` flag or its submission time. `graded_at`
-        # (this run's wall clock) is stamped fresh on every (re)grade.
+        # Overwrite any autograder-written `datetime`. `graded_at` (this run's
+        # wall clock) is stamped fresh on every (re)grade.
         result["datetime"] = finalize.submitted_at.strftime("%Y-%m-%dT%H:%M:%SZ")
         result["graded_at"] = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
         # The actual pusher (GITHUB_ACTOR), also runner-authoritative. Stamp
-        # unconditionally: set it when known, and DROP any autograder-written
-        # `submitted_by` when the runner couldn't resolve the actor — never
-        # let a custom result.json's self-asserted pusher survive (it is
-        # student-influenced and would forge `submitted_by`).
+        # unconditionally: set it when known, DROP any autograder-written
+        # `submitted_by` when the actor couldn't be resolved — never let a
+        # custom result.json's self-asserted (student-influenced) pusher survive.
         if finalize.submitted_by is not None:
             result["submitted_by"] = finalize.submitted_by
         else:
@@ -1849,8 +1756,8 @@ def finalize_result(finalize: Finalizer, *, is_group: bool) -> int:
 
 def detect_acceptance_mode() -> int:
     """`runner.py --detect-acceptance`: write is-acceptance=true|false to
-    $GITHUB_OUTPUT for the setup job's skip gate. Always exits 0; fails
-    open (False) on any uncertainty.
+    $GITHUB_OUTPUT for the setup job's skip gate. Always exits 0; fails open
+    (False) on any uncertainty.
     """
     workspace = pathlib.Path.cwd()
     head_sha = os.environ.get("GITHUB_SHA", "").strip()
@@ -1885,10 +1792,10 @@ def main() -> int:
         )
         return 1
 
-    # Optional capability-URL secret (set by the workflow from the student
-    # repo's .classroom50.yaml). Present -> resources at <classroom>/<secret>/;
-    # absent -> plain path. The setup job already validates it; re-check here
-    # as defense-in-depth since it composes into a URL.
+    # Optional capability-URL secret (from the student repo's .classroom50.yaml).
+    # Present -> resources at <classroom>/<secret>/; absent -> plain path. The
+    # setup job validates it; re-check here as defense-in-depth since it composes
+    # into a URL.
     secret = os.environ.get("SECRET", "").strip()
     if secret and not re.fullmatch(r"[a-z0-9]{4,64}", secret):
         print(
@@ -1902,11 +1809,9 @@ def main() -> int:
     sha = os.environ.get("GITHUB_SHA", "")
     server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
     actor = os.environ.get("GITHUB_ACTOR", "")
-    # Assignment mode flows from assignments.json (config repo) via the
-    # setup job's `mode` output. Unknown/missing defaults to individual —
-    # the stricter `assignment_type` — so a missing env can't loosen
-    # validation. Drives the assignment_type check below; adds no
-    # student-repo state.
+    # Assignment mode flows from assignments.json via the setup job's `mode`
+    # output. Unknown/missing defaults to individual (the stricter
+    # `assignment_type`) so a missing env can't loosen validation.
     is_group = mode_is_group(os.environ.get("MODE"))
     github_output = os.environ.get("GITHUB_OUTPUT")
     workspace = pathlib.Path.cwd()
@@ -1914,37 +1819,33 @@ def main() -> int:
     username = username_from_repo(repository, classroom, assignment, actor)
     commit_link = commit_url(server_url, repository, sha)
     release_link = release_url(server_url, repository, submission)
-    # The submission instant is the graded commit's committer date — stable
-    # across regrades, so re-running grading on the same commit never moves the
-    # `datetime`/`late` in the gradebook (the regrade only refreshes the score).
+    # Submission instant is the graded commit's committer date — stable across
+    # regrades, so re-grading the same commit never moves `datetime`/`late`.
     submitted_at = commit_submitted_at(sha, workspace)
-    # Resolve the baseline once: both the review-compare link and the
-    # Feedback PR gate need it, and the scan issues several sequential
-    # git calls, so a second walk would double the worst-case time
-    # against the grade job's 15-minute ceiling.
+    # Resolve the baseline once: both the review-compare link and the Feedback
+    # PR gate need it, and the scan issues several sequential git calls, so a
+    # second walk would double the worst-case time against the 15-min ceiling.
     baseline_scan = _baseline_scan(workspace)
     base_sha = baseline_scan[0]
     review_link = review_url(server_url, repository, base_sha, sha)
     if base_sha is None:
         print("runner: no baseline commit found; review link falls back to the commit view")
 
-    # Hand the baseline + graded SHAs to the workflow so the post-grade
-    # step can open/refresh the Feedback PR without recomputing git
-    # state. Emitted unconditionally and early so the step runs even
-    # when grading fails (teachers review failing work too). The step
-    # itself is the gate: it opens the PR only when the assignment opted
-    # in (feedback-pr) and there's a diff (baseline-sha != head-sha).
-    # The base is the accept commit when detected, else the root commit:
-    # a root fallback still opens the PR but warns it's UNTRUSTED; only
-    # an unresolvable baseline (git unreadable / not a repo) skips.
+    # Hand the baseline + graded SHAs to the workflow so the post-grade step can
+    # open/refresh the Feedback PR without recomputing git state. Emitted
+    # unconditionally and early so the step runs even when grading fails
+    # (teachers review failing work too). The step is the gate: it opens the PR
+    # only when the assignment opted in (feedback-pr) and there's a diff. The
+    # base is the accept commit when detected, else the root commit: a root
+    # fallback still opens the PR but warns it's UNTRUSTED; only an unresolvable
+    # baseline (git unreadable / not a repo) skips.
     fb_base_sha, fb_source = feedback_base_outcome(workspace, baseline_scan)
     append_sha_outputs(github_output, fb_base_sha, sha)
     if fb_source == SOURCE_ROOT:
         print(untrusted_baseline_warning())
     elif fb_base_sha is None:
-        # No baseline -> the step skips. Visible annotation (not a plain
-        # log) so a skipped Feedback PR is diagnosable. A warning, not an
-        # error: the step is opt-in.
+        # No baseline -> the step skips. Visible annotation (not a plain log) so
+        # a skipped Feedback PR is diagnosable. A warning, not an error: opt-in.
         print(no_baseline_warning(fb_source))
 
     print(
@@ -1977,12 +1878,10 @@ def main() -> int:
         if f.exists():
             f.unlink()
 
-    # Enforce allowed_files before grading: remove disallowed
-    # files so the autograder only sees allowed ones. Fails open — if the
-    # matcher can't run, enforce_allowed_files returns [] and grading
-    # proceeds on the unfiltered tree (see its docstring for how to flip to
-    # fail-closed via finalize.error here). The removed list is appended to
-    # release-body.md on every exit path below.
+    # Enforce allowed_files before grading so the autograder only sees allowed
+    # files. Fails open — if the matcher can't run, returns [] and grading
+    # proceeds on the unfiltered tree (see its docstring to flip to fail-closed).
+    # The removed list is appended to release-body.md on every exit path below.
     removed_files = enforce_allowed_files(workspace, parse_allowed_files(os.environ.get("ALLOWED_FILES")))
 
     def _grade() -> int:

--- a/cli/gh-teacher/skeleton_tests/conftest.py
+++ b/cli/gh-teacher/skeleton_tests/conftest.py
@@ -1,18 +1,16 @@
 """Loads the embedded publish/collect-time scripts for the test suite.
 
-These scripts live under `cli/gh-teacher/skeleton/dotgithub/scripts/`
-because `gh teacher init` embeds them at `.github/scripts/` in each org's
-`classroom50` repo:
+These live under `cli/gh-teacher/skeleton/dotgithub/scripts/` because `gh
+teacher init` embeds them at `.github/scripts/` in each org's `classroom50`
+repo:
 
   - collect_scores.py    — score collector (collect-scores.yaml)
-  - regrade_repos.py     — regrade fan-out: re-tags student repos so the
-                           autograder re-runs (regrade.yaml)
+  - regrade_repos.py     — regrade fan-out (regrade.yaml)
   - materialize_tests.py — translates assignments.json `tests` blocks into
                            per-assignment tests.json bundles (publish-pages.yaml)
   - probe_token.py       — service-token scope probe (probe-token.yaml)
 
-Importing via `importlib` keeps the embedded path canonical — no second
-copy to keep in sync.
+Importing via `importlib` keeps the embedded path canonical — no second copy.
 """
 
 from __future__ import annotations

--- a/cli/gh-teacher/skeleton_tests/test_artifact_schemas.py
+++ b/cli/gh-teacher/skeleton_tests/test_artifact_schemas.py
@@ -1,19 +1,18 @@
 """Keeps the result/scores/tests/classroom JSON Schemas honest.
 
-Companion to test_assignments_schema.py. These schemas exist so non-CLI
-clients (the GUI) can validate the artifacts the system produces without
-hand-porting the Go/Python validators. Two kinds of check here:
+Companion to test_assignments_schema.py. These schemas let non-CLI clients
+(the GUI) validate the artifacts the system produces without hand-porting the
+Go/Python validators. Two kinds of check:
 
-  1. Accepts/rejects: pin each schema against real emitted shapes and
-     against malformed ones, so schema drift fails CI rather than
-     surfacing as a GUI/CLI disagreement.
-  2. Cross-validator parity: feed a table of result.json payloads through
-     BOTH the result-v1 schema and the authoritative Python validators
-     (runner.py / collect_scores.py validate_result) and assert they
-     agree on the rules the schema CAN express. Rules JSON Schema cannot
-     express (identity match, mode-dependent assignment_type, owner
-     identity match, score<=max-score cross-field) are enumerated below
-     and excluded from the parity assertion — the code validators own them.
+  1. Accepts/rejects: pin each schema against real emitted shapes and malformed
+     ones, so schema drift fails CI rather than surfacing as a GUI/CLI
+     disagreement.
+  2. Cross-validator parity: feed result.json payloads through BOTH the
+     result-v1 schema and the authoritative Python validators (runner.py /
+     collect_scores.py validate_result) and assert they agree on rules the
+     schema CAN express. Rules JSON Schema can't express (identity match,
+     mode-dependent assignment_type, owner match, score<=max-score) are
+     enumerated below and excluded — the code validators own them.
 """
 
 from __future__ import annotations
@@ -24,18 +23,17 @@ import pathlib
 import pytest
 from jsonschema import Draft202012Validator
 
-# Reuse conftest's importlib loader (the established skeleton_tests
-# pattern — see test_materialize_tests.py) rather than re-implementing it.
-# collect_scores is exposed directly; runner.py is loaded on demand because
-# this suite (collect/materialize/schema) doesn't import it by default.
+# Reuse conftest's importlib loader (the established skeleton_tests pattern)
+# rather than re-implementing it. collect_scores is exposed directly; runner.py
+# is loaded on demand since this suite doesn't import it by default.
 from conftest import _SCRIPTS_DIR, _load_module
 from conftest import collect_scores as cs
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 _SCHEMAS = _REPO_ROOT / "schemas"
 
-# runner.py isn't loaded by skeleton_tests/conftest (that suite is
-# collect/materialize), so load it here for the result-validator parity.
+# runner.py isn't loaded by skeleton_tests/conftest, so load it here for the
+# result-validator parity.
 runner = _load_module("runner", _SCRIPTS_DIR / "runner.py")
 
 
@@ -143,23 +141,19 @@ class TestResultSchema:
 # --- result/v1 cross-validator parity ---------------------------------------
 #
 # The schema and the code validators (runner.py / collect_scores.py
-# validate_result) must agree on the rules BOTH layers check. Two classes
-# of rule are deliberately EXCLUDED from the equality assertion:
+# validate_result) must agree on the rules BOTH layers check. Two classes of
+# rule are deliberately EXCLUDED from the equality assertion:
 #
-#   1. Rules the schema cannot express (the code validators own them):
-#      - identity match (classroom/assignment/owner vs the source repo)
-#      - mode-dependent assignment_type (individual vs group must match the run)
-#      - score <= max-score and per-test score <= max-score (cross-field)
+#   1. Rules the schema can't express (the code validators own them):
+#      identity match; mode-dependent assignment_type; score <= max-score and
+#      per-test score <= max-score.
 #   2. Rules the schema expresses MORE STRICTLY than the code validators
-#      (the schema is the canonical closed form; the code validators are
-#      deliberately lenient on these):
-#      - additionalProperties:false (code tolerates unknown top-level keys)
-#      - the exact UTC datetime pattern (code only requires a non-empty string)
-#      These are asserted explicitly in test_schema_stricter_than_code below,
-#      NOT folded into the equality table (which would make it fail).
+#      (schema is the canonical closed form; the code is deliberately lenient):
+#      additionalProperties:false; the exact UTC datetime pattern. Asserted in
+#      test_schema_stricter_than_code, NOT folded into the equality table.
 #
-# The parity table therefore keeps identity + scores valid, no extra keys,
-# and a canonical datetime, varying only rules both layers should agree on.
+# So the parity table keeps identity + scores valid, no extra keys, and a
+# canonical datetime, varying only rules both layers should agree on.
 
 _PARITY_CLASSROOM = "cs-principles"
 _PARITY_ASSIGNMENT = "hello"

--- a/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
+++ b/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
@@ -1,10 +1,9 @@
 """Keeps schemas/assignments-v1.schema.json honest.
 
-The JSON Schema exists so non-CLI clients (the GUI) can validate
-assignments.json writes without hand-porting the Go validators. These
-tests pin it against the same shapes the Go suite pins, including the
-example kit's tests.json, so schema drift fails CI rather than
-surfacing as a GUI/CLI disagreement.
+The JSON Schema lets non-CLI clients (the GUI) validate assignments.json writes
+without hand-porting the Go validators. These tests pin it against the same
+shapes the Go suite pins, including the example kit's tests.json, so schema
+drift fails CI rather than surfacing as a GUI/CLI disagreement.
 """
 
 from __future__ import annotations

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1,10 +1,9 @@
 """Pure-helper tests for `collect_scores.py`.
 
-The HTTP / GitHub-API layer is exercised end-to-end by the
-functional smoke test against a live classroom; these tests focus
-on the data-shape invariants the rest of the loop depends on:
-schema validation, override-respect, atomic write semantics, the
-roster CSV parser, and the deterministic repo-name formula.
+The HTTP / GitHub-API layer is exercised end-to-end by the functional smoke
+test against a live classroom; these focus on the data-shape invariants the
+loop depends on: schema validation, override-respect, atomic write semantics,
+the roster CSV parser, and the deterministic repo-name formula.
 """
 
 from __future__ import annotations
@@ -34,10 +33,9 @@ def make_result(
     assignment_type: str = "individual",
     **overrides,
 ) -> dict:
-    """Return a valid v1 result payload, with overrides for the targeted
-    field. Carries `owner` (== username, the identity anchor) and
-    `assignment_type`. There is no `usernames` field — who pushed is
-    `submitted_by`, who owns the repo is `owner`."""
+    """Return a valid v1 result payload, with overrides for the targeted field.
+    Carries `owner` (== username, the identity anchor) and `assignment_type`.
+    No `usernames` field — who pushed is `submitted_by`, who owns is `owner`."""
     base = {
         "schema": cs.RESULT_SCHEMA_V1,
         "classroom": classroom,
@@ -70,8 +68,8 @@ def stored_record(**kwargs) -> dict:
 def make_update(*, assignment: str = "hello", assignment_type: str = "individual", **kwargs) -> dict:
     """An apply_updates input entry: a result-shaped record carrying the
     transport hints `_assignment` (bucket slug) and `_type` (mode) that
-    apply_updates buckets on and strips on store. owner stays; the bucket
-    key `assignment` is dropped."""
+    apply_updates buckets on and strips on store. owner stays; the bucket key
+    `assignment` is dropped."""
     rec = make_result(assignment=assignment, assignment_type=assignment_type, **kwargs)
     rec.pop("assignment", None)
     rec["_assignment"] = assignment
@@ -90,10 +88,9 @@ def write_roster(path, rows: list[dict[str, str]]) -> None:
 
 
 def stub_team_members(monkeypatch, logins: list[str]) -> None:
-    """Stub the team-member listing so collect_classroom's team-driven
-    username source yields `logins` (collection is now team-driven; the
-    classroom team, not students.csv, provides the (student, assignment)
-    pairs)."""
+    """Stub the team-member listing so collect_classroom's team-driven username
+    source yields `logins` (collection is team-driven; the classroom team, not
+    students.csv, provides the pairs)."""
     monkeypatch.setattr(cs, "list_team_member_logins", lambda *a, **k: list(logins))
 
 
@@ -321,13 +318,12 @@ class TestApplyUpdates:
         assert entries[0]["member_usernames"] == ["alice", "bob"]
 
     def test_group_credited_set_shrink_warns_and_still_replaces(self, capsys):
-        # A previously-credited teammate (bob) is dropped on re-collect (e.g.
-        # he left the classroom team but is still a repo collaborator, so the
-        # team-driven crediting gate no longer includes him). The entry is
-        # still replaced in place, but the silent revocation must now surface
-        # a warning naming the dropped member so a team/CSV divergence isn't
-        # invisible. The owner-only warning in collect_classroom only covers
-        # the len==1 collapse, so a >=2 -> >=1 shrink needs this guard.
+        # A previously-credited teammate (bob) is dropped on re-collect (e.g. he
+        # left the classroom team but is still a repo collaborator). The entry is
+        # still replaced in place, but the silent revocation must surface a
+        # warning naming the dropped member. The owner-only warning in
+        # collect_classroom only covers the len==1 collapse, so a >=2 -> >=1
+        # shrink needs this guard.
         scores = {"schema": cs.SCORES_SCHEMA_V1, "assignments": {}}
         first = make_update(username="alice", assignment_type="group", score=8)
         first["member_usernames"] = ["alice", "bob", "carol"]

--- a/cli/gh-teacher/skeleton_tests/test_ensure_feedback_pr.py
+++ b/cli/gh-teacher/skeleton_tests/test_ensure_feedback_pr.py
@@ -1,15 +1,14 @@
 """Tests for ensure_feedback_pr.py — the Feedback PR maintainer the
 autograde-runner fetches from Pages (like runner.py) and runs.
 
-The script routes every GitHub call through the module-level `gh()`
-function, so these tests monkeypatch that single seam with a fake that
-dispatches on the `gh` argument tuple, then assert the (state, description,
-url) the orchestrator returns and the status it emits. This covers the
-branch matrix the former inline bash had no way to test:
-  empty base -> create + open; wrong base -> failure, no PR; no PR -> create;
-  create race lost -> re-query success; existing open -> in place;
-  closed-unmerged -> reopen (and failed-reopen -> failure, the F8 fix);
-  merged -> leave; HEAD_BRANCH lookup failure -> error status (the F3 fix).
+The script routes every GitHub call through the module-level `gh()`, so these
+tests monkeypatch that single seam with a fake that dispatches on the `gh`
+argument tuple, then assert the (state, description, url) the orchestrator
+returns and the status it emits. Covers the branch matrix the former inline bash
+couldn't test: empty base -> create + open; wrong base -> failure, no PR; no PR
+-> create; create race lost -> re-query success; existing open -> in place;
+closed-unmerged -> reopen (and failed-reopen -> failure, the F8 fix); merged ->
+leave; HEAD_BRANCH lookup failure -> error status (the F3 fix).
 """
 
 from __future__ import annotations
@@ -37,8 +36,8 @@ def _pr_list_json(number="", state="", merged=""):
 
 
 class FakeGh:
-    """A stub for efp.gh. Routes calls by a key built from the gh subcommand
-    + a few distinguishing args; returns scripted output or raises GhError.
+    """A stub for efp.gh. Routes calls by a key built from the gh subcommand +
+    a few distinguishing args; returns scripted output or raises GhError.
     Records every call for assertions.
     """
 
@@ -47,9 +46,7 @@ class FakeGh:
         self.calls: list[tuple[str, ...]] = []
 
     def _key(self, args: tuple[str, ...]) -> str:
-        # repo view / api <path> / pr list / pr create / pr reopen / pr view /
-        # label create. Use the first 2 args, plus the api path or pr number
-        # where it disambiguates.
+        # First 2 args, plus the api path or pr number where it disambiguates.
         if args[0] == "api":
             path = args[1]
             if path.startswith(f"repos/{REPO}/git/ref/heads/"):

--- a/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
+++ b/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
@@ -1,11 +1,10 @@
 """Tests for materialize_tests.py.
 
-The script reads each <classroom>/assignments.json and writes a
-<classroom>/autograders/<slug>/tests.json for every assignment that
-declares a `tests` block, so publish-pages.yaml's bundle step ships it to
-the runner. It must be slug-safe (the slug becomes a directory path) and
-forgiving (a malformed manifest warns and is skipped, never aborting the
-Pages deploy).
+Reads each <classroom>/assignments.json and writes a
+<classroom>/autograders/<slug>/tests.json for every assignment that declares a
+`tests` block, so publish-pages.yaml's bundle step ships it to the runner. Must
+be slug-safe (the slug becomes a directory path) and forgiving (a malformed
+manifest warns and is skipped, never aborting the Pages deploy).
 """
 
 from __future__ import annotations
@@ -16,8 +15,8 @@ from conftest import _load_module, _SCRIPTS_DIR
 from conftest import materialize_tests as mt
 
 # Load the grade-time runner too: materialize_tests (publish) and
-# runner.load_tests (grade) are the two halves of the tests.json contract,
-# so one test below pins that they agree.
+# runner.load_tests (grade) are the two halves of the tests.json contract, so
+# one test below pins that they agree.
 runner = _load_module("runner", _SCRIPTS_DIR / "runner.py")
 
 

--- a/cli/gh-teacher/skeleton_tests/test_probe_token.py
+++ b/cli/gh-teacher/skeleton_tests/test_probe_token.py
@@ -1,8 +1,8 @@
 """Unit tests for `probe_token.py`.
 
-The probe's transport is stubbed (monkeypatched `http_get`); these tests cover
-the per-scope check outcomes, the team-slug resolution and classroom iteration,
-the 404-team "skip as pass" behavior, and main()'s exit-code contract. The
+The probe's transport is stubbed (monkeypatched `http_get`); these cover the
+per-scope check outcomes, team-slug resolution and classroom iteration, the
+404-team "skip as pass" behavior, and main()'s exit-code contract. The
 side-effect-free promise is enforced structurally: the checks only ever call
 `http_get` (a GET), never any write helper — there is none.
 """

--- a/cli/gh-teacher/skeleton_tests/test_regrade_repos.py
+++ b/cli/gh-teacher/skeleton_tests/test_regrade_repos.py
@@ -1,10 +1,9 @@
 """Unit tests for `regrade_repos.py`.
 
-The GitHub-API transport is exercised end-to-end against a live classroom
-by the functional smoke test; these tests focus on the pure helpers and the
-per-repo decision logic (tag construction, idempotent reuse, missing-repo
-handling, hard-vs-skip error classification) and the roster/manifest loader,
-with the HTTP layer stubbed.
+The GitHub-API transport is exercised end-to-end by the functional smoke test;
+these focus on the pure helpers and per-repo decision logic (tag construction,
+idempotent reuse, missing-repo handling, hard-vs-skip error classification) and
+the roster/manifest loader, with the HTTP layer stubbed.
 """
 
 from __future__ import annotations

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -1,89 +1,82 @@
-// Package contract holds the cross-binary protocol constants shared by the
+// Package contract holds the cross-binary wire constants shared by the
 // gh-teacher and gh-student CLIs (and, by value, the Python autograde/collect
-// scripts). These are the literal wire contract: repo names, schema sentinels,
-// assignment modes, and the default autograder name. Keeping them in one place
-// replaces the per-module copies that were previously coupled only by
-// "keep in lockstep" comments — a drift here silently breaks a cross-binary
+// scripts): repo names, schema sentinels, assignment modes, the default
+// autograder name. One place replaces per-module copies coupled only by
+// "keep in lockstep" comments — drift here silently breaks a cross-binary
 // handoff with no compile error.
 //
 // Values must stay byte-identical to the Python literals in
 // cli/gh-teacher/skeleton/dotgithub/scripts/ (runner.py, collect_scores.py,
-// materialize_tests.py) and the JSON Schemas under schemas/. There is no
-// compile-time link to those: the Python skeleton_tests assert their own
-// literals independently and do not import these Go constants, so Go<->Python
-// agreement is a convention, not an enforced invariant. The Go half is pinned
-// by contract_test.go (a change-detector that fails if any literal here drifts),
-// which turns an accidental Go-side edit into a test failure even though the
-// cross-language check stays manual.
+// materialize_tests.py) and the JSON Schemas under schemas/. Nothing links
+// them at compile time — Python's skeleton_tests assert their own copies and
+// don't import these constants — so Go<->Python agreement is convention, not
+// enforced. contract_test.go pins the Go half: a Go-side edit fails a test,
+// but the cross-language check stays manual.
 package contract
 
 const (
 	// ConfigRepoName is the per-org classroom config repo. Hardcoded across
-	// student repos and the collect-scores workflow — part of the public
-	// contract.
+	// student repos and the collect-scores workflow — part of the public contract.
 	ConfigRepoName = "classroom50"
 
 	// AssignmentsSchemaV1 is the schema sentinel for <classroom>/assignments.json.
 	AssignmentsSchemaV1 = "classroom50/assignments/v1"
 
-	// DefaultAutograderName is the universal-shim autograder name; it resolves
-	// to the shim embedded in gh-student rather than a per-classroom override.
+	// DefaultAutograderName is the universal-shim autograder name; resolves to
+	// the shim embedded in gh-student, not a per-classroom override.
 	DefaultAutograderName = "default"
 
-	// ModeIndividual and ModeGroup are the assignment modes. Individual = one
+	// ModeIndividual and ModeGroup are the assignment modes: individual = one
 	// repo per student; group = a shared repo teammates join.
 	ModeIndividual = "individual"
 	ModeGroup      = "group"
 
 	// ResultFilename and ReleaseBodyFilename are the autograder's output
-	// artifacts in the student workspace: the required result.json (the
-	// grading payload collect-scores ingests) and the optional
-	// release-body.md. The submit/allowed_files paths must never strip
-	// them. Mirror runner.py's RESULT_FILENAME / RELEASE_BODY_FILENAME.
+	// artifacts in the student workspace: the required result.json (the grading
+	// payload collect-scores ingests) and the optional release-body.md. The
+	// submit/allowed_files paths must never strip them. Mirror runner.py's
+	// RESULT_FILENAME / RELEASE_BODY_FILENAME.
 	ResultFilename      = "result.json"
 	ReleaseBodyFilename = "release-body.md"
 
-	// SecretPattern is the anchored regex a per-classroom capability-URL
-	// secret must match: 4-64 lowercase-alphanumeric chars (a single safe URL
-	// path segment for `<classroom>/<secret>/...`). Single-sourced here
-	// because the rule is a cross-binary AND cross-language contract. Both Go
-	// modules compile their regex from this (configrepo.SecretPattern,
-	// classroomcfg secretPattern); the non-importable copies (runner.py,
-	// autograde-runner.yaml, publish-pages.yaml, both schemas/, the web GUI)
-	// must stay byte-identical and are pinned by contract_test.go.
+	// SecretPattern is the anchored regex a per-classroom capability-URL secret
+	// must match: 4-64 lowercase-alphanumeric chars (one safe URL path segment
+	// for `<classroom>/<secret>/...`). Single-sourced because the rule is a
+	// cross-binary AND cross-language contract. Both Go modules compile their
+	// regex from this (configrepo.SecretPattern, classroomcfg secretPattern);
+	// the non-importable copies (runner.py, autograde-runner.yaml,
+	// publish-pages.yaml, both schemas/, the web GUI) must stay byte-identical
+	// and are pinned by contract_test.go.
 	SecretPattern = "^[a-z0-9]{4,64}$"
 
 	// SecretPatternDescription is the human-readable summary in the "invalid
 	// secret" error, kept in lockstep with SecretPattern.
 	SecretPatternDescription = "4-64 lowercase letters or digits ([a-z0-9])"
 
-	// CommitPrefix marks every tool-authored commit Classroom 50 makes so a
-	// teacher or student can tell them apart from their own commits in the
-	// repo history. Prepended (via PrefixCommit) by every CLI commit path;
-	// hand-mirrored with NO compile-time link in the web GUI
-	// (web/src/util/commit.ts COMMIT_PREFIX) and the skeleton
-	// collect-scores.yaml workflow, so keep all three byte-identical.
+	// CommitPrefix marks every tool-authored commit so teacher and student can
+	// tell them apart from their own in the repo history. Prepended (via
+	// PrefixCommit) by every CLI commit path; hand-mirrored with NO compile-time
+	// link in the web GUI (web/src/util/commit.ts COMMIT_PREFIX) and the
+	// skeleton collect-scores.yaml workflow — keep all three byte-identical.
 	CommitPrefix = "[Classroom 50]"
 )
 
-// requiredOAuthScopes is the unified OAuth scope set both the gh-teacher and
-// gh-student CLIs request on top of gh's defaults. The two binaries request an
-// identical set (issue #246) so a user who authenticates for one never has to
-// re-auth for the other, and any classroom command lands the same grant.
+// requiredOAuthScopes is the unified OAuth scope set both CLIs request on top
+// of gh's defaults. Identical across the two binaries (issue #246) so a user
+// who authenticates for one never re-auths for the other.
 //   - admin:org: org-membership/invite endpoints (`gh teacher invite`,
 //     `gh teacher member list`, pending-invitation reads). Implies read:org.
 //   - read:org:  the org-membership lookup in `gh student accept`. Kept
 //     explicit for clarity and web-GUI parity even though admin:org implies it.
-//   - repo:      assignment-repo creation, contents writes, collaborator
-//     management.
+//   - repo:      assignment-repo creation, contents writes, collaborator mgmt.
 //   - workflow:  committing .github/workflows/* via the Git Data API (both
 //     `gh teacher init` and `gh student accept`); GitHub 404s that write
 //     without it and gh adds it only incidentally.
 //
-// delete_repo is deliberately NOT here: it stays an opt-in scope for
-// `gh teacher teardown` (`gh teacher login -s delete_repo`) so nobody wipes an
-// org by accident. The web GUI requests a superset (adds read:user and
-// delete_repo); that is intentional and separate from this CLI-parity set.
+// delete_repo is deliberately NOT here: it stays opt-in for `gh teacher
+// teardown` (`gh teacher login -s delete_repo`) so nobody wipes an org by
+// accident. The web GUI intentionally requests a superset (adds read:user and
+// delete_repo), separate from this CLI-parity set.
 var requiredOAuthScopes = []string{"admin:org", "read:org", "repo", "workflow"}
 
 // RequiredOAuthScopes returns the unified OAuth scope set (a fresh copy so
@@ -93,9 +86,9 @@ func RequiredOAuthScopes() []string {
 	return append([]string(nil), requiredOAuthScopes...)
 }
 
-// PrefixCommit prepends CommitPrefix to a commit message, producing the
-// canonical "[Classroom 50] <message>" form. The trailing "(gh ... )"
-// provenance hint some callers add is preserved verbatim inside message.
+// PrefixCommit prepends CommitPrefix, producing the canonical "[Classroom 50]
+// <message>" form. Any trailing "(gh ... )" provenance hint inside message is
+// preserved verbatim.
 func PrefixCommit(message string) string {
 	return CommitPrefix + " " + message
 }

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -5,16 +5,15 @@ import (
 	"testing"
 )
 
-// TestContractLiterals is a change-detector: it pins each cross-binary constant
-// to its exact wire value. These literals must stay byte-identical to the
-// Python scripts (runner.py, collect_scores.py, materialize_tests.py) and the
-// JSON Schemas under schemas/, which assert their own copies independently.
-// There is no compile-time link across languages, so an accidental edit here
-// (a typo, or a unilateral v1->v2 bump) would otherwise compile and pass every
-// other Go test while silently breaking outcome-equivalence with the GUI,
-// the Python autograde/collect pipeline, and already-bootstrapped repos. If a
-// value genuinely changes, update this test AND every cross-language copy in
-// lockstep.
+// TestContractLiterals is a change-detector pinning each cross-binary constant
+// to its exact wire value. These must stay byte-identical to the Python scripts
+// (runner.py, collect_scores.py, materialize_tests.py) and the JSON Schemas
+// under schemas/, which assert their own copies. With no compile-time link
+// across languages, an accidental edit here (a typo, a unilateral v1->v2 bump)
+// would compile and pass every other Go test while silently breaking
+// outcome-equivalence with the GUI, the Python autograde/collect pipeline, and
+// already-bootstrapped repos. On a genuine change, update this test AND every
+// cross-language copy in lockstep.
 func TestContractLiterals(t *testing.T) {
 	cases := []struct {
 		name string
@@ -49,11 +48,11 @@ func TestContractLiterals(t *testing.T) {
 	}
 }
 
-// TestRequiredOAuthScopes pins the unified CLI scope set (issue #246): both the
-// gh-teacher and gh-student binaries request exactly these, and delete_repo
-// stays out of the default set (opt-in for teardown). The exact list is the
-// behavior oracle for the login command and the teacher preflight; a change
-// here must move in lockstep with those and the wiki scope tables.
+// TestRequiredOAuthScopes pins the unified CLI scope set (issue #246): both
+// binaries request exactly these, and delete_repo stays out (opt-in for
+// teardown). This list is the behavior oracle for the login command and the
+// teacher preflight; changes must move in lockstep with those and the wiki
+// scope tables.
 func TestRequiredOAuthScopes(t *testing.T) {
 	want := []string{"admin:org", "read:org", "repo", "workflow"}
 	got := RequiredOAuthScopes()

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -1,10 +1,9 @@
 // Package ghauth holds the auth scaffolding shared by the gh-teacher and
 // gh-student CLIs: resolving an authenticated go-gh REST client (auto-running
-// `gh auth login` when no token is present), the interactive-TTY guard, and
-// the `gh auth login` shell-out used by both the auto-login path and the
-// explicit `login` command. The two CLIs differ only in their required OAuth
-// scopes and their command name ("gh teacher" vs "gh student"), which are
-// passed in via Options.
+// `gh auth login` when no token is present), the interactive-TTY guard, and the
+// `gh auth login` shell-out used by both the auto-login path and the explicit
+// `login` command. The two CLIs differ only in required OAuth scopes and
+// command name ("gh teacher" vs "gh student"), passed in via Options.
 package ghauth
 
 import (
@@ -41,7 +40,7 @@ func defaultHost() string {
 
 // RequireClient returns an authenticated REST client, auto-running
 // `gh auth login` (with opts.RequiredScopes) when no token is set for the
-// default host so the cryptic "token not found" failure becomes a guided
+// default host, turning the cryptic "token not found" failure into a guided
 // login. Non-interactive shells get a clear error instead.
 func RequireClient(out, errOut writer, opts Options) (*api.RESTClient, error) {
 	host := defaultHost()

--- a/cli/shared/ghui/ghui.go
+++ b/cli/shared/ghui/ghui.go
@@ -1,16 +1,16 @@
-// Package ghui holds the terminal-feedback primitives shared by the
-// gh-teacher and gh-student CLIs so both render long-running work the
-// same way: a self-rewriting spinner line on an interactive terminal,
-// stable one-shot lines everywhere else.
+// Package ghui holds the terminal-feedback primitives shared by the gh-teacher
+// and gh-student CLIs so both render long-running work the same way: a
+// self-rewriting spinner line on an interactive terminal, stable one-shot lines
+// everywhere else.
 //
-// Stdlib-only (plus the shared ghauth TTY guard) — no third-party
-// spinner dependency; the animation is a hand-rolled time.Ticker.
+// Stdlib-only (plus the shared ghauth TTY guard) — no third-party spinner; the
+// animation is a hand-rolled time.Ticker.
 //
-// Channel discipline (matching the rest of the CLIs): the spinner always
-// writes to the human channel (stderr) and animates only when stderr is
-// a TTY. On a non-TTY (pipe, redirect, CI) it falls back to plain
-// "<message>..." / "<message> done"/"failed" lines, so no cursor escapes
-// leak into captured output.
+// Channel discipline (matching the rest of the CLIs): the spinner always writes
+// to the human channel (stderr) and animates only when stderr is a TTY. On a
+// non-TTY (pipe, redirect, CI) it falls back to plain "<message>..." /
+// "<message> done"/"failed" lines, so no cursor escapes leak into captured
+// output.
 package ghui
 
 import (
@@ -23,8 +23,8 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/ghauth"
 )
 
-// spinnerFrames is a Braille-dot cycle — one cell wide so the in-place
-// rewrite never wraps.
+// spinnerFrames is a Braille-dot cycle — one cell wide so the in-place rewrite
+// never wraps.
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
 // spinnerInterval is the frame cadence (~10fps).
@@ -37,13 +37,13 @@ const (
 	ansiDim   = "\x1b[2m"
 )
 
-// Spinner renders a single live status line for a long-running step.
-// Construct with NewSpinner, call Start once, optionally Update the
-// message, then exactly one of Stop / Fail to finalize.
+// Spinner renders a single live status line for a long-running step. Construct
+// with NewSpinner, call Start once, optionally Update the message, then exactly
+// one of Stop / Fail.
 //
-// The ticker goroutine and the caller race on the message and writer; a
-// mutex guards the shared fields and finish() joins the goroutine before
-// its final write.
+// The ticker goroutine and the caller race on the message and writer; a mutex
+// guards the shared fields and finish() joins the goroutine before its final
+// write.
 type Spinner struct {
 	w     io.Writer
 	tty   bool
@@ -59,10 +59,10 @@ type Spinner struct {
 	wg   sync.WaitGroup
 }
 
-// NewSpinner builds a spinner writing to w. Animation + color are gated
-// on w being os.Stderr AND a TTY (and color additionally on NO_COLOR /
-// CLASSROOM50_NO_COLOR being unset). Any other writer (captured buffer,
-// pipe, redirect) gets the plain non-TTY fallback.
+// NewSpinner builds a spinner writing to w. Animation + color are gated on w
+// being os.Stderr AND a TTY (color additionally on NO_COLOR /
+// CLASSROOM50_NO_COLOR being unset). Any other writer (captured buffer, pipe,
+// redirect) gets the plain non-TTY fallback.
 func NewSpinner(w io.Writer, message string) *Spinner {
 	return &Spinner{
 		w:     w,
@@ -73,17 +73,17 @@ func NewSpinner(w io.Writer, message string) *Spinner {
 	}
 }
 
-// IsStderrTTY reports whether w is the real stderr and a TTY — the
-// single source of the "interactive human channel?" check shared by ghui
-// and both CLIs' ui packages. Only stderr is eligible, so a UI renderer
-// can never write cursor escapes to a redirected stdout.
+// IsStderrTTY reports whether w is the real stderr and a TTY — the single
+// source of the "interactive human channel?" check shared by ghui and both
+// CLIs' ui packages. Only stderr is eligible, so a UI renderer can never write
+// cursor escapes to a redirected stdout.
 func IsStderrTTY(w io.Writer) bool {
 	return w == io.Writer(os.Stderr) && ghauth.IsCharDevice(os.Stderr)
 }
 
-// UseColor reports whether to emit SGR color to w: TTY-gated (via
-// IsStderrTTY), honoring NO_COLOR and CLASSROOM50_NO_COLOR. The single
-// source both CLIs' ui packages delegate to.
+// UseColor reports whether to emit SGR color to w: TTY-gated (via IsStderrTTY),
+// honoring NO_COLOR and CLASSROOM50_NO_COLOR. The single source both CLIs' ui
+// packages delegate to.
 func UseColor(w io.Writer) bool {
 	if os.Getenv("NO_COLOR") != "" || os.Getenv("CLASSROOM50_NO_COLOR") != "" {
 		return false
@@ -91,15 +91,14 @@ func UseColor(w io.Writer) bool {
 	return IsStderrTTY(w)
 }
 
-// Active reports whether the spinner animates (TTY). Callers use it to
-// decide whether to suppress per-substep lines that would otherwise
-// scroll the spinner away.
+// Active reports whether the spinner animates (TTY). Callers use it to decide
+// whether to suppress per-substep lines that would scroll the spinner away.
 func (s *Spinner) Active() bool { return s.tty }
 
-// Start begins the spinner. On a TTY it launches the ticker goroutine
-// that rewrites the line in place; on a non-TTY it prints one plain
-// "<message>..." line so a piped/CI run still shows the step beginning.
-// Calling Start more than once is a no-op.
+// Start begins the spinner. On a TTY it launches the ticker goroutine that
+// rewrites the line in place; on a non-TTY it prints one plain "<message>..."
+// line so a piped/CI run still shows the step beginning. A second Start is a
+// no-op.
 func (s *Spinner) Start() {
 	s.mu.Lock()
 	if s.started {
@@ -139,9 +138,8 @@ func (s *Spinner) run() {
 	}
 }
 
-// render draws the current frame + message, rewriting the line via
-// carriage return + clear-to-EOL so a shorter message leaves no trailing
-// characters.
+// render draws the current frame + message, rewriting the line via carriage
+// return + clear-to-EOL so a shorter message leaves no trailing characters.
 func (s *Spinner) render() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -155,24 +153,23 @@ func (s *Spinner) render() {
 	_, _ = fmt.Fprintf(s.w, "\r\x1b[K%s %s", glyph, s.msg)
 }
 
-// Update changes the live message. A no-op on a non-TTY, so a polling
-// loop doesn't spam a line per attempt into a log.
+// Update changes the live message. A no-op on a non-TTY, so a polling loop
+// doesn't spam a line per attempt into a log.
 func (s *Spinner) Update(message string) {
 	s.mu.Lock()
 	s.msg = message
 	s.mu.Unlock()
 }
 
-// Stop finalizes the spinner as success. On a TTY it replaces the live
-// line with a green ✓ and the final message; on a non-TTY it prints a
-// plain "<message> done" line. Idempotent.
+// Stop finalizes the spinner as success: on a TTY a green ✓ replaces the live
+// line; on a non-TTY a plain "<message> done" line. Idempotent.
 func (s *Spinner) Stop(message string) {
 	s.finish(message, outcomeOK)
 }
 
-// Fail finalizes the spinner as failure: a red ✗ on a TTY, "<message>
-// failed" plain. Use on the error path so a half-drawn spinner line
-// isn't left dangling above an error message.
+// Fail finalizes the spinner as failure: a red ✗ on a TTY, "<message> failed"
+// plain. Use on the error path so a half-drawn spinner line isn't left dangling
+// above an error message.
 func (s *Spinner) Fail(message string) {
 	s.finish(message, outcomeFail)
 }
@@ -200,8 +197,8 @@ func (s *Spinner) finish(message string, oc outcome) {
 	final := s.msg
 	s.mu.Unlock()
 
-	// Stop the ticker goroutine and wait for it to exit before the final
-	// write, so the two don't race on s.w. No-op wait on a non-TTY.
+	// Stop the ticker goroutine and wait for it to exit before the final write,
+	// so the two don't race on s.w. No-op wait on a non-TTY.
 	close(s.stop)
 	s.wg.Wait()
 
@@ -223,8 +220,7 @@ func (s *Spinner) finish(message string, oc outcome) {
 	}
 }
 
-// paint wraps s in an SGR code when color is on; otherwise returns s
-// unchanged.
+// paint wraps s in an SGR code when color is on, else returns s unchanged.
 func paint(color bool, code, s string) string {
 	if !color {
 		return s

--- a/cli/shared/ghui/ghui_test.go
+++ b/cli/shared/ghui/ghui_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-// A spinner writing to a plain buffer (not os.Stderr) must take the
-// non-TTY path: no ANSI escapes, no carriage returns, just stable lines.
+// A spinner writing to a plain buffer (not os.Stderr) must take the non-TTY
+// path: no ANSI escapes, no carriage returns, just stable lines.
 func TestSpinner_NonTTY_PlainLines(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewSpinner(&buf, "Waiting for repo")
@@ -44,8 +44,8 @@ func TestSpinner_NonTTY_Fail(t *testing.T) {
 	}
 }
 
-// Calling a finalizer twice must be a safe no-op (no double close panic,
-// no duplicate output).
+// Calling a finalizer twice must be a safe no-op (no double-close panic, no
+// duplicate output).
 func TestSpinner_DoubleStopIsSafe(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewSpinner(&buf, "Step")
@@ -59,8 +59,8 @@ func TestSpinner_DoubleStopIsSafe(t *testing.T) {
 	}
 }
 
-// Finalizing without Start must not panic or emit an outcome (nothing
-// was ever started).
+// Finalizing without Start must not panic or emit an outcome (nothing was ever
+// started).
 func TestSpinner_FinishWithoutStart(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewSpinner(&buf, "Step")
@@ -70,11 +70,10 @@ func TestSpinner_FinishWithoutStart(t *testing.T) {
 	}
 }
 
-// render() is the TTY draw path. It can't be reached through Start on a
-// buffer (which is non-TTY), so exercise it directly to lock the frame
-// shape: a carriage return + clear-to-EOL, the current frame glyph, and
-// the message. This guards the in-place rewrite contract independently
-// of whether a real terminal is attached.
+// render() is the TTY draw path. It can't be reached through Start on a buffer
+// (non-TTY), so exercise it directly to lock the frame shape: carriage return +
+// clear-to-EOL, the current frame glyph, and the message. Guards the in-place
+// rewrite contract independently of whether a real terminal is attached.
 func TestSpinner_RenderFrameShape(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewSpinner(&buf, "Cloning hello")

--- a/cli/shared/ghutil/ghutil.go
+++ b/cli/shared/ghutil/ghutil.go
@@ -1,8 +1,8 @@
 // Package ghutil holds small, proven-duplicated helpers for talking to the
-// GitHub API via go-gh, shared by the gh-teacher and gh-student CLIs. It is
-// deliberately NOT a client wrapper — go-gh's *api.RESTClient already is the
-// standardization. This package only collects the few primitives both modules
-// had copied: HTTP-status classification and the retry backoff schedule.
+// GitHub API via go-gh, shared by the gh-teacher and gh-student CLIs. Not a
+// client wrapper — go-gh's *api.RESTClient already is that; this only collects
+// the primitives both modules had copied: HTTP-status classification and the
+// retry backoff schedule.
 package ghutil
 
 import (
@@ -21,20 +21,17 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 )
 
-// linkNextRe extracts the `rel="next"` target from a GitHub `Link`
-// response header, e.g.
+// linkNextRe extracts the `rel="next"` target from a GitHub `Link` header, e.g.
 //
 //	<https://api.github.com/...&page=2>; rel="next", <...>; rel="last"
 //
-// GitHub's pagination guidance is to follow this URL rather than to
-// synthesize page numbers, because page size and the presence of a next
-// page are the server's to decide.
+// GitHub's guidance is to follow this URL rather than synthesize page numbers:
+// page size and whether a next page exists are the server's to decide.
 var linkNextRe = regexp.MustCompile(`<([^>]+)>\s*;\s*[^,]*rel="next"`)
 
-// NextPageLink returns the `rel="next"` URL from a Link response header,
-// or "" when there is no next page (or no Link header at all). Shared by
-// both CLIs' paginated walks so they follow GitHub's authoritative
-// pagination contract identically.
+// NextPageLink returns the `rel="next"` URL from a Link header, or "" when
+// there is no next page (or no Link header). Shared by both CLIs' paginated
+// walks so they follow GitHub's pagination contract identically.
 func NextPageLink(header string) string {
 	if header == "" {
 		return ""
@@ -46,20 +43,19 @@ func NextPageLink(header string) string {
 	return m[1]
 }
 
-// NextPage centralizes the page-walk termination decision both Go CLIs
-// rely on, so the error-prone predicate isn't re-implemented (and prone
-// to drift) at each call site. Given a response's Link header plus the
-// just-decoded batch length and the requested per-page size, it returns:
+// NextPage centralizes the page-walk termination decision both Go CLIs rely
+// on, so the error-prone predicate isn't re-implemented (and drifting) at each
+// call site. Given a response's Link header, the just-decoded batch length, and
+// the requested per-page size, it returns:
 //
-//   - (nextURL, false) — follow GitHub's authoritative `rel="next"` URL.
-//   - ("", true)       — stop: either the Link header is present without a
-//     `rel="next"` (this was the last page), or — with NO Link header (a
-//     test server / Link-less endpoint) — the page was short
-//     (len < perPage, including empty).
-//   - ("", false)      — no Link header AND a full page: the caller should
-//     synthesize the next page (e.g. pageURL(page+1)) and continue.
+//   - (nextURL, false) — follow GitHub's `rel="next"` URL.
+//   - ("", true)       — stop: Link header present without a `rel="next"` (last
+//     page), or NO Link header (test server / Link-less endpoint) with a short
+//     page (len < perPage, including empty).
+//   - ("", false)      — no Link header AND a full page: the caller synthesizes
+//     the next page (e.g. pageURL(page+1)) and continues.
 //
-// Callers own how they build a synthesized next page, so that URL is not
+// Callers own how they build a synthesized next page, so that URL isn't
 // returned here; only the decision is shared.
 func NextPage(linkHeader string, batchLen, perPage int) (nextURL string, stop bool) {
 	if next := NextPageLink(linkHeader); next != "" {
@@ -72,8 +68,8 @@ func NextPage(linkHeader string, batchLen, perPage int) (nextURL string, stop bo
 }
 
 // IsHTTPStatus reports whether err is a *api.HTTPError with the given status
-// code. Collapses the err -> *api.HTTPError -> StatusCode pattern used to
-// distinguish 404/409/422 from transport errors.
+// code, collapsing the err -> *api.HTTPError -> StatusCode pattern used to
+// tell 404/409/422 from transport errors.
 func IsHTTPStatus(err error, code int) bool {
 	httpErr, ok := errors.AsType[*api.HTTPError](err)
 	return ok && httpErr.StatusCode == code
@@ -91,10 +87,10 @@ func BackoffDelay(attempt int) time.Duration {
 	return time.Duration(200*(1<<attempt)) * time.Millisecond
 }
 
-// WaitForStableBranch polls until two consecutive reads agree on a
-// non-empty commit SHA (max 20 attempts, ~10s total). Required against a
-// freshly-created/templated branch — the contents/git-data APIs briefly
-// 409 with "Git Repository is empty" until the ref propagates.
+// WaitForStableBranch polls until two consecutive reads agree on a non-empty
+// commit SHA (max 20 attempts, ~10s). Needed against a freshly created/templated
+// branch — the contents/git-data APIs briefly 409 "Git Repository is empty"
+// until the ref propagates.
 func WaitForStableBranch(client *api.RESTClient, owner, repo, branch string) error {
 	path := fmt.Sprintf(
 		"repos/%s/%s/branches/%s",
@@ -110,14 +106,12 @@ func WaitForStableBranch(client *api.RESTClient, owner, repo, branch string) err
 			} `json:"commit"`
 		}
 		if err := client.Get(path, &resp); err != nil {
-			// Transient error; reset the baseline.
-			lastSHA = ""
+			lastSHA = "" // transient error; reset the baseline
 			time.Sleep(time.Duration(250*(i+1)) * time.Millisecond)
 			continue
 		}
 		if resp.Commit.SHA == "" {
-			// No commit reported yet; reset the baseline.
-			lastSHA = ""
+			lastSHA = "" // no commit yet; reset the baseline
 			time.Sleep(500 * time.Millisecond)
 			continue
 		}
@@ -131,7 +125,7 @@ func WaitForStableBranch(client *api.RESTClient, owner, repo, branch string) err
 }
 
 // CurrentUser returns the authenticated user's login and immutable numeric ID
-// via GET /user. Callers that only need the login can ignore the id (e.g.
+// via GET /user. Callers needing only the login can ignore the id (e.g.
 // whoami); gh-student's identity.Fetch uses both to build the noreply email.
 func CurrentUser(client *api.RESTClient) (login string, id int64, err error) {
 	var user struct {
@@ -145,9 +139,9 @@ func CurrentUser(client *api.RESTClient) (login string, id int64, err error) {
 }
 
 // SetCollaborator PUTs username as a collaborator on owner/repo with the given
-// permission and returns the HTTP status code (201 when an invitation was
-// created and awaits acceptance, 204 when the user was added directly). Callers
-// format their own messages off the status; an unexpected status is an error.
+// permission and returns the HTTP status (201 = invitation created and awaiting
+// acceptance, 204 = added directly). Callers format their own messages off the
+// status; an unexpected status is an error.
 func SetCollaborator(client *api.RESTClient, owner, repo, username, permission string) (int, error) {
 	body, err := json.Marshal(map[string]string{"permission": permission})
 	if err != nil {
@@ -168,8 +162,8 @@ func SetCollaborator(client *api.RESTClient, owner, repo, username, permission s
 }
 
 // DecodeContentsBase64 decodes the base64 envelope the GitHub contents/git-data
-// APIs return. They wrap the payload at column 60, and Go's std decoder rejects
-// embedded newlines, so strip them first.
+// APIs return. They wrap at column 60 and Go's std decoder rejects embedded
+// newlines, so strip them first.
 func DecodeContentsBase64(content string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(strings.ReplaceAll(content, "\n", ""))
 }

--- a/cli/shared/ghutil/ghutil_test.go
+++ b/cli/shared/ghutil/ghutil_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 )
 
-// TestNextPageLink pins the Link-header `rel="next"` parser both Go CLIs
-// rely on. The regex is the single authoritative next-page extractor, so
-// these edge cases guard against silent drift breaking pagination in both
-// binaries with the rest of the suite still green.
+// TestNextPageLink pins the Link-header `rel="next"` parser both Go CLIs rely
+// on. This regex is the single next-page extractor, so these edge cases guard
+// against silent drift breaking pagination in both binaries while the rest of
+// the suite stays green.
 func TestNextPageLink(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -47,9 +47,9 @@ func TestNextPageLink(t *testing.T) {
 	}
 }
 
-// TestNextPage pins the shared termination decision both Go walks use, so
-// the error-prone "follow next / stop / synthesize" predicate can't drift
-// between paginateAll and the student collaborator walk.
+// TestNextPage pins the shared termination decision both Go walks use, so the
+// "follow next / stop / synthesize" predicate can't drift between paginateAll
+// and the student collaborator walk.
 func TestNextPage(t *testing.T) {
 	const perPage = 100
 	t.Run("follows rel=next regardless of page length", func(t *testing.T) {
@@ -79,8 +79,8 @@ func TestNextPage(t *testing.T) {
 }
 
 func TestDecodeContentsBase64(t *testing.T) {
-	// The contents API wraps base64 at column 60 with embedded newlines;
-	// the std decoder rejects those, so the helper must strip them first.
+	// The contents API wraps base64 at column 60 with embedded newlines, which
+	// the std decoder rejects, so the helper must strip them first.
 	t.Run("strips embedded newlines", func(t *testing.T) {
 		// "hello world" repeated, encoded then line-wrapped.
 		wrapped := "aGVsbG8gd29ybGQgaGVsbG8gd29ybGQgaGVsbG8gd29ybGQgaGVsbG8gd29y\nbGQ="
@@ -155,8 +155,8 @@ func TestCurrentUser(t *testing.T) {
 }
 
 func TestSetCollaborator(t *testing.T) {
-	// 201 means an invitation was created; 204 means added directly. The
-	// helper surfaces both verbatim and rejects anything else.
+	// 201 = invitation created; 204 = added directly. The helper surfaces both
+	// verbatim and rejects anything else.
 	cases := []struct {
 		name    string
 		status  int
@@ -199,9 +199,9 @@ func TestSetCollaborator(t *testing.T) {
 	}
 }
 
-// TestWaitForStableBranch pins the post-create branch-stabilization poll
-// the accept flow relies on: a branch that reports the same non-empty SHA
-// on two consecutive reads resolves without error.
+// TestWaitForStableBranch pins the post-create branch-stabilization poll the
+// accept flow relies on: a branch reporting the same non-empty SHA on two
+// consecutive reads resolves without error.
 func TestWaitForStableBranch(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/o/r/branches/main", func(w http.ResponseWriter, r *http.Request) {

--- a/cli/shared/gittree/gittree.go
+++ b/cli/shared/gittree/gittree.go
@@ -1,13 +1,13 @@
 // Package gittree holds the git Tree-commit plumbing shared by the gh-teacher
 // and gh-student CLIs: upload blobs, build a tree over a base_tree, create a
-// commit, and move a ref. Both modules had byte-near-identical copies of these
-// primitives; this package is the single source.
+// commit, move a ref. Both modules had byte-near-identical copies; this is the
+// single source.
 //
-// Two retry policies sit on top of the plumbing, because the two callers face
-// different hazards:
+// Two retry policies sit on top, because the two callers face different
+// hazards:
 //
-//   - CommitWithRebase — optimistic-update with non-fast-forward retry, for
-//     writes to a repo that may have *concurrent writers* (the teacher's
+//   - CommitWithRebase — optimistic update with non-fast-forward retry, for
+//     writes to a repo with *concurrent writers* (the teacher's
 //     <org>/classroom50 config repo).
 //   - CommitWithFreshRepoRetry — retry the tree+commit build against a
 //     *freshly-created* repo whose ref/git-data APIs briefly 404/409 until they
@@ -40,13 +40,13 @@ import (
 // descendant of the current branch tip. CommitWithRebase retries on it.
 var ErrNonFastForward = errors.New("non-fast-forward ref update")
 
-// rebaseAttempts: 5 attempts at 200ms × 2^n backoff (~6.2s total) — absorbs
-// concurrent CLI invocations, fails fast on a wedged repo.
+// rebaseAttempts: 5 tries at 200ms × 2^n backoff (~6.2s) — absorbs concurrent
+// CLI invocations, fails fast on a wedged repo.
 const rebaseAttempts = 5
 
 // TreeEntry is one entry in a git Tree create request. SHA is a pointer so a
 // nil value marshals to `"sha":null`, which the Trees API treats as "remove
-// this path from base_tree" — see DeletionEntries. Upserts carry a non-nil blob
+// this path from base_tree" (see DeletionEntries). Upserts carry a non-nil blob
 // SHA from UploadBlobs.
 type TreeEntry struct {
 	Path string  `json:"path"`
@@ -57,7 +57,7 @@ type TreeEntry struct {
 
 // Change describes the mutations for a single commit: Upserts (path -> new
 // content) are created or overwritten; Deletes (repo-root-relative paths) are
-// removed from the tree. An empty change (no upserts, no deletes) is a no-op.
+// removed from the tree. An empty change is a no-op.
 type Change struct {
 	Upserts map[string]string
 	Deletes []string
@@ -67,9 +67,9 @@ func (c Change) isEmpty() bool {
 	return len(c.Upserts) == 0 && len(c.Deletes) == 0
 }
 
-// RefAndTree returns (parentCommitSHA, parentTreeSHA) for branch.
-// parentTreeSHA becomes the new tree's `base_tree` so unchanged paths inherit
-// without re-uploading.
+// RefAndTree returns (parentCommitSHA, parentTreeSHA) for branch. parentTreeSHA
+// becomes the new tree's `base_tree` so unchanged paths inherit without
+// re-uploading.
 func RefAndTree(client *api.RESTClient, owner, repo, branch string) (commitSHA, treeSHA string, err error) {
 	refPath := fmt.Sprintf("repos/%s/%s/git/refs/heads/%s",
 		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(branch))
@@ -96,7 +96,7 @@ func RefAndTree(client *api.RESTClient, owner, repo, branch string) (commitSHA, 
 }
 
 // UploadBlobs creates one blob per file and returns the tree entries. Always
-// base64-encoded; simpler than per-file encoding detection with negligible
+// base64-encoded; simpler than per-file encoding detection, with negligible
 // overhead.
 func UploadBlobs(client *api.RESTClient, owner, repo string, files map[string]string) ([]TreeEntry, error) {
 	paths := make([]string, 0, len(files))
@@ -136,9 +136,9 @@ func UploadBlobs(client *api.RESTClient, owner, repo string, files map[string]st
 }
 
 // DeletionEntries builds tree entries that remove `paths` from base_tree. A nil
-// SHA marshals to `"sha":null`, which the git Trees API treats as a deletion.
-// Paths are sorted for a deterministic payload. Git prunes any trees left empty
-// by the deletions, so only blob paths need listing.
+// SHA marshals to `"sha":null`, which the Trees API treats as a deletion. Paths
+// are sorted for a deterministic payload. Git prunes trees left empty by the
+// deletions, so only blob paths need listing.
 func DeletionEntries(paths []string) []TreeEntry {
 	if len(paths) == 0 {
 		return nil
@@ -152,11 +152,11 @@ func DeletionEntries(paths []string) []TreeEntry {
 	return entries
 }
 
-// CreateTree posts a tree over baseTreeSHA. classify404, if non-nil, is given
-// the raw error when the POST returns 404 and may return a terminal error to
-// surface instead (the teacher uses this to distinguish a missing-`workflow`-
-// scope 404 from fresh-repo lag). Returning nil from classify404 (or passing a
-// nil func) leaves the original error intact.
+// CreateTree posts a tree over baseTreeSHA. classify404, if non-nil, receives
+// the raw error on a 404 POST and may return a terminal error to surface
+// instead (the teacher uses this to tell a missing-`workflow`-scope 404 from
+// fresh-repo lag). Returning nil (or a nil func) leaves the original error
+// intact.
 func CreateTree(client *api.RESTClient, owner, repo, baseTreeSHA string, entries []TreeEntry, classify404 func(error) error) (string, error) {
 	body, err := json.Marshal(struct {
 		BaseTree string      `json:"base_tree"`
@@ -208,8 +208,8 @@ func CreateCommit(client *api.RESTClient, owner, repo, treeSHA, parentSHA, messa
 }
 
 // UpdateRef force-moves branch to commitSHA via a plain PATCH (error on any
-// non-200). Use this when there are no concurrent writers; for the contended
-// case use CommitWithRebase, which routes through PatchRef.
+// non-200). Use when there are no concurrent writers; for the contended case
+// use CommitWithRebase, which routes through PatchRef.
 func UpdateRef(client *api.RESTClient, owner, repo, branch, commitSHA string) error {
 	body, err := json.Marshal(struct {
 		SHA string `json:"sha"`
@@ -231,10 +231,10 @@ func UpdateRef(client *api.RESTClient, owner, repo, branch, commitSHA string) er
 	return nil
 }
 
-// PatchRef returns ErrNonFastForward on race so CommitWithRebase can
-// distinguish "retry" from "real failure". 422 alone isn't enough (GitHub also
-// uses it for permission failures and malformed refs); matching on the message
-// text keeps retries from papering over real failures.
+// PatchRef returns ErrNonFastForward on a race so CommitWithRebase can tell
+// "retry" from "real failure". 422 alone isn't enough (GitHub also uses it for
+// permission failures and malformed refs); matching the message text keeps
+// retries from papering over real failures.
 func PatchRef(client *api.RESTClient, owner, repo, branch, commitSHA string) error {
 	body, err := json.Marshal(struct {
 		SHA string `json:"sha"`
@@ -271,9 +271,9 @@ func isNonFastForwardMessage(message string) bool {
 
 // CommitWithRebase is the optimistic-update-with-rebase helper for writes to a
 // repo that may have concurrent writers. build is invoked per attempt with the
-// parent commit SHA so it sees the current state of every path it intends to
-// upsert or delete. classify404 is forwarded to CreateTree (pass nil if the
-// caller has no 404 specialization).
+// parent commit SHA so it sees the current state of every path it upserts or
+// deletes. classify404 is forwarded to CreateTree (nil if the caller has no 404
+// specialization).
 //
 // Return shape:
 //   - ("<sha>", nil) — commit landed.
@@ -325,8 +325,8 @@ func CommitWithRebase(
 			return "", err
 		}
 
-		// Concurrent writer won; back off before retrying. Skip the sleep
-		// after the final attempt — it would just delay the error.
+		// Concurrent writer won; back off before retrying. Skip the sleep after
+		// the final attempt — it would just delay the error.
 		if attempt < rebaseAttempts-1 {
 			time.Sleep(ghutil.BackoffDelay(attempt))
 		}
@@ -340,9 +340,9 @@ func CommitWithRebase(
 type FreshRepoRetry struct {
 	// Attempts is the number of read-parent + build-tree tries.
 	Attempts int
-	// ValidateParent, if non-nil, inspects the parent SHAs returned by
-	// RefAndTree before the tree build; returning a (retryable) error here lets
-	// the loop ride out a ref that reads 200 with an empty SHA. Optional.
+	// ValidateParent, if non-nil, inspects the parent SHAs from RefAndTree
+	// before the tree build; a (retryable) error here lets the loop ride out a
+	// ref that reads 200 with an empty SHA. Optional.
 	ValidateParent func(parentSHA, parentTreeSHA string) error
 	// Classify404 is forwarded to CreateTree (e.g. the teacher's
 	// missing-workflow-scope terminal mapping). Optional.
@@ -356,11 +356,11 @@ type FreshRepoRetry struct {
 // CommitWithFreshRepoRetry builds the tree+commit for `entries` over `branch`'s
 // current tip and force-moves the ref, retrying the read+build (not the ref
 // move) while the repo's git-data APIs lag. Blobs are content-addressed, so the
-// caller uploads them once (via UploadBlobs) and passes the resulting entries;
-// a retry reuses the same SHAs.
+// caller uploads them once (via UploadBlobs) and passes the entries; a retry
+// reuses the same SHAs.
 //
-// Returns the landed commit SHA. There is no no-op case: callers pass a
-// non-empty entry set.
+// Returns the landed commit SHA. No no-op case: callers pass a non-empty entry
+// set.
 func CommitWithFreshRepoRetry(
 	client *api.RESTClient,
 	owner, repo, branch, message string,

--- a/cli/shared/gittree/gittree_test.go
+++ b/cli/shared/gittree/gittree_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 // TestDeletionEntriesMarshalNullSHA pins the wire contract the Trees API
-// depends on: a deletion entry must serialize `"sha":null`, while an upsert
-// entry serializes a string SHA.
+// depends on: a deletion entry serializes `"sha":null`, an upsert entry a
+// string SHA.
 func TestDeletionEntriesMarshalNullSHA(t *testing.T) {
 	entries := DeletionEntries([]string{"b/2.txt", "a/1.txt"})
 	if len(entries) != 2 {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,10 +7,10 @@ import { Spinner } from "@/components/Spinner"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 
 // Auth-gated route prefixes. When the session ends mid-flight, the router keeps
-// the matched _authed route mounted until a post-commit invalidate() swaps it
-// out — one render frame in which the authed subtree re-renders against a now
-// null GitHub client and useGitHubClient() throws into the root error boundary.
-// We detect that transient window below and render a redirect state instead.
+// the matched _authed route mounted until invalidate() swaps it out — one frame
+// where the authed subtree re-renders against a now-null GitHub client and
+// useGitHubClient() throws into the root error boundary. We detect that window
+// below and render a redirect state instead.
 function isAuthedPath(pathname: string): boolean {
   const base = import.meta.env.BASE_URL.replace(/\/$/, "")
   const path =
@@ -27,10 +27,10 @@ export function App() {
     void router.invalidate()
   }, [status, token])
 
-  // When the session ends while on an authed route, redirect to /login eagerly
-  // (carrying the destination so re-auth can return there — see issue #71)
-  // rather than waiting for the post-commit invalidate(). This unmounts the
-  // authed subtree synchronously, closing the null-client crash window.
+  // When the session ends on an authed route, redirect to /login eagerly
+  // (carrying the destination for re-auth return — #71) rather than waiting for
+  // invalidate(). Unmounts the authed subtree synchronously, closing the
+  // null-client crash window.
   const pathname = window.location.pathname
   const sessionEndedOnAuthedRoute =
     status === "unauthenticated" && isAuthedPath(pathname)

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -143,7 +143,7 @@ describe("buildReusedEntry", () => {
   })
 
   it("preserves an empty tests/allowed_files array (present, not dropped)", () => {
-    // An empty array is truthy, so the omitempty cleanup must NOT delete it —
+    // Empty array is truthy, so the omitempty cleanup must NOT delete it —
     // absent vs [] can mean different things to the CLI, so reuse copies the
     // source's choice verbatim.
     const source: Assignment = {
@@ -277,8 +277,8 @@ describe("editAssignment (preserved-entry integration)", () => {
   const SLUG = "hw1"
 
   // The CLI-authored entry the GUI is about to edit: carries a CLI-only
-  // migrated_from block (the form never manages it) and a managed `due` the
-  // edit clears.
+  // migrated_from block (the form never manages it) and a managed `due` the edit
+  // clears.
   const existingEntry: Assignment = {
     slug: SLUG,
     name: "Homework 1",
@@ -295,10 +295,10 @@ describe("editAssignment (preserved-entry integration)", () => {
     },
   }
 
-  // Wire up a route-table GitHubClient covering exactly the endpoints
-  // editAssignment hits on the template-less path: ref read, commit read,
-  // assignments.json contents read, then tree/commit/ref writes. classroom.json
-  // is absent (404) so the archive guard reads the classroom as active.
+  // Route-table GitHubClient covering exactly the endpoints editAssignment hits
+  // on the template-less path: ref read, commit read, assignments.json contents
+  // read, then tree/commit/ref writes. classroom.json is absent (404) so the
+  // archive guard reads the classroom as active.
   function makeClient(): {
     client: GitHubClient
     committedContent: () => string
@@ -401,10 +401,10 @@ describe("editAssignment (preserved-entry integration)", () => {
   })
 
   it("re-validates an unchanged stored ref and blocks a now-cross-org private fork", async () => {
-    // An assignment whose stored template is an in-org private fork of a
-    // private cross-org upstream (created before the fork guard shipped, or a
-    // parent that went private after create). Editing WITHOUT changing the ref
-    // must still trip the fork guard rather than trusting the stored block.
+    // An assignment whose stored template is an in-org private fork of a private
+    // cross-org upstream (created before the fork guard shipped, or a parent
+    // that went private after create). Editing WITHOUT changing the ref must
+    // still trip the fork guard rather than trusting the stored block.
     const forkEntry: Assignment = {
       slug: SLUG,
       name: "Homework 1",
@@ -484,9 +484,9 @@ describe("copyAssignmentToClassroom (reuse fork guard)", () => {
     retryAfter: null,
   }
 
-  // A client that answers the three pre-commit reads copyAssignmentToClassroom
-  // runs in parallel (archive guard via requestRaw 404, getRepo, getBranchRef).
-  // The fork guard throws before any commit, so no write routes are needed.
+  // Answers the three pre-commit reads copyAssignmentToClassroom runs in
+  // parallel (archive guard via requestRaw 404, getRepo, getBranchRef). The fork
+  // guard throws before any commit, so no write routes are needed.
   function makeClient(repo: unknown): GitHubClient {
     const request = vi.fn(async (url: string) => {
       if (url.includes("/git/ref/heads/main")) return { object: { sha: "s" } }

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -56,19 +56,16 @@ import {
 } from "@/util/templateAccessError"
 import { githubOrgOAuthPolicyUrl } from "@/auth/constants"
 
-// The accept commit's subject. Written by both this GUI and the CLI's
-// `gh student accept`; kept byte-identical (via prefixCommit) per the
-// synchronized-release rule. The subject carries NO contract — the runner
-// resolves the trusted Feedback-PR baseline by the commit that introduced
-// the `.classroom50.yaml` marker (runner.py: ACCEPT_MARKER_PATH), not by
-// matching this string — so it can be reworded freely as long as both
-// accept clients stay in lockstep.
+// Kept byte-identical with the CLI's `gh student accept` (via prefixCommit) per
+// the synchronized-release rule. Carries no contract — the runner keys the
+// Feedback-PR baseline off the `.classroom50.yaml` marker commit, not this
+// string — so it's freely rewordable as long as both accept clients match.
 const ACCEPT_COMMIT_SUBJECT = prefixCommit(
   "Initialize .classroom50.yaml and autograde workflow (gh student accept)",
 )
 
-// A student-facing accept failure. The accept page renders `error.message`
-// verbatim, so this keeps a raw GitHub "Not Found" from reaching a student.
+// Student-facing accept failure: the accept page renders `error.message`
+// verbatim, so a raw GitHub "Not Found" never reaches a student.
 class AcceptStepError extends Error {
   constructor(message: string, cause?: unknown) {
     super(message)
@@ -79,8 +76,7 @@ class AcceptStepError extends Error {
   }
 }
 
-// Ordered phases of the accept flow, surfaced as a progress checklist in the
-// GUI.
+// Ordered accept-flow phases, shown as a progress checklist in the GUI.
 export type AcceptStepId =
   | "account"
   | "membership"
@@ -95,18 +91,18 @@ export type AcceptStepStatus = "pending" | "running" | "complete" | "error"
 type AcceptStepUpdate = {
   id: AcceptStepId
   status: AcceptStepStatus
-  // The label shown for the step; on resolution it can override the default
-  // (e.g. "Repository already exists").
+  // Step label; on resolution can override the default (e.g. "Repository
+  // already exists").
   message?: string
   error?: string
 }
 
 type OnAcceptStepUpdate = (update: AcceptStepUpdate) => void
 
-// Run one accept step, emitting progress around it. Its core job is to
-// translate a raw GitHubAPIError into a student-facing, actionable message
-// (`actions`) so a bare "Not Found" never reaches the student; already-friendly
-// errors pass through untouched.
+// Run one accept step, emitting progress around it. Translates a raw
+// GitHubAPIError into a student-facing, actionable message (`actions`) so a
+// bare "Not Found" never reaches the student; already-friendly errors pass
+// through untouched.
 async function withAcceptStep<T>(
   params: {
     id: AcceptStepId
@@ -152,8 +148,8 @@ async function withAcceptStep<T>(
       }
       fail(`${label} failed (HTTP ${err.status}). ${actions}`, err)
     }
-    // Unexpected non-GitHub error (network/parse/etc.): surface it on the step
-    // so the checklist row leaves "running" instead of spinning forever.
+    // Unexpected non-GitHub error (network/parse/etc.): surface it so the
+    // checklist row leaves "running" instead of spinning forever.
     onStepUpdate?.({
       id,
       status: "error",
@@ -163,15 +159,15 @@ async function withAcceptStep<T>(
   }
 }
 
-// Parse a `--template` ref — `<owner>/<repo>[@<branch>]` or a bare `<repo>`
+// Parse a `--template` ref — `<owner>/<repo>[@<branch>]` or bare `<repo>`
 // (owner defaults to the org). Mirrors the CLI's parseTemplateRef so the GUI
 // accepts the same inputs and writes the same template block.
 type ParsedTemplate = { owner: string; repo: string; branch?: string }
 function parseTemplateRef(raw: string, defaultOwner: string): ParsedTemplate {
   const trimmed = raw.trim()
   if (!trimmed) {
-    // Callers gate on a non-empty ref (the template is optional), so this is
-    // an internal invariant, not user input.
+    // Callers gate on a non-empty ref (template is optional), so this is an
+    // internal invariant, not user input.
     throw new Error("Template ref is empty.")
   }
 
@@ -218,11 +214,10 @@ export type TemplateAccessVerification =
   // (e.g. a commitless template). resolveTemplate rejects this too.
   | { kind: "no-branch"; owner: string; repo: string }
   | { kind: "private-out-of-org"; owner: string; repo: string }
-  // Read denied (HTTP 403): the owning org likely restricts third-party apps,
-  // OR the per-user OAuth-App grant for this org was never authorized, OR the
-  // token's scopes are stale. `message` carries GitHub's actual error text and
-  // `httpStatus` the status, so the note surfaces the real cause instead of a
-  // fixed assumption. `scopeGap` is true when GitHub reported required scopes
+  // Read denied (HTTP 403): org restricts third-party apps, the per-user
+  // OAuth-App grant was never authorized, or the token's scopes are stale.
+  // `message`/`httpStatus` carry GitHub's actual error so the note shows the
+  // real cause. `scopeGap` is true when GitHub reported required scopes
   // (X-Accepted-OAuth-Scopes) the token appears to lack.
   | {
       kind: "restricted"
@@ -233,7 +228,7 @@ export type TemplateAccessVerification =
       httpStatus: number
       scopeGap: boolean
     }
-  // GitHub rate limit hit; the check is inconclusive and should be retried.
+  // Rate limit hit; the check is inconclusive and should be retried.
   | { kind: "rate-limited"; owner: string; repo: string }
   // Verification couldn't complete (network or unexpected error).
   | { kind: "unknown"; owner: string; repo: string }
@@ -258,10 +253,9 @@ export type TemplateAccessVerification =
     }
   // A private fork used as a template. `generate` copies the fork's tree but can
   // fail (403/404) when the fork's upstream parent is private and inaccessible
-  // to the OAuth token. `parentInOrg` distinguishes the two cases: a parent in
-  // the classroom org (Classroom 50 already has access — usually fine, advisory)
-  // vs. a cross-org private parent (likely to fail at generate — strongly
-  // discouraged). `parent` names the upstream when GitHub reported it.
+  // to the OAuth token. `parentInOrg` splits the cases: an in-org parent
+  // (usually fine, advisory) vs. a cross-org private parent (likely to fail —
+  // strongly discouraged). `parent` names the upstream when GitHub reported it.
   | {
       kind: "private-fork"
       owner: string
@@ -274,14 +268,13 @@ export type TemplateAccessVerification =
 // Classify a repo as a risky private fork for template use. `generate` copies
 // the fork's tree but can be blocked (403/404) when GitHub can't reach the
 // fork's private upstream parent — common when the parent lives in another org.
-// A public parent (or a non-fork / non-private repo) generates fine, so
-// `isRiskyPrivateFork` is only true when the repo is a private fork whose parent
-// is private or of unknown visibility. `parentInOrg` splits the two risky cases:
-// an in-org private parent (reachable, usually fine) vs. a cross-org or unknown
-// parent (likely to fail at generate). An absent/malformed parent fails closed
-// to the higher-risk cross-org case (`parentInOrg: false`). Single source of
-// truth for the pre-flight verdict (verifyTemplateAccess), the create/edit block
-// (resolveTemplate), and the reuse re-check (copyAssignmentToClassroom).
+// True only for a private fork whose parent is private or of unknown
+// visibility (a public parent or non-fork/non-private repo generates fine).
+// `parentInOrg` splits the risky cases: an in-org private parent (reachable,
+// usually fine) vs. a cross-org or unknown parent (likely to fail). An
+// absent/malformed parent fails closed to cross-org (`parentInOrg: false`).
+// Single source of truth for verifyTemplateAccess, resolveTemplate, and
+// copyAssignmentToClassroom.
 function classifyPrivateFork(
   repo: GitHubRepo,
   org: string,
@@ -299,7 +292,7 @@ function classifyPrivateFork(
   }
 }
 
-// The hard-block error thrown at create/edit/reuse for a cross-org (or
+// Hard-block error thrown at create/edit/reuse for a cross-org (or
 // unknown-parent) private fork. `parent` is the upstream's full_name when
 // GitHub reported it. Shared so every write path emits identical guidance.
 function crossOrgPrivateForkError(
@@ -336,8 +329,8 @@ export async function verifyTemplateAccess(
 
   let repo: GitHubRepo | null
   try {
-    // getRepo is 404-tolerant (returns null). A rate-limit also surfaces as 403,
-    // so check it before treating a 403 as an org restriction.
+    // getRepo is 404-tolerant (returns null). A rate-limit also surfaces as
+    // 403, so check it before treating a 403 as an org restriction.
     repo = await getRepo(client, parsed.owner, parsed.repo)
   } catch (err) {
     if (err instanceof GitHubAPIError && err.isRateLimited) {
@@ -351,10 +344,10 @@ export async function verifyTemplateAccess(
         policyUrl: githubOrgOAuthPolicyUrl(parsed.owner),
         message: err.message,
         httpStatus: err.status,
-        // A true scope gap is the token's granted scopes failing to satisfy the
-        // endpoint's required scopes — not the mere presence of the header, which
-        // GitHub sends on most 403s (an org restriction would otherwise be
-        // mislabeled as a scope problem). See GitHubAPIError.isScopeGap.
+        // A true scope gap is granted scopes failing to satisfy the endpoint's
+        // required scopes — not the mere presence of the header, which GitHub
+        // sends on most 403s (else an org restriction would be mislabeled a
+        // scope problem). See GitHubAPIError.isScopeGap.
         scopeGap: err.isScopeGap,
       }
     }
@@ -401,9 +394,9 @@ export async function verifyTemplateAccess(
 
   // A private fork whose upstream parent is private: `generate` copies the
   // fork's tree but can be blocked (403/404) when GitHub can't reach the private
-  // parent — common when the parent lives in another org. Warn before create so
-  // the teacher isn't surprised at accept. A public parent generates fine, so
-  // only warn when the parent is private (or its visibility is unknown).
+  // parent — common cross-org. Warn before create so the teacher isn't
+  // surprised at accept. A public parent generates fine, so only warn when the
+  // parent is private (or unknown).
   const fork = classifyPrivateFork(repo, org)
   if (fork.isRiskyPrivateFork) {
     return {
@@ -465,11 +458,11 @@ export async function resolveTemplate(
     )
   }
 
-  // Block a private fork whose upstream parent is private and cross-org (or of
-  // unknown visibility): GitHub's template generate reaches into the private
-  // upstream, which Classroom 50 can't access across orgs, so accept would fail.
-  // In-org private forks are allowed (the upstream is reachable). Mirrors the
-  // red "private-fork" pre-flight verdict. A public parent generates fine.
+  // Block a private fork whose upstream parent is private and cross-org (or
+  // unknown): generate reaches into the private upstream, which Classroom 50
+  // can't access across orgs, so accept would fail. In-org private forks are
+  // allowed (upstream reachable). Mirrors the "private-fork" verdict; a public
+  // parent generates fine.
   const fork = classifyPrivateFork(repo, org)
   if (fork.isRiskyPrivateFork && !fork.parentInOrg) {
     throw crossOrgPrivateForkError(parsed.owner, parsed.repo, org, fork.parent)
@@ -483,8 +476,8 @@ export async function resolveTemplate(
 
 // True when a parsed ref still points at the assignment's stored template, so
 // an edit can reuse the stored block instead of re-resolving live. Owner/repo
-// are case-insensitive (per GitHub); an omitted @branch means "keep the
-// stored branch". Edit only.
+// case-insensitive (per GitHub); an omitted @branch means "keep the stored
+// branch". Edit only.
 function templateRefUnchanged(
   parsed: ParsedTemplate,
   existing: Assignment["template"] | undefined,
@@ -496,8 +489,8 @@ function templateRefUnchanged(
   return sameOwner && sameRepo && sameBranch
 }
 
-// 404 -> false, 200 -> true, else throws. Wraps repoContentsPathExists for
-// the config repo (classroom50).
+// 404 -> false, 200 -> true, else throws. Wraps repoContentsPathExists for the
+// config repo (classroom50).
 async function contentsPathExists(
   client: GitHubClient,
   org: string,
@@ -558,10 +551,9 @@ export async function editAssignment(
     throw new Error(`Existing assignment matching ${slug} was not found.`)
   }
 
-  // Normalize the edit the same way as create so it never leaves stray
-  // non-schema keys the CLI rejects. Pass the stored template so an unchanged
-  // ref is reused without a live lookup (non-template edits save even if the
-  // template moved).
+  // Normalize the edit like create so it never leaves stray non-schema keys
+  // the CLI rejects. Pass the stored template so an unchanged ref is reused
+  // without a live lookup (non-template edits save even if the template moved).
   const { entry: editedAssignment, needsTeamGrant } =
     await buildAssignmentEntry(client, input, targetAssignment.template)
 
@@ -625,8 +617,8 @@ export async function editAssignment(
   }
 }
 
-// Same pre-write probes gh-teacher runs before writing declarative
-// tests (see the "For other clients" section of the Autograders wiki).
+// Same pre-write probes gh-teacher runs before writing declarative tests (see
+// the "For other clients" section of the Autograders wiki).
 async function ensureDeclarativeTestsWritable(
   client: GitHubClient,
   org: string,
@@ -672,10 +664,9 @@ async function buildAssignmentEntry(
 ): Promise<{ entry: Assignment; needsTeamGrant: boolean }> {
   const userTests = input.tests.map(draftToTest)
 
-  // A setup command is written as a leading 0-point `run` test named "setup"
-  // — the CLI-blessed pre-grading idiom (no runtime.setup field exists; the
-  // runner runs tests in order, non-zero exit fails the step). See
-  // makeSetupTest/isSetupTest.
+  // A setup command is written as a leading 0-point `run` test named "setup" —
+  // the CLI-blessed pre-grading idiom (no runtime.setup field; the runner runs
+  // tests in order, non-zero exit fails the step). See makeSetupTest/isSetupTest.
   const setupCommand = input.setup_command?.trim()
   const tests = setupCommand
     ? [makeSetupTest(setupCommand), ...userTests]
@@ -699,13 +690,11 @@ async function buildAssignmentEntry(
   if (input.template_repo.trim()) {
     const parsedTemplate = parseTemplateRef(input.template_repo, input.org)
     if (templateRefUnchanged(parsedTemplate, existingTemplate)) {
-      // The ref is unchanged, so the team was already granted at create time —
-      // no re-grant needed (needsTeamGrant stays false). But the stored ref may
-      // point at a template that has since become unreliable (e.g. a fork whose
-      // upstream went private, or a repo created before the fork guard shipped),
-      // so still re-validate it live via resolveTemplate — which now runs the
-      // cross-org private-fork guard — and fail closed before any commit rather
-      // than trusting the stored block blindly.
+      // Ref unchanged, so the team was already granted at create (needsTeamGrant
+      // stays false). But the stored ref may now be unreliable (e.g. a fork whose
+      // upstream went private, or a repo predating the fork guard), so still
+      // re-validate live via resolveTemplate — which runs the cross-org
+      // private-fork guard — and fail closed before any commit.
       await resolveTemplate(client, input.org, parsedTemplate)
       template = existingTemplate!
     } else {
@@ -716,8 +705,8 @@ async function buildAssignmentEntry(
   }
 
   // Must match classroom50/assignments/v1 exactly — the CLI rejects unknown
-  // fields, so a stray key breaks `gh teacher` for the whole classroom.
-  // Optional fields are omitted (not written empty), as the CLI writes them.
+  // fields, so a stray key breaks `gh teacher` for the whole classroom. Omit
+  // optional fields (don't write them empty), as the CLI does.
   const entry: Assignment = {
     slug: input.slug,
     name: input.name,
@@ -727,7 +716,7 @@ async function buildAssignmentEntry(
     feedback_pr: input.feedback_pr ?? true,
   }
   // Omit the template block entirely for a template-less assignment, matching
-  // how the CLI writes a nil TemplateRef.
+  // the CLI's nil TemplateRef.
   if (template) {
     entry.template = template
   }
@@ -743,8 +732,8 @@ async function buildAssignmentEntry(
   }
   if (input.mode === "group") {
     // A group size outside [GROUP_SIZE_MIN, GROUP_SIZE_MAX] (or non-integer)
-    // produces an assignments.json the CLI refuses to parse; enforce the schema
-    // bounds here, not just in the form.
+    // produces an assignments.json the CLI refuses to parse; enforce the
+    // schema bounds here, not just in the form.
     if (
       !Number.isInteger(input.max_group_size) ||
       input.max_group_size < GROUP_SIZE_MIN ||
@@ -792,10 +781,10 @@ async function buildAssignmentEntry(
     entry.tests = tests
   }
 
-  // pass_threshold: opt-in integer percentage [0,100]. Absent (undefined) means
-  // the teacher didn't enable a passing threshold, so the field is omitted
-  // entirely — absent = "no passing concept" everywhere downstream. Validate
-  // the bounds so a bad value can't produce a file the CLI refuses to parse.
+  // pass_threshold: opt-in integer percentage [0,100]. Absent means the teacher
+  // didn't enable a passing threshold, so omit the field entirely — absent =
+  // "no passing concept" everywhere downstream. Validate bounds so a bad value
+  // can't produce a file the CLI refuses to parse.
   if (input.pass_threshold !== undefined) {
     const threshold = input.pass_threshold
     if (
@@ -857,8 +846,8 @@ async function grantTeamTemplateRead(
   })
 }
 
-// Grant the template read but never throw: the commit has already landed, so
-// a grant failure can't be reported as a failed save. Returns an actionable
+// Grant the template read but never throw: the commit already landed, so a
+// grant failure can't be reported as a failed save. Returns an actionable
 // warning on failure (the assignment works except for student accept against
 // the private template), or undefined on success. Mirrors teamDeleteWarning.
 async function tryGrantTeamTemplateRead(
@@ -887,18 +876,17 @@ async function tryGrantTeamTemplateRead(
 }
 
 // Refuse a write into an archived classroom (active: false). The UI hides the
-// New-assignment / reuse / edit affordances, but the write path is the
-// authoritative guard — a stale tab, a direct API call, or a CLI/agent must not
-// be able to mutate an archived classroom. Reads classroom.json fresh and fails
-// closed before any commit. A genuinely teamless/legacy classroom (no `active`)
-// reads as active, so this never blocks normal use.
+// affordances, but the write path is the authoritative guard — a stale tab, a
+// direct API call, or a CLI/agent must not mutate an archived classroom. Reads
+// classroom.json fresh and fails closed before any commit. A teamless/legacy
+// classroom (no `active`) reads as active, so this never blocks normal use.
 export async function createAssignment(
   client: GitHubClient,
   input: CreateAssignmentInput,
 ): Promise<CreateAssignmentResult> {
-  // The archive guard, the assignment-entry build, and the org ref read are
-  // independent, so run them concurrently — Promise.all rejects on the first
-  // rejection, so an archived classroom still fails closed before any write.
+  // The archive guard, entry build, and org ref read are independent, so run
+  // them concurrently — Promise.all rejects on the first rejection, so an
+  // archived classroom still fails closed before any write.
   const [, { entry: assignmentBody, needsTeamGrant }, ref] = await Promise.all([
     assertClassroomNotArchived(client, input.org, input.classroom),
     buildAssignmentEntry(client, input),
@@ -1047,15 +1035,14 @@ export async function createAssignmentRepo(params: {
             )
       }
 
-      // Any other status is a real failure too — don't mask it with an empty
-      // repo.
+      // Any other status is a real failure too — don't mask it with an empty repo.
       throw err
     }
   }
 
   // No template specified — create an empty starter repo. auto_init seeds the
-  // README/initial commit; the metadata + shim land in the downstream tree
-  // commit (see provisionAcceptedRepo), together in one commit.
+  // initial commit; the metadata + shim land in the downstream tree commit (see
+  // provisionAcceptedRepo), all in one commit.
   return await createEmptyAssignmentRepo({
     client,
     owner,
@@ -1090,9 +1077,8 @@ async function createEmptyAssignmentRepo(params: {
   try {
     // metadata + workflow must land in ONE commit so the accept marker and the
     // autograde workflow share the runner's Feedback-PR baseline. auto_init
-    // gives us the initial commit to build that single tree commit on; we used
-    // to commit .classroom50.yaml alone first, splitting them and skewing the
-    // baseline.
+    // gives the initial commit to build that single tree commit on; committing
+    // .classroom50.yaml alone first would split them and skew the baseline.
     repo = await client.request<GitHubRepo>(`/orgs/${owner}/repos`, {
       method: "POST",
       body: {
@@ -1119,7 +1105,6 @@ async function createEmptyAssignmentRepo(params: {
   // Commit onto the repo's real default branch (GitHub picks it for an
   // auto_init repo); fall back to the requested branch, then "main".
   const targetBranch = repo.default_branch || branch || "main"
-
   return {
     kind: "fallback-empty",
     repo: {
@@ -1161,8 +1146,8 @@ export type CopyAssignmentInput = {
   // A resolved, schema-valid record from the source classroom's
   // assignments.json — copied verbatim, not re-derived from form input.
   source: Assignment
-  // Sibling classroom under classroom50/. In-org only for v1: a private template
-  // can only be team-granted within its own org.
+  // Sibling classroom under classroom50/. In-org only for v1: a private
+  // template can only be team-granted within its own org.
   targetClassroom: string
   // Default to the source slug/name; the slug must be unique in the target.
   targetSlug?: string
@@ -1213,10 +1198,10 @@ export function buildReusedEntry(
   const entry: Assignment = {
     // Spread the whole source so a field this client doesn't model yet rides
     // through — deliberate. assignments.json is a strict cross-binary contract
-    // that evolves by one binary adding a field before the others; preserving
-    // unknown keys is the "tolerate AND preserve" rule from
-    // evolving-strict-cross-binary-schemas.md (an allowlist would drop them).
-    // Known nested objects/arrays are re-cloned below so nothing is shared.
+    // that evolves by one binary adding a field before the others; "tolerate
+    // AND preserve" (evolving-strict-cross-binary-schemas.md; an allowlist would
+    // drop them). Known nested objects/arrays are re-cloned below so nothing is
+    // shared.
     ...source,
     slug,
     name,
@@ -1244,13 +1229,13 @@ export function buildReusedEntry(
 }
 
 // Ownership of every Assignment entry-level key on the edit path. Typed as a
-// total Record<keyof Assignment, ...>, so adding a field to the Assignment type
-// fails to compile here until it is classified — closing the silent-desync trap
-// where a new managed field omitted from the set lets an edit that clears it get
+// total Record<keyof Assignment, ...>, so adding a field to Assignment fails to
+// compile here until classified — closing the silent-desync trap where a new
+// managed field omitted from the set lets an edit that clears it get
 // re-populated from the stale existing entry. "managed": buildAssignmentEntry
-// rebuilds it from input, so an edit clearing it must win. "unmanaged": the form
-// never touches it; preserve it verbatim on a read-modify-write (mirrors the
-// CLI's AssignmentEntry.Extra).
+// rebuilds it from input, so a clearing edit must win. "unmanaged": the form
+// never touches it; preserve verbatim on read-modify-write (mirrors the CLI's
+// AssignmentEntry.Extra).
 const ASSIGNMENT_KEY_OWNERSHIP: Record<
   keyof Assignment,
   "managed" | "unmanaged"
@@ -1312,11 +1297,10 @@ export async function copyAssignmentToClassroom(
     name: input.targetName ?? source.name,
   })
 
-  // The archive guard (refuse reuse into an archived target), the template
-  // re-check, and the org ref read are all independent, so run them
-  // concurrently — one fewer serial round-trip per conflict-retry attempt.
-  // Promise.all rejects on the first rejection, so an archived classroom or a
-  // bad template still throws before any write — no commit.
+  // The archive guard, template re-check, and org ref read are independent, so
+  // run them concurrently — one fewer serial round-trip per retry attempt.
+  // Promise.all rejects on the first rejection, so an archived classroom or bad
+  // template throws before any write.
   const [, repo, ref] = await Promise.all([
     assertClassroomNotArchived(client, org, targetClassroom),
     entry.template
@@ -1348,8 +1332,8 @@ export async function copyAssignmentToClassroom(
     }
     // Same cross-org private-fork guard as resolveTemplate (create/edit): a
     // private fork whose private upstream lives in another org can't be reached
-    // by generate, so accept would fail. Enforce it here so reuse can't smuggle
-    // in a template that create/edit would have rejected.
+    // by generate, so accept would fail. Enforce here so reuse can't smuggle in
+    // a template create/edit would reject.
     const fork = classifyPrivateFork(repo, org)
     if (fork.isRiskyPrivateFork && !fork.parentInOrg) {
       throw crossOrgPrivateForkError(
@@ -1440,8 +1424,8 @@ export async function copyAssignmentWithConflictRetry(
 
 // editAssignment writes to the same classroom50 main branch as createAssignment
 // and the roster commits, so a concurrent write 409s non-fast-forward. It
-// re-reads the ref + assignments.json each call, so it's safe to retry — mirror
-// the create path.
+// re-reads the ref + assignments.json each call, so it's safe to retry —
+// mirror the create path.
 export async function editAssignmentWithConflictRetry(
   client: GitHubClient,
   input: CreateAssignmentInput,
@@ -1452,14 +1436,14 @@ export async function editAssignmentWithConflictRetry(
 export function createClassroom50Yaml(params: {
   classroom: string
   assignment: string
-  // `id` is the immutable numeric GitHub user id, recorded so the
-  // repo<->student binding survives a username rename.
+  // `id` is the immutable numeric GitHub user id, recorded so the repo<->student
+  // binding survives a username rename.
   ownerUsername: string
   ownerId?: number | null
   acceptedAt?: string
   // Optional capability-URL secret copied from the classroom's classroom.json
-  // at accept. Written only for a protected classroom; when present, submit
-  // and the autograde runner build the `<classroom>/<secret>/...` Pages path.
+  // at accept. Written only for a protected classroom; when present, submit and
+  // the autograde runner build the `<classroom>/<secret>/...` Pages path.
   secret?: string
   // Lets `gh student submit` re-fetch instructor files; omitted when template-less.
   sourceOwner?: string
@@ -1490,8 +1474,8 @@ export function createClassroom50Yaml(params: {
     `assignment: ${JSON.stringify(assignment)}`,
   ]
 
-  // Emit the secret right after the identity fields (matching the CLI's
-  // field order) and only when present, mirroring the CLI's `omitempty`.
+  // Emit the secret right after the identity fields (matching the CLI's field
+  // order) and only when present, mirroring the CLI's `omitempty`.
   if (secret) {
     lines.push(`secret: ${JSON.stringify(secret)}`)
   }
@@ -1591,8 +1575,8 @@ export async function deleteAssignment(
 }
 
 // Grant the student `admin` (not `maintain`) on their own repo. Intentional and
-// CLI-aligned: only an admin can manage collaborators for the
-// founder-driven group-invite flow (`gh student invite`).
+// CLI-aligned: only an admin can manage collaborators for the founder-driven
+// group-invite flow (`gh student invite`).
 async function addAdminCollaborator(params: {
   client: GitHubClient
   owner: string
@@ -1703,8 +1687,8 @@ function freshRepoNotReadyError(owner: string, repo: string) {
 
 // Land .classroom50.yaml + the autograde workflow as one Tree commit, riding out
 // GitHub's git-data lag after POST .../generate (reads 404, the first write 409s
-// "Git Repository is empty"). The whole read→build→commit→update sequence runs
-// inside withFreshRepoRetry, re-reading the ref + parent commit each attempt and
+// "Git Repository is empty"). The whole read→build→commit→update runs inside
+// withFreshRepoRetry, re-reading the ref + parent commit each attempt and
 // requiring non-empty SHAs before writing. Safe because the student's
 // just-accepted repo has no concurrent writers.
 async function commitAcceptFilesWithFreshRepoRetry(params: {
@@ -1834,10 +1818,10 @@ export async function acceptAssignment(params: {
   classroom: string
   assignmentSlug: string
   // Capability-URL access key from the accept link (?k=). Selects the
-  // <classroom>/<secret>/ Pages path for a protected classroom and is
-  // written into .classroom50.yaml so submit + the runner can rebuild the
-  // URLs. Undefined for an unprotected classroom (plain path). Not read
-  // from classroom.json — students can't access the private config repo.
+  // <classroom>/<secret>/ Pages path for a protected classroom and is written
+  // into .classroom50.yaml so submit + the runner can rebuild the URLs.
+  // Undefined for an unprotected classroom (plain path). Not read from
+  // classroom.json — students can't access the private config repo.
   secret?: string
   onStepUpdate?: OnAcceptStepUpdate
 }): Promise<AcceptAssignmentResult> {
@@ -1858,10 +1842,10 @@ export async function acceptAssignment(params: {
   const username = user.login
 
   // Tracked membership step: accept any pending org invite and verify the
-  // student is now an ACTIVE member before we attempt repo creation (a pending
-  // invitee can't create their repo). Verifying here means a SAML-SSO-gated 403
-  // surfaces as an actionable step failure right away (with the SSO/HTTP status
-  // in the message) instead of a confusing downstream repo/access failure.
+  // student is now an ACTIVE member before repo creation (a pending invitee
+  // can't create their repo). Verifying here means a SAML-SSO-gated 403 surfaces
+  // as an actionable step failure right away (with the SSO/HTTP status) instead
+  // of a confusing downstream repo/access failure.
   await withAcceptStep(
     {
       id: "membership",
@@ -1958,11 +1942,10 @@ export async function acceptAssignment(params: {
   if (created.kind === "already-accepted") {
     // The repo exists, but a prior accept may have failed AFTER creating it but
     // BEFORE committing the metadata/workflow (seeding lag, transient 5xx),
-    // leaving a repo that looks accepted but never autogrades. Heal it: a repo
-    // is only "genuinely accepted" when BOTH the metadata and the autograde
-    // workflow landed (they're written in one commit, so a missing workflow
-    // means the prior accept failed mid-flow). If either is missing, re-run the
-    // idempotent provisioning.
+    // leaving a repo that looks accepted but never autogrades. A repo is only
+    // "genuinely accepted" when BOTH the metadata and workflow landed (one
+    // commit, so a missing workflow means the prior accept failed mid-flow). If
+    // either is missing, re-run the idempotent provisioning.
     const [hasMetadata, hasWorkflow] = await Promise.all([
       repoContentsPathExists(
         client,

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1545,7 +1545,6 @@ export async function deleteAssignment(
     ref: ref.object.sha,
   })
 
-  // find the assignment if it exists already
   const targetAssignment = currentAssignments.assignments.find(
     (a) => a.slug === slug,
   )
@@ -1554,7 +1553,6 @@ export async function deleteAssignment(
     throw new Error(`Existing assignment matching ${slug} was not found.`)
   }
 
-  // expand all but the targeted assignment to filter it out
   const nextAssignments = {
     ...currentAssignments,
     assignments: [

--- a/web/src/api/mutations/classrooms.ts
+++ b/web/src/api/mutations/classrooms.ts
@@ -34,9 +34,9 @@ export async function createClassroomFiles(
   input: CreateClassroomInput,
 ): Promise<CreateClassroomResult> {
   // Create (or adopt) the teams BEFORE scaffolding so their { id, slug } land in
-  // classroom.json (mirrors the CLI's ordering). The students team grants
-  // rostered students read on private org templates; the staff teams
-  // (instructor, ta) get config-repo write and back the in-app roles.
+  // classroom.json (mirrors the CLI). The students team grants rostered students
+  // read on private org templates; the staff teams (instructor, ta) get
+  // config-repo write and back the in-app roles.
   const { created: teamCreated, ...team } = await ensureClassroomTeam(
     client,
     input.org,
@@ -160,10 +160,9 @@ export type CreateClassroomInput = {
   name?: string
   classroom: string
   term: string
-  // Optional capability-URL secret (opt-in). When set, classroom.json
-  // records it and published Pages resources live under
-  // `<classroom>/<secret>/...`. Validated to `[a-z0-9]{4,64}` before the
-  // mutation runs.
+  // Optional capability-URL secret (opt-in). When set, classroom.json records
+  // it and published Pages resources live under `<classroom>/<secret>/...`.
+  // Validated to `[a-z0-9]{4,64}` before the mutation runs.
   secret?: string
   // The viewer's GitHub login, added to the instructor staff team on create so
   // the creator gets the instructor role. Optional — the classroom still
@@ -177,9 +176,6 @@ export async function createClassroomFilesWithConflictRetry(
   return withGitConflictRetry(() => createClassroomFiles(client, input))
 }
 
-// editClassroom does a read-modify-write on the shared classroom50 main branch
-// (re-reading the ref + classroom.json each call), so a concurrent write 409s
-// the updateRef. It is safe to retry.
 // Refuse a write into an archived classroom (active: false). The UI hides the
 // affordances, but the write path is the authoritative guard (stale tab, direct
 // API call, CLI/agent). Reads classroom.json fresh and fails closed before any
@@ -197,9 +193,8 @@ export async function assertClassroomNotArchived(
     // A missing/legacy classroom.json reads as active — never block.
     if (err instanceof GitHubAPIError && err.isNotFound) return
     // A transient read failure (rate-limit / 5xx / network) can't prove the
-    // classroom's state. Stay fail-closed (don't let a write into a possibly
-    // archived classroom through), but surface an actionable message instead
-    // of bubbling the raw GitHub error as if the write itself failed.
+    // classroom's state. Stay fail-closed, but surface an actionable message
+    // instead of bubbling the raw GitHub error as if the write itself failed.
     if (isTransientReadError(err)) {
       throw new Error(
         `Couldn't verify whether classroom "${classroom}" is archived (a temporary problem reading its settings). Please try again.`,
@@ -301,8 +296,8 @@ export async function deleteClassroom(
 
   // Resolve the team refs from classroom.json BEFORE the deletion commit
   // removes the file. No team block (pre-feature) or a read failure yields no
-  // refs, making the deletes below no-ops. Both the students team and the staff
-  // teams are removed so repo deletion doesn't orphan them.
+  // refs, making the deletes below no-ops. Both the students and staff teams are
+  // removed so repo deletion doesn't orphan them.
   let team: { id: number; slug: string } | undefined
   let staffTeams: StaffTeamRefs
   try {
@@ -385,12 +380,12 @@ export async function deleteClassroom(
     },
   })
 
-  // Delete the per-classroom teams (idempotent; 404 = already gone): the
-  // students team plus the staff teams. Filtered through the shared guard so a
-  // drifted/hand-edited ref outside the classroom50- namespace never enters the
-  // delete set. A delete failure must NOT undo the already-committed config
-  // removal — surface it as a non-fatal warning. Each delete retries a transient
-  // blip; a permanent refusal is recorded without retrying.
+  // Delete the per-classroom teams (idempotent; 404 = already gone): students
+  // plus staff. Filtered through the shared guard so a drifted/hand-edited ref
+  // outside the classroom50- namespace never enters the delete set. A delete
+  // failure must NOT undo the already-committed config removal — surface it as a
+  // non-fatal warning. Each delete retries a transient blip; a permanent refusal
+  // is recorded without retrying.
   const refsToDelete = [team, staffTeams.instructor, staffTeams.ta].filter(
     isDeletableClassroomTeamRef,
   )

--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -14,10 +14,10 @@ import {
 import { GitHubAPIError } from "@/hooks/github/errors"
 import type { GitHubClient } from "@/hooks/github/client"
 
-// An already-org-member must land `enrolled` (not stuck "awaiting"), the
-// per-row confirm must refuse a non-member, and an already-member email invite
-// must resolve cross-roster or drop the stub. I/O is stubbed via a path-routing
-// fake client; assertions read the students.csv committed to git/trees.
+// An already-org-member must land `enrolled` (not stuck "awaiting"), the per-row
+// confirm must refuse a non-member, and an already-member email invite must
+// resolve cross-roster or drop the stub. I/O is stubbed via a path-routing fake
+// client; assertions read the students.csv committed to git/trees.
 
 type CommittedCsv = { content: string | null }
 
@@ -104,11 +104,11 @@ const HEADER = "username,first_name,last_name,email,section,github_id\n"
 
 // The web leg of the three-way students.csv header lockstep. The Go
 // (TestFullRosterHeader) and Python (test_full_roster_header_matches_go_constant)
-// suites each pin their own header constant to this exact string; the web app is
-// what WRITES the file's column order (via STUDENT_CSV_FIELDS), so without this
+// suites each pin their own header constant to this exact string; the web app
+// WRITES the file's column order (via STUDENT_CSV_FIELDS), so without this
 // assertion a web-only reorder/rename would keep every web test green while the
 // CLI's ParseRoster and the collector's read_students_csv reject every roster
-// the web subsequently writes. Pin the source-of-truth constant, not a fixture.
+// the web writes. Pin the source-of-truth constant, not a fixture.
 describe("students.csv header lockstep (web leg)", () => {
   it("STUDENT_CSV_FIELDS matches the Go/Python header verbatim", () => {
     expect(STUDENT_CSV_FIELDS.join(",")).toBe(
@@ -329,8 +329,8 @@ describe("inviteStudentByEmail — already-member email resolution (email path)"
   it("warns when the classroom team can't be attached (team-less invite risk)", async () => {
     // With no persisted team block, the invite goes out team-less. That must
     // warn: with the onboarding reconcile path removed and collection now
-    // team-driven, a student who accepts a team-less invite is uncollected
-    // until the teacher runs Sync roster. The invite MUST still be sent.
+    // team-driven, a student who accepts a team-less invite is uncollected until
+    // the teacher runs Sync roster. The invite MUST still be sent.
     const { client, rosters } = makeEmailClient({
       rosters: { cs101: HEADER },
       inviteSucceeds: true,
@@ -903,10 +903,10 @@ describe("updateStudent — edit a roster row's teacher-facing fields in place",
   })
 })
 
-// Unenroll is classroom-scoped — it never removes an ACTIVE org member
-// (that would leave other rosters showing them enrolled while non-member of the
-// org). A pending invite is still cancelled. The fake tracks org-membership
-// DELETEs and the committed roster so we can assert both.
+// Unenroll is classroom-scoped — it never removes an ACTIVE org member (that
+// would leave other rosters showing them enrolled while non-member of the org).
+// A pending invite is still cancelled. The fake tracks org-membership DELETEs
+// and the committed roster so we can assert both.
 describe("unenrollStudent — classroom-scoped, no active-member org removal", () => {
   const aliceEnrolled = "alice,Alice,A,alice@x.edu,,42\n"
   const bobInvited = "bob,Bob,B,bob@x.edu,,43\n"
@@ -1306,8 +1306,8 @@ describe("bulkUnenrollStudents — single-commit batch removal", () => {
 
   it("email-only target drops ONLY an email-only row, never a same-email identified sibling", async () => {
     // Regression: an email-only removal target (no username, no github_id) must
-    // match only an unclaimed email-only row. Two rows share sam@x.edu — one is
-    // a fully-identified enrolled student, the other an unclaimed email invite.
+    // match only an unclaimed email-only row. Two rows share sam@x.edu — one a
+    // fully-identified enrolled student, the other an unclaimed email invite.
     // Removing the email-only target must not silently unenroll the sibling.
     const startingCsv =
       HEADER +

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -157,23 +157,21 @@ function parseStudentsCsv(csv: string): StudentCsvRow[] {
     .filter((row) => row.username || row.github_id || row.email)
 }
 
-// Neutralize spreadsheet formula injection (OWASP CSV injection) in the
-// free-text fields a teacher OR a GitHub member can influence. A value starting
-// with = + - @ (or a leading tab/CR that a spreadsheet treats as a formula
-// lead) is prefixed with a single quote so Excel/Sheets render it as text.
-// Idempotent: a value already quote-guarded isn't double-prefixed. Applied to
-// name/section free text AND to email — email is a member-controlled GitHub
-// profile field written verbatim by syncRosterFromTeam/bulk import, so a
+// Neutralize spreadsheet formula injection (OWASP CSV injection) in free-text
+// fields a teacher OR a GitHub member can influence. A value starting with
+// = + - @ (or a leading tab/CR a spreadsheet treats as a formula lead) is
+// prefixed with a single quote so Excel/Sheets render it as text. Idempotent.
+// Applied to name/section free text AND email — email is a member-controlled
+// GitHub profile field written verbatim by syncRosterFromTeam/bulk import, so a
 // formula-leading verified email (e.g. `=1+1@evil.com`) would otherwise reach
-// students.csv and execute on open. Deliberately NOT applied to
+// students.csv and execute on open. NOT applied to
 // github_id/tokens/hashes/timestamps, which must round-trip byte-exact.
 //
 // NOTE: this writes the leading quote into the STORED value, so any consumer of
-// students.csv (this app's parse layer and the gh-teacher CLI) sees and must
-// tolerate it on these fields. The gh-teacher Go writer defangs the same set;
-// keep them in lockstep. The guard runs on the stored cell only; email matching
-// keys on the normalized (trim+lowercase) email, so guarding the cell does not
-// affect match-by-email.
+// students.csv (this app's parse layer, the gh-teacher CLI) must tolerate it on
+// these fields. The Go writer defangs the same set; keep them in lockstep.
+// Email matching keys on the normalized (trim+lowercase) email, so guarding the
+// cell doesn't affect match-by-email.
 const FORMULA_LEAD = /^[=+\-@\t\r]/
 const FORMULA_GUARDED_FIELDS = [
   "first_name",
@@ -582,12 +580,12 @@ export async function inviteStudentByEmail(
   // Attach the classroom team to the invite so the student lands in it on
   // acceptance. If the team id can't be attached — the resolve threw, or the
   // classroom has no persisted team block — we still send the invite (the row
-  // already landed and a team-less org member is recoverable), but we MUST warn:
-  // the reconcile path that used to re-add such a student was removed with the
+  // landed and a team-less org member is recoverable), but we MUST warn: the
+  // reconcile path that used to re-add such a student was removed with the
   // self-report subsystem, and grade collection is now team-driven — a student
   // who accepts a team-less invite becomes an org member absent from the team,
-  // so they render as an `unprovisioned` drift row and are silently uncollected
-  // until the teacher runs "Sync roster" or "Match account".
+  // rendering as an `unprovisioned` drift row, silently uncollected until the
+  // teacher runs "Sync roster" or "Match account".
   let teamId: number | undefined
   try {
     teamId = (await resolveClassroomTeam(client, input.org, input.classroom)).id
@@ -670,12 +668,10 @@ export async function inviteStudentByEmail(
         }
       } else if (!resolved || resolved.status === "ambiguous") {
         // Member but unidentifiable from any roster (no match, or an ambiguous
-        // email mapping to multiple students). Keep the invited email row
-        // (don't drop it): the student is in the org, but the email->login link
-        // is unrecoverable post-accept, so the teacher must complete the match
-        // by hand (the "Match account" affordance) or delete the row from this
-        // classroom's roster. Reconcile surfaces it as
-        // needsMatch.
+        // email mapping to multiple students). Keep the invited email row: the
+        // student is in the org, but the email->login link is unrecoverable
+        // post-accept, so the teacher must complete the match by hand ("Match
+        // account") or delete the row. Reconcile surfaces it as needsMatch.
         return {
           ...result,
           inviteWarning:
@@ -720,7 +716,8 @@ export async function enrollStudentInClassroom(
   const { org, classroom } = input
   await assertClassroomNotArchived(client, org, classroom)
   // Resolve the classroom team (slug + id) once, concurrently with the commit.
-  // Can reject on a transient read; attach a catch to avoid an unhandled rejection.
+  // Can reject on a transient read; attach a catch to avoid an unhandled
+  // rejection.
   const teamPromise = resolveClassroomTeam(client, org, classroom)
   teamPromise.catch(() => {})
 
@@ -809,13 +806,12 @@ export type MatchStudentToAccountInput = {
 }
 
 // Teacher-initiated manual match for an email-invited row whose student joined
-// the org directly and whose identity GitHub no longer exposes (the
-// email->login link is dropped once an invite is accepted). The
-// teacher selects which org/team member owns the email; this writes that
-// identity onto the email-keyed row and enrolls it. Re-verifies the chosen
-// account is an ACTIVE member before binding (the same active-membership
-// trust model used across the enroll paths, #65/#50), so a wrong/stale pick
-// can't bind a non-member.
+// the org directly and whose identity GitHub no longer exposes (the email->login
+// link is dropped once an invite is accepted). The teacher picks which org/team
+// member owns the email; this writes that identity onto the email-keyed row and
+// enrolls it. Re-verifies the chosen account is an ACTIVE member before binding
+// (the active-membership trust model used across the enroll paths, #65/#50), so
+// a wrong/stale pick can't bind a non-member.
 async function matchStudentToAccount(
   client: GitHubClient,
   input: MatchStudentToAccountInput,
@@ -1182,11 +1178,11 @@ export type SyncRosterFromTeamResult = {
 // team is the source of truth for enrollment; this only persists optional
 // display metadata. Never removes rows (CSV-only rows are drift, not deletions).
 //
-// The diff is recomputed INSIDE the retried closure (re-reading both the team
-// and the CSV each attempt) so a 409 retry or a concurrent teacher edit can't
-// reintroduce or duplicate rows. Uses the same github_id -> username fallback
-// join as the roster view when deciding "missing", so a pre-resolution row with
-// an empty github_id isn't treated as missing (which would append a duplicate).
+// The diff is recomputed INSIDE the retried closure (re-reading both team and
+// CSV each attempt) so a 409 retry or concurrent edit can't reintroduce or
+// duplicate rows. Uses the same github_id -> username fallback join as the
+// roster view when deciding "missing", so a pre-resolution row with an empty
+// github_id isn't treated as missing (which would append a duplicate).
 export async function syncRosterFromTeam(
   client: GitHubClient,
   input: { org: string; classroom: string },
@@ -1215,10 +1211,10 @@ export async function syncRosterFromTeam(
 
     const { ids, logins } = rosterClaimSet(currentStudents)
     // Email set mirrors buildTeamRoster's indexCsv.byEmail fold: a member whose
-    // GitHub profile email matches an existing (e.g. pre-resolution, id/login-
-    // less) CSV row is the SAME person the view already folds by email, so
-    // appending would create a duplicate email-colliding row the view masks but
-    // that breaks email-keyed logic (match-by-email, invite dedupe).
+    // GitHub email matches an existing (e.g. pre-resolution, id/login-less) CSV
+    // row is the SAME person the view folds by email, so appending would create
+    // a duplicate email-colliding row the view masks but that breaks email-keyed
+    // logic (match-by-email, invite dedupe).
     const emails = new Set(
       currentStudents
         .map((s) => s.email?.trim().toLowerCase())
@@ -1412,12 +1408,11 @@ export async function bulkEnrollStudentsInClassroom(
 // unenrollStudent and bulkUnenrollStudents so the two can't drift.
 //
 // Precedence mirrors enrollment identity: when the target carries a username or
-// github_id, match on those only (never on email — a shared email must not
-// widen the match). Email is a fallback ONLY for an email-only target (no
-// username, no github_id), and then it matches ONLY an email-only row (a row
-// that is itself unclaimed: no username, no github_id). Without that guard a
-// batch remove of one email-only invite would drop every other roster row that
-// happens to share the email, silently unenrolling an unselected student.
+// github_id, match on those only (never email — a shared email must not widen
+// the match). Email is a fallback ONLY for an email-only target (no username,
+// no github_id), and then matches ONLY an email-only row (itself unclaimed).
+// Without that guard, batch-removing one email-only invite would drop every
+// other row sharing the email, silently unenrolling an unselected student.
 export function matchesRosterRow(row: StudentCsvRow, target: Student): boolean {
   const username = target.username?.trim()
   const githubId = target.github_id?.trim()
@@ -1453,8 +1448,8 @@ export async function unenrollStudent(
   const normalizedUsername = toRemoveStudent?.username.trim()
   const normalizedEmail = toRemoveStudent?.email?.trim()
 
-  // An email-invited row that hasn't been claimed yet has no username, so accept
-  // email too. One of the two must be present to target a row.
+  // An email-invited row not yet claimed has no username, so accept email too.
+  // One of the two must be present to target a row.
   if (!normalizedUsername && !normalizedEmail) {
     throw new Error("Student's GitHub username or email is required")
   }
@@ -1553,8 +1548,8 @@ export async function unenrollStudent(
 
   // Cancel a pending invite (a not-yet-accepted invitee has no cross-classroom
   // footprint). An ACTIVE member is never removed here — unenroll is
-  // classroom-scoped; org removal lives on the Members page.
-  // Resolve defensively: a reject after the roster commit landed would discard
+  // classroom-scoped; org removal lives on the Members page. Resolve
+  // defensively: a reject after the roster commit landed would discard
   // accumulated warnings and break the "commit landed -> non-fatal" guarantee.
   const orgState = await orgStatePromise.catch(() => null)
 
@@ -1620,18 +1615,16 @@ export type BulkUnenrollStudentsResult = {
 
 // Remove MANY students from one classroom in a SINGLE roster commit, then run
 // the per-student org-side side effects (team drop + pending-invite cancel)
-// best-effort. This is the batch form of unenrollStudent: looping that per
-// student produces one commit PER student (N noisy "Remove student" commits
-// racing the same ref), whereas real classes are unenrolled in bulk. Mirrors
-// bulkEnrollStudentsInClassroom / addStudentsToClassroom, which already write
-// all rows in one commit.
+// best-effort. The batch form of unenrollStudent: looping that per student
+// would produce one commit PER student (N noisy commits racing the same ref),
+// whereas real classes are unenrolled in bulk. Mirrors
+// bulkEnrollStudentsInClassroom / addStudentsToClassroom (one commit for all).
 //
 // The CSV rewrite is conflict-retried and re-reads inside the closure, so a
 // concurrent edit can't be clobbered. Org-side steps run only AFTER the commit
-// lands, so — as in unenrollStudent — they are non-fatal warnings, never fail
-// the removal. Active members are never removed from the org here (unenroll is
-// classroom-scoped); only a still-PENDING invite is cancelled, and never the
-// signed-in teacher's own.
+// lands, so — as in unenrollStudent — they are non-fatal warnings. Active
+// members are never removed from the org here (unenroll is classroom-scoped);
+// only a still-PENDING invite is cancelled, and never the signed-in teacher's.
 export async function bulkUnenrollStudents(
   client: GitHubClient,
   input: BulkUnenrollStudentsInput,
@@ -1855,11 +1848,10 @@ export async function updateStudent(
   const emailChanged = nextEmail.toLowerCase() !== existing.email.toLowerCase()
 
   // An email-only row (no username, no github_id) is identified solely by its
-  // email: it's that row's studentKey, both server-side here and in the UI's
-  // optimistic cache. Editing the email would re-key (or, if cleared, drop) the
-  // row — stringifyStudentsCsv discards keyless rows, so a cleared email
-  // silently deletes the student. Refuse any email change on such a row; the
-  // teacher should unenroll instead.
+  // email — its studentKey, both here and in the UI's optimistic cache. Editing
+  // the email would re-key it (or, if cleared, drop it: stringifyStudentsCsv
+  // discards keyless rows, silently deleting the student). Refuse any email
+  // change on such a row; the teacher should unenroll instead.
   if (emailChanged && !existing.username && !existing.github_id) {
     throw new Error(
       "Can't change the email for this student: they have no GitHub username " +

--- a/web/src/api/mutations/teardown.test.ts
+++ b/web/src/api/mutations/teardown.test.ts
@@ -14,9 +14,9 @@ import type { GitHubClient } from "@/hooks/github/client"
 
 // Teardown mirrors the CLI: marker-gated (refuse orgs without classroom50),
 // delete ALL org repos, marker deleted last (re-runnable), 403 = scope wall.
-// It also deletes the per-classroom team of every classroom in classroom.json
-// (only teams a classroom links to — never a stray classroom50-* team). The
-// fake client serves the marker probe, repo list, classroom dir listing,
+// Also deletes the per-classroom team of every classroom in classroom.json
+// (only teams a classroom links to — never a stray classroom50-* team). The fake
+// client serves the marker probe, repo list, classroom dir listing,
 // per-classroom classroom.json, and the team id-match GET + DELETE.
 
 function notFound(): GitHubAPIError {
@@ -539,7 +539,7 @@ describe("executeTeardown", () => {
 
   it("refuses to delete a team whose live id no longer matches (reused slug)", async () => {
     // The slug now points at a different team (different id) than the one this
-    // classroom recorded — deleteClassroomTeam refuses with a TeamIdMismatchError,
+    // classroom recorded — deleteClassroomTeam refuses with TeamIdMismatchError,
     // it lands in teamsFailed without clobbering the unrelated team, and because
     // the refusal is PERMANENT (a re-run repeats it) the marker is still deleted
     // so teardown isn't wedged forever.

--- a/web/src/api/mutations/teardown.ts
+++ b/web/src/api/mutations/teardown.ts
@@ -1,10 +1,10 @@
 // Org teardown — the web mirror of the CLI's `gh teacher teardown` (delete
 // every repo in the org, marker-gated, marker deleted last). Mirrors the CLI's
-// scope decision (ALL org repos, not a leaky managed-only filter) and its
-// safety model. It also removes the per-classroom team of every classroom in
-// the org's classroom.json so repo deletion doesn't leave those teams orphaned.
-// Destructive and irreversible — the caller gates it behind a typed-org-name
-// ConfirmModal that lists exactly what will be deleted.
+// scope decision (ALL org repos, not a leaky managed-only filter) and safety
+// model. Also removes the per-classroom team of every classroom in the org's
+// classroom.json so repo deletion doesn't orphan those teams. Destructive and
+// irreversible — the caller gates it behind a typed-org-name ConfirmModal that
+// lists exactly what will be deleted.
 
 import type { GitHubClient } from "@/hooks/github/client"
 import { getClassroomJson } from "@/api/github/queries"
@@ -58,17 +58,17 @@ export type TeardownPlan = {
   org: string
   repoNames: string[]
   // Per-classroom teams to delete, resolved from each classroom's classroom.json
-  // (deduped by slug). Surfaced so the confirm UI can list exactly what's
-  // removed. Only teams a classroom actually links to are deleted — a manually
-  // created team is never touched, even if it shares the classroom50- naming.
+  // (deduped by slug). Surfaced so the confirm UI lists exactly what's removed.
+  // Only teams a classroom actually links to are deleted — a manually created
+  // team is never touched, even if it shares the classroom50- naming.
   teams: ClassroomTeamRef[]
 }
 
 // Read each classroom's classroom.json and collect its team ref, deduped by
 // slug. Per-classroom reads are best-effort: a classroom with no team block
-// (pre-feature) or an unreadable classroom.json simply contributes no ref, so a
-// single bad file never blocks the rest of teardown. classroom.json lives in
-// the marker repo, so this must run before the marker is deleted.
+// (pre-feature) or an unreadable classroom.json contributes no ref, so one bad
+// file never blocks the rest of teardown. classroom.json lives in the marker
+// repo, so this must run before the marker is deleted.
 async function collectClassroomTeams(
   client: GitHubClient,
   org: string,
@@ -87,9 +87,9 @@ async function collectClassroomTeams(
     try {
       const json = await getClassroomJson(client, { org, classroom: dir.name })
       // classroom.json is anyone-with-config-repo-write authored and parsed
-      // without schema validation, so the team refs it names are untrusted
-      // input to a destructive bulk DELETE. Only queue refs the app owns and
-      // can safely delete — see isDeletableClassroomTeamRef.
+      // without schema validation, so its team refs are untrusted input to a
+      // destructive bulk DELETE. Only queue refs the app owns and can safely
+      // delete — see isDeletableClassroomTeamRef.
       const candidates = [json.team, json.teams?.instructor, json.teams?.ta]
       for (const team of candidates) {
         if (isDeletableClassroomTeamRef(team)) {
@@ -104,7 +104,7 @@ async function collectClassroomTeams(
   return [...bySlug.values()]
 }
 
-// Enumerate the deletion plan: every repo in the org (marker ordered last so an
+// Enumerate the deletion plan: every repo in the org (marker last so an
 // interrupted run leaves the marker behind, re-runnable) plus the per-classroom
 // teams resolved from classroom.json. Refuses an org without the classroom50
 // marker repo.
@@ -135,10 +135,10 @@ export type TeardownResult = {
   // Team slugs that could not be deleted (run stays re-runnable).
   teamsFailed: string[]
   // Whether the marker repo (classroom50) was deleted this run. False means it
-  // was retained because something recoverable failed, so the org is still
-  // re-runnable; true means teardown completed the marker and a re-run would
-  // refuse on the now-missing marker (any leftover teams must be removed by
-  // hand). The UI's remedy message keys off this.
+  // was retained because something recoverable failed, so the org stays
+  // re-runnable; true means teardown finished the marker and a re-run would
+  // refuse on the now-missing marker (leftover teams must be removed by hand).
+  // The UI's remedy message keys off this.
   markerDeleted: boolean
 }
 
@@ -170,9 +170,9 @@ type UnretryableDisposition = "rethrow" | "permanent" | null
 
 // Shared bounded-retry loop for destructive deletes (repos and teams). Owns the
 // attempt count, exponential backoff + jitter, and Retry-After honoring; the
-// only per-caller policy is `classifyUnretryable`, which decides what to do
-// with a non-rate-limit error. Factored out so the repo and team delete paths
-// can't drift in their backoff/retry behavior.
+// only per-caller policy is `classifyUnretryable`, deciding what to do with a
+// non-rate-limit error. Factored out so repo and team deletes can't drift in
+// backoff/retry behavior.
 async function withDeleteRetry(
   deleteFn: () => Promise<void>,
   classifyUnretryable: (
@@ -189,7 +189,7 @@ async function withDeleteRetry(
       lastWasRateLimit = isRateLimited
 
       // A non-GitHubAPIError (e.g. the id-mismatch guard) can never succeed on
-      // retry: it's a permanent refusal.
+      // retry: a permanent refusal.
       if (!(err instanceof GitHubAPIError)) return "permanent-failed"
 
       if (!isRateLimited) {
@@ -230,11 +230,11 @@ function deleteRepoWithRetry(
 }
 
 // Delete one classroom team (by its persisted { id, slug }), retrying transient
-// failures the same way repo deletes do. Uses deleteClassroomTeam, which
-// confirms the live team's id matches the persisted id before deleting (so a
-// reused slug isn't clobbered) and treats 404 as already-gone. A scope/
-// permission 403 (the team-delete path swallows rather than rethrows the scope
-// wall) and an id mismatch are permanent refusals: recorded without retrying.
+// failures like repo deletes do. Uses deleteClassroomTeam, which confirms the
+// live team's id matches the persisted id before deleting (so a reused slug
+// isn't clobbered) and treats 404 as already-gone. A scope/permission 403 (the
+// team-delete path swallows rather than rethrows the scope wall) and an id
+// mismatch are permanent refusals: recorded without retrying.
 function deleteClassroomTeamWithRetry(
   client: GitHubClient,
   org: string,
@@ -246,15 +246,15 @@ function deleteClassroomTeamWithRetry(
   )
 }
 
-// Delete the per-classroom teams resolved from classroom.json. Deletes are
-// best-effort: a failure is recorded but never aborts teardown, mirroring the
-// repo flow's re-runnable contract. A *recoverable* failure (a throttle or a
-// transient 5xx) is reported separately (teamsRecoverable): unlike a permanent
-// refusal it can succeed on a re-run, so the caller retains the marker repo
-// (which holds classroom.json, the only team-ref source) rather than deleting
-// it and orphaning a team a re-run would otherwise have cleaned up. A permanent
-// refusal (a reused-slug id mismatch, or a scope 403) lands in teamsFailed and
-// does NOT retain the marker — a re-run would just refuse it again.
+// Delete the per-classroom teams resolved from classroom.json. Best-effort: a
+// failure is recorded but never aborts teardown, mirroring the repo flow's
+// re-runnable contract. A *recoverable* failure (throttle or transient 5xx) is
+// reported separately (teamsRecoverable): unlike a permanent refusal it can
+// succeed on a re-run, so the caller retains the marker repo (which holds
+// classroom.json, the only team-ref source) rather than orphaning a team a
+// re-run would have cleaned up. A permanent refusal (reused-slug id mismatch,
+// or a scope 403) lands in teamsFailed and does NOT retain the marker — a
+// re-run would just refuse it again.
 async function deleteClassroomTeams(
   client: GitHubClient,
   org: string,
@@ -290,8 +290,8 @@ async function deleteClassroomTeams(
 //
 // The repo set is re-enumerated here, not taken from plan.repoNames: the plan
 // is captured when the confirm modal opens, but a repo can be created during
-// the type-to-confirm pause. Re-listing keeps the "delete every repo"
-// guarantee against the live org and re-checks the marker gate.
+// the type-to-confirm pause. Re-listing keeps the "delete every repo" guarantee
+// against the live org and re-checks the marker gate.
 export async function executeTeardown(
   client: GitHubClient,
   plan: TeardownPlan,
@@ -339,14 +339,14 @@ export async function executeTeardown(
   abortIfBlocked()
 
   // Remove the per-classroom teams BEFORE the marker repo is deleted —
-  // classroom.json (the team-ref source) lives in the marker repo, so reading
-  // it after would be impossible. `current.teams` was resolved fresh by the
-  // re-enumerating planTeardown above (not the possibly-stale modal plan).
-  // Best-effort: a team failure never blocks the marker.
+  // classroom.json (the team-ref source) lives in the marker repo, so reading it
+  // after would be impossible. `current.teams` was resolved fresh by the
+  // re-enumerating planTeardown above (not the stale modal plan). Best-effort: a
+  // team failure never blocks the marker.
   const { teamsDeleted, teamsFailed, teamsRecoverable } =
     await deleteClassroomTeams(client, plan.org, current.teams)
 
-  // Marker deleted only on a fully-successful run; otherwise it's left behind so
+  // Marker deleted only on a fully-successful run; otherwise left behind so
   // planTeardown's gate still passes and the run stays re-runnable. A
   // *recoverable* team failure (throttle or transient 5xx) retains the marker
   // too, so a re-run can re-resolve classroom.json and finish the team; a
@@ -393,9 +393,9 @@ export function formatTeardownResult(
       : "",
   ].filter(Boolean)
 
-  // The marker is the team-ref source (classroom.json). If it's still present,
-  // a re-run can finish the job; if it's gone, a re-run would just refuse on the
-  // missing marker, so any leftover teams must be removed by hand.
+  // The marker is the team-ref source (classroom.json). If still present, a
+  // re-run can finish the job; if gone, a re-run would refuse on the missing
+  // marker, so any leftover teams must be removed by hand.
   const remedy = !result.markerDeleted
     ? "Re-run teardown to finish."
     : `Remove the leftover ${result.teamsFailed.length === 1 ? "team" : "teams"} by hand at ${orgTeamsUrl}.`

--- a/web/src/api/mutations/users.ts
+++ b/web/src/api/mutations/users.ts
@@ -3,9 +3,9 @@ import { getPendingOrgInvite } from "@/hooks/github/mutations"
 import type { GitHubOrgMembership } from "@/hooks/github/types"
 
 // Accept a pending org invitation for the authenticated user. Returns whether
-// the PATCH succeeded so callers can distinguish "now active" from a transient
-// failure (a swallowed failure previously stranded the accept/verify round-trip
-// on a redirect that never fired). Still best-effort: never throws.
+// the PATCH succeeded so callers can tell "now active" from a transient failure
+// (a swallowed failure previously stranded the accept/verify round-trip on a
+// redirect that never fired). Still best-effort: never throws.
 export async function acceptPendingOrgInvite(
   client: GitHubClient,
   org: string,
@@ -18,10 +18,10 @@ export async function acceptPendingOrgInvite(
   }
 }
 
-// PATCH /user/memberships/orgs/{org} -> {state:"active"}. The throwing variant:
+// PATCH /user/memberships/orgs/{org} -> {state:"active"}. Throwing variant:
 // surfaces the raw GitHubAPIError (status, url, body, X-GitHub-SSO) so callers
-// can distinguish an SSO-gated 403 from a genuine failure. Used by the shared
-// verified-accept path below; acceptPendingOrgInvite wraps it best-effort.
+// can tell an SSO-gated 403 from a genuine failure. Used by the verified-accept
+// path below; acceptPendingOrgInvite wraps it best-effort.
 export async function acceptPendingOrgInviteOrThrow(
   client: GitHubClient,
   org: string,
@@ -34,11 +34,11 @@ export async function acceptPendingOrgInviteOrThrow(
   })
 }
 
-// The single verified-accept path consumed by every call site (OnboardingPage,
+// The single verified-accept path used by every call site (OnboardingPage,
 // AcceptAssignmentPage, the accept mutation): accept the pending org invite,
 // re-read GET /user/memberships/orgs/{org}, and assert state === "active".
 // Throws the raw GitHubAPIError on any read/PATCH failure (a 403 + X-GitHub-SSO
-// SSO gate, a 404 not-a-member, or a transient blip) so the caller can render a
+// gate, a 404 not-a-member, or a transient blip) so the caller can render a
 // cause-specific screen from the shared MembershipError component. Returns the
 // active membership on success.
 export async function acceptAndVerifyOrgMembership(
@@ -46,7 +46,7 @@ export async function acceptAndVerifyOrgMembership(
   org: string,
 ): Promise<GitHubOrgMembership> {
   // Accepting a pending invite is idempotent-ish: an already-active member's
-  // PATCH still succeeds, so we don't pre-read state here — one PATCH then one
+  // PATCH still succeeds, so we don't pre-read state — one PATCH then one
   // authoritative read keeps the composition thin.
   await acceptPendingOrgInviteOrThrow(client, org)
   const membership = await getPendingOrgInvite(client, org)

--- a/web/src/auth/GitHubDevicePrompt.tsx
+++ b/web/src/auth/GitHubDevicePrompt.tsx
@@ -55,11 +55,11 @@ export function GitHubDevicePrompt({
     try {
       await navigator.clipboard.writeText(device.userCode)
       setCopied(true)
-      // Re-arm the reset timer on a repeat click while still showing "Copied!".
+      // Re-arm the reset timer on a repeat click while "Copied!" still shows.
       setCopyTick((t) => t + 1)
       onCodeCopied()
     } catch {
-      // nothing for now
+      // ignore: clipboard may be unavailable
     }
   }
 

--- a/web/src/auth/LoginLanguageMenu.tsx
+++ b/web/src/auth/LoginLanguageMenu.tsx
@@ -11,11 +11,10 @@ import {
 } from "@/i18n/customLocale"
 
 // Minimal language switcher for the login card. Installed languages (base +
-// any previously installed packs) switch instantly; registry languages are
-// loaded on mount and installed on select so a first-time visitor can still
-// read the login page in their own language. Native names are used
-// (languageLabel(code, code)) so each entry is legible regardless of the
-// current UI language.
+// previously installed packs) switch instantly; registry languages load on
+// mount and install on select so a first-time visitor can read the login page
+// in their own language. Native names (languageLabel(code, code)) keep each
+// entry legible regardless of the current UI language.
 export function LoginLanguageMenu() {
   const { t } = useTranslation()
   const { lang, availableLangs, setLang, availableBuiltInLangs, commitPack } =
@@ -40,7 +39,7 @@ export function LoginLanguageMenu() {
     try {
       setRegistry(await availableBuiltInLangs())
     } catch {
-      // Registry unreachable: keep the installed list usable and let the user
+      // Registry unreachable: keep the installed list usable; the user can
       // retry by reopening the menu.
       setRegistryError(true)
       setRegistry(null)
@@ -49,9 +48,8 @@ export function LoginLanguageMenu() {
     }
   }
 
-  // Prefetch the registry on mount so the full list is ready the moment the
-  // menu opens (don't wait for the trigger click). Set state only after the
-  // fetch resolves, and bail if unmounted mid-flight.
+  // Prefetch the registry on mount so the list is ready when the menu opens.
+  // Set state only after the fetch resolves, and bail if unmounted mid-flight.
   useEffect(() => {
     let active = true
     availableBuiltInLangs()
@@ -108,7 +106,7 @@ export function LoginLanguageMenu() {
       const preview = await prepareFromBuiltIn(code)
       await commitPack(preview.code, preview.bundle)
       // Newly installed language becomes available; reflect it locally so it
-      // moves to the "available now" group without a second registry fetch.
+      // moves to "available now" without a second registry fetch.
       setRegistry((prev) => (prev ? prev.filter((l) => l.code !== code) : prev))
       return preview.code
     } catch {

--- a/web/src/auth/ScopeWarningBanner.tsx
+++ b/web/src/auth/ScopeWarningBanner.tsx
@@ -8,7 +8,7 @@ import { AppBanner } from "@/components/AppBanner"
 import { useMissingScopes } from "@/context/github/GitHubProvider"
 
 // Surfaces missing required scopes detected from live API responses:
-// best-effort, non-blocking; offers a re-authorize action. A revoked/expired
+// best-effort, non-blocking, with a re-authorize action. A revoked/expired
 // token is handled separately — a live 401 tears the session down and redirects
 // to /login (see GitHubProvider.onResponse and useGithubAuth.expireSession).
 export function ScopeWarningBanner() {

--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -9,14 +9,14 @@ export const GITHUB_AUTH_SESSION = {
   STATE: "gh_oauth_state",
   CLIENT_ID: "gh_oauth_client_id",
   SCOPE: "gh_oauth_scope",
-  // Deep link to return to after sign-in; the /login redirect_uri can't carry
-  // it across the GitHub round-trip, so it rides the session instead (#71).
+  // Deep link to return to after sign-in; /login's redirect_uri can't carry it
+  // across the GitHub round-trip, so it rides the session instead (#71).
   RETURN_TO: "gh_oauth_return_to",
 } as const
 
 // Scopes: admin:org enables org-invite management + team writes; repo covers
 // roster commits and repo archiving; delete_repo lets teardown delete repos
-// (without it, deletion 403s and callers fall back to archiving). delete_repo is
+// (else deletion 403s and callers fall back to archiving). delete_repo is
 // requested here for the GUI; the CLIs keep it opt-in.
 export const DEFAULT_GITHUB_SCOPE =
   "read:user read:org repo workflow admin:org delete_repo"

--- a/web/src/auth/github-oauth-api.ts
+++ b/web/src/auth/github-oauth-api.ts
@@ -2,8 +2,8 @@ import { GITHUB_OAUTH_WORKER_BASE } from "./constants"
 import type { GithubDeviceCodeResponse, GithubTokenResponse } from "./types"
 
 // Must exactly match the OAuth App's registered callback URL (.../login).
-// Deriving it from the live pathname breaks the web flow when launched from
-// any other route (e.g. the re-authorize banner). See issue #57.
+// Deriving it from the live pathname breaks the flow when launched from another
+// route (e.g. the re-authorize banner). See #57.
 const OAUTH_CALLBACK_PATH = "/login"
 
 function redirectUri() {

--- a/web/src/auth/github-user-api.test.ts
+++ b/web/src/auth/github-user-api.test.ts
@@ -42,8 +42,8 @@ describe("fetchGithubUser", () => {
       vi.fn(async () => new Response("Bad credentials", { status: 401 })),
     )
 
-    // The session-expiry logic in useGithubAuth branches on `status === 401`,
-    // so the carried status is the contract this test locks in.
+    // useGithubAuth's session-expiry logic branches on `status === 401`, so the
+    // carried status is the contract this test locks in.
     const error = await fetchGithubUser("tok").catch((e) => e)
 
     expect(error).toBeInstanceOf(GitHubUserFetchError)

--- a/web/src/auth/returnTo.navigation.test.ts
+++ b/web/src/auth/returnTo.navigation.test.ts
@@ -8,7 +8,7 @@ import {
 
 // Regression guard for #71: a query-bearing returnTo (e.g. the ?k= accept key)
 // must survive navigation. navigate({ to: returnTo }) folds "?k=..." into the
-// pathname; history.push preserves it. Pins the behavior useGithubAuth and the
+// pathname; history.push preserves it — the behavior useGithubAuth and the
 // /login guard rely on.
 function buildTestRouter() {
   const rootRoute = createRootRoute()
@@ -45,8 +45,8 @@ describe("returnTo navigation (query preservation)", () => {
     const router = buildTestRouter()
 
     const built = router.buildLocation({
-      // Cast: the point of this test is passing a raw path+query string, which
-      // is not a literal member of the typed route union.
+      // Cast: this test passes a raw path+query string, not a literal member of
+      // the typed route union.
       to: "/org/cls/assignments/a1/accept?k=SECRET" as never,
     })
 

--- a/web/src/auth/returnTo.ts
+++ b/web/src/auth/returnTo.ts
@@ -1,10 +1,9 @@
-// Open-redirect guard for post-auth / post-onboarding return targets: accept
-// only a same-origin relative path. Beyond the leading-single-slash checks
-// (which reject "//host" and absolute URLs), we also reject vectors that a
-// naive startsWith("/") misses and then confirm same-origin via the URL parser
-// so the guard owns its property rather than relying on a browser quirk:
-//   - "\": URL parsers treat it as "/", so "/\evil.com" resolves cross-origin.
-//   - Encoded slashes/backslashes (%2F, %5C): a downstream decode can restore "//".
+// Open-redirect guard for post-auth return targets: accept only a same-origin
+// relative path. Beyond the leading-slash checks (reject "//host" and absolute
+// URLs), we also reject vectors a naive startsWith("/") misses, then confirm
+// same-origin via the URL parser so the guard owns its property:
+//   - "\": parsers treat it as "/", so "/\evil.com" resolves cross-origin.
+//   - Encoded slashes (%2F, %5C): a downstream decode can restore "//".
 //   - ASCII control chars: parsers strip some, shifting how the value resolves.
 const SAME_ORIGIN_FALLBACK = "http://localhost"
 

--- a/web/src/auth/scopes.test.ts
+++ b/web/src/auth/scopes.test.ts
@@ -62,10 +62,10 @@ describe("missingScopes", () => {
   })
 
   // Drift guard: a captured X-OAuth-Scopes header for a token authorized with
-  // DEFAULT_GITHUB_SCOPE. GitHub returns the granted scopes comma-delimited and
-  // may add implied entries. If GitHub's expansion drifts from SCOPE_IMPLICATIONS
-  // such that a required scope no longer resolves, this diff goes non-empty and
-  // the test fails — catching a source of spurious production banners.
+  // DEFAULT_GITHUB_SCOPE (comma-delimited, possibly with implied entries). If
+  // GitHub's expansion drifts from SCOPE_IMPLICATIONS such that a required scope
+  // no longer resolves, this diff goes non-empty and the test fails — catching a
+  // source of spurious production banners.
   it("diffs a captured DEFAULT_GITHUB_SCOPE header to zero missing", () => {
     const capturedHeader =
       "read:org, read:user, repo, workflow, admin:org, write:org, delete_repo"

--- a/web/src/auth/scopes.ts
+++ b/web/src/auth/scopes.ts
@@ -2,13 +2,11 @@ import { DEFAULT_GITHUB_SCOPE } from "./constants"
 
 export const REQUIRED_SCOPES = DEFAULT_GITHUB_SCOPE.split(/\s+/).filter(Boolean)
 
-// GitHub normalizes granted scopes and a broader scope implies narrower ones.
-// We encode each grantable scope -> the set of scopes it also satisfies, so a
-// token granted `repo` covers `repo:status`, a token granted `admin:org`
-// covers `read:org`, etc. The map is intentionally small and focused on the
-// scopes in DEFAULT_GITHUB_SCOPE; unknown granted scopes simply satisfy
-// themselves. Keep this biased toward over-satisfying: a missed gap is a softer
-// failure than a spurious banner a re-auth can't clear.
+// GitHub normalizes granted scopes and a broader scope implies narrower ones,
+// so we map each grantable scope -> the scopes it also satisfies (e.g. `repo`
+// covers `repo:status`, `admin:org` covers `read:org`); unknown scopes satisfy
+// only themselves. Biased toward over-satisfying: a missed gap is softer than a
+// spurious banner a re-auth can't clear.
 const SCOPE_IMPLICATIONS: Record<string, readonly string[]> = {
   repo: [
     "repo:status",
@@ -39,8 +37,8 @@ export function expandScopes(granted: string): Set<string> {
 }
 
 // Required scopes not satisfied by the expanded granted set. Empty granted ->
-// every required scope is reported missing; callers decide whether an absent
-// signal should suppress the warning entirely (see useMissingScopes).
+// every required scope reported missing; callers decide whether an absent
+// signal should suppress the warning (see useMissingScopes).
 export function missingScopes(granted: string): string[] {
   const have = expandScopes(granted)
   return REQUIRED_SCOPES.filter((scope) => !have.has(scope))

--- a/web/src/auth/storage.ts
+++ b/web/src/auth/storage.ts
@@ -43,10 +43,9 @@ export function saveOAuthSession(input: {
   clientId: string
   scope: string
   // Same-origin deep link to return to after sign-in (#71); kept only if it
-  // passes isSafeReturnTo. May carry the accept ?k= key (needed to land on the
-  // right link), so it is briefly persisted — acceptable since sessionStorage
-  // is same-origin and per-tab, cleared on consume, and the same secret is
-  // already in the URL the user arrived from.
+  // passes isSafeReturnTo. May carry the accept ?k= key, so it's briefly
+  // persisted — safe: sessionStorage is same-origin and per-tab, cleared on
+  // consume, and the secret is already in the URL the user arrived from.
   returnTo?: string | null
 }) {
   if (!canUseBrowserStorage()) return

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -61,8 +61,8 @@ function sleep(ms: number, signal: AbortSignal) {
   })
 }
 
-// Holds all auth state. Must only be instantiated once, by GitHubAuthProvider;
-// every other consumer goes through the useGithubAuth() context hook below.
+// Holds all auth state. Instantiate only once, in GitHubAuthProvider; other
+// consumers use the useGithubAuth() context hook below.
 function useGithubAuthState() {
   const queryClient = useQueryClient()
   const abortRef = useRef<AbortController | null>(null)
@@ -79,8 +79,8 @@ function useGithubAuthState() {
   const [device, setDevice] = useState<DeviceAuthState | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [hasLoadedStoredAuth, setHasLoadedStoredAuth] = useState(false)
-  // Set when a live API 401 (revoked/expired token) tears the session down,
-  // so /login can explain why the user was signed out. A deliberate signOut()
+  // Set when a live API 401 (revoked/expired token) tears the session down, so
+  // /login can explain why the user was signed out. A deliberate signOut()
   // clears it.
   const [sessionExpired, setSessionExpired] = useState(false)
 
@@ -90,11 +90,10 @@ function useGithubAuthState() {
     enabled: Boolean(token),
     staleTime: 60 * 60 * 1000,
     // A definitive status (401 revoked, 403 SSO/blocked, 404) resolves
-    // immediately — retrying can't change it and only widens the window before
-    // the session settles. Transient failures (5xx / network) still self-heal
-    // with a bounded retry so a momentary GitHub blip doesn't eject a signed-in
-    // user. Shares the definitive-status policy with the GitHub-client reads
-    // (see retryTransientGitHubError / isDefinitiveGitHubStatus).
+    // immediately — retrying can't change it. Transient failures (5xx/network)
+    // self-heal with a bounded retry so a momentary blip doesn't eject a
+    // signed-in user. Shares the policy with the GitHub-client reads (see
+    // retryTransientGitHubError / isDefinitiveGitHubStatus).
     retry: (failureCount, error) => {
       if (
         error instanceof GitHubUserFetchError &&
@@ -114,10 +113,9 @@ function useGithubAuthState() {
     mutationFn: requestDeviceCode,
   })
 
-  // Shared landing point for both web and device flows. Shows the success
-  // screen; once the profile loads, the /login route guard redirects to "/".
-  // The timeout below settles the screen state in case that doesn't happen
-  // (e.g. the profile fetch fails and the user stays on the card).
+  // Shared landing for both web and device flows. Shows the success screen; once
+  // the profile loads, the /login guard redirects to "/". The timeout below
+  // settles the screen state if that doesn't happen (e.g. profile fetch fails).
   const completeSignIn = useCallback(
     (data: { access_token: string; scope?: string }) => {
       persistGithubToken(data.access_token, data.scope || "")
@@ -141,7 +139,7 @@ function useGithubAuthState() {
   )
 
   // On unmount mid-flow, abort the device poll loop and clear the pending
-  // success-screen timer so neither runs (or setStates) after teardown.
+  // success-screen timer so neither runs after teardown.
   useEffect(
     () => () => {
       abortRef.current?.abort()
@@ -225,8 +223,8 @@ function useGithubAuthState() {
         onSuccess: (data) => {
           completeSignIn(data)
           // Defer the return until status is "authenticated" (effect below);
-          // navigating now would race the router context and bounce through
-          // the _authed guard (#71).
+          // navigating now would race the router context and bounce through the
+          // _authed guard (#71).
           pendingReturnToRef.current = returnTo
         },
         onError: (err) => {
@@ -475,8 +473,8 @@ function useGithubAuthState() {
       setError(null)
       setScreen("config")
       setSessionExpired(expired)
-      // Cancel in-flight ["github"] requests before evicting them so they
-      // don't resolve/reject into removed cache state after teardown.
+      // Cancel in-flight ["github"] requests before evicting them so they don't
+      // resolve into removed cache state after teardown.
       void queryClient.cancelQueries({ queryKey: ["github"] })
       queryClient.removeQueries({ queryKey: ["github"] })
     },
@@ -486,19 +484,16 @@ function useGithubAuthState() {
   const signOut = useCallback(() => clearSession(false), [clearSession])
 
   // Called when a revoked/expired token is detected on a live API 401. Clears
-  // the token so `status` flips to unauthenticated and the _authed guard
-  // redirects to /login. Guards on the in-memory token (the authoritative
-  // source) rather than localStorage, so a live 401 still tears the session
-  // down even if storage was cleared out-of-band. No-ops once the token is
-  // already gone, keeping it safe to call repeatedly.
+  // the token so `status` flips to unauthenticated and the guard redirects to
+  // /login. Guards on the in-memory token (authoritative) so a live 401 tears
+  // down even if storage was cleared out-of-band. No-ops once the token is gone.
   const expireSession = useCallback(() => {
     if (!token) return
     clearSession(true)
   }, [clearSession, token])
 
   // Cold-reload path: a stored-but-revoked token fails /user validation with a
-  // 401. Tear the session down so the token doesn't linger across reloads and
-  // the guard redirects to /login.
+  // 401. Tear down so the token doesn't linger and the guard redirects to /login.
   useEffect(() => {
     const error = githubUserQuery.error
     if (error instanceof GitHubUserFetchError && error.status === 401) {
@@ -559,8 +554,7 @@ function useGithubAuthState() {
   // Navigate to the stashed deep link once status is "authenticated", so the
   // target _authed guard sees an authenticated context instead of bouncing
   // through /login (#71). history.push (not navigate({ to })) preserves the
-  // query — e.g. the ?k= accept key — which navigate({ to }) would fold into
-  // the pathname. A bad path degrades to the homepage.
+  // query — e.g. the ?k= accept key. A bad path degrades to the homepage.
   useEffect(() => {
     if (status !== "authenticated") return
     const returnTo = pendingReturnToRef.current

--- a/web/src/components/AboutDialog.tsx
+++ b/web/src/components/AboutDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/version"
 
 // A single feedback/support link card. The two support links differ only in
-// href + labels, so they share one definition to stay in sync.
+// href + labels, so they share one definition.
 function SupportLink({
   href,
   title,
@@ -40,10 +40,10 @@ function SupportLink({
   )
 }
 
-// About modal shown from the profile menu — always-accessible build/version
-// info. Version links to the GitHub Release for this build's `web-v<version>`
-// tag (when it exists); the commit links to the exact source commit, so a bug
-// report can point at precisely what shipped.
+// About modal from the profile menu — always-accessible build/version info.
+// Version links to the GitHub Release for this build's `web-v<version>` tag
+// (when it exists); the commit links to the exact source commit, so a bug report
+// can point at precisely what shipped.
 export const AboutDialog = forwardRef<HTMLDialogElement, { titleId: string }>(
   function AboutDialog({ titleId }, ref) {
     const { t } = useTranslation()

--- a/web/src/components/AppBanner/index.tsx
+++ b/web/src/components/AppBanner/index.tsx
@@ -20,11 +20,11 @@ const TONE_CLASS: Record<AppBannerTone, { bar: string; icon: string }> = {
   },
 }
 
-// Presentational shell for a global, full-bleed banner pinned to the top of the
-// app (above the routed content). Height-collapses on exit via collapseVariants
-// so a dismissed banner leaves no gap. Owns only chrome — callers supply copy,
-// actions, and the icon. Wrap in an <AnimatePresence> and set a stable `key` on
-// this element (AnimatePresence tracks the key of its direct child).
+// Presentational shell for a global, full-bleed banner pinned to the top (above
+// routed content). Height-collapses on exit via collapseVariants so a dismissed
+// banner leaves no gap. Owns only chrome — callers supply copy, actions, icon.
+// Wrap in <AnimatePresence> and set a stable `key` on this element
+// (AnimatePresence tracks its direct child's key).
 export const AppBanner = ({
   tone,
   icon,

--- a/web/src/components/AppVersionBadge.tsx
+++ b/web/src/components/AppVersionBadge.tsx
@@ -1,9 +1,8 @@
 import { appVersion, shortCommit } from "@/version"
 
 // Small, unobtrusive build identifier. The version is a build-time constant
-// (see version.ts), not user-facing prose, so it is not translated; the commit
-// is included to make bug reports precise, and the full build date is exposed
-// via the title tooltip.
+// (version.ts), not user-facing prose, so it isn't translated; the commit makes
+// bug reports precise and the full build date shows in the title tooltip.
 export function AppVersionBadge({ className }: { className?: string }) {
   return (
     <span

--- a/web/src/components/ArchivedClassroomNotice.tsx
+++ b/web/src/components/ArchivedClassroomNotice.tsx
@@ -2,8 +2,8 @@ import type { PropsWithChildren } from "react"
 
 // The "this classroom is archived" info banner. Owns the daisyUI alert shell +
 // ARIA so the three teacher pages that surface it (assignments list, edit
-// assignment, classroom settings) can't drift in markup; each passes its own
-// page-specific copy as children. `className` tunes spacing per page.
+// assignment, settings) can't drift in markup; each passes its own copy as
+// children. `className` tunes spacing per page.
 export const ArchivedClassroomNotice = ({
   className = "mb-4",
   children,

--- a/web/src/components/EmptyRosterNotice.tsx
+++ b/web/src/components/EmptyRosterNotice.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from "react-i18next"
 
 // Empty/unenrolled-roster warning. Owns the daisyUI alert shell + ARIA so the
 // assignments list and create pages can't drift in markup; copy adapts to
-// whether the roster has rows (invited but not joined) or is entirely empty.
-// Render only when useEmptyRosterWarning().show is true.
+// whether the roster has rows (invited, not joined) or is empty. Render only
+// when useEmptyRosterWarning().show is true.
 export const EmptyRosterNotice = ({
   org,
   classroom,

--- a/web/src/components/InlineNote/index.tsx
+++ b/web/src/components/InlineNote/index.tsx
@@ -2,8 +2,8 @@ import type { ComponentType, ReactNode, SVGProps } from "react"
 
 export type InlineNoteTone = "success" | "warning" | "error" | "neutral"
 
-// Explicit dark-on-light colors rather than daisyUI's *-content tones, which
-// are too light to read on a white form background.
+// Explicit dark-on-light colors rather than daisyUI's *-content tones, too light
+// to read on a white form background.
 const TONE_CLASS: Record<InlineNoteTone, string> = {
   success: "bg-green-50 border-green-200 text-green-800",
   warning: "bg-amber-50 border-amber-200 text-amber-900",

--- a/web/src/components/LanguageDialog.tsx
+++ b/web/src/components/LanguageDialog.tsx
@@ -5,18 +5,16 @@ import { X } from "lucide-react"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 
 // Language-pack modal shown from the sidebar footer. Extracted alongside
-// AboutDialog (same forwardRef<HTMLDialogElement> shape) so the sidebar footer
-// wires two consistent portalled dialogs rather than inlining one and importing
-// the other. Closing on apply is driven by the same ref the caller opens with.
+// AboutDialog (same forwardRef<HTMLDialogElement> shape) so the footer wires two
+// consistent portalled dialogs. Closing on apply uses the caller's open ref.
 export const LanguageDialog = forwardRef<
   HTMLDialogElement,
   { titleId: string }
 >(function LanguageDialog({ titleId }, ref) {
   const { t } = useTranslation()
 
-  // Close via the forwarded ref once a pack is applied. The ref is a
-  // MutableRefObject here (the caller passes useRef), so read .current; guard
-  // the RefCallback shape defensively.
+  // Close via the forwarded ref once a pack is applied. It's a MutableRefObject
+  // here (caller passes useRef), so read .current; guard the RefCallback shape.
   const close = () => {
     if (typeof ref === "object" && ref !== null) {
       ref.current?.close()

--- a/web/src/components/MembershipError.tsx
+++ b/web/src/components/MembershipError.tsx
@@ -3,14 +3,14 @@ import { useTranslation } from "react-i18next"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 
-// The distinct membership-failure causes the student flow (onboarding + accept)
-// can hit. Each maps to a specific title/body and at least one recovery action.
+// Distinct membership-failure causes the student flow (onboarding + accept) can
+// hit; each maps to a title/body and at least one recovery action.
 //   - ssoWithUrl:  403 + X-GitHub-SSO carrying a usable authorization URL.
 //   - ssoUrlless:  403 + X-GitHub-SSO but no parseable url (enterprise
 //                  `partial-results` shape). Same screen minus the button.
-//   - notAMember:  404 / the accept genuinely failed — no membership record.
-//   - generic:     anything else (transient, unexpected). Absorbs the widest
-//                  range, so it must not be a dead end — always offers Retry.
+//   - notAMember:  404 / accept genuinely failed — no membership record.
+//   - generic:     anything else. Widest range, so never a dead end — always
+//                  offers Retry.
 export type MembershipErrorCause =
   "ssoWithUrl" | "ssoUrlless" | "notAMember" | "generic"
 
@@ -19,9 +19,8 @@ export type MembershipErrorInfo = {
   // Present only for `ssoWithUrl`; a validated https://github.com SSO URL.
   ssoUrl: string | null
   // Data-minimized diagnostics for the copyable "for your instructor" block.
-  // Deliberately NOT the raw response body or the raw X-GitHub-SSO header (that
-  // header carries an authorization_request token) — only an allow-listed,
-  // non-sensitive subset leaves the client.
+  // NOT the raw response body or raw X-GitHub-SSO header (which carries an
+  // authorization_request token) — only an allow-listed, non-sensitive subset.
   details: {
     org?: string
     username?: string
@@ -32,8 +31,8 @@ export type MembershipErrorInfo = {
   }
 }
 
-// Classify a caught error (plus context) into one of the membership causes.
-// Keeps the branching in one place so onboarding and accept can't diverge.
+// Classify a caught error (plus context) into a membership cause. One place so
+// onboarding and accept can't diverge.
 export function classifyMembershipError(
   error: unknown,
   context: { org?: string; username?: string; membershipState?: string },
@@ -73,8 +72,8 @@ const CopyableDetails = ({
   details: MembershipErrorInfo["details"]
 }) => {
   const { t } = useTranslation()
-  // Build the allow-listed, human-readable diagnostics block. Never includes
-  // the raw response body or the raw X-GitHub-SSO header value.
+  // Allow-listed, human-readable diagnostics. Never the raw response body or
+  // raw X-GitHub-SSO header value.
   const lines = [
     details.org ? `${t("membership.details.org")}: ${details.org}` : null,
     details.username
@@ -126,11 +125,11 @@ const CopyableDetails = ({
   )
 }
 
-// A shared, cause-specific membership error card used by both the onboarding
-// and accept pages. Renders a specific title/body per cause, at least one
-// recovery action (never a dead end), and a collapsed, data-minimized copyable
-// diagnostics block for the student's instructor. `onRetry` (when provided)
-// backs the generic Retry action; SSO/not-a-member causes point elsewhere.
+// Shared, cause-specific membership error card for the onboarding and accept
+// pages: a per-cause title/body, at least one recovery action (never a dead
+// end), and a collapsed, data-minimized diagnostics block for the instructor.
+// `onRetry` backs the generic Retry action; SSO/not-a-member causes point
+// elsewhere.
 export const MembershipError = ({
   info,
   org,

--- a/web/src/components/MissingParams.tsx
+++ b/web/src/components/MissingParams.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from "react-i18next"
 
-// Full-page bail when a route is missing an expected URL param. Shared so the
-// guard markup stays consistent across pages. Callers may pass a context-specific
-// message; when omitted it falls back to the translated generic message.
+// Full-page bail when a route is missing an expected URL param; shared so the
+// guard markup stays consistent. Callers may pass a context-specific message,
+// else the translated generic one.
 export const MissingParams = ({ message }: { message?: string }) => {
   const { t } = useTranslation()
   return (

--- a/web/src/components/NotFound.tsx
+++ b/web/src/components/NotFound.tsx
@@ -5,11 +5,10 @@ import { useTranslation } from "react-i18next"
 
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 
-// Role/visibility-gated pages render this when the current user can't access a
-// resource. We deliberately present a 404 ("not found") rather than a 403
-// ("forbidden"): access is ultimately enforced by GitHub, so this is a UX
-// concern, and a 404 avoids confirming the resource exists to someone whose
-// role can't see it. Reused across teacher-only pages and future TA roles.
+// Rendered by role/visibility-gated pages when the user can't access a resource.
+// We present a 404 ("not found"), not a 403 ("forbidden"): access is enforced by
+// GitHub, so this is UX-only, and a 404 avoids confirming the resource exists to
+// someone whose role can't see it. Reused across teacher-only pages and TA roles.
 const NotFound = ({ title, message }: { title?: string; message?: string }) => {
   const { t } = useTranslation()
   const resolvedTitle = title ?? t("notFound.title")
@@ -17,9 +16,9 @@ const NotFound = ({ title, message }: { title?: string; message?: string }) => {
   useDocumentTitle(resolvedTitle)
   const headingRef = useRef<HTMLHeadingElement | null>(null)
 
-  // Client-side navigation doesn't reload the page, so a screen reader isn't
-  // told the view changed to "not found". Move focus to the heading to announce
-  // it and give keyboard users a sensible starting point.
+  // Client-side navigation doesn't reload, so a screen reader isn't told the
+  // view changed to "not found". Move focus to the heading to announce it and
+  // give keyboard users a sensible starting point.
   useEffect(() => {
     headingRef.current?.focus()
   }, [])

--- a/web/src/components/PlanBadge.tsx
+++ b/web/src/components/PlanBadge.tsx
@@ -1,9 +1,9 @@
 import GitHub from "@/assets/github.svg?react"
 import { useTranslation } from "react-i18next"
 
-// Shared GitHub-plan badge (org's billing plan). GitHub only returns the plan
-// name to org owners, so callers pass `undefined` for non-owners and nothing
-// renders. The GitHub mark signals this reflects the org's GitHub plan, not a
+// Shared GitHub-plan badge (org's billing plan). GitHub returns the plan name
+// only to org owners, so callers pass `undefined` for non-owners and nothing
+// renders. The GitHub mark signals this is the org's GitHub plan, not a
 // Classroom 50 state.
 const PlanBadge = ({
   name,

--- a/web/src/components/QueryErrorAlert.tsx
+++ b/web/src/components/QueryErrorAlert.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
-// A dismissable-free error banner with an inline retry, shared by the panels
-// that load an independent data source (roster, gradebook) on the submissions
-// dashboard. Extracted so the two blocks can't drift on markup/retry wiring.
+// Error banner (no dismiss) with an inline retry, shared by the submissions
+// dashboard panels that load an independent data source (roster, gradebook).
+// Extracted so the two blocks can't drift on markup/retry wiring.
 export function QueryErrorAlert({
   message,
   onRetry,

--- a/web/src/components/RequireTeacher.tsx
+++ b/web/src/components/RequireTeacher.tsx
@@ -8,17 +8,17 @@ import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 
 // What a guarded surface requires:
 // - "staff": any classroom staff (owner/instructor/ta) — for classroom CONTENT
-//   (roster, assignment authoring, submissions). Backed by config-repo access.
+//   (roster, authoring, submissions). Backed by config-repo access.
 // - "instructor": owner OR instructor of THIS classroom (excludes TAs) — for
 //   classroom SETTINGS. Needs a `$classroom` route param.
 // - "owner": org admin only — for ORG-wide settings/setup, where TA and
 //   instructor can't be distinguished without a classroom context.
 export type RequireRole = "staff" | "instructor" | "owner"
 
-// Gate page content by role. While the role resolves we render a spinner (so we
-// never flash a 404 at a real teacher), then the children or NotFound. Access
-// is GitHub-enforced underneath; this is a UX guard that 404s rather than 403s
-// by design. Default `allow: "staff"` preserves the original behavior.
+// Gate page content by role. While the role resolves we show a spinner (never
+// flash a 404 at a real teacher), then children or NotFound. Access is
+// GitHub-enforced underneath; this UX guard 404s rather than 403s by design.
+// Default `allow: "staff"` preserves the original behavior.
 const RequireTeacher = ({
   children,
   allow = "staff",
@@ -55,7 +55,7 @@ const RequireElevated = ({
   const { role, isLoading } = useClassroomRole(org, classroom, user?.login)
 
   // `unresolved` means a signal is still in flight or hit a transient error —
-  // hold the spinner rather than flashing NotFound at a real instructor/owner.
+  // hold the spinner rather than flash NotFound at a real instructor/owner.
   if (isLoading || role === "unresolved") return <RoleResolvingFallback />
 
   // "instructor" allows owner OR instructor; "owner" is owner-only.

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -8,18 +8,14 @@ import { AppBanner } from "@/components/AppBanner"
 import { useSkeletonDrift } from "@/hooks/useSkeletonDrift"
 import { RERUN_ORG_SETUP_ANCHOR } from "@/pages/orgSettings/RerunOrgSetup"
 
-// Global warning banner shown to an org owner when the `classroom50` config
-// repo's scaffolded workflows have drifted from the current bundled skeleton
-// (e.g. after an action-pin bump). Routes to the owner-only "Re-run org setup"
-// Org Settings section, which performs the overwrite.
+// Global warning banner for an org owner when the `classroom50` config repo's
+// scaffolded workflows have drifted from the bundled skeleton (e.g. after an
+// action-pin bump). Routes to the owner-only "Re-run org setup" section, which
+// overwrites (its modal still confirms per file).
 //
-// The copy warns that re-running overwrites customized workflow files with the
-// skeleton defaults (the re-run flow's modal still confirms per file).
-//
-// Dismiss is per-session and per-org: the banner is mounted once in the stable
+// Dismiss is per-session and per-org: the banner mounts once in the stable
 // _authed layout and never remounts on org navigation, so dismissal is tracked
-// by org — dismissing org A must not suppress org B's drift. Reappears on
-// reload until resolved.
+// by org — dismissing org A must not suppress org B. Reappears on reload.
 export function SkeletonDriftBanner() {
   // Loose param read: org-less routes (the org picker) yield undefined and the
   // owner-gated hook stays disabled.

--- a/web/src/components/Spinner.tsx
+++ b/web/src/components/Spinner.tsx
@@ -4,21 +4,12 @@ import { useTranslation } from "react-i18next"
 type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl"
 
 /**
- * Accessible loading spinner. Wraps the daisyUI `loading loading-spinner` in a
- * `role="status"` region with a visually-hidden label so screen readers
- * announce the busy state instead of hitting a silent, decorative `<span>`.
- *
- * Pass `label` to customize what's announced (e.g. "Loading submissions").
- *
- * When to use which:
- * - Use `<Spinner>` for a spinner that is the ONLY indicator of a loading
- *   region/page (otherwise silent to screen readers).
- * - Keep a bare `loading loading-spinner` span (with `aria-hidden`) when the
- *   busy state is already announced by adjacent visible text or by the enclosing
- *   control's accessible name (e.g. an in-button spinner while a labeled button
- *   is disabled, or a spinner beside a "Loading…" paragraph). The
- *   `no-restricted-syntax` lint rule flags bare spinners as a nudge; `aria-hidden`
- *   is the correct resolution for those already-announced cases.
+ * Accessible loading spinner: daisyUI `loading-spinner` in a `role="status"`
+ * region with a visually-hidden `label` so screen readers announce the busy
+ * state. Use when the spinner is the ONLY loading indicator; when the busy
+ * state is already announced (adjacent text, an in-button spinner on a labeled
+ * disabled button), keep a bare `aria-hidden` span — the resolution the
+ * `no-restricted-syntax` lint nudge expects.
  */
 export function Spinner({
   size = "md",

--- a/web/src/components/avatar/index.tsx
+++ b/web/src/components/avatar/index.tsx
@@ -10,10 +10,10 @@ const Avatar = ({
   initials: string
   name: string
   github: string
-  // Secondary line under the name (e.g. a section badge, or a GitHub handle).
-  // Shown only when set — no implicit handle fallback.
+  // Secondary line under the name (e.g. section badge or GitHub handle). Shown
+  // only when set — no implicit handle fallback.
   subtitle?: React.ReactNode
-  // When provided, the avatar circle + name become a button opening details.
+  // When set, the avatar circle + name become a button opening details.
   onClick?: () => void
 }) => {
   const { t } = useTranslation()

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -170,14 +170,13 @@ const navItemClass = (active: boolean, collapsed: boolean) =>
       : "border-transparent hover:bg-[var(--sidebar-surface)]/60"
   }`
 
-// Shared sidebar tooltip tokens (dark rail): the tooltip bubble + text colors
-// that every collapsed-sidebar tooltip uses. Kept as one source so a token
-// rename lands in one place instead of ~5 hand-copied class strings.
+// Shared sidebar tooltip tokens (dark rail): bubble + text colors every
+// collapsed-sidebar tooltip uses. One source so a token rename lands once.
 const sidebarTooltip =
   "tooltip tooltip-right [--tt-bg:var(--sidebar-surface)] before:text-neutral-content"
 
-// Interactive icon-button row inside the rail (back-links, collapse/expand):
-// the tooltip base plus a muted icon that lightens and gains a surface on hover.
+// Interactive icon-button row in the rail (back-links, collapse/expand): tooltip
+// base plus a muted icon that lightens and gains a surface on hover.
 const sidebarIconButton = (padding: "p-1" | "p-2" = "p-1") =>
   `${sidebarTooltip} cursor-pointer rounded-md ${padding} text-neutral-content/60 transition-colors hover:bg-[var(--sidebar-surface)] hover:text-neutral-content`
 
@@ -191,8 +190,8 @@ const Tip = ({ label, children }: { label: string; children: ReactNode }) => {
   )
 }
 
-// Inner markup of a sidebar nav row. Callers keep their own typed
-// <Link to params> wrapping this so router type inference stays intact.
+// Inner markup of a sidebar nav row. Callers keep their own typed <Link to
+// params> around this so router type inference stays intact.
 const SidebarItemBody = ({
   label,
   icon,
@@ -348,7 +347,7 @@ const AssignmentSidebarMenu = ({
   const { user } = useGithubAuth()
 
   // Resolve the display name from whichever source the role can read. The
-  // teacher config-repo source is gated on role so a student doesn't fire a
+  // teacher config-repo source is role-gated so a student doesn't fire a
   // guaranteed 404; the public Pages source covers the student (and is a
   // teacher fallback before Pages publishes).
   const { data: teacherAssignments } = useGetClassroomAssignments(
@@ -356,12 +355,12 @@ const AssignmentSidebarMenu = ({
     classroom,
     { enabled: showTeacherUi },
   )
-  // For a protected classroom the public Pages fetch needs the capability
-  // secret. A student reads it from their own repo's .classroom50.yaml (the
-  // only source they can access); a teacher gets it from classroom.json. Gate
-  // the classroom.json read on the viewer's ACTUAL role (not the preview) so an
-  // instructor previewing as a student still resolves the secret for a working
-  // accept link — a real student's read stays disabled (guaranteed 404).
+  // A protected classroom's public Pages fetch needs the capability secret. A
+  // student reads it from their own repo's .classroom50.yaml (their only
+  // source); a teacher gets it from classroom.json. Gate the classroom.json read
+  // on the viewer's ACTUAL role (not the preview) so an instructor previewing as
+  // a student still resolves the secret for a working accept link — a real
+  // student's read stays disabled (guaranteed 404).
   const studentRepoNameForSecret = user?.login
     ? studentRepoName(classroom, assignment, user.login)
     : ""
@@ -386,9 +385,9 @@ const AssignmentSidebarMenu = ({
     publicAssignment?.name ||
     assignment
 
-  // Group assignments give students something to manage (collaborators);
-  // individual assignments have nothing student-editable, so we omit the
-  // settings entry rather than route them to a dead-end.
+  // Group assignments give students collaborators to manage; individual
+  // assignments have nothing student-editable, so we omit the settings entry
+  // rather than route to a dead-end.
   const isGroupAssignment = publicAssignment?.mode === "group"
 
   const onRoute = (to: Parameters<typeof matchRoute>[0]["to"]) =>
@@ -404,8 +403,8 @@ const AssignmentSidebarMenu = ({
   const onAccept = onRoute("/$org/$classroom/assignments/$assignment/accept")
 
   // Students only: surface "Accept" until they have their repo. Hidden while
-  // loading to avoid a flash. Also hidden for a real staff member previewing as
-  // a student — they have no student repo and "Accept" would be a dead-end.
+  // loading (avoid a flash) and for a real staffer previewing as a student —
+  // they have no student repo, so "Accept" would dead-end.
   const { assignment: studentRepo, isLoading: repoLoading } =
     useGetAssignmentRepo(org, classroom, assignment, user?.login)
   const showAccept =
@@ -417,7 +416,6 @@ const AssignmentSidebarMenu = ({
 
   return (
     <>
-      {/* Back to the assignments list */}
       {collapsed ? (
         <div className="flex justify-center py-2 text-sm">
           <Link
@@ -544,10 +542,9 @@ export const TeacherSidebarMenu = ({
 }) => {
   // Placeholder while pending so items never flash in then out.
   const { showTeacherUi, roleResolved } = useCourseTeacherAccess(org)
-  // Finer, preview-aware classroom role. The roster is staff-only and Settings
-  // is instructor-only; gating on this role makes "View as student/TA"
-  // faithfully hide what a real student/TA wouldn't see. `unresolved` is
-  // permissive to avoid flashing.
+  // Finer, preview-aware classroom role. Roster is staff-only, Settings
+  // instructor-only; gating on this makes "View as student/TA" faithfully hide
+  // what a real student/TA wouldn't see. `unresolved` is permissive (no flash).
   const { user } = useGithubAuth()
   const { role: classroomRole } = useClassroomRole(org, classroom, user?.login)
   const showStaffItems = showTeacherUi && isStaffRole(classroomRole)
@@ -622,23 +619,22 @@ export const SidebarFooter = () => {
     shouldThrow: false,
   })
   const { isStudent, isLoading: roleLoading } = useCourseTeacherAccess(org)
-  // Precise classroom role (Instructor vs TA) inside a classroom; respects the
-  // "view as" preview. `actualRole` is the real (preview-independent) role.
+  // Precise classroom role (Instructor vs TA); respects the "view as" preview.
+  // `actualRole` is the real (preview-independent) role.
   const {
     role: classroomRole,
     actualRole: actualClassroomRole,
     isLoading: classroomRoleLoading,
   } = useClassroomRole(org, classroom, user?.login)
   const { viewAs, setViewAs } = useRoleView()
-  // Offer "View as" only to a real owner/instructor inside a classroom (they're
-  // the roles with something lower to preview).
+  // Offer "View as" only to a real owner/instructor in a classroom (the roles
+  // with something lower to preview).
   const canPreviewRoles =
     Boolean(classroom) &&
     (actualClassroomRole === "owner" || actualClassroomRole === "instructor")
 
   // Apply a "view as" change and, if the current route is role-specific, move to
-  // the analogous route for the new role so the user isn't stranded on a page
-  // meant for the other side.
+  // the analogous route for the new role so the user isn't stranded.
   const selectViewAs = (next: ViewAsRole | null) => {
     setViewAs(next)
     if (!org || !classroom || !assignment) return
@@ -655,15 +651,15 @@ export const SidebarFooter = () => {
       to: "/$org/$classroom/assignments/$assignment/edit",
       fuzzy: false,
     })
-    // -> student view while on a staff-only assignment page: land on the student
-    // per-assignment page rather than stranding them on a staff surface.
+    // -> student view on a staff-only assignment page: land on the student
+    // per-assignment page, not a staff surface.
     if (next === "student" && (onStaffSubmissions || onStaffEdit)) {
       void navigate({
         to: "/$org/$classroom/assignments/$assignment/submission",
         params,
       })
     } else if (next !== "student" && onStudentSubmission) {
-      // -> staff view while on the student submission page: go to the gradebook.
+      // -> staff view on the student submission page: go to the gradebook.
       void navigate({
         to: "/$org/$classroom/assignments/$assignment/submissions",
         params,
@@ -677,9 +673,9 @@ export const SidebarFooter = () => {
     useGetOrgMembership(org)
   const isOwner = orgMembership?.role === "admin"
 
-  // Role label per the product mapping (owner shows as Instructor). On a
-  // classroom route use the precise role; on an org-level route only assert
-  // owner or a definite student, else blank.
+  // Role label per product mapping (owner shows as Instructor). On a classroom
+  // route use the precise role; on org-level routes assert only owner or a
+  // definite student, else blank.
   let roleLabelText: string | null
   if (classroom) {
     const key = classroomRoleLoading ? null : roleLabelKey(classroomRole)
@@ -951,8 +947,8 @@ export const SidebarContent = ({ selected }: { selected: string }) => {
   const { org, classroom, assignment } = useParams({ strict: false })
   const { data: classData } = useGetClassroom(org, classroom)
 
-  // Inside a single assignment the nav becomes assignment-scoped: show
-  // assignment actions (and a back link) instead of the classroom menu.
+  // Inside a single assignment the nav is assignment-scoped: show assignment
+  // actions (and a back link) instead of the classroom menu.
   if (org && classroom && assignment) {
     return (
       <>
@@ -990,8 +986,8 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
   const { org } = useParams({ strict: false })
   const { t } = useTranslation()
   const { showTeacherUi, roleResolved } = useCourseTeacherAccess(org)
-  // Org-level Members/Settings are owner-only surfaces, so gate those two links
-  // on org ownership rather than the broad staff signal.
+  // Org-level Members/Settings are owner-only, so gate those two links on org
+  // ownership rather than the broad staff signal.
   const { data: orgMembership } = useGetOrgMembership(org)
   const isOwner = orgMembership?.role === "admin"
   const onSettings = settings || selected === "settings"

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -27,8 +27,8 @@ const rejectedItems = <T,>(
     result.status === "rejected" ? [items[i]] : [],
   )
 
-// Map a rejected add/remove to a human-readable reason. Collapsing every
-// status into "bad username" hides real causes like a 429 rate limit or a 403.
+// Map a rejected add/remove to a human-readable reason. Collapsing every status
+// into "bad username" would hide real causes like a 429 or a 403.
 const describeFailure = (reason: unknown, t: TFunction): string | null => {
   if (reason instanceof GitHubAPIError) {
     if (reason.isRateLimited)
@@ -45,7 +45,7 @@ const describeFailure = (reason: unknown, t: TFunction): string | null => {
 }
 
 // Two-line identity when we have a roster name (name + @handle), else just the
-// @handle. Shared by the owner, member, and marked-for-removal rows.
+// @handle. Shared by owner, member, and marked-for-removal rows.
 const CollaboratorIdentity = ({
   login,
   students,
@@ -77,7 +77,7 @@ type GroupCollaboratorsModalProps = {
   repoUrl?: string
   assignmentName?: string
   maxGroupSize?: number
-  // Optional roster, used to show full names alongside GitHub handles.
+  // Optional roster, to show full names alongside GitHub handles.
   students?: Student[]
 }
 
@@ -95,8 +95,8 @@ export function GroupCollaboratorsModal({
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Synchronous re-entrancy guard: isSaving (from mutation.isPending) updates a
-  // tick late, so a rapid double-click could start two overlapping saves.
+  // Synchronous re-entrancy guard: isSaving (mutation.isPending) updates a tick
+  // late, so a rapid double-click could start two overlapping saves.
   const savingRef = useRef(false)
   const { user } = useGithubAuth()
   const { t } = useTranslation()
@@ -126,8 +126,8 @@ export function GroupCollaboratorsModal({
 
   // Manage access = founder, or admin on this repo. We read the viewer's
   // effective permission from the repo object (which includes inherited
-  // org-owner admin) rather than the affiliation=direct collaborator list,
-  // which omits inherited access and would lock out org-owner teachers.
+  // org-owner admin) rather than the affiliation=direct collaborator list, which
+  // omits inherited access and would lock out org-owner teachers.
   const { data: repo } = useGetRepo(org, repoName, { enabled: open })
   const viewerLogin = user?.login ? normalizeUsername(user.login) : null
   const canManage = Boolean(
@@ -135,7 +135,7 @@ export function GroupCollaboratorsModal({
     (viewerLogin === ownerLoginResolved || repo?.permissions?.admin === true),
   )
 
-  // Members = every direct collaborator except the founder.
+  // Direct collaborators except the founder.
   const initialCollaborators = useMemo(
     () =>
       collaborators
@@ -222,7 +222,7 @@ export function GroupCollaboratorsModal({
     addCollaboratorMutation.isPending || removeCollaboratorMutation.isPending
 
   // Dropped from the draft but still a live collaborator: removed only on Save,
-  // and restorable via undo until then.
+  // restorable via undo until then.
   const draftSet = useMemo(
     () => new Set(draftCollaborators.map(normalizeUsername)),
     [draftCollaborators],
@@ -294,8 +294,8 @@ export function GroupCollaboratorsModal({
 
       const failedRemoves = rejectedItems(removeResults, toRemove)
 
-      // A failed remove keeps its slot, so cap adds at the remaining capacity —
-      // otherwise a swap at max size would push GitHub to max+1.
+      // A failed remove keeps its slot, so cap adds at remaining capacity —
+      // else a swap at max size would push GitHub to max+1.
       const succeededRemoves = toRemove.length - failedRemoves.length
       const liveCount = initialCollaborators.length - succeededRemoves
       const capacity = Math.max(maxCollaborators - liveCount, 0)
@@ -472,8 +472,8 @@ export function GroupCollaboratorsModal({
                 </span>
               </div>
 
-              {/* One bordered list for owner + members + pending removals, so
-                  the modal reads as a single roster rather than stacked cards. */}
+              {/* One bordered list for owner + members + pending removals, so it
+                  reads as a single roster rather than stacked cards. */}
               <ul className="divide-y divide-base-200 rounded-2xl border border-base-200">
                 {ownerDisplayLogin && (
                   <li className="flex items-center gap-3 px-4 py-2.5">

--- a/web/src/components/modals/ReuseFromClassroomModal.tsx
+++ b/web/src/components/modals/ReuseFromClassroomModal.tsx
@@ -11,8 +11,8 @@ import {
 
 // Reuse an assignment FROM another classroom INTO the current one — the "pull"
 // counterpart to the per-row "push" reuse on the assignments table. Opened from
-// the assignments page's "New assignment" split button. v1 is in-org only:
-// source classrooms are siblings under classroom50/, never a different org.
+// the "New assignment" split button. v1 is in-org only: sources are siblings
+// under classroom50/, never a different org.
 export const ReuseFromClassroomModal = ({
   org,
   classroom,

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 
 // Shared chrome for the two reuse modals — close button, header, error/warning
-// alerts, Cancel/Reuse footer — so each only supplies its title, description,
+// alerts, Cancel/Reuse footer — so each supplies only its title, description,
 // and direction-specific selectors. The modal owns the <dialog> ref (the reuse
-// hook needs it for its closer); the shell just opens it on mount.
+// hook needs it); the shell just opens it on mount.
 export const ReuseModalShell = ({
   dialogRef,
   title,
@@ -27,8 +27,8 @@ export const ReuseModalShell = ({
   warning: string | null
   errorMessage: string | null
   canSubmit: boolean
-  // Hide the Reuse button when there's nothing to submit into / from, or after a
-  // grant warning has turned the flow into a "Done" acknowledgement.
+  // Hide the Reuse button when there's nothing to submit into/from, or after a
+  // grant warning turns the flow into a "Done" acknowledgement.
   showSubmit: boolean
   onSubmit: () => void
   onClose: () => void
@@ -132,8 +132,8 @@ export const ReuseModalShell = ({
 
 export default ReuseModalShell
 
-// Slug-field helper text. `loading`/`error`/`slugTaken` are prioritized in
-// order; otherwise preview the normalized form or fall back to `uniqueHint`.
+// Slug-field helper text. `loading`/`error`/`slugTaken` take priority in order;
+// otherwise preview the normalized form or fall back to `uniqueHint`.
 // `classroomLabel`/`uniqueHint` carry each modal's wording.
 export const reuseSlugStatus = ({
   t,

--- a/web/src/components/modals/StudentProfileModal.tsx
+++ b/web/src/components/modals/StudentProfileModal.tsx
@@ -9,8 +9,8 @@ import { getName, getInitials } from "@/util/students"
 type ProfileRow = { label: string; value: React.ReactNode }
 
 // Read-only student profile. Opened from a gradebook/roster avatar to surface
-// the details we hide from the dense row (GitHub handle, email, section,
-// enrollment) plus a link to the student's assignment repo when known.
+// details hidden in the dense row (GitHub handle, email, section) plus a link to
+// the student's assignment repo when known.
 export const StudentProfileModal = ({
   onClose,
   student,
@@ -28,9 +28,8 @@ export const StudentProfileModal = ({
   const titleId = useId()
   const { t } = useTranslation()
 
-  // Mounted only while a profile is selected (caller gates on `profileStudent`
-  // + remounts via `key`), so open once on mount; ESC/backdrop/X fire onClose,
-  // which the caller uses to clear the selection.
+  // Mounted only while a profile is selected (caller gates + remounts via
+  // `key`), so open once; ESC/backdrop/X fire onClose to clear the selection.
   useEffect(() => {
     dialogRef.current?.showModal()
   }, [])

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -34,18 +34,17 @@ export function ConfirmModal({
   const resolvedConfirmLabel =
     confirmLabel ?? t("components.confirmModal.confirm")
   const resolvedCancelLabel = cancelLabel ?? t("common.cancel")
-  // Honor a caller's cancelLabel here too (not just the type-to-confirm step),
-  // since the description copy may refer to it; default to "No".
+  // Honor a caller's cancelLabel here too (the description copy may refer to it);
+  // default to "No".
   const acknowledgeCancelLabel = cancelLabel ?? t("components.confirmModal.no")
   const [hasAcknowledged, setHasAcknowledged] = useState(false)
   const [typedText, setTypedText] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Synchronous re-entrancy latch. `isSubmitting` (React state) updates a tick
-  // late and the button's disabled attribute lags one render, so two clicks in
-  // the same tick would both pass an `isSubmitting` check and both run
-  // onConfirm(). This ref flips synchronously, so a second same-tick submit is
-  // rejected before it can start a duplicate write.
+  // late and the button's disabled attr lags a render, so two same-tick clicks
+  // could both pass the check and both run onConfirm(). This ref flips
+  // synchronously, rejecting the second before it starts a duplicate write.
   const submittingRef = useRef(false)
 
   const matches = typedText === confirmText
@@ -66,9 +65,9 @@ export function ConfirmModal({
     }
   }, [open])
 
-  // The acknowledge → confirm step swaps content inside the same open dialog, so
-  // the input's `autoFocus` won't re-fire. Move focus to it explicitly so a
-  // keyboard/SR user lands on the field they now have to fill in.
+  // The acknowledge → confirm step swaps content in the same open dialog, so the
+  // input's `autoFocus` won't re-fire. Focus it explicitly so a keyboard/SR user
+  // lands on the field they now have to fill in.
   useEffect(() => {
     if (hasAcknowledged) confirmInputRef.current?.focus()
   }, [hasAcknowledged])

--- a/web/src/components/settings/LanguagePackUpdateToaster.tsx
+++ b/web/src/components/settings/LanguagePackUpdateToaster.tsx
@@ -5,8 +5,8 @@ import { useOptionalToast } from "@/context/notifications/NotificationProvider"
 import { languageLabel, subscribeToPackUpdates } from "@/i18n/customLocale"
 
 // Bridges the non-React startup auto-refresh (refreshInstalledPacks) to a toast:
-// codes updated before mount are buffered and flushed to this subscriber; later
-// refreshes notify live. Renders nothing. Mount under NotificationProvider.
+// codes updated before mount are buffered and flushed here; later refreshes
+// notify live. Renders nothing. Mount under NotificationProvider.
 export function LanguagePackUpdateToaster() {
   const { t, i18n } = useTranslation()
   const toast = useOptionalToast()

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -64,9 +64,7 @@ export const LanguageSwitcher = ({
   const [shareCodeOverride, setShareCodeOverride] = useState<string | null>(
     null,
   )
-  // Synchronous re-entry lock shared by all prepare entry points (file, URL,
-  // built-in): `busy` is async React state, so a fast second click can fire
-  // before it re-renders. A ref flips immediately. Owned by runPrepare.
+  // Synchronous re-entry lock owned by runPrepare (see there for why).
   const preparingRef = useRef(false)
 
   const showError = (err: unknown) => {
@@ -82,16 +80,16 @@ export const LanguageSwitcher = ({
 
   const runPrepare = async (
     prepare: () => Promise<PackPreview>,
-    // The accordion section this prepare belongs to. On preview/error we keep it
-    // open so the resulting preview/error card stays visually tied to its origin
-    // (the cards render below all sections; a detached preview is confusing).
+    // Accordion section this prepare belongs to; kept open on preview/error so
+    // the resulting card stays tied to its origin (cards render below all
+    // sections, and a detached preview is confusing).
     section: "add" | "install",
   ) => {
     // Synchronous re-entry lock shared by all prepare entry points (file, URL,
     // built-in). `busy` is async React state, so a fast second click or an
-    // overlapping URL/file prepare would otherwise race two fetches over the
-    // shared preview and let the last fetch to resolve win — installing a pack
-    // that isn't the one the user last chose. The ref flips immediately.
+    // overlapping prepare would race two fetches over the shared preview and let
+    // the last to resolve win — installing a pack the user didn't last choose.
+    // The ref flips immediately.
     if (preparingRef.current) return
     preparingRef.current = true
     setError(null)
@@ -131,7 +129,7 @@ export const LanguageSwitcher = ({
   }
 
   // Lazily load the registry when Browse first opens; every language the
-  // manifest lists is offered (the publish workflow only lists deployed packs).
+  // manifest lists is offered (publish only lists deployed packs).
   const loadRegistry = async () => {
     if (registry || registryBusy) return
     setRegistryBusy(true)
@@ -149,9 +147,9 @@ export const LanguageSwitcher = ({
     }
   }
 
-  // Controlled accordion: driving the native <details> via its own toggle event
-  // fights React's `open` prop (a closed section needs two clicks to open), so
-  // we intercept the summary click and set the open section ourselves.
+  // Controlled accordion: driving native <details> via its toggle event fights
+  // React's `open` prop (closed sections need two clicks), so we intercept the
+  // summary click and set the open section ourselves.
   const toggleSection = (
     event: React.MouseEvent,
     section: AccordionSectionId,
@@ -163,9 +161,7 @@ export const LanguageSwitcher = ({
   }
 
   const handleBuiltIn = async (builtInCode: string) => {
-    // The re-entry lock now lives in runPrepare (shared across all entry
-    // points), so a second concurrent click is a no-op there. Set preparingCode
-    // for the per-row spinner; runPrepare's guard prevents the racing install.
+    // runPrepare owns the re-entry lock; set preparingCode for the per-row spinner.
     if (preparingRef.current) return
     setPreparingCode(builtInCode)
     try {
@@ -212,10 +208,9 @@ export const LanguageSwitcher = ({
     reset: resetShareCopied,
   } = useCopyToClipboard(shareUrl ?? "")
 
-  // One storage read for all installed packs (vs. one per pack), memoized so
-  // unrelated re-renders (typing, accordion toggles, copy timer) don't re-parse
-  // the whole localStorage pack store. installedLangs is a stable-identity
-  // useSyncExternalStore snapshot, so it's a reliable memo key.
+  // One storage read for all installed packs, memoized so unrelated re-renders
+  // (typing, accordion toggles, copy timer) don't re-parse the pack store.
+  // installedLangs is a stable useSyncExternalStore snapshot — a reliable key.
   const coverages = useMemo(
     () => (installedLangs.length > 0 ? packCoverages() : {}),
     [installedLangs, packCoverages],
@@ -544,8 +539,8 @@ export const LanguageSwitcher = ({
 
 export default LanguageSwitcher
 
-// Shared shell for the collapsible sections: a controlled native <details> with
-// a rotating chevron. `open` stays an explicit prop so a section can widen its
+// Shared shell for collapsible sections: a controlled native <details> with a
+// rotating chevron. `open` stays an explicit prop so a section can widen its
 // open condition (e.g. install also opens when a code is needed).
 const AccordionSection = ({
   section,

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -19,8 +19,7 @@ import { useTranslation } from "react-i18next"
 import { useActionActivity, type Tracker } from "@/hooks/useActionActivity"
 import { DURATION, EASE_OUT } from "@/lib/motion"
 
-// Compact elapsed duration ("8s", "1m 12s", "3m", "1h 5m"). "" for a
-// non-positive span.
+// Compact elapsed duration ("8s", "1m 12s", "3m", "1h 5m"); "" for non-positive.
 function formatElapsed(ms: number): string {
   const total = Math.max(0, Math.round(ms / 1000))
   if (total < 60) return `${total}s`
@@ -47,12 +46,11 @@ const ElapsedLabel = ({ tracker, now }: { tracker: Tracker; now: number }) => {
 
 // App-wide banner fixed to the top, showing GitHub Actions activity for the
 // current org as per-operation trackers. One tracker shows inline; several
-// collapse to a header (latest action + count) that expands to a per-row list.
-// Mounts above the router (so it survives route changes) — hence NO TanStack
-// <Link>; run links are plain <a href> to github.com.
+// collapse to a header (latest + count) that expands to a per-row list. Mounts
+// above the router, so run links are plain <a href>, not TanStack <Link>.
 
-// Phase icon. `tinted` applies the phase's semantic color (per-row list on a
-// neutral surface); without it the icon inherits the solid-tone header color.
+// Phase icon. `tinted` applies the phase's semantic color (per-row list);
+// without it the icon inherits the solid-tone header color.
 const StatusIcon = ({
   phase,
   tinted,
@@ -82,7 +80,7 @@ const StatusIcon = ({
   )
 }
 
-// Per-phase tone for an expanded row, so each row is distinguishable inside the
+// Per-phase tone for an expanded row, so rows stay distinguishable in the
 // neutral list even when the header is red.
 const ROW_TONE: Record<Tracker["phase"], string> = {
   failed: "bg-error/10 text-error",
@@ -104,8 +102,8 @@ const TrackerRow = ({
   onRetry: (id: string) => void
   retrying: boolean
   now: number
-  // compact = inline in the collapsed single-tracker bar (inherits header tone);
-  // otherwise the row carries its own per-phase tone.
+  // compact = inline in the collapsed single-tracker bar (inherits header
+  // tone); otherwise the row carries its own per-phase tone.
   compact?: boolean
 }) => {
   const { t } = useTranslation()
@@ -159,8 +157,8 @@ const TrackerRow = ({
   )
 }
 
-// The banner's inner content (one row, or the expandable header + list).
-// Extracted so it renders both in the hidden measuring probe and the visible bar.
+// Inner banner content (one row, or the expandable header + list). Extracted so
+// it renders in both the hidden measuring probe and the visible bar.
 const BannerBody = ({
   trackers,
   primary,
@@ -177,8 +175,8 @@ const BannerBody = ({
   trackers: Tracker[]
   primary: Tracker | undefined
   primaryPhase: Tracker["phase"]
-  // Failed actions the header isn't leading with — shown as a "needs attention"
-  // badge, independent of the bar's tone.
+  // Failed actions the header isn't leading with — a "needs attention" badge,
+  // independent of the bar's tone.
   attentionCount: number
   single: boolean
   showList: boolean
@@ -279,9 +277,8 @@ export function ActionsBanner() {
     return () => window.clearInterval(id)
   }, [anyRunning])
 
-  // Hold the banner until after the page paints so it slides in after the app
-  // content on a refresh, not with/before it. Gate on document.readyState so a
-  // slow load waits too.
+  // Hold the banner until after first paint so it slides in after the app
+  // content on refresh, not with it. Gate on readyState so a slow load waits.
   const [ready, setReady] = useState(false)
   useEffect(() => {
     let timer: number | undefined
@@ -304,14 +301,13 @@ export function ActionsBanner() {
   const canExpand = trackers.length > 1
 
   // Header leads with the LATEST action (trackers are newest-first), so a new
-  // action after a failure takes over the title; its own phase drives the icon.
+  // action after a failure takes over the title; its phase drives the icon.
   const primary = trackers[0]
   const primaryPhase = primary?.phase ?? "running"
   const failedCount = trackers.filter((tr) => tr.phase === "failed").length
 
-  // Tone follows the LATEST action's phase (green/orange/red) — an older
-  // failure does NOT repaint the whole bar; it surfaces as the attention badge
-  // below instead. Solid fill with the matching -content color.
+  // Tone follows the LATEST action's phase — an older failure does NOT repaint
+  // the whole bar; it surfaces as the attention badge below. Solid fill.
   const tone =
     primaryPhase === "failed"
       ? "border-error bg-error text-error-content"
@@ -319,22 +315,18 @@ export function ActionsBanner() {
         ? "border-success bg-success text-success-content"
         : "border-warning bg-warning text-warning-content"
 
-  // Failed actions NOT leading the header (the badge count). When the latest
-  // action is itself the failure, the bar is already red, so exclude it.
+  // Failed actions NOT leading the header. When the latest action is itself the
+  // failure the bar is already red, so exclude it.
   const attentionCount =
     primaryPhase === "failed" ? failedCount - 1 : failedCount
 
   const showList = canExpand && expanded
 
-  // Reserve body padding equal to the banner height so it PUSHES the app down
-  // instead of overlaying page content. The banner is a full-width fixed bar
-  // above the router (out of normal flow), so we mirror its position onto
-  // document.body's padding-top, shifting the whole app down as one.
-  //
-  // Enter/exit slide `y` from -height to 0 and back; padding = height + y tracks
-  // the banner's bottom edge frame-for-frame, so the app slides with it. Height
-  // is measured from the inner content (unaffected by the slide) via a
-  // ResizeObserver so expanding the list keeps the reservation in sync.
+  // Reserve body padding equal to banner height so it PUSHES the app down
+  // rather than overlaying it (the fixed bar is out of normal flow). During
+  // enter/exit, padding = height + y tracks the banner's bottom edge frame-for-
+  // frame so the app slides with it. Height is measured from the inner content
+  // (unaffected by the slide) via a ResizeObserver so expanding stays in sync.
   const contentRef = useRef<HTMLDivElement | null>(null)
   const [bannerHeight, setBannerHeight] = useState(0)
   useLayoutEffect(() => {
@@ -347,9 +339,9 @@ export function ActionsBanner() {
     return () => observer.disconnect()
   }, [visible])
 
-  // `y` (Framer-animated on enter/exit) drives body padding = height + y, so the
-  // app slides with the banner. onExitComplete below hard-clears the gap so a
-  // reduced-motion or interrupted exit can't strand a permanent top gap.
+  // `y` (animated on enter/exit) drives body padding = height + y. onExitComplete
+  // below hard-clears the gap so a reduced-motion or interrupted exit can't
+  // strand a permanent top gap.
   const y = useMotionValue(-bannerHeight)
   useMotionValueEvent(y, "change", (value) => {
     const px = Math.max(0, bannerHeight + value)
@@ -385,9 +377,9 @@ export function ActionsBanner() {
 
   return (
     <div className="pointer-events-none fixed inset-x-0 top-0 z-50">
-      {/* Hidden probe: measures the banner height before the animated bar
-          mounts so the slide-in can start from the true offset. Laid out (not
-          display:none) but invisible and inert. */}
+      {/* Hidden probe: measures banner height before the animated bar mounts so
+          the slide-in starts from the true offset. Laid out but invisible and
+          inert. */}
       {visible && (
         <div
           ref={contentRef}

--- a/web/src/context/actions/ActionActivityProvider.tsx
+++ b/web/src/context/actions/ActionActivityProvider.tsx
@@ -34,7 +34,7 @@ type ActionActivityContextValue = {
   // Ops recorded this session for the org, oldest first (stable order for
   // same-workflow disambiguation).
   operationsForOrg: (org: string | undefined) => ActionOperation[]
-  // Time of the most recent register() for an org (0 if none) — the banner uses
+  // Time of the most recent register() for an org (0 if none); the banner uses
   // it to appear and poll immediately, before the run shows in the API.
   lastRegisteredAt: (org: string | undefined) => number
   // Whether the teacher dismissed an op (hidden from the banner).
@@ -88,8 +88,8 @@ const saveState = (state: PersistedState) => {
   }
 }
 
-// Records session-initiated GitHub operations for the banner. Mounted above the
-// router so a registration survives the page that fired it navigating away;
+// Records session-initiated GitHub operations for the banner. Above the router
+// so a registration survives the page that fired it navigating away;
 // sessionStorage-backed (tab-scoped) to match the trackers' lifetime.
 export function ActionActivityProvider({ children }: PropsWithChildren) {
   const [state, setState] = useState<PersistedState>(() => loadState())

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -16,11 +16,10 @@ import { missingScopes } from "@/auth/scopes"
 
 const GitHubClientContext = createContext<GitHubClient | null>(null)
 
-// Latest per-response signal observed on a real API call, stamped with the
-// token it belongs to. `scopes === null` means the X-OAuth-Scopes header was
-// absent (e.g. a fine-grained PAT) — treated as "unknown", not "no scopes". The
-// stamp lets the reader ignore a value left over from a previous token without
-// a reset effect.
+// Latest per-response signal from a real API call, stamped with the token it
+// belongs to. `scopes === null` means the X-OAuth-Scopes header was absent (e.g.
+// a fine-grained PAT) — "unknown", not "no scopes". The stamp lets the reader
+// ignore a value left over from a previous token without a reset effect.
 type Observed = { token: string; signal: GitHubResponseSignal }
 const ObservedContext = createContext<Observed | null>(null)
 
@@ -32,20 +31,20 @@ export function GitHubProvider({
   const { expireSession } = useGithubAuth()
 
   // Stamp each observation with the active token so a value carried over from a
-  // previous token is ignored on read, rather than cleared via an effect (which
-  // tripped the cascading-render lint).
+  // previous token is ignored on read, not cleared via an effect (which tripped
+  // the cascading-render lint).
   const onResponse = useCallback(
     (signal: GitHubResponseSignal) => {
       if (!token) return
       // A live 401 means the token is revoked/expired: tear the session down so
-      // the _authed guard redirects to /login instead of stranding the user on
-      // a dead authed page. expireSession() no-ops once the token is cleared.
+      // the guard redirects to /login instead of stranding the user on a dead
+      // authed page. expireSession() no-ops once the token is cleared.
       if (signal.status === 401) {
         expireSession()
         return
       }
-      // Keep the prior reference when the signal is unchanged so React bails
-      // out — onResponse fires on every API response and the steady state is an
+      // Keep the prior reference when the signal is unchanged so React bails out
+      // — onResponse fires on every response and the steady state is an
       // unchanging 200 + scopes header.
       setObserved((prev) =>
         prev &&
@@ -91,10 +90,9 @@ export function useOptionalGitHubClient() {
 }
 
 // Required scopes the current token is missing, for the scope-warning banner.
-// Prefers the live X-OAuth-Scopes observation; falls back to the scope string
-// captured at login. Fails open: when neither source has a value (no client, or
-// a token that reports no scope header), returns [] so the banner stays hidden
-// rather than nagging about scopes we cannot actually verify.
+// Prefers the live X-OAuth-Scopes observation; falls back to the login scope
+// string. Fails open: with no value from either source, returns [] so the
+// banner stays hidden rather than nagging about scopes we can't verify.
 export function useMissingScopes(): string[] {
   const { tokenScope } = useGithubAuth()
   const observed = useContext(ObservedContext)

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -25,11 +25,11 @@ export type Toast = {
 
 export type NotifyInput = {
   tone?: ToastTone
-  // Toast content. NOTE: the toast viewport is mounted ABOVE the RouterProvider
-  // (so toasts survive route changes), which means it has NO router context.
-  // Do NOT put a TanStack Router <Link> in here — it throws on render and blanks
-  // the app (the throw escapes the route-level errorComponent). Use plain text,
-  // or a plain <a href> / a button calling router.navigate if a link is needed.
+  // Toast content. The toast viewport mounts ABOVE the RouterProvider (so toasts
+  // survive route changes), so it has NO router context. Do NOT put a TanStack
+  // <Link> here — it throws on render and blanks the app (the throw escapes the
+  // route-level errorComponent). Use plain text, a plain <a href>, or a button
+  // calling router.navigate.
   message: React.ReactNode
   // Optional dedup key: a later notify() with the same key replaces the prior
   // toast in place instead of stacking a duplicate (e.g. repeated retries).
@@ -44,8 +44,8 @@ type NotificationContextValue = {
 
 const NotificationContext = createContext<NotificationContextValue | null>(null)
 
-// daisyUI alert classes per tone. `alert-soft` matches the house style used by
-// the inline alerts this provider generalizes (EnrolledStudents, EditAssignment).
+// daisyUI alert classes per tone. `alert-soft` matches the inline alerts this
+// provider generalizes (EnrolledStudents, EditAssignment).
 const TONE_CLASS: Record<ToastTone, string> = {
   info: "alert alert-info alert-soft",
   success: "alert alert-success alert-soft",
@@ -58,9 +58,8 @@ const nextId = () => `toast-${++toastSeq}`
 
 // App-wide toast surface. Lives above the router so a toast survives the
 // component that fired it unmounting (archiving removes the card, reuse
-// navigates away). Modeled on the ad-hoc inline-alert region in
-// EnrolledStudents (tones, keyed dedup, dismissible) — that surface still runs
-// its own inline alerts; migrating it onto notify()/useToast is a follow-up.
+// navigates away). Modeled on EnrolledStudents' inline-alert region (tones,
+// keyed dedup, dismissible); migrating that onto notify()/useToast is a follow-up.
 export function NotificationProvider({ children }: PropsWithChildren) {
   const [toasts, setToasts] = useState<Toast[]>([])
   // Track auto-dismiss timers so a keyed replace / manual dismiss clears them.
@@ -175,7 +174,7 @@ export function useToast() {
 }
 
 // Like useToast() but returns null instead of throwing when no provider is
-// mounted, for consumers that render both inside and outside it (e.g. the banner).
+// mounted, for consumers rendered both inside and outside it (e.g. the banner).
 export function useOptionalToast() {
   return useContext(NotificationContext)
 }

--- a/web/src/context/regrade/RegradeCoordinator.tsx
+++ b/web/src/context/regrade/RegradeCoordinator.tsx
@@ -8,22 +8,21 @@ import {
   type PropsWithChildren,
 } from "react"
 
-// Coordinates every regrade tracker on a Submissions page — the page-level
-// "Regrade all" hook and each per-row RegradeButton hook — so they share one
-// in-flight signal. Without this, the page's `regrading` flag only reflected
-// the assignment-wide hook and couldn't see per-row regrades, so "Collect now"
-// / "Regrade all" stayed enabled during a single-student regrade (overlapping
-// dispatches) and two trackers polling the same regrade.yaml run list could
-// bind to each other's run. The provider is page-scoped, so its membership is
-// implicitly the current assignment.
+// Coordinates every regrade tracker on a Submissions page — the "Regrade all"
+// hook and each per-row RegradeButton hook — so they share one in-flight signal.
+// Without it the page's `regrading` flag only saw the assignment-wide hook, so
+// "Collect now" / "Regrade all" stayed enabled during a single-student regrade
+// (overlapping dispatches) and two trackers polling the same regrade.yaml run
+// list could bind to each other's run. Page-scoped, so membership is implicitly
+// the current assignment.
 
 type RegradeCoordinator = {
   // True while ANY regrade (whole-assignment or per-student) is in flight.
   anyInFlight: boolean
   setInFlight: (key: string, inFlight: boolean) => void
-  // Whether a NEW regrade may be dispatched now. False while any regrade is in
-  // flight, so concurrent dispatches against the shared run list are prevented
-  // (the monotonic-id binding assumes one outstanding dispatch at a time).
+  // Whether a NEW regrade may dispatch now. False while any regrade is in
+  // flight, preventing concurrent dispatches against the shared run list (the
+  // monotonic-id binding assumes one outstanding dispatch at a time).
   canDispatch: () => boolean
 }
 
@@ -55,8 +54,8 @@ export function RegradeCoordinatorProvider({ children }: PropsWithChildren) {
   )
 }
 
-// Optional: trackers used outside a provider (e.g. in isolation/tests) get a
-// no-op coordinator so they keep working standalone.
+// Optional: trackers outside a provider (isolation/tests) get a no-op
+// coordinator so they keep working standalone.
 export function useRegradeCoordinator(): RegradeCoordinator {
   const ctx = useContext(RegradeCoordinatorContext)
   if (ctx) return ctx

--- a/web/src/context/roleView/RoleViewProvider.tsx
+++ b/web/src/context/roleView/RoleViewProvider.tsx
@@ -10,14 +10,12 @@ import {
 } from "react"
 import type { ViewAsRole } from "@/hooks/useClassroomRole"
 
-// "View as" preview state. A client-side lens letting an instructor/owner
-// preview the app as a TA or student. Persisted per org+classroom in
-// sessionStorage and applied DOWNGRADE-ONLY by useClassroomRole.
-//
-// The preview is CLASSROOM-scoped: a teacher who is an instructor in one
-// classroom and a TA in another must not carry a "view as student" across,
-// where it would silently demote them with no visible control to clear it.
-// Keying by org+classroom — and clearing on classroom change — isolates each.
+// "View as" preview: a client-side lens letting an instructor/owner preview the
+// app as a TA or student. Persisted per org+classroom in sessionStorage and
+// applied DOWNGRADE-ONLY by useClassroomRole. CLASSROOM-scoped so a teacher who
+// is an instructor in one classroom and a TA in another can't carry "view as
+// student" across (a silent demote with no visible control to clear it); keying
+// by org+classroom and clearing on classroom change isolates each.
 type RoleViewContextValue = {
   viewAs: ViewAsRole | null
   setViewAs: (next: ViewAsRole | null) => void
@@ -46,9 +44,8 @@ function readStored(
   return raw === "ta" || raw === "student" ? raw : null
 }
 
-// Scoped to one org (remounts on org change via the `key` prop) and one
-// classroom (re-synced below), so the preview never leaks across orgs or
-// classrooms.
+// Scoped to one org (remounts on org change via `key`) and one classroom
+// (re-synced below), so the preview never leaks across orgs or classrooms.
 export function RoleViewProvider({
   org,
   classroom,
@@ -61,9 +58,9 @@ export function RoleViewProvider({
     readStored(org, classroom),
   )
 
-  // When the active classroom changes (the provider stays mounted across
-  // intra-org navigation), re-read this classroom's stored preview so one set
-  // in classroom A never bleeds into classroom B.
+  // On classroom change (the provider stays mounted across intra-org
+  // navigation), re-read this classroom's stored preview so one set in classroom
+  // A never bleeds into classroom B.
   const prevClassroomRef = useRef(classroom)
   useEffect(() => {
     if (prevClassroomRef.current !== classroom) {
@@ -94,7 +91,7 @@ export function RoleViewProvider({
 }
 
 // Read the current preview. Returns a no-op default when no provider is mounted
-// (e.g. org-less routes), so callers never need to null-check.
+// (e.g. org-less routes), so callers never null-check.
 export function useRoleView(): RoleViewContextValue {
   return useContext(RoleViewContext) ?? { viewAs: null, setViewAs: () => {} }
 }

--- a/web/src/hooks/github/activityRuns.ts
+++ b/web/src/hooks/github/activityRuns.ts
@@ -19,8 +19,8 @@ const RUNS_PER_PAGE = 50
 //
 // A 404 (repo missing / not a classroom50 org / not visible) means "no runs" ->
 // []. A 403/429/5xx (rate limit, lost Actions read, outage) MUST propagate so
-// React Query marks the query errored — otherwise the banner would show a false
-// "all clear". Aborts also propagate.
+// React Query marks the query errored — else the banner shows a false "all
+// clear". Aborts also propagate.
 export async function listActiveAndRecentRuns(
   client: GitHubClient,
   org: string,

--- a/web/src/hooks/github/client.ts
+++ b/web/src/hooks/github/client.ts
@@ -26,7 +26,7 @@ export type GitHubRequestOptions = {
   timeoutMs?: number
 }
 
-// A per-response signal about the token's live state, reported to the provider
+// Per-response signal about the token's live state, reported to the provider
 // for the session/scope banner. Fires on every response (success and error)
 // before any throw.
 export type GitHubResponseSignal = {
@@ -82,8 +82,8 @@ export function createGitHubClient(args: {
     // Report the token's live state to the provider before any throw, so the
     // 401/403 revocation path still surfaces. `scopes` is the X-OAuth-Scopes
     // header (`null` when absent, e.g. a fine-grained PAT — distinct from an
-    // empty grant); `status` lets the provider distinguish a dead token (401)
-    // from a healthy one.
+    // empty grant); `status` lets the provider tell a dead token (401) from a
+    // healthy one.
     args.onResponse?.({
       status: res.status,
       scopes: res.headers.get("x-oauth-scopes"),

--- a/web/src/hooks/github/errors.test.ts
+++ b/web/src/hooks/github/errors.test.ts
@@ -72,8 +72,8 @@ describe("SAML SSO detection", () => {
 
   it("isSsoRequired is false when the header rides a non-403 status", () => {
     // GitHub only emits X-GitHub-SSO on a 403; a header echoed onto a dead-token
-    // 401 or a transient 5xx/429 (e.g. copied by a proxy) must NOT be read as an
-    // SSO gate, or it would mask a re-auth / outage as "authorize SSO".
+    // 401 or a transient 5xx/429 (e.g. proxy-copied) must NOT read as an SSO
+    // gate, or it would mask a re-auth / outage as "authorize SSO".
     const header = `required; url=${orgSsoUrl}`
     expect(apiError(401, header).isSsoRequired).toBe(false)
     expect(apiError(500, header).isSsoRequired).toBe(false)
@@ -108,8 +108,8 @@ describe("SAML SSO detection", () => {
   it("rejects github.com spoofs that shift the real host (userinfo / subdomain)", () => {
     // The `hostname === "github.com"` guard is the security-relevant sentinel;
     // these are the classic ways a naive substring/`includes` check would be
-    // fooled. `new URL()` puts `github.com` in the userinfo (host = evil.com)
-    // for the `@` form, and the trailing-domain form has host github.com.evil.com.
+    // fooled. `new URL()` puts `github.com` in the userinfo (host = evil.com) for
+    // the `@` form, and the trailing-domain form has host github.com.evil.com.
     expect(
       parseSsoAuthorizationUrl("required; url=https://github.com@evil.com/sso"),
     ).toBeNull()

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -12,17 +12,16 @@ export class GitHubAPIError extends Error {
   url: string
   body: unknown
   rateLimit: GitHubRateLimit
-  // Raw X-GitHub-SSO response header, when present. GitHub sets this on a
-  // 403 (and omits SSO-gated orgs from multi-org reads) when the token lacks a
-  // live SAML SSO session for the org/enterprise. `null` when the header was
-  // absent. See parseSsoAuthorizationUrl for extracting the authorization URL.
+  // Raw X-GitHub-SSO response header, when present. GitHub sets this on a 403
+  // (and omits SSO-gated orgs from multi-org reads) when the token lacks a live
+  // SAML SSO session for the org/enterprise. `null` when absent. See
+  // parseSsoAuthorizationUrl for extracting the authorization URL.
   ssoHeader: string | null
-  // Raw X-Accepted-OAuth-Scopes response header, when present. On a 403 caused
-  // by a scope gap, GitHub reports the scopes the endpoint *requires* here (vs
-  // X-OAuth-Scopes, the scopes the token actually has). `null` when absent.
-  // Used with `oauthScopes` to distinguish a real scope gap from an org
-  // restriction — presence alone is NOT a gap (GitHub sends this header on most
-  // responses); a gap is `acceptedScopes` not satisfied by `oauthScopes`.
+  // Raw X-Accepted-OAuth-Scopes response header, when present. On a scope-gap
+  // 403, GitHub reports the scopes the endpoint *requires* here (vs
+  // X-OAuth-Scopes, what the token has). `null` when absent. Used with
+  // `oauthScopes` to tell a real scope gap from an org restriction — presence
+  // alone is NOT a gap (GitHub sends it on most responses).
   acceptedScopes: string | null
   // Raw X-OAuth-Scopes response header (the scopes the token actually holds),
   // when present. `null` for a fine-grained PAT or when absent. Compared against
@@ -71,22 +70,21 @@ export class GitHubAPIError extends Error {
   }
 
   // The org/enterprise enforces SAML SSO and this token has no live SSO session
-  // for it. GitHub signals this with the X-GitHub-SSO header (a 403 carrying
-  // `required; url=…`, or `partial-results; organizations=…` on multi-org reads).
-  // Scoped to 403: GitHub only emits X-GitHub-SSO on a forbidden response, so a
-  // header echoed on any other status (a 401 dead token, a 5xx/429 that a proxy
-  // copied the header onto) is NOT an SSO gate and must not misroute the user.
+  // for it. GitHub signals this via X-GitHub-SSO (a 403 carrying `required;
+  // url=…`, or `partial-results; organizations=…` on multi-org reads). Scoped to
+  // 403: GitHub only emits X-GitHub-SSO on a forbidden response, so a header
+  // echoed on any other status (a 401 dead token, a proxy-copied 5xx/429) is NOT
+  // an SSO gate and must not misroute the user.
   get isSsoRequired() {
     return this.status === 403 && this.ssoHeader !== null
   }
 
-  // A 403 caused by the token missing a scope the endpoint requires — as opposed
-  // to an org restriction, SAML gate, or rate limit (all also 403). GitHub sends
-  // X-Accepted-OAuth-Scopes on most responses, so its mere presence is NOT a gap;
-  // a real gap is when the accepted set has a requirement the token's granted
-  // scopes (X-OAuth-Scopes) don't satisfy. When either header is absent we cannot
-  // prove a gap, so this is false (fail closed — never mislabel a restriction as
-  // a scope problem). An empty required set ("" — endpoint needs no scope) is
+  // A 403 caused by the token missing a scope the endpoint requires — vs an org
+  // restriction, SAML gate, or rate limit (all also 403). GitHub sends
+  // X-Accepted-OAuth-Scopes on most responses, so its mere presence is NOT a
+  // gap; a real gap is when the accepted set has a requirement the token's
+  // granted scopes (X-OAuth-Scopes) don't satisfy. When either header is absent
+  // we can't prove a gap, so false (fail closed). An empty required set ("") is
   // never a gap.
   get isScopeGap() {
     if (this.status !== 403) return false
@@ -100,13 +98,13 @@ export class GitHubAPIError extends Error {
     if (required.length === 0) return false
     const granted = new Set(parse(this.oauthScopes))
     // GitHub treats X-Accepted-OAuth-Scopes as "any one of these satisfies the
-    // endpoint", so a gap is only when the token holds NONE of the accepted scopes.
+    // endpoint", so a gap is only when the token holds NONE of them.
     return !required.some((scope) => granted.has(scope))
   }
 
   // The GitHub SSO authorization URL to send the user to, if the header carried
-  // one (`required; url=…`). Returns null for the `partial-results` shape or
-  // when no header is present.
+  // one (`required; url=…`). Null for the `partial-results` shape or when no
+  // header is present.
   get ssoAuthorizationUrl() {
     return parseSsoAuthorizationUrl(this.ssoHeader)
   }
@@ -128,10 +126,10 @@ export function parseSsoAuthorizationUrl(
   try {
     const url = new URL(match[1])
     // Only ever hand back an https://github.com SSO URL, never an
-    // attacker-influenced origin or scheme (the header is from GitHub, but stay
-    // defensive since we render this as a clickable redirect). The explicit
-    // https: check makes the intent durable rather than relying on the
-    // incidental fact that javascript:/data: URLs parse to an empty hostname.
+    // attacker-influenced origin or scheme (the header is from GitHub, but we
+    // render this as a clickable redirect). The explicit https: check makes the
+    // intent durable rather than relying on javascript:/data: URLs parsing to an
+    // empty hostname.
     if (url.protocol !== "https:") return null
     if (url.hostname !== "github.com") return null
     return url.toString()
@@ -143,8 +141,7 @@ export function parseSsoAuthorizationUrl(
 // Shared React Query `retry` predicate for fail-closed role/permission reads: a
 // definitive status (401 revoked/expired, 403 blocked, 404 not found / not a
 // member — see isDefinitiveGitHubStatus) must NOT retry, while a transient
-// 5xx/429/network blip self-heals (bounded to 2). Named for its behavior (retry
-// only transient errors); the definitive set includes 401 as well as 403/404.
+// 5xx/429/network blip self-heals (bounded to 2).
 export function retryTransientGitHubError(
   failureCount: number,
   error: unknown,
@@ -158,12 +155,11 @@ export function retryTransientGitHubError(
   return failureCount < 2
 }
 
-// Statuses that are DEFINITIVE for a GitHub read — retrying cannot change the
-// outcome, so the query should resolve immediately: 401 (revoked/expired
-// credentials), 403 (blocked, incl. SAML-SSO-gated — see #66), 404 (absent).
-// Any other failure (5xx / 429 / network) is treated as transient by the retry
-// predicates above/below. Works off a bare status so it is shared across the
-// bespoke GitHubUserFetchError and the canonical GitHubAPIError.
+// Statuses that are DEFINITIVE for a GitHub read — retrying can't change the
+// outcome, so the query resolves immediately: 401 (revoked/expired), 403
+// (blocked, incl. SAML-SSO-gated — see #66), 404 (absent). Any other failure
+// (5xx / 429 / network) is transient per the retry predicates. Works off a bare
+// status so it's shared across GitHubUserFetchError and GitHubAPIError.
 export function isDefinitiveGitHubStatus(status: number): boolean {
   return status === 401 || status === 403 || status === 404
 }

--- a/web/src/hooks/github/mutations.test.ts
+++ b/web/src/hooks/github/mutations.test.ts
@@ -93,12 +93,11 @@ describe("buildClassroomUpdate", () => {
 
 // editClassroom enforces "archived classrooms are read-only" on the write path
 // — the authoritative guard, not just UI gating. The gate must (a) refuse a
-// settings edit (name/term) on an archived classroom even
-// when a crafted payload bundles `active: false` to re-assert the archived
-// state, and (b) let a genuine unarchive (active: true) through. editClassroom
-// does I/O via getBranchRef/getCommit/getClassroomJson/createBlob/
-// createTreeFromEntries/createCommit/updateRef, all on the GitHubClient, so we
-// stub a path-routing fake client.
+// settings edit (name/term) on an archived classroom even when a crafted payload
+// bundles `active: false` to re-assert the archived state, and (b) let a genuine
+// unarchive (active: true) through. editClassroom does I/O via getBranchRef/
+// getCommit/getClassroomJson/createBlob/createTreeFromEntries/createCommit/
+// updateRef, all on the GitHubClient, so we stub a path-routing fake client.
 describe("editClassroom archived read-only guard", () => {
   // A fake client routing each git/contents path to a canned response. The
   // archived classroom.json is returned by the contents endpoint; if the guard
@@ -797,8 +796,7 @@ describe("ensureSkeletonFiles overwrite confirmation", () => {
 // The skeleton commit uses a force:false ref PATCH and retries on a 422
 // non-fast-forward (the concurrent-writer race the confirm-modal pause opens),
 // re-diffing against the freshly-read parent each attempt; a non-422 error and
-// retry exhaustion both surface to the caller. This is the PR's concurrency
-// safety claim, so it gets its own coverage.
+// retry exhaustion both surface to the caller.
 describe("ensureSkeletonFiles non-fast-forward retry", () => {
   const org = "acme"
 

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -45,8 +45,8 @@ const createClassroomMetadata = (
   // Written only when a team was provisioned (matches the CLI's `omitempty`).
   // Grants rostered students read on private org templates.
   ...(team ? { team } : {}),
-  // Per-classroom staff teams (instructor/ta) backing in-app roles. Written
-  // only when provisioned.
+  // Per-classroom staff teams (instructor/ta) backing in-app roles. Written only
+  // when provisioned.
   ...(teams && (teams.instructor || teams.ta) ? { teams } : {}),
   // Written only when the teacher opted into protected resources (CLI
   // `omitempty`). When present, Pages resources publish under
@@ -56,8 +56,8 @@ const createClassroomMetadata = (
 
 // Seed header for a new classroom's empty students.csv. Derived from the single
 // source of truth (STUDENT_CSV_FIELDS) so it can't drift; computed lazily (not
-// at module-eval time) to avoid the students.ts <-> mutations.ts circular-import
-// TDZ. The parser is header-based, so an older roster still parses.
+// at module-eval) to dodge the students.ts <-> mutations.ts circular-import TDZ.
+// The parser is header-based, so an older roster still parses.
 const studentsCsvHeader = () => STUDENT_CSV_FIELDS.join(",") + "\n"
 const createClassroomBody = (
   base_tree: string,
@@ -417,10 +417,9 @@ export type ClassroomTeamRef = {
 // classroom.json is config-repo-write authored and parsed without schema
 // validation, so a team ref read from it is untrusted input to a destructive
 // DELETE. A ref is safe to delete only when it (a) names a slug in the
-// `classroom50-` namespace this app owns — so a drifted ref can't steer a
-// delete into an unrelated org team — and (b) carries a positive integer id to
-// confirm against the live team before deleting, so a reused slug isn't
-// clobbered blind.
+// `classroom50-` namespace this app owns — so a drifted ref can't steer a delete
+// into an unrelated org team — and (b) carries a positive integer id, confirmed
+// against the live team before deleting so a reused slug isn't clobbered blind.
 export function isDeletableClassroomTeamRef(
   team: { id?: unknown; slug?: unknown } | undefined | null,
 ): team is ClassroomTeamRef {
@@ -441,7 +440,7 @@ function isCanonicalTeamShortName(shortName: string): boolean {
 // Create (or adopt) a `secret` team by exact name. Idempotent: adopts a
 // same-named team on 422 and reconciles privacy to `secret`. `created: false`
 // means it pre-existed and must NOT be deleted on a create-failure rollback.
-// The shared core both the students team and the staff teams build on.
+// The shared core the students team and staff teams build on.
 async function ensureSecretTeamByName(
   client: GitHubClient,
   org: string,
@@ -563,10 +562,9 @@ export async function ensureStaffTeams(
 }
 
 // Thrown by deleteClassroomTeam when the live team's id no longer matches the
-// id recorded in classroom.json (a slug was reused for a different team). A
-// dedicated type lets callers and telemetry distinguish this deliberate safety
-// refusal — which a re-run will repeat forever — from a transient failure that
-// is worth retrying.
+// id recorded in classroom.json (a slug reused for a different team). A
+// dedicated type lets callers and telemetry tell this deliberate safety refusal
+// — which a re-run repeats forever — from a transient, worth-retrying failure.
 export class TeamIdMismatchError extends Error {
   slug: string
   recordedId: number
@@ -788,7 +786,7 @@ export type OrgMembershipState = "active" | "pending"
 
 // PATCH /repos/{owner}/{repo} { archived: true }. Reversible and covered by the
 // existing `repo` scope (unlike deletion, which needs delete_repo and a
-// re-auth). Used as the safe fallback when deletion isn't permitted. 404 = success.
+// re-auth). The safe fallback when deletion isn't permitted. 404 = success.
 export async function archiveRepo(
   client: GitHubClient,
   input: { owner: string; repo: string },
@@ -848,11 +846,11 @@ export async function getOrgMembershipState(
 
 // Error-safe "is this login an active org member?" — the boolean form of the
 // membership re-check used across the enroll/reconcile paths. A missing username
-// or any read failure resolves to false (never throws), so callers that just
-// need a yes/no gate don't each re-inline the getOrgMembershipState === "active"
-// + try/catch dance. A caller that must surface a tailored error on a
-// non-member (matchStudentToAccount) still calls getOrgMembershipState
-// directly so it can throw its own message.
+// or any read failure resolves to false (never throws), so a yes/no-gate caller
+// needn't re-inline the getOrgMembershipState === "active" + try/catch dance. A
+// caller that must surface a tailored error on a non-member
+// (matchStudentToAccount) calls getOrgMembershipState directly to throw its own
+// message.
 export async function isActiveMember(
   client: GitHubClient,
   org: string,
@@ -867,7 +865,7 @@ type EnsureOrgMembershipResult = {
   state: OrgMembershipState | "invited"
 }
 
-// Precheck membership, only invite when neither active nor pending, and treat a
+// Precheck membership, invite only when neither active nor pending, and treat a
 // 422 (already member/invited) as success via a follow-up read. Optional
 // teamIds attach to a fresh invite so accepting the single org invitation
 // activates team membership atomically (no separate team invite that could
@@ -911,8 +909,8 @@ export async function ensureOrgMembership(
 // pending. When they ARE still pending and we know the stale invitation id,
 // cancel it and recreate so the invite is genuinely re-sent (previously this
 // short-circuited on the pending precheck and re-sent nothing). If the recreate
-// then hits a 422 (a pending invite still blocks it), that existing invite is
-// the live one, so leave it in place.
+// then 422s (a pending invite still blocks it), that existing invite is the
+// live one, so leave it in place.
 export async function resendOrgInvitation(
   client: GitHubClient,
   input: {
@@ -1106,7 +1104,7 @@ async function listTargetRepoBlobs(
   )
 }
 
-// The git blob SHA-1 GitHub reports for a file: sha1("blob <bytelen>\0" + body),
+// The git blob SHA-1 GitHub reports for a file: sha1("blob <bytelen>\0" + body)
 // over the UTF-8 bytes. Lets us compare a bundled skeleton file against the
 // repo's tree entry by SHA, mirroring `git hash-object`. (See the CLI's
 // gitBlobSHA in autograder_crud.go.)
@@ -1120,10 +1118,10 @@ export async function gitBlobSha(content: string): Promise<string> {
   return bytesToHex(new Uint8Array(digest))
 }
 
-// A bundled skeleton file that needs writing, tagged with whether a file
-// already exists at that path in the repo. `exists: false` is a create (always
-// safe); `exists: true` is an overwrite of a drifted file (the GUI confirms
-// these with the teacher first, mirroring the CLI's refresh prompt).
+// A bundled skeleton file that needs writing, tagged with whether a file already
+// exists at that path in the repo. `exists: false` is a create (always safe);
+// `exists: true` is an overwrite of a drifted file (the GUI confirms these with
+// the teacher first, mirroring the CLI's refresh prompt).
 export type StaleSkeletonFile = SkeletonFile & { exists: boolean }
 
 // Bounded retries for the skeleton commit's optimistic-rebase loop: re-diff
@@ -1144,7 +1142,7 @@ function isNonFastForward(err: unknown): boolean {
 // Skeleton files whose repo content is missing OR differs from the bundled
 // version. Mirrors the CLI's diffSkeleton/refreshSkeleton: re-running setup
 // picks up skeleton updates (new workflows, updated runner/scripts) instead of
-// only filling in absent paths. Skeleton files are not teacher-editable, so a
+// only filling in absent paths. Skeleton files aren't teacher-editable, so a
 // drifted file is treated as stale; callers decide whether to overwrite.
 export async function findStaleSkeletonFiles(
   client: GitHubClient,
@@ -1178,10 +1176,10 @@ export async function findStaleSkeletonFiles(
 
 // Commits missing skeleton files and refreshes drifted ones. Overwriting an
 // existing (drifted) file resets it to the bundled version, so callers can gate
-// that with confirmOverwrite: it's invoked with the existing paths about to be
-// overwritten, and resolving false leaves those files untouched while still
-// creating any missing ones. Omitting the hook overwrites without asking (the
-// first-time wizard, where nothing pre-exists).
+// that with confirmOverwrite: invoked with the existing paths about to be
+// overwritten, resolving false leaves those files untouched while still creating
+// any missing ones. Omitting the hook overwrites without asking (the first-time
+// wizard, where nothing pre-exists).
 export async function ensureSkeletonFiles(
   client: GitHubClient,
   org: string,
@@ -1219,8 +1217,8 @@ export async function ensureSkeletonFiles(
   }
 
   // Commit the stale files. The confirm modal can park this for an arbitrarily
-  // long time, so the branch tip may have advanced (another tab/owner, any
-  // push) by the time we write; updateRefForRepo uses force:false and rejects a
+  // long time, so the branch tip may have advanced (another tab/owner, any push)
+  // by the time we write; updateRefForRepo uses force:false and rejects a
   // non-fast-forward rather than clobbering. On such a rejection we re-diff
   // against the new parent and retry, mirroring the CLI's refreshSkeleton
   // (init_skeleton.go): the retry sees the new parent and never re-commits an
@@ -1229,11 +1227,11 @@ export async function ensureSkeletonFiles(
   let changed = toWrite.map((f) => f.path)
 
   for (let attempt = 0; attempt < SKELETON_COMMIT_ATTEMPTS; attempt++) {
-    // Attempt 0 reuses the diff we already computed; only a retry re-diffs,
-    // where a concurrent writer may have advanced the tip during the confirm
-    // pause (the force:false PATCH's 422 below is what catches that race). The
-    // re-diff avoids reverting that writer's changes and never re-commits an
-    // already-current file; an empty re-diff is a clean no-op.
+    // Attempt 0 reuses the diff we already computed; a retry re-diffs, where a
+    // concurrent writer may have advanced the tip during the confirm pause (the
+    // force:false PATCH's 422 below catches that race). The re-diff avoids
+    // reverting that writer's changes and never re-commits an already-current
+    // file; an empty re-diff is a clean no-op.
     const stillStale =
       attempt === 0
         ? toWrite
@@ -1409,8 +1407,8 @@ export async function ensurePages(
 
   // Trust the live read-back, not the write outcome: the writes are idempotent
   // and a re-run on an already-public site can 422 the visibility PUT while the
-  // site is in fact correct. Using checkPages also keeps this in lockstep with
-  // the audit.
+  // site is in fact correct. checkPages also keeps this in lockstep with the
+  // audit.
   const verdict = await checkPages(client, org, repo)
 
   const base = {
@@ -1506,18 +1504,18 @@ export async function ensureWorkflowPermissions(
       message: `${owner}/${repo}: workflow permissions set to write.`,
     }
   } catch {
-    // The PUT failed — typically a 409 because workflow write is org/enterprise-
-    // managed. That's benign (the skeleton workflows declare their own
-    // permissions), so re-read and report the effective state instead of
-    // failing setup.
+    // The PUT failed — typically a 409 because workflow write is
+    // org/enterprise-managed. That's benign (the skeleton workflows declare
+    // their own permissions), so re-read and report the effective state instead
+    // of failing setup.
     return reportOrgWorkflowPermissions(client, owner, repo)
   }
 }
 
-// Report the effective (org-managed) workflow-permission state when the repo
-// PUT didn't apply. A read default is acceptable because the skeleton workflows
-// declare workflow-level write where needed, so both "write" and "read" are
-// reported complete; only an unreadable state warrants a warning.
+// Report the effective (org-managed) workflow-permission state when the repo PUT
+// didn't apply. A read default is acceptable because the skeleton workflows
+// declare workflow-level write where needed, so both "write" and "read" report
+// complete; only an unreadable state warrants a warning.
 async function reportOrgWorkflowPermissions(
   client: GitHubClient,
   owner: string,
@@ -1545,7 +1543,8 @@ async function reportOrgWorkflowPermissions(
     }
   } catch {
     // Couldn't confirm the effective state — surface a warning to check rather
-    // than a clean complete. Setup still proceeds (skeleton workflows self-declare).
+    // than a clean complete. Setup still proceeds (skeleton workflows
+    // self-declare).
     return {
       status: "warning",
       repo: `${owner}/${repo}`,
@@ -1784,18 +1783,17 @@ export async function encryptSecret(publicKey: string, secret: string) {
  * reading the classroom50 repo *as the supplied token* and asserting it can
  * WRITE (permissions.push), mapping failures to actionable messages.
  *
- * The shared token now needs Contents: Read and write AND Actions: Read and
- * write on the student repos: collect-scores reads, but regrade (re-running a
- * student repo's autograde run, or pushing a submit/* tag) WRITES. We can't
- * introspect a fine-grained PAT's Actions scope via the API, so we assert the
- * Contents write capability (permissions.push) here — a read-only token is
- * rejected — and the UI instructs the teacher to also grant Actions: Read and
- * write. Mirrors the CLI's servicetoken.validateTokenWithClient.
+ * The shared token needs Contents: Read and write AND Actions: Read and write on
+ * student repos: collect-scores reads, but regrade (re-running an autograde run,
+ * or pushing a submit/* tag) WRITES. We can't introspect a fine-grained PAT's
+ * Actions scope via the API, so we assert the Contents write capability
+ * (permissions.push) here — a read-only token is rejected — and the UI instructs
+ * the teacher to also grant Actions: Read and write. Mirrors the CLI's
+ * servicetoken.validateTokenWithClient.
  *
- * Caveat: GET /repos/{org}/classroom50 proves the token's access to the config
- * repo, not the student repos the workflows touch (fine-grained PATs don't
- * expose their repo selection via the API). Hence the UI requires "All
- * repositories".
+ * Caveat: GET /repos/{org}/classroom50 proves access to the config repo, not the
+ * student repos the workflows touch (fine-grained PATs don't expose their repo
+ * selection via the API). Hence the UI requires "All repositories".
  */
 export async function validateServiceToken(
   token: string,
@@ -1848,8 +1846,8 @@ export async function validateServiceToken(
         )
       }
     }
-    // A fetch that never reached GitHub (network/CORS) throws a TypeError, not
-    // a GitHubAPIError — don't blame the token for that.
+    // A fetch that never reached GitHub (network/CORS) throws a TypeError, not a
+    // GitHubAPIError — don't blame the token for that.
     if (err instanceof TypeError) {
       throw new Error(
         `Couldn't reach GitHub to verify the token (network or CORS issue). Check your connection and try again. (${err.message})`,
@@ -1864,9 +1862,9 @@ export async function validateServiceToken(
     )
   }
 
-  // The token can read the repo, but regrade needs to write (re-run runs /
-  // push submit/* tags). A read-only PAT reports permissions.push === false;
-  // reject it with the same actionable scope hint.
+  // The token can read the repo, but regrade needs to write (re-run runs / push
+  // submit/* tags). A read-only PAT reports permissions.push === false; reject
+  // it with the same actionable scope hint.
   if (!repo.permissions?.push) {
     throw new Error(
       `This token can read ${org}/classroom50 but lacks write access — collecting scores needs read, but regrading needs write. ${scopeHint}`,
@@ -1874,18 +1872,18 @@ export async function validateServiceToken(
   }
 
   // Contents/Actions are proven, but collection is team-driven: it lists the
-  // classroom team's members, which needs the org-level Members: Read
-  // permission — NOT implied by any repository scope, so a Contents/Actions-only
-  // token passes every check above yet 403s on the first API call collect-scores
-  // makes. Probe GET /orgs/{org}/members (same Members: Read permission the
+  // classroom team's members, which needs the org-level Members: Read permission
+  // — NOT implied by any repository scope, so a Contents/Actions-only token
+  // passes every check above yet 403s on the first collect-scores API call.
+  // Probe GET /orgs/{org}/members (same Members: Read permission the
   // team-members endpoint needs, but not dependent on a specific team existing).
   //
-  // FAIL-OPEN on ambiguity: a 403/404 is a definitive scope gap and is
-  // rejected; any other failure (401 after a 200 repo read, 5xx, rate-limit,
-  // network/CORS) is inconclusive and allowed to proceed — the repo read above
-  // already proved the token live, so blocking on this second round-trip's
-  // flakiness would reject a valid token. The probe-token.yaml workflow is the
-  // exhaustive post-provision signal.
+  // FAIL-OPEN on ambiguity: a 403/404 is a definitive scope gap and is rejected;
+  // any other failure (401 after a 200 repo read, 5xx, rate-limit, network/CORS)
+  // is inconclusive and allowed to proceed — the repo read above already proved
+  // the token live, so blocking on this second round-trip's flakiness would
+  // reject a valid token. The probe-token.yaml workflow is the exhaustive
+  // post-provision signal.
   try {
     await tokenClient.request(
       `/orgs/${encodeURIComponent(org)}/members?per_page=1`,
@@ -1900,17 +1898,17 @@ export async function validateServiceToken(
         { cause: err },
       )
     }
-    // Inconclusive (401/5xx/network) — proceed; the repo read already
-    // proved the token valid.
+    // Inconclusive (401/5xx/network) — proceed; the repo read already proved the
+    // token valid.
   }
 }
 
 export const COLLECT_SCORES_WORKFLOW = "collect-scores.yaml"
 
-// The regrade fan-out workflow in <org>/classroom50.
-// Dispatched per assignment (optionally per repo owner); it re-runs each
-// student repo's autograde workflow. Grading then happens asynchronously inside
-// the student repos, so a follow-up collect-scores run refreshes the gradebook.
+// The regrade fan-out workflow in <org>/classroom50. Dispatched per assignment
+// (optionally per repo owner); it re-runs each student repo's autograde
+// workflow. Grading then happens asynchronously inside the student repos, so a
+// follow-up collect-scores run refreshes the gradebook.
 export const REGRADE_WORKFLOW = "regrade.yaml"
 
 /**
@@ -2235,10 +2233,10 @@ type OrgWorkflowPermissions = {
   can_approve_pull_request_reviews: boolean
 }
 
-// The opt-in Feedback PR, opened by each student repo's autograde
-// workflow, is rejected unless the org-level "Allow GitHub Actions to create
-// and approve pull requests" toggle is on (defaults off, settable only at the
-// org level). Preserves default_workflow_permissions.
+// The opt-in Feedback PR, opened by each student repo's autograde workflow, is
+// rejected unless the org-level "Allow GitHub Actions to create and approve pull
+// requests" toggle is on (defaults off, settable only at the org level).
+// Preserves default_workflow_permissions.
 export async function ensureOrgCanCreatePullRequests(
   client: GitHubClient,
   org: string,
@@ -2349,7 +2347,7 @@ export async function initClassroom50({
   // Invoked before drifted skeleton files are overwritten, with the paths at
   // risk. Resolving false skips the overwrite (missing files are still created)
   // — the GUI's "are you sure" prompt. Omitted on the first-time wizard, where
-  // the repo is fresh and nothing pre-exists to overwrite.
+  // the repo is fresh and nothing pre-exists.
   confirmSkeletonOverwrite?: (paths: string[]) => Promise<boolean>
 }) {
   const results: Partial<Record<InitStepId, unknown>> = {}
@@ -2394,8 +2392,8 @@ export async function initClassroom50({
   })
 
   // configRepo is a hard prerequisite for every step below. If it errored,
-  // continuing only cascades 404s and would report success on a half-
-  // initialized org. Stop here.
+  // continuing only cascades 404s and would report success on a
+  // half-initialized org. Stop here.
   if (stepFailed(results.configRepo)) {
     return buildResult("error")
   }
@@ -2622,9 +2620,9 @@ export async function editClassroom(
   // Archived classrooms are read-only — refuse a settings edit (name / term),
   // but let a lifecycle toggle through since unarchiving re-enables editing.
   // Gate on whether a settings field is actually present rather than on
-  // `active === undefined`, so a payload that bundles a settings change with
-  // `active: false` (a stale tab, a direct API call, or a CLI/agent) cannot slip
-  // an edit past the guard by re-asserting the archived state.
+  // `active === undefined`, so a payload bundling a settings change with
+  // `active: false` (a stale tab, direct API call, or CLI/agent) can't slip an
+  // edit past the guard by re-asserting the archived state.
   const editsSettings = name !== undefined || term !== undefined
   if (editsSettings && active !== true && isClassroomArchived(current)) {
     throw new Error(

--- a/web/src/hooks/github/orgChecks.ts
+++ b/web/src/hooks/github/orgChecks.ts
@@ -1,8 +1,8 @@
 // Read-only org/repo policy checks — the non-mutating half of the
-// check*/repair* split. The audit (useGetOrgAudit) and the
-// centralized Org Settings page consume these to render drift verdicts
-// without writing. Each check tolerates 404/403 with a verdict rather than
-// throwing, so a single unreadable concern never breaks the whole audit.
+// check*/repair* split. The audit (useGetOrgAudit) and the centralized Org
+// Settings page consume these to render drift verdicts without writing. Each
+// check tolerates 404/403 with a verdict rather than throwing, so a single
+// unreadable concern never breaks the whole audit.
 
 import type { GitHubClient } from "./client"
 import { GitHubAPIError } from "./errors"
@@ -293,9 +293,9 @@ function rateLimitedResult(org: string): OrgDefaultsRepairResult {
 }
 
 // repairOrgDefaults applies the full plan-filtered member-default lockdown,
-// mirroring the CLI's applyOrgMemberDefaults: one combined PATCH /orgs/{org};
-// on a 403/422 (not a rate limit) drop to a per-field fallback; on a
-// secondary-rate-limit abort as transient (do not amplify the throttle); then
+// mirroring the CLI's applyOrgMemberDefaults: one combined PATCH /orgs/{org}; on
+// a 403/422 (not a rate limit) drop to a per-field fallback; on a
+// secondary-rate-limit abort as transient (don't amplify the throttle); then
 // always read the org back and classify.
 export async function repairOrgDefaults(
   client: GitHubClient,
@@ -361,9 +361,9 @@ export async function repairOrgDefaults(
 }
 
 // The four repo-creation booleans are entangled at the API layer through the
-// deprecated members_allowed_repository_creation_type field: sending any of
-// them alone makes GitHub recompute that legacy field from the partial input
-// and silently reset the omitted ones. They must always be PATCHed together.
+// deprecated members_allowed_repository_creation_type field: sending any alone
+// makes GitHub recompute that legacy field from the partial input and silently
+// reset the omitted ones. They must always be PATCHed together.
 // (https://github.com/integrations/terraform-provider-github/issues/3429)
 const REPO_CREATION_FIELDS = new Set([
   "members_can_create_repositories",

--- a/web/src/hooks/github/orgDefaults.test.ts
+++ b/web/src/hooks/github/orgDefaults.test.ts
@@ -168,8 +168,8 @@ describe("repairOrgDefaults", () => {
     })
     await repairOrgDefaults(client, "acme", "enterprise")
     // Exactly one fallback sub-PATCH carries the repo-creation booleans, and it
-    // carries ALL four of them together (never split — splitting makes GitHub
-    // reset the omitted ones via the deprecated legacy field).
+    // carries ALL four together (never split — splitting makes GitHub reset the
+    // omitted ones via the deprecated legacy field).
     const repoCreationPatches = patchBodies.filter((b) =>
       Object.keys(b).some(
         (k) =>

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -755,10 +755,6 @@ export async function ensureTeam(
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url, {
     cache: "no-store",
-    // headers: {
-    //   "Cache-Control": "no-cache, no-store, max-age=0",
-    //   Pragma: "no-cache",
-    // },
   })
 
   if (response.status === 404) {

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -46,7 +46,7 @@ export const githubKeys = {
   orgMembers: (org: string) => ["orgs", "list", "members", org] as const,
 
   // Distinct from `orgMembers` (page-1 via listOrgMembers): this keys the
-  // all-pages fetch used by the org Members page. Sharing one key would let the
+  // all-pages fetch for the org Members page. Sharing one key would let the
   // page-1 and all-pages results overwrite each other in the cache.
   orgMembersAll: (org: string) =>
     ["orgs", "list", "members", "all", org] as const,
@@ -163,7 +163,7 @@ export function getUser(client: GitHubClient, username: string) {
 }
 
 // Resolve a user by their immutable numeric account id (GET /user/{id}). The
-// stored CSV username can be stale if the student renamed their GitHub account,
+// stored CSV username goes stale if the student renames their GitHub account,
 // but the id never changes — so this returns their CURRENT login. Used when
 // re-inviting a roster student whose username may have drifted.
 export function getUserById(client: GitHubClient, id: number | string) {
@@ -196,10 +196,10 @@ export function orgMembershipQuery(client: GitHubClient, org: string) {
   })
 }
 
-// Self-hosted runners registered in the org (GitHub's admin:org endpoint),
-// used only to advise whether a typed label exists. Tolerant: 403/404 resolve
-// to an "unavailable" sentinel so the form degrades to "couldn't verify"
-// instead of erroring. GitHub-hosted labels are recognized separately.
+// Self-hosted runners registered in the org (GitHub's admin:org endpoint), used
+// only to advise whether a typed label exists. Tolerant: 403/404 resolve to an
+// "unavailable" sentinel so the form degrades to "couldn't verify" instead of
+// erroring. GitHub-hosted labels are recognized separately.
 export function orgRunnersQuery(client: GitHubClient, org: string) {
   return queryOptions<OrgRunnersResult>({
     queryKey: githubKeys.orgRunners(org),
@@ -276,9 +276,9 @@ function isNotFoundError(error: unknown) {
 }
 
 // A freshly-generated repo's git-data APIs lag the 200 from POST .../generate:
-// reads 404 and first write 409s "Git Repository is empty" while GitHub seeds.
-// A bare 409 (no empty-repo message) is a real conflict (e.g. non-fast-forward
-// updateRef), so the 409 branch is gated on the message.
+// reads 404 and the first write 409s "Git Repository is empty" while GitHub
+// seeds. A bare 409 (no empty-repo message) is a real conflict (e.g.
+// non-fast-forward updateRef), so the 409 branch is gated on the message.
 export function isFreshRepoLagError(error: unknown) {
   if (error instanceof GitHubAPIError) {
     if (error.status === 404) {
@@ -459,8 +459,8 @@ export function jsonFileQuery<T>(
 const SUBMISSION_TAG_PREFIX = "submit/"
 
 // All graded-submission releases for a student's repo, newest first. A repo
-// with no releases yet (or the very first push still grading) returns []. The
-// release page itself shows the rendered grade, so we only need the metadata.
+// with no releases yet (or a first push still grading) returns []. The release
+// page shows the rendered grade, so we only need the metadata.
 export function releasesQuery(
   client: GitHubClient,
   owner: string,
@@ -483,7 +483,7 @@ export function releasesQuery(
       } catch (err) {
         // A missing repo (student hasn't accepted, or a previewing teacher with
         // no repo) 404s here — no releases. Return [] so the page falls through
-        // to its empty state instead of erroring. Other errors throw.
+        // to its empty state. Other errors throw.
         if (err instanceof GitHubAPIError && err.status === 404) {
           return []
         }
@@ -593,8 +593,8 @@ export function listAllOrgMembers(client: GitHubClient, org: string) {
 
 // Org owners/admins across all pages (GET /orgs/{org}/members?role=admin). Used
 // to badge the Members page: an admin is an "Owner", not a "Member". 403/404
-// (can't read the member list with role filter) -> [] so the page degrades to
-// treating everyone as a plain member rather than erroring.
+// (can't read the filtered member list) -> [] so the page degrades to treating
+// everyone as a plain member rather than erroring.
 export async function listOrgAdmins(
   client: GitHubClient,
   org: string,
@@ -795,12 +795,12 @@ export async function orgPublishesClassroom50Pages(
       // Bound the probe so a hung github.io host can't stall the orgs load.
       signal: AbortSignal.timeout(5000),
     })
-    // A clean 404 is a definitive "not a Classroom50 org". Other non-ok
-    // statuses (5xx, 429) are transient -> indeterminate, don't penalize.
+    // A clean 404 is a definitive "not a Classroom50 org". Other non-ok statuses
+    // (5xx, 429) are transient -> indeterminate.
     if (res.status === 404) return "no"
     if (!res.ok) return "indeterminate"
-    // Confirm it's actually the index shape, not a stray 200 (e.g. a custom
-    // 404 page served with 200).
+    // Confirm it's actually the index shape, not a stray 200 (e.g. a custom 404
+    // page served with 200).
     const data = (await res.json()) as { classrooms?: unknown }
     return Array.isArray(data?.classrooms) ? "yes" : "no"
   } catch {
@@ -899,10 +899,10 @@ export async function getClassroom50OrgSummary(
     status = "ready"
 
     // The service-token read is deliberately NOT done here: this summary runs
-    // for every org the user can see, and reading the token per org fans out
-    // an extra GitHub API call across potentially many orgs. The token (and
-    // the full policy audit) is checked only when a specific org is opened
-    // (the teacher preflight on ClassesPage).
+    // for every org the user can see, so reading the token per org fans out an
+    // extra API call across many orgs. The token (and full policy audit) is
+    // checked only when a specific org is opened (teacher preflight on
+    // ClassesPage).
   } catch (error) {
     if (error instanceof GitHubAPIError && error.status === 404) {
       canAccessRepo = false
@@ -995,10 +995,10 @@ export function teamMembersQuery(
 }
 
 // Every team in the org across all pages (GET /orgs/{org}/teams). Owner/member
-// visibility applies (secret teams are only listed for members who can see
-// them). Used to cross-reference each `classroom50-<classroom>` team's live
-// membership against CSV-derived classroom access, surfacing drift on the
-// Members page. 404 (no access) -> [] so the page degrades to CSV-only display.
+// visibility applies (secret teams only listed for members who can see them).
+// Used to cross-reference each `classroom50-<classroom>` team's live membership
+// against CSV-derived classroom access, surfacing drift on the Members page.
+// 404 (no access) -> [] so the page degrades to CSV-only display.
 export async function listOrgTeams(
   client: GitHubClient,
   org: string,
@@ -1059,9 +1059,9 @@ export async function getOpenPullRequests(
 export async function getOrgRepos(client: GitHubClient, owner: string) {
   try {
     // Paginate to exhaustion: a single per_page=100 page silently under-counts
-    // orgs with >100 repos, which would make repo-list-derived signals (e.g.
-    // assignment acceptance on the submissions dashboard) miss students in
-    // large orgs. The first page's failure still surfaces a 404 as null below.
+    // orgs with >100 repos, making repo-list-derived signals (e.g. assignment
+    // acceptance on the submissions dashboard) miss students in large orgs. A
+    // first-page failure still surfaces a 404 as null below.
     return await paginateAll<GitHubRepo>(
       client,
       (page) => `/orgs/${owner}/repos?per_page=100&page=${page}&type=all`,
@@ -1164,10 +1164,10 @@ export async function getRepoPermissionForUser(params: {
   )
 }
 
-// Fetches the most recent workflow run matching the given filters (or null if
-// none) from a classroom50 workflow. Shared by the collect-scores "track my
-// dispatch" / "last collected" reads and the regrade dispatch tracker, so the
-// workflow file is a parameter (defaults to collect-scores).
+// Fetches the most recent workflow run matching the given filters (or null) from
+// a classroom50 workflow. Shared by the collect-scores "track my dispatch" /
+// "last collected" reads and the regrade dispatch tracker, so the workflow file
+// is a parameter (defaults to collect-scores).
 async function listLatestWorkflowRun(
   client: GitHubClient,
   org: string,
@@ -1200,8 +1200,8 @@ async function listLatestWorkflowRun(
 // Finds the run we dispatched: run ids are monotonic, so it's the oldest
 // dispatch run with an id greater than `sinceRunId` (the newest id before our
 // POST). Binding to our own run avoids mistaking a concurrent dispatch for ours
-// and needs no clock. Returns null until our run registers; `sinceRunId === null`
-// means no prior runs, so the oldest run on the first page is ours.
+// and needs no clock. Null until our run registers; `sinceRunId === null` means
+// no prior runs, so the oldest run on the first page is ours.
 export async function getCollectScoresRunAfterId(
   client: GitHubClient,
   org: string,
@@ -1223,16 +1223,16 @@ export async function getCollectScoresRunAfterId(
 }
 
 // Finds the regrade run we dispatched, by the same monotonic-id binding as
-// getCollectScoresRunAfterId but against the regrade.yaml workflow. Returns
-// null until our run registers.
+// getCollectScoresRunAfterId but against regrade.yaml. Null until our run
+// registers.
 //
-// Unlike collect (one org-wide dispatcher), regrade can fan out one dispatch
-// per student via the per-row buttons, so far more than a single page of
-// dispatch runs can pile up between our snapshot and this poll. A fixed first
-// page would let our own run scroll off and bind us to a later student's run.
-// So we page newest-first, accumulating only runs with id > sinceRunId, and
-// stop as soon as a page contains a run at/below the baseline (everything older
-// is irrelevant) or we hit the page cap. The bound run is the oldest such run.
+// Unlike collect (one org-wide dispatcher), regrade can fan out one dispatch per
+// student via the per-row buttons, so far more than a page of dispatch runs can
+// pile up between our snapshot and this poll. A fixed first page would let our
+// own run scroll off and bind us to a later student's run. So we page
+// newest-first, accumulating only runs with id > sinceRunId, and stop once a
+// page contains a run at/below the baseline (everything older is irrelevant) or
+// we hit the page cap. The bound run is the oldest such run.
 const REGRADE_RUNS_PER_PAGE = 30
 const REGRADE_MAX_PAGES = 10
 

--- a/web/src/hooks/github/rulesets.ts
+++ b/web/src/hooks/github/rulesets.ts
@@ -1,8 +1,8 @@
 // Web mirror of the CLI's org ruleset install (classroom50-cli init_repo.go
 // ensureClassroomRulesets). Two org branch rulesets protect submission history
-// and lock the Feedback PR base branch. Reconciled by name: PUT over an
-// existing ruleset, else POST to create. Definitions must match the CLI
-// exactly — a divergence is a parity bug.
+// and lock the Feedback PR base branch. Reconciled by name: PUT over an existing
+// ruleset, else POST to create. Definitions must match the CLI exactly — a
+// divergence is a parity bug.
 
 import type { GitHubClient } from "./client"
 import { paginateAll } from "./queries"
@@ -41,7 +41,7 @@ type OrgRulesetBody = {
 }
 
 // OrganizationAdmin (actor_id 1) is the org-owner role — the teacher — so they
-// can merge the Feedback PR and force-push/delete in a pinch while students
+// can merge the Feedback PR and force-push/delete in a pinch, while students
 // (maintain, no bypass) cannot.
 const ADMIN_BYPASS: RulesetBypassActor[] = [
   { actor_id: 1, actor_type: "OrganizationAdmin", bypass_mode: "always" },
@@ -127,8 +127,8 @@ export type RulesetsRepairResult = {
 }
 
 // repairRulesets: reconcile both rulesets — PUT over an existing one (by id),
-// else POST to create. Warn-and-continue on any single failure (init never
-// fails on a ruleset error), mirroring the CLI's ensureClassroomRulesets.
+// else POST to create. Warn-and-continue on any single failure (init never fails
+// on a ruleset error), mirroring the CLI's ensureClassroomRulesets.
 export async function repairRulesets(
   client: GitHubClient,
   org: string,

--- a/web/src/hooks/github/types.ts
+++ b/web/src/hooks/github/types.ts
@@ -12,7 +12,8 @@ export type GitHubOrgMembership = {
 
 // Shared by GET /orgs/{org}/invitations and /failed_invitations. failed_at /
 // failed_reason are only set on the failed list. No invitee numeric id, so
-// students match on login / email. id is needed to cancel (DELETE) before resend.
+// students match on login / email. id is needed to cancel (DELETE) before
+// resend.
 export type GitHubOrgInvitation = {
   id: number
   login: string | null

--- a/web/src/hooks/useAcceptAndVerifyMembership.ts
+++ b/web/src/hooks/useAcceptAndVerifyMembership.ts
@@ -23,9 +23,8 @@ export type UseAcceptAndVerifyMembershipResult = {
 
 // Centralizes the accept-and-verify orchestration shared by the /onboard page
 // and AcceptAssignmentPage: a mount-fired mutation (once, while `enabled`), a
-// success path that seeds the shared membership cache, and a single retry()
-// source of truth that never overlaps an in-flight verify. The seed and retry
-// rationale live at their call sites below.
+// success path that seeds the shared membership cache, and one retry() source of
+// truth that never overlaps an in-flight verify. Seed/retry rationale below.
 export function useAcceptAndVerifyMembership(input: {
   org?: string
   // Fire the verify only when a (pending) membership record exists and isn't
@@ -40,8 +39,8 @@ export function useAcceptAndVerifyMembership(input: {
     mutationFn: () => acceptAndVerifyOrgMembership(client, org ?? ""),
     onSuccess: (membership: GitHubOrgMembership) => {
       // Seed the shared membership query with the active membership the verify
-      // authoritatively read, so this page's redirect gate and the accept
-      // page's read agree immediately instead of racing a lagged re-fetch.
+      // read, so this page's redirect gate and the accept page's read agree
+      // immediately instead of racing a lagged re-fetch.
       queryClient.setQueryData(membershipQueryKey(org), membership)
     },
   })
@@ -62,10 +61,10 @@ export function useAcceptAndVerifyMembership(input: {
     error: mutation.error,
     retry: () => {
       // Single source of truth: reset() then mutate(). Do NOT also invalidate
-      // the membership query here — an unawaited invalidate refetch resolving
-      // to a lagged value would race this mutate(). On success, onSuccess seeds
-      // the cache with the verified value. Skip while a verify is in flight so
-      // a retry tap can't spawn a second overlapping PATCH+verify.
+      // the membership query — an unawaited invalidate refetch resolving to a
+      // lagged value would race this mutate(); onSuccess seeds the verified
+      // value instead. Skip while a verify is in flight so a retry tap can't
+      // spawn a second overlapping PATCH+verify.
       if (!enabled || mutation.isPending) {
         return
       }

--- a/web/src/hooks/useActionActivity.ts
+++ b/web/src/hooks/useActionActivity.ts
@@ -34,8 +34,7 @@ const PENDING_GRACE_MS = 20_000
 
 // Drop a still-pending op only if it NEVER produced a run within this window (a
 // mis-registration). Generous — a push-triggered deploy can take minutes. An op
-// that bound to a run or finished is never dropped by this; it persists as
-// history until dismissed.
+// bound to a run or finished persists as history until dismissed.
 const PENDING_TTL_MS = 5 * 60_000
 
 // After a retry, show the tracker "running" for this window (holding the poll
@@ -60,7 +59,7 @@ export type Tracker = {
   htmlUrl?: string
   // Resolved run id, when known — enables retry.
   runId?: number
-  // Terminal session-op trackers can be dismissed; discovered/non-terminal cannot.
+  // Terminal session-op trackers can be dismissed; discovered/non-terminal can't.
   dismissible: boolean
   // A failed run with a known runId can be retried.
   retriable: boolean
@@ -82,8 +81,8 @@ export type ActionActivity = {
 
 // Drives the global activity banner: one repo-wide poll advances a collection of
 // per-operation trackers. Each session op resolves to its own run and reflects
-// that run's real status/conclusion; runs matching no op surface as "discovered"
-// trackers. Terminal trackers persist as history until dismissed.
+// that run's status/conclusion; runs matching no op surface as "discovered".
+// Terminal trackers persist as history until dismissed.
 export function useActionActivity(): ActionActivity {
   const { t } = useTranslation()
   const org = useActiveOrg()
@@ -100,7 +99,7 @@ export function useActionActivity(): ActionActivity {
   const lastSeenRegisteredAt = useRef(registeredAt)
   // While nowMs() < expectingUntil the poll stays fast — set on a new
   // registration and on retry. A self-expiring timestamp (not a boolean+timer)
-  // can't get stuck on: once the window passes, the poll backs off on its own.
+  // can't get stuck: once the window passes, the poll backs off on its own.
   const [expectingUntil, setExpectingUntil] = useState(0)
   const bumpExpecting = useCallback(
     () => setExpectingUntil(nowMs() + PENDING_GRACE_MS),
@@ -129,7 +128,7 @@ export function useActionActivity(): ActionActivity {
     // Fast while anything runs or a dispatch/retry is expected; slow while a
     // finished run or outstanding op is still shown; stop (false) once there's
     // nothing to track. A new dispatch/retry re-arms via invalidate +
-    // bumpExpecting, so an idle tab doesn't poll GitHub forever.
+    // bumpExpecting, so an idle tab doesn't poll forever.
     refetchInterval: (query) => {
       const runs = query.state.data ?? []
       const anyRunning = runs.some(isRunning)
@@ -214,8 +213,8 @@ export function useActionActivity(): ActionActivity {
     const remembered = boundRunId[op.id]
     // A bound op stays pinned to THAT run — never re-resolves. A poll that
     // transiently omits it yields null (reads as pending/latched) rather than
-    // falling through to resolveOpRun, which would re-bind onto a sibling's run.
-    // Claim the remembered id even when absent so a sibling can't grab it.
+    // re-binding onto a sibling's run via resolveOpRun. Claim the remembered id
+    // even when absent so a sibling can't grab it.
     let run: GitHubWorkflowRun | null
     if (remembered !== undefined) {
       run = claimed.has(remembered) ? null : (runsById.get(remembered) ?? null)
@@ -293,8 +292,8 @@ export function useActionActivity(): ActionActivity {
   }, [phaseSignature])
 
   // Time-based GC (kept in an effect so render stays pure): drop a pending op
-  // only if it never produced a run within the window. An op that bound to a run
-  // or reached a terminal state is real history and persists until dismissed.
+  // only if it never produced a run within the window. An op bound to a run or
+  // terminal is real history and persists until dismissed.
   const [tick, setTick] = useState(0)
   useEffect(() => {
     const at = nowMs()
@@ -322,8 +321,8 @@ export function useActionActivity(): ActionActivity {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phaseSignature, tick, clearOp])
 
-  // Session trackers: every non-dismissed op, as a pure projection of ops +
-  // resolved phase (time-based removal is handled by the GC effect above). The
+  // Session trackers: every non-dismissed op, a pure projection of ops +
+  // resolved phase (time-based removal handled by the GC effect above). The
   // runId/URL fall back to the stable binding so a transient poll gap doesn't
   // drop the "View run" link.
   const sessionTrackers: Tracker[] = resolved
@@ -375,8 +374,8 @@ export function useActionActivity(): ActionActivity {
     })
 
   // Newest-first so trackers[0] leads the collapsed header: session ops (a
-  // retried op jumps ahead as a fresh action, else reverse registration order),
-  // then discovered runs by descending id.
+  // retried op jumps ahead, else reverse registration order), then discovered
+  // runs by descending id.
   const discoveredNewestFirst = [...discoveredTrackers].sort(
     (a, b) => (b.runId ?? 0) - (a.runId ?? 0),
   )
@@ -397,9 +396,9 @@ export function useActionActivity(): ActionActivity {
   const trackers = [...sessionNewestFirst, ...discoveredNewestFirst]
 
   // Reconcile the optimistic-running set: clear an id once the poll sees its
-  // re-run running or succeeded — or re-failed, but only once GitHub has
-  // re-touched the run since the retry (endedAtMs >= retriedAt), so we don't
-  // clear on the stale pre-retry "failed". A safety timer backstops the rest.
+  // re-run running or succeeded — or re-failed, but only once GitHub re-touched
+  // the run since the retry (endedAtMs >= retriedAt), so we don't clear on the
+  // stale pre-retry "failed". A safety timer backstops the rest.
   const optimisticSignature = [...optimisticRunning].sort().join(",")
   const realStateById = new Map(
     resolved.map(({ op, run, realPhase }) => [op.id, { realPhase, run }]),
@@ -444,7 +443,7 @@ export function useActionActivity(): ActionActivity {
     setOptimisticRunning((prev) => new Set(prev).add(id))
     // rerun-failed-jobs reuses the same run id, so the monotonic latch would
     // otherwise pin the pre-retry "failed" forever (resurrecting a stale red row
-    // once the re-run scrolls out). Clear it so the re-run re-latches its new
+    // once the re-run scrolls out). Clear it so the re-run re-latches its
     // outcome; optimisticRunning + boundRunId keep the row from being GC'd.
     setLatchedPhase((prev) => {
       if (prev[id] === undefined) return prev

--- a/web/src/hooks/useClassroomRole.ts
+++ b/web/src/hooks/useClassroomRole.ts
@@ -44,26 +44,24 @@ export type ClassroomRoleInput = {
 export function resolveClassroomRole(input: ClassroomRoleInput): EffectiveRole {
   const { org, classroom, isOwner, staffRoleResolved, isStaff } = input
 
-  // No org at all => no role to resolve.
   if (!org) return "student"
 
-  // Owner (org admin) outranks all and isn't classroom-scoped: resolve it before
-  // the classroom check so an owner on an org-level route (e.g. Create
-  // Classroom) isn't misclassified. While in flight (undefined) fall through.
+  // Owner (org admin) outranks all and isn't classroom-scoped: resolve before
+  // the classroom check so an owner on an org-level route isn't misclassified.
+  // While in flight (undefined) fall through.
   if (isOwner === true) return "owner"
 
-  // Below here we refine the CLASSROOM role (instructor/ta), which needs a
-  // classroom. A non-owner on an org-level route has no finer role; hold
-  // `unresolved` while ownership is still resolving so we don't flash NotFound.
+  // Refine the CLASSROOM role (instructor/ta), which needs a classroom. A
+  // non-owner on an org-level route has no finer role; hold `unresolved` while
+  // ownership is still resolving so we don't flash NotFound.
   if (!classroom) return isOwner === undefined ? "unresolved" : "student"
 
   // Need the staff (config-repo) verdict before deciding non-owner roles.
   if (!staffRoleResolved) return "unresolved"
 
   // Staff team membership is definitive and outranks the (slower) owner read, so
-  // resolve a confirmed instructor/ta before waiting on ownership. Only these
-  // positive matches are safe while isOwner is unknown — a demotion below must
-  // still wait for ownership.
+  // resolve a confirmed instructor/ta before waiting on ownership. Only positive
+  // matches are safe while isOwner is unknown — a demotion below must wait.
   if (isStaff) {
     if (input.instructor === "member") return "instructor"
     if (input.ta === "member") return "ta"
@@ -79,8 +77,8 @@ export function resolveClassroomRole(input: ClassroomRoleInput): EffectiveRole {
   // A non-staff non-owner is a student, regardless of any stale team signal.
   if (!isStaff) return "student"
 
-  // Staff (reads the config repo) but in neither staff team — treat as student
-  // for role-gated UI; owners are handled above.
+  // Staff (reads the config repo) but in neither staff team — treat as student;
+  // owners are handled above.
   return "student"
 }
 
@@ -101,8 +99,8 @@ export function isInstructorRole(role: EffectiveRole): boolean {
   return role === "owner" || role === "instructor" || role === "unresolved"
 }
 
-// The roles an instructor/owner can preview the app AS. A client-side
-// lens for verifying what each role sees — never escalates.
+// The roles an instructor/owner can preview the app AS. A client-side lens for
+// verifying what each role sees — never escalates.
 export type ViewAsRole = "ta" | "student"
 
 // Rank for the downgrade-only clamp. `unresolved` is intentionally absent — we
@@ -126,10 +124,9 @@ export function applyViewAs(
   return ROLE_RANK[viewAs] < ROLE_RANK[actual] ? viewAs : actual
 }
 
-// Translation key for the human role label per the product mapping:
-// owner + instructor => "nav.roleInstructor", ta => "nav.roleTa",
-// student => "nav.roleStudent", unresolved => null (so callers show a skeleton
-// rather than guessing mid-load). Callers pass the returned key through t().
+// Translation key for the human role label: owner + instructor =>
+// "nav.roleInstructor", ta => "nav.roleTa", student => "nav.roleStudent",
+// unresolved => null (so callers show a skeleton mid-load). Pass through t().
 export function roleLabelKey(role: EffectiveRole): string | null {
   switch (role) {
     case "owner":
@@ -145,8 +142,7 @@ export function roleLabelKey(role: EffectiveRole): string | null {
 }
 
 // Reduce a team-membership query (404 => non-member, other error => unresolved)
-// to the tri-state. Distinguishes a definitive "not a member" from a transient
-// failure so a blip never demotes a real staff member.
+// to the tri-state, so a blip never demotes a real staff member.
 function membershipFromQuery(isSuccess: boolean, error: unknown): Membership {
   if (isSuccess) return "member"
   if (error instanceof GitHubAPIError && error.status === 404) {
@@ -202,8 +198,8 @@ export function teamMembershipQuery(
 
 // Resolve the viewer's effective role for an org/classroom from live queries:
 // org membership (owner), the classroom50 repo read (staff gate), and
-// instructor/ta team membership. Applies the "view as" preview as a
-// downgrade-only lens: `role` reflects the preview, `actualRole` is the real one.
+// instructor/ta team membership. Applies "view as" as a downgrade-only lens:
+// `role` reflects the preview, `actualRole` is the real one.
 export function useClassroomRole(
   org: string | undefined,
   classroom: string | undefined,
@@ -215,9 +211,9 @@ export function useClassroomRole(
   const ownerQuery = useQuery({
     ...orgMembershipQuery(client, org ?? ""),
     enabled: Boolean(org),
-    // orgMembershipQuery defaults to retry:false, but a transient blip on the
-    // membership read must self-heal rather than pin isOwner at `undefined`
-    // (which would silently demote a real owner). A 404/403 is definitive.
+    // orgMembershipQuery defaults to retry:false, but a transient blip must
+    // self-heal rather than pin isOwner at `undefined` (silently demoting a real
+    // owner). A 404/403 is definitive.
     retry: retryTransientGitHubError,
   })
 
@@ -248,9 +244,9 @@ export function useClassroomRole(
     enabled: Boolean(org && classroom && username),
   })
 
-  // owner = active org admin. A success or a 404/403 (not a member) both give a
-  // concrete true/false; only an in-flight/transient read leaves it `undefined`,
-  // which the resolver holds as `unresolved`.
+  // owner = active org admin. A success or a 404/403 both give a concrete
+  // true/false; only an in-flight/transient read leaves it `undefined`, which
+  // the resolver holds as `unresolved`.
   const ownerErrorIsDefinitive =
     ownerQuery.error instanceof GitHubAPIError &&
     (ownerQuery.error.status === 404 || ownerQuery.error.status === 403)

--- a/web/src/hooks/useCopyToClipboard.ts
+++ b/web/src/hooks/useCopyToClipboard.ts
@@ -29,8 +29,8 @@ export function useCopyToClipboard(text: string, resetMs = 2000) {
     }
   }
 
-  // Clear the flag and any pending timer immediately (e.g. when the text to
-  // copy changes so a stale "Copied" doesn't linger).
+  // Clear the flag and any pending timer immediately (e.g. when the copy text
+  // changes so a stale "Copied" doesn't linger).
   const reset = () => {
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
     resetTimerRef.current = null

--- a/web/src/hooks/useCourseTeacherAccess.test.ts
+++ b/web/src/hooks/useCourseTeacherAccess.test.ts
@@ -120,7 +120,7 @@ describe("resolveTeacherVerdict", () => {
         error: null,
       })
       expect(v.showTeacherUi).toBe(false)
-      // isTeacher is still true (the permission is real); only the UI gate is
+      // isTeacher stays true (the permission is real); only the UI gate is
       // org-scoped, so an org-less route can't surface teacher UI.
       expect(v.isTeacher).toBe(true)
     })

--- a/web/src/hooks/useCourseTeacherAccess.ts
+++ b/web/src/hooks/useCourseTeacherAccess.ts
@@ -20,8 +20,8 @@ export type CourseManifest = {
   }>
 }
 
-// The repo-query state the verdict depends on. Structural so the verdict logic
-// stays a pure, unit-testable function (no React Query needed).
+// The repo-query state the verdict depends on. Structural so the verdict stays a
+// pure, testable function (no React Query).
 export type TeacherVerdictInput = {
   org: string | undefined
   isSuccess: boolean
@@ -46,8 +46,7 @@ export type TeacherVerdict = {
 // teacher = repo GET succeeded with a non-trivial permission, student = 404,
 // blocked = 403. Resolved only on a definitive verdict (success/404/403) — a
 // transient 5xx/429/network error must NOT resolve, or a student during a blip
-// would be promoted into teacher UI. showTeacherUi also needs a positive
-// success, so a transient error keeps it false. Org-less routes have no role.
+// would be promoted into teacher UI. Org-less routes have no role.
 export function resolveTeacherVerdict(
   input: TeacherVerdictInput,
 ): TeacherVerdict {
@@ -71,11 +70,11 @@ export function resolveTeacherVerdict(
   return { isTeacher, isStudent, isBlocked, roleResolved, showTeacherUi }
 }
 
-// Apply a "view as" preview to the coarse teacher/student verdict, so
-// every surface reading showTeacherUi/isStudent transforms together.
-// DOWNGRADE-ONLY: a preview can only hide teacher UI, never reveal it. Only
-// "student" affects this coarse switch (a TA still sees staff content); the
-// TA/instructor split lives in useClassroomRole.
+// Apply a "view as" preview to the coarse teacher/student verdict, so every
+// surface reading showTeacherUi/isStudent transforms together. DOWNGRADE-ONLY:
+// a preview can only hide teacher UI, never reveal it. Only "student" affects
+// this coarse switch (a TA still sees staff content); the TA/instructor split
+// lives in useClassroomRole.
 export function applyViewAsToVerdict(
   verdict: TeacherVerdict,
   viewAs: ViewAsRole | null,
@@ -92,8 +91,8 @@ export function applyViewAsToVerdict(
 export function useCourseTeacherAccess(org: string | undefined) {
   const teacherRepo = "classroom50"
   // Bounded retry on transient errors only: a 404 (student) / 403 (blocked) is
-  // a definitive verdict and must not be retried, but a 5xx/429/network blip
-  // should self-heal instead of stranding the role unresolved.
+  // definitive and must not retry, but a 5xx/429/network blip should self-heal
+  // instead of stranding the role unresolved.
   const repoQuery = useGitHubRepo(org, teacherRepo, {
     retry: retryTransientGitHubError,
   })

--- a/web/src/hooks/useDocumentTitle.ts
+++ b/web/src/hooks/useDocumentTitle.ts
@@ -4,9 +4,9 @@ const BASE_TITLE = "Classroom 50"
 
 /**
  * Sets `document.title` for the current page and restores the base title on
- * unmount. Client-only SPA, so we manage the title imperatively rather than via
- * a server-rendered <head>. Pass the page-specific part; the base app name is
- * appended automatically (e.g. "Assignments · Classroom 50").
+ * unmount. Client-only SPA, so the title is managed imperatively. Pass the
+ * page-specific part; the app name is appended (e.g. "Assignments · Classroom
+ * 50").
  */
 export function useDocumentTitle(title?: string) {
   useEffect(() => {

--- a/web/src/hooks/useDotClassroom50.ts
+++ b/web/src/hooks/useDotClassroom50.ts
@@ -13,8 +13,8 @@ const useDotClassroom50 = (
     queryKey: ["github", "repos", org, repo, ".classroom50.yaml"],
     queryFn: () => getClassroom50Yaml(client, org, repo),
     // Skip until both coordinates are known — callers may pass "" while a
-    // username/repo name is still resolving, and an empty repo would fetch a
-    // malformed contents path (guaranteed 404).
+    // username/repo name resolves, and an empty repo fetches a malformed contents
+    // path (guaranteed 404).
     enabled: Boolean(org && repo),
     staleTime: 10 * 60 * 1000,
   })

--- a/web/src/hooks/useEmptyRosterWarning.ts
+++ b/web/src/hooks/useEmptyRosterWarning.ts
@@ -5,10 +5,10 @@ import type { EmptyRosterDecision } from "@/util/roster"
 
 // Whether to warn a teacher that no student can yet accept an assignment.
 //
-// The assignment accept link only works for students who are active GitHub org
-// members. Enrollment is now team membership (the classroom team is the source
-// of truth), so the signal is "zero enrolled team members" — a classroom with
-// only pending invites still warrants the warning.
+// The accept link only works for active GitHub org members. Enrollment is team
+// membership (the classroom team is the source of truth), so the signal is "zero
+// enrolled team members" — a classroom with only pending invites still warrants
+// the warning.
 export type EmptyRosterWarning = EmptyRosterDecision
 
 const useEmptyRosterWarning = (
@@ -19,16 +19,16 @@ const useEmptyRosterWarning = (
     org,
     classroom,
   )
-  // Team roster drives enrollment; students.csv is only metadata (passed so the
-  // rows can enrich, and so `hasRosterRows` reflects known students).
+  // Team roster drives enrollment; students.csv is only metadata (passed so rows
+  // enrich and `hasRosterRows` reflects known students).
   const { counts, isLoading, isError } = useTeamRoster(
     org ?? "",
     classroom ?? "",
     students,
   )
 
-  // Decision lives in a pure, unit-tested fn so the branches (esp. the
-  // error-as-loading fail-safe) can't drift silently.
+  // Decision lives in a pure, tested fn so the branches (esp. the
+  // error-as-loading fail-safe) can't drift.
   return resolveEmptyRosterWarning({
     studentsLoading,
     isLoading,

--- a/web/src/hooks/useGetAssignmentRepo.ts
+++ b/web/src/hooks/useGetAssignmentRepo.ts
@@ -8,10 +8,9 @@ const useGetAssignmentRepo = (
   username: string | undefined,
 ) => {
   // Resolve the student's repo by an exact GET /repos/{org}/{name} (404 -> null
-  // via getRepo) instead of scanning the org's repo list. This is one small
-  // request, avoids the per_page=100 ceiling that could miss a repo in large
-  // orgs, and can't prefix-collide (alice vs alice2). Gated on a known
-  // username so we never probe an arbitrary name.
+  // via getRepo) instead of scanning the org's repo list: one small request,
+  // avoids the per_page=100 ceiling, and can't prefix-collide (alice vs alice2).
+  // Gated on a known username so we never probe an arbitrary name.
   const expectedName = username
     ? studentRepoName(classroom, assignment, username)
     : ""

--- a/web/src/hooks/useGetClassAssignments.ts
+++ b/web/src/hooks/useGetClassAssignments.ts
@@ -4,8 +4,8 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import type { Assignment } from "@/types/classroom"
 
 // Mirrors classroom50/assignments/v1: a `schema` sentinel plus the list.
-// `runtime`, `max_group_size`, `tests`, `due`, etc. are all optional — a
-// minimal assignment carries only slug/name/template/mode/autograder.
+// `runtime`, `max_group_size`, `tests`, `due`, etc. are optional — a minimal
+// assignment carries only slug/name/template/mode/autograder.
 type AssignmentsSchema = {
   schema: string
   assignments: Assignment[]

--- a/web/src/hooks/useGetClassroom.ts
+++ b/web/src/hooks/useGetClassroom.ts
@@ -17,8 +17,8 @@ const useGetClassroom = (
       `${classroom ?? ""}/classroom.json`,
     ),
     // classroom.json lives in the private config repo, so a student fetch is a
-    // guaranteed 404. Callers on student-reachable pages pass enabled:false
-    // (or gate on teacher role); the default stays enabled for teacher views.
+    // guaranteed 404. Student-reachable callers pass enabled:false (or gate on
+    // teacher role); the default stays enabled for teacher views.
     enabled: Boolean(org && classroom) && (options?.enabled ?? true),
   })
 }

--- a/web/src/hooks/useGetFeedbackPr.ts
+++ b/web/src/hooks/useGetFeedbackPr.ts
@@ -8,10 +8,9 @@ import {
 } from "./github/queries"
 
 // The Feedback PR for a student/group repo: the open PR the autograde workflow
-// opens after an accept. Returns the first open PR (there is at most one), or
-// null when none exists yet (no submission graded, or the PR step skipped).
-// `enabled` defaults to true; pass false to defer the request (e.g. resolve
-// the PR on demand instead of one /pulls call per table row on mount).
+// opens after an accept. Returns the first open PR (there's at most one), or null
+// when none exists yet. `enabled` defaults true; pass false to defer (e.g.
+// resolve on demand instead of one /pulls call per table row on mount).
 const useGetFeedbackPr = (
   org: string | undefined,
   repo: string | undefined,

--- a/web/src/hooks/useGetOrgAudit.ts
+++ b/web/src/hooks/useGetOrgAudit.ts
@@ -5,8 +5,8 @@ import { githubKeys } from "./github/queries"
 import { buildOrgAuditReport } from "@/orgPolicy/audit"
 
 // Read-only org policy audit. Plan-aware (enterprise unlocks the 4
-// enterprise-only fields), so it waits for the org plan to be known before
-// running — otherwise an enterprise org would be audited as non-enterprise.
+// enterprise-only fields), so it waits for the plan to be known — otherwise an
+// enterprise org would be audited as non-enterprise.
 const useGetOrgAudit = (org: string, plan: string | undefined) => {
   const client = useGitHubClient()
   return useQuery({

--- a/web/src/hooks/useGetOwnOrgMembership.ts
+++ b/web/src/hooks/useGetOwnOrgMembership.ts
@@ -5,12 +5,11 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 
 // Reads the authenticated user's OWN membership in `org` (GET
 // /user/memberships/orgs/{org}). A definitive 404 (no membership) or 403
-// (blocked / SAML SSO gated) does NOT retry — callers must inspect the error to
-// tell "genuinely not a member" (404) from "SSO/authorization" (403, see
-// GitHubAPIError.isSsoRequired) — while a transient 5xx/429/network blip
-// self-heals (bounded). The query is intentionally allowed to error (rather
-// than swallowing to `undefined`) so the accept/onboarding gate can render a
-// cause-specific screen instead of a blanket "not a member".
+// (blocked / SAML SSO gated) does NOT retry — callers inspect the error to tell
+// "not a member" (404) from "SSO/authorization" (403, see
+// GitHubAPIError.isSsoRequired); a transient 5xx/429/network blip self-heals.
+// The query is allowed to error (not swallowed to `undefined`) so the
+// accept/onboarding gate can render a cause-specific screen.
 const useGetOwnOrgMembership = (org: string | undefined) => {
   const client = useGitHubClient()
 

--- a/web/src/hooks/useGetPublicAssignment.ts
+++ b/web/src/hooks/useGetPublicAssignment.ts
@@ -6,8 +6,8 @@ const useGetPublicAssignment = (
   classroom: string | undefined,
   assignment: string | undefined,
   // Optional capability-URL secret, supplied by the caller (see
-  // usePagesAssignments). Not fetched here — students can't read the
-  // private classroom.json. Empty/undefined uses the plain path.
+  // usePagesAssignments). Not fetched here — students can't read the private
+  // classroom.json. Empty/undefined uses the plain path.
   secret?: string,
 ) => {
   const assignmentQuery = useQuery({

--- a/web/src/hooks/useGetRepoCollaborators.ts
+++ b/web/src/hooks/useGetRepoCollaborators.ts
@@ -13,10 +13,10 @@ const useGetRepoCollaborators = (
   return useQuery({
     queryKey: githubKeys.collaborators(org, repoName),
     queryFn: () => {
-      // affiliation=direct excludes collaborators whose access is only
-      // inherited from org membership (e.g. org owners, who hold admin on
-      // every repo). Without it, every org owner shows up as an admin
-      // collaborator, masking the real repo owner (the student founder).
+      // affiliation=direct excludes collaborators whose access is only inherited
+      // from org membership (e.g. org owners, admin on every repo). Without it,
+      // every owner shows as an admin collaborator, masking the real repo owner
+      // (the student founder).
       return client.request<GitHubUser[]>(
         `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repoName)}/collaborators?affiliation=direct`,
       )

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -22,9 +22,9 @@ type SubmissionRecord = {
   tests: unknown[]
   late?: boolean
   // The wall-clock instant this submission was last (re-)graded. Distinct from
-  // `datetime` (the fixed submission time = commit committer date): a teacher
-  // regrade refreshes `graded_at` but never moves `datetime`. Optional —
-  // absent on results graded before the field existed.
+  // `datetime` (fixed submission time = commit committer date): a teacher
+  // regrade refreshes `graded_at` but never moves `datetime`. Optional — absent
+  // on results graded before the field existed.
   graded_at?: string
   submitted_by?: {
     username: string
@@ -49,9 +49,9 @@ type ScoresSchema = {
   assignments: Record<string, AssignmentBucket>
 }
 
-// The flattened row the submissions UI renders: one per student repo, with
-// the latest submission's fields, credited usernames, and submission count.
-// Keeps the legacy field names so table/CSV consumers stay simple.
+// The flattened row the submissions UI renders: one per student repo, with the
+// latest submission's fields, credited usernames, and count. Keeps the legacy
+// field names so table/CSV consumers stay simple.
 export type SubmissionRow = {
   usernames: string[]
   owner: string
@@ -88,7 +88,7 @@ export type NormalizedScores = {
 
 // Collapse a bucket's entries to one row each (latest submission first).
 // `member_usernames` credits the whole group; individual entries fall back to
-// `owner`. We sort defensively in case a hand-edit reordered submissions.
+// `owner`. Sorted defensively in case a hand-edit reordered submissions.
 function bucketToRows(bucket: AssignmentBucket): SubmissionRow[] {
   // A hand-edited or partial scores.json bucket can lack `entries`; degrade to
   // no rows instead of throwing in the react-query select (which would blank

--- a/web/src/hooks/useGetStudents.ts
+++ b/web/src/hooks/useGetStudents.ts
@@ -9,9 +9,10 @@ const rosterKey = (org: string, classroom: string) =>
   githubKeys.csvFile(org, "classroom50", `${classroom}/students.csv`)
 
 // Module-level so the reference is stable: react-query memoizes a `select`
-// result only while the selector identity is unchanged, so an inline arrow
-// would re-map (and re-allocate the roster array) on every render, breaking
-// referential stability for downstream useMemo/partition deps.
+// result only while the selector identity is unchanged. An inline arrow would
+// re-map (re-allocating the roster) each render, breaking referential stability
+// for downstream useMemo/partition deps. toStudent is a thin, idempotent
+// pass-through, so optimistic cache writes pass through unchanged.
 const selectStudents = (rows: Student[]): Student[] => rows.map(toStudent)
 
 const useGetStudents = (
@@ -19,10 +20,6 @@ const useGetStudents = (
   classroom: string | undefined,
 ) => {
   const client = useGitHubClient()
-  // toStudent is a thin pass-through over the 6-column Student (via
-  // normalizeStudentRow), kept module-level so `selectStudents`'s identity is
-  // stable for react-query's memoized `select`. It is idempotent over an
-  // already-typed Student, so optimistic cache writes pass through unchanged.
   const { data: students, isLoading } = useQuery({
     ...csvFileQuery<Student>(
       client,
@@ -41,10 +38,9 @@ const useGetStudents = (
 
 // Optimistically patch the cached roster. GitHub's Contents API is eventually
 // consistent per path: right after a commit it often still serves the previous
-// students.csv, so an immediate refetch would clobber the cache with stale rows
-// until a later refresh. Mutations already compute the authoritative post-write
-// rows, so write them straight in and let a natural refetch reconcile. Pass a
-// function mapping the current roster to the next.
+// students.csv, so an immediate refetch would clobber the cache with stale rows.
+// Mutations already compute the authoritative post-write rows, so write them in
+// and let a natural refetch reconcile. Pass a current->next mapping.
 export const useUpdateRosterCache = (
   org: string | undefined,
   classroom: string | undefined,
@@ -55,7 +51,7 @@ export const useUpdateRosterCache = (
     const key = rosterKey(org, classroom)
     // Cancel any in-flight roster fetch first: a refetch started before the
     // commit (window-focus/reconnect) could resolve after this setQueryData and
-    // clobber the optimistic write with stale rows. cancelQueries drops it.
+    // clobber the optimistic write with stale rows.
     void queryClient.cancelQueries({ queryKey: key })
     queryClient.setQueryData<Student[]>(key, (current) => update(current ?? []))
   }

--- a/web/src/hooks/useGetSubmissionReleases.ts
+++ b/web/src/hooks/useGetSubmissionReleases.ts
@@ -5,8 +5,7 @@ import { studentRepoName } from "@/util/studentRepo"
 
 // The student's graded-submission releases (`submit/*` tags) for an assignment,
 // newest first. Each release page renders the score + per-test table, so the
-// student page links straight to them. Empty until the autograder publishes the
-// first release.
+// student page links straight to them. Empty until the first release.
 const useGetSubmissionReleases = (
   org: string | undefined,
   classroom: string | undefined,

--- a/web/src/hooks/useGitHubOperation.ts
+++ b/web/src/hooks/useGitHubOperation.ts
@@ -88,8 +88,7 @@ const saveDispatch = (
  * past it — binding to our own run, independent of clocks and concurrent
  * dispatches. State persists to sessionStorage (per `storageKey`) so a remount
  * re-attaches; `phase` latches at completed/failed/timeout until the next
- * dispatch or a `resetKey` change. Callers supply the workflow specifics and
- * layer their own concerns (banner registration, the regrade coordinator).
+ * dispatch or a `resetKey` change. Callers supply the workflow specifics.
  */
 export function useGitHubOperation(config: GitHubOperationConfig) {
   const timeoutMs = config.timeoutMs ?? DEFAULTS.timeoutMs
@@ -104,7 +103,7 @@ export function useGitHubOperation(config: GitHubOperationConfig) {
   const [timedOut, setTimedOut] = useState(false)
 
   // Re-derive tracking when the reset key changes (org / target), during render
-  // — the idiomatic alternative to a setState-in-effect.
+  // — the idiomatic alternative to setState-in-effect.
   const [trackedKey, setTrackedKey] = useState(config.resetKey)
   if (config.resetKey !== trackedKey) {
     setTrackedKey(config.resetKey)
@@ -147,9 +146,9 @@ export function useGitHubOperation(config: GitHubOperationConfig) {
   const run = runQuery.data
   const runCompleted = Boolean(dispatch) && isRunFinished(run)
 
-  // Clear persisted state once the run terminates so a remount doesn't re-attach
-  // to it; `phase` stays latched (dispatch is only reset on a reset-key change
-  // or a new dispatch).
+  // Clear persisted state once the run terminates so a remount doesn't re-attach;
+  // `phase` stays latched (dispatch resets only on a reset-key change or new
+  // dispatch).
   useEffect(() => {
     if (runCompleted) saveDispatch(config.storageKey, null)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,8 +156,7 @@ export function useGitHubOperation(config: GitHubOperationConfig) {
 
   // Time out the wait: flip a flag that stops the query and latches phase to
   // "timeout". Deadline anchored to dispatch time, so a remount doesn't grant a
-  // fresh window (a past deadline fires a 0ms timer rather than setting state
-  // during render).
+  // fresh window (a past deadline fires a 0ms timer, not a render-time setState).
   useEffect(() => {
     if (!dispatch || runCompleted || timedOut) return
     const remaining = Math.max(0, dispatch.startedAt + timeoutMs - Date.now())

--- a/web/src/hooks/useLanguage.ts
+++ b/web/src/hooks/useLanguage.ts
@@ -23,8 +23,8 @@ const SERVER_INSTALLED: string[] = []
 
 // React hook over the i18n custom-locale layer. Loading a pack is two-step:
 // prepare (parse + preview, no side effects) then commit (install + activate).
-// Pack operations are module-level functions with stable identity, so they're
-// returned directly rather than wrapped in useCallback.
+// Pack operations have stable module-level identity, so they're returned
+// directly rather than wrapped in useCallback.
 export function useLanguage() {
   const { i18n } = useTranslation()
 

--- a/web/src/hooks/useNeedsSetupPlans.ts
+++ b/web/src/hooks/useNeedsSetupPlans.ts
@@ -5,10 +5,10 @@ import type { GitHubOrgDetails } from "@/hooks/github/types"
 
 // Batch plan-name fetches for a set of org logins. Only the "needs setup" subset
 // of the home view is passed in — every such org is admin-owned, so `plan` is
-// visible there — which keeps this fan-out off the general org list the home
-// path deliberately avoids paying for. Keyed identically to useGetOrgPlanDetails
-// so the setup page reuses the same cache entry. Maps login -> plan name, or
-// undefined when the plan isn't visible (non-owner) or hasn't loaded yet.
+// visible — which keeps this fan-out off the general org list the home path
+// avoids paying for. Keyed identically to useGetOrgPlanDetails so the setup page
+// reuses the same cache. Maps login -> plan name, or undefined when the plan
+// isn't visible (non-owner) or hasn't loaded.
 const useNeedsSetupPlans = (
   logins: string[],
 ): Record<string, string | undefined> => {

--- a/web/src/hooks/useOrgMembersOverview.ts
+++ b/web/src/hooks/useOrgMembersOverview.ts
@@ -26,18 +26,17 @@ export type OrgMembersOverview = {
   // The org's live members (all pages), the trust anchor for bulk-add
   // membership verification.
   members: GitHubUser[]
-  // Numeric ids of org owners/admins, so the view can badge them "Owner"
-  // instead of "Member". Empty when the admin list couldn't be read.
+  // Numeric ids of org owners/admins, so the view can badge them "Owner".
+  // Empty when the admin list couldn't be read.
   ownerIds: Set<string>
   isLoading: boolean
   isError: boolean
   // classroom path -> resolved GitHub team slug (classroom.json.team.slug, else
   // the classroom50-<classroom> heuristic). The SAME slug teamMembersByClassroom
-  // is keyed from, so optimistic team-cache writes on the Members page target the
-  // cache this hook actually reads (a name-collision classroom's real slug can
-  // differ from the heuristic).
+  // keys from, so optimistic team-cache writes on the Members page target the
+  // cache this hook reads (a collided classroom's real slug can differ).
   teamSlugByClassroom: Map<string, string>
-  // Per-classroom roster read failures (a 404 / parse error contributes no
+  // Per-classroom roster read failures (a 404/parse error contributes no
   // students rather than failing the whole page).
   notes: string[]
 }
@@ -98,9 +97,9 @@ const useOrgMembersOverview = (org: string | undefined): OrgMembersOverview => {
     .join("|")
 
   // Live members of each classroom's `classroom50-<classroom>` team — the
-  // enrollment source of truth. Cross-referenced against the CSV-derived access
-  // to surface CSV/team drift. Slug resolves from classroom.json when present
-  // (GitHub may slugify a collided name differently), else the heuristic.
+  // enrollment source of truth, cross-referenced against CSV-derived access to
+  // surface drift. Slug resolves from classroom.json when present (GitHub may
+  // slugify a collided name differently), else the heuristic.
   const teamSlugs = useMemo(
     () =>
       classroomNames.map(
@@ -154,9 +153,9 @@ const useOrgMembersOverview = (org: string | undefined): OrgMembersOverview => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [classroomNames, metaSignature, rosterSignature])
 
-  // classroom -> set of live team-member numeric-id strings. Only classrooms
-  // whose team query has resolved are included; an unresolved/failed team read
-  // is omitted so aggregateOrgMembers treats it as "unknown" (never drift).
+  // classroom -> set of live team-member id strings. Only classrooms whose team
+  // query resolved are included; an unresolved/failed read is omitted so
+  // aggregateOrgMembers treats it as "unknown" (never drift).
   const teamMembersByClassroom = useMemo(() => {
     const map = new Map<string, Set<string>>()
     classroomNames.forEach((name, i) => {
@@ -181,8 +180,8 @@ const useOrgMembersOverview = (org: string | undefined): OrgMembersOverview => {
   )
 
   // classroom path -> resolved team slug, from the same teamSlugs array that
-  // keys the team-member queries above, so the Members page seeds/invalidates
-  // the exact team cache this hook reads.
+  // keys the team-member queries, so the Members page seeds/invalidates the
+  // exact team cache this hook reads.
   const teamSlugByClassroom = useMemo(() => {
     const map = new Map<string, string>()
     classroomNames.forEach((name, i) => {

--- a/web/src/hooks/usePagesAssignments.ts
+++ b/web/src/hooks/usePagesAssignments.ts
@@ -4,11 +4,11 @@ import { fetchPagesAssignments } from "./github/queries"
 const usePagesAssignments = (
   org: string | undefined,
   classroom: string | undefined,
-  // Optional capability-URL secret. The hook does NOT fetch it (students
-  // can't read the private classroom.json) — the caller supplies it from
-  // whatever source fits its context: the `?k=` accept link, the student
-  // repo's .classroom50.yaml (post-accept), or classroom.json (teachers).
-  // Empty/undefined fetches the plain path (unprotected classroom).
+  // Optional capability-URL secret. The hook does NOT fetch it (students can't
+  // read the private classroom.json) — the caller supplies it from whatever fits
+  // its context: the `?k=` accept link, the student repo's .classroom50.yaml
+  // (post-accept), or classroom.json (teachers). Empty/undefined fetches the
+  // plain path (unprotected classroom).
   secret?: string,
 ) => {
   return useQuery({

--- a/web/src/hooks/useReuseAssignment.ts
+++ b/web/src/hooks/useReuseAssignment.ts
@@ -30,8 +30,8 @@ type UseReuseAssignmentParams = {
 
 // Shared reuse machinery for both modals: the derived slug (auto-suffixed
 // default + optimistic case-insensitive collision check) and the copy mutation
-// with its success/grant-warning handling. Each modal owns its own <dialog> and
-// renders its direction-specific selectors; this hook is ref-free.
+// with its success/grant-warning handling. Ref-free — each modal owns its own
+// <dialog> and direction-specific selectors.
 export function useReuseAssignment({
   org,
   targetClassroom,
@@ -66,8 +66,7 @@ export function useReuseAssignment({
   }, [normalizedSlug, takenSlugs])
 
   // Synchronous re-entrancy guard: reuse.isPending updates a tick late, so a
-  // rapid double-click could start two overlapping copy commits (mirrors
-  // GroupCollaboratorsModal's savingRef).
+  // rapid double-click could start two overlapping copy commits.
   const submittingRef = useRef(false)
 
   const reuse = useMutation({

--- a/web/src/hooks/useSafeSubmit.test.ts
+++ b/web/src/hooks/useSafeSubmit.test.ts
@@ -4,9 +4,8 @@ import { createSafeSubmit } from "./useSafeSubmit"
 
 // useSafeSubmit's correctness is the synchronous latch: a second same-tick call
 // must be a no-op while the first is in flight, and the latch must reset after
-// the work settles (success or failure) so the next genuine submit proceeds.
-// The latch lives in createSafeSubmit (pure, no React) so it tests in this
-// repo's pure-function style.
+// the work settles so the next genuine submit proceeds. The latch lives in
+// createSafeSubmit (pure, no React) so it tests in the pure-function style.
 describe("createSafeSubmit", () => {
   it("rejects a second same-tick call while the first is in flight", async () => {
     const run = createSafeSubmit()

--- a/web/src/hooks/useSafeSubmit.ts
+++ b/web/src/hooks/useSafeSubmit.ts
@@ -3,11 +3,10 @@ import { useMemo } from "react"
 // Synchronous re-entrancy guard for write submissions.
 //
 // react-query's `isPending` (and any React state used to disable a submit
-// button) updates a render tick late, so two clicks dispatched in the same tick
-// — a fast double-click, or Enter + click — can both pass an `isPending` check
-// and both start a write. This guard flips a flag synchronously BEFORE awaiting,
-// so a second same-tick call is rejected before it can start a duplicate write,
-// and resets the flag once the work settles.
+// button) updates a render tick late, so two clicks in the same tick — a fast
+// double-click, or Enter + click — can both pass an `isPending` check and both
+// start a write. This guard flips a flag synchronously BEFORE awaiting, so a
+// second same-tick call is rejected, and resets once the work settles.
 //
 // IMPORTANT: `run` only spans the write when `fn` returns the settling promise.
 // Pass `() => mutation.mutateAsync(...)` (awaitable), NOT `() => mutation.mutate(...)`
@@ -16,13 +15,12 @@ import { useMemo } from "react"
 
 export type SafeSubmitRun = (fn: () => Promise<unknown>) => Promise<void>
 
-// Pure factory (no React) so the latch behavior is unit-testable in this repo's
-// pure-function test style. The hook below is a thin, stable wrapper.
+// Pure factory (no React) so the latch is testable in the pure-function style.
+// The hook below is a thin, stable wrapper.
 //
-// `run` does not surface errors: the wrapped mutation owns failure handling (its
-// own `onError`/`isError`), and `run` is purely the re-entrancy guard. It
+// `run` does not surface errors: the wrapped mutation owns failure handling. It
 // swallows the rejection after the latch resets so callers can `void run(...)`
-// from an onClick without producing an unhandled promise rejection.
+// from an onClick without an unhandled promise rejection.
 export function createSafeSubmit(): SafeSubmitRun {
   let submitting = false
   return async (fn: () => Promise<unknown>) => {

--- a/web/src/hooks/useSkeletonDrift.ts
+++ b/web/src/hooks/useSkeletonDrift.ts
@@ -5,8 +5,8 @@ import { findStaleSkeletonFiles } from "./github/mutations"
 import { githubKeys } from "./github/queries"
 import useGetOrgMembership from "./useGetOrgMembership"
 
-// State subset the verdict depends on — kept structural so the fail-open logic
-// stays a pure, unit-testable function.
+// State subset the verdict depends on — structural so the fail-open logic stays
+// a pure, testable function.
 export type SkeletonDriftInput = {
   isSuccess: boolean
   driftedCount: number | undefined
@@ -15,7 +15,7 @@ export type SkeletonDriftInput = {
 
 // Fail-open verdict: show only on a definitive success that found drift. A read
 // error or in-flight query resolves to "no drift" so we never nag on incomplete
-// info (the issue's "on any read error, show nothing").
+// info.
 export function resolveSkeletonDrift(input: SkeletonDriftInput): boolean {
   const { isSuccess, driftedCount, isError } = input
   if (isError || !isSuccess) return false
@@ -23,13 +23,12 @@ export function resolveSkeletonDrift(input: SkeletonDriftInput): boolean {
 }
 
 // Owner-gated, cached, fail-open check for whether the org's `classroom50`
-// config repo has drifted from the bundled skeleton (e.g. after #88's pin
-// bump). Reuses findStaleSkeletonFiles read-only — no version marker.
+// config repo has drifted from the bundled skeleton. Reuses findStaleSkeletonFiles
+// read-only — no version marker.
 //
-// Gated on org owner (admin), not any staff: the banner routes to the
-// owner-only Re-run org setup section, so surfacing it to a TA/non-owner
-// instructor would dead-end their CTA on a NotFound — and only an owner should
-// trigger the config-repo read.
+// Gated on org owner (admin), not any staff: the banner routes to the owner-only
+// Re-run org setup section, so surfacing it to a TA/non-owner instructor would
+// dead-end their CTA on a NotFound.
 export function useSkeletonDrift(org: string | undefined) {
   const client = useGitHubClient()
   const { data: membership } = useGetOrgMembership(org)

--- a/web/src/hooks/useTeamRoster.ts
+++ b/web/src/hooks/useTeamRoster.ts
@@ -22,34 +22,32 @@ export type UseTeamRosterResult = {
   isLoading: boolean
   // The team-member fetch (enrolled source of truth) failed for a reason other
   // than a missing team (listTeamMembers swallows 404 -> []). When true, the
-  // roster couldn't be read and the view must show an error+retry instead of
-  // the empty state, so a transient/permission failure isn't rendered as an
-  // authoritative "nobody enrolled".
+  // view must show error+retry instead of the empty state, so a
+  // transient/permission failure isn't rendered as "nobody enrolled".
   isError: boolean
   // The classroom has zero team members AND zero pending invites — a brand-new
   // classroom nobody has joined yet.
   isEmpty: boolean
   // Pending invites couldn't be read (getOrgInvitations is owner-only; a
   // non-owner TA/instructor gets 403). The view then hides the pending section
-  // and shows an "owners only" note instead of silently rendering zero pending.
+  // and shows an "owners only" note instead of rendering zero pending.
   pendingHidden: boolean
   // The resolved team slug (classroom.json.team.slug, else classroom50-<c>).
   teamSlug: string
-  // Count of team members with no students.csv metadata row — the exact set
-  // "Sync roster" appends. 0 = the CSV is in sync with the team (the button is
-  // disabled and reads "In sync"); >0 = drift the teacher can sync (and which
-  // the page auto-syncs on open). Distinct from the `unprovisioned` count,
-  // which is the opposite direction (on CSV, not on team) that sync can't fix.
+  // Count of team members with no students.csv row — the exact set "Sync roster"
+  // appends. 0 = in sync (button disabled, "In sync"); >0 = drift the teacher
+  // can sync (auto-synced on open). Opposite direction from `unprovisioned` (on
+  // CSV, not on team), which sync can't fix.
   csvMissingCount: number
-  // Re-run the team-member fetch (the enrolled source of truth) so an error
-  // surface can offer a retry without a full page reload.
+  // Re-run the team-member fetch so an error surface can offer a retry without a
+  // full page reload.
   refetch: () => void
 }
 
 // The teacher roster, driven by GitHub (team members + pending org invites),
 // with students.csv joined only as optional display metadata. Resolves the team
-// slug from classroom.json (fallback classroom50-<classroom>), matching the
-// grade collector and Go download so all three consumers agree on the slug.
+// slug from classroom.json (fallback classroom50-<classroom>) so the grade
+// collector, Go download, and this view agree on the slug.
 export function useTeamRoster(
   org: string,
   classroom: string,
@@ -96,8 +94,8 @@ export function useTeamRoster(
   )
 
   // Enrolled rows come from team membership (readable by non-owners), so the
-  // roster is usable even when invites are forbidden. Only wait on the invite
-  // fetch when it's actually readable.
+  // roster is usable even when invites are forbidden. Wait on the invite fetch
+  // only when it's readable.
   const isLoading = membersLoading || (!invitesForbidden && invitesLoading)
 
   return {
@@ -116,9 +114,9 @@ export function useTeamRoster(
 }
 
 // Invalidate the team-members query that drives the enrolled roster (slug
-// resolved as in useTeamRoster). Any mutation that changes classroom-team
+// resolved as in useTeamRoster). Any mutation changing classroom-team
 // membership (enroll/unenroll/match) must call this, or the change only shows
-// after the members query's 60s staleTime lapses. Stable callback.
+// after the members query's staleTime lapses.
 export function useInvalidateTeamRoster(
   org: string,
   classroom: string,
@@ -146,8 +144,8 @@ export type OptimisticMember = {
 // Optimistically add a just-enrolled member to the team-members cache, then
 // invalidate to reconcile. Enrolling an already-active org member team-adds them
 // with no pending invite, so without the seed buildTeamRoster flashes the row as
-// "unprovisioned" until the refetch lands. Dedup is by id; the refetch replaces
-// the stub (or drops it if the add didn't land). No-ops a blank/invalid id.
+// "unprovisioned" until the refetch lands. Dedup by id; the refetch replaces the
+// stub (or drops it if the add didn't land). No-ops a blank/invalid id.
 export function useSeedTeamMember(
   org: string,
   classroom: string,

--- a/web/src/hooks/useTheme.test.ts
+++ b/web/src/hooks/useTheme.test.ts
@@ -6,9 +6,9 @@ import { THEME_STORAGE_KEY, type Theme } from "./useTheme"
 
 // The anti-flash inline script in index.html hand-mirrors resolveInitialTheme
 // (same storage key + theme names) so the pre-mount paint matches what React
-// resolves. Nothing else binds them, and the drift symptom (a wrong-theme
-// flash) is nearly invisible in review — so guard the contract here, mirroring
-// the repo's other hand-mirrored-contract drift tests (e.g. skeleton.test.ts).
+// resolves. Nothing else binds them and the drift symptom (a wrong-theme flash)
+// is nearly invisible in review — so guard the contract here, like the repo's
+// other hand-mirrored-contract drift tests (e.g. skeleton.test.ts).
 describe("theme anti-flash contract (index.html <-> useTheme)", () => {
   const indexHtml = readFileSync(
     fileURLToPath(new URL("../../index.html", import.meta.url)),

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
 
 // Client-side theme preference. Mirrors the `classroom50:sidebar-collapsed`
-// pattern: a single localStorage key, applied by toggling `data-theme` on <html>.
+// pattern: one localStorage key, applied by toggling `data-theme` on <html>.
 // The two theme names are the ones registered in index.css.
 export const THEME_STORAGE_KEY = "classroom50:theme"
 
@@ -10,9 +10,9 @@ export type Theme = "corporate" | "corporate-dark"
 const LIGHT: Theme = "corporate"
 const DARK: Theme = "corporate-dark"
 
-// Resolve the initial theme: an explicit stored choice always wins; otherwise
-// fall back to the OS `prefers-color-scheme`. Kept in sync with the anti-flash
-// inline script in index.html, which applies the same logic before React mounts.
+// Resolve the initial theme: an explicit stored choice wins; else fall back to
+// the OS `prefers-color-scheme`. Kept in sync with the anti-flash inline script
+// in index.html, which applies the same logic before React mounts.
 export function resolveInitialTheme(): Theme {
   if (typeof window === "undefined") return LIGHT
   const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
@@ -38,15 +38,15 @@ export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(resolveInitialTheme)
 
   // Apply the active theme to <html>. Persistence is deliberately NOT done here:
-  // writing on mount would freeze a first-visit OS-derived default into a locked
-  // explicit choice, so `follow the OS` could never recover. We persist only on
-  // an explicit user action (setTheme/toggleTheme) below.
+  // writing on mount would freeze a first-visit OS default into a locked explicit
+  // choice, so "follow the OS" could never recover. We persist only on an
+  // explicit user action (setTheme/toggleTheme) below.
   useEffect(() => {
     applyTheme(theme)
   }, [theme])
 
-  // While the user has made no explicit choice, keep following the OS and any
-  // choice made in another tab. Both listeners are no-ops once a value is stored.
+  // While the user has made no explicit choice, follow the OS and any choice
+  // made in another tab. Both listeners are no-ops once a value is stored.
   useEffect(() => {
     if (typeof window === "undefined") return
 

--- a/web/src/hooks/useTriggerRegrade.ts
+++ b/web/src/hooks/useTriggerRegrade.ts
@@ -11,7 +11,7 @@ import { useGitHubOperation, type OperationPhase } from "./useGitHubOperation"
 export type RegradePhase = OperationPhase
 
 // The regrade dispatch is quick; the timeout is generous but shorter than
-// collect's since we're only tracking the fan-out kickoff, not grading itself.
+// collect's since we only track the fan-out kickoff, not grading itself.
 const REGRADE_TIMEOUT_MS = 5 * 60 * 1000
 const REGRADE_INTERVAL_MS = 4000
 const REGRADE_BACKOFF_AFTER_MS = 45 * 1000
@@ -112,7 +112,7 @@ const useTriggerRegrade = (target: RegradeTarget) => {
     run,
     error,
     // True while ANY regrade (this one, another row, or "Regrade all") is in
-    // flight — callers use it to disable collect/regrade controls page-wide.
+    // flight — callers disable collect/regrade controls page-wide.
     anyRegrading: coordinator.anyInFlight,
   }
 }

--- a/web/src/lib/LoadingSwap.tsx
+++ b/web/src/lib/LoadingSwap.tsx
@@ -3,13 +3,12 @@ import type { ReactNode } from "react"
 import { crossFade } from "./motion"
 
 /**
- * Cross-fades a loading fallback with resolved content. While `loading` is
- * true it renders `fallback`; once false it renders `children`, and Motion
- * fades the outgoing view out as the incoming one fades in (`mode="wait"`).
+ * Cross-fades a loading fallback with resolved content. Renders `fallback`
+ * while `loading`, else `children`, with Motion fading out->in (`mode="wait"`).
  *
- * Keyed on the loading boolean so it fires once on the load->resolved
- * boundary and not on subsequent content re-renders. Honors reduced motion
- * via the app-level MotionConfig.
+ * Keyed on the loading boolean so it fires once on the load->resolved boundary,
+ * not on subsequent content re-renders. Honors reduced motion via the app-level
+ * MotionConfig.
  */
 export function LoadingSwap({
   loading,

--- a/web/src/lib/motion.ts
+++ b/web/src/lib/motion.ts
@@ -1,9 +1,9 @@
 import type { Transition, Variants } from "motion/react"
 
 // Shared motion primitives mirroring the CSS token values in index.css
-// (durations 100/150/200ms, ease-out). Keep JS and CSS motion consistent so
-// the app feels like one system. Every consumer pairs with MotionConfig
-// reducedMotion="user", so these never need their own reduced-motion guard.
+// (durations 100/150/200ms, ease-out) so JS and CSS motion stay consistent.
+// Every consumer pairs with MotionConfig reducedMotion="user", so these need no
+// reduced-motion guard.
 
 export const DURATION = {
   fast: 0.1,
@@ -11,13 +11,11 @@ export const DURATION = {
   slow: 0.2,
 } as const
 
-// Standard ease-out curve (fast start, gentle settle), matching the
-// `--ease-out-soft` token in index.css.
+// Standard ease-out curve, matching the `--ease-out-soft` token in index.css.
 export const EASE_OUT: Transition["ease"] = [0, 0, 0.2, 1]
 
-// Staggered entrance for a list of cards: each item's delay is its index * 60ms,
-// capped so a long list doesn't leave later items visibly waiting. Pair with the
-// `enterExit` variants.
+// Staggered entrance for a list of cards: delay is index * 60ms, capped so a
+// long list doesn't leave later items waiting. Pair with `enterExit`.
 export const staggerTransition = (index: number): Transition => ({
   duration: DURATION.slow,
   ease: EASE_OUT,
@@ -38,9 +36,9 @@ export const enterExit: Variants = {
   },
 }
 
-// Entrance for notice/alert-style callouts that appear after an async check and
-// push content down: a gentle slide-down + fade, distinct from the scale-up
-// used for cards/content so a "notice arrived" reads differently from a card.
+// Entrance for notice/alert callouts that appear after an async check and push
+// content down: a gentle slide-down + fade, distinct from the card scale-up so a
+// "notice arrived" reads differently.
 export const calloutVariants: Variants = {
   initial: { opacity: 0, y: -8 },
   animate: {
@@ -55,8 +53,8 @@ export const calloutVariants: Variants = {
   },
 }
 
-// Hover affordance for clickable list rows: a subtle lift + shadow, matching
-// the former `clickable-row` CSS utility. Pair with a `bg` hover via className.
+// Hover affordance for clickable list rows: a subtle lift + shadow (the former
+// `clickable-row` CSS utility). Pair with a `bg` hover via className.
 export const rowHover = {
   whileHover: { y: -1, boxShadow: "0 1px 3px rgb(0 0 0 / 0.08)" },
   transition: { duration: DURATION.base, ease: EASE_OUT },
@@ -96,7 +94,7 @@ export const collapseVariants: Variants = {
 }
 
 // Short cross-fade for swapping loading skeletons with resolved content
-// (LoadingSwap). Deliberately fast so the app never feels sluggish.
+// (LoadingSwap). Fast so the app never feels sluggish.
 export const crossFade: Variants = {
   initial: { opacity: 0 },
   animate: { opacity: 1, transition: { duration: DURATION.base } },

--- a/web/src/lib/motionComponents.tsx
+++ b/web/src/lib/motionComponents.tsx
@@ -2,14 +2,13 @@ import { motion } from "motion/react"
 import type { ComponentPropsWithoutRef } from "react"
 import { calloutVariants, enterExit, rowHover } from "./motion"
 
-// Reusable Motion wrappers that replace the per-element CSS animation utilities
-// (animate-enter, animate-callout, clickable-row). Centralizing them keeps
-// every call site terse and every animation consistent. All honor reduced
-// motion via the app-level MotionConfig, so no per-component guard is needed.
+// Reusable Motion wrappers replacing the per-element CSS animation utilities
+// (animate-enter, animate-callout, clickable-row), keeping call sites terse and
+// animations consistent. All honor reduced motion via the app-level MotionConfig.
 //
-// Note: the global `.btn` press feedback and `skeleton-shimmer` intentionally
-// stay as CSS utilities in index.css — they apply broadly (every button, every
-// skeleton) where a single CSS rule is simpler than a per-site Motion wrapper.
+// The global `.btn` press feedback and `skeleton-shimmer` intentionally stay as
+// CSS utilities in index.css — they apply broadly (every button, every skeleton)
+// where a single CSS rule beats a per-site Motion wrapper.
 
 type DivProps = ComponentPropsWithoutRef<typeof motion.div>
 

--- a/web/src/lib/orgPlan.test.ts
+++ b/web/src/lib/orgPlan.test.ts
@@ -17,8 +17,8 @@ describe("classifyPlan", () => {
   })
 
   it("treats unrecognized or future plan names as unknown, never free", () => {
-    // An unknown value must not be misclassified as free, or we'd hide/demote
-    // an org the user can actually work with.
+    // An unknown value must not be misclassified as free, or we'd hide an org
+    // the user can actually work with.
     expect(classifyPlan("business")).toBe("unknown")
     expect(classifyPlan("Team")).toBe("unknown")
   })

--- a/web/src/lib/orgPlan.ts
+++ b/web/src/lib/orgPlan.ts
@@ -1,8 +1,7 @@
 // Org-plan eligibility for Classroom 50. GitHub's GET /orgs/{org} only returns
-// `plan` to org owners; a non-owner member gets a response without it, so the
-// plan name is often absent (unknown). Team/Enterprise are the plans Classroom
-// 50 can be set up on; free can't. Unknown must never be treated as free — we'd
-// hide/demote orgs the user can actually work with.
+// `plan` to org owners, so it's often absent (unknown) for a non-owner member.
+// Team/Enterprise are supported; free isn't. Unknown must never be treated as
+// free — we'd hide orgs the user can actually work with.
 
 export type PlanCategory = "supported" | "free" | "unknown"
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,9 +17,9 @@ import { appVersion, formatAppVersion } from "./version"
 
 const client = new QueryClient()
 
-// Make the deployed release identifiable from the browser console (there is no
-// version in the URL or a server header for a static SPA). Deliberate release
-// diagnostic, not stray debug logging — hence the no-console exception.
+// Make the deployed release identifiable from the browser console (a static SPA
+// has no version in the URL or a server header). Deliberate release diagnostic,
+// not stray debug logging — hence the no-console exception.
 // eslint-disable-next-line no-console
 console.info(
   `Classroom 50 — ${formatAppVersion()} — built ${appVersion.buildDate}`,

--- a/web/src/orgPolicy/audit.test.ts
+++ b/web/src/orgPolicy/audit.test.ts
@@ -97,8 +97,8 @@ describe("buildOrgAuditReport", () => {
     expect(report.lockdownComplete).toBe(true)
     expect(report.unenforcedDefaults).toHaveLength(0)
     expect(report.manualUnreadable).toHaveLength(4)
-    // The full member-default list is surfaced so teachers see every
-    // permission we set, all enforced here (12 on a team plan).
+    // The full member-default list is surfaced so teachers see every permission
+    // we set, all enforced here (12 on a team plan).
     expect(report.defaultVerdicts).toHaveLength(12)
     expect(report.defaultVerdicts.every((v) => v.enforced)).toBe(true)
   })
@@ -132,7 +132,7 @@ describe("buildOrgAuditReport", () => {
     )
     expect(report.verdict).toBe("fail")
     // lockdownComplete is critical-only (CLI parity): non-critical drift keeps
-    // it true, but the overall verdict still fails since any drift is actionable.
+    // it true, but the verdict still fails since any drift is actionable.
     expect(report.lockdownComplete).toBe(true)
     expect(report.unenforcedDefaults.map((s) => s.field)).toContain(
       "members_can_create_pages",
@@ -283,9 +283,9 @@ describe("buildOrgAuditReport", () => {
 
   it("emits a concern for every ConcernId (no concern silently dropped)", async () => {
     const report = await buildOrgAuditReport(makeClient(), "acme", "team")
-    // Guards against a new ConcernId being wired into titles/repair but
-    // forgotten in buildOrgAuditReport's concerns array. Keep this list in
-    // sync with the ConcernId union.
+    // Guards against a new ConcernId wired into titles/repair but forgotten in
+    // buildOrgAuditReport's concerns array. Keep in sync with the ConcernId
+    // union.
     const expected: ConcernId[] = [
       "orgDefaults",
       "orgActions",

--- a/web/src/orgPolicy/audit.ts
+++ b/web/src/orgPolicy/audit.ts
@@ -1,6 +1,6 @@
 // Read-only org audit — the web mirror of the CLI's buildAuditReport.
 // Deliberate divergence: the CLI is three-state (OK / WARN / FAIL), but the GUI
-// collapses WARN into FAIL — any drift is treated as actionable (deriveVerdict).
+// collapses WARN into FAIL — any drift is actionable (deriveVerdict).
 
 import type { GitHubClient } from "@/hooks/github/client"
 import {
@@ -54,8 +54,8 @@ export type OrgAuditReport = {
   // Per-field member-default drift, each carrying its manualFix.
   unenforcedDefaults: MemberDefaultSetting[]
   // The full member-default lockdown we configure, each with whether the live
-  // org value currently matches — so teachers can see every permission we set,
-  // not just the drifted ones. Empty when the org couldn't be read.
+  // org value matches — so teachers see every permission we set, not just the
+  // drifted ones. Empty when the org couldn't be read.
   defaultVerdicts: DefaultVerdict[]
   // Per-concern check verdicts (Actions, Pages, rulesets, …).
   concerns: ConcernCheck[]
@@ -74,9 +74,9 @@ const CONCERN_TITLES: Record<ConcernId, string> = {
   rulesets: "Branch protection rulesets",
 }
 
-// The GitHub settings page each concern maps to, so a teacher can jump
-// straight to where they'd inspect or fix it. Org-level concerns point at the
-// org settings; repo-level concerns point at the classroom50 config repo.
+// The GitHub settings page each concern maps to, so a teacher can jump straight
+// to where they'd fix it. Org-level concerns point at org settings; repo-level
+// concerns at the classroom50 config repo.
 function concernSettingsUrl(id: ConcernId, org: string): string {
   const orgBase = `https://github.com/organizations/${org}/settings`
   const repoBase = `https://github.com/${org}/classroom50/settings`
@@ -100,7 +100,7 @@ function concernSettingsUrl(id: ConcernId, org: string): string {
 
 // Any drift fails the audit — stricter than the CLI, which warns on
 // non-critical drift (see header). An unreadable concern also fails: a partial
-// read outage is "needs attention", not a clean bill of health.
+// read outage is "needs attention", not a clean bill.
 function deriveVerdict(
   readOk: boolean,
   lockdownComplete: boolean,
@@ -147,9 +147,9 @@ export async function buildOrgAuditReport(
       .filter((v) => !v.enforced)
       .map((v) => v.setting) ?? []
   const defaultVerdicts = defaults.classification?.verdicts ?? []
-  // lockdownComplete mirrors the CLI: critical defaults only. Non-critical
-  // drift leaves it true but still fails the verdict via the orgDefaults
-  // concern being "unenforced" (see deriveVerdict).
+  // lockdownComplete mirrors the CLI: critical defaults only. Non-critical drift
+  // leaves it true but still fails the verdict via the orgDefaults concern being
+  // "unenforced" (see deriveVerdict).
   const lockdownComplete =
     readOk && !(defaults.classification?.criticalMissed ?? false)
 
@@ -170,7 +170,7 @@ export async function buildOrgAuditReport(
     verdict,
     settingsUrl: concernSettingsUrl(id, org),
   }))
-  // Sort the audit list alphabetically by title for predictable scanning.
+  // Sort alphabetically by title for predictable scanning.
   concerns.sort((a, b) => a.title.localeCompare(b.title))
 
   return {

--- a/web/src/orgPolicy/desiredState.test.ts
+++ b/web/src/orgPolicy/desiredState.test.ts
@@ -7,9 +7,9 @@ import {
 } from "./desiredState"
 
 // The desired-state module is the web mirror of the CLI's orgpolicy seam.
-// These tests pin the parity-critical invariants: the plan-aware field count,
-// the criticality flags, and the three-state classification both the settings
-// page and the audit depend on.
+// These tests pin the parity-critical invariants: plan-aware field count,
+// criticality flags, and the three-state classification the settings page and
+// audit depend on.
 
 const ENTERPRISE_ONLY_FIELDS = [
   "members_can_create_public_repositories",

--- a/web/src/orgPolicy/desiredState.ts
+++ b/web/src/orgPolicy/desiredState.ts
@@ -1,10 +1,10 @@
 // Web mirror of the CLI's org-policy desired-state seam
 // (classroom50-cli/cli/gh-teacher/internal/orgpolicy/orgpolicy.go).
 //
-// This is the single source of truth for the org member-default lockdown the
-// GUI enforces and audits. It must stay a 1:1 mirror of the CLI's
-// allMemberDefaultSettings()/MemberDefaultSettings()/ClassifyDefaults() so the
-// two tools can't drift — a divergence here is a parity bug.
+// Single source of truth for the org member-default lockdown the GUI enforces
+// and audits. Must stay a 1:1 mirror of the CLI's
+// allMemberDefaultSettings()/MemberDefaultSettings()/ClassifyDefaults() — a
+// divergence here is a parity bug.
 
 export type MemberDefaultValue = boolean | string
 
@@ -18,10 +18,9 @@ export type MemberDefaultSetting = {
 }
 
 // The 16 member-default fields, in the CLI's order. Criticality and
-// enterprise-only flags mirror the CLI exactly: critical marks the lockdown
-// fields whose absence re-opens the org-wide repo-admin danger; the
-// enterprise-only fields have no member-privileges toggle on Team/Free, so
-// init skips them there.
+// enterprise-only flags mirror the CLI: critical marks lockdown fields whose
+// absence re-opens the org-wide repo-admin danger; enterprise-only fields have
+// no member-privileges toggle on Team/Free, so init skips them there.
 const ALL_MEMBER_DEFAULT_SETTINGS: readonly MemberDefaultSetting[] = [
   {
     field: "default_repository_permission",
@@ -80,8 +79,8 @@ const ALL_MEMBER_DEFAULT_SETTINGS: readonly MemberDefaultSetting[] = [
     enterpriseOnly: false,
   },
   {
-    // Enforced TRUE for the same reason: the config-repo Pages site must be
-    // allowed to publish publicly.
+    // Enforced TRUE for the same reason: the config-repo Pages site must be able
+    // to publish publicly.
     field: "members_can_create_public_pages",
     value: true,
     desc: "public Pages creation enabled (required for the public config-repo site)",
@@ -167,9 +166,8 @@ const ALL_MEMBER_DEFAULT_SETTINGS: readonly MemberDefaultSetting[] = [
 ]
 
 // memberDefaultSettings returns the in-scope settings for a plan. Only
-// "enterprise" gets the full 16; every other plan (team/free/unknown) is
-// treated conservatively as non-enterprise and the 4 enterprise-only fields
-// are filtered out, leaving 12.
+// "enterprise" gets all 16; every other plan (team/free/unknown) is treated as
+// non-enterprise and the 4 enterprise-only fields are filtered out, leaving 12.
 export function memberDefaultSettings(
   plan: string | undefined,
 ): MemberDefaultSetting[] {
@@ -191,9 +189,8 @@ export type ClassifyResult = {
 
 // classifyDefaults compares each in-scope (plan-filtered) setting against the
 // live GET /orgs/{org} values, reporting per-setting whether it's enforced and
-// whether any critical setting is unenforced. The single source of truth for
-// interpreting an org response against the desired lockdown — shared by the
-// settings page and the audit so they can't drift.
+// whether any critical setting is unenforced. Single source of truth for
+// interpreting an org response — shared by the settings page and the audit.
 export function classifyDefaults(
   live: Record<string, unknown>,
   plan: string | undefined,
@@ -216,16 +213,16 @@ export type ManualStep = {
   url: string
 }
 
-// The org member-privileges settings page — the single place a teacher
-// inspects/sets the member-default lockdown by hand. Shared so the desired
-// state, audit, and any deep links can't drift on the path.
+// The org member-privileges settings page — where a teacher inspects/sets the
+// member-default lockdown by hand. Shared so desired state, audit, and deep
+// links can't drift on the path.
 export function memberPrivilegesUrl(org: string): string {
   return `https://github.com/organizations/${org}/settings/member_privileges`
 }
 
 // manualHardeningSteps is the canonical list of the four member-privilege
-// settings with no REST API — the teacher applies them by hand. All four live
-// on the org member-privileges settings page.
+// settings with no REST API — applied by hand, all on the org
+// member-privileges settings page.
 export function manualHardeningSteps(org: string): ManualStep[] {
   const url = memberPrivilegesUrl(org)
   return [

--- a/web/src/orgPolicy/repair.test.ts
+++ b/web/src/orgPolicy/repair.test.ts
@@ -10,8 +10,8 @@ import {
 import type { GitHubClient } from "@/hooks/github/client"
 
 // repairConcern dispatches each audit concern to the mutation that restores its
-// setting. The fake client records the write paths/methods so each case can
-// assert it hit the right GitHub endpoint.
+// setting. The fake client records write paths/methods so each case can assert
+// it hit the right GitHub endpoint.
 
 type Recorded = { method: string; path: string }
 

--- a/web/src/orgPolicy/repair.ts
+++ b/web/src/orgPolicy/repair.ts
@@ -1,8 +1,8 @@
-// Per-concern repair dispatcher for the org policy audit. Maps each audit
-// ConcernId to the callable mutation that restores its required setting, so the
-// settings page can offer a per-concern "Fix it" button. This lives in its own
-// module (not orgChecks.ts) to avoid an import cycle: mutations.ts already
-// imports orgChecks.ts for repairOrgDefaults.
+// Per-concern repair dispatcher for the org policy audit. Maps each ConcernId to
+// the mutation that restores its setting, so the settings page can offer a
+// per-concern "Fix it" button. Kept in its own module (not orgChecks.ts) to
+// avoid an import cycle: mutations.ts already imports orgChecks.ts for
+// repairOrgDefaults.
 
 import type { GitHubClient } from "@/hooks/github/client"
 import {
@@ -19,7 +19,7 @@ import type { ConcernId } from "./audit"
 
 // Whether a concern can be repaired by an API call. The four manual-only
 // member-privilege settings have no API and are excluded by design; every
-// audit concern here is API-repairable.
+// concern here is API-repairable.
 export const REPAIRABLE_CONCERNS: ReadonlySet<ConcernId> = new Set<ConcernId>([
   "orgDefaults",
   "orgActions",
@@ -34,7 +34,7 @@ export const REPAIRABLE_CONCERNS: ReadonlySet<ConcernId> = new Set<ConcernId>([
 // Result of a repair attempt. `unfixableFields` lists member-default fields the
 // API accepted but that didn't stick on read-back — silently overridden by an
 // enterprise policy (200 but ignored). Plan-gated fields the API rejected
-// (403/422) are excluded. Only populated for the orgDefaults concern.
+// (403/422) are excluded. Only populated for orgDefaults.
 export type RepairResult = {
   unfixableFields: string[]
 }

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -277,9 +277,9 @@ const AcceptProgress = ({ steps }: { steps: StepState }) => {
   const isRunning = stepStates.some((s) => s.status === "running")
   const allDone = completed === ACCEPT_STEP_ORDER.length
 
-  // Start collapsed — the header summary + count carries enough signal — and
-  // let the student expand the per-step detail on demand. Force open only on
-  // an error so a failure is never hidden. An explicit toggle takes precedence.
+  // Start collapsed (header summary + count is enough); let the student expand
+  // detail on demand. Force open on error so a failure is never hidden; an
+  // explicit toggle takes precedence.
   const [userOpen, setUserOpen] = useState<boolean | null>(null)
   const expanded = userOpen ?? hasError
 
@@ -393,10 +393,9 @@ const AcceptAssignmentPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.acceptAssignment"))
   const { org, classroom, assignment } = useParams({ strict: false })
-  // The capability key from the accept link (?k=...). For a protected
-  // classroom this selects the <classroom>/<secret>/ Pages path; absent for
-  // an unprotected classroom. Read loosely so the page also works if
-  // mounted without the typed route in tests.
+  // Capability key from the accept link (?k=...). For a protected classroom it
+  // selects the <classroom>/<secret>/ Pages path; absent otherwise. Read
+  // loosely so the page works if mounted without the typed route in tests.
   const search = useSearch({ strict: false }) as { k?: string }
   const secret = typeof search.k === "string" ? search.k : undefined
   const client = useGitHubClient()
@@ -436,9 +435,8 @@ const AcceptAssignmentPage = () => {
   const runAccept = useSafeSubmit()
 
   // A pending invitee opened the accept link before becoming an active member.
-  // Rather than bouncing them to /onboard, accept + verify membership inline
-  // (same shared verified-accept path), showing loading + error UI here, then
-  // proceed to the accept flow once active.
+  // Rather than bouncing to /onboard, accept + verify membership inline (shared
+  // verified-accept path), then proceed to the accept flow once active.
   const isPending = orgInvite?.state === "pending"
   const membershipAccept = useAcceptAndVerifyMembership({
     org,
@@ -467,7 +465,7 @@ const AcceptAssignmentPage = () => {
     },
     onSuccess: (result) => {
       // Celebrate a freshly created repo; an already-accepted repo isn't a new
-      // milestone, so it skips the confetti.
+      // milestone, so skip the confetti.
       if (result.status === "created") {
         fireConfetti()
       }
@@ -487,14 +485,11 @@ const AcceptAssignmentPage = () => {
     )
   }
 
-  // Membership read failed on the INITIAL read. Distinguish causes rather than a
-  // blanket "not a member": classifyMembershipError routes a 403 + X-GitHub-SSO
-  // to the SSO screen (with the authorize button when GitHub gave a URL, or the
-  // url-less LMS/re-auth copy otherwise), a 404 to not-a-member, and anything
-  // else to a retryable generic. (Transient 5xx/429 are retried by the query, so
-  // they don't reach here as errors — and on any error the query's `data` is
-  // undefined, so the pending auto-accept below is only reachable from a
-  // successful read.)
+  // Initial membership read failed. classifyMembershipError routes a 403 +
+  // X-GitHub-SSO to the SSO screen (authorize button when GitHub gave a URL,
+  // else url-less LMS/re-auth copy), a 404 to not-a-member, else a retryable
+  // generic. (Transient 5xx/429 are retried by the query, so on any error
+  // `data` is undefined and the pending auto-accept below stays unreachable.)
   if (orgMembershipError) {
     const info = classifyMembershipError(orgMembershipError, {
       org,
@@ -530,9 +525,9 @@ const AcceptAssignmentPage = () => {
     )
   }
 
-  // Render the inline accept+verify while the pending invitee is being made
-  // active: a cause-specific error (SSO / not-a-member / retryable) on failure,
-  // otherwise a spinner until the hook reports active.
+  // Inline accept+verify while the pending invitee is made active: a
+  // cause-specific error (SSO / not-a-member / retryable) on failure, else a
+  // spinner until the hook reports active.
   if (isPending && !membershipAccept.isActive) {
     if (membershipAccept.isError) {
       const info = classifyMembershipError(membershipAccept.error, {

--- a/web/src/pages/AssignmentIndexPage.tsx
+++ b/web/src/pages/AssignmentIndexPage.tsx
@@ -3,9 +3,9 @@ import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
 import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 
 // The bare assignment route has no view of its own: it forwards to the
-// role-appropriate landing. Teachers go to the submissions gradebook; students
-// go to their own submission results. We wait for the role to resolve so we
-// never bounce a teacher through the student page (or vice versa).
+// role-appropriate landing (teachers → submissions gradebook, students → their
+// own submission). Wait for the role to resolve so we never bounce a teacher
+// through the student page (or vice versa).
 const AssignmentIndexPage = () => {
   const { org, classroom, assignment } = useParams({ strict: false })
   const { showTeacherUi, roleResolved } = useCourseTeacherAccess(org)

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -25,7 +25,7 @@ import { isClassroomArchived } from "@/types/classroom"
 import { OrgRepos } from "./ClassesPage"
 
 // Split button: primary "Assignment" creates; the caret reveals "Reuse
-// assignment", which pulls one from another classroom into this one.
+// assignment", pulling one from another classroom into this one.
 const NewAssignmentButton = ({
   org,
   classroom,

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -57,13 +57,11 @@ const ClassCard = ({
   const canEdit = isTeacher && cl.name
   const archived = isClassroomArchived(classroomData ?? {})
 
-  // Defer rendering until the classroom's lifecycle is known, for every tab.
-  // We can't tell active from archived until classroomData loads, so painting a
-  // full card (or even a skeleton slot) under Active/All and then unmounting it
-  // when it resolves archived causes a grid relayout flash. Rendering nothing
-  // until resolved means each card appears exactly once, in its correct tab —
-  // never painted then self-unmounted. (The page already shows a top-level
-  // skeleton grid during the initial classes load.)
+  // Defer rendering until the classroom's lifecycle is known. We can't tell
+  // active from archived until classroomData loads, so painting a card under
+  // Active/All then unmounting it when it resolves archived causes a grid
+  // relayout flash. Rendering nothing until resolved means each card appears
+  // once, in its correct tab.
   if (!classroomData) return null
   if (filter === "active" && archived) return null
   if (filter === "archived" && !archived) return null
@@ -395,8 +393,8 @@ const ClassesPage = () => {
 
   const isMember = membership?.state === "active"
   // The org preflight (service token + policy audit) is an OWNER concern: a
-  // non-owner can't read the service-token secret, which would surface a false
-  // "failed" alert. Gate it on org ownership, not the broad teacher signal.
+  // non-owner can't read the service-token secret and would see a false
+  // "failed" alert. Gate on ownership, not the broad teacher signal.
   const isOwner = membership?.role === "admin"
   const [filter, setFilter] = useState<ClassFilter>("active")
 

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -54,16 +54,12 @@ const CreateAssignmentPage = () => {
       if (err instanceof GitHubAPIError) {
         switch (err.status) {
           case 409:
-            // conflict
             break
           case 404:
-            // not found
             break
           case 422:
-            // validation
             break
           default:
-            // unspecified
             break
         }
       } else {
@@ -80,8 +76,7 @@ const CreateAssignmentPage = () => {
           `${classroom ?? ""}/assignments.json`,
         ),
       })
-      // Track the publish-pages deploy this commit triggers, anchored on the
-      // commit SHA (head_sha on the runs API).
+      // Track the publish-pages deploy this commit triggers, anchored on SHA.
       if (org && result.newCommitSha) {
         register({
           org,
@@ -89,8 +84,8 @@ const CreateAssignmentPage = () => {
           anchor: { kind: "sha", sha: result.newCommitSha },
         })
       }
-      // Assignment created. If the template team grant failed, stay on the
-      // page to show the warning instead of navigating away.
+      // If the template team grant failed, stay on the page to show the warning
+      // instead of navigating away.
       if (result.templateGrantWarning) {
         setWarningMessage(result.templateGrantWarning)
         window.scrollTo({ top: 0, behavior: "smooth" })

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -45,16 +45,12 @@ const CreateClassroomPage = () => {
       if (err instanceof GitHubAPIError) {
         switch (err.status) {
           case 409:
-            // conflict
             break
           case 404:
-            // not found
             break
           case 422:
-            // validation
             break
           default:
-            // unspecified
             break
         }
       } else {
@@ -69,8 +65,7 @@ const CreateClassroomPage = () => {
       queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(org ?? "", "classroom50"),
       })
-      // Track the publish-pages deploy this commit triggers, anchored on the
-      // commit SHA (head_sha on the runs API).
+      // Track the publish-pages deploy this commit triggers, anchored on SHA.
       if (org && result.newCommitSha) {
         register({
           org,

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -38,10 +38,9 @@ const EditAssignmentFormStudent = ({
   const { user } = useGithubAuth()
   const { isLoading: loadingRepo, assignment: assignmentRepo } =
     useGetAssignmentRepo(org, classroom, assignment, user?.login)
-  // The group student is on this page post-accept, so the capability-URL
-  // secret (if the classroom is protected) lives in their repo's
-  // .classroom50.yaml — the source they can actually read (not the private
-  // classroom.json). Empty for an unprotected classroom -> plain path.
+  // Post-accept, so the capability-URL secret (protected classroom) lives in
+  // the student's repo .classroom50.yaml — the source they can read (not the
+  // private classroom.json). Empty for unprotected -> plain path.
   const { secret } = useDotClassroom50(org, assignmentRepo?.name ?? "")
   const { isLoading: loadingPublic, assignment: assignmentData } =
     useGetPublicAssignment(org, classroom, assignment, secret)
@@ -236,8 +235,8 @@ const EditAssignmentPage = () => {
                 window.scrollTo({ top: 0, behavior: "smooth" })
               }}
               onSuccess={(result) => {
-                // Surface a non-fatal template-grant warning inline if
-                // present; otherwise show the success banner.
+                // Surface a non-fatal template-grant warning inline; else show
+                // the success banner.
                 if (result?.templateGrantWarning) {
                   setEditWarning(result.templateGrantWarning)
                 } else {

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -64,8 +64,6 @@ const EditClassroomContent = ({
     onSuccess: (result) => {
       // Refresh the exact classroom.json query useGetClassroom reads (so a
       // renamed name/term updates in place), plus the classes-list listing.
-      // A bare rawFile("/") key matched no live query — useGetClassroom keys on
-      // jsonFile(org,"classroom50",`${classroom}/classroom.json`).
       queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(
           org ?? "",
@@ -77,7 +75,7 @@ const EditClassroomContent = ({
         queryKey: githubKeys.jsonFile(org ?? "", "classroom50"),
       })
       // A classroom.json write triggers a publish-pages deploy — surface it in
-      // the global activity banner, anchored on the commit SHA (head_sha).
+      // the global activity banner, anchored on the commit SHA.
       if (org && result?.newCommitSha) {
         register({
           org,
@@ -85,11 +83,10 @@ const EditClassroomContent = ({
           anchor: { kind: "sha", sha: result.newCommitSha },
         })
       }
-      // Plain-text message only: the toast surface (NotificationProvider) is
-      // mounted ABOVE the RouterProvider, so a TanStack <Link> here has no
-      // router context and throws on render, blanking the whole app (the throw
-      // escapes the route-level errorComponent). The settings already update in
-      // place via the invalidations above, so no navigation link is needed.
+      // Plain-text message only: NotificationProvider is mounted ABOVE the
+      // RouterProvider, so a TanStack <Link> here has no router context and
+      // throws on render, blanking the app. Settings update in place via the
+      // invalidations above, so no navigation link is needed.
       notify({
         tone: "success",
         durationMs: 5000,

--- a/web/src/pages/OnboardingPage.tsx
+++ b/web/src/pages/OnboardingPage.tsx
@@ -172,9 +172,8 @@ const AllSet = ({
   )
 }
 
-// Surface a "still checking…" hint plus a manual Retry once the loading state
-// has persisted this long, so a GitHub lag never strands the student on an
-// unbounded spinner.
+// Show a "still checking…" hint + manual Retry once loading persists this
+// long, so a GitHub lag never strands the student on an unbounded spinner.
 const SLOW_AFTER_MS = 10_000
 
 const OnboardingPage = () => {
@@ -182,8 +181,8 @@ const OnboardingPage = () => {
   useDocumentTitle(t("documentTitle.getStarted"))
   const { org, classroom } = useParams({ strict: false })
   const { user } = useGithubAuth()
-  // Where to send the student once they've become an active org member (set by
-  // the accept page). The route already validated it's a safe relative path.
+  // Where to send the student once they're an active org member (set by the
+  // accept page). The route already validated it's a safe relative path.
   const search = useSearch({ strict: false }) as { returnTo?: string }
   const returnTo =
     typeof search.returnTo === "string" ? search.returnTo : undefined
@@ -196,27 +195,26 @@ const OnboardingPage = () => {
     refetch: refetchMembership,
   } = useGetOwnOrgMembership(org)
 
-  // A 404 from GET /user/memberships/orgs/{org} is not a read *failure* — it is
-  // GitHub's authoritative "no membership record", i.e. the student was never
-  // invited. Treat it as "no membership" so we fall through to the calm
-  // notInvited screen, and reserve the error screen for genuine read failures
-  // (403 / SSO-gated / transient). The accept page keeps its own 404 handling;
-  // this remapping is scoped to /onboard.
+  // A 404 from GET /user/memberships/orgs/{org} isn't a read *failure* — it's
+  // GitHub's authoritative "no membership record" (student never invited).
+  // Treat it as "no membership" so we fall through to the calm notInvited
+  // screen, reserving the error screen for genuine read failures (403 / SSO /
+  // transient). This remapping is scoped to /onboard.
   const membershipReadError = isMembershipReadError(rawMembershipError)
 
   const hasMembership = Boolean(orgMembership)
   const alreadyActive = orgMembership?.state === "active"
 
-  // Fire the accept/verify only when a (pending) membership record exists, isn't
-  // already active, and the read didn't error. The hook owns fire-once semantics.
+  // Fire accept/verify only when a pending membership record exists, isn't
+  // active, and the read didn't error. The hook owns fire-once semantics.
   const shouldAccept = hasMembership && !alreadyActive && !membershipReadError
   const accept = useAcceptAndVerifyMembership({ org, enabled: shouldAccept })
 
   const active = alreadyActive || accept.isActive
 
-  // Precedence: a read error (or accept failure) takes priority over everything
-  // else so a stale "active" can't mask a failure; then active; then loading
-  // (initial read OR accept/verify in flight); then notInvited (no record).
+  // Precedence: a read error (or accept failure) beats everything so a stale
+  // "active" can't mask a failure; then active; then loading (initial read OR
+  // accept/verify in flight); then notInvited (no record).
   const state = deriveOnboardingState({
     loadingMembership,
     membershipReadError,
@@ -225,15 +223,15 @@ const OnboardingPage = () => {
     active,
   })
 
-  // A read error can't be recovered by re-running accept (the read failed before
-  // any pending record was seen), so refetch the membership query in that case;
-  // otherwise re-run the accept/verify.
+  // A read error can't be fixed by re-running accept (it failed before any
+  // pending record was seen), so refetch the membership query then; else re-run
+  // accept/verify.
   const retry = membershipReadError
     ? () => void refetchMembership()
     : accept.retry
 
-  // One-shot latch: history.push stacks entries, so fire once when membership
-  // first goes active rather than on every re-render.
+  // One-shot latch: fire once when membership first goes active, not on every
+  // re-render (history.push stacks entries).
   const navigatedRef = useRef(false)
   useEffect(() => {
     if (state === "active" && returnTo && !navigatedRef.current) {
@@ -308,7 +306,6 @@ const OnboardingPage = () => {
     )
   }
 
-  // active
   return (
     <AllSet
       org={org}

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -47,14 +47,13 @@ import {
 } from "@/pages/orgMembers/memberPresentation"
 import useGetClasses from "@/hooks/useGetClasses"
 
-// How long to wait before reconciling an optimistically-updated students.csv
-// cache with the authoritative GitHub read. GitHub's contents API lags a fresh
-// commit by a beat, so an immediate refetch would read the pre-commit file and
-// revert the optimistic change; this delay lets it catch up.
+// Delay before reconciling an optimistically-updated students.csv cache with
+// the authoritative GitHub read: the contents API lags a fresh commit, so an
+// immediate refetch reads the pre-commit file and reverts the optimistic change.
 const CSV_RECONCILE_DELAY_MS = 4000
 
-// Sentinel classroom-filter value for "members on no classroom roster". A real
-// classroom path can't collide with it (paths don't contain a leading colon).
+// Sentinel classroom-filter value for "members on no roster". A real classroom
+// path can't collide (paths don't contain a leading colon).
 const NO_CLASSROOM_FILTER = ":none:"
 
 const OrgMembersPage = () => {
@@ -86,11 +85,10 @@ const OrgMembersPage = () => {
   // on); "select all" targets the currently-filtered rows.
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  // Refresh after an org-level member removal (removeMemberFromOrg unenrolls the
-  // member from every classroom + removes org membership). Optimistically drop
-  // them from each affected classroom's CSV + team caches CONSISTENTLY (so no
-  // false "unprovisioned" flashes while the two reconcile), then reconcile with
-  // the server on a delay.
+  // Refresh after an org-level member removal (unenrolls from every classroom +
+  // removes org membership). Optimistically drop them from each affected
+  // classroom's CSV + team caches together (no false "unprovisioned" flash),
+  // then reconcile with the server on a delay.
   const refresh = (affected?: OrgMemberRow) => {
     if (!org) return
     queryClient.invalidateQueries({ queryKey: githubKeys.orgMembersAll(org) })
@@ -102,32 +100,29 @@ const OrgMembersPage = () => {
     }
   }
 
-  // Refresh after an org invite (no classroom membership changed — only the
-  // org-invite state). Just re-read the members + invite lists.
+  // Refresh after an org invite (only org-invite state changed). Just re-read
+  // the members + invite lists.
   const refreshInvite = () => {
     if (!org) return
     queryClient.invalidateQueries({ queryKey: githubKeys.orgMembersAll(org) })
     invalidateInviteQueries(queryClient, org)
   }
 
-  // The resolved GitHub team slug for a classroom (classroom.json.team.slug,
-  // else the classroom50-<classroom> heuristic). Must match the key
-  // useOrgMembersOverview reads the team cache under, or optimistic team-cache
-  // writes below would target a cache nobody reads (a name-collision classroom's
-  // real slug differs from the heuristic) and reintroduce the false
-  // "unprovisioned" flash the optimistic machinery exists to prevent.
+  // Resolved GitHub team slug for a classroom (classroom.json.team.slug, else
+  // the classroom50-<classroom> heuristic). Must match the key
+  // useOrgMembersOverview reads the team cache under, or optimistic writes below
+  // target a cache nobody reads (a name-collision classroom's real slug differs
+  // from the heuristic) and reintroduce the false "unprovisioned" flash.
   const teamSlugFor = (classroom: string) =>
     teamSlugByClassroom.get(classroom) ?? `classroom50-${classroom}`
 
-  // Invalidate the non-racy caches a roster write touches for one classroom:
-  // classroom.json (rarely changes) and, unless suppressed, the CSV. The
-  // team-members query is deliberately NOT invalidated here — it's handled by
-  // the optimistic seed + delayed reconcile in the bulk/remove paths, because
-  // invalidating the CSV and the team at different beats lets aggregateOrgMembers
-  // momentarily compare a fresh team against a stale CSV (or vice-versa) and
-  // flash a false "unprovisioned" state. `skipCsv` is set right after we've
-  // optimistically seeded the CSV (invalidating it would refetch the pre-commit
-  // file and revert the seed).
+  // Invalidate the non-racy caches a roster write touches: classroom.json and,
+  // unless suppressed, the CSV. The team-members query is deliberately NOT
+  // invalidated here — it's handled by the optimistic seed + delayed reconcile,
+  // because invalidating CSV and team at different beats lets aggregateOrgMembers
+  // compare a fresh team against a stale CSV and flash a false "unprovisioned"
+  // state. `skipCsv` is set after we've optimistically seeded the CSV
+  // (invalidating it would refetch the pre-commit file and revert the seed).
   const invalidateClassroom = (
     classroom: string,
     opts?: { skipCsv?: boolean },
@@ -152,10 +147,9 @@ const OrgMembersPage = () => {
   }
 
   // Optimistically drop members (by resolved id/login) from BOTH the target
-  // classroom's students.csv cache AND its team-members cache, in the same tick,
-  // so the two never momentarily disagree (which would flash a false
-  // "unprovisioned" state). teamSlug is the resolved slug (matches the cache the
-  // Members overview reads), so a collided-name classroom is updated correctly.
+  // classroom's students.csv AND its team-members cache, in the same tick, so
+  // the two never disagree (which would flash a false "unprovisioned" state).
+  // teamSlug is the resolved slug, so a collided-name classroom updates right.
   const optimisticRemove = (classroom: string, removed: OrgMemberRow[]) => {
     if (!org || removed.length === 0) return
     const ids = new Set(removed.map((r) => r.github_id?.trim()).filter(Boolean))
@@ -180,10 +174,9 @@ const OrgMembersPage = () => {
     )
   }
 
-  // Reconcile a classroom's CSV + team caches with the authoritative server
-  // once GitHub's APIs have caught up with the commit (both lag a beat). Done on
-  // one delayed tick so they refetch together and can't flash an inconsistent
-  // intermediate state.
+  // Reconcile a classroom's CSV + team caches with the server once GitHub's
+  // APIs have caught up with the commit (both lag). Done on one delayed tick so
+  // they refetch together and can't flash an inconsistent intermediate state.
   const scheduleClassroomReconcile = (classroom: string) => {
     if (!org) return
     window.setTimeout(() => {
@@ -201,8 +194,8 @@ const OrgMembersPage = () => {
   }
 
   // After a bulk add/remove: optimistically reflect the change in the CSV +
-  // team caches the row status derives from (keeping them consistent so no false
-  // "unprovisioned" flashes), then reconcile both with the server on a delay.
+  // team caches the row status derives from (kept consistent, no false
+  // "unprovisioned" flash), then reconcile both with the server on a delay.
   const handleBulkDone = (input: {
     classroom: string
     action: "add" | "remove"
@@ -233,8 +226,8 @@ const OrgMembersPage = () => {
         )
         return toAppend.length > 0 ? [...list, ...toAppend] : list
       })
-      // Seed the team cache too, so the member reads as "enrolled" (not
-      // "unprovisioned") immediately. buildTeamRoster/aggregate read id+login.
+      // Seed the team cache too, so the member reads as "enrolled" immediately.
+      // buildTeamRoster/aggregate read id+login.
       queryClient.setQueryData<GitHubUser[]>(
         githubKeys.teamMembers(org, teamSlugFor(classroom)),
         (current) => {
@@ -270,8 +263,8 @@ const OrgMembersPage = () => {
       optimisticRemove(classroom, removedRows)
     }
 
-    // Recompute the members list against the (now-consistently-seeded) caches,
-    // leaving the seeded CSV/team alone; reconcile both on a delay.
+    // Recompute members against the seeded caches, leaving them alone;
+    // reconcile both on a delay.
     queryClient.invalidateQueries({ queryKey: githubKeys.orgMembersAll(org) })
     invalidateInviteQueries(queryClient, org)
     invalidateClassroom(classroom, { skipCsv: true })
@@ -294,7 +287,6 @@ const OrgMembersPage = () => {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
     return rows.filter((row) => {
-      // Text search across username / name / email.
       if (
         q &&
         ![row.username, row.name, row.email].some((field) =>
@@ -332,18 +324,17 @@ const OrgMembersPage = () => {
     })
 
   // An org owner/admin: in the fetched admin-id set, or the signed-in account
-  // (always an owner here — the page is owner-gated — even if the admin list
+  // (always an owner here — page is owner-gated — even if the admin list
   // couldn't be read).
   const isOwner = (row: OrgMemberRow) =>
     (Boolean(row.github_id) && ownerIds.has(row.github_id)) || isSelf(row)
 
-  // The signed-in account (an org owner, since this page is owner-gated) can't
-  // be bulk-added/removed — a row is selectable only when it isn't self.
+  // The signed-in owner can't be bulk-added/removed — a row is selectable only
+  // when it isn't self.
   const isSelectable = (row: OrgMemberRow) => !isSelf(row)
 
   // Rows backing the current selection, across the full set (a selected row
-  // hidden by search is still acted on), with self always excluded so even a
-  // stale selection can't target the signed-in owner.
+  // hidden by search is still acted on), self always excluded.
   const selectedRows = useMemo(
     () => resolveSelectedRows(rows, selectedKeys, isSelectable),
     // isSelf/isSelectable depend on viewer; recompute when it changes.
@@ -355,7 +346,7 @@ const OrgMembersPage = () => {
     setSelectedKeys((prev) => toggleRow(prev, key))
 
   // Select-all targets the currently-filtered SELECTABLE rows (self excluded),
-  // without disturbing any selected rows outside the current filter.
+  // without disturbing selected rows outside the current filter.
   const selectableFiltered = useMemo(
     () => selectableRows(filtered, isSelectable),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -32,12 +32,12 @@ const DEFAULT_EXPIRY_DAYS = 120
 const MIN_EXPIRY_DAYS = 1
 
 // GitHub rejects a fine-grained PAT *name* over 40 chars, so the prefill must
-// fit. We don't interpolate the org (most slugs overflow it) — the prefilled
-// `target_name` and description identify the org instead.
+// fit. We don't interpolate the org (most slugs overflow) — the prefilled
+// target_name and description identify the org instead.
 const GITHUB_TOKEN_NAME_MAX = 40
 
-// Guarded at module load so a future edit that overflows the 40-char limit
-// fails fast in dev/CI instead of shipping a name GitHub's form rejects.
+// Guarded at module load so a future edit overflowing the 40-char limit fails
+// fast in dev/CI instead of shipping a name GitHub's form rejects.
 const SERVICE_TOKEN_NAME = "Classroom 50 Actions Token"
 if (SERVICE_TOKEN_NAME.length > GITHUB_TOKEN_NAME_MAX) {
   throw new Error(
@@ -46,10 +46,9 @@ if (SERVICE_TOKEN_NAME.length > GITHUB_TOKEN_NAME_MAX) {
   )
 }
 
-// GitHub caps a token at one calendar year, so the max day count is 366 when that
-// window spans a leap day and 365 otherwise. `from` is a proxy for the token's
-// start (GitHub's clock actually starts at "Generate"); pass a real start date
-// here if we ever add a picker.
+// GitHub caps a token at one calendar year, so max days is 366 across a leap
+// day, else 365. `from` proxies the token's start (GitHub's clock starts at
+// "Generate"); pass a real start date here if we ever add a picker.
 function maxExpiryDays(from: Date): number {
   const oneYearOut = new Date(from)
   oneYearOut.setFullYear(oneYearOut.getFullYear() + 1)
@@ -57,8 +56,8 @@ function maxExpiryDays(from: Date): number {
   return Math.round((oneYearOut.getTime() - from.getTime()) / msPerDay)
 }
 
-// One descriptor per service-token status, keeping the banner's style, icon, and
-// titleKey in sync from a single source.
+// One descriptor per service-token status, keeping the banner's style, icon,
+// and titleKey in sync from a single source.
 const TOKEN_STATUS_BANNER = {
   present: {
     className: "border-success/30 bg-success/10",
@@ -157,10 +156,9 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
     useGetServiceTokenStatus(org ?? "")
   const tokenAlreadySet = tokenStatus?.status === "present"
 
-  // When a token is already set, collapse the configuration fields by default
-  // and let the user expand them. When the token is missing/unknown (an issue),
-  // they stay expanded. `manualOpen` lets the user override the default once
-  // they interact; until then it follows the token status.
+  // When a token is set, collapse the config fields by default; when
+  // missing/unknown they stay expanded. `manualOpen` lets the user override
+  // once they interact; until then it follows the token status.
   const [manualOpen, setManualOpen] = useState<boolean | null>(null)
   const configOpen = manualOpen ?? !tokenAlreadySet
 
@@ -187,10 +185,10 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
       expires_in: String(expiryValid ? parsedExpiry : DEFAULT_EXPIRY_DAYS),
       contents: "write",
       actions: "write",
-      // Organization-level Members: Read. Collection is team-driven — it
-      // lists the classroom team's members — which needs this org permission,
-      // and it is NOT implied by any repository scope. GitHub only honors the
-      // `members` prefill param when target_name is an org (it is, above).
+      // Org-level Members: Read. Collection is team-driven (it lists the
+      // classroom team's members), which needs this org permission and is NOT
+      // implied by any repo scope. GitHub only honors the `members` prefill
+      // when target_name is an org (it is, above).
       members: "read",
     }).toString()
 
@@ -336,8 +334,8 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
             rel="noreferrer"
             aria-disabled={!expiryValid}
             onClick={(e) => {
-              // aria-disabled is visual only; also block activation so an invalid
-              // expiry can't navigate to GitHub with the silent default.
+              // aria-disabled is visual only; also block activation so an
+              // invalid expiry can't navigate to GitHub with the silent default.
               if (!expiryValid) {
                 e.preventDefault()
                 expiryInputRef.current?.focus()

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -167,16 +167,13 @@ const OrgSetupPage = () => {
     useGetOrgPlanDetails(org)
   const [nextStep, setNextStep] = useState(false)
 
-  // 1 = init classroom50 repo etc
-  // 2 = PAT
-  // 3 = finished
+  // Stage: 1 = init classroom50 repo, 2 = PAT, 3 = finished.
   const [currentStage, setCurrentStage] = useState(1)
 
-  // Skeleton-overwrite confirmation, mirroring RerunOrgSetup. The wizard
-  // usually runs on a fresh repo (nothing pre-exists), but the /setup route has
-  // no re-entry guard, so a re-run on an already-set-up org can hit drifted,
-  // hand-edited skeleton files — prompt before overwriting those rather than
-  // clobbering them silently.
+  // Skeleton-overwrite confirmation, mirroring RerunOrgSetup. /setup has no
+  // re-entry guard, so a re-run on an already-set-up org can hit drifted,
+  // hand-edited skeleton files — prompt before overwriting rather than
+  // clobbering silently.
   const { overwritePaths, resolveOverwrite, confirmSkeletonOverwrite } =
     useSkeletonOverwriteConfirm()
 
@@ -199,8 +196,8 @@ const OrgSetupPage = () => {
       queryClient.invalidateQueries({
         queryKey: ["orgs"],
       })
-      // Don't advance the wizard if a prerequisite step failed; initClassroom50
-      // resolves with status "error" rather than throwing.
+      // Don't advance if a prerequisite step failed; initClassroom50 resolves
+      // with status "error" rather than throwing.
       if (data && data.status === "error") {
         return
       }

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -98,22 +98,21 @@ function OrgCard({
   const isAdmin = membership.role === "admin"
   const isActiveMember = membership.state === "active"
 
-  // Show a plan badge whenever GitHub actually returned a plan name (owners of
+  // Show a plan badge whenever GitHub returned a plan name (owners of
   // Team/Enterprise/Free orgs). Unknown (non-owner, no plan visible) stays
-  // badge-less — there's nothing accurate to show.
+  // badge-less.
   const showPlanBadge = classifyPlan(planName) !== "unknown"
 
-  // No-access-as-admin is the only role-derived badge we keep: it's a concrete
-  // "you can't read classroom50 here" state, not an inferred Teacher/Student
-  // label (which is just GitHub org-admin status and misleads students).
+  // No-access-as-admin is the only role-derived badge we keep: a concrete "you
+  // can't read classroom50 here" state, not an inferred Teacher/Student label
+  // (which is just GitHub org-admin status and misleads students).
   const showNoAccessBadge = noAccess && isAdmin
 
   // A student is an active member who can't read the classroom50 config repo
-  // (hence no_access). That's the normal student state, not a dead end: they
-  // can still open the org to reach their own assignment repos. A teacher
-  // (admin) opens any ready org; the service-token / policy preflight runs
-  // inside the org (ClassesPage), not here — checking every org in the list
-  // would fan out far too many GitHub API calls.
+  // (no_access). Normal, not a dead end: they can still open the org to reach
+  // their assignment repos. A teacher (admin) opens any ready org; the
+  // service-token/policy preflight runs inside the org (ClassesPage), not here
+  // — checking every org would fan out too many GitHub API calls.
   const canOpen = isAdmin ? isReady : isActiveMember
 
   return (
@@ -215,32 +214,31 @@ const OrgsPage = () => {
   const { data: orgs = [], isLoading, isFetching } = useGetOrgs()
   const [showUnsupported, setShowUnsupported] = useState(false)
 
-  // Orgs that are confirmed Classroom 50 orgs the user can use: a teacher's
-  // ready org, or a student's enrolled org (no_access but the public Pages
-  // index confirmed it).
+  // Confirmed Classroom 50 orgs the user can use: a teacher's ready org, or a
+  // student's enrolled org (no_access but the public Pages index confirmed it).
   const cl50Orgs = orgs?.filter(
     (summary) =>
       summary.classroom50.status === "ready" ||
       summary.classroom50.status === "no_access",
   )
-  // Orgs where the signed-in user is an admin who hasn't set up Classroom 50
-  // yet — offered in the "Set Up" section. Unrelated orgs (not_classroom50)
-  // and indeterminate ones (unknown) are filtered out entirely.
+  // Orgs where the user is an admin who hasn't set up Classroom 50 yet —
+  // offered in "Set Up". Unrelated (not_classroom50) and indeterminate
+  // (unknown) orgs are filtered out.
   const nonCl50Orgs = orgs?.filter(
     (summary) => summary.classroom50.status === "needs_setup",
   )
 
   // Plan is fetched only for the needs-setup subset (all admin-owned, so plan
-  // is visible) to drive the badge, the eligible-first sort, and the free-org
-  // filter — without paying the per-org fan-out on the whole list.
+  // is visible) to drive the badge, sort, and free-org filter — without the
+  // per-org fan-out on the whole list.
   const needsSetupLogins = useMemo(
     () => nonCl50Orgs.map((summary) => summary.org.login),
     [nonCl50Orgs],
   )
   const plans = useNeedsSetupPlans(needsSetupLogins)
 
-  // Bubble Team/Enterprise (supported) orgs to the top, then unknown, then
-  // free. Stable sort keeps GitHub's original order within each bucket.
+  // Bubble Team/Enterprise (supported) to top, then unknown, then free. Stable
+  // sort keeps GitHub's order within each bucket.
   const sortedNonCl50Orgs = useMemo(
     () =>
       [...nonCl50Orgs].sort((a, b) => {
@@ -252,8 +250,7 @@ const OrgsPage = () => {
   )
 
   // Free-plan orgs can't be set up, so hide them by default. Unknown plan
-  // (never happens for admins here, but guarded anyway) is always shown so a
-  // usable org is never hidden.
+  // (guarded anyway) is always shown so a usable org is never hidden.
   const visibleNonCl50Orgs = showUnsupported
     ? sortedNonCl50Orgs
     : sortedNonCl50Orgs.filter(

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -28,9 +28,8 @@ import usePagesAssignments from "@/hooks/usePagesAssignments"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { classroomPagesSegment } from "@/util/secret"
 
-// The Pages base for an org's classroom50 config repo. The `classroom50`
-// path segment is the fixed repo name, not the org name. Single-sourced
-// here so every row below derives from the same builder.
+// Pages base for an org's classroom50 config repo. `classroom50` is the fixed
+// repo name, not the org name. Single-sourced so every row derives from it.
 function pagesBaseUrl(org: string) {
   return `https://${org}.github.io/classroom50`
 }
@@ -46,8 +45,8 @@ type Resource = {
   // Why it's published / who reads it.
   description: string
   kind: ResourceKind
-  // Some artifacts are only present once a teacher configures them (e.g. a
-  // classroom default autograder), so a 404 is expected, not a problem.
+  // Some artifacts exist only once a teacher configures them (e.g. a classroom
+  // default autograder), so a 404 is expected, not a problem.
   optional?: boolean
 }
 
@@ -66,8 +65,8 @@ const KIND_BADGE: Record<
 }
 
 // Live reachability probe for a published URL. Anonymous GET (exactly how
-// students and the autograder fetch it) so the teacher sees what the public
-// sees. Bounded so a hung github.io host can't stall the page.
+// students and the autograder fetch it) so the teacher sees the public view.
+// Bounded so a hung github.io host can't stall the page.
 function useResourceStatus(url: string, enabled: boolean) {
   return useQuery({
     queryKey: ["published-resource", url],
@@ -89,12 +88,11 @@ function useResourceStatus(url: string, enabled: boolean) {
   })
 }
 
-// Reports whether `ref` has entered the viewport at least once. Used to defer
-// the per-resource reachability probe until the row is actually visible, so a
-// teacher with many classrooms/assignments doesn't fire dozens of simultaneous
-// anonymous github.io requests on mount (which edge rate-limits would surface
-// as false "Unreachable" badges). Once seen, it stays true so the status
-// doesn't flip back to "Checking" on scroll-out.
+// Whether `ref` has entered the viewport at least once. Defers the
+// reachability probe until the row is visible, so a teacher with many
+// classrooms/assignments doesn't fire dozens of simultaneous anonymous
+// github.io requests on mount (edge rate-limits would show as false
+// "Unreachable"). Stays true once seen, so it doesn't flip to "Checking".
 function useInView<T extends Element>(ref: RefObject<T | null>): boolean {
   // Fail open when IntersectionObserver is unavailable (jsdom/older browsers):
   // start visible so the probe still runs rather than hanging on "Checking".
@@ -145,9 +143,8 @@ function StatusBadge({ url }: { url: string }) {
   const inView = useInView(ref)
   const { data: status, isLoading } = useResourceStatus(url, inView)
 
-  // Before the row scrolls into view the probe is disabled (so status is
-  // undefined and isLoading is false); show the pending state rather than a
-  // premature "Unreachable".
+  // Before the row scrolls into view the probe is disabled (status undefined,
+  // isLoading false); show pending rather than a premature "Unreachable".
   if (!inView || isLoading) {
     return (
       <span
@@ -238,10 +235,10 @@ function ResourceRow({ resource }: { resource: Resource }) {
   )
 }
 
-// Per-classroom artifacts. Reads the published assignments.json to enumerate
-// the exact per-assignment bundles/shims so the list reflects reality, not a
-// guess. A classroom that hasn't published yet still shows its index/manifest
-// rows (which will read "Not published").
+// Per-classroom artifacts. Reads published assignments.json to enumerate the
+// exact per-assignment bundles/shims so the list reflects reality. A classroom
+// that hasn't published yet still shows its index/manifest rows (as "Not
+// published").
 function ClassroomResources({
   org,
   classroom,
@@ -258,9 +255,8 @@ function ClassroomResources({
   const { data: assignments } = usePagesAssignments(org, classroom, secret)
   const [open, setOpen] = useState(true)
 
-  // When the classroom is protected, everything for it is served under the
-  // capability-URL segment; otherwise the plain classroom path. Same segment
-  // builder the Pages URL helpers use, so the two can't drift.
+  // When protected, everything is served under the capability-URL segment; else
+  // the plain classroom path. Same segment builder the Pages URL helpers use.
   const classroomBase = `${base}/${classroomPagesSegment(classroom, secret)}`
 
   const resources = useMemo<Resource[]>(() => {
@@ -290,7 +286,7 @@ function ClassroomResources({
         kind: "data",
       })
       // Only assignments using a non-default named autograder publish a
-      // workflow shim; the default autograder uses the embedded shim instead.
+      // workflow shim; the default uses the embedded shim instead.
       if (a.autograder && a.autograder !== "default") {
         rows.push({
           url: `${classroomBase}/autograders/${a.autograder}.yaml`,
@@ -372,8 +368,8 @@ export const PublishedResourcesPane = ({ org }: { org: string }) => {
   const base = pagesBaseUrl(org)
   const { classes } = useGetClasses(org)
 
-  // Org-level resources are independent of any classroom: the public index
-  // and the two generic engine scripts served at the Pages site root.
+  // Org-level resources are classroom-independent: the public index and the two
+  // generic engine scripts served at the Pages site root.
   const orgResources: Resource[] = [
     {
       url: `${base}/classrooms-index.json`,

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -32,17 +32,16 @@ const StudentListContent = ({
   const client = useGitHubClient()
   const queryClient = useQueryClient()
   const updateRosterCache = useUpdateRosterCache(org, classroom)
-  // Count enrolled from the team roster (the same source the Enrolled section
-  // in EnrolledStudents uses), so header and section agree. Enrollment is
-  // team membership, not the CSV.
+  // Count enrolled from the team roster (same source as EnrolledStudents), so
+  // header and section agree. Enrollment is team membership, not the CSV.
   const {
     counts,
     isLoading: rosterLoading,
     isError: rosterError,
   } = useTeamRoster(org, classroom, students)
-  // Suppress the count while the enrolled source of truth is loading or errored
-  // (counts.enrolled reads 0 in both cases), so the header can't assert
-  // "0 enrolled" next to the error/retry banner EnrolledStudents shows.
+  // Suppress the count while the enrolled source of truth is loading/errored
+  // (counts.enrolled reads 0 in both), so the header can't assert "0 enrolled"
+  // next to the error/retry banner EnrolledStudents shows.
   const countReady = !rosterLoading && !rosterError
   const enrolledCount = counts.enrolled
   const className =

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -36,8 +36,8 @@ const releaseLabel = (release: GitHubRelease): string =>
 
 const ReleaseRow = ({ release }: { release: GitHubRelease }) => {
   const { t } = useTranslation()
-  // html_url comes from the GitHub API (always http(s)); guard anyway to keep
-  // the no-unsafe-href rule uniform across views.
+  // html_url is from the GitHub API (always http(s)); guard anyway to keep the
+  // no-unsafe-href rule uniform across views.
   const href = safeHttpUrl(release.html_url)
   const when = release.published_at ?? release.created_at
 
@@ -124,8 +124,8 @@ const SubmissionBody = ({
   } = useGetSubmissionReleases(org, classroom, assignment, user?.login)
   // Distinguish "never accepted" (no repo) from "accepted but not yet graded".
   // getRepo returns null only on a true 404; a 403/5xx throws, so read the repo
-  // query's error too — otherwise a transient/permission failure falls through
-  // to the "haven't accepted yet" CTA and misdirects the student.
+  // query's error too — else a transient/permission failure falls through to
+  // the "haven't accepted yet" CTA and misdirects the student.
   const {
     assignment: studentRepo,
     isLoading: repoLoading,
@@ -229,17 +229,17 @@ const StudentSubmissionPage = () => {
   useDocumentTitle(t("documentTitle.mySubmission"))
   const { org, classroom, assignment } = useParams({ strict: false })
   const { user } = useGithubAuth()
-  // Resolve the capability-URL secret (if the classroom is protected) from two
-  // sources, in order: (1) the student's own accepted repo's .classroom50.yaml —
-  // the only source a real student can read; (2) the private classroom.json —
-  // readable only by staff (incl. an instructor previewing as a student), so a
-  // not-yet-accepted preview still gets a working link. Empty when unprotected.
+  // Resolve the capability-URL secret (protected classrooms) from two sources
+  // in order: (1) the student's accepted repo's .classroom50.yaml — the only
+  // source a real student can read; (2) the private classroom.json — staff-only
+  // (incl. an instructor previewing as a student), so a not-yet-accepted
+  // preview still gets a working link. Empty when unprotected.
   const repoName =
     classroom && assignment && user?.login
       ? studentRepoName(classroom, assignment, user.login)
       : ""
   const { secret: repoSecret } = useDotClassroom50(org ?? "", repoName)
-  // classroom.json 404s for a real student (private) — fine, it just yields no
+  // classroom.json 404s for a real student (private) — fine, just yields no
   // secret; the repo secret covers the post-accept case.
   const { data: classroomMeta } = useGetClassroom(org, classroom)
   const secret = repoSecret || classroomMeta?.secret || undefined

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -67,7 +67,7 @@ import {
 } from "@/hooks/github/mutations"
 import { formatDueDateTime, formatRelativeToNow } from "@/util/formatDate"
 
-// Re-renders on an interval to keep relative timestamps fresh; returns nothing.
+// Re-renders on an interval to keep relative timestamps fresh.
 const usePeriodicRerender = (intervalMs = 30_000) => {
   const [, setNow] = useState(() => Date.now())
 
@@ -77,9 +77,8 @@ const usePeriodicRerender = (intervalMs = 30_000) => {
   }, [intervalMs])
 }
 
-// Shared presentational copy button: a primary outline button that swaps to a
-// success check while `copied`. The clipboard state itself is owned by the
-// caller (via useCopyToClipboard) so each button tracks its own copy.
+// Copy button that swaps to a success check while `copied`; clipboard state is
+// owned by the caller (useCopyToClipboard) so each button tracks its own copy.
 const CopyIconButton = ({
   copied,
   onCopy,
@@ -104,9 +103,7 @@ const CopyIconButton = ({
   </button>
 )
 
-// Shared chrome for the dashboard stat strip: a bordered card with an uppercase
-// label. The body (value, denominator, sub-links) varies per stat and is passed
-// as children.
+// Bordered stat card with an uppercase label; body varies per stat.
 const StatCard = ({
   label,
   children,
@@ -136,16 +133,13 @@ const SubmissionsPageContent = () => {
     dataUpdatedAt: scoresUpdatedAt,
   } = useGetScores(org, classroom)
   const { data: assignmentData } = useGetClassroomAssignments(org, classroom)
-  // Team-driven username source (Section 7): the classroom GitHub team is
-  // authoritative for who is enrolled; students.csv is joined by
-  // useTeamRoster only to enrich display (name/section/email). The dashboard
-  // (non-submitters, sections, accepted, gradebook) consumes a Student[], so
-  // map the enrolled team rows into that shape. Non-submitters = team members
-  // minus credited usernames (below).
+  // Team-driven usernames (Section 7): the classroom GitHub team is
+  // authoritative for enrollment; students.csv enriches display only. The
+  // dashboard consumes Student[], so map enrolled team rows into that shape.
   const { students: csvStudents } = useGetStudents(org, classroom)
-  // Surface the team-member fetch's error/loading (useTeamRoster exposes them
-  // deliberately): a transient or permission failure of the enrolled source of
-  // truth must render as an error+retry, not as an authoritative empty roster.
+  // Surface the team fetch's error/loading: a transient or permission failure
+  // of the enrolled source of truth must render as error+retry, not an
+  // authoritative empty roster.
   const {
     rows: teamRows,
     isError: rosterError,
@@ -155,14 +149,13 @@ const SubmissionsPageContent = () => {
     () => teamRows.filter((r) => r.state === "enrolled").map(rowToStudent),
     [teamRows],
   )
-  // Gate Regrade all / Collect now on an empty roster: dispatching a workflow
-  // with no students to act on is wasted effort. `show` is loading-aware (won't
-  // flash before the roster resolves), matching AssignmentsPage's usage.
+  // Gate Regrade all / Collect now on an empty roster: dispatching with no
+  // students is wasted effort. `show` is loading-aware (won't flash before the
+  // roster resolves).
   const emptyRoster = useEmptyRosterWarning(org, classroom)
-  // This is a teacher-only page, so reading the classroom's capability-URL
-  // secret from the (teacher-readable) classroom.json is fine. When the
-  // classroom is protected, the shared accept link must carry the key as
-  // `?k=<secret>` — otherwise students hit "assignment not found".
+  // Teacher-only page, so reading the classroom's capability-URL secret from
+  // classroom.json is fine. For a protected classroom the shared accept link
+  // must carry the key as `?k=<secret>`, else students hit "not found".
   const { data: classroomMeta } = useGetClassroom(org, classroom)
   const secret = classroomMeta?.secret
   const scoresLastUpdated =
@@ -173,7 +166,7 @@ const SubmissionsPageContent = () => {
   const assignmentSubmitUrl =
     `${window.location.origin}/${org}/${classroom}/assignments/${assignment}/accept` +
     (secret ? `?k=${secret}` : "")
-  // The CLI equivalent of the browser accept link, for students who prefer it.
+  // CLI equivalent of the browser accept link, for students who prefer it.
   const assignmentSubmitCli =
     `gh student accept ${org} ${classroom} ${assignment}` +
     (secret ? ` --key ${secret}` : "")
@@ -196,18 +189,14 @@ const SubmissionsPageContent = () => {
     [scoresData, assignment],
   )
 
-  // Count repos whose latest submission landed after the deadline. `late` is
-  // computed upstream (collect_scores.py) from the push time, not the grade
-  // time, so an on-time push graded after the deadline still counts as on time.
+  // Repos whose latest submission landed after the deadline. `late` is computed
+  // upstream (collect_scores.py) from push time, not grade time.
   const lateCount = scoresInfo.filter((row) => row.late).length
 
-  // Roster students with no submission. A student is "credited" if their login
-  // appears in any row's `usernames` (which is `member_usernames` for groups,
-  // else `[owner]`), so group teammates aren't falsely flagged. Group
-  // assignments don't surface an "X of Y" roster denominator, so we only
-  // compute non-submitters for individual assignments. Gated on scores having
-  // loaded (`scoresData` present): until then `scoresInfo` is empty, which
-  // would otherwise flag the entire roster as non-submitters mid-load.
+  // Roster students with no submission. "Credited" = login appears in any row's
+  // `usernames` (member_usernames for groups, else [owner]), so group teammates
+  // aren't falsely flagged. Individual assignments only. Gated on scores having
+  // loaded — until then scoresInfo is empty and would flag the whole roster.
   const scoresLoaded = scoresData !== undefined
   const nonSubmitters = useMemo(() => {
     if (isGroupAssignment || !scoresLoaded) return []
@@ -227,7 +216,7 @@ const SubmissionsPageContent = () => {
   const [sort, setSort] = useState<SubmissionSort>(DEFAULT_SORT)
 
   // Deterministic acceptance from the org repo list (see acceptedUsernames);
-  // individual assignments only, so the filter is gated on acceptedAvailable.
+  // individual assignments only, so gated on acceptedAvailable.
   const { data: orgRepos } = useGetOrgRepos(org ?? "")
   const acceptedSet = useMemo(
     () =>
@@ -236,7 +225,7 @@ const SubmissionsPageContent = () => {
   )
   const acceptedAvailable = !isGroupAssignment && orgRepos != null
 
-  // Section filtering: distinct sections for the dropdown, and a username ->
+  // Section filtering: distinct sections for the dropdown, plus a username ->
   // section lookup so submitted rows (which carry only logins) can be matched.
   const sections = useMemo(() => distinctSections(students), [students])
   const sectionByUsername = useMemo(
@@ -244,8 +233,8 @@ const SubmissionsPageContent = () => {
     [students],
   )
 
-  // With a section filter active, scope the roster and rows to that section so
-  // the stat cards describe the filtered view, not the whole class.
+  // With a section filter active, scope roster and rows to it so the stat cards
+  // describe the filtered view, not the whole class.
   const sectionFilter = filters.section
   const scopedStudents = useMemo(
     () =>
@@ -272,7 +261,7 @@ const SubmissionsPageContent = () => {
   )
 
   // Passing bar as a fraction of max, or null when the teacher didn't opt in
-  // (off by default) — then no Passing rollup/filter and neutral badges.
+  // (off by default) — then no Passing rollup/filter, neutral badges.
   const passThresholdPct = assignmentInfo?.pass_threshold
   const passingEnabled =
     typeof passThresholdPct === "number" && Number.isFinite(passThresholdPct)
@@ -284,25 +273,24 @@ const SubmissionsPageContent = () => {
     [scopedScores, scopedStudents, thresholdFraction],
   )
 
-  // Class average over numeric scores in the (section-scoped) set; null -> "N/A".
+  // Class average over numeric scores in the section-scoped set; null -> "N/A".
   const avgScore = useMemo(() => classAverage(scopedScores), [scopedScores])
 
-  // Roster-scoped accepted count (scoped to the active section to match the
-  // Accepted card's denominator).
+  // Accepted count scoped to the active section (matches the card's denominator).
   const acceptedCount = useMemo(
     () => acceptedRosterCount(scopedStudents, acceptedSet),
     [scopedStudents, acceptedSet],
   )
 
-  // Accepted-but-not-submitted count: roster students who accepted (repo
-  // exists) but have no submission row. Individual assignments only.
+  // Roster students who accepted (repo exists) but have no submission row.
+  // Individual assignments only.
   const acceptedNotSubmittedCount = acceptedAvailable
     ? scopedNonSubmitters.filter((s) => hasAccepted(s.username, acceptedSet))
         .length
     : 0
 
-  // One-click stat shortcuts: jump straight to the students a sub-label calls
-  // out. Reset the other axes so the surfaced set matches the label exactly.
+  // One-click stat shortcuts: jump to the students a sub-label calls out. Reset
+  // the other axes so the surfaced set matches the label exactly.
   const showFailing = () =>
     setFilters({ ...DEFAULT_FILTERS, passing: "failing" })
   const showAcceptedNotSubmitted = () =>
@@ -312,8 +300,8 @@ const SubmissionsPageContent = () => {
       submission: "not-submitted",
     })
 
-  // Rows actually rendered. When acceptance data isn't loaded yet, neutralize
-  // the accepted axis so a transient empty repo list can't flip the visible set.
+  // Rows actually rendered. When acceptance data isn't loaded, neutralize the
+  // accepted axis so a transient empty repo list can't flip the visible set.
   const effectiveFilters = useMemo(
     () =>
       acceptedAvailable ? filters : { ...filters, accepted: "all" as const },
@@ -355,11 +343,11 @@ const SubmissionsPageContent = () => {
   const collectScores = useTriggerScoreCollection(org)
   const regradeAll = useTriggerRegrade({ org, classroom, assignment })
   // `anyRegrading` covers the whole-assignment regrade AND every per-row
-  // regrade (shared via the page coordinator), so collect/regrade controls
-  // disable while any regrade is in flight — not just the assignment-wide one.
+  // regrade (via the page coordinator), so collect/regrade controls disable
+  // while any regrade is in flight.
   const regrading = regradeAll.anyRegrading
-  // Whether the assignment-wide "Regrade all" specifically is mid-dispatch, for
-  // its own spinner/label (distinct from the page-wide `regrading` gate).
+  // Whether "Regrade all" specifically is mid-dispatch, for its own
+  // spinner/label (distinct from the page-wide `regrading` gate).
   const regradeAllActive =
     regradeAll.phase === "dispatching" || regradeAll.phase === "running"
   const { data: lastRun, refetch: refetchLastRun } =
@@ -369,10 +357,10 @@ const SubmissionsPageContent = () => {
   const collecting =
     collectScores.phase === "dispatching" || collectScores.phase === "running"
 
-  // Which action the single "View …" link points at and which status strip
-  // (if any) shows. Running takes precedence; otherwise the most recently
-  // finished action; else null (both idle → link defaults to collect). Derived
-  // fresh every render so the link can never get "stuck" on a stale action.
+  // Which action the single "View …" link points at and which status strip (if
+  // any) shows. Running takes precedence; else most recently finished; else
+  // null. Derived fresh every render so the link never gets stuck on a stale
+  // action.
   const activeAction: "collect" | "regrade" | null = (() => {
     if (collecting) return "collect"
     if (regrading) return "regrade"
@@ -399,7 +387,7 @@ const SubmissionsPageContent = () => {
       ? formatRelativeToNow(new Date(lastRun.created_at))
       : null
 
-  // Refresh scores and the last-run timestamp once a manual collection finishes.
+  // Refresh scores + last-run timestamp once a manual collection finishes.
   useEffect(() => {
     if (collectScores.phase === "completed") {
       refetchScores()
@@ -427,8 +415,8 @@ const SubmissionsPageContent = () => {
         }),
       )
 
-    // Append non-submitters so the exported gradebook covers the whole roster.
-    // Scored 0 with blank submission fields; pinned after submitters.
+    // Append non-submitters so the exported gradebook covers the whole roster:
+    // scored 0, blank submission fields, pinned after submitters.
     const nonSubmittedRows = nonSubmitters.map((student) => ({
       usernames: student.username,
       score: 0,
@@ -538,8 +526,8 @@ const SubmissionsPageContent = () => {
             </div>
           </div>
           <div className="mb-4 rounded-box border border-info/20 bg-info/5">
-            {/* Compact action bar: standing note on the left, the two actions
-                + a single contextual View link on the right. */}
+            {/* Action bar: standing note left, the two actions + a single
+                contextual View link right. */}
             <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-start gap-3">
                 <Info
@@ -627,7 +615,7 @@ const SubmissionsPageContent = () => {
               </div>
             </div>
 
-            {/* Status strip — only when an action is active or recently
+            {/* Status strip — only while an action is active or recently
                 finished. Color + copy reflect that one action. */}
             {activeAction === "collect" && collectScores.phase !== "idle" && (
               <div
@@ -956,10 +944,9 @@ const SubmissionsPageContent = () => {
   )
 }
 
-// The teacher gradebook. Students who land here directly (e.g. an old link)
-// are redirected to their own submission view; we wait for the role to resolve
-// so a real teacher never bounces. Gating here (before mounting the content)
-// also avoids firing the teacher-only score/roster reads for a student.
+// The teacher gradebook. Students who land here directly (e.g. an old link) are
+// redirected to their own submission view; we wait for the role to resolve so a
+// real teacher never bounces, and avoid firing teacher-only reads for a student.
 const SubmissionsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.submissions"))

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -186,7 +186,6 @@ const SubmissionsPageContent = () => {
     1500,
   )
 
-  // Re-render every 30s so the relative "last collected"/"last updated" labels stay fresh.
   usePeriodicRerender()
   const assignmentInfo = assignmentData?.assignments.find(
     (a) => a.slug === assignment,

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -164,8 +164,8 @@ const AssignmentsTable = ({
   assignments?: Assignment[]
   students?: Student[]
   loading?: boolean
-  // When the classroom is archived, hide the per-row mutating actions
-  // (edit / reuse / delete) — viewing stays available.
+  // When archived, hide per-row mutating actions (edit/reuse/delete); viewing
+  // stays available.
   archived?: boolean
 }) => {
   const { t } = useTranslation()
@@ -276,7 +276,7 @@ const AssignmentsTable = ({
                       scoresData?.submissions?.[assignment.slug]?.length || 0
 
                     // Group assignments submit per-repo, not per-student, so a
-                    // roster-size denominator is meaningless — show the count.
+                    // roster denominator is meaningless — show the count.
                     if (assignment.mode === "group") {
                       return (
                         <span className="whitespace-nowrap">

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -33,8 +33,8 @@ const FieldError = ({ error, id }: { error?: string; id?: string }) =>
     </p>
   ) : null
 
-// Every draft field that can carry a validation error; stale errors on
-// these are cleared whenever the test re-validates.
+// Draft fields that can carry a validation error; stale errors are cleared on
+// each re-validation.
 const VALIDATED_FIELDS = [
   "name",
   "run",
@@ -63,9 +63,8 @@ const AutogradingTestModal = ({
   const titleId = useId()
   if (index === null) return null
 
-  // Validate this test now (the form-level validator only runs on the
-  // page's submit) and surface per-field errors. Returns whether the
-  // test is valid; "Done" keeps the modal open until it is.
+  // Validate this test now (form-level validator only runs on page submit) and
+  // surface per-field errors. Returns valid?; "Done" waits until valid.
   const validateAndShowErrors = () => {
     const drafts: AssignmentTestDraft[] = form.state.values.tests
     const otherNames = drafts
@@ -78,9 +77,8 @@ const AutogradingTestModal = ({
       const key = `tests[${index}].${fieldName}` as Parameters<
         typeof form.getFieldMeta
       >[0]
-      // Fields that never mounted (e.g. exit code on an io test, or the
-      // not-yet-built fixture-file inputs) have no meta to update — and
-      // nowhere to display an error anyway.
+      // Fields that never mounted (e.g. exit code on an io test, or unbuilt
+      // fixture-file inputs) have no meta and nowhere to show an error.
       if (!form.getFieldMeta(key)) continue
       form.setFieldMeta(key, (meta) => ({
         ...meta,
@@ -102,10 +100,9 @@ const AutogradingTestModal = ({
       aria-labelledby={titleId}
       onClose={onClose}
       onKeyDown={(e) => {
-        // Enter inside a modal input would implicitly submit the
-        // surrounding create-assignment form (this dialog renders
-        // inside it). Repurpose it as "Done"; textareas keep Enter
-        // for newlines.
+        // Enter inside a modal input would implicitly submit the surrounding
+        // create-assignment form (this dialog renders inside it). Repurpose as
+        // "Done"; textareas keep Enter for newlines.
         if (
           e.key === "Enter" &&
           e.target instanceof HTMLElement &&

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -72,10 +72,9 @@ export type CreateAssignmentFormValues = {
   tests: AssignmentTestDraft[]
 }
 
-// The concrete form instance type for this form's values, shared with child
-// panes (AutogradingTestsPane, FormErrors) so their `form` prop is fully typed
-// without re-stating useForm's many (invariant) generics. Derived from the
-// actual hook below so the validator generics always match the real form.
+// Concrete form-instance type shared with child panes (AutogradingTestsPane,
+// FormErrors) so their `form` prop is typed without restating useForm's
+// generics. Derived from the hook below so the generics always match.
 export type AssignmentForm = ReturnType<typeof useAssignmentForm>
 
 const useAssignmentForm = (
@@ -112,7 +111,7 @@ const useAssignmentForm = (
         if (!value.name.trim()) {
           errors.name = t("assignments.form.validation.nameRequired")
         }
-        // edit mode does not rename, so the slug is only validated on create.
+        // Edit mode doesn't rename, so slug is only validated on create.
         if (!slugContext?.edit) {
           const slug = slugify(value.slug)
           if (!slug) {
@@ -123,7 +122,7 @@ const useAssignmentForm = (
             )
           ) {
             // Case-insensitive collision (slugs become repo path segments);
-            // the write path re-checks authoritatively (nextAvailableSlug).
+            // write path re-checks authoritatively (nextAvailableSlug).
             errors.slug = t("validation.assignmentSlugTaken", { slug })
           }
         }
@@ -137,17 +136,16 @@ const useAssignmentForm = (
             Number(value.max_group_size) < GROUP_SIZE_MIN ||
             Number(value.max_group_size) > GROUP_SIZE_MAX)
         ) {
-          // Mirror the buildAssignmentEntry guard: the CLI schema needs a whole
-          // number in [MIN, MAX] or assignments.json becomes unparseable.
+          // Mirror buildAssignmentEntry: CLI schema needs a whole number in
+          // [MIN, MAX] or assignments.json becomes unparseable.
           errors.max_group_size = t("validation.groupSizeRange", {
             min: GROUP_SIZE_MIN,
             max: GROUP_SIZE_MAX,
           })
         }
 
-        // Mirrors gh-teacher's write-time validation so a bad test is
-        // caught in the form, not by a failed commit (or worse, a file
-        // the CLI later refuses to parse).
+        // Mirror gh-teacher's write-time validation so a bad test is caught in
+        // the form, not by a failed commit or an unparseable file.
         Object.assign(errors, validateTestDrafts(value.tests))
 
         // Mirror the CLI's cap/shape rules so a bad value can't reach the file.
@@ -158,8 +156,8 @@ const useAssignmentForm = (
           errors.allowed_files = allowedFilesError
         }
 
-        // pass_threshold: only validated when the teacher enabled it. Integer
-        // percentage in [0, 100] (mirrors the CLI schema bounds).
+        // Only validated when the teacher enabled it. Integer percentage in
+        // [0, 100] (mirrors the CLI schema bounds).
         if (value.pass_threshold_enabled) {
           const threshold = Number(value.pass_threshold)
           if (
@@ -205,15 +203,14 @@ type CreateAssignmentFormProps = {
   onCancel?: () => void
   edit?: boolean
   loading?: boolean
-  // Render every field/button disabled (e.g. an archived classroom's assignment
-  // is viewable but read-only). A disabled <fieldset> natively disables all
-  // descendant controls, including the submit button.
+  // Render every field/button disabled (e.g. an archived classroom). A disabled
+  // <fieldset> natively disables all descendant controls, including submit.
   readOnly?: boolean
   // Org slug for verifying a runner label against the org's self-hosted
   // runners. When absent, verification never blocks.
   org?: string
-  // Classroom slug, used by the template pre-flight to check whether the
-  // classroom team already has read on an in-org private template.
+  // Classroom slug; template pre-flight uses it to check whether the classroom
+  // team already has read on an in-org private template.
   classroom?: string
   // Existing assignment slugs, for the create-mode uniqueness check.
   takenSlugs?: string[]
@@ -232,16 +229,16 @@ const FormErrors = ({ form }: { form: AssignmentForm }) => (
   </form.Subscribe>
 )
 
-// Free-form runner input with advisory, non-blocking verification: it
-// annotates the value but never rewrites or clears what the teacher typed.
+// Free-form runner input with advisory, non-blocking verification: annotates
+// the value but never rewrites or clears what the teacher typed.
 const RunnerField = ({ field, org }: { field: StringField; org?: string }) => {
   const { t } = useTranslation()
   const client = useOptionalGitHubClient()
   const rawValue = field.state.value
   const debouncedValue = useDebouncedValue(rawValue.trim(), 400)
 
-  // Hit the org runners API only for a well-shaped label not already
-  // recognized client-side; everything else needs no network call.
+  // Hit the org runners API only for a well-shaped label not already recognized
+  // client-side; everything else needs no network call.
   const needsOrgLookup = Boolean(
     client &&
     org &&
@@ -442,17 +439,17 @@ const utcIsoToDatetimeLocalValue = (value?: string) => {
   return toDatetimeLocalValue(date)
 }
 
-// Map a stored classroom50/assignments/v1 entry back into the form's value
-// shape: template as `owner/repo`, due as datetime-local, runtime split into
-// runner/container fields, and the leading 0-point "setup" run-test lifted
-// back into the setup command.
+// Map a stored classroom50/assignments/v1 entry back into form values:
+// template as `owner/repo`, due as datetime-local, runtime split into
+// runner/container fields, and the leading 0-point "setup" test lifted back
+// into the setup command.
 export const assignmentToFormValues = (
   assignment: Assignment,
 ): Partial<CreateAssignmentFormValues> => {
   const allTests = (assignment.tests ?? []).map(testToDraft)
-  // Lift the setup command only from a leading setup test (isSetupTest), never
-  // a later or graded one, so a round-trip can't swallow a user-authored test.
-  // (Reserved at write time; this also guards pre-reservation assignments.)
+  // Lift the setup command only from a leading setup test (isSetupTest), never a
+  // later or graded one, so a round-trip can't swallow a user-authored test.
+  // (Also guards pre-reservation assignments.)
   const head = allTests[0]
   const setupIsLeading = head !== undefined && isSetupTest(head)
   const setupCommand = setupIsLeading ? head.run : ""
@@ -497,8 +494,8 @@ const CreateAssignmentForm = ({
     takenSlugs,
     edit,
   })
-  // Auto-prefill the slug from the name until the teacher edits the slug
-  // directly, so a deliberate slug isn't clobbered by later name edits.
+  // Auto-prefill slug from name until the teacher edits it directly, so a
+  // deliberate slug isn't clobbered by later name edits.
   const [slugTouched, setSlugTouched] = useState(false)
   const tzShort = new Intl.DateTimeFormat(undefined, {
     timeZoneName: "short",
@@ -514,7 +511,7 @@ const CreateAssignmentForm = ({
         form.handleSubmit()
       }}
     >
-      {/* readOnly disables every descendant control at once. */}
+      {/* readOnly disables every descendant control. */}
       <fieldset disabled={readOnly} className="m-0 min-w-0 border-0 p-0">
         <div className="card bg-base-100 w-full shadow-sm mb-6">
           <div className="card-body">

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -29,8 +29,8 @@ import {
 } from "./templateNoteView"
 
 // Advisory, non-blocking pre-flight for the Template Repository field: checks
-// the OAuth token can reach the typed repo and annotates the field without
-// rewriting it. Mirrors RunnerField.
+// the OAuth token can reach the typed repo and annotates without rewriting it.
+// Mirrors RunnerField.
 export const TemplateField = ({
   field,
   org,
@@ -61,7 +61,7 @@ export const TemplateField = ({
     retry: false,
   })
 
-  // A cleared field has nothing to verify, so don't show "Checking…" while the
+  // Cleared field has nothing to verify — don't show "Checking…" while the
   // debounce drains.
   const pending =
     enabled &&
@@ -156,7 +156,7 @@ const TemplateVerificationNote = ({
   pending: boolean
   org?: string
   // For an in-org private template: true if the classroom team already has
-  // read, false if it'll be granted on create, undefined if N/A or unresolved.
+  // read, false if granted on create, undefined if N/A or unresolved.
   teamHasAccess?: boolean
 }) => {
   const { t } = useTranslation()
@@ -176,8 +176,8 @@ const TemplateVerificationNote = ({
   switch (verification.kind) {
     case "ok": {
       // Students can't read an in-org private template directly; the classroom
-      // team grant is what lets them. Show whether that grant already exists or
-      // will be added on create (see tryGrantTeamTemplateRead).
+      // team grant is what lets them. Show whether it already exists or will be
+      // added on create (see tryGrantTeamTemplateRead).
       if (verification.inOrg && verification.visibility === "private") {
         if (teamHasAccess === true) {
           return (
@@ -231,16 +231,14 @@ const TemplateVerificationNote = ({
 
     case "private-fork": {
       const view = templateForkNoteView(verification)
-      // labelKey/tone/suffixKey all come from templateForkNoteView (single
-      // source of truth, tested). All three label keys take the same
-      // interpolation set; t() ignores `parent` for the no-parent key.
+      // tone/labelKey/suffixKey come from templateForkNoteView (tested source of
+      // truth). All three label keys share this interpolation set; t() ignores
+      // `parent` for the no-parent key.
       const label = t(view.labelKey, {
         owner: verification.owner,
         repo: verification.repo,
         parent: verification.parent,
       })
-      // In-org parent is usually reachable (advisory, amber); a cross-org or
-      // unknown parent is likely to fail at generate (error, red).
       return (
         <Note
           tone={view.tone}
@@ -348,8 +346,8 @@ const TemplateVerificationNote = ({
   }
 }
 
-// Wraps InlineNote with an optional OAuth-policy link for the cases where an
-// org owner must approve the app.
+// Wraps InlineNote with an optional OAuth-policy link for cases where an org
+// owner must approve the app.
 const Note = ({
   tone,
   icon,

--- a/web/src/pages/assignments/formFieldHelpers.ts
+++ b/web/src/pages/assignments/formFieldHelpers.ts
@@ -19,8 +19,7 @@ export type StringField = {
   handleChange: (value: string) => void
 }
 
-// onBlur handler that normalizes the value (default: trim), writing back
-// only on change.
+// onBlur handler that normalizes (default: trim), writing back only on change.
 export const normalizeOnBlur = (
   field: StringField,
   normalize: (value: string) => string = (value) => value.trim(),

--- a/web/src/pages/assignments/templateNoteView.test.ts
+++ b/web/src/pages/assignments/templateNoteView.test.ts
@@ -39,8 +39,7 @@ describe("templateForkNoteView", () => {
     const view = templateForkNoteView({ ...base, parentInOrg: false })
     expect(view.tone).toBe("error")
     expect(view.labelKey).toBe("assignments.template.privateForkNoParent_1")
-    // No dedicated privateForkNoParent_2 key — unknown upstream is the
-    // higher-risk cross-org case and reuses that suffix.
+    // Unknown upstream is the higher-risk cross-org case and reuses that suffix.
     expect(view.suffixKey).toBe("assignments.template.privateForkCrossOrg_2")
   })
 })

--- a/web/src/pages/assignments/templateNoteView.ts
+++ b/web/src/pages/assignments/templateNoteView.ts
@@ -1,17 +1,13 @@
 import type { TemplateAccessVerification } from "@/api/mutations/assignments"
 
-// Pure view-model helpers for the two template-access verdicts whose rendering
-// branches on data (tone + which i18n key). Extracted from TemplateField's
-// TemplateVerificationNote so the tone/key decision is a single source of truth
-// and unit-testable without a DOM (mirrors classifyMembershipError). The JSX
-// only interpolates the returned keys and picks the Note tone.
+// Pure view-model for the two data-branched template verdicts (tone + i18n key),
+// so the decision is one testable source of truth (mirrors classifyMembershipError).
 
 export type NoteTone = "warning" | "error"
 
-// A private fork used as a template. In-org parent is usually reachable
-// (advisory amber); a cross-org or unknown parent is likely to fail at generate
-// (error red). The no-parent case reuses the cross-org suffix (no dedicated
-// privateForkNoParent_2 key) because an unknown upstream is treated as the
+// Private fork used as a template. In-org parent is usually reachable (advisory
+// amber); cross-org or unknown parent likely fails at generate (error red). The
+// no-parent case reuses the cross-org suffix, treating unknown upstream as the
 // higher-risk cross-org case.
 export function templateForkNoteView(
   verification: Extract<TemplateAccessVerification, { kind: "private-fork" }>,
@@ -34,9 +30,9 @@ export function templateForkNoteView(
       }
 }
 
-// A 403 read denial. A real token scope gap points the user at re-authorizing
+// A 403 read denial. A real token scope gap points at re-authorizing
 // (restrictedScope); any other 403 uses the org-restriction copy (restricted).
-// GitHub's actual message + status is always surfaced alongside via githubSaid.
+// GitHub's own message + status is surfaced alongside via githubSaid.
 export function templateRestrictedNoteView(
   verification: Extract<TemplateAccessVerification, { kind: "restricted" }>,
 ): { messageKey: string } {

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -23,17 +23,16 @@ import { GitHubAPIError } from "@/hooks/github/errors"
 import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
 import type { GitHubUser } from "@/hooks/github/types"
 
-// i18n key for each role's singular display label. Kept as a map (not inline
-// t() calls) so it stays usable in module scope; components translate it via
-// t(ROLE_LABEL_KEY[role]).
+// i18n key for each role's singular label. A map (not inline t()) so it works in
+// module scope; components translate via t(ROLE_LABEL_KEY[role]).
 const ROLE_LABEL_KEY: Record<StaffRole, string> = {
   instructor: "classes.staff.roleInstructor",
   ta: "classes.staff.roleTa",
 }
 
 // Manage a classroom's staff (instructor / TA), backed by the per-classroom
-// GitHub teams `classroom50-<classroom>-<role>`. The page already gates the
-// route; the actions assume instructor/owner.
+// GitHub teams `classroom50-<classroom>-<role>`. The route already gates; the
+// actions assume instructor/owner.
 const ClassroomStaffSection = ({
   org,
   classroom,
@@ -85,9 +84,9 @@ const ClassroomStaffSection = ({
   )
 }
 
-// Add a GitHub user to a role team. Ensures the team exists first (the
-// "preflight" guarantee: a classroom missing a staff team self-heals here) and
-// grants it config-repo write, then adds the user.
+// Add a GitHub user to a role team. Ensures the team exists first (self-healing
+// preflight: a classroom missing a staff team is created here) and grants it
+// config-repo write, then adds the user.
 const AddStaff = ({
   org,
   classroom,
@@ -119,10 +118,9 @@ const AddStaff = ({
         input.role,
       )
       await grantTeamConfigRepoWrite(client, org, team.slug)
-      // GitHub auto-adds the team CREATOR as a maintainer. If THIS action just
-      // created the team, the acting user got auto-added — remove them unless
-      // they're the intended target, so adding a TA doesn't make the instructor
-      // a TA too.
+      // GitHub auto-adds the team CREATOR as maintainer. If this action just
+      // created the team, remove the acting user unless they're the target — so
+      // adding a TA doesn't also make the instructor a TA.
       if (
         team.created &&
         user?.login &&

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -15,10 +15,10 @@ export type CreateClassroomFormValues = {
   name: string
   slug: string
   term: string
-  // Opt-in: when true the classroom's published resources are served under
-  // an unguessable capability-URL secret path segment. Off by default.
+  // Opt-in: when true, published resources are served under an unguessable
+  // capability-URL secret path segment. Off by default.
   protectPages: boolean
-  // The capability-URL secret. Empty when protectPages is false; a generated
+  // Capability-URL secret. Empty when protectPages is false; a generated
   // (editable) value when true. Validated to `[a-z0-9]{4,64}` on submit.
   secret: string
 }
@@ -26,7 +26,7 @@ export type CreateClassroomFormValues = {
 type CreateClassroomFormProps = {
   defaultValues?: Partial<CreateClassroomFormValues>
   // Returns the submit's settling promise (or void) so the form can await the
-  // real write and only latch its loading state on success.
+  // real write and latch its loading state only on success.
   onSubmit: (values: CreateClassroomFormValues) => void | Promise<unknown>
 }
 
@@ -63,8 +63,8 @@ const CreateClassroomForm = ({
           errors.slug = t("validation.classroomSlugTaken")
         }
 
-        // Only validate the secret when protection is enabled; a disabled
-        // toggle leaves it empty (unprotected, the default).
+        // Only validate the secret when protection is on; a disabled toggle
+        // leaves it empty (unprotected, the default).
         if (value.protectPages && !isValidSecret(value.secret.trim())) {
           errors.secret = t("classes.form.secretInvalid", {
             description: SECRET_PATTERN_DESCRIPTION,
@@ -79,9 +79,9 @@ const CreateClassroomForm = ({
       },
     },
     onSubmit: async ({ value }) => {
-      // Latch `submitted` only on success: a rejected create skips it (the
-      // page's mutation onError toasts), so the button re-enables for a retry
-      // instead of sticking on "Creating...".
+      // Latch `submitted` only on success: a rejected create skips it (page's
+      // mutation onError toasts), so the button re-enables for a retry instead
+      // of sticking on "Creating...".
       await onSubmit({
         name: value.name.trim(),
         slug: slugify(value.slug),
@@ -229,11 +229,10 @@ const CreateClassroomForm = ({
                   onChange={(e) => {
                     const on = e.target.checked
                     field.handleChange(on)
-                    // Generate a candidate the first time protection is
-                    // enabled (and the field is empty) so the teacher sees a
-                    // ready-to-use key they can accept or replace. Turning it
-                    // off clears the secret so an unprotected classroom never
-                    // carries one.
+                    // Generate a candidate the first time protection is enabled
+                    // (and the field is empty) so the teacher sees a ready-to-use
+                    // key to accept or replace. Turning it off clears the secret
+                    // so an unprotected classroom never carries one.
                     if (on) {
                       if (!form.getFieldValue("secret")) {
                         form.setFieldValue(
@@ -320,8 +319,8 @@ const CreateClassroomForm = ({
             selector={(state) => [state.canSubmit, state.isSubmitting]}
           >
             {([canSubmit, isSubmitting]) => {
-              // Hold the loading state through the post-create navigation, so
-              // the button never reverts to a bare disabled state.
+              // Hold the loading state through post-create navigation so the
+              // button never reverts to a bare disabled state.
               const busy = isSubmitting || submitted
               return (
                 <button

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -89,9 +89,9 @@ const DeleteClassroomButton = ({
 }
 
 // Archive / unarchive toggles the classroom's `active` flag (false = archived)
-// via the conflict-retried edit, immediately (not through the Save form), and
-// surfaces the result as a toast. Archived classrooms drop out of the default
-// classes list and refuse new assignments/accepts.
+// via the conflict-retried edit, immediately (not through Save), toasting the
+// result. Archived classrooms drop out of the default list and refuse new
+// assignments/accepts.
 const ArchiveClassroomButton = ({
   org,
   classroom,
@@ -108,8 +108,8 @@ const ArchiveClassroomButton = ({
   const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
 
-  // A pure archive/unarchive write: editClassroom now preserves name/term when
-  // they're omitted, so we send only `active` — no refetch, no stale name/term.
+  // A pure archive/unarchive write: editClassroom preserves name/term when
+  // omitted, so we send only `active` — no refetch, no stale name/term.
   const archiveMutation = useMutation({
     mutationFn: (active: boolean) =>
       editClassroomWithConflictRetry(client, {
@@ -119,12 +119,11 @@ const ArchiveClassroomButton = ({
       }),
     onSuccess: (_result, active) => {
       // Optimistically flip the cached classroom.json `active` so the button,
-      // the read-only fieldset, and the badges update immediately — GitHub's
-      // contents API is read-after-write eventual, so we do NOT invalidate (and
-      // thus refetch) this exact classroom.json key: an immediate unpinned
-      // refetch can read the pre-write body and clobber the optimistic flip,
-      // reverting the UI until staleTime expires. The optimistic value stays
-      // authoritative and the normal staleTime refetch reconciles later.
+      // read-only fieldset, and badges update immediately. GitHub's contents API
+      // is read-after-write eventual, so we do NOT invalidate this exact key: an
+      // immediate refetch can read the pre-write body and clobber the optimistic
+      // flip. The optimistic value stays authoritative; the staleTime refetch
+      // reconciles later.
       const key = githubKeys.jsonFile(
         org,
         "classroom50",
@@ -135,8 +134,8 @@ const ArchiveClassroomButton = ({
         (prev: Record<string, unknown> | undefined) =>
           prev ? { ...prev, active } : prev,
       )
-      // Repartition the classes list (Active/Archived/All) — this is a
-      // different query than the per-classroom classroom.json above.
+      // Repartition the classes list (Active/Archived/All) — a different query
+      // than the per-classroom classroom.json above.
       queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(org, "classroom50"),
       })
@@ -243,8 +242,8 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
   const navigate = useNavigate()
   const { org, classroom } = useParams({ strict: false })
   const [submitted, setSubmitted] = useState(false)
-  // Archived = read-only: disable the settings fields + Save (the Archive /
-  // Delete header actions stay live). editClassroom enforces this server-side.
+  // Archived = read-only: disable settings fields + Save (Archive/Delete header
+  // actions stay live). editClassroom enforces this server-side.
   const archived = isClassroomArchived(cl ?? {})
 
   const form = useForm({

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -23,8 +23,7 @@ type Phase = "idle" | "working" | "complete" | "error"
 type Progress = { processed: number; total: number; message: string }
 
 // A completed run of either action, normalized so the results modal renders one
-// shape. `sections` are labeled groups of per-row lines (added / skipped /
-// failed etc.).
+// shape. `sections` are labeled groups of per-row lines (added / skipped etc.).
 type ResultView = {
   headline: string
   sections: {
@@ -121,8 +120,8 @@ const buildRemoveResult = (
       })),
     })
   }
-  // Non-fatal side-effect warnings (team drop / invite cancel) — the roster
-  // removal itself still succeeded, so these are informational.
+  // Non-fatal side-effect warnings (team drop / invite cancel) — roster removal
+  // itself succeeded, so these are informational.
   if (res.warnings.length > 0) {
     sections.push({
       title: t("orgMembers.bulk.resultWarnings"),
@@ -167,13 +166,12 @@ const ResultSection = ({
   </div>
 )
 
-// The members table's header toolbar. It always shows the select-all checkbox +
-// a contextual label; once rows are selected it reveals the classroom picker +
-// Add/Remove/Clear actions inline (no separate floating bar, no layout shift —
-// the header is always present and only its right side fills in). Owns its own
-// run modal (progress -> results) and drives the bulk add/remove orchestrators.
-// On a successful run it calls onDone with the rows the server enrolled so the
-// page can optimistically seed its caches.
+// The members table's header toolbar: always shows select-all + a contextual
+// label; once rows are selected it reveals the classroom picker +
+// Add/Remove/Clear inline (no floating bar, no layout shift — only the right
+// side fills in). Owns its run modal (progress -> results) and drives the bulk
+// orchestrators. On success it calls onDone with the enrolled rows so the page
+// can optimistically seed caches.
 const BulkActionsBar = ({
   org,
   client,
@@ -201,10 +199,10 @@ const BulkActionsBar = ({
   onDone: (input: {
     classroom: string
     action: "add" | "remove"
-    // Rows the server actually enrolled (add only), for optimistic cache seeding.
+    // Rows the server actually enrolled (add only), for optimistic seeding.
     addedStudents: StudentCsvRow[]
     // Keys of the selection acted on (both actions), so the page can locate the
-    // affected members for optimistic cache updates.
+    // affected members for cache updates.
     affectedKeys: string[]
   }) => void
 }) => {
@@ -227,9 +225,9 @@ const BulkActionsBar = ({
 
   const hasSelection = selectedRows.length > 0
 
-  // The picker starts unset; until the teacher picks one, default to the first
-  // classroom. Derived (not synced via an effect) so there's no cascading
-  // render, and it stays correct if the classroom list arrives after mount.
+  // Picker starts unset; until the teacher picks one, default to the first
+  // classroom. Derived (not effect-synced) so there's no cascading render, and
+  // it stays correct if the classroom list arrives after mount.
   const effectiveClassroom =
     classroom || (classrooms.length > 0 ? classrooms[0].path : "")
 
@@ -422,10 +420,10 @@ const BulkActionsBar = ({
         })}
         confirmLabel={t("orgMembers.bulk.remove")}
         onConfirm={async () => {
-          // Close the confirm dialog first, then start the run on the next tick:
-          // two open <dialog showModal> at once is invalid (the second throws),
-          // so let the confirm dialog's close settle before run() opens the
-          // progress/results dialog. Not awaited — run() drives its own dialog.
+          // Close the confirm dialog first, then start the run next tick: two
+          // open <dialog showModal> at once is invalid (the second throws), so
+          // let the confirm close settle before run() opens the progress dialog.
+          // Not awaited — run() drives its own dialog.
           setConfirmingRemove(false)
           setTimeout(() => void run("remove"), 0)
         }}

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -22,11 +22,10 @@ import {
 import type { OrgMemberRow } from "@/util/orgMembers"
 
 // Centered modal showing one org member's details: identity, classification,
-// per-classroom access, and the member-level actions (invite an on-roster
-// non-member; remove an active member from the org). Replaces the former
-// right-side drawer. Driven by an `open` prop over a native <dialog> (matching
-// BulkActionsBar / ConfirmModal) so it gets focus-trap, Escape, and an inert
-// backdrop for free.
+// per-classroom access, and member-level actions (invite an on-roster
+// non-member; remove an active member). Driven by an `open` prop over a native
+// <dialog> (like BulkActionsBar / ConfirmModal) for free focus-trap, Escape, and
+// an inert backdrop.
 const MemberDetailModal = ({
   open,
   org,
@@ -40,15 +39,15 @@ const MemberDetailModal = ({
   open: boolean
   org: string
   // The member to show. Null is tolerated so the modal can stay mounted across
-  // open/close without the caller juggling conditional rendering.
+  // open/close without conditional rendering by the caller.
   row: OrgMemberRow | null
   isSelf: boolean
   isOwner: boolean
   onClose: () => void
   // Called after the member is removed from the org (refresh + optimistic drop).
   onRemoved: () => void
-  // Called after an on-roster non-member is invited to the org (refresh only —
-  // no classroom membership changed).
+  // Called after an on-roster non-member is invited (refresh only — no classroom
+  // membership changed).
   onInvited: () => void
 }) => {
   const { t } = useTranslation()
@@ -67,10 +66,9 @@ const MemberDetailModal = ({
     if (!open && dialog.open) dialog.close()
   }, [open])
 
-  // Close and reset the transient confirm/in-flight state in one place. Every
-  // close path (the X button, the backdrop, and Escape via onCancel) routes
-  // through here, so a reopened modal never shows a stale "confirm remove"
-  // panel — no reset-in-effect needed.
+  // Close and reset transient confirm/in-flight state in one place. Every close
+  // path (X, backdrop, Escape via onCancel) routes here, so a reopened modal
+  // never shows a stale "confirm remove" panel — no reset-in-effect needed.
   const handleClose = () => {
     if (working) return
     setConfirming(false)
@@ -79,14 +77,14 @@ const MemberDetailModal = ({
   }
 
   if (!row) {
-    // Keep the <dialog> element mounted (so the open/close effect has a target)
-    // but render no body when there's no member selected.
+    // Keep the <dialog> mounted (so the open/close effect has a target) but
+    // render no body with no member selected.
     return <dialog ref={dialogRef} className="modal" aria-hidden />
   }
 
   const label = row.username || row.email
-  // Only non-archived classrooms are actually unenrolled (archived ones can't
-  // be; removeMemberFromOrg skips them), so the confirm copy counts those.
+  // Only non-archived classrooms are unenrolled (removeMemberFromOrg skips
+  // archived), so the confirm copy counts those.
   const activeClassrooms = row.classrooms.filter((c) => !c.archived)
 
   const handleInvite = async () => {

--- a/web/src/pages/orgMembers/bulkAddToClassroom.test.ts
+++ b/web/src/pages/orgMembers/bulkAddToClassroom.test.ts
@@ -4,11 +4,10 @@ import { bulkAddToClassroom } from "./bulkAddToClassroom"
 import type { OrgMemberRow } from "@/util/orgMembers"
 import type { GitHubUser } from "@/hooks/github/types"
 
-// The engine (bulkEnrollStudentsInClassroom), getUserById, and the live
-// membership re-check (isActiveMember) are stubbed: this orchestrator's contract
-// is the pre-filter (skip already-on-classroom + obvious non-members), resolving
-// the current login by id, re-verifying live active membership, and how it feeds
-// the engine — not the engine's own CSV/team work.
+// The engine (bulkEnrollStudentsInClassroom), getUserById, and isActiveMember
+// are stubbed: this orchestrator's contract is the pre-filter, resolving the
+// current login by id, re-verifying live membership, and how it feeds the
+// engine — not the engine's own CSV/team work.
 const bulkEnrollMock = vi.fn()
 const getUserByIdMock = vi.fn()
 const isActiveMemberMock = vi.fn()
@@ -114,9 +113,8 @@ describe("bulkAddToClassroom", () => {
   })
 
   it("reports an isMember row that resolves to no member id as 'no-id'", async () => {
-    // isMember:true but neither the github_id nor the username matches any
-    // loaded org member, so matchedId stays null on the isMember branch of the
-    // reason ternary. The engine is never called for it.
+    // isMember:true but neither github_id nor username matches a loaded member,
+    // so matchedId stays null on the isMember branch. Engine never called.
     getUserByIdMock.mockReset()
     bulkEnrollMock.mockReset()
 
@@ -197,8 +195,8 @@ describe("bulkAddToClassroom", () => {
   })
 
   it("skips a since-removed member (stale loaded list) after the live re-check", async () => {
-    // Passes the loaded-list pre-filter, resolves a current login, but the live
-    // membership re-check says they're no longer an active member.
+    // Passes the loaded-list pre-filter, resolves a login, but the live re-check
+    // says they're no longer an active member.
     getUserByIdMock.mockReset().mockResolvedValue({ login: "alice" })
     isActiveMemberMock.mockReset().mockResolvedValue(false)
     bulkEnrollMock.mockReset()

--- a/web/src/pages/orgMembers/bulkAddToClassroom.ts
+++ b/web/src/pages/orgMembers/bulkAddToClassroom.ts
@@ -8,8 +8,8 @@ import type { GitHubUser } from "@/hooks/github/types"
 import type { OrgMemberRow } from "@/util/orgMembers"
 
 // Per-row outcome of resolving a selection to a placeable current login BEFORE
-// the enroll engine runs. `skipped` covers the rows we intentionally don't send
-// (not a live member, no id to resolve, already on the target classroom).
+// the enroll engine runs. `skipped` = rows we intentionally don't send (not a
+// live member, no id to resolve, already on the target classroom).
 export type BulkAddSkip = {
   key: string
   label: string
@@ -23,11 +23,11 @@ export type BulkAddProgress = {
 }
 
 export type BulkAddToClassroomResult = {
-  // The enroll engine's result (added / skipped-by-csv / per-student team
-  // results), null when nothing was eligible to send.
+  // Enroll engine's result (added / skipped-by-csv / per-student team results);
+  // null when nothing was eligible to send.
   enroll: BulkEnrollStudentsResult | null
-  // Rows we filtered out before the engine (with why), so the UI can report
-  // them alongside the engine's own duplicate/team skips.
+  // Rows we filtered out before the engine (with why), reported alongside the
+  // engine's own duplicate/team skips.
   preSkipped: BulkAddSkip[]
 }
 
@@ -35,23 +35,20 @@ const labelFor = (row: OrgMemberRow) => row.username || row.email || row.key
 
 // Place selected org members into a classroom's team + roster in one bulk
 // action. Composition-only over the existing engine:
-//   1. Pre-filter to rows that look like members in the already-loaded org-member
-//      list (numeric id, or login fallback) — a cheap gate that avoids a live
-//      read for the obvious non-members, and the SAML "place existing members"
-//      requirement (we never invite from here).
+//   1. Pre-filter to rows that look like members in the already-loaded list
+//      (numeric id, or login fallback) — a cheap gate, and enforces the SAML
+//      "place existing members" rule (we never invite from here).
 //   2. Skip rows already on the target classroom (by CSV-derived access).
 //   3. Resolve each remaining row to its CURRENT login via the immutable
-//      github_id (stored usernames go stale), then RE-VERIFY the account is a
-//      live ACTIVE member (the loaded list can be up to its staleTime old; a
-//      since-removed member must not be enrolled, or the engine would still
-//      write a CSV roster row for a non-member — a drift row).
-//   4. Hand the surviving logins to bulkEnrollStudentsInClassroom, which is
-//      itself idempotent (skips CSV duplicates; addUserToTeam is a PUT).
+//      github_id (stored usernames go stale), then RE-VERIFY it's a live ACTIVE
+//      member (the loaded list may be staleTime old; enrolling a since-removed
+//      member would write a CSV drift row).
+//   4. Hand surviving logins to bulkEnrollStudentsInClassroom (idempotent:
+//      skips CSV duplicates; addUserToTeam is a PUT).
 //
 // The engine commits the roster append first, then best-effort team-adds each
-// student, returning per-student teamResults + skips — so a partial team
-// failure never rejects the whole batch. We surface both our pre-skips and the
-// engine's results to the caller.
+// student, so a partial team failure never rejects the batch. We surface both
+// our pre-skips and the engine's results.
 export async function bulkAddToClassroom(
   client: GitHubClient,
   input: {
@@ -59,7 +56,7 @@ export async function bulkAddToClassroom(
     classroom: string
     rows: OrgMemberRow[]
     // The org's live members, already loaded by the page — the trust anchor for
-    // "is this selection a real member" without an extra read per row.
+    // "is this selection a real member" without a per-row read.
     members: GitHubUser[]
     onProgress?: (progress: BulkAddProgress) => void
   },
@@ -72,13 +69,13 @@ export async function bulkAddToClassroom(
   )
 
   const preSkipped: BulkAddSkip[] = []
-  // Rows that pass the member/duplicate gates, paired with the immutable id we
+  // Rows passing the member/duplicate gates, paired with the immutable id we
   // resolve their current login from.
   const toResolve: { row: OrgMemberRow; matchedId: string }[] = []
 
   for (const row of rows) {
     // Already on the target classroom (CSV-derived): nothing to do. The engine
-    // would skip it anyway, but reporting it here is clearer and saves a lookup.
+    // would skip it, but reporting here is clearer and saves a lookup.
     if (row.classrooms.some((c) => c.classroom === classroom)) {
       preSkipped.push({
         key: row.key,
@@ -96,8 +93,8 @@ export async function bulkAddToClassroom(
         ? row.github_id
         : (loginId ?? null)
 
-    // Not a live active member -> never invite from here (SAML-safe: we only
-    // place existing members). Send them to the row's invite affordance instead.
+    // Not a live active member -> never invite from here (SAML-safe: place
+    // existing members only). Send them to the row's invite affordance instead.
     if (!matchedId) {
       preSkipped.push({
         key: row.key,
@@ -116,9 +113,9 @@ export async function bulkAddToClassroom(
 
   // Resolve current logins from the immutable id (usernames drift after a
   // rename), then re-verify LIVE active membership before enrolling — the loaded
-  // member list can be stale, and enrolling a since-removed account would write
-  // a CSV drift row. A row whose id no longer resolves, or is no longer an
-  // active member, is skipped rather than enrolled.
+  // list can be stale, and enrolling a since-removed account writes a CSV drift
+  // row. A row whose id no longer resolves, or isn't an active member, is
+  // skipped.
   const usernames: string[] = []
   let resolved = 0
   for (const { row, matchedId } of toResolve) {
@@ -130,7 +127,7 @@ export async function bulkAddToClassroom(
     const id = parseGitHubId(matchedId)
     if (id === null) {
       // matchedId came from a live member, so this is unexpected; treat as a
-      // resolve failure rather than trusting a possibly-stale username.
+      // resolve failure rather than trusting a maybe-stale username.
       preSkipped.push({
         key: row.key,
         label: labelFor(row),
@@ -151,9 +148,9 @@ export async function bulkAddToClassroom(
       resolved++
       continue
     }
-    // Authoritative membership re-check on the resolved current login. A read
-    // failure resolves to false (isActiveMember never throws), so we fail safe:
-    // an unverifiable account is not enrolled.
+    // Authoritative membership re-check on the resolved login. A read failure
+    // resolves to false (isActiveMember never throws), so we fail safe: an
+    // unverifiable account is not enrolled.
     if (!(await isActiveMember(client, org, login))) {
       preSkipped.push({
         key: row.key,

--- a/web/src/pages/orgMembers/bulkRemoveFromClassroom.test.ts
+++ b/web/src/pages/orgMembers/bulkRemoveFromClassroom.test.ts
@@ -6,8 +6,8 @@ import type { Student } from "@/types/classroom"
 
 // bulkUnenrollStudents (the single-commit batch writer) is stubbed: this
 // orchestrator's contract is the per-row PRE-filter (only rows on the target,
-// non-archived classroom reach the writer) and reconciling the batch result
-// back to per-row outcomes.
+// non-archived classroom reach the writer) and reconciling the batch result to
+// per-row outcomes.
 const bulkUnenrollMock = vi.fn()
 
 vi.mock("@/api/mutations/students", () => ({

--- a/web/src/pages/orgMembers/bulkRemoveFromClassroom.ts
+++ b/web/src/pages/orgMembers/bulkRemoveFromClassroom.ts
@@ -40,21 +40,19 @@ const rowToStudent = (row: OrgMemberRow): Student => ({
 })
 
 // Remove selected members from ONE classroom in a SINGLE roster commit (drops
-// the CSV rows + classroom-team membership, cancels pending invites; org
-// membership is left intact — that stays the separate, guarded "Remove from
-// organization" action).
+// CSV rows + classroom-team membership, cancels pending invites; org membership
+// stays intact — that's the separate, guarded "Remove from organization"
+// action).
 //
 // Delegates the write to bulkUnenrollStudents, which drops every matched row in
-// one commit instead of one commit per student — real classes are unenrolled in
-// bulk, and the per-student loop this used to run cluttered students.csv history
-// with N racing "Remove student" commits.
+// one commit instead of one-per-student, avoiding N racing "Remove student"
+// commits cluttering students.csv history.
 //
-// This layer still owns the per-row PRE-filtering the members view needs:
+// This layer owns the per-row PRE-filtering the members view needs:
 //   - rows not on the target classroom (nothing to remove) -> skipped
-//   - rows on an ARCHIVED instance of the classroom -> skipped (an archived
-//     classroom is read-only; the write would throw)
-// so only genuinely-removable rows are sent to the batch writer. Per-row
-// outcomes are reconciled from the batch result (removed / not-found).
+//   - rows on an ARCHIVED instance -> skipped (read-only; the write would throw)
+// so only removable rows reach the batch writer. Per-row outcomes are
+// reconciled from the batch result (removed / not-found).
 export async function bulkRemoveFromClassroom(
   client: GitHubClient,
   input: {
@@ -97,7 +95,7 @@ export async function bulkRemoveFromClassroom(
   }
 
   // Map each eligible row to the Student we send, keeping the row alongside so
-  // outcomes can be reconciled back to a row key/label.
+  // outcomes reconcile back to a row key/label.
   const byStudent = eligible.map((row) => ({ row, student: rowToStudent(row) }))
 
   try {
@@ -108,12 +106,12 @@ export async function bulkRemoveFromClassroom(
       onProgress,
     })
 
-    // Reconcile the batch result back to per-row outcomes by studentKey (the
-    // shared identity precedence github_id || username || email) rather than
-    // object reference: a row whose person is in the writer's `removed` set was
-    // dropped; one only in `notFound` was already gone at write time (a racing
-    // edit / prior removal) — distinct from the pre-filter "not-on-classroom".
-    // rowToStudent copies the row's identity fields, so both sides key alike.
+    // Reconcile the batch result to per-row outcomes by studentKey (shared
+    // identity precedence github_id || username || email), not object ref: a
+    // person in `removed` was dropped; one only in `notFound` was already gone
+    // at write time (racing edit / prior removal) — distinct from the pre-filter
+    // "not-on-classroom". rowToStudent copies identity fields so both sides key
+    // alike.
     const removedKeys = new Set(result.removed.map((s) => studentKey(s)))
     for (const { row } of byStudent) {
       const wasRemoved = removedKeys.has(studentKey(row))
@@ -131,8 +129,8 @@ export async function bulkRemoveFromClassroom(
       warnings: result.warnings,
     }
   } catch (err) {
-    // A hard failure of the single roster write fails the whole eligible batch
-    // (nothing was committed). Report each eligible row as failed.
+    // A hard failure of the single roster write fails the whole batch (nothing
+    // committed). Report each eligible row as failed.
     const detail = getErrorMessage(err)
     for (const { row } of byStudent) {
       outcomes.push({

--- a/web/src/pages/orgMembers/inviteMemberToOrg.ts
+++ b/web/src/pages/orgMembers/inviteMemberToOrg.ts
@@ -11,9 +11,8 @@ export type InviteToOrgResult = {
   invited: boolean
 }
 
-// Invite a roster student who isn't (yet) an org member. Sent by
-// invitee_id (the immutable github_id), NOT username — the CSV username can be
-// stale after a rename.
+// Invite a roster student who isn't (yet) an org member. Sent by invitee_id (the
+// immutable github_id), NOT username — the CSV username can be stale.
 export async function inviteMemberToOrg(
   client: GitHubClient,
   input: { org: string; row: OrgMemberRow },

--- a/web/src/pages/orgMembers/memberPresentation.tsx
+++ b/web/src/pages/orgMembers/memberPresentation.tsx
@@ -9,16 +9,15 @@ import { inviteMemberToOrg } from "@/pages/orgMembers/inviteMemberToOrg"
 import type { OrgMemberRow } from "@/util/orgMembers"
 
 // Presentation helpers shared by the Members list rows and the member-detail
-// modal: the avatar-initial fallback, the GitHub identity line, the
-// classification badge, and the shared invite flow. Kept in one module so the
-// row and the modal render members identically and there's a single invite path.
+// modal (avatar-initial fallback, GitHub identity line, classification badge,
+// invite flow), so both render identically via a single invite path.
 
 // First initial of a row's best display string, for the avatar fallback.
 export const initialsFor = (row: OrgMemberRow) =>
   (row.name || row.username || row.email || "?")[0]?.toUpperCase() ?? "?"
 
-// GitHub identity line: makes it explicit these are GitHub members by showing
-// the @username and the immutable numeric GitHub id together.
+// GitHub identity line: shows @username and the immutable numeric GitHub id to
+// make clear these are GitHub members.
 export const GitHubIdentity = ({ row }: { row: OrgMemberRow }) => {
   const { t } = useTranslation()
   return (
@@ -54,8 +53,8 @@ export const ClassificationBadge = ({
       </span>
     )
   }
-  // An org owner/admin is labeled "Owner", not "Member" — takes precedence over
-  // the no-roster badge (an owner with no classroom is still an owner).
+  // An owner/admin is labeled "Owner", not "Member" — takes precedence over the
+  // no-roster badge (an owner with no classroom is still an owner).
   if (isOwner) {
     return (
       <span className="badge badge-sm badge-info badge-soft gap-1">

--- a/web/src/pages/orgMembers/removeMemberFromOrg.test.ts
+++ b/web/src/pages/orgMembers/removeMemberFromOrg.test.ts
@@ -5,7 +5,7 @@ import type { OrgMemberRow } from "@/util/orgMembers"
 
 // unenrollStudent and removeOrgMembership are stubbed: this helper's contract is
 // the SEQUENCE (unenroll every roster, then remove org membership last) and its
-// warning accumulation, not the underlying GitHub calls.
+// warning accumulation, not the GitHub calls.
 const unenrollMock = vi.fn()
 const removeOrgMembershipMock = vi.fn()
 const getAuthenticatedUserMock = vi.fn()

--- a/web/src/pages/orgMembers/removeMemberFromOrg.ts
+++ b/web/src/pages/orgMembers/removeMemberFromOrg.ts
@@ -42,12 +42,12 @@ export async function removeMemberFromOrg(
   const warnings: string[] = []
 
   // Defense-in-depth self-guard: the Members page hides this action for the
-  // signed-in viewer, but that guard is UI-only and depends on the viewer query
-  // being loaded. Re-resolve the viewer server-side and refuse to remove the
-  // acting account from the org. This guards an org-wide DELETE that is
-  // effectively irreversible from the app, so it fails CLOSED: if the viewer
-  // can't be resolved we refuse rather than risk a self-lockout. (unenrollStudent
-  // can fail open since it's classroom-scoped and reversible; this can't.)
+  // viewer, but that guard is UI-only and depends on the viewer query loading.
+  // Re-resolve the viewer server-side and refuse to remove the acting account.
+  // This org-wide DELETE is effectively irreversible from the app, so it fails
+  // CLOSED: if the viewer can't be resolved we refuse rather than risk a
+  // self-lockout. (unenrollStudent can fail open — classroom-scoped and
+  // reversible; this can't.)
   const viewer = await getAuthenticatedUser(client).catch(() => null)
   if (!viewer) {
     throw new Error(
@@ -65,10 +65,9 @@ export async function removeMemberFromOrg(
     )
   }
 
-  // Without a GitHub username we can't DELETE the org membership (the GitHub
-  // endpoint is keyed by username). Bail BEFORE clearing any rosters — clearing
-  // them under a "Remove from organization" action that can't actually remove
-  // the membership would be misleading, destructive work.
+  // Without a GitHub username we can't DELETE the org membership (endpoint keyed
+  // by username). Bail BEFORE clearing rosters — doing so under an action that
+  // can't actually remove membership would be misleading, destructive work.
   if (!row.username) {
     return {
       unenrolledClassrooms: [],
@@ -81,9 +80,9 @@ export async function removeMemberFromOrg(
 
   for (const access of row.classrooms) {
     // Archived classrooms can't be unenrolled (unenrollStudent throws via
-    // assertClassroomNotArchived), and the org DELETE below would still run —
-    // leaving the student off the org but stuck on the archived roster, the very
-    // inconsistency this flow exists to prevent. Skip them and report instead.
+    // assertClassroomNotArchived); the org DELETE below would still run, leaving
+    // the student off the org but stuck on the archived roster — the very
+    // inconsistency this flow prevents. Skip and report instead.
     if (access.archived) {
       warnings.push(
         t

--- a/web/src/pages/orgMembers/selection.test.ts
+++ b/web/src/pages/orgMembers/selection.test.ts
@@ -55,8 +55,8 @@ describe("selection helpers", () => {
   })
 
   it("toggleSelectAll selects the filtered set and leaves out-of-filter selections intact", () => {
-    // Selection already holds "z" (hidden by the current filter). Toggling
-    // select-all over [a, b] adds them without disturbing "z".
+    // Selection already holds "z" (hidden by the filter). Select-all over [a, b]
+    // adds them without disturbing "z".
     const next = toggleSelectAll([row("a"), row("b")], new Set(["z"]))
     expect([...next].sort()).toEqual(["a", "b", "z"])
   })
@@ -75,8 +75,8 @@ describe("selection helpers", () => {
   })
 
   it("resolveSelectedRows spans the full set and drops the non-selectable (self) row", () => {
-    // "self" is checked (a stale selection) but must never be resolved into the
-    // actionable set; "hidden" is selected but not in the filtered view — still
+    // "self" is checked (stale selection) but must never resolve into the
+    // actionable set; "hidden" is selected but out of the filtered view — still
     // acted on because resolve spans the full row set.
     const all = [row("a"), row("self"), row("hidden")]
     const resolved = resolveSelectedRows(

--- a/web/src/pages/orgMembers/selection.ts
+++ b/web/src/pages/orgMembers/selection.ts
@@ -1,9 +1,9 @@
 import type { OrgMemberRow } from "@/util/orgMembers"
 
 // Pure selection logic for the Members page's multi-select, extracted so the
-// tricky invariants (select-all targets only the filtered + selectable rows;
-// the signed-in owner is never selectable; a selection persists across search
-// filtering) are unit-testable without rendering the page.
+// tricky invariants (select-all targets only filtered + selectable rows; the
+// signed-in owner is never selectable; a selection persists across filtering)
+// are unit-testable without rendering.
 
 // The rows in the current filtered view that MAY be selected — everything the
 // `selectable` predicate (typically "not the signed-in self") allows.
@@ -57,9 +57,9 @@ export function toggleRow(
   return next
 }
 
-// The rows backing the current selection, across the FULL set (not just the
-// filtered view — a selected row hidden by search is still acted on), with any
-// non-selectable row (self) excluded so a stale selection can't target it.
+// Rows backing the current selection across the FULL set (a selected row hidden
+// by search is still acted on), with non-selectable rows (self) excluded so a
+// stale selection can't target them.
 export function resolveSelectedRows(
   rows: OrgMemberRow[],
   selectedKeys: ReadonlySet<string>,

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -28,12 +28,11 @@ import type { CheckState } from "@/hooks/github/orgChecks"
 import SettingsSection from "./SettingsSection"
 import { CalloutDiv } from "@/lib/motionComponents"
 
-// Org policy audit pane: surfaces every org/repo policy concern with its live
-// drift verdict, the unenforced member-default fields (each with its manual
-// fix), and the four API-less manual steps. Each drifted, API-repairable
-// concern gets an owner-gated per-concern "Fix it" button; Re-run Setup below
-// is the "repair everything" alternative. Mirrors the service-token pane's
-// banner shape.
+// Org policy audit pane: surfaces every policy concern with its live drift
+// verdict, the unenforced member-default fields (each with a manual fix), and
+// the API-less manual steps. Each drifted, API-repairable concern gets an
+// owner-gated "Fix it"; Re-run Setup is the "repair everything" alternative.
+// Mirrors the service-token pane's banner shape.
 
 const VERDICT_BANNER: Record<
   AuditVerdict,
@@ -91,7 +90,7 @@ function ConcernRow({
   const { t } = useTranslation()
   const isDrifted = concern.verdict.state === "unenforced"
   // Hide "Fix it" when every drifted member-default is enterprise-pinned — the
-  // API write can't change them, so the button would silently do nothing.
+  // API write can't change them, so the button would do nothing.
   const allPinned =
     driftedDetails !== undefined &&
     driftedDetails.length > 0 &&
@@ -367,9 +366,9 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
   const isOwner = membership?.role === "admin"
 
   // Member-default fields a Fix it / re-run wrote but that didn't stick on
-  // read-back — silently overridden by an enterprise policy (GitHub returns
-  // 200 but ignores the change). Surfaced as "Managed by enterprise" so we
-  // stop offering a Fix it that can't work.
+  // read-back — silently overridden by an enterprise policy (GitHub returns 200
+  // but ignores the change). Surfaced as "Managed by enterprise" so we stop
+  // offering a Fix it that can't work.
   const [enterprisePinned, setEnterprisePinned] = useState<Set<string>>(
     new Set(),
   )

--- a/web/src/pages/orgSettings/OrgPreflightNotice.tsx
+++ b/web/src/pages/orgSettings/OrgPreflightNotice.tsx
@@ -8,9 +8,9 @@ import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import { CalloutDiv } from "@/lib/motionComponents"
 
 // Teacher preflight banner shown when an org is opened. The service-token and
-// policy checks live here (one org at a time) rather than on the org list,
-// which would fan these reads out across every org. One aggregated banner names
-// every failing category; the org settings page holds the per-item detail.
+// policy checks live here (one org at a time), not on the org list where they'd
+// fan out across every org. One aggregated banner names every failing category;
+// per-item detail lives on the org settings page.
 const OrgPreflightNotice = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   const { data: tokenStatus, isPending: tokenPending } =
@@ -26,14 +26,13 @@ const OrgPreflightNotice = ({ org }: { org: string }) => {
   // the audit: it's false for a disabled query, so an org whose plan can't be
   // read (GitHub omits it for non-owners) doesn't keep the banner suppressed.
   const checking = tokenPending || planPending || auditLoading
-
   if (checking) return null
 
   const tokenMissing = tokenStatus?.status === "missing"
   const policyFail = audit?.verdict === "fail"
 
-  // Both categories are hard failures, so the banner is always an error; it
-  // just names every failing one at once.
+  // Both categories are hard failures, so the banner is always an error; it just
+  // names every failing one at once.
   const failing: string[] = []
   if (tokenMissing)
     failing.push(t("orgSettings.preflight.categoryServiceToken"))

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -54,9 +54,9 @@ const SummaryBanner = ({
 export const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
 
 // Re-run the org setup from Org Settings: re-invokes the idempotent
-// initClassroom50 to re-apply the full lockdown, rulesets, and repo settings.
-// Owner-gated; shows the same badge board the wizard uses. This is the
-// "repair everything" path that complements the per-concern audit (U5/U6).
+// initClassroom50 to re-apply lockdown, rulesets, and repo settings. Owner-gated;
+// shows the wizard's badge board. The "repair everything" path complementing the
+// per-concern audit (U5/U6).
 const RerunOrgSetup = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   const client = useGitHubClient()
@@ -73,8 +73,8 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
   const [failed, setFailed] = useState(false)
   const [done, setDone] = useState(false)
 
-  // Skeleton-overwrite confirmation. initClassroom50 calls confirmSkeletonOverwrite
-  // mid-run with the drifted files about to be overwritten; the hook opens the
+  // Skeleton-overwrite confirmation. initClassroom50 calls
+  // confirmSkeletonOverwrite mid-run with the drifted files; the hook opens the
   // modal and parks the run until the teacher confirms or cancels.
   const {
     overwritePaths,
@@ -83,8 +83,8 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
     mountedRef,
   } = useSkeletonOverwriteConfirm()
 
-  // After a completed run, surface whether any step finished with a warning so
-  // the per-step messages on the board have a headline to explain them.
+  // After a run, surface whether any step warned so the board's per-step
+  // messages have a headline.
   const warningCount = started
     ? INIT_STEP_ORDER.filter((id) => steps[id].status === "warning").length
     : 0
@@ -102,7 +102,7 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
         onStepUpdate: (update) => {
           // init fires onStepUpdate across ~10 sequential steps; the user can
           // navigate away mid-run. The work isn't cancelable (no AbortSignal),
-          // so the mounted guard just stops the setState churn.
+          // so the mounted guard just stops setState churn.
           if (!mountedRef.current) return
           setSteps((prev) => applyStepUpdate(prev, update))
         },
@@ -113,7 +113,7 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
       if (!mountedRef.current) return
       setDone(true)
       // init resolves (not throws) with status "error" on a prerequisite
-      // failure; surface it instead of treating it as a clean success.
+      // failure; surface it instead of treating it as success.
       if (data && data.status === "error") {
         setFailed(true)
         return

--- a/web/src/pages/orgSettings/SettingsSection.tsx
+++ b/web/src/pages/orgSettings/SettingsSection.tsx
@@ -1,11 +1,10 @@
 import type { PropsWithChildren, ReactNode } from "react"
 
-// Standardized wrapper for each Org Settings group (Service Token,
-// Organization Policy, Re-run Setup, Danger Zone) so the page reads as a set
-// of consistent sections rather than mismatched cards. Owns the card shell and
-// the header (title + optional description, an optional right-aligned action,
-// and an optional adornment beside the title such as an info popover). The
-// `tone="danger"` variant styles destructive groups (Danger Zone).
+// Standardized wrapper for each Org Settings group (Service Token, Organization
+// Policy, Re-run Setup, Danger Zone) so the page reads as consistent sections.
+// Owns the card shell and header (title + optional description, optional
+// right-aligned action, optional title adornment). `tone="danger"` styles
+// destructive groups (Danger Zone).
 const SettingsSection = ({
   title,
   description,

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -20,8 +20,8 @@ import SettingsSection from "./SettingsSection"
 import { CalloutDiv, CalloutText } from "@/lib/motionComponents"
 
 // Teardown / org reset: deletes ALL repos in the org (mirroring the CLI's
-// `gh teacher teardown`), marker-gated and behind a typed-org-name
-// confirmation. Owner-gated; destructive and irreversible.
+// `gh teacher teardown`), marker-gated and behind a typed-org-name confirmation.
+// Owner-gated; destructive and irreversible.
 const TeardownSection = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   const client = useGitHubClient()
@@ -69,8 +69,8 @@ const TeardownSection = ({ org }: { org: string }) => {
       }
       void queryClient.invalidateQueries({ queryKey: ["orgs"] })
       // Redirect home only on a fully-clean run. executeTeardown RESOLVES on
-      // partial failure (marker retained, run re-runnable); on that path the
-      // `done` banner carries the re-run remedy, so stay on the page to show it.
+      // partial failure (marker retained, re-runnable); on that path the `done`
+      // banner carries the re-run remedy, so stay to show it.
       const cleanRun =
         !!result &&
         result.markerDeleted &&
@@ -193,9 +193,9 @@ const TeardownSection = ({ org }: { org: string }) => {
         }
         onConfirm={async () => {
           // Let a failure REJECT so ConfirmModal's catch keeps the modal open
-          // with the error inline (its submittingRef already guards double
-          // submits). Scope/rate-limit errors carry user-facing messages;
-          // anything else is normalized.
+          // with the error inline (its submittingRef guards double submits).
+          // Scope/rate-limit errors carry user-facing messages; anything else is
+          // normalized.
           try {
             await runMutation.mutateAsync()
           } catch (err) {

--- a/web/src/pages/orgSettings/initStepBoard.test.ts
+++ b/web/src/pages/orgSettings/initStepBoard.test.ts
@@ -9,9 +9,9 @@ import {
 } from "./initStepBoard"
 
 // The board is the single source of truth shared by the org setup wizard and
-// the re-run surface. These guard against the three ways the surfaces could
-// drift: a step missing from the order, a step missing its explanation, or a
-// settings link that no longer points at the org/repo it's supposed to.
+// re-run surface. These guard the three drift modes: a step missing from the
+// order, a step missing its explanation, or a settings link pointing at the
+// wrong org/repo.
 
 describe("init step board metadata", () => {
   it("orders, initial state, and explanations cover the exact same steps", () => {

--- a/web/src/pages/orgSettings/initStepBoard.tsx
+++ b/web/src/pages/orgSettings/initStepBoard.tsx
@@ -15,10 +15,9 @@ import type {
   InitStepUpdate,
 } from "@/hooks/github/mutations"
 
-// Shared init "badge board" used by both the org setup wizard (OrgSetupPage)
-// and the re-run action on the Org Settings page. One source of truth for the
-// step order, titles, per-step explanations, and rendering so the two surfaces
-// can't drift.
+// Shared init "badge board" used by the org setup wizard (OrgSetupPage) and the
+// re-run action on Org Settings. One source of truth for step order, titles,
+// explanations, and rendering so the two surfaces can't drift.
 
 export const INIT_STEP_ORDER: InitStepId[] = [
   "orgDefaults",
@@ -33,21 +32,18 @@ export const INIT_STEP_ORDER: InitStepId[] = [
   "rulesets",
 ]
 
-// Per-step explanation shared by the wizard and the re-run surface. `what`
-// says what we change on the org/repo, `why` says why Classroom 50 needs it,
-// and `remediation` is the actionable next step a teacher takes when the step
-// warns or errors (paired with the GitHub deep link below). The three text
-// fields hold i18n keys (resolved with `t()` at render), so translations live
-// in the locale files while this map stays the single source of truth for
-// which steps exist and where they deep-link.
+// Per-step explanation shared by the wizard and re-run surface. `what` = what we
+// change, `why` = why Classroom 50 needs it, `remediation` = the teacher's next
+// step on warn/error (paired with the GitHub deep link). The three text fields
+// hold i18n keys (resolved with `t()` at render), so this map stays the single
+// source of truth for which steps exist and where they deep-link.
 type InitStepMeta = {
   what: string
   why: string
   remediation: string
-  // The GitHub settings page where the teacher inspects/fixes this step. Some
-  // steps are org-scoped, others target the classroom50 config repo. Returns
-  // null for steps with no single settings page to point at (repo + file
-  // creation), where the remediation is "retry" rather than "go change X".
+  // GitHub settings page where the teacher inspects/fixes this step (org- or
+  // config-repo-scoped). Null for steps with no single page (repo + file
+  // creation), where remediation is "retry" rather than "go change X".
   settingsUrl: (org: string) => string | null
 }
 
@@ -217,17 +213,16 @@ export const InitStep = ({
   status: InitStepStatus
   message?: string
   // Without an org the per-step GitHub deep link can't be built, so it's
-  // omitted; the explanation and remediation text still render.
+  // omitted; the explanation and remediation still render.
   org?: string
 }) => {
   const { t } = useTranslation()
   const meta = INIT_STEP_META[id]
   const needsAttention = status === "warning" || status === "error"
-  // Auto-expand the steps that need action so the teacher sees the fix without
-  // hunting; everything else starts collapsed to keep the board scannable. We
-  // keep `open` as the single source of truth (seeded from needsAttention and
-  // re-opened whenever a step transitions into attention) so the disclosure
-  // toggle can always collapse a panel — even a warning/error one.
+  // Auto-expand steps needing action so the teacher sees the fix without
+  // hunting; the rest start collapsed. `open` is the single source of truth
+  // (seeded from needsAttention, re-opened on each transition into attention) so
+  // the toggle can always collapse a panel — even a warning/error one.
   const [open, setOpen] = useState(needsAttention)
   const prevNeedsAttention = useRef(needsAttention)
   useEffect(() => {

--- a/web/src/pages/orgSettings/overwriteConfirm.test.ts
+++ b/web/src/pages/orgSettings/overwriteConfirm.test.ts
@@ -7,10 +7,9 @@ import {
 } from "./overwriteConfirm"
 
 // These pin the "settle the parked overwrite promise exactly once" guarantees
-// that RerunOrgSetup/OrgSetupPage depend on but can't easily assert without a
-// DOM. The modal calls onConfirm() (settle true) and then onClose() (settle
-// false) on every confirm, and the native <dialog> close fires onClose again —
-// so the resolver is hit multiple times per interaction and must not flip.
+// RerunOrgSetup/OrgSetupPage depend on but can't easily assert with a DOM. Every
+// confirm hits the resolver multiple times (onConfirm true, onClose false, the
+// native <dialog> close false again) and must not flip.
 
 describe("settleOverwrite", () => {
   it("resolves the parked promise with the first value and ignores later calls", async () => {
@@ -19,8 +18,8 @@ describe("settleOverwrite", () => {
       ref.current = resolve
     })
 
-    // onConfirm -> true, then ConfirmModal's onClose -> false, then the dialog's
-    // native onClose -> false again. True must win; the later falses are inert.
+    // onConfirm -> true, then onClose -> false, then the dialog's native onClose
+    // -> false again. True must win; the falses are inert.
     settleOverwrite(ref, true)
     settleOverwrite(ref, false)
     settleOverwrite(ref, false)

--- a/web/src/pages/orgSettings/overwriteConfirm.ts
+++ b/web/src/pages/orgSettings/overwriteConfirm.ts
@@ -1,34 +1,31 @@
 // The skeleton-overwrite confirmation parks initClassroom50's run on a promise
-// while a modal asks the teacher whether to overwrite drifted skeleton files.
-// The resolver lives in a ref so the modal's button handlers (and an unmount
-// cleanup) can settle the awaiting hook. This factors the resolver bookkeeping
-// out of the React components so the tricky "settle exactly once" guarantees
-// are unit-testable without a DOM: both the wizard (OrgSetupPage) and the
-// re-run surface (RerunOrgSetup) build their confirmSkeletonOverwrite hook
-// from this.
+// while a modal asks whether to overwrite drifted skeleton files. The resolver
+// lives in a ref so the modal's handlers (and unmount cleanup) can settle the
+// awaiting hook. Factored out of the components so the "settle exactly once"
+// guarantees are unit-testable without a DOM; both the wizard (OrgSetupPage) and
+// re-run surface (RerunOrgSetup) build their confirmSkeletonOverwrite from this.
 
-// A mutable ref cell — structurally compatible with React's
-// useRef<((ok: boolean) => void) | null>() so callers can pass their ref
-// straight through.
+// Mutable ref cell — structurally compatible with
+// useRef<((ok: boolean) => void) | null>() so callers pass their ref straight
+// through.
 export type ResolverRef = { current: ((ok: boolean) => void) | null }
 
 // Settle the parked promise (if any) with `ok`, then clear the resolver so a
-// follow-up call can't settle it again. This null-after-settle is what makes
-// the modal's onConfirm-then-onClose double call, and the unmount cleanup,
-// idempotent: only the first call wins.
+// follow-up can't settle it again. This null-after-settle makes the modal's
+// onConfirm-then-onClose double call, and the unmount cleanup, idempotent: only
+// the first call wins.
 export function settleOverwrite(ref: ResolverRef, ok: boolean): void {
   ref.current?.(ok)
   ref.current = null
 }
 
-// Build a confirmSkeletonOverwrite hook. It is invoked mid-run with the paths
-// about to be overwritten; it opens the modal (via setPending) and parks on a
-// promise whose resolver is stashed in `ref`. If the surface is already
-// unmounted (isMounted() === false) it declines synchronously rather than
-// parking a promise that could never settle. If a resolver is somehow already
-// parked (re-entrant invocation — not reachable with today's sequential init,
-// but cheap to guard), the prior one is declined before the new one parks so it
-// can't be orphaned into a permanent hang.
+// Build a confirmSkeletonOverwrite hook. Invoked mid-run with the paths about to
+// be overwritten; opens the modal (via setPending) and parks on a promise whose
+// resolver is stashed in `ref`. If already unmounted (isMounted() === false) it
+// declines synchronously rather than parking a promise that can't settle. If a
+// resolver is somehow already parked (re-entrant — not reachable with today's
+// sequential init, but cheap to guard), the prior one is declined first so it
+// can't hang.
 export function makeConfirmSkeletonOverwrite(
   ref: ResolverRef,
   setPending: (paths: string[] | null) => void,

--- a/web/src/pages/orgSettings/skeletonOverwriteUi.tsx
+++ b/web/src/pages/orgSettings/skeletonOverwriteUi.tsx
@@ -10,8 +10,8 @@ import {
 // Wires the skeleton-overwrite confirmation into a React surface: owns the
 // modal-open state, the resolver ref, and the unmount cleanup that settles a
 // parked run rather than letting it hang. Shared by the wizard (OrgSetupPage)
-// and the re-run surface (RerunOrgSetup) so the two can't drift. Pass the
-// returned `confirmSkeletonOverwrite` to initClassroom50 and render
+// and re-run surface (RerunOrgSetup). Pass the returned
+// `confirmSkeletonOverwrite` to initClassroom50 and render
 // <SkeletonOverwriteModal> with `overwritePaths`/`resolveOverwrite`.
 export function useSkeletonOverwriteConfirm() {
   const [overwritePaths, setOverwritePaths] = useState<string[] | null>(null)
@@ -31,8 +31,8 @@ export function useSkeletonOverwriteConfirm() {
     setOverwritePaths(null)
   }
 
-  // Built lazily (useCallback) so the resolver ref is only touched when the hook
-  // is actually invoked mid-run, not during render.
+  // Built lazily (useCallback) so the resolver ref is only touched when invoked
+  // mid-run, not during render.
   const confirmSkeletonOverwrite = useCallback(
     (paths: string[]) =>
       makeConfirmSkeletonOverwrite(
@@ -52,8 +52,8 @@ export function useSkeletonOverwriteConfirm() {
 }
 
 // The "are you sure" prompt before overwriting drifted skeleton files. Open when
-// `paths` is non-null; the bundled copy explains that overwriting resets local
-// customizations (matching the CLI's stance that these files are user-editable).
+// `paths` is non-null; the copy explains overwriting resets local customizations
+// (matching the CLI's stance that these files are user-editable).
 export function SkeletonOverwriteModal({
   paths,
   onConfirm,

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -31,8 +31,8 @@ type AddStudentFormValues = {
 }
 
 // Single add/invite form. A username enrolls via GitHub (resolve, add to team,
-// send org invite) and still stores the email; email-only sends an email invite.
-// Either way the student joins the classroom team when they accept the invite.
+// send org invite) and stores the email; email-only sends an email invite.
+// Either way the student joins the classroom team on accepting the invite.
 const AddStudent = ({ className = "", org, classroom }: AddStudentProps) => {
   const { team } = useEnsureTeam(org, classroom)
   const queryClient = useQueryClient()
@@ -66,8 +66,8 @@ const AddStudent = ({ className = "", org, classroom }: AddStudentProps) => {
           label: username,
           warning: result?.teamWarning ?? "",
           student: toStudent(result.student),
-          // Already-active org member: team-added directly (no invite), so seed
-          // the members cache to avoid an "unprovisioned" flash.
+          // Already-active member: team-added directly (no invite), so seed the
+          // members cache to avoid an "unprovisioned" flash.
           enrolledMember: result.enrolled
             ? {
                 id: Number(result.student.github_id),
@@ -78,7 +78,7 @@ const AddStudent = ({ className = "", org, classroom }: AddStudentProps) => {
       }
 
       // Email-only -> email invite carrying the classroom team, so the student
-      // lands in the team when they accept.
+      // lands in the team on accept.
       const result = await inviteStudentByEmail(githubClient, {
         org,
         classroom,
@@ -102,15 +102,15 @@ const AddStudent = ({ className = "", org, classroom }: AddStudentProps) => {
     }) => {
       setWarning(warningMessage)
       // Clear the form so the next student starts clean and a stray re-click
-      // can't resubmit into a duplicate error. A warning still shows alongside.
+      // can't resubmit into a duplicate error.
       setSuccess(t("students.added", { label }))
       form.reset()
       // Show the new row immediately (see useUpdateRosterCache).
       updateRosterCache((current) => [...current, student])
       invalidateInviteQueries(queryClient, org)
-      // Enrolled member -> seed the team-members cache (drives the enrolled
-      // list) so the row shows enrolled at once; the invited path is already
-      // represented by a pending invite, so just invalidate.
+      // Enrolled member -> seed the team-members cache so the row shows enrolled
+      // at once; the invited path already shows a pending invite, so just
+      // invalidate.
       if (enrolledMember) {
         seedTeamMember(enrolledMember)
       } else {
@@ -127,8 +127,8 @@ const AddStudent = ({ className = "", org, classroom }: AddStudentProps) => {
       section: "",
     } satisfies AddStudentFormValues,
     // Validate on submit, then re-validate on every change after the first
-    // attempt. Without this, a failed form-level validation leaves canSubmit
-    // false and the validator never re-runs, so the button never recovers.
+    // attempt. Otherwise a failed form-level validation leaves canSubmit false
+    // and never re-runs, so the button never recovers.
     validationLogic: revalidateLogic(),
     validators: {
       onDynamic: ({ value }) => {

--- a/web/src/pages/students/EditStudent.tsx
+++ b/web/src/pages/students/EditStudent.tsx
@@ -31,9 +31,9 @@ type EditStudentFormValues = {
 }
 
 // Edit modal for a roster row's teacher-facing fields. Identity (username,
-// github_id, email) is shown read-only until the student is enrolled — it's
-// bound by membership, not the teacher — and first/last name and section stay
-// editable. Once enrolled, the email becomes editable too.
+// github_id, email) is read-only until the student is enrolled — it's bound by
+// membership, not the teacher — while name and section stay editable. Once
+// enrolled, the email becomes editable too.
 const EditStudent = ({
   org,
   classroom,
@@ -51,8 +51,8 @@ const EditStudent = ({
 
   const displayHandle = student.username || student.email
   // An email-only row (no username, no github_id) is keyed by its email, so it
-  // can't be changed here without re-keying the row. A github-identified row's
-  // email is just metadata and is freely editable.
+  // can't change here without re-keying the row. A github-identified row's email
+  // is just metadata and is freely editable.
   const emailLocked = !student.username && !student.github_id
 
   const defaults = useCallback(
@@ -112,8 +112,8 @@ const EditStudent = ({
   })
 
   // Drive the native dialog from the `open` prop. Reset to the student's CURRENT
-  // values on open: this dialog is never remounted (its row key is stable), so
-  // an argument-less reset would restore mount-time values that go stale after a
+  // values on open: this dialog is never remounted (stable row key), so an
+  // argument-less reset would restore mount-time values that go stale after a
   // save.
   useEffect(() => {
     const dialog = dialogRef.current

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -46,8 +46,8 @@ import { useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 // Group rows by `section`, sorted by name with the unlabeled ("No section")
-// bucket last. Generic over any row carrying a `section` field, so it serves
-// both the CSV Student shape and the team-driven TeamRosterRow.
+// bucket last. Generic over any row with a `section` field, so it serves both
+// the CSV Student shape and the team-driven TeamRosterRow.
 const NO_SECTION = "No section"
 export function groupStudentsBySection<T extends { section?: string }>(
   students: T[],
@@ -393,10 +393,10 @@ const OnboardingLink = ({
 }
 
 // Manual-match affordance for an email-invited row whose student joined the org
-// directly and whose GitHub identity GitHub no longer exposes (the email->login
-// link is dropped once an invite is accepted). The teacher picks which unmatched
-// team member owns the email; matchStudentToAccount re-verifies the pick is an
-// active member before binding. Kept because email invites remain supported.
+// directly (GitHub drops the email->login link once an invite is accepted). The
+// teacher picks which unmatched team member owns the email; matchStudentToAccount
+// re-verifies the pick is an active member before binding. Kept because email
+// invites remain supported.
 const MatchAccountButton = ({
   org,
   classroom,
@@ -729,7 +729,7 @@ const EnrolledStudents = ({
 
   // Explicit teacher-triggered backfill: append missing team members into
   // students.csv as metadata (Section 5). Not automatic — the team-driven view
-  // renders correctly without it; this only persists optional metadata.
+  // renders fine without it; this only persists optional metadata.
   const syncMutation = useMutation({
     mutationFn: () => syncRosterFromTeam(client, { org, classroom }),
     onSuccess: (result) => {
@@ -740,9 +740,9 @@ const EnrolledStudents = ({
           ? t("students.syncUpToDate")
           : t("students.syncAdded", { count: result.addedUsernames.length }),
       })
-      // The CSV changed; invalidate the roster (csv-file) query so a refetch
-      // picks up the newly-appended metadata rows. Uses the same key
-      // useGetStudents reads (a bare prefix wouldn't match).
+      // CSV changed; invalidate the roster (csv-file) query so a refetch picks
+      // up the appended metadata rows. Uses the same key useGetStudents reads (a
+      // bare prefix wouldn't match).
       void queryClient.invalidateQueries({
         queryKey: githubKeys.csvFile(
           org,
@@ -759,16 +759,16 @@ const EnrolledStudents = ({
     },
   })
 
-  // Auto-sync on open: when team members are missing a students.csv metadata row
-  // (csvMissingCount > 0), append them automatically so the teacher never has to
-  // press "Sync roster" for the common case. Reaching this component already
-  // implies config-repo write access (RequireTeacher staff-gates the page).
+  // Auto-sync on open: when team members lack a students.csv metadata row
+  // (csvMissingCount > 0), append them automatically so the teacher needn't
+  // press "Sync roster" for the common case. Reaching this component implies
+  // config-repo write (RequireTeacher staff-gates the page).
   //
-  // Fire once per drift episode: the ref latches after we trigger, so a re-render
-  // (or the post-sync CSV refetch briefly still showing >0) can't re-fire it, and
-  // it re-arms only once the roster is genuinely back in sync (count returns to
-  // 0). A failed auto-sync toasts (via onError) and, because it stays latched,
-  // does NOT retry in a loop — the teacher retries with the now-enabled button.
+  // Fire once per drift episode: the ref latches after triggering so a re-render
+  // (or the post-sync CSV refetch briefly showing >0) can't re-fire it, and it
+  // re-arms only once count returns to 0. A failed auto-sync toasts (onError)
+  // and, staying latched, does NOT retry in a loop — the teacher retries via the
+  // now-enabled button.
   const autoSyncedRef = useRef(false)
   useEffect(() => {
     if (isLoading || isError) return
@@ -779,8 +779,8 @@ const EnrolledStudents = ({
     if (autoSyncedRef.current || syncMutation.isPending) return
     autoSyncedRef.current = true
     syncMutation.mutate()
-    // syncMutation identity is stable across renders (useMutation); the guard
-    // ref + count/loading deps are what gate re-firing.
+    // syncMutation identity is stable (useMutation); the ref + count/loading
+    // deps gate re-firing.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [csvMissingCount, isLoading, isError])
 
@@ -857,8 +857,8 @@ const EnrolledStudents = ({
         }),
       )
     } else if (resent === 0 && skipped > 0) {
-      // Nothing was actually re-sent (e.g. every row lacked a resolvable invite
-      // id). Don't report an unqualified success.
+      // Nothing was re-sent (e.g. every row lacked a resolvable invite id).
+      // Don't report an unqualified success.
       setWarning(key, t("students.resendAllNothing", { count: skipped }))
     } else {
       setWarning(key, t("students.resendAllSuccess", { count: resent }))
@@ -871,7 +871,7 @@ const EnrolledStudents = ({
         studentKey(s) === rowKey ? toStudent(updated) : s,
       )
       // A member with no prior CSV row (blank metadata) has no row to replace;
-      // append the newly-written one so the edit sticks optimistically.
+      // append the new one so the edit sticks optimistically.
       const exists = current.some((s) => studentKey(s) === rowKey)
       return exists ? next : [...next, toStudent(updated)]
     })
@@ -1002,8 +1002,8 @@ const EnrolledStudents = ({
             onRemoveStudent={(_username, warning) => {
               if (warning) setWarning(row.key, warning)
               // Drop the CSV metadata row so nothing lingers as
-              // unprovisioned/pending, then refresh the team-driven enrolled
-              // list (unenroll removed them from the classroom team).
+              // unprovisioned/pending, then refresh the enrolled list (unenroll
+              // removed them from the classroom team).
               updateRosterCache((current) =>
                 current.filter((s) => studentKey(s) !== row.key),
               )
@@ -1018,9 +1018,8 @@ const EnrolledStudents = ({
 
   return (
     <div className="flex w-full flex-col gap-6">
-      {/* Warnings / action results surface at the top. Rendered only when
-          present so the empty container doesn't add a phantom gap that pushes
-          the first card below the sibling column's top. */}
+      {/* Warnings / action results at the top. Rendered only when present so an
+          empty container doesn't add a phantom gap. */}
       {Object.keys(warnings).length > 0 ? (
         <div className="flex w-full flex-col gap-2">
           <AnimatePresence initial={false}>
@@ -1050,8 +1049,8 @@ const EnrolledStudents = ({
       ) : null}
 
       {/* Data-drift banner: CSV-only rows with no team member / pending invite.
-          Kept VISIBLE below as a distinct "not yet provisioned" section, but the
-          banner surfaces the count + a disclosure so the teacher sees which. */}
+          Also shown below as a distinct "not yet provisioned" section; this just
+          surfaces the count + disclosure. */}
       {!isLoading && !isError && unprovisioned.length > 0 ? (
         <div
           role="alert"

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -125,8 +125,8 @@ const UploadRoster = ({
 
   const isOpen = phase !== "idle"
 
-  // Drive the native <dialog> so we get focus-trap, Escape, and backdrop
-  // inertness for free (matches the app's other modals).
+  // Drive the native <dialog> for free focus-trap, Escape, and backdrop
+  // inertness (matches the app's other modals).
   useEffect(() => {
     const dialog = dialogRef.current
     if (!dialog) return

--- a/web/src/pages/submissions/SubmissionsControls.tsx
+++ b/web/src/pages/submissions/SubmissionsControls.tsx
@@ -8,9 +8,9 @@ import type {
 import { DEFAULT_FILTERS } from "@/pages/submissions/dashboard"
 
 // Search + sort + filter controls for the assignment overview dashboard.
-// Controlled by SubmissionsPage; emits filter/sort/query changes.
-// The not-submitted filter is hidden for group assignments (no roster
-// denominator); passing/accepted selects appear only when available.
+// Controlled by SubmissionsPage; emits filter/sort/query changes. The
+// not-submitted filter is hidden for group assignments; passing/accepted selects
+// appear only when available.
 const SubmissionsControls = ({
   query,
   onQueryChange,

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -36,7 +36,7 @@ const formatDateTime = (datetime: string) =>
   })
 
 // Badge color from the assignment's pass threshold: green at/above the bar, red
-// below, neutral when ungraded (max 0) or no threshold is set (`null`).
+// below, neutral when ungraded (max 0) or no threshold (`null`).
 const scoreToBadgeType = (
   score: number,
   max: number,
@@ -47,7 +47,7 @@ const scoreToBadgeType = (
 }
 
 // Icon action in the Actions cell: an external link when a URL is present, else
-// a dimmed non-clickable span (with a "no … yet" label) so the row stays aligned.
+// a dimmed non-clickable span (with a "no … yet" label) to keep the row aligned.
 type IconComponent = React.ComponentType<{ className?: string }>
 
 const ACTION_BTN = "btn btn-ghost btn-sm btn-square"
@@ -88,10 +88,9 @@ const ActionIconLink = ({
     </span>
   )
 
-// An inline commit/details link in the expanded submission-history row.
-// Renders an external link when a URL is present, else dimmed non-clickable
-// text. The label text is shown next to the icon (unlike the icon-only
-// row-action variant above).
+// Inline commit/details link in the expanded history row: external link when a
+// URL is present, else dimmed non-clickable text (label shown beside the icon,
+// unlike the icon-only row-action above).
 const HistoryLink = ({
   href,
   icon: Icon,
@@ -119,9 +118,9 @@ const HistoryLink = ({
   )
 
 // Compact group identity: shared repo + stacked avatars. Renders from the
-// scores.json `usernames` snapshot and never fetches (enabled: false) to avoid
-// a per-row GitHub call on mount; reads the shared collaborators cache so the
-// avatars upgrade to live data once the Members modal populates it.
+// scores.json `usernames` snapshot and never fetches (enabled: false) to avoid a
+// per-row GitHub call; reads the shared collaborators cache so avatars upgrade to
+// live data once the Members modal populates it.
 const MAX_VISIBLE_AVATARS = 4
 
 const GroupMembers = ({
@@ -201,11 +200,8 @@ const GroupMembers = ({
 
 // Review action: links to the open Feedback PR (opened by the autograde
 // workflow) when one exists, else opens an info modal. The PR is the source of
-// truth — the old scores.json `review` compare-link is unused.
-//
-// The /pulls lookup is deferred until Review is clicked; an eager per-row query
-// would fan out to one request per repo on table mount. On click we refetch and
-// act on the result.
+// truth. The /pulls lookup is deferred until Review is clicked (an eager per-row
+// query would fan out to one request per repo on mount); on click we refetch.
 const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
   const { t } = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
@@ -218,8 +214,8 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
   const handleReview = async () => {
     setResolving(true)
     try {
-      // getOpenPullRequests maps 404 -> [], so a non-404 failure surfaces here
-      // as `error`; show it rather than the misleading "no PR yet" message.
+      // getOpenPullRequests maps 404 -> [], so a non-404 failure surfaces as
+      // `error`; show it rather than the misleading "no PR yet" message.
       const { data: pr, error } = await refetch()
       if (error) {
         setErrorMsg(error instanceof Error ? error.message : String(error))
@@ -303,10 +299,9 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
   )
 }
 
-// Per-row regrade: dispatches regrade.yaml scoped to one owner and tracks the
-// run via useTriggerRegrade (icon shows progress; disabled while any regrade is
-// in flight). The button only kicks off grading — the gradebook refreshes on
-// the next collect.
+// Per-row regrade: dispatches regrade.yaml scoped to one owner, tracked via
+// useTriggerRegrade (icon shows progress; disabled while any regrade is in
+// flight). Only kicks off grading — the gradebook refreshes on the next collect.
 const RegradeButton = ({
   org,
   classroom,
@@ -319,7 +314,7 @@ const RegradeButton = ({
   assignment: string
   owner: string
   // The student's display name (individual assignments) when known; falls back
-  // to the `owner` login. Omitted for group repos (owner is the founder/group).
+  // to `owner`. Omitted for group repos (owner is the founder/group).
   displayName?: string
 }) => {
   const { t } = useTranslation()
@@ -330,9 +325,9 @@ const RegradeButton = ({
     owner,
   })
   const inFlight = phase === "dispatching" || phase === "running"
-  // Disable while ANY regrade (this row, another row, or "Regrade all") is in
-  // flight: trackers share one regrade.yaml run list and bind by monotonic id,
-  // so only one outstanding dispatch at a time keeps the binding unambiguous.
+  // Disable while ANY regrade (this row, another, or "Regrade all") is in flight:
+  // trackers share one regrade.yaml run list and bind by monotonic id, so a
+  // single outstanding dispatch keeps the binding unambiguous.
   const blocked = anyRegrading && !inFlight
   const [confirmOpen, setConfirmOpen] = useState(false)
 
@@ -502,13 +497,12 @@ const SubmissionsTable = ({
   assignment: string
   assignmentName?: string
   maxGroupSize?: number
-  // Lowercased usernames with an assignment repo (individual assignments).
-  // Used to decide whether the profile modal shows the "Open repo" button for a
-  // non-submitter — a never-accepted student has no repo, so the link would 404.
+  // Lowercased usernames with an assignment repo (individual assignments). Used
+  // to decide whether the profile modal shows "Open repo" for a non-submitter —
+  // a never-accepted student has no repo, so the link would 404.
   acceptedUsernames?: Set<string>
-  // Passing bar as a fraction of max (e.g. 1.0 = full marks); drives score
-  // badge color. `null`/omitted means the assignment has no passing threshold
-  // (badges render neutral).
+  // Passing bar as a fraction of max (e.g. 1.0 = full marks); drives score badge
+  // color. `null`/omitted means no passing threshold (badges render neutral).
   thresholdFraction?: number | null
 }) => {
   const { t } = useTranslation()
@@ -520,17 +514,16 @@ const SubmissionsTable = ({
   // The owner (group founder) whose collaborators modal is open, or null.
   const [manageOwner, setManageOwner] = useState<string | null>(null)
 
-  // The student whose profile modal is open (resolved from a row's username),
-  // or null. Resolves to a roster Student for the richer detail view.
+  // The student whose profile modal is open (resolved from a row's username), or
+  // null. Resolves to a roster Student for the richer detail view.
   const [profileUsername, setProfileUsername] = useState<string | null>(null)
   const profileStudent = profileUsername
     ? resolveStudent(profileUsername, students)
     : null
 
-  // The profiled student has an assignment repo iff they submitted (their
-  // login is credited on a score row) or they accepted (in acceptedUsernames).
-  // A never-accepted non-submitter has no repo, so we omit the modal's repo link
-  // rather than point it at a 404.
+  // The profiled student has a repo iff they submitted (login credited on a
+  // score row) or accepted (in acceptedUsernames). A never-accepted non-submitter
+  // has none, so we omit the modal's repo link rather than point it at a 404.
   const profileHasRepo = (() => {
     if (!profileUsername) return false
     const login = profileUsername.toLowerCase()

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -270,8 +270,8 @@ describe("acceptedUsernames / hasAccepted / acceptedRosterCount", () => {
   const repos = [
     repo("cs101-hw1-alice"),
     repo("cs101-hw1-bob"),
-    repo("cs101-hw2-alice"), // different assignment
-    repo("cs101-hw1"), // bare prefix, no owner -> ignored
+    repo("cs101-hw2-alice"),
+    repo("cs101-hw1"),
     repo("unrelated-repo"),
   ]
 
@@ -289,15 +289,15 @@ describe("acceptedUsernames / hasAccepted / acceptedRosterCount", () => {
   })
 
   it("does NOT bleed a sibling assignment whose slug extends this one", () => {
-    // Assignment "hw" (prefix "cs101-hw-") must not capture repos belonging to
-    // assignment "hw-bonus" (regression test for the prefix-collision bug).
+    // Assignment "hw" (prefix "cs101-hw-") must not capture repos of "hw-bonus"
+    // (prefix-collision regression).
     const set = acceptedUsernames(
       [repo("cs101-hw-bonus-alice"), repo("cs101-hw-alice")],
       "cs101",
       "hw",
       [student({ username: "alice" })],
     )
-    expect([...set]).toEqual(["alice"]) // only the exact cs101-hw-alice repo
+    expect([...set]).toEqual(["alice"])
     expect(set.has("bonus-alice")).toBe(false)
   })
 

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -1,6 +1,6 @@
 // Pure derivation/filter/sort primitives for the assignment overview dashboard,
 // over already-loaded scores/roster data — no fetches, no React, so the
-// classification is reusable and unit-testable.
+// classification is reusable and testable.
 
 import type { SubmissionRow } from "@/hooks/useGetScores"
 import type { GitHubRepo } from "@/hooks/github/types"
@@ -9,8 +9,8 @@ import { getName } from "@/util/students"
 import { studentRepoName } from "@/util/studentRepo"
 
 // `thresholdFraction` is the passing bar as a fraction of max, or `null` when
-// the assignment sets no threshold (the opt-in feature is off) — then every
-// row is "ungraded" (also the case for an ungraded/zero-max row).
+// the assignment sets no threshold — then every row is "ungraded" (as is an
+// ungraded/zero-max row).
 export type PassState = "passing" | "failing" | "ungraded"
 
 export function rowPassState(
@@ -27,9 +27,9 @@ export function rowPassState(
   return row.score / max >= thresholdFraction ? "passing" : "failing"
 }
 
-// Top-line stat-strip counts. `rostered` is meaningless as a denominator for
-// group assignments (the UI hides it there); `ungraded` is kept separate so it
-// inflates neither passing nor failing.
+// Top-line stat-strip counts. `rostered` is meaningless as a group-assignment
+// denominator (hidden there); `ungraded` is separate so it inflates neither
+// passing nor failing.
 export type SubmissionStats = {
   submitted: number
   rostered: number
@@ -71,9 +71,9 @@ export function computeStats(
   }
 }
 
-// Mean of the numeric scores, rounded to 2 decimals, or null when none is
-// finite (rendered "N/A"). Avoids the old `sum/length || 1` bug where an
-// empty/NaN result showed "1" (`/` binds before `||`).
+// Mean of the numeric scores, rounded to 2 decimals, or null when none is finite
+// (rendered "N/A"). Avoids the old `sum/length || 1` bug where an empty/NaN
+// result showed "1" (`/` binds before `||`).
 export function classAverage(rows: SubmissionRow[]): number | null {
   const numericScores = rows
     .map((row) => Number(row["score"]))
@@ -84,9 +84,8 @@ export function classAverage(rows: SubmissionRow[]): number | null {
   return Math.round(avg * 100) / 100
 }
 
-// Filters the dashboard exposes. Each is independent; an unset value ("all")
-// means "no constraint on this axis". Combined filters AND together. `section`
-// is "all" or an exact section value from the roster.
+// Filters the dashboard exposes. Each is independent ("all" = no constraint);
+// combined filters AND together. `section` is "all" or an exact roster value.
 export type SubmissionFilters = {
   submission: "all" | "submitted" | "on-time" | "late" | "not-submitted"
   passing: "all" | "passing" | "failing"
@@ -146,17 +145,16 @@ export const DEFAULT_SORT: SubmissionSort = "recent"
 
 // Who has accepted an INDIVIDUAL assignment, derived from the org repo list: a
 // student accepted iff `<classroom>-<assignment>-<username>` exists. Independent
-// of submission — a student can accept (repo exists) without a graded push.
+// of submission — a repo can exist without a graded push.
 //
-// We forward-construct each roster student's expected name and test existence,
-// rather than reverse-parsing a `<classroom>-<assignment>-` prefix off repo
-// names — prefix-stripping over-matches a sibling assignment whose slug extends
-// this one (assignment "hw" would capture `cs-hw-bonus-alice` from "hw-bonus"),
-// polluting the set and risking a 404 when the modal rebuilds a URL from a bogus
-// owner. (See docs/solutions/.../forward-only-cross-binary-repo-name-contract.md.)
+// Forward-construct each student's expected repo name rather than reverse-parsing
+// a `<classroom>-<assignment>-` prefix: prefix-stripping over-matches a sibling
+// whose slug extends this one (assignment "hw" would capture `cs-hw-bonus-alice`
+// from "hw-bonus"), polluting the set and risking a 404 when the modal rebuilds
+// a URL. (See docs/solutions/.../forward-only-cross-binary-repo-name-contract.md.)
 //
-// Group assignments are excluded (the repo is named after the owner, not each
-// member), so callers offer the accepted filter for individual assignments only.
+// Group assignments are excluded (repo named after the owner, not each member),
+// so callers offer the accepted filter for individual assignments only.
 export function acceptedUsernames(
   repos: GitHubRepo[] | null | undefined,
   classroom: string,
@@ -184,7 +182,7 @@ export function hasAccepted(username: string, accepted: Set<string>): boolean {
 
 // Count of ROSTER students who accepted. Intersecting with the roster keeps the
 // "Accepted N / roster" stat from exceeding its denominator when `accepted`
-// includes non-roster owners (a since-unenrolled student, a stray test repo).
+// includes non-roster owners (an unenrolled student, a stray test repo).
 export function acceptedRosterCount(
   students: Student[],
   accepted: Set<string>,
@@ -194,8 +192,8 @@ export function acceptedRosterCount(
 }
 
 // Case-insensitive match of a query against a row's identities: each credited
-// username plus its roster display name (so searching a real name works even
-// though scores.json only carries logins).
+// username plus its roster display name (so searching a real name works though
+// scores.json only carries logins).
 export function rowMatchesQuery(
   row: SubmissionRow,
   query: string,
@@ -211,8 +209,8 @@ export function rowMatchesQuery(
 }
 
 // Search + filters + sort over the submitted rows. "not-submitted" lives in the
-// caller's nonSubmitters list, not here, so that filter hides every submitted
-// row; likewise "not-accepted", since a submitted row always has a repo.
+// caller's nonSubmitters list, so that filter hides every submitted row;
+// likewise "not-accepted", since a submitted row always has a repo.
 export function filterAndSortRows(
   rows: SubmissionRow[],
   {
@@ -270,8 +268,8 @@ export function filterAndSortRows(
       ""
     ).toLowerCase()
 
-  // Key each row's name + time once before sorting: byName does a linear roster
-  // scan, so calling it inside the comparator would repeat it O(rows·log rows).
+  // Key each row's name + time once before sorting: byName scans the roster
+  // linearly, so calling it in the comparator would repeat it O(rows·log rows).
   const keyed = filtered.map((row) => ({
     row,
     name: byName(row),
@@ -296,16 +294,16 @@ export function filterAndSortRows(
 }
 
 // Whether non-submitters should still appear under the current filters. Any
-// submission/passing constraint implies a submission exists, so it hides them;
-// the accepted filter does not (both accepted-not-submitted and not-accepted
-// are non-submitter states).
+// submission/passing constraint implies a submission exists, hiding them; the
+// accepted filter does not (both accepted-not-submitted and not-accepted are
+// non-submitter states).
 export function showsNonSubmitters(filters: SubmissionFilters): boolean {
   if (filters.passing !== "all") return false
   return filters.submission === "all" || filters.submission === "not-submitted"
 }
 
-// Filters non-submitters by search query and the accepted filter. `accepted`
-// is the set from acceptedUsernames (empty for group assignments, where the UI
+// Filters non-submitters by search query and the accepted filter. `accepted` is
+// the set from acceptedUsernames (empty for group assignments, where the UI
 // disables the accepted filter).
 export function filterNonSubmitters(
   nonSubmitters: Student[],

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -9,9 +9,9 @@ import { useTranslation } from "react-i18next"
 import { RoleViewProvider } from "@/context/roleView/RoleViewProvider"
 
 const RootComponent = () => {
-  // Scope the "view as" preview to the current org (reset across orgs via
-  // the key); the provider re-syncs on classroom change so it's classroom-scoped.
-  // Reading params at the root keeps the provider inside the router.
+  // Scope "view as" to the current org (reset across orgs via the key); the
+  // provider re-syncs on classroom change. Reading params at the root keeps the
+  // provider inside the router.
   const { org, classroom } = useParams({ strict: false })
   return (
     <RoleViewProvider key={org ?? "no-org"} org={org} classroom={classroom}>
@@ -20,9 +20,8 @@ const RootComponent = () => {
   )
 }
 
-// App-wide safety net: any uncaught render error in a route subtree (e.g. a
-// malformed external payload reaching a component) degrades to this screen
-// instead of a blank white page.
+// App-wide safety net: any uncaught render error in a route subtree degrades to
+// this screen instead of a blank white page.
 const RootErrorComponent = ({ error }: { error: Error }) => {
   const { t } = useTranslation()
   return (

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -9,9 +9,9 @@ export const Route = createFileRoute("/_authed")({
       throw redirect({
         to: "/login",
         search: {
-          // Same-origin relative path only (see isSafeReturnTo), so the
-          // destination survives the round-trip without open-redirect risk.
-          // Consumed post-auth in useGithubAuth and login.tsx's guard (#71).
+          // Same-origin relative path only (see isSafeReturnTo), so it survives
+          // the round-trip without open-redirect risk. Consumed post-auth in
+          // useGithubAuth and login.tsx's guard (#71).
           redirect: location.pathname + location.searchStr,
         },
       })

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -5,12 +5,10 @@ import { isSafeReturnTo } from "@/auth/returnTo"
 // `redirect`: same-origin path to return to after sign-in, set when the _authed
 // guard (or App's session-expiry redirect) bounces an unauthenticated user here
 // (#71). useGithubAuth handles the sign-in round-trip; this guard covers the
-// already-authenticated case.
-//
-// The value is built as pathname + search (see _authed.tsx / App.tsx), so it may
-// carry a query (e.g. the ?k= accept capability key). Passing it whole as
-// `redirect({ to })` folds the query into the pathname, so split it into
-// { to, search } first. /login itself is rejected to avoid a self-redirect hop.
+// already-authenticated case. The value is pathname + search, so it may carry a
+// query (e.g. the ?k= accept key); `redirect({ to })` would fold that into the
+// pathname, so split into { to, search } first. /login is rejected to avoid a
+// self-redirect hop.
 function toRedirectTarget(value: string): {
   to: string
   search: Record<string, string>

--- a/web/src/skeleton/skeleton.test.ts
+++ b/web/src/skeleton/skeleton.test.ts
@@ -21,10 +21,10 @@ describe("bundled skeleton", () => {
   })
 
   it("deploys every bundled path it declares (no silent CLI-side additions)", () => {
-    // Reverse of the check above: a skeleton file the CLI commits (now in the
-    // bundle) that the GUI forgot to add to SKELETON_PATHS would ship via
-    // `gh teacher init` but never via GUI org setup — the action-parity gap
-    // this bundling closes, silently reopened. Fail the build instead.
+    // Reverse of the check above: a skeleton file the CLI commits (now bundled)
+    // that the GUI forgot to add to SKELETON_PATHS would ship via
+    // `gh teacher init` but never via GUI org setup — silently reopening the
+    // action-parity gap this bundling closes. Fail the build instead.
     const declared = new Set<string>(SKELETON_PATHS)
     for (const rel of bundledSkeletonPaths()) {
       expect(
@@ -64,8 +64,8 @@ describe("bundled skeleton", () => {
 
   it("throws a build-bug error when a declared path is not bundled", () => {
     // The drift safety net buildSkeletonFiles relies on: a SKELETON_PATHS entry
-    // missing from the bundle (renamed/removed/extension-swapped source file)
-    // must fail loudly at build time, not 404 a teacher's first org setup.
+    // missing from the bundle (renamed/removed/extension-swapped source) must
+    // fail loudly at build time, not 404 a teacher's first org setup.
     const partialBundle = new Map<string, string>([
       ["workflows/publish-pages.yaml", "on: push\n"],
     ])

--- a/web/src/skeleton/skeleton.ts
+++ b/web/src/skeleton/skeleton.ts
@@ -2,8 +2,8 @@
 // into its deploy artifact rather than fetching it from the CLI mirror at
 // runtime. The one canonical copy stays at `cli/gh-teacher/skeleton/dotgithub/`
 // because the CLI embeds it via `//go:embed`, which can't reference a parent
-// directory. Vite inlines the files below at build time, so each deploy carries
-// the skeleton from its own commit.
+// dir. Vite inlines the files below at build time, so each deploy carries the
+// skeleton from its own commit.
 
 // dotgithub/ is rewritten to .github/ at commit time; the source dir is named
 // `dotgithub` because `//go:embed` (no `all:`) skips dot-prefixed paths.
@@ -73,10 +73,10 @@ export type SkeletonFile = {
   content: string
 }
 
-// Resolve a declared skeleton set into target-repo files from a given bundle,
-// with the default-branch placeholder substituted. Throws if a declared path
-// isn't in the bundle. Extracted from buildSkeletonFiles so the missing-path
-// throw is exercisable in skeleton.test.ts without faking the build-time glob.
+// Resolve a declared skeleton set into target-repo files from a bundle, with the
+// default-branch placeholder substituted. Throws if a declared path isn't in the
+// bundle. Extracted from buildSkeletonFiles so the missing-path throw is
+// exercisable in skeleton.test.ts without faking the build-time glob.
 export function buildSkeletonFilesFromBundle(
   paths: readonly string[],
   bundle: ReadonlyMap<string, string>,

--- a/web/src/types/classroom.test.ts
+++ b/web/src/types/classroom.test.ts
@@ -13,7 +13,7 @@ describe("isClassroomArchived", () => {
 
   it("treats an absent active flag as not archived (legacy classrooms)", () => {
     // Legacy classroom.json never wrote `active`, so undefined must read as
-    // active — not archived.
+    // active.
     expect(isClassroomArchived({})).toBe(false)
     expect(isClassroomArchived({ active: undefined })).toBe(false)
   })

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -1,11 +1,10 @@
 export type Classroom = {
   path: string
-  // Archive lifecycle flag. `active: false` means the classroom is ARCHIVED —
-  // it blocks new assignments and new student accepts and drops out of the
-  // default classes list, while preserving its roster/assignments. Reversible
-  // (unarchive sets it back to true). Absent or true = active; legacy
-  // classrooms (no `active` written) therefore read as active. Written via the
-  // omitempty pattern; kept in lockstep with the CLI's classroom-v1 schema.
+  // Archive lifecycle flag. `active: false` = ARCHIVED: blocks new assignments
+  // and student accepts and drops out of the default classes list, while
+  // preserving roster/assignments. Reversible. Absent or true = active, so
+  // legacy classrooms (no `active` written) read as active. Written omitempty;
+  // in lockstep with the CLI's classroom-v1 schema.
   active?: boolean
   term: string
   name: string
@@ -15,16 +14,16 @@ export type Classroom = {
   // templates. Absent on classrooms created before this feature.
   team?: TeamRef
   // Per-classroom GitHub staff teams backing in-app roles. Each is a `secret`
-  // team `classroom50-<short_name>-<role>` granted config-repo write;
-  // ensured-on-touch. Absent on classrooms created before this feature.
+  // team `classroom50-<short_name>-<role>` granted config-repo write, ensured
+  // on touch. Absent on classrooms created before this feature.
   teams?: {
     instructor?: TeamRef
     ta?: TeamRef
   }
   // Optional capability-URL secret. When present, this classroom's Pages
   // resources live under `<classroom>/<secret>/...` (every consumer inserts it);
-  // when absent, the plain `<classroom>/...` path. Opt-in per classroom (off by
-  // default). Kept in lockstep with the CLI's classroom-v1 schema (`[a-z0-9]{4,64}`).
+  // else the plain `<classroom>/...` path. Opt-in, off by default. In lockstep
+  // with the CLI's classroom-v1 schema (`[a-z0-9]{4,64}`).
   secret?: string
 }
 
@@ -41,8 +40,7 @@ export type StaffRole = "instructor" | "ta"
 
 export const STAFF_ROLES: readonly StaffRole[] = ["instructor", "ta"]
 
-// A classroom is archived when `active` is explicitly false. Absent or true
-// reads as active, so legacy classrooms (which never wrote `active`) are active.
+// Archived when `active` is explicitly false (see the `active` field).
 export const isClassroomArchived = (cl: { active?: boolean }): boolean =>
   cl.active === false
 
@@ -101,11 +99,10 @@ export type Assignment = {
   // Empty/absent = all files allowed. Enforced server-side.
   allowed_files?: string[]
   // Integer percentage (0–100) at/above which a submission counts as "passing"
-  // in the gradebook's Passing rollup, badges, and passing/failing filter. A
-  // display/contract field only — it does not change a student's actual score
-  // (grading is points-based via the autograder). Absent = default (see
-  // DEFAULT_PASS_THRESHOLD). Kept in lockstep with the CLI's assignments-v1
-  // schema (`pass_threshold`, integer, omitempty) — see classroom50-cli.
+  // in the gradebook rollup, badges, and passing/failing filter. Display/contract
+  // only — it doesn't change a student's actual (points-based) score. Absent =
+  // DEFAULT_PASS_THRESHOLD. In lockstep with the CLI's assignments-v1 schema
+  // (`pass_threshold`, integer, omitempty).
   pass_threshold?: number
   tests?: AssignmentTest[]
   // CLI migrate provenance. The GUI doesn't write it but must round-trip it.
@@ -128,8 +125,8 @@ export const PASS_THRESHOLD_MIN = 0
 export const PASS_THRESHOLD_MAX = 100
 
 // Default passing bar when an assignment sets no pass_threshold: a submission
-// must score full marks to count as "passing". Deliberately strict — a teacher
-// lowers it per assignment when partial credit should count as a pass.
+// must score full marks. Deliberately strict — a teacher lowers it when partial
+// credit should count as a pass.
 export const DEFAULT_PASS_THRESHOLD = 100
 
 // Write-side provenance for `due`. Since `due` is stored as a UTC instant
@@ -162,12 +159,10 @@ export type AssignmentTest = {
   points: number
 }
 
-// students.csv is now just the 6 identity/metadata columns — the classroom
-// GitHub team is the source of truth for enrollment, so the email-first
-// onboarding lifecycle columns (enrollment_status/method, email_hash,
-// invite_token, invited_at, enrolled_at) were pruned. The CSV is a data
-// contract shared with the gh-teacher CLI (separate repo) and the Python
-// collector; all three moved in lockstep.
+// students.csv is just the 6 identity/metadata columns — the classroom GitHub
+// team is the source of truth for enrollment, so the email-first onboarding
+// lifecycle columns were pruned. A data contract shared with the gh-teacher CLI
+// and the Python collector; all three moved in lockstep.
 export type Student = {
   username: string
   first_name: string

--- a/web/src/util/actionActivity.test.ts
+++ b/web/src/util/actionActivity.test.ts
@@ -166,7 +166,7 @@ describe("runMatchesOp", () => {
   it("null baseline does NOT match a run that started well before the dispatch (later cron/other run)", () => {
     const started = Date.now()
     // A run that started 10 minutes before this op was dispatched — e.g. an
-    // earlier cron run that only now shows in the poll window.
+    // earlier cron run only now in the poll window.
     const r = dispatchRun(5, "regrade.yaml", {
       run_started_at: new Date(started - 10 * 60_000).toISOString(),
     })

--- a/web/src/util/actionActivity.ts
+++ b/web/src/util/actionActivity.ts
@@ -2,7 +2,7 @@ import type { GitHubWorkflowRun } from "@/hooks/github/types"
 import type { ActionOperation } from "@/context/actions/ActionActivityProvider"
 
 // Pure helpers behind the activity banner, split out so run-attribution and
-// org-parsing are unit-testable without React / the router.
+// org-parsing are testable without React / the router.
 
 // Reserved top-level URL segments that aren't an org slug.
 const RESERVED_FIRST_SEGMENTS = new Set(["login"])
@@ -25,8 +25,8 @@ export function orgFromPathname(
 }
 
 // Wall-clock now via a named import, so callers can read the clock inside
-// effects without tripping the react-hooks purity rule (which flags a bare
-// `Date.now()` in a hook body but not an imported call).
+// effects without tripping the react-hooks purity rule (bare `Date.now()` in a
+// hook body is flagged, an imported call isn't).
 export function nowMs(): number {
   return Date.now()
 }
@@ -72,7 +72,7 @@ const NULL_BASELINE_SKEW_MS = 60_000
 // Null-baseline (no prior dispatch runs at dispatch time): an id comparison
 // alone would match ANY future run, mis-attributing a later cron/other run — so
 // gate on the run having started at/after the dispatch (with skew). A run
-// missing a timestamp falls back to the id-only match.
+// missing a timestamp falls back to id-only.
 export function runMatchesOp(
   run: GitHubWorkflowRun,
   op: ActionOperation,
@@ -95,7 +95,7 @@ export function runMatchesOp(
 // Resolve the run an op is tracking from the polled runs. "sha" -> matching
 // head_sha; "sinceRunId" -> the OLDEST run past the baseline (ids are
 // monotonic). `claimedRunIds` excludes runs already bound to an earlier op, so
-// racing same-workflow dispatches each claim a distinct run. Null until surfaced.
+// racing same-workflow dispatches each claim a distinct run.
 export function resolveOpRun(
   op: ActionOperation,
   runs: GitHubWorkflowRun[],
@@ -107,7 +107,7 @@ export function resolveOpRun(
   const candidates = runs
     .filter((r) => runMatchesOp(r, op))
     .filter((r) => !claimedRunIds?.has(r.id))
-    // Oldest first — the oldest run past the baseline is the one this dispatch created.
+    // Oldest run past the baseline is the one this dispatch created.
     .sort((a, b) => a.id - b.id)
   return candidates[0] ?? null
 }

--- a/web/src/util/allowedFiles.ts
+++ b/web/src/util/allowedFiles.ts
@@ -1,16 +1,16 @@
 // Authoring helpers for an assignment's `allowed_files`: an ordered,
 // .gitignore-style allowlist (last match wins, `!` re-includes; empty = all
-// files allowed). Edited as a textarea (one pattern per line); these convert
-// to/from the wire-shape `string[]`. Validation mirrors the CLI's
-// ValidateAllowedFiles and the assignments-v1 schema so a bad value is caught
-// here, not by a rejected commit that breaks assignments.json.
+// allowed). Edited as a textarea (one pattern per line); these convert to/from
+// the wire-shape `string[]`. Validation mirrors the CLI's ValidateAllowedFiles
+// and the assignments-v1 schema so a bad value is caught here, not by a rejected
+// commit.
 
 export const ALLOWED_FILES_CAP = 100
 
 // One pattern per line; blank lines dropped. Strips only the line separator
 // (trailing CR from CRLF) — other whitespace is significant in .gitignore and
 // stored verbatim by the CLI, so rewriting it would corrupt CLI-authored
-// patterns on re-save. Order is preserved (last match wins).
+// patterns on re-save. Order preserved (last match wins).
 export function parseAllowedFiles(raw: string): string[] {
   return raw
     .split("\n")

--- a/web/src/util/assignmentTests.ts
+++ b/web/src/util/assignmentTests.ts
@@ -4,10 +4,9 @@ import type {
   AssignmentTestType,
 } from "@/types/classroom"
 
-// Form-side draft for one declarative test. Camel-cased and
-// all-fields-present so it plugs into @tanstack/react-form cleanly;
-// `draftToTest` converts to the kebab-case v1 wire shape and drops
-// fields that don't apply to the chosen type.
+// Form-side draft for one declarative test. Camel-cased and all-fields-present
+// so it plugs into @tanstack/react-form cleanly; `draftToTest` converts to the
+// kebab-case v1 wire shape and drops fields that don't apply to the type.
 export type AssignmentTestDraft = {
   name: string
   type: AssignmentTestType
@@ -24,9 +23,9 @@ export type AssignmentTestDraft = {
 }
 
 // A setup command is encoded as a leading 0-point `run` test with this reserved
-// name — the CLI-blessed pre-grading idiom (no runtime.setup field; the runner
-// runs tests in order, non-zero exit fails). Reserved from user-authored tests
-// so a graded "setup" test can't be confused with the synthesized one.
+// name — the CLI-blessed pre-grading idiom (the runner runs tests in order,
+// non-zero exit fails). Reserved from user tests so a graded "setup" can't be
+// confused with the synthesized one.
 export const SETUP_TEST_NAME = "setup"
 
 export const makeSetupTest = (command: string): AssignmentTest => ({
@@ -76,11 +75,10 @@ export const testToDraft = (test: AssignmentTest): AssignmentTestDraft => ({
   points: test.points,
 })
 
-// draftToTest serializes a draft into the exact v1 wire shape:
-// kebab-case keys, type-inapplicable fields dropped (the CLI rejects
-// e.g. `expected` on a run test), and optional fields omitted when
-// empty/zero — the same normalized form `gh teacher assignment test
-// add` writes.
+// draftToTest serializes a draft into the exact v1 wire shape: kebab-case keys,
+// type-inapplicable fields dropped (the CLI rejects e.g. `expected` on a run
+// test), optional fields omitted when empty/zero — the same normalized form
+// `gh teacher assignment test add` writes.
 export function draftToTest(draft: AssignmentTestDraft): AssignmentTest {
   const test: AssignmentTest = {
     name: draft.name.trim(),
@@ -92,9 +90,9 @@ export function draftToTest(draft: AssignmentTestDraft): AssignmentTest {
   if (draft.setup.trim()) test.setup = draft.setup.trim()
   if (draft.timeout > 0) test.timeout = draft.timeout
 
-  // Commands and file names are trimmed; stdin and expected output are
-  // written raw (leading/trailing whitespace and newlines are
-  // meaningful there) and only their *emptiness* is judged trimmed.
+  // Commands and file names are trimmed; stdin and expected output are written
+  // raw (leading/trailing whitespace and newlines are meaningful there), only
+  // their *emptiness* judged trimmed.
   if (draft.type === "io") {
     test.comparison = draft.comparison
     if (draft.input.trim() && !draft.inputFile.trim()) test.input = draft.input
@@ -125,9 +123,9 @@ const hasControlChars = (value: string) =>
 
 // validateTestDraft mirrors the rules gh-teacher enforces at write time
 // (cli/gh-teacher/tests.go, pinned by schemas/assignments-v1.schema.json),
-// including the two rules JSON Schema can't express: unique names and a
-// 100-UTF-8-byte name cap. Returns one message per offending field,
-// keyed for `tests[index].<field>` form errors.
+// including the two JSON Schema can't express: unique names and a 100-UTF-8-byte
+// name cap. Returns one message per offending field, keyed for
+// `tests[index].<field>` form errors.
 export function validateTestDraft(
   draft: AssignmentTestDraft,
   otherNames: string[],
@@ -175,9 +173,9 @@ export function validateTestDraft(
       errors.expectedFile =
         "Provide inline expected output or an expected file, not both."
     }
-    // `included`/`regex` against an empty (or whitespace-only) expected
-    // match almost everything — an always-passing test, so reject it
-    // here like the CLI does at write time.
+    // `included`/`regex` against an empty (or whitespace-only) expected match
+    // almost everything — an always-passing test, so reject it here like the CLI
+    // does at write time.
     if (
       draft.comparison !== "exact" &&
       !draft.expected.trim() &&
@@ -201,8 +199,8 @@ export function validateTestDraft(
 }
 
 // validateTestDrafts validates the whole list, returning a flat map of
-// `tests[i].<field>` -> message (the key shape @tanstack/react-form
-// expects for array-field errors).
+// `tests[i].<field>` -> message (the key shape @tanstack/react-form expects for
+// array-field errors).
 export function validateTestDrafts(
   drafts: AssignmentTestDraft[],
 ): Record<string, string> {

--- a/web/src/util/commit.test.ts
+++ b/web/src/util/commit.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest"
 import { COMMIT_PREFIX, prefixCommit } from "./commit"
 
 describe("commit prefix", () => {
-  // Pins the literal so it can't silently drift from the CLI's
-  // cli/shared/contract CommitPrefix and the collect-scores.yaml workflow
-  // (there is no compile-time link across the three).
+  // Pins the literal so it can't drift from the CLI's cli/shared/contract
+  // CommitPrefix and the collect-scores.yaml workflow (no compile-time link
+  // across the three).
   it("uses the [Classroom 50] wire prefix", () => {
     expect(COMMIT_PREFIX).toBe("[Classroom 50]")
   })

--- a/web/src/util/commit.ts
+++ b/web/src/util/commit.ts
@@ -1,15 +1,13 @@
 // Commit-message prefix for every tool-authored commit the GUI makes, so a
-// teacher or student can tell them apart from their own commits in the repo
-// history. Kept byte-identical with the CLI's cli/shared/contract
-// (contract.CommitPrefix / contract.PrefixCommit) and the skeleton
-// collect-scores.yaml workflow — there is no compile-time link across the
-// three, so update every copy in lockstep on change.
+// teacher or student can tell them apart in the repo history. Kept byte-identical
+// with the CLI's cli/shared/contract (CommitPrefix / PrefixCommit) and the
+// skeleton collect-scores.yaml workflow — no compile-time link across the three,
+// so update every copy in lockstep.
 
 export const COMMIT_PREFIX = "[Classroom 50]"
 
-// prefixCommit prepends COMMIT_PREFIX to a commit message, producing the
-// canonical "[Classroom 50] <message>" form. Any trailing "(gh ... )"
-// provenance hint a caller includes is preserved verbatim inside message.
+// prefixCommit prepends COMMIT_PREFIX, producing "[Classroom 50] <message>".
+// Any trailing "(gh ... )" provenance hint a caller includes is preserved.
 export function prefixCommit(message: string): string {
   return `${COMMIT_PREFIX} ${message}`
 }

--- a/web/src/util/concurrency.ts
+++ b/web/src/util/concurrency.ts
@@ -1,8 +1,8 @@
 // Map over items running at most `limit` async tasks at once, preserving input
 // order. The bound keeps GitHub's per-repo reads from fanning out into hundreds
 // of simultaneous requests (which trip secondary rate limits) while staying far
-// faster than a sequential loop. The first rejection rejects the returned
-// promise (Promise.all semantics).
+// faster than a sequential loop. The first rejection rejects the result
+// (Promise.all semantics).
 export async function mapWithConcurrency<T, R>(
   items: readonly T[],
   limit: number,

--- a/web/src/util/formatDate.test.ts
+++ b/web/src/util/formatDate.test.ts
@@ -37,8 +37,8 @@ describe("formatDueDateTime", () => {
 
   it("includes a time component for a full timestamp", () => {
     const out = formatDueDateTime("2026-06-23T23:59:00Z")
-    // Wall-clock time + timezone abbreviation are locale/TZ-dependent, so just
-    // assert a time-like "HH:MM" pattern is present rather than an exact string.
+    // Wall-clock time + TZ abbreviation are locale/TZ-dependent, so assert a
+    // time-like "HH:MM" pattern rather than an exact string.
     expect(out).toMatch(/\d{1,2}:\d{2}/)
   })
 
@@ -56,8 +56,8 @@ describe("isPastDue", () => {
   })
 
   it("treats a bare date as past due only after local end-of-day", () => {
-    // Same calendar day as the deadline: must NOT be past due (the bug this
-    // guards against flagged it past due at local midnight, ~24h early).
+    // Same calendar day as the deadline: must NOT be past due (the guarded bug
+    // flagged it past due at local midnight, ~24h early).
     vi.setSystemTime(new Date(2026, 5, 23, 9, 0, 0)) // local 2026-06-23 09:00
     expect(isPastDue("2026-06-23")).toBe(false)
 

--- a/web/src/util/formatDate.ts
+++ b/web/src/util/formatDate.ts
@@ -4,9 +4,9 @@ import i18n from "@/i18n"
 import { BASE_LANG } from "@/i18n/customLocale"
 
 // Drive Intl formatting off the active language. Bare "en" maps to "en-US" to
-// preserve the exact US-style output the app/tests expect. A sideloaded pack
-// can carry a code Intl rejects with a RangeError, so validate and fall back to
-// "en-US" rather than let every date render throw.
+// preserve US-style output. A sideloaded pack can carry a code Intl rejects with
+// a RangeError, so validate and fall back to "en-US" rather than throw on every
+// date render.
 const resolveLocale = (): string => {
   const lang = i18n.language || "en-US"
   const candidate = lang === BASE_LANG ? "en-US" : lang
@@ -75,9 +75,8 @@ export const formatDueDateTime = (dateString: string): string => {
   return dueDateTimeFormatter().format(date)
 }
 
-// Unlike DateTimeFormat above, an unsupported-but-well-formed tag must fall
-// back to English, not to the browser's default locale — hence the extra
-// supportedLocalesOf check.
+// Unlike DateTimeFormat above, an unsupported-but-well-formed tag must fall back
+// to English, not the browser default — hence the supportedLocalesOf check.
 const relativeTimeFormatter = () => {
   const supported = Intl.RelativeTimeFormat.supportedLocalesOf([
     resolveLocale(),
@@ -97,8 +96,8 @@ const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ["minute", 60],
 ]
 
-// Relative "x ago" / "in x" in the active UI language, via the platform's
-// Intl locale data — sideloaded languages need no per-language bundles.
+// Relative "x ago" / "in x" in the active UI language via the platform's Intl
+// locale data — sideloaded languages need no per-language bundles.
 export const formatRelativeToNow = (date: Date | number): string => {
   const diffSeconds = Math.round((new Date(date).getTime() - Date.now()) / 1000)
   const abs = Math.abs(diffSeconds)
@@ -120,7 +119,7 @@ export const formatInvitedAt = (dateString?: string | null): string | null => {
 export const isPastDue = (dateString: string): boolean => {
   // A bare YYYY-MM-DD has no time. buildDueFields pins such a deadline to 23:59
   // local, so treat the whole day as "not past due" until local end-of-day —
-  // otherwise we'd flag it past-due ~24h early (at local midnight).
+  // else we'd flag it ~24h early (at local midnight).
   const date = isBareDate(dateString)
     ? new Date(`${dateString}T23:59:59.999`)
     : parseDueDate(dateString)
@@ -146,7 +145,7 @@ export type DueFields = { due: string; due_meta?: DueMeta }
 // gh-teacher's --due: local wall time becomes a UTC instant, with the
 // pre-normalization local value/offset/zone in due_meta. Accepts
 // `YYYY-MM-DDTHH:MM` and bare `YYYY-MM-DD` (pinned to 23:59 local); anything
-// else is stored verbatim.
+// else stored verbatim.
 export const buildDueFields = (dueInput: string): DueFields => {
   const dateOnly = isBareDate(dueInput)
   const localDateTime = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(
@@ -173,8 +172,8 @@ export const buildDueFields = (dueInput: string): DueFields => {
 
   const local = new Date(year, month - 1, day, hour, minute, 0)
   // `new Date` rolls over out-of-range components (Feb 30 -> Mar 2) instead of
-  // returning NaN; reject anything that didn't round-trip so `due` can't
-  // silently disagree with due_meta.input.
+  // NaN; reject anything that didn't round-trip so `due` can't disagree with
+  // due_meta.input.
   const rolledOver =
     local.getFullYear() !== year ||
     local.getMonth() !== month - 1 ||

--- a/web/src/util/identity.ts
+++ b/web/src/util/identity.ts
@@ -1,12 +1,11 @@
 import type { GitHubUser } from "@/hooks/github/types"
 
-// Canonical identity helpers for relating GitHub accounts, org members, and
-// roster rows — one home so the id/login/"claimed" logic can't drift across the
-// callers that used to each re-implement it.
+// Canonical identity helpers relating GitHub accounts, org members, and roster
+// rows — one home so id/login/"claimed" logic can't drift across callers.
 
-// Stable, position-independent per-row identity. Prefer github_id (survives a
-// rename), then username, then email. Rows always carry at least one
-// (parseStudentsCsv drops fully-empty rows), so no index fallback is needed.
+// Stable, position-independent per-row identity: github_id (survives rename),
+// then username, then email. Rows always carry one (parseStudentsCsv drops
+// fully-empty rows), so no index fallback is needed.
 export function studentKey(student: {
   github_id?: string
   username?: string
@@ -28,23 +27,22 @@ export function isSameGitHubUser(
   )
 }
 
-// Parse a roster row's github_id into a positive numeric GitHub id, or null
-// when it's absent/non-numeric. GitHub ids are positive integers; the CSV stores
-// them as strings.
+// Parse a roster row's github_id into a positive numeric id, else null. GitHub
+// ids are positive integers; the CSV stores them as strings.
 export function parseGitHubId(githubId: string): number | null {
   const id = Number(githubId)
   return Number.isFinite(id) && id > 0 ? id : null
 }
 
-// String github_ids of the org's live members — the key member-status
-// classification and the "Mark enrolled" gate match a roster row's github_id on.
+// String github_ids of the org's live members — member-status classification
+// and the "Mark enrolled" gate match a roster row's github_id against these.
 export function memberIdSet(members: GitHubUser[]): Set<string> {
   return new Set(members.map((member) => String(member.id)))
 }
 
-// The set of GitHub ids and lowercased logins already claimed by a roster. A
-// member is "claimed" when their numeric id or login appears on any row. Shared
-// so the org-members aggregation and the manual-match picker apply one predicate.
+// GitHub ids and lowercased logins already claimed by a roster; a member is
+// "claimed" when their id or login appears on any row. Shared so org-members
+// aggregation and the manual-match picker apply one predicate.
 export function rosterClaimSet(
   students: { github_id?: string; username?: string }[],
 ): {

--- a/web/src/util/membershipReadError.test.ts
+++ b/web/src/util/membershipReadError.test.ts
@@ -22,9 +22,9 @@ const apiError = (status: number) =>
 
 describe("isMembershipReadError (/onboard 404 -> notInvited boundary)", () => {
   it("treats a definitive 404 as NOT a read error (never invited)", () => {
-    // Regression for the bug where getPendingOrgInvite's 404 set
-    // membershipReadError, routing a never-invited student to the error screen
-    // instead of notInvited. A 404 means "no membership record".
+    // Regression: getPendingOrgInvite's 404 once set membershipReadError,
+    // routing a never-invited student to the error screen instead of notInvited.
+    // A 404 means "no membership record".
     expect(isMembershipReadError(apiError(404))).toBe(false)
   })
 

--- a/web/src/util/membershipReadError.ts
+++ b/web/src/util/membershipReadError.ts
@@ -2,10 +2,9 @@ import { GitHubAPIError } from "@/hooks/github/errors"
 
 // Whether a membership-read error should surface the error screen. A definitive
 // 404 is NOT a read failure — it is GitHub's authoritative "no membership
-// record" (the student was never invited), which must fall through to the calm
-// notInvited screen. Every other error (403 / SSO-gated / transient 5xx) is a
-// genuine read failure. Extracted so the 404 boundary stays unit-testable
-// without importing the whole page.
+// record" (never invited), which falls through to the calm notInvited screen.
+// Every other error (403 / SSO-gated / transient 5xx) is a genuine failure.
+// Extracted so the 404 boundary stays testable without the whole page.
 export function isMembershipReadError(error: unknown): boolean {
   if (error instanceof GitHubAPIError && error.isNotFound) {
     return false

--- a/web/src/util/onboardingState.test.ts
+++ b/web/src/util/onboardingState.test.ts
@@ -23,8 +23,8 @@ describe("deriveOnboardingState", () => {
   })
 
   it("is loading once a membership exists but is not yet active", () => {
-    // A pending invite exists; the accept/verify mutation is (about to be) in
-    // flight. Never fall through to notInvited here.
+    // A pending invite exists; accept/verify is (about to be) in flight. Never
+    // fall through to notInvited here.
     expect(deriveOnboardingState(base)).toBe("loading")
   })
 
@@ -86,8 +86,8 @@ const apiError = (status: number) =>
 describe("404 -> notInvited boundary (end-to-end through the precedence)", () => {
   it("a 404 read feeds hasMembership:false -> notInvited", () => {
     // The live page maps a 404 to membershipReadError:false + hasMembership:false;
-    // fold that through the precedence to prove the calm screen is reached (the
-    // regression guarded here: a 404 must not route to the error screen).
+    // fold that through precedence to prove the calm screen is reached (a 404
+    // must not route to the error screen).
     const state = deriveOnboardingState({
       loadingMembership: false,
       membershipReadError: isMembershipReadError(apiError(404)),

--- a/web/src/util/onboardingState.ts
+++ b/web/src/util/onboardingState.ts
@@ -1,14 +1,14 @@
-// The /onboard page's state precedence as a pure function, so the ordering +
-// gates are unit-testable without a DOM. OnboardingPage feeds it the membership
-// read + auto-accept mutation status and renders the returned state.
+// The /onboard page's state precedence as a pure function, so ordering + gates
+// are testable without a DOM. OnboardingPage feeds it the membership read +
+// auto-accept status and renders the returned state.
 //
-// Precedence the page short-circuits through:
-//   1. error      — the membership read failed, or accept/verify failed. A read
-//                   error takes priority so a stale "active" can't mask it.
+// Precedence:
+//   1. error      — membership read or accept/verify failed. A read error wins
+//                   so a stale "active" can't mask it.
 //   2. active     — verified active membership; "you're all set" / redirect.
-//   3. loading    — the initial membership read is resolving, OR a membership
-//                   record exists and the accept/verify mutation is (about to
-//                   be) in flight. A pending invite is NOT notInvited.
+//   3. loading    — the initial read is resolving, OR a membership record exists
+//                   and accept/verify is (about to be) in flight. A pending
+//                   invite is NOT notInvited.
 //   4. notInvited — no membership record at all (never invited).
 export type OnboardingState = "loading" | "notInvited" | "active" | "error"
 

--- a/web/src/util/orgMembers.test.ts
+++ b/web/src/util/orgMembers.test.ts
@@ -126,9 +126,8 @@ describe("aggregateOrgMembers", () => {
   })
 
   it("matches an empty-github_id roster row to a member by login (no duplicate row)", () => {
-    // A roster row typed before reconcile has a username but no github_id. It
-    // must be classified member-on-roster and NOT also surface as a separate
-    // member-no-roster row for the same person.
+    // A roster row typed before reconcile has a username but no github_id. Must
+    // be member-on-roster and NOT also surface as a separate member-no-roster.
     const rows = aggregateOrgMembers(
       [member(42, "alice")],
       [roster("cs101", [student({ username: "alice", github_id: "" })])],
@@ -141,10 +140,10 @@ describe("aggregateOrgMembers", () => {
   })
 
   it("matches a STALE-github_id roster row to a member by login and prefers the live id", () => {
-    // CSV carries a stale/wrong github_id ("999") that no longer matches any
-    // member, but the username still matches a live member. The row must be
-    // classified member-on-roster, not duplicated, and surface the LIVE id (42)
-    // rather than the stale one so id-keyed display/actions don't use "999".
+    // CSV carries a stale github_id ("999") that matches no member, but the
+    // username still matches a live member. The row must be member-on-roster,
+    // not duplicated, and surface the LIVE id (42) so id-keyed display/actions
+    // don't use "999".
     const rows = aggregateOrgMembers(
       [member(42, "alice")],
       [roster("cs101", [student({ username: "alice", github_id: "999" })])],

--- a/web/src/util/orgMembers.ts
+++ b/web/src/util/orgMembers.ts
@@ -2,15 +2,13 @@ import type { Student } from "@/types/classroom"
 import type { GitHubUser } from "@/hooks/github/types"
 import { memberIdSet, rosterClaimSet, studentKey } from "@/util/identity"
 
-// Per-classroom enrollment state for an aggregated member, mirroring the
-// per-classroom roster's model (buildTeamRoster) so the two views agree:
-//  - enrolled:      on the classroom's `classroom50-<classroom>` GitHub team
-//                   (the enrollment source of truth), OR team data wasn't
-//                   available for this classroom (unknown is treated as enrolled,
-//                   never surfaced as a problem).
-//  - unprovisioned: on the CSV roster but NOT on the team — a rostered student
-//                   who hasn't formed team membership yet (or a failed team-add).
-//                   Grade collection is team-driven, so these are uncollected.
+// Per-classroom enrollment state for an aggregated member, mirroring
+// buildTeamRoster so the two views agree:
+//  - enrolled:      on the classroom's `classroom50-<classroom>` team (the
+//                   enrollment source of truth), OR team data was unavailable
+//                   (unknown is treated as enrolled, never flagged).
+//  - unprovisioned: on the CSV roster but NOT on the team (or a failed
+//                   team-add). Grade collection is team-driven, so uncollected.
 export type ClassroomAccessState = "enrolled" | "unprovisioned"
 
 // One classroom a student appears on.
@@ -23,10 +21,10 @@ export type ClassroomAccess = {
 
 // How an aggregated row relates org membership to roster presence:
 //  - member-on-roster: a healthy member on >=1 roster.
-//  - on-roster-not-member: the discrepancy this classification targets — on a roster but
-//    no longer (or never) an org member.
-//  - member-no-roster: an org member on no classroom roster (e.g. a co-teacher,
-//    or a leftover after an unenroll).
+//  - on-roster-not-member: the target discrepancy — on a roster but no longer
+//    (or never) an org member.
+//  - member-no-roster: an org member on no roster (e.g. co-teacher, or a
+//    leftover after an unenroll).
 export type MemberClassification =
   "member-on-roster" | "on-roster-not-member" | "member-no-roster"
 
@@ -41,10 +39,9 @@ export type OrgMemberRow = {
   classrooms: ClassroomAccess[]
   classification: MemberClassification
   // Classrooms where the member is on the CSV roster but NOT on the live
-  // `classroom50-<classroom>` team (state: "unprovisioned") — grade collection
-  // is team-driven, so these are uncollected. Empty when team data was
-  // unavailable or everything is consistent. Only meaningful for members
-  // (a non-member is already flagged on-roster-not-member).
+  // `classroom50-<classroom>` team (grade collection is team-driven, so
+  // uncollected). Empty when team data was unavailable or all consistent. Only
+  // meaningful for members (a non-member is already on-roster-not-member).
   unprovisionedClassrooms: string[]
 }
 
@@ -62,31 +59,30 @@ const fullName = (s: Student) =>
     .filter(Boolean)
     .join(" ")
 
-// Deduplicate students across every roster (by studentKey), match each to a live
-// org member by numeric github_id, fold in org members that appear on no roster,
-// and classify every row. Pure so the dedupe/match/classify logic is testable
-// without react-query. Members and rosters are matched on the SAME keys the
-// per-classroom roster uses (studentKey / memberIdSet) so the two views agree.
+// Deduplicate students across rosters (by studentKey), match each to a live org
+// member by numeric github_id, fold in members on no roster, and classify every
+// row. Pure so the dedupe/match/classify logic is testable without react-query.
+// Uses the SAME keys as the per-classroom roster (studentKey / memberIdSet) so
+// the two views agree.
 export function aggregateOrgMembers(
   members: GitHubUser[],
   rosters: ClassroomRoster[],
-  // Optional classroom -> set of live team-member numeric-id strings. When
-  // provided, each ClassroomAccess is marked onTeam and CSV/team drift is
-  // surfaced. A classroom absent from the map has "unknown" team data and is
-  // never flagged as drift.
+  // Optional classroom -> set of live team-member id strings. When provided,
+  // each ClassroomAccess is marked onTeam and CSV/team drift surfaced. A
+  // classroom absent from the map has "unknown" team data and is never flagged.
   teamMembersByClassroom?: Map<string, Set<string>>,
 ): OrgMemberRow[] {
   const memberIds = memberIdSet(members)
-  // Login -> numeric id, so a roster row that carries a username but no
-  // github_id (typed before reconcile) can still be matched to a live member.
-  // Without this, such a row is classified on-roster-not-member AND the member
-  // is also emitted as member-no-roster — the same person counted twice.
+  // Login -> id, so a roster row with a username but no github_id (typed before
+  // reconcile) still matches a live member. Without this it's classified
+  // on-roster-not-member AND the member is emitted as member-no-roster — the
+  // same person counted twice.
   const memberIdByLogin = new Map<string, string>(
     members.map((m) => [m.login.toLowerCase(), String(m.id)]),
   )
 
   // Raw per-classroom access before the member id is resolved; onTeam is
-  // computed in the classify loop below once we know the member's numeric id.
+  // computed in the classify loop once we know the member's id.
   type RawAccess = { classroom: string; archived: boolean; section: string }
   type Acc = {
     key: string
@@ -134,9 +130,9 @@ export function aggregateOrgMembers(
   const matchedMemberIds = new Set<string>()
 
   for (const acc of byKey.values()) {
-    // Match by github_id when present; otherwise fall back to login (a row that
-    // hasn't been reconciled to an id yet). The resolved id is recorded in
-    // matchedMemberIds so the no-roster fold below doesn't emit a duplicate row.
+    // Match by github_id when present, else fall back to login (a row not yet
+    // reconciled to an id). The resolved id is recorded in matchedMemberIds so
+    // the no-roster fold below doesn't emit a duplicate.
     const loginId = acc.username
       ? memberIdByLogin.get(acc.username.toLowerCase())
       : undefined
@@ -148,11 +144,10 @@ export function aggregateOrgMembers(
     if (isMember) matchedMemberIds.add(matchedId)
 
     // Finalize each access with its team-authoritative state. A classroom with
-    // no team data (absent from the map) is "unknown" -> enrolled (never
-    // surfaced as a problem). unprovisioned = a member on the CSV roster but not
-    // the team. Only real members can be unprovisioned — a non-member is already
-    // flagged on-roster-not-member. Archived classrooms are excluded (their team
-    // may be intentionally gone).
+    // no team data is "unknown" -> enrolled. unprovisioned = a member on the CSV
+    // roster but not the team; only real members can be unprovisioned (a
+    // non-member is already on-roster-not-member). Archived classrooms are
+    // excluded (their team may be intentionally gone).
     const unprovisionedClassrooms: string[] = []
     const classrooms: ClassroomAccess[] = acc.classrooms.map((raw) => {
       const teamSet = teamMembersByClassroom?.get(raw.classroom)
@@ -170,8 +165,8 @@ export function aggregateOrgMembers(
     rows.push({
       key: acc.key,
       username: acc.username,
-      // Prefer the resolved live member id over a roster id: a stale CSV id that
-      // matched a member only by login would otherwise be displayed/used.
+      // Prefer the resolved live member id over a roster id: a stale CSV id
+      // that matched only by login would otherwise be shown/used.
       github_id: matchedId || acc.github_id,
       name: acc.name,
       email: acc.email,
@@ -227,13 +222,12 @@ export type MatchCandidate = {
 }
 
 // Live org/team members NOT already claimed by any roster row in this classroom
-// — the smallest, most accurate set for the manual-match picker. A member is
-// "claimed" when their numeric id or login appears on a roster row (by github_id
-// or username), so a teacher only sees accounts that aren't yet bound to a
-// student here. Pure for unit-testing without react-query.
+// — the tightest set for the manual-match picker. "Claimed" = their id or login
+// appears on a row (by github_id or username), so a teacher only sees accounts
+// not yet bound to a student. Pure for testing without react-query.
 //
-// Accepts the minimal member shape it reads (id/login/name/avatar_url) so
-// callers don't have to fabricate a full GitHubUser just to feed it.
+// Accepts the minimal member shape it reads so callers needn't fabricate a full
+// GitHubUser.
 export type MatchMember = Pick<
   GitHubUser,
   "id" | "login" | "name" | "avatar_url"

--- a/web/src/util/orgMembership.ts
+++ b/web/src/util/orgMembership.ts
@@ -1,28 +1,25 @@
 // Email + classroom-team-slug helpers shared by the CSV write path
-// (students.ts) and the student org-membership flow (the /onboard and accept
-// pages). These are the survivors of the team-as-source-of-truth rework — the
-// self-report / onboarding-repo machinery and the email_hash/invite-token
-// columns that once lived alongside them were removed with the students.csv
-// schema prune.
+// (students.ts) and the student org-membership flow (/onboard and accept
+// pages). Survivors of the team-as-source-of-truth rework.
 
 // The classroom team slug a STUDENT derives (the authoritative slug is in the
 // private classroom.json they can't read). Safe-degrade: on a slug collision the
-// derived slug 404s and the membership read simply reports "not a member", so a
-// miss never grants false access. The teacher side reads the real slug via
+// derived slug 404s and the membership read reports "not a member", so a miss
+// never grants false access. The teacher side reads the real slug via
 // resolveClassroomTeam.
 export function classroomTeamSlugHeuristic(classroom: string): string {
   return `classroom50-${classroom}`
 }
 
 // Canonical form for email comparison. Lowercase + trim only: deliberately do
-// NOT strip Gmail-style `+tags` or dots, since those are provider-specific and
-// would collapse genuinely distinct addresses onto one key.
+// NOT strip Gmail-style `+tags` or dots — those are provider-specific and would
+// collapse genuinely distinct addresses onto one key.
 export function normalizeEmail(email: string): string {
   return email.trim().toLowerCase()
 }
 
-// Minimal email shape check. Deliberately permissive (GitHub is the real
-// validator at invite time); only catches obvious typos before committing.
+// Minimal email shape check. Deliberately permissive (GitHub validates at
+// invite time); only catches obvious typos before committing.
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 export function isValidEmail(email: string): boolean {

--- a/web/src/util/roster.test.ts
+++ b/web/src/util/roster.test.ts
@@ -166,8 +166,7 @@ describe("resolveEmptyRosterWarning", () => {
 
   it("treats a team-roster read error as loading (never asserts empty on a failure)", () => {
     // A transient/permission team-members read failure must NOT surface the
-    // "nobody can accept assignments" banner — the view shows error+retry, and
-    // the banner self-heals on recovery.
+    // "nobody can accept" banner — the view shows error+retry and self-heals.
     expect(resolveEmptyRosterWarning({ ...base, isError: true })).toEqual({
       show: false,
       hasRosterRows: false,

--- a/web/src/util/roster.ts
+++ b/web/src/util/roster.ts
@@ -2,42 +2,41 @@ import type { Student } from "@/types/classroom"
 import { normalizeStudentRow, splitName } from "@/api/mutations/students"
 import { studentKey } from "@/util/identity"
 
-// Re-exported so UI callers keep importing splitName/studentKey from the roster
-// util while the single canonical implementations live elsewhere (splitName
-// alongside the CSV write path; studentKey in @/util/identity).
+// Re-exported so UI callers keep importing splitName/studentKey from here while
+// the canonical implementations live elsewhere (splitName by the CSV write
+// path; studentKey in @/util/identity).
 export { splitName, studentKey }
 
-// Narrow a raw CSV row into a typed Student. Defaulting + trimming of every
-// column is delegated to the canonical normalizeStudentRow (one shared column
-// list with the write path). The CSV is now just the 6 identity/metadata
-// columns, so this is a thin pass-through.
+// Narrow a raw CSV row into a typed Student. Defaulting/trimming is delegated
+// to the canonical normalizeStudentRow (one shared column list with the write
+// path), so this is a thin pass-through.
 export function toStudent(row: Record<string, string>): Student {
   return normalizeStudentRow(row)
 }
 
 // Remove rows matching `key` for the optimistic unenroll update. Removes ALL
-// rows that collapse to the same key (mirroring the server's match predicate);
-// a later refetch restores any survivor.
+// rows that collapse to `key` (mirroring the server); a refetch restores any
+// survivor.
 export function removeFromRoster(current: Student[], key: string): Student[] {
   return current.filter((student) => studentKey(student) !== key)
 }
 
-// Pure decision shape for the empty-roster warning (computed team-driven in
-// useEmptyRosterWarning). Kept as a type so the hook's return stays named.
+// Pure decision shape for the empty-roster warning. Kept as a type so the
+// hook's return stays named.
 export type EmptyRosterDecision = {
   show: boolean
   hasRosterRows: boolean
   isLoading: boolean
 }
 
-// Pure decision for the empty-roster warning, kept React-free (no hooks) so the
-// branches are unit-testable in isolation. Enrollment is team membership, so
-// `enrolledCount` is the team-member enrolled count.
+// Pure decision for the empty-roster warning, React-free so branches are
+// testable. Enrollment is team membership, so `enrolledCount` is the team-member
+// count.
 //
 // A team-roster READ ERROR folds into loading on purpose: never assert an empty
-// classroom on a transient/permission failure — the view shows an error+retry
-// instead, and the banner self-heals on recovery. The alternative (treating an
-// error as "settled") would false-warn a populated classroom during a blip.
+// classroom on a transient/permission failure — the view shows error+retry and
+// the banner self-heals. Treating an error as "settled" would false-warn a
+// populated classroom during a blip.
 export function resolveEmptyRosterWarning(input: {
   studentsLoading: boolean
   isLoading: boolean

--- a/web/src/util/runners.ts
+++ b/web/src/util/runners.ts
@@ -1,11 +1,11 @@
-// Advisory, non-blocking verification for the "GitHub Runner" field.
-// Per the autograder spec, `runtime.runs-on` is one or more GitHub Actions
-// labels with no allow-list: a single GitHub-hosted label ("ubuntu-latest")
-// or AND-ed labels for a self-hosted runner ("self-hosted, linux, x64").
-// Helpers never rewrite the teacher's value — they only classify it.
+// Advisory, non-blocking verification for the "GitHub Runner" field. Per the
+// autograder spec, `runtime.runs-on` is one or more GitHub Actions labels with
+// no allow-list: a single GitHub-hosted label ("ubuntu-latest") or AND-ed
+// labels for a self-hosted runner ("self-hosted, linux, x64"). Helpers only
+// classify the teacher's value, never rewrite it.
 
 // GitHub-hosted labels (from the org's default runner settings). Not
-// exhaustive; used only to recognize a label as always-available.
+// exhaustive; only used to recognize a label as always-available.
 const KNOWN_HOSTED_RUNNER_LABELS = [
   "ubuntu-latest",
   "ubuntu-24.04",
@@ -27,9 +27,9 @@ const KNOWN_HOSTED_RUNNER_SET = new Set<string>(
   KNOWN_HOSTED_RUNNER_LABELS.map((label) => label.toLowerCase()),
 )
 
-// Default labels a self-hosted runner gets at registration (self-hosted +
-// OS + arch). Recognized as valid so the UI doesn't flag them as typos when
-// the org runner list can't be read.
+// Default labels a self-hosted runner gets at registration (self-hosted + OS +
+// arch). Recognized as valid so the UI doesn't flag them as typos when the org
+// runner list can't be read.
 const STANDARD_SELF_HOSTED_LABELS = new Set<string>([
   "self-hosted",
   "linux",
@@ -60,10 +60,9 @@ export function isRunnerLabelShapeValid(label: string): boolean {
 // The CLI rejects more than 10 labels.
 const MAX_RUNNER_LABELS = 10
 
-// Mirrors the CLI exactly: a prefix-only deny-list of the labels we KNOW
-// can't run a Linux container. Bare "macos"/"windows" pass (the CLI accepts
-// them — the teacher owns OS matching), so flagging them would be a false
-// warning.
+// Mirrors the CLI exactly: a prefix-only deny-list of labels we KNOW can't run
+// a Linux container. Bare "macos"/"windows" pass (the CLI accepts them — the
+// teacher owns OS matching), so flagging them would be a false warning.
 function isNonUbuntuHostedLabel(label: string): boolean {
   const normalized = label.trim().toLowerCase()
   return normalized.startsWith("macos-") || normalized.startsWith("windows-")
@@ -165,8 +164,8 @@ export function verifyRunnerLabels(
   )
 
   if (looksSelfHosted) {
-    // Unconfirmed only when an unrecognized label couldn't be checked (org
-    // list unreadable); standard/known-hosted labels are self-evidently fine.
+    // Unconfirmed only when an unrecognized label couldn't be checked (org list
+    // unreadable); standard/known-hosted labels are self-evidently fine.
     const confirmed = !labels.some((l) => l.kind === "unknown")
     return { kind: "self-hosted", labels, confirmed }
   }
@@ -174,9 +173,9 @@ export function verifyRunnerLabels(
   return { kind: "unknown", labels }
 }
 
-// Non-blocking warning mirroring the CLI's container rule: a macOS/Windows
-// label with a container image is rejected (containers run on Ubuntu only).
-// Returns a message only — the caller must NOT clear the runner value.
+// Non-blocking warning mirroring the CLI's container rule: a macOS/Windows label
+// with a container image is rejected (containers run on Ubuntu only). Returns a
+// message only — the caller must NOT clear the runner value.
 export function containerRunnerWarning(
   raw: string,
   rawContainerImage: string,

--- a/web/src/util/secret.test.ts
+++ b/web/src/util/secret.test.ts
@@ -70,8 +70,8 @@ describe("classroomPagesSegment", () => {
   })
 
   it("URL-encodes the secret segment defensively", () => {
-    // A well-formed secret is [a-z0-9] and unaffected by encoding; a value
-    // that slipped past the boundary guards must not break out of the path.
+    // A well-formed secret is [a-z0-9] and unaffected by encoding; a value that
+    // slipped past the boundary guards must not break out of the path.
     expect(classroomPagesSegment("cs50", "a/b")).toBe("cs50/a%2Fb")
   })
 })

--- a/web/src/util/secret.ts
+++ b/web/src/util/secret.ts
@@ -1,41 +1,37 @@
-// Capability-URL secret helpers for protected classrooms. Kept in
-// lockstep with the CLI's cli/gh-teacher/internal/configrepo/secret.go and
-// the classroom-v1 / repo-config-v1 JSON schemas: a secret is a single
-// safe URL path segment, 4-64 lowercase-alphanumeric characters. When a
-// classroom has one, its published Pages resources live under
+// Capability-URL secret helpers for protected classrooms. Kept in lockstep with
+// the CLI's cli/gh-teacher/internal/configrepo/secret.go and the classroom-v1 /
+// repo-config-v1 JSON schemas: a secret is a single safe URL path segment, 4-64
+// lowercase-alphanumeric chars. When set, published Pages resources live under
 // `<classroom>/<secret>/...` instead of the guessable `<classroom>/...`.
 
 const SECRET_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 // Default generated length when a teacher opts in without typing their own.
-// 8 chars of [a-z0-9] is ~41 bits — ample for anti-discovery (this is
-// friction, not cryptography).
+// 8 chars of [a-z0-9] is ~41 bits — ample anti-discovery friction (not crypto).
 export const DEFAULT_SECRET_LENGTH = 8
 
-// Matches the CLI's SecretPattern exactly. Anchored so a value with a
-// stray separator (`/`, `-`, space) or uppercase is rejected before it can
-// become a bad path segment.
+// Matches the CLI's SecretPattern exactly. Anchored so a value with a stray
+// separator (`/`, `-`, space) or uppercase is rejected before it can become a
+// bad path segment.
 export const SECRET_PATTERN = /^[a-z0-9]{4,64}$/
 
 export const SECRET_PATTERN_DESCRIPTION =
   "4-64 lowercase letters or digits ([a-z0-9])"
 
-// isValidSecret reports whether a teacher-supplied (or generated) secret is
-// a safe path segment. An empty string is NOT valid here; callers that
-// allow "no secret" (the unprotected default) must branch on emptiness
-// before calling this.
+// isValidSecret reports whether a secret is a safe path segment. An empty
+// string is NOT valid; callers that allow "no secret" (the unprotected default)
+// must branch on emptiness first.
 export function isValidSecret(secret: string): boolean {
   return SECRET_PATTERN.test(secret)
 }
 
-// classroomPagesSegment builds the Pages path segment for a classroom: the
-// guessable `<classroom>` when no secret is set, or the unlisted
-// `<classroom>/<secret>` capability path when it is. Single source of truth
-// for the invariant every Pages URL builder depends on (the GUI's
-// pagesAssignmentUrl/pagesAutograderUrl and the Published Resources page),
-// so the three consumers can't drift. The secret is encoded defensively —
-// it is already pattern-constrained to `[a-z0-9]` at every trust boundary,
-// but encoding keeps a future, looser source from injecting a path.
+// classroomPagesSegment builds the Pages path segment: the guessable
+// `<classroom>` when no secret is set, or the unlisted `<classroom>/<secret>`
+// capability path when it is. Single source of truth for the invariant every
+// Pages URL builder depends on (pagesAssignmentUrl/pagesAutograderUrl and the
+// Published Resources page). The secret is encoded defensively — it is already
+// `[a-z0-9]`-constrained at every trust boundary, but encoding stops a future
+// looser source from injecting a path.
 export function classroomPagesSegment(
   classroom: string,
   secret?: string,
@@ -43,17 +39,16 @@ export function classroomPagesSegment(
   return secret ? `${classroom}/${encodeURIComponent(secret)}` : classroom
 }
 
-// generateSecret returns a cryptographically random secret of `length`
-// chars from SECRET_ALPHABET, using rejection sampling so the modulo bias a
-// naive `byte % 36` would introduce is eliminated (matches the CLI's
-// generator).
+// generateSecret returns a cryptographically random secret of `length` chars
+// from SECRET_ALPHABET, using rejection sampling to avoid the modulo bias a
+// naive `byte % 36` would introduce (matches the CLI's generator).
 export function generateSecret(length: number = DEFAULT_SECRET_LENGTH): string {
   if (length <= 0) {
     throw new Error(`secret length must be positive, got ${length}`)
   }
   const alphabetLen = SECRET_ALPHABET.length
-  // Largest multiple of the alphabet size that fits in a byte; bytes >=
-  // this would bias the low residues, so reject and redraw.
+  // Largest multiple of the alphabet size that fits in a byte; bytes >= this
+  // would bias the low residues, so reject and redraw.
   const max = 256 - (256 % alphabetLen)
   const out: string[] = []
   const buf = new Uint8Array(1)

--- a/web/src/util/studentRepo.ts
+++ b/web/src/util/studentRepo.ts
@@ -1,8 +1,7 @@
 // Student/group repo name: the cross-binary formula `<classroom>-<assignment>-
-// <owner>` (lowercased), same as the CLI and `gh student accept`. `owner` is the
-// repo-name component (student, or group owner), so the name is stable
-// regardless of who pushed last. Shared with the Go CLI as the single source of
-// truth so call sites can't drift.
+// <owner>` (lowercased), same as the CLI and `gh student accept`. `owner` is
+// the repo-name component (student or group owner), so the name is stable
+// regardless of who pushed last. Single source of truth shared with the Go CLI.
 export const studentRepoName = (
   classroom: string,
   assignment: string,

--- a/web/src/util/students.ts
+++ b/web/src/util/students.ts
@@ -6,16 +6,14 @@ export { isSameGitHubUser, parseGitHubId }
 export const capitalize = (s: string) =>
   s ? s.charAt(0).toUpperCase() + s.slice(1) : ""
 
-// Find a roster student by username, case-insensitively — GitHub logins are
-// case-insensitive and scores.json logins can differ in case from the CSV, so
-// an exact `===` would drop the name/section for a real student.
+// Find a roster student by username, case-insensitively: GitHub logins and
+// scores.json logins can differ in case from the CSV, so `===` would miss.
 const findByUsername = (key: string, students: Student[]) => {
   const k = key.trim().toLowerCase()
   return students.find((s) => s.username.trim().toLowerCase() === k)
 }
 
-// A minimal Student carrying only the username; fallback when a row's username
-// isn't on the roster.
+// Minimal Student carrying only the username; fallback when off-roster.
 export const placeholderStudent = (username: string): Student => ({
   username,
   first_name: "",
@@ -29,19 +27,13 @@ export const placeholderStudent = (username: string): Student => ({
 export const resolveStudent = (key: string, students: Student[]): Student =>
   findByUsername(key, students) ?? placeholderStudent(key)
 
-// Whether a GitHub account is the same person as a roster student: numeric id
-// first, then case-insensitive login (the CSV may predate id capture).
-// (Canonical implementation in @/util/identity; re-exported above.)
-
 export const getName = (key: string, students: Student[]) => {
   const student = findByUsername(key, students)
   if (!student) return ""
   return nameFromParts(student.first_name, student.last_name)
 }
 
-// Display name from a roster row's first/last name parts. CSV stays
-// authoritative; callers use this only to fill a row that has no CSV name yet.
-// Empty when neither name is present.
+// Display name from a roster row's first/last parts; "" when neither present.
 export const nameFromParts = (
   firstName?: string,
   lastName?: string,
@@ -60,8 +52,7 @@ export const getInitials = (key: string, students: Student[]) => {
   return initialsFromParts(student.first_name, student.last_name)
 }
 
-// Avatar initials from self-reported names, mirroring getInitials. Empty when
-// neither name is present.
+// Avatar initials from first/last parts; "" when neither present.
 export const initialsFromParts = (
   firstName?: string,
   lastName?: string,

--- a/web/src/util/teamRoster.test.ts
+++ b/web/src/util/teamRoster.test.ts
@@ -86,8 +86,8 @@ describe("buildTeamRoster", () => {
   })
 
   it("joins CSV by login when the CSV row has no github_id (no drift, no dup)", () => {
-    // Pre-resolution CSV row: username only, empty github_id. Must be treated as
-    // the SAME person as the member, not counted as drift + member twice.
+    // Pre-resolution CSV row: username only, empty github_id. Must be the SAME
+    // person as the member, not counted as drift + member twice.
     const rows = buildTeamRoster({
       members: [member(55, "linus")],
       students: [csvRow({ username: "Linus", first_name: "Linus" })],
@@ -105,8 +105,7 @@ describe("buildTeamRoster", () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatchObject({ state: "pending", username: "pendinguser" })
     // The pending row MUST carry the org-invitation id: resendOrgInvitation
-    // short-circuits (re-sends nothing) without it, so dropping it is a silent
-    // no-op, not a crash. Pin it here so a regression fails loudly.
+    // short-circuits without it (a silent no-op). Pin it so a regression fails.
     expect(rows[0].invitation_id).toBe(2)
   })
 
@@ -269,8 +268,8 @@ describe("teamMembersMissingFromCsv", () => {
   })
 
   it("does not count a CSV-only row (unprovisioned) as missing — wrong direction", () => {
-    // grace is on the CSV but not the team; that's the opposite drift and is
-    // NOT what this helper (or Sync) addresses.
+    // grace is on the CSV but not the team — the opposite drift, NOT what this
+    // helper (or Sync) addresses.
     const missing = teamMembersMissingFromCsv(
       [member(101, "ada")],
       [csvRow({ github_id: "101" }), csvRow({ username: "grace" })],

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -3,32 +3,29 @@ import type { GitHubUser, GitHubOrgInvitation } from "@/hooks/github/types"
 import { rosterClaimSet } from "@/util/identity"
 
 // Team-driven roster: the classroom GitHub team is the source of truth for who
-// belongs, not students.csv. This module computes the teacher-facing roster
-// PURELY from team members + pending org invitations, then enriches each row
-// with optional students.csv metadata (name/section/email). The CSV never
-// decides enrollment — it can be absent or partial and the roster still renders.
+// belongs, not students.csv. The roster is computed PURELY from team members +
+// pending org invitations, then enriched with optional students.csv metadata
+// (name/section/email). The CSV never decides enrollment — it can be absent or
+// partial and the roster still renders.
 //
 // Row states:
-//  - enrolled:     an active classroom-team / org member.
-//  - pending:      a pending org invitation (no active membership yet).
-//  - unprovisioned: on students.csv but NOT a team member and NOT a pending
-//                   invite — e.g. a rostered student who can't yet form
-//                   membership (not yet IdP/SSO-provisioned). Kept VISIBLE as a
-//                   distinct state so a student the teacher trusts never
-//                   silently disappears (decided over hiding-behind-drift).
+//  - enrolled:      an active classroom-team / org member.
+//  - pending:       a pending org invitation (no active membership yet).
+//  - unprovisioned: on students.csv but NOT a member and NOT a pending invite
+//                   (e.g. not yet IdP/SSO-provisioned). Kept VISIBLE as a
+//                   distinct state so a trusted rostered student never silently
+//                   disappears.
 //
-// "drift" in this model is folded into `unprovisioned` (a CSV row with no
-// matching member/invite); the count of unprovisioned rows drives the banner.
+// "drift" is folded into `unprovisioned`; its count drives the banner.
 
 export type TeamRosterRowState = "enrolled" | "pending" | "unprovisioned"
 
 export type TeamRosterRow = {
-  // Stable identity for React keys and joins: github_id (member) || login ||
-  // email (invite/CSV-only). Mirrors studentKey.
+  // Stable identity for React keys and joins: github_id || login || email.
+  // Mirrors studentKey.
   key: string
   state: TeamRosterRowState
-  // GitHub identity when known (member or username-invite). Empty for an
-  // email-only pending invite or an email-only CSV row.
+  // GitHub identity when known. Empty for an email-only invite or CSV row.
   username: string
   github_id: string
   // Display metadata joined from students.csv (blank when absent).
@@ -37,19 +34,16 @@ export type TeamRosterRow = {
   section: string
   email: string
   avatar_url: string
-  // The pending org-invitation id, set only for `pending` rows. Threaded to
-  // resendOrgInvitation so a still-pending invite is actually recreated (a
-  // resend without it short-circuits and re-sends nothing).
+  // Pending org-invitation id, set only for `pending` rows. Threaded to
+  // resendOrgInvitation, which short-circuits without it.
   invitation_id?: number
 }
 
-// A CSV row keyed for the fallback join: github_id first, then lowercased
-// username, then lowercased email. Section 4/5 require the SAME fallback chain
-// (github_id -> username) so an imported/hand-edited/pre-resolution row with an
-// empty github_id isn't misclassified as drift AND doesn't cause the backfill
-// to append a duplicate. Exported so the org-wide members aggregation
-// (aggregateOrgMembers) reconciles team-vs-CSV with the SAME join this
-// per-classroom roster uses, so the two views can't disagree.
+// A CSV row keyed for the fallback join: github_id, then lowercased username,
+// then lowercased email. The same fallback chain (github_id -> username) keeps
+// a pre-resolution row with an empty github_id from being misclassified as
+// drift or causing a duplicate backfill. Exported so aggregateOrgMembers
+// reconciles team-vs-CSV with the SAME join, so the two views can't disagree.
 export type CsvIndex = {
   byGithubId: Map<string, Student>
   byLogin: Map<string, Student>
@@ -92,29 +86,27 @@ const metadataFrom = (student: Student | undefined) => ({
 export type BuildTeamRosterInput = {
   // Active classroom-team / org members (the enrolled source of truth).
   members: GitHubUser[]
-  // Pending org invitations. May be empty/omitted for a non-owner who can't
-  // read them (owner-only endpoint) — the roster still renders enrolled rows.
+  // Pending org invitations. May be empty for a non-owner who can't read them
+  // (owner-only endpoint) — enrolled rows still render.
   invitations?: GitHubOrgInvitation[]
   // Optional students.csv rows (display metadata only).
   students: Student[]
 }
 
-// Compute the team-driven roster. Members -> enrolled; pending invitations that
-// don't correspond to an already-counted member -> pending; students.csv rows
-// with no matching member or invite -> unprovisioned. Never returns duplicates
-// for the same person (a member on the CSV appears once; a username-invite that
-// is also a member is credited as the member).
+// Compute the team-driven roster. Members -> enrolled; pending invitations not
+// already a member -> pending; CSV rows with no member/invite -> unprovisioned.
+// Never duplicates a person (a member on the CSV appears once; a username-invite
+// that is also a member is credited as the member).
 export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
   const { members, invitations = [], students } = input
   const csv = indexCsv(students)
 
   const rows: TeamRosterRow[] = []
-  // Track which identities we've already emitted so invites/CSV don't double up.
+  // Track emitted identities so invites/CSV don't double up.
   const seenIds = new Set<string>()
   const seenLogins = new Set<string>()
   const seenEmails = new Set<string>()
 
-  // 1. Members -> enrolled.
   for (const member of members) {
     const id = String(member.id)
     const login = member.login.toLowerCase()
@@ -133,14 +125,13 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
     })
   }
 
-  // 2. Pending invitations -> pending (unless already an active member).
   for (const invite of invitations) {
     const login = invite.login?.trim() ?? ""
     const loginKey = login.toLowerCase()
     const email = invite.email?.trim() ?? ""
     const emailKey = email.toLowerCase()
-    // A login-carrying invite for an account already counted as a member is
-    // stale — skip it. Email-only invites can't collide with a member here.
+    // A login-carrying invite for an account already a member is stale — skip.
+    // Email-only invites can't collide with a member here.
     if (loginKey && seenLogins.has(loginKey)) continue
 
     // Join CSV metadata by login first, then email.
@@ -161,12 +152,11 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
     })
   }
 
-  // 3. students.csv rows with no matching member or invite -> unprovisioned.
   for (const student of students) {
     const id = student.github_id?.trim() ?? ""
     const login = student.username?.trim().toLowerCase() ?? ""
     const email = student.email?.trim().toLowerCase() ?? ""
-    // Already represented as an enrolled member or a pending invite?
+    // Already an enrolled member or a pending invite?
     if (id && seenIds.has(id)) continue
     if (login && seenLogins.has(login)) continue
     if (email && seenEmails.has(email)) continue
@@ -209,10 +199,9 @@ function sortRows(rows: TeamRosterRow[]): TeamRosterRow[] {
 }
 
 // Project a roster row back to the display-metadata Student shape the grade
-// dashboard consumes. Single-sourced here (the row already carries every
-// Student field) so callers can't drift on the field list — a new Student
-// field surfaces as a type error here rather than a silently dropped column at
-// each inline call site.
+// dashboard consumes. Single-sourced here so callers can't drift on the field
+// list — a new Student field surfaces as a type error rather than a dropped
+// column at each call site.
 export function rowToStudent(row: TeamRosterRow): Student {
   return {
     username: row.username,
@@ -240,13 +229,11 @@ export function countByState(
   )
 }
 
-// Team members with NO students.csv metadata row — the exact set
-// syncRosterFromTeam appends. A member is "missing" when their numeric id,
-// login, AND profile email are all unclaimed by any CSV row (the same
-// id -> login -> email fallback join syncRosterFromTeam uses, so this count and
-// the write can't diverge). Drives the "Sync roster" button's enabled/in-sync
-// state and the auto-sync-on-open trigger. Pure so it's unit-testable and can
-// be evaluated before deciding whether to write.
+// Team members with NO students.csv row — the exact set syncRosterFromTeam
+// appends. "Missing" when their id, login, AND profile email are all unclaimed
+// by any CSV row (the same id -> login -> email join syncRosterFromTeam uses,
+// so this count and the write can't diverge). Drives the "Sync roster" button
+// and auto-sync-on-open. Pure so it's testable before deciding to write.
 export function teamMembersMissingFromCsv(
   members: GitHubUser[],
   students: Student[],

--- a/web/src/util/templateAccessError.ts
+++ b/web/src/util/templateAccessError.ts
@@ -1,6 +1,6 @@
 // A template-generate failure at accept time, with a plain-text message the
-// accept page renders as-is. Messages point students at their instructor —
-// they can't approve an OAuth app or grant team read themselves.
+// accept page renders as-is. Messages point students at their instructor (they
+// can't approve an OAuth app or grant team read themselves).
 export class TemplateAccessError extends Error {
   constructor(message: string) {
     super(message)
@@ -9,8 +9,8 @@ export class TemplateAccessError extends Error {
 }
 
 // Out-of-org template: the owning org likely restricts third-party apps, but a
-// 403 has other causes too (per-user OAuth grant, SSO, scope), so GitHub's
-// actual message is appended rather than asserting a single cause.
+// 403 has other causes (per-user OAuth grant, SSO, scope), so GitHub's message
+// is appended rather than asserting one cause.
 export function outOfOrgTemplateError(
   templateOwner: string,
   templateRepo: string,

--- a/web/src/util/url.ts
+++ b/web/src/util/url.ts
@@ -1,6 +1,6 @@
 // Guards hrefs built from untrusted data (e.g. a student's committed
-// `result.json`): a `javascript:`/`data:` value in an anchor href is a script
-// sink, so only http(s) links are safe to render.
+// `result.json`): a `javascript:`/`data:` href is a script sink, so only
+// http(s) links are safe to render.
 
 export function isSafeHttpUrl(
   value: string | null | undefined,

--- a/web/src/util/yaml.ts
+++ b/web/src/util/yaml.ts
@@ -17,9 +17,9 @@ const Classroom50YamlSchema = z.object({
   classroom: z.string().min(1),
   assignment: z.string().min(1),
   // Optional capability-URL secret, present only for a protected classroom.
-  // Mirrors the CLI's repo-config-v1 schema. Pattern-checked at the read
-  // boundary so a hand-edited/desynced value can't reach a Pages URL segment;
-  // an invalid value degrades to "no secret" rather than failing the parse.
+  // Mirrors the CLI's repo-config-v1 schema. Pattern-checked here so a
+  // hand-edited/desynced value can't reach a Pages URL segment; an invalid
+  // value degrades to "no secret" rather than failing the parse.
   secret: z.string().regex(SECRET_PATTERN).optional().catch(undefined),
   owner: IdentitySchema.optional(),
   source: z

--- a/web/src/version.ts
+++ b/web/src/version.ts
@@ -1,15 +1,14 @@
-// Release identity for the built web app, sourced from compile-time constants
-// injected by Vite (see vite.config.ts). Centralised here so nothing reads the
-// `__APP_*__` globals directly.
+// Release identity for the built web app, from compile-time constants injected
+// by Vite (see vite.config.ts). Centralised so nothing reads the `__APP_*__`
+// globals directly.
 
 export interface AppVersion {
   /** Semver from package.json, or the `web-v*` release tag when built in CI. */
   version: string
   /**
-   * Commit the build was produced from. Length varies by build: the full
-   * 40-char `github.sha` in CI, a 12-char short hash from the local git
-   * fallback. Use `shortCommit()` for display; `commitUrl()` links the raw
-   * value (GitHub resolves any prefix length).
+   * Commit the build came from. Length varies: full 40-char `github.sha` in CI,
+   * 12-char short hash from the local git fallback. Use `shortCommit()` for
+   * display; `commitUrl()` links the raw value (GitHub resolves any prefix).
    */
   commit: string
   /** ISO-8601 UTC build timestamp. */
@@ -36,9 +35,8 @@ export function formatAppVersion(v: AppVersion = appVersion): string {
 }
 
 /**
- * Commit truncated for display. The stored `commit` length varies by build
- * (see AppVersion.commit), so every display site truncates to a single width
- * here rather than duplicating a slice literal.
+ * Commit truncated for display. The stored `commit` length varies by build (see
+ * AppVersion.commit), so every display site truncates to one width here.
  */
 export function shortCommit(v: AppVersion = appVersion): string {
   return v.commit.slice(0, 7)
@@ -50,13 +48,13 @@ export function commitUrl(v: AppVersion = appVersion): string {
 }
 
 /**
- * Link to the GitHub Release for this build's `web-v<version>` tag. Returns
- * null for untagged/dev builds (version still at package.json's placeholder or
- * a non-release value), where no release page exists to link to.
+ * Link to the GitHub Release for this build's `web-v<version>` tag. Returns null
+ * for untagged/dev builds (version at package.json's placeholder or non-release),
+ * where no release page exists.
  */
 export function releaseUrl(v: AppVersion = appVersion): string | null {
   // A real release is a semver like 1.2.3[-rc.1]; the dev placeholder (0.0.0)
-  // and anything non-semver has no published release page.
+  // and non-semver have no published release page.
   if (!/^\d+\.\d+\.\d+(?:[-+].+)?$/.test(v.version) || v.version === "0.0.0") {
     return null
   }

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,8 +1,7 @@
 /// <reference types="vite/client" />
 
-// Release identity injected at build time via Vite `define` (see
-// vite.config.ts). Available anywhere in the app; use the `appVersion` helper
-// (src/version.ts) rather than reading these globals directly.
+// Release identity injected at build time via Vite `define` (see vite.config.ts).
+// Use the `appVersion` helper (src/version.ts), not these globals directly.
 declare const __APP_VERSION__: string
 declare const __APP_COMMIT__: string
 declare const __APP_BUILD_DATE__: string


### PR DESCRIPTION
## Summary

Two-stage comment cleanup across the whole monorepo, comments/docstrings only — **no behavior change**.

**Stage 1 (conservative):** fixed 2 stale comments and removed 3 narration/dead-code lines.

**Stage 2 (aggressive concision):** compressed verbose multi-line "why" blocks and docstrings to their tightest phrasing while preserving every load-bearing constraint, trade-off, gotcha, and cross-tool contract note. GoDoc `// Name ...` form kept intact (lint clean).

Net across the branch: **322 files, ~1800 net lines removed** (7.7k deletions / 5.9k insertions — mostly reflowed shorter).

Excluded throughout: generated `routeTree.gen.ts`, functional pragmas (`eslint-disable`, `@ts-expect-error`, `//go:embed`, `# noqa`), i18n `t()` strings, and the load-bearing facts/warnings in the hand-mirrored `contract.go` wire contract (tightened wording only).

## Safety verification

- Structurally verified **every changed line is inside a comment/docstring** by stripping comments from `HEAD` vs. the working tree per language and diffing the remaining code (0 code deltas after review).
- This caught 2 route files an automated pass had accidentally reduced to router scaffolding stubs; both were restored from `HEAD` before committing.

## Test plan

- [x] web: `npm run check` — 0 errors, prettier clean, 676 tests pass
- [x] gh-teacher / gh-student / shared: `go build` + `go test` pass; `golangci-lint run` → 0 issues
- [x] Python: skeleton 406, autograders 287, locales 25 — all pass