### PR TITLE
fix(web): trigger preview Pages deploy after publish

### DIFF
--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -4,7 +4,6 @@ name: web Deploy to Preview (preview.classroom50.org)
 # (foundation50/classroom50-web-preview), whose GitHub Pages serves
 # preview.classroom50.org. Runs on every web-affecting push to `main`, so
 # day-to-day work merged into main is continuously deployed to the preview site.
-# Manual runs are available via the Actions tab.
 #
 # Branch model: single trunk. `main` is the default/integration branch — feature
 # PRs merge into it (squash) and each merge deploys here to preview. Production
@@ -41,7 +40,11 @@ concurrency:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Covers build + test + publish plus the wait on the preview repo's Pages
+    # deploy (which can queue behind its own `pages` concurrency group).
+    timeout-minutes: 20
+    env:
+      PREVIEW_REPOSITORY: foundation50/classroom50-web-preview
     defaults:
       run:
         working-directory: web
@@ -79,6 +82,18 @@ jobs:
       - name: Write CNAME for preview domain
         run: echo "preview.classroom50.org" > dist/CNAME
 
+      # Fail before mutating build when private-repo 404s mask token scope bugs.
+      - name: Verify preview repo access
+        env:
+          GH_TOKEN: ${{ secrets.CLASSROOM50_PREVIEW_DEPLOY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh api "repos/$PREVIEW_REPOSITORY" -q .name >/dev/null; then
+            echo "CLASSROOM50_PREVIEW_DEPLOY_TOKEN cannot access $PREVIEW_REPOSITORY." >&2
+            echo "It needs Actions read+write on that repo (a 404 here usually means missing access, not a missing repo)." >&2
+            exit 1
+          fi
+
       # Publish dist/ to the preview repo's `build` branch. A separate branch
       # (not `main`) is required: force_orphan recreates the branch with only
       # these files, which would delete the preview repo's deploy workflow. Uses
@@ -87,7 +102,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           deploy_key: ${{ secrets.PREVIEW_DEPLOY_KEY }}
-          external_repository: foundation50/classroom50-web-preview
+          external_repository: ${{ env.PREVIEW_REPOSITORY }}
           publish_branch: build
           # Repo-root-relative; the build wrote to web/dist.
           publish_dir: ./web/dist
@@ -104,9 +119,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          repo="foundation50/classroom50-web-preview"
+          repo="$PREVIEW_REPOSITORY"
           workflow="deploy-pages.yaml"
-          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          # `gh workflow run` returns no run id, so correlate by databaseId: the
+          # dispatched run is the lowest id created after this cursor. A
+          # timestamp window can't distinguish two dispatches in the same second.
+          before="$(
+            gh run list \
+              --repo "$repo" \
+              --workflow "$workflow" \
+              --event workflow_dispatch \
+              --json databaseId \
+              --jq '[.[].databaseId] | max // 0' \
+              --limit 20
+          )"
 
           gh workflow run "$workflow" --repo "$repo" --ref main
 
@@ -117,9 +144,9 @@ jobs:
                 --repo "$repo" \
                 --workflow "$workflow" \
                 --event workflow_dispatch \
-                --json databaseId,createdAt \
-                --jq 'map(select(.createdAt >= "'"$started_at"'")) | first | .databaseId // ""' \
-                --limit 10
+                --json databaseId \
+                --jq "map(select(.databaseId > $before)) | min_by(.databaseId) | .databaseId // \"\"" \
+                --limit 20
             )"
 
             if [ -n "$run_id" ]; then
@@ -134,4 +161,12 @@ jobs:
             exit 1
           fi
 
-          gh run watch "$run_id" --repo "$repo" --exit-status
+          # A failure here is the *target* deploy failing; the new artifact is
+          # already on `build` but the live site still serves the previous
+          # deploy. Surface the target run so the red X is self-service.
+          if ! gh run watch "$run_id" --repo "$repo" --exit-status; then
+            url="$(gh run view "$run_id" --repo "$repo" --json url --jq .url)"
+            echo "Preview Pages deploy failed: $url" >&2
+            echo "The build branch holds the new artifact but the site still serves the previous deploy; re-run to retry." >&2
+            exit 1
+          fi

--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -2,9 +2,9 @@ name: web Deploy to Preview (preview.classroom50.org)
 
 # Builds the web app (web/) and publishes the built dist/ to the preview repo
 # (foundation50/classroom50-web-preview), whose GitHub Pages serves
-# preview.classroom50.org. Runs on every push to `main` (scoped to web/**), so
+# preview.classroom50.org. Runs on every web-affecting push to `main`, so
 # day-to-day work merged into main is continuously deployed to the preview site.
-# Manual runs available via the Actions tab.
+# Manual runs are available via the Actions tab.
 #
 # Branch model: single trunk. `main` is the default/integration branch — feature
 # PRs merge into it (squash) and each merge deploys here to preview. Production
@@ -16,20 +16,21 @@ name: web Deploy to Preview (preview.classroom50.org)
 # production (classroom50.org) and preview must live in different repos. Source
 # stays here; the preview repo holds only the built artifact + its own CNAME.
 #
-# Deploy mechanism: the preview repo uses Actions-based Pages. This force-pushes
-# dist/ to the preview repo's `build` branch, and its deploy-pages.yaml (on
-# `main`) publishes it.
+# Deploy mechanism: the preview repo uses Actions-based Pages. This workflow
+# force-pushes dist/ to the preview repo's `build` branch, then dispatches that
+# repo's deploy-pages.yaml on `main` to publish it.
 
 on:
   push:
     branches: [main]
     paths:
-      - 'web/**'
-      - '.github/workflows/web-deploy-preview.yaml'
+      - "web/**"
+      - "cli/gh-teacher/skeleton/dotgithub/**"
+      - ".github/workflows/web-deploy-preview.yaml"
   workflow_dispatch:
 
-# Only the cross-repo push needs auth (provided via PREVIEW_DEPLOY_KEY); this
-# workflow does not use the local repo's GITHUB_TOKEN to write anything.
+# Cross-repo writes use narrowly scoped credentials: PREVIEW_DEPLOY_KEY pushes
+# the artifact branch, and CLASSROOM50_PREVIEW_DEPLOY_TOKEN dispatches Pages.
 permissions:
   contents: read
 
@@ -78,11 +79,10 @@ jobs:
       - name: Write CNAME for preview domain
         run: echo "preview.classroom50.org" > dist/CNAME
 
-      # Publish dist/ to the preview repo's `build` branch, which triggers its
-      # Actions-based Pages deploy. A separate branch (not `main`) is required:
-      # force_orphan recreates the branch with only these files, which would
-      # delete the preview repo's deploy workflow. Uses an SSH deploy key scoped
-      # to only the preview repo.
+      # Publish dist/ to the preview repo's `build` branch. A separate branch
+      # (not `main`) is required: force_orphan recreates the branch with only
+      # these files, which would delete the preview repo's deploy workflow. Uses
+      # an SSH deploy key scoped to only the preview repo.
       - name: Publish to preview repo
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
@@ -95,3 +95,43 @@ jobs:
           # holds only the built artifact, no source history worth keeping).
           force_orphan: true
           full_commit_message: "deploy: preview.classroom50.org from ${{ github.sha }}"
+
+      # The orphan build branch intentionally does not contain .github/workflows,
+      # so GitHub cannot run the preview repo's push trigger from that ref.
+      - name: Deploy preview Pages site
+        env:
+          GH_TOKEN: ${{ secrets.CLASSROOM50_PREVIEW_DEPLOY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          repo="foundation50/classroom50-web-preview"
+          workflow="deploy-pages.yaml"
+          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          gh workflow run "$workflow" --repo "$repo" --ref main
+
+          run_id=""
+          for _ in {1..30}; do
+            run_id="$(
+              gh run list \
+                --repo "$repo" \
+                --workflow "$workflow" \
+                --event workflow_dispatch \
+                --json databaseId,createdAt \
+                --jq 'map(select(.createdAt >= "'"$started_at"'")) | first | .databaseId // ""' \
+                --limit 10
+            )"
+
+            if [ -n "$run_id" ]; then
+              break
+            fi
+
+            sleep 2
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "Timed out waiting for preview Pages workflow to start" >&2
+            exit 1
+          fi
+
+          gh run watch "$run_id" --repo "$repo" --exit-status

--- a/web/README.md
+++ b/web/README.md
@@ -37,6 +37,19 @@ rules, and the translate-`en.json`-with-an-LLM workflow.
 
 ## Deployment
 
-Pushes to `main` deploy to [classroom50.org](https://classroom50.org) via GitHub Pages (`.github/workflows/deploy.yml`). The production client ID comes from the `VITE_GITHUB_CLIENT_ID` repository variable (Settings → Secrets and variables → Actions → Variables) — it is a public identifier, not a secret.
+Web-affecting pushes to `main` deploy to
+[preview.classroom50.org](https://preview.classroom50.org) via
+`.github/workflows/web-deploy-preview.yaml`. That workflow builds and tests the
+web app, publishes `web/dist` to the `build` branch of
+`foundation50/classroom50-web-preview`, then dispatches that repo's GitHub Pages
+workflow.
 
-Note: the deploy workflow runs `vite build` directly, skipping the `tsc` typecheck that `npm run build` performs (the codebase currently has pre-existing type errors).
+Production deploys to [classroom50.org](https://classroom50.org) only when the
+release-please Release PR is merged and a `web-v*` release is created. Manual
+production redeploys are available through `.github/workflows/web-deploy.yaml`
+as an escape hatch.
+
+The GitHub OAuth client ID comes from the `VITE_GITHUB_CLIENT_ID` repository
+variable (Settings → Secrets and variables → Actions → Variables) — it is a
+public identifier, not a secret. If preview reuses the same OAuth app, include
+`https://preview.classroom50.org/login` in its allowed callback URLs.


### PR DESCRIPTION
## Summary
- Automatically dispatches the preview repo Pages workflow after publishing the built artifact, so preview deploys no longer depend on manual runs.
- Hardens the dispatch path with a pre-publish token access check, databaseId-based run correlation, a larger deploy-watch budget, and target-run failure links.
- Aligns preview deploy triggers with web CI for bundled skeleton source changes and updates deployment docs for preview-on-main plus release-gated production.

## Test plan
- `npx prettier --check .github/workflows/web-deploy-preview.yaml web/README.md`
- `git diff --check -- .github/workflows/web-deploy-preview.yaml web/README.md`
- `actionlint .github/workflows/web-deploy-preview.yaml`
- `npm --prefix web run typecheck`
- `npm --prefix web run lint` (passes with existing warnings only, 0 errors)
- Verified the source repo has `PREVIEW_DEPLOY_KEY`, `CLASSROOM50_PREVIEW_DEPLOY_TOKEN`, and `VITE_GITHUB_CLIENT_ID`, and the preview repo workflow exposes `workflow_dispatch`.

