### PR TITLE
feat(web): make skeleton-drift banner self-service

### DIFF
--- a/web/src/components/AppBanner/index.tsx
+++ b/web/src/components/AppBanner/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 
 import { collapseVariants } from "@/lib/motion"
 
-export type AppBannerTone = "error" | "warning"
+export type AppBannerTone = "error" | "warning" | "success"
 
 // Full-bleed vs. constrained: the coloured bar spans the viewport, but its
 // contents align with the page below via the inner max-w container.
@@ -17,6 +17,10 @@ const TONE_CLASS: Record<AppBannerTone, { bar: string; icon: string }> = {
   warning: {
     bar: "border-warning/25 bg-warning/10 text-base-content",
     icon: "text-warning",
+  },
+  success: {
+    bar: "border-success/25 bg-success/10 text-base-content",
+    icon: "text-success",
   },
 }
 

--- a/web/src/components/SkeletonDriftBanner.test.ts
+++ b/web/src/components/SkeletonDriftBanner.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  resolveDriftBannerView,
+  type DriftBannerInput,
+} from "./SkeletonDriftBanner"
+
+const base: DriftBannerInput = {
+  hasOrg: true,
+  hasDrift: true,
+  fixedThisOrg: false,
+  dismissed: false,
+  isPending: false,
+  isFetching: false,
+}
+
+describe("resolveDriftBannerView", () => {
+  it("shows the warning when drift exists and nothing was fixed yet", () => {
+    expect(resolveDriftBannerView(base)).toBe("warning")
+  })
+
+  it("hides everything when there is no org (org picker route)", () => {
+    expect(resolveDriftBannerView({ ...base, hasOrg: false })).toBe("hidden")
+  })
+
+  it("hides after dismissal even while drift remains", () => {
+    expect(resolveDriftBannerView({ ...base, dismissed: true })).toBe("hidden")
+  })
+
+  it("stays hidden on a first-load clean org (no fix run, no drift)", () => {
+    expect(resolveDriftBannerView({ ...base, hasDrift: false })).toBe("hidden")
+  })
+
+  it("shows the success check once a fix cleared the drift", () => {
+    expect(
+      resolveDriftBannerView({ ...base, fixedThisOrg: true, hasDrift: false }),
+    ).toBe("success")
+  })
+
+  it("keeps the warning when a fix left drift (declined overwrite)", () => {
+    // fixedThisOrg is set, but drift remains — must not flash green.
+    expect(
+      resolveDriftBannerView({ ...base, fixedThisOrg: true, hasDrift: true }),
+    ).toBe("warning")
+  })
+
+  it("does not flash success while the post-fix re-check is in flight", () => {
+    expect(
+      resolveDriftBannerView({
+        ...base,
+        fixedThisOrg: true,
+        hasDrift: false,
+        isFetching: true,
+      }),
+    ).toBe("hidden")
+  })
+
+  it("does not flash success while the fix mutation is still pending", () => {
+    expect(
+      resolveDriftBannerView({
+        ...base,
+        fixedThisOrg: true,
+        hasDrift: false,
+        isPending: true,
+      }),
+    ).toBe("hidden")
+  })
+
+  it("suppresses the success check after dismissal wins", () => {
+    expect(
+      resolveDriftBannerView({
+        ...base,
+        fixedThisOrg: true,
+        hasDrift: false,
+        dismissed: true,
+      }),
+    ).toBe("hidden")
+  })
+})

--- a/web/src/components/SkeletonDriftBanner.test.ts
+++ b/web/src/components/SkeletonDriftBanner.test.ts
@@ -8,10 +8,9 @@ import {
 const base: DriftBannerInput = {
   hasOrg: true,
   hasDrift: true,
-  fixedThisOrg: false,
   dismissed: false,
   isPending: false,
-  isFetching: false,
+  fixResolvedClean: false,
 }
 
 describe("resolveDriftBannerView", () => {
@@ -31,47 +30,47 @@ describe("resolveDriftBannerView", () => {
     expect(resolveDriftBannerView({ ...base, hasDrift: false })).toBe("hidden")
   })
 
-  it("shows the success check once a fix cleared the drift", () => {
+  it("shows the success check once a fix resolved with no drift left", () => {
+    // Driven off the mutation result, so it holds even if the cached drift
+    // read hasn't refreshed yet (post-commit tree reads are eventually
+    // consistent and may still report the old SHAs).
     expect(
-      resolveDriftBannerView({ ...base, fixedThisOrg: true, hasDrift: false }),
+      resolveDriftBannerView({
+        ...base,
+        fixResolvedClean: true,
+        hasDrift: true,
+      }),
     ).toBe("success")
   })
 
-  it("keeps the warning when a fix left drift (declined overwrite)", () => {
-    // fixedThisOrg is set, but drift remains — must not flash green.
+  it("keeps the warning when a fix skipped files (declined overwrite)", () => {
+    // fixResolvedClean is false because skippedOverwrite was non-empty.
     expect(
-      resolveDriftBannerView({ ...base, fixedThisOrg: true, hasDrift: true }),
+      resolveDriftBannerView({
+        ...base,
+        fixResolvedClean: false,
+        hasDrift: true,
+      }),
     ).toBe("warning")
   })
 
-  it("does not flash success while the post-fix re-check is in flight", () => {
-    expect(
-      resolveDriftBannerView({
-        ...base,
-        fixedThisOrg: true,
-        hasDrift: false,
-        isFetching: true,
-      }),
-    ).toBe("hidden")
-  })
-
   it("does not flash success while the fix mutation is still pending", () => {
+    // Pending + drift still present -> stay on the warning view (the button
+    // shows its spinner); success must wait until the mutation settles.
     expect(
       resolveDriftBannerView({
         ...base,
-        fixedThisOrg: true,
-        hasDrift: false,
+        fixResolvedClean: true,
         isPending: true,
       }),
-    ).toBe("hidden")
+    ).toBe("warning")
   })
 
   it("suppresses the success check after dismissal wins", () => {
     expect(
       resolveDriftBannerView({
         ...base,
-        fixedThisOrg: true,
-        hasDrift: false,
+        fixResolvedClean: true,
         dismissed: true,
       }),
     ).toBe("hidden")

--- a/web/src/components/SkeletonDriftBanner.test.ts
+++ b/web/src/components/SkeletonDriftBanner.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  isFixResolvedClean,
   resolveDriftBannerView,
   type DriftBannerInput,
 } from "./SkeletonDriftBanner"
@@ -74,5 +75,28 @@ describe("resolveDriftBannerView", () => {
         dismissed: true,
       }),
     ).toBe("hidden")
+  })
+})
+
+describe("isFixResolvedClean", () => {
+  it("is true when the fix completed and skipped nothing", () => {
+    expect(
+      isFixResolvedClean({ status: "complete", skippedOverwrite: [] }),
+    ).toBe(true)
+  })
+
+  it("is false when the fix left files skipped (declined overwrite)", () => {
+    expect(
+      isFixResolvedClean({
+        status: "complete",
+        skippedOverwrite: ["workflows/collect-scores.yaml"],
+      }),
+    ).toBe(false)
+  })
+
+  it("is false for any non-complete status", () => {
+    expect(isFixResolvedClean({ status: "error", skippedOverwrite: [] })).toBe(
+      false,
+    )
   })
 })

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next"
 import { AppBanner } from "@/components/AppBanner"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { ensureSkeletonFiles } from "@/hooks/github/mutations"
+import type { StaleSkeletonFile } from "@/hooks/github/mutations"
 import { githubKeys } from "@/hooks/github/queries"
 import { useSkeletonDrift } from "@/hooks/useSkeletonDrift"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
@@ -85,14 +86,11 @@ export function SkeletonDriftBanner() {
   const runFix = useSafeSubmit()
 
   // The org whose fix just completed with nothing left drifted. Drives the green
-  // success view directly off the mutation result (see DriftBannerInput) and is
-  // tracked per-org so a fix on org A never greets org B after navigation.
+  // success view directly off the mutation result (see DriftBannerInput).
   const [fixedCleanOrg, setFixedCleanOrg] = useState<string>()
 
-  // The org a fix is currently running for. The banner is a singleton (mounted
-  // once in _authed, never remounts on org navigation), so a single mutation is
-  // shared across orgs; this scopes the pending spinner/disabled state to the
-  // org that actually launched the run.
+  // The org a fix is currently running for. The mutation is shared across orgs,
+  // so this scopes the pending spinner/disabled state to the org that launched it.
   const [pendingOrg, setPendingOrg] = useState<string>()
 
   const {
@@ -102,10 +100,9 @@ export function SkeletonDriftBanner() {
     mountedRef,
   } = useSkeletonOverwriteConfirm()
 
-  // Decline any parked overwrite modal when the org changes. The banner is a
-  // singleton (never remounts on org navigation), so a modal opened for org A
-  // would otherwise linger on org B. resolveOverwrite is a no-op when nothing is
-  // parked. Read through a ref so the decline effect can depend on org alone yet
+  // Decline any parked overwrite modal when the org changes, so a modal opened
+  // for org A doesn't linger on org B (resolveOverwrite is a no-op when nothing
+  // is parked). Read through a ref so the effect can depend on org alone yet
   // always call the latest resolver.
   const resolveOverwriteRef = useRef(resolveOverwrite)
   useEffect(() => {
@@ -123,15 +120,17 @@ export function SkeletonDriftBanner() {
       ensureSkeletonFiles(client, targetOrg, confirmSkeletonOverwrite),
     onSuccess: (result, targetOrg) => {
       if (!mountedRef.current) return
+      const key = githubKeys.skeletonDrift(targetOrg)
       // A declined overwrite leaves files drifted -> stay on the warning view.
       if (isFixResolvedClean(result)) {
         setFixedCleanOrg(targetOrg)
+        // Seed the drift cache as clean directly. A post-commit tree read is
+        // eventually consistent and would refetch the old (drifted) SHAs, so
+        // invalidating here could re-flash the warning on the next mount.
+        queryClient.setQueryData<StaleSkeletonFile[]>(key, [])
+      } else {
+        void queryClient.invalidateQueries({ queryKey: key })
       }
-      // Refresh the fixed org's cached drift check so its warning doesn't
-      // re-flash on the next mount. The success view no longer depends on this.
-      void queryClient.invalidateQueries({
-        queryKey: githubKeys.skeletonDrift(targetOrg),
-      })
     },
     onSettled: () => {
       if (mountedRef.current) setPendingOrg(undefined)
@@ -148,66 +147,77 @@ export function SkeletonDriftBanner() {
     fixResolvedClean: fixedCleanOrg === org,
   })
 
+  const isSuccess = view === "success"
+
   return (
     <>
       <AnimatePresence initial={false}>
-        {view === "success" ? (
+        {view !== "hidden" ? (
+          // key stays view-scoped so AnimatePresence animates the warning->success swap.
           <AppBanner
-            key="skeleton-drift-success"
-            tone="success"
-            icon={<CheckCircle2 className="size-5" aria-hidden="true" />}
-            title={t("skeletonDrift.success.title")}
-            onDismiss={() => setDismissedOrg(org)}
-          >
-            <p className="text-base-content/70">
-              {t("skeletonDrift.success.body")}
-            </p>
-            <button
-              type="button"
-              className="btn btn-sm btn-success self-start"
-              onClick={() => setDismissedOrg(org)}
-            >
-              {t("skeletonDrift.success.dismiss")}
-            </button>
-          </AppBanner>
-        ) : view === "warning" ? (
-          <AppBanner
-            key="skeleton-drift"
-            tone="warning"
-            icon={<FileWarning className="size-5" aria-hidden="true" />}
-            title={t("skeletonDrift.title")}
-            onDismiss={() => setDismissedOrg(org)}
-          >
-            <p className="text-base-content/70">{t("skeletonDrift.body")}</p>
-            <p className="text-base-content/70">
-              <span className="font-semibold text-base-content">
-                {t("skeletonDrift.overwriteWarning_label")}
-              </span>{" "}
-              {t("skeletonDrift.overwriteWarning")}
-            </p>
-            <button
-              type="button"
-              className="btn btn-sm btn-warning self-start"
-              disabled={pendingOrg === org}
-              onClick={() => {
-                if (org && pendingOrg !== org) {
-                  setPendingOrg(org)
-                  void runFix(() => mutation.mutateAsync(org))
-                }
-              }}
-            >
-              {pendingOrg === org ? (
-                <>
-                  <span
-                    className="loading loading-spinner loading-xs"
-                    aria-hidden="true"
-                  />
-                  {t("skeletonDrift.updating")}
-                </>
+            key={isSuccess ? "skeleton-drift-success" : "skeleton-drift"}
+            tone={view}
+            icon={
+              isSuccess ? (
+                <CheckCircle2 className="size-5" aria-hidden="true" />
               ) : (
-                t("skeletonDrift.action")
-              )}
-            </button>
+                <FileWarning className="size-5" aria-hidden="true" />
+              )
+            }
+            title={t(
+              isSuccess ? "skeletonDrift.success.title" : "skeletonDrift.title",
+            )}
+            onDismiss={() => setDismissedOrg(org)}
+          >
+            {isSuccess ? (
+              <>
+                <p className="text-base-content/70">
+                  {t("skeletonDrift.success.body")}
+                </p>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-success self-start"
+                  onClick={() => setDismissedOrg(org)}
+                >
+                  {t("skeletonDrift.success.dismiss")}
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="text-base-content/70">
+                  {t("skeletonDrift.body")}
+                </p>
+                <p className="text-base-content/70">
+                  <span className="font-semibold text-base-content">
+                    {t("skeletonDrift.overwriteWarning_label")}
+                  </span>{" "}
+                  {t("skeletonDrift.overwriteWarning")}
+                </p>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-warning self-start"
+                  disabled={pendingOrg === org}
+                  onClick={() => {
+                    if (org && pendingOrg !== org) {
+                      setPendingOrg(org)
+                      void runFix(() => mutation.mutateAsync(org))
+                    }
+                  }}
+                >
+                  {pendingOrg === org ? (
+                    <>
+                      <span
+                        className="loading loading-spinner loading-xs"
+                        aria-hidden="true"
+                      />
+                      {t("skeletonDrift.updating")}
+                    </>
+                  ) : (
+                    t("skeletonDrift.action")
+                  )}
+                </button>
+              </>
+            )}
           </AppBanner>
         ) : null}
       </AnimatePresence>

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -1,17 +1,65 @@
-import { useState } from "react"
-import { Link, useParams } from "@tanstack/react-router"
-import { FileWarning } from "lucide-react"
+import { useEffect, useState } from "react"
+import { useParams } from "@tanstack/react-router"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { CheckCircle2, FileWarning } from "lucide-react"
 import { AnimatePresence } from "motion/react"
 import { useTranslation } from "react-i18next"
 
 import { AppBanner } from "@/components/AppBanner"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { ensureSkeletonFiles } from "@/hooks/github/mutations"
+import { githubKeys } from "@/hooks/github/queries"
 import { useSkeletonDrift } from "@/hooks/useSkeletonDrift"
-import { RERUN_ORG_SETUP_ANCHOR } from "@/pages/orgSettings/RerunOrgSetup"
+import { useSafeSubmit } from "@/hooks/useSafeSubmit"
+import {
+  SkeletonOverwriteModal,
+  useSkeletonOverwriteConfirm,
+} from "@/pages/orgSettings/skeletonOverwriteUi"
+
+// How long the green "up to date" confirmation lingers before the banner
+// auto-dismisses after a successful in-place fix.
+const SUCCESS_LINGER_MS = 2000
+
+export type DriftBannerView = "warning" | "success" | "hidden"
+
+// State the banner view depends on — structural so the tri-state decision stays
+// a pure, testable function (mirrors resolveSkeletonDrift).
+export type DriftBannerInput = {
+  hasOrg: boolean
+  hasDrift: boolean
+  // The org the user just ran a fix for, if any. Gates the success view so a
+  // first-load clean org never flashes a check the user didn't ask for.
+  fixedThisOrg: boolean
+  dismissed: boolean
+  isPending: boolean
+  // True while the post-fix re-check is in flight; gates out the window between
+  // the invalidate and the refetch resolving so we don't flash green early.
+  isFetching: boolean
+}
+
+// Tri-state view verdict:
+// - success: the user fixed this org and a settled re-check found no drift.
+// - warning: drift remains (including after a declined/failed fix or on first
+//   load), and the banner isn't dismissed.
+// - hidden: everything else.
+// Success is checked first so a just-fixed clean org shows the check rather than
+// nothing; a fix that left drift falls through to warning.
+export function resolveDriftBannerView(
+  input: DriftBannerInput,
+): DriftBannerView {
+  const { hasOrg, hasDrift, fixedThisOrg, dismissed, isPending, isFetching } =
+    input
+  if (!hasOrg || dismissed) return "hidden"
+  if (fixedThisOrg && !hasDrift && !isPending && !isFetching) return "success"
+  if (hasDrift) return "warning"
+  return "hidden"
+}
 
 // Global warning banner for an org owner when the `classroom50` config repo's
 // scaffolded workflows have drifted from the bundled skeleton (e.g. after an
-// action-pin bump). Routes to the owner-only "Re-run org setup" section, which
-// overwrites (its modal still confirms per file).
+// action-pin bump). Self-service: the owner refreshes the drifted files inline
+// (confirming the overwrite), and once a re-check finds no drift we flash a
+// green check and auto-dismiss.
 //
 // Dismiss is per-session and per-org: the banner mounts once in the stable
 // _authed layout and never remounts on org navigation, so dismissal is tracked
@@ -20,40 +68,118 @@ export function SkeletonDriftBanner() {
   // Loose param read: org-less routes (the org picker) yield undefined and the
   // owner-gated hook stays disabled.
   const { org } = useParams({ strict: false })
-  const { hasDrift } = useSkeletonDrift(org)
+  const { hasDrift, isFetching } = useSkeletonDrift(org)
   const [dismissedOrg, setDismissedOrg] = useState<string>()
   const { t } = useTranslation()
 
-  const show = Boolean(org) && hasDrift && dismissedOrg !== org
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+  const runFix = useSafeSubmit()
+
+  // Set once the user runs a fix; gates the green success state so a first-load
+  // clean org never flashes a check the user didn't ask for.
+  const [fixedOrg, setFixedOrg] = useState<string>()
+
+  const {
+    overwritePaths,
+    resolveOverwrite,
+    confirmSkeletonOverwrite,
+    mountedRef,
+  } = useSkeletonOverwriteConfirm()
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      ensureSkeletonFiles(client, org as string, confirmSkeletonOverwrite),
+    onSuccess: () => {
+      if (!mountedRef.current) return
+      setFixedOrg(org)
+      // Re-check drift: an explicit invalidate ignores the hook's staleTime, so
+      // the banner reflects the post-fix state instead of stale cache.
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.skeletonDrift(org ?? ""),
+      })
+    },
+  })
+
+  const view = resolveDriftBannerView({
+    hasOrg: Boolean(org),
+    hasDrift,
+    fixedThisOrg: fixedOrg === org,
+    dismissed: dismissedOrg === org,
+    isPending: mutation.isPending,
+    isFetching,
+  })
+
+  // Auto-dismiss after the success check has lingered.
+  useEffect(() => {
+    if (view !== "success") return
+    const timer = setTimeout(() => {
+      if (mountedRef.current) setDismissedOrg(org)
+    }, SUCCESS_LINGER_MS)
+    return () => clearTimeout(timer)
+  }, [view, org, mountedRef])
 
   return (
-    <AnimatePresence initial={false}>
-      {show ? (
-        <AppBanner
-          key="skeleton-drift"
-          tone="warning"
-          icon={<FileWarning className="size-5" aria-hidden="true" />}
-          title={t("skeletonDrift.title")}
-          onDismiss={() => setDismissedOrg(org)}
-        >
-          <p className="text-base-content/70">{t("skeletonDrift.body")}</p>
-          <p className="text-base-content/70">
-            <span className="font-semibold text-base-content">
-              {t("skeletonDrift.overwriteWarning_label")}
-            </span>{" "}
-            {t("skeletonDrift.overwriteWarning")}
-          </p>
-          <Link
-            to="/$org/settings"
-            params={{ org: org as string }}
-            hash={RERUN_ORG_SETUP_ANCHOR}
-            className="btn btn-sm btn-warning self-start"
+    <>
+      <AnimatePresence initial={false}>
+        {view === "success" ? (
+          <AppBanner
+            key="skeleton-drift-success"
+            tone="success"
+            icon={<CheckCircle2 className="size-5" aria-hidden="true" />}
+            title={t("skeletonDrift.success.title")}
           >
-            {t("skeletonDrift.action")}
-          </Link>
-        </AppBanner>
-      ) : null}
-    </AnimatePresence>
+            <p className="text-base-content/70">
+              {t("skeletonDrift.success.body")}
+            </p>
+          </AppBanner>
+        ) : view === "warning" ? (
+          <AppBanner
+            key="skeleton-drift"
+            tone="warning"
+            icon={<FileWarning className="size-5" aria-hidden="true" />}
+            title={t("skeletonDrift.title")}
+            onDismiss={() => setDismissedOrg(org)}
+          >
+            <p className="text-base-content/70">{t("skeletonDrift.body")}</p>
+            <p className="text-base-content/70">
+              <span className="font-semibold text-base-content">
+                {t("skeletonDrift.overwriteWarning_label")}
+              </span>{" "}
+              {t("skeletonDrift.overwriteWarning")}
+            </p>
+            <button
+              type="button"
+              className="btn btn-sm btn-warning self-start"
+              disabled={mutation.isPending}
+              onClick={() => {
+                if (!mutation.isPending) {
+                  void runFix(() => mutation.mutateAsync())
+                }
+              }}
+            >
+              {mutation.isPending ? (
+                <>
+                  <span
+                    className="loading loading-spinner loading-xs"
+                    aria-hidden="true"
+                  />
+                  {t("skeletonDrift.updating")}
+                </>
+              ) : (
+                t("skeletonDrift.action")
+              )}
+            </button>
+          </AppBanner>
+        ) : null}
+      </AnimatePresence>
+
+      <SkeletonOverwriteModal
+        paths={overwritePaths}
+        onConfirm={() => resolveOverwrite(true)}
+        onClose={() => resolveOverwrite(false)}
+      />
+    </>
   )
 }
 

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useParams } from "@tanstack/react-router"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { CheckCircle2, FileWarning } from "lucide-react"
@@ -16,10 +16,6 @@ import {
   useSkeletonOverwriteConfirm,
 } from "@/pages/orgSettings/skeletonOverwriteUi"
 
-// How long the green "up to date" confirmation lingers before the banner
-// auto-dismisses after a successful in-place fix.
-const SUCCESS_LINGER_MS = 2000
-
 export type DriftBannerView = "warning" | "success" | "hidden"
 
 // State the banner view depends on — structural so the tri-state decision stays
@@ -27,30 +23,30 @@ export type DriftBannerView = "warning" | "success" | "hidden"
 export type DriftBannerInput = {
   hasOrg: boolean
   hasDrift: boolean
-  // The org the user just ran a fix for, if any. Gates the success view so a
-  // first-load clean org never flashes a check the user didn't ask for.
-  fixedThisOrg: boolean
   dismissed: boolean
   isPending: boolean
-  // True while the post-fix re-check is in flight; gates out the window between
-  // the invalidate and the refetch resolving so we don't flash green early.
-  isFetching: boolean
+  // True once a fix for this org completed with no files left drifted. Drives
+  // the success view directly off the mutation result rather than re-reading
+  // the repo tree — a post-commit tree read is eventually consistent and can
+  // still report the old (drifted) SHAs, which would wrongly keep us on the
+  // warning view.
+  fixResolvedClean: boolean
 }
 
 // Tri-state view verdict:
-// - success: the user fixed this org and a settled re-check found no drift.
+// - success: a fix for this org completed and left no drift.
 // - warning: drift remains (including after a declined/failed fix or on first
-//   load), and the banner isn't dismissed.
+//   load) and a clean fix hasn't just completed, and the banner isn't dismissed.
 // - hidden: everything else.
-// Success is checked first so a just-fixed clean org shows the check rather than
-// nothing; a fix that left drift falls through to warning.
+// Success is checked first so a just-fixed org shows the check; a fix that
+// skipped files (declined overwrite) has fixResolvedClean=false and falls
+// through to warning.
 export function resolveDriftBannerView(
   input: DriftBannerInput,
 ): DriftBannerView {
-  const { hasOrg, hasDrift, fixedThisOrg, dismissed, isPending, isFetching } =
-    input
+  const { hasOrg, hasDrift, dismissed, isPending, fixResolvedClean } = input
   if (!hasOrg || dismissed) return "hidden"
-  if (fixedThisOrg && !hasDrift && !isPending && !isFetching) return "success"
+  if (fixResolvedClean && !isPending) return "success"
   if (hasDrift) return "warning"
   return "hidden"
 }
@@ -58,8 +54,8 @@ export function resolveDriftBannerView(
 // Global warning banner for an org owner when the `classroom50` config repo's
 // scaffolded workflows have drifted from the bundled skeleton (e.g. after an
 // action-pin bump). Self-service: the owner refreshes the drifted files inline
-// (confirming the overwrite), and once a re-check finds no drift we flash a
-// green check and auto-dismiss.
+// (confirming the overwrite), and once the fix resolves cleanly we show a green
+// confirmation the owner dismisses (X or the Dismiss button).
 //
 // Dismiss is per-session and per-org: the banner mounts once in the stable
 // _authed layout and never remounts on org navigation, so dismissal is tracked
@@ -68,7 +64,7 @@ export function SkeletonDriftBanner() {
   // Loose param read: org-less routes (the org picker) yield undefined and the
   // owner-gated hook stays disabled.
   const { org } = useParams({ strict: false })
-  const { hasDrift, isFetching } = useSkeletonDrift(org)
+  const { hasDrift } = useSkeletonDrift(org)
   const [dismissedOrg, setDismissedOrg] = useState<string>()
   const { t } = useTranslation()
 
@@ -76,9 +72,10 @@ export function SkeletonDriftBanner() {
   const queryClient = useQueryClient()
   const runFix = useSafeSubmit()
 
-  // Set once the user runs a fix; gates the green success state so a first-load
-  // clean org never flashes a check the user didn't ask for.
-  const [fixedOrg, setFixedOrg] = useState<string>()
+  // The org whose fix just completed with nothing left drifted. Drives the green
+  // success view directly off the mutation result (see DriftBannerInput) and is
+  // tracked per-org so a fix on org A never greets org B after navigation.
+  const [fixedCleanOrg, setFixedCleanOrg] = useState<string>()
 
   const {
     overwritePaths,
@@ -90,11 +87,18 @@ export function SkeletonDriftBanner() {
   const mutation = useMutation({
     mutationFn: () =>
       ensureSkeletonFiles(client, org as string, confirmSkeletonOverwrite),
-    onSuccess: () => {
+    onSuccess: (result) => {
       if (!mountedRef.current) return
-      setFixedOrg(org)
-      // Re-check drift: an explicit invalidate ignores the hook's staleTime, so
-      // the banner reflects the post-fix state instead of stale cache.
+      // Clean iff the fix completed and left no drifted files behind (a declined
+      // overwrite leaves skippedOverwrite non-empty -> stay on the warning view).
+      if (
+        result.status === "complete" &&
+        result.skippedOverwrite.length === 0
+      ) {
+        setFixedCleanOrg(org)
+      }
+      // Refresh the cached drift check so the warning banner doesn't re-flash on
+      // the next mount. The success view no longer depends on this resolving.
       void queryClient.invalidateQueries({
         queryKey: githubKeys.skeletonDrift(org ?? ""),
       })
@@ -104,20 +108,10 @@ export function SkeletonDriftBanner() {
   const view = resolveDriftBannerView({
     hasOrg: Boolean(org),
     hasDrift,
-    fixedThisOrg: fixedOrg === org,
     dismissed: dismissedOrg === org,
     isPending: mutation.isPending,
-    isFetching,
+    fixResolvedClean: fixedCleanOrg === org,
   })
-
-  // Auto-dismiss after the success check has lingered.
-  useEffect(() => {
-    if (view !== "success") return
-    const timer = setTimeout(() => {
-      if (mountedRef.current) setDismissedOrg(org)
-    }, SUCCESS_LINGER_MS)
-    return () => clearTimeout(timer)
-  }, [view, org, mountedRef])
 
   return (
     <>
@@ -128,10 +122,18 @@ export function SkeletonDriftBanner() {
             tone="success"
             icon={<CheckCircle2 className="size-5" aria-hidden="true" />}
             title={t("skeletonDrift.success.title")}
+            onDismiss={() => setDismissedOrg(org)}
           >
             <p className="text-base-content/70">
               {t("skeletonDrift.success.body")}
             </p>
+            <button
+              type="button"
+              className="btn btn-sm btn-success self-start"
+              onClick={() => setDismissedOrg(org)}
+            >
+              {t("skeletonDrift.success.dismiss")}
+            </button>
           </AppBanner>
         ) : view === "warning" ? (
           <AppBanner

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useParams } from "@tanstack/react-router"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { CheckCircle2, FileWarning } from "lucide-react"
@@ -51,6 +51,17 @@ export function resolveDriftBannerView(
   return "hidden"
 }
 
+// A fix leaves the org clean only when it completed and skipped nothing; a
+// declined overwrite leaves skippedOverwrite non-empty and must stay on the
+// warning view. Pure so the result-contract mapping is testable (mirrors
+// resolveSkeletonDrift), independent of the component's async wiring.
+export function isFixResolvedClean(result: {
+  status: string
+  skippedOverwrite: string[]
+}): boolean {
+  return result.status === "complete" && result.skippedOverwrite.length === 0
+}
+
 // Global warning banner for an org owner when the `classroom50` config repo's
 // scaffolded workflows have drifted from the bundled skeleton (e.g. after an
 // action-pin bump). Self-service: the owner refreshes the drifted files inline
@@ -58,8 +69,9 @@ export function resolveDriftBannerView(
 // confirmation the owner dismisses (X or the Dismiss button).
 //
 // Dismiss is per-session and per-org: the banner mounts once in the stable
-// _authed layout and never remounts on org navigation, so dismissal is tracked
-// by org — dismissing org A must not suppress org B. Reappears on reload.
+// _authed layout and never remounts on org navigation, so all per-org state
+// (dismissal, the just-fixed org, the in-flight org) is keyed by org — a fix or
+// dismiss on org A must not affect org B. Reappears on reload.
 export function SkeletonDriftBanner() {
   // Loose param read: org-less routes (the org picker) yield undefined and the
   // owner-gated hook stays disabled.
@@ -77,6 +89,12 @@ export function SkeletonDriftBanner() {
   // tracked per-org so a fix on org A never greets org B after navigation.
   const [fixedCleanOrg, setFixedCleanOrg] = useState<string>()
 
+  // The org a fix is currently running for. The banner is a singleton (mounted
+  // once in _authed, never remounts on org navigation), so a single mutation is
+  // shared across orgs; this scopes the pending spinner/disabled state to the
+  // org that actually launched the run.
+  const [pendingOrg, setPendingOrg] = useState<string>()
+
   const {
     overwritePaths,
     resolveOverwrite,
@@ -84,24 +102,39 @@ export function SkeletonDriftBanner() {
     mountedRef,
   } = useSkeletonOverwriteConfirm()
 
+  // Decline any parked overwrite modal when the org changes. The banner is a
+  // singleton (never remounts on org navigation), so a modal opened for org A
+  // would otherwise linger on org B. resolveOverwrite is a no-op when nothing is
+  // parked. Read through a ref so the decline effect can depend on org alone yet
+  // always call the latest resolver.
+  const resolveOverwriteRef = useRef(resolveOverwrite)
+  useEffect(() => {
+    resolveOverwriteRef.current = resolveOverwrite
+  })
+  useEffect(() => {
+    return () => resolveOverwriteRef.current(false)
+  }, [org])
+
   const mutation = useMutation({
-    mutationFn: () =>
-      ensureSkeletonFiles(client, org as string, confirmSkeletonOverwrite),
-    onSuccess: (result) => {
+    // org is captured as a mutate variable so onSuccess attributes the result to
+    // the org the fix actually ran against, not the live param (which can change
+    // if the owner navigates while the run is in flight).
+    mutationFn: (targetOrg: string) =>
+      ensureSkeletonFiles(client, targetOrg, confirmSkeletonOverwrite),
+    onSuccess: (result, targetOrg) => {
       if (!mountedRef.current) return
-      // Clean iff the fix completed and left no drifted files behind (a declined
-      // overwrite leaves skippedOverwrite non-empty -> stay on the warning view).
-      if (
-        result.status === "complete" &&
-        result.skippedOverwrite.length === 0
-      ) {
-        setFixedCleanOrg(org)
+      // A declined overwrite leaves files drifted -> stay on the warning view.
+      if (isFixResolvedClean(result)) {
+        setFixedCleanOrg(targetOrg)
       }
-      // Refresh the cached drift check so the warning banner doesn't re-flash on
-      // the next mount. The success view no longer depends on this resolving.
+      // Refresh the fixed org's cached drift check so its warning doesn't
+      // re-flash on the next mount. The success view no longer depends on this.
       void queryClient.invalidateQueries({
-        queryKey: githubKeys.skeletonDrift(org ?? ""),
+        queryKey: githubKeys.skeletonDrift(targetOrg),
       })
+    },
+    onSettled: () => {
+      if (mountedRef.current) setPendingOrg(undefined)
     },
   })
 
@@ -109,7 +142,9 @@ export function SkeletonDriftBanner() {
     hasOrg: Boolean(org),
     hasDrift,
     dismissed: dismissedOrg === org,
-    isPending: mutation.isPending,
+    // Scope pending to this org: a fix parked for another org must not disable
+    // or spin this org's button.
+    isPending: pendingOrg === org,
     fixResolvedClean: fixedCleanOrg === org,
   })
 
@@ -153,14 +188,15 @@ export function SkeletonDriftBanner() {
             <button
               type="button"
               className="btn btn-sm btn-warning self-start"
-              disabled={mutation.isPending}
+              disabled={pendingOrg === org}
               onClick={() => {
-                if (!mutation.isPending) {
-                  void runFix(() => mutation.mutateAsync())
+                if (org && pendingOrg !== org) {
+                  setPendingOrg(org)
+                  void runFix(() => mutation.mutateAsync(org))
                 }
               }}
             >
-              {mutation.isPending ? (
+              {pendingOrg === org ? (
                 <>
                   <span
                     className="loading loading-spinner loading-xs"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1062,10 +1062,15 @@
   },
   "skeletonDrift": {
     "title": "Classroom workflow files are out of date",
-    "body": "The GitHub Actions workflows in this org's classroom50 config repo are out of date. Re-run org setup to update them and keep grading, score collection, and Pages publishing working.",
+    "body": "The GitHub Actions workflows in this org's classroom50 config repo are out of date. Update them here to keep grading, score collection, and Pages publishing working.",
     "overwriteWarning_label": "Heads up:",
-    "overwriteWarning": "Updating overwrites the scaffolded workflow files (collect-scores, regrade, publish-pages, autograde-runner) with the defaults, replacing any manual edits — you'll confirm each one first.",
-    "action": "Update workflows"
+    "overwriteWarning": "Updating overwrites the scaffolded workflow files (collect-scores, regrade, publish-pages, autograde-runner) with the defaults, replacing any manual edits — you'll confirm first.",
+    "action": "Update workflows now",
+    "updating": "Updating…",
+    "success": {
+      "title": "Classroom workflow files are up to date",
+      "body": "All Classroom 50 workflow files now match the latest bundled version."
+    }
   },
   "classes": {
     "createTitle": "Create Classroom",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -984,14 +984,14 @@
       "reviewFixSuffix": "."
     },
     "overwrite": {
-      "title": "Update workflow files to the latest version?",
-      "confirmLabel": "Overwrite",
-      "cancelLabel": "Keep mine",
-      "body_one": "1 Classroom 50 workflow/script file in your config repo differs from the latest bundled version and will be overwritten:",
-      "body_other": "{{count}} Classroom 50 workflow/script files in your config repo differ from the latest bundled version and will be overwritten:",
-      "warning_prefix": "If you customized any of these files, overwriting resets your changes to the bundled version — choose",
-      "keepMine": "Keep mine",
-      "warning_suffix": "to leave them untouched and continue with everything else."
+      "title": "Update workflow files to keep grading working?",
+      "confirmLabel": "Update now",
+      "cancelLabel": "Not now",
+      "body_one": "1 Classroom 50 workflow/script file in your config repo is out of date and will be refreshed:",
+      "body_other": "{{count}} Classroom 50 workflow/script files in your config repo are out of date and will be refreshed:",
+      "warning_prefix": "Classroom 50 manages these files, so updating is safe. Leaving them out of date can stop features like the autograder from running. If you customized a file, choose",
+      "keepMine": "Not now",
+      "warning_suffix": "to keep it as-is for now."
     },
     "steps": {
       "whyLabel": "Why:",
@@ -1069,7 +1069,8 @@
     "updating": "Updating…",
     "success": {
       "title": "Classroom workflow files are up to date",
-      "body": "All Classroom 50 workflow files now match the latest bundled version."
+      "body": "All Classroom 50 workflow files now match the latest bundled version.",
+      "dismiss": "Dismiss"
     }
   },
   "classes": {

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -49,9 +49,8 @@ const SummaryBanner = ({
   </CalloutDiv>
 )
 
-// DOM anchor shared with SkeletonDriftBanner so its "Update workflows" action
-// scrolls straight to this section.
-export const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
+// DOM anchor for this section, used as its SettingsSection id.
+const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
 
 // Re-run the org setup from Org Settings: re-invokes the idempotent
 // initClassroom50 to re-apply lockdown, rulesets, and repo settings. Owner-gated;


### PR DESCRIPTION
## Summary

Makes the skeleton-drift banner self-service. Instead of only deep-linking org owners to Settings -> "Re-run org setup", the owner can now refresh the drifted skeleton files **inline from the banner**, confirm the overwrite, and get a green "up to date" confirmation.

- **Inline fix:** the banner's action runs `ensureSkeletonFiles(client, org, confirmSkeletonOverwrite)`, reusing the existing `useSkeletonOverwriteConfirm` + `SkeletonOverwriteModal` so per-file overwrite confirmation happens right there. Shows a spinner + "Updating…" while it runs.
- **Success confirmation:** driven directly off the mutation result (`status === "complete" && skippedOverwrite.length === 0`, extracted as `isFixResolvedClean`) rather than a post-commit drift re-check. GitHub's git-tree read is eventually consistent right after a commit and often still reported the old SHAs, so the re-check-based approach frequently never reached the success view. On a clean fix we seed the drift cache empty via `setQueryData` (skipping the redundant, still-stale refetch); a declined overwrite leaves `skippedOverwrite` non-empty, invalidates instead, and correctly stays on the warning view.
- **Singleton-safe, per-org state:** the banner mounts once in `_authed` and never remounts on org navigation, so dismissal, the just-fixed org, and the in-flight (pending) org are all keyed by org — a fix or dismiss on org A can't affect org B. The mutation captures its `targetOrg` as a mutate variable, and a parked overwrite modal is declined when the org changes.
- **Manual dismiss:** the green banner is dismissed by the owner (X or a "Dismiss" button) — no auto-dismiss timer.
- **Softer confirm copy:** the overwrite dialog now nudges applying updates ("Update now" / "Not now"), notes Classroom 50 manages these files so updating is safe, and mentions that leaving them out of date can stop features like the autograder from running.
- **New `success` tone** added to `AppBanner` (green).

Closes #134.

## Files

- `web/src/components/SkeletonDriftBanner.tsx` — inline mutation, tri-state `resolveDriftBannerView` + `isFixResolvedClean`, per-org state, single config-driven `AppBanner` for success/warning
- `web/src/components/SkeletonDriftBanner.test.ts` — unit tests for the view verdict and the clean-fix predicate
- `web/src/components/AppBanner/index.tsx` — `success` tone
- `web/src/pages/orgSettings/RerunOrgSetup.tsx` — drop the now-unused `RERUN_ORG_SETUP_ANCHOR` export (the banner no longer deep-links here)
- `web/src/locales/en.json` — `skeletonDrift.updating` / `skeletonDrift.success.*`; reworded `orgSettings.overwrite.*`

## Test plan

- [x] `npm run check` green (tsc + eslint + prettier + vitest): 758 tests pass
- [x] i18n audit passes (`audit_i18n.py`)
- [ ] Manual: as an org owner with drifted workflows, click Update now -> confirm overwrite -> green banner appears -> dismiss via X and via button
- [ ] Manual: decline the overwrite -> banner stays on the warning view
- [ ] Manual: start a fix on org A, navigate to org B mid-run -> B's banner is unaffected (no spinner, no stray success)