### PR TITLE
fix(web): surface a warning when re-adding an already-enrolled student

### DIFF
--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -14,6 +14,7 @@ import {
   updateStudentWithConflictRetry,
   parseStudentsCsv,
   STUDENT_CSV_FIELDS,
+  StudentAlreadyEnrolledError,
 } from "./students"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import type { GitHubClient } from "@/hooks/github/client"
@@ -166,6 +167,43 @@ describe("enrollStudentInClassroom — already-member writes the row directly", 
     const rows = rowsFromCsv(committed.content!)
     const bob = rows.find((r) => r.username === "bob")
     expect(bob?.github_id).toBe("43")
+  })
+
+  // A duplicate must surface a typed error so the Add Student modal can render a
+  // gentle, non-blocking, translated "already enrolled" warning instead of
+  // silently reverting (the reported bug).
+  it("throws StudentAlreadyEnrolledError when the login is already on the roster", async () => {
+    const { client } = makeClient({
+      startingCsv: `${HEADER}alice,,,,,42\n`,
+      membershipState: "active",
+      user: { login: "alice", id: 42 },
+    })
+
+    await expect(
+      enrollStudentInClassroom(client, {
+        org: "acme",
+        classroom: "cs101",
+        username: "alice",
+      }),
+    ).rejects.toBeInstanceOf(StudentAlreadyEnrolledError)
+  })
+
+  it("throws StudentAlreadyEnrolledError when the github_id matches a renamed login", async () => {
+    // The CSV stores a stale login but the same github_id; the current account
+    // resolves to a different login. Dedupe by id must still catch it.
+    const { client } = makeClient({
+      startingCsv: `${HEADER}old-alice,,,,,42\n`,
+      membershipState: "active",
+      user: { login: "new-alice", id: 42 },
+    })
+
+    await expect(
+      enrollStudentInClassroom(client, {
+        org: "acme",
+        classroom: "cs101",
+        username: "new-alice",
+      }),
+    ).rejects.toMatchObject({ login: "new-alice" })
   })
 })
 

--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -169,9 +169,6 @@ describe("enrollStudentInClassroom — already-member writes the row directly", 
     expect(bob?.github_id).toBe("43")
   })
 
-  // A duplicate must surface a typed error so the Add Student modal can render a
-  // gentle, non-blocking, translated "already enrolled" warning instead of
-  // silently reverting (the reported bug).
   it("throws StudentAlreadyEnrolledError when the login is already on the roster", async () => {
     const { client } = makeClient({
       startingCsv: `${HEADER}alice,,,,,42\n`,

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -93,6 +93,21 @@ export type AddStudentToClassroomResult = CreateClassroomResult & {
   teamWarning?: string
 }
 
+// Thrown when the student is already on this classroom's roster (by login or
+// github_id). A typed error so the UI can render a gentle, non-blocking,
+// translated "already enrolled" message instead of string-matching this
+// (English) message. Adding an existing ORG member who isn't yet on this
+// classroom is NOT this case — that path enrolls them (see
+// enrollStudentInClassroom).
+export class StudentAlreadyEnrolledError extends Error {
+  login: string
+  constructor(login: string) {
+    super(`Student already exists: ${login}`)
+    this.name = "StudentAlreadyEnrolledError"
+    this.login = login
+  }
+}
+
 // Best-effort single-user team add (enroll/mark/match paths). Returns the error
 // detail on failure so each caller phrases its own warning; team membership is
 // only read access to private templates and is retryable, so it never fails the
@@ -314,7 +329,7 @@ export async function addStudentToClassroom(
   )
 
   if (alreadyExists) {
-    throw new Error(`Student already exists: ${githubUser.login}`)
+    throw new StudentAlreadyEnrolledError(githubUser.login)
   }
 
   const nameParts = splitName(githubUser.name)

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -93,12 +93,8 @@ export type AddStudentToClassroomResult = CreateClassroomResult & {
   teamWarning?: string
 }
 
-// Thrown when the student is already on this classroom's roster (by login or
-// github_id). A typed error so the UI can render a gentle, non-blocking,
-// translated "already enrolled" message instead of string-matching this
-// (English) message. Adding an existing ORG member who isn't yet on this
-// classroom is NOT this case — that path enrolls them (see
-// enrollStudentInClassroom).
+// Already on this classroom's roster (matched by login or github_id). Typed so
+// the UI can branch on it instead of string-matching this message.
 export class StudentAlreadyEnrolledError extends Error {
   login: string
   constructor(login: string) {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -161,6 +161,8 @@
     "unenrollStudent": "Unenroll student",
     "added": "Added {{label}}.",
     "invited": "Sent an organization invite to {{label}}.",
+    "alreadyEnrolled": "{{label}} is already enrolled in this classroom.",
+    "addFailed": "Couldn't add {{label}}: {{message}}",
     "count_one": "{{count}} Student",
     "count_other": "{{count}} Students",
     "untitledClass": "Untitled class",

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -11,8 +11,14 @@ import {
   useInvalidateTeamRoster,
   useSeedTeamMember,
 } from "@/hooks/useTeamRoster"
-import { enrollStudentInClassroom } from "@/hooks/github/mutations"
-import { inviteByEmail } from "@/api/mutations/students"
+import {
+  enrollStudentInClassroom,
+  getErrorMessage,
+} from "@/hooks/github/mutations"
+import {
+  inviteByEmail,
+  StudentAlreadyEnrolledError,
+} from "@/api/mutations/students"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { isValidEmail } from "@/util/orgMembership"
 import { splitName, toStudent } from "@/util/roster"
@@ -126,6 +132,21 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
         invalidateTeamRoster()
       }
     },
+    onError: (err, value) => {
+      // The mutation swallowed failures before, so a duplicate (or any other
+      // error) left the form silently reverting. Surface it as a gentle,
+      // non-blocking warning and keep the modal + form intact so the teacher
+      // can fix the entry or add someone else.
+      setSuccess("")
+      const label = value.username.trim() || value.email.trim()
+      if (err instanceof StudentAlreadyEnrolledError) {
+        setWarning(t("students.alreadyEnrolled", { label: err.login }))
+        return
+      }
+      setWarning(
+        t("students.addFailed", { label, message: getErrorMessage(err) }),
+      )
+    },
   })
 
   const form = useForm({
@@ -158,7 +179,10 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
     onSubmit: async ({ value }) => {
       setWarning("")
       setSuccess("")
-      await addMutation.mutateAsync(value)
+      // Errors are surfaced by the mutation's onError (as a warning); swallow
+      // the rejection here so it isn't also recorded as a form-level error while
+      // still letting isSubmitting track the in-flight request.
+      await addMutation.mutateAsync(value).catch(() => {})
     },
   })
 

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -133,10 +133,8 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
       }
     },
     onError: (err, value) => {
-      // The mutation swallowed failures before, so a duplicate (or any other
-      // error) left the form silently reverting. Surface it as a gentle,
-      // non-blocking warning and keep the modal + form intact so the teacher
-      // can fix the entry or add someone else.
+      // Surface every failure as a non-blocking warning, keeping the modal and
+      // form intact so the teacher can fix the entry or add someone else.
       setSuccess("")
       const label = value.username.trim() || value.email.trim()
       if (err instanceof StudentAlreadyEnrolledError) {
@@ -179,9 +177,8 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
     onSubmit: async ({ value }) => {
       setWarning("")
       setSuccess("")
-      // Errors are surfaced by the mutation's onError (as a warning); swallow
-      // the rejection here so it isn't also recorded as a form-level error while
-      // still letting isSubmitting track the in-flight request.
+      // onError already surfaces failures; swallow the rejection so it isn't
+      // also recorded as a form-level error.
       await addMutation.mutateAsync(value).catch(() => {})
     },
   })


### PR DESCRIPTION
## Summary

The **Add Student** modal's mutation had an `onSuccess` handler but no `onError`, so adding a student already on the classroom roster (or any other failure) left the form spinning and silently reverting with no feedback.

- Introduce a typed `StudentAlreadyEnrolledError` thrown by the `alreadyExists` guard in `addStudentToClassroom`, so the UI can branch on type instead of matching a hardcoded English string.
- Add an `onError` handler to the Add Student mutation: a gentle, non-blocking `students.alreadyEnrolled` warning for duplicates, and a generic `students.addFailed` message for any other failure (network, user-not-found, team resolution). The modal and form stay intact on error; only success resets the form.
- Add `students.alreadyEnrolled` and `students.addFailed` locale keys (all user-facing text via `t()`).

The "already an org member but not yet in this classroom" case was already handled correctly (`enrollStudentInClassroom` writes the row `enrolled` and team-adds directly), so the only true duplicate is "already on this classroom's roster," which now reports cleanly.

Closes #135.

## Test plan

- [x] `npm run check` green (tsc, eslint 0 errors, prettier, 760 tests incl. i18n audit)
- [x] New tests: duplicate by login and by `github_id` (renamed login) both throw `StudentAlreadyEnrolledError`
- [ ] Manually re-add an already-enrolled student and confirm the modal shows the warning and stays open