### PR TITLE
feat(web): link org name in page headings to github.com

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -27,7 +27,8 @@
     "done": "Done",
     "yes": "Yes",
     "no": "No",
-    "skipToMainContent": "Skip to main content"
+    "skipToMainContent": "Skip to main content",
+    "openOrgOnGitHub": "Open {{org}} on GitHub"
   },
   "notFound": {
     "title": "Page not found",

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -37,6 +37,7 @@ import useDotClassroom50 from "@/hooks/useDotClassroom50"
 import useGetPublicAssignment from "@/hooks/useGetPublicAssignment"
 import OrgPreflightNotice from "@/pages/orgSettings/OrgPreflightNotice"
 import { EnterDiv } from "@/lib/motionComponents"
+import { githubOrgUrl } from "@/util/orgUrl"
 
 type ClassFilter = "active" | "archived" | "all"
 
@@ -417,9 +418,15 @@ const ClassesPage = () => {
                     <div className="text-xs font-medium uppercase tracking-wide text-base-content/70">
                       {t("classes.githubOrganization")}
                     </div>
-                    <div className="font-mono text-sm font-semibold text-base-content">
+                    <a
+                      href={githubOrgUrl(org)}
+                      target="_blank"
+                      rel="noreferrer"
+                      title={t("common.openOrgOnGitHub", { org })}
+                      className="font-mono text-sm font-semibold text-base-content hover:text-primary hover:underline"
+                    >
                       {org}
-                    </div>
+                    </a>
                   </div>
                 </div>
 

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -24,6 +24,7 @@ import { useGitHubViewer } from "@/hooks/github/hooks"
 import { githubKeys, invalidateInviteQueries } from "@/hooks/github/queries"
 import useOrgMembersOverview from "@/hooks/useOrgMembersOverview"
 import type { OrgMemberRow } from "@/util/orgMembers"
+import { githubOrgPeopleUrl } from "@/util/orgUrl"
 import type { StudentCsvRow } from "@/api/mutations/students"
 import type { GitHubUser } from "@/hooks/github/types"
 import { isSameGitHubUser } from "@/util/students"
@@ -381,7 +382,19 @@ const OrgMembersPage = () => {
               </h1>
               <p className="mt-1 text-sm text-base-content/70">
                 {t("orgMembers.subtitlePrefix")}{" "}
-                <span className="font-mono font-semibold">{org}</span>{" "}
+                {org ? (
+                  <a
+                    href={githubOrgPeopleUrl(org)}
+                    target="_blank"
+                    rel="noreferrer"
+                    title={t("common.openOrgOnGitHub", { org })}
+                    className="font-mono font-semibold hover:text-primary hover:underline"
+                  >
+                    {org}
+                  </a>
+                ) : (
+                  <span className="font-mono font-semibold">{org}</span>
+                )}{" "}
                 {t("orgMembers.subtitleSuffix")}
               </p>
               <a

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -18,6 +18,7 @@ import OrgPolicyAuditPane from "@/pages/orgSettings/OrgPolicyAuditPane"
 import RerunOrgSetup from "@/pages/orgSettings/RerunOrgSetup"
 import TeardownSection from "@/pages/orgSettings/TeardownSection"
 import SettingsSection from "@/pages/orgSettings/SettingsSection"
+import { githubOrgSettingsUrl } from "@/util/orgUrl"
 import { CalloutDiv } from "@/lib/motionComponents"
 import {
   CalendarClock,
@@ -512,7 +513,19 @@ const OrgSettingsPage = () => {
               </h1>
               <p className="mt-1 text-sm text-base-content/70">
                 {t("orgSettings.page.subheading_prefix")}{" "}
-                <span className="font-mono font-semibold">{org}</span>
+                {org ? (
+                  <a
+                    href={githubOrgSettingsUrl(org)}
+                    target="_blank"
+                    rel="noreferrer"
+                    title={t("common.openOrgOnGitHub", { org })}
+                    className="font-mono font-semibold hover:text-primary hover:underline"
+                  >
+                    {org}
+                  </a>
+                ) : (
+                  <span className="font-mono font-semibold">{org}</span>
+                )}
                 {t("orgSettings.page.subheading_suffix")}
               </p>
             </div>

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -27,6 +27,7 @@ import useGetClassroom from "@/hooks/useGetClassroom"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { classroomPagesSegment } from "@/util/secret"
+import { githubOrgUrl } from "@/util/orgUrl"
 
 // Pages base for an org's classroom50 config repo. `classroom50` is the fixed
 // repo name, not the org name. Single-sourced so every row derives from it.
@@ -470,7 +471,19 @@ const PublishedResourcesPage = () => {
               </h1>
               <p className="mt-1 text-sm text-base-content/70">
                 {t("published.pageSubheadingPrefix")}{" "}
-                <span className="font-mono font-semibold">{org}</span>
+                {org ? (
+                  <a
+                    href={githubOrgUrl(org)}
+                    target="_blank"
+                    rel="noreferrer"
+                    title={t("common.openOrgOnGitHub", { org })}
+                    className="font-mono font-semibold hover:text-primary hover:underline"
+                  >
+                    {org}
+                  </a>
+                ) : (
+                  <span className="font-mono font-semibold">{org}</span>
+                )}
                 {t("published.pageSubheadingSuffix")}
               </p>
             </div>

--- a/web/src/util/orgUrl.ts
+++ b/web/src/util/orgUrl.ts
@@ -1,0 +1,10 @@
+// Context-relevant github.com deep-links for an org login, built here rather
+// than inline so the heading/subtitle links stay consistent across pages.
+export const githubOrgUrl = (org: string): string =>
+  `https://github.com/orgs/${org}/repositories`
+
+export const githubOrgPeopleUrl = (org: string): string =>
+  `https://github.com/orgs/${org}/people`
+
+export const githubOrgSettingsUrl = (org: string): string =>
+  `https://github.com/organizations/${org}/settings/profile`


### PR DESCRIPTION
## Summary

When the GitHub organization is shown in a page heading/title/section subtitle, the org name is now a clickable link that opens the most context-relevant page on github.com in a new tab.

- New helper `web/src/util/orgUrl.ts` builds the context URLs (`githubOrgUrl` -> repositories, `githubOrgPeopleUrl` -> people, `githubOrgSettingsUrl` -> org settings), mirroring `studentRepo.ts`.
- Linked the org name in four spots, matching the app's `target="_blank" rel="noreferrer"` convention and preserving the `font-mono font-semibold` styling with a hover affordance + tooltip:
  - Classes header -> org repositories view (the primary "GITHUB ORGANIZATION" case)
  - Org Members subtitle -> org people view
  - Org Settings subtitle -> org settings
  - Published Resources subtitle -> org repositories view
- Added `common.openOrgOnGitHub` (`Open {{org}} on GitHub`) to `en.json` for the link tooltip, routed through `t()`.

For the three pages where the route param `org` is `string | undefined`, the link renders only when `org` is present (plain span fallback), keeping types clean.

Scope is limited to headings/subtitles; inline body copy and modals are intentionally left as plain text.

Closes #139.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` on touched files: 0 errors (only pre-existing spinner warnings)
- [x] `prettier --check` clean
- [x] `vitest run`: 770/770 passing
- [ ] Manual: click the org name in Classes / Org Members / Org Settings / Published headers and confirm each opens the expected github.com page in a new tab