### PR TITLE
feat(web): link assignment to its source repository

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -651,7 +651,9 @@
       "deleteConfirm": "Delete assignment",
       "deleteCancel": "Keep assignment",
       "reuseTitle": "Reuse in another classroom",
-      "reuseAria": "Reuse assignment in another classroom"
+      "reuseAria": "Reuse assignment in another classroom",
+      "sourceRepoTitle": "View source repository",
+      "sourceRepoAria": "View source repository for {{name}}"
     },
     "template": {
       "label": "Template Repository",
@@ -1257,6 +1259,7 @@
     "lateBadge_one": "{{count}} late",
     "lateBadge_other": "{{count}} late",
     "downloadCsv": "Download Scores (CSV)",
+    "viewSourceRepo": "View source repository",
     "collectionNote": "Submissions are collected automatically, but new ones can take up to 24 hours to appear.",
     "lastCollected": "Last collected (org-wide) {{when}}.",
     "updated": "Updated {{when}}",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -66,6 +66,8 @@ import {
   REGRADE_WORKFLOW,
 } from "@/hooks/github/mutations"
 import { formatDueDateTime, formatRelativeToNow } from "@/util/formatDate"
+import { githubTemplateRepoUrl } from "@/util/orgUrl"
+import { GitHubLink } from "@/components/GitHubLink"
 
 // Re-renders on an interval to keep relative timestamps fresh.
 const usePeriodicRerender = (intervalMs = 30_000) => {
@@ -510,6 +512,17 @@ const SubmissionsPageContent = () => {
                   <span className="badge badge-sm badge-error badge-soft">
                     {t("submissions.lateBadge", { count: lateCount })}
                   </span>
+                )}
+                {assignmentInfo?.template && (
+                  <GitHubLink
+                    href={githubTemplateRepoUrl(
+                      assignmentInfo.template.owner,
+                      assignmentInfo.template.repo,
+                      assignmentInfo.template.branch,
+                    )}
+                    label={t("submissions.viewSourceRepo")}
+                    title={`${assignmentInfo.template.owner}/${assignmentInfo.template.repo}`}
+                  />
                 )}
               </div>
             </div>

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -2,8 +2,10 @@ import { useNavigate } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { Copy, Eye, Pencil, Trash2, UserRound, UsersRound } from "lucide-react"
 
+import GitHub from "@/assets/github.svg?react"
 import useGetScores from "@/hooks/useGetScores"
 import { formatDueDate } from "@/util/formatDate"
+import { githubTemplateRepoUrl } from "@/util/orgUrl"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 import { ConfirmModal } from "@/components/modals"
@@ -304,6 +306,27 @@ const AssignmentsTable = ({
                   })()}
                 </td>
                 <td>
+                  {assignment.template && (
+                    <a
+                      href={githubTemplateRepoUrl(
+                        assignment.template.owner,
+                        assignment.template.repo,
+                        assignment.template.branch,
+                      )}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="btn btn-circle btn-sm btn-ghost"
+                      title={t("assignments.table.sourceRepoTitle")}
+                      aria-label={t("assignments.table.sourceRepoAria", {
+                        name: assignment.name || assignment.slug,
+                      })}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                      }}
+                    >
+                      <GitHub aria-hidden="true" className="size-4" />
+                    </a>
+                  )}
                   <Link
                     className="btn btn-circle btn-sm btn-ghost"
                     to="/$org/$classroom/assignments/$assignment/edit"

--- a/web/src/util/orgUrl.test.ts
+++ b/web/src/util/orgUrl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { githubTemplateRepoUrl } from "./orgUrl"
+
+describe("githubTemplateRepoUrl", () => {
+  it("links to the repo root when no branch is given", () => {
+    expect(githubTemplateRepoUrl("acme", "starter")).toBe(
+      "https://github.com/acme/starter",
+    )
+  })
+
+  it("deep-links to the branch when one is set", () => {
+    expect(githubTemplateRepoUrl("acme", "starter", "main")).toBe(
+      "https://github.com/acme/starter/tree/main",
+    )
+  })
+
+  it("uses the given owner, not the classroom org", () => {
+    expect(githubTemplateRepoUrl("other-org", "starter", "dev")).toBe(
+      "https://github.com/other-org/starter/tree/dev",
+    )
+  })
+})

--- a/web/src/util/orgUrl.ts
+++ b/web/src/util/orgUrl.ts
@@ -8,3 +8,13 @@ export const githubOrgPeopleUrl = (org: string): string =>
 
 export const githubOrgSettingsUrl = (org: string): string =>
   `https://github.com/organizations/${org}/settings/profile`
+
+// An assignment's starter-code (template) repo. Built from `template.owner`, not
+// the classroom org — a template can live under a different owner. Deep-links to
+// the stored branch when one is set.
+export const githubTemplateRepoUrl = (
+  owner: string,
+  repo: string,
+  branch?: string,
+): string =>
+  `https://github.com/${owner}/${repo}${branch ? `/tree/${branch}` : ""}`


### PR DESCRIPTION
## Summary

Closes #147. GitHub Classroom links an assignment to its source (template) repo; Classroom 50 had no equivalent. This adds that link, built entirely from the assignment's existing `template` ref — no schema or contract changes.

- **`SubmissionsPage.tsx`** — a "View source repository" `GitHubLink` in the assignment header, next to the due date.
- **`AssignmentsTable.tsx`** — a per-row GitHub-icon link in the row actions (shown for active and archived assignments).
- **`orgUrl.ts`** — new `githubTemplateRepoUrl(owner, repo, branch?)` helper, colocated with the existing org URL helpers; deep-links to `/tree/<branch>` when a branch is set.
- **`en.json`** — new i18n strings.

### Edge cases
- Template-less assignments → link hidden on both surfaces.
- Cross-owner templates → URL uses `template.owner`, not the classroom org.
- Table link stops propagation so it doesn't trigger the row's navigate-to-submissions click.

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npx prettier --check` — clean
- [x] `npx eslint` — 0 errors on touched files
- [x] `npx vitest run` — 770 passed
- [ ] Manual: open an assignment's submissions page and the assignments table; confirm the link appears only when a template is set and opens `github.com/<owner>/<repo>/tree/<branch>` in a new tab; confirm no link for a template-less assignment.