### PR TITLE
feat(web): list the specific settings needing a manual fix at setup

### DIFF
--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -2364,10 +2364,9 @@ export async function initClassroom50({
     onStepUpdate,
     fn: async () => {
       const result = await repairOrgDefaults(client, org, plan)
-      // Forward the whole result so tryStep puts it on InitStepUpdate.data — the
-      // setup board lists the specific unenforced settings (badging enterprise-
-      // pinned ones) instead of only a count. Warn on ANY unenforced field, not
-      // just critical, so the board matches what the check page surfaces.
+      // Forward the whole result (not just status/message) so the board can list
+      // the specific unenforced settings, and warn on ANY unenforced field so it
+      // matches the check page rather than `ok`'s critical-only verdict.
       const status =
         result.unenforced.length > 0 || result.transient
           ? ("warning" as const)

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -2364,10 +2364,20 @@ export async function initClassroom50({
     onStepUpdate,
     fn: async () => {
       const result = await repairOrgDefaults(client, org, plan)
-      if (!result.ok || result.transient) {
-        return { status: "warning" as const, message: result.message }
+      // Forward the whole result so tryStep puts it on InitStepUpdate.data — the
+      // setup board lists the specific unenforced settings (badging enterprise-
+      // pinned ones) instead of only a count. Warn on ANY unenforced field, not
+      // just critical, so the board matches what the check page surfaces.
+      const status =
+        result.unenforced.length > 0 || result.transient
+          ? ("warning" as const)
+          : ("complete" as const)
+      return {
+        status,
+        message: result.message,
+        unenforced: result.unenforced,
+        enterprisePinned: result.enterprisePinned,
       }
-      return { status: "complete" as const, message: result.message }
     },
     options: { warningCodes: [403, 422] },
   })

--- a/web/src/hooks/github/orgChecks.ts
+++ b/web/src/hooks/github/orgChecks.ts
@@ -354,9 +354,12 @@ export async function repairOrgDefaults(
     transient: false,
     unenforced,
     enterprisePinned,
-    message: ok
-      ? `${org}: org member-privilege lockdown applied.`
-      : `${org}: org member-privilege lockdown incomplete — ${unenforced.length} setting(s) need manual attention.`,
+    // Key the message on ANY drift (not just critical, which `ok` tracks) so the
+    // setup board flags non-critical settings the check page would also show.
+    message:
+      unenforced.length === 0
+        ? `${org}: org member-privilege lockdown applied.`
+        : `${org}: org member-privilege lockdown incomplete — ${unenforced.length} setting(s) need manual attention.`,
   }
 }
 

--- a/web/src/hooks/github/orgDefaults.test.ts
+++ b/web/src/hooks/github/orgDefaults.test.ts
@@ -213,6 +213,20 @@ describe("repairOrgDefaults", () => {
     )
   })
 
+  it("flags non-critical-only drift so setup surfaces it too", async () => {
+    const live = enforced("team")
+    live.members_can_create_pages = false // non-critical, stays drifted
+    const { client } = makeClient({ readback: live })
+    const result = await repairOrgDefaults(client, "acme", "team")
+    // `ok` stays the critical-only "lockdown complete" verdict (CLI parity)...
+    expect(result.ok).toBe(true)
+    expect(result.unenforced.map((s) => s.field)).toContain(
+      "members_can_create_pages",
+    )
+    // ...but the message flags the drift so the setup board doesn't stay silent.
+    expect(result.message).toContain("need manual attention")
+  })
+
   it("aborts as transient on a secondary-rate-limit without falling back per-field", async () => {
     const { client, getPatchCount } = makeClient({
       combinedPatch: () => Promise.reject(rateLimited()),

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -984,7 +984,7 @@
       "changeThemOn_other": "— change them on",
       "gitHub": "GitHub",
       "orUseFixIt": " (or use \"Fix it\")",
-      "managedByEnterprise": "Managed by enterprise — set manually",
+      "requiresManualFix": "Set manually",
       "readError": "Couldn't read the organization to audit the lockdown. Check your access and retry.",
       "driftCanFix": "Use “Fix it” on a drifted setting, or re-run setup below to re-apply everything at once.",
       "driftCannotFix": "Ask an organization owner to repair the drift — these changes require owner permissions.",

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -179,6 +179,10 @@ const OrgSetupPage = () => {
       if (!org) {
         return
       }
+      // Reset the board before a (re-)run so a prior run's per-step results —
+      // including the orgDefaults unenforced-settings list — can't linger on an
+      // error path that emits no fresh data. Mirrors RerunOrgSetup.
+      setSteps(initialInitSteps)
       return initClassroom50({
         client: githubClient,
         org,

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -340,9 +340,9 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
   const isOwner = membership?.role === "admin"
 
   // Member-default fields a Fix it / re-run wrote but that didn't stick on
-  // read-back — silently overridden by an enterprise policy (GitHub returns 200
-  // but ignores the change). Surfaced as "Managed by enterprise" so we stop
-  // offering a Fix it that can't work.
+  // read-back (GitHub returns 200 but ignores the change) — often an org or
+  // enterprise policy, but we can't prove which. Surfaced as "set manually" so
+  // we stop offering a Fix it that can't work.
   const [enterprisePinned, setEnterprisePinned] = useState<Set<string>>(
     new Set(),
   )

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -337,10 +337,8 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
   const { data: membership } = useGetOrgMembership(org)
   const isOwner = membership?.role === "admin"
 
-  // Member-default fields a Fix it / re-run wrote but that didn't stick on
-  // read-back (GitHub returns 200 but ignores the change) — often an org or
-  // enterprise policy, but we can't prove which. Surfaced as "set manually" so
-  // we stop offering a Fix it that can't work.
+  // Fields a Fix it / re-run wrote that didn't stick on read-back; we stop
+  // offering a Fix it for them since it can't work. (See OrgDefaultsStepData.)
   const [enterprisePinned, setEnterprisePinned] = useState<Set<string>>(
     new Set(),
   )

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -26,6 +26,8 @@ import type {
 import { REPAIRABLE_CONCERNS, repairConcern } from "@/orgPolicy/repair"
 import type { CheckState } from "@/hooks/github/orgChecks"
 import SettingsSection from "./SettingsSection"
+import { UnenforcedDefaultsList } from "./UnenforcedDefaultsList"
+import type { UnenforcedDefaultItem } from "./orgDefaultsStepData"
 import { CalloutDiv } from "@/lib/motionComponents"
 
 // Org policy audit pane: surfaces every policy concern with its live drift
@@ -80,12 +82,7 @@ function ConcernRow({
   canFix: boolean
   fixing: boolean
   onFix: (id: ConcernId) => void
-  driftedDetails?: {
-    field: string
-    desc: string
-    manualFix: string
-    pinned: boolean
-  }[]
+  driftedDetails?: UnenforcedDefaultItem[]
 }) {
   const { t } = useTranslation()
   const isDrifted = concern.verdict.state === "unenforced"
@@ -164,30 +161,7 @@ function ConcernRow({
             </a>
             {showFix ? t("orgSettings.audit.orUseFixIt") : ""}:
           </p>
-          <ul className="mt-1 space-y-1">
-            {driftedDetails.map((d) => (
-              <li key={d.field} className="flex items-start gap-2 text-xs">
-                <TriangleAlert
-                  aria-hidden="true"
-                  className="mt-0.5 size-3.5 shrink-0 text-error"
-                />
-                <span className="text-base-content/70">
-                  {d.desc}
-                  {d.manualFix && (
-                    <span className="text-base-content/70">
-                      {" "}
-                      — {d.manualFix}
-                    </span>
-                  )}
-                  {d.pinned && (
-                    <span className="ml-1 badge badge-ghost badge-xs align-middle">
-                      {t("orgSettings.audit.managedByEnterprise")}
-                    </span>
-                  )}
-                </span>
-              </li>
-            ))}
-          </ul>
+          <UnenforcedDefaultsList items={driftedDetails} />
         </div>
       )}
     </div>

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -27,7 +27,10 @@ import { REPAIRABLE_CONCERNS, repairConcern } from "@/orgPolicy/repair"
 import type { CheckState } from "@/hooks/github/orgChecks"
 import SettingsSection from "./SettingsSection"
 import { UnenforcedDefaultsList } from "./UnenforcedDefaultsList"
-import type { UnenforcedDefaultItem } from "./orgDefaultsStepData"
+import {
+  toUnenforcedItems,
+  type UnenforcedDefaultItem,
+} from "./orgDefaultsStepData"
 import { CalloutDiv } from "@/lib/motionComponents"
 
 // Org policy audit pane: surfaces every policy concern with its live drift
@@ -224,12 +227,7 @@ function AuditBody({
             onFix={onFix}
             driftedDetails={
               c.id === "orgDefaults"
-                ? report.unenforcedDefaults.map((s) => ({
-                    field: s.field,
-                    desc: s.desc,
-                    manualFix: s.manualFix,
-                    pinned: enterprisePinned.has(s.field),
-                  }))
+                ? toUnenforcedItems(report.unenforcedDefaults, enterprisePinned)
                 : undefined
             }
           />

--- a/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
+++ b/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from "react-i18next"
+import { TriangleAlert } from "lucide-react"
+
+import type { UnenforcedDefaultItem } from "./orgDefaultsStepData"
+
+// The per-field list of member-privilege settings that need a manual fix, shared
+// by the setup step board and the org-policy audit pane so the two can't drift.
+// Each row is the setting, its by-hand fix, and an enterprise-pinned badge when
+// GitHub won't let the value change from the org. Renders nothing when empty.
+export const UnenforcedDefaultsList = ({
+  items,
+}: {
+  items: UnenforcedDefaultItem[]
+}) => {
+  const { t } = useTranslation()
+  if (items.length === 0) return null
+  return (
+    <ul className="mt-1 space-y-1">
+      {items.map((d) => (
+        <li key={d.field} className="flex items-start gap-2 text-xs">
+          <TriangleAlert
+            aria-hidden="true"
+            className="mt-0.5 size-3.5 shrink-0 text-error"
+          />
+          <span className="text-base-content/70">
+            {d.desc}
+            {d.manualFix && (
+              <span className="text-base-content/70"> — {d.manualFix}</span>
+            )}
+            {d.pinned && (
+              <span className="ml-1 badge badge-ghost badge-xs align-middle">
+                {t("orgSettings.audit.managedByEnterprise")}
+              </span>
+            )}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
+++ b/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
@@ -5,8 +5,9 @@ import type { UnenforcedDefaultItem } from "./orgDefaultsStepData"
 
 // The per-field list of member-privilege settings that need a manual fix, shared
 // by the setup step board and the org-policy audit pane so the two can't drift.
-// Each row is the setting, its by-hand fix, and an enterprise-pinned badge when
-// GitHub won't let the value change from the org. Renders nothing when empty.
+// Each row is the setting and its by-hand fix; the `pinned` subset (API accepted
+// the write but the value didn't stick on read-back) gets a "set manually" badge,
+// since a Fix it / re-run can't change those. Renders nothing when empty.
 export const UnenforcedDefaultsList = ({
   items,
 }: {
@@ -29,7 +30,7 @@ export const UnenforcedDefaultsList = ({
             )}
             {d.pinned && (
               <span className="ml-1 badge badge-ghost badge-xs align-middle">
-                {t("orgSettings.audit.managedByEnterprise")}
+                {t("orgSettings.audit.requiresManualFix")}
               </span>
             )}
           </span>

--- a/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
+++ b/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
@@ -3,11 +3,8 @@ import { TriangleAlert } from "lucide-react"
 
 import type { UnenforcedDefaultItem } from "./orgDefaultsStepData"
 
-// The per-field list of member-privilege settings that need a manual fix, shared
-// by the setup step board and the org-policy audit pane so the two can't drift.
-// Each row is the setting and its by-hand fix; the `pinned` subset (API accepted
-// the write but the value didn't stick on read-back) gets a "set manually" badge,
-// since a Fix it / re-run can't change those. Renders nothing when empty.
+// The per-field list of settings needing a manual fix, shared by the setup step
+// board and the audit pane so the two can't drift. Renders nothing when empty.
 export const UnenforcedDefaultsList = ({
   items,
 }: {

--- a/web/src/pages/orgSettings/initStepBoard.tsx
+++ b/web/src/pages/orgSettings/initStepBoard.tsx
@@ -14,6 +14,11 @@ import type {
   InitStepStatus,
   InitStepUpdate,
 } from "@/hooks/github/mutations"
+import { UnenforcedDefaultsList } from "./UnenforcedDefaultsList"
+import {
+  isOrgDefaultsStepData,
+  unenforcedDefaultItems,
+} from "./orgDefaultsStepData"
 
 // Shared init "badge board" used by the org setup wizard (OrgSetupPage) and the
 // re-run action on Org Settings. One source of truth for step order, titles,
@@ -207,6 +212,7 @@ export const InitStep = ({
   status,
   message,
   org,
+  data,
 }: {
   id: InitStepId
   title: string
@@ -215,6 +221,9 @@ export const InitStep = ({
   // Without an org the per-step GitHub deep link can't be built, so it's
   // omitted; the explanation and remediation still render.
   org?: string
+  // The step's structured result (InitStepUpdate.data). For orgDefaults it
+  // carries the specific unenforced member-privilege settings.
+  data?: unknown
 }) => {
   const { t } = useTranslation()
   const meta = INIT_STEP_META[id]
@@ -299,6 +308,9 @@ export const InitStep = ({
                   <ExternalLink aria-hidden="true" className="size-3.5" />
                 </a>
               )}
+              {id === "orgDefaults" && isOrgDefaultsStepData(data) && (
+                <UnenforcedDefaultsList items={unenforcedDefaultItems(data)} />
+              )}
             </div>
           )}
         </div>
@@ -325,6 +337,7 @@ export const InitStepBoard = ({
           status={step.status}
           message={step.message ?? step.error}
           org={org}
+          data={step.data}
         />
       )
     })}

--- a/web/src/pages/orgSettings/initStepBoard.tsx
+++ b/web/src/pages/orgSettings/initStepBoard.tsx
@@ -221,8 +221,8 @@ export const InitStep = ({
   // Without an org the per-step GitHub deep link can't be built, so it's
   // omitted; the explanation and remediation still render.
   org?: string
-  // The step's structured result (InitStepUpdate.data). For orgDefaults it
-  // carries the specific unenforced member-privilege settings.
+  // The step's structured result (InitStepUpdate.data); orgDefaults narrows it
+  // to OrgDefaultsStepData before rendering.
   data?: unknown
 }) => {
   const { t } = useTranslation()

--- a/web/src/pages/orgSettings/orgDefaultsStepData.test.ts
+++ b/web/src/pages/orgSettings/orgDefaultsStepData.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import type { MemberDefaultSetting } from "@/orgPolicy/desiredState"
+
+import {
+  isOrgDefaultsStepData,
+  unenforcedDefaultItems,
+} from "./orgDefaultsStepData"
+
+const setting = (field: string): MemberDefaultSetting => ({
+  field,
+  value: false,
+  desc: `${field} desc`,
+  manualFix: `fix ${field}`,
+  critical: false,
+  enterpriseOnly: false,
+})
+
+describe("isOrgDefaultsStepData", () => {
+  it("accepts an object carrying both arrays", () => {
+    expect(
+      isOrgDefaultsStepData({ unenforced: [], enterprisePinned: [] }),
+    ).toBe(true)
+  })
+
+  it("rejects null, non-objects, and missing/mistyped fields", () => {
+    expect(isOrgDefaultsStepData(null)).toBe(false)
+    expect(isOrgDefaultsStepData("nope")).toBe(false)
+    expect(isOrgDefaultsStepData({ unenforced: [] })).toBe(false)
+    expect(
+      isOrgDefaultsStepData({ unenforced: {}, enterprisePinned: [] }),
+    ).toBe(false)
+  })
+})
+
+describe("unenforcedDefaultItems", () => {
+  it("returns one row per unenforced field, flagging the enterprise-pinned subset", () => {
+    const items = unenforcedDefaultItems({
+      unenforced: [setting("a"), setting("b")],
+      enterprisePinned: [setting("b")],
+    })
+    expect(items).toEqual([
+      { field: "a", desc: "a desc", manualFix: "fix a", pinned: false },
+      { field: "b", desc: "b desc", manualFix: "fix b", pinned: true },
+    ])
+  })
+
+  it("returns an empty list when nothing is unenforced", () => {
+    expect(
+      unenforcedDefaultItems({ unenforced: [], enterprisePinned: [] }),
+    ).toEqual([])
+  })
+})

--- a/web/src/pages/orgSettings/orgDefaultsStepData.ts
+++ b/web/src/pages/orgSettings/orgDefaultsStepData.ts
@@ -1,0 +1,42 @@
+import type { MemberDefaultSetting } from "@/orgPolicy/desiredState"
+
+// Structured detail the orgDefaults setup step carries in InitStepUpdate.data:
+// the member-privilege settings that didn't stick, plus the subset GitHub
+// silently refuses because an enterprise policy pins them (a subset of
+// `unenforced`).
+export type OrgDefaultsStepData = {
+  unenforced: MemberDefaultSetting[]
+  enterprisePinned: MemberDefaultSetting[]
+}
+
+// One row of the failed-settings list: the setting, its by-hand fix, and whether
+// it's enterprise-pinned (unfixable from the org, shown as a badge).
+export type UnenforcedDefaultItem = {
+  field: string
+  desc: string
+  manualFix: string
+  pinned: boolean
+}
+
+// tryStep forwards the whole step result as `data: unknown`, so narrow it before
+// rendering — a shape change must render nothing, not throw.
+export function isOrgDefaultsStepData(
+  data: unknown,
+): data is OrgDefaultsStepData {
+  if (typeof data !== "object" || data === null) return false
+  const d = data as Record<string, unknown>
+  return Array.isArray(d.unenforced) && Array.isArray(d.enterprisePinned)
+}
+
+// Render every unenforced field, flagging the enterprise-pinned subset by field.
+export function unenforcedDefaultItems(
+  data: OrgDefaultsStepData,
+): UnenforcedDefaultItem[] {
+  const pinned = new Set(data.enterprisePinned.map((s) => s.field))
+  return data.unenforced.map((s) => ({
+    field: s.field,
+    desc: s.desc,
+    manualFix: s.manualFix,
+    pinned: pinned.has(s.field),
+  }))
+}

--- a/web/src/pages/orgSettings/orgDefaultsStepData.ts
+++ b/web/src/pages/orgSettings/orgDefaultsStepData.ts
@@ -1,28 +1,24 @@
 import type { MemberDefaultSetting } from "@/orgPolicy/desiredState"
 
-// Structured detail the orgDefaults setup step carries in InitStepUpdate.data:
-// the member-privilege settings that didn't stick, plus the subset the API
-// accepted (200) but that still didn't take on read-back — a subset of
-// `unenforced` that a Fix it / re-run can't change (often an org or enterprise
-// policy, but we can't prove which).
+// Structured detail the orgDefaults setup step carries in InitStepUpdate.data.
+// `enterprisePinned` is the subset of `unenforced` the API accepted (200) but
+// that still didn't take on read-back, so a Fix it / re-run can't change it
+// (often an org or enterprise policy, but we can't prove which).
 export type OrgDefaultsStepData = {
   unenforced: MemberDefaultSetting[]
   enterprisePinned: MemberDefaultSetting[]
 }
 
-// One row of the failed-settings list: the setting, its by-hand fix, and whether
-// it's pinned — the write was accepted but didn't stick, so it must be set
-// manually (shown as a badge).
 export type UnenforcedDefaultItem = {
   field: string
   desc: string
   manualFix: string
+  // Write accepted but didn't stick — must be set manually (shown as a badge).
   pinned: boolean
 }
 
 // The one place a MemberDefaultSetting becomes a display row, shared by the setup
-// step and the audit pane so the two can't map differently. `pinnedFields` is the
-// subset (by field) that couldn't be written, sourced per surface.
+// step and the audit pane so the two can't map differently.
 export function toUnenforcedItems(
   settings: MemberDefaultSetting[],
   pinnedFields: Set<string>,
@@ -45,7 +41,6 @@ export function isOrgDefaultsStepData(
   return Array.isArray(d.unenforced) && Array.isArray(d.enterprisePinned)
 }
 
-// Render every unenforced field, flagging the pinned subset by field.
 export function unenforcedDefaultItems(
   data: OrgDefaultsStepData,
 ): UnenforcedDefaultItem[] {

--- a/web/src/pages/orgSettings/orgDefaultsStepData.ts
+++ b/web/src/pages/orgSettings/orgDefaultsStepData.ts
@@ -1,21 +1,38 @@
 import type { MemberDefaultSetting } from "@/orgPolicy/desiredState"
 
 // Structured detail the orgDefaults setup step carries in InitStepUpdate.data:
-// the member-privilege settings that didn't stick, plus the subset GitHub
-// silently refuses because an enterprise policy pins them (a subset of
-// `unenforced`).
+// the member-privilege settings that didn't stick, plus the subset the API
+// accepted (200) but that still didn't take on read-back — a subset of
+// `unenforced` that a Fix it / re-run can't change (often an org or enterprise
+// policy, but we can't prove which).
 export type OrgDefaultsStepData = {
   unenforced: MemberDefaultSetting[]
   enterprisePinned: MemberDefaultSetting[]
 }
 
 // One row of the failed-settings list: the setting, its by-hand fix, and whether
-// it's enterprise-pinned (unfixable from the org, shown as a badge).
+// it's pinned — the write was accepted but didn't stick, so it must be set
+// manually (shown as a badge).
 export type UnenforcedDefaultItem = {
   field: string
   desc: string
   manualFix: string
   pinned: boolean
+}
+
+// The one place a MemberDefaultSetting becomes a display row, shared by the setup
+// step and the audit pane so the two can't map differently. `pinnedFields` is the
+// subset (by field) that couldn't be written, sourced per surface.
+export function toUnenforcedItems(
+  settings: MemberDefaultSetting[],
+  pinnedFields: Set<string>,
+): UnenforcedDefaultItem[] {
+  return settings.map((s) => ({
+    field: s.field,
+    desc: s.desc,
+    manualFix: s.manualFix,
+    pinned: pinnedFields.has(s.field),
+  }))
 }
 
 // tryStep forwards the whole step result as `data: unknown`, so narrow it before
@@ -28,15 +45,12 @@ export function isOrgDefaultsStepData(
   return Array.isArray(d.unenforced) && Array.isArray(d.enterprisePinned)
 }
 
-// Render every unenforced field, flagging the enterprise-pinned subset by field.
+// Render every unenforced field, flagging the pinned subset by field.
 export function unenforcedDefaultItems(
   data: OrgDefaultsStepData,
 ): UnenforcedDefaultItem[] {
-  const pinned = new Set(data.enterprisePinned.map((s) => s.field))
-  return data.unenforced.map((s) => ({
-    field: s.field,
-    desc: s.desc,
-    manualFix: s.manualFix,
-    pinned: pinned.has(s.field),
-  }))
+  return toUnenforcedItems(
+    data.unenforced,
+    new Set(data.enterprisePinned.map((s) => s.field)),
+  )
 }


### PR DESCRIPTION
## Summary

On a pre-existing GitHub org, setup runs a member-privilege lockdown step that can leave some settings unenforced. Previously it only showed a count without saying which ones needed to be changed, so a teacher couldn't tell what to fix by hand. The org Settings audit page already spells them out, and #68 asks for the same thing at setup.

The step now lists the specific settings in its existing attention panel, each with how to fix it by hand and a "set manually" badge for the ones a Fix it / re-run can't change (the API accepts the write but the value doesn't stick on read-back — often an org or enterprise policy, but we can't prove which). Nothing new had to be computed since `repairOrgDefaults` already returns the unenforced settings and that pinned subset, and `tryStep` already forwards the step result as its `data`, so the step was just throwing that away. The per-field list is a small shared component, and both surfaces now build their rows through one `toUnenforcedItems` helper, so the audit page and the setup board can't drift. It also flags any unenforced setting (not just the critical ones).

One extra change I made is that the wizard now clears the board at the start of a run, like the "Re-run setup" action already does, so a re-run can't show leftovers from the previous one on an error path that emits no fresh data. That also fixes a stale-message case that was already there.

Closes #68

## Type of change

- [x] New feature

## Checklist

- [x] Ran `cd web && npm run check` for the web app (tests pass, no new lint warnings)
- [x] Cross-binary contract — n/a, web-only
- [x] CLI command/flag docs — n/a
- [x] Commits follow Conventional Commits