### PR TITLE
feat(web): redesign the organization homepage (search, views, sort, setup modal)

### DIFF
--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -1,0 +1,155 @@
+import { useNavigate } from "@tanstack/react-router"
+import { ExternalLink, Settings } from "lucide-react"
+import { useEffect, useId, useRef } from "react"
+import { useTranslation } from "react-i18next"
+
+import PlanBadge from "@/components/PlanBadge"
+import type { Classroom50OrgSummary } from "@/hooks/github/queries"
+import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
+import { classifyPlan } from "@/lib/orgPlan"
+
+// Modal that lets a teacher start Classroom 50 setup on an existing GitHub org.
+// GitHub orgs can't be created client-side, so this lists the orgs the user
+// already owns that lack a classroom50 config repo (needs_setup) and routes the
+// chosen one into the existing /$org/setup wizard. Free-plan orgs are shown but
+// disabled — they can't complete setup, so routing them to the wizard would be a
+// dead end.
+function NewOrgModal({
+  open,
+  needsSetupOrgs,
+  onClose,
+}: {
+  open: boolean
+  needsSetupOrgs: Classroom50OrgSummary[]
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
+  const titleId = useId()
+
+  const logins = needsSetupOrgs.map((summary) => summary.org.login)
+  const plans = useNeedsSetupPlans(open ? logins : [])
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (open && !dialog.open) dialog.showModal()
+    if (!open && dialog.open) dialog.close()
+  }, [open])
+
+  const handleSelect = (login: string) => {
+    onClose()
+    void navigate({ to: "/$org/setup", params: { org: login } })
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="modal"
+      aria-labelledby={titleId}
+      onClose={onClose}
+    >
+      <div className="modal-box max-w-lg">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h3 id={titleId} className="text-lg font-bold">
+              {t("orgs.newOrg.title")}
+            </h3>
+            <p className="mt-1 text-sm text-base-content/70">
+              {t("orgs.newOrg.description")}
+            </p>
+          </div>
+          <form method="dialog">
+            <button type="submit" className="btn btn-sm btn-circle btn-ghost">
+              ✕<span className="sr-only">{t("common.close")}</span>
+            </button>
+          </form>
+        </div>
+
+        {needsSetupOrgs.length === 0 ? (
+          <p className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+            {t("orgs.newOrg.allSetUp")}
+          </p>
+        ) : (
+          <>
+            <p className="mt-6 text-xs font-semibold uppercase tracking-wide text-base-content/60">
+              {t("orgs.newOrg.pickPrompt")}
+            </p>
+            <ul className="mt-2 flex max-h-80 flex-col gap-2 overflow-y-auto">
+              {needsSetupOrgs.map((summary) => {
+                const { org } = summary
+                const planName = plans[org.login]
+                const isFree = classifyPlan(planName) === "free"
+                return (
+                  <li key={org.id}>
+                    <button
+                      type="button"
+                      disabled={isFree}
+                      title={
+                        isFree ? t("orgs.newOrg.freePlanDisabled") : undefined
+                      }
+                      onClick={() => handleSelect(org.login)}
+                      className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-left transition-colors hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
+                    >
+                      <img
+                        src={org.avatar_url}
+                        alt=""
+                        className="size-9 shrink-0 rounded-lg border border-base-300"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-semibold">
+                          {org.login}
+                        </span>
+                        {org.description && (
+                          <span className="block truncate text-sm text-base-content/60">
+                            {org.description}
+                          </span>
+                        )}
+                      </span>
+                      {planName && (
+                        <PlanBadge
+                          name={planName}
+                          title={
+                            isFree
+                              ? t("orgs.card.planTitleFree")
+                              : t("orgs.card.planTitlePaid")
+                          }
+                          className="shrink-0"
+                        />
+                      )}
+                      {!isFree && (
+                        <span className="btn btn-primary btn-xs shrink-0">
+                          <Settings aria-hidden="true" className="size-3" />
+                          {t("orgs.newOrg.setUp")}
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </>
+        )}
+
+        <div className="modal-action">
+          <a
+            href="https://github.com/organizations/new"
+            target="_blank"
+            rel="noreferrer"
+            className="btn btn-ghost btn-sm"
+          >
+            {t("orgs.newOrg.createOnGitHub")}
+            <ExternalLink aria-hidden="true" className="size-4" />
+          </a>
+        </div>
+      </div>
+
+      <form method="dialog" className="modal-backdrop">
+        <button>{t("common.close")}</button>
+      </form>
+    </dialog>
+  )
+}
+
+export default NewOrgModal

--- a/web/src/hooks/github/types.ts
+++ b/web/src/hooks/github/types.ts
@@ -82,6 +82,11 @@ export type GitHubRepo = {
   default_branch: string
   visibility?: "public" | "private" | "internal"
   archived?: boolean
+  // Last push to the repo; used to sort orgs by "last modified" on the home
+  // page. GitHub returns both on GET /repos; typed optional as older callers
+  // don't rely on them.
+  pushed_at?: string
+  updated_at?: string
   description?: string | null
   owner?: {
     login: string

--- a/web/src/hooks/useOrgLastModified.ts
+++ b/web/src/hooks/useOrgLastModified.ts
@@ -4,12 +4,13 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { repoQuery } from "@/hooks/github/queries"
 
 // Reads each org's `classroom50` config-repo `pushed_at` to drive the home
-// page's "last modified" sort. Reuses `repoQuery` (same cache key as the
-// ready-org existence read) so we don't fan out a second request per org or
-// collide with githubKeys.repo. Only called with `enabled` true when the user
-// actually selects the last-modified sort, keeping the default view
-// fan-out-free. Maps login -> ISO timestamp, or undefined when pending /
-// unreadable (e.g. no_access orgs, 404s) — the caller pins those to the bottom.
+// page's "last modified" sort. Uses `repoQuery` so the result shares the
+// `githubKeys.repo(login, "classroom50")` cache with other classroom50-repo
+// readers instead of adding a bespoke per-org query. Only called with `enabled`
+// true when the user actually selects the last-modified sort, keeping the
+// default view fan-out-free. Maps login -> ISO timestamp, or undefined when
+// pending / unreadable (e.g. no_access orgs, 404s) — the caller pins those to
+// the bottom.
 const useOrgLastModified = (
   logins: string[],
   enabled: boolean,

--- a/web/src/hooks/useOrgLastModified.ts
+++ b/web/src/hooks/useOrgLastModified.ts
@@ -1,0 +1,34 @@
+import { useQueries } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { repoQuery } from "@/hooks/github/queries"
+
+// Reads each org's `classroom50` config-repo `pushed_at` to drive the home
+// page's "last modified" sort. Reuses `repoQuery` (same cache key as the
+// ready-org existence read) so we don't fan out a second request per org or
+// collide with githubKeys.repo. Only called with `enabled` true when the user
+// actually selects the last-modified sort, keeping the default view
+// fan-out-free. Maps login -> ISO timestamp, or undefined when pending /
+// unreadable (e.g. no_access orgs, 404s) — the caller pins those to the bottom.
+const useOrgLastModified = (
+  logins: string[],
+  enabled: boolean,
+): Record<string, string | undefined> => {
+  const client = useGitHubClient()
+
+  const results = useQueries({
+    queries: logins.map((login) => ({
+      ...repoQuery(client, login, "classroom50"),
+      enabled: enabled && Boolean(login),
+    })),
+  })
+
+  const byLogin: Record<string, string | undefined> = {}
+  logins.forEach((login, i) => {
+    byLogin[login] = results[i]?.data?.pushed_at ?? undefined
+  })
+
+  return byLogin
+}
+
+export default useOrgLastModified

--- a/web/src/lib/orgListPrefs.ts
+++ b/web/src/lib/orgListPrefs.ts
@@ -1,0 +1,56 @@
+// Home-page org-list display preferences, persisted per browser so a returning
+// user keeps their chosen view/sort. Kept out of React Query — this is UI state,
+// not server data.
+
+export type OrgViewMode = "grid" | "list"
+export type OrgSortKey = "name-asc" | "name-desc" | "last-modified" | "status"
+
+const VIEW_KEY = "orgs_view_mode"
+const SORT_KEY = "orgs_sort_key"
+
+const DEFAULT_VIEW: OrgViewMode = "grid"
+const DEFAULT_SORT: OrgSortKey = "name-asc"
+
+const VIEW_VALUES: OrgViewMode[] = ["grid", "list"]
+const SORT_VALUES: OrgSortKey[] = [
+  "name-asc",
+  "name-desc",
+  "last-modified",
+  "status",
+]
+
+function canUseStorage() {
+  return typeof window !== "undefined"
+}
+
+export function getStoredViewMode(): OrgViewMode {
+  if (!canUseStorage()) return DEFAULT_VIEW
+  const raw = localStorage.getItem(VIEW_KEY)
+  return VIEW_VALUES.includes(raw as OrgViewMode)
+    ? (raw as OrgViewMode)
+    : DEFAULT_VIEW
+}
+
+export function persistViewMode(mode: OrgViewMode) {
+  if (!canUseStorage()) return
+  localStorage.setItem(VIEW_KEY, mode)
+}
+
+// The persisted sort is honored on load EXCEPT "last-modified": restoring it
+// would silently re-arm the per-org pushed_at fan-out on every visit, breaking
+// the home page's no-fan-out-by-default contract. The preference is still
+// saved (so re-selecting feels sticky within a session), but load falls back to
+// the name sort until the user picks last-modified again.
+export function getStoredSortKey(): OrgSortKey {
+  if (!canUseStorage()) return DEFAULT_SORT
+  const raw = localStorage.getItem(SORT_KEY)
+  const parsed = SORT_VALUES.includes(raw as OrgSortKey)
+    ? (raw as OrgSortKey)
+    : DEFAULT_SORT
+  return parsed === "last-modified" ? DEFAULT_SORT : parsed
+}
+
+export function persistSortKey(key: OrgSortKey) {
+  if (!canUseStorage()) return
+  localStorage.setItem(SORT_KEY, key)
+}

--- a/web/src/lib/orgListPrefs.ts
+++ b/web/src/lib/orgListPrefs.ts
@@ -3,7 +3,7 @@
 // not server data.
 
 export type OrgViewMode = "grid" | "list"
-export type OrgSortKey = "name-asc" | "name-desc" | "last-modified" | "status"
+export type OrgSortKey = "name-asc" | "last-modified" | "status"
 
 const VIEW_KEY = "orgs_view_mode"
 const SORT_KEY = "orgs_sort_key"
@@ -12,12 +12,7 @@ const DEFAULT_VIEW: OrgViewMode = "grid"
 const DEFAULT_SORT: OrgSortKey = "name-asc"
 
 const VIEW_VALUES: OrgViewMode[] = ["grid", "list"]
-const SORT_VALUES: OrgSortKey[] = [
-  "name-asc",
-  "name-desc",
-  "last-modified",
-  "status",
-]
+const SORT_VALUES: OrgSortKey[] = ["name-asc", "last-modified", "status"]
 
 function canUseStorage() {
   return typeof window !== "undefined"

--- a/web/src/lib/orgPlan.test.ts
+++ b/web/src/lib/orgPlan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { classifyPlan, planSortWeight } from "./orgPlan"
+import { classifyPlan } from "./orgPlan"
 
 describe("classifyPlan", () => {
   it("treats team and enterprise as supported", () => {
@@ -21,16 +21,5 @@ describe("classifyPlan", () => {
     // the user can actually work with.
     expect(classifyPlan("business")).toBe("unknown")
     expect(classifyPlan("Team")).toBe("unknown")
-  })
-})
-
-describe("planSortWeight", () => {
-  it("orders supported before unknown before free", () => {
-    expect(planSortWeight("supported")).toBeLessThan(planSortWeight("unknown"))
-    expect(planSortWeight("unknown")).toBeLessThan(planSortWeight("free"))
-  })
-
-  it("keeps unknown above free so an unknown-plan org is never demoted below free", () => {
-    expect(planSortWeight("unknown")).toBeLessThan(planSortWeight("free"))
   })
 })

--- a/web/src/lib/orgPlan.ts
+++ b/web/src/lib/orgPlan.ts
@@ -10,16 +10,3 @@ export function classifyPlan(name?: string): PlanCategory {
   if (name === "free") return "free"
   return "unknown"
 }
-
-// Sort weight for the "Set Up" list: supported orgs bubble to the top, unknown
-// in the middle (never demoted below free), free last.
-export function planSortWeight(category: PlanCategory): number {
-  switch (category) {
-    case "supported":
-      return 0
-    case "unknown":
-      return 1
-    case "free":
-      return 2
-  }
-}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -454,12 +454,46 @@
   },
   "orgs": {
     "headingCl50": "Classroom 50 Organizations",
-    "headingSetUp": "Set Up New Classroom 50 Organization",
     "loadingTitle": "Loading your organizations…",
     "loadingSubtitle": "This may take a moment.",
     "emptyTitle": "No Classroom 50 organizations yet",
     "emptyBody": "Organizations you belong to that use Classroom 50 will appear here. If you expect one, ask your instructor to confirm you've been added, then refresh.",
-    "showUnsupported": "Show unsupported organizations",
+    "toolbar": {
+      "searchPlaceholder": "Search organizations…",
+      "searchLabel": "Search organizations",
+      "view": {
+        "label": "View",
+        "gridLabel": "Grid view",
+        "listLabel": "List view"
+      },
+      "sort": {
+        "label": "Sort",
+        "nameAsc": "Name (A–Z)",
+        "nameDesc": "Name (Z–A)",
+        "lastModified": "Last modified",
+        "status": "Status"
+      }
+    },
+    "noResults": {
+      "title": "No organizations match your search",
+      "body": "No organizations match \u201c{{query}}\u201d.",
+      "clear": "Clear search"
+    },
+    "setUpFirst": {
+      "title": "Set up your first Classroom 50 organization",
+      "body": "You own organizations that aren't set up yet. Configure Classroom 50 to start creating classrooms and assignments.",
+      "cta": "Set up an organization"
+    },
+    "newOrg": {
+      "button": "New organization",
+      "title": "Set up a new Classroom 50 organization",
+      "description": "Pick one of your GitHub organizations to configure Classroom 50 in. Don't see the one you want? Create it on GitHub first.",
+      "pickPrompt": "Organizations ready to set up",
+      "createOnGitHub": "Create an organization on GitHub",
+      "allSetUp": "All of your organizations are already set up.",
+      "setUp": "Set up",
+      "freePlanDisabled": "Free plan — Classroom 50 needs a Team or Enterprise organization"
+    },
     "missingNotice": {
       "title": "Not seeing your organization?",
       "body": "Classroom 50 can only show GitHub organizations that you have explicitly granted access to during sign-in. If an organization is missing, you may need to update your OAuth permissions.",
@@ -475,8 +509,8 @@
       "viewOnGitHub": "View on GitHub",
       "openOnGitHub": "Open {{org}} on GitHub",
       "open": "Open",
-      "setUp": "Set Up",
-      "askTeacher": "Ask a teacher for access"
+      "askTeacher": "Ask a teacher for access",
+      "updatedAgo": "Updated {{when}}"
     }
   },
   "assignments": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -469,7 +469,6 @@
       "sort": {
         "label": "Sort",
         "nameAsc": "Name (A–Z)",
-        "nameDesc": "Name (Z–A)",
         "lastModified": "Last modified",
         "status": "Status"
       }
@@ -485,7 +484,7 @@
       "cta": "Set up an organization"
     },
     "newOrg": {
-      "button": "New organization",
+      "button": "Set up new organization",
       "title": "Set up a new Classroom 50 organization",
       "description": "Pick one of your GitHub organizations to configure Classroom 50 in. Don't see the one you want? Create it on GitHub first.",
       "pickPrompt": "Organizations ready to set up",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -509,7 +509,6 @@
       "viewOnGitHub": "View on GitHub",
       "openOnGitHub": "Open {{org}} on GitHub",
       "open": "Open",
-      "askTeacher": "Ask a teacher for access",
       "updatedAgo": "Updated {{when}}"
     }
   },

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -6,17 +6,35 @@ import Drawer, {
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { Classroom50OrgSummary } from "@/hooks/github/queries"
 import useGetOrgs from "@/hooks/useGetOrgs"
-import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
+import useOrgLastModified from "@/hooks/useOrgLastModified"
 import { useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { ExternalLink, Info, Lock, RefreshCw } from "lucide-react"
+import {
+  ExternalLink,
+  Info,
+  LayoutGrid,
+  List as ListIcon,
+  Lock,
+  Plus,
+  RefreshCw,
+  Search,
+} from "lucide-react"
 import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
-import PlanBadge from "@/components/PlanBadge"
-import { enterExit, staggerTransition } from "@/lib/motion"
-import { classifyPlan, planSortWeight } from "@/lib/orgPlan"
+import NewOrgModal from "@/components/modals/NewOrgModal"
+import Spinner from "@/components/Spinner"
+import { enterExit } from "@/lib/motion"
+import {
+  getStoredSortKey,
+  getStoredViewMode,
+  persistSortKey,
+  persistViewMode,
+  type OrgSortKey,
+  type OrgViewMode,
+} from "@/lib/orgListPrefs"
+import { formatRelativeToNow } from "@/util/formatDate"
 
 function MissingOrgNotice({
   refreshing,
@@ -80,40 +98,87 @@ function MissingOrgNotice({
   )
 }
 
-function OrgCard({
-  summary,
-  index = 0,
-  planName,
-}: {
-  summary: Classroom50OrgSummary
-  index?: number
-  planName?: string
-}) {
-  const { t } = useTranslation()
+// Shared per-org affordances (whether the card/row can open, badges, actions),
+// so the grid card and list row stay in sync.
+function useOrgAffordances(summary: Classroom50OrgSummary) {
   const { org, membership, classroom50 } = summary
-
   const isReady = classroom50.status === "ready"
-  const needsSetup = classroom50.status === "needs_setup"
   const noAccess = classroom50.status === "no_access"
   const isAdmin = membership.role === "admin"
   const isActiveMember = membership.state === "active"
 
-  // Show a plan badge whenever GitHub returned a plan name (owners of
-  // Team/Enterprise/Free orgs). Unknown (non-owner, no plan visible) stays
-  // badge-less.
-  const showPlanBadge = classifyPlan(planName) !== "unknown"
+  return {
+    org,
+    noAccess,
+    showNoAccessBadge: noAccess && isAdmin,
+    // Teachers open ready orgs; students open any org they're an active member
+    // of (their assignment repos live there even without classroom50 access).
+    canOpen: isAdmin ? isReady : isActiveMember,
+    askTeacher: noAccess && !isActiveMember,
+  }
+}
 
-  // No-access-as-admin is the only role-derived badge we keep: a concrete "you
-  // can't read classroom50 here" state, not an inferred Teacher/Student label
-  // (which is just GitHub org-admin status and misleads students).
-  const showNoAccessBadge = noAccess && isAdmin
+function OrgActions({
+  summary,
+  updatedAgo,
+}: {
+  summary: Classroom50OrgSummary
+  updatedAgo?: string
+}) {
+  const { t } = useTranslation()
+  const { org, canOpen, askTeacher } = useOrgAffordances(summary)
+  return (
+    <>
+      <GitHubLink
+        href={`https://github.com/${org.login}`}
+        label={t("orgs.card.viewOnGitHub")}
+        title={t("orgs.card.openOnGitHub", { org: org.login })}
+        className="shrink-0"
+        showLogo={false}
+      />
+      {canOpen && (
+        <Link
+          to="/$org"
+          params={{ org: org.login }}
+          className="btn btn-primary btn-sm"
+        >
+          {t("orgs.card.open")}
+        </Link>
+      )}
+      {askTeacher && (
+        <button className="btn btn-disabled btn-sm">
+          {t("orgs.card.askTeacher")}
+        </button>
+      )}
+      {updatedAgo && (
+        <span className="sr-only">
+          {t("orgs.card.updatedAgo", { when: updatedAgo })}
+        </span>
+      )}
+    </>
+  )
+}
 
-  // A student is an active member who can't read the classroom50 config repo
-  // (no_access). Normal, not a dead end: they can still open the org to reach
-  // their assignment repos. A teacher (admin) opens any ready org; the
-  // service-token/policy preflight runs inside the org (ClassesPage), not here
-  // — checking every org would fan out too many GitHub API calls.
-  const canOpen = isAdmin ? isReady : isActiveMember
+function NoAccessBadge() {
+  const { t } = useTranslation()
+  return (
+    <span className="badge badge-neutral gap-1">
+      <Lock aria-hidden="true" className="size-3" />
+      {t("orgs.card.noAccessBadge_prefix")} <code>classroom50</code>{" "}
+      {t("orgs.card.noAccessBadge_suffix")}
+    </span>
+  )
+}
+
+function OrgCard({
+  summary,
+  updatedAgo,
+}: {
+  summary: Classroom50OrgSummary
+  updatedAgo?: string
+}) {
+  const { t } = useTranslation()
+  const { org, showNoAccessBadge } = useOrgAffordances(summary)
 
   return (
     <motion.div
@@ -121,7 +186,6 @@ function OrgCard({
       variants={enterExit}
       initial="initial"
       animate="animate"
-      transition={staggerTransition(index)}
     >
       <div className="card-body justify-between">
         <div className="flex gap-4">
@@ -140,126 +204,185 @@ function OrgCard({
               </p>
             )}
 
+            {updatedAgo && (
+              <p className="mt-1 text-xs text-base-content/50">
+                {t("orgs.card.updatedAgo", { when: updatedAgo })}
+              </p>
+            )}
+
             {showNoAccessBadge && (
               <div className="mt-3 flex flex-wrap gap-2">
-                <span className="badge badge-neutral gap-1">
-                  <Lock aria-hidden="true" className="size-3" />
-                  {t("orgs.card.noAccessBadge_prefix")} <code>classroom50</code>{" "}
-                  {t("orgs.card.noAccessBadge_suffix")}
-                </span>
+                <NoAccessBadge />
               </div>
             )}
           </div>
         </div>
 
-        <div className="card-actions mt-5 items-center justify-between">
-          <div className="flex items-center gap-3">
-            {showPlanBadge && (
-              <PlanBadge
-                name={planName}
-                title={
-                  classifyPlan(planName) === "free"
-                    ? t("orgs.card.planTitleFree")
-                    : t("orgs.card.planTitlePaid")
-                }
-              />
-            )}
-
-            <GitHubLink
-              href={`https://github.com/${org.login}`}
-              label={t("orgs.card.viewOnGitHub")}
-              title={t("orgs.card.openOnGitHub", { org: org.login })}
-              className="shrink-0"
-              showLogo={false}
-            />
-          </div>
-
-          <div className="flex items-center gap-2">
-            {canOpen && (
-              <Link
-                to="/$org"
-                params={{ org: org.login }}
-                className="btn btn-primary btn-sm"
-              >
-                {t("orgs.card.open")}
-              </Link>
-            )}
-
-            {needsSetup && (
-              <Link
-                to="/$org/setup"
-                params={{ org: org.login }}
-                className="btn btn-warning btn-sm"
-              >
-                {t("orgs.card.setUp")}
-              </Link>
-            )}
-
-            {noAccess && !isActiveMember && (
-              <button className="btn btn-disabled btn-sm">
-                {t("orgs.card.askTeacher")}
-              </button>
-            )}
-          </div>
+        <div className="card-actions mt-5 items-center justify-end gap-2">
+          <OrgActions summary={summary} />
         </div>
       </div>
     </motion.div>
   )
 }
 
+function OrgRow({
+  summary,
+  updatedAgo,
+}: {
+  summary: Classroom50OrgSummary
+  updatedAgo?: string
+}) {
+  const { org, showNoAccessBadge } = useOrgAffordances(summary)
+
+  return (
+    <motion.div
+      className="col-span-12 flex flex-col gap-3 rounded-xl border border-base-300 bg-base-100 p-4 sm:flex-row sm:items-center sm:justify-between"
+      variants={enterExit}
+      initial="initial"
+      animate="animate"
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <img
+          src={org.avatar_url}
+          alt=""
+          className="size-9 shrink-0 rounded-lg border border-base-300"
+        />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-semibold">{org.login}</span>
+            {showNoAccessBadge && (
+              <span className="hidden sm:inline-flex">
+                <NoAccessBadge />
+              </span>
+            )}
+          </div>
+          {org.description && (
+            <p className="truncate text-sm text-base-content/60">
+              {org.description}
+            </p>
+          )}
+          {updatedAgo && (
+            <p className="truncate text-xs text-base-content/50">
+              {updatedAgo}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center justify-end gap-2">
+        <OrgActions summary={summary} updatedAgo={updatedAgo} />
+      </div>
+    </motion.div>
+  )
+}
+
+const SORT_OPTIONS: { key: OrgSortKey; labelKey: string }[] = [
+  { key: "name-asc", labelKey: "orgs.toolbar.sort.nameAsc" },
+  { key: "name-desc", labelKey: "orgs.toolbar.sort.nameDesc" },
+  { key: "last-modified", labelKey: "orgs.toolbar.sort.lastModified" },
+  { key: "status", labelKey: "orgs.toolbar.sort.status" },
+]
+
+// "ready" (teacher) before "no_access" (enrolled student) for the status sort.
+const statusWeight = (summary: Classroom50OrgSummary) =>
+  summary.classroom50.status === "ready" ? 0 : 1
+
 const OrgsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.organizations"))
   const queryClient = useQueryClient()
   const { data: orgs = [], isLoading, isFetching } = useGetOrgs()
-  const [showUnsupported, setShowUnsupported] = useState(false)
+
+  const [viewMode, setViewMode] = useState<OrgViewMode>(getStoredViewMode)
+  const [sortKey, setSortKey] = useState<OrgSortKey>(getStoredSortKey)
+  const [search, setSearch] = useState("")
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const changeView = (mode: OrgViewMode) => {
+    setViewMode(mode)
+    persistViewMode(mode)
+  }
+  const changeSort = (key: OrgSortKey) => {
+    setSortKey(key)
+    persistSortKey(key)
+  }
 
   // Confirmed Classroom 50 orgs the user can use: a teacher's ready org, or a
-  // student's enrolled org (no_access but the public Pages index confirmed it).
-  const cl50Orgs = orgs?.filter(
-    (summary) =>
-      summary.classroom50.status === "ready" ||
-      summary.classroom50.status === "no_access",
-  )
-  // Orgs where the user is an admin who hasn't set up Classroom 50 yet —
-  // offered in "Set Up". Unrelated (not_classroom50) and indeterminate
-  // (unknown) orgs are filtered out.
-  const nonCl50Orgs = orgs?.filter(
-    (summary) => summary.classroom50.status === "needs_setup",
-  )
-
-  // Plan is fetched only for the needs-setup subset (all admin-owned, so plan
-  // is visible) to drive the badge, sort, and free-org filter — without the
-  // per-org fan-out on the whole list.
-  const needsSetupLogins = useMemo(
-    () => nonCl50Orgs.map((summary) => summary.org.login),
-    [nonCl50Orgs],
-  )
-  const plans = useNeedsSetupPlans(needsSetupLogins)
-
-  // Bubble Team/Enterprise (supported) to top, then unknown, then free. Stable
-  // sort keeps GitHub's order within each bucket.
-  const sortedNonCl50Orgs = useMemo(
+  // student's enrolled org (no_access confirmed via the public Pages index).
+  const cl50Orgs = useMemo(
     () =>
-      [...nonCl50Orgs].sort((a, b) => {
-        const wa = planSortWeight(classifyPlan(plans[a.org.login]))
-        const wb = planSortWeight(classifyPlan(plans[b.org.login]))
-        return wa - wb
-      }),
-    [nonCl50Orgs, plans],
+      orgs.filter(
+        (summary) =>
+          summary.classroom50.status === "ready" ||
+          summary.classroom50.status === "no_access",
+      ),
+    [orgs],
+  )
+  // Admin-owned orgs without Classroom 50 yet — offered through the modal.
+  const needsSetupOrgs = useMemo(
+    () =>
+      orgs.filter((summary) => summary.classroom50.status === "needs_setup"),
+    [orgs],
   )
 
-  // Free-plan orgs can't be set up, so hide them by default. Unknown plan
-  // (guarded anyway) is always shown so a usable org is never hidden.
-  const visibleNonCl50Orgs = showUnsupported
-    ? sortedNonCl50Orgs
-    : sortedNonCl50Orgs.filter(
-        (summary) => classifyPlan(plans[summary.org.login]) !== "free",
-      )
-  const hiddenFreeCount = sortedNonCl50Orgs.length - visibleNonCl50Orgs.length
+  const query = search.trim().toLowerCase()
+  const filtered = useMemo(
+    () =>
+      query
+        ? cl50Orgs.filter((summary) => {
+            const { login, description } = summary.org
+            return (
+              login.toLowerCase().includes(query) ||
+              (description ?? "").toLowerCase().includes(query)
+            )
+          })
+        : cl50Orgs,
+    [cl50Orgs, query],
+  )
+
+  // Last-modified data is fetched only when its sort is active, for the shown
+  // set, so other views never fan out per-org.
+  const lastModifiedActive = sortKey === "last-modified"
+  const shownLogins = useMemo(
+    () => filtered.map((summary) => summary.org.login),
+    [filtered],
+  )
+  const lastModified = useOrgLastModified(shownLogins, lastModifiedActive)
+
+  const sorted = useMemo(() => {
+    const byName = (a: Classroom50OrgSummary, b: Classroom50OrgSummary) =>
+      a.org.login.localeCompare(b.org.login)
+    const list = [...filtered]
+    switch (sortKey) {
+      case "name-desc":
+        return list.sort((a, b) => byName(b, a))
+      case "status":
+        return list.sort(
+          (a, b) => statusWeight(a) - statusWeight(b) || byName(a, b),
+        )
+      case "last-modified":
+        // Known timestamps newest-first; pending/unknown pinned to the bottom
+        // in stable Name order so rows don't reshuffle as queries resolve.
+        return list.sort((a, b) => {
+          const ta = lastModified[a.org.login]
+          const tb = lastModified[b.org.login]
+          if (ta && tb) return tb.localeCompare(ta)
+          if (ta) return -1
+          if (tb) return 1
+          return byName(a, b)
+        })
+      case "name-asc":
+      default:
+        return list.sort(byName)
+    }
+  }, [filtered, sortKey, lastModified])
 
   const handleRefresh = () =>
     queryClient.invalidateQueries({ queryKey: ["orgs"] })
+
+  const hasAnyOrgs = cl50Orgs.length > 0
+  const noSearchResults = hasAnyOrgs && sorted.length === 0
 
   return (
     <div className="min-h-screen">
@@ -268,10 +391,7 @@ const OrgsPage = () => {
         <DrawerContent className="p-10 bg-base-200 2xl:px-50">
           {isLoading ? (
             <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-              <span
-                className="loading loading-spinner loading-lg text-primary"
-                aria-hidden="true"
-              />
+              <Spinner size="lg" className="text-primary" />
               <div>
                 <p className="text-base font-semibold">
                   {t("orgs.loadingTitle")}
@@ -284,74 +404,151 @@ const OrgsPage = () => {
           ) : (
             <div className="mb-8">
               <div className="flex flex-col gap-6 p-6">
-                <div className="w-full space-y-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <h1 className="text-2xl font-bold tracking-tight">
                     {t("orgs.headingCl50")}
                   </h1>
-                  <MissingOrgNotice
-                    refreshing={isFetching}
-                    onRefresh={handleRefresh}
-                  />
-                  <div className="grid grid-cols-12 gap-4">
-                    {cl50Orgs?.map((summary, i) => (
-                      <OrgCard
-                        key={summary.org.id}
-                        summary={summary}
-                        index={i}
-                      />
-                    ))}
-                  </div>
-                  {cl50Orgs?.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
-                      <h2 className="text-lg font-semibold">
-                        {t("orgs.emptyTitle")}
-                      </h2>
-                      <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
-                        {t("orgs.emptyBody")}
-                      </p>
-                    </div>
-                  )}
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-sm"
+                    onClick={() => setModalOpen(true)}
+                  >
+                    <Plus aria-hidden="true" className="size-4" />
+                    {t("orgs.newOrg.button")}
+                  </button>
                 </div>
-                {nonCl50Orgs.length > 0 && <div className="divider" />}
-                {nonCl50Orgs.length > 0 && (
-                  <div className="w-full space-y-4">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <h1 className="text-2xl font-bold tracking-tight">
-                        {t("orgs.headingSetUp")}
-                      </h1>
-                      {(hiddenFreeCount > 0 || showUnsupported) && (
-                        <label className="label cursor-pointer gap-2 text-sm">
-                          <input
-                            type="checkbox"
-                            className="toggle toggle-sm"
-                            checked={showUnsupported}
-                            onChange={(e) =>
-                              setShowUnsupported(e.target.checked)
-                            }
-                            aria-label={t("orgs.showUnsupported")}
-                          />
-                          <span className="label-text">
-                            {t("orgs.showUnsupported")}
-                            {hiddenFreeCount > 0 && !showUnsupported && (
-                              <span aria-hidden="true">
-                                {" "}
-                                ({hiddenFreeCount})
-                              </span>
-                            )}
-                          </span>
-                        </label>
-                      )}
+
+                <MissingOrgNotice
+                  refreshing={isFetching}
+                  onRefresh={handleRefresh}
+                />
+
+                {hasAnyOrgs && (
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
+                      <Search
+                        aria-hidden="true"
+                        className="size-4 text-base-content/50"
+                      />
+                      <input
+                        type="search"
+                        className="grow"
+                        placeholder={t("orgs.toolbar.searchPlaceholder")}
+                        aria-label={t("orgs.toolbar.searchLabel")}
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                      />
+                    </label>
+
+                    <div className="flex items-center gap-3">
+                      <select
+                        className="select select-bordered select-sm"
+                        aria-label={t("orgs.toolbar.sort.label")}
+                        value={sortKey}
+                        onChange={(e) =>
+                          changeSort(e.target.value as OrgSortKey)
+                        }
+                      >
+                        {SORT_OPTIONS.map((opt) => (
+                          <option key={opt.key} value={opt.key}>
+                            {t(opt.labelKey)}
+                          </option>
+                        ))}
+                      </select>
+
+                      <div
+                        role="group"
+                        aria-label={t("orgs.toolbar.view.label")}
+                        className="tabs tabs-box tabs-sm"
+                      >
+                        <button
+                          type="button"
+                          className={`tab ${viewMode === "grid" ? "tab-active" : ""}`}
+                          aria-label={t("orgs.toolbar.view.gridLabel")}
+                          aria-pressed={viewMode === "grid"}
+                          onClick={() => changeView("grid")}
+                        >
+                          <LayoutGrid aria-hidden="true" className="size-4" />
+                        </button>
+                        <button
+                          type="button"
+                          className={`tab ${viewMode === "list" ? "tab-active" : ""}`}
+                          aria-label={t("orgs.toolbar.view.listLabel")}
+                          aria-pressed={viewMode === "list"}
+                          onClick={() => changeView("list")}
+                        >
+                          <ListIcon aria-hidden="true" className="size-4" />
+                        </button>
+                      </div>
                     </div>
-                    <div className="grid grid-cols-12 gap-4">
-                      {visibleNonCl50Orgs.map((summary, i) => (
+                  </div>
+                )}
+
+                {noSearchResults ? (
+                  <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
+                    <h2 className="text-lg font-semibold">
+                      {t("orgs.noResults.title")}
+                    </h2>
+                    <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+                      {t("orgs.noResults.body", { query: search.trim() })}
+                    </p>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-sm mt-4"
+                      onClick={() => setSearch("")}
+                    >
+                      {t("orgs.noResults.clear")}
+                    </button>
+                  </div>
+                ) : sorted.length > 0 ? (
+                  <div className="grid grid-cols-12 gap-4">
+                    {sorted.map((summary) => {
+                      const updatedIso = lastModifiedActive
+                        ? lastModified[summary.org.login]
+                        : undefined
+                      const updatedAgo = updatedIso
+                        ? formatRelativeToNow(new Date(updatedIso))
+                        : undefined
+                      return viewMode === "grid" ? (
                         <OrgCard
                           key={summary.org.id}
                           summary={summary}
-                          index={i}
-                          planName={plans[summary.org.login]}
+                          updatedAgo={updatedAgo}
                         />
-                      ))}
-                    </div>
+                      ) : (
+                        <OrgRow
+                          key={summary.org.id}
+                          summary={summary}
+                          updatedAgo={updatedAgo}
+                        />
+                      )
+                    })}
+                  </div>
+                ) : needsSetupOrgs.length > 0 ? (
+                  <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
+                    <h2 className="text-lg font-semibold">
+                      {t("orgs.setUpFirst.title")}
+                    </h2>
+                    <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+                      {t("orgs.setUpFirst.body")}
+                    </p>
+                    <button
+                      type="button"
+                      className="btn btn-primary btn-sm mt-4"
+                      onClick={() => setModalOpen(true)}
+                    >
+                      <Plus aria-hidden="true" className="size-4" />
+                      {t("orgs.setUpFirst.cta")}
+                    </button>
+                  </div>
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
+                    <h2 className="text-lg font-semibold">
+                      {t("orgs.emptyTitle")}
+                    </h2>
+                    <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+                      {t("orgs.emptyBody")}
+                    </p>
                   </div>
                 )}
               </div>
@@ -360,6 +557,12 @@ const OrgsPage = () => {
         </DrawerContent>
         <DrawerSidebar page="orgs" />
       </Drawer>
+
+      <NewOrgModal
+        open={modalOpen}
+        needsSetupOrgs={needsSetupOrgs}
+        onClose={() => setModalOpen(false)}
+      />
     </div>
   )
 }

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -105,6 +105,8 @@ function useOrgAffordances(summary: Classroom50OrgSummary) {
   const isReady = classroom50.status === "ready"
   const noAccess = classroom50.status === "no_access"
   const isAdmin = membership.role === "admin"
+  // useGetOrgs only surfaces active memberships, so every summary here is an
+  // active member.
   const isActiveMember = membership.state === "active"
 
   return {
@@ -114,7 +116,6 @@ function useOrgAffordances(summary: Classroom50OrgSummary) {
     // Teachers open ready orgs; students open any org they're an active member
     // of (their assignment repos live there even without classroom50 access).
     canOpen: isAdmin ? isReady : isActiveMember,
-    askTeacher: noAccess && !isActiveMember,
   }
 }
 
@@ -126,7 +127,7 @@ function OrgActions({
   updatedAgo?: string
 }) {
   const { t } = useTranslation()
-  const { org, canOpen, askTeacher } = useOrgAffordances(summary)
+  const { org, canOpen } = useOrgAffordances(summary)
   return (
     <>
       <GitHubLink
@@ -144,11 +145,6 @@ function OrgActions({
         >
           {t("orgs.card.open")}
         </Link>
-      )}
-      {askTeacher && (
-        <button className="btn btn-disabled btn-sm">
-          {t("orgs.card.askTeacher")}
-        </button>
       )}
       {updatedAgo && (
         <span className="sr-only">

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -116,13 +116,7 @@ function useOrgAffordances(summary: Classroom50OrgSummary) {
   }
 }
 
-function OrgActions({
-  summary,
-  updatedAgo,
-}: {
-  summary: Classroom50OrgSummary
-  updatedAgo?: string
-}) {
+function OrgActions({ summary }: { summary: Classroom50OrgSummary }) {
   const { t } = useTranslation()
   const { org, canOpen } = useOrgAffordances(summary)
   return (
@@ -142,11 +136,6 @@ function OrgActions({
         >
           {t("orgs.card.open")}
         </Link>
-      )}
-      {updatedAgo && (
-        <span className="sr-only">
-          {t("orgs.card.updatedAgo", { when: updatedAgo })}
-        </span>
       )}
     </>
   )
@@ -226,6 +215,7 @@ function OrgRow({
   summary: Classroom50OrgSummary
   updatedAgo?: string
 }) {
+  const { t } = useTranslation()
   const { org, showNoAccessBadge } = useOrgAffordances(summary)
 
   return (
@@ -257,14 +247,14 @@ function OrgRow({
           )}
           {updatedAgo && (
             <p className="truncate text-xs text-base-content/50">
-              {updatedAgo}
+              {t("orgs.card.updatedAgo", { when: updatedAgo })}
             </p>
           )}
         </div>
       </div>
 
       <div className="flex shrink-0 items-center justify-end gap-2">
-        <OrgActions summary={summary} updatedAgo={updatedAgo} />
+        <OrgActions summary={summary} />
       </div>
     </motion.div>
   )

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -10,6 +10,7 @@ import useOrgLastModified from "@/hooks/useOrgLastModified"
 import { useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import {
+  ChevronDown,
   ExternalLink,
   Info,
   LayoutGrid,
@@ -45,56 +46,52 @@ function MissingOrgNotice({
 }) {
   const { t } = useTranslation()
   return (
-    <div className="rounded-2xl border border-info/20 bg-info/5 p-5 shadow-sm">
-      <div className="flex gap-4">
-        <div className="mt-1 flex size-10 shrink-0 items-center justify-center rounded-full bg-info/10 text-info">
-          <Info aria-hidden="true" className="size-5" />
-        </div>
+    <details className="group rounded-xl border border-info/20 bg-info/5">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-sm">
+        <Info aria-hidden="true" className="size-4 shrink-0 text-info" />
+        <span className="min-w-0 flex-1 truncate font-medium text-base-content">
+          {t("orgs.missingNotice.title")}
+        </span>
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs"
+          disabled={refreshing}
+          onClick={(e) => {
+            // The button lives inside <summary>; stop the click from toggling
+            // the disclosure so refreshing doesn't also expand/collapse it.
+            e.preventDefault()
+            onRefresh()
+          }}
+        >
+          <RefreshCw
+            aria-hidden="true"
+            className={["size-3.5", refreshing ? "animate-spin" : ""].join(" ")}
+          />
+          {refreshing
+            ? t("orgs.missingNotice.refreshing")
+            : t("orgs.missingNotice.refresh")}
+        </button>
+        <ChevronDown
+          aria-hidden="true"
+          className="size-4 shrink-0 text-base-content/50 transition-transform group-open:rotate-180"
+        />
+      </summary>
 
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h2 className="text-base font-semibold text-base-content">
-                {t("orgs.missingNotice.title")}
-              </h2>
-
-              <p className="mt-1 text-sm leading-6 text-base-content/70">
-                {t("orgs.missingNotice.body")}
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-            <a
-              href="https://github.com/settings/connections/applications"
-              target="_blank"
-              rel="noreferrer"
-              className="btn btn-info btn-sm"
-            >
-              {t("orgs.missingNotice.manageOauth")}
-              <ExternalLink aria-hidden="true" className="size-4" />
-            </a>
-
-            <button
-              type="button"
-              className="btn btn-ghost btn-sm"
-              disabled={refreshing}
-              onClick={onRefresh}
-            >
-              <RefreshCw
-                aria-hidden="true"
-                className={["size-4", refreshing ? "animate-spin" : ""].join(
-                  " ",
-                )}
-              />
-              {refreshing
-                ? t("orgs.missingNotice.refreshing")
-                : t("orgs.missingNotice.refresh")}
-            </button>
-          </div>
-        </div>
+      <div className="border-t border-info/20 px-4 py-3">
+        <p className="text-sm leading-6 text-base-content/70">
+          {t("orgs.missingNotice.body")}
+        </p>
+        <a
+          href="https://github.com/settings/connections/applications"
+          target="_blank"
+          rel="noreferrer"
+          className="btn btn-info btn-sm mt-3"
+        >
+          {t("orgs.missingNotice.manageOauth")}
+          <ExternalLink aria-hidden="true" className="size-4" />
+        </a>
       </div>
-    </div>
+    </details>
   )
 }
 
@@ -275,7 +272,6 @@ function OrgRow({
 
 const SORT_OPTIONS: { key: OrgSortKey; labelKey: string }[] = [
   { key: "name-asc", labelKey: "orgs.toolbar.sort.nameAsc" },
-  { key: "name-desc", labelKey: "orgs.toolbar.sort.nameDesc" },
   { key: "last-modified", labelKey: "orgs.toolbar.sort.lastModified" },
   { key: "status", labelKey: "orgs.toolbar.sort.status" },
 ]
@@ -351,8 +347,6 @@ const OrgsPage = () => {
       a.org.login.localeCompare(b.org.login)
     const list = [...filtered]
     switch (sortKey) {
-      case "name-desc":
-        return list.sort((a, b) => byName(b, a))
       case "status":
         return list.sort(
           (a, b) => statusWeight(a) - statusWeight(b) || byName(a, b),
@@ -404,14 +398,6 @@ const OrgsPage = () => {
                   <h1 className="text-2xl font-bold tracking-tight">
                     {t("orgs.headingCl50")}
                   </h1>
-                  <button
-                    type="button"
-                    className="btn btn-primary btn-sm"
-                    onClick={() => setModalOpen(true)}
-                  >
-                    <Plus aria-hidden="true" className="size-4" />
-                    {t("orgs.newOrg.button")}
-                  </button>
                 </div>
 
                 <MissingOrgNotice
@@ -455,11 +441,11 @@ const OrgsPage = () => {
                       <div
                         role="group"
                         aria-label={t("orgs.toolbar.view.label")}
-                        className="tabs tabs-box tabs-sm"
+                        className="join"
                       >
                         <button
                           type="button"
-                          className={`tab ${viewMode === "grid" ? "tab-active" : ""}`}
+                          className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
                           aria-label={t("orgs.toolbar.view.gridLabel")}
                           aria-pressed={viewMode === "grid"}
                           onClick={() => changeView("grid")}
@@ -468,7 +454,7 @@ const OrgsPage = () => {
                         </button>
                         <button
                           type="button"
-                          className={`tab ${viewMode === "list" ? "tab-active" : ""}`}
+                          className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
                           aria-label={t("orgs.toolbar.view.listLabel")}
                           aria-pressed={viewMode === "list"}
                           onClick={() => changeView("list")}
@@ -476,6 +462,14 @@ const OrgsPage = () => {
                           <ListIcon aria-hidden="true" className="size-4" />
                         </button>
                       </div>
+
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm"
+                        onClick={() => setModalOpen(true)}
+                      >
+                        {t("orgs.newOrg.button")}
+                      </button>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

Redesigns the organization homepage (`web/src/pages/OrgsPage.tsx`) from a static two-section layout into a single, controllable list of the user's Classroom 50 organizations.

- **Grid/list view toggle** — switch between the card grid and a compact one-row-per-org list; the choice persists to `localStorage`.
- **Search** — case-insensitive filter over org login + description.
- **Sort** — Name (A-Z), Last modified, and Status (teacher orgs before enrolled), persisted (last-modified never auto-restores, to avoid re-arming the per-org fetch on load).
- **"Set up new organization" modal** (`NewOrgModal.tsx`) — lists the user's not-yet-configured orgs (with plan badges), disables free-plan orgs that can't complete setup, and routes the chosen one into the existing `/$org/setup` wizard; links to github.com to create a new GitHub org. Lives in the toolbar row alongside sort and the view toggle.
- **Last modified** reads the `classroom50` config repo's `pushed_at` only when that sort is active, reusing the shared `githubKeys.repo` cache so other views never fan out per-org.
- **Compact "Not seeing your organization?" notice** — a one-line expandable disclosure with refresh inline, replacing the previous always-on banner.
- Distinct empty states: first-time-teacher setup CTA, student empty state, and a search "no results" state with a clear-search action.

Closes #153.

## Notes / decisions

- GitHub orgs can't be created client-side, so the modal configures Classroom 50 in an existing org rather than creating one.
- "Last modified" is defined as the config-repo push time (a deliberate cheap proxy; it does not reflect student/assignment-repo activity).
- Free-plan orgs are shown but disabled in the modal (they can't complete setup) rather than hidden.

## Review

A multi-persona code review (correctness, maintainability, frontend/a11y, adversarial) ran on the branch. No P0/P1 issues. Fixes applied in the `fix(review): ...` commits:

- Removed a dead `askTeacher` branch (unreachable since `useGetOrgs` only returns active memberships) and its i18n key.
- De-duplicated the list-view "Updated ..." relative time (it was announced twice to screen readers) and made it consistent with the card view.
- Removed `planSortWeight` (and its tests) — the redesign deleted its only production caller.
- Corrected a misleading cache comment in `useOrgLastModified`.

Remaining non-blocking follow-ups (P3, deferred): guard the modal's free-plan row during the plan-load window; surface the no-access badge in list view below the `sm` breakpoint; add unit tests for `orgListPrefs` and the sort comparator.

## Test plan

- [x] `npm run check` green (tsc + eslint + prettier + vitest, 773 tests)
- [x] i18n audit gate passes; no missing or dead `orgs.*` keys
- [ ] Manual: search filters; grid and list both render; each sort works (incl. lazy last-modified fetch); view/sort persist across reload; modal routes to `/$org/setup` and disables free-plan orgs; compact notice expands/collapses and refresh works