### PR TITLE
feat(web): redesign the My Classrooms page (unified toolbar, richer cards, card actions)

### DIFF
--- a/web/src/hooks/useClassroomSummaries.ts
+++ b/web/src/hooks/useClassroomSummaries.ts
@@ -19,10 +19,10 @@ export type ClassroomSummary = {
   // Archived lifecycle derived from classroom.json's `active` flag via
   // isClassroomArchived; an unresolved/errored read is treated as active.
   archived: boolean
-  // Student count for the student-count sort. undefined while the roster is
-  // pending or unreadable; callers pin undefined to the bottom in name order.
+  // studentCount undefined while pending/unreadable (or when counts aren't
+  // requested); callers pin undefined to the bottom in name order.
   studentCount?: number
-  // classroom.json is still loading (distinct from a resolved-but-empty read).
+  // Distinct from a resolved-but-empty classroom.json read.
   loading: boolean
 }
 
@@ -82,3 +82,8 @@ const useClassroomSummaries = (
 }
 
 export default useClassroomSummaries
+
+export const classroomDisplayName = (
+  summary: ClassroomSummary,
+  fallback = "",
+) => summary.name || summary.short_name || summary.path || fallback

--- a/web/src/hooks/useClassroomSummaries.ts
+++ b/web/src/hooks/useClassroomSummaries.ts
@@ -16,9 +16,8 @@ export type ClassroomSummary = {
   name?: string
   short_name?: string
   term?: string
-  // Absent/true reads as active (per isClassroomArchived); an unresolved or
-  // errored classroom.json leaves this undefined -> treated as active.
-  active?: boolean
+  // Archived lifecycle derived from classroom.json's `active` flag via
+  // isClassroomArchived; an unresolved/errored read is treated as active.
   archived: boolean
   // Student count for the student-count sort. undefined while the roster is
   // pending or unreadable; callers pin undefined to the bottom in name order.
@@ -75,7 +74,6 @@ const useClassroomSummaries = (
       name: cl?.name,
       short_name: cl?.short_name,
       term: cl?.term,
-      active: cl?.active,
       archived: isClassroomArchived(cl ?? {}),
       studentCount: withStudentCounts ? roster?.length : undefined,
       loading: classroomResults[i]?.isPending ?? false,

--- a/web/src/hooks/useClassroomSummaries.ts
+++ b/web/src/hooks/useClassroomSummaries.ts
@@ -1,0 +1,86 @@
+import { useQueries } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { csvFileQuery, jsonFileQuery } from "@/hooks/github/queries"
+import type { GitHubFileListing } from "@/hooks/github/types"
+import {
+  isClassroomArchived,
+  type Classroom,
+  type Student,
+} from "@/types/classroom"
+
+export type ClassroomSummary = {
+  // The classroom directory slug. Always present, even when classroom.json
+  // could not be read, so the row never disappears silently.
+  path: string
+  name?: string
+  short_name?: string
+  term?: string
+  // Absent/true reads as active (per isClassroomArchived); an unresolved or
+  // errored classroom.json leaves this undefined -> treated as active.
+  active?: boolean
+  archived: boolean
+  // Student count for the student-count sort. undefined while the roster is
+  // pending or unreadable; callers pin undefined to the bottom in name order.
+  studentCount?: number
+  // classroom.json is still loading (distinct from a resolved-but-empty read).
+  loading: boolean
+}
+
+// Lifts each classroom's classroom.json (and optionally its roster) to the
+// parent so the My Classrooms list can search/sort/filter before rendering.
+// Reuses useGetClassroom's jsonFileQuery cache keys and useGetStudents'
+// csvFileQuery keys, so no duplicate requests vs. the per-card reads. Roster
+// fetches are gated behind `withStudentCounts` (only true when the
+// student-count sort is active) to avoid an unnecessary fan-out otherwise.
+//
+// jsonFileQuery/csvFileQuery use retry:false, so a dir with a missing/malformed
+// classroom.json resolves to data===undefined: we keep {path} and mark the rest
+// optional rather than dropping a real classroom from the list.
+const useClassroomSummaries = (
+  org: string | undefined,
+  dirs: GitHubFileListing[],
+  withStudentCounts: boolean,
+): ClassroomSummary[] => {
+  const client = useGitHubClient()
+
+  const classroomResults = useQueries({
+    queries: dirs.map((dir) =>
+      jsonFileQuery<Classroom>(
+        client,
+        org ?? "",
+        "classroom50",
+        `${dir.path}/classroom.json`,
+      ),
+    ),
+  })
+
+  const rosterResults = useQueries({
+    queries: dirs.map((dir) => ({
+      ...csvFileQuery<Student>(
+        client,
+        org ?? "",
+        "classroom50",
+        `${dir.path}/students.csv`,
+      ),
+      enabled: withStudentCounts && Boolean(org && dir.path),
+    })),
+  })
+
+  return dirs.map((dir, i) => {
+    const cl = classroomResults[i]?.data
+    const roster = rosterResults[i]?.data
+    return {
+      path: dir.path,
+      name: cl?.name,
+      short_name: cl?.short_name,
+      term: cl?.term,
+      active: cl?.active,
+      archived: isClassroomArchived(cl ?? {}),
+      studentCount: withStudentCounts ? roster?.length : undefined,
+      loading: classroomResults[i]?.isPending ?? false,
+    }
+  })
+}
+
+export default useClassroomSummaries

--- a/web/src/lib/classroomListPrefs.ts
+++ b/web/src/lib/classroomListPrefs.ts
@@ -1,0 +1,23 @@
+// Classroom-list display preferences (My Classrooms), persisted per browser.
+// Built on the shared createListPrefs factory. All three sorts read only summary
+// data the parent already fetches (name/term) or the roster it fetches for the
+// list, so there is no fan-out-bearing sort to guard against on load.
+
+import { createListPrefs } from "@/lib/listPrefs"
+
+export type ClassroomViewMode = "grid" | "list"
+export type ClassroomSortKey = "name-asc" | "term" | "student-count"
+
+const prefs = createListPrefs<ClassroomViewMode, ClassroomSortKey>({
+  viewKey: "classrooms_view_mode",
+  sortKey: "classrooms_sort_key",
+  viewValues: ["grid", "list"],
+  sortValues: ["name-asc", "term", "student-count"],
+  defaultView: "grid",
+  defaultSort: "name-asc",
+})
+
+export const getStoredViewMode = prefs.getStoredViewMode
+export const persistViewMode = prefs.persistViewMode
+export const getStoredSortKey = prefs.getStoredSortKey
+export const persistSortKey = prefs.persistSortKey

--- a/web/src/lib/listPrefs.ts
+++ b/web/src/lib/listPrefs.ts
@@ -1,0 +1,61 @@
+// Generic per-browser display-preference storage for list pages (view mode +
+// sort key). UI state, not server data, so it lives in localStorage rather than
+// React Query. Each list page instantiates its own accessor with its own
+// storage keys and allowed values via createListPrefs.
+
+function canUseStorage() {
+  return typeof window !== "undefined"
+}
+
+export type ListPrefsConfig<ViewMode extends string, SortKey extends string> = {
+  viewKey: string
+  sortKey: string
+  viewValues: readonly ViewMode[]
+  sortValues: readonly SortKey[]
+  defaultView: ViewMode
+  defaultSort: SortKey
+  // Optional hook to rewrite a validated sort on read — e.g. a page that must
+  // not auto-restore a fan-out-bearing sort returns its default instead.
+  sanitizeSortOnLoad?: (sort: SortKey, defaultSort: SortKey) => SortKey
+}
+
+export function createListPrefs<
+  ViewMode extends string,
+  SortKey extends string,
+>(config: ListPrefsConfig<ViewMode, SortKey>) {
+  const getStoredViewMode = (): ViewMode => {
+    if (!canUseStorage()) return config.defaultView
+    const raw = localStorage.getItem(config.viewKey)
+    return config.viewValues.includes(raw as ViewMode)
+      ? (raw as ViewMode)
+      : config.defaultView
+  }
+
+  const persistViewMode = (mode: ViewMode) => {
+    if (!canUseStorage()) return
+    localStorage.setItem(config.viewKey, mode)
+  }
+
+  const getStoredSortKey = (): SortKey => {
+    if (!canUseStorage()) return config.defaultSort
+    const raw = localStorage.getItem(config.sortKey)
+    const parsed = config.sortValues.includes(raw as SortKey)
+      ? (raw as SortKey)
+      : config.defaultSort
+    return config.sanitizeSortOnLoad
+      ? config.sanitizeSortOnLoad(parsed, config.defaultSort)
+      : parsed
+  }
+
+  const persistSortKey = (key: SortKey) => {
+    if (!canUseStorage()) return
+    localStorage.setItem(config.sortKey, key)
+  }
+
+  return {
+    getStoredViewMode,
+    persistViewMode,
+    getStoredSortKey,
+    persistSortKey,
+  }
+}

--- a/web/src/lib/orgListPrefs.ts
+++ b/web/src/lib/orgListPrefs.ts
@@ -1,51 +1,27 @@
 // Home-page org-list display preferences, persisted per browser so a returning
-// user keeps their chosen view/sort. Kept out of React Query — this is UI state,
-// not server data.
+// user keeps their chosen view/sort. Built on the shared createListPrefs factory.
+
+import { createListPrefs } from "@/lib/listPrefs"
 
 export type OrgViewMode = "grid" | "list"
 export type OrgSortKey = "name-asc" | "last-modified" | "status"
 
-const VIEW_KEY = "orgs_view_mode"
-const SORT_KEY = "orgs_sort_key"
+const prefs = createListPrefs<OrgViewMode, OrgSortKey>({
+  viewKey: "orgs_view_mode",
+  sortKey: "orgs_sort_key",
+  viewValues: ["grid", "list"],
+  sortValues: ["name-asc", "last-modified", "status"],
+  defaultView: "grid",
+  defaultSort: "name-asc",
+  // Honor the persisted sort on load EXCEPT "last-modified": restoring it would
+  // silently re-arm the per-org pushed_at fan-out on every visit, breaking the
+  // home page's no-fan-out-by-default contract. The preference is still saved
+  // (sticky within a session); load falls back to the name sort until re-picked.
+  sanitizeSortOnLoad: (sort, defaultSort) =>
+    sort === "last-modified" ? defaultSort : sort,
+})
 
-const DEFAULT_VIEW: OrgViewMode = "grid"
-const DEFAULT_SORT: OrgSortKey = "name-asc"
-
-const VIEW_VALUES: OrgViewMode[] = ["grid", "list"]
-const SORT_VALUES: OrgSortKey[] = ["name-asc", "last-modified", "status"]
-
-function canUseStorage() {
-  return typeof window !== "undefined"
-}
-
-export function getStoredViewMode(): OrgViewMode {
-  if (!canUseStorage()) return DEFAULT_VIEW
-  const raw = localStorage.getItem(VIEW_KEY)
-  return VIEW_VALUES.includes(raw as OrgViewMode)
-    ? (raw as OrgViewMode)
-    : DEFAULT_VIEW
-}
-
-export function persistViewMode(mode: OrgViewMode) {
-  if (!canUseStorage()) return
-  localStorage.setItem(VIEW_KEY, mode)
-}
-
-// The persisted sort is honored on load EXCEPT "last-modified": restoring it
-// would silently re-arm the per-org pushed_at fan-out on every visit, breaking
-// the home page's no-fan-out-by-default contract. The preference is still
-// saved (so re-selecting feels sticky within a session), but load falls back to
-// the name sort until the user picks last-modified again.
-export function getStoredSortKey(): OrgSortKey {
-  if (!canUseStorage()) return DEFAULT_SORT
-  const raw = localStorage.getItem(SORT_KEY)
-  const parsed = SORT_VALUES.includes(raw as OrgSortKey)
-    ? (raw as OrgSortKey)
-    : DEFAULT_SORT
-  return parsed === "last-modified" ? DEFAULT_SORT : parsed
-}
-
-export function persistSortKey(key: OrgSortKey) {
-  if (!canUseStorage()) return
-  localStorage.setItem(SORT_KEY, key)
-}
+export const getStoredViewMode = prefs.getStoredViewMode
+export const persistViewMode = prefs.persistViewMode
+export const getStoredSortKey = prefs.getStoredSortKey
+export const persistSortKey = prefs.persistSortKey

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1189,6 +1189,10 @@
     "toolbar": {
       "searchPlaceholder": "Search classrooms…",
       "searchLabel": "Search classrooms",
+      "termLabel": "Filter by term",
+      "termPrefix": "Term",
+      "sortPrefix": "Sort",
+      "allTerms": "All terms",
       "sort": {
         "label": "Sort",
         "nameAsc": "Name (A–Z)",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -49,8 +49,8 @@
     "primary": "Primary",
     "expandSidebar": "Expand sidebar",
     "collapseSidebar": "Collapse sidebar",
-    "allClasses": "All Classes",
-    "allClassesArrow": "‹ All Classes",
+    "allClasses": "All Classrooms",
+    "allClassesArrow": "‹ All Classrooms",
     "allAssignments": "All Assignments",
     "allAssignmentsArrow": "‹ All Assignments",
     "accountMenu": "Account menu",
@@ -62,7 +62,7 @@
     "mySubmission": "My Submission",
     "manageGroup": "Manage Group",
     "acceptAssignment": "Accept Assignment",
-    "myClasses": "My Classes",
+    "myClasses": "My Classrooms",
     "myAssignments": "My Assignments",
     "published": "Published",
     "members": "Members",
@@ -147,7 +147,7 @@
     "acceptAssignment": "Accept Assignment",
     "members": "Members",
     "newClassroom": "New Classroom",
-    "classes": "Classes",
+    "classes": "Classrooms",
     "mySubmission": "My Submission",
     "submissions": "Submissions"
   },
@@ -1152,12 +1152,12 @@
     "noStudents": "No Students",
     "viewAssignments": "View Assignments",
     "editClassAria": "Edit {{name}}",
-    "editClassTitle": "Edit assignment",
+    "editClassTitle": "Edit classroom",
     "githubOrganization": "GitHub Organization",
-    "myClasses": "My Classes",
+    "myClasses": "My Classrooms",
     "myAssignments": "My Assignments",
     "manageSubtitle": "Manage your courses and assignments.",
-    "newClass": "+ New Class",
+    "newClass": "New classroom",
     "empty": {
       "title": "No classrooms yet",
       "body": "Create your first classroom to start adding assignments, importing students, and managing submissions.",
@@ -1176,6 +1176,38 @@
       "archived": "Archived",
       "all": "All"
     },
+    "card": {
+      "assignmentCount_one": "{{count}} Assignment",
+      "assignmentCount_other": "{{count}} Assignments",
+      "noAssignments": "No Assignments",
+      "countsUnavailable": "Counts unavailable",
+      "actionsAria": "Actions for {{name}}",
+      "edit": "Edit classroom",
+      "viewOnGitHub": "View on GitHub"
+    },
+    "toolbar": {
+      "searchPlaceholder": "Search classrooms…",
+      "searchLabel": "Search classrooms",
+      "sort": {
+        "label": "Sort",
+        "nameAsc": "Name (A–Z)",
+        "term": "Term",
+        "studentCount": "Student count"
+      },
+      "view": {
+        "label": "View",
+        "gridLabel": "Grid view",
+        "listLabel": "List view"
+      }
+    },
+    "noResults": {
+      "title": "No classrooms match your search",
+      "body": "No classrooms match \u201c{{query}}\u201d.",
+      "clear": "Clear search"
+    },
+    "deleteTeamWarning": "Deleted {{classroom}}, but some GitHub teams could not be removed. Delete them manually in the organization's team settings.",
+    "deletedToast": "Deleted {{classroom}}.",
+    "deleteFailed": "Couldn't delete {{classroom}}: {{error}}",
     "repo": {
       "manageGroupAria": "Manage group for {{assignment}}",
       "manageGroupTitle": "Manage group",
@@ -1595,7 +1627,7 @@
     },
     "breadcrumb": {
       "label": "Breadcrumb",
-      "classes": "Classes",
+      "classes": "Classrooms",
       "assignments": "Assignments"
     },
     "planBadge": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1182,8 +1182,11 @@
       "assignmentCount_other": "{{count}} Assignments",
       "noAssignments": "No Assignments",
       "countsUnavailable": "Counts unavailable",
+      "loadingStudents": "Loading student count…",
+      "loadingAssignments": "Loading assignment count…",
       "actionsAria": "Actions for {{name}}",
       "edit": "Edit classroom",
+      "delete": "Delete classroom",
       "viewOnGitHub": "View on GitHub"
     },
     "toolbar": {
@@ -1217,6 +1220,7 @@
     },
     "deleteTeamWarning": "Deleted {{classroom}}, but some GitHub teams could not be removed. Delete them manually in the organization's team settings.",
     "deletedToast": "Deleted {{classroom}}.",
+    "deleteNoop": "{{classroom}} was already deleted.",
     "deleteFailed": "Couldn't delete {{classroom}}: {{error}}",
     "repo": {
       "manageGroupAria": "Manage group for {{assignment}}",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1172,6 +1172,7 @@
       "joinButton": "Join organization"
     },
     "filter": {
+      "label": "Filter by status",
       "active": "Active",
       "archived": "Archived",
       "all": "All"
@@ -1204,6 +1205,11 @@
       "title": "No classrooms match your search",
       "body": "No classrooms match \u201c{{query}}\u201d.",
       "clear": "Clear search"
+    },
+    "emptyFilter": {
+      "active": "No active classrooms.",
+      "archived": "No archived classrooms.",
+      "all": "No classrooms yet."
     },
     "deleteTeamWarning": "Deleted {{classroom}}, but some GitHub teams could not be removed. Delete them manually in the organization's team settings.",
     "deletedToast": "Deleted {{classroom}}.",

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -1,9 +1,7 @@
 import { useParams, Link } from "@tanstack/react-router"
-import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   BookOpen,
-  BookText,
   ExternalLink,
   GraduationCap,
   Pencil,
@@ -14,8 +12,6 @@ import {
 import GitHub from "@/assets/github.svg?react"
 
 import useGetClasses from "@/hooks/useGetClasses"
-import useGetStudents from "@/hooks/useGetStudents"
-import { isClassroomArchived } from "@/types/classroom"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 
 import Drawer, {
@@ -24,9 +20,8 @@ import Drawer, {
   DrawerToggle,
 } from "@/components/drawer"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
-import type { GitHubFileListing, GitHubRepo } from "@/hooks/github/types"
+import type { GitHubRepo } from "@/hooks/github/types"
 import MissingParams from "@/components/MissingParams"
-import useGetClassroom from "@/hooks/useGetClassroom"
 import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
 import useGetOwnOrgMembership from "@/hooks/useGetOwnOrgMembership"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -36,85 +31,9 @@ import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
 import useGetPublicAssignment from "@/hooks/useGetPublicAssignment"
 import OrgPreflightNotice from "@/pages/orgSettings/OrgPreflightNotice"
+import ClassroomList from "@/pages/classes/ClassroomList"
 import { EnterDiv } from "@/lib/motionComponents"
 import { githubOrgUrl } from "@/util/orgUrl"
-
-type ClassFilter = "active" | "archived" | "all"
-
-const ClassCard = ({
-  cl,
-  org,
-  filter,
-}: {
-  cl: GitHubFileListing
-  org: string
-  filter: ClassFilter
-}) => {
-  const { t } = useTranslation()
-  const { data: classroomData } = useGetClassroom(org, cl.path)
-  const { students } = useGetStudents(org, cl.path)
-  const { isTeacher } = useCourseTeacherAccess(org)
-
-  const canEdit = isTeacher && cl.name
-  const archived = isClassroomArchived(classroomData ?? {})
-
-  // Defer rendering until the classroom's lifecycle is known. We can't tell
-  // active from archived until classroomData loads, so painting a card under
-  // Active/All then unmounting it when it resolves archived causes a grid
-  // relayout flash. Rendering nothing until resolved means each card appears
-  // once, in its correct tab.
-  if (!classroomData) return null
-  if (filter === "active" && archived) return null
-  if (filter === "archived" && !archived) return null
-
-  return (
-    <EnterDiv className="card bg-base-100 rounded-xl col-span-6 border border-base-300">
-      {canEdit && (
-        <Link
-          to="/$org/$classroom/edit"
-          params={{ org, classroom: cl.name }}
-          className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3 z-10 text-base-content/70 hover:text-primary"
-          aria-label={t("classes.editClassAria", { name: cl.name })}
-          title={t("classes.editClassTitle")}
-        >
-          <Pencil aria-hidden="true" className="size-4" />
-        </Link>
-      )}
-      <div className="card-body gap-4">
-        <div className="flex items-center gap-2">
-          <label className="h-6 badge badge-soft badge-primary">
-            {classroomData?.term || t("classes.noTermSpecified")}
-          </label>
-          {archived ? (
-            <span className="h-6 badge badge-soft badge-neutral">
-              {t("classes.archived")}
-            </span>
-          ) : null}
-        </div>
-        <h1 className="text-xl h-8">
-          {classroomData?.name ||
-            classroomData?.short_name ||
-            t("classes.unknownClassName")}
-        </h1>
-        <div className="flex gap-2 h-6">
-          <UsersRound aria-hidden="true" />
-          {students
-            ? t("classes.studentCount", { count: students.length })
-            : t("classes.noStudents")}
-        </div>
-        <Link
-          type="button"
-          to="/$org/$classroom/assignments"
-          params={{ org, classroom: cl.path }}
-          className="btn btn-outline btn-primary w-full"
-        >
-          <BookText aria-hidden="true" />
-          {t("classes.viewAssignments")}
-        </Link>
-      </div>
-    </EnterDiv>
-  )
-}
 
 const CreateClassroomPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
@@ -397,7 +316,6 @@ const ClassesPage = () => {
   // non-owner can't read the service-token secret and would see a false
   // "failed" alert. Gate on ownership, not the broad teacher signal.
   const isOwner = membership?.role === "admin"
-  const [filter, setFilter] = useState<ClassFilter>("active")
 
   if (!org) {
     return <MissingParams message={t("classes.missingOrg")} />
@@ -445,19 +363,6 @@ const ClassesPage = () => {
                   </p>
                 </div>
               </div>
-
-              {isTeacher && classes.length > 0 && (
-                <div className="flex sm:self-end">
-                  <Link
-                    type="button"
-                    to="/$org/classes/new"
-                    params={{ org }}
-                    className="btn btn-primary"
-                  >
-                    {t("classes.newClass")}
-                  </Link>
-                </div>
-              )}
             </div>
             {isStudent && !isMember && !loadingMembership && (
               <JoinOrgCard org={org} />
@@ -478,37 +383,8 @@ const ClassesPage = () => {
               {classes.length === 0 && isTeacher && (
                 <CreateClassroomPane org={org} />
               )}
-              {isTeacher && (
-                <>
-                  {classes.length > 0 && (
-                    <div className="mb-4 flex justify-end">
-                      <div role="tablist" className="tabs tabs-box tabs-sm">
-                        {(["active", "archived", "all"] as const).map((f) => (
-                          <button
-                            key={f}
-                            role="tab"
-                            type="button"
-                            className={`tab capitalize ${filter === f ? "tab-active" : ""}`}
-                            aria-selected={filter === f}
-                            onClick={() => setFilter(f)}
-                          >
-                            {t(`classes.filter.${f}`)}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  <div className="grid grid-cols-12 gap-4 mb-6">
-                    {classes.map((cl) => (
-                      <ClassCard
-                        key={cl.path}
-                        cl={cl}
-                        org={org}
-                        filter={filter}
-                      />
-                    ))}
-                  </div>
-                </>
+              {isTeacher && classes.length > 0 && (
+                <ClassroomList org={org} dirs={classes} />
               )}
               {isStudent && isMember && <OrgRepos org={org} />}
             </>

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -10,8 +10,12 @@ import { GitHubAPIError } from "@/hooks/github/errors"
 import type { GitHubFileListing } from "@/hooks/github/types"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetStudents from "@/hooks/useGetStudents"
-import type { ClassroomSummary } from "@/hooks/useClassroomSummaries"
+import {
+  classroomDisplayName,
+  type ClassroomSummary,
+} from "@/hooks/useClassroomSummaries"
 import { EnterDiv } from "@/lib/motionComponents"
+import { classroomConfigTreeUrl } from "@/util/orgUrl"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import {
@@ -35,9 +39,6 @@ type ClassroomCardProps = {
   // an async re-sort can't shift a different classroom under the open menu.
   onMenuOpenChange?: (open: boolean) => void
 }
-
-const classroomDisplayName = (summary: ClassroomSummary, unknown: string) =>
-  summary.name || summary.short_name || summary.path || unknown
 
 // Student + assignment counts for a single visible card. Reuses the shared
 // roster/assignments caches. Assignment count coalesces to 0 (unlike students,
@@ -123,13 +124,9 @@ function ClassroomMenu({
   const name = classroomDisplayName(summary, t("classes.unknownClassName"))
   const archived = summary.archived
 
-  const setMenuOpen = (next: boolean) => {
-    setOpen(next)
-  }
-
   const menuRef = useRef<HTMLUListElement | null>(null)
 
-  // Close the menu; optionally return focus to the trigger (keyboard paths).
+  // Escape returns focus to the trigger; a plain close does not.
   const closeMenu = (returnFocus = false) => {
     setOpen(false)
     if (returnFocus) triggerRef.current?.focus()
@@ -231,21 +228,16 @@ function ClassroomMenu({
       if (ctx) queryClient.setQueryData(ctx.key, ctx.prev)
       notify({
         tone: "error",
-        message: archived
-          ? t("classes.unarchiveFailed", {
-              classroom: slug,
-              error:
-                err instanceof Error
-                  ? err.message
-                  : t("classes.somethingWentWrong"),
-            })
-          : t("classes.archiveFailed", {
-              classroom: slug,
-              error:
-                err instanceof Error
-                  ? err.message
-                  : t("classes.somethingWentWrong"),
-            }),
+        message: t(
+          archived ? "classes.unarchiveFailed" : "classes.archiveFailed",
+          {
+            classroom: slug,
+            error:
+              err instanceof Error
+                ? err.message
+                : t("classes.somethingWentWrong"),
+          },
+        ),
       })
     },
     onSuccess: (_r, active) => {
@@ -332,7 +324,7 @@ function ClassroomMenu({
         aria-label={t("classes.card.actionsAria", { name })}
         onClick={(e) => {
           e.stopPropagation()
-          setMenuOpen(!open)
+          setOpen(!open)
         }}
         onKeyDown={(e) => {
           if (e.key === "ArrowDown" || e.key === "ArrowUp") {
@@ -388,7 +380,7 @@ function ClassroomMenu({
             <a
               role="menuitem"
               tabIndex={-1}
-              href={`https://github.com/${org}/classroom50/tree/main/${slug}`}
+              href={classroomConfigTreeUrl(org, slug)}
               target="_blank"
               rel="noreferrer"
               className={menuItem}
@@ -440,7 +432,6 @@ function ClassroomMenu({
         }
         confirmLabel={archived ? t("classes.unarchive") : t("classes.archive")}
         cancelLabel={t("common.cancel")}
-        confirmText=""
         needsConfirm={false}
         dangerous={false}
         onConfirm={async () => {

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -6,6 +6,7 @@ import { ConfirmModal } from "@/components/modals"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { githubKeys } from "@/hooks/github/queries"
+import { GitHubAPIError } from "@/hooks/github/errors"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetStudents from "@/hooks/useGetStudents"
 import type { ClassroomSummary } from "@/hooks/useClassroomSummaries"
@@ -47,12 +48,17 @@ function useCardCounts(org: string, classroom: string) {
     classroom,
   )
   const assignmentsQuery = useGetClassroomAssignments(org, classroom)
+  // A missing assignments.json 404s (a brand-new classroom has none), which is
+  // the normal zero case — not a failure. Only a non-404 error is "unavailable".
+  const assignmentsNotFound =
+    assignmentsQuery.error instanceof GitHubAPIError &&
+    assignmentsQuery.error.status === 404
   return {
     studentCount: studentsLoading ? undefined : students.length,
     assignmentCount: assignmentsQuery.isPending
       ? undefined
       : (assignmentsQuery.data?.assignments.length ?? 0),
-    assignmentsError: assignmentsQuery.isError,
+    assignmentsError: assignmentsQuery.isError && !assignmentsNotFound,
   }
 }
 

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -127,6 +127,14 @@ function ClassroomMenu({
     setOpen(next)
   }
 
+  const menuRef = useRef<HTMLUListElement | null>(null)
+
+  // Close the menu; optionally return focus to the trigger (keyboard paths).
+  const closeMenu = (returnFocus = false) => {
+    setOpen(false)
+    if (returnFocus) triggerRef.current?.focus()
+  }
+
   // Hold the parent's list order frozen while this card is "busy" — the menu is
   // open OR a destructive confirm modal is open — so an async re-sort (e.g. a
   // roster resolving under the student-count sort) can't reshuffle the list out
@@ -136,17 +144,23 @@ function ClassroomMenu({
     onMenuOpenChange?.(open || archiveOpen || deleteOpen)
   }, [open, archiveOpen, deleteOpen, onMenuOpenChange])
 
-  // Escape + outside-click close; return focus to the trigger on Escape.
+  // On open, move focus into the menu (first item), per the WAI-ARIA menu
+  // button pattern.
+  useEffect(() => {
+    if (!open) return
+    const first =
+      menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')
+    first?.focus()
+  }, [open])
+
+  // Escape + outside-click close; Escape returns focus to the trigger.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setMenuOpen(false)
-        triggerRef.current?.focus()
-      }
+      if (e.key === "Escape") closeMenu(true)
     }
     const onClick = (e: MouseEvent) => {
-      if (!containerRef.current?.contains(e.target as Node)) setMenuOpen(false)
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
     }
     document.addEventListener("keydown", onKey)
     document.addEventListener("mousedown", onClick)
@@ -155,6 +169,38 @@ function ClassroomMenu({
       document.removeEventListener("mousedown", onClick)
     }
   }, [open])
+
+  // Arrow/Home/End roving between menu items (WAI-ARIA menu keyboard model).
+  const onMenuKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
+    )
+    if (items.length === 0) return
+    const current = items.indexOf(document.activeElement as HTMLElement)
+    let next: number
+    switch (e.key) {
+      case "ArrowDown":
+        next = current < 0 ? 0 : (current + 1) % items.length
+        break
+      case "ArrowUp":
+        next = current <= 0 ? items.length - 1 : current - 1
+        break
+      case "Home":
+        next = 0
+        break
+      case "End":
+        next = items.length - 1
+        break
+      case "Tab":
+        // Tabbing out closes the menu (focus leaves), matching native menus.
+        setOpen(false)
+        return
+      default:
+        return
+    }
+    e.preventDefault()
+    items[next]?.focus()
+  }
 
   const archiveMutation = useMutation({
     mutationFn: (active: boolean) =>
@@ -288,6 +334,12 @@ function ClassroomMenu({
           e.stopPropagation()
           setMenuOpen(!open)
         }}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+            e.preventDefault()
+            setOpen(true)
+          }
+        }}
       >
         <MoreVertical aria-hidden="true" className="size-4" />
       </button>
@@ -295,15 +347,19 @@ function ClassroomMenu({
       {open && (
         <ul
           id={menuId}
+          ref={menuRef}
           role="menu"
+          onKeyDown={onMenuKeyDown}
           className="absolute right-0 z-20 mt-1 w-52 overflow-hidden rounded-box border border-base-300 bg-base-100 py-1 shadow-lg"
         >
           <li role="none">
             <Link
               role="menuitem"
+              tabIndex={-1}
               to="/$org/$classroom/edit"
               params={{ org, classroom: slug }}
               className={menuItem}
+              onClick={() => closeMenu()}
             >
               <Pencil aria-hidden="true" className="size-4" />
               {t("classes.card.edit")}
@@ -313,9 +369,10 @@ function ClassroomMenu({
             <button
               type="button"
               role="menuitem"
+              tabIndex={-1}
               className={menuItem}
               onClick={() => {
-                setMenuOpen(false)
+                closeMenu()
                 setArchiveOpen(true)
               }}
             >
@@ -330,10 +387,12 @@ function ClassroomMenu({
           <li role="none">
             <a
               role="menuitem"
+              tabIndex={-1}
               href={`https://github.com/${org}/classroom50/tree/main/${slug}`}
               target="_blank"
               rel="noreferrer"
               className={menuItem}
+              onClick={() => closeMenu()}
             >
               <ExternalLink aria-hidden="true" className="size-4" />
               {t("classes.card.viewOnGitHub")}
@@ -343,9 +402,10 @@ function ClassroomMenu({
             <button
               type="button"
               role="menuitem"
+              tabIndex={-1}
               className={`${menuItem} text-error`}
               onClick={() => {
-                setMenuOpen(false)
+                closeMenu()
                 setDeleteOpen(true)
               }}
             >

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -1,0 +1,506 @@
+import {
+  deleteClassroom,
+  editClassroomWithConflictRetry,
+} from "@/api/mutations/classrooms"
+import { ConfirmModal } from "@/components/modals"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import { githubKeys } from "@/hooks/github/queries"
+import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
+import useGetStudents from "@/hooks/useGetStudents"
+import type { ClassroomSummary } from "@/hooks/useClassroomSummaries"
+import { EnterDiv } from "@/lib/motionComponents"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import {
+  Archive,
+  ArchiveRestore,
+  BookText,
+  ExternalLink,
+  MoreVertical,
+  Pencil,
+  Trash2,
+  UsersRound,
+} from "lucide-react"
+import { useEffect, useId, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+type ClassroomCardProps = {
+  summary: ClassroomSummary
+  org: string
+  canManage: boolean
+  // Notify the parent to hold list order stable while a card's menu is open, so
+  // an async re-sort can't shift a different classroom under the open menu.
+  onMenuOpenChange?: (open: boolean) => void
+}
+
+const classroomDisplayName = (summary: ClassroomSummary, unknown: string) =>
+  summary.name || summary.short_name || summary.path || unknown
+
+// Student + assignment counts for a single visible card. Reuses the shared
+// roster/assignments caches. Assignment count coalesces to 0 (unlike students,
+// useGetClassroomAssignments does not pre-default and 404s for a classroom with
+// no assignments.json); error surfaces as a null so the caller can show "—".
+function useCardCounts(org: string, classroom: string) {
+  const { students, isLoading: studentsLoading } = useGetStudents(
+    org,
+    classroom,
+  )
+  const assignmentsQuery = useGetClassroomAssignments(org, classroom)
+  return {
+    studentCount: studentsLoading ? undefined : students.length,
+    assignmentCount: assignmentsQuery.isPending
+      ? undefined
+      : (assignmentsQuery.data?.assignments.length ?? 0),
+    assignmentsError: assignmentsQuery.isError,
+  }
+}
+
+function CountStat({
+  icon,
+  loading,
+  label,
+}: {
+  icon: React.ReactNode
+  loading: boolean
+  label: string
+}) {
+  return (
+    <span className="flex items-center gap-1.5 text-sm text-base-content/70">
+      {icon}
+      {loading ? (
+        <span
+          className="skeleton skeleton-shimmer inline-block h-4 w-16 align-middle"
+          aria-hidden="true"
+        />
+      ) : (
+        label
+      )}
+    </span>
+  )
+}
+
+// The kebab actions menu: Edit (link), Archive/Unarchive (inline, optimistic +
+// rollback), Delete (type-to-confirm, stays on list, surfaces teamDeleteWarning),
+// View on GitHub. Accessible menu semantics with Escape + outside-click close
+// and focus return to the trigger.
+function ClassroomMenu({
+  summary,
+  org,
+  onMenuOpenChange,
+}: {
+  summary: ClassroomSummary
+  org: string
+  onMenuOpenChange?: (open: boolean) => void
+}) {
+  const { t } = useTranslation()
+  const client = useGitHubClient()
+  const { notify } = useToast()
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [archiveOpen, setArchiveOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const menuId = useId()
+
+  const slug = summary.path
+  const name = classroomDisplayName(summary, t("classes.unknownClassName"))
+  const archived = summary.archived
+
+  const setMenuOpen = (next: boolean) => {
+    setOpen(next)
+    onMenuOpenChange?.(next)
+  }
+
+  // Escape + outside-click close; return focus to the trigger on Escape.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    const onClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setMenuOpen(false)
+    }
+    document.addEventListener("keydown", onKey)
+    document.addEventListener("mousedown", onClick)
+    return () => {
+      document.removeEventListener("keydown", onKey)
+      document.removeEventListener("mousedown", onClick)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  const archiveMutation = useMutation({
+    mutationFn: (active: boolean) =>
+      editClassroomWithConflictRetry(client, { org, slug, active }),
+    onMutate: (active: boolean) => {
+      const key = githubKeys.jsonFile(
+        org,
+        "classroom50",
+        `${slug}/classroom.json`,
+      )
+      const prev = queryClient.getQueryData(key)
+      // Optimistically flip the cached active so the card repartitions at once.
+      queryClient.setQueryData(
+        key,
+        (current: Record<string, unknown> | undefined) =>
+          current ? { ...current, active } : current,
+      )
+      // Do NOT invalidate this exact key (GitHub contents is read-after-write
+      // eventual). Repartition the list via the list-level key instead.
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(org, "classroom50"),
+      })
+      return { key, prev }
+    },
+    onError: (err, _active, ctx) => {
+      // Roll back the optimistic flip so a failed write can't strand the card
+      // in the wrong tab.
+      if (ctx) queryClient.setQueryData(ctx.key, ctx.prev)
+      notify({
+        tone: "error",
+        message: archived
+          ? t("classes.unarchiveFailed", {
+              classroom: slug,
+              error:
+                err instanceof Error
+                  ? err.message
+                  : t("classes.somethingWentWrong"),
+            })
+          : t("classes.archiveFailed", {
+              classroom: slug,
+              error:
+                err instanceof Error
+                  ? err.message
+                  : t("classes.somethingWentWrong"),
+            }),
+      })
+    },
+    onSuccess: (_r, active) => {
+      notify({
+        tone: "success",
+        durationMs: 5000,
+        message: active
+          ? t("classes.unarchivedToast", { classroom: slug })
+          : t("classes.archivedToast", { classroom: slug }),
+      })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteClassroom(client, { org, classroom: slug }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(org, "classroom50"),
+      })
+      // The list flow stays put (no navigate), so it is the natural place to
+      // finally surface the non-fatal team-cleanup warning that the edit page
+      // silently dropped.
+      if (result.teamDeleteWarning) {
+        notify({
+          tone: "warning",
+          message: t("classes.deleteTeamWarning", { classroom: slug }),
+        })
+      } else {
+        notify({
+          tone: "success",
+          durationMs: 5000,
+          message: t("classes.deletedToast", { classroom: slug }),
+        })
+      }
+    },
+    onError: (err) => {
+      notify({
+        tone: "error",
+        message: t("classes.deleteFailed", {
+          classroom: slug,
+          error:
+            err instanceof Error
+              ? err.message
+              : t("classes.somethingWentWrong"),
+        }),
+      })
+    },
+  })
+
+  const menuItem =
+    "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-base-200"
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="btn btn-ghost btn-sm btn-circle text-base-content/70 hover:text-primary"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        aria-label={t("classes.card.actionsAria", { name })}
+        onClick={(e) => {
+          e.stopPropagation()
+          setMenuOpen(!open)
+        }}
+      >
+        <MoreVertical aria-hidden="true" className="size-4" />
+      </button>
+
+      {open && (
+        <ul
+          id={menuId}
+          role="menu"
+          className="absolute right-0 z-20 mt-1 w-52 overflow-hidden rounded-box border border-base-300 bg-base-100 py-1 shadow-lg"
+        >
+          <li role="none">
+            <Link
+              role="menuitem"
+              to="/$org/$classroom/edit"
+              params={{ org, classroom: slug }}
+              className={menuItem}
+            >
+              <Pencil aria-hidden="true" className="size-4" />
+              {t("classes.card.edit")}
+            </Link>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className={menuItem}
+              onClick={() => {
+                setMenuOpen(false)
+                setArchiveOpen(true)
+              }}
+            >
+              {archived ? (
+                <ArchiveRestore aria-hidden="true" className="size-4" />
+              ) : (
+                <Archive aria-hidden="true" className="size-4" />
+              )}
+              {archived ? t("classes.unarchive") : t("classes.archive")}
+            </button>
+          </li>
+          <li role="none">
+            <a
+              role="menuitem"
+              href={`https://github.com/${org}/classroom50/tree/main/${slug}`}
+              target="_blank"
+              rel="noreferrer"
+              className={menuItem}
+            >
+              <ExternalLink aria-hidden="true" className="size-4" />
+              {t("classes.card.viewOnGitHub")}
+            </a>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className={`${menuItem} text-error`}
+              onClick={() => {
+                setMenuOpen(false)
+                setDeleteOpen(true)
+              }}
+            >
+              <Trash2 aria-hidden="true" className="size-4" />
+              {t("classes.deleteClassroomAria")}
+            </button>
+          </li>
+        </ul>
+      )}
+
+      <ConfirmModal
+        open={archiveOpen}
+        title={
+          archived
+            ? t("classes.unarchiveConfirmTitle")
+            : t("classes.archiveConfirmTitle")
+        }
+        description={
+          archived ? (
+            <>
+              {t("classes.unarchiveBody_prefix")}{" "}
+              <span className="font-semibold text-base-content">{slug}</span>{" "}
+              {t("classes.unarchiveBody_suffix")}
+            </>
+          ) : (
+            <>
+              {t("classes.archiveBody_prefix")}{" "}
+              <span className="font-semibold text-base-content">{slug}</span>
+              {t("classes.archiveBody_suffix")}
+            </>
+          )
+        }
+        confirmLabel={archived ? t("classes.unarchive") : t("classes.archive")}
+        cancelLabel={t("common.cancel")}
+        confirmText=""
+        needsConfirm={false}
+        dangerous={false}
+        onConfirm={async () => {
+          await archiveMutation.mutateAsync(archived)
+        }}
+        onClose={() => setArchiveOpen(false)}
+      />
+
+      <ConfirmModal
+        open={deleteOpen}
+        title={t("classes.deleteClassroomTitle")}
+        description={
+          <>
+            {t("classes.deleteClassroomBody_1")}{" "}
+            <span className="font-semibold text-base-content">{slug}</span>{" "}
+            {t("classes.deleteClassroomBody_2")}{" "}
+            <span className="font-semibold text-base-content">{org}</span>{" "}
+            {t("classes.deleteClassroomBody_3")}
+          </>
+        }
+        confirmText={`${org}/${slug}`}
+        confirmLabel={t("classes.deleteClassroomConfirm")}
+        cancelLabel={t("classes.deleteClassroomCancel")}
+        dangerous
+        onConfirm={async () => {
+          await deleteMutation.mutateAsync()
+        }}
+        onClose={() => setDeleteOpen(false)}
+      />
+    </div>
+  )
+}
+
+function ClassroomBadges({ summary }: { summary: ClassroomSummary }) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-2">
+      <span className="badge badge-soft badge-primary">
+        {summary.term || t("classes.noTermSpecified")}
+      </span>
+      {summary.archived && (
+        <span className="badge badge-soft badge-neutral">
+          {t("classes.archived")}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function ClassroomStats({ org, slug }: { org: string; slug: string }) {
+  const { t } = useTranslation()
+  const { studentCount, assignmentCount, assignmentsError } = useCardCounts(
+    org,
+    slug,
+  )
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+      <CountStat
+        icon={<UsersRound aria-hidden="true" className="size-4" />}
+        loading={studentCount === undefined}
+        label={
+          studentCount === 0
+            ? t("classes.noStudents")
+            : t("classes.studentCount", { count: studentCount ?? 0 })
+        }
+      />
+      <CountStat
+        icon={<BookText aria-hidden="true" className="size-4" />}
+        loading={assignmentCount === undefined && !assignmentsError}
+        label={
+          assignmentsError
+            ? t("classes.card.countsUnavailable")
+            : assignmentCount === 0
+              ? t("classes.card.noAssignments")
+              : t("classes.card.assignmentCount", {
+                  count: assignmentCount ?? 0,
+                })
+        }
+      />
+    </div>
+  )
+}
+
+function ViewAssignmentsButton({
+  org,
+  slug,
+  block,
+}: {
+  org: string
+  slug: string
+  block?: boolean
+}) {
+  const { t } = useTranslation()
+  return (
+    <Link
+      type="button"
+      to="/$org/$classroom/assignments"
+      params={{ org, classroom: slug }}
+      className={`btn btn-outline btn-primary btn-sm ${block ? "w-full" : ""}`}
+    >
+      <BookText aria-hidden="true" className="size-4" />
+      {t("classes.viewAssignments")}
+    </Link>
+  )
+}
+
+export function ClassroomCard({
+  summary,
+  org,
+  canManage,
+  onMenuOpenChange,
+}: ClassroomCardProps) {
+  const { t } = useTranslation()
+  const name = classroomDisplayName(summary, t("classes.unknownClassName"))
+
+  return (
+    <EnterDiv className="card bg-base-100 col-span-12 rounded-xl border border-base-300 md:col-span-6 xl:col-span-4">
+      <div className="card-body gap-4">
+        <div className="flex items-start justify-between gap-2">
+          <ClassroomBadges summary={summary} />
+          {canManage && (
+            <ClassroomMenu
+              summary={summary}
+              org={org}
+              onMenuOpenChange={onMenuOpenChange}
+            />
+          )}
+        </div>
+        <h2 className="truncate text-xl font-semibold">{name}</h2>
+        <ClassroomStats org={org} slug={summary.path} />
+        <ViewAssignmentsButton org={org} slug={summary.path} block />
+      </div>
+    </EnterDiv>
+  )
+}
+
+export function ClassroomRow({
+  summary,
+  org,
+  canManage,
+  onMenuOpenChange,
+}: ClassroomCardProps) {
+  const { t } = useTranslation()
+  const name = classroomDisplayName(summary, t("classes.unknownClassName"))
+
+  return (
+    <EnterDiv className="col-span-12 flex flex-col gap-3 rounded-xl border border-base-300 bg-base-100 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-semibold">{name}</span>
+          <ClassroomBadges summary={summary} />
+        </div>
+        <ClassroomStats org={org} slug={summary.path} />
+      </div>
+      <div className="flex shrink-0 items-center justify-end gap-2">
+        <ViewAssignmentsButton org={org} slug={summary.path} />
+        {canManage && (
+          <ClassroomMenu
+            summary={summary}
+            org={org}
+            onMenuOpenChange={onMenuOpenChange}
+          />
+        )}
+      </div>
+    </EnterDiv>
+  )
+}

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -7,6 +7,7 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { githubKeys } from "@/hooks/github/queries"
 import { GitHubAPIError } from "@/hooks/github/errors"
+import type { GitHubFileListing } from "@/hooks/github/types"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetStudents from "@/hooks/useGetStudents"
 import type { ClassroomSummary } from "@/hooks/useClassroomSummaries"
@@ -41,7 +42,8 @@ const classroomDisplayName = (summary: ClassroomSummary, unknown: string) =>
 // Student + assignment counts for a single visible card. Reuses the shared
 // roster/assignments caches. Assignment count coalesces to 0 (unlike students,
 // useGetClassroomAssignments does not pre-default and 404s for a classroom with
-// no assignments.json); error surfaces as a null so the caller can show "—".
+// no assignments.json); a non-404 error sets assignmentsError so the caller can
+// show "Counts unavailable".
 function useCardCounts(org: string, classroom: string) {
   const { students, isLoading: studentsLoading } = useGetStudents(
     org,
@@ -55,9 +57,11 @@ function useCardCounts(org: string, classroom: string) {
     assignmentsQuery.error.status === 404
   return {
     studentCount: studentsLoading ? undefined : students.length,
+    // Optional-chain `assignments` too: jsonFileQuery does no shape validation,
+    // so a file that parses without an `assignments` array must not throw.
     assignmentCount: assignmentsQuery.isPending
       ? undefined
-      : (assignmentsQuery.data?.assignments.length ?? 0),
+      : (assignmentsQuery.data?.assignments?.length ?? 0),
     assignmentsError: assignmentsQuery.isError && !assignmentsNotFound,
   }
 }
@@ -65,20 +69,25 @@ function useCardCounts(org: string, classroom: string) {
 function CountStat({
   icon,
   loading,
+  loadingLabel,
   label,
 }: {
   icon: React.ReactNode
   loading: boolean
+  loadingLabel: string
   label: string
 }) {
   return (
     <span className="flex items-center gap-1.5 text-sm text-base-content/70">
       {icon}
       {loading ? (
-        <span
-          className="skeleton skeleton-shimmer inline-block h-4 w-16 align-middle"
-          aria-hidden="true"
-        />
+        <>
+          <span
+            className="skeleton skeleton-shimmer inline-block h-4 w-16 align-middle"
+            aria-hidden="true"
+          />
+          <span className="sr-only">{loadingLabel}</span>
+        </>
       ) : (
         label
       )}
@@ -116,8 +125,16 @@ function ClassroomMenu({
 
   const setMenuOpen = (next: boolean) => {
     setOpen(next)
-    onMenuOpenChange?.(next)
   }
+
+  // Hold the parent's list order frozen while this card is "busy" — the menu is
+  // open OR a destructive confirm modal is open — so an async re-sort (e.g. a
+  // roster resolving under the student-count sort) can't reshuffle the list out
+  // from under an in-flight Archive/Delete. The menu closes before the modal
+  // opens, so gating on the menu alone would release the freeze mid-flow.
+  useEffect(() => {
+    onMenuOpenChange?.(open || archiveOpen || deleteOpen)
+  }, [open, archiveOpen, deleteOpen, onMenuOpenChange])
 
   // Escape + outside-click close; return focus to the trigger on Escape.
   useEffect(() => {
@@ -137,7 +154,6 @@ function ClassroomMenu({
       document.removeEventListener("keydown", onKey)
       document.removeEventListener("mousedown", onClick)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
   const archiveMutation = useMutation({
@@ -200,6 +216,28 @@ function ClassroomMenu({
   const deleteMutation = useMutation({
     mutationFn: () => deleteClassroom(client, { org, classroom: slug }),
     onSuccess: (result) => {
+      // deleteClassroom returns { deleted: false } as a no-op (e.g. the dir was
+      // already gone). Don't claim success in that case.
+      if (!result.deleted) {
+        notify({
+          tone: "warning",
+          message: t("classes.deleteNoop", { classroom: slug }),
+        })
+        queryClient.invalidateQueries({
+          queryKey: githubKeys.jsonFile(org, "classroom50"),
+        })
+        return
+      }
+      // Optimistically drop the dir from the cached listing so the card leaves
+      // at once — the Contents API is read-after-write eventual, so an immediate
+      // refetch can still return the just-deleted dir. Then invalidate to
+      // reconcile.
+      const listKey = githubKeys.jsonFile(org, "classroom50", "")
+      queryClient.setQueryData(
+        listKey,
+        (prev: GitHubFileListing[] | undefined) =>
+          prev ? prev.filter((entry) => entry.path !== slug) : prev,
+      )
       queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(org, "classroom50"),
       })
@@ -312,7 +350,7 @@ function ClassroomMenu({
               }}
             >
               <Trash2 aria-hidden="true" className="size-4" />
-              {t("classes.deleteClassroomAria")}
+              {t("classes.card.delete")}
             </button>
           </li>
         </ul>
@@ -403,6 +441,7 @@ function ClassroomStats({ org, slug }: { org: string; slug: string }) {
       <CountStat
         icon={<UsersRound aria-hidden="true" className="size-4" />}
         loading={studentCount === undefined}
+        loadingLabel={t("classes.card.loadingStudents")}
         label={
           studentCount === 0
             ? t("classes.noStudents")
@@ -412,6 +451,7 @@ function ClassroomStats({ org, slug }: { org: string; slug: string }) {
       <CountStat
         icon={<BookText aria-hidden="true" className="size-4" />}
         loading={assignmentCount === undefined && !assignmentsError}
+        loadingLabel={t("classes.card.loadingAssignments")}
         label={
           assignmentsError
             ? t("classes.card.countsUnavailable")

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -1,0 +1,248 @@
+import { Link } from "@tanstack/react-router"
+import { LayoutGrid, List as ListIcon, Plus, Search } from "lucide-react"
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import useClassroomSummaries, {
+  type ClassroomSummary,
+} from "@/hooks/useClassroomSummaries"
+import type { GitHubFileListing } from "@/hooks/github/types"
+import {
+  getStoredSortKey,
+  getStoredViewMode,
+  persistSortKey,
+  persistViewMode,
+  type ClassroomSortKey,
+  type ClassroomViewMode,
+} from "@/lib/classroomListPrefs"
+import { ClassroomCard, ClassroomRow } from "@/pages/classes/ClassroomCard"
+
+type ClassFilter = "active" | "archived" | "all"
+
+const SORT_OPTIONS: { key: ClassroomSortKey; labelKey: string }[] = [
+  { key: "name-asc", labelKey: "classes.toolbar.sort.nameAsc" },
+  { key: "term", labelKey: "classes.toolbar.sort.term" },
+  { key: "student-count", labelKey: "classes.toolbar.sort.studentCount" },
+]
+
+const displayName = (s: ClassroomSummary) =>
+  s.name || s.short_name || s.path || ""
+
+// New classroom directories carry only name/path until classroom.json resolves;
+// the summaries hook lifts term/active/counts so this list can filter, search,
+// and sort before rendering the cards.
+const ClassroomList = ({
+  org,
+  dirs,
+}: {
+  org: string
+  dirs: GitHubFileListing[]
+}) => {
+  const { t } = useTranslation()
+  const [viewMode, setViewMode] = useState<ClassroomViewMode>(getStoredViewMode)
+  const [sortKey, setSortKey] = useState<ClassroomSortKey>(getStoredSortKey)
+  const [filter, setFilter] = useState<ClassFilter>("active")
+  const [search, setSearch] = useState("")
+  // While any card's menu is open, freeze the rendered order so an async
+  // re-sort (e.g. a roster resolving under student-count sort) can't shift a
+  // different classroom under the open menu and mis-target a destructive click.
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  const changeView = (mode: ClassroomViewMode) => {
+    setViewMode(mode)
+    persistViewMode(mode)
+  }
+  const changeSort = (key: ClassroomSortKey) => {
+    setSortKey(key)
+    persistSortKey(key)
+  }
+
+  const summaries = useClassroomSummaries(
+    org,
+    dirs,
+    sortKey === "student-count",
+  )
+
+  const query = search.trim().toLowerCase()
+  const filtered = useMemo(
+    () =>
+      summaries.filter((s) => {
+        if (s.loading) return false
+        if (filter === "active" && s.archived) return false
+        if (filter === "archived" && !s.archived) return false
+        if (!query) return true
+        return (
+          displayName(s).toLowerCase().includes(query) ||
+          s.path.toLowerCase().includes(query) ||
+          (s.term ?? "").toLowerCase().includes(query)
+        )
+      }),
+    [summaries, filter, query],
+  )
+
+  const sorted = useMemo(() => {
+    const byName = (a: ClassroomSummary, b: ClassroomSummary) =>
+      displayName(a).localeCompare(displayName(b))
+    const list = [...filtered]
+    switch (sortKey) {
+      case "term":
+        return list.sort(
+          (a, b) => (a.term ?? "").localeCompare(b.term ?? "") || byName(a, b),
+        )
+      case "student-count":
+        // Known counts high-to-low; unresolved/unknown pinned to the bottom in
+        // stable name order so rows don't reshuffle as rosters resolve.
+        return list.sort((a, b) => {
+          const ca = a.studentCount
+          const cb = b.studentCount
+          if (ca !== undefined && cb !== undefined)
+            return cb - ca || byName(a, b)
+          if (ca !== undefined) return -1
+          if (cb !== undefined) return 1
+          return byName(a, b)
+        })
+      case "name-asc":
+      default:
+        return list.sort(byName)
+    }
+  }, [filtered, sortKey])
+
+  // Snapshot the order while a menu is open (see menuOpen above).
+  const [frozen, setFrozen] = useState<ClassroomSummary[] | null>(null)
+  const displayList = menuOpen && frozen ? frozen : sorted
+  const handleMenuOpenChange = (open: boolean) => {
+    setFrozen(open ? sorted : null)
+    setMenuOpen(open)
+  }
+
+  const anyResolved = summaries.some((s) => !s.loading)
+  const noResults = anyResolved && query.length > 0 && sorted.length === 0
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
+          <Search aria-hidden="true" className="size-4 text-base-content/50" />
+          <input
+            type="search"
+            className="grow"
+            placeholder={t("classes.toolbar.searchPlaceholder")}
+            aria-label={t("classes.toolbar.searchLabel")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <div
+            role="group"
+            aria-label={t("assignments.archived")}
+            className="join"
+          >
+            {(["active", "archived", "all"] as const).map((f) => (
+              <button
+                key={f}
+                type="button"
+                className={`btn btn-sm join-item ${filter === f ? "btn-active" : ""}`}
+                aria-pressed={filter === f}
+                onClick={() => setFilter(f)}
+              >
+                {t(`classes.filter.${f}`)}
+              </button>
+            ))}
+          </div>
+
+          <select
+            className="select select-bordered select-sm"
+            aria-label={t("classes.toolbar.sort.label")}
+            value={sortKey}
+            onChange={(e) => changeSort(e.target.value as ClassroomSortKey)}
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.key} value={opt.key}>
+                {t(opt.labelKey)}
+              </option>
+            ))}
+          </select>
+
+          <div
+            role="group"
+            aria-label={t("classes.toolbar.view.label")}
+            className="join"
+          >
+            <button
+              type="button"
+              className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
+              aria-label={t("classes.toolbar.view.gridLabel")}
+              aria-pressed={viewMode === "grid"}
+              onClick={() => changeView("grid")}
+            >
+              <LayoutGrid aria-hidden="true" className="size-4" />
+            </button>
+            <button
+              type="button"
+              className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
+              aria-label={t("classes.toolbar.view.listLabel")}
+              aria-pressed={viewMode === "list"}
+              onClick={() => changeView("list")}
+            >
+              <ListIcon aria-hidden="true" className="size-4" />
+            </button>
+          </div>
+
+          <Link
+            to="/$org/classes/new"
+            params={{ org }}
+            type="button"
+            className="btn btn-primary btn-sm"
+          >
+            <Plus aria-hidden="true" className="size-4" />
+            {t("classes.newClass")}
+          </Link>
+        </div>
+      </div>
+
+      {noResults ? (
+        <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
+          <h2 className="text-lg font-semibold">
+            {t("classes.noResults.title")}
+          </h2>
+          <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+            {t("classes.noResults.body", { query: search.trim() })}
+          </p>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm mt-4"
+            onClick={() => setSearch("")}
+          >
+            {t("classes.noResults.clear")}
+          </button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-12 gap-4">
+          {displayList.map((summary) =>
+            viewMode === "grid" ? (
+              <ClassroomCard
+                key={summary.path}
+                summary={summary}
+                org={org}
+                canManage
+                onMenuOpenChange={handleMenuOpenChange}
+              />
+            ) : (
+              <ClassroomRow
+                key={summary.path}
+                summary={summary}
+                org={org}
+                canManage
+                onMenuOpenChange={handleMenuOpenChange}
+              />
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ClassroomList

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -117,6 +117,7 @@ const ClassroomList = ({
 
   const anyResolved = summaries.some((s) => !s.loading)
   const noResults = anyResolved && query.length > 0 && sorted.length === 0
+  const emptyFilter = anyResolved && query.length === 0 && sorted.length === 0
 
   return (
     <div className="space-y-4">
@@ -136,7 +137,7 @@ const ClassroomList = ({
         <div className="flex flex-wrap items-center gap-3">
           <div
             role="group"
-            aria-label={t("assignments.archived")}
+            aria-label={t("classes.filter.label")}
             className="join"
           >
             {(["active", "archived", "all"] as const).map((f) => (
@@ -217,6 +218,12 @@ const ClassroomList = ({
           >
             {t("classes.noResults.clear")}
           </button>
+        </div>
+      ) : emptyFilter ? (
+        <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
+          <p className="text-sm text-base-content/70">
+            {t(`classes.emptyFilter.${filter}`)}
+          </p>
         </div>
       ) : (
         <div className="grid grid-cols-12 gap-4">

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router"
 import { LayoutGrid, List as ListIcon, Plus, Search } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import useClassroomSummaries, {
@@ -44,10 +44,6 @@ const ClassroomList = ({
   const [filter, setFilter] = useState<ClassFilter>("active")
   const [termFilter, setTermFilter] = useState<string>("all")
   const [search, setSearch] = useState("")
-  // While any card's menu is open, freeze the rendered order so an async
-  // re-sort (e.g. a roster resolving under student-count sort) can't shift a
-  // different classroom under the open menu and mis-target a destructive click.
-  const [menuOpen, setMenuOpen] = useState(false)
 
   const changeView = (mode: ClassroomViewMode) => {
     setViewMode(mode)
@@ -126,13 +122,20 @@ const ClassroomList = ({
     }
   }, [filtered, sortKey])
 
-  // Snapshot the order while a menu is open (see menuOpen above).
+  // While a card is "busy" (its menu or a destructive confirm modal is open),
+  // freeze the rendered order so an async re-sort (e.g. a roster resolving under
+  // the student-count sort) can't reshuffle the list under an in-flight action.
+  // A ref holds the latest sorted list so the callback can stay stable (a
+  // changing callback identity would re-fire the child's effect every render).
   const [frozen, setFrozen] = useState<ClassroomSummary[] | null>(null)
-  const displayList = menuOpen && frozen ? frozen : sorted
-  const handleMenuOpenChange = (open: boolean) => {
-    setFrozen(open ? sorted : null)
-    setMenuOpen(open)
-  }
+  const sortedRef = useRef(sorted)
+  useEffect(() => {
+    sortedRef.current = sorted
+  }, [sorted])
+  const displayList = frozen ?? sorted
+  const handleMenuOpenChange = useCallback((busy: boolean) => {
+    setFrozen(busy ? sortedRef.current : null)
+  }, [])
 
   const anyResolved = summaries.some((s) => !s.loading)
   const noResults = anyResolved && query.length > 0 && sorted.length === 0

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import useClassroomSummaries, {
+  classroomDisplayName,
   type ClassroomSummary,
 } from "@/hooks/useClassroomSummaries"
 import type { GitHubFileListing } from "@/hooks/github/types"
@@ -24,9 +25,6 @@ const SORT_OPTIONS: { key: ClassroomSortKey; labelKey: string }[] = [
   { key: "term", labelKey: "classes.toolbar.sort.term" },
   { key: "student-count", labelKey: "classes.toolbar.sort.studentCount" },
 ]
-
-const displayName = (s: ClassroomSummary) =>
-  s.name || s.short_name || s.path || ""
 
 // New classroom directories carry only name/path until classroom.json resolves;
 // the summaries hook lifts term/active/counts so this list can filter, search,
@@ -87,7 +85,7 @@ const ClassroomList = ({
           return false
         if (!query) return true
         return (
-          displayName(s).toLowerCase().includes(query) ||
+          classroomDisplayName(s).toLowerCase().includes(query) ||
           s.path.toLowerCase().includes(query) ||
           (s.term ?? "").toLowerCase().includes(query)
         )
@@ -97,7 +95,7 @@ const ClassroomList = ({
 
   const sorted = useMemo(() => {
     const byName = (a: ClassroomSummary, b: ClassroomSummary) =>
-      displayName(a).localeCompare(displayName(b))
+      classroomDisplayName(a).localeCompare(classroomDisplayName(b))
     const list = [...filtered]
     switch (sortKey) {
       case "term":

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -42,6 +42,7 @@ const ClassroomList = ({
   const [viewMode, setViewMode] = useState<ClassroomViewMode>(getStoredViewMode)
   const [sortKey, setSortKey] = useState<ClassroomSortKey>(getStoredSortKey)
   const [filter, setFilter] = useState<ClassFilter>("active")
+  const [termFilter, setTermFilter] = useState<string>("all")
   const [search, setSearch] = useState("")
   // While any card's menu is open, freeze the rendered order so an async
   // re-sort (e.g. a roster resolving under student-count sort) can't shift a
@@ -63,6 +64,22 @@ const ClassroomList = ({
     sortKey === "student-count",
   )
 
+  // Distinct non-empty terms across the (resolved) classrooms, for the term
+  // filter. Only offered when a teacher actually uses terms on 2+ of them.
+  const terms = useMemo(() => {
+    const set = new Set<string>()
+    for (const s of summaries) {
+      const term = s.term?.trim()
+      if (term) set.add(term)
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b))
+  }, [summaries])
+  const showTermFilter = terms.length > 1
+  // Guard against a stale selection when the available terms change (e.g. the
+  // last classroom of a term is deleted): fall back to "all".
+  const activeTerm =
+    termFilter !== "all" && !terms.includes(termFilter) ? "all" : termFilter
+
   const query = search.trim().toLowerCase()
   const filtered = useMemo(
     () =>
@@ -70,6 +87,8 @@ const ClassroomList = ({
         if (s.loading) return false
         if (filter === "active" && s.archived) return false
         if (filter === "archived" && !s.archived) return false
+        if (activeTerm !== "all" && (s.term?.trim() ?? "") !== activeTerm)
+          return false
         if (!query) return true
         return (
           displayName(s).toLowerCase().includes(query) ||
@@ -77,7 +96,7 @@ const ClassroomList = ({
           (s.term ?? "").toLowerCase().includes(query)
         )
       }),
-    [summaries, filter, query],
+    [summaries, filter, activeTerm, query],
   )
 
   const sorted = useMemo(() => {
@@ -121,8 +140,8 @@ const ClassroomList = ({
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border border-base-300 bg-base-100 p-2">
+        <label className="input input-sm input-bordered flex min-w-48 flex-1 items-center gap-2">
           <Search aria-hidden="true" className="size-4 text-base-content/50" />
           <input
             type="search"
@@ -134,27 +153,51 @@ const ClassroomList = ({
           />
         </label>
 
-        <div className="flex flex-wrap items-center gap-3">
-          <div
-            role="group"
-            aria-label={t("classes.filter.label")}
-            className="join"
-          >
-            {(["active", "archived", "all"] as const).map((f) => (
-              <button
-                key={f}
-                type="button"
-                className={`btn btn-sm join-item ${filter === f ? "btn-active" : ""}`}
-                aria-pressed={filter === f}
-                onClick={() => setFilter(f)}
-              >
-                {t(`classes.filter.${f}`)}
-              </button>
-            ))}
-          </div>
+        <div
+          role="group"
+          aria-label={t("classes.filter.label")}
+          className="join"
+        >
+          {(["active", "archived", "all"] as const).map((f) => (
+            <button
+              key={f}
+              type="button"
+              className={`btn btn-sm join-item ${filter === f ? "btn-active" : ""}`}
+              aria-pressed={filter === f}
+              onClick={() => setFilter(f)}
+            >
+              {t(`classes.filter.${f}`)}
+            </button>
+          ))}
+        </div>
 
+        {showTermFilter && (
+          <div className="join">
+            <span className="join-item flex items-center border border-base-300 bg-base-200 px-3 text-sm text-base-content/70">
+              {t("classes.toolbar.termPrefix")}
+            </span>
+            <select
+              className="select select-bordered select-sm join-item"
+              aria-label={t("classes.toolbar.termLabel")}
+              value={activeTerm}
+              onChange={(e) => setTermFilter(e.target.value)}
+            >
+              <option value="all">{t("classes.toolbar.allTerms")}</option>
+              {terms.map((term) => (
+                <option key={term} value={term}>
+                  {term}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="join">
+          <span className="join-item flex items-center border border-base-300 bg-base-200 px-3 text-sm text-base-content/70">
+            {t("classes.toolbar.sortPrefix")}
+          </span>
           <select
-            className="select select-bordered select-sm"
+            className="select select-bordered select-sm join-item"
             aria-label={t("classes.toolbar.sort.label")}
             value={sortKey}
             onChange={(e) => changeSort(e.target.value as ClassroomSortKey)}
@@ -165,42 +208,44 @@ const ClassroomList = ({
               </option>
             ))}
           </select>
-
-          <div
-            role="group"
-            aria-label={t("classes.toolbar.view.label")}
-            className="join"
-          >
-            <button
-              type="button"
-              className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
-              aria-label={t("classes.toolbar.view.gridLabel")}
-              aria-pressed={viewMode === "grid"}
-              onClick={() => changeView("grid")}
-            >
-              <LayoutGrid aria-hidden="true" className="size-4" />
-            </button>
-            <button
-              type="button"
-              className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
-              aria-label={t("classes.toolbar.view.listLabel")}
-              aria-pressed={viewMode === "list"}
-              onClick={() => changeView("list")}
-            >
-              <ListIcon aria-hidden="true" className="size-4" />
-            </button>
-          </div>
-
-          <Link
-            to="/$org/classes/new"
-            params={{ org }}
-            type="button"
-            className="btn btn-primary btn-sm"
-          >
-            <Plus aria-hidden="true" className="size-4" />
-            {t("classes.newClass")}
-          </Link>
         </div>
+
+        <div
+          role="group"
+          aria-label={t("classes.toolbar.view.label")}
+          className="join"
+        >
+          <button
+            type="button"
+            className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
+            aria-label={t("classes.toolbar.view.gridLabel")}
+            aria-pressed={viewMode === "grid"}
+            onClick={() => changeView("grid")}
+          >
+            <LayoutGrid aria-hidden="true" className="size-4" />
+          </button>
+          <button
+            type="button"
+            className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
+            aria-label={t("classes.toolbar.view.listLabel")}
+            aria-pressed={viewMode === "list"}
+            onClick={() => changeView("list")}
+          >
+            <ListIcon aria-hidden="true" className="size-4" />
+          </button>
+        </div>
+
+        <div className="mx-1 hidden h-6 w-px self-center bg-base-300 sm:block" />
+
+        <Link
+          to="/$org/classes/new"
+          params={{ org }}
+          type="button"
+          className="btn btn-primary btn-sm"
+        >
+          <Plus aria-hidden="true" className="size-4" />
+          {t("classes.newClass")}
+        </Link>
       </div>
 
       {noResults ? (

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -13,6 +13,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { Archive, ArchiveRestore, Trash2 } from "lucide-react"
 import { GitHubLink } from "@/components/GitHubLink"
+import { classroomConfigTreeUrl } from "@/util/orgUrl"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { isClassroomArchived, type Classroom } from "@/types/classroom"
@@ -291,7 +292,7 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
           <div className="flex items-center gap-3 pb-4">
             <h3 className="text-lg font-bold">{t("classes.form.basicInfo")}</h3>
             <GitHubLink
-              href={`https://github.com/${org}/classroom50/tree/main/${classroom}`}
+              href={classroomConfigTreeUrl(org, classroom)}
               label={t("classes.configRepo")}
               title={t("classes.configRepoTitle")}
             />

--- a/web/src/util/orgUrl.ts
+++ b/web/src/util/orgUrl.ts
@@ -9,6 +9,10 @@ export const githubOrgPeopleUrl = (org: string): string =>
 export const githubOrgSettingsUrl = (org: string): string =>
   `https://github.com/organizations/${org}/settings/profile`
 
+// The private config repo's directory for a classroom slug.
+export const classroomConfigTreeUrl = (org: string, slug: string): string =>
+  `https://github.com/${org}/classroom50/tree/main/${slug}`
+
 // An assignment's starter-code (template) repo. Built from `template.owner`, not
 // the classroom org — a template can live under a different owner. Deep-links to
 // the stored branch when one is set.


### PR DESCRIPTION
## Summary

Redesigns the teacher classroom list (`web/src/pages/ClassesPage.tsx`, `/$org`) from a sparse 2-up grid into a polished, controllable list, adapting the org-homepage foundation from #154. Delivered in one PR across reviewable commits.

- **Rename to "My Classrooms"** — the app already calls every entity a "Classroom", so the collection strings (header, sidebar, breadcrumb, tab title, New classroom button) are renamed for consistency; also fixes the class-card edit tooltip that read "Edit assignment".
- **Unified toolbar** — a single bordered bar holds search (flexes to fill), an Active/Archived/All status filter, an optional term filter, a sort dropdown, a grid/list view toggle, and the New classroom button. The term and sort dropdowns are inline-labeled ("Term:" / "Sort:") so it's clear which filters and which sorts. View + sort persist to localStorage.
- **Term filter** — lists the distinct terms a teacher actually used (shown only when 2+ exist) and composes with status + search; falls back to "All terms" if the selected term's last classroom is deleted.
- **Richer cards** — denser 3-up `ClassroomCard` + a compact `ClassroomRow`, each showing term/archived badges, name, and **student + assignment counts** (with loading/zero/error states), a primary "View Assignments" action, and a kebab actions menu.
- **Card actions** — Edit, Archive/Unarchive, Delete, and View on GitHub from the kebab. Archive flips the cache optimistically and rolls back on failure; Delete uses type-to-confirm, stays on the list, and surfaces the previously-dropped GitHub team-cleanup warning. List order freezes while a card menu is open so an async re-sort can't mis-target a destructive action.

## Architecture

Classrooms are directories in the private `classroom50` config repo (no manifest), so a new `useClassroomSummaries` hook lifts each `classroom.json` to the parent (reusing `useGetClassroom`'s cache keys) so the list can filter/search/sort before render, with defined missing/404 handling. Roster fetches are gated behind the student-count sort. A shared `createListPrefs` factory now backs both the org and classroom list preferences (the org-specific last-modified guard stays in its caller). The config-repo tree deep-link lives in `util/orgUrl.ts` (`classroomConfigTreeUrl`), shared with `EditClassroomForm`.

## Review

A multi-persona doc review shaped the plan (phasing, destructive-action contracts) and a code review of the branch found one P1 (missing `assignments.json` mislabeled as "Counts unavailable" instead of "No Assignments") plus two P2s (filter aria-label, filter empty state) — all fixed. No P0/P1 remaining. Deferred P3: full APG arrow-key nav in the kebab menu (menu is otherwise keyboard-accessible).

A final behavior-preserving simplification pass then deduped the shared display-name helper, collapsed the archive/unarchive error toast, and dropped a pass-through setter, a default-valued prop, and a couple of narration comments.

Closes #155.

## Test plan

- [x] `npm run check` green (tsc + eslint + prettier + 773 tests)
- [x] i18n audit MISSING-gate passes; no dead `classes.*` keys
- [ ] Manual: teacher list renders with student + assignment counts; search/status-filter/term-filter/sort/view all work and persist; term filter appears only with 2+ terms; archive rolls back on failure; delete stays on the list and surfaces the team warning; kebab menu keyboard/Escape/focus-return; student view and owner preflight unchanged; rename consistent in nav/header/breadcrumb/tab title