### PR TITLE
refactor(web): share list toolbar chrome across org and classroom lists

### DIFF
--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -1,0 +1,72 @@
+// Shared list-page chrome reused by the org homepage and the My Classrooms
+// list. Labels are passed in (already run through t()) so each page keeps its
+// own i18n namespace while sharing the markup and behavior.
+
+import { LayoutGrid, List as ListIcon } from "lucide-react"
+
+export type ListViewMode = "grid" | "list"
+
+export function ViewToggle({
+  viewMode,
+  onChange,
+  groupLabel,
+  gridLabel,
+  listLabel,
+}: {
+  viewMode: ListViewMode
+  onChange: (mode: ListViewMode) => void
+  groupLabel: string
+  gridLabel: string
+  listLabel: string
+}) {
+  return (
+    <div role="group" aria-label={groupLabel} className="join">
+      <button
+        type="button"
+        className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
+        aria-label={gridLabel}
+        aria-pressed={viewMode === "grid"}
+        onClick={() => onChange("grid")}
+      >
+        <LayoutGrid aria-hidden="true" className="size-4" />
+      </button>
+      <button
+        type="button"
+        className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
+        aria-label={listLabel}
+        aria-pressed={viewMode === "list"}
+        onClick={() => onChange("list")}
+      >
+        <ListIcon aria-hidden="true" className="size-4" />
+      </button>
+    </div>
+  )
+}
+
+export function NoSearchResults({
+  title,
+  body,
+  clearLabel,
+  onClear,
+}: {
+  title: string
+  body: string
+  clearLabel: string
+  onClear: () => void
+}) {
+  return (
+    <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+        {body}
+      </p>
+      <button
+        type="button"
+        className="btn btn-ghost btn-sm mt-4"
+        onClick={onClear}
+      >
+        {clearLabel}
+      </button>
+    </div>
+  )
+}

--- a/web/src/lib/classroomListPrefs.ts
+++ b/web/src/lib/classroomListPrefs.ts
@@ -19,8 +19,3 @@ export const classroomListPrefs = createListPrefs<
   defaultView: "grid",
   defaultSort: "name-asc",
 })
-
-export const getStoredViewMode = classroomListPrefs.getStoredViewMode
-export const persistViewMode = classroomListPrefs.persistViewMode
-export const getStoredSortKey = classroomListPrefs.getStoredSortKey
-export const persistSortKey = classroomListPrefs.persistSortKey

--- a/web/src/lib/classroomListPrefs.ts
+++ b/web/src/lib/classroomListPrefs.ts
@@ -8,7 +8,10 @@ import { createListPrefs } from "@/lib/listPrefs"
 export type ClassroomViewMode = "grid" | "list"
 export type ClassroomSortKey = "name-asc" | "term" | "student-count"
 
-const prefs = createListPrefs<ClassroomViewMode, ClassroomSortKey>({
+export const classroomListPrefs = createListPrefs<
+  ClassroomViewMode,
+  ClassroomSortKey
+>({
   viewKey: "classrooms_view_mode",
   sortKey: "classrooms_sort_key",
   viewValues: ["grid", "list"],
@@ -17,7 +20,7 @@ const prefs = createListPrefs<ClassroomViewMode, ClassroomSortKey>({
   defaultSort: "name-asc",
 })
 
-export const getStoredViewMode = prefs.getStoredViewMode
-export const persistViewMode = prefs.persistViewMode
-export const getStoredSortKey = prefs.getStoredSortKey
-export const persistSortKey = prefs.persistSortKey
+export const getStoredViewMode = classroomListPrefs.getStoredViewMode
+export const persistViewMode = classroomListPrefs.persistViewMode
+export const getStoredSortKey = classroomListPrefs.getStoredSortKey
+export const persistSortKey = classroomListPrefs.persistSortKey

--- a/web/src/lib/listPrefs.ts
+++ b/web/src/lib/listPrefs.ts
@@ -3,6 +3,8 @@
 // React Query. Each list page instantiates its own accessor with its own
 // storage keys and allowed values via createListPrefs.
 
+import { useState } from "react"
+
 function canUseStorage() {
   return typeof window !== "undefined"
 }
@@ -58,4 +60,32 @@ export function createListPrefs<
     getStoredSortKey,
     persistSortKey,
   }
+}
+
+export type ListPrefs<
+  ViewMode extends string,
+  SortKey extends string,
+> = ReturnType<typeof createListPrefs<ViewMode, SortKey>>
+
+// Owns the view/sort UI state for a list page: seeds from storage on mount and
+// persists on change, so pages don't re-implement the setState-then-persist
+// wiring. Returns setters, not raw dispatchers, so callers can't set state
+// without persisting.
+export function useListPrefsState<
+  ViewMode extends string,
+  SortKey extends string,
+>(prefs: ListPrefs<ViewMode, SortKey>) {
+  const [viewMode, setViewMode] = useState<ViewMode>(prefs.getStoredViewMode)
+  const [sortKey, setSortKey] = useState<SortKey>(prefs.getStoredSortKey)
+
+  const changeView = (mode: ViewMode) => {
+    setViewMode(mode)
+    prefs.persistViewMode(mode)
+  }
+  const changeSort = (key: SortKey) => {
+    setSortKey(key)
+    prefs.persistSortKey(key)
+  }
+
+  return { viewMode, sortKey, changeView, changeSort }
 }

--- a/web/src/lib/orgListPrefs.ts
+++ b/web/src/lib/orgListPrefs.ts
@@ -20,8 +20,3 @@ export const orgListPrefs = createListPrefs<OrgViewMode, OrgSortKey>({
   sanitizeSortOnLoad: (sort, defaultSort) =>
     sort === "last-modified" ? defaultSort : sort,
 })
-
-export const getStoredViewMode = orgListPrefs.getStoredViewMode
-export const persistViewMode = orgListPrefs.persistViewMode
-export const getStoredSortKey = orgListPrefs.getStoredSortKey
-export const persistSortKey = orgListPrefs.persistSortKey

--- a/web/src/lib/orgListPrefs.ts
+++ b/web/src/lib/orgListPrefs.ts
@@ -6,7 +6,7 @@ import { createListPrefs } from "@/lib/listPrefs"
 export type OrgViewMode = "grid" | "list"
 export type OrgSortKey = "name-asc" | "last-modified" | "status"
 
-const prefs = createListPrefs<OrgViewMode, OrgSortKey>({
+export const orgListPrefs = createListPrefs<OrgViewMode, OrgSortKey>({
   viewKey: "orgs_view_mode",
   sortKey: "orgs_sort_key",
   viewValues: ["grid", "list"],
@@ -21,7 +21,7 @@ const prefs = createListPrefs<OrgViewMode, OrgSortKey>({
     sort === "last-modified" ? defaultSort : sort,
 })
 
-export const getStoredViewMode = prefs.getStoredViewMode
-export const persistViewMode = prefs.persistViewMode
-export const getStoredSortKey = prefs.getStoredSortKey
-export const persistSortKey = prefs.persistSortKey
+export const getStoredViewMode = orgListPrefs.getStoredViewMode
+export const persistViewMode = orgListPrefs.persistViewMode
+export const getStoredSortKey = orgListPrefs.getStoredSortKey
+export const persistSortKey = orgListPrefs.persistSortKey

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -13,8 +13,6 @@ import {
   ChevronDown,
   ExternalLink,
   Info,
-  LayoutGrid,
-  List as ListIcon,
   Lock,
   Plus,
   RefreshCw,
@@ -24,17 +22,12 @@ import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
+import { NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
 import Spinner from "@/components/Spinner"
 import { enterExit } from "@/lib/motion"
-import {
-  getStoredSortKey,
-  getStoredViewMode,
-  persistSortKey,
-  persistViewMode,
-  type OrgSortKey,
-  type OrgViewMode,
-} from "@/lib/orgListPrefs"
+import { orgListPrefs, type OrgSortKey } from "@/lib/orgListPrefs"
+import { useListPrefsState } from "@/lib/listPrefs"
 import { formatRelativeToNow } from "@/util/formatDate"
 
 function MissingOrgNotice({
@@ -276,19 +269,10 @@ const OrgsPage = () => {
   const queryClient = useQueryClient()
   const { data: orgs = [], isLoading, isFetching } = useGetOrgs()
 
-  const [viewMode, setViewMode] = useState<OrgViewMode>(getStoredViewMode)
-  const [sortKey, setSortKey] = useState<OrgSortKey>(getStoredSortKey)
+  const { viewMode, sortKey, changeView, changeSort } =
+    useListPrefsState(orgListPrefs)
   const [search, setSearch] = useState("")
   const [modalOpen, setModalOpen] = useState(false)
-
-  const changeView = (mode: OrgViewMode) => {
-    setViewMode(mode)
-    persistViewMode(mode)
-  }
-  const changeSort = (key: OrgSortKey) => {
-    setSortKey(key)
-    persistSortKey(key)
-  }
 
   // Confirmed Classroom 50 orgs the user can use: a teacher's ready org, or a
   // student's enrolled org (no_access confirmed via the public Pages index).
@@ -428,30 +412,13 @@ const OrgsPage = () => {
                         ))}
                       </select>
 
-                      <div
-                        role="group"
-                        aria-label={t("orgs.toolbar.view.label")}
-                        className="join"
-                      >
-                        <button
-                          type="button"
-                          className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
-                          aria-label={t("orgs.toolbar.view.gridLabel")}
-                          aria-pressed={viewMode === "grid"}
-                          onClick={() => changeView("grid")}
-                        >
-                          <LayoutGrid aria-hidden="true" className="size-4" />
-                        </button>
-                        <button
-                          type="button"
-                          className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
-                          aria-label={t("orgs.toolbar.view.listLabel")}
-                          aria-pressed={viewMode === "list"}
-                          onClick={() => changeView("list")}
-                        >
-                          <ListIcon aria-hidden="true" className="size-4" />
-                        </button>
-                      </div>
+                      <ViewToggle
+                        viewMode={viewMode}
+                        onChange={changeView}
+                        groupLabel={t("orgs.toolbar.view.label")}
+                        gridLabel={t("orgs.toolbar.view.gridLabel")}
+                        listLabel={t("orgs.toolbar.view.listLabel")}
+                      />
 
                       <button
                         type="button"
@@ -465,21 +432,12 @@ const OrgsPage = () => {
                 )}
 
                 {noSearchResults ? (
-                  <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
-                    <h2 className="text-lg font-semibold">
-                      {t("orgs.noResults.title")}
-                    </h2>
-                    <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
-                      {t("orgs.noResults.body", { query: search.trim() })}
-                    </p>
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-sm mt-4"
-                      onClick={() => setSearch("")}
-                    >
-                      {t("orgs.noResults.clear")}
-                    </button>
-                  </div>
+                  <NoSearchResults
+                    title={t("orgs.noResults.title")}
+                    body={t("orgs.noResults.body", { query: search.trim() })}
+                    clearLabel={t("orgs.noResults.clear")}
+                    onClear={() => setSearch("")}
+                  />
                 ) : sorted.length > 0 ? (
                   <div className="grid grid-cols-12 gap-4">
                     {sorted.map((summary) => {

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -1,21 +1,19 @@
 import { Link } from "@tanstack/react-router"
-import { LayoutGrid, List as ListIcon, Plus, Search } from "lucide-react"
+import { Plus, Search } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { NoSearchResults, ViewToggle } from "@/components/list"
 import useClassroomSummaries, {
   classroomDisplayName,
   type ClassroomSummary,
 } from "@/hooks/useClassroomSummaries"
 import type { GitHubFileListing } from "@/hooks/github/types"
 import {
-  getStoredSortKey,
-  getStoredViewMode,
-  persistSortKey,
-  persistViewMode,
+  classroomListPrefs,
   type ClassroomSortKey,
-  type ClassroomViewMode,
 } from "@/lib/classroomListPrefs"
+import { useListPrefsState } from "@/lib/listPrefs"
 import { ClassroomCard, ClassroomRow } from "@/pages/classes/ClassroomCard"
 
 type ClassFilter = "active" | "archived" | "all"
@@ -37,20 +35,11 @@ const ClassroomList = ({
   dirs: GitHubFileListing[]
 }) => {
   const { t } = useTranslation()
-  const [viewMode, setViewMode] = useState<ClassroomViewMode>(getStoredViewMode)
-  const [sortKey, setSortKey] = useState<ClassroomSortKey>(getStoredSortKey)
+  const { viewMode, sortKey, changeView, changeSort } =
+    useListPrefsState(classroomListPrefs)
   const [filter, setFilter] = useState<ClassFilter>("active")
   const [termFilter, setTermFilter] = useState<string>("all")
   const [search, setSearch] = useState("")
-
-  const changeView = (mode: ClassroomViewMode) => {
-    setViewMode(mode)
-    persistViewMode(mode)
-  }
-  const changeSort = (key: ClassroomSortKey) => {
-    setSortKey(key)
-    persistSortKey(key)
-  }
 
   const summaries = useClassroomSummaries(
     org,
@@ -211,30 +200,13 @@ const ClassroomList = ({
           </select>
         </div>
 
-        <div
-          role="group"
-          aria-label={t("classes.toolbar.view.label")}
-          className="join"
-        >
-          <button
-            type="button"
-            className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
-            aria-label={t("classes.toolbar.view.gridLabel")}
-            aria-pressed={viewMode === "grid"}
-            onClick={() => changeView("grid")}
-          >
-            <LayoutGrid aria-hidden="true" className="size-4" />
-          </button>
-          <button
-            type="button"
-            className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
-            aria-label={t("classes.toolbar.view.listLabel")}
-            aria-pressed={viewMode === "list"}
-            onClick={() => changeView("list")}
-          >
-            <ListIcon aria-hidden="true" className="size-4" />
-          </button>
-        </div>
+        <ViewToggle
+          viewMode={viewMode}
+          onChange={changeView}
+          groupLabel={t("classes.toolbar.view.label")}
+          gridLabel={t("classes.toolbar.view.gridLabel")}
+          listLabel={t("classes.toolbar.view.listLabel")}
+        />
 
         <div className="mx-1 hidden h-6 w-px self-center bg-base-300 sm:block" />
 
@@ -250,21 +222,12 @@ const ClassroomList = ({
       </div>
 
       {noResults ? (
-        <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
-          <h2 className="text-lg font-semibold">
-            {t("classes.noResults.title")}
-          </h2>
-          <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
-            {t("classes.noResults.body", { query: search.trim() })}
-          </p>
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm mt-4"
-            onClick={() => setSearch("")}
-          >
-            {t("classes.noResults.clear")}
-          </button>
-        </div>
+        <NoSearchResults
+          title={t("classes.noResults.title")}
+          body={t("classes.noResults.body", { query: search.trim() })}
+          clearLabel={t("classes.noResults.clear")}
+          onClear={() => setSearch("")}
+        />
       ) : emptyFilter ? (
         <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
           <p className="text-sm text-base-content/70">


### PR DESCRIPTION
## Summary

Follow-up cleanup on the org-homepage (#154) and My Classrooms (#157) redesigns: the two list pages had forked identical toolbar chrome. This extracts the shared pieces with no behavior change.

- Add `components/list` with a shared `ViewToggle` (grid/list join buttons) and `NoSearchResults` empty-state card — both were previously copy-pasted verbatim into `OrgsPage` and `ClassroomList`.
- Add `useListPrefsState` in `lib/listPrefs` to own the seed-from-storage + persist-on-change view/sort wiring both pages reimplemented. It returns `changeView`/`changeSort` setters (not raw dispatchers) so state can't be set without persisting.
- Drop the now-dead per-accessor re-exports (`getStoredViewMode`/`persistViewMode`/`getStoredSortKey`/`persistSortKey`) from `orgListPrefs`/`classroomListPrefs` — pages now pass the whole prefs object to `useListPrefsState`, leaving those exports with no consumers.
- Shared components take already-translated label strings as props, so each page keeps its own i18n namespace (no shared string table, no coupling).

Net: `OrgsPage.tsx` and `ClassroomList.tsx` each drop their duplicated toolbar/empty-state markup and state boilerplate.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on touched files
- [x] `prettier --check` clean
- [x] `vitest run` — 773 tests pass
- [x] Sanity-check both pages: grid/list toggle + sort persist across reloads; "clear search" empty state works on both