### PR TITLE
feat(web): add personal access token sign-in

### DIFF
--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -6,6 +6,7 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useGithubAuth } from "./useGithubAuth"
 import { GitHubAuthedPanel } from "./GitHubAuthedPanel"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
+import { GitHubPatPrompt } from "./GitHubPatPrompt"
 import { LoginLanguageMenu } from "./LoginLanguageMenu"
 import { AppVersionBadge } from "@/components/AppVersionBadge"
 import { WIKI_URL } from "@/version"
@@ -68,6 +69,13 @@ export function GitHubAuthCard() {
               onCodeCopied={auth.markDeviceCodeCopied}
               onVerificationOpened={auth.markVerificationOpened}
             />
+          ) : auth.screen === "pat-prompt" ? (
+            <GitHubPatPrompt
+              onSubmit={auth.submitPat}
+              onCancel={auth.cancelPatFlow}
+              isValidating={auth.isValidatingPat}
+              error={auth.patError}
+            />
           ) : (
             <form
               className="space-y-5"
@@ -111,20 +119,36 @@ export function GitHubAuthCard() {
                   {t("auth.signInWithGitHub")}
                 </button>
 
-                <button
-                  className="btn btn-outline btn-primary w-full"
-                  type="button"
-                  disabled={auth.isRequestingDeviceCode}
-                  onClick={() => void auth.startDeviceFlow()}
-                >
-                  {auth.isRequestingDeviceCode ? (
-                    <span
-                      className="loading loading-spinner loading-sm"
-                      aria-hidden="true"
-                    />
-                  ) : null}
-                  {t("auth.useDeviceCode")}
-                </button>
+                <details className="collapse collapse-arrow border border-base-300 bg-base-100">
+                  <summary className="collapse-title min-h-0 px-4 py-3 text-sm font-medium">
+                    {t("auth.otherSignInMethods")}
+                  </summary>
+
+                  <div className="collapse-content space-y-3">
+                    <button
+                      className="btn btn-outline btn-primary w-full"
+                      type="button"
+                      disabled={auth.isRequestingDeviceCode}
+                      onClick={() => void auth.startDeviceFlow()}
+                    >
+                      {auth.isRequestingDeviceCode ? (
+                        <span
+                          className="loading loading-spinner loading-sm"
+                          aria-hidden="true"
+                        />
+                      ) : null}
+                      {t("auth.useDeviceCode")}
+                    </button>
+
+                    <button
+                      className="btn btn-outline btn-primary w-full"
+                      type="button"
+                      onClick={() => auth.startPatFlow()}
+                    >
+                      {t("auth.usePersonalAccessToken")}
+                    </button>
+                  </div>
+                </details>
               </div>
             </form>
           )}

--- a/web/src/auth/GitHubPatPrompt.tsx
+++ b/web/src/auth/GitHubPatPrompt.tsx
@@ -14,10 +14,15 @@ const REQUIRED_PAT_SCOPES = [
   "delete_repo",
 ] as const
 
-// Classic-token page with the required scopes pre-checked.
-const CREATE_TOKEN_URL = `https://github.com/settings/tokens/new?description=${encodeURIComponent(
-  "Classroom 50",
-)}&scopes=${REQUIRED_PAT_SCOPES.join(",")}`
+// Classic-token page with the required scopes pre-checked. Built with
+// URLSearchParams (matching buildGithubAuthorizeUrl) so the scope list's
+// reserved characters (e.g. the ":" in admin:org) are encoded correctly.
+const CREATE_TOKEN_URL = `https://github.com/settings/tokens/new?${new URLSearchParams(
+  {
+    description: "Classroom 50",
+    scopes: REQUIRED_PAT_SCOPES.join(","),
+  },
+).toString()}`
 
 export function GitHubPatPrompt({
   onSubmit,
@@ -64,7 +69,7 @@ export function GitHubPatPrompt({
           className="link link-info link-hover inline-flex items-center gap-1 text-xs"
           href={CREATE_TOKEN_URL}
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
         >
           <ExternalLink aria-hidden="true" className="size-3" />
           {t("auth.patCreateTokenLink")}

--- a/web/src/auth/GitHubPatPrompt.tsx
+++ b/web/src/auth/GitHubPatPrompt.tsx
@@ -2,17 +2,31 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { AlertTriangle, ExternalLink, KeyRound } from "lucide-react"
 
-// The classic-PAT checkboxes to tick, in the order GitHub's token page lists
-// them. read:org is omitted because admin:org already implies it (see
-// SCOPE_IMPLICATIONS in scopes.ts) — it isn't a box the user ticks separately.
-// Kept in sync with DEFAULT_GITHUB_SCOPE, which drives actual validation.
-const REQUIRED_PAT_SCOPES = [
+import { REQUIRED_SCOPES } from "./scopes"
+
+// The classic-PAT checkboxes to tick, derived from REQUIRED_SCOPES (the same
+// source missingScopes() validates against) so the on-screen list and the
+// pre-checked token URL can't drift from DEFAULT_GITHUB_SCOPE. read:org is
+// dropped because admin:org already implies it (SCOPE_IMPLICATIONS in
+// scopes.ts) — it isn't a box the user ticks separately. Displayed in GitHub's
+// token-page order; scopes without an explicit rank sort to the end so a newly
+// added required scope still appears (just not perfectly ordered) instead of
+// silently vanishing.
+const IMPLIED_PAT_SCOPES = new Set(["read:org"])
+const PAT_SCOPE_ORDER = [
   "repo",
   "workflow",
   "admin:org",
   "read:user",
   "delete_repo",
-] as const
+]
+const REQUIRED_PAT_SCOPES = REQUIRED_SCOPES.filter(
+  (scope) => !IMPLIED_PAT_SCOPES.has(scope),
+).sort((a, b) => {
+  const ai = PAT_SCOPE_ORDER.indexOf(a)
+  const bi = PAT_SCOPE_ORDER.indexOf(b)
+  return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi)
+})
 
 // Classic-token page with the required scopes pre-checked. Built with
 // URLSearchParams (matching buildGithubAuthorizeUrl) so the scope list's

--- a/web/src/auth/GitHubPatPrompt.tsx
+++ b/web/src/auth/GitHubPatPrompt.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { AlertTriangle, ExternalLink, KeyRound } from "lucide-react"
+
+// The classic-PAT checkboxes to tick, in the order GitHub's token page lists
+// them. read:org is omitted because admin:org already implies it (see
+// SCOPE_IMPLICATIONS in scopes.ts) — it isn't a box the user ticks separately.
+// Kept in sync with DEFAULT_GITHUB_SCOPE, which drives actual validation.
+const REQUIRED_PAT_SCOPES = [
+  "repo",
+  "workflow",
+  "admin:org",
+  "read:user",
+  "delete_repo",
+] as const
+
+// Classic-token page with the required scopes pre-checked.
+const CREATE_TOKEN_URL = `https://github.com/settings/tokens/new?description=${encodeURIComponent(
+  "Classroom 50",
+)}&scopes=${REQUIRED_PAT_SCOPES.join(",")}`
+
+export function GitHubPatPrompt({
+  onSubmit,
+  onCancel,
+  isValidating,
+  error,
+}: {
+  onSubmit: (token: string) => void
+  onCancel: () => void
+  isValidating: boolean
+  error: string | null
+}) {
+  const { t } = useTranslation()
+  const [token, setToken] = useState("")
+  const trimmed = token.trim()
+
+  return (
+    <form
+      className="space-y-5"
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (!trimmed || isValidating) return
+        onSubmit(trimmed)
+      }}
+    >
+      {error ? (
+        <div className="alert alert-error items-start text-sm">
+          <AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        <h2 className="text-sm font-semibold">{t("auth.patTitle")}</h2>
+        <p className="text-xs leading-relaxed text-base-content/70">
+          {t("auth.patInstructions")}
+        </p>
+        <ul className="grid gap-1 rounded-lg border border-base-300 bg-base-200 px-4 py-3 font-mono text-xs">
+          {REQUIRED_PAT_SCOPES.map((scope) => (
+            <li key={scope}>{scope}</li>
+          ))}
+        </ul>
+        <a
+          className="link link-info link-hover inline-flex items-center gap-1 text-xs"
+          href={CREATE_TOKEN_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <ExternalLink aria-hidden="true" className="size-3" />
+          {t("auth.patCreateTokenLink")}
+        </a>
+        <p className="text-xs leading-relaxed text-base-content/60">
+          {t("auth.patFineGrainedNote")}
+        </p>
+      </div>
+
+      <label className="form-control w-full">
+        <span className="label-text sr-only">{t("auth.patTokenLabel")}</span>
+        <input
+          className="input input-bordered w-full font-mono text-sm"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="ghp_…"
+          value={token}
+          onChange={(event) => setToken(event.target.value)}
+          disabled={isValidating}
+          aria-label={t("auth.patTokenLabel")}
+        />
+      </label>
+
+      <p className="text-xs leading-relaxed text-base-content/70">
+        {t("auth.patStorageNote")}
+      </p>
+
+      <div className="space-y-3">
+        <button
+          className="btn btn-primary w-full"
+          type="submit"
+          disabled={!trimmed || isValidating}
+        >
+          {isValidating ? (
+            <span
+              className="loading loading-spinner loading-sm"
+              aria-hidden="true"
+            />
+          ) : (
+            <KeyRound aria-hidden="true" className="size-4" />
+          )}
+          {t("auth.patSubmit")}
+        </button>
+
+        <button
+          className="btn btn-outline w-full"
+          type="button"
+          onClick={onCancel}
+          disabled={isValidating}
+        >
+          {t("auth.patCancel")}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/web/src/auth/github-user-api.test.ts
+++ b/web/src/auth/github-user-api.test.ts
@@ -1,6 +1,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { fetchGithubUser, GitHubUserFetchError } from "./github-user-api"
+import {
+  fetchGithubUser,
+  fetchGithubUserWithScopes,
+  GitHubUserFetchError,
+} from "./github-user-api"
+
+function mockFetch(res: {
+  ok: boolean
+  status: number
+  scopesHeader?: string | null
+  body?: unknown
+}) {
+  const headers = new Headers()
+  if (typeof res.scopesHeader === "string") {
+    headers.set("x-oauth-scopes", res.scopesHeader)
+  }
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: res.ok,
+      status: res.status,
+      headers,
+      json: async () => res.body ?? {},
+    }),
+  )
+}
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -66,5 +92,41 @@ describe("fetchGithubUser", () => {
 
   it("preserves the HTTP status in the error message", () => {
     expect(new GitHubUserFetchError(403).message).toBe("GitHub API: HTTP 403")
+  })
+})
+
+describe("fetchGithubUserWithScopes", () => {
+  it("returns the user and the X-OAuth-Scopes header (classic PAT)", async () => {
+    mockFetch({
+      ok: true,
+      status: 200,
+      scopesHeader: "repo, workflow",
+      body: { login: "octocat" },
+    })
+
+    const result = await fetchGithubUserWithScopes("ghp_token")
+
+    expect(result.user).toEqual({ login: "octocat" })
+    expect(result.scopes).toBe("repo, workflow")
+  })
+
+  it("returns null scopes when the header is absent (fine-grained PAT)", async () => {
+    mockFetch({ ok: true, status: 200, body: { login: "octocat" } })
+
+    const result = await fetchGithubUserWithScopes("github_pat_token")
+
+    expect(result.scopes).toBeNull()
+  })
+
+  it("throws GitHubUserFetchError carrying the status on a failed response", async () => {
+    mockFetch({ ok: false, status: 401 })
+
+    await expect(fetchGithubUserWithScopes("bad")).rejects.toMatchObject({
+      name: "GitHubUserFetchError",
+      status: 401,
+    })
+    await expect(fetchGithubUserWithScopes("bad")).rejects.toBeInstanceOf(
+      GitHubUserFetchError,
+    )
   })
 })

--- a/web/src/auth/github-user-api.ts
+++ b/web/src/auth/github-user-api.ts
@@ -26,3 +26,28 @@ export async function fetchGithubUser(token: string): Promise<GitHubUser> {
 
   return res.json()
 }
+
+// Validate a pasted PAT against GET /user and surface the granted scopes in one
+// call, so the PAT sign-in path can block on missing scopes before completing.
+// `scopes` is the X-OAuth-Scopes header: a string for classic PATs (and OAuth
+// tokens), or `null` when absent (e.g. a fine-grained PAT) — the caller must
+// treat null as "unknown", not "no scopes", matching useMissingScopes.
+export async function fetchGithubUserWithScopes(
+  token: string,
+): Promise<{ user: GitHubUser; scopes: string | null }> {
+  const res = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+  })
+
+  if (!res.ok) {
+    throw new GitHubUserFetchError(res.status)
+  }
+
+  return {
+    user: await res.json(),
+    scopes: res.headers.get("x-oauth-scopes"),
+  }
+}

--- a/web/src/auth/types.ts
+++ b/web/src/auth/types.ts
@@ -28,4 +28,4 @@ export type DeviceAuthState = {
 }
 
 export type GithubAuthScreen =
-  "config" | "exchanging" | "device-prompt" | "authed"
+  "config" | "exchanging" | "device-prompt" | "pat-prompt" | "authed"

--- a/web/src/auth/useGithubAuth.recovery.test.ts
+++ b/web/src/auth/useGithubAuth.recovery.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  classifyPatResult,
   recoverStrandedExchange,
   shouldExpireOnUserError,
 } from "./useGithubAuth"
@@ -44,5 +45,47 @@ describe("recoverStrandedExchange", () => {
     expect(recoverStrandedExchange("config")).toBe("config")
     expect(recoverStrandedExchange("device-prompt")).toBe("device-prompt")
     expect(recoverStrandedExchange("authed")).toBe("authed")
+  })
+})
+
+// The PAT entry gate: submitPat routes a validated token's X-OAuth-Scopes
+// header through classifyPatResult before deciding sign-in vs error. A null
+// header (fine-grained PAT) is blocked, an under-scoped classic token is
+// rejected with the missing list, and a fully-scoped token signs in.
+describe("classifyPatResult", () => {
+  it("blocks a fine-grained token (null header -> unverifiable)", () => {
+    expect(classifyPatResult(null)).toEqual({ kind: "fine-grained" })
+  })
+
+  it("rejects a classic token missing required scopes, listing them", () => {
+    const result = classifyPatResult("repo, workflow")
+    expect(result.kind).toBe("missing")
+    if (result.kind === "missing") {
+      // read:org is implied by admin:org, so it should not be reported once
+      // admin:org is present, but here neither admin:org nor read:user/delete_repo
+      // is granted.
+      expect(result.missing).toContain("admin:org")
+      expect(result.missing).toContain("read:user")
+      expect(result.missing).toContain("delete_repo")
+    }
+  })
+
+  it("treats an empty-scope classic token (empty string, not null) as missing every scope, not fine-grained", () => {
+    const result = classifyPatResult("")
+    expect(result.kind).toBe("missing")
+    if (result.kind === "missing") {
+      expect(result.missing.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("signs in a fully-scoped classic token, carrying the scope string forward", () => {
+    // admin:org implies read:org, so the granted set need not list it explicitly.
+    const granted = "read:user repo workflow admin:org delete_repo"
+    expect(classifyPatResult(granted)).toEqual({ kind: "ok", scopes: granted })
+  })
+
+  it("accepts a comma+space delimited header the same as a space-delimited one", () => {
+    const granted = "read:user, repo, workflow, admin:org, delete_repo"
+    expect(classifyPatResult(granted)).toEqual({ kind: "ok", scopes: granted })
   })
 })

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   type PropsWithChildren,
 } from "react"
+import { useTranslation } from "react-i18next"
 import { DEFAULT_GITHUB_SCOPE, GITHUB_OAUTH_CLIENT_ID } from "./constants"
 import {
   buildGithubAuthorizeUrl,
@@ -38,13 +39,18 @@ import {
 import type { DeviceAuthState, GithubAuthScreen } from "./types"
 import type { AuthStatus } from "@/types/router"
 
+// Translator shape used for the auth error strings. Matches the subset of
+// react-i18next's `t` we rely on (key + optional interpolation values).
+type Translate = (key: string, options?: Record<string, unknown>) => string
+
 function formatError(
+  t: Translate,
   err: unknown,
   // The subsystem a network failure most likely implicates. The web/device
   // flows go through the Worker OAuth proxy; the PAT flow hits api.github.com
   // directly, so it passes its own label instead of blaming a proxy it never
-  // touches.
-  networkTarget = "the Cloudflare Worker proxy",
+  // touches. Defaults to the proxy target for the OAuth/device callers.
+  networkTarget: string = t("auth.errorNetworkProxyTarget"),
 ) {
   const message = err instanceof Error ? err.message : String(err)
 
@@ -52,9 +58,11 @@ function formatError(
     message.toLowerCase().includes("failed to fetch") ||
     message.toLowerCase().includes("networkerror")
   ) {
-    return `Network error reaching ${networkTarget}; it may be down or unreachable.`
+    return t("auth.errorNetwork", { target: networkTarget })
   }
 
+  // A server-provided message (e.g. an OAuth error_description) is already a
+  // formed string we can't pre-translate; pass it through unchanged.
   return message
 }
 
@@ -115,6 +123,7 @@ function sleep(ms: number, signal: AbortSignal) {
 // consumers use the useGithubAuth() context hook below.
 function useGithubAuthState() {
   const queryClient = useQueryClient()
+  const { t } = useTranslation()
   const abortRef = useRef<AbortController | null>(null)
   // Deep link (#71) stashed at code-exchange, consumed by the status-driven
   // effect below so navigation runs against an authenticated router context.
@@ -251,15 +260,13 @@ function useGithubAuthState() {
     } = consumeOAuthSession()
 
     if (!returnedState || returnedState !== expectedState) {
-      setError("State mismatch -- possible CSRF. Please try signing in again.")
+      setError(t("auth.errorStateMismatch"))
       setScreen("config")
       return
     }
 
     if (!verifier || !callbackClientId) {
-      setError(
-        "Missing PKCE verifier or client ID. Please try signing in again.",
-      )
+      setError(t("auth.errorMissingPkce"))
       setScreen("config")
       return
     }
@@ -285,7 +292,7 @@ function useGithubAuthState() {
           pendingReturnToRef.current = returnTo
         },
         onError: (err) => {
-          setError(formatError(err))
+          setError(formatError(t, err))
           setScreen("config")
         },
       },
@@ -309,9 +316,7 @@ function useGithubAuthState() {
     const trimmedClientId = clientId.trim()
 
     if (!trimmedClientId) {
-      setError(
-        "GitHub OAuth client ID is not configured (VITE_GITHUB_CLIENT_ID).",
-      )
+      setError(t("auth.errorClientIdMissing"))
       return null
     }
 
@@ -322,7 +327,7 @@ function useGithubAuthState() {
       clientId: trimmedClientId,
       scope: DEFAULT_GITHUB_SCOPE,
     }
-  }, [clientId])
+  }, [clientId, t])
 
   const startWebFlow = useCallback(async () => {
     const config = validateConfig()
@@ -379,7 +384,7 @@ function useGithubAuthState() {
 
       while (!controller.signal.aborted) {
         if (Date.now() > input.expiresAt) {
-          failDeviceFlow("Device code expired. Please try again.")
+          failDeviceFlow(t("auth.errorDeviceExpired"))
           return
         }
 
@@ -418,7 +423,7 @@ function useGithubAuthState() {
           })
         } catch (err) {
           if (controller.signal.aborted) return
-          failDeviceFlow(formatError(err))
+          failDeviceFlow(formatError(t, err))
           return
         }
 
@@ -430,12 +435,12 @@ function useGithubAuthState() {
         }
 
         if (data.error === "access_denied") {
-          failDeviceFlow("You declined the authorization request.")
+          failDeviceFlow(t("auth.errorDeviceDeclined"))
           return
         }
 
         if (data.error === "expired_token") {
-          failDeviceFlow("Device code expired. Please try again.")
+          failDeviceFlow(t("auth.errorDeviceExpired"))
           return
         }
 
@@ -445,9 +450,7 @@ function useGithubAuthState() {
         }
 
         if (!data.access_token) {
-          failDeviceFlow(
-            "Token endpoint returned no access_token and no error.",
-          )
+          failDeviceFlow(t("auth.errorDeviceNoToken"))
           return
         }
 
@@ -456,7 +459,7 @@ function useGithubAuthState() {
         return
       }
     },
-    [completeSignIn, failDeviceFlow],
+    [completeSignIn, failDeviceFlow, t],
   )
 
   const startDeviceFlow = useCallback(async () => {
@@ -491,7 +494,7 @@ function useGithubAuthState() {
         })
       },
       onError: (err) => {
-        failDeviceFlow(formatError(err))
+        failDeviceFlow(formatError(t, err))
       },
     })
   }, [
@@ -499,6 +502,7 @@ function useGithubAuthState() {
     requestDeviceCodeMutation,
     startDevicePolling,
     validateConfig,
+    t,
   ])
 
   const cancelDeviceFlow = useCallback(() => {
@@ -557,15 +561,15 @@ function useGithubAuthState() {
           // mid-operation, so block it at entry rather than sign in on a token
           // we can't vet.
           if (result.kind === "fine-grained") {
-            setPatError(
-              "That looks like a fine-grained token, which can't be verified. Use a classic token with the scopes listed above.",
-            )
+            setPatError(t("auth.errorPatFineGrained"))
             return
           }
 
           if (result.kind === "missing") {
             setPatError(
-              `That token is missing required scopes: ${result.missing.join(", ")}. Add them and try again.`,
+              t("auth.errorPatMissingScopes", {
+                scopes: result.missing.join(", "),
+              }),
             )
             return
           }
@@ -574,16 +578,14 @@ function useGithubAuthState() {
         },
         onError: (err) => {
           if (err instanceof GitHubUserFetchError && err.status === 401) {
-            setPatError(
-              "That token was rejected by GitHub (401). Check it's valid and not expired.",
-            )
+            setPatError(t("auth.errorPatRejected401"))
             return
           }
-          setPatError(formatError(err, "api.github.com"))
+          setPatError(formatError(t, err, "api.github.com"))
         },
       })
     },
-    [completeSignIn, validatePatMutation],
+    [completeSignIn, validatePatMutation, t],
   )
 
   // Shared teardown for both a deliberate sign-out and an involuntary expiry.

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -38,14 +38,21 @@ import {
 import type { DeviceAuthState, GithubAuthScreen } from "./types"
 import type { AuthStatus } from "@/types/router"
 
-function formatError(err: unknown) {
+function formatError(
+  err: unknown,
+  // The subsystem a network failure most likely implicates. The web/device
+  // flows go through the Worker OAuth proxy; the PAT flow hits api.github.com
+  // directly, so it passes its own label instead of blaming a proxy it never
+  // touches.
+  networkTarget = "the Cloudflare Worker proxy",
+) {
   const message = err instanceof Error ? err.message : String(err)
 
   if (
     message.toLowerCase().includes("failed to fetch") ||
     message.toLowerCase().includes("networkerror")
   ) {
-    return "Network error reaching the Cloudflare Worker proxy; it may be down or unreachable."
+    return `Network error reaching ${networkTarget}; it may be down or unreachable.`
   }
 
   return message
@@ -67,6 +74,26 @@ export function recoverStrandedExchange(
   current: GithubAuthScreen,
 ): GithubAuthScreen {
   return current === "exchanging" ? "config" : current
+}
+
+// Decision for a validated PAT's X-OAuth-Scopes header, split out so every
+// branch is unit-testable. A null header means the scopes are unverifiable —
+// a fine-grained PAT — which we block at entry rather than sign in on a token
+// we can't vet. An empty string is a classic token with no boxes ticked, which
+// falls through to the missing-scopes check (missingScopes("") reports every
+// required scope). "ok" carries the scope string forward to completeSignIn.
+export type PatResult =
+  | { kind: "fine-grained" }
+  | { kind: "missing"; missing: string[] }
+  | { kind: "ok"; scopes: string }
+
+export function classifyPatResult(scopes: string | null): PatResult {
+  if (scopes === null) return { kind: "fine-grained" }
+
+  const missing = missingScopes(scopes)
+  if (missing.length > 0) return { kind: "missing", missing }
+
+  return { kind: "ok", scopes }
 }
 
 function sleep(ms: number, signal: AbortSignal) {
@@ -523,26 +550,27 @@ function useGithubAuthState() {
 
       validatePatMutation.mutate(token, {
         onSuccess: ({ scopes }) => {
-          // A null X-OAuth-Scopes header means the token carries no verifiable
-          // scopes — a fine-grained PAT. Its per-resource permissions can't be
-          // checked here and typically fail mid-operation, so block it at entry
-          // rather than sign the user in on a token we can't vet.
-          if (scopes === null) {
+          const result = classifyPatResult(scopes)
+
+          // A fine-grained PAT (null header) carries no verifiable scopes; its
+          // per-resource permissions can't be checked here and typically fail
+          // mid-operation, so block it at entry rather than sign in on a token
+          // we can't vet.
+          if (result.kind === "fine-grained") {
             setPatError(
               "That looks like a fine-grained token, which can't be verified. Use a classic token with the scopes listed above.",
             )
             return
           }
 
-          const missing = missingScopes(scopes)
-          if (missing.length > 0) {
+          if (result.kind === "missing") {
             setPatError(
-              `That token is missing required scopes: ${missing.join(", ")}. Add them and try again.`,
+              `That token is missing required scopes: ${result.missing.join(", ")}. Add them and try again.`,
             )
             return
           }
 
-          completeSignIn({ access_token: token, scope: scopes })
+          completeSignIn({ access_token: token, scope: result.scopes })
         },
         onError: (err) => {
           if (err instanceof GitHubUserFetchError && err.status === 401) {
@@ -551,7 +579,7 @@ function useGithubAuthState() {
             )
             return
           }
-          setPatError(formatError(err))
+          setPatError(formatError(err, "api.github.com"))
         },
       })
     },

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -16,10 +16,15 @@ import {
   pollDeviceToken,
   requestDeviceCode,
 } from "./github-oauth-api"
-import { fetchGithubUser, GitHubUserFetchError } from "./github-user-api"
+import {
+  fetchGithubUser,
+  fetchGithubUserWithScopes,
+  GitHubUserFetchError,
+} from "./github-user-api"
 import { isDefinitiveGitHubStatus } from "@/hooks/github/errors"
 import router from "@/router"
 import { deriveChallenge, generateVerifier, randomBase64Url } from "./pkce"
+import { missingScopes } from "./scopes"
 import {
   clearGithubToken,
   consumeOAuthSession,
@@ -93,6 +98,9 @@ function useGithubAuthState() {
   const [token, setToken] = useState<string | null>(null)
   const [tokenScope, setTokenScope] = useState("")
   const [error, setError] = useState<string | null>(null)
+  // Scoped to the PAT prompt so a token-entry failure surfaces on that screen
+  // without disturbing the config screen's `error`.
+  const [patError, setPatError] = useState<string | null>(null)
   const [device, setDevice] = useState<DeviceAuthState | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [hasLoadedStoredAuth, setHasLoadedStoredAuth] = useState(false)
@@ -128,6 +136,10 @@ function useGithubAuthState() {
 
   const requestDeviceCodeMutation = useMutation({
     mutationFn: requestDeviceCode,
+  })
+
+  const validatePatMutation = useMutation({
+    mutationFn: fetchGithubUserWithScopes,
   })
 
   // Shared landing for both web and device flows. Goes straight to the authed
@@ -492,6 +504,60 @@ function useGithubAuthState() {
     )
   }, [])
 
+  const startPatFlow = useCallback(() => {
+    setPatError(null)
+    setScreen("pat-prompt")
+  }, [])
+
+  const cancelPatFlow = useCallback(() => {
+    setPatError(null)
+    setScreen("config")
+  }, [])
+
+  const submitPat = useCallback(
+    (rawToken: string) => {
+      const token = rawToken.trim()
+      if (!token) return
+
+      setPatError(null)
+
+      validatePatMutation.mutate(token, {
+        onSuccess: ({ scopes }) => {
+          // A null X-OAuth-Scopes header means the token carries no verifiable
+          // scopes — a fine-grained PAT. Its per-resource permissions can't be
+          // checked here and typically fail mid-operation, so block it at entry
+          // rather than sign the user in on a token we can't vet.
+          if (scopes === null) {
+            setPatError(
+              "That looks like a fine-grained token, which can't be verified. Use a classic token with the scopes listed above.",
+            )
+            return
+          }
+
+          const missing = missingScopes(scopes)
+          if (missing.length > 0) {
+            setPatError(
+              `That token is missing required scopes: ${missing.join(", ")}. Add them and try again.`,
+            )
+            return
+          }
+
+          completeSignIn({ access_token: token, scope: scopes })
+        },
+        onError: (err) => {
+          if (err instanceof GitHubUserFetchError && err.status === 401) {
+            setPatError(
+              "That token was rejected by GitHub (401). Check it's valid and not expired.",
+            )
+            return
+          }
+          setPatError(formatError(err))
+        },
+      })
+    },
+    [completeSignIn, validatePatMutation],
+  )
+
   // Shared teardown for both a deliberate sign-out and an involuntary expiry.
   // `expired` flags the involuntary case so /login can explain the redirect.
   const clearSession = useCallback(
@@ -614,6 +680,11 @@ function useGithubAuthState() {
     cancelDeviceFlow,
     markDeviceCodeCopied,
     markVerificationOpened,
+    startPatFlow,
+    cancelPatFlow,
+    submitPat,
+    patError,
+    isValidatingPat: validatePatMutation.isPending,
     signOut,
     expireSession,
     sessionExpired,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -104,7 +104,9 @@
     "signInSubtitle": "Sign in with your GitHub account to continue.",
     "exchangingCode": "Exchanging code for access token...",
     "signInWithGitHub": "Sign in with GitHub",
+    "otherSignInMethods": "Other sign-in methods",
     "useDeviceCode": "Use a device code instead",
+    "usePersonalAccessToken": "Use a personal access token",
     "footerTagline": "Manage assignments and submissions via GitHub.",
     "visitDocs": "Visit Classroom 50's docs",
     "signedInConfirmed": "Signed in - your session is active",
@@ -130,7 +132,15 @@
     "missingScopesBody_suffix_one": ". Some actions may fail until it is granted.",
     "missingScopesBody_suffix_other": ". Some actions may fail until they are granted.",
     "reauthorize": "Re-authorize",
-    "reauthorizeHint": "If re-authorizing doesn't clear this, an organization owner may need to approve the app in the org's OAuth policy settings."
+    "reauthorizeHint": "If re-authorizing doesn't clear this, an organization owner may need to approve the app in the org's OAuth policy settings.",
+    "patTitle": "Sign in with a personal access token",
+    "patInstructions": "Paste a GitHub personal access token (classic) to sign in directly, without the OAuth proxy. The token must have these scopes checked:",
+    "patCreateTokenLink": "Create a token with these scopes pre-selected",
+    "patFineGrainedNote": "Fine-grained tokens aren't supported — use a classic token.",
+    "patTokenLabel": "Personal access token",
+    "patStorageNote": "The token is stored in this browser's local storage, the same as tokens from the other sign-in methods.",
+    "patSubmit": "Sign in with token",
+    "patCancel": "Cancel"
   },
   "documentTitle": {
     "assignments": "Assignments",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -140,7 +140,18 @@
     "patTokenLabel": "Personal access token",
     "patStorageNote": "The token is stored in this browser's local storage, the same as tokens from the other sign-in methods.",
     "patSubmit": "Sign in with token",
-    "patCancel": "Cancel"
+    "patCancel": "Cancel",
+    "errorNetwork": "Network error reaching {{target}}; it may be down or unreachable.",
+    "errorNetworkProxyTarget": "the Cloudflare Worker proxy",
+    "errorStateMismatch": "State mismatch -- possible CSRF. Please try signing in again.",
+    "errorMissingPkce": "Missing PKCE verifier or client ID. Please try signing in again.",
+    "errorClientIdMissing": "GitHub OAuth client ID is not configured (VITE_GITHUB_CLIENT_ID).",
+    "errorDeviceExpired": "Device code expired. Please try again.",
+    "errorDeviceDeclined": "You declined the authorization request.",
+    "errorDeviceNoToken": "Token endpoint returned no access_token and no error.",
+    "errorPatFineGrained": "That looks like a fine-grained token, which can't be verified. Use a classic token with the scopes listed above.",
+    "errorPatMissingScopes": "That token is missing required scopes: {{scopes}}. Add them and try again.",
+    "errorPatRejected401": "That token was rejected by GitHub (401). Check it's valid and not expired."
   },
   "documentTitle": {
     "assignments": "Assignments",

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
+import { useTranslation } from "react-i18next"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
 import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
@@ -30,12 +31,13 @@ function AuthedLayout() {
   // invalidate fires the redirect to /login. Hold the authed subtree until the
   // client exists so its pages don't mount and call useGitHubClient() on a null
   // client — otherwise every authed hook throws during that gap.
+  const { t } = useTranslation()
   const client = useOptionalGitHubClient()
 
   if (!client) {
     return (
       <div className="min-h-screen grid place-items-center">
-        <Spinner size="lg" label="Loading Classroom 50" />
+        <Spinner size="lg" label={t("common.loadingApp")} />
       </div>
     )
   }

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
 import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
+import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
+import { Spinner } from "@/components/Spinner"
 
 export const Route = createFileRoute("/_authed")({
   beforeLoad: ({ context, location }) => {
@@ -23,6 +25,21 @@ export const Route = createFileRoute("/_authed")({
 })
 
 function AuthedLayout() {
+  // The GitHub client is null for a render frame when the token is torn down
+  // (sign-out, or a 401 expiring the session) before the router's async
+  // invalidate fires the redirect to /login. Hold the authed subtree until the
+  // client exists so its pages don't mount and call useGitHubClient() on a null
+  // client — otherwise every authed hook throws during that gap.
+  const client = useOptionalGitHubClient()
+
+  if (!client) {
+    return (
+      <div className="min-h-screen grid place-items-center">
+        <Spinner size="lg" label="Loading Classroom 50" />
+      </div>
+    )
+  }
+
   return (
     <>
       <ScopeWarningBanner />


### PR DESCRIPTION
## Summary

Closes #56

Adds a third GitHub sign-in method alongside the existing web flow and device flow: pasting a **classic personal access token**. A PAT is already a bearer token, so it authenticates directly against `api.github.com` with no dependency on the Cloudflare Worker OAuth proxy — a useful fallback when the Worker is down, for power users who already hold a PAT, and in orgs where the OAuth App isn't approved.

**How it works**

- A new **"Other sign-in methods"** collapsible on the login card groups the existing device-flow button with a new **"Use a personal access token"** button. The primary "Sign in with GitHub" button is unchanged.
- The PAT prompt validates the token with `GET /user` (`Authorization: Bearer <token>`), then reads the `x-oauth-scopes` response header to verify the required scopes are present **before** signing in.
- On success it reuses the existing `completeSignIn` path, so token storage, the profile query, and the redirect behave identically to the OAuth flows.

**Classic tokens only** — fine-grained tokens are blocked at entry. GitHub omits the `x-oauth-scopes` header for fine-grained PATs, so their permissions can't be verified up front; rather than sign in on a token we can't vet, the prompt rejects it and points the user to a classic token. Classic tokens missing a required scope are rejected at entry with the missing scopes listed. The prompt links to GitHub's token-creation page with the required scopes pre-selected (`repo`, `workflow`, `admin:org`, `read:user`, `delete_repo` — `read:org` is implied by `admin:org`).

The required-scope checklist and the pre-checked token URL are now **derived from `REQUIRED_SCOPES`** (the same source `missingScopes()` validates against, minus the `admin:org`-implied `read:org`), so the displayed list can't drift from `DEFAULT_GITHUB_SCOPE`.

All PAT prompt/login-card strings **and** every auth error message in `useGithubAuth.tsx` (CSRF/PKCE, client-id, device-flow, and PAT) are wired through i18n (`en.json`) so language packs cover them and the CI `en.json` audit tracks them; genuine server-provided messages (OAuth `error_description`) still pass through untranslated. The PAT network-error path names `api.github.com` rather than the Cloudflare Worker proxy it never calls.

Also folds in a small fix to `_authed.tsx` that holds the authed subtree until the GitHub client exists, resolving a `useGitHubClient` console error during auth teardown.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): \`go build ./... && go test ./... && golangci-lint run\` in the module dir (\`cli/gh-teacher\`, \`cli/gh-student\`, or \`cli/shared\`)
  - Web: \`cd web && npm run check\`
  - Skeleton scripts (Python): \`python3 -m pytest cli/gh-teacher/skeleton_tests -q\`
- [ ] If I changed a cross-binary contract, I updated \`schemas/*.schema.json\` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [ ] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. \`feat(web): ...\`, \`fix(gh-teacher): ...\`).