### PR TITLE
refactor(web): add PageShell + EmptyState primitives

### DIFF
--- a/web/src/components/PageShell.tsx
+++ b/web/src/components/PageShell.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react"
+
+import Drawer, {
+  DrawerContent,
+  DrawerSidebar,
+  DrawerToggle,
+} from "@/components/drawer"
+
+const DEFAULT_CONTENT_CLASS = "p-10 bg-base-200 2xl:px-50"
+
+// The standard authenticated page shell: the drawer wrapper, mobile toggle, the
+// scrolling content pane, and the sidebar rail. Every drawer page repeated this
+// same structure; PageShell owns it so pages render only their content.
+//
+// contentClassName overrides the DrawerContent padding — the default matches the
+// 10 pages on `2xl:px-50`; the three `xl:px-50` owner pages pass their variant.
+// The DrawerSidebar props (page/selected/settings) are threaded through
+// unchanged; PR 4 will replace them with route-derived active-state.
+export default function PageShell({
+  children,
+  contentClassName = DEFAULT_CONTENT_CLASS,
+  page,
+  selected,
+  settings,
+}: {
+  children: ReactNode
+  contentClassName?: string
+  page?: string
+  selected?: string
+  settings?: boolean
+}) {
+  return (
+    <div className="min-h-screen">
+      <Drawer>
+        <DrawerToggle />
+        <DrawerContent className={contentClassName}>{children}</DrawerContent>
+        <DrawerSidebar page={page} selected={selected} settings={settings} />
+      </Drawer>
+    </div>
+  )
+}

--- a/web/src/components/PageShell.tsx
+++ b/web/src/components/PageShell.tsx
@@ -8,9 +8,8 @@ import Drawer, {
 
 const DEFAULT_CONTENT_CLASS = "p-10 bg-base-200 2xl:px-50"
 
-// The standard authenticated page shell: the drawer wrapper, mobile toggle, the
-// scrolling content pane, and the sidebar rail. Every drawer page repeated this
-// same structure; PageShell owns it so pages render only their content.
+// Every drawer page repeated the Drawer/toggle/content/sidebar structure;
+// PageShell owns it so pages render only their content.
 //
 // contentClassName overrides the DrawerContent padding — the default matches the
 // 10 pages on `2xl:px-50`; the three `xl:px-50` owner pages pass their variant.

--- a/web/src/components/list/emptyState.test.tsx
+++ b/web/src/components/list/emptyState.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { EmptyState, NoSearchResults } from "./index"
+
+afterEach(cleanup)
+
+// EmptyState is the single dashed-card implementation every empty state now
+// renders through, so these lock the slot contract: title is always present,
+// body/action wrappers appear only when passed, and className fully overrides
+// the default shell.
+describe("EmptyState", () => {
+  it("renders the title and omits body/action when not passed", () => {
+    render(<EmptyState title="Nothing here" />)
+    expect(screen.getByRole("heading", { name: "Nothing here" })).toBeDefined()
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("renders body and action when passed", () => {
+    render(
+      <EmptyState
+        title="Empty"
+        body="Add something to get started"
+        action={<button type="button">Do it</button>}
+      />,
+    )
+    expect(screen.getByText("Add something to get started")).toBeDefined()
+    expect(screen.getByRole("button", { name: "Do it" })).toBeDefined()
+  })
+
+  it("replaces the default shell class when className is provided", () => {
+    const { container } = render(
+      <EmptyState title="Custom" className="my-shell" />,
+    )
+    const root = container.firstElementChild
+    expect(root?.className).toBe("my-shell")
+  })
+})
+
+describe("NoSearchResults", () => {
+  it("renders the labels and fires onClear when the clear button is clicked", async () => {
+    const onClear = vi.fn()
+    render(
+      <NoSearchResults
+        title="No results"
+        body="Nothing matched your search"
+        clearLabel="Clear search"
+        onClear={onClear}
+      />,
+    )
+    expect(screen.getByRole("heading", { name: "No results" })).toBeDefined()
+    expect(screen.getByText("Nothing matched your search")).toBeDefined()
+    await userEvent.click(screen.getByRole("button", { name: "Clear search" }))
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -3,6 +3,7 @@
 // own i18n namespace while sharing the markup and behavior.
 
 import { LayoutGrid, List as ListIcon } from "lucide-react"
+import type { ReactNode } from "react"
 
 export type ListViewMode = "grid" | "list"
 
@@ -43,6 +44,37 @@ export function ViewToggle({
   )
 }
 
+// The single dashed-border empty-state card. `className` overrides the default
+// shell so the non-uniform call sites keep their own radius/padding (e.g.
+// PublishedResourcesPage's rounded-xl/p-6). NoSearchResults and the zero-data
+// states across the list pages all render through this.
+export function EmptyState({
+  icon,
+  title,
+  body,
+  action,
+  className = "rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center",
+}: {
+  icon?: ReactNode
+  title: ReactNode
+  body?: ReactNode
+  action?: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={className}>
+      {icon}
+      <h2 className="text-lg font-semibold">{title}</h2>
+      {body && (
+        <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+          {body}
+        </p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  )
+}
+
 export function NoSearchResults({
   title,
   body,
@@ -55,18 +87,18 @@ export function NoSearchResults({
   onClear: () => void
 }) {
   return (
-    <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
-      <h2 className="text-lg font-semibold">{title}</h2>
-      <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
-        {body}
-      </p>
-      <button
-        type="button"
-        className="btn btn-ghost btn-sm mt-4"
-        onClick={onClear}
-      >
-        {clearLabel}
-      </button>
-    </div>
+    <EmptyState
+      title={title}
+      body={body}
+      action={
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={onClear}
+        >
+          {clearLabel}
+        </button>
+      }
+    />
   )
 }

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -14,11 +14,7 @@ import GitHub from "@/assets/github.svg?react"
 import useGetClasses from "@/hooks/useGetClasses"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 
-import Drawer, {
-  DrawerContent,
-  DrawerSidebar,
-  DrawerToggle,
-} from "@/components/drawer"
+import PageShell from "@/components/PageShell"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubRepo } from "@/hooks/github/types"
 import MissingParams from "@/components/MissingParams"
@@ -322,77 +318,71 @@ const ClassesPage = () => {
   }
 
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <DrawerToggle />
-        <DrawerContent className="p-10 bg-base-200 2xl:px-50">
-          <div className="mb-8">
-            <div className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
-              <div className="space-y-4">
-                <div className="flex items-center gap-3">
-                  <GitHub aria-hidden="true" className="size-5 opacity-70" />
+    <PageShell page="classes" selected="assignments">
+      <div className="mb-8">
+        <div className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <GitHub aria-hidden="true" className="size-5 opacity-70" />
 
-                  <div>
-                    <div className="text-xs font-medium uppercase tracking-wide text-base-content/70">
-                      {t("classes.githubOrganization")}
-                    </div>
-                    <a
-                      href={githubOrgUrl(org)}
-                      target="_blank"
-                      rel="noreferrer"
-                      title={t("common.openOrgOnGitHub", { org })}
-                      className="font-mono text-sm font-semibold text-base-content hover:text-primary hover:underline"
-                    >
-                      {org}
-                    </a>
-                  </div>
+              <div>
+                <div className="text-xs font-medium uppercase tracking-wide text-base-content/70">
+                  {t("classes.githubOrganization")}
                 </div>
-
-                <div>
-                  {roleLoading ? (
-                    <div className="skeleton skeleton-shimmer h-8 w-48" />
-                  ) : (
-                    <h1 className="text-2xl font-bold tracking-tight">
-                      {isTeacher
-                        ? t("classes.myClasses")
-                        : t("classes.myAssignments")}
-                    </h1>
-                  )}
-                  <p className="mt-2 max-w-2xl text-sm text-base-content/70">
-                    {t("classes.manageSubtitle")}
-                  </p>
-                </div>
+                <a
+                  href={githubOrgUrl(org)}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={t("common.openOrgOnGitHub", { org })}
+                  className="font-mono text-sm font-semibold text-base-content hover:text-primary hover:underline"
+                >
+                  {org}
+                </a>
               </div>
             </div>
-            {isStudent && !isMember && !loadingMembership && (
-              <JoinOrgCard org={org} />
-            )}
-          </div>
-          {isOwner && <OrgPreflightNotice org={org} />}
-          {roleLoading ? (
-            <div className="grid grid-cols-12 gap-4 mb-6">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="skeleton skeleton-shimmer col-span-6 h-32 rounded-xl xl:col-span-4"
-                />
-              ))}
+
+            <div>
+              {roleLoading ? (
+                <div className="skeleton skeleton-shimmer h-8 w-48" />
+              ) : (
+                <h1 className="text-2xl font-bold tracking-tight">
+                  {isTeacher
+                    ? t("classes.myClasses")
+                    : t("classes.myAssignments")}
+                </h1>
+              )}
+              <p className="mt-2 max-w-2xl text-sm text-base-content/70">
+                {t("classes.manageSubtitle")}
+              </p>
             </div>
-          ) : (
-            <>
-              {classes.length === 0 && isTeacher && (
-                <CreateClassroomPane org={org} />
-              )}
-              {isTeacher && classes.length > 0 && (
-                <ClassroomList org={org} dirs={classes} />
-              )}
-              {isStudent && isMember && <OrgRepos org={org} />}
-            </>
+          </div>
+        </div>
+        {isStudent && !isMember && !loadingMembership && (
+          <JoinOrgCard org={org} />
+        )}
+      </div>
+      {isOwner && <OrgPreflightNotice org={org} />}
+      {roleLoading ? (
+        <div className="grid grid-cols-12 gap-4 mb-6">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="skeleton skeleton-shimmer col-span-6 h-32 rounded-xl xl:col-span-4"
+            />
+          ))}
+        </div>
+      ) : (
+        <>
+          {classes.length === 0 && isTeacher && (
+            <CreateClassroomPane org={org} />
           )}
-        </DrawerContent>
-        <DrawerSidebar page="classes" selected="assignments" />
-      </Drawer>
-    </div>
+          {isTeacher && classes.length > 0 && (
+            <ClassroomList org={org} dirs={classes} />
+          )}
+          {isStudent && isMember && <OrgRepos org={org} />}
+        </>
+      )}
+    </PageShell>
   )
 }
 

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -1,8 +1,4 @@
-import Drawer, {
-  DrawerContent,
-  DrawerSidebar,
-  DrawerToggle,
-} from "@/components/drawer"
+import PageShell from "@/components/PageShell"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { Classroom50OrgSummary } from "@/hooks/github/queries"
 import useGetOrgs from "@/hooks/useGetOrgs"
@@ -22,7 +18,7 @@ import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
-import { NoSearchResults, ViewToggle } from "@/components/list"
+import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
 import Spinner from "@/components/Spinner"
 import { enterExit } from "@/lib/motion"
@@ -349,159 +345,147 @@ const OrgsPage = () => {
   const noSearchResults = hasAnyOrgs && sorted.length === 0
 
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <DrawerToggle />
-        <DrawerContent className="p-10 bg-base-200 2xl:px-50">
-          {isLoading ? (
-            <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-              <Spinner size="lg" className="text-primary" />
-              <div>
-                <p className="text-base font-semibold">
-                  {t("orgs.loadingTitle")}
-                </p>
-                <p className="mt-1 text-sm text-base-content/70">
-                  {t("orgs.loadingSubtitle")}
-                </p>
-              </div>
+    <>
+      <PageShell page="orgs">
+        {isLoading ? (
+          <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+            <Spinner size="lg" className="text-primary" />
+            <div>
+              <p className="text-base font-semibold">
+                {t("orgs.loadingTitle")}
+              </p>
+              <p className="mt-1 text-sm text-base-content/70">
+                {t("orgs.loadingSubtitle")}
+              </p>
             </div>
-          ) : (
-            <div className="mb-8">
-              <div className="flex flex-col gap-6 p-6">
+          </div>
+        ) : (
+          <div className="mb-8">
+            <div className="flex flex-col gap-6 p-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <h1 className="text-2xl font-bold tracking-tight">
+                  {t("orgs.headingCl50")}
+                </h1>
+              </div>
+
+              <MissingOrgNotice
+                refreshing={isFetching}
+                onRefresh={handleRefresh}
+              />
+
+              {hasAnyOrgs && (
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <h1 className="text-2xl font-bold tracking-tight">
-                    {t("orgs.headingCl50")}
-                  </h1>
-                </div>
+                  <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
+                    <Search
+                      aria-hidden="true"
+                      className="size-4 text-base-content/50"
+                    />
+                    <input
+                      type="search"
+                      className="grow"
+                      placeholder={t("orgs.toolbar.searchPlaceholder")}
+                      aria-label={t("orgs.toolbar.searchLabel")}
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                    />
+                  </label>
 
-                <MissingOrgNotice
-                  refreshing={isFetching}
-                  onRefresh={handleRefresh}
-                />
+                  <div className="flex items-center gap-3">
+                    <select
+                      className="select select-bordered select-sm"
+                      aria-label={t("orgs.toolbar.sort.label")}
+                      value={sortKey}
+                      onChange={(e) => changeSort(e.target.value as OrgSortKey)}
+                    >
+                      {SORT_OPTIONS.map((opt) => (
+                        <option key={opt.key} value={opt.key}>
+                          {t(opt.labelKey)}
+                        </option>
+                      ))}
+                    </select>
 
-                {hasAnyOrgs && (
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
-                      <Search
-                        aria-hidden="true"
-                        className="size-4 text-base-content/50"
-                      />
-                      <input
-                        type="search"
-                        className="grow"
-                        placeholder={t("orgs.toolbar.searchPlaceholder")}
-                        aria-label={t("orgs.toolbar.searchLabel")}
-                        value={search}
-                        onChange={(e) => setSearch(e.target.value)}
-                      />
-                    </label>
+                    <ViewToggle
+                      viewMode={viewMode}
+                      onChange={changeView}
+                      groupLabel={t("orgs.toolbar.view.label")}
+                      gridLabel={t("orgs.toolbar.view.gridLabel")}
+                      listLabel={t("orgs.toolbar.view.listLabel")}
+                    />
 
-                    <div className="flex items-center gap-3">
-                      <select
-                        className="select select-bordered select-sm"
-                        aria-label={t("orgs.toolbar.sort.label")}
-                        value={sortKey}
-                        onChange={(e) =>
-                          changeSort(e.target.value as OrgSortKey)
-                        }
-                      >
-                        {SORT_OPTIONS.map((opt) => (
-                          <option key={opt.key} value={opt.key}>
-                            {t(opt.labelKey)}
-                          </option>
-                        ))}
-                      </select>
-
-                      <ViewToggle
-                        viewMode={viewMode}
-                        onChange={changeView}
-                        groupLabel={t("orgs.toolbar.view.label")}
-                        gridLabel={t("orgs.toolbar.view.gridLabel")}
-                        listLabel={t("orgs.toolbar.view.listLabel")}
-                      />
-
-                      <button
-                        type="button"
-                        className="btn btn-primary btn-sm"
-                        onClick={() => setModalOpen(true)}
-                      >
-                        {t("orgs.newOrg.button")}
-                      </button>
-                    </div>
-                  </div>
-                )}
-
-                {noSearchResults ? (
-                  <NoSearchResults
-                    title={t("orgs.noResults.title")}
-                    body={t("orgs.noResults.body", { query: search.trim() })}
-                    clearLabel={t("orgs.noResults.clear")}
-                    onClear={() => setSearch("")}
-                  />
-                ) : sorted.length > 0 ? (
-                  <div className="grid grid-cols-12 gap-4">
-                    {sorted.map((summary) => {
-                      const updatedIso = lastModifiedActive
-                        ? lastModified[summary.org.login]
-                        : undefined
-                      const updatedAgo = updatedIso
-                        ? formatRelativeToNow(new Date(updatedIso))
-                        : undefined
-                      return viewMode === "grid" ? (
-                        <OrgCard
-                          key={summary.org.id}
-                          summary={summary}
-                          updatedAgo={updatedAgo}
-                        />
-                      ) : (
-                        <OrgRow
-                          key={summary.org.id}
-                          summary={summary}
-                          updatedAgo={updatedAgo}
-                        />
-                      )
-                    })}
-                  </div>
-                ) : needsSetupOrgs.length > 0 ? (
-                  <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
-                    <h2 className="text-lg font-semibold">
-                      {t("orgs.setUpFirst.title")}
-                    </h2>
-                    <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
-                      {t("orgs.setUpFirst.body")}
-                    </p>
                     <button
                       type="button"
-                      className="btn btn-primary btn-sm mt-4"
+                      className="btn btn-primary btn-sm"
+                      onClick={() => setModalOpen(true)}
+                    >
+                      {t("orgs.newOrg.button")}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {noSearchResults ? (
+                <NoSearchResults
+                  title={t("orgs.noResults.title")}
+                  body={t("orgs.noResults.body", { query: search.trim() })}
+                  clearLabel={t("orgs.noResults.clear")}
+                  onClear={() => setSearch("")}
+                />
+              ) : sorted.length > 0 ? (
+                <div className="grid grid-cols-12 gap-4">
+                  {sorted.map((summary) => {
+                    const updatedIso = lastModifiedActive
+                      ? lastModified[summary.org.login]
+                      : undefined
+                    const updatedAgo = updatedIso
+                      ? formatRelativeToNow(new Date(updatedIso))
+                      : undefined
+                    return viewMode === "grid" ? (
+                      <OrgCard
+                        key={summary.org.id}
+                        summary={summary}
+                        updatedAgo={updatedAgo}
+                      />
+                    ) : (
+                      <OrgRow
+                        key={summary.org.id}
+                        summary={summary}
+                        updatedAgo={updatedAgo}
+                      />
+                    )
+                  })}
+                </div>
+              ) : needsSetupOrgs.length > 0 ? (
+                <EmptyState
+                  title={t("orgs.setUpFirst.title")}
+                  body={t("orgs.setUpFirst.body")}
+                  action={
+                    <button
+                      type="button"
+                      className="btn btn-primary btn-sm"
                       onClick={() => setModalOpen(true)}
                     >
                       <Plus aria-hidden="true" className="size-4" />
                       {t("orgs.setUpFirst.cta")}
                     </button>
-                  </div>
-                ) : (
-                  <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
-                    <h2 className="text-lg font-semibold">
-                      {t("orgs.emptyTitle")}
-                    </h2>
-                    <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
-                      {t("orgs.emptyBody")}
-                    </p>
-                  </div>
-                )}
-              </div>
+                  }
+                />
+              ) : (
+                <EmptyState
+                  title={t("orgs.emptyTitle")}
+                  body={t("orgs.emptyBody")}
+                />
+              )}
             </div>
-          )}
-        </DrawerContent>
-        <DrawerSidebar page="orgs" />
-      </Drawer>
+          </div>
+        )}
+      </PageShell>
 
       <NewOrgModal
         open={modalOpen}
         needsSetupOrgs={needsSetupOrgs}
         onClose={() => setModalOpen(false)}
       />
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

PR 1 of the layout/navigation standardization (tracking: #162). Behavior-preserving — extracts the repeated page chrome into shared primitives.

- Add `PageShell` (`web/src/components/PageShell.tsx`) — wraps the `Drawer` + `DrawerToggle` + `DrawerContent` + `DrawerSidebar` shell every drawer page hand-rolled, with the `DrawerContent` padding as an overridable `contentClassName` (default `p-10 bg-base-200 2xl:px-50`; the three `xl:px-50` owner pages will pass their variant). The `page`/`selected`/`settings` sidebar props are threaded through unchanged — PR 4 replaces them with route-derived active-state.
- Add `EmptyState` to `components/list` — the single dashed-border empty-state card (`title` + optional `body`/`action`/`icon`, overridable `className`). **`NoSearchResults` now renders `EmptyState` internally**, so there is one implementation of the dashed shell rather than two.
- Migrate `OrgsPage` and `ClassesPage` to `PageShell` + `EmptyState` to validate the API.
- Add render tests locking the `EmptyState`/`NoSearchResults` slot contract.

The large line counts on `OrgsPage`/`ClassesPage` are mostly prettier re-indentation from removing one JSX nesting level, not logic changes.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on touched files
- [x] `prettier --check` clean
- [x] `vitest run` — 777 tests pass (773 + 4 new EmptyState tests)
- [x] Reviewed with ce-code-review (verdict: ready to merge; the one advisory finding was applied)
- [ ] Sanity-check both migrated pages render identically (drawer chrome, empty states, New Org modal)