### PR TITLE
refactor(web): add PageHeader + OrgLink, migrate dashboard headings

### DIFF
--- a/web/src/components/PageHeader.test.tsx
+++ b/web/src/components/PageHeader.test.tsx
@@ -36,6 +36,9 @@ describe("OrgLink", () => {
     render(<OrgLink org="acme" href="https://gh/acme" title="Open acme" />)
     const link = screen.getByRole("link", { name: "acme" })
     expect(link.getAttribute("href")).toBe("https://gh/acme")
+    expect(link.getAttribute("target")).toBe("_blank")
+    expect(link.getAttribute("rel")).toBe("noreferrer")
+    expect(link.getAttribute("title")).toBe("Open acme")
   })
 
   it("renders plain text (no link) when org is undefined", () => {

--- a/web/src/components/PageHeader.test.tsx
+++ b/web/src/components/PageHeader.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import PageHeader, { OrgLink } from "./PageHeader"
+
+afterEach(cleanup)
+
+describe("PageHeader", () => {
+  it("renders the title and omits subtitle/action when not passed", () => {
+    render(<PageHeader title="Members" />)
+    expect(screen.getByRole("heading", { name: "Members" })).toBeDefined()
+  })
+
+  it("renders subtitle and action nodes when passed", () => {
+    render(
+      <PageHeader
+        title="Settings"
+        subtitle={<span>manage the org</span>}
+        action={<button type="button">Do it</button>}
+      />,
+    )
+    expect(screen.getByText("manage the org")).toBeDefined()
+    expect(screen.getByRole("button", { name: "Do it" })).toBeDefined()
+  })
+
+  it("shows a skeleton instead of the title while loading", () => {
+    const { container } = render(<PageHeader title="Late" loading />)
+    expect(screen.queryByRole("heading")).toBeNull()
+    expect(container.querySelector(".skeleton")).not.toBeNull()
+  })
+})
+
+describe("OrgLink", () => {
+  it("renders a github link when org is set", () => {
+    render(<OrgLink org="acme" href="https://gh/acme" title="Open acme" />)
+    const link = screen.getByRole("link", { name: "acme" })
+    expect(link.getAttribute("href")).toBe("https://gh/acme")
+  })
+
+  it("renders plain text (no link) when org is undefined", () => {
+    render(<OrgLink org={undefined} href="https://gh/x" title="x" />)
+    expect(screen.queryByRole("link")).toBeNull()
+  })
+})

--- a/web/src/components/PageHeader.tsx
+++ b/web/src/components/PageHeader.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react"
+
+// The dashboard page heading: a title, an optional subtitle line, and an
+// optional right-aligned action. `loading` swaps the title for the standard
+// skeleton placeholder (pages that resolve the title async render it there
+// instead of hand-rolling the swap). title/subtitle/action are ReactNode so a
+// page can render an inline badge in the heading or a composite subtitle
+// (org-link line, follow-up link) through the slots.
+export default function PageHeader({
+  title,
+  subtitle,
+  action,
+  loading = false,
+}: {
+  title: ReactNode
+  subtitle?: ReactNode
+  action?: ReactNode
+  loading?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        {loading ? (
+          <div className="skeleton skeleton-shimmer h-8 w-48" />
+        ) : (
+          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+        )}
+        {subtitle && (
+          <div className="mt-1 text-sm text-base-content/70">{subtitle}</div>
+        )}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  )
+}
+
+// The org deep-link fragment shared by the owner-page subtitles: a monospace
+// link to the org on github.com, falling back to plain text when the slug isn't
+// resolved yet. The surrounding prefix/suffix text and any follow-up link stay
+// in the page's subtitle/action slots — they differ per page.
+export function OrgLink({
+  org,
+  href,
+  title,
+}: {
+  org: string | undefined
+  href: string
+  title: string
+}) {
+  if (!org) return <span className="font-mono font-semibold">{org}</span>
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      title={title}
+      className="font-mono font-semibold hover:text-primary hover:underline"
+    >
+      {org}
+    </a>
+  )
+}

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -10,11 +10,8 @@ import {
   UserPlus,
 } from "lucide-react"
 
-import Drawer, {
-  DrawerContent,
-  DrawerSidebar,
-  DrawerToggle,
-} from "@/components/drawer"
+import PageShell from "@/components/PageShell"
+import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import RequireTeacher from "@/components/RequireTeacher"
 import Avatar from "@/components/avatar"
@@ -371,255 +368,244 @@ const OrgMembersPage = () => {
   )
 
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <DrawerToggle />
-        <DrawerContent className="p-10 bg-base-200 xl:px-50">
-          <RequireTeacher allow="owner">
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">
-                {t("orgMembers.heading")}
-              </h1>
-              <p className="mt-1 text-sm text-base-content/70">
+    <>
+      <PageShell
+        contentClassName="p-10 bg-base-200 xl:px-50"
+        page="classes"
+        selected="members"
+      >
+        <RequireTeacher allow="owner">
+          <PageHeader
+            title={t("orgMembers.heading")}
+            subtitle={
+              <>
                 {t("orgMembers.subtitlePrefix")}{" "}
-                {org ? (
-                  <a
-                    href={githubOrgPeopleUrl(org)}
-                    target="_blank"
-                    rel="noreferrer"
-                    title={t("common.openOrgOnGitHub", { org })}
-                    className="font-mono font-semibold hover:text-primary hover:underline"
-                  >
-                    {org}
-                  </a>
-                ) : (
-                  <span className="font-mono font-semibold">{org}</span>
-                )}{" "}
+                <OrgLink
+                  org={org}
+                  href={githubOrgPeopleUrl(org ?? "")}
+                  title={t("common.openOrgOnGitHub", { org })}
+                />{" "}
                 {t("orgMembers.subtitleSuffix")}
-              </p>
-              <a
-                href={`https://github.com/orgs/${org}/people`}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-2 inline-flex items-center gap-1 text-sm text-primary hover:underline"
-              >
-                <ExternalLink aria-hidden="true" className="size-3.5" />
-                {t("orgMembers.manageMembersOnGitHub")}
-              </a>
+                <a
+                  href={`https://github.com/orgs/${org}/people`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-2 flex w-fit items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  <ExternalLink aria-hidden="true" className="size-3.5" />
+                  {t("orgMembers.manageMembersOnGitHub")}
+                </a>
+              </>
+            }
+          />
+
+          {notes.length > 0 ? (
+            <div
+              className="alert alert-warning alert-soft mt-6 text-sm"
+              role="status"
+            >
+              <span>{notes.join(" ")}</span>
             </div>
+          ) : null}
 
-            {notes.length > 0 ? (
-              <div
-                className="alert alert-warning alert-soft mt-6 text-sm"
-                role="status"
-              >
-                <span>{notes.join(" ")}</span>
-              </div>
-            ) : null}
+          {discrepancyCount > 0 ? (
+            <div
+              className="alert alert-error alert-soft mt-6 text-sm"
+              role="status"
+            >
+              <AlertTriangle className="size-4" aria-hidden="true" />
+              <span>
+                {t("orgMembers.discrepancy", { count: discrepancyCount })}
+              </span>
+            </div>
+          ) : null}
 
-            {discrepancyCount > 0 ? (
-              <div
-                className="alert alert-error alert-soft mt-6 text-sm"
-                role="status"
-              >
-                <AlertTriangle className="size-4" aria-hidden="true" />
-                <span>
-                  {t("orgMembers.discrepancy", { count: discrepancyCount })}
-                </span>
-              </div>
-            ) : null}
-
-            <div className="mt-6 flex flex-wrap items-center gap-3">
-              <label className="input input-bordered flex min-w-0 flex-1 items-center gap-2">
-                <Search aria-hidden="true" className="size-4 opacity-50" />
-                <input
-                  type="search"
-                  className="grow"
-                  placeholder={t("orgMembers.searchPlaceholder")}
-                  aria-label={t("orgMembers.searchLabel")}
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                />
-              </label>
-              <select
-                className="select select-bordered w-full sm:w-auto sm:min-w-[14rem]"
-                aria-label={t("orgMembers.filterByClassroomLabel")}
-                value={classroomFilter}
-                onChange={(e) => setClassroomFilter(e.target.value)}
-              >
-                <option value="">{t("orgMembers.filterAllClassrooms")}</option>
-                <option value={NO_CLASSROOM_FILTER}>
-                  {t("orgMembers.filterNoClassroom")}
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <label className="input input-bordered flex min-w-0 flex-1 items-center gap-2">
+              <Search aria-hidden="true" className="size-4 opacity-50" />
+              <input
+                type="search"
+                className="grow"
+                placeholder={t("orgMembers.searchPlaceholder")}
+                aria-label={t("orgMembers.searchLabel")}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+            </label>
+            <select
+              className="select select-bordered w-full sm:w-auto sm:min-w-[14rem]"
+              aria-label={t("orgMembers.filterByClassroomLabel")}
+              value={classroomFilter}
+              onChange={(e) => setClassroomFilter(e.target.value)}
+            >
+              <option value="">{t("orgMembers.filterAllClassrooms")}</option>
+              <option value={NO_CLASSROOM_FILTER}>
+                {t("orgMembers.filterNoClassroom")}
+              </option>
+              {classroomOptions.map((c) => (
+                <option key={c.path} value={c.path}>
+                  {c.name}
                 </option>
-                {classroomOptions.map((c) => (
-                  <option key={c.path} value={c.path}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+              ))}
+            </select>
+          </div>
 
-            <div className="mt-4 card card-border w-full overflow-hidden bg-base-100 shadow-sm">
-              {isLoading ? (
-                <div className="flex items-center justify-center gap-3 px-6 py-12 text-base-content/70">
-                  <span
-                    className="loading loading-spinner loading-md"
-                    aria-hidden="true"
+          <div className="mt-4 card card-border w-full overflow-hidden bg-base-100 shadow-sm">
+            {isLoading ? (
+              <div className="flex items-center justify-center gap-3 px-6 py-12 text-base-content/70">
+                <span
+                  className="loading loading-spinner loading-md"
+                  aria-hidden="true"
+                />
+                <span className="text-sm">{t("orgMembers.loading")}</span>
+              </div>
+            ) : isError ? (
+              <div className="px-6 py-10 text-center text-sm text-error">
+                {t("orgMembers.loadError")}
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="px-6 py-10 text-center text-sm text-base-content/70">
+                {classroomFilter === NO_CLASSROOM_FILTER
+                  ? t("orgMembers.noMembersNoClassroom")
+                  : classroomFilter
+                    ? t("orgMembers.noMembersInClassroom", {
+                        classroom:
+                          classroomOptions.find(
+                            (c) => c.path === classroomFilter,
+                          )?.name ?? classroomFilter,
+                      })
+                    : t("orgMembers.noMatch")}
+              </div>
+            ) : (
+              <>
+                {org ? (
+                  <BulkActionsBar
+                    org={org}
+                    client={client}
+                    selectedRows={selectedRows}
+                    totalCount={filtered.length}
+                    allSelected={allFilteredSelected}
+                    someSelected={someFilteredSelected}
+                    onToggleSelectAll={handleToggleSelectAll}
+                    members={members}
+                    classrooms={classroomOptions}
+                    onClearSelection={() => setSelectedKeys(new Set())}
+                    onDone={handleBulkDone}
                   />
-                  <span className="text-sm">{t("orgMembers.loading")}</span>
-                </div>
-              ) : isError ? (
-                <div className="px-6 py-10 text-center text-sm text-error">
-                  {t("orgMembers.loadError")}
-                </div>
-              ) : filtered.length === 0 ? (
-                <div className="px-6 py-10 text-center text-sm text-base-content/70">
-                  {classroomFilter === NO_CLASSROOM_FILTER
-                    ? t("orgMembers.noMembersNoClassroom")
-                    : classroomFilter
-                      ? t("orgMembers.noMembersInClassroom", {
-                          classroom:
-                            classroomOptions.find(
-                              (c) => c.path === classroomFilter,
-                            )?.name ?? classroomFilter,
-                        })
-                      : t("orgMembers.noMatch")}
-                </div>
-              ) : (
-                <>
-                  {org ? (
-                    <BulkActionsBar
-                      org={org}
-                      client={client}
-                      selectedRows={selectedRows}
-                      totalCount={filtered.length}
-                      allSelected={allFilteredSelected}
-                      someSelected={someFilteredSelected}
-                      onToggleSelectAll={handleToggleSelectAll}
-                      members={members}
-                      classrooms={classroomOptions}
-                      onClearSelection={() => setSelectedKeys(new Set())}
-                      onDone={handleBulkDone}
-                    />
-                  ) : null}
-                  <motion.ul
-                    className="divide-y divide-base-300"
-                    variants={enterExit}
-                    initial="initial"
-                    animate="animate"
-                  >
-                    {filtered.map((row) => (
-                      <ClickableRow
-                        key={row.key}
-                        className="group/row flex cursor-pointer items-center justify-between gap-4 px-6 py-4 hover:bg-base-200"
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => setSelectedKey(row.key)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault()
-                            setSelectedKey(row.key)
-                          }
+                ) : null}
+                <motion.ul
+                  className="divide-y divide-base-300"
+                  variants={enterExit}
+                  initial="initial"
+                  animate="animate"
+                >
+                  {filtered.map((row) => (
+                    <ClickableRow
+                      key={row.key}
+                      className="group/row flex cursor-pointer items-center justify-between gap-4 px-6 py-4 hover:bg-base-200"
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setSelectedKey(row.key)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault()
+                          setSelectedKey(row.key)
+                        }
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        className="checkbox checkbox-sm shrink-0"
+                        aria-label={
+                          isSelf(row)
+                            ? t("orgMembers.bulk.selfNotSelectable")
+                            : t("orgMembers.bulk.selectRow", {
+                                label: row.username || row.email || row.name,
+                              })
+                        }
+                        disabled={isSelf(row)}
+                        title={
+                          isSelf(row)
+                            ? t("orgMembers.bulk.selfNotSelectable")
+                            : undefined
+                        }
+                        checked={selectedKeys.has(row.key)}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleRowCheckboxClick(e, row.key)
                         }}
-                      >
-                        <input
-                          type="checkbox"
-                          className="checkbox checkbox-sm shrink-0"
-                          aria-label={
-                            isSelf(row)
-                              ? t("orgMembers.bulk.selfNotSelectable")
-                              : t("orgMembers.bulk.selectRow", {
-                                  label: row.username || row.email || row.name,
-                                })
-                          }
-                          disabled={isSelf(row)}
-                          title={
-                            isSelf(row)
-                              ? t("orgMembers.bulk.selfNotSelectable")
-                              : undefined
-                          }
-                          checked={selectedKeys.has(row.key)}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleRowCheckboxClick(e, row.key)
-                          }}
-                          onChange={() => handleToggleRow(row.key)}
+                        onChange={() => handleToggleRow(row.key)}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <Avatar
+                          name={row.name || row.username || row.email}
+                          github={row.username}
+                          initials={initialsFor(row)}
+                          subtitle={<GitHubIdentity row={row} />}
                         />
-                        <div className="min-w-0 flex-1">
-                          <Avatar
-                            name={row.name || row.username || row.email}
-                            github={row.username}
-                            initials={initialsFor(row)}
-                            subtitle={<GitHubIdentity row={row} />}
-                          />
-                        </div>
-                        <div className="flex shrink-0 items-center gap-3">
-                          {row.classification === "on-roster-not-member" &&
-                          row.github_id ? (
-                            <button
-                              type="button"
-                              className="btn btn-xs btn-primary"
-                              disabled={invitingKey === row.key}
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                void handleQuickInvite(row)
-                              }}
-                            >
-                              {invitingKey === row.key ? (
-                                <span
-                                  className="loading loading-spinner loading-xs"
-                                  aria-hidden="true"
-                                />
-                              ) : (
-                                <>
-                                  <UserPlus
-                                    aria-hidden="true"
-                                    className="size-3.5"
-                                  />
-                                  {t("orgMembers.invite")}
-                                </>
-                              )}
-                            </button>
-                          ) : null}
-                          <span className="hidden text-xs text-base-content/70 sm:inline">
-                            {t("orgMembers.classroomCount", {
-                              count: row.classrooms.length,
-                            })}
-                          </span>
-                          {row.unprovisionedClassrooms.length > 0 ? (
-                            <span
-                              className="badge badge-sm badge-warning badge-soft gap-1"
-                              title={t("orgMembers.unprovisionedTitle", {
-                                classrooms:
-                                  row.unprovisionedClassrooms.join(", "),
-                              })}
-                            >
-                              <AlertTriangle
+                      </div>
+                      <div className="flex shrink-0 items-center gap-3">
+                        {row.classification === "on-roster-not-member" &&
+                        row.github_id ? (
+                          <button
+                            type="button"
+                            className="btn btn-xs btn-primary"
+                            disabled={invitingKey === row.key}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              void handleQuickInvite(row)
+                            }}
+                          >
+                            {invitingKey === row.key ? (
+                              <span
+                                className="loading loading-spinner loading-xs"
                                 aria-hidden="true"
-                                className="size-3"
                               />
-                              {t("orgMembers.unprovisionedBadge")}
-                            </span>
-                          ) : null}
-                          <ClassificationBadge
-                            row={row}
-                            isOwner={isOwner(row)}
-                          />
-                          <ChevronRight
-                            aria-hidden="true"
-                            className="size-4 text-base-content/30 transition-transform duration-150 group-hover/row:translate-x-0.5 group-hover/row:text-base-content/70"
-                          />
-                        </div>
-                      </ClickableRow>
-                    ))}
-                  </motion.ul>
-                </>
-              )}
-            </div>
-          </RequireTeacher>
-        </DrawerContent>
-        <DrawerSidebar page="classes" selected="members" />
-      </Drawer>
+                            ) : (
+                              <>
+                                <UserPlus
+                                  aria-hidden="true"
+                                  className="size-3.5"
+                                />
+                                {t("orgMembers.invite")}
+                              </>
+                            )}
+                          </button>
+                        ) : null}
+                        <span className="hidden text-xs text-base-content/70 sm:inline">
+                          {t("orgMembers.classroomCount", {
+                            count: row.classrooms.length,
+                          })}
+                        </span>
+                        {row.unprovisionedClassrooms.length > 0 ? (
+                          <span
+                            className="badge badge-sm badge-warning badge-soft gap-1"
+                            title={t("orgMembers.unprovisionedTitle", {
+                              classrooms:
+                                row.unprovisionedClassrooms.join(", "),
+                            })}
+                          >
+                            <AlertTriangle
+                              aria-hidden="true"
+                              className="size-3"
+                            />
+                            {t("orgMembers.unprovisionedBadge")}
+                          </span>
+                        ) : null}
+                        <ClassificationBadge row={row} isOwner={isOwner(row)} />
+                        <ChevronRight
+                          aria-hidden="true"
+                          className="size-4 text-base-content/30 transition-transform duration-150 group-hover/row:translate-x-0.5 group-hover/row:text-base-content/70"
+                        />
+                      </div>
+                    </ClickableRow>
+                  ))}
+                </motion.ul>
+              </>
+            )}
+          </div>
+        </RequireTeacher>
+      </PageShell>
 
       {org ? (
         <MemberDetailModal
@@ -640,7 +626,7 @@ const OrgMembersPage = () => {
           }}
         />
       ) : null}
-    </div>
+    </>
   )
 }
 

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -386,15 +386,17 @@ const OrgMembersPage = () => {
                   title={t("common.openOrgOnGitHub", { org })}
                 />{" "}
                 {t("orgMembers.subtitleSuffix")}
-                <a
-                  href={`https://github.com/orgs/${org}/people`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mt-2 flex w-fit items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  <ExternalLink aria-hidden="true" className="size-3.5" />
-                  {t("orgMembers.manageMembersOnGitHub")}
-                </a>
+                {org && (
+                  <a
+                    href={githubOrgPeopleUrl(org)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-2 flex w-fit items-center gap-1 text-sm text-primary hover:underline"
+                  >
+                    <ExternalLink aria-hidden="true" className="size-3.5" />
+                    {t("orgMembers.manageMembersOnGitHub")}
+                  </a>
+                )}
               </>
             }
           />

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import Drawer, {
-  DrawerContent,
-  DrawerSidebar,
-  DrawerToggle,
-} from "@/components/drawer"
+import PageShell from "@/components/PageShell"
+import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useParams } from "@tanstack/react-router"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -502,44 +499,35 @@ const OrgSettingsPage = () => {
   const { org } = useParams({ strict: false })
 
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <DrawerToggle />
-        <DrawerContent className="p-10 bg-base-200 xl:px-50">
-          <RequireTeacher allow="owner">
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">
-                {t("orgSettings.page.heading")}
-              </h1>
-              <p className="mt-1 text-sm text-base-content/70">
-                {t("orgSettings.page.subheading_prefix")}{" "}
-                {org ? (
-                  <a
-                    href={githubOrgSettingsUrl(org)}
-                    target="_blank"
-                    rel="noreferrer"
-                    title={t("common.openOrgOnGitHub", { org })}
-                    className="font-mono font-semibold hover:text-primary hover:underline"
-                  >
-                    {org}
-                  </a>
-                ) : (
-                  <span className="font-mono font-semibold">{org}</span>
-                )}
-                {t("orgSettings.page.subheading_suffix")}
-              </p>
-            </div>
-            <div className="mt-8 space-y-8">
-              <OrgSettingsPane />
-              {org && <OrgPolicyAuditPane org={org} />}
-              {org && <RerunOrgSetup org={org} />}
-              {org && <TeardownSection org={org} />}
-            </div>
-          </RequireTeacher>
-        </DrawerContent>
-        <DrawerSidebar page="classes" settings selected="settings" />
-      </Drawer>
-    </div>
+    <PageShell
+      contentClassName="p-10 bg-base-200 xl:px-50"
+      page="classes"
+      settings
+      selected="settings"
+    >
+      <RequireTeacher allow="owner">
+        <PageHeader
+          title={t("orgSettings.page.heading")}
+          subtitle={
+            <>
+              {t("orgSettings.page.subheading_prefix")}{" "}
+              <OrgLink
+                org={org}
+                href={githubOrgSettingsUrl(org ?? "")}
+                title={t("common.openOrgOnGitHub", { org })}
+              />
+              {t("orgSettings.page.subheading_suffix")}
+            </>
+          }
+        />
+        <div className="mt-8 space-y-8">
+          <OrgSettingsPane />
+          {org && <OrgPolicyAuditPane org={org} />}
+          {org && <RerunOrgSetup org={org} />}
+          {org && <TeardownSection org={org} />}
+        </div>
+      </RequireTeacher>
+    </PageShell>
   )
 }
 

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -3,11 +3,8 @@ import { ArrowLeft, ArrowRight, CheckCircle2 } from "lucide-react"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useTranslation } from "react-i18next"
 
-import Drawer, {
-  DrawerContent,
-  DrawerSidebar,
-  DrawerToggle,
-} from "@/components/drawer"
+import PageShell from "@/components/PageShell"
+import PageHeader from "@/components/PageHeader"
 import { Spinner } from "@/components/Spinner"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import useGetOrgMembership from "@/hooks/useGetOrgMembership"
@@ -213,41 +210,35 @@ const OrgSetupPage = () => {
     orgPlanDetails?.plan?.name === "enterprise"
 
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <DrawerToggle />
-        <DrawerContent className="p-10 bg-base-200 2xl:px-50">
-          <div className="mb-8">
-            <h1 className="font-bold text-2xl">{t("setup.pageHeading")}</h1>
-            <p className="text-sm text-base-content/70">
-              {t("setup.pageSubheading")}
-            </p>
-          </div>
-          {!isLoadingPlanDetails && !isTeamOrEnterprise && (
-            <NotTeamOrEnterpriseWarning />
-          )}
-          {isLoading && <Spinner label={t("setup.loadingSetup")} />}
-          {!isLoading && !isOwner && <NotAdminAlert />}
-          {!isLoading && isOwner && (
-            <OrgSteps
-              steps={steps}
-              mutation={mutation}
-              nextStep={nextStep}
-              org={org}
-              setStage={setCurrentStage}
-              stage={currentStage}
-            />
-          )}
+    <PageShell page="classes" selected="assignments">
+      <div className="mb-8">
+        <PageHeader
+          title={t("setup.pageHeading")}
+          subtitle={t("setup.pageSubheading")}
+        />
+      </div>
+      {!isLoadingPlanDetails && !isTeamOrEnterprise && (
+        <NotTeamOrEnterpriseWarning />
+      )}
+      {isLoading && <Spinner label={t("setup.loadingSetup")} />}
+      {!isLoading && !isOwner && <NotAdminAlert />}
+      {!isLoading && isOwner && (
+        <OrgSteps
+          steps={steps}
+          mutation={mutation}
+          nextStep={nextStep}
+          org={org}
+          setStage={setCurrentStage}
+          stage={currentStage}
+        />
+      )}
 
-          <SkeletonOverwriteModal
-            paths={overwritePaths}
-            onConfirm={() => resolveOverwrite(true)}
-            onClose={() => resolveOverwrite(false)}
-          />
-        </DrawerContent>
-        <DrawerSidebar page="classes" selected="assignments" />
-      </Drawer>
-    </div>
+      <SkeletonOverwriteModal
+        paths={overwritePaths}
+        onConfirm={() => resolveOverwrite(true)}
+        onClose={() => resolveOverwrite(false)}
+      />
+    </PageShell>
   )
 }
 

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -1,4 +1,5 @@
 import PageShell from "@/components/PageShell"
+import PageHeader from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { Classroom50OrgSummary } from "@/hooks/github/queries"
 import useGetOrgs from "@/hooks/useGetOrgs"
@@ -362,11 +363,7 @@ const OrgsPage = () => {
         ) : (
           <div className="mb-8">
             <div className="flex flex-col gap-6 p-6">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <h1 className="text-2xl font-bold tracking-tight">
-                  {t("orgs.headingCl50")}
-                </h1>
-              </div>
+              <PageHeader title={t("orgs.headingCl50")} />
 
               <MissingOrgNotice
                 refreshing={isFetching}

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -15,11 +15,8 @@ import { motion } from "motion/react"
 import { useTranslation } from "react-i18next"
 import { enterExit, staggerTransition } from "@/lib/motion"
 
-import Drawer, {
-  DrawerContent,
-  DrawerSidebar,
-  DrawerToggle,
-} from "@/components/drawer"
+import PageShell from "@/components/PageShell"
+import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import RequireTeacher from "@/components/RequireTeacher"
 import useGetClasses from "@/hooks/useGetClasses"
@@ -460,39 +457,29 @@ const PublishedResourcesPage = () => {
   const { org } = useParams({ strict: false })
 
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <DrawerToggle />
-        <DrawerContent className="p-10 bg-base-200 xl:px-50">
-          <RequireTeacher>
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight">
-                {t("published.pageHeading")}
-              </h1>
-              <p className="mt-1 text-sm text-base-content/70">
-                {t("published.pageSubheadingPrefix")}{" "}
-                {org ? (
-                  <a
-                    href={githubOrgUrl(org)}
-                    target="_blank"
-                    rel="noreferrer"
-                    title={t("common.openOrgOnGitHub", { org })}
-                    className="font-mono font-semibold hover:text-primary hover:underline"
-                  >
-                    {org}
-                  </a>
-                ) : (
-                  <span className="font-mono font-semibold">{org}</span>
-                )}
-                {t("published.pageSubheadingSuffix")}
-              </p>
-            </div>
-            {org && <PublishedResourcesPane org={org} />}
-          </RequireTeacher>
-        </DrawerContent>
-        <DrawerSidebar page="classes" selected="published" />
-      </Drawer>
-    </div>
+    <PageShell
+      contentClassName="p-10 bg-base-200 xl:px-50"
+      page="classes"
+      selected="published"
+    >
+      <RequireTeacher>
+        <PageHeader
+          title={t("published.pageHeading")}
+          subtitle={
+            <>
+              {t("published.pageSubheadingPrefix")}{" "}
+              <OrgLink
+                org={org}
+                href={githubOrgUrl(org ?? "")}
+                title={t("common.openOrgOnGitHub", { org })}
+              />
+              {t("published.pageSubheadingSuffix")}
+            </>
+          }
+        />
+        {org && <PublishedResourcesPane org={org} />}
+      </RequireTeacher>
+    </PageShell>
   )
 }
 


### PR DESCRIPTION
## Summary

PR 2 of the layout/navigation standardization (tracking: #162; builds on #163). Behavior-preserving.

- Add `PageHeader` (`web/src/components/PageHeader.tsx`) — the shared dashboard heading: `title`/`subtitle`/`action` as `ReactNode` (so a page can render an inline badge in the heading or a composite subtitle), plus a `loading` skeleton for async-resolved titles.
- Add `OrgLink` (exported from `PageHeader`) — the monospace org deep-link fragment the owner-page subtitles all repeated, falling back to plain text when the slug isn't resolved.
- Migrate to `PageHeader`: `OrgsPage`, `OrgMembersPage`, `OrgSettingsPage`, `PublishedResourcesPage`, and `OrgSetupPage`. The three owner pages also move off hand-rolled `<Drawer>` onto `PageShell` (`xl:px-50` variant).
- Add `PageHeader`/`OrgLink` render tests.
- Drive-by fix (surfaced in review): the "manage members on GitHub" link in `OrgMembersPage` now reuses `githubOrgPeopleUrl` and is gated on `org`, so an unresolved slug no longer builds an `/orgs/undefined/people` URL.

### Scope note
`ClassesPage` is intentionally **not** migrated. Its header is a bespoke GitHub-icon + "GitHub organization" label + org-link block — a distinct shape, not the title/subtitle dialect — so folding it into `PageHeader` would contort the API. Left as-is.

`OrgSetupPage`'s heading was `font-bold text-2xl` (no `tracking-tight`) with a `text-sm` subtitle (no `mt-1`); via `PageHeader` it now matches the shared `text-2xl font-bold tracking-tight` + `mt-1` dashboard dialect. This is a deliberate (near-imperceptible) alignment — the point of standardizing.

The large line counts are mostly prettier re-indentation from removing a JSX nesting level, not logic changes.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on touched files (2 pre-existing in-button-spinner warnings on untouched lines)
- [x] `prettier --check` clean
- [x] `vitest run` — 782 tests pass (777 + 5 new PageHeader/OrgLink tests)
- [x] Reviewed with ce-code-review (verdict: ready to merge; the two worthwhile findings were applied)
- [ ] Sanity-check the 5 migrated pages render identically (headings, org-link subtitles, OrgSetup heading, drawer chrome)