### PR TITLE
refactor(web): normalize all page-level headings onto PageHeader

### DIFF
--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 
 import AssignmentsTable from "@/pages/assignments/AssignmentsTable"
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import Drawer, {
@@ -115,36 +116,37 @@ const TeacherAssignmentsView = ({
 
   return (
     <div>
-      <div className="flex justify-between">
-        <div>
-          {classroomLoading ? (
-            <div className="skeleton skeleton-shimmer mt-8 mb-2 h-6 w-48" />
-          ) : (
-            <h1 className="text-lg pt-8 pb-2 font-bold flex items-center gap-2">
+      <div className="mb-8">
+        <PageHeader
+          loading={classroomLoading}
+          title={
+            <span className="flex items-center gap-2">
               {classroomData?.name || classroomData?.short_name || classroom}
               {myRoleLabel ? (
                 <span className="badge badge-soft badge-primary badge-sm align-middle">
                   {myRoleLabel}
                 </span>
               ) : null}
-            </h1>
-          )}
-          <h3 className="pb-10">
-            {classroomData?.term ? `${classroomData?.term} • ` : ""}
-            {studentsLoading
-              ? "…"
-              : t("assignments.studentCount", { count: students.length })}
-          </h3>
-        </div>
-        <div className="pt-10">
-          {archived ? (
-            <span className="badge badge-soft badge-neutral">
-              {t("assignments.archived")}
             </span>
-          ) : (
-            <NewAssignmentButton org={org} classroom={classroom} />
-          )}
-        </div>
+          }
+          subtitle={
+            <>
+              {classroomData?.term ? `${classroomData?.term} • ` : ""}
+              {studentsLoading
+                ? "…"
+                : t("assignments.studentCount", { count: students.length })}
+            </>
+          }
+          action={
+            archived ? (
+              <span className="badge badge-soft badge-neutral">
+                {t("assignments.archived")}
+              </span>
+            ) : (
+              <NewAssignmentButton org={org} classroom={classroom} />
+            )
+          }
+        />
       </div>
       {archived ? (
         <ArchivedClassroomNotice>

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -190,14 +190,18 @@ const StudentAssignmentsView = ({
   const { t } = useTranslation()
   return (
     <div>
-      <h1 className="text-2xl font-bold mt-6">
-        {t("assignments.studentHeading")}
-      </h1>
-      <label className="text-sm label mb-6">
-        {t("assignments.studentViewAll_prefix")}{" "}
-        <span className="font-bold">{classroom}</span>{" "}
-        {t("assignments.studentViewAll_suffix")}
-      </label>
+      <div className="mb-8">
+        <PageHeader
+          title={t("assignments.studentHeading")}
+          subtitle={
+            <>
+              {t("assignments.studentViewAll_prefix")}{" "}
+              <span className="font-bold">{classroom}</span>{" "}
+              {t("assignments.studentViewAll_suffix")}
+            </>
+          }
+        />
+      </div>
       <OrgRepos org={org} classroom={classroom} />
     </div>
   )

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
 import RequireTeacher from "@/components/RequireTeacher"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
@@ -119,12 +120,8 @@ const CreateAssignmentPage = () => {
         <DrawerContent className="p-10 bg-base-200 2xl:px-50">
           <Breadcrumb endpoint={t("assignments.createBreadcrumb")} />
           <RequireTeacher>
-            <div className="flex justify-between">
-              <div>
-                <h1 className="text-xl pt-8 pb-10 font-bold">
-                  {t("assignments.createHeading")}
-                </h1>
-              </div>
+            <div className="mb-8">
+              <PageHeader title={t("assignments.createHeading")} />
             </div>
             {emptyRoster.show ? (
               <EmptyRosterNotice

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -15,6 +15,7 @@ import Drawer, {
 } from "@/components/drawer"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
 import RequireTeacher from "@/components/RequireTeacher"
 import CreateClassroomForm from "./classes/CreateClassroomForm"
@@ -98,12 +99,8 @@ const CreateClassroomPage = () => {
         <DrawerContent className="p-10 bg-base-200 2xl:px-50">
           <Breadcrumb endpoint={t("documentTitle.newClassroom")} />
           <RequireTeacher allow="owner">
-            <div className="flex justify-between">
-              <div>
-                <h1 className="text-xl pt-8 pb-10 font-bold">
-                  {t("classes.createTitle")}
-                </h1>
-              </div>
+            <div className="mb-8">
+              <PageHeader title={t("classes.createTitle")} />
             </div>
             <div className="flex flex-col">
               <div className="mb-8">

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { Link, useParams, useRouter } from "@tanstack/react-router"
 import { UsersRound } from "lucide-react"
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import Drawer, {
   DrawerContent,
@@ -198,9 +199,9 @@ const EditAssignmentPage = () => {
           {editWarning && (
             <div className="alert alert-warning mt-6">{editWarning}</div>
           )}
-          <h1 className="text-2xl font-bold mt-4 mb-6">
-            {t("assignmentSettings.heading")}
-          </h1>
+          <div className="mb-6">
+            <PageHeader title={t("assignmentSettings.heading")} />
+          </div>
           {isTeacher && archived && (
             <ArchivedClassroomNotice>
               {t("assignmentSettings.archivedNotice_prefix")}{" "}

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -1,4 +1,5 @@
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
 import Drawer, {
   DrawerContent,
@@ -108,19 +109,19 @@ const EditClassroomContent = ({
         <div className="alert alert-error">{t("classes.couldNotLoad")}</div>
       ) : (
         <>
-          <div className="flex justify-between">
-            <div>
-              <h1 className="text-xl pt-8 pb-2 font-bold">
-                {t("documentTitle.classroomSettings")}
-              </h1>
-              <p className="pb-10 text-sm text-base-content/70">
-                {t("classes.settingsSubtitle_prefix")}{" "}
-                <span className="font-semibold">
-                  {cl.name || cl.short_name || classroom}
-                </span>{" "}
-                {t("classes.settingsSubtitle_suffix")}
-              </p>
-            </div>
+          <div className="mb-8">
+            <PageHeader
+              title={t("documentTitle.classroomSettings")}
+              subtitle={
+                <>
+                  {t("classes.settingsSubtitle_prefix")}{" "}
+                  <span className="font-semibold">
+                    {cl.name || cl.short_name || classroom}
+                  </span>{" "}
+                  {t("classes.settingsSubtitle_suffix")}
+                </>
+              }
+            />
           </div>
           <div className="flex flex-col">
             <div className="mb-8">

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 
 import AddStudent from "@/pages/students/AddStudent"
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import Drawer, {
   DrawerContent,
   DrawerSidebar,
@@ -53,20 +54,26 @@ const StudentListContent = ({
 
   return (
     <>
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 pt-8 pb-10">
-        <h1 className="text-lg font-bold">{t("nav.students")}</h1>
-        <span className="text-sm text-base-content/70">
-          {countReady
-            ? t("students.enrolledCount", { count: enrolledCount })
-            : t("students.enrolledCountLoading")}
-        </span>
-        <span aria-hidden="true" className="text-base-content/30">
-          ·
-        </span>
-        <GitHubLink
-          href={`https://github.com/${org}/${CONFIG_REPO}/blob/main/${classroom}/students.csv`}
-          label={t("students.viewCsvOnGitHub")}
-          title={t("students.viewCsvOnGitHub")}
+      <div className="mb-8">
+        <PageHeader
+          title={t("nav.students")}
+          subtitle={
+            <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span>
+                {countReady
+                  ? t("students.enrolledCount", { count: enrolledCount })
+                  : t("students.enrolledCountLoading")}
+              </span>
+              <span aria-hidden="true" className="text-base-content/30">
+                ·
+              </span>
+              <GitHubLink
+                href={`https://github.com/${org}/${CONFIG_REPO}/blob/main/${classroom}/students.csv`}
+                label={t("students.viewCsvOnGitHub")}
+                title={t("students.viewCsvOnGitHub")}
+              />
+            </span>
+          }
         />
       </div>
 

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react"
 
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
 import Drawer, {
   DrawerContent,
@@ -257,11 +258,13 @@ const StudentSubmissionPage = () => {
         <DrawerToggle />
         <DrawerContent className="p-10 bg-base-200 2xl:px-50">
           <Breadcrumb endpoint={t("nav.mySubmission")} />
-          <h1 className="text-2xl font-bold mt-4">
-            {assignmentData?.name ||
+          <PageHeader
+            title={
+              assignmentData?.name ||
               assignment ||
-              t("submissions.student.fallbackTitle")}
-          </h1>
+              t("submissions.student.fallbackTitle")
+            }
+          />
           <AssignmentMeta assignment={assignmentData} />
           {org && classroom && assignment ? (
             <SubmissionBody

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -15,6 +15,7 @@ import {
 import { useParams, Navigate } from "@tanstack/react-router"
 
 import Breadcrumb from "@/components/breadcrumb"
+import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
 import Drawer, {
   DrawerContent,
@@ -495,48 +496,48 @@ const SubmissionsPageContent = () => {
               onRetry={() => refetchScores()}
             />
           )}
-          <div className="flex justify-between">
-            <div>
-              <h1 className="text-lg pt-8 pb-2 font-bold">
-                {assignmentInfo?.name}
-              </h1>
-              <div className="flex flex-wrap items-center gap-2 pb-10 text-sm text-base-content/70">
-                <span>
-                  {assignmentInfo?.due
-                    ? t("submissions.dueDate", {
-                        date: formatDueDateTime(assignmentInfo.due),
-                      })
-                    : t("submissions.noDueDate")}
-                </span>
-                {lateCount > 0 && (
-                  <span className="badge badge-sm badge-error badge-soft">
-                    {t("submissions.lateBadge", { count: lateCount })}
+          <div className="mb-8">
+            <PageHeader
+              title={assignmentInfo?.name}
+              subtitle={
+                <div className="flex flex-wrap items-center gap-2">
+                  <span>
+                    {assignmentInfo?.due
+                      ? t("submissions.dueDate", {
+                          date: formatDueDateTime(assignmentInfo.due),
+                        })
+                      : t("submissions.noDueDate")}
                   </span>
-                )}
-                {assignmentInfo?.template && (
-                  <GitHubLink
-                    href={githubTemplateRepoUrl(
-                      assignmentInfo.template.owner,
-                      assignmentInfo.template.repo,
-                      assignmentInfo.template.branch,
-                    )}
-                    label={t("submissions.viewSourceRepo")}
-                    title={`${assignmentInfo.template.owner}/${assignmentInfo.template.repo}`}
-                  />
-                )}
-              </div>
-            </div>
-            <div className="pt-10">
-              <button
-                type="button"
-                className="btn btn-outline"
-                onClick={downloadScoresCsv}
-                disabled={!scoresInfo.length && !nonSubmitters.length}
-              >
-                <HardDriveDownload aria-hidden="true" />{" "}
-                {t("submissions.downloadCsv")}
-              </button>
-            </div>
+                  {lateCount > 0 && (
+                    <span className="badge badge-sm badge-error badge-soft">
+                      {t("submissions.lateBadge", { count: lateCount })}
+                    </span>
+                  )}
+                  {assignmentInfo?.template && (
+                    <GitHubLink
+                      href={githubTemplateRepoUrl(
+                        assignmentInfo.template.owner,
+                        assignmentInfo.template.repo,
+                        assignmentInfo.template.branch,
+                      )}
+                      label={t("submissions.viewSourceRepo")}
+                      title={`${assignmentInfo.template.owner}/${assignmentInfo.template.repo}`}
+                    />
+                  )}
+                </div>
+              }
+              action={
+                <button
+                  type="button"
+                  className="btn btn-outline"
+                  onClick={downloadScoresCsv}
+                  disabled={!scoresInfo.length && !nonSubmitters.length}
+                >
+                  <HardDriveDownload aria-hidden="true" />{" "}
+                  {t("submissions.downloadCsv")}
+                </button>
+              }
+            />
           </div>
           <div className="mb-4 rounded-box border border-info/20 bg-info/5">
             {/* Action bar: standing note left, the two actions + a single


### PR DESCRIPTION
## Summary

PR 3 of the layout/navigation standardization (tracking: #162; builds on #163, #164). Migrates the remaining hand-rolled **page-level** headings onto the shared `PageHeader` (from PR 2) so every drawer page's title is consistent.

**Classroom-detail dialect (first commit):**
- `AssignmentsPage` (teacher) — title + inline role badge, `loading` skeleton, term/student-count subtitle, archived-badge / `NewAssignmentButton` action.
- `SubmissionsPage` — title, due/late/source-repo `GitHubLink` subtitle, Download-CSV action (disabled predicate preserved).
- `CreateClassroomPage`, `CreateAssignmentPage` — title-only.
- `EditClassroomPage` — title + settings subtitle.

**Consistency sweep (second commit) — the last stragglers:**
- `StudentListPage` — the enrolled count + CSV link move from an inline `text-lg` row into the subtitle line (this was the visible outlier).
- `AssignmentsPage` (student view) — title + "all assignments for {classroom}" subtitle.
- `StudentSubmissionPage` — title-only (the `AssignmentMeta` badges stay directly below).
- `EditAssignmentPage` — teacher settings heading.

## Scope notes

- **Intentional visual change.** These headings previously ranged from `text-lg` to `text-2xl` with bespoke spacing; they now all render the standard `PageHeader` dashboard style (`text-2xl font-bold tracking-tight` + `mt-1` subtitle). This normalization is the goal — headings become uniform app-wide — chosen over adding a `size`/`variant` prop to `PageHeader`.
- **Deliberately left as-is:** `EditAssignmentPage`'s student-collaborators `card-title` (a card header, not a page title); the standalone `AcceptAssignmentPage`/`OnboardingPage` entry shells; and error/auth screens (`NotFound`, `MembershipError`, `GitHubAuthCard`).

After this PR, every drawer page-level `<h1>` goes through `PageHeader`.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on the migration (pre-existing spinner/tabIndex warnings on untouched lines)
- [x] `prettier --check` clean
- [x] `vitest run` — 782 tests pass
- [x] Reviewed with ce-code-review (both commits; verdict: ready to merge, 0 actionable findings)
- [ ] **Visual check needed** — the headings on these pages change size/layout; confirm they look right at desktop + mobile, especially StudentListPage (count/CSV-link now on the subtitle line) and long names wrapping

## Follow-ups (non-blocking, from review)
- `SubmissionsPage` renders an empty `<h1>` while `assignmentInfo` loads (pre-existing; could pass `loading` now).
- The migrated pages have no page-level render tests (pre-existing; `PageHeader` itself is covered).