### PR TITLE
feat(web): prompt users to reload when a new version is deployed

### DIFF
--- a/web/src/components/UpdateAvailableBanner.test.ts
+++ b/web/src/components/UpdateAvailableBanner.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  resolveUpdateBannerVisible,
+  type UpdateBannerInput,
+} from "./UpdateAvailableBanner"
+
+const deployed = "b".repeat(40)
+
+const base: UpdateBannerInput = {
+  hasUpdate: true,
+  dismissedCommit: undefined,
+  deployedCommit: deployed,
+}
+
+describe("resolveUpdateBannerVisible", () => {
+  it("shows the banner when an update exists and nothing was dismissed", () => {
+    expect(resolveUpdateBannerVisible(base)).toBe(true)
+  })
+
+  it("hides the banner after the current deployed commit was dismissed", () => {
+    expect(
+      resolveUpdateBannerVisible({ ...base, dismissedCommit: deployed }),
+    ).toBe(false)
+  })
+
+  it("re-shows when a newer deploy lands after a dismissal", () => {
+    expect(
+      resolveUpdateBannerVisible({ ...base, dismissedCommit: "c".repeat(40) }),
+    ).toBe(true)
+  })
+
+  it("hides the banner when there is no update", () => {
+    expect(resolveUpdateBannerVisible({ ...base, hasUpdate: false })).toBe(
+      false,
+    )
+  })
+
+  it("hides the banner when the deployed commit is unknown (defensive)", () => {
+    // hasUpdate should already be false without a deployed commit; the guard
+    // keeps dismissal comparable even if the inputs ever disagree.
+    expect(
+      resolveUpdateBannerVisible({ ...base, deployedCommit: undefined }),
+    ).toBe(false)
+  })
+})

--- a/web/src/components/UpdateAvailableBanner.tsx
+++ b/web/src/components/UpdateAvailableBanner.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence } from "motion/react"
 import { useTranslation } from "react-i18next"
 
 import { AppBanner } from "@/components/AppBanner"
+import { Button } from "@/components/ui"
 import { useVersionCheck } from "@/hooks/useVersionCheck"
 
 // State the banner depends on — structural so the decision stays a pure,
@@ -50,13 +51,14 @@ export function UpdateAvailableBanner() {
           onDismiss={() => setDismissedCommit(data?.commit)}
         >
           <p className="text-base-content/70">{t("appUpdate.body")}</p>
-          <button
-            type="button"
-            className="btn btn-sm btn-success self-start"
+          <Button
+            variant="success"
+            size="sm"
+            className="self-start"
             onClick={() => window.location.reload()}
           >
             {t("appUpdate.action")}
-          </button>
+          </Button>
         </AppBanner>
       ) : null}
     </AnimatePresence>

--- a/web/src/components/UpdateAvailableBanner.tsx
+++ b/web/src/components/UpdateAvailableBanner.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react"
+import { RefreshCw } from "lucide-react"
+import { AnimatePresence } from "motion/react"
+import { useTranslation } from "react-i18next"
+
+import { AppBanner } from "@/components/AppBanner"
+import { useVersionCheck } from "@/hooks/useVersionCheck"
+
+// State the banner depends on — structural so the decision stays a pure,
+// testable function (mirrors resolveDriftBannerView).
+export type UpdateBannerInput = {
+  hasUpdate: boolean
+  // Deployed commit the user dismissed. Keyed by commit so a newer deploy
+  // after dismissal re-prompts; session-only, so it also reappears on reload —
+  // fine, since reloading is exactly what fetches the new build.
+  dismissedCommit: string | undefined
+  deployedCommit: string | undefined
+}
+
+export function resolveUpdateBannerVisible(input: UpdateBannerInput): boolean {
+  const { hasUpdate, dismissedCommit, deployedCommit } = input
+  if (!hasUpdate || !deployedCommit) return false
+  return dismissedCommit !== deployedCommit
+}
+
+// Global prompt to reload when a newer build than the one this tab is running
+// has been deployed (see useVersionCheck). Reload is loop-safe: the banner
+// only shows when commits differ, and the reloaded build's commit matches. If
+// a CDN edge still serves the old index.html after reload, the banner just
+// re-shows dismissibly — fail-open.
+export function UpdateAvailableBanner() {
+  const { hasUpdate, data } = useVersionCheck()
+  const [dismissedCommit, setDismissedCommit] = useState<string>()
+  const { t } = useTranslation()
+
+  const visible = resolveUpdateBannerVisible({
+    hasUpdate,
+    dismissedCommit,
+    deployedCommit: data?.commit,
+  })
+
+  return (
+    <AnimatePresence initial={false}>
+      {visible ? (
+        <AppBanner
+          key="app-update"
+          tone="success"
+          icon={<RefreshCw className="size-5" aria-hidden="true" />}
+          title={t("appUpdate.title")}
+          onDismiss={() => setDismissedCommit(data?.commit)}
+        >
+          <p className="text-base-content/70">{t("appUpdate.body")}</p>
+          <button
+            type="button"
+            className="btn btn-sm btn-success self-start"
+            onClick={() => window.location.reload()}
+          >
+            {t("appUpdate.action")}
+          </button>
+        </AppBanner>
+      ) : null}
+    </AnimatePresence>
+  )
+}
+
+export default UpdateAvailableBanner

--- a/web/src/hooks/useVersionCheck.test.ts
+++ b/web/src/hooks/useVersionCheck.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveUpdateAvailable } from "./useVersionCheck"
+
+// Realistic hash widths: CI stamps full 40-char shas, local builds 12-char.
+const runningFull = "a".repeat(40)
+const deployedFull = "b".repeat(40)
+
+describe("resolveUpdateAvailable", () => {
+  it("prompts when the deployed commit differs from the running commit", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: deployedFull,
+        runningCommit: runningFull,
+      }),
+    ).toBe(true)
+  })
+
+  it("stays quiet when the commits are identical", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: runningFull,
+        runningCommit: runningFull,
+      }),
+    ).toBe(false)
+  })
+
+  it("stays quiet when the running short hash prefixes the deployed sha (local build of the deployed commit)", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: runningFull,
+        runningCommit: runningFull.slice(0, 12),
+      }),
+    ).toBe(false)
+  })
+
+  it("stays quiet when the deployed hash prefixes the running sha (symmetry)", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: runningFull.slice(0, 12),
+        runningCommit: runningFull,
+      }),
+    ).toBe(false)
+  })
+
+  it("fails open when the deployed commit is missing (fetch/parse failure)", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: undefined,
+        runningCommit: runningFull,
+      }),
+    ).toBe(false)
+  })
+
+  it("fails open when the deployed commit is empty (malformed manifest)", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: "",
+        runningCommit: runningFull,
+      }),
+    ).toBe(false)
+  })
+
+  it("stays quiet for a dev build with no stamped commit", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: deployedFull,
+        runningCommit: "unknown",
+      }),
+    ).toBe(false)
+  })
+
+  it("fails open when the running commit is empty", () => {
+    expect(
+      resolveUpdateAvailable({
+        deployedCommit: deployedFull,
+        runningCommit: "",
+      }),
+    ).toBe(false)
+  })
+})

--- a/web/src/hooks/useVersionCheck.ts
+++ b/web/src/hooks/useVersionCheck.ts
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { appVersion } from "@/version"
+
+// Payload of /version.json, emitted at build time from the same release object
+// as the __APP_*__ defines (see vite.config.ts). Network input — treat every
+// field as possibly missing.
+export type DeployedVersion = {
+  version?: string
+  commit?: string
+  buildDate?: string
+}
+
+// State subset the verdict depends on — structural so the fail-open logic stays
+// a pure, testable function (mirrors resolveSkeletonDrift).
+export type UpdateAvailableInput = {
+  deployedCommit: string | undefined
+  runningCommit: string
+}
+
+// Fail-open verdict: prompt only when both commits are known and genuinely
+// differ. A missing/empty deployed commit (fetch or parse failure) or an
+// "unknown" running commit (dev build where git stamping failed) resolves to
+// "no update" so we never nag on incomplete info.
+//
+// Prefix-tolerant: CI stamps the full 40-char github.sha on both sides, but
+// local builds stamp a 12-char short hash — a running commit that prefixes the
+// deployed one (or vice versa) is the same commit and must not prompt.
+export function resolveUpdateAvailable(input: UpdateAvailableInput): boolean {
+  const { deployedCommit, runningCommit } = input
+  if (!runningCommit || runningCommit === "unknown") return false
+  if (!deployedCommit) return false
+  return (
+    !deployedCommit.startsWith(runningCommit) &&
+    !runningCommit.startsWith(deployedCommit)
+  )
+}
+
+async function fetchDeployedVersion(): Promise<DeployedVersion> {
+  // no-store bypasses the HTTP cache entirely — the whole point is to see the
+  // currently deployed manifest, not a cached copy. BASE_URL always ends in "/".
+  const res = await fetch(`${import.meta.env.BASE_URL}version.json`, {
+    cache: "no-store",
+  })
+  if (!res.ok) throw new Error(`version.json fetch failed: ${res.status}`)
+  return (await res.json()) as DeployedVersion
+}
+
+// Fail-open check for whether a newer build than the one this tab is running
+// has been deployed. GitHub Pages serves hashed bundles that self-invalidate,
+// but the entry index.html can't carry Cache-Control, so a long-lived tab
+// could otherwise run a stale build indefinitely. Compares commits, not
+// versions, so redeploys of the same version still count as updates.
+export function useVersionCheck() {
+  const query = useQuery({
+    queryKey: ["appUpdate", "deployedVersion"],
+    queryFn: fetchDeployedVersion,
+    // Dev/untagged builds without a stamped commit have nothing to compare.
+    enabled: appVersion.commit !== "unknown",
+    refetchInterval: 5 * 60 * 1000,
+    // React Query's focus manager listens to visibilitychange, so returning to
+    // a long-backgrounded tab re-checks immediately (the case this exists for).
+    refetchOnWindowFocus: true,
+    staleTime: 60 * 1000,
+    // Fail-open (see resolveUpdateAvailable); no point retrying a check whose
+    // failure mode is "stay quiet".
+    retry: false,
+  })
+
+  const hasUpdate = resolveUpdateAvailable({
+    deployedCommit: query.data?.commit,
+    runningCommit: appVersion.commit,
+  })
+
+  return { ...query, hasUpdate }
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1119,6 +1119,11 @@
       }
     }
   },
+  "appUpdate": {
+    "title": "A new version of Classroom 50 is available",
+    "body": "Reload the page to get the latest version.",
+    "action": "Reload now"
+  },
   "skeletonDrift": {
     "title": "Classroom workflow files are out of date",
     "body": "The GitHub Actions workflows in this org's classroom50 config repo are out of date. Update them here to keep grading, score collection, and Pages publishing working.",

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
 import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
+import { UpdateAvailableBanner } from "@/components/UpdateAvailableBanner"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { Spinner } from "@/components/Spinner"
 
@@ -46,6 +47,7 @@ function AuthedLayout() {
     <>
       <ScopeWarningBanner />
       <SkeletonDriftBanner />
+      <UpdateAvailableBanner />
       <Outlet />
     </>
   )

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config"
+import type { Plugin } from "vite"
 import react, { reactCompilerPreset } from "@vitejs/plugin-react"
 import babel from "@rolldown/plugin-babel"
 import tailwindcss from "@tailwindcss/vite"
@@ -46,6 +47,29 @@ function resolveReleaseInfo() {
 
 const release = resolveReleaseInfo()
 
+// Publishes the release identity as a fetchable /version.json alongside the
+// compile-time defines below. GitHub Pages can't set Cache-Control, so a
+// long-lived tab could run a stale build forever; it polls this unhashed,
+// short-cached file and compares the deployed commit against its inlined
+// __APP_COMMIT__ (see src/hooks/useVersionCheck.ts). generateBundle covers
+// `vite build`; configureServer serves the same payload in dev so the check
+// has an endpoint instead of a 404.
+function versionJsonPlugin(): Plugin {
+  const body = JSON.stringify(release, null, 2)
+  return {
+    name: "classroom50:version-json",
+    generateBundle() {
+      this.emitFile({ type: "asset", fileName: "version.json", source: body })
+    },
+    configureServer(server) {
+      server.middlewares.use("/version.json", (_req, res) => {
+        res.setHeader("Content-Type", "application/json")
+        res.end(body)
+      })
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   define: {
@@ -62,6 +86,7 @@ export default defineConfig({
     svgr(),
     tailwindcss(),
     babel({ presets: [reactCompilerPreset()] }),
+    versionJsonPlugin(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Prompts users to reload when a newer build of the web app has been deployed, so a long-lived open tab can't run a stale build indefinitely (GitHub Pages can't set `Cache-Control` on the entry `index.html`).

- Emit `dist/version.json` (`{ version, commit, buildDate }`) via an inline Vite plugin from the existing release object in `vite.config.ts`; a `configureServer` middleware serves the same payload in dev. No deploy-workflow changes needed — all deploy paths publish whatever `vite build` puts in `dist/`.
- New `useVersionCheck` hook polls `/version.json` with `cache: "no-store"` every 5 minutes and on focus/visibilitychange (React Query), `retry: false`, disabled for dev builds without a stamped commit. The pure `resolveUpdateAvailable()` verdict is fail-open (any fetch/parse error means no prompt) and prefix-tolerant, so a 12-char local hash vs the 40-char CI sha of the same commit never prompts.
- New dismissible `UpdateAvailableBanner` on `AppBanner` with a "Reload now" button; dismissal is per-deployed-commit, so a newer deploy after dismissing re-prompts. Mounted in `_authed.tsx` alongside the existing banners.
- New `appUpdate` strings in `en.json` (all copy through `t()`); 13 new unit tests mirroring the `resolveSkeletonDrift` style.

Closes #144

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. *(N/A — web-only change)*
- [ ] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). *(N/A — no CLI changes)*
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(web): ...`, `fix(gh-teacher): ...`).