### PR TITLE
feat(web): sumi theme redesign and shared UI component standardization

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,12 +13,12 @@
         try {
           var stored = localStorage.getItem("classroom50:theme")
           var theme =
-            stored === "corporate" || stored === "corporate-dark"
+            stored === "sumi" || stored === "sumi-dark"
               ? stored
               : window.matchMedia &&
                   window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "corporate-dark"
-                : "corporate"
+                ? "sumi-dark"
+                : "sumi"
           document.documentElement.setAttribute("data-theme", theme)
         } catch (e) {}
       })()

--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -10,6 +10,7 @@ import { GitHubPatPrompt } from "./GitHubPatPrompt"
 import { LoginLanguageMenu } from "./LoginLanguageMenu"
 import { AppVersionBadge } from "@/components/AppVersionBadge"
 import { WIKI_URL } from "@/version"
+import { Alert, Button, Card, Spinner } from "@/components/ui"
 
 function LoadingScreen({ label }: { label: string }) {
   return (
@@ -17,7 +18,7 @@ function LoadingScreen({ label }: { label: string }) {
       className="flex flex-col items-center gap-4 py-10 text-center text-base-content/70"
       role="status"
     >
-      <span className="loading loading-spinner loading-lg" aria-hidden="true" />
+      <Spinner size="lg" />
       <p className="text-sm">{label}</p>
     </div>
   )
@@ -30,7 +31,7 @@ export function GitHubAuthCard() {
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-base-200 px-4 py-8">
-      <section className="card relative w-full max-w-lg rounded-xl border border-base-300 bg-base-100 shadow-sm">
+      <Card as="section" radius="xl" className="relative w-full max-w-lg">
         <div className="absolute right-3 top-3 z-10">
           <LoginLanguageMenu />
         </div>
@@ -48,7 +49,7 @@ export function GitHubAuthCard() {
           </div>
         </header>
 
-        <div className="card-body">
+        <Card.Body>
           {auth.screen === "authed" ? (
             auth.isLoadingUser && !auth.user ? (
               // "authed" screen before GET /user resolves: on cold reload (mount
@@ -85,39 +86,36 @@ export function GitHubAuthCard() {
               }}
             >
               {auth.error ? (
-                <div className="alert alert-error items-start text-sm">
+                <Alert tone="error" className="items-start text-sm">
                   <AlertTriangle
                     aria-hidden="true"
                     className="size-4 shrink-0"
                   />
                   <span>{auth.error}</span>
-                </div>
+                </Alert>
               ) : auth.sessionExpired ? (
-                <div className="alert alert-warning items-start text-sm">
+                <Alert tone="warning" className="items-start text-sm">
                   <AlertTriangle
                     aria-hidden="true"
                     className="size-4 shrink-0"
                   />
                   <span>Your session expired — sign in again to continue.</span>
-                </div>
+                </Alert>
               ) : null}
 
               <div className="space-y-3">
-                <button
-                  className="btn btn-primary w-full"
+                <Button
+                  variant="primary"
+                  className="w-full"
                   type="submit"
+                  loading={auth.isStartingWebFlow}
                   disabled={auth.isStartingWebFlow}
                 >
-                  {auth.isStartingWebFlow ? (
-                    <span
-                      className="loading loading-spinner loading-sm"
-                      aria-hidden="true"
-                    />
-                  ) : (
+                  {auth.isStartingWebFlow ? null : (
                     <GitHub aria-hidden="true" className="size-4" />
                   )}
                   {t("auth.signInWithGitHub")}
-                </button>
+                </Button>
 
                 <details className="collapse collapse-arrow border border-base-300 bg-base-100">
                   <summary className="collapse-title min-h-0 px-4 py-3 text-sm font-medium">
@@ -125,34 +123,31 @@ export function GitHubAuthCard() {
                   </summary>
 
                   <div className="collapse-content space-y-3">
-                    <button
-                      className="btn btn-outline btn-primary w-full"
+                    <Button
+                      variant="outline"
+                      className="w-full"
                       type="button"
+                      loading={auth.isRequestingDeviceCode}
                       disabled={auth.isRequestingDeviceCode}
                       onClick={() => void auth.startDeviceFlow()}
                     >
-                      {auth.isRequestingDeviceCode ? (
-                        <span
-                          className="loading loading-spinner loading-sm"
-                          aria-hidden="true"
-                        />
-                      ) : null}
                       {t("auth.useDeviceCode")}
-                    </button>
+                    </Button>
 
-                    <button
-                      className="btn btn-outline btn-primary w-full"
+                    <Button
+                      variant="outline"
+                      className="w-full"
                       type="button"
                       onClick={() => auth.startPatFlow()}
                     >
                       {t("auth.usePersonalAccessToken")}
-                    </button>
+                    </Button>
                   </div>
                 </details>
               </div>
             </form>
           )}
-        </div>
+        </Card.Body>
 
         <footer className="flex items-center justify-between gap-3 border-t border-base-200 px-7 py-4 text-xs text-base-content/70">
           <span>{t("auth.footerTagline")}</span>
@@ -168,7 +163,7 @@ export function GitHubAuthCard() {
             </a>
           </div>
         </footer>
-      </section>
+      </Card>
     </main>
   )
 }

--- a/web/src/auth/GitHubAuthedPanel.tsx
+++ b/web/src/auth/GitHubAuthedPanel.tsx
@@ -2,6 +2,7 @@ import { CheckCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import type { GitHubUser } from "@/hooks/github/types"
+import { Alert, Button } from "@/components/ui"
 
 export function GitHubAuthedPanel({
   user,
@@ -18,10 +19,10 @@ export function GitHubAuthedPanel({
           spinner instead while the profile is still loading, so this panel only
           sees a resolved user or a genuine failure. */}
       {user ? (
-        <div className="alert alert-success items-start text-sm">
+        <Alert tone="success" className="items-start text-sm">
           <CheckCircle aria-hidden="true" className="size-4 shrink-0" />
           <span>{t("auth.signedInConfirmed")}</span>
-        </div>
+        </Alert>
       ) : null}
 
       <div className="flex flex-col items-center gap-3 text-center">
@@ -56,9 +57,9 @@ export function GitHubAuthedPanel({
 
       <div className="divider" />
 
-      <button className="btn btn-outline w-full" onClick={onSignOut}>
+      <Button variant="outline" className="w-full" onClick={onSignOut}>
         {t("auth.signOutClearToken")}
-      </button>
+      </Button>
     </div>
   )
 }

--- a/web/src/auth/GitHubDevicePrompt.tsx
+++ b/web/src/auth/GitHubDevicePrompt.tsx
@@ -3,6 +3,7 @@ import { Check, Copy, ExternalLink } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import type { DeviceAuthState } from "./types"
+import { Button } from "@/components/ui"
 
 function StepNumber({ value, done }: { value: number; done: boolean }) {
   return (
@@ -77,11 +78,10 @@ export function GitHubDevicePrompt({
             {device.userCode}
           </div>
 
-          <button
-            className={[
-              "btn btn-sm w-full",
-              copied ? "btn-success" : "btn-outline btn-primary",
-            ].join(" ")}
+          <Button
+            variant={copied ? "success" : "outline"}
+            size="sm"
+            className="w-full"
             onClick={copyCode}
           >
             {copied ? (
@@ -95,7 +95,7 @@ export function GitHubDevicePrompt({
                 {t("auth.deviceCopyCode")}
               </>
             )}
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -150,9 +150,9 @@ export function GitHubDevicePrompt({
 
       <div className="divider" />
 
-      <button className="btn btn-outline w-full" onClick={onCancel}>
+      <Button variant="outline" className="w-full" onClick={onCancel}>
         {t("common.cancel")}
-      </button>
+      </Button>
     </div>
   )
 }

--- a/web/src/auth/GitHubPatPrompt.tsx
+++ b/web/src/auth/GitHubPatPrompt.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { AlertTriangle, ExternalLink, KeyRound } from "lucide-react"
 
 import { REQUIRED_SCOPES } from "./scopes"
+import { Alert, Button, Input } from "@/components/ui"
 
 // The classic-PAT checkboxes to tick, derived from REQUIRED_SCOPES (the same
 // source missingScopes() validates against) so the on-screen list and the
@@ -63,10 +64,10 @@ export function GitHubPatPrompt({
       }}
     >
       {error ? (
-        <div className="alert alert-error items-start text-sm">
+        <Alert tone="error" className="items-start text-sm">
           <AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
           <span>{error}</span>
-        </div>
+        </Alert>
       ) : null}
 
       <div className="space-y-2">
@@ -95,8 +96,8 @@ export function GitHubPatPrompt({
 
       <label className="form-control w-full">
         <span className="label-text sr-only">{t("auth.patTokenLabel")}</span>
-        <input
-          className="input input-bordered w-full font-mono text-sm"
+        <Input
+          className="font-mono text-sm"
           type="password"
           autoComplete="off"
           spellCheck={false}
@@ -113,30 +114,28 @@ export function GitHubPatPrompt({
       </p>
 
       <div className="space-y-3">
-        <button
-          className="btn btn-primary w-full"
+        <Button
+          variant="primary"
+          className="w-full"
           type="submit"
+          loading={isValidating}
           disabled={!trimmed || isValidating}
         >
-          {isValidating ? (
-            <span
-              className="loading loading-spinner loading-sm"
-              aria-hidden="true"
-            />
-          ) : (
+          {isValidating ? null : (
             <KeyRound aria-hidden="true" className="size-4" />
           )}
           {t("auth.patSubmit")}
-        </button>
+        </Button>
 
-        <button
-          className="btn btn-outline w-full"
+        <Button
+          variant="outline"
+          className="w-full"
           type="button"
           onClick={onCancel}
           disabled={isValidating}
         >
           {t("auth.patCancel")}
-        </button>
+        </Button>
       </div>
     </form>
   )

--- a/web/src/auth/LoginLanguageMenu.tsx
+++ b/web/src/auth/LoginLanguageMenu.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react"
 import { Check, Globe, Loader2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
+import { Button } from "@/components/ui"
 import { useLanguage } from "@/hooks/useLanguage"
 import { useLanguageRegistry } from "@/hooks/useLanguageRegistry"
 import { BASE_LANG, languageLabel } from "@/i18n/customLocale"
@@ -73,16 +74,18 @@ export function LoginLanguageMenu() {
 
   return (
     <div className="dropdown dropdown-end">
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="circle"
+        className="text-base-content/70"
         tabIndex={0}
-        className="btn btn-ghost btn-sm btn-circle text-base-content/70"
         aria-label={t("language.switcherLabel")}
         title={t("language.switcherLabel")}
         onClick={() => void loadRegistry()}
       >
         <Globe aria-hidden="true" className="size-5" />
-      </button>{" "}
+      </Button>{" "}
       <ul
         tabIndex={0}
         className="dropdown-content menu z-10 mt-1 max-h-80 w-60 flex-nowrap overflow-y-auto rounded-box border border-base-content/5 bg-base-100 p-1 shadow"

--- a/web/src/auth/ScopeWarningBanner.tsx
+++ b/web/src/auth/ScopeWarningBanner.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next"
 import { useGithubAuth } from "./useGithubAuth"
 import { AppBanner } from "@/components/AppBanner"
 import { useMissingScopes } from "@/context/github/GitHubProvider"
+import { Button } from "@/components/ui"
 
 // Surfaces missing required scopes detected from live API responses:
 // best-effort, non-blocking, with a re-authorize action. A revoked/expired
@@ -35,13 +36,14 @@ export function ScopeWarningBanner() {
             <code className="font-mono text-xs">{missing.join(", ")}</code>
             {t("auth.missingScopesBody_suffix", { count: scopeCount })}
           </p>
-          <button
-            type="button"
-            className="btn btn-sm btn-warning self-start"
+          <Button
+            variant="warning"
+            size="sm"
+            className="self-start"
             onClick={() => void startWebFlow()}
           >
             {t("auth.reauthorize")}
-          </button>
+          </Button>
           <p className="text-xs text-base-content/70">
             {t("auth.reauthorizeHint")}
           </p>

--- a/web/src/components/AboutDialog.tsx
+++ b/web/src/components/AboutDialog.tsx
@@ -1,6 +1,8 @@
 import { forwardRef } from "react"
 import { useTranslation } from "react-i18next"
-import { ExternalLink, X } from "lucide-react"
+import { ExternalLink } from "lucide-react"
+
+import { Modal } from "@/components/ui"
 import {
   appVersion,
   commitUrl,
@@ -50,80 +52,72 @@ export const AboutDialog = forwardRef<HTMLDialogElement, { titleId: string }>(
     const release = releaseUrl()
 
     return (
-      <dialog ref={ref} className="modal" aria-labelledby={titleId}>
-        <div className="modal-box flex max-h-[85vh] max-w-md flex-col overflow-y-auto text-base-content">
-          <form method="dialog">
-            <button
-              className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
-              aria-label={t("common.close")}
-            >
-              <X className="size-4" aria-hidden="true" />
-            </button>
-          </form>
-          <h3 id={titleId} className="text-lg font-bold">
-            {t("nav.aboutDialogTitle")}
-          </h3>
-          <p className="mt-1 mb-4 text-sm text-base-content/70">
-            {t("nav.aboutDialogDescription")}
-          </p>
+      <Modal
+        ref={ref}
+        size="md"
+        boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
+        aria-labelledby={titleId}
+      >
+        <h3 id={titleId} className="text-lg font-bold">
+          {t("nav.aboutDialogTitle")}
+        </h3>
+        <p className="mt-1 mb-4 text-sm text-base-content/70">
+          {t("nav.aboutDialogDescription")}
+        </p>
 
-          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
-            <dt className="text-base-content/60">{t("nav.aboutVersion")}</dt>
-            <dd className="font-mono tabular-nums">
-              {release ? (
-                <a
-                  className="link link-info link-hover inline-flex items-center gap-1"
-                  href={release}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  v{appVersion.version}
-                  <ExternalLink aria-hidden="true" className="size-3" />
-                </a>
-              ) : (
-                <>v{appVersion.version}</>
-              )}
-            </dd>
-
-            <dt className="text-base-content/60">{t("nav.aboutCommit")}</dt>
-            <dd className="font-mono">
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt className="text-base-content/60">{t("nav.aboutVersion")}</dt>
+          <dd className="font-mono tabular-nums">
+            {release ? (
               <a
                 className="link link-info link-hover inline-flex items-center gap-1"
-                href={commitUrl()}
+                href={release}
                 target="_blank"
                 rel="noreferrer"
               >
-                {shortCommit()}
+                v{appVersion.version}
                 <ExternalLink aria-hidden="true" className="size-3" />
               </a>
-            </dd>
+            ) : (
+              <>v{appVersion.version}</>
+            )}
+          </dd>
 
-            <dt className="text-base-content/60">{t("nav.aboutBuilt")}</dt>
-            <dd className="font-mono tabular-nums">{appVersion.buildDate}</dd>
-          </dl>
+          <dt className="text-base-content/60">{t("nav.aboutCommit")}</dt>
+          <dd className="font-mono">
+            <a
+              className="link link-info link-hover inline-flex items-center gap-1"
+              href={commitUrl()}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {shortCommit()}
+              <ExternalLink aria-hidden="true" className="size-3" />
+            </a>
+          </dd>
 
-          <div className="divider my-4" />
+          <dt className="text-base-content/60">{t("nav.aboutBuilt")}</dt>
+          <dd className="font-mono tabular-nums">{appVersion.buildDate}</dd>
+        </dl>
 
-          <h4 className="mb-3 text-sm font-semibold">
-            {t("nav.aboutSupportTitle")}
-          </h4>
-          <div className="flex flex-col gap-2">
-            <SupportLink
-              href={DISCUSSIONS_URL}
-              title={t("nav.aboutAskQuestion")}
-              hint={t("nav.aboutAskQuestionHint")}
-            />
-            <SupportLink
-              href={ISSUES_URL}
-              title={t("nav.aboutReportIssue")}
-              hint={t("nav.aboutReportIssueHint")}
-            />
-          </div>
+        <div className="divider my-4" />
+
+        <h4 className="mb-3 text-sm font-semibold">
+          {t("nav.aboutSupportTitle")}
+        </h4>
+        <div className="flex flex-col gap-2">
+          <SupportLink
+            href={DISCUSSIONS_URL}
+            title={t("nav.aboutAskQuestion")}
+            hint={t("nav.aboutAskQuestionHint")}
+          />
+          <SupportLink
+            href={ISSUES_URL}
+            title={t("nav.aboutReportIssue")}
+            hint={t("nav.aboutReportIssueHint")}
+          />
         </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>{t("common.close")}</button>
-        </form>
-      </dialog>
+      </Modal>
     )
   },
 )

--- a/web/src/components/AppBanner/index.tsx
+++ b/web/src/components/AppBanner/index.tsx
@@ -4,6 +4,7 @@ import { motion } from "motion/react"
 import { useTranslation } from "react-i18next"
 
 import { collapseVariants } from "@/lib/motion"
+import { Button } from "@/components/ui"
 
 export type AppBannerTone = "error" | "warning" | "success"
 
@@ -60,14 +61,16 @@ export const AppBanner = ({
           {children}
         </div>
         {onDismiss ? (
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="xs"
+            shape="square"
             aria-label={t("components.banner.dismiss")}
-            className="btn btn-ghost btn-xs btn-square -mr-1 shrink-0"
+            className="-mr-1 shrink-0"
             onClick={onDismiss}
           >
             <X aria-hidden="true" className="size-4" />
-          </button>
+          </Button>
         ) : null}
       </div>
     </motion.div>

--- a/web/src/components/EmptyRosterNotice.tsx
+++ b/web/src/components/EmptyRosterNotice.tsx
@@ -2,10 +2,11 @@ import { Link } from "@tanstack/react-router"
 import { Info, UserPlus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
-// Empty/unenrolled-roster warning. Owns the daisyUI alert shell + ARIA so the
+// Empty/unenrolled-roster notice. Owns the daisyUI alert shell + ARIA so the
 // assignments list and create pages can't drift in markup; copy adapts to
-// whether the roster has rows (invited, not joined) or is empty. Render only
-// when useEmptyRosterWarning().show is true.
+// whether the roster has rows (invited, not joined) or is empty. Rendered as an
+// informational (info) tone — an empty roster is an expected state, not an
+// error. Render only when useEmptyRosterWarning().show is true.
 export const EmptyRosterNotice = ({
   org,
   classroom,

--- a/web/src/components/InlineNote/index.tsx
+++ b/web/src/components/InlineNote/index.tsx
@@ -2,13 +2,15 @@ import type { ComponentType, ReactNode, SVGProps } from "react"
 
 export type InlineNoteTone = "success" | "warning" | "error" | "neutral"
 
-// Explicit dark-on-light colors rather than daisyUI's *-content tones, too light
-// to read on a white form background.
+// DaisyUI semantic tints (theme-aware), replacing the former raw Tailwind
+// palette (`green-50`/`amber-50`/...) so inline notes track the active theme
+// like the rest of the app. Each tone is a soft tint of its semantic token with
+// a matching border and readable foreground.
 const TONE_CLASS: Record<InlineNoteTone, string> = {
-  success: "bg-green-50 border-green-200 text-green-800",
-  warning: "bg-amber-50 border-amber-200 text-amber-900",
-  error: "bg-red-50 border-red-200 text-red-800",
-  neutral: "bg-base-200 border-base-300 text-base-content/80",
+  success: "border-success/30 bg-success/10 text-success",
+  warning: "border-warning/30 bg-warning/10 text-warning",
+  error: "border-error/30 bg-error/10 text-error",
+  neutral: "border-base-300 bg-base-200 text-base-content/80",
 }
 
 // Compact tinted note for inline field feedback (an icon plus a short message).

--- a/web/src/components/LanguageDialog.tsx
+++ b/web/src/components/LanguageDialog.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react"
 import { useTranslation } from "react-i18next"
-import { X } from "lucide-react"
 
+import { Modal } from "@/components/ui"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 
 // Language-pack modal shown from the sidebar footer. Extracted alongside
@@ -22,27 +22,19 @@ export const LanguageDialog = forwardRef<
   }
 
   return (
-    <dialog ref={ref} className="modal" aria-labelledby={titleId}>
-      <div className="modal-box flex max-h-[85vh] max-w-lg flex-col overflow-y-auto text-base-content">
-        <form method="dialog">
-          <button
-            className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
-            aria-label={t("common.close")}
-          >
-            <X className="size-4" aria-hidden="true" />
-          </button>
-        </form>
-        <h3 id={titleId} className="text-lg font-bold">
-          {t("nav.languageDialogTitle")}
-        </h3>
-        <p className="mt-1 mb-4 text-sm text-base-content/70">
-          {t("nav.languageDialogDescription")}
-        </p>
-        <LanguageSwitcher onApplied={close} />
-      </div>
-      <form method="dialog" className="modal-backdrop">
-        <button>{t("common.close")}</button>
-      </form>
-    </dialog>
+    <Modal
+      ref={ref}
+      size="lg"
+      boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
+      aria-labelledby={titleId}
+    >
+      <h3 id={titleId} className="text-lg font-bold">
+        {t("nav.languageDialogTitle")}
+      </h3>
+      <p className="mt-1 mb-4 text-sm text-base-content/70">
+        {t("nav.languageDialogDescription")}
+      </p>
+      <LanguageSwitcher onApplied={close} />
+    </Modal>
   )
 })

--- a/web/src/components/MembershipError.tsx
+++ b/web/src/components/MembershipError.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, Check, ClipboardCopy, UserPlus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { Button, Card } from "@/components/ui"
 
 // Distinct membership-failure causes the student flow (onboarding + accept) can
 // hit; each maps to a title/body and at least one recovery action.
@@ -105,18 +106,14 @@ const CopyableDetails = ({
         <pre className="overflow-x-auto rounded-lg bg-base-100 p-3 text-xs whitespace-pre-wrap">
           {text}
         </pre>
-        <button
-          type="button"
-          className="btn btn-outline btn-sm"
-          onClick={() => void copy()}
-        >
+        <Button variant="outline" size="sm" onClick={() => void copy()}>
           {copied ? (
             <Check aria-hidden="true" className="size-4" />
           ) : (
             <ClipboardCopy aria-hidden="true" className="size-4" />
           )}
           {copied ? t("membership.copied") : t("membership.copyDetails")}
-        </button>
+        </Button>
         <span aria-live="polite" className="sr-only">
           {copied ? t("membership.copied") : ""}
         </span>
@@ -157,7 +154,7 @@ export const MembershipError = ({
   }[cause]
 
   return (
-    <div className="card-body gap-6">
+    <Card.Body className="gap-6">
       <div>
         <span className={`badge ${badgeTone} badge-soft gap-2`}>
           <AlertTriangle aria-hidden="true" className="size-4" />
@@ -210,19 +207,15 @@ export const MembershipError = ({
             )}
 
             {cause === "generic" && onRetry && (
-              <button
-                type="button"
-                className="btn btn-primary btn-sm"
-                onClick={onRetry}
-              >
+              <Button variant="primary" size="sm" onClick={onRetry}>
                 {t("membership.generic.retry")}
-              </button>
+              </Button>
             )}
           </div>
         </div>
       </div>
 
       <CopyableDetails details={details} />
-    </div>
+    </Card.Body>
   )
 }

--- a/web/src/components/MissingParams.tsx
+++ b/web/src/components/MissingParams.tsx
@@ -1,14 +1,16 @@
 import { useTranslation } from "react-i18next"
 
+import { Alert } from "@/components/ui"
+
 // Full-page bail when a route is missing an expected URL param; shared so the
 // guard markup stays consistent. Callers may pass a context-specific message,
 // else the translated generic one.
 export const MissingParams = ({ message }: { message?: string }) => {
   const { t } = useTranslation()
   return (
-    <div className="alert alert-error m-10" role="alert">
+    <Alert tone="error" className="m-10">
       {message ?? t("missingParams.message")}
-    </div>
+    </Alert>
   )
 }
 

--- a/web/src/components/PageShell.tsx
+++ b/web/src/components/PageShell.tsx
@@ -6,15 +6,16 @@ import Drawer, {
   DrawerToggle,
 } from "@/components/drawer"
 
-const DEFAULT_CONTENT_CLASS = "p-10 bg-base-200 2xl:px-50"
+const DEFAULT_CONTENT_CLASS = "p-6 bg-base-200 2xl:px-8"
 
 // Every drawer page repeated the Drawer/toggle/content/sidebar structure;
 // PageShell owns it so pages render only their content.
 //
-// contentClassName overrides the DrawerContent padding — the default matches the
-// 10 pages on `2xl:px-50`; the three `xl:px-50` owner pages pass their variant.
-// The DrawerSidebar props (page/selected/settings) are threaded through
-// unchanged; PR 4 will replace them with route-derived active-state.
+// contentClassName overrides the DrawerContent padding — the default (a tight
+// p-6 frame with only a modest 2xl gutter) now covers every page, including the
+// former owner-page variants. The DrawerSidebar props (page/selected/settings)
+// are threaded through unchanged; PR 4 will replace them with route-derived
+// active-state.
 export default function PageShell({
   children,
   contentClassName = DEFAULT_CONTENT_CLASS,
@@ -32,7 +33,12 @@ export default function PageShell({
     <div className="min-h-screen">
       <Drawer>
         <DrawerToggle />
-        <DrawerContent className={contentClassName}>{children}</DrawerContent>
+        <DrawerContent className={contentClassName}>
+          {/* One vertical rhythm for every page: sections are direct children
+              spaced by gap-6, so pages don't hand-roll per-block margins (the
+              org homepage's look, now the default). */}
+          <div className="flex flex-col gap-6">{children}</div>
+        </DrawerContent>
         <DrawerSidebar page={page} selected={selected} settings={settings} />
       </Drawer>
     </div>

--- a/web/src/components/PlanBadge.tsx
+++ b/web/src/components/PlanBadge.tsx
@@ -1,6 +1,8 @@
 import GitHub from "@/assets/github.svg?react"
 import { useTranslation } from "react-i18next"
 
+import { Badge } from "@/components/ui"
+
 // Shared GitHub-plan badge (org's billing plan). GitHub returns the plan name
 // only to org owners, so callers pass `undefined` for non-owners and nothing
 // renders. The GitHub mark signals this is the org's GitHub plan, not a
@@ -18,13 +20,14 @@ const PlanBadge = ({
   if (!name) return null
 
   return (
-    <span
-      className={`badge badge-ghost badge-sm gap-1 capitalize ${className}`.trim()}
+    <Badge
+      ghost
+      className={`gap-1 capitalize ${className}`.trim()}
       title={title}
     >
       <GitHub className="size-3" aria-hidden="true" />
       {t("components.planBadge.label", { name })}
-    </span>
+    </Badge>
   )
 }
 

--- a/web/src/components/QueryErrorAlert.tsx
+++ b/web/src/components/QueryErrorAlert.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
+import { Alert, Button } from "@/components/ui"
+
 // Error banner (no dismiss) with an inline retry, shared by the submissions
 // dashboard panels that load an independent data source (roster, gradebook).
 // Extracted so the two blocks can't drift on markup/retry wiring.
@@ -15,17 +17,13 @@ export function QueryErrorAlert({
 }) {
   const { t } = useTranslation()
   return (
-    <div className={`alert alert-error ${className}`}>
+    <Alert tone="error" className={className}>
       <div>
         {message}
-        <button
-          type="button"
-          className="btn btn-sm btn-ghost ml-2"
-          onClick={onRetry}
-        >
+        <Button variant="ghost" size="sm" className="ml-2" onClick={onRetry}>
           {t("submissions.errors.retry")}
-        </button>
+        </Button>
       </div>
-    </div>
+    </Alert>
   )
 }

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -16,6 +16,7 @@ import {
   SkeletonOverwriteModal,
   useSkeletonOverwriteConfirm,
 } from "@/pages/orgSettings/skeletonOverwriteUi"
+import { Button } from "@/components/ui"
 
 export type DriftBannerView = "warning" | "success" | "hidden"
 
@@ -174,13 +175,14 @@ export function SkeletonDriftBanner() {
                 <p className="text-base-content/70">
                   {t("skeletonDrift.success.body")}
                 </p>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-success self-start"
+                <Button
+                  variant="success"
+                  size="sm"
+                  className="self-start"
                   onClick={() => setDismissedOrg(org)}
                 >
                   {t("skeletonDrift.success.dismiss")}
-                </button>
+                </Button>
               </>
             ) : (
               <>
@@ -193,9 +195,12 @@ export function SkeletonDriftBanner() {
                   </span>{" "}
                   {t("skeletonDrift.overwriteWarning")}
                 </p>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-warning self-start"
+                <Button
+                  variant="warning"
+                  size="sm"
+                  className="self-start"
+                  loading={pendingOrg === org}
+                  loadingLabel={t("skeletonDrift.updating")}
                   disabled={pendingOrg === org}
                   onClick={() => {
                     if (org && pendingOrg !== org) {
@@ -204,18 +209,10 @@ export function SkeletonDriftBanner() {
                     }
                   }}
                 >
-                  {pendingOrg === org ? (
-                    <>
-                      <span
-                        className="loading loading-spinner loading-xs"
-                        aria-hidden="true"
-                      />
-                      {t("skeletonDrift.updating")}
-                    </>
-                  ) : (
-                    t("skeletonDrift.action")
-                  )}
-                </button>
+                  {pendingOrg === org
+                    ? t("skeletonDrift.updating")
+                    : t("skeletonDrift.action")}
+                </Button>
               </>
             )}
           </AppBanner>

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -28,6 +28,7 @@ import {
 } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { useGithubAuth } from "../../auth/useGithubAuth"
+import GitHub from "@/assets/github.svg?react"
 import duck from "@/assets/duck.png"
 import { useCourseTeacherAccess } from "../../hooks/useCourseTeacherAccess"
 import {
@@ -43,6 +44,7 @@ import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetPublicAssignment from "@/hooks/useGetPublicAssignment"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
 import { studentRepoName } from "@/util/studentRepo"
+import { githubOrgUrl } from "@/util/orgUrl"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import { useTheme } from "@/hooks/useTheme"
 import { LanguageDialog } from "@/components/LanguageDialog"
@@ -720,9 +722,31 @@ export const SidebarFooter = () => {
 
   return (
     <>
+      {org ? (
+        <a
+          href={githubOrgUrl(org)}
+          target="_blank"
+          rel="noreferrer"
+          title={t("common.openOrgOnGitHub", { org })}
+          className={`mt-auto block border-t border-neutral-content/20 py-2 text-neutral-content/70 transition-colors hover:text-neutral-content ${collapsed ? "flex justify-center px-2" : "px-6"}`}
+        >
+          {collapsed ? (
+            <GitHub aria-hidden="true" className="size-4 shrink-0 opacity-80" />
+          ) : (
+            <>
+              <span className="block text-[0.625rem] font-medium uppercase tracking-wide text-neutral-content/50">
+                {t("classes.githubOrganization")}
+              </span>
+              <span className="block break-words font-mono text-xs font-semibold text-neutral-content">
+                {org}
+              </span>
+            </>
+          )}
+        </a>
+      ) : null}
       <div
         ref={footerRef}
-        className="relative mt-auto cursor-pointer border-t border-neutral-content/20 py-4"
+        className={`relative cursor-pointer border-t border-neutral-content/20 py-4 ${org ? "" : "mt-auto"}`}
         onClick={() => setMenuOpen((open) => !open)}
         role="button"
         tabIndex={0}

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -746,7 +746,7 @@ export const SidebarFooter = () => {
       ) : null}
       <div
         ref={footerRef}
-        className={`relative cursor-pointer border-t border-neutral-content/20 py-4 ${org ? "" : "mt-auto"}`}
+        className={`relative cursor-pointer border-t border-neutral-content/20 py-4 transition-colors hover:bg-[var(--sidebar-surface)]/60 ${org ? "" : "mt-auto"}`}
         onClick={() => setMenuOpen((open) => !open)}
         role="button"
         tabIndex={0}
@@ -912,14 +912,14 @@ export const SidebarFooter = () => {
         </div>
 
         <div
-          className={`flex w-full items-center gap-4 text-left ${collapsed ? "justify-center" : "justify-start"}`}
+          className={`flex w-full items-center gap-3 text-left ${collapsed ? "justify-center" : "justify-start"}`}
           title={collapsed ? name : undefined}
         >
           <div className="avatar avatar-placeholder">
             <img
               src={avatar_img}
               alt={t("nav.avatarAlt", { name })}
-              className={`rounded-full ${collapsed ? "w-10" : "w-12"}`}
+              className={`rounded-full ${collapsed ? "w-8" : "w-9"}`}
             />
           </div>
 

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -5,6 +5,8 @@
 import { LayoutGrid, List as ListIcon } from "lucide-react"
 import type { ReactNode } from "react"
 
+import { Button } from "@/components/ui"
+
 export type ListViewMode = "grid" | "list"
 
 export function ViewToggle({
@@ -22,24 +24,26 @@ export function ViewToggle({
 }) {
   return (
     <div role="group" aria-label={groupLabel} className="join">
-      <button
-        type="button"
-        className={`btn btn-sm join-item ${viewMode === "grid" ? "btn-active" : ""}`}
+      <Button
+        size="sm"
+        active={viewMode === "grid"}
+        className="join-item"
         aria-label={gridLabel}
         aria-pressed={viewMode === "grid"}
         onClick={() => onChange("grid")}
       >
         <LayoutGrid aria-hidden="true" className="size-4" />
-      </button>
-      <button
-        type="button"
-        className={`btn btn-sm join-item ${viewMode === "list" ? "btn-active" : ""}`}
+      </Button>
+      <Button
+        size="sm"
+        active={viewMode === "list"}
+        className="join-item"
         aria-label={listLabel}
         aria-pressed={viewMode === "list"}
         onClick={() => onChange("list")}
       >
         <ListIcon aria-hidden="true" className="size-4" />
-      </button>
+      </Button>
     </div>
   )
 }
@@ -91,13 +95,9 @@ export function NoSearchResults({
       title={title}
       body={body}
       action={
-        <button
-          type="button"
-          className="btn btn-ghost btn-sm"
-          onClick={onClear}
-        >
+        <Button variant="ghost" size="sm" onClick={onClear}>
           {clearLabel}
-        </button>
+        </Button>
       }
     />
   )

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -5,6 +5,7 @@ import { Plus, Trash2, UsersRound } from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
 import { Spinner } from "@/components/Spinner"
+import { Alert, Button, Modal } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
@@ -92,7 +93,6 @@ export function GroupCollaboratorsModal({
   maxGroupSize,
   students = [],
 }: GroupCollaboratorsModalProps) {
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Synchronous re-entrancy guard: isSaving (mutation.isPending) updates a tick
@@ -158,19 +158,6 @@ export function GroupCollaboratorsModal({
     seededKeyRef.current = repoName
     setDraftCollaborators(initialCollaborators)
   }, [open, repoName, loadingCollaborators, initialCollaborators])
-
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-
-    if (open && !dialog.open) {
-      dialog.showModal()
-    }
-
-    if (!open && dialog.open) {
-      dialog.close()
-    }
-  }, [open])
 
   useEffect(() => {
     if (!open) {
@@ -386,307 +373,277 @@ export function GroupCollaboratorsModal({
   const personCount = draftCollaborators.length + (ownerDisplayLogin ? 1 : 0)
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
+    <Modal
+      open={open}
+      onClose={onClose}
+      closeDisabled={isSaving}
+      size="xl"
       aria-labelledby={titleId}
-      onClose={() => {
-        if (!isSaving) onClose()
-      }}
-      onCancel={(event) => {
-        if (isSaving) {
-          event.preventDefault()
-          return
-        }
-        onClose()
-      }}
     >
-      <div className="modal-box max-w-xl">
-        <div className="flex items-start gap-4">
-          <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-            <UsersRound className="size-5" aria-hidden="true" />
-          </div>
-
-          <div className="min-w-0 flex-1">
-            <h3 id={titleId} className="text-lg font-bold">
-              {assignmentName ||
-                t("components.modals.groupCollaborators.title")}
-            </h3>
-            {repoName && (
-              <a
-                className="link mt-1 inline-flex items-center gap-1.5 text-sm"
-                href={repoUrl || `https://github.com/${org}/${repoName}`}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <GitHub aria-hidden="true" className="size-4" />
-                {t("components.modals.groupCollaborators.viewRepository")}
-              </a>
-            )}
-          </div>
+      <div className="flex items-start gap-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <UsersRound className="size-5" aria-hidden="true" />
         </div>
 
-        {loadingCollaborators ? (
-          <div className="flex py-10">
-            <Spinner
-              className="m-auto"
-              label={t("components.modals.groupCollaborators.loading")}
-            />
-          </div>
-        ) : (
-          <>
-            {saved && (
-              <div className="alert alert-success alert-soft mt-4 text-sm">
-                {t("components.modals.groupCollaborators.saved")}
-              </div>
-            )}
-
-            {submitError && (
-              <div className="alert alert-error alert-soft mt-4 text-sm">
-                {submitError}
-              </div>
-            )}
-
-            {!canManage && (
-              <div className="alert alert-info alert-soft mt-4 text-sm">
-                {t("components.modals.groupCollaborators.onlyOwner_prefix")}
-                {ownerDisplayLogin ? (
-                  <>
-                    {" "}
-                    (<span className="font-mono">{ownerDisplayLogin}</span>)
-                  </>
-                ) : null}{" "}
-                {t("components.modals.groupCollaborators.onlyOwner_suffix")}
-              </div>
-            )}
-
-            <div className="mt-4">
-              <div className="mb-2 flex items-center justify-between gap-4">
-                <span className="text-sm font-medium">
-                  {t("components.modals.groupCollaborators.groupMembers")}
-                </span>
-                <span className="text-xs text-base-content/70">
-                  {t("components.modals.groupCollaborators.personCount", {
-                    count: personCount,
-                  })}
-                </span>
-              </div>
-
-              {/* One bordered list for owner + members + pending removals, so it
-                  reads as a single roster rather than stacked cards. */}
-              <ul className="divide-y divide-base-200 rounded-2xl border border-base-200">
-                {ownerDisplayLogin && (
-                  <li className="flex items-center gap-3 px-4 py-2.5">
-                    <GitHub
-                      aria-hidden="true"
-                      className="size-5 shrink-0 text-base-content/70"
-                    />
-                    <span className="min-w-0 flex-1 leading-tight">
-                      <CollaboratorIdentity
-                        login={ownerDisplayLogin}
-                        students={students}
-                      />
-                    </span>
-                    <span className="badge badge-primary badge-soft badge-sm">
-                      {t("components.modals.groupCollaborators.ownerBadge")}
-                    </span>
-                  </li>
-                )}
-
-                {draftCollaborators.map((username) => {
-                  const normalized = normalizeUsername(username)
-                  const isInvalid = invalidCollaborators.has(normalized)
-
-                  return (
-                    <li
-                      key={username}
-                      className={[
-                        "flex items-center gap-3 px-4 py-2.5",
-                        isInvalid ? "bg-error/5" : "",
-                      ].join(" ")}
-                    >
-                      <GitHub
-                        aria-hidden="true"
-                        className={[
-                          "size-5 shrink-0",
-                          isInvalid ? "text-error" : "text-base-content/70",
-                        ].join(" ")}
-                      />
-                      <span className="min-w-0 flex-1 leading-tight">
-                        <CollaboratorIdentity
-                          login={username}
-                          students={students}
-                        />
-                        {isInvalid && (
-                          <span className="mt-0.5 block text-xs text-error">
-                            {t(
-                              "components.modals.groupCollaborators.couldntAdd",
-                            )}
-                          </span>
-                        )}
-                      </span>
-                      {canManage && (
-                        <button
-                          type="button"
-                          className="btn btn-ghost btn-sm btn-square text-base-content/70 hover:text-error"
-                          aria-label={t(
-                            "components.modals.groupCollaborators.removeUser",
-                            { username },
-                          )}
-                          onClick={() => removeFromDraft(username)}
-                        >
-                          <Trash2 aria-hidden="true" className="size-4" />
-                        </button>
-                      )}
-                    </li>
-                  )
-                })}
-
-                {markedForRemoval.map((username) => {
-                  const failedToRemove = invalidCollaborators.has(
-                    normalizeUsername(username),
-                  )
-                  return (
-                    <li
-                      key={`remove-${username}`}
-                      className="flex items-center gap-3 bg-error/5 px-4 py-2.5"
-                    >
-                      <GitHub
-                        aria-hidden="true"
-                        className="size-5 shrink-0 text-error/50"
-                      />
-                      <span className="min-w-0 flex-1 leading-tight text-error line-through opacity-70">
-                        <CollaboratorIdentity
-                          login={username}
-                          students={students}
-                        />
-                      </span>
-                      <span className="text-xs font-medium text-error/70">
-                        {failedToRemove
-                          ? t(
-                              "components.modals.groupCollaborators.couldntRemove",
-                            )
-                          : t("components.modals.groupCollaborators.removing")}
-                      </span>
-                      {canManage && (
-                        <button
-                          type="button"
-                          className="btn btn-ghost btn-sm text-error"
-                          onClick={() => restoreToDraft(username)}
-                        >
-                          {t("components.modals.groupCollaborators.undo")}
-                        </button>
-                      )}
-                    </li>
-                  )
-                })}
-
-                {draftCollaborators.length === 0 &&
-                  markedForRemoval.length === 0 && (
-                    <li className="px-4 py-6 text-center text-sm text-base-content/70">
-                      {t(
-                        "components.modals.groupCollaborators.noCollaborators",
-                      )}
-                    </li>
-                  )}
-              </ul>
-
-              {tooMany && (
-                <p className="mt-2 text-sm text-error">
-                  {t("components.modals.groupCollaborators.tooMany", {
-                    max: maxGroupSize ?? 1,
-                  })}
-                </p>
-              )}
-              {hasDuplicates && (
-                <p className="mt-2 text-sm text-error">
-                  {t("components.modals.groupCollaborators.mustBeUnique")}
-                </p>
-              )}
-
-              {canManage && !isFull && (
-                <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-                  <input
-                    className="input input-bordered flex-1"
-                    placeholder={t(
-                      "components.modals.groupCollaborators.addPlaceholder",
-                    )}
-                    aria-label={t(
-                      "components.modals.groupCollaborators.addAriaLabel",
-                    )}
-                    value={newCollaborator}
-                    onChange={(e) => setNewCollaborator(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault()
-                        addPendingUsername()
-                      }
-                    }}
-                  />
-                  <button
-                    type="button"
-                    className="btn btn-outline"
-                    onClick={addPendingUsername}
-                  >
-                    <Plus aria-hidden="true" className="size-4" />
-                    {t("components.modals.groupCollaborators.add")}
-                  </button>
-                </div>
-              )}
-
-              {canManage && isFull && (
-                <p className="mt-3 text-xs text-base-content/70">
-                  {t("components.modals.groupCollaborators.groupFull")}
-                </p>
-              )}
-            </div>
-          </>
-        )}
-
-        <div className="modal-action">
-          <button
-            type="button"
-            className="btn btn-ghost"
-            disabled={isSaving}
-            onClick={() => onClose()}
-          >
-            {t("common.cancel")}
-          </button>
-          {canManage && hasChanges && (
-            <button
-              type="button"
-              className="btn btn-ghost"
-              disabled={isSaving}
-              onClick={discardChanges}
+        <div className="min-w-0 flex-1">
+          <h3 id={titleId} className="text-lg font-bold">
+            {assignmentName || t("components.modals.groupCollaborators.title")}
+          </h3>
+          {repoName && (
+            <a
+              className="link mt-1 inline-flex items-center gap-1.5 text-sm"
+              href={repoUrl || `https://github.com/${org}/${repoName}`}
+              target="_blank"
+              rel="noreferrer"
             >
-              {t("components.modals.groupCollaborators.discardChanges")}
-            </button>
-          )}
-          {canManage && (
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={
-                loadingCollaborators ||
-                isSaving ||
-                tooMany ||
-                hasDuplicates ||
-                !hasChanges
-              }
-              onClick={() => void handleSave()}
-            >
-              {isSaving && (
-                <span className="loading loading-spinner" aria-hidden="true" />
-              )}
-              {t("components.modals.groupCollaborators.saveCollaborators")}
-            </button>
+              <GitHub aria-hidden="true" className="size-4" />
+              {t("components.modals.groupCollaborators.viewRepository")}
+            </a>
           )}
         </div>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        <button disabled={isSaving}>{t("common.close")}</button>
-      </form>
-    </dialog>
+      {loadingCollaborators ? (
+        <div className="flex py-10">
+          <Spinner
+            className="m-auto"
+            label={t("components.modals.groupCollaborators.loading")}
+          />
+        </div>
+      ) : (
+        <>
+          {saved && (
+            <Alert tone="success" className="mt-4 text-sm">
+              {t("components.modals.groupCollaborators.saved")}
+            </Alert>
+          )}
+
+          {submitError && (
+            <Alert tone="error" className="mt-4 text-sm">
+              {submitError}
+            </Alert>
+          )}
+
+          {!canManage && (
+            <Alert tone="info" className="mt-4 text-sm">
+              {t("components.modals.groupCollaborators.onlyOwner_prefix")}
+              {ownerDisplayLogin ? (
+                <>
+                  {" "}
+                  (<span className="font-mono">{ownerDisplayLogin}</span>)
+                </>
+              ) : null}{" "}
+              {t("components.modals.groupCollaborators.onlyOwner_suffix")}
+            </Alert>
+          )}
+
+          <div className="mt-4">
+            <div className="mb-2 flex items-center justify-between gap-4">
+              <span className="text-sm font-medium">
+                {t("components.modals.groupCollaborators.groupMembers")}
+              </span>
+              <span className="text-xs text-base-content/70">
+                {t("components.modals.groupCollaborators.personCount", {
+                  count: personCount,
+                })}
+              </span>
+            </div>
+
+            {/* One bordered list for owner + members + pending removals, so it
+                  reads as a single roster rather than stacked cards. */}
+            <ul className="divide-y divide-base-200 rounded-2xl border border-base-200">
+              {ownerDisplayLogin && (
+                <li className="flex items-center gap-3 px-4 py-2.5">
+                  <GitHub
+                    aria-hidden="true"
+                    className="size-5 shrink-0 text-base-content/70"
+                  />
+                  <span className="min-w-0 flex-1 leading-tight">
+                    <CollaboratorIdentity
+                      login={ownerDisplayLogin}
+                      students={students}
+                    />
+                  </span>
+                  <span className="badge badge-primary badge-soft badge-sm">
+                    {t("components.modals.groupCollaborators.ownerBadge")}
+                  </span>
+                </li>
+              )}
+
+              {draftCollaborators.map((username) => {
+                const normalized = normalizeUsername(username)
+                const isInvalid = invalidCollaborators.has(normalized)
+
+                return (
+                  <li
+                    key={username}
+                    className={[
+                      "flex items-center gap-3 px-4 py-2.5",
+                      isInvalid ? "bg-error/5" : "",
+                    ].join(" ")}
+                  >
+                    <GitHub
+                      aria-hidden="true"
+                      className={[
+                        "size-5 shrink-0",
+                        isInvalid ? "text-error" : "text-base-content/70",
+                      ].join(" ")}
+                    />
+                    <span className="min-w-0 flex-1 leading-tight">
+                      <CollaboratorIdentity
+                        login={username}
+                        students={students}
+                      />
+                      {isInvalid && (
+                        <span className="mt-0.5 block text-xs text-error">
+                          {t("components.modals.groupCollaborators.couldntAdd")}
+                        </span>
+                      )}
+                    </span>
+                    {canManage && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        shape="square"
+                        className="text-base-content/70 hover:text-error"
+                        aria-label={t(
+                          "components.modals.groupCollaborators.removeUser",
+                          { username },
+                        )}
+                        onClick={() => removeFromDraft(username)}
+                      >
+                        <Trash2 aria-hidden="true" className="size-4" />
+                      </Button>
+                    )}
+                  </li>
+                )
+              })}
+
+              {markedForRemoval.map((username) => {
+                const failedToRemove = invalidCollaborators.has(
+                  normalizeUsername(username),
+                )
+                return (
+                  <li
+                    key={`remove-${username}`}
+                    className="flex items-center gap-3 bg-error/5 px-4 py-2.5"
+                  >
+                    <GitHub
+                      aria-hidden="true"
+                      className="size-5 shrink-0 text-error/50"
+                    />
+                    <span className="min-w-0 flex-1 leading-tight text-error line-through opacity-70">
+                      <CollaboratorIdentity
+                        login={username}
+                        students={students}
+                      />
+                    </span>
+                    <span className="text-xs font-medium text-error/70">
+                      {failedToRemove
+                        ? t(
+                            "components.modals.groupCollaborators.couldntRemove",
+                          )
+                        : t("components.modals.groupCollaborators.removing")}
+                    </span>
+                    {canManage && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-error"
+                        onClick={() => restoreToDraft(username)}
+                      >
+                        {t("components.modals.groupCollaborators.undo")}
+                      </Button>
+                    )}
+                  </li>
+                )
+              })}
+
+              {draftCollaborators.length === 0 &&
+                markedForRemoval.length === 0 && (
+                  <li className="px-4 py-6 text-center text-sm text-base-content/70">
+                    {t("components.modals.groupCollaborators.noCollaborators")}
+                  </li>
+                )}
+            </ul>
+
+            {tooMany && (
+              <p className="mt-2 text-sm text-error">
+                {t("components.modals.groupCollaborators.tooMany", {
+                  max: maxGroupSize ?? 1,
+                })}
+              </p>
+            )}
+            {hasDuplicates && (
+              <p className="mt-2 text-sm text-error">
+                {t("components.modals.groupCollaborators.mustBeUnique")}
+              </p>
+            )}
+
+            {canManage && !isFull && (
+              <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                <input
+                  className="input input-bordered flex-1"
+                  placeholder={t(
+                    "components.modals.groupCollaborators.addPlaceholder",
+                  )}
+                  aria-label={t(
+                    "components.modals.groupCollaborators.addAriaLabel",
+                  )}
+                  value={newCollaborator}
+                  onChange={(e) => setNewCollaborator(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault()
+                      addPendingUsername()
+                    }
+                  }}
+                />
+                <Button variant="outline" onClick={addPendingUsername}>
+                  <Plus aria-hidden="true" className="size-4" />
+                  {t("components.modals.groupCollaborators.add")}
+                </Button>
+              </div>
+            )}
+
+            {canManage && isFull && (
+              <p className="mt-3 text-xs text-base-content/70">
+                {t("components.modals.groupCollaborators.groupFull")}
+              </p>
+            )}
+          </div>
+        </>
+      )}
+
+      <div className="modal-action">
+        <Button variant="ghost" disabled={isSaving} onClick={() => onClose()}>
+          {t("common.cancel")}
+        </Button>
+        {canManage && hasChanges && (
+          <Button variant="ghost" disabled={isSaving} onClick={discardChanges}>
+            {t("components.modals.groupCollaborators.discardChanges")}
+          </Button>
+        )}
+        {canManage && (
+          <Button
+            variant="primary"
+            disabled={
+              loadingCollaborators ||
+              isSaving ||
+              tooMany ||
+              hasDuplicates ||
+              !hasChanges
+            }
+            loading={isSaving}
+            loadingLabel={t(
+              "components.modals.groupCollaborators.saveCollaborators",
+            )}
+            onClick={() => void handleSave()}
+          >
+            {t("components.modals.groupCollaborators.saveCollaborators")}
+          </Button>
+        )}
+      </div>
+    </Modal>
   )
 }

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -425,7 +425,7 @@ export function GroupCollaboratorsModal({
           )}
 
           {!canManage && (
-            <Alert tone="info" className="mt-4 text-sm">
+            <Alert tone="error" className="mt-4 text-sm">
               {t("components.modals.groupCollaborators.onlyOwner_prefix")}
               {ownerDisplayLogin ? (
                 <>

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -1,9 +1,10 @@
 import { useNavigate } from "@tanstack/react-router"
 import { ExternalLink, Settings } from "lucide-react"
-import { useEffect, useId, useRef } from "react"
+import { useId } from "react"
 import { useTranslation } from "react-i18next"
 
 import PlanBadge from "@/components/PlanBadge"
+import { Modal } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/hooks/github/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import { classifyPlan } from "@/lib/orgPlan"
@@ -25,18 +26,10 @@ function NewOrgModal({
 }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
 
   const logins = needsSetupOrgs.map((summary) => summary.org.login)
   const plans = useNeedsSetupPlans(open ? logins : [])
-
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (open && !dialog.open) dialog.showModal()
-    if (!open && dialog.open) dialog.close()
-  }, [open])
 
   const handleSelect = (login: string) => {
     onClose()
@@ -44,111 +37,95 @@ function NewOrgModal({
   }
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
-      aria-labelledby={titleId}
-      onClose={onClose}
-    >
-      <div className="modal-box max-w-lg">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <h3 id={titleId} className="text-lg font-bold">
-              {t("orgs.newOrg.title")}
-            </h3>
-            <p className="mt-1 text-sm text-base-content/70">
-              {t("orgs.newOrg.description")}
-            </p>
-          </div>
-          <form method="dialog">
-            <button type="submit" className="btn btn-sm btn-circle btn-ghost">
-              ✕<span className="sr-only">{t("common.close")}</span>
-            </button>
-          </form>
-        </div>
-
-        {needsSetupOrgs.length === 0 ? (
-          <p className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
-            {t("orgs.newOrg.allSetUp")}
+    <Modal open={open} onClose={onClose} size="lg" aria-labelledby={titleId}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("orgs.newOrg.title")}
+          </h3>
+          <p className="mt-1 text-sm text-base-content/70">
+            {t("orgs.newOrg.description")}
           </p>
-        ) : (
-          <>
-            <p className="mt-6 text-xs font-semibold uppercase tracking-wide text-base-content/60">
-              {t("orgs.newOrg.pickPrompt")}
-            </p>
-            <ul className="mt-2 flex max-h-80 flex-col gap-2 overflow-y-auto">
-              {needsSetupOrgs.map((summary) => {
-                const { org } = summary
-                const planName = plans[org.login]
-                const isFree = classifyPlan(planName) === "free"
-                return (
-                  <li key={org.id}>
-                    <button
-                      type="button"
-                      disabled={isFree}
-                      title={
-                        isFree ? t("orgs.newOrg.freePlanDisabled") : undefined
-                      }
-                      onClick={() => handleSelect(org.login)}
-                      className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-left transition-colors hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
-                    >
-                      <img
-                        src={org.avatar_url}
-                        alt=""
-                        className="size-9 shrink-0 rounded-lg border border-base-300"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate font-semibold">
-                          {org.login}
-                        </span>
-                        {org.description && (
-                          <span className="block truncate text-sm text-base-content/60">
-                            {org.description}
-                          </span>
-                        )}
-                      </span>
-                      {planName && (
-                        <PlanBadge
-                          name={planName}
-                          title={
-                            isFree
-                              ? t("orgs.card.planTitleFree")
-                              : t("orgs.card.planTitlePaid")
-                          }
-                          className="shrink-0"
-                        />
-                      )}
-                      {!isFree && (
-                        <span className="btn btn-primary btn-xs shrink-0">
-                          <Settings aria-hidden="true" className="size-3" />
-                          {t("orgs.newOrg.setUp")}
-                        </span>
-                      )}
-                    </button>
-                  </li>
-                )
-              })}
-            </ul>
-          </>
-        )}
-
-        <div className="modal-action">
-          <a
-            href="https://github.com/organizations/new"
-            target="_blank"
-            rel="noreferrer"
-            className="btn btn-ghost btn-sm"
-          >
-            {t("orgs.newOrg.createOnGitHub")}
-            <ExternalLink aria-hidden="true" className="size-4" />
-          </a>
         </div>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        <button>{t("common.close")}</button>
-      </form>
-    </dialog>
+      {needsSetupOrgs.length === 0 ? (
+        <p className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+          {t("orgs.newOrg.allSetUp")}
+        </p>
+      ) : (
+        <>
+          <p className="mt-6 text-xs font-semibold uppercase tracking-wide text-base-content/60">
+            {t("orgs.newOrg.pickPrompt")}
+          </p>
+          <ul className="mt-2 flex max-h-80 flex-col gap-2 overflow-y-auto">
+            {needsSetupOrgs.map((summary) => {
+              const { org } = summary
+              const planName = plans[org.login]
+              const isFree = classifyPlan(planName) === "free"
+              return (
+                <li key={org.id}>
+                  <button
+                    type="button"
+                    disabled={isFree}
+                    title={
+                      isFree ? t("orgs.newOrg.freePlanDisabled") : undefined
+                    }
+                    onClick={() => handleSelect(org.login)}
+                    className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-left transition-colors hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
+                  >
+                    <img
+                      src={org.avatar_url}
+                      alt=""
+                      className="size-9 shrink-0 rounded-lg border border-base-300"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-semibold">
+                        {org.login}
+                      </span>
+                      {org.description && (
+                        <span className="block truncate text-sm text-base-content/60">
+                          {org.description}
+                        </span>
+                      )}
+                    </span>
+                    {planName && (
+                      <PlanBadge
+                        name={planName}
+                        title={
+                          isFree
+                            ? t("orgs.card.planTitleFree")
+                            : t("orgs.card.planTitlePaid")
+                        }
+                        className="shrink-0"
+                      />
+                    )}
+                    {!isFree && (
+                      <span className="btn btn-primary btn-xs shrink-0">
+                        <Settings aria-hidden="true" className="size-3" />
+                        {t("orgs.newOrg.setUp")}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </>
+      )}
+
+      <div className="modal-action">
+        <a
+          href="https://github.com/organizations/new"
+          target="_blank"
+          rel="noreferrer"
+          className="btn btn-ghost btn-sm"
+        >
+          {t("orgs.newOrg.createOnGitHub")}
+          <ExternalLink aria-hidden="true" className="size-4" />
+        </a>
+      </div>
+    </Modal>
   )
 }
 

--- a/web/src/components/modals/ReuseAssignmentModal.tsx
+++ b/web/src/components/modals/ReuseAssignmentModal.tsx
@@ -9,6 +9,7 @@ import {
   ReuseModalShell,
   reuseSlugStatus,
 } from "@/components/modals/ReuseModalShell"
+import { FormField, Input, Select } from "@/components/ui"
 
 // Reuse ("Duplicate") an assignment into any classroom in the same org —
 // our equivalent of GitHub Classroom's "Reuse assignment", including into the
@@ -92,70 +93,74 @@ export const ReuseAssignmentModal = ({
         </div>
       ) : (
         <div className="mt-6 space-y-4">
-          <label className="form-control w-full">
-            <span className="label-text mb-1 font-medium">
-              {t("components.modals.reuseAssignment.targetClassroom")}
-            </span>
-            <select
-              className="select select-bordered w-full"
-              value={targetClassroom}
-              disabled={reuse.isPending}
-              onChange={(e) => handlePickTarget(e.target.value)}
-            >
-              <option value="" disabled>
-                {t("components.modals.reuseAssignment.chooseClassroom")}
-              </option>
-              {targets.map((c) => (
-                <option key={c.name} value={c.name}>
-                  {c.name === classroom
-                    ? t(
-                        "components.modals.reuseAssignment.thisClassroomOption",
-                        {
-                          classroom: c.name,
-                        },
-                      )
-                    : c.name}
+          <FormField
+            label={t("components.modals.reuseAssignment.targetClassroom")}
+          >
+            {({ id, describedById, invalid }) => (
+              <Select
+                id={id}
+                aria-describedby={describedById}
+                invalid={invalid}
+                value={targetClassroom}
+                disabled={reuse.isPending}
+                onChange={(e) => handlePickTarget(e.target.value)}
+              >
+                <option value="" disabled>
+                  {t("components.modals.reuseAssignment.chooseClassroom")}
                 </option>
-              ))}
-            </select>
-          </label>
+                {targets.map((c) => (
+                  <option key={c.name} value={c.name}>
+                    {c.name === classroom
+                      ? t(
+                          "components.modals.reuseAssignment.thisClassroomOption",
+                          {
+                            classroom: c.name,
+                          },
+                        )
+                      : c.name}
+                  </option>
+                ))}
+              </Select>
+            )}
+          </FormField>
 
-          <label className="form-control w-full">
-            <span className="label-text mb-1 font-medium">
-              {t("components.modals.reuseAssignment.slugLabel")}
-            </span>
-            <input
-              type="text"
-              className={`input input-bordered w-full font-mono ${
-                reuse.slugTaken ? "input-error" : ""
-              }`}
-              value={reuse.displayedSlug}
-              disabled={reuse.isPending || !targetClassroom || targetLoading}
-              onChange={(e) => reuse.onSlugChange(e.target.value)}
-              onBlur={reuse.onSlugBlur}
-            />
-            <span
-              className={`label-text-alt mt-1 ${
-                reuse.slugTaken ? "text-error" : "text-base-content/70"
-              }`}
-            >
-              {!targetClassroom
-                ? t("components.modals.reuseAssignment.chooseClassroomFirst")
-                : reuseSlugStatus({
-                    t,
-                    loading: targetLoading,
-                    error: targetError,
-                    slugTaken: reuse.slugTaken,
-                    slugTouched: reuse.slugTouched,
-                    normalizedSlug: reuse.normalizedSlug,
-                    displayedSlug: reuse.displayedSlug,
-                    classroomLabel: targetClassroom,
-                    uniqueHint: t(
-                      "components.modals.reuseAssignment.uniqueHint",
-                    ),
-                  })}
-            </span>
-          </label>
+          {(() => {
+            const slugStatus = !targetClassroom
+              ? t("components.modals.reuseAssignment.chooseClassroomFirst")
+              : reuseSlugStatus({
+                  t,
+                  loading: targetLoading,
+                  error: targetError,
+                  slugTaken: reuse.slugTaken,
+                  slugTouched: reuse.slugTouched,
+                  normalizedSlug: reuse.normalizedSlug,
+                  displayedSlug: reuse.displayedSlug,
+                  classroomLabel: targetClassroom,
+                  uniqueHint: t("components.modals.reuseAssignment.uniqueHint"),
+                })
+            return (
+              <FormField
+                label={t("components.modals.reuseAssignment.slugLabel")}
+                error={reuse.slugTaken ? slugStatus : undefined}
+                hint={slugStatus}
+              >
+                {({ id, describedById, invalid }) => (
+                  <Input
+                    id={id}
+                    aria-describedby={describedById}
+                    invalid={invalid}
+                    className="font-mono"
+                    value={reuse.displayedSlug}
+                    disabled={
+                      reuse.isPending || !targetClassroom || targetLoading
+                    }
+                    onChange={(e) => reuse.onSlugChange(e.target.value)}
+                    onBlur={reuse.onSlugBlur}
+                  />
+                )}
+              </FormField>
+            )
+          })()}
         </div>
       )}
     </ReuseModalShell>

--- a/web/src/components/modals/ReuseFromClassroomModal.tsx
+++ b/web/src/components/modals/ReuseFromClassroomModal.tsx
@@ -8,6 +8,7 @@ import {
   ReuseModalShell,
   reuseSlugStatus,
 } from "@/components/modals/ReuseModalShell"
+import { FormField, Input, Select } from "@/components/ui"
 
 // Reuse an assignment FROM any classroom INTO the current one — the "pull"
 // counterpart to the per-row "push" reuse on the assignments table. Opened from
@@ -111,97 +112,85 @@ export const ReuseFromClassroomModal = ({
         </div>
       ) : (
         <div className="mt-6 space-y-4">
-          <label className="form-control w-full">
-            <span className="label-text mb-1 font-medium">
-              {t("components.modals.reuseFromClassroom.sourceClassroom")}
-            </span>
-            <select
-              className="select select-bordered w-full"
-              value={sourceClassroom}
-              disabled={reuse.isPending}
-              onChange={(e) => handlePickClassroom(e.target.value)}
-            >
-              <option value="" disabled>
-                {t("components.modals.reuseFromClassroom.chooseClassroom")}
-              </option>
-              {sources.map((c) => (
-                <option key={c.name} value={c.name}>
-                  {c.name === classroom
-                    ? t(
-                        "components.modals.reuseFromClassroom.thisClassroomOption",
-                        { classroom: c.name },
-                      )
-                    : c.name}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          {sourceClassroom ? (
-            <label className="form-control w-full">
-              <span className="label-text mb-1 font-medium">
-                {t("components.modals.reuseFromClassroom.assignment")}
-              </span>
-              <select
-                className="select select-bordered w-full"
-                value={sourceSlug}
-                disabled={
-                  reuse.isPending ||
-                  sourceLoading ||
-                  sourceAssignments.length === 0
-                }
-                onChange={(e) => handlePickAssignment(e.target.value)}
+          <FormField
+            label={t("components.modals.reuseFromClassroom.sourceClassroom")}
+          >
+            {({ id, describedById, invalid }) => (
+              <Select
+                id={id}
+                aria-describedby={describedById}
+                invalid={invalid}
+                value={sourceClassroom}
+                disabled={reuse.isPending}
+                onChange={(e) => handlePickClassroom(e.target.value)}
               >
                 <option value="" disabled>
-                  {sourceLoading
-                    ? t(
-                        "components.modals.reuseFromClassroom.loadingAssignments",
-                      )
-                    : sourceAssignments.length === 0
-                      ? t("components.modals.reuseFromClassroom.noAssignments")
-                      : t(
-                          "components.modals.reuseFromClassroom.chooseAssignment",
-                        )}
+                  {t("components.modals.reuseFromClassroom.chooseClassroom")}
                 </option>
-                {sourceAssignments.map((a) => (
-                  <option key={a.slug} value={a.slug}>
-                    {a.name || a.slug}
+                {sources.map((c) => (
+                  <option key={c.name} value={c.name}>
+                    {c.name === classroom
+                      ? t(
+                          "components.modals.reuseFromClassroom.thisClassroomOption",
+                          { classroom: c.name },
+                        )
+                      : c.name}
                   </option>
                 ))}
-              </select>
-              {sourceError ? (
-                <span className="label-text-alt mt-1 text-error">
-                  {t("components.modals.reuseFromClassroom.loadError", {
-                    classroom: sourceClassroom,
-                  })}
-                </span>
-              ) : null}
-            </label>
+              </Select>
+            )}
+          </FormField>
+
+          {sourceClassroom ? (
+            <FormField
+              label={t("components.modals.reuseFromClassroom.assignment")}
+              error={
+                sourceError
+                  ? t("components.modals.reuseFromClassroom.loadError", {
+                      classroom: sourceClassroom,
+                    })
+                  : undefined
+              }
+            >
+              {({ id, describedById, invalid }) => (
+                <Select
+                  id={id}
+                  aria-describedby={describedById}
+                  invalid={invalid}
+                  value={sourceSlug}
+                  disabled={
+                    reuse.isPending ||
+                    sourceLoading ||
+                    sourceAssignments.length === 0
+                  }
+                  onChange={(e) => handlePickAssignment(e.target.value)}
+                >
+                  <option value="" disabled>
+                    {sourceLoading
+                      ? t(
+                          "components.modals.reuseFromClassroom.loadingAssignments",
+                        )
+                      : sourceAssignments.length === 0
+                        ? t(
+                            "components.modals.reuseFromClassroom.noAssignments",
+                          )
+                        : t(
+                            "components.modals.reuseFromClassroom.chooseAssignment",
+                          )}
+                  </option>
+                  {sourceAssignments.map((a) => (
+                    <option key={a.slug} value={a.slug}>
+                      {a.name || a.slug}
+                    </option>
+                  ))}
+                </Select>
+              )}
+            </FormField>
           ) : null}
 
-          {selectedAssignment ? (
-            <label className="form-control w-full">
-              <span className="label-text mb-1 font-medium">
-                {t("components.modals.reuseFromClassroom.slugLabel", {
-                  classroom,
-                })}
-              </span>
-              <input
-                type="text"
-                className={`input input-bordered w-full font-mono ${
-                  reuse.slugTaken ? "input-error" : ""
-                }`}
-                value={reuse.displayedSlug}
-                disabled={reuse.isPending || destLoading}
-                onChange={(e) => reuse.onSlugChange(e.target.value)}
-                onBlur={reuse.onSlugBlur}
-              />
-              <span
-                className={`label-text-alt mt-1 ${
-                  reuse.slugTaken ? "text-error" : "text-base-content/70"
-                }`}
-              >
-                {reuseSlugStatus({
+          {selectedAssignment
+            ? (() => {
+                const slugStatus = reuseSlugStatus({
                   t,
                   loading: destLoading,
                   error: destError,
@@ -213,10 +202,31 @@ export const ReuseFromClassroomModal = ({
                   uniqueHint: t(
                     "components.modals.reuseFromClassroom.uniqueHint",
                   ),
-                })}
-              </span>
-            </label>
-          ) : null}
+                })
+                return (
+                  <FormField
+                    label={t("components.modals.reuseFromClassroom.slugLabel", {
+                      classroom,
+                    })}
+                    error={reuse.slugTaken ? slugStatus : undefined}
+                    hint={slugStatus}
+                  >
+                    {({ id, describedById, invalid }) => (
+                      <Input
+                        id={id}
+                        aria-describedby={describedById}
+                        invalid={invalid}
+                        className="font-mono"
+                        value={reuse.displayedSlug}
+                        disabled={reuse.isPending || destLoading}
+                        onChange={(e) => reuse.onSlugChange(e.target.value)}
+                        onBlur={reuse.onSlugBlur}
+                      />
+                    )}
+                  </FormField>
+                )
+              })()
+            : null}
         </div>
       )}
     </ReuseModalShell>

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -1,7 +1,9 @@
-import { Copy, TriangleAlert, X } from "lucide-react"
+import { Copy, TriangleAlert } from "lucide-react"
 import { useEffect, useId, type ReactNode, type RefObject } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
+
+import { Alert, Button, Modal } from "@/components/ui"
 
 // Shared chrome for the two reuse modals — close button, header, error/warning
 // alerts, Cancel/Reuse footer — so each supplies only its title, description,
@@ -44,89 +46,63 @@ export const ReuseModalShell = ({
   const { t } = useTranslation()
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
+    <Modal
+      dialogRef={dialogRef}
       onClose={onClose}
+      closeDisabled={isPending}
       aria-labelledby={titleId}
     >
-      <div className="modal-box max-w-lg">
-        <form method="dialog">
-          <button
-            className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
-            aria-label={t("common.close")}
-            disabled={isPending}
-          >
-            <X className="size-4" aria-hidden="true" />
-          </button>
-        </form>
-
-        <div className="flex items-start gap-4">
-          <div className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-            <Copy className="size-5" aria-hidden="true" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <h3 id={titleId} className="text-lg font-bold">
-              {title}
-            </h3>
-            <p className="mt-1 text-sm text-base-content/70">{description}</p>
-          </div>
+      <div className="flex items-start gap-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Copy className="size-5" aria-hidden="true" />
         </div>
-
-        {children}
-
-        {errorMessage ? (
-          <div className="alert alert-error alert-soft mt-4 text-sm">
-            {errorMessage}
-          </div>
-        ) : null}
-
-        {warning ? (
-          <div className="alert alert-warning alert-soft mt-4 items-start text-sm">
-            <TriangleAlert aria-hidden="true" className="size-4 shrink-0" />
-            <span>{warning}</span>
-          </div>
-        ) : null}
-
-        <div className="modal-action">
-          <button
-            type="button"
-            className="btn btn-ghost"
-            disabled={isPending}
-            onClick={closeDialog}
-          >
-            {warning ? t("common.done") : t("common.cancel")}
-          </button>
-          {showSubmit && !warning ? (
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={!canSubmit}
-              onClick={onSubmit}
-            >
-              {isPending ? (
-                <>
-                  <span
-                    className="loading loading-spinner loading-sm"
-                    aria-hidden="true"
-                  />
-                  {t("components.modals.reuseShell.copying")}
-                </>
-              ) : (
-                <>
-                  <Copy aria-hidden="true" className="size-4" />{" "}
-                  {t("components.modals.reuseShell.reuseAssignment")}
-                </>
-              )}
-            </button>
-          ) : null}
+        <div className="min-w-0 flex-1">
+          <h3 id={titleId} className="text-lg font-bold">
+            {title}
+          </h3>
+          <p className="mt-1 text-sm text-base-content/70">{description}</p>
         </div>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        <button disabled={isPending}>{t("common.close")}</button>
-      </form>
-    </dialog>
+      {children}
+
+      {errorMessage ? (
+        <Alert tone="error" className="mt-4 text-sm">
+          {errorMessage}
+        </Alert>
+      ) : null}
+
+      {warning ? (
+        <Alert tone="warning" className="mt-4 items-start text-sm">
+          <TriangleAlert aria-hidden="true" className="size-4 shrink-0" />
+          <span>{warning}</span>
+        </Alert>
+      ) : null}
+
+      <div className="modal-action">
+        <Button variant="ghost" disabled={isPending} onClick={closeDialog}>
+          {warning ? t("common.done") : t("common.cancel")}
+        </Button>
+        {showSubmit && !warning ? (
+          <Button
+            variant="primary"
+            disabled={!canSubmit}
+            loading={isPending}
+            loadingLabel={t("components.modals.reuseShell.copying")}
+            onClick={onSubmit}
+          >
+            {isPending ? (
+              t("components.modals.reuseShell.copying")
+            ) : (
+              <>
+                <Copy aria-hidden="true" className="size-4" />{" "}
+                {t("components.modals.reuseShell.reuseAssignment")}
+              </>
+            )}
+          </Button>
+        ) : null}
+      </div>
+    </Modal>
   )
 }
 

--- a/web/src/components/modals/StudentProfileModal.tsx
+++ b/web/src/components/modals/StudentProfileModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useId, useRef } from "react"
 import { useTranslation } from "react-i18next"
-import { ExternalLink, X } from "lucide-react"
+import { ExternalLink } from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
+import { Modal } from "@/components/ui"
 import type { Student } from "@/types/classroom"
 import { getName, getInitials } from "@/util/students"
 
@@ -70,73 +71,58 @@ export const StudentProfileModal = ({
   ]
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
+    <Modal
+      dialogRef={dialogRef}
       onClose={onClose}
+      size="md"
       aria-labelledby={titleId}
     >
-      <div className="modal-box max-w-md">
-        <form method="dialog">
-          <button
-            className="btn btn-sm btn-circle btn-ghost absolute right-3 top-3"
-            aria-label={t("common.close")}
-          >
-            <X className="size-4" aria-hidden="true" />
-          </button>
-        </form>
-
-        <div className="flex items-center gap-4">
-          <div className="avatar avatar-placeholder">
-            <div className="bg-base-200 text-primary rounded-full w-14">
-              <span className="text-lg">{initials}</span>
-            </div>
-          </div>
-          <div className="min-w-0">
-            <h3 id={titleId} className="truncate text-lg font-bold">
-              {name}
-            </h3>
-            {student.section?.trim() ? (
-              <span className="badge badge-sm badge-ghost">
-                {student.section.trim()}
-              </span>
-            ) : null}
+      <div className="flex items-center gap-4">
+        <div className="avatar avatar-placeholder">
+          <div className="bg-base-200 text-primary rounded-full w-14">
+            <span className="text-lg">{initials}</span>
           </div>
         </div>
-
-        <dl className="mt-6 divide-y divide-base-200">
-          {rows.map((row) => (
-            <div
-              key={row.label}
-              className="flex items-center justify-between gap-4 py-2.5 text-sm"
-            >
-              <dt className="text-base-content/70">{row.label}</dt>
-              <dd className="min-w-0 truncate text-right font-medium">
-                {row.value}
-              </dd>
-            </div>
-          ))}
-        </dl>
-
-        {repoUrl ? (
-          <a
-            className="btn btn-outline btn-sm mt-4 w-full"
-            href={repoUrl}
-            target="_blank"
-            rel="noreferrer"
-            title={repoName}
-          >
-            <GitHub aria-hidden="true" className="size-4" />{" "}
-            {t("components.modals.studentProfile.openRepo")}
-            <ExternalLink aria-hidden="true" className="size-3.5" />
-          </a>
-        ) : null}
+        <div className="min-w-0">
+          <h3 id={titleId} className="truncate text-lg font-bold">
+            {name}
+          </h3>
+          {student.section?.trim() ? (
+            <span className="badge badge-sm badge-ghost">
+              {student.section.trim()}
+            </span>
+          ) : null}
+        </div>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        <button>{t("common.close")}</button>
-      </form>
-    </dialog>
+      <dl className="mt-6 divide-y divide-base-200">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-center justify-between gap-4 py-2.5 text-sm"
+          >
+            <dt className="text-base-content/70">{row.label}</dt>
+            <dd className="min-w-0 truncate text-right font-medium">
+              {row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {repoUrl ? (
+        <a
+          className="btn btn-outline btn-sm mt-4 w-full"
+          href={repoUrl}
+          target="_blank"
+          rel="noreferrer"
+          title={repoName}
+        >
+          <GitHub aria-hidden="true" className="size-4" />{" "}
+          {t("components.modals.studentProfile.openRepo")}
+          <ExternalLink aria-hidden="true" className="size-3.5" />
+        </a>
+      ) : null}
+    </Modal>
   )
 }
 

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -2,6 +2,8 @@ import { AlertTriangle } from "lucide-react"
 import { useEffect, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { Button, Alert, type ButtonVariant } from "@/components/ui"
+
 type ConfirmModalProps = {
   open: boolean
   title: string
@@ -112,9 +114,11 @@ export function ConfirmModal({
     }
   }
 
-  const confirmButtonClass = dangerous ? "btn btn-error" : "btn btn-primary"
+  const confirmButtonVariant: ButtonVariant = dangerous ? "error" : "primary"
 
-  const acknowledgeButtonClass = dangerous ? "btn btn-error" : "btn btn-warning"
+  const acknowledgeButtonVariant: ButtonVariant = dangerous
+    ? "error"
+    : "warning"
 
   return (
     <dialog
@@ -166,28 +170,25 @@ export function ConfirmModal({
             ) : null}
 
             {error ? (
-              <div
-                className="alert alert-error alert-soft mt-4 text-sm"
-                role="alert"
-              >
+              <Alert tone="error" className="mt-4 text-sm">
                 {error}
-              </div>
+              </Alert>
             ) : null}
 
             <div className="modal-action">
-              <button
-                type="button"
-                className="btn btn-ghost"
+              <Button
+                variant="ghost"
                 disabled={isSubmitting}
                 onClick={handleClose}
               >
                 {acknowledgeCancelLabel}
-              </button>
+              </Button>
 
-              <button
-                type="button"
-                className={acknowledgeButtonClass}
+              <Button
+                variant={acknowledgeButtonVariant}
                 disabled={isSubmitting}
+                loading={isSubmitting && !needsConfirm}
+                loadingLabel={t("common.working")}
                 onClick={(event) => {
                   event.stopPropagation()
 
@@ -199,20 +200,12 @@ export function ConfirmModal({
                   void handleSubmit()
                 }}
               >
-                {isSubmitting && !needsConfirm ? (
-                  <>
-                    <span
-                      className="loading loading-spinner loading-sm"
-                      aria-hidden="true"
-                    />
-                    {t("common.working")}
-                  </>
-                ) : needsConfirm ? (
-                  t("components.confirmModal.yesContinue")
-                ) : (
-                  resolvedConfirmLabel
-                )}
-              </button>
+                {isSubmitting && !needsConfirm
+                  ? t("common.working")
+                  : needsConfirm
+                    ? t("components.confirmModal.yesContinue")
+                    : resolvedConfirmLabel}
+              </Button>
             </div>
           </>
         ) : (
@@ -246,43 +239,30 @@ export function ConfirmModal({
               />
 
               {error ? (
-                <div
-                  className="alert alert-error alert-soft text-sm"
-                  role="alert"
-                >
+                <Alert tone="error" className="text-sm">
                   {error}
-                </div>
+                </Alert>
               ) : null}
             </div>
 
             <div className="modal-action">
-              <button
-                type="button"
-                className="btn btn-ghost"
+              <Button
+                variant="ghost"
                 disabled={isSubmitting}
                 onClick={handleClose}
               >
                 {resolvedCancelLabel}
-              </button>
+              </Button>
 
-              <button
-                type="button"
-                className={confirmButtonClass}
+              <Button
+                variant={confirmButtonVariant}
                 disabled={!canSubmit || isSubmitting}
+                loading={isSubmitting}
+                loadingLabel={t("common.working")}
                 onClick={() => void handleSubmit()}
               >
-                {isSubmitting ? (
-                  <>
-                    <span
-                      className="loading loading-spinner loading-sm"
-                      aria-hidden="true"
-                    />
-                    {t("common.working")}
-                  </>
-                ) : (
-                  resolvedConfirmLabel
-                )}
-              </button>
+                {isSubmitting ? t("common.working") : resolvedConfirmLabel}
+              </Button>
             </div>
           </>
         )}

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
+import { Alert, Button } from "@/components/ui"
 import { useLanguage } from "@/hooks/useLanguage"
 import { useLanguageRegistry } from "@/hooks/useLanguageRegistry"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
@@ -298,9 +299,9 @@ export const LanguageSwitcher = ({
               aria-label={t("language.shareUrlLabel")}
               onFocus={(e) => e.currentTarget.select()}
             />
-            <button
-              type="button"
-              className="btn btn-sm btn-primary"
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => void copyShareUrl()}
               disabled={!shareUrl}
             >
@@ -312,7 +313,7 @@ export const LanguageSwitcher = ({
               {shareCopied
                 ? t("language.shareCopied")
                 : t("language.shareCopy")}
-            </button>
+            </Button>
           </div>
         </div>
       </AccordionSection>
@@ -372,14 +373,14 @@ export const LanguageSwitcher = ({
               onChange={(e) => setUrl(e.target.value)}
               disabled={busy}
             />
-            <button
-              type="button"
-              className="btn btn-sm btn-primary"
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => void handleUrl()}
               disabled={busy}
             >
               {t("language.fetch")}
-            </button>
+            </Button>
           </div>
         </div>
       </AccordionSection>
@@ -419,14 +420,14 @@ export const LanguageSwitcher = ({
                         </span>
                       )}
                     </span>
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-xs"
+                    <Button
+                      variant="ghost"
+                      size="xs"
                       aria-label={t("language.removePack", { code: c })}
                       onClick={() => removePack(c)}
                     >
                       <Trash2 className="size-4" aria-hidden="true" />
-                    </button>
+                    </Button>
                   </div>
                 </li>
               )
@@ -463,18 +464,18 @@ export const LanguageSwitcher = ({
             </div>
           )}
           <div className="flex flex-row justify-end gap-2">
-            <button
-              type="button"
-              className="btn btn-sm btn-ghost"
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={handleCancel}
               disabled={busy}
             >
               <X className="size-4" aria-hidden="true" />
               {t("language.previewCancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm btn-primary"
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => void handleConfirm()}
               disabled={busy}
             >
@@ -484,15 +485,15 @@ export const LanguageSwitcher = ({
                 <Check className="size-4" aria-hidden="true" />
               )}
               {t("language.previewConfirm", { code: preview.code })}
-            </button>
+            </Button>
           </div>
         </div>
       )}
 
       {error && (
-        <div className="alert alert-error" role="alert">
+        <Alert tone="error">
           <span className="text-sm">{error}</span>
-        </div>
+        </Alert>
       )}
     </div>
   )

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -75,7 +75,7 @@ const StatusIcon = ({
   return (
     <Loader2
       aria-hidden="true"
-      className={`size-4 shrink-0 animate-spin ${tinted ? "text-warning" : ""}`}
+      className={`size-4 shrink-0 animate-spin ${tinted ? "text-info" : ""}`}
     />
   )
 }
@@ -85,8 +85,8 @@ const StatusIcon = ({
 const ROW_TONE: Record<Tracker["phase"], string> = {
   failed: "bg-error/10 text-error",
   success: "bg-success/10 text-success",
-  running: "bg-warning/10 text-warning",
-  pending: "bg-warning/10 text-warning",
+  running: "bg-info/10 text-info",
+  pending: "bg-info/10 text-info",
 }
 
 const TrackerRow = ({
@@ -313,7 +313,7 @@ export function ActionsBanner() {
       ? "border-error bg-error text-error-content"
       : primaryPhase === "success"
         ? "border-success bg-success text-success-content"
-        : "border-warning bg-warning text-warning-content"
+        : "border-info bg-info text-info-content"
 
   // Failed actions NOT leading the header. When the latest action is itself the
   // failure the bar is already red, so exclude it.

--- a/web/src/components/ui/Alert.test.tsx
+++ b/web/src/components/ui/Alert.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Alert } from "./Alert"
+
+afterEach(cleanup)
+
+describe("Alert", () => {
+  it("renders the soft tone recipe with role=alert by default", () => {
+    render(<Alert tone="error">boom</Alert>)
+    const el = screen.getByRole("alert")
+    expect(el.className).toContain("alert")
+    expect(el.className).toContain("alert-error")
+    expect(el.className).toContain("alert-soft")
+    expect(el.textContent).toBe("boom")
+  })
+
+  it("drops alert-soft when soft is false", () => {
+    render(<Alert tone="success" soft={false} aria-label="s" />)
+    const el = screen.getByRole("alert")
+    expect(el.className).toContain("alert-success")
+    expect(el.className).not.toContain("alert-soft")
+  })
+
+  it("honors an explicit role and appends className last", () => {
+    render(
+      <Alert tone="info" role="status" className="mt-4">
+        i
+      </Alert>,
+    )
+    const el = screen.getByRole("status")
+    expect(el.className.endsWith("mt-4")).toBe(true)
+  })
+})

--- a/web/src/components/ui/Alert.tsx
+++ b/web/src/components/ui/Alert.tsx
@@ -1,0 +1,45 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+
+import { cx } from "./cx"
+
+// The canonical inline alert. Wraps daisyUI `alert` with the house `alert-soft`
+// style (the tone->class map mirrors the toast provider) so the soft-vs-non-soft
+// split converges. `soft` defaults on; pass `soft={false}` for a solid fill.
+// `role` defaults to "alert" (assertive); pass `role="status"` for passive
+// updates.
+
+export type AlertTone = "info" | "success" | "warning" | "error"
+
+const TONE_CLASS: Record<AlertTone, string> = {
+  info: "alert-info",
+  success: "alert-success",
+  warning: "alert-warning",
+  error: "alert-error",
+}
+
+export type AlertProps = {
+  tone: AlertTone
+  soft?: boolean
+  children?: ReactNode
+} & ComponentPropsWithoutRef<"div">
+
+export function Alert({
+  tone,
+  soft = true,
+  role = "alert",
+  className,
+  children,
+  ...props
+}: AlertProps) {
+  return (
+    <div
+      role={role}
+      className={cx("alert", TONE_CLASS[tone], soft && "alert-soft", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default Alert

--- a/web/src/components/ui/Alert.tsx
+++ b/web/src/components/ui/Alert.tsx
@@ -3,8 +3,9 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react"
 import { cx } from "./cx"
 
 // The canonical inline alert. Wraps daisyUI `alert` with the house `alert-soft`
-// style (the tone->class map mirrors the toast provider) so the soft-vs-non-soft
-// split converges. `soft` defaults on; pass `soft={false}` for a solid fill.
+// style; the tone->class recipe is exported as `alertToneClass` so the toast
+// provider (which needs a motion wrapper, not <Alert>) shares one source and
+// can't drift. `soft` defaults on; pass `soft={false}` for a solid fill.
 // `role` defaults to "alert" (assertive); pass `role="status"` for passive
 // updates.
 
@@ -15,6 +16,13 @@ const TONE_CLASS: Record<AlertTone, string> = {
   success: "alert-success",
   warning: "alert-warning",
   error: "alert-error",
+}
+
+// The single source of truth for the alert tone->class recipe. Reused by the
+// toast provider (which can't render <Alert> directly — it needs a motion.div
+// wrapper) so the two surfaces can't drift.
+export function alertToneClass(tone: AlertTone, soft = true): string {
+  return cx("alert", TONE_CLASS[tone], soft && "alert-soft")
 }
 
 export type AlertProps = {
@@ -34,7 +42,7 @@ export function Alert({
   return (
     <div
       role={role}
-      className={cx("alert", TONE_CLASS[tone], soft && "alert-soft", className)}
+      className={cx(alertToneClass(tone, soft), className)}
       {...props}
     >
       {children}

--- a/web/src/components/ui/Badge.test.tsx
+++ b/web/src/components/ui/Badge.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Badge } from "./Badge"
+
+afterEach(cleanup)
+
+// Badge is the one status-chip recipe, so these lock the tone/size/soft/ghost
+// mapping and confirm neutral stays a bare `badge` without a soft modifier.
+describe("Badge", () => {
+  it("renders a bare badge (sm) for the neutral default", () => {
+    render(<Badge>n</Badge>)
+    const cls = screen.getByText("n").className
+    expect(cls).toContain("badge")
+    expect(cls).toContain("badge-sm")
+    expect(cls).not.toContain("badge-soft")
+  })
+
+  it("maps a semantic tone to a soft badge by default", () => {
+    render(<Badge tone="error">e</Badge>)
+    const cls = screen.getByText("e").className
+    expect(cls).toContain("badge-error")
+    expect(cls).toContain("badge-soft")
+  })
+
+  it("drops the soft modifier when soft is false", () => {
+    render(
+      <Badge tone="success" soft={false}>
+        s
+      </Badge>,
+    )
+    const cls = screen.getByText("s").className
+    expect(cls).toContain("badge-success")
+    expect(cls).not.toContain("badge-soft")
+  })
+
+  it("uses badge-ghost and ignores tone when ghost", () => {
+    render(
+      <Badge ghost tone="error">
+        g
+      </Badge>,
+    )
+    const cls = screen.getByText("g").className
+    expect(cls).toContain("badge-ghost")
+    expect(cls).not.toContain("badge-error")
+    expect(cls).not.toContain("badge-soft")
+  })
+
+  it("maps the size prop", () => {
+    render(<Badge size="xs">x</Badge>)
+    expect(screen.getByText("x").className).toContain("badge-xs")
+  })
+})

--- a/web/src/components/ui/Badge.tsx
+++ b/web/src/components/ui/Badge.tsx
@@ -1,0 +1,63 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+
+import { cx } from "./cx"
+
+// The canonical status chip. Wraps daisyUI `badge` so the ~45 inline sites
+// share one mapping. `soft` (default true) is the house style for semantic
+// status; `ghost` covers neutral count/tag chips. Semantic tones inherit the
+// per-theme `.badge-soft` contrast nudge from index.css.
+
+export type BadgeTone =
+  "neutral" | "primary" | "info" | "success" | "warning" | "error"
+
+export type BadgeSize = "xs" | "sm" | "md"
+
+const TONE_CLASS: Record<BadgeTone, string> = {
+  neutral: "",
+  primary: "badge-primary",
+  info: "badge-info",
+  success: "badge-success",
+  warning: "badge-warning",
+  error: "badge-error",
+}
+
+const SIZE_CLASS: Record<BadgeSize, string> = {
+  xs: "badge-xs",
+  sm: "badge-sm",
+  md: "",
+}
+
+export type BadgeProps = {
+  tone?: BadgeTone
+  size?: BadgeSize
+  soft?: boolean
+  ghost?: boolean
+  children?: ReactNode
+} & ComponentPropsWithoutRef<"span">
+
+export function Badge({
+  tone = "neutral",
+  size = "sm",
+  soft = true,
+  ghost = false,
+  className,
+  children,
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      className={cx(
+        "badge",
+        SIZE_CLASS[size],
+        ghost ? "badge-ghost" : TONE_CLASS[tone],
+        !ghost && soft && tone !== "neutral" && "badge-soft",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  )
+}
+
+export default Badge

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { Button } from "./Button"
+
+afterEach(cleanup)
+
+// Button is the one prop->class mapping every `btn` site renders through, so
+// these lock the recipe: variant/size/shape map to the expected daisyUI
+// modifiers, `neutral` stays a bare `btn`, and loading disables + announces.
+describe("Button", () => {
+  it("renders a bare btn for the default neutral variant", () => {
+    render(<Button>Go</Button>)
+    const btn = screen.getByRole("button", { name: "Go" })
+    expect(btn.className).toBe("btn")
+    expect(btn.getAttribute("type")).toBe("button")
+  })
+
+  it("maps variant, size, and shape to daisyUI modifiers", () => {
+    render(
+      <Button variant="primary" size="sm" shape="square">
+        X
+      </Button>,
+    )
+    const cls = screen.getByRole("button", { name: "X" }).className
+    expect(cls).toContain("btn")
+    expect(cls).toContain("btn-primary")
+    expect(cls).toContain("btn-sm")
+    expect(cls).toContain("btn-square")
+  })
+
+  it("maps the outline variant to the primary outline", () => {
+    render(<Button variant="outline">O</Button>)
+    const cls = screen.getByRole("button", { name: "O" }).className
+    expect(cls).toContain("btn-outline")
+    expect(cls).toContain("btn-primary")
+  })
+
+  it("adds btn-active when active", () => {
+    render(<Button active>A</Button>)
+    expect(screen.getByRole("button", { name: "A" }).className).toContain(
+      "btn-active",
+    )
+  })
+
+  it("appends the className escape hatch last", () => {
+    render(
+      <Button variant="ghost" className="w-full join-item">
+        E
+      </Button>,
+    )
+    const cls = screen.getByRole("button", { name: "E" }).className
+    expect(cls.endsWith("w-full join-item")).toBe(true)
+  })
+
+  it("disables and marks aria-busy while loading", () => {
+    render(<Button loading>Save</Button>)
+    const btn = screen.getByRole("button", { name: /Save/ })
+    expect(btn.hasAttribute("disabled")).toBe(true)
+    expect(btn.getAttribute("aria-busy")).toBe("true")
+    expect(btn.querySelector(".loading")).not.toBeNull()
+  })
+
+  it("does not fire onClick when disabled", async () => {
+    const onClick = vi.fn()
+    render(
+      <Button disabled onClick={onClick}>
+        No
+      </Button>,
+    )
+    await userEvent.click(screen.getByRole("button", { name: "No" }))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it("respects an explicit submit type", () => {
+    render(
+      <Button type="submit" variant="primary">
+        Submit
+      </Button>,
+    )
+    expect(
+      screen.getByRole("button", { name: "Submit" }).getAttribute("type"),
+    ).toBe("submit")
+  })
+})

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,0 +1,108 @@
+import type { ComponentPropsWithoutRef, ReactNode, Ref } from "react"
+
+import { Spinner } from "@/components/Spinner"
+
+import { cx } from "./cx"
+
+// The canonical button. Wraps daisyUI `btn` so the ~160 inline sites share one
+// prop->class mapping instead of hand-ordered modifier strings. Color/size are
+// props; icon-only buttons pick a `shape`; `loading` renders the accessible
+// Spinner inside and disables the button (replacing the hand-placed inner
+// spinners the audit found). A trailing `className` escape hatch stays for the
+// per-site layout utilities (`w-full`, `join-item`, `self-start`, ...). `ref`
+// is a plain prop (React 19) so sites that manage focus can still reach the
+// underlying <button>.
+
+export type ButtonVariant =
+  | "primary"
+  | "ghost"
+  | "outline"
+  | "error"
+  | "warning"
+  | "success"
+  | "info"
+  | "neutral"
+
+export type ButtonSize = "xs" | "sm" | "md"
+
+export type ButtonShape = "default" | "square" | "circle"
+
+// `neutral` is the bare `btn` (no color modifier); `outline` maps to the
+// primary outline, the only outline color used across the app.
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary: "btn-primary",
+  ghost: "btn-ghost",
+  outline: "btn-outline btn-primary",
+  error: "btn-error",
+  warning: "btn-warning",
+  success: "btn-success",
+  info: "btn-info",
+  neutral: "",
+}
+
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  xs: "btn-xs",
+  sm: "btn-sm",
+  md: "",
+}
+
+const SHAPE_CLASS: Record<ButtonShape, string> = {
+  default: "",
+  square: "btn-square",
+  circle: "btn-circle",
+}
+
+const SPINNER_SIZE: Record<ButtonSize, "xs" | "sm" | "md"> = {
+  xs: "xs",
+  sm: "sm",
+  md: "sm",
+}
+
+export type ButtonProps = {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  shape?: ButtonShape
+  active?: boolean
+  loading?: boolean
+  loadingLabel?: string
+  ref?: Ref<HTMLButtonElement>
+  children?: ReactNode
+} & Omit<ComponentPropsWithoutRef<"button">, "children">
+
+export function Button({
+  variant = "neutral",
+  size = "md",
+  shape = "default",
+  active = false,
+  loading = false,
+  loadingLabel,
+  className,
+  disabled,
+  type,
+  ref,
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      ref={ref}
+      type={type ?? "button"}
+      className={cx(
+        "btn",
+        VARIANT_CLASS[variant],
+        SIZE_CLASS[size],
+        SHAPE_CLASS[shape],
+        active && "btn-active",
+        className,
+      )}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      {...props}
+    >
+      {loading && <Spinner size={SPINNER_SIZE[size]} label={loadingLabel} />}
+      {children}
+    </button>
+  )
+}
+
+export default Button

--- a/web/src/components/ui/Card.test.tsx
+++ b/web/src/components/ui/Card.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Card, CardBody, CardTitle, CardActions } from "./Card"
+
+afterEach(cleanup)
+
+// Card is the one surface recipe every panel renders through, so these lock the
+// border/shadow/radius toggles and the subcomponent classes.
+describe("Card", () => {
+  it("renders the default bordered + shadow box recipe", () => {
+    const { container } = render(<Card>body</Card>)
+    const cls = container.firstElementChild?.className ?? ""
+    expect(cls).toContain("card")
+    expect(cls).toContain("bg-base-100")
+    expect(cls).toContain("border-base-300")
+    expect(cls).toContain("shadow-sm")
+    expect(cls).not.toContain("rounded-")
+  })
+
+  it("drops border and shadow when disabled", () => {
+    const { container } = render(
+      <Card bordered={false} shadow={false}>
+        x
+      </Card>,
+    )
+    const cls = container.firstElementChild?.className ?? ""
+    expect(cls).not.toContain("border")
+    expect(cls).not.toContain("shadow")
+  })
+
+  it("applies the dashed border variant", () => {
+    const { container } = render(<Card dashed>x</Card>)
+    expect(container.firstElementChild?.className).toContain("border-dashed")
+  })
+
+  it("maps the radius prop", () => {
+    const { container } = render(<Card radius="2xl">x</Card>)
+    expect(container.firstElementChild?.className).toContain("rounded-2xl")
+  })
+
+  it("appends the className escape hatch last", () => {
+    const { container } = render(<Card className="col-span-12">x</Card>)
+    expect(container.firstElementChild?.className.endsWith("col-span-12")).toBe(
+      true,
+    )
+  })
+
+  it("renders the element from the `as` prop", () => {
+    const { container } = render(
+      <Card as="section" id="settings">
+        x
+      </Card>,
+    )
+    const root = container.firstElementChild
+    expect(root?.tagName).toBe("SECTION")
+    expect(root?.id).toBe("settings")
+  })
+
+  it("renders subcomponents with their daisyUI classes", () => {
+    render(
+      <Card>
+        <CardBody>
+          <CardTitle>Title</CardTitle>
+          <CardActions>
+            <button type="button">Do</button>
+          </CardActions>
+        </CardBody>
+      </Card>,
+    )
+    expect(screen.getByRole("heading", { name: "Title" }).className).toContain(
+      "card-title",
+    )
+    expect(
+      screen.getByRole("button", { name: "Do" }).parentElement?.className,
+    ).toContain("card-actions")
+  })
+})

--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -1,0 +1,99 @@
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from "react"
+
+import { cx } from "./cx"
+
+// The canonical surface card. Wraps daisyUI `card` with one border/shadow/
+// radius recipe so the ~6 divergent inline recipes converge. Defaults match the
+// most common form/panel card (`bg-base-100 border-base-300 shadow-sm`, box
+// radius); `bordered`/`shadow`/`radius` toggle the variants the audit found
+// (dashed empties, rounded-xl/2xl list cards). `as` swaps the element tag for
+// semantics (e.g. `section`). The `className` escape hatch keeps per-site
+// layout utilities (grid spans, `w-full`, `overflow-hidden`).
+
+type CardRadius = "box" | "xl" | "2xl"
+
+const RADIUS_CLASS: Record<CardRadius, string> = {
+  box: "",
+  xl: "rounded-xl",
+  "2xl": "rounded-2xl",
+}
+
+export type CardProps = {
+  as?: ElementType
+  bordered?: boolean
+  dashed?: boolean
+  shadow?: boolean
+  radius?: CardRadius
+  children?: ReactNode
+} & ComponentPropsWithoutRef<"div">
+
+export function Card({
+  as: Tag = "div",
+  bordered = true,
+  dashed = false,
+  shadow = true,
+  radius = "box",
+  className,
+  children,
+  ...props
+}: CardProps) {
+  return (
+    <Tag
+      className={cx(
+        "card bg-base-100",
+        RADIUS_CLASS[radius],
+        bordered &&
+          (dashed
+            ? "border border-dashed border-base-300"
+            : "border border-base-300"),
+        shadow && "shadow-sm",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Tag>
+  )
+}
+
+export function CardBody({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div className={cx("card-body", className)} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export function CardTitle({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"h2">) {
+  return (
+    <h2 className={cx("card-title", className)} {...props}>
+      {children}
+    </h2>
+  )
+}
+
+export function CardActions({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div className={cx("card-actions", className)} {...props}>
+      {children}
+    </div>
+  )
+}
+
+Card.Body = CardBody
+Card.Title = CardTitle
+Card.Actions = CardActions
+
+export default Card

--- a/web/src/components/ui/FormField.test.tsx
+++ b/web/src/components/ui/FormField.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { FormField } from "./FormField"
+
+afterEach(cleanup)
+
+// FormField is the one field wrapper unifying the label + error + helper markup,
+// so these lock the a11y wiring: label->control association, required marker,
+// error (role=alert) with aria-describedby, and helper text swap.
+describe("FormField", () => {
+  it("links the label to the control via the generated id", () => {
+    render(
+      <FormField label="Name">
+        {({ id }) => <input id={id} aria-label="Name" />}
+      </FormField>,
+    )
+    const input = screen.getByLabelText("Name")
+    const label = screen.getByText("Name")
+    expect(label.getAttribute("for")).toBe(input.id)
+    expect(input.id).toBeTruthy()
+  })
+
+  it("uses the provided htmlFor id", () => {
+    render(
+      <FormField label="Slug" htmlFor="slug">
+        {({ id }) => <input id={id} aria-label="Slug" />}
+      </FormField>,
+    )
+    expect(screen.getByLabelText("Slug").id).toBe("slug")
+  })
+
+  it("renders the required marker", () => {
+    render(
+      <FormField label="Name" required>
+        {({ id }) => <input id={id} aria-label="Name" />}
+      </FormField>,
+    )
+    expect(screen.getByText("*")).toBeDefined()
+  })
+
+  it("shows an error with role=alert and wires aria-describedby + invalid", () => {
+    render(
+      <FormField label="Name" htmlFor="n" error="Required">
+        {({ describedById, invalid }) => (
+          <input
+            id="n"
+            aria-label="Name"
+            aria-describedby={describedById}
+            aria-invalid={invalid}
+          />
+        )}
+      </FormField>,
+    )
+    const alert = screen.getByRole("alert")
+    expect(alert.textContent).toBe("Required")
+    const input = screen.getByLabelText("Name")
+    expect(input.getAttribute("aria-describedby")).toBe(alert.id)
+    expect(input.getAttribute("aria-invalid")).toBe("true")
+  })
+
+  it("shows helper text (not an alert) when there is no error", () => {
+    render(
+      <FormField label="Name" htmlFor="n" hint="Use lowercase">
+        {({ describedById }) => (
+          <input id="n" aria-label="Name" aria-describedby={describedById} />
+        )}
+      </FormField>,
+    )
+    expect(screen.queryByRole("alert")).toBeNull()
+    const hint = screen.getByText("Use lowercase")
+    expect(screen.getByLabelText("Name").getAttribute("aria-describedby")).toBe(
+      hint.id,
+    )
+  })
+})

--- a/web/src/components/ui/FormField.tsx
+++ b/web/src/components/ui/FormField.tsx
@@ -1,0 +1,100 @@
+import { HelpCircle } from "lucide-react"
+import { useId, type ReactNode } from "react"
+
+import { Button } from "./Button"
+import { cx } from "./cx"
+
+// A question-mark help affordance: a focusable button carrying detailed
+// guidance as its accessible name, wrapped in a theme-aware DaisyUI tooltip.
+// The single source for the help-icon markup + a11y contract.
+export function HelpTooltip({ help }: { help: string }) {
+  return (
+    <span
+      className="tooltip tooltip-bottom before:max-w-xs before:whitespace-normal before:text-left"
+      data-tip={help}
+    >
+      <Button
+        variant="ghost"
+        size="xs"
+        shape="circle"
+        aria-label={help}
+        className="text-base-content/50 hover:text-base-content"
+      >
+        <HelpCircle aria-hidden="true" className="size-4" />
+      </Button>
+    </span>
+  )
+}
+
+type FieldRenderArgs = {
+  // Wire these onto the control so the label, error, and control stay linked.
+  id: string
+  describedById: string | undefined
+  invalid: boolean
+}
+
+// The canonical form field: a bold label (optional required marker + help
+// tooltip), the control, an optional error message (role="alert"), and optional
+// helper text. Unifies the 4 label patterns and 3 error-display markups the
+// audit found. `children` is a render prop that receives the generated `id`,
+// the `aria-describedby` target (error/help), and `invalid` so the control can
+// wire its a11y attributes; pass the field's error into `error` (a truthy value
+// switches the field into the invalid state).
+export function FormField({
+  label,
+  htmlFor,
+  required = false,
+  help,
+  error,
+  hint,
+  className,
+  children,
+}: {
+  label: ReactNode
+  // Provide when the control has its own stable id (e.g. TanStack `field.name`);
+  // otherwise an id is generated.
+  htmlFor?: string
+  required?: boolean
+  help?: string
+  error?: ReactNode
+  hint?: ReactNode
+  className?: string
+  children: (args: FieldRenderArgs) => ReactNode
+}) {
+  const generatedId = useId()
+  const id = htmlFor ?? generatedId
+  const invalid = Boolean(error)
+  const errorId = `${id}-error`
+  const hintId = `${id}-hint`
+  const describedById = invalid ? errorId : hint ? hintId : undefined
+
+  return (
+    <div className={cx("flex flex-col gap-1.5", className)}>
+      <div className="flex items-center gap-1.5">
+        <label htmlFor={id} className="label font-bold">
+          {label}
+          {required ? (
+            <span className="text-error" aria-hidden="true">
+              *
+            </span>
+          ) : null}
+        </label>
+        {help ? <HelpTooltip help={help} /> : null}
+      </div>
+
+      {children({ id, describedById, invalid })}
+
+      {invalid ? (
+        <p id={errorId} role="alert" className="text-sm text-error">
+          {error}
+        </p>
+      ) : hint ? (
+        <p id={hintId} className="text-sm text-base-content/70">
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export default FormField

--- a/web/src/components/ui/Input.test.tsx
+++ b/web/src/components/ui/Input.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Input } from "./Input"
+
+afterEach(cleanup)
+
+describe("Input", () => {
+  it("renders the bordered convention and defaults to type text", () => {
+    render(<Input aria-label="name" />)
+    const el = screen.getByLabelText("name")
+    expect(el.className).toContain("input")
+    expect(el.className).toContain("input-bordered")
+    expect(el.className).toContain("w-full")
+    expect(el.getAttribute("type")).toBe("text")
+  })
+
+  it("adds input-error and aria-invalid when invalid", () => {
+    render(<Input aria-label="e" invalid />)
+    const el = screen.getByLabelText("e")
+    expect(el.className).toContain("input-error")
+    expect(el.getAttribute("aria-invalid")).toBe("true")
+  })
+
+  it("maps the size prop and appends className last", () => {
+    render(<Input aria-label="s" inputSize="sm" className="font-mono" />)
+    const cls = screen.getByLabelText("s").className
+    expect(cls).toContain("input-sm")
+    expect(cls).toContain("w-full")
+    expect(cls.endsWith("font-mono")).toBe(true)
+  })
+
+  it("drops the default w-full when the caller sets a width", () => {
+    render(<Input aria-label="w" className="w-32" />)
+    const cls = screen.getByLabelText("w").className
+    expect(cls).not.toContain("w-full")
+    expect(cls).toContain("w-32")
+  })
+})

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -1,0 +1,54 @@
+import type { ComponentPropsWithoutRef, Ref } from "react"
+
+import { cx } from "./cx"
+
+// The canonical text input. Wraps daisyUI `input input-bordered w-full` so the
+// two competing conventions (`input w-full` vs `input input-bordered`) converge
+// on the bordered one. `invalid` adds `input-error` (wire it to the field's
+// error state); `size` maps the daisyUI size modifiers. `ref` is a plain prop
+// (React 19). The `className` escape hatch keeps per-site layout utilities
+// (`font-mono`, `join-item`, width overrides).
+
+export type InputSize = "xs" | "sm" | "md"
+
+const SIZE_CLASS: Record<InputSize, string> = {
+  xs: "input-xs",
+  sm: "input-sm",
+  md: "",
+}
+
+export type InputProps = {
+  inputSize?: InputSize
+  invalid?: boolean
+  ref?: Ref<HTMLInputElement>
+} & ComponentPropsWithoutRef<"input">
+
+export function Input({
+  inputSize = "md",
+  invalid = false,
+  className,
+  type,
+  ...props
+}: InputProps) {
+  // Only default to full width when the caller hasn't set their own width; a
+  // trailing `w-full` in the recipe would otherwise beat a per-site `w-32` (cx
+  // doesn't merge Tailwind classes, and same-property source order is
+  // unspecified).
+  const hasWidth = className ? /(?:^|\s)w-/.test(className) : false
+  return (
+    <input
+      type={type ?? "text"}
+      className={cx(
+        "input input-bordered",
+        !hasWidth && "w-full",
+        SIZE_CLASS[inputSize],
+        invalid && "input-error",
+        className,
+      )}
+      aria-invalid={invalid || undefined}
+      {...props}
+    />
+  )
+}
+
+export default Input

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, afterEach, vi, beforeAll } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
+import { createRef } from "react"
 
 import { Modal } from "./Modal"
 
@@ -97,5 +98,27 @@ describe("Modal", () => {
     const cancel = new Event("cancel", { cancelable: true })
     dialog.dispatchEvent(cancel)
     expect(cancel.defaultPrevented).toBe(false)
+  })
+
+  it("stays closed in ref-driven mode until opened imperatively, and wires dialogRef", () => {
+    const onClose = vi.fn()
+    const dialogRef = createRef<HTMLDialogElement | null>()
+    const { container } = render(
+      <Modal dialogRef={dialogRef} onClose={onClose} aria-label="dlg">
+        x
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+
+    // `open` is omitted: the sync effect early-returns, so the dialog is not
+    // auto-opened and the ref is populated for the caller to drive.
+    expect(dialog.open).toBe(false)
+    expect(dialogRef.current).toBe(dialog)
+
+    // Opening imperatively still routes native close through onClose.
+    dialogRef.current?.showModal()
+    expect(dialog.open).toBe(true)
+    dialog.close()
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach, vi, beforeAll } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Modal } from "./Modal"
+
+// happy-dom doesn't implement <dialog> showModal/close; stub them so the
+// open-sync effect can run without throwing.
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function () {
+    this.open = true
+  }
+  HTMLDialogElement.prototype.close = function () {
+    this.open = false
+    this.dispatchEvent(new Event("close"))
+  }
+})
+
+afterEach(cleanup)
+
+describe("Modal", () => {
+  it("renders the box with the mapped size and a close button", () => {
+    const { container } = render(
+      <Modal open size="md" aria-label="dlg">
+        <p>hi</p>
+      </Modal>,
+    )
+    const box = container.querySelector(".modal-box")
+    expect(box?.className).toContain("max-w-md")
+    expect(screen.getByText("hi")).toBeDefined()
+    // one close X + one backdrop close button
+    expect(screen.getAllByRole("button").length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("hides the close X when hideCloseButton", () => {
+    render(
+      <Modal open hideCloseButton aria-label="dlg">
+        x
+      </Modal>,
+    )
+    // only the backdrop close button remains
+    expect(screen.getAllByRole("button")).toHaveLength(1)
+  })
+
+  it("opens the native dialog when open flips true", () => {
+    const { container } = render(
+      <Modal open aria-label="dlg">
+        x
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+    expect(dialog.open).toBe(true)
+  })
+
+  it("fires onClose on the native close event", async () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <Modal open onClose={onClose} aria-label="dlg">
+        x
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+    dialog.close()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables the close controls when closeDisabled", () => {
+    render(
+      <Modal open closeDisabled aria-label="dlg">
+        x
+      </Modal>,
+    )
+    for (const btn of screen.getAllByRole("button")) {
+      expect((btn as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+
+  it("vetoes Esc (cancel) when closeDisabled", () => {
+    const { container } = render(
+      <Modal open closeDisabled aria-label="dlg">
+        x
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+    const cancel = new Event("cancel", { cancelable: true })
+    dialog.dispatchEvent(cancel)
+    expect(cancel.defaultPrevented).toBe(true)
+  })
+
+  it("allows Esc (cancel) when not closeDisabled", () => {
+    const { container } = render(
+      <Modal open aria-label="dlg">
+        x
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+    const cancel = new Event("cancel", { cancelable: true })
+    dialog.dispatchEvent(cancel)
+    expect(cancel.defaultPrevented).toBe(false)
+  })
+})

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -1,0 +1,128 @@
+import { X } from "lucide-react"
+import {
+  useEffect,
+  useId,
+  useRef,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+} from "react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "./Button"
+import { cx } from "./cx"
+
+// The canonical dialog. Wraps the native `<dialog className="modal">` idiom the
+// app uses everywhere: it owns the `modal-box` (sized via `size`), the top-right
+// close X, the click-outside `modal-backdrop`, and the open/close sync. Two
+// control modes:
+//   - controlled: pass `open` + `onClose` (the common case). The effect calls
+//     showModal()/close() to match `open`.
+//   - ref-driven: pass a `dialogRef` you open imperatively (e.g. a hook that
+//     needs the element). `open` may be omitted.
+// `onClose` fires on the native dialog close (Esc, backdrop, close button).
+
+export type ModalSize = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl"
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+  "2xl": "max-w-2xl",
+  "3xl": "max-w-3xl",
+}
+
+export type ModalProps = {
+  open?: boolean
+  onClose?: () => void
+  size?: ModalSize
+  // Hide the built-in top-right close X (some modals render their own header
+  // affordance or must block dismissal while submitting).
+  hideCloseButton?: boolean
+  // Disable the close X + backdrop close, and block Esc-dismiss, while a submit
+  // is in flight (see the onCancel guard below).
+  closeDisabled?: boolean
+  "aria-labelledby"?: string
+  "aria-label"?: string
+  // Extra classes for the modal-box.
+  boxClassName?: string
+  dialogRef?: RefObject<HTMLDialogElement | null>
+  ref?: Ref<HTMLDialogElement>
+  children?: ReactNode
+}
+
+export function Modal({
+  open,
+  onClose,
+  size = "lg",
+  hideCloseButton = false,
+  closeDisabled = false,
+  boxClassName,
+  dialogRef,
+  ref,
+  children,
+  ...aria
+}: ModalProps) {
+  const { t } = useTranslation()
+  const internalRef = useRef<HTMLDialogElement | null>(null)
+  const closeId = useId()
+
+  // Keep the native dialog in sync with `open` (controlled mode). Skipped when
+  // the caller drives the dialog through `dialogRef` and never passes `open`.
+  useEffect(() => {
+    if (open === undefined) return
+    const dialog = dialogRef?.current ?? internalRef.current
+    if (!dialog) return
+    if (open && !dialog.open) dialog.showModal()
+    if (!open && dialog.open) dialog.close()
+  }, [open, dialogRef])
+
+  const setRefs = (node: HTMLDialogElement | null) => {
+    internalRef.current = node
+    if (dialogRef) dialogRef.current = node
+    if (typeof ref === "function") ref(node)
+    else if (ref) (ref as { current: HTMLDialogElement | null }).current = node
+  }
+
+  return (
+    <dialog
+      ref={setRefs}
+      className="modal"
+      onClose={() => onClose?.()}
+      onCancel={(event) => {
+        // Esc triggers `cancel` before `close`. When dismissal is blocked
+        // (e.g. a submit is in flight), veto it so the dialog stays open —
+        // matching the hand-rolled modals' Esc guard.
+        if (closeDisabled) event.preventDefault()
+      }}
+      {...aria}
+    >
+      <div className={cx("modal-box", SIZE_CLASS[size], boxClassName)}>
+        {!hideCloseButton && (
+          <form method="dialog">
+            <Button
+              type="submit"
+              variant="ghost"
+              size="sm"
+              shape="circle"
+              className="absolute right-3 top-3"
+              aria-label={t("common.close")}
+              disabled={closeDisabled}
+              key={closeId}
+            >
+              <X className="size-4" aria-hidden="true" />
+            </Button>
+          </form>
+        )}
+        {children}
+      </div>
+
+      <form method="dialog" className="modal-backdrop">
+        <button disabled={closeDisabled}>{t("common.close")}</button>
+      </form>
+    </dialog>
+  )
+}
+
+export default Modal

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -1,0 +1,48 @@
+import type { ComponentPropsWithoutRef, Ref } from "react"
+
+import { cx } from "./cx"
+
+// The canonical select. Wraps daisyUI `select select-bordered w-full` to match
+// the Input convention. `invalid` adds `select-error`; `selectSize` maps size
+// modifiers. `className` keeps per-site layout (`w-auto`, `min-w-0`, `flex-1`).
+
+export type SelectSize = "xs" | "sm" | "md"
+
+const SIZE_CLASS: Record<SelectSize, string> = {
+  xs: "select-xs",
+  sm: "select-sm",
+  md: "",
+}
+
+export type SelectProps = {
+  selectSize?: SelectSize
+  invalid?: boolean
+  ref?: Ref<HTMLSelectElement>
+} & ComponentPropsWithoutRef<"select">
+
+export function Select({
+  selectSize = "md",
+  invalid = false,
+  className,
+  children,
+  ...props
+}: SelectProps) {
+  const hasWidth = className ? /(?:^|\s)w-/.test(className) : false
+  return (
+    <select
+      className={cx(
+        "select select-bordered",
+        !hasWidth && "w-full",
+        SIZE_CLASS[selectSize],
+        invalid && "select-error",
+        className,
+      )}
+      aria-invalid={invalid || undefined}
+      {...props}
+    >
+      {children}
+    </select>
+  )
+}
+
+export default Select

--- a/web/src/components/ui/Textarea.tsx
+++ b/web/src/components/ui/Textarea.tsx
@@ -1,0 +1,31 @@
+import type { ComponentPropsWithoutRef, Ref } from "react"
+
+import { cx } from "./cx"
+
+// The canonical multi-line input. Wraps daisyUI `textarea textarea-bordered
+// w-full` (the audit found multi-line entry was styled ad hoc). `invalid` adds
+// `textarea-error`.
+export type TextareaProps = {
+  invalid?: boolean
+  ref?: Ref<HTMLTextAreaElement>
+} & ComponentPropsWithoutRef<"textarea">
+
+export function Textarea({
+  invalid = false,
+  className,
+  ...props
+}: TextareaProps) {
+  return (
+    <textarea
+      className={cx(
+        "textarea textarea-bordered w-full",
+        invalid && "textarea-error",
+        className,
+      )}
+      aria-invalid={invalid || undefined}
+      {...props}
+    />
+  )
+}
+
+export default Textarea

--- a/web/src/components/ui/cx.ts
+++ b/web/src/components/ui/cx.ts
@@ -1,0 +1,8 @@
+// Join class fragments, dropping falsy ones, so primitives can compose their
+// canonical DaisyUI recipe with conditional modifiers and a trailing
+// `className` escape hatch without leaving stray double spaces. Deliberately
+// tiny (no clsx/tailwind-merge dependency) — the app already builds classes
+// with template strings; this just centralizes the falsy-drop + trim.
+export function cx(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(" ").trim()
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -1,0 +1,38 @@
+// Shared UI primitives: thin typed wrappers over the app's daisyUI class
+// recipes so inline copy-pasted classes converge on one prop->class mapping.
+// Spinner already lived at components/Spinner; re-exported here so callers have
+// a single `@/components/ui` entry point.
+export { Button } from "./Button"
+export type {
+  ButtonProps,
+  ButtonVariant,
+  ButtonSize,
+  ButtonShape,
+} from "./Button"
+
+export { Card, CardBody, CardTitle, CardActions } from "./Card"
+export type { CardProps } from "./Card"
+
+export { Badge } from "./Badge"
+export type { BadgeProps, BadgeTone, BadgeSize } from "./Badge"
+
+export { Input } from "./Input"
+export type { InputProps, InputSize } from "./Input"
+
+export { Select } from "./Select"
+export type { SelectProps, SelectSize } from "./Select"
+
+export { Textarea } from "./Textarea"
+export type { TextareaProps } from "./Textarea"
+
+export { FormField, HelpTooltip } from "./FormField"
+
+export { Modal } from "./Modal"
+export type { ModalProps, ModalSize } from "./Modal"
+
+export { Alert } from "./Alert"
+export type { AlertProps, AlertTone } from "./Alert"
+
+export { Spinner } from "@/components/Spinner"
+
+export { cx } from "./cx"

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -30,7 +30,7 @@ export { FormField, HelpTooltip } from "./FormField"
 export { Modal } from "./Modal"
 export type { ModalProps, ModalSize } from "./Modal"
 
-export { Alert } from "./Alert"
+export { Alert, alertToneClass } from "./Alert"
 export type { AlertProps, AlertTone } from "./Alert"
 
 export { Spinner } from "@/components/Spinner"

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -11,6 +11,7 @@ import {
 import { X } from "lucide-react"
 import { AnimatePresence, motion } from "motion/react"
 import { toastVariants } from "@/lib/motion"
+import { Button } from "@/components/ui"
 
 export type ToastTone = "info" | "success" | "warning" | "error"
 
@@ -149,14 +150,14 @@ const ToastViewport = ({
             className={`${TONE_CLASS[toast.tone]} max-w-sm`}
           >
             <span className="text-sm">{toast.message}</span>
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs"
+            <Button
+              variant="ghost"
+              size="xs"
               aria-label="Dismiss notification"
               onClick={() => onDismiss(toast.id)}
             >
               <X aria-hidden="true" className="size-4" />
-            </button>
+            </Button>
           </motion.div>
         ))}
       </AnimatePresence>

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -11,7 +11,7 @@ import {
 import { X } from "lucide-react"
 import { AnimatePresence, motion } from "motion/react"
 import { toastVariants } from "@/lib/motion"
-import { Button } from "@/components/ui"
+import { Button, alertToneClass } from "@/components/ui"
 
 export type ToastTone = "info" | "success" | "warning" | "error"
 
@@ -44,15 +44,6 @@ type NotificationContextValue = {
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null)
-
-// daisyUI alert classes per tone. `alert-soft` matches the inline alerts this
-// provider generalizes (EnrolledStudents, EditAssignment).
-const TONE_CLASS: Record<ToastTone, string> = {
-  info: "alert alert-info alert-soft",
-  success: "alert alert-success alert-soft",
-  warning: "alert alert-warning alert-soft",
-  error: "alert alert-error alert-soft",
-}
 
 let toastSeq = 0
 const nextId = () => `toast-${++toastSeq}`
@@ -147,7 +138,7 @@ const ToastViewport = ({
             exit="exit"
             role="alert"
             aria-live={toast.tone === "error" ? "assertive" : "polite"}
-            className={`${TONE_CLASS[toast.tone]} max-w-sm`}
+            className={`${alertToneClass(toast.tone)} max-w-sm`}
           >
             <span className="text-sm">{toast.message}</span>
             <Button

--- a/web/src/hooks/useTheme.test.ts
+++ b/web/src/hooks/useTheme.test.ts
@@ -14,7 +14,7 @@ describe("theme anti-flash contract (index.html <-> useTheme)", () => {
     fileURLToPath(new URL("../../index.html", import.meta.url)),
     "utf8",
   )
-  const THEMES: Theme[] = ["corporate", "corporate-dark"]
+  const THEMES: Theme[] = ["sumi", "sumi-dark"]
 
   it("index.html references the same storage key", () => {
     expect(indexHtml).toContain(THEME_STORAGE_KEY)

--- a/web/src/hooks/useTheme.test.ts
+++ b/web/src/hooks/useTheme.test.ts
@@ -1,8 +1,15 @@
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs"
-import { fileURLToPath } from "node:url"
-import { describe, it, expect } from "vitest"
+import path from "node:path"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
 
-import { THEME_STORAGE_KEY, type Theme } from "./useTheme"
+import {
+  THEME_STORAGE_KEY,
+  resolveInitialTheme,
+  useTheme,
+  type Theme,
+} from "./useTheme"
 
 // The anti-flash inline script in index.html hand-mirrors resolveInitialTheme
 // (same storage key + theme names) so the pre-mount paint matches what React
@@ -10,10 +17,10 @@ import { THEME_STORAGE_KEY, type Theme } from "./useTheme"
 // is nearly invisible in review — so guard the contract here, like the repo's
 // other hand-mirrored-contract drift tests (e.g. skeleton.test.ts).
 describe("theme anti-flash contract (index.html <-> useTheme)", () => {
-  const indexHtml = readFileSync(
-    fileURLToPath(new URL("../../index.html", import.meta.url)),
-    "utf8",
-  )
+  // Resolve from the vitest cwd (the web package root) rather than
+  // import.meta.url: this suite runs under happy-dom, where import.meta.url is
+  // not a file: URL and fileURLToPath would throw.
+  const indexHtml = readFileSync(path.join(process.cwd(), "index.html"), "utf8")
   const THEMES: Theme[] = ["sumi", "sumi-dark"]
 
   it("index.html references the same storage key", () => {
@@ -26,5 +33,194 @@ describe("theme anti-flash contract (index.html <-> useTheme)", () => {
         `"${theme}"`,
       )
     }
+  })
+})
+
+// Drive a `prefers-color-scheme: dark` result plus a captured change listener so
+// tests can flip the OS preference at runtime. matchMedia isn't implemented in
+// happy-dom, so we install a minimal stub.
+function stubMatchMedia(initialDark: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>()
+  let matches = initialDark
+  window.matchMedia = ((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) =>
+      listeners.add(cb),
+    removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) =>
+      listeners.delete(cb),
+  })) as unknown as typeof window.matchMedia
+  return {
+    listenerCount: () => listeners.size,
+    emit(dark: boolean) {
+      matches = dark
+      for (const cb of listeners) cb({ matches: dark } as MediaQueryListEvent)
+    },
+  }
+}
+
+function getTheme() {
+  return document.documentElement.getAttribute("data-theme")
+}
+
+// happy-dom (v15) doesn't back window.localStorage here, so install a minimal
+// in-memory store — the same shape the i18n customLocale tests use.
+function installLocalStorage() {
+  const store = new Map<string, string>()
+  const localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size
+    },
+  }
+  Object.defineProperty(window, "localStorage", {
+    value: localStorage,
+    configurable: true,
+  })
+}
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    installLocalStorage()
+    document.documentElement.removeAttribute("data-theme")
+    // Default: no View Transitions API (exercises the instant fallback); a
+    // specific test opts into the animated branch.
+    delete (document as { startViewTransition?: unknown }).startViewTransition
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (window as { matchMedia?: unknown }).matchMedia
+  })
+
+  describe("resolveInitialTheme", () => {
+    it("prefers an explicit stored choice over the OS preference", () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, "sumi-dark")
+      stubMatchMedia(false)
+      expect(resolveInitialTheme()).toBe("sumi-dark")
+    })
+
+    it("falls back to the OS preference when nothing is stored", () => {
+      stubMatchMedia(true)
+      expect(resolveInitialTheme()).toBe("sumi-dark")
+      stubMatchMedia(false)
+      expect(resolveInitialTheme()).toBe("sumi")
+    })
+
+    it("ignores a corrupt stored value and falls back to the OS", () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, "neon")
+      stubMatchMedia(true)
+      expect(resolveInitialTheme()).toBe("sumi-dark")
+    })
+  })
+
+  it("applies the initial theme to <html> on mount", () => {
+    stubMatchMedia(false)
+    renderHook(() => useTheme())
+    expect(getTheme()).toBe("sumi")
+  })
+
+  it("does not animate the first apply but cross-fades a later user toggle", () => {
+    stubMatchMedia(false)
+    const startViewTransition = vi.fn((cb: () => void) => cb())
+    ;(
+      document as { startViewTransition?: (cb: () => void) => void }
+    ).startViewTransition = startViewTransition
+
+    const { result } = renderHook(() => useTheme())
+    // First apply re-asserts the anti-flash paint — must not go through the
+    // View Transition.
+    expect(startViewTransition).not.toHaveBeenCalled()
+    expect(getTheme()).toBe("sumi")
+
+    act(() => result.current.toggleTheme())
+    expect(startViewTransition).toHaveBeenCalledTimes(1)
+    expect(getTheme()).toBe("sumi-dark")
+  })
+
+  it("applies the theme via the fallback when startViewTransition is absent", () => {
+    stubMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+    act(() => result.current.setTheme("sumi-dark"))
+    expect(getTheme()).toBe("sumi-dark")
+  })
+
+  it("persists an explicit choice to localStorage", () => {
+    stubMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+    act(() => result.current.setTheme("sumi-dark"))
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("sumi-dark")
+    expect(result.current.theme).toBe("sumi-dark")
+    expect(result.current.isDark).toBe(true)
+  })
+
+  it("follows OS changes only while no explicit choice is stored", () => {
+    const mql = stubMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+
+    act(() => mql.emit(true))
+    expect(result.current.theme).toBe("sumi-dark")
+
+    // Once the user picks explicitly, later OS changes are ignored.
+    act(() => result.current.setTheme("sumi"))
+    act(() => mql.emit(true))
+    expect(result.current.theme).toBe("sumi")
+  })
+
+  it("does NOT animate an OS-driven change (only user toggles cross-fade)", () => {
+    const mql = stubMatchMedia(false)
+    const startViewTransition = vi.fn((cb: () => void) => cb())
+    ;(
+      document as { startViewTransition?: (cb: () => void) => void }
+    ).startViewTransition = startViewTransition
+
+    renderHook(() => useTheme())
+    act(() => mql.emit(true))
+    expect(startViewTransition).not.toHaveBeenCalled()
+    expect(getTheme()).toBe("sumi-dark")
+  })
+
+  it("follows a cross-tab storage write for a valid value and ignores others", () => {
+    stubMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: THEME_STORAGE_KEY,
+          newValue: "sumi-dark",
+        }),
+      )
+    })
+    expect(result.current.theme).toBe("sumi-dark")
+
+    // A write to an unrelated key, or a corrupt value, is ignored.
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "other", newValue: "sumi" }),
+      )
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: THEME_STORAGE_KEY,
+          newValue: "neon",
+        }),
+      )
+    })
+    expect(result.current.theme).toBe("sumi-dark")
+  })
+
+  it("removes the OS and storage listeners on unmount", () => {
+    const mql = stubMatchMedia(false)
+    const removeStorage = vi.spyOn(window, "removeEventListener")
+    const { unmount } = renderHook(() => useTheme())
+    expect(mql.listenerCount()).toBe(1)
+
+    unmount()
+    expect(mql.listenerCount()).toBe(0)
+    expect(removeStorage).toHaveBeenCalledWith("storage", expect.any(Function))
   })
 })

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -2,13 +2,14 @@ import { useCallback, useEffect, useState } from "react"
 
 // Client-side theme preference. Mirrors the `classroom50:sidebar-collapsed`
 // pattern: one localStorage key, applied by toggling `data-theme` on <html>.
-// The two theme names are the ones registered in index.css.
+// The two theme names ("sumi" light / "sumi-dark" dark) are the ones registered
+// in index.css.
 export const THEME_STORAGE_KEY = "classroom50:theme"
 
-export type Theme = "corporate" | "corporate-dark"
+export type Theme = "sumi" | "sumi-dark"
 
-const LIGHT: Theme = "corporate"
-const DARK: Theme = "corporate-dark"
+const LIGHT: Theme = "sumi"
+const DARK: Theme = "sumi-dark"
 
 // Resolve the initial theme: an explicit stored choice wins; else fall back to
 // the OS `prefers-color-scheme`. Kept in sync with the anti-flash inline script

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 // Client-side theme preference. Mirrors the `classroom50:sidebar-collapsed`
 // pattern: one localStorage key, applied by toggling `data-theme` on <html>.
@@ -35,6 +35,26 @@ function applyTheme(theme: Theme) {
   document.documentElement.setAttribute("data-theme", theme)
 }
 
+// Cross-fade an explicit light<->dark switch via the View Transitions API: the
+// browser snapshots the old page, applies the theme, and GPU-composites a
+// single cross-fade between the two snapshots (smooth, unlike transitioning
+// every element's colors at once). Falls back to an instant apply where the API
+// is unavailable. Duration/easing live in the `::view-transition-*` rules in
+// index.css; reduced-motion is handled there too.
+function applyThemeAnimated(theme: Theme) {
+  if (typeof document === "undefined") return
+  const startViewTransition = (
+    document as Document & {
+      startViewTransition?: (cb: () => void) => unknown
+    }
+  ).startViewTransition
+  if (typeof startViewTransition !== "function") {
+    applyTheme(theme)
+    return
+  }
+  startViewTransition.call(document, () => applyTheme(theme))
+}
+
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(resolveInitialTheme)
 
@@ -42,8 +62,18 @@ export function useTheme() {
   // writing on mount would freeze a first-visit OS default into a locked explicit
   // choice, so "follow the OS" could never recover. We persist only on an
   // explicit user action (setTheme/toggleTheme) below.
+  //
+  // The first run only re-asserts what the anti-flash script already painted, so
+  // it must NOT animate; every later change (toggle, OS, cross-tab) cross-fades
+  // via the View Transitions API.
+  const firstApply = useRef(true)
   useEffect(() => {
-    applyTheme(theme)
+    if (firstApply.current) {
+      firstApply.current = false
+      applyTheme(theme)
+    } else {
+      applyThemeAnimated(theme)
+    }
   }, [theme])
 
   // While the user has made no explicit choice, follow the OS and any choice

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 // Client-side theme preference. Mirrors the `classroom50:sidebar-collapsed`
 // pattern: one localStorage key, applied by toggling `data-theme` on <html>.
@@ -58,26 +58,22 @@ function applyThemeAnimated(theme: Theme) {
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(resolveInitialTheme)
 
-  // Apply the active theme to <html>. Persistence is deliberately NOT done here:
-  // writing on mount would freeze a first-visit OS default into a locked explicit
-  // choice, so "follow the OS" could never recover. We persist only on an
-  // explicit user action (setTheme/toggleTheme) below.
-  //
-  // The first run only re-asserts what the anti-flash script already painted, so
-  // it must NOT animate; every later change (toggle, OS, cross-tab) cross-fades
-  // via the View Transitions API.
-  const firstApply = useRef(true)
+  // Only an explicit user toggle cross-fades. Apply the active theme to <html>
+  // here without animating: the first run re-asserts what the anti-flash script
+  // already painted, and OS/cross-tab changes are external — cross-fading either
+  // would abort a user's in-flight transition (a non-user event landing inside
+  // the ~600ms fade re-snapshots the page) and animate motion the user didn't
+  // ask for. Persistence is deliberately NOT done here: writing on mount would
+  // freeze a first-visit OS default into a locked explicit choice, so "follow
+  // the OS" could never recover. We persist (and animate) only on an explicit
+  // user action (setTheme/toggleTheme) below.
   useEffect(() => {
-    if (firstApply.current) {
-      firstApply.current = false
-      applyTheme(theme)
-    } else {
-      applyThemeAnimated(theme)
-    }
+    applyTheme(theme)
   }, [theme])
 
   // While the user has made no explicit choice, follow the OS and any choice
-  // made in another tab. Both listeners are no-ops once a value is stored.
+  // made in another tab. Both listeners are no-ops once a value is stored, so a
+  // tab holding an explicit choice ignores cross-tab writes too.
   useEffect(() => {
     if (typeof window === "undefined") return
 
@@ -102,6 +98,10 @@ export function useTheme() {
   }, [])
 
   const persist = useCallback((next: Theme) => {
+    // A user toggle is the only path that cross-fades; state still holds the new
+    // theme, but painting it through the View Transition here (rather than in the
+    // [theme] effect) keeps OS/cross-tab-driven changes instant.
+    applyThemeAnimated(next)
     setThemeState(next)
     if (typeof window !== "undefined") {
       window.localStorage.setItem(THEME_STORAGE_KEY, next)

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,58 +1,46 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Noto+Sans+JP:wght@400;500;700&display=swap");
 @import "tailwindcss";
 @plugin "daisyui/index.js" {
   themes: corporate --default;
 }
 
-/* Keep the original dark-navy sidebar look in light mode: the sidebar
-   uses `neutral`, but corporate's stock neutral is pure black. Pin it to the
-   pre-existing hand-picked palette (#212a3a rail / #accefb accent). The dark
-   theme redefines neutral separately below. */
+/* ── Light theme ────────────────────────────────────────────────────────────
+   A minimalist palette for an educational tool. Base surfaces are neutral
+   off-whites (no warm tint) — soft, not clinical pure white; text is a neutral
+   charcoal instead of pure black; the accent is `ai` (traditional Japanese
+   indigo) — calm and scholarly. A muted vermilion (`aka`) is reserved for the
+   accent/error family. Shapes stay flat and near-square (--depth/--noise 0,
+   small radii) for restraint. */
 @plugin "daisyui/theme" {
   name: "corporate";
   default: true;
   color-scheme: light;
-  --color-neutral: #212a3a;
-  --color-neutral-content: #ffffff;
-}
 
-/* Dark theme. Deliberately NOT a stock daisyUI dark theme: we keep
-   corporate's exact primary/secondary/accent/status hues and its radius/border
-   so switching light<->dark only inverts the base surfaces — the app's feel
-   (blue accent, flat corporate shapes) is identical in both. Only the base and
-   neutral surface + content colors change. Accent/radius values below are
-   copied verbatim from daisyui/theme/corporate.css. */
-@plugin "daisyui/theme" {
-  name: "corporate-dark";
-  default: false;
-  prefersdark: true;
-  color-scheme: dark;
+  --color-base-100: #fafafa;
+  --color-base-200: #f1f1f1;
+  --color-base-300: #e3e3e3;
+  --color-base-content: #2a2a2a;
 
-  --color-base-100: oklch(21% 0.02 262);
-  --color-base-200: oklch(17% 0.02 262);
-  --color-base-300: oklch(13% 0.02 262);
-  --color-base-content: oklch(93% 0.01 262);
+  --color-primary: #2a4d69;
+  --color-primary-content: #fafafa;
+  --color-secondary: #5f5f5f;
+  --color-secondary-content: #fafafa;
+  --color-accent: #b7472a;
+  --color-accent-content: #fafafa;
 
-  --color-primary: oklch(62% 0.158 241.966);
-  --color-primary-content: oklch(0% 0 0);
-  --color-secondary: oklch(62% 0.046 257.417);
-  --color-secondary-content: oklch(0% 0 0);
-  --color-accent: oklch(62% 0.118 184.704);
-  --color-accent-content: oklch(0% 0 0);
+  /* Sidebar rail follows `neutral`: a deep charcoal so the rail reads as a
+     quiet dark panel against the light canvas. */
+  --color-neutral: #2a2a2a;
+  --color-neutral-content: #f1f1f1;
 
-  /* Sidebar surface: a slightly lighter panel than base so it reads as a
-     distinct rail in dark mode (in light mode corporate's neutral is black). */
-  --color-neutral: oklch(26% 0.02 262);
-  --color-neutral-content: oklch(93% 0.01 262);
-
-  --color-info: oklch(65% 0.126 221.723);
-  --color-info-content: oklch(0% 0 0);
-  --color-success: oklch(62% 0.194 149.214);
-  --color-success-content: oklch(0% 0 0);
-  --color-warning: oklch(85% 0.199 91.936);
-  --color-warning-content: oklch(0% 0 0);
-  --color-error: oklch(70% 0.191 22.216);
-  --color-error-content: oklch(0% 0 0);
+  --color-info: #2a6f7a;
+  --color-info-content: #fafafa;
+  --color-success: #4f6f3f;
+  --color-success-content: #fafafa;
+  --color-warning: #b5822e;
+  --color-warning-content: #fafafa;
+  --color-error: #a83232;
+  --color-error-content: #fafafa;
 
   --radius-selector: 0.25rem;
   --radius-field: 0.25rem;
@@ -64,14 +52,60 @@
   --noise: 0;
 }
 
-/* Sidebar accent tokens. The rail/text follow daisyUI `neutral`, but the
-   active-border/logo accent and the active/hover surface were hand-picked hexes
-   that don't map to a theme token. Scope them per theme so light mode keeps the
-   original #accefb / #323b49 exactly, and dark mode uses theme-appropriate
-   equivalents. Consumed via arbitrary values in components/drawer. */
+/* ── Dark theme: "sumi" ──────────────────────────────────────────────────────
+   The night side of the same palette. Base surfaces are deep sumi ink; text is
+   a soft off-white. Accents lift slightly for legibility on dark, but keep the
+   indigo / vermilion identity so switching light<->dark only inverts surfaces. */
+@plugin "daisyui/theme" {
+  name: "corporate-dark";
+  default: false;
+  prefersdark: true;
+  color-scheme: dark;
+
+  --color-base-100: #1c1b19;
+  --color-base-200: #161513;
+  --color-base-300: #100f0e;
+  --color-base-content: #ece7dc;
+
+  --color-primary: #7fa8c9;
+  --color-primary-content: #14181c;
+  --color-secondary: #b3a894;
+  --color-secondary-content: #14181c;
+  --color-accent: #e0785c;
+  --color-accent-content: #14181c;
+
+  /* Sidebar surface: a slightly lighter ink panel than base so the rail reads
+     as a distinct surface in dark mode. */
+  --color-neutral: #26241f;
+  --color-neutral-content: #ece7dc;
+
+  --color-info: #6fb3bd;
+  --color-info-content: #14181c;
+  --color-success: #93b57f;
+  --color-success-content: #14181c;
+  --color-warning: #d9ab5e;
+  --color-warning-content: #14181c;
+  --color-error: #dd7a7a;
+  --color-error-content: #14181c;
+
+  --radius-selector: 0.25rem;
+  --radius-field: 0.25rem;
+  --radius-box: 0.25rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 0;
+  --noise: 0;
+}
+
+/* Sidebar accent tokens. The rail/text follow daisyUI `neutral` (sumi ink); the
+   active-border/logo accent and the active/hover surface don't map to a single
+   theme token, so scope them per theme. Light uses a soft washi-indigo accent
+   over a faint warm tint; dark reuses the theme primary over a translucent
+   sheet. Consumed via arbitrary values in components/drawer. */
 [data-theme="corporate"] {
-  --sidebar-accent: #accefb;
-  --sidebar-surface: #323b49;
+  --sidebar-accent: #9cb8d4;
+  --sidebar-surface: #3a3a3a;
 }
 [data-theme="corporate-dark"] {
   --sidebar-accent: var(--color-primary);
@@ -95,7 +129,8 @@
 
 html,
 body {
-  font-family: "Inter", system-ui, sans-serif;
+  font-family:
+    "Noto Sans", "Noto Sans JP", "Noto Sans CJK JP", system-ui, sans-serif;
 }
 
 /* Loading skeletons: a moving sheen sweeping left-to-right signals "loading"
@@ -163,29 +198,14 @@ body {
 }
 
 /* ── WCAG 2.1 AA contrast overrides ────────────────────────────────────────
-   DaisyUI `corporate` ships several semantic colors that fail AA (4.5:1) as
-   text or button labels. We darken them (same hue, lower lightness) so they
-   clear AA against the app's white / #fafafa / light-tint backgrounds, while
-   staying close to the original palette. Declared unlayered so they win over
-   DaisyUI's layered theme definitions. Scoped to `[data-theme="corporate"]`
-   only (NOT bare `:root`): `data-theme` is always set on <html> — which IS
-   `:root` — so a `:root` branch would also match `corporate-dark` and clobber
-   its separately-tuned dark tokens. */
+   The light palette is hand-picked so the semantic hues clear AA (4.5:1) as
+   text on the neutral surfaces (#fafafa / #f1f1f1) — dark indigo, teal, green,
+   and red all pass comfortably. The one exception is `warning` (a gold), which is legible as a fill but dips under AA as small text or on a
+   soft badge; darken it for text use while keeping the gold identity. Declared
+   unlayered so it wins over DaisyUI's layered theme definition. Scoped to the
+   light theme only (NOT bare `:root`, which would also match the dark theme). */
 [data-theme="corporate"] {
-  /* #0082ce → #0069b4 : 4.1 → 5.7:1 */
-  --color-primary: oklch(50% 0.158 241.966);
-  /* #0091b4 → #007196 : 3.7 → 5.5:1 */
-  --color-info: oklch(50% 0.126 221.723);
-  /* #fe6366 → #d2152b : 2.9 → 5.4:1 */
-  --color-error: oklch(55% 0.214 24);
-  /* black → white (text on darker error) */
-  --color-error-content: oklch(100% 0 0);
-  /* #01a53b → #007b2a : 3.0 → 5.4:1 */
-  --color-success: oklch(50% 0.16 150);
-  /* #fdc700 → #8f5e00 : 1.6 → 5.0:1 on soft badge */
-  --color-warning: oklch(52% 0.13 80);
-  /* dark → white (text on darker warning fill) */
-  --color-warning-content: oklch(100% 0 0);
+  --color-warning: #8a5e1c;
 }
 
 /* Input placeholders ship at base-content/0.5 (~3.3:1). Raise to ~0.65 (~5.3:1). */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,45 +1,47 @@
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Noto+Sans+JP:wght@400;500;700&display=swap");
 @import "tailwindcss";
 @plugin "daisyui/index.js" {
-  themes: corporate --default;
+  themes: sumi --default;
 }
 
-/* ── Light theme ────────────────────────────────────────────────────────────
-   A minimalist palette for an educational tool. Base surfaces are neutral
-   off-whites (no warm tint) — soft, not clinical pure white; text is a neutral
-   charcoal instead of pure black; the accent is `ai` (traditional Japanese
-   indigo) — calm and scholarly. A muted vermilion (`aka`) is reserved for the
-   accent/error family. Shapes stay flat and near-square (--depth/--noise 0,
-   small radii) for restraint. */
+/* ── Light theme: "sumi" ─────────────────────────────────────────────────────
+   Our own custom daisyUI theme (not a stock one). A minimalist, ink-on-paper
+   palette on neutral surfaces: neutral off-white base (no warm tint) — soft,
+   not clinical white; near-black neutral ink for strong text contrast; a single
+   calm indigo accent (#3e5da8). Semantic hues sit at a deliberate mid chroma —
+   saturated enough to read as distinct at a glance, low enough to stay in
+   harmony so the palette never tires the eye (each pairs with a soft tint via
+   daisyUI). A warm vermilion is the secondary pop. Flat, near-square shapes
+   (--depth/--noise 0, small radii) keep the look restrained. */
 @plugin "daisyui/theme" {
-  name: "corporate";
+  name: "sumi";
   default: true;
   color-scheme: light;
 
   --color-base-100: #fafafa;
   --color-base-200: #f1f1f1;
   --color-base-300: #e3e3e3;
-  --color-base-content: #2a2a2a;
+  --color-base-content: #232323;
 
-  --color-primary: #2a4d69;
+  --color-primary: #3e5da8;
   --color-primary-content: #fafafa;
-  --color-secondary: #5f5f5f;
+  --color-secondary: #5a5a5a;
   --color-secondary-content: #fafafa;
-  --color-accent: #b7472a;
+  --color-accent: #c04a2b;
   --color-accent-content: #fafafa;
 
   /* Sidebar rail follows `neutral`: a deep charcoal so the rail reads as a
      quiet dark panel against the light canvas. */
-  --color-neutral: #2a2a2a;
+  --color-neutral: #232323;
   --color-neutral-content: #f1f1f1;
 
-  --color-info: #2a6f7a;
+  --color-info: #2f7d8a;
   --color-info-content: #fafafa;
-  --color-success: #4f6f3f;
+  --color-success: #3f7d54;
   --color-success-content: #fafafa;
-  --color-warning: #b5822e;
-  --color-warning-content: #fafafa;
-  --color-error: #a83232;
+  --color-warning: #a4741d;
+  --color-warning-content: #1b1b1d;
+  --color-error: #b0392f;
   --color-error-content: #fafafa;
 
   --radius-selector: 0.25rem;
@@ -52,40 +54,41 @@
   --noise: 0;
 }
 
-/* ── Dark theme: "sumi" ──────────────────────────────────────────────────────
-   The night side of the same palette. Base surfaces are deep sumi ink; text is
-   a soft off-white. Accents lift slightly for legibility on dark, but keep the
-   indigo / vermilion identity so switching light<->dark only inverts surfaces. */
+/* ── Dark theme: "sumi-dark" ──────────────────────────────────────────────────
+   The night side of our custom sumi theme. Neutral dark surfaces with soft
+   off-white ink; the accent and semantics lift to lighter, still-saturated
+   hues (indigo #8ba3d4, etc.) so they pop against the dark ground while keeping
+   the same identity — and the same restrained harmony — as light mode. */
 @plugin "daisyui/theme" {
-  name: "corporate-dark";
+  name: "sumi-dark";
   default: false;
   prefersdark: true;
   color-scheme: dark;
 
-  --color-base-100: #1c1b19;
-  --color-base-200: #161513;
-  --color-base-300: #100f0e;
-  --color-base-content: #ece7dc;
+  --color-base-100: #1b1b1d;
+  --color-base-200: #161618;
+  --color-base-300: #100f11;
+  --color-base-content: #ececee;
 
-  --color-primary: #7fa8c9;
+  --color-primary: #8ba3d4;
   --color-primary-content: #14181c;
-  --color-secondary: #b3a894;
+  --color-secondary: #a8a8ac;
   --color-secondary-content: #14181c;
-  --color-accent: #e0785c;
+  --color-accent: #e08a6f;
   --color-accent-content: #14181c;
 
-  /* Sidebar surface: a slightly lighter ink panel than base so the rail reads
+  /* Sidebar surface: a slightly lighter panel than base so the rail reads
      as a distinct surface in dark mode. */
-  --color-neutral: #26241f;
-  --color-neutral-content: #ece7dc;
+  --color-neutral: #26262a;
+  --color-neutral-content: #ececee;
 
-  --color-info: #6fb3bd;
+  --color-info: #6fb8c4;
   --color-info-content: #14181c;
-  --color-success: #93b57f;
+  --color-success: #8fb89f;
   --color-success-content: #14181c;
-  --color-warning: #d9ab5e;
+  --color-warning: #d0ad6e;
   --color-warning-content: #14181c;
-  --color-error: #dd7a7a;
+  --color-error: #d08a82;
   --color-error-content: #14181c;
 
   --radius-selector: 0.25rem;
@@ -98,16 +101,16 @@
   --noise: 0;
 }
 
-/* Sidebar accent tokens. The rail/text follow daisyUI `neutral` (sumi ink); the
-   active-border/logo accent and the active/hover surface don't map to a single
-   theme token, so scope them per theme. Light uses a soft washi-indigo accent
-   over a faint warm tint; dark reuses the theme primary over a translucent
-   sheet. Consumed via arbitrary values in components/drawer. */
-[data-theme="corporate"] {
-  --sidebar-accent: #9cb8d4;
+/* Sidebar accent tokens. The rail/text follow daisyUI `neutral` (the ink
+   charcoal); the active-border/logo accent and the active/hover surface don't
+   map to a single theme token, so scope them per theme. Light uses a soft
+   indigo accent over a neutral charcoal surface; dark reuses the theme primary
+   over a translucent sheet. Consumed via arbitrary values in components/drawer. */
+[data-theme="sumi"] {
+  --sidebar-accent: #8ba3d4;
   --sidebar-surface: #3a3a3a;
 }
-[data-theme="corporate-dark"] {
+[data-theme="sumi-dark"] {
   --sidebar-accent: var(--color-primary);
   --sidebar-surface: color-mix(
     in oklch,
@@ -198,13 +201,14 @@ body {
 }
 
 /* ── WCAG 2.1 AA contrast overrides ────────────────────────────────────────
-   The light palette is hand-picked so the semantic hues clear AA (4.5:1) as
-   text on the neutral surfaces (#fafafa / #f1f1f1) — dark indigo, teal, green,
-   and red all pass comfortably. The one exception is `warning` (a gold), which is legible as a fill but dips under AA as small text or on a
-   soft badge; darken it for text use while keeping the gold identity. Declared
-   unlayered so it wins over DaisyUI's layered theme definition. Scoped to the
-   light theme only (NOT bare `:root`, which would also match the dark theme). */
-[data-theme="corporate"] {
+   The light semantic tokens are tuned a touch vivid so button fills (color +
+   white label) pop. `warning` (gold) is the one that fails AA as small text /
+   soft-badge foreground, so darken just that token for text use while keeping a
+   gold fill. info/success/error/primary clear AA as text at body size; soft
+   badges get an extra per-theme darkening below. Declared unlayered so it wins
+   over daisyUI's layered theme definition; scoped to the light theme only (a
+   bare :root would also match the dark theme). */
+[data-theme="sumi"] {
   --color-warning: #8a5e1c;
 }
 
@@ -229,14 +233,14 @@ textarea::placeholder {
    dark, where the token is tuned for white button labels rather than text.
    Nudge the badge foreground per theme (darker in light, lighter in dark) so
    every soft badge clears AA without touching the button-fill tokens. */
-[data-theme="corporate"] .badge-soft {
+[data-theme="sumi"] .badge-soft {
   color: color-mix(
     in oklab,
     var(--badge-color, var(--color-base-content)) 88%,
     black
   );
 }
-[data-theme="corporate-dark"] .badge-soft {
+[data-theme="sumi-dark"] .badge-soft {
   color: color-mix(
     in oklab,
     var(--badge-color, var(--color-base-content)) 75%,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -136,6 +136,25 @@ body {
     "Noto Sans", "Noto Sans JP", "Noto Sans CJK JP", system-ui, sans-serif;
 }
 
+/* Theme cross-fade via the View Transitions API. `useTheme` wraps an explicit
+   light<->dark switch in `document.startViewTransition`, so the browser
+   GPU-composites a single fade between a snapshot of the old page and the new
+   one — far smoother than transitioning every element's colors at once, and
+   never applied to the anti-flash first paint. Tune only the duration/easing;
+   the default cross-fade (opacity of old vs. new) is exactly what we want. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 600ms;
+  animation-timing-function: var(--ease-out-soft);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}
+
 /* Loading skeletons: a moving sheen sweeping left-to-right signals "loading"
    more clearly than a static block. Layered over daisyUI's `skeleton` base via
    `className="skeleton skeleton-shimmer"`. */

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -9,6 +9,7 @@ import {
 
 import GitHub from "@/assets/github.svg?react"
 import { Spinner } from "@/components/Spinner"
+import { Alert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubUser } from "@/hooks/github/types"
 import { Link, useParams, useSearch } from "@tanstack/react-router"
@@ -68,14 +69,15 @@ const AcceptNavbar = () => {
         </Link>
       </div>
       <div className="flex-none pr-4">
-        <button
-          type="button"
-          className="btn btn-ghost btn-sm gap-2"
+        <Button
+          variant="ghost"
+          size="sm"
+          className="gap-2"
           onClick={() => langDialogRef.current?.showModal()}
         >
           <Languages aria-hidden="true" className="size-5" />
           <span className="hidden sm:inline">{t("nav.language")}</span>
-        </button>
+        </Button>
       </div>
       <LanguageDialog ref={langDialogRef} titleId={langDialogTitleId} />
     </div>
@@ -84,9 +86,9 @@ const AcceptNavbar = () => {
 
 const AcceptCard = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="card w-200 max-w-full p-8 rounded-xl border border-base-300">
+    <Card radius="xl" shadow={false} className="w-200 max-w-full p-8">
       {children}
-    </div>
+    </Card>
   )
 }
 
@@ -148,7 +150,7 @@ const AssignmentNotFound = ({
   return (
     <AcceptLayout>
       <AcceptCard>
-        <div className="card-body gap-8">
+        <Card.Body className="gap-8">
           <div>
             <span className="badge badge-error badge-soft gap-2">
               <AlertTriangle aria-hidden="true" className="size-4" />
@@ -207,7 +209,7 @@ const AssignmentNotFound = ({
 
             <UserInfo user={user} />
           </div>
-        </div>
+        </Card.Body>
       </AcceptCard>
     </AcceptLayout>
   )
@@ -498,14 +500,15 @@ const RepairToggle = ({
           <p className="text-sm text-base-content/70">
             {t("accept.repair.hint")}
           </p>
-          <button
-            type="button"
-            className="btn btn-warning btn-sm mt-3 w-full"
+          <Button
+            variant="warning"
+            size="sm"
+            className="mt-3 w-full"
             disabled={disabled}
             onClick={onRerun}
           >
             {t("accept.repair.rerun")}
-          </button>
+          </Button>
         </div>
       )}
     </div>
@@ -731,7 +734,7 @@ const AcceptAssignmentPage = () => {
               acceptMutation.isSuccess) && <AcceptProgress steps={steps} />}
 
             {acceptMutation.isError && (
-              <div className="alert alert-error items-start">
+              <Alert tone="error" className="items-start">
                 <AlertTriangle aria-hidden="true" className="size-5 shrink-0" />
                 <div>
                   <div className="font-bold">{t("accept.errorTitle")}</div>
@@ -744,7 +747,7 @@ const AcceptAssignmentPage = () => {
                     {t("accept.errorRetryHint")}
                   </div>
                 </div>
-              </div>
+              </Alert>
             )}
 
             <AnimatePresence initial={false}>
@@ -772,13 +775,13 @@ const AcceptAssignmentPage = () => {
                     </a>
 
                     {assignmentData?.mode === "group" && (
-                      <button
-                        type="button"
-                        className="btn btn-outline w-full text-lg p-5"
+                      <Button
+                        variant="outline"
+                        className="w-full text-lg p-5"
                         onClick={() => setCollaboratorsOpen(true)}
                       >
                         {t("accept.editCollaborators")}
-                      </button>
+                      </Button>
                     )}
 
                     {org && classroom && (
@@ -797,16 +800,16 @@ const AcceptAssignmentPage = () => {
             {!acceptMutation.data &&
               !repoExistsAlready &&
               !acceptMutation.isPending && (
-                <button
-                  type="button"
-                  className="btn btn-primary w-full text-lg p-5"
+                <Button
+                  variant="primary"
+                  className="w-full text-lg p-5"
                   disabled={!username || acceptMutation.isPending}
                   onClick={() =>
                     void runAccept(() => acceptMutation.mutateAsync())
                   }
                 >
                   {t("accept.acceptButton")}
-                </button>
+                </Button>
               )}
 
             {(repoExistsAlready || acceptMutation.isError) &&

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -113,39 +113,37 @@ const TeacherAssignmentsView = ({
   const emptyRoster = useEmptyRosterWarning(org, classroom)
 
   return (
-    <div>
-      <div className="mb-8">
-        <PageHeader
-          loading={classroomLoading}
-          title={
-            <span className="flex items-center gap-2">
-              {classroomData?.name || classroomData?.short_name || classroom}
-              {myRoleLabel ? (
-                <span className="badge badge-soft badge-primary badge-sm align-middle">
-                  {myRoleLabel}
-                </span>
-              ) : null}
-            </span>
-          }
-          subtitle={
-            <>
-              {classroomData?.term ? `${classroomData?.term} • ` : ""}
-              {studentsLoading
-                ? "…"
-                : t("assignments.studentCount", { count: students.length })}
-            </>
-          }
-          action={
-            archived ? (
-              <span className="badge badge-soft badge-neutral">
-                {t("assignments.archived")}
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        loading={classroomLoading}
+        title={
+          <span className="flex items-center gap-2">
+            {classroomData?.name || classroomData?.short_name || classroom}
+            {myRoleLabel ? (
+              <span className="badge badge-soft badge-primary badge-sm align-middle">
+                {myRoleLabel}
               </span>
-            ) : (
-              <NewAssignmentButton org={org} classroom={classroom} />
-            )
-          }
-        />
-      </div>
+            ) : null}
+          </span>
+        }
+        subtitle={
+          <>
+            {classroomData?.term ? `${classroomData?.term} • ` : ""}
+            {studentsLoading
+              ? "…"
+              : t("assignments.studentCount", { count: students.length })}
+          </>
+        }
+        action={
+          archived ? (
+            <span className="badge badge-soft badge-neutral">
+              {t("assignments.archived")}
+            </span>
+          ) : (
+            <NewAssignmentButton org={org} classroom={classroom} />
+          )
+        }
+      />
       {archived ? (
         <ArchivedClassroomNotice>
           {t("assignments.archivedNotice_prefix")}{" "}
@@ -163,7 +161,6 @@ const TeacherAssignmentsView = ({
           org={org}
           classroom={classroom}
           hasRosterRows={emptyRoster.hasRosterRows}
-          className="mb-4"
         />
       ) : null}
       <AssignmentsTable
@@ -187,19 +184,17 @@ const StudentAssignmentsView = ({
 }) => {
   const { t } = useTranslation()
   return (
-    <div>
-      <div className="mb-8">
-        <PageHeader
-          title={t("assignments.studentHeading")}
-          subtitle={
-            <>
-              {t("assignments.studentViewAll_prefix")}{" "}
-              <span className="font-bold">{classroom}</span>{" "}
-              {t("assignments.studentViewAll_suffix")}
-            </>
-          }
-        />
-      </div>
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title={t("assignments.studentHeading")}
+        subtitle={
+          <>
+            {t("assignments.studentViewAll_prefix")}{" "}
+            <span className="font-bold">{classroom}</span>{" "}
+            {t("assignments.studentViewAll_suffix")}
+          </>
+        }
+      />
       <OrgRepos org={org} classroom={classroom} />
     </div>
   )
@@ -219,7 +214,7 @@ const AssignmentsPage = () => {
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("nav.assignments")} />
       {roleLoading && (
-        <div className="mt-8 space-y-4">
+        <div className="space-y-4">
           <div className="skeleton skeleton-shimmer h-6 w-48" />
           <div className="skeleton skeleton-shimmer h-4 w-32" />
           <div className="skeleton skeleton-shimmer h-64 w-full rounded-box" />

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import AssignmentsTable from "@/pages/assignments/AssignmentsTable"
+import { Button } from "@/components/ui"
 import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
@@ -45,13 +46,14 @@ const NewAssignmentButton = ({
           {t("assignments.newButton.assignment")}
         </Link>
         <div className="dropdown dropdown-end join-item">
-          <button
+          <Button
+            variant="primary"
             tabIndex={0}
-            className="btn btn-primary join-item h-full border-l border-primary-content/20 px-2"
+            className="join-item h-full border-l border-primary-content/20 px-2"
             aria-label={t("assignments.newButton.moreOptions")}
           >
             <ChevronDown aria-hidden="true" className="size-4" />
-          </button>
+          </Button>
           <ul
             tabIndex={0}
             className="dropdown-content menu z-10 mt-1 w-max rounded-box border border-base-content/5 bg-base-100 p-1 shadow"

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -15,6 +15,8 @@ import useGetClasses from "@/hooks/useGetClasses"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 
 import PageShell from "@/components/PageShell"
+import PageHeader from "@/components/PageHeader"
+import { Alert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubRepo } from "@/hooks/github/types"
 import MissingParams from "@/components/MissingParams"
@@ -34,19 +36,19 @@ import { githubOrgUrl } from "@/util/orgUrl"
 const CreateClassroomPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   return (
-    <div className="card border border-dashed border-base-300 bg-base-100 shadow-sm">
-      <div className="card-body items-center py-12 text-center">
+    <Card dashed>
+      <Card.Body className="items-center py-12 text-center">
         <div className="mb-2 flex size-14 items-center justify-center rounded-full bg-primary/10 text-primary">
           <Plus aria-hidden="true" className="size-7" />
         </div>
 
-        <h2 className="card-title text-xl">{t("classes.empty.title")}</h2>
+        <Card.Title className="text-xl">{t("classes.empty.title")}</Card.Title>
 
         <p className="max-w-md text-base-content/70">
           {t("classes.empty.body")}
         </p>
 
-        <div className="card-actions mt-4">
+        <Card.Actions className="mt-4">
           <Link
             to="/$org/classes/new"
             params={{ org }}
@@ -56,9 +58,9 @@ const CreateClassroomPane = ({ org }: { org: string }) => {
             <Plus aria-hidden="true" className="size-4" />
             {t("classes.empty.createButton")}
           </Link>
-        </div>
-      </div>
-    </div>
+        </Card.Actions>
+      </Card.Body>
+    </Card>
   )
 }
 
@@ -79,13 +81,13 @@ const JoinOrgCard = ({ org }: { org: string }) => {
   })
 
   return (
-    <div className="card border border-dashed border-base-300 bg-base-100 shadow-sm">
-      <div className="card-body items-center py-12 text-center">
+    <Card dashed>
+      <Card.Body className="items-center py-12 text-center">
         <div className="mb-2 flex size-14 items-center justify-center rounded-full bg-primary/10 text-primary">
           <Plus aria-hidden="true" className="size-7" />
         </div>
 
-        <h2 className="card-title text-xl">{t("classes.join.title")}</h2>
+        <Card.Title className="text-xl">{t("classes.join.title")}</Card.Title>
 
         <p className="max-w-md text-base-content/70">
           {t("classes.join.body_prefix")}{" "}
@@ -94,33 +96,29 @@ const JoinOrgCard = ({ org }: { org: string }) => {
         </p>
 
         {mutation.isError ? (
-          <div className="alert alert-error mt-4 max-w-md text-left">
+          <Alert tone="error" className="mt-4 max-w-md text-left">
             {t("classes.join.error")}
-          </div>
+          </Alert>
         ) : null}
 
-        <div className="card-actions mt-4">
-          <button
-            type="button"
-            className="btn btn-primary"
+        <Card.Actions className="mt-4">
+          <Button
+            variant="primary"
+            loading={mutation.isPending}
+            loadingLabel={t("classes.join.joining")}
             disabled={mutation.isPending}
             onClick={() => void run(() => mutation.mutateAsync())}
           >
-            {mutation.isPending ? (
-              <span
-                className="loading loading-spinner loading-sm"
-                aria-hidden="true"
-              />
-            ) : (
+            {mutation.isPending ? null : (
               <Plus aria-hidden="true" className="size-4" />
             )}
             {mutation.isPending
               ? t("classes.join.joining")
               : t("classes.join.joinButton")}
-          </button>
-        </div>
-      </div>
-    </div>
+          </Button>
+        </Card.Actions>
+      </Card.Body>
+    </Card>
   )
 }
 
@@ -141,7 +139,13 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
     Boolean(classroom && assignment) && assignmentData?.mode === "group"
 
   return (
-    <EnterDiv className="card relative col-span-12 rounded-2xl border border-base-200 bg-base-100 md:col-span-6 xl:col-span-4">
+    <Card
+      as={EnterDiv}
+      radius="2xl"
+      bordered={false}
+      shadow={false}
+      className="relative col-span-12 border border-base-200 md:col-span-6 xl:col-span-4"
+    >
       {canManageGroup && classroom && assignment && (
         <Link
           to="/$org/$classroom/assignments/$assignment/edit"
@@ -154,7 +158,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
         </Link>
       )}
 
-      <div className="card-body gap-4">
+      <Card.Body className="gap-4">
         <div className="flex items-start justify-between gap-4 pr-8">
           <div className="min-w-0">
             <div className="mb-2 flex items-center gap-2">
@@ -214,7 +218,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           </div>
         )}
 
-        <div className="card-actions items-center justify-between pt-1">
+        <Card.Actions className="items-center justify-between pt-1">
           <div className="flex flex-wrap items-end gap-2">
             {assignmentData?.mode === "individual" && (
               <div className="badge badge-ghost badge-sm py-3">
@@ -239,9 +243,9 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
             {t("classes.repo.openRepo")}
             <ExternalLink aria-hidden="true" className="size-4" />
           </a>
-        </div>
-      </div>
-    </EnterDiv>
+        </Card.Actions>
+      </Card.Body>
+    </Card>
   )
 }
 
@@ -319,44 +323,34 @@ const ClassesPage = () => {
 
   return (
     <PageShell page="classes" selected="assignments">
-      <div className="mb-8">
-        <div className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-4">
-            <div className="flex items-center gap-3">
-              <GitHub aria-hidden="true" className="size-5 opacity-70" />
+      <div className="mb-8 space-y-4">
+        <div className="flex items-center gap-3">
+          <GitHub aria-hidden="true" className="size-5 opacity-70" />
 
-              <div>
-                <div className="text-xs font-medium uppercase tracking-wide text-base-content/70">
-                  {t("classes.githubOrganization")}
-                </div>
-                <a
-                  href={githubOrgUrl(org)}
-                  target="_blank"
-                  rel="noreferrer"
-                  title={t("common.openOrgOnGitHub", { org })}
-                  className="font-mono text-sm font-semibold text-base-content hover:text-primary hover:underline"
-                >
-                  {org}
-                </a>
-              </div>
+          <div>
+            <div className="text-xs font-medium uppercase tracking-wide text-base-content/70">
+              {t("classes.githubOrganization")}
             </div>
-
-            <div>
-              {roleLoading ? (
-                <div className="skeleton skeleton-shimmer h-8 w-48" />
-              ) : (
-                <h1 className="text-2xl font-bold tracking-tight">
-                  {isTeacher
-                    ? t("classes.myClasses")
-                    : t("classes.myAssignments")}
-                </h1>
-              )}
-              <p className="mt-2 max-w-2xl text-sm text-base-content/70">
-                {t("classes.manageSubtitle")}
-              </p>
-            </div>
+            <a
+              href={githubOrgUrl(org)}
+              target="_blank"
+              rel="noreferrer"
+              title={t("common.openOrgOnGitHub", { org })}
+              className="font-mono text-sm font-semibold text-base-content hover:text-primary hover:underline"
+            >
+              {org}
+            </a>
           </div>
         </div>
+
+        <PageHeader
+          loading={roleLoading}
+          title={
+            isTeacher ? t("classes.myClasses") : t("classes.myAssignments")
+          }
+          subtitle={<p className="max-w-2xl">{t("classes.manageSubtitle")}</p>}
+        />
+
         {isStudent && !isMember && !loadingMembership && (
           <JoinOrgCard org={org} />
         )}

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -323,7 +323,7 @@ const ClassesPage = () => {
 
   return (
     <PageShell page="classes" selected="assignments">
-      <div className="mb-8 space-y-4">
+      <div className="space-y-4">
         <div className="flex items-center gap-3">
           <GitHub aria-hidden="true" className="size-5 opacity-70" />
 
@@ -357,7 +357,7 @@ const ClassesPage = () => {
       </div>
       {isOwner && <OrgPreflightNotice org={org} />}
       {roleLoading ? (
-        <div className="grid grid-cols-12 gap-4 mb-6">
+        <div className="grid grid-cols-12 gap-4">
           {Array.from({ length: 3 }).map((_, i) => (
             <div
               key={i}

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -9,7 +9,6 @@ import {
   UserRound,
   UsersRound,
 } from "lucide-react"
-import GitHub from "@/assets/github.svg?react"
 
 import useGetClasses from "@/hooks/useGetClasses"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
@@ -31,7 +30,6 @@ import useGetPublicAssignment from "@/hooks/useGetPublicAssignment"
 import OrgPreflightNotice from "@/pages/orgSettings/OrgPreflightNotice"
 import ClassroomList from "@/pages/classes/ClassroomList"
 import { EnterDiv } from "@/lib/motionComponents"
-import { githubOrgUrl } from "@/util/orgUrl"
 
 const CreateClassroomPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
@@ -323,38 +321,15 @@ const ClassesPage = () => {
 
   return (
     <PageShell page="classes" selected="assignments">
-      <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <GitHub aria-hidden="true" className="size-5 opacity-70" />
+      <PageHeader
+        loading={roleLoading}
+        title={isTeacher ? t("classes.myClasses") : t("classes.myAssignments")}
+        subtitle={<p className="max-w-2xl">{t("classes.manageSubtitle")}</p>}
+      />
 
-          <div>
-            <div className="text-xs font-medium uppercase tracking-wide text-base-content/70">
-              {t("classes.githubOrganization")}
-            </div>
-            <a
-              href={githubOrgUrl(org)}
-              target="_blank"
-              rel="noreferrer"
-              title={t("common.openOrgOnGitHub", { org })}
-              className="font-mono text-sm font-semibold text-base-content hover:text-primary hover:underline"
-            >
-              {org}
-            </a>
-          </div>
-        </div>
-
-        <PageHeader
-          loading={roleLoading}
-          title={
-            isTeacher ? t("classes.myClasses") : t("classes.myAssignments")
-          }
-          subtitle={<p className="max-w-2xl">{t("classes.manageSubtitle")}</p>}
-        />
-
-        {isStudent && !isMember && !loadingMembership && (
-          <JoinOrgCard org={org} />
-        )}
-      </div>
+      {isStudent && !isMember && !loadingMembership && (
+        <JoinOrgCard org={org} />
+      )}
       {isOwner && <OrgPreflightNotice org={org} />}
       {roleLoading ? (
         <div className="grid grid-cols-12 gap-4">

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -114,9 +114,7 @@ const CreateAssignmentPage = () => {
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("assignments.createBreadcrumb")} />
       <RequireTeacher>
-        <div className="mb-8">
-          <PageHeader title={t("assignments.createHeading")} />
-        </div>
+        <PageHeader title={t("assignments.createHeading")} />
         {emptyRoster.show ? (
           <EmptyRosterNotice
             org={org}
@@ -124,18 +122,9 @@ const CreateAssignmentPage = () => {
             hasRosterRows={emptyRoster.hasRosterRows}
           />
         ) : null}
-        {errorMessage ? (
-          <Alert tone="error" className="mb-6">
-            {errorMessage}
-          </Alert>
-        ) : (
-          <></>
-        )}
+        {errorMessage ? <Alert tone="error">{errorMessage}</Alert> : <></>}
         {warningMessage ? (
-          <Alert
-            tone="warning"
-            className="mb-6 flex flex-col items-start gap-2"
-          >
+          <Alert tone="warning" className="flex flex-col items-start gap-2">
             <span>{warningMessage}</span>
             <Button
               size="sm"
@@ -152,47 +141,43 @@ const CreateAssignmentPage = () => {
         ) : (
           <></>
         )}
-        <div className="flex flex-col">
-          <div className="mb-8">
-            <CreateAssignmentForm
-              loading={createClassroomMutation.isPending}
-              org={org}
-              classroom={classroom}
-              takenSlugs={takenSlugs}
-              onSubmit={(values) => {
-                setErrorMessage("")
-                setWarningMessage("")
-                createClassroomMutation.mutateAsync({
-                  name: values.name,
-                  slug: values.slug,
-                  mode: values.mode,
-                  org,
-                  template_repo: values.template_repo,
-                  description: values.description,
-                  due_date: values.due_date,
-                  max_group_size: values.max_group_size,
-                  feedback_pr: values.feedback_pr,
-                  runs_on: values.runs_on,
-                  container_image: values.container_image,
-                  container_user: values.container_user,
-                  runtime_python: values.runtime_python,
-                  runtime_node: values.runtime_node,
-                  runtime_java: values.runtime_java,
-                  runtime_go: values.runtime_go,
-                  runtime_rust: values.runtime_rust,
-                  runtime_apt: values.runtime_apt,
-                  setup_command: values.setup_command,
-                  allowed_files: values.allowed_files,
-                  pass_threshold: values.pass_threshold_enabled
-                    ? values.pass_threshold
-                    : undefined,
-                  classroom,
-                  tests: values.tests,
-                })
-              }}
-            />
-          </div>
-        </div>
+        <CreateAssignmentForm
+          loading={createClassroomMutation.isPending}
+          org={org}
+          classroom={classroom}
+          takenSlugs={takenSlugs}
+          onSubmit={(values) => {
+            setErrorMessage("")
+            setWarningMessage("")
+            createClassroomMutation.mutateAsync({
+              name: values.name,
+              slug: values.slug,
+              mode: values.mode,
+              org,
+              template_repo: values.template_repo,
+              description: values.description,
+              due_date: values.due_date,
+              max_group_size: values.max_group_size,
+              feedback_pr: values.feedback_pr,
+              runs_on: values.runs_on,
+              container_image: values.container_image,
+              container_user: values.container_user,
+              runtime_python: values.runtime_python,
+              runtime_node: values.runtime_node,
+              runtime_java: values.runtime_java,
+              runtime_go: values.runtime_go,
+              runtime_rust: values.runtime_rust,
+              runtime_apt: values.runtime_apt,
+              setup_command: values.setup_command,
+              allowed_files: values.allowed_files,
+              pass_threshold: values.pass_threshold_enabled
+                ? values.pass_threshold
+                : undefined,
+              classroom,
+              tests: values.tests,
+            })
+          }}
+        />
       </RequireTeacher>
     </PageShell>
   )

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -6,6 +6,7 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import MissingParams from "@/components/MissingParams"
 import RequireTeacher from "@/components/RequireTeacher"
+import { Alert, Button } from "@/components/ui"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import CreateAssignmentForm from "@/pages/assignments/CreateAssignmentForm"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -124,16 +125,20 @@ const CreateAssignmentPage = () => {
           />
         ) : null}
         {errorMessage ? (
-          <div className="alert alert-error mb-6">{errorMessage}</div>
+          <Alert tone="error" className="mb-6">
+            {errorMessage}
+          </Alert>
         ) : (
           <></>
         )}
         {warningMessage ? (
-          <div className="alert alert-warning mb-6 flex flex-col items-start gap-2">
+          <Alert
+            tone="warning"
+            className="mb-6 flex flex-col items-start gap-2"
+          >
             <span>{warningMessage}</span>
-            <button
-              type="button"
-              className="btn btn-sm"
+            <Button
+              size="sm"
               onClick={() =>
                 navigate({
                   to: "/$org/$classroom/assignments",
@@ -142,8 +147,8 @@ const CreateAssignmentPage = () => {
               }
             >
               {t("assignments.goToAssignments")}
-            </button>
-          </div>
+            </Button>
+          </Alert>
         ) : (
           <></>
         )}

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -92,25 +92,19 @@ const CreateClassroomPage = () => {
     <PageShell page="classes" selected="classes">
       <Breadcrumb endpoint={t("documentTitle.newClassroom")} />
       <RequireTeacher allow="owner">
-        <div className="mb-8">
-          <PageHeader title={t("classes.createTitle")} />
-        </div>
-        <div className="flex flex-col">
-          <div className="mb-8">
-            <CreateClassroomForm
-              onSubmit={(values) =>
-                createClassroomMutation.mutateAsync({
-                  name: values.name,
-                  classroom: values.slug,
-                  org,
-                  term: values.term,
-                  secret: values.secret || undefined,
-                  creator: user?.login,
-                })
-              }
-            />
-          </div>
-        </div>
+        <PageHeader title={t("classes.createTitle")} />
+        <CreateClassroomForm
+          onSubmit={(values) =>
+            createClassroomMutation.mutateAsync({
+              name: values.name,
+              classroom: values.slug,
+              org,
+              term: values.term,
+              secret: values.secret || undefined,
+              creator: user?.login,
+            })
+          }
+        />
       </RequireTeacher>
     </PageShell>
   )

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -181,24 +181,12 @@ const EditAssignmentPage = () => {
   return (
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("documentTitle.assignmentSettings")} />
-      {editError && (
-        <Alert tone="error" className="mt-6">
-          {editError}
-        </Alert>
-      )}
+      {editError && <Alert tone="error">{editError}</Alert>}
       {editSuccess && (
-        <Alert tone="success" className="mt-6">
-          {t("assignmentSettings.editSuccess")}
-        </Alert>
+        <Alert tone="success">{t("assignmentSettings.editSuccess")}</Alert>
       )}
-      {editWarning && (
-        <Alert tone="warning" className="mt-6">
-          {editWarning}
-        </Alert>
-      )}
-      <div className="mb-6">
-        <PageHeader title={t("assignmentSettings.heading")} />
-      </div>
+      {editWarning && <Alert tone="warning">{editWarning}</Alert>}
+      <PageHeader title={t("assignmentSettings.heading")} />
       {isTeacher && archived && (
         <ArchivedClassroomNotice>
           {t("assignmentSettings.archivedNotice_prefix")}{" "}

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -62,7 +62,7 @@ const EditAssignmentFormStudent = ({
 
   if (!assignmentRepo) {
     return (
-      <EnterDiv className="alert alert-warning mt-6">
+      <EnterDiv className="alert alert-info alert-soft mt-6">
         <div>
           {t("assignmentSettings.notAccepted_prefix")}{" "}
           <Link

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -6,6 +6,7 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { Spinner } from "@/components/Spinner"
+import { Alert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
@@ -80,7 +81,7 @@ const EditAssignmentFormStudent = ({
   if (assignmentMode === "individual") {
     return (
       <div className="mt-6">
-        <div className="alert alert-info">
+        <Alert tone="info">
           <div>
             {t("assignmentSettings.individual_prefix")}{" "}
             <Link
@@ -92,15 +93,15 @@ const EditAssignmentFormStudent = ({
             </Link>
             {t("assignmentSettings.individual_suffix")}
           </div>
-        </div>
+        </Alert>
       </div>
     )
   }
 
   return (
     <>
-      <div className="card mb-6 w-full border border-base-200 bg-base-100 shadow-sm">
-        <div className="card-body gap-6">
+      <Card bordered={false} className="mb-6 w-full border border-base-200">
+        <Card.Body className="gap-6">
           <div className="flex items-start gap-4">
             <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
               <UsersRound aria-hidden="true" className="size-6" />
@@ -132,18 +133,17 @@ const EditAssignmentFormStudent = ({
             </div>
           </div>
 
-          <div className="card-actions justify-end border-t border-base-200 pt-6">
-            <button
-              type="button"
-              className="btn btn-primary"
+          <Card.Actions className="justify-end border-t border-base-200 pt-6">
+            <Button
+              variant="primary"
               onClick={() => setCollaboratorsOpen(true)}
             >
               <UsersRound aria-hidden="true" className="size-4" />
               {t("assignmentSettings.manageCollaborators")}
-            </button>
-          </div>
-        </div>
-      </div>
+            </Button>
+          </Card.Actions>
+        </Card.Body>
+      </Card>
 
       {user?.login && (
         <GroupCollaboratorsModal
@@ -181,14 +181,20 @@ const EditAssignmentPage = () => {
   return (
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("documentTitle.assignmentSettings")} />
-      {editError && <div className="alert alert-error mt-6">{editError}</div>}
+      {editError && (
+        <Alert tone="error" className="mt-6">
+          {editError}
+        </Alert>
+      )}
       {editSuccess && (
-        <div className="alert alert-success mt-6">
+        <Alert tone="success" className="mt-6">
           {t("assignmentSettings.editSuccess")}
-        </div>
+        </Alert>
       )}
       {editWarning && (
-        <div className="alert alert-warning mt-6">{editWarning}</div>
+        <Alert tone="warning" className="mt-6">
+          {editWarning}
+        </Alert>
       )}
       <div className="mb-6">
         <PageHeader title={t("assignmentSettings.heading")} />

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -105,44 +105,38 @@ const EditClassroomContent = ({
       {!cl ? (
         <Alert tone="error">{t("classes.couldNotLoad")}</Alert>
       ) : (
-        <>
-          <div className="mb-8">
-            <PageHeader
-              title={t("documentTitle.classroomSettings")}
-              subtitle={
-                <>
-                  {t("classes.settingsSubtitle_prefix")}{" "}
-                  <span className="font-semibold">
-                    {cl.name || cl.short_name || classroom}
-                  </span>{" "}
-                  {t("classes.settingsSubtitle_suffix")}
-                </>
-              }
-            />
-          </div>
-          <div className="flex flex-col">
-            <div className="mb-8">
-              <EditClassroomForm
-                cl={cl}
-                onSubmit={(values) =>
-                  runSave(() =>
-                    editClassroomMutation.mutateAsync({
-                      name: values.name,
-                      slug: classroom,
-                      org,
-                      term: values.term,
-                    }),
-                  )
-                }
-              />
-              <ClassroomStaffSection
-                org={org}
-                classroom={classroom}
-                disabled={isClassroomArchived(cl)}
-              />
-            </div>
-          </div>
-        </>
+        <div className="flex flex-col gap-6">
+          <PageHeader
+            title={t("documentTitle.classroomSettings")}
+            subtitle={
+              <>
+                {t("classes.settingsSubtitle_prefix")}{" "}
+                <span className="font-semibold">
+                  {cl.name || cl.short_name || classroom}
+                </span>{" "}
+                {t("classes.settingsSubtitle_suffix")}
+              </>
+            }
+          />
+          <EditClassroomForm
+            cl={cl}
+            onSubmit={(values) =>
+              runSave(() =>
+                editClassroomMutation.mutateAsync({
+                  name: values.name,
+                  slug: classroom,
+                  org,
+                  term: values.term,
+                }),
+              )
+            }
+          />
+          <ClassroomStaffSection
+            org={org}
+            classroom={classroom}
+            disabled={isClassroomArchived(cl)}
+          />
+        </div>
       )}
     </LoadingSwap>
   )

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -24,6 +24,7 @@ import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvi
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import RequireTeacher from "@/components/RequireTeacher"
 import { LoadingSwap } from "@/lib/LoadingSwap"
+import { Alert } from "@/components/ui"
 
 const EditClassroomContent = ({
   org,
@@ -102,7 +103,7 @@ const EditClassroomContent = ({
       }
     >
       {!cl ? (
-        <div className="alert alert-error">{t("classes.couldNotLoad")}</div>
+        <Alert tone="error">{t("classes.couldNotLoad")}</Alert>
       ) : (
         <>
           <div className="mb-8">

--- a/web/src/pages/OnboardingPage.tsx
+++ b/web/src/pages/OnboardingPage.tsx
@@ -7,6 +7,7 @@ import {
   UserPlus,
 } from "lucide-react"
 import { Spinner } from "@/components/Spinner"
+import { Button, Card } from "@/components/ui"
 import {
   MembershipError,
   classifyMembershipError,
@@ -40,9 +41,13 @@ const OnboardNavbar = () => {
 }
 
 const OnboardCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="card w-200 max-w-[calc(100vw-2em)] p-8 m-auto rounded-xl mt-10 border border-base-300">
+  <Card
+    radius="xl"
+    shadow={false}
+    className="w-200 max-w-[calc(100vw-2em)] p-8 m-auto mt-10"
+  >
     {children}
-  </div>
+  </Card>
 )
 
 const OnboardShell = ({ children }: { children: React.ReactNode }) => (
@@ -271,14 +276,10 @@ const OnboardingPage = () => {
               <p className="text-center text-sm text-base-content/70">
                 {t("getStarted.checking.stillChecking")}
               </p>
-              <button
-                type="button"
-                className="btn btn-outline w-full"
-                onClick={retry}
-              >
+              <Button variant="outline" className="w-full" onClick={retry}>
                 <Loader2 aria-hidden="true" className="size-4" />
                 {t("getStarted.checking.retry")}
-              </button>
+              </Button>
             </div>
           )}
         </EnterDiv>

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -370,11 +370,7 @@ const OrgMembersPage = () => {
 
   return (
     <>
-      <PageShell
-        contentClassName="p-10 bg-base-200 xl:px-50"
-        page="classes"
-        selected="members"
-      >
+      <PageShell page="classes" selected="members">
         <RequireTeacher allow="owner">
           <PageHeader
             title={t("orgMembers.heading")}

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -10,6 +10,7 @@ import {
   UserPlus,
 } from "lucide-react"
 
+import { Alert, Button, Card, Spinner } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -402,24 +403,18 @@ const OrgMembersPage = () => {
           />
 
           {notes.length > 0 ? (
-            <div
-              className="alert alert-warning alert-soft mt-6 text-sm"
-              role="status"
-            >
+            <Alert tone="warning" className="mt-6 text-sm" role="status">
               <span>{notes.join(" ")}</span>
-            </div>
+            </Alert>
           ) : null}
 
           {discrepancyCount > 0 ? (
-            <div
-              className="alert alert-error alert-soft mt-6 text-sm"
-              role="status"
-            >
+            <Alert tone="error" className="mt-6 text-sm" role="status">
               <AlertTriangle className="size-4" aria-hidden="true" />
               <span>
                 {t("orgMembers.discrepancy", { count: discrepancyCount })}
               </span>
-            </div>
+            </Alert>
           ) : null}
 
           <div className="mt-6 flex flex-wrap items-center gap-3">
@@ -452,13 +447,10 @@ const OrgMembersPage = () => {
             </select>
           </div>
 
-          <div className="mt-4 card card-border w-full overflow-hidden bg-base-100 shadow-sm">
+          <Card className="mt-4 w-full overflow-hidden">
             {isLoading ? (
               <div className="flex items-center justify-center gap-3 px-6 py-12 text-base-content/70">
-                <span
-                  className="loading loading-spinner loading-md"
-                  aria-hidden="true"
-                />
+                <Spinner size="md" />
                 <span className="text-sm">{t("orgMembers.loading")}</span>
               </div>
             ) : isError ? (
@@ -549,21 +541,17 @@ const OrgMembersPage = () => {
                       <div className="flex shrink-0 items-center gap-3">
                         {row.classification === "on-roster-not-member" &&
                         row.github_id ? (
-                          <button
-                            type="button"
-                            className="btn btn-xs btn-primary"
+                          <Button
+                            variant="primary"
+                            size="xs"
+                            loading={invitingKey === row.key}
                             disabled={invitingKey === row.key}
                             onClick={(e) => {
                               e.stopPropagation()
                               void handleQuickInvite(row)
                             }}
                           >
-                            {invitingKey === row.key ? (
-                              <span
-                                className="loading loading-spinner loading-xs"
-                                aria-hidden="true"
-                              />
-                            ) : (
+                            {invitingKey === row.key ? null : (
                               <>
                                 <UserPlus
                                   aria-hidden="true"
@@ -572,7 +560,7 @@ const OrgMembersPage = () => {
                                 {t("orgMembers.invite")}
                               </>
                             )}
-                          </button>
+                          </Button>
                         ) : null}
                         <span className="hidden text-xs text-base-content/70 sm:inline">
                           {t("orgMembers.classroomCount", {
@@ -605,7 +593,7 @@ const OrgMembersPage = () => {
                 </motion.ul>
               </>
             )}
-          </div>
+          </Card>
         </RequireTeacher>
       </PageShell>
 

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -498,12 +498,7 @@ const OrgSettingsPage = () => {
   const { org } = useParams({ strict: false })
 
   return (
-    <PageShell
-      contentClassName="p-10 bg-base-200 xl:px-50"
-      page="classes"
-      settings
-      selected="settings"
-    >
+    <PageShell page="classes" settings selected="settings">
       <RequireTeacher allow="owner">
         <PageHeader
           title={t("orgSettings.page.heading")}

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { Button } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -111,9 +112,11 @@ export function ServiceTokenInfo() {
 
   return (
     <div ref={popupRef} className="dropdown">
-      <button
-        type="button"
-        className="btn btn-circle btn-ghost btn-xs text-base-content/70 hover:text-base-content"
+      <Button
+        variant="ghost"
+        shape="circle"
+        size="xs"
+        className="text-base-content/70 hover:text-base-content"
         aria-label={t("orgSettings.serviceToken.infoAria")}
         aria-expanded={open}
         onClick={() => setOpen((open) => !open)}
@@ -121,7 +124,7 @@ export function ServiceTokenInfo() {
         <span className="flex h-4 w-4 items-center justify-center rounded-full border border-current text-[11px] font-bold">
           i
         </span>
-      </button>
+      </Button>
 
       {open && (
         <div className="dropdown-content z-50 mt-2 w-80 rounded-box border border-base-300 bg-base-100 p-4 text-sm shadow-xl">
@@ -250,9 +253,10 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
         })()}
 
       {tokenAlreadySet && (
-        <button
-          type="button"
-          className="btn btn-ghost btn-sm mt-4 gap-1"
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mt-4 gap-1"
           aria-expanded={configOpen}
           onClick={() => setManualOpen(!configOpen)}
         >
@@ -264,7 +268,7 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
           {configOpen
             ? t("orgSettings.serviceToken.hideConfig")
             : t("orgSettings.serviceToken.updateOrReplace")}
-        </button>
+        </Button>
       )}
 
       {configOpen && (
@@ -466,25 +470,20 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
                     : t("orgSettings.serviceToken.savedNew")}
                 </p>
               )}
-              <button
-                disabled={patMutation.isPending || !serviceToken}
+              <Button
+                variant="primary"
                 type="submit"
-                className="btn btn-primary self-end mt-2"
+                className="self-end mt-2"
+                loading={patMutation.isPending}
+                loadingLabel={t("orgSettings.serviceToken.validating")}
+                disabled={patMutation.isPending || !serviceToken}
               >
-                {patMutation.isPending ? (
-                  <>
-                    <span
-                      className="loading loading-spinner loading-sm"
-                      aria-hidden="true"
-                    />
-                    {t("orgSettings.serviceToken.validating")}
-                  </>
-                ) : tokenAlreadySet ? (
-                  t("orgSettings.serviceToken.updateButton")
-                ) : (
-                  t("orgSettings.serviceToken.saveButton")
-                )}
-              </button>
+                {patMutation.isPending
+                  ? t("orgSettings.serviceToken.validating")
+                  : tokenAlreadySet
+                    ? t("orgSettings.serviceToken.updateButton")
+                    : t("orgSettings.serviceToken.saveButton")}
+              </Button>
             </div>
           </form>
         </>

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next"
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { Spinner } from "@/components/Spinner"
+import { Alert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import useGetOrgMembership from "@/hooks/useGetOrgMembership"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
@@ -47,8 +48,8 @@ const OrgSteps = ({
   const { t } = useTranslation()
   const runSetup = useSafeSubmit()
   return (
-    <div className="card border border-base-300 bg-base-100 shadow-sm">
-      <div className="card-body gap-5">
+    <Card>
+      <Card.Body className="gap-5">
         <div className="grid grid-cols-[1fr_auto_1fr] items-center">
           <ul className="steps steps-horizontal col-start-2 justify-self-center">
             <li
@@ -61,39 +62,36 @@ const OrgSteps = ({
               className={`step ${stage === 3 ? "step-primary" : "[--step-bg:var(--color-base-300)]"}`}
             ></li>
           </ul>
-          <div className="card-actions col-start-3 justify-self-end">
+          <Card.Actions className="col-start-3 justify-self-end">
             {stage === 1 &&
               (!nextStep ? (
-                <button
+                <Button
+                  variant="primary"
+                  className="ml-auto"
+                  loading={mutation.isPending}
+                  loadingLabel={t("setup.runSetup")}
                   disabled={mutation.isPending}
-                  className="btn btn-primary ml-auto"
                   onClick={() => void runSetup(() => mutation.mutateAsync())}
                 >
-                  {mutation.isPending ? (
-                    <span
-                      className="loading loading-spinner"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    t("setup.runSetup")
-                  )}
-                </button>
+                  {mutation.isPending ? null : t("setup.runSetup")}
+                </Button>
               ) : (
-                <button
-                  className="btn btn-primary ml-auto"
+                <Button
+                  variant="primary"
+                  className="ml-auto"
                   onClick={() => setStage(2)}
                 >
                   {t("setup.nextServiceToken")}
                   <ArrowRight aria-hidden="true" className="size-4" />
-                </button>
+                </Button>
               ))}
             {stage === 2 && (
-              <button className="btn btn-ghost" onClick={() => setStage(1)}>
+              <Button variant="ghost" onClick={() => setStage(1)}>
                 <ArrowLeft aria-hidden="true" className="size-4" />
                 {t("setup.back")}
-              </button>
+              </Button>
             )}
-          </div>
+          </Card.Actions>
         </div>
 
         {stage === 1 ? (
@@ -131,22 +129,22 @@ const OrgSteps = ({
             </Link>
           </EnterDiv>
         )}
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   )
 }
 
 const NotAdminAlert = () => {
   const { t } = useTranslation()
-  return <div className="alert alert-error">{t("setup.notAdmin")}</div>
+  return <Alert tone="error">{t("setup.notAdmin")}</Alert>
 }
 
 const NotTeamOrEnterpriseWarning = () => {
   const { t } = useTranslation()
   return (
-    <div className="alert alert-warning mb-4">
+    <Alert tone="warning" className="mb-4">
       {t("setup.notTeamOrEnterprise")}
-    </div>
+    </Alert>
   )
 }
 

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -139,9 +139,9 @@ const NotAdminAlert = () => {
   return <Alert tone="error">{t("setup.notAdmin")}</Alert>
 }
 
-const NotTeamOrEnterpriseWarning = () => {
+const NotTeamOrEnterpriseNotice = () => {
   const { t } = useTranslation()
-  return <Alert tone="warning">{t("setup.notTeamOrEnterprise")}</Alert>
+  return <Alert tone="error">{t("setup.notTeamOrEnterprise")}</Alert>
 }
 
 const OrgSetupPage = () => {
@@ -214,7 +214,7 @@ const OrgSetupPage = () => {
         subtitle={t("setup.pageSubheading")}
       />
       {!isLoadingPlanDetails && !isTeamOrEnterprise && (
-        <NotTeamOrEnterpriseWarning />
+        <NotTeamOrEnterpriseNotice />
       )}
       {isLoading && <Spinner label={t("setup.loadingSetup")} />}
       {!isLoading && !isOwner && <NotAdminAlert />}

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -141,11 +141,7 @@ const NotAdminAlert = () => {
 
 const NotTeamOrEnterpriseWarning = () => {
   const { t } = useTranslation()
-  return (
-    <Alert tone="warning" className="mb-4">
-      {t("setup.notTeamOrEnterprise")}
-    </Alert>
-  )
+  return <Alert tone="warning">{t("setup.notTeamOrEnterprise")}</Alert>
 }
 
 const OrgSetupPage = () => {
@@ -213,12 +209,10 @@ const OrgSetupPage = () => {
 
   return (
     <PageShell page="classes" selected="assignments">
-      <div className="mb-8">
-        <PageHeader
-          title={t("setup.pageHeading")}
-          subtitle={t("setup.pageSubheading")}
-        />
-      </div>
+      <PageHeader
+        title={t("setup.pageHeading")}
+        subtitle={t("setup.pageSubheading")}
+      />
       {!isLoadingPlanDetails && !isTeamOrEnterprise && (
         <NotTeamOrEnterpriseWarning />
       )}

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -19,10 +19,12 @@ import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
+import { Button, Card } from "@/components/ui"
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
 import Spinner from "@/components/Spinner"
 import { enterExit } from "@/lib/motion"
+import { EnterDiv } from "@/lib/motionComponents"
 import { orgListPrefs, type OrgSortKey } from "@/lib/orgListPrefs"
 import { useListPrefsState } from "@/lib/listPrefs"
 import { formatRelativeToNow } from "@/util/formatDate"
@@ -42,9 +44,9 @@ function MissingOrgNotice({
         <span className="min-w-0 flex-1 truncate font-medium text-base-content">
           {t("orgs.missingNotice.title")}
         </span>
-        <button
-          type="button"
-          className="btn btn-ghost btn-xs"
+        <Button
+          variant="ghost"
+          size="xs"
           disabled={refreshing}
           onClick={(e) => {
             // The button lives inside <summary>; stop the click from toggling
@@ -60,7 +62,7 @@ function MissingOrgNotice({
           {refreshing
             ? t("orgs.missingNotice.refreshing")
             : t("orgs.missingNotice.refresh")}
-        </button>
+        </Button>
         <ChevronDown
           aria-hidden="true"
           className="size-4 shrink-0 text-base-content/50 transition-transform group-open:rotate-180"
@@ -153,13 +155,13 @@ function OrgCard({
   const { org, showNoAccessBadge } = useOrgAffordances(summary)
 
   return (
-    <motion.div
-      className="card bg-base-100 rounded-xl col-span-12 border border-base-300 md:col-span-6"
-      variants={enterExit}
-      initial="initial"
-      animate="animate"
+    <Card
+      as={EnterDiv}
+      radius="xl"
+      shadow={false}
+      className="col-span-12 md:col-span-6"
     >
-      <div className="card-body justify-between">
+      <Card.Body className="justify-between">
         <div className="flex gap-4">
           <img
             src={org.avatar_url}
@@ -190,11 +192,11 @@ function OrgCard({
           </div>
         </div>
 
-        <div className="card-actions mt-5 items-center justify-end gap-2">
+        <Card.Actions className="mt-5 items-center justify-end gap-2">
           <OrgActions summary={summary} />
-        </div>
-      </div>
-    </motion.div>
+        </Card.Actions>
+      </Card.Body>
+    </Card>
   )
 }
 
@@ -409,13 +411,13 @@ const OrgsPage = () => {
                       listLabel={t("orgs.toolbar.view.listLabel")}
                     />
 
-                    <button
-                      type="button"
-                      className="btn btn-primary btn-sm"
+                    <Button
+                      variant="primary"
+                      size="sm"
                       onClick={() => setModalOpen(true)}
                     >
                       {t("orgs.newOrg.button")}
-                    </button>
+                    </Button>
                   </div>
                 </div>
               )}
@@ -456,14 +458,14 @@ const OrgsPage = () => {
                   title={t("orgs.setUpFirst.title")}
                   body={t("orgs.setUpFirst.body")}
                   action={
-                    <button
-                      type="button"
-                      className="btn btn-primary btn-sm"
+                    <Button
+                      variant="primary"
+                      size="sm"
                       onClick={() => setModalOpen(true)}
                     >
                       <Plus aria-hidden="true" className="size-4" />
                       {t("orgs.setUpFirst.cta")}
-                    </button>
+                    </Button>
                   }
                 />
               ) : (

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -363,119 +363,117 @@ const OrgsPage = () => {
             </div>
           </div>
         ) : (
-          <div className="mb-8">
-            <div className="flex flex-col gap-6 p-6">
-              <PageHeader title={t("orgs.headingCl50")} />
+          <>
+            <PageHeader title={t("orgs.headingCl50")} />
 
-              <MissingOrgNotice
-                refreshing={isFetching}
-                onRefresh={handleRefresh}
+            <MissingOrgNotice
+              refreshing={isFetching}
+              onRefresh={handleRefresh}
+            />
+
+            {hasAnyOrgs && (
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
+                  <Search
+                    aria-hidden="true"
+                    className="size-4 text-base-content/50"
+                  />
+                  <input
+                    type="search"
+                    className="grow"
+                    placeholder={t("orgs.toolbar.searchPlaceholder")}
+                    aria-label={t("orgs.toolbar.searchLabel")}
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                  />
+                </label>
+
+                <div className="flex items-center gap-3">
+                  <select
+                    className="select select-bordered select-sm"
+                    aria-label={t("orgs.toolbar.sort.label")}
+                    value={sortKey}
+                    onChange={(e) => changeSort(e.target.value as OrgSortKey)}
+                  >
+                    {SORT_OPTIONS.map((opt) => (
+                      <option key={opt.key} value={opt.key}>
+                        {t(opt.labelKey)}
+                      </option>
+                    ))}
+                  </select>
+
+                  <ViewToggle
+                    viewMode={viewMode}
+                    onChange={changeView}
+                    groupLabel={t("orgs.toolbar.view.label")}
+                    gridLabel={t("orgs.toolbar.view.gridLabel")}
+                    listLabel={t("orgs.toolbar.view.listLabel")}
+                  />
+
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => setModalOpen(true)}
+                  >
+                    {t("orgs.newOrg.button")}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {noSearchResults ? (
+              <NoSearchResults
+                title={t("orgs.noResults.title")}
+                body={t("orgs.noResults.body", { query: search.trim() })}
+                clearLabel={t("orgs.noResults.clear")}
+                onClear={() => setSearch("")}
               />
-
-              {hasAnyOrgs && (
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
-                    <Search
-                      aria-hidden="true"
-                      className="size-4 text-base-content/50"
+            ) : sorted.length > 0 ? (
+              <div className="grid grid-cols-12 gap-4">
+                {sorted.map((summary) => {
+                  const updatedIso = lastModifiedActive
+                    ? lastModified[summary.org.login]
+                    : undefined
+                  const updatedAgo = updatedIso
+                    ? formatRelativeToNow(new Date(updatedIso))
+                    : undefined
+                  return viewMode === "grid" ? (
+                    <OrgCard
+                      key={summary.org.id}
+                      summary={summary}
+                      updatedAgo={updatedAgo}
                     />
-                    <input
-                      type="search"
-                      className="grow"
-                      placeholder={t("orgs.toolbar.searchPlaceholder")}
-                      aria-label={t("orgs.toolbar.searchLabel")}
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
+                  ) : (
+                    <OrgRow
+                      key={summary.org.id}
+                      summary={summary}
+                      updatedAgo={updatedAgo}
                     />
-                  </label>
-
-                  <div className="flex items-center gap-3">
-                    <select
-                      className="select select-bordered select-sm"
-                      aria-label={t("orgs.toolbar.sort.label")}
-                      value={sortKey}
-                      onChange={(e) => changeSort(e.target.value as OrgSortKey)}
-                    >
-                      {SORT_OPTIONS.map((opt) => (
-                        <option key={opt.key} value={opt.key}>
-                          {t(opt.labelKey)}
-                        </option>
-                      ))}
-                    </select>
-
-                    <ViewToggle
-                      viewMode={viewMode}
-                      onChange={changeView}
-                      groupLabel={t("orgs.toolbar.view.label")}
-                      gridLabel={t("orgs.toolbar.view.gridLabel")}
-                      listLabel={t("orgs.toolbar.view.listLabel")}
-                    />
-
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      onClick={() => setModalOpen(true)}
-                    >
-                      {t("orgs.newOrg.button")}
-                    </Button>
-                  </div>
-                </div>
-              )}
-
-              {noSearchResults ? (
-                <NoSearchResults
-                  title={t("orgs.noResults.title")}
-                  body={t("orgs.noResults.body", { query: search.trim() })}
-                  clearLabel={t("orgs.noResults.clear")}
-                  onClear={() => setSearch("")}
-                />
-              ) : sorted.length > 0 ? (
-                <div className="grid grid-cols-12 gap-4">
-                  {sorted.map((summary) => {
-                    const updatedIso = lastModifiedActive
-                      ? lastModified[summary.org.login]
-                      : undefined
-                    const updatedAgo = updatedIso
-                      ? formatRelativeToNow(new Date(updatedIso))
-                      : undefined
-                    return viewMode === "grid" ? (
-                      <OrgCard
-                        key={summary.org.id}
-                        summary={summary}
-                        updatedAgo={updatedAgo}
-                      />
-                    ) : (
-                      <OrgRow
-                        key={summary.org.id}
-                        summary={summary}
-                        updatedAgo={updatedAgo}
-                      />
-                    )
-                  })}
-                </div>
-              ) : needsSetupOrgs.length > 0 ? (
-                <EmptyState
-                  title={t("orgs.setUpFirst.title")}
-                  body={t("orgs.setUpFirst.body")}
-                  action={
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      onClick={() => setModalOpen(true)}
-                    >
-                      <Plus aria-hidden="true" className="size-4" />
-                      {t("orgs.setUpFirst.cta")}
-                    </Button>
-                  }
-                />
-              ) : (
-                <EmptyState
-                  title={t("orgs.emptyTitle")}
-                  body={t("orgs.emptyBody")}
-                />
-              )}
-            </div>
-          </div>
+                  )
+                })}
+              </div>
+            ) : needsSetupOrgs.length > 0 ? (
+              <EmptyState
+                title={t("orgs.setUpFirst.title")}
+                body={t("orgs.setUpFirst.body")}
+                action={
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => setModalOpen(true)}
+                  >
+                    <Plus aria-hidden="true" className="size-4" />
+                    {t("orgs.setUpFirst.cta")}
+                  </Button>
+                }
+              />
+            ) : (
+              <EmptyState
+                title={t("orgs.emptyTitle")}
+                body={t("orgs.emptyBody")}
+              />
+            )}
+          </>
         )}
       </PageShell>
 

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -458,11 +458,7 @@ const PublishedResourcesPage = () => {
   const { org } = useParams({ strict: false })
 
   return (
-    <PageShell
-      contentClassName="p-10 bg-base-200 xl:px-50"
-      page="classes"
-      selected="published"
-    >
+    <PageShell page="classes" selected="published">
       <RequireTeacher>
         <PageHeader
           title={t("published.pageHeading")}

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -17,6 +17,7 @@ import { enterExit, staggerTransition } from "@/lib/motion"
 
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
+import { Button } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import RequireTeacher from "@/components/RequireTeacher"
 import useGetClasses from "@/hooks/useGetClasses"
@@ -119,9 +120,9 @@ function CopyButton({ value }: { value: string }) {
   const { t } = useTranslation()
   const { copied, copy } = useCopyToClipboard(value, 1200)
   return (
-    <button
-      type="button"
-      className="btn btn-ghost btn-xs"
+    <Button
+      variant="ghost"
+      size="xs"
       aria-label={t("published.copyUrl")}
       title={t("published.copyUrl")}
       onClick={copy}
@@ -131,7 +132,7 @@ function CopyButton({ value }: { value: string }) {
       ) : (
         <Copy aria-hidden="true" className="size-3.5" />
       )}
-    </button>
+    </Button>
   )
 }
 

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -50,28 +50,26 @@ const StudentListContent = ({
 
   return (
     <>
-      <div className="mb-8">
-        <PageHeader
-          title={t("nav.students")}
-          subtitle={
-            <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
-              <span>
-                {countReady
-                  ? t("students.enrolledCount", { count: enrolledCount })
-                  : t("students.enrolledCountLoading")}
-              </span>
-              <span aria-hidden="true" className="text-base-content/30">
-                ·
-              </span>
-              <GitHubLink
-                href={`https://github.com/${org}/${CONFIG_REPO}/blob/main/${classroom}/students.csv`}
-                label={t("students.viewCsvOnGitHub")}
-                title={t("students.viewCsvOnGitHub")}
-              />
+      <PageHeader
+        title={t("nav.students")}
+        subtitle={
+          <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span>
+              {countReady
+                ? t("students.enrolledCount", { count: enrolledCount })
+                : t("students.enrolledCountLoading")}
             </span>
-          }
-        />
-      </div>
+            <span aria-hidden="true" className="text-base-content/30">
+              ·
+            </span>
+            <GitHubLink
+              href={`https://github.com/${org}/${CONFIG_REPO}/blob/main/${classroom}/students.csv`}
+              label={t("students.viewCsvOnGitHub")}
+              title={t("students.viewCsvOnGitHub")}
+            />
+          </span>
+        }
+      />
 
       <EnrolledStudents
         students={students}

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -158,7 +158,7 @@ const SubmissionBody = ({
   // No repo means the student hasn't accepted yet.
   if (!studentRepo) {
     return (
-      <EnterDiv className="alert alert-warning mt-6">
+      <EnterDiv className="alert alert-info alert-soft mt-6">
         <div>
           {t("submissions.student.notAccepted_prefix")}{" "}
           <Link

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -25,6 +25,7 @@ import { safeHttpUrl } from "@/util/url"
 import type { GitHubRelease } from "@/hooks/github/types"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
+import { Alert, Card } from "@/components/ui"
 
 // Strips the `submit/` tag prefix for a friendlier label, falling back to the
 // release name when present.
@@ -147,10 +148,10 @@ const SubmissionBody = ({
           ? repoError.message
           : ""
     return (
-      <div className="alert alert-error mt-6">
+      <Alert tone="error" className="mt-6">
         {t("submissions.student.loadError")}
         {message ? ` ${message}` : ""}
-      </div>
+      </Alert>
     )
   }
 
@@ -177,9 +178,9 @@ const SubmissionBody = ({
   if (!releases || releases.length === 0) {
     return (
       <EnterDiv className="mt-6 space-y-4">
-        <div className="alert alert-info">
+        <Alert tone="info">
           <div>{t("submissions.student.noGradedYet")}</div>
-        </div>
+        </Alert>
         <a
           href={studentRepo.html_url}
           target="_blank"
@@ -210,13 +211,13 @@ const SubmissionBody = ({
         </a>
       </div>
 
-      <EnterDiv className="card border border-base-200 bg-base-100 shadow-sm">
+      <Card as={EnterDiv} bordered={false} className="border border-base-200">
         <ul className="divide-y divide-base-200">
           {releases.map((release) => (
             <ReleaseRow key={release.id} release={release} />
           ))}
         </ul>
-      </EnterDiv>
+      </Card>
     </div>
   )
 }

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -18,6 +18,7 @@ import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import MissingParams from "@/components/MissingParams"
+import { Button, Card, Spinner } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import SubmissionsTable from "@/pages/submissions/SubmissionsTable"
 import SubmissionsControls from "@/pages/submissions/SubmissionsControls"
@@ -87,9 +88,10 @@ const CopyIconButton = ({
   onCopy: (e: React.MouseEvent<HTMLButtonElement>) => void
   label: string
 }) => (
-  <button
-    type="button"
-    className={`btn ${copied ? "btn-success" : "btn-primary"} btn-sm btn-outline mr-2`}
+  <Button
+    variant={copied ? "success" : "outline"}
+    size="sm"
+    className={copied ? "btn-outline mr-2" : "mr-2"}
     onClick={onCopy}
     aria-label={label}
     title={label}
@@ -99,7 +101,7 @@ const CopyIconButton = ({
     ) : (
       <Copy aria-hidden="true" className="size-4" />
     )}
-  </button>
+  </Button>
 )
 
 // Bordered stat card with an uppercase label; body varies per stat.
@@ -110,14 +112,14 @@ const StatCard = ({
   label: string
   children: React.ReactNode
 }) => (
-  <div className="card bg-base-100 rounded-xl border border-base-300">
-    <div className="card-body gap-1 p-4">
+  <Card radius="xl" shadow={false}>
+    <Card.Body className="gap-1 p-4">
       <label className="text-xs uppercase tracking-wide text-base-content/70">
         {label}
       </label>
       {children}
-    </div>
-  </div>
+    </Card.Body>
+  </Card>
 )
 
 const SubmissionsPageContent = () => {
@@ -520,15 +522,14 @@ const SubmissionsPageContent = () => {
             </div>
           }
           action={
-            <button
-              type="button"
-              className="btn btn-outline"
+            <Button
+              variant="outline"
               onClick={downloadScoresCsv}
               disabled={!scoresInfo.length && !nonSubmitters.length}
             >
               <HardDriveDownload aria-hidden="true" />{" "}
               {t("submissions.downloadCsv")}
-            </button>
+            </Button>
           }
         />
       </div>
@@ -556,9 +557,9 @@ const SubmissionsPageContent = () => {
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <button
-              type="button"
-              className="btn btn-sm btn-outline"
+            <Button
+              variant="outline"
+              size="sm"
               disabled={regrading || collecting || emptyRoster.show}
               title={
                 emptyRoster.show
@@ -569,24 +570,20 @@ const SubmissionsPageContent = () => {
                       ? t("submissions.regradeAll.titleRegrading")
                       : t("submissions.regradeAll.title")
               }
+              loading={regradeAllActive}
+              loadingLabel={t("submissions.regradeAll.active")}
               onClick={() => {
                 if (regrading || collecting || emptyRoster.show) return
                 setRegradeConfirmOpen(true)
               }}
             >
-              {regradeAllActive && (
-                <span
-                  className="loading loading-spinner loading-xs"
-                  aria-hidden="true"
-                />
-              )}
               {regradeAllActive
                 ? t("submissions.regradeAll.active")
                 : t("submissions.regradeAll.label")}
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm btn-primary"
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
               disabled={collecting || regrading || emptyRoster.show}
               title={
                 emptyRoster.show
@@ -595,21 +592,17 @@ const SubmissionsPageContent = () => {
                     ? t("submissions.collect.titleRegrading")
                     : t("submissions.collect.title")
               }
+              loading={collecting}
+              loadingLabel={t("submissions.collect.active")}
               onClick={() => {
                 if (collecting || regrading || emptyRoster.show) return
                 collectScores.collect()
               }}
             >
-              {collecting && (
-                <span
-                  className="loading loading-spinner loading-xs"
-                  aria-hidden="true"
-                />
-              )}
               {collecting
                 ? t("submissions.collect.active")
                 : t("submissions.collect.label")}
-            </button>
+            </Button>
             <a
               className="btn btn-sm btn-ghost"
               href={viewRun?.html_url || viewWorkflowUrl}
@@ -637,10 +630,7 @@ const SubmissionsPageContent = () => {
             )}
             {collectScores.phase === "running" && (
               <span className="flex items-center gap-1.5 text-base-content/70">
-                <span
-                  className="loading loading-spinner loading-xs"
-                  aria-hidden="true"
-                />
+                <Spinner size="xs" />
                 {t("submissions.collect.statusRunning")}
               </span>
             )}
@@ -683,10 +673,7 @@ const SubmissionsPageContent = () => {
             )}
             {regradeAll.phase === "running" && (
               <span className="flex items-center gap-1.5">
-                <span
-                  className="loading loading-spinner loading-xs"
-                  aria-hidden="true"
-                />
+                <Spinner size="xs" />
                 {t("submissions.regradeAll.statusRunning")}
               </span>
             )}
@@ -875,9 +862,10 @@ const SubmissionsPageContent = () => {
       <div className="mb-2 flex items-center justify-end gap-1 text-sm text-base-content/70">
         <span>{t("submissions.updated", { when: scoresLastUpdated })}</span>
 
-        <button
-          type="button"
-          className="btn btn-ghost btn-xs btn-circle"
+        <Button
+          variant="ghost"
+          size="xs"
+          shape="circle"
           disabled={scoresFetching}
           onClick={() => refetchScores()}
           aria-label={t("submissions.refresh")}
@@ -888,7 +876,7 @@ const SubmissionsPageContent = () => {
             size={14}
             className={scoresFetching ? "animate-spin" : ""}
           />
-        </button>
+        </Button>
       </div>
       <SubmissionsControls
         query={query}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -626,7 +626,7 @@ const SubmissionsPageContent = () => {
               </span>
             )}
             {collectScores.phase === "running" && (
-              <span className="flex items-center gap-1.5 text-base-content/70">
+              <span className="flex items-center gap-1.5 text-info">
                 <Spinner size="xs" />
                 {t("submissions.collect.statusRunning")}
               </span>
@@ -660,7 +660,7 @@ const SubmissionsPageContent = () => {
                 ? "border-error/20 text-error"
                 : regradeAll.phase === "completed"
                   ? "border-success/20 text-success"
-                  : "border-warning/20 text-base-content/70"
+                  : "border-info/20 text-info"
             }`}
             role="status"
             aria-live="polite"

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -462,7 +462,6 @@ const SubmissionsPageContent = () => {
           org={org}
           classroom={classroom}
           hasRosterRows={emptyRoster.hasRosterRows}
-          className="mt-4"
         />
       )}
       {rosterError && (
@@ -491,49 +490,47 @@ const SubmissionsPageContent = () => {
           onRetry={() => refetchScores()}
         />
       )}
-      <div className="mb-8">
-        <PageHeader
-          title={assignmentInfo?.name}
-          subtitle={
-            <div className="flex flex-wrap items-center gap-2">
-              <span>
-                {assignmentInfo?.due
-                  ? t("submissions.dueDate", {
-                      date: formatDueDateTime(assignmentInfo.due),
-                    })
-                  : t("submissions.noDueDate")}
+      <PageHeader
+        title={assignmentInfo?.name}
+        subtitle={
+          <div className="flex flex-wrap items-center gap-2">
+            <span>
+              {assignmentInfo?.due
+                ? t("submissions.dueDate", {
+                    date: formatDueDateTime(assignmentInfo.due),
+                  })
+                : t("submissions.noDueDate")}
+            </span>
+            {lateCount > 0 && (
+              <span className="badge badge-sm badge-error badge-soft">
+                {t("submissions.lateBadge", { count: lateCount })}
               </span>
-              {lateCount > 0 && (
-                <span className="badge badge-sm badge-error badge-soft">
-                  {t("submissions.lateBadge", { count: lateCount })}
-                </span>
-              )}
-              {assignmentInfo?.template && (
-                <GitHubLink
-                  href={githubTemplateRepoUrl(
-                    assignmentInfo.template.owner,
-                    assignmentInfo.template.repo,
-                    assignmentInfo.template.branch,
-                  )}
-                  label={t("submissions.viewSourceRepo")}
-                  title={`${assignmentInfo.template.owner}/${assignmentInfo.template.repo}`}
-                />
-              )}
-            </div>
-          }
-          action={
-            <Button
-              variant="outline"
-              onClick={downloadScoresCsv}
-              disabled={!scoresInfo.length && !nonSubmitters.length}
-            >
-              <HardDriveDownload aria-hidden="true" />{" "}
-              {t("submissions.downloadCsv")}
-            </Button>
-          }
-        />
-      </div>
-      <div className="mb-4 rounded-box border border-info/20 bg-info/5">
+            )}
+            {assignmentInfo?.template && (
+              <GitHubLink
+                href={githubTemplateRepoUrl(
+                  assignmentInfo.template.owner,
+                  assignmentInfo.template.repo,
+                  assignmentInfo.template.branch,
+                )}
+                label={t("submissions.viewSourceRepo")}
+                title={`${assignmentInfo.template.owner}/${assignmentInfo.template.repo}`}
+              />
+            )}
+          </div>
+        }
+        action={
+          <Button
+            variant="outline"
+            onClick={downloadScoresCsv}
+            disabled={!scoresInfo.length && !nonSubmitters.length}
+          >
+            <HardDriveDownload aria-hidden="true" />{" "}
+            {t("submissions.downloadCsv")}
+          </Button>
+        }
+      />
+      <div className="rounded-box border border-info/20 bg-info/5">
         {/* Action bar: standing note left, the two actions + a single
                 contextual View link right. */}
         <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
@@ -704,7 +701,7 @@ const SubmissionsPageContent = () => {
       </div>
       <details
         open
-        className="card bg-base-100 rounded-xl border border-base-300 mb-4 group"
+        className="card bg-base-100 rounded-xl border border-base-300 group"
       >
         <summary className="card-body flex-row items-center gap-3 cursor-pointer list-none py-4">
           <div className="rounded-xl bg-primary/10 p-2.5 text-primary">
@@ -760,7 +757,7 @@ const SubmissionsPageContent = () => {
           </details>
         </div>
       </details>{" "}
-      <div className="grid grid-cols-2 gap-4 mb-6 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <StatCard
           label={
             isGroupAssignment
@@ -859,7 +856,7 @@ const SubmissionsPageContent = () => {
           </StatCard>
         ) : null}
       </div>
-      <div className="mb-2 flex items-center justify-end gap-1 text-sm text-base-content/70">
+      <div className="flex items-center justify-end gap-1 text-sm text-base-content/70">
         <span>{t("submissions.updated", { when: scoresLastUpdated })}</span>
 
         <Button

--- a/web/src/pages/assignments/AdvancedRuntimeFields.tsx
+++ b/web/src/pages/assignments/AdvancedRuntimeFields.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react"
 import { orgRunnersQuery } from "@/hooks/github/queries"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
+import { Button, HelpTooltip } from "@/components/ui"
 import {
   isKnownHostedRunnerLabel,
   isRunnerLabelShapeValid,
@@ -32,24 +33,9 @@ import {
 } from "./formFieldHelpers"
 import type { AssignmentForm } from "./CreateAssignmentForm"
 
-// A question-mark help affordance: a focusable button carrying detailed
-// guidance as its accessible name, wrapped in a theme-aware DaisyUI tooltip
-// that reveals `help` on hover/focus. The single source for the help-icon
-// markup and a11y contract — reused by FieldLabel and any inline toggle label.
-export const HelpTooltip = ({ help }: { help: string }) => (
-  <span
-    className="tooltip tooltip-bottom before:max-w-xs before:whitespace-normal before:text-left"
-    data-tip={help}
-  >
-    <button
-      type="button"
-      aria-label={help}
-      className="btn btn-ghost btn-xs btn-circle text-base-content/50 hover:text-base-content"
-    >
-      <HelpCircle aria-hidden="true" className="size-4" />
-    </button>
-  </span>
-)
+// A question-mark help affordance now lives in the shared ui module; re-exported
+// here so existing importers (CreateAssignmentForm) keep working.
+export { HelpTooltip }
 
 // A bold field label with an optional help affordance: a question-mark icon
 // that reveals detailed guidance on hover/focus (DaisyUI tooltip, theme-aware).
@@ -123,16 +109,16 @@ export const LanguageVersionField = ({
                   onBlur={normalizeOnBlur(field)}
                   onChange={(e) => field.handleChange(e.target.value)}
                 />
-                <button
-                  type="button"
+                <Button
+                  shape="square"
                   tabIndex={0}
-                  className="btn btn-square join-item border-base-content/20"
+                  className="join-item border-base-content/20"
                   aria-label={t("assignments.form.runtime.versionMenu", {
                     language: meta.label,
                   })}
                 >
                   <ChevronDown aria-hidden="true" className="size-4" />
-                </button>
+                </Button>
               </div>
               <ul
                 tabIndex={0}

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -19,6 +19,7 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import type { Assignment, Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
+import { Button } from "@/components/ui"
 
 const DeleteAssignmentButton = ({
   org,
@@ -42,19 +43,21 @@ const DeleteAssignmentButton = ({
 
   return (
     <>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="circle"
         onClick={(e) => {
           e.stopPropagation()
           setOpen(true)
         }}
-        className="btn btn-circle btn-sm btn-ghost text-error"
+        className="text-error"
         aria-label={t("assignments.table.deleteAria", {
           name: assignment.name || assignment.slug,
         })}
       >
         <Trash2 className="size-4" aria-hidden="true" />
-      </button>
+      </Button>
 
       <ConfirmModal
         open={open}
@@ -104,18 +107,19 @@ const ReuseAssignmentButton = ({
 
   return (
     <>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="circle"
         onClick={(e) => {
           e.stopPropagation()
           setOpen(true)
         }}
-        className="btn btn-circle btn-sm btn-ghost"
         title={t("assignments.table.reuseTitle")}
         aria-label={t("assignments.table.reuseAria")}
       >
         <Copy aria-hidden="true" className="size-4" />
-      </button>
+      </Button>
 
       {open ? (
         <ReuseAssignmentModal

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -4,6 +4,7 @@ import type { TFunction } from "i18next"
 import { Pencil, Trash } from "lucide-react"
 import type { AssignmentForm } from "./CreateAssignmentForm"
 
+import { Button, Card, Input, Select } from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import { emptyTestDraft, validateTestDraft } from "@/util/assignmentTests"
 import type { AssignmentTestComparison } from "@/types/classroom"
@@ -131,14 +132,13 @@ const AutogradingTestModal = ({
                 <label htmlFor={field.name} className="label font-bold">
                   {t("assignments.autograder.testName")}
                 </label>
-                <input
+                <Input
                   id={field.name}
-                  className="input w-full"
                   value={field.state.value}
                   onBlur={field.handleBlur}
                   onChange={(e) => field.handleChange(e.target.value)}
                   placeholder={t("assignments.autograder.testNamePlaceholder")}
-                  aria-invalid={field.state.meta.errors.length > 0}
+                  invalid={field.state.meta.errors.length > 0}
                   aria-describedby={
                     field.state.meta.errors.length > 0
                       ? `${field.name}-error`
@@ -190,9 +190,9 @@ const AutogradingTestModal = ({
                 <label htmlFor={field.name} className="label font-bold">
                   {t("assignments.autograder.setupCommand")}
                 </label>
-                <input
+                <Input
                   id={field.name}
-                  className="input w-full font-mono"
+                  className="font-mono"
                   value={field.state.value}
                   onBlur={field.handleBlur}
                   onChange={(e) => field.handleChange(e.target.value)}
@@ -210,16 +210,16 @@ const AutogradingTestModal = ({
                 <label htmlFor={field.name} className="label font-bold">
                   {t("assignments.autograder.runCommand")}
                 </label>
-                <input
+                <Input
                   id={field.name}
-                  className="input w-full font-mono"
+                  className="font-mono"
                   value={field.state.value}
                   onBlur={field.handleBlur}
                   onChange={(e) => field.handleChange(e.target.value)}
                   placeholder={t(
                     "assignments.autograder.runCommandPlaceholder",
                   )}
-                  aria-invalid={field.state.meta.errors.length > 0}
+                  invalid={field.state.meta.errors.length > 0}
                   aria-describedby={
                     field.state.meta.errors.length > 0
                       ? `${field.name}-error`
@@ -306,9 +306,8 @@ const AutogradingTestModal = ({
                           >
                             {t("assignments.autograder.comparison")}
                           </label>
-                          <select
+                          <Select
                             id={field.name}
-                            className="select w-full"
                             value={field.state.value}
                             onBlur={field.handleBlur}
                             onChange={(e) =>
@@ -326,7 +325,7 @@ const AutogradingTestModal = ({
                             <option value="regex">
                               {t("assignments.autograder.comparisonRegex")}
                             </option>
-                          </select>
+                          </Select>
                         </div>
                       )}
                     </form.Field>
@@ -340,9 +339,9 @@ const AutogradingTestModal = ({
                         <label htmlFor={field.name} className="label font-bold">
                           {t("assignments.autograder.exitCode")}
                         </label>
-                        <input
+                        <Input
                           id={field.name}
-                          className="input w-32"
+                          className="w-32"
                           type="number"
                           min={0}
                           max={255}
@@ -357,7 +356,7 @@ const AutogradingTestModal = ({
                             )
                           }
                           placeholder="0"
-                          aria-invalid={field.state.meta.errors.length > 0}
+                          invalid={field.state.meta.errors.length > 0}
                           aria-describedby={
                             field.state.meta.errors.length > 0
                               ? `${field.name}-error`
@@ -394,9 +393,9 @@ const AutogradingTestModal = ({
                   <label htmlFor={field.name} className="label font-bold">
                     {t("assignments.autograder.timeout")}
                   </label>
-                  <input
+                  <Input
                     id={field.name}
-                    className="input w-32"
+                    className="w-32"
                     type="number"
                     min={0}
                     max={600}
@@ -408,7 +407,7 @@ const AutogradingTestModal = ({
                         e.target.value === "" ? 0 : e.target.valueAsNumber,
                       )
                     }
-                    aria-invalid={field.state.meta.errors.length > 0}
+                    invalid={field.state.meta.errors.length > 0}
                     aria-describedby={
                       field.state.meta.errors.length > 0
                         ? `${field.name}-error`
@@ -432,9 +431,9 @@ const AutogradingTestModal = ({
                   <label htmlFor={field.name} className="label font-bold">
                     {t("assignments.autograder.points")}
                   </label>
-                  <input
+                  <Input
                     id={field.name}
-                    className="input w-32"
+                    className="w-32"
                     type="number"
                     min={0}
                     max={1000}
@@ -446,7 +445,7 @@ const AutogradingTestModal = ({
                         e.target.value === "" ? 0 : e.target.valueAsNumber,
                       )
                     }
-                    aria-invalid={field.state.meta.errors.length > 0}
+                    invalid={field.state.meta.errors.length > 0}
                     aria-describedby={
                       field.state.meta.errors.length > 0
                         ? `${field.name}-error`
@@ -464,13 +463,9 @@ const AutogradingTestModal = ({
         </div>
 
         <div className="modal-action">
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={handleDone}
-          >
+          <Button variant="primary" onClick={handleDone}>
             {t("assignments.autograder.done")}
-          </button>
+          </Button>
         </div>
       </div>
       <div className="modal-backdrop">
@@ -512,10 +507,10 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
   }
 
   return (
-    <div className="card bg-base-100 shadow-sm">
+    <Card bordered={false}>
       <form.Field name="tests" mode="array">
         {(field) => (
-          <div className="card-body">
+          <Card.Body>
             <div className="flex justify-between mb-6">
               <div>
                 <h3 className="text-lg font-bold">
@@ -539,9 +534,8 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                 </h3>
               </div>
               <div>
-                <button
-                  type="button"
-                  className="btn btn-primary btn-outline"
+                <Button
+                  variant="outline"
                   onClick={() => {
                     const newIndex = field.state.value.length
                     field.pushValue(emptyTestDraft())
@@ -549,7 +543,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                   }}
                 >
                   {t("assignments.autograder.addTest")}
-                </button>
+                </Button>
               </div>
             </div>
             <table className="table">
@@ -613,20 +607,21 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
 
                         <td>
                           <div className="flex justify-end gap-2">
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-ghost"
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               onClick={() => openEditor(index)}
                               aria-label={t("assignments.autograder.editTest", {
                                 number: index + 1,
                               })}
                             >
                               <Pencil aria-hidden="true" size={16} />
-                            </button>
+                            </Button>
 
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-ghost text-error"
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-error"
                               onClick={() => field.removeValue(index)}
                               aria-label={t(
                                 "assignments.autograder.removeTest",
@@ -634,7 +629,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                               )}
                             >
                               <Trash aria-hidden="true" size={16} />
-                            </button>
+                            </Button>
                           </div>
                         </td>
                       </tr>
@@ -650,10 +645,10 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
               index={editingIndex}
               onClose={closeEditor}
             />
-          </div>
+          </Card.Body>
         )}
       </form.Field>
-    </div>
+    </Card>
   )
 }
 

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from "i18next"
 import { slugify } from "@/util/slug"
 import { AlertTriangle } from "lucide-react"
 import AutogradingTestsPane from "./AutogradingTestsPane"
+import { Button, Card } from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
   testToDraft,
@@ -421,8 +422,8 @@ const CreateAssignmentForm = ({
     >
       {/* readOnly disables every descendant control. */}
       <fieldset disabled={readOnly} className="m-0 min-w-0 border-0 p-0">
-        <div className="card bg-base-100 w-full shadow-sm mb-6">
-          <div className="card-body">
+        <Card bordered={false} className="w-full mb-6">
+          <Card.Body>
             <h3 className="text-lg font-bold pb-4">
               {t("assignments.form.basicInfo")}
             </h3>
@@ -700,12 +701,12 @@ const CreateAssignmentForm = ({
                 </div>
               )}
             </form.Field>
-          </div>
+          </Card.Body>
           <FormErrors form={form} />
-        </div>
+        </Card>
 
-        <div className="card bg-base-100 w-full shadow-sm mb-6">
-          <div className="card-body">
+        <Card bordered={false} className="w-full mb-6">
+          <Card.Body>
             <details className="group">
               <summary className="cursor-pointer text-lg font-bold marker:content-none flex items-center gap-2">
                 <span className="transition-transform group-open:rotate-90">
@@ -946,22 +947,17 @@ const CreateAssignmentForm = ({
                 )}
               </form.Field>
             </details>
-          </div>
-        </div>
+          </Card.Body>
+        </Card>
 
         <AutogradingTestsPane form={form} />
       </fieldset>
       <div className="divider" />
       <div className="card-actions justify-end p-2">
         {onCancel && (
-          <button
-            type="button"
-            className="btn btn-ghost"
-            onClick={onCancel}
-            disabled={loading}
-          >
+          <Button variant="ghost" onClick={onCancel} disabled={loading}>
             {readOnly ? t("assignments.form.back") : t("common.cancel")}
-          </button>
+          </Button>
         )}
         {!readOnly && (
           <form.Subscribe
@@ -972,9 +968,10 @@ const CreateAssignmentForm = ({
             ]}
           >
             {([canSubmit, isSubmitting, isDefaultValue]) => (
-              <button
+              <Button
+                variant="primary"
                 type="submit"
-                className="btn btn-primary"
+                loading={isSubmitting || loading}
                 disabled={
                   !canSubmit ||
                   isSubmitting ||
@@ -982,17 +979,12 @@ const CreateAssignmentForm = ({
                   (edit && isDefaultValue)
                 }
               >
-                {isSubmitting || loading ? (
-                  <span
-                    className="loading loading-spinner"
-                    aria-hidden="true"
-                  />
-                ) : edit ? (
-                  t("assignments.form.saveChanges")
-                ) : (
-                  t("assignments.form.createButton")
-                )}
-              </button>
+                {isSubmitting || loading
+                  ? null
+                  : edit
+                    ? t("assignments.form.saveChanges")
+                    : t("assignments.form.createButton")}
+              </Button>
             )}
           </form.Subscribe>
         )}

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -3,6 +3,7 @@ import {
   editClassroomWithConflictRetry,
 } from "@/api/mutations/classrooms"
 import { ConfirmModal } from "@/components/modals"
+import { Button, Card } from "@/components/ui"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { githubKeys } from "@/hooks/github/queries"
@@ -314,10 +315,12 @@ function ClassroomMenu({
 
   return (
     <div ref={containerRef} className="relative">
-      <button
+      <Button
         ref={triggerRef}
-        type="button"
-        className="btn btn-ghost btn-sm btn-circle text-base-content/70 hover:text-primary"
+        variant="ghost"
+        size="sm"
+        shape="circle"
+        className="text-base-content/70 hover:text-primary"
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={menuId}
@@ -334,7 +337,7 @@ function ClassroomMenu({
         }}
       >
         <MoreVertical aria-hidden="true" className="size-4" />
-      </button>
+      </Button>
 
       {open && (
         <ul
@@ -550,8 +553,13 @@ export function ClassroomCard({
   const name = classroomDisplayName(summary, t("classes.unknownClassName"))
 
   return (
-    <EnterDiv className="card bg-base-100 col-span-12 rounded-xl border border-base-300 md:col-span-6 xl:col-span-4">
-      <div className="card-body gap-4">
+    <Card
+      as={EnterDiv}
+      radius="xl"
+      shadow={false}
+      className="col-span-12 md:col-span-6 xl:col-span-4"
+    >
+      <Card.Body className="gap-4">
         <div className="flex items-start justify-between gap-2">
           <ClassroomBadges summary={summary} />
           {canManage && (
@@ -565,8 +573,8 @@ export function ClassroomCard({
         <h2 className="truncate text-xl font-semibold">{name}</h2>
         <ClassroomStats org={org} slug={summary.path} />
         <ViewAssignmentsButton org={org} slug={summary.path} block />
-      </div>
-    </EnterDiv>
+      </Card.Body>
+    </Card>
   )
 }
 

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { NoSearchResults, ViewToggle } from "@/components/list"
+import { Button } from "@/components/ui"
 import useClassroomSummaries, {
   classroomDisplayName,
   type ClassroomSummary,
@@ -149,15 +150,16 @@ const ClassroomList = ({
           className="join"
         >
           {(["active", "archived", "all"] as const).map((f) => (
-            <button
+            <Button
               key={f}
-              type="button"
-              className={`btn btn-sm join-item ${filter === f ? "btn-active" : ""}`}
+              size="sm"
+              className="join-item"
+              active={filter === f}
               aria-pressed={filter === f}
               onClick={() => setFilter(f)}
             >
               {t(`classes.filter.${f}`)}
-            </button>
+            </Button>
           ))}
         </div>
 

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -22,6 +22,7 @@ import { normalizeGithubUsername } from "@/api/mutations/students"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
 import type { GitHubUser } from "@/hooks/github/types"
+import { Button, Card, FormField, Input, Select } from "@/components/ui"
 
 // i18n key for each role's singular label. A map (not inline t()) so it works in
 // module scope; components translate via t(ROLE_LABEL_KEY[role]).
@@ -45,8 +46,8 @@ const ClassroomStaffSection = ({
 }) => {
   const { t } = useTranslation()
   return (
-    <div className="card bg-base-100 w-full shadow-sm mt-8">
-      <div className="card-body">
+    <Card bordered={false} className="w-full mt-8">
+      <Card.Body>
         <div className="flex items-center gap-3 pb-1">
           <div className="flex items-center gap-2">
             <ShieldCheck
@@ -79,8 +80,8 @@ const ClassroomStaffSection = ({
             />
           ))}
         </div>
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   )
 }
 
@@ -185,42 +186,44 @@ const AddStaff = ({
       }}
     >
       <div className="grow min-w-[12rem]">
-        <label htmlFor="staff-username" className="label font-bold text-sm">
-          {t("classes.staff.githubUsername")}
-        </label>
-        <input
-          id="staff-username"
-          type="text"
-          autoComplete="off"
-          spellCheck={false}
-          className="input w-full"
-          placeholder={t("classes.staff.usernamePlaceholder")}
-          value={username}
-          disabled={disabled || addMutation.isPending}
-          onChange={(e) => setUsername(e.target.value)}
-        />
+        <FormField
+          label={t("classes.staff.githubUsername")}
+          htmlFor="staff-username"
+        >
+          {({ id }) => (
+            <Input
+              id={id}
+              autoComplete="off"
+              spellCheck={false}
+              placeholder={t("classes.staff.usernamePlaceholder")}
+              value={username}
+              disabled={disabled || addMutation.isPending}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+          )}
+        </FormField>
       </div>
       <div>
-        <label htmlFor="staff-role" className="label font-bold text-sm">
-          {t("classes.staff.role")}
-        </label>
-        <select
-          id="staff-role"
-          className="select"
-          value={role}
-          disabled={disabled || addMutation.isPending}
-          onChange={(e) => setRole(e.target.value as StaffRole)}
-        >
-          {STAFF_ROLES.map((r) => (
-            <option key={r} value={r}>
-              {t(ROLE_LABEL_KEY[r])}
-            </option>
-          ))}
-        </select>
+        <FormField label={t("classes.staff.role")} htmlFor="staff-role">
+          {({ id }) => (
+            <Select
+              id={id}
+              value={role}
+              disabled={disabled || addMutation.isPending}
+              onChange={(e) => setRole(e.target.value as StaffRole)}
+            >
+              {STAFF_ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {t(ROLE_LABEL_KEY[r])}
+                </option>
+              ))}
+            </Select>
+          )}
+        </FormField>
       </div>
-      <button
+      <Button
         type="submit"
-        className="btn btn-primary"
+        variant="primary"
         disabled={disabled || addMutation.isPending || !username.trim()}
       >
         {addMutation.isPending ? (
@@ -229,7 +232,7 @@ const AddStaff = ({
           <UserPlus aria-hidden="true" className="size-4" />
         )}
         {t("classes.staff.add")}
-      </button>
+      </Button>
     </form>
   )
 }
@@ -369,9 +372,10 @@ const StaffMemberRow = ({
           {roleLabel}
         </span>
       </a>
-      <button
-        type="button"
-        className="btn btn-ghost btn-xs text-error"
+      <Button
+        variant="ghost"
+        size="xs"
+        className="text-error"
         title={t("classes.staff.removeRole", { role: roleLabel })}
         disabled={disabled || removeMutation.isPending}
         onClick={() => removeMutation.mutate()}
@@ -381,7 +385,7 @@ const StaffMemberRow = ({
         ) : (
           <X aria-hidden="true" className="size-3.5" />
         )}
-      </button>
+      </Button>
     </li>
   )
 }

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -10,6 +10,7 @@ import {
   isValidSecret,
 } from "@/util/secret"
 import { slugify } from "@/util/slug"
+import { Button, Card, FormField, Input } from "@/components/ui"
 
 export type CreateClassroomFormValues = {
   name: string
@@ -95,126 +96,111 @@ const CreateClassroomForm = ({
     },
   })
   return (
-    <form
-      className="card bg-base-100 w-full shadow-sm"
+    <Card
+      as="form"
+      bordered={false}
+      className="w-full"
       onSubmit={(e) => {
         e.preventDefault()
         e.stopPropagation()
         form.handleSubmit()
       }}
     >
-      <div className="card-body">
+      <Card.Body>
         <h3 className="text-lg font-bold pb-4">
           {t("classes.form.basicInfo")}
         </h3>
 
         <form.Field name="name">
           {(field) => (
-            <>
-              <label htmlFor={field.name} className="label font-bold">
-                {t("classes.form.name")}
-                <span className="text-error">*</span>
-              </label>
-
-              <input
-                id={field.name}
-                name={field.name}
-                type="text"
-                required
-                aria-required="true"
-                aria-invalid={field.state.meta.errors.length > 0}
-                aria-describedby={
-                  field.state.meta.errors.length > 0
-                    ? `${field.name}-error`
-                    : undefined
-                }
-                className="input w-full mb-4"
-                placeholder={t("classes.form.namePlaceholder")}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => {
-                  field.handleChange(e.target.value)
-                  form.setFieldValue("slug", slugify(e.target.value))
-                }}
-              />
-
-              {field.state.meta.errors.length > 0 && (
-                <p
-                  id={`${field.name}-error`}
-                  className="text-error text-sm mb-4"
-                  role="alert"
-                >
-                  {field.state.meta.errors[0]}
-                </p>
+            <FormField
+              label={t("classes.form.name")}
+              htmlFor={field.name}
+              required
+              error={
+                field.state.meta.errors.length > 0
+                  ? field.state.meta.errors[0]
+                  : undefined
+              }
+              className="mb-4"
+            >
+              {({ id, describedById, invalid }) => (
+                <Input
+                  id={id}
+                  name={field.name}
+                  required
+                  aria-required="true"
+                  aria-describedby={describedById}
+                  invalid={invalid}
+                  placeholder={t("classes.form.namePlaceholder")}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value)
+                    form.setFieldValue("slug", slugify(e.target.value))
+                  }}
+                />
               )}
-            </>
+            </FormField>
           )}
         </form.Field>
 
         <form.Field name="slug">
           {(field) => (
-            <>
-              <label htmlFor={field.name} className="label font-bold">
-                {t("classes.form.slug")}
-                <span className="text-error">*</span>
-              </label>
-
-              <input
-                id={field.name}
-                name={field.name}
-                type="text"
-                required
-                aria-required="true"
-                aria-invalid={field.state.meta.errors.length > 0}
-                aria-describedby={
-                  field.state.meta.errors.length > 0
-                    ? `${field.name}-error`
-                    : undefined
-                }
-                className="input w-full mb-4"
-                placeholder={t("classes.form.slugPlaceholder")}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-
-              {field.state.meta.errors.length > 0 && (
-                <p
-                  id={`${field.name}-error`}
-                  className="text-error text-sm mb-4"
-                  role="alert"
-                >
-                  {field.state.meta.errors[0]}
-                </p>
+            <FormField
+              label={t("classes.form.slug")}
+              htmlFor={field.name}
+              required
+              error={
+                field.state.meta.errors.length > 0
+                  ? field.state.meta.errors[0]
+                  : undefined
+              }
+              className="mb-4"
+            >
+              {({ id, describedById, invalid }) => (
+                <Input
+                  id={id}
+                  name={field.name}
+                  required
+                  aria-required="true"
+                  aria-describedby={describedById}
+                  invalid={invalid}
+                  placeholder={t("classes.form.slugPlaceholder")}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )}
-            </>
+            </FormField>
           )}
         </form.Field>
 
         <form.Field name="term">
           {(field) => (
-            <>
-              <label htmlFor={field.name} className="label font-bold">
-                {t("classes.form.term")}
-              </label>
-
-              <input
-                id={field.name}
-                name={field.name}
-                type="text"
-                className="input w-full mb-4"
-                placeholder={t("classes.form.termPlaceholder")}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-
-              {field.state.meta.errors.length > 0 && (
-                <p className="text-error text-sm mb-4" role="alert">
-                  {field.state.meta.errors[0]}
-                </p>
+            <FormField
+              label={t("classes.form.term")}
+              htmlFor={field.name}
+              error={
+                field.state.meta.errors.length > 0
+                  ? field.state.meta.errors[0]
+                  : undefined
+              }
+              className="mb-4"
+            >
+              {({ id, describedById, invalid }) => (
+                <Input
+                  id={id}
+                  name={field.name}
+                  aria-describedby={describedById}
+                  invalid={invalid}
+                  placeholder={t("classes.form.termPlaceholder")}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )}
-            </>
+            </FormField>
           )}
         </form.Field>
 
@@ -268,11 +254,10 @@ const CreateClassroomForm = ({
                             {t("classes.form.accessKey")}
                           </label>
                           <div className="flex gap-2">
-                            <input
+                            <Input
                               id={secretField.name}
                               name={secretField.name}
-                              type="text"
-                              className="input w-full font-mono"
+                              className="font-mono"
                               placeholder={t(
                                 "classes.form.accessKeyPlaceholder",
                               )}
@@ -282,9 +267,8 @@ const CreateClassroomForm = ({
                                 secretField.handleChange(e.target.value)
                               }
                             />
-                            <button
-                              type="button"
-                              className="btn btn-ghost"
+                            <Button
+                              variant="ghost"
                               onClick={() =>
                                 secretField.handleChange(
                                   generateSecret(DEFAULT_SECRET_LENGTH),
@@ -292,7 +276,7 @@ const CreateClassroomForm = ({
                               }
                             >
                               {t("classes.form.regenerate")}
-                            </button>
+                            </Button>
                           </div>
                           <p className="mt-1 text-xs text-base-content/70">
                             {t("classes.form.accessKeyHelp", {
@@ -314,7 +298,7 @@ const CreateClassroomForm = ({
           )}
         </form.Field>
 
-        <div className="card-actions justify-end p-2">
+        <Card.Actions className="justify-end p-2">
           <form.Subscribe
             selector={(state) => [state.canSubmit, state.isSubmitting]}
           >
@@ -323,29 +307,23 @@ const CreateClassroomForm = ({
               // button never reverts to a bare disabled state.
               const busy = isSubmitting || submitted
               return (
-                <button
+                <Button
                   type="submit"
-                  className="btn btn-primary"
+                  variant="primary"
+                  loading={busy}
+                  loadingLabel={t("classes.form.creating")}
                   disabled={!canSubmit || busy}
                 >
-                  {busy ? (
-                    <>
-                      <span
-                        className="loading loading-spinner loading-sm"
-                        aria-hidden="true"
-                      />
-                      {t("classes.form.creating")}
-                    </>
-                  ) : (
-                    t("classes.form.createButton")
-                  )}
-                </button>
+                  {busy
+                    ? t("classes.form.creating")
+                    : t("classes.form.createButton")}
+                </Button>
               )
             }}
           </form.Subscribe>
-        </div>
-      </div>
-    </form>
+        </Card.Actions>
+      </Card.Body>
+    </Card>
   )
 }
 

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -17,6 +17,7 @@ import { classroomConfigTreeUrl } from "@/util/orgUrl"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { isClassroomArchived, type Classroom } from "@/types/classroom"
+import { Button, Card, FormField, Input } from "@/components/ui"
 
 export type EditClassroomFormValues = {
   name: string
@@ -48,17 +49,19 @@ const DeleteClassroomButton = ({
 
   return (
     <>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="circle"
         onClick={(e) => {
           e.stopPropagation()
           setOpen(true)
         }}
-        className="btn btn-circle btn-sm btn-ghost text-error"
+        className="text-error"
         aria-label={t("classes.deleteClassroomAria")}
       >
         <Trash2 className="size-4" aria-hidden="true" />
-      </button>
+      </Button>
 
       <ConfirmModal
         open={open}
@@ -145,13 +148,13 @@ const ArchiveClassroomButton = ({
 
   return (
     <>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={(e) => {
           e.stopPropagation()
           setOpen(true)
         }}
-        className="btn btn-sm btn-ghost"
         title={
           archived ? t("classes.unarchiveTitle") : t("classes.archiveTitle")
         }
@@ -167,7 +170,7 @@ const ArchiveClassroomButton = ({
             {t("classes.archive")}
           </>
         )}
-      </button>
+      </Button>
 
       <ConfirmModal
         open={open}
@@ -279,15 +282,17 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
   if (!org || !classroom) return null
 
   return (
-    <form
-      className="card bg-base-100 w-full shadow-sm"
+    <Card
+      as="form"
+      bordered={false}
+      className="w-full"
       onSubmit={(e) => {
         e.preventDefault()
         e.stopPropagation()
         form.handleSubmit()
       }}
     >
-      <div className="card-body">
+      <Card.Body>
         <div className="flex justify-between">
           <div className="flex items-center gap-3 pb-4">
             <h3 className="text-lg font-bold">{t("classes.form.basicInfo")}</h3>
@@ -325,88 +330,80 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
         <fieldset disabled={archived} className="m-0 min-w-0 border-0 p-0">
           <form.Field name="name">
             {(field) => (
-              <>
-                <label htmlFor={field.name} className="label font-bold">
-                  {t("classes.form.name")}
-                  <span className="text-error">*</span>
-                </label>
-
-                <input
-                  id={field.name}
-                  name={field.name}
-                  type="text"
-                  required
-                  aria-required="true"
-                  aria-invalid={field.state.meta.errors.length > 0}
-                  aria-describedby={
-                    field.state.meta.errors.length > 0
-                      ? `${field.name}-error`
-                      : undefined
-                  }
-                  className="input w-full mb-4"
-                  placeholder={t("classes.form.namePlaceholder")}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-
-                {field.state.meta.errors.length > 0 && (
-                  <p
-                    id={`${field.name}-error`}
-                    className="text-error text-sm mb-4"
-                    role="alert"
-                  >
-                    {field.state.meta.errors[0]}
-                  </p>
+              <FormField
+                label={t("classes.form.name")}
+                htmlFor={field.name}
+                required
+                error={
+                  field.state.meta.errors.length > 0
+                    ? field.state.meta.errors[0]
+                    : undefined
+                }
+                className="mb-4"
+              >
+                {({ id, describedById, invalid }) => (
+                  <Input
+                    id={id}
+                    name={field.name}
+                    required
+                    aria-required="true"
+                    aria-describedby={describedById}
+                    invalid={invalid}
+                    placeholder={t("classes.form.namePlaceholder")}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
                 )}
-              </>
+              </FormField>
             )}
           </form.Field>
 
-          <>
-            <label htmlFor="classroom-slug-display" className="label font-bold">
-              {t("classes.form.slug")}
-              <span className="text-error">*</span>
-            </label>
-
-            <input
-              id="classroom-slug-display"
-              type="text"
-              disabled
-              className="input w-full mb-4"
-              placeholder={t("classes.form.slugPlaceholder")}
-              value={classroom}
-            />
-          </>
+          <FormField
+            label={t("classes.form.slug")}
+            htmlFor="classroom-slug-display"
+            required
+            className="mb-4"
+          >
+            {({ id }) => (
+              <Input
+                id={id}
+                disabled
+                placeholder={t("classes.form.slugPlaceholder")}
+                value={classroom}
+              />
+            )}
+          </FormField>
 
           <form.Field name="term">
             {(field) => (
-              <>
-                <label htmlFor={field.name} className="label font-bold">
-                  {t("classes.form.term")}
-                </label>
-
-                <input
-                  id={field.name}
-                  name={field.name}
-                  type="text"
-                  className="input w-full mb-4"
-                  placeholder={t("classes.form.termPlaceholder")}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-
-                {field.state.meta.errors.length > 0 && (
-                  <p className="text-error text-sm mb-4" role="alert">
-                    {field.state.meta.errors[0]}
-                  </p>
+              <FormField
+                label={t("classes.form.term")}
+                htmlFor={field.name}
+                error={
+                  field.state.meta.errors.length > 0
+                    ? field.state.meta.errors[0]
+                    : undefined
+                }
+                className="mb-4"
+              >
+                {({ id, describedById, invalid }) => (
+                  <Input
+                    id={id}
+                    name={field.name}
+                    aria-describedby={describedById}
+                    invalid={invalid}
+                    placeholder={t("classes.form.termPlaceholder")}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
                 )}
-              </>
+              </FormField>
             )}
           </form.Field>
 
-          <div className="card-actions justify-end p-2">
+          <Card.Actions className="justify-end p-2">
             <form.Subscribe
               selector={(state) => [
                 state.canSubmit,
@@ -415,9 +412,11 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
               ]}
             >
               {([canSubmit, isSubmitting, isDefaultValue]) => (
-                <button
+                <Button
                   type="submit"
-                  className="btn btn-primary"
+                  variant="primary"
+                  loading={isSubmitting}
+                  loadingLabel={t("classes.form.saving")}
                   disabled={
                     !canSubmit || isSubmitting || submitted || isDefaultValue
                   }
@@ -427,24 +426,16 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
                       : undefined
                   }
                 >
-                  {isSubmitting ? (
-                    <>
-                      <span
-                        className="loading loading-spinner loading-sm"
-                        aria-hidden="true"
-                      />
-                      {t("classes.form.saving")}
-                    </>
-                  ) : (
-                    t("classes.form.saveButton")
-                  )}
-                </button>
+                  {isSubmitting
+                    ? t("classes.form.saving")
+                    : t("classes.form.saveButton")}
+                </Button>
               )}
             </form.Subscribe>
-          </div>
+          </Card.Actions>
         </fieldset>
-      </div>
-    </form>
+      </Card.Body>
+    </Card>
   )
 }
 

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useId, useRef, useState } from "react"
+import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Plus, UserMinus, X } from "lucide-react"
 
+import { Alert, Button, Modal } from "@/components/ui"
 import type { GitHubClient } from "@/hooks/github/client"
 import type { GitHubUser } from "@/hooks/github/types"
 import type { StudentCsvRow } from "@/api/mutations/students"
@@ -174,7 +175,6 @@ const BulkActionsBar = ({
   }) => void
 }) => {
   const { t } = useTranslation()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
 
   const [classroom, setClassroom] = useState("")
@@ -201,12 +201,6 @@ const BulkActionsBar = ({
     classroom || (classrooms.length > 0 ? classrooms[0].path : "")
 
   const isOpen = phase !== "idle"
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (isOpen && !dialog.open) dialog.showModal()
-    if (!isOpen && dialog.open) dialog.close()
-  }, [isOpen])
 
   const closeModal = () => {
     if (phase === "working") return
@@ -330,9 +324,10 @@ const BulkActionsBar = ({
             </select>
 
             <div className="join">
-              <button
-                type="button"
-                className="btn btn-sm btn-primary join-item"
+              <Button
+                variant="primary"
+                size="sm"
+                className="join-item"
                 disabled={!effectiveClassroom}
                 aria-label={t("orgMembers.bulk.addToClassroom", {
                   classroom: effectiveClassroom,
@@ -344,10 +339,11 @@ const BulkActionsBar = ({
               >
                 <Plus aria-hidden="true" className="size-4" />
                 {t("orgMembers.bulk.add")}
-              </button>
-              <button
-                type="button"
-                className="btn btn-sm btn-ghost join-item text-error hover:bg-error/10"
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="join-item text-error hover:bg-error/10"
                 disabled={!effectiveClassroom}
                 aria-label={t("orgMembers.bulk.removeFromClassroom", {
                   classroom: effectiveClassroom,
@@ -359,18 +355,19 @@ const BulkActionsBar = ({
               >
                 <UserMinus aria-hidden="true" className="size-4" />
                 {t("orgMembers.bulk.remove")}
-              </button>
+              </Button>
             </div>
 
-            <button
-              type="button"
-              className="btn btn-sm btn-ghost btn-square"
+            <Button
+              variant="ghost"
+              size="sm"
+              shape="square"
               aria-label={t("orgMembers.bulk.clearSelection")}
               title={t("orgMembers.bulk.clearSelection")}
               onClick={onClearSelection}
             >
               <X aria-hidden="true" className="size-4" />
-            </button>
+            </Button>
           </div>
         ) : null}
       </div>
@@ -419,114 +416,81 @@ const BulkActionsBar = ({
         onClose={() => setConfirmingAdd(false)}
       />
 
-      <dialog
-        ref={dialogRef}
-        className="modal"
+      <Modal
+        open={isOpen}
+        onClose={closeModal}
+        closeDisabled={phase === "working"}
+        size="2xl"
         aria-labelledby={titleId}
-        onCancel={(event) => {
-          if (phase === "working") {
-            event.preventDefault()
-            return
-          }
-          closeModal()
-        }}
       >
-        <div className="modal-box max-w-2xl">
-          <div className="flex items-start justify-between gap-4">
-            <h3 id={titleId} className="text-lg font-bold">
-              {action === "remove"
-                ? t("orgMembers.bulk.removeTitle", {
-                    classroom: effectiveClassroom,
-                  })
-                : t("orgMembers.bulk.addTitle", {
-                    classroom: effectiveClassroom,
-                  })}
-            </h3>
-            {phase !== "working" && (
-              <button
-                type="button"
-                className="btn btn-sm btn-circle btn-ghost"
-                aria-label={t("common.close")}
-                onClick={closeModal}
-              >
-                <X size={16} aria-hidden="true" />
-              </button>
-            )}
-          </div>
-
-          {phase === "working" && (
-            <div className="mt-6">
-              <p className="mb-2 font-medium">{progress.message}</p>
-              <progress
-                className="progress progress-primary w-full"
-                value={progress.processed}
-                max={progress.total || 1}
-              />
-              <div className="mt-2 flex justify-between text-sm opacity-70">
-                <span>
-                  {t("orgMembers.bulk.progressProcessed", {
-                    processed: progress.processed,
-                    total: progress.total,
-                  })}
-                </span>
-                <span>{progressPercent}%</span>
-              </div>
-              <div className="alert mt-6">
-                <span>{t("orgMembers.bulk.keepTabOpen")}</span>
-              </div>
-            </div>
-          )}
-
-          {phase === "complete" && result && (
-            <div className="mt-6 space-y-4">
-              <div className="alert alert-success">
-                <span>{result.headline}</span>
-              </div>
-              {result.sections.map((section) => (
-                <BulkResultSection
-                  key={section.title}
-                  title={section.title}
-                  rows={section.rows}
-                />
-              ))}
-              <div className="modal-action">
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={closeModal}
-                >
-                  {t("orgMembers.bulk.done")}
-                </button>
-              </div>
-            </div>
-          )}
-
-          {phase === "error" && (
-            <div className="mt-6">
-              <div className="alert alert-error" role="alert">
-                <span>{error ?? t("orgMembers.somethingWrong")}</span>
-              </div>
-              <div className="modal-action">
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  onClick={closeModal}
-                >
-                  {t("common.close")}
-                </button>
-              </div>
-            </div>
-          )}
+        <div className="flex items-start justify-between gap-4">
+          <h3 id={titleId} className="text-lg font-bold">
+            {action === "remove"
+              ? t("orgMembers.bulk.removeTitle", {
+                  classroom: effectiveClassroom,
+                })
+              : t("orgMembers.bulk.addTitle", {
+                  classroom: effectiveClassroom,
+                })}
+          </h3>
         </div>
 
-        {phase !== "working" && (
-          <form method="dialog" className="modal-backdrop">
-            <button type="button" onClick={closeModal}>
-              {t("common.close")}
-            </button>
-          </form>
+        {phase === "working" && (
+          <div className="mt-6">
+            <p className="mb-2 font-medium">{progress.message}</p>
+            <progress
+              className="progress progress-primary w-full"
+              value={progress.processed}
+              max={progress.total || 1}
+            />
+            <div className="mt-2 flex justify-between text-sm opacity-70">
+              <span>
+                {t("orgMembers.bulk.progressProcessed", {
+                  processed: progress.processed,
+                  total: progress.total,
+                })}
+              </span>
+              <span>{progressPercent}%</span>
+            </div>
+            <Alert tone="info" className="mt-6">
+              <span>{t("orgMembers.bulk.keepTabOpen")}</span>
+            </Alert>
+          </div>
         )}
-      </dialog>
+
+        {phase === "complete" && result && (
+          <div className="mt-6 space-y-4">
+            <Alert tone="success">
+              <span>{result.headline}</span>
+            </Alert>
+            {result.sections.map((section) => (
+              <BulkResultSection
+                key={section.title}
+                title={section.title}
+                rows={section.rows}
+              />
+            ))}
+            <div className="modal-action">
+              <Button variant="primary" onClick={closeModal}>
+                {t("orgMembers.bulk.done")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {phase === "error" && (
+          <div className="mt-6">
+            <Alert tone="error">
+              <span>{error ?? t("orgMembers.somethingWrong")}</span>
+            </Alert>
+            <div className="modal-action">
+              <Button variant="ghost" onClick={closeModal}>
+                {t("common.close")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
     </>
   )
 }

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useId, useRef, useState } from "react"
+import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "@tanstack/react-router"
 import { AlertTriangle, ChevronRight, UserPlus, X } from "lucide-react"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
+import { Button, Modal } from "@/components/ui"
 import { removeMemberFromOrg } from "@/pages/orgMembers/removeMemberFromOrg"
 import {
   ClassificationBadge,
@@ -45,19 +46,11 @@ const MemberDetailModal = ({
   const { t } = useTranslation()
   const client = useGitHubClient()
   const { notify } = useToast()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const [confirming, setConfirming] = useState(false)
   const [confirmingInvite, setConfirmingInvite] = useState(false)
   const [working, setWorking] = useState(false)
   const [inviting, setInviting] = useState(false)
-
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (open && !dialog.open) dialog.showModal()
-    if (!open && dialog.open) dialog.close()
-  }, [open])
 
   // Close and reset transient confirm/in-flight state in one place. Every close
   // path (X, backdrop, Escape via onCancel) routes here, so a reopened modal
@@ -71,9 +64,8 @@ const MemberDetailModal = ({
   }
 
   if (!row) {
-    // Keep the <dialog> mounted (so the open/close effect has a target) but
-    // render no body with no member selected.
-    return <dialog ref={dialogRef} className="modal" aria-hidden />
+    // No selected member: render nothing (the modal is closed in this state).
+    return <Modal open={open} onClose={handleClose} aria-labelledby={titleId} />
   }
 
   const label = row.username || row.email
@@ -133,243 +125,223 @@ const MemberDetailModal = ({
   }
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
+    <Modal
+      open={open}
+      onClose={handleClose}
+      closeDisabled={working}
+      hideCloseButton
+      size="lg"
+      boxClassName="p-0"
       aria-labelledby={titleId}
-      onCancel={(event) => {
-        // Block Escape while a remove is in flight.
-        if (working) {
-          event.preventDefault()
-          return
-        }
-        handleClose()
-      }}
     >
-      <div className="modal-box max-w-lg p-0">
-        <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
-          <h2 id={titleId} className="text-lg font-bold">
-            {t("orgMembers.detailTitle")}
-          </h2>
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm btn-square"
-            onClick={handleClose}
-            disabled={working}
-            aria-label={t("common.close")}
-          >
-            <X aria-hidden="true" className="size-4" />
-          </button>
-        </div>
-
-        <div className="flex flex-col gap-4 px-6 py-5">
-          <MemberDetailHeader row={row} org={org} />
-
-          <div className="flex flex-wrap items-center gap-2">
-            <ClassificationBadge row={row} isOwner={isOwner} />
-            {row.email ? (
-              <span className="text-sm text-base-content/70">{row.email}</span>
-            ) : null}
-          </div>
-
-          <div>
-            <h3 className="mb-2 text-sm font-semibold">
-              {t("orgMembers.classroomAccess")}
-            </h3>
-            {row.classrooms.length === 0 ? (
-              <p className="text-sm text-base-content/70">
-                {t("orgMembers.noRoster")}
-              </p>
-            ) : (
-              <ul className="divide-y divide-base-300 rounded-box border border-base-300">
-                {row.classrooms.map((access) => (
-                  <Link
-                    key={access.classroom}
-                    to="/$org/$classroom"
-                    params={{ org, classroom: access.classroom }}
-                    onClick={onClose}
-                    className="group/cls flex items-center justify-between px-3 py-2 text-sm first:rounded-t-box last:rounded-b-box cursor-pointer transition-[background-color,transform,box-shadow] duration-150 ease-out hover:bg-base-200 hover:-translate-y-px hover:shadow-sm motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-none"
-                  >
-                    <span className="font-medium">
-                      {access.classroom}
-                      {access.archived ? (
-                        <span className="badge badge-xs badge-ghost ml-2">
-                          {t("orgMembers.archived")}
-                        </span>
-                      ) : null}
-                      {access.state === "unprovisioned" && !access.archived ? (
-                        <span
-                          className="badge badge-xs badge-warning badge-soft ml-2 gap-1"
-                          title={t("orgMembers.unprovisionedAccessTitle")}
-                        >
-                          <AlertTriangle
-                            aria-hidden="true"
-                            className="size-2.5"
-                          />
-                          {t("orgMembers.unprovisionedAccessBadge")}
-                        </span>
-                      ) : null}
-                    </span>
-                    <span className="flex items-center gap-2 text-base-content/70">
-                      {access.section ? (
-                        <span className="badge badge-xs badge-ghost">
-                          {access.section}
-                        </span>
-                      ) : null}
-                      <ChevronRight
-                        aria-hidden="true"
-                        className="size-4 text-base-content/30 transition-transform duration-150 group-hover/cls:translate-x-0.5 group-hover/cls:text-base-content/70"
-                      />
-                    </span>
-                  </Link>
-                ))}
-              </ul>
-            )}
-          </div>
-
-          {isSelf ? (
-            <div className="rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
-              {t("orgMembers.selfNotice")}
-            </div>
-          ) : !row.isMember ? (
-            row.github_id ? (
-              <div className="rounded-box border border-warning/30 bg-warning/5 p-4 text-sm">
-                <p className="text-base-content/80">
-                  {t("orgMembers.notMemberPrefix", { label })}{" "}
-                  <span className="font-semibold">
-                    {t("orgMembers.notMemberEmphasis")}
-                  </span>
-                  {t("orgMembers.notMemberSuffix")}
-                </p>
-                <button
-                  type="button"
-                  className="btn btn-primary btn-sm mt-3"
-                  disabled={inviting}
-                  hidden={confirmingInvite}
-                  onClick={() => setConfirmingInvite(true)}
-                >
-                  <UserPlus aria-hidden="true" className="size-4" />
-                  {t("orgMembers.inviteToOrg")}
-                </button>
-                {confirmingInvite ? (
-                  <div className="mt-3 flex flex-col gap-3 border-t border-warning/30 pt-3">
-                    <p className="text-base-content/80">
-                      {t("orgMembers.confirmInviteBody", { label, org })}
-                    </p>
-                    <div className="flex justify-end gap-2">
-                      <button
-                        type="button"
-                        className="btn btn-ghost btn-sm"
-                        disabled={inviting}
-                        onClick={() => setConfirmingInvite(false)}
-                      >
-                        {t("common.cancel")}
-                      </button>
-                      <button
-                        type="button"
-                        className="btn btn-primary btn-sm"
-                        disabled={inviting}
-                        onClick={() => void handleInvite()}
-                      >
-                        {inviting ? (
-                          <>
-                            <span
-                              className="loading loading-spinner loading-xs"
-                              aria-hidden="true"
-                            />
-                            {t("orgMembers.inviting")}
-                          </>
-                        ) : (
-                          <>
-                            <UserPlus aria-hidden="true" className="size-4" />
-                            {t("orgMembers.inviteToOrg")}
-                          </>
-                        )}
-                      </button>
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            ) : (
-              <div className="rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
-                {t("orgMembers.notMemberNoId")}
-              </div>
-            )
-          ) : confirming ? (
-            <div className="rounded-box border border-error/30 bg-error/5 p-4 text-sm">
-              <p className="text-base-content/80">
-                {activeClassrooms.length > 0 ? (
-                  <>
-                    {t("orgMembers.confirmUnenrollPrefix", { label })}{" "}
-                    <span className="font-semibold">
-                      {t("orgMembers.confirmClassroomCount", {
-                        count: activeClassrooms.length,
-                      })}
-                    </span>{" "}
-                    {t("orgMembers.confirmUnenrollMid", {
-                      classrooms: activeClassrooms
-                        .map((c) => c.classroom)
-                        .join(", "),
-                    })}{" "}
-                    <span className="font-semibold">{org}</span>{" "}
-                    {t("orgMembers.confirmUnenrollSuffix")}
-                  </>
-                ) : (
-                  <>
-                    {t("orgMembers.confirmRemovePrefix", { label })}{" "}
-                    <span className="font-semibold">{org}</span>{" "}
-                    {t("orgMembers.confirmRemoveSuffix")}
-                  </>
-                )}
-              </p>
-              <div className="mt-3 flex justify-end gap-2">
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-sm"
-                  disabled={working}
-                  onClick={() => setConfirming(false)}
-                >
-                  {t("common.cancel")}
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-error btn-sm"
-                  disabled={working}
-                  onClick={() => void handleRemove()}
-                >
-                  {working ? (
-                    <>
-                      <span
-                        className="loading loading-spinner loading-xs"
-                        aria-hidden="true"
-                      />
-                      {t("orgMembers.removing")}
-                    </>
-                  ) : (
-                    t("orgMembers.removeFromOrg")
-                  )}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button
-              type="button"
-              className="btn btn-error btn-outline btn-sm self-start"
-              onClick={() => setConfirming(true)}
-            >
-              {t("orgMembers.removeFromOrg")}
-            </button>
-          )}
-        </div>
+      <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
+        <h2 id={titleId} className="text-lg font-bold">
+          {t("orgMembers.detailTitle")}
+        </h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          shape="square"
+          onClick={handleClose}
+          disabled={working}
+          aria-label={t("common.close")}
+        >
+          <X aria-hidden="true" className="size-4" />
+        </Button>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        {/* Backdrop click closes; disabled mid-remove. */}
-        <button type="button" onClick={handleClose} disabled={working}>
-          {t("common.close")}
-        </button>
-      </form>
-    </dialog>
+      <div className="flex flex-col gap-4 px-6 py-5">
+        <MemberDetailHeader row={row} org={org} />
+
+        <div className="flex flex-wrap items-center gap-2">
+          <ClassificationBadge row={row} isOwner={isOwner} />
+          {row.email ? (
+            <span className="text-sm text-base-content/70">{row.email}</span>
+          ) : null}
+        </div>
+
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">
+            {t("orgMembers.classroomAccess")}
+          </h3>
+          {row.classrooms.length === 0 ? (
+            <p className="text-sm text-base-content/70">
+              {t("orgMembers.noRoster")}
+            </p>
+          ) : (
+            <ul className="divide-y divide-base-300 rounded-box border border-base-300">
+              {row.classrooms.map((access) => (
+                <Link
+                  key={access.classroom}
+                  to="/$org/$classroom"
+                  params={{ org, classroom: access.classroom }}
+                  onClick={onClose}
+                  className="group/cls flex items-center justify-between px-3 py-2 text-sm first:rounded-t-box last:rounded-b-box cursor-pointer transition-[background-color,transform,box-shadow] duration-150 ease-out hover:bg-base-200 hover:-translate-y-px hover:shadow-sm motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-none"
+                >
+                  <span className="font-medium">
+                    {access.classroom}
+                    {access.archived ? (
+                      <span className="badge badge-xs badge-ghost ml-2">
+                        {t("orgMembers.archived")}
+                      </span>
+                    ) : null}
+                    {access.state === "unprovisioned" && !access.archived ? (
+                      <span
+                        className="badge badge-xs badge-warning badge-soft ml-2 gap-1"
+                        title={t("orgMembers.unprovisionedAccessTitle")}
+                      >
+                        <AlertTriangle
+                          aria-hidden="true"
+                          className="size-2.5"
+                        />
+                        {t("orgMembers.unprovisionedAccessBadge")}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="flex items-center gap-2 text-base-content/70">
+                    {access.section ? (
+                      <span className="badge badge-xs badge-ghost">
+                        {access.section}
+                      </span>
+                    ) : null}
+                    <ChevronRight
+                      aria-hidden="true"
+                      className="size-4 text-base-content/30 transition-transform duration-150 group-hover/cls:translate-x-0.5 group-hover/cls:text-base-content/70"
+                    />
+                  </span>
+                </Link>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {isSelf ? (
+          <div className="rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+            {t("orgMembers.selfNotice")}
+          </div>
+        ) : !row.isMember ? (
+          row.github_id ? (
+            <div className="rounded-box border border-warning/30 bg-warning/5 p-4 text-sm">
+              <p className="text-base-content/80">
+                {t("orgMembers.notMemberPrefix", { label })}{" "}
+                <span className="font-semibold">
+                  {t("orgMembers.notMemberEmphasis")}
+                </span>
+                {t("orgMembers.notMemberSuffix")}
+              </p>
+              <Button
+                variant="primary"
+                size="sm"
+                className="mt-3"
+                disabled={inviting}
+                hidden={confirmingInvite}
+                onClick={() => setConfirmingInvite(true)}
+              >
+                <UserPlus aria-hidden="true" className="size-4" />
+                {t("orgMembers.inviteToOrg")}
+              </Button>
+              {confirmingInvite ? (
+                <div className="mt-3 flex flex-col gap-3 border-t border-warning/30 pt-3">
+                  <p className="text-base-content/80">
+                    {t("orgMembers.confirmInviteBody", { label, org })}
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={inviting}
+                      onClick={() => setConfirmingInvite(false)}
+                    >
+                      {t("common.cancel")}
+                    </Button>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      loading={inviting}
+                      loadingLabel={t("orgMembers.inviting")}
+                      disabled={inviting}
+                      onClick={() => void handleInvite()}
+                    >
+                      {inviting ? (
+                        t("orgMembers.inviting")
+                      ) : (
+                        <>
+                          <UserPlus aria-hidden="true" className="size-4" />
+                          {t("orgMembers.inviteToOrg")}
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <div className="rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+              {t("orgMembers.notMemberNoId")}
+            </div>
+          )
+        ) : confirming ? (
+          <div className="rounded-box border border-error/30 bg-error/5 p-4 text-sm">
+            <p className="text-base-content/80">
+              {activeClassrooms.length > 0 ? (
+                <>
+                  {t("orgMembers.confirmUnenrollPrefix", { label })}{" "}
+                  <span className="font-semibold">
+                    {t("orgMembers.confirmClassroomCount", {
+                      count: activeClassrooms.length,
+                    })}
+                  </span>{" "}
+                  {t("orgMembers.confirmUnenrollMid", {
+                    classrooms: activeClassrooms
+                      .map((c) => c.classroom)
+                      .join(", "),
+                  })}{" "}
+                  <span className="font-semibold">{org}</span>{" "}
+                  {t("orgMembers.confirmUnenrollSuffix")}
+                </>
+              ) : (
+                <>
+                  {t("orgMembers.confirmRemovePrefix", { label })}{" "}
+                  <span className="font-semibold">{org}</span>{" "}
+                  {t("orgMembers.confirmRemoveSuffix")}
+                </>
+              )}
+            </p>
+            <div className="mt-3 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={working}
+                onClick={() => setConfirming(false)}
+              >
+                {t("common.cancel")}
+              </Button>
+              <Button
+                variant="error"
+                size="sm"
+                loading={working}
+                loadingLabel={t("orgMembers.removing")}
+                disabled={working}
+                onClick={() => void handleRemove()}
+              >
+                {working
+                  ? t("orgMembers.removing")
+                  : t("orgMembers.removeFromOrg")}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            className="btn-error self-start"
+            onClick={() => setConfirming(true)}
+          >
+            {t("orgMembers.removeFromOrg")}
+          </Button>
+        )}
+      </div>
+    </Modal>
   )
 }
 

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -12,6 +12,7 @@ import {
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { githubKeys } from "@/hooks/github/queries"
+import { Button, Spinner } from "@/components/ui"
 import PlanBadge from "@/components/PlanBadge"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import useGetOrgAudit from "@/hooks/useGetOrgAudit"
@@ -120,21 +121,15 @@ function ConcernRow({
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {showFix && (
-            <button
-              type="button"
-              className="btn btn-xs btn-primary"
+            <Button
+              variant="primary"
+              size="xs"
+              loading={fixing}
               disabled={fixing}
               onClick={() => onFix(concern.id)}
             >
-              {fixing ? (
-                <span
-                  className="loading loading-spinner loading-xs"
-                  aria-hidden="true"
-                />
-              ) : (
-                t("orgSettings.audit.fixIt")
-              )}
-            </button>
+              {fixing ? null : t("orgSettings.audit.fixIt")}
+            </Button>
           )}
           <span
             className={`badge ${CONCERN_STATE_BADGE[concern.verdict.state]}`}
@@ -381,9 +376,9 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
       }
       description={t("orgSettings.audit.description")}
       action={
-        <button
-          type="button"
-          className="btn btn-sm btn-ghost"
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={() => {
             void queryClient.invalidateQueries({
               queryKey: githubKeys.orgAuditPrefix(org),
@@ -391,15 +386,12 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
           }}
         >
           {t("orgSettings.audit.recheck")}
-        </button>
+        </Button>
       }
     >
       {isLoading && (
         <div className="flex items-center gap-2 text-sm text-base-content/70">
-          <span
-            className="loading loading-spinner loading-sm"
-            aria-hidden="true"
-          />
+          <Spinner size="sm" />
           {t("orgSettings.audit.auditing")}
         </div>
       )}

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
+import { Button } from "@/components/ui"
 import {
   initClassroom50,
   type InitStepId,
@@ -130,9 +131,11 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
       title={t("orgSettings.rerun.title")}
       description={t("orgSettings.rerun.description")}
       action={
-        <button
-          type="button"
-          className="btn btn-primary btn-sm"
+        <Button
+          variant="primary"
+          size="sm"
+          loading={mutation.isPending}
+          loadingLabel={t("orgSettings.rerun.running")}
           disabled={!isOwner || mutation.isPending}
           title={
             isOwner ? undefined : t("orgSettings.rerun.requiresOwnerTitle")
@@ -141,18 +144,10 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
             if (!mutation.isPending) void runRerun(() => mutation.mutateAsync())
           }}
         >
-          {mutation.isPending ? (
-            <>
-              <span
-                className="loading loading-spinner loading-sm"
-                aria-hidden="true"
-              />
-              {t("orgSettings.rerun.running")}
-            </>
-          ) : (
-            t("orgSettings.rerun.button")
-          )}
-        </button>
+          {mutation.isPending
+            ? t("orgSettings.rerun.running")
+            : t("orgSettings.rerun.button")}
+        </Button>
       }
     >
       {!isOwner && (

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -151,7 +151,7 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
       }
     >
       {!isOwner && (
-        <SummaryBanner tone="warning">
+        <SummaryBanner tone="error">
           {t("orgSettings.rerun.requiresOwnerNote")}
         </SummaryBanner>
       )}

--- a/web/src/pages/orgSettings/SettingsSection.tsx
+++ b/web/src/pages/orgSettings/SettingsSection.tsx
@@ -1,10 +1,13 @@
 import type { PropsWithChildren, ReactNode } from "react"
 
+import { Card } from "@/components/ui"
+
 // Standardized wrapper for each Org Settings group (Service Token, Organization
 // Policy, Re-run Setup, Danger Zone) so the page reads as consistent sections.
-// Owns the card shell and header (title + optional description, optional
-// right-aligned action, optional title adornment). `tone="danger"` styles
-// destructive groups (Danger Zone).
+// Renders the shared Card primitive (2xl radius, no shadow) as its shell, plus
+// the section header (title + optional description, optional right-aligned
+// action, optional title adornment). `tone="danger"` restyles the shell for
+// destructive groups (Danger Zone) via the error-tinted border/bg.
 const SettingsSection = ({
   title,
   description,
@@ -24,12 +27,17 @@ const SettingsSection = ({
   const isDanger = tone === "danger"
 
   return (
-    <section
+    <Card
+      as="section"
       id={id}
-      className={[
-        "scroll-mt-24 rounded-2xl border p-6",
-        isDanger ? "border-error/30 bg-error/5" : "border-base-300 bg-base-100",
-      ].join(" ")}
+      radius="2xl"
+      shadow={false}
+      bordered={!isDanger}
+      className={
+        isDanger
+          ? "scroll-mt-24 border border-error/30 bg-error/5 p-6"
+          : "scroll-mt-24 p-6"
+      }
     >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
@@ -52,7 +60,7 @@ const SettingsSection = ({
       </div>
 
       <div className="mt-4">{children}</div>
-    </section>
+    </Card>
   )
 }
 

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 import { TriangleAlert } from "lucide-react"
 
 import { ConfirmModal } from "@/components/modals"
+import { Button } from "@/components/ui"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import useGetOrgMembership from "@/hooks/useGetOrgMembership"
 import {
@@ -115,9 +116,10 @@ const TeardownSection = ({ org }: { org: string }) => {
         <CalloutText className="text-sm text-success">{done}</CalloutText>
       )}
 
-      <button
-        type="button"
-        className={`btn btn-error btn-sm ${error || done ? "mt-4" : ""}`}
+      <Button
+        variant="error"
+        size="sm"
+        className={error || done ? "mt-4" : ""}
         disabled={!isOwner || openMutation.isPending}
         title={
           isOwner ? undefined : t("orgSettings.teardown.requiresOwnerTitle")
@@ -129,7 +131,7 @@ const TeardownSection = ({ org }: { org: string }) => {
         {openMutation.isPending
           ? t("orgSettings.teardown.preparing")
           : t("orgSettings.teardown.button")}
-      </button>
+      </Button>
 
       {!isOwner && (
         <p className="mt-2 text-xs text-base-content/70">

--- a/web/src/pages/orgSettings/initStepBoard.tsx
+++ b/web/src/pages/orgSettings/initStepBoard.tsx
@@ -19,6 +19,7 @@ import {
   isOrgDefaultsStepData,
   unenforcedDefaultItems,
 } from "./orgDefaultsStepData"
+import { Spinner } from "@/components/ui"
 
 // Shared init "badge board" used by the org setup wizard (OrgSetupPage) and the
 // re-run action on Org Settings. One source of truth for step order, titles,
@@ -199,9 +200,7 @@ const STATUS_ICON: Record<InitStepStatus, ReactNode> = {
   complete: <CheckCircle aria-hidden="true" className="size-4" />,
   warning: <AlertCircle aria-hidden="true" className="size-4" />,
   error: <AlertTriangle aria-hidden="true" className="size-4" />,
-  running: (
-    <span className="loading loading-spinner size-4" aria-hidden="true" />
-  ),
+  running: <Spinner size="xs" className="size-4" />,
   pending: null,
   skipped: null,
 }

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -1,8 +1,8 @@
-import { Mail, UserRound, Users, X } from "lucide-react"
+import { Mail, UserRound, Users } from "lucide-react"
 import GitHub from "@/assets/github.svg?react"
 import { revalidateLogic, useForm } from "@tanstack/react-form"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { useEffect, useId, useRef, useState } from "react"
+import { useEffect, useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import useEnsureTeam from "@/hooks/useEnsureTeam"
 import { invalidateInviteQueries } from "@/hooks/github/queries"
@@ -22,6 +22,7 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { isValidEmail } from "@/util/orgMembership"
 import { splitName, toStudent } from "@/util/roster"
+import { Alert, Button, Modal } from "@/components/ui"
 
 type AddStudentProps = {
   org: string
@@ -49,7 +50,6 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
   const invalidateTeamRoster = useInvalidateTeamRoster(org, classroom)
   const seedTeamMember = useSeedTeamMember(org, classroom)
   const { t } = useTranslation()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const [warning, setWarning] = useState("")
   const [success, setSuccess] = useState("")
@@ -185,17 +185,13 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
 
   const submitting = form.state.isSubmitting
 
-  // Drive the native dialog from `open`; reset transient state on open.
+  // Reset transient state whenever the modal opens (Modal owns the open/close
+  // sync now).
   useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (open && !dialog.open) {
-      setWarning("")
-      setSuccess("")
-      form.reset()
-      dialog.showModal()
-    }
-    if (!open && dialog.open) dialog.close()
+    if (!open) return
+    setWarning("")
+    setSuccess("")
+    form.reset()
   }, [open, form])
 
   const closeDialog = () => {
@@ -204,213 +200,186 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
   }
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
+    <Modal
+      open={open}
+      onClose={closeDialog}
+      closeDisabled={submitting}
+      size="lg"
       aria-labelledby={titleId}
-      onCancel={(event) => {
-        if (submitting) {
-          event.preventDefault()
-          return
-        }
-        closeDialog()
-      }}
     >
-      <div className="modal-box max-w-lg">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h3 id={titleId} className="text-lg font-bold">
-              {t("students.addTitle")}
-            </h3>
-            <p className="mt-1 text-sm text-base-content/70">
-              {t("students.addHint")}
-            </p>
-          </div>
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm btn-square"
-            aria-label={t("common.close")}
-            disabled={submitting}
-            onClick={closeDialog}
-          >
-            <X aria-hidden="true" className="size-4" />
-          </button>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("students.addTitle")}
+          </h3>
+          <p className="mt-1 text-sm text-base-content/70">
+            {t("students.addHint")}
+          </p>
         </div>
-
-        <form
-          onSubmit={(e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            form.handleSubmit()
-          }}
-        >
-          {warning && (
-            <div className="alert alert-warning alert-soft mt-4 text-sm">
-              {warning}
-            </div>
-          )}
-
-          {success && (
-            <div className="alert alert-success alert-soft mt-4 text-sm">
-              {success}
-            </div>
-          )}
-
-          <div className="mt-4 flex flex-col gap-3">
-            <form.Field name="name">
-              {(field) => (
-                <label className="input input-bordered flex w-full items-center gap-2">
-                  <UserRound
-                    className="size-4 text-base-content/50"
-                    aria-hidden="true"
-                  />
-                  <input
-                    id={field.name}
-                    name={field.name}
-                    type="text"
-                    className="grow"
-                    placeholder={t("students.namePlaceholder")}
-                    aria-label={t("students.namePlaceholder")}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </label>
-              )}
-            </form.Field>
-
-            <form.Field name="username">
-              {(field) => (
-                <div>
-                  <label className="input input-bordered flex w-full items-center gap-2">
-                    <GitHub className="size-4 opacity-40" aria-hidden="true" />
-                    <input
-                      id={field.name}
-                      name={field.name}
-                      type="text"
-                      className="grow"
-                      placeholder={t("students.usernamePlaceholder")}
-                      aria-label={t("students.usernameAria")}
-                      aria-invalid={field.state.meta.errors.length > 0}
-                      aria-describedby={
-                        field.state.meta.errors.length > 0
-                          ? `${field.name}-error`
-                          : undefined
-                      }
-                      value={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                    />
-                  </label>
-                  {field.state.meta.errors.length > 0 && (
-                    <p
-                      id={`${field.name}-error`}
-                      className="text-error text-sm mt-1"
-                      role="alert"
-                    >
-                      {String(field.state.meta.errors[0] ?? "")}
-                    </p>
-                  )}
-                </div>
-              )}
-            </form.Field>
-
-            <form.Field name="email">
-              {(field) => (
-                <div>
-                  <label className="input input-bordered flex w-full items-center gap-2">
-                    <Mail
-                      className="size-4 text-base-content/50"
-                      aria-hidden="true"
-                    />
-                    <input
-                      id={field.name}
-                      name={field.name}
-                      type="email"
-                      className="grow"
-                      placeholder={t("students.emailPlaceholder")}
-                      aria-label={t("students.emailAria")}
-                      aria-invalid={field.state.meta.errors.length > 0}
-                      aria-describedby={
-                        field.state.meta.errors.length > 0
-                          ? `${field.name}-error`
-                          : undefined
-                      }
-                      value={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                    />
-                  </label>
-                  {field.state.meta.errors.length > 0 && (
-                    <p
-                      id={`${field.name}-error`}
-                      className="text-error text-sm mt-1"
-                      role="alert"
-                    >
-                      {String(field.state.meta.errors[0] ?? "")}
-                    </p>
-                  )}
-                </div>
-              )}
-            </form.Field>
-
-            <form.Field name="section">
-              {(field) => (
-                <label className="input input-bordered flex w-full items-center gap-2">
-                  <Users
-                    className="size-4 text-base-content/50"
-                    aria-hidden="true"
-                  />
-                  <input
-                    id={field.name}
-                    name={field.name}
-                    type="text"
-                    className="grow"
-                    placeholder={t("students.sectionPlaceholder")}
-                    aria-label={t("students.sectionAria")}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </label>
-              )}
-            </form.Field>
-          </div>
-
-          <div className="modal-action">
-            <button
-              type="button"
-              className="btn btn-ghost"
-              disabled={submitting}
-              onClick={closeDialog}
-            >
-              {t("common.close")}
-            </button>
-            <form.Subscribe
-              selector={(state) => [state.canSubmit, state.isSubmitting]}
-            >
-              {([canSubmit, isSubmitting]) => (
-                <button
-                  type="submit"
-                  disabled={!canSubmit || isSubmitting || !team}
-                  className="btn btn-primary"
-                >
-                  {!isSubmitting
-                    ? t("students.addButton")
-                    : t("students.submitting")}
-                </button>
-              )}
-            </form.Subscribe>
-          </div>
-        </form>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        <button type="button" disabled={submitting} onClick={closeDialog}>
-          {t("common.close")}
-        </button>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          form.handleSubmit()
+        }}
+      >
+        {warning && (
+          <Alert tone="warning" className="mt-4 text-sm">
+            {warning}
+          </Alert>
+        )}
+
+        {success && (
+          <Alert tone="success" className="mt-4 text-sm">
+            {success}
+          </Alert>
+        )}
+
+        <div className="mt-4 flex flex-col gap-3">
+          <form.Field name="name">
+            {(field) => (
+              <label className="input input-bordered flex w-full items-center gap-2">
+                <UserRound
+                  className="size-4 text-base-content/50"
+                  aria-hidden="true"
+                />
+                <input
+                  id={field.name}
+                  name={field.name}
+                  type="text"
+                  className="grow"
+                  placeholder={t("students.namePlaceholder")}
+                  aria-label={t("students.namePlaceholder")}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
+              </label>
+            )}
+          </form.Field>
+
+          <form.Field name="username">
+            {(field) => (
+              <div>
+                <label className="input input-bordered flex w-full items-center gap-2">
+                  <GitHub className="size-4 opacity-40" aria-hidden="true" />
+                  <input
+                    id={field.name}
+                    name={field.name}
+                    type="text"
+                    className="grow"
+                    placeholder={t("students.usernamePlaceholder")}
+                    aria-label={t("students.usernameAria")}
+                    aria-invalid={field.state.meta.errors.length > 0}
+                    aria-describedby={
+                      field.state.meta.errors.length > 0
+                        ? `${field.name}-error`
+                        : undefined
+                    }
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
+                </label>
+                {field.state.meta.errors.length > 0 && (
+                  <p
+                    id={`${field.name}-error`}
+                    className="text-error text-sm mt-1"
+                    role="alert"
+                  >
+                    {String(field.state.meta.errors[0] ?? "")}
+                  </p>
+                )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="email">
+            {(field) => (
+              <div>
+                <label className="input input-bordered flex w-full items-center gap-2">
+                  <Mail
+                    className="size-4 text-base-content/50"
+                    aria-hidden="true"
+                  />
+                  <input
+                    id={field.name}
+                    name={field.name}
+                    type="email"
+                    className="grow"
+                    placeholder={t("students.emailPlaceholder")}
+                    aria-label={t("students.emailAria")}
+                    aria-invalid={field.state.meta.errors.length > 0}
+                    aria-describedby={
+                      field.state.meta.errors.length > 0
+                        ? `${field.name}-error`
+                        : undefined
+                    }
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
+                </label>
+                {field.state.meta.errors.length > 0 && (
+                  <p
+                    id={`${field.name}-error`}
+                    className="text-error text-sm mt-1"
+                    role="alert"
+                  >
+                    {String(field.state.meta.errors[0] ?? "")}
+                  </p>
+                )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="section">
+            {(field) => (
+              <label className="input input-bordered flex w-full items-center gap-2">
+                <Users
+                  className="size-4 text-base-content/50"
+                  aria-hidden="true"
+                />
+                <input
+                  id={field.name}
+                  name={field.name}
+                  type="text"
+                  className="grow"
+                  placeholder={t("students.sectionPlaceholder")}
+                  aria-label={t("students.sectionAria")}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
+              </label>
+            )}
+          </form.Field>
+        </div>
+
+        <div className="modal-action">
+          <Button variant="ghost" disabled={submitting} onClick={closeDialog}>
+            {t("common.close")}
+          </Button>
+          <form.Subscribe
+            selector={(state) => [state.canSubmit, state.isSubmitting]}
+          >
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                type="submit"
+                disabled={!canSubmit || isSubmitting || !team}
+                variant="primary"
+              >
+                {!isSubmitting
+                  ? t("students.addButton")
+                  : t("students.submitting")}
+              </Button>
+            )}
+          </form.Subscribe>
+        </div>
       </form>
-    </dialog>
+    </Modal>
   )
 }
 

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -12,6 +12,7 @@ import { isValidEmail } from "@/util/orgMembership"
 import { studentKey } from "@/util/roster"
 import type { Student } from "@/types/classroom"
 import type { StudentCsvRow } from "@/api/mutations/students"
+import { Alert, Button, Input } from "@/components/ui"
 
 export type EditStudentFormValues = {
   first_name: string
@@ -140,13 +141,11 @@ const EditStudentForm = ({
                 className="mr-2 text-base-content/70"
                 aria-hidden="true"
               />
-              <input
+              <Input
                 id={field.name}
                 name={field.name}
-                type="text"
                 placeholder={t("students.firstNamePlaceholder")}
                 aria-label={t("students.firstNamePlaceholder")}
-                className="input w-full"
                 value={field.state.value}
                 onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(e.target.value)}
@@ -162,13 +161,11 @@ const EditStudentForm = ({
                 className="mr-2 text-base-content/70"
                 aria-hidden="true"
               />
-              <input
+              <Input
                 id={field.name}
                 name={field.name}
-                type="text"
                 placeholder={t("students.lastNamePlaceholder")}
                 aria-label={t("students.lastNamePlaceholder")}
-                className="input w-full"
                 value={field.state.value}
                 onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(e.target.value)}
@@ -186,19 +183,18 @@ const EditStudentForm = ({
                     className="size-6 mr-2 text-base-content/70"
                     aria-hidden="true"
                   />
-                  <input
+                  <Input
                     id={field.name}
                     name={field.name}
                     type="email"
                     placeholder={t("students.editEmailPlaceholder")}
                     aria-label={t("students.emailLabel")}
-                    aria-invalid={field.state.meta.errors.length > 0}
+                    invalid={field.state.meta.errors.length > 0}
                     aria-describedby={
                       field.state.meta.errors.length > 0
                         ? `${field.name}-error`
                         : undefined
                     }
-                    className="input w-full"
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={(e) => field.handleChange(e.target.value)}
@@ -222,13 +218,11 @@ const EditStudentForm = ({
           {(field) => (
             <div className="flex items-center">
               <Users className="mr-2 text-base-content/70" aria-hidden="true" />
-              <input
+              <Input
                 id={field.name}
                 name={field.name}
-                type="text"
                 placeholder={t("students.editSectionPlaceholder")}
                 aria-label={t("students.sectionLabel")}
-                className="input w-full"
                 value={field.state.value}
                 onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(e.target.value)}
@@ -252,39 +246,28 @@ const EditStudentForm = ({
       </div>
 
       {error ? (
-        <div className="alert alert-error alert-soft mt-4 text-sm">{error}</div>
+        <Alert tone="error" className="mt-4 text-sm">
+          {error}
+        </Alert>
       ) : null}
 
       <div className="modal-action">
-        <button
-          type="button"
-          className="btn btn-ghost"
-          disabled={submitting}
-          onClick={onCancel}
-        >
+        <Button variant="ghost" disabled={submitting} onClick={onCancel}>
           {t("common.cancel")}
-        </button>
+        </Button>
         <form.Subscribe
           selector={(state) => [state.canSubmit, state.isSubmitting]}
         >
           {([canSubmit, isSubmitting]) => (
-            <button
+            <Button
               type="submit"
-              className="btn btn-primary"
+              variant="primary"
+              loading={isSubmitting}
+              loadingLabel={t("students.saving")}
               disabled={!canSubmit || isSubmitting}
             >
-              {isSubmitting ? (
-                <>
-                  <span
-                    className="loading loading-spinner loading-sm"
-                    aria-hidden="true"
-                  />
-                  {t("students.saving")}
-                </>
-              ) : (
-                t("students.saveChanges")
-              )}
-            </button>
+              {isSubmitting ? t("students.saving") : t("students.saveChanges")}
+            </Button>
           )}
         </form.Subscribe>
       </div>

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 
 import { nameFromParts } from "@/util/students"
+import { Alert, Button, Card, Spinner } from "@/components/ui"
 import Avatar from "@/components/avatar"
 import type { Student } from "@/types/classroom"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -485,13 +486,13 @@ const EnrolledStudents = ({
                 className="alert alert-warning alert-soft overflow-hidden"
               >
                 <span className="text-sm">{warning}</span>
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-xs"
+                <Button
+                  variant="ghost"
+                  size="xs"
                   onClick={() => dismissWarning(key)}
                 >
                   {t("students.dismiss")}
-                </button>
+                </Button>
               </motion.div>
             ))}
           </AnimatePresence>
@@ -502,35 +503,36 @@ const EnrolledStudents = ({
           not_in_org rather than expanding an inline list. Dismissable for the
           session; a refresh re-derives and shows it again. */}
       {!isLoading && !isError && !driftDismissed && notInOrg.length > 0 ? (
-        <div
-          role="alert"
-          className="alert alert-warning alert-soft flex items-center justify-between gap-3"
+        <Alert
+          tone="warning"
+          className="flex items-center justify-between gap-3"
         >
           <span className="flex items-center gap-2 text-sm">
             <AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
             {t("students.driftBanner", { count: notInOrg.length })}
           </span>
           <div className="flex shrink-0 items-center gap-1">
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs"
+            <Button
+              variant="ghost"
+              size="xs"
               onClick={() => {
                 setStatusFilter("not_in_org")
               }}
             >
               {t("students.driftReview")}
-            </button>
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs btn-square"
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              shape="square"
               aria-label={t("students.dismiss")}
               title={t("students.dismiss")}
               onClick={() => setDriftDismissed(true)}
             >
               <X aria-hidden="true" className="size-4" />
-            </button>
+            </Button>
           </div>
-        </div>
+        </Alert>
       ) : null}
 
       {/* Pending-invites banner: clicking "Review" filters to pending so the
@@ -541,40 +543,38 @@ const EnrolledStudents = ({
       !pendingHidden &&
       !pendingDismissed &&
       counts.pending > 0 ? (
-        <div
-          role="alert"
-          className="alert alert-info alert-soft flex items-center justify-between gap-3"
-        >
+        <Alert tone="info" className="flex items-center justify-between gap-3">
           <span className="flex items-center gap-2 text-sm">
             <Send aria-hidden="true" className="size-4 shrink-0" />
             {t("students.pendingBanner", { count: counts.pending })}
           </span>
           <div className="flex shrink-0 items-center gap-1">
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs"
+            <Button
+              variant="ghost"
+              size="xs"
               onClick={() => setStatusFilter("pending")}
             >
               {t("students.pendingReview")}
-            </button>
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs btn-square"
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              shape="square"
               aria-label={t("students.dismiss")}
               title={t("students.dismiss")}
               onClick={() => setPendingDismissed(true)}
             >
               <X aria-hidden="true" className="size-4" />
-            </button>
+            </Button>
           </div>
-        </div>
+        </Alert>
       ) : null}
 
       {/* Non-owner: pending invites are owner-only. */}
       {!isLoading && !isError && pendingHidden ? (
-        <div role="alert" className="alert alert-info alert-soft">
+        <Alert tone="info">
           <span className="text-sm">{t("students.pendingOwnerOnly")}</span>
-        </div>
+        </Alert>
       ) : null}
 
       {/* Toolbar: search + status filter (group-by-section lives in the table
@@ -620,9 +620,10 @@ const EnrolledStudents = ({
             </select>
           ) : null}
           {syncMutation.isPending || csvMissingCount > 0 ? (
-            <button
-              type="button"
-              className="btn btn-ghost btn-sm btn-square"
+            <Button
+              variant="ghost"
+              size="sm"
+              shape="square"
               disabled={syncMutation.isPending}
               onClick={() => {
                 // Explicit backfill: clear any post-unenroll suppression so the
@@ -637,19 +638,16 @@ const EnrolledStudents = ({
                 aria-hidden="true"
                 className={`size-4 ${syncMutation.isPending ? "animate-spin" : ""}`}
               />
-            </button>
+            </Button>
           ) : null}
         </div>
       ) : null}
 
       {/* The list card. */}
-      <div className="card card-border w-full overflow-hidden bg-base-100 shadow-sm">
+      <Card className="w-full overflow-hidden">
         {isLoading ? (
           <div className="flex items-center justify-center gap-3 px-6 py-12 text-base-content/70">
-            <span
-              className="loading loading-spinner loading-md"
-              aria-hidden="true"
-            />
+            <Spinner size="md" />
             <span className="text-sm">{t("students.loadingRoster")}</span>
           </div>
         ) : isError ? (
@@ -661,9 +659,9 @@ const EnrolledStudents = ({
               <AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
               {t("students.rosterLoadError")}
             </span>
-            <button
-              type="button"
-              className="btn btn-sm btn-ghost"
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() =>
                 void queryClient.invalidateQueries({
                   queryKey: githubKeys.teamMembers(org, teamSlug),
@@ -672,7 +670,7 @@ const EnrolledStudents = ({
             >
               <RefreshCw aria-hidden="true" className="size-4" />
               {t("students.rosterRetry")}
-            </button>
+            </Button>
           </div>
         ) : isEmpty ? (
           <div className="px-6 py-12 text-center">
@@ -684,30 +682,22 @@ const EnrolledStudents = ({
             </p>
             {addActions ? (
               <div className="mt-4 flex justify-center gap-2">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-primary"
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={addActions.onAddStudent}
                 >
                   <Plus aria-hidden="true" className="size-4" />
                   {t("students.addTitle")}
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-sm"
-                  onClick={addActions.onUploadRoster}
-                >
+                </Button>
+                <Button size="sm" onClick={addActions.onUploadRoster}>
                   <Upload aria-hidden="true" className="size-4" />
                   {t("students.uploadRosterTitle")}
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-sm"
-                  onClick={addActions.onInviteLinks}
-                >
+                </Button>
+                <Button size="sm" onClick={addActions.onInviteLinks}>
                   <Send aria-hidden="true" className="size-4" />
                   {t("students.inviteStudents")}
-                </button>
+                </Button>
               </div>
             ) : null}
           </div>
@@ -783,7 +773,7 @@ const EnrolledStudents = ({
             )}
           </>
         )}
-      </div>
+      </Card>
 
       <RosterMemberModal
         open={Boolean(selected)}

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -572,7 +572,7 @@ const EnrolledStudents = ({
 
       {/* Non-owner: pending invites are owner-only. */}
       {!isLoading && !isError && pendingHidden ? (
-        <Alert tone="info">
+        <Alert tone="error">
           <span className="text-sm">{t("students.pendingOwnerOnly")}</span>
         </Alert>
       ) : null}

--- a/web/src/pages/students/InviteLinksModal.tsx
+++ b/web/src/pages/students/InviteLinksModal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useId, useRef } from "react"
+import { useId } from "react"
 import { useTranslation } from "react-i18next"
-import { Check, Copy, X } from "lucide-react"
+import { Check, Copy } from "lucide-react"
 
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { Button, Modal } from "@/components/ui"
 
 // A single copyable link row (read-only input + copy button).
 const CopyLinkField = ({
@@ -34,9 +35,9 @@ const CopyLinkField = ({
           onFocus={(event) => event.currentTarget.select()}
           className="input input-sm input-bordered join-item w-full font-mono text-xs"
         />
-        <button
-          type="button"
-          className="btn btn-sm join-item"
+        <Button
+          size="sm"
+          className="join-item"
           onClick={() => void copy()}
           aria-label={copyAriaLabel}
         >
@@ -51,7 +52,7 @@ const CopyLinkField = ({
               {t("students.copy")}
             </>
           )}
-        </button>
+        </Button>
       </div>
     </div>
   )
@@ -73,76 +74,47 @@ const InviteLinksModal = ({
   onClose: () => void
 }) => {
   const { t } = useTranslation()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
 
   const onboardUrl = `${window.location.origin}/${org}/${classroom}/onboard`
   const inviteUrl = `https://github.com/orgs/${org}/invitation`
 
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (open && !dialog.open) dialog.showModal()
-    if (!open && dialog.open) dialog.close()
-  }, [open])
-
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
-      aria-labelledby={titleId}
-      onCancel={onClose}
-    >
-      <div className="modal-box max-w-lg">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h3 id={titleId} className="text-lg font-bold">
-              {t("students.inviteStudents")}
-            </h3>
-            <p className="mt-1 text-sm text-base-content/70">
-              {t("students.inviteLinksHint")}
-            </p>
-          </div>
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm btn-square"
-            aria-label={t("common.close")}
-            onClick={onClose}
-          >
-            <X aria-hidden="true" className="size-4" />
-          </button>
-        </div>
-
-        <div className="mt-5 flex flex-col gap-5">
-          <CopyLinkField
-            label={t("students.onboardingLinkLabel")}
-            hint={t("students.onboardingLinkHint")}
-            url={onboardUrl}
-            ariaLabel={t("students.onboardingLinkAria")}
-            copyAriaLabel={t("students.copyOnboardingLinkAria")}
-          />
-          <CopyLinkField
-            label={t("students.nativeInviteLabel")}
-            hint={t("students.nativeInviteHint")}
-            url={inviteUrl}
-            ariaLabel={t("students.studentInviteLinkAria")}
-            copyAriaLabel={t("students.copyInviteLinkAria")}
-          />
-        </div>
-
-        <div className="modal-action">
-          <button type="button" className="btn btn-ghost" onClick={onClose}>
-            {t("common.close")}
-          </button>
+    <Modal open={open} onClose={onClose} size="lg" aria-labelledby={titleId}>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("students.inviteStudents")}
+          </h3>
+          <p className="mt-1 text-sm text-base-content/70">
+            {t("students.inviteLinksHint")}
+          </p>
         </div>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        <button type="button" onClick={onClose}>
+      <div className="mt-5 flex flex-col gap-5">
+        <CopyLinkField
+          label={t("students.onboardingLinkLabel")}
+          hint={t("students.onboardingLinkHint")}
+          url={onboardUrl}
+          ariaLabel={t("students.onboardingLinkAria")}
+          copyAriaLabel={t("students.copyOnboardingLinkAria")}
+        />
+        <CopyLinkField
+          label={t("students.nativeInviteLabel")}
+          hint={t("students.nativeInviteHint")}
+          url={inviteUrl}
+          ariaLabel={t("students.studentInviteLinkAria")}
+          copyAriaLabel={t("students.copyInviteLinkAria")}
+        />
+      </div>
+
+      <div className="modal-action">
+        <Button variant="ghost" onClick={onClose}>
           {t("common.close")}
-        </button>
-      </form>
-    </dialog>
+        </Button>
+      </div>
+    </Modal>
   )
 }
 

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useId, useRef, useState } from "react"
+import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Plus, Send, Upload, UserMinus, X } from "lucide-react"
 
 import type { GitHubClient } from "@/hooks/github/client"
 import { ConfirmModal } from "@/components/modals"
+import { Alert, Button, Modal } from "@/components/ui"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import { resendOrgInvitation, getErrorMessage } from "@/hooks/github/mutations"
 import {
@@ -123,7 +124,6 @@ const RosterBulkActionsBar = ({
   canGroupBySection?: boolean
 }) => {
   const { t } = useTranslation()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
 
   const [action, setAction] = useState<"unenroll" | "invite" | null>(null)
@@ -152,12 +152,6 @@ const RosterBulkActionsBar = ({
   ).length
 
   const isOpen = phase !== "idle"
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (isOpen && !dialog.open) dialog.showModal()
-    if (!isOpen && dialog.open) dialog.close()
-  }, [isOpen])
 
   const closeModal = () => {
     if (phase === "working") return
@@ -373,9 +367,9 @@ const RosterBulkActionsBar = ({
         {hasSelection ? (
           <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
             <div className="join">
-              <button
-                type="button"
-                className="btn btn-sm join-item"
+              <Button
+                size="sm"
+                className="join-item"
                 disabled={invitableSelected === 0}
                 title={
                   invitableSelected === 0
@@ -388,10 +382,11 @@ const RosterBulkActionsBar = ({
               >
                 <Send aria-hidden="true" className="size-4" />
                 {t("students.bulk.invite")}
-              </button>
-              <button
-                type="button"
-                className="btn btn-sm btn-ghost join-item text-error hover:bg-error/10"
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="join-item text-error hover:bg-error/10"
                 aria-label={t("students.bulk.unenrollSelected", {
                   count: selectedRows.length,
                 })}
@@ -402,48 +397,49 @@ const RosterBulkActionsBar = ({
               >
                 <UserMinus aria-hidden="true" className="size-4" />
                 {t("students.bulk.unenroll")}
-              </button>
+              </Button>
             </div>
 
-            <button
-              type="button"
-              className="btn btn-sm btn-ghost btn-square"
+            <Button
+              variant="ghost"
+              size="sm"
+              shape="square"
               aria-label={t("students.bulk.clearSelection")}
               title={t("students.bulk.clearSelection")}
               onClick={onClearSelection}
             >
               <X aria-hidden="true" className="size-4" />
-            </button>
+            </Button>
           </div>
         ) : addActions ? (
           <div className="join ml-auto">
-            <button
-              type="button"
-              className="btn btn-sm join-item"
+            <Button
+              size="sm"
+              className="join-item"
               aria-label={t("students.addTitle")}
               title={t("students.addTitle")}
               onClick={addActions.onAddStudent}
             >
               <Plus aria-hidden="true" className="size-4" />
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm join-item"
+            </Button>
+            <Button
+              size="sm"
+              className="join-item"
               aria-label={t("students.uploadRosterTitle")}
               title={t("students.uploadRosterTitle")}
               onClick={addActions.onUploadRoster}
             >
               <Upload aria-hidden="true" className="size-4" />
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm join-item"
+            </Button>
+            <Button
+              size="sm"
+              className="join-item"
               aria-label={t("students.inviteStudents")}
               title={t("students.inviteStudents")}
               onClick={addActions.onInviteLinks}
             >
               <Send aria-hidden="true" className="size-4" />
-            </button>
+            </Button>
           </div>
         ) : null}
       </div>
@@ -490,110 +486,77 @@ const RosterBulkActionsBar = ({
         onClose={() => setConfirmingInvite(false)}
       />
 
-      <dialog
-        ref={dialogRef}
-        className="modal"
+      <Modal
+        open={isOpen}
+        onClose={closeModal}
+        closeDisabled={phase === "working"}
+        size="2xl"
         aria-labelledby={titleId}
-        onCancel={(event) => {
-          if (phase === "working") {
-            event.preventDefault()
-            return
-          }
-          closeModal()
-        }}
       >
-        <div className="modal-box max-w-2xl">
-          <div className="flex items-start justify-between gap-4">
-            <h3 id={titleId} className="text-lg font-bold">
-              {action === "invite"
-                ? t("students.bulk.inviteTitle")
-                : t("students.bulk.unenrollTitle")}
-            </h3>
-            {phase !== "working" && (
-              <button
-                type="button"
-                className="btn btn-sm btn-circle btn-ghost"
-                aria-label={t("common.close")}
-                onClick={closeModal}
-              >
-                <X size={16} aria-hidden="true" />
-              </button>
-            )}
-          </div>
-
-          {phase === "working" && (
-            <div className="mt-6">
-              <p className="mb-2 font-medium">{progress.message}</p>
-              <progress
-                className="progress progress-primary w-full"
-                value={progress.processed}
-                max={progress.total || 1}
-              />
-              <div className="mt-2 flex justify-between text-sm opacity-70">
-                <span>
-                  {t("students.bulk.progressProcessed", {
-                    processed: progress.processed,
-                    total: progress.total,
-                  })}
-                </span>
-                <span>{progressPercent}%</span>
-              </div>
-              <div className="alert mt-6">
-                <span>{t("students.bulk.keepTabOpen")}</span>
-              </div>
-            </div>
-          )}
-
-          {phase === "complete" && result && (
-            <div className="mt-6 space-y-4">
-              <div className="alert alert-success">
-                <span>{result.headline}</span>
-              </div>
-              {result.sections.map((section) => (
-                <BulkResultSection
-                  key={section.title}
-                  title={section.title}
-                  rows={section.rows}
-                />
-              ))}
-              <div className="modal-action">
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={closeModal}
-                >
-                  {t("students.bulk.done")}
-                </button>
-              </div>
-            </div>
-          )}
-
-          {phase === "error" && (
-            <div className="mt-6">
-              <div className="alert alert-error" role="alert">
-                <span>{error ?? t("students.somethingWentWrong")}</span>
-              </div>
-              <div className="modal-action">
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  onClick={closeModal}
-                >
-                  {t("common.close")}
-                </button>
-              </div>
-            </div>
-          )}
+        <div className="flex items-start justify-between gap-4">
+          <h3 id={titleId} className="text-lg font-bold">
+            {action === "invite"
+              ? t("students.bulk.inviteTitle")
+              : t("students.bulk.unenrollTitle")}
+          </h3>
         </div>
 
-        {phase !== "working" && (
-          <form method="dialog" className="modal-backdrop">
-            <button type="button" onClick={closeModal}>
-              {t("common.close")}
-            </button>
-          </form>
+        {phase === "working" && (
+          <div className="mt-6">
+            <p className="mb-2 font-medium">{progress.message}</p>
+            <progress
+              className="progress progress-primary w-full"
+              value={progress.processed}
+              max={progress.total || 1}
+            />
+            <div className="mt-2 flex justify-between text-sm opacity-70">
+              <span>
+                {t("students.bulk.progressProcessed", {
+                  processed: progress.processed,
+                  total: progress.total,
+                })}
+              </span>
+              <span>{progressPercent}%</span>
+            </div>
+            <Alert tone="info" className="mt-6">
+              <span>{t("students.bulk.keepTabOpen")}</span>
+            </Alert>
+          </div>
         )}
-      </dialog>
+
+        {phase === "complete" && result && (
+          <div className="mt-6 space-y-4">
+            <Alert tone="success">
+              <span>{result.headline}</span>
+            </Alert>
+            {result.sections.map((section) => (
+              <BulkResultSection
+                key={section.title}
+                title={section.title}
+                rows={section.rows}
+              />
+            ))}
+            <div className="modal-action">
+              <Button variant="primary" onClick={closeModal}>
+                {t("students.bulk.done")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {phase === "error" && (
+          <div className="mt-6">
+            <Alert tone="error">
+              <span>{error ?? t("students.somethingWentWrong")}</span>
+            </Alert>
+            <div className="modal-action">
+              <Button variant="ghost" onClick={closeModal}>
+                {t("common.close")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
     </>
   )
 }

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "react"
+import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   ExternalLink,
@@ -24,6 +24,7 @@ import { resendOrgInvitation, getErrorMessage } from "@/hooks/github/mutations"
 import { nameFromParts, parseGitHubId } from "@/util/students"
 import { rosterRowInitials } from "@/util/memberRow"
 import { rowToStudent, type TeamRosterRow } from "@/util/teamRoster"
+import { Button, Modal } from "@/components/ui"
 
 // Roster-owned detail modal (single native <dialog>), opened by clicking a
 // roster row. Shares the identity header with the Org Members modal; everything
@@ -63,7 +64,6 @@ const RosterMemberModal = ({
 }) => {
   const { t } = useTranslation()
   const client = useGitHubClient()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const [confirmingUnenroll, setConfirmingUnenroll] = useState(false)
   const [confirmingInvite, setConfirmingInvite] = useState(false)
@@ -77,13 +77,6 @@ const RosterMemberModal = ({
     mutationFn: (student: ReturnType<typeof rowToStudent>) =>
       unenrollStudent(client, { org, classroom, student }),
   })
-
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (open && !dialog.open) dialog.showModal()
-    if (!open && dialog.open) dialog.close()
-  }, [open])
 
   // `resending` covers an in-flight invite/resend; folding it into `busy` keeps
   // the modal non-closeable (button, backdrop, Escape) while a write is pending,
@@ -102,8 +95,8 @@ const RosterMemberModal = ({
   }
 
   if (!row) {
-    // Keep the dialog mounted (target for the open/close effect) with no body.
-    return <dialog ref={dialogRef} className="modal" aria-hidden />
+    // No selected row: render nothing (the modal is closed in this state).
+    return <Modal open={open} onClose={handleClose} aria-labelledby={titleId} />
   }
 
   const student = rowToStudent(row)
@@ -218,373 +211,345 @@ const RosterMemberModal = ({
   const label = row.username || row.email
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
+    <Modal
+      open={open}
+      onClose={handleClose}
+      closeDisabled={busy}
+      hideCloseButton
+      size="lg"
+      boxClassName="p-0"
       aria-labelledby={titleId}
-      onCancel={(event) => {
-        if (busy) {
-          event.preventDefault()
-          return
-        }
-        handleClose()
-      }}
     >
-      <div className="modal-box max-w-lg p-0">
-        <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
-          <h2 id={titleId} className="text-lg font-bold">
-            {t("students.detailTitle")}
-          </h2>
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm btn-square"
-            onClick={handleClose}
-            disabled={busy}
-            aria-label={t("common.close")}
-          >
-            <X aria-hidden="true" className="size-4" />
-          </button>
-        </div>
-
-        <div className="flex flex-col gap-5 px-6 py-5">
-          {/* Identity with the enrollment actions as icons on the right — the
-              GitHub username itself links to the profile. */}
-          <div className="flex items-start justify-between gap-4">
-            <Avatar
-              name={displayName}
-              github={row.username || row.email}
-              initials={displayInitials}
-              subtitle={
-                row.username ? (
-                  <a
-                    href={`https://github.com/${row.username}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
-                  >
-                    <GitHub
-                      aria-hidden="true"
-                      className="size-3.5 opacity-70"
-                    />
-                    <span className="font-mono">@{row.username}</span>
-                    <ExternalLink aria-hidden="true" className="size-3" />
-                  </a>
-                ) : row.email ? (
-                  <span className="text-sm text-base-content/70">
-                    {row.email}
-                  </span>
-                ) : undefined
-              }
-            />
-
-            <div className="flex shrink-0 items-center gap-1">
-              {canInvite && !confirmingInvite ? (
-                <button
-                  type="button"
-                  className="btn btn-primary btn-sm"
-                  disabled={busy}
-                  onClick={() => setConfirmingInvite(true)}
-                >
-                  <UserPlus aria-hidden="true" className="size-4" />
-                  {t("students.invite")}
-                </button>
-              ) : null}
-
-              {canResend && !confirmingResend ? (
-                <button
-                  type="button"
-                  className="btn btn-sm"
-                  disabled={busy}
-                  onClick={() => setConfirmingResend(true)}
-                >
-                  <Send aria-hidden="true" className="size-4" />
-                  {t("students.resend")}
-                </button>
-              ) : null}
-
-              {!confirmingUnenroll ? (
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-sm text-error hover:bg-error/10"
-                  disabled={busy}
-                  onClick={() => setConfirmingUnenroll(true)}
-                >
-                  <UserMinus aria-hidden="true" className="size-4" />
-                  {t("students.remove")}
-                </button>
-              ) : null}
-            </div>
-          </div>
-
-          {/* Inline confirmations for the enrollment actions above. */}
-          {(canInvite && confirmingInvite) ||
-          (canResend && confirmingResend) ||
-          confirmingUnenroll ? (
-            <section className="flex flex-col gap-3">
-              {canInvite && confirmingInvite ? (
-                <div className="flex flex-col gap-3 rounded-box border border-primary/30 bg-primary/5 p-4 text-sm">
-                  <p className="text-base-content/80">
-                    {t(
-                      row.github_id
-                        ? "students.confirmInviteBody"
-                        : "students.confirmInviteBodyNoId",
-                      {
-                        label: row.username || row.email,
-                        org,
-                      },
-                    )}
-                  </p>
-                  <div className="flex justify-end gap-2">
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-sm"
-                      disabled={resending}
-                      onClick={() => setConfirmingInvite(false)}
-                    >
-                      {t("common.cancel")}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-primary btn-sm"
-                      disabled={resending}
-                      onClick={() => void handleInvite()}
-                    >
-                      {resending ? (
-                        <>
-                          <span
-                            className="loading loading-spinner loading-xs"
-                            aria-hidden="true"
-                          />
-                          {t("common.working")}
-                        </>
-                      ) : (
-                        <>
-                          <Send aria-hidden="true" className="size-4" />
-                          {t("students.sendInvite")}
-                        </>
-                      )}
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-
-              {canResend && confirmingResend ? (
-                <div className="flex flex-col gap-3 rounded-box border border-primary/30 bg-primary/5 p-4 text-sm">
-                  <p className="text-base-content/80">
-                    {t("students.confirmResendBody", {
-                      label: row.username || row.email,
-                      org,
-                    })}
-                  </p>
-                  <div className="flex justify-end gap-2">
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-sm"
-                      disabled={resending}
-                      onClick={() => setConfirmingResend(false)}
-                    >
-                      {t("common.cancel")}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-primary btn-sm"
-                      disabled={resending}
-                      onClick={() => void handleResend()}
-                    >
-                      {resending ? (
-                        <>
-                          <span
-                            className="loading loading-spinner loading-xs"
-                            aria-hidden="true"
-                          />
-                          {t("common.working")}
-                        </>
-                      ) : (
-                        <>
-                          <Send aria-hidden="true" className="size-4" />
-                          {t("students.resend")}
-                        </>
-                      )}
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-
-              {confirmingUnenroll ? (
-                <div className="flex flex-col gap-3 rounded-box border border-error/30 bg-error/5 p-4 text-sm">
-                  <p className="text-base-content/80">
-                    {t("students.unenrollBodyPrefix")}{" "}
-                    <span className="font-semibold text-base-content">
-                      {label}
-                    </span>{" "}
-                    {t("students.unenrollBodyFrom")}{" "}
-                    <span className="font-semibold text-base-content">
-                      {org}
-                    </span>{" "}
-                    {t("students.unenrollBodySuffix", { classroom })}
-                  </p>
-                  <div className="flex justify-end gap-2">
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-sm"
-                      disabled={working}
-                      onClick={() => setConfirmingUnenroll(false)}
-                    >
-                      {t("students.keepStudent")}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-error btn-sm"
-                      disabled={working}
-                      onClick={() => void handleUnenroll()}
-                    >
-                      {working ? (
-                        <>
-                          <span
-                            className="loading loading-spinner loading-xs"
-                            aria-hidden="true"
-                          />
-                          {t("common.working")}
-                        </>
-                      ) : (
-                        t("students.unenrollStudent")
-                      )}
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-            </section>
-          ) : null}
-
-          {/* GitHub & enrollment — a single read-only summary: status + the
-              classroom team. */}
-          <section className="flex flex-col gap-2">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-base-content/50">
-              {t("students.sectionGithub")}
-            </h3>
-            <div className="divide-y divide-base-300 rounded-box border border-base-300">
-              <div className="flex items-center justify-between gap-3 px-4 py-2.5">
-                <span className="text-sm text-base-content/70">
-                  {t("students.statusLabel")}
-                </span>
-                {row.state === "enrolled" ? (
-                  <span className="badge badge-sm badge-success badge-soft">
-                    {t("students.statusEnrolled")}
-                  </span>
-                ) : row.state === "pending" ? (
-                  <span className="badge badge-sm badge-warning badge-soft">
-                    {t("students.statusPending")}
-                  </span>
-                ) : (
-                  <span className="badge badge-sm badge-error badge-soft">
-                    {t("students.statusNotInOrg")}
-                  </span>
-                )}
-              </div>
-              <div className="flex items-center justify-between gap-3 px-4 py-2.5">
-                <span className="text-sm text-base-content/70">
-                  {t("students.classroomTeamLabel")}
-                </span>
-                <a
-                  href={`https://github.com/orgs/${org}/teams/${teamSlug}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 font-mono text-sm text-primary hover:underline"
-                >
-                  {teamSlug}
-                  <ExternalLink aria-hidden="true" className="size-3.5" />
-                </a>
-              </div>
-            </div>
-          </section>
-
-          {/* Profile — read-only by default with an inline Edit toggle, so the
-              teacher isn't shown every action at once. */}
-          <section className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-3">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-base-content/50">
-                {t("students.sectionProfile")}
-              </h3>
-              {canEdit && !editingProfile ? (
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-xs gap-1"
-                  onClick={() => setEditingProfile(true)}
-                >
-                  <Pencil aria-hidden="true" className="size-3.5" />
-                  {t("common.edit")}
-                </button>
-              ) : null}
-            </div>
-
-            {!canEdit ? (
-              <p className="text-sm text-base-content/70">
-                {t("students.pendingNoEdit")}
-              </p>
-            ) : editingProfile ? (
-              <EditStudentForm
-                org={org}
-                classroom={classroom}
-                student={student}
-                resetSignal={`${row.key}:${open}:${editingProfile}`}
-                onCancel={() => setEditingProfile(false)}
-                onSubmittingChange={setSubmitting}
-                onSaved={(updated) => {
-                  onSaved(row.key, updated)
-                  setEditingProfile(false)
-                }}
-                showGitHubPanel={false}
-              />
-            ) : (
-              <dl className="divide-y divide-base-300 rounded-box border border-base-300">
-                <div className="flex items-center justify-between gap-3 px-4 py-2.5">
-                  <dt className="text-sm text-base-content/70">
-                    {t("students.nameColumn")}
-                  </dt>
-                  <dd className="text-sm">
-                    {nameFromParts(row.first_name, row.last_name) || (
-                      <span className="text-base-content/40">
-                        {t("students.notSet")}
-                      </span>
-                    )}
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-3 px-4 py-2.5">
-                  <dt className="text-sm text-base-content/70">
-                    {t("students.emailColumn")}
-                  </dt>
-                  <dd className="text-sm">
-                    {row.email || (
-                      <span className="text-base-content/40">
-                        {t("students.notSet")}
-                      </span>
-                    )}
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-3 px-4 py-2.5">
-                  <dt className="text-sm text-base-content/70">
-                    {t("students.sectionColumn")}
-                  </dt>
-                  <dd className="text-sm">
-                    {row.section.trim() || (
-                      <span className="text-base-content/40">
-                        {t("students.notSet")}
-                      </span>
-                    )}
-                  </dd>
-                </div>
-              </dl>
-            )}
-          </section>
-        </div>
+      <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
+        <h2 id={titleId} className="text-lg font-bold">
+          {t("students.detailTitle")}
+        </h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          shape="square"
+          onClick={handleClose}
+          disabled={busy}
+          aria-label={t("common.close")}
+        >
+          <X aria-hidden="true" className="size-4" />
+        </Button>
       </div>
 
-      <form method="dialog" className="modal-backdrop">
-        <button type="button" onClick={handleClose} disabled={busy}>
-          {t("common.close")}
-        </button>
-      </form>
-    </dialog>
+      <div className="flex flex-col gap-5 px-6 py-5">
+        {/* Identity with the enrollment actions as icons on the right — the
+              GitHub username itself links to the profile. */}
+        <div className="flex items-start justify-between gap-4">
+          <Avatar
+            name={displayName}
+            github={row.username || row.email}
+            initials={displayInitials}
+            subtitle={
+              row.username ? (
+                <a
+                  href={`https://github.com/${row.username}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+                >
+                  <GitHub aria-hidden="true" className="size-3.5 opacity-70" />
+                  <span className="font-mono">@{row.username}</span>
+                  <ExternalLink aria-hidden="true" className="size-3" />
+                </a>
+              ) : row.email ? (
+                <span className="text-sm text-base-content/70">
+                  {row.email}
+                </span>
+              ) : undefined
+            }
+          />
+
+          <div className="flex shrink-0 items-center gap-1">
+            {canInvite && !confirmingInvite ? (
+              <Button
+                variant="primary"
+                size="sm"
+                disabled={busy}
+                onClick={() => setConfirmingInvite(true)}
+              >
+                <UserPlus aria-hidden="true" className="size-4" />
+                {t("students.invite")}
+              </Button>
+            ) : null}
+
+            {canResend && !confirmingResend ? (
+              <Button
+                size="sm"
+                disabled={busy}
+                onClick={() => setConfirmingResend(true)}
+              >
+                <Send aria-hidden="true" className="size-4" />
+                {t("students.resend")}
+              </Button>
+            ) : null}
+
+            {!confirmingUnenroll ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-error hover:bg-error/10"
+                disabled={busy}
+                onClick={() => setConfirmingUnenroll(true)}
+              >
+                <UserMinus aria-hidden="true" className="size-4" />
+                {t("students.remove")}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Inline confirmations for the enrollment actions above. */}
+        {(canInvite && confirmingInvite) ||
+        (canResend && confirmingResend) ||
+        confirmingUnenroll ? (
+          <section className="flex flex-col gap-3">
+            {canInvite && confirmingInvite ? (
+              <div className="flex flex-col gap-3 rounded-box border border-primary/30 bg-primary/5 p-4 text-sm">
+                <p className="text-base-content/80">
+                  {t(
+                    row.github_id
+                      ? "students.confirmInviteBody"
+                      : "students.confirmInviteBodyNoId",
+                    {
+                      label: row.username || row.email,
+                      org,
+                    },
+                  )}
+                </p>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={resending}
+                    onClick={() => setConfirmingInvite(false)}
+                  >
+                    {t("common.cancel")}
+                  </Button>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    loading={resending}
+                    loadingLabel={t("common.working")}
+                    disabled={resending}
+                    onClick={() => void handleInvite()}
+                  >
+                    {resending ? (
+                      t("common.working")
+                    ) : (
+                      <>
+                        <Send aria-hidden="true" className="size-4" />
+                        {t("students.sendInvite")}
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
+            {canResend && confirmingResend ? (
+              <div className="flex flex-col gap-3 rounded-box border border-primary/30 bg-primary/5 p-4 text-sm">
+                <p className="text-base-content/80">
+                  {t("students.confirmResendBody", {
+                    label: row.username || row.email,
+                    org,
+                  })}
+                </p>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={resending}
+                    onClick={() => setConfirmingResend(false)}
+                  >
+                    {t("common.cancel")}
+                  </Button>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    loading={resending}
+                    loadingLabel={t("common.working")}
+                    disabled={resending}
+                    onClick={() => void handleResend()}
+                  >
+                    {resending ? (
+                      t("common.working")
+                    ) : (
+                      <>
+                        <Send aria-hidden="true" className="size-4" />
+                        {t("students.resend")}
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
+            {confirmingUnenroll ? (
+              <div className="flex flex-col gap-3 rounded-box border border-error/30 bg-error/5 p-4 text-sm">
+                <p className="text-base-content/80">
+                  {t("students.unenrollBodyPrefix")}{" "}
+                  <span className="font-semibold text-base-content">
+                    {label}
+                  </span>{" "}
+                  {t("students.unenrollBodyFrom")}{" "}
+                  <span className="font-semibold text-base-content">{org}</span>{" "}
+                  {t("students.unenrollBodySuffix", { classroom })}
+                </p>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={working}
+                    onClick={() => setConfirmingUnenroll(false)}
+                  >
+                    {t("students.keepStudent")}
+                  </Button>
+                  <Button
+                    variant="error"
+                    size="sm"
+                    loading={working}
+                    loadingLabel={t("common.working")}
+                    disabled={working}
+                    onClick={() => void handleUnenroll()}
+                  >
+                    {working
+                      ? t("common.working")
+                      : t("students.unenrollStudent")}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </section>
+        ) : null}
+
+        {/* GitHub & enrollment — a single read-only summary: status + the
+              classroom team. */}
+        <section className="flex flex-col gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-base-content/50">
+            {t("students.sectionGithub")}
+          </h3>
+          <div className="divide-y divide-base-300 rounded-box border border-base-300">
+            <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+              <span className="text-sm text-base-content/70">
+                {t("students.statusLabel")}
+              </span>
+              {row.state === "enrolled" ? (
+                <span className="badge badge-sm badge-success badge-soft">
+                  {t("students.statusEnrolled")}
+                </span>
+              ) : row.state === "pending" ? (
+                <span className="badge badge-sm badge-warning badge-soft">
+                  {t("students.statusPending")}
+                </span>
+              ) : (
+                <span className="badge badge-sm badge-error badge-soft">
+                  {t("students.statusNotInOrg")}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+              <span className="text-sm text-base-content/70">
+                {t("students.classroomTeamLabel")}
+              </span>
+              <a
+                href={`https://github.com/orgs/${org}/teams/${teamSlug}`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 font-mono text-sm text-primary hover:underline"
+              >
+                {teamSlug}
+                <ExternalLink aria-hidden="true" className="size-3.5" />
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* Profile — read-only by default with an inline Edit toggle, so the
+              teacher isn't shown every action at once. */}
+        <section className="flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-base-content/50">
+              {t("students.sectionProfile")}
+            </h3>
+            {canEdit && !editingProfile ? (
+              <Button
+                variant="ghost"
+                size="xs"
+                className="gap-1"
+                onClick={() => setEditingProfile(true)}
+              >
+                <Pencil aria-hidden="true" className="size-3.5" />
+                {t("common.edit")}
+              </Button>
+            ) : null}
+          </div>
+
+          {!canEdit ? (
+            <p className="text-sm text-base-content/70">
+              {t("students.pendingNoEdit")}
+            </p>
+          ) : editingProfile ? (
+            <EditStudentForm
+              org={org}
+              classroom={classroom}
+              student={student}
+              resetSignal={`${row.key}:${open}:${editingProfile}`}
+              onCancel={() => setEditingProfile(false)}
+              onSubmittingChange={setSubmitting}
+              onSaved={(updated) => {
+                onSaved(row.key, updated)
+                setEditingProfile(false)
+              }}
+              showGitHubPanel={false}
+            />
+          ) : (
+            <dl className="divide-y divide-base-300 rounded-box border border-base-300">
+              <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+                <dt className="text-sm text-base-content/70">
+                  {t("students.nameColumn")}
+                </dt>
+                <dd className="text-sm">
+                  {nameFromParts(row.first_name, row.last_name) || (
+                    <span className="text-base-content/40">
+                      {t("students.notSet")}
+                    </span>
+                  )}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+                <dt className="text-sm text-base-content/70">
+                  {t("students.emailColumn")}
+                </dt>
+                <dd className="text-sm">
+                  {row.email || (
+                    <span className="text-base-content/40">
+                      {t("students.notSet")}
+                    </span>
+                  )}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+                <dt className="text-sm text-base-content/70">
+                  {t("students.sectionColumn")}
+                </dt>
+                <dd className="text-sm">
+                  {row.section.trim() || (
+                    <span className="text-base-content/40">
+                      {t("students.notSet")}
+                    </span>
+                  )}
+                </dd>
+              </div>
+            </dl>
+          )}
+        </section>
+      </div>
+    </Modal>
   )
 }
 

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -1,10 +1,10 @@
-import { X } from "lucide-react"
 import { useEffect, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import Papa from "papaparse"
 import { bulkEnrollStudentsInClassroom } from "@/hooks/github/mutations"
 import type { GitHubClient } from "@/hooks/github/client"
+import { Alert, Button, Modal } from "@/components/ui"
 import {
   isLikelyGithubUsername,
   normalizeGithubUsername,
@@ -126,7 +126,6 @@ const UploadRoster = ({
   onOpenChange,
 }: UploadRosterProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const { t } = useTranslation()
 
@@ -142,15 +141,6 @@ const UploadRoster = ({
   const [error, setError] = useState<string | null>(null)
 
   const isOpen = phase !== "idle"
-
-  // Drive the native <dialog> for free focus-trap, Escape, and backdrop
-  // inertness (matches the app's other modals).
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (isOpen && !dialog.open) dialog.showModal()
-    if (!isOpen && dialog.open) dialog.close()
-  }, [isOpen])
 
   const reset = () => {
     setPhase("idle")
@@ -257,240 +247,203 @@ const UploadRoster = ({
         onChange={handleFileChange}
       />
 
-      <dialog
-        ref={dialogRef}
-        className="modal"
+      <Modal
+        open={isOpen}
+        onClose={reset}
+        closeDisabled={phase === "importing"}
+        size="3xl"
         aria-labelledby={titleId}
-        onCancel={(event) => {
-          // Escape during an in-flight import would abandon it; block it.
-          if (phase === "importing") {
-            event.preventDefault()
-            return
-          }
-          reset()
-        }}
       >
-        <div className="modal-box max-w-3xl">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <h3 id={titleId} className="text-lg font-bold">
-                {t("students.importStudentsTitle")}
-              </h3>
-              {fileName && (
-                <p className="text-sm opacity-70 mt-1">
-                  {t("students.fileLabel", { fileName })}
-                </p>
-              )}
-            </div>
-
-            {phase !== "importing" && (
-              <button
-                type="button"
-                className="btn btn-sm btn-circle btn-ghost"
-                aria-label={t("common.close")}
-                onClick={reset}
-              >
-                <X size={16} aria-hidden="true" />
-              </button>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 id={titleId} className="text-lg font-bold">
+              {t("students.importStudentsTitle")}
+            </h3>
+            {fileName && (
+              <p className="text-sm opacity-70 mt-1">
+                {t("students.fileLabel", { fileName })}
+              </p>
             )}
           </div>
-
-          {phase === "preview" && (
-            <div className="mt-6">
-              <div className="alert mb-4">
-                <span>
-                  {t("students.usernamesFound", { count: rows.length })}
-                </span>
-              </div>
-
-              {rows.length > 0 ? (
-                <div className="max-h-80 overflow-auto rounded-box border border-base-300">
-                  <table className="table table-sm">
-                    <thead>
-                      <tr>
-                        <th scope="col">#</th>
-                        <th scope="col">
-                          {t("students.githubUsernameColumn")}
-                        </th>
-                        <th scope="col">{t("students.nameColumn")}</th>
-                        <th scope="col">{t("students.emailColumn")}</th>
-                        <th scope="col">{t("students.sectionColumn")}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {rows.map((row, index) => (
-                        <tr key={row.username.toLowerCase()}>
-                          <td>{index + 1}</td>
-                          <td>
-                            <code>{row.username}</code>
-                          </td>
-                          <td className="opacity-70">
-                            {[row.first_name, row.last_name]
-                              .filter(Boolean)
-                              .join(" ")}
-                          </td>
-                          <td className="opacity-70">{row.email}</td>
-                          <td className="opacity-70">{row.section}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              ) : (
-                <div className="alert alert-warning">
-                  {t("students.noValidUsernames")}
-                </div>
-              )}
-
-              <div className="modal-action">
-                <button type="button" className="btn btn-ghost" onClick={reset}>
-                  {t("common.cancel")}
-                </button>
-
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  disabled={rows.length === 0}
-                  onClick={startImport}
-                >
-                  {t("students.importCount", { count: rows.length })}
-                </button>
-              </div>
-            </div>
-          )}
-
-          {phase === "importing" && (
-            <div className="mt-6">
-              <p className="mb-2 font-medium">{progress.message}</p>
-
-              <progress
-                className="progress progress-primary w-full"
-                value={progress.processed}
-                max={progress.total || 1}
-              />
-
-              <div className="mt-2 flex justify-between text-sm opacity-70">
-                <span>
-                  {t("students.progressProcessed", {
-                    processed: progress.processed,
-                    total: progress.total,
-                  })}
-                </span>
-                <span>
-                  {t("students.progressPercent", { percent: progressPercent })}
-                </span>
-              </div>
-
-              <div className="mt-6 alert">
-                <span>{t("students.keepTabOpen")}</span>
-              </div>
-            </div>
-          )}
-
-          {phase === "complete" && result && (
-            <div className="mt-6 space-y-4">
-              <div className="alert alert-success">
-                <span>
-                  {t("students.addedCount", {
-                    count: result.addedStudents.length,
-                  })}
-                </span>
-              </div>
-
-              {result.addedStudents.length > 0 && (
-                <ImportResultSection
-                  title={t("students.resultAdded")}
-                  rows={result.addedStudents.map((student) => ({
-                    key: student.username,
-                    label: student.username,
-                    detail: [student.first_name, student.last_name]
-                      .filter(Boolean)
-                      .join(" "),
-                  }))}
-                />
-              )}
-
-              {result.skippedStudents.length > 0 && (
-                <ImportResultSection
-                  title={t("students.resultSkipped")}
-                  rows={result.skippedStudents.map((student) => ({
-                    key: student.username,
-                    label: student.username,
-                    detail: student.message ?? student.reason,
-                  }))}
-                />
-              )}
-
-              {result.teamResults?.some(
-                (teamResult) => teamResult.status === "failed",
-              ) && (
-                <ImportResultSection
-                  title={t("students.resultTeamFailures")}
-                  rows={result.teamResults
-                    .filter((teamResult) => teamResult.status === "failed")
-                    .map((teamResult) => ({
-                      key: teamResult.username,
-                      label: teamResult.username,
-                      detail:
-                        teamResult.message ?? t("students.couldNotAddToTeam"),
-                    }))}
-                />
-              )}
-
-              {result.notInOrg && result.notInOrg.length > 0 && (
-                <ImportResultSection
-                  title={t("students.resultNotInOrg")}
-                  rows={result.notInOrg.map((username) => ({
-                    key: username,
-                    label: username,
-                    detail: t("students.notInOrgDetail"),
-                  }))}
-                />
-              )}
-
-              <div className="modal-action">
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={reset}
-                >
-                  {t("students.done")}
-                </button>
-              </div>
-            </div>
-          )}
-
-          {phase === "error" && (
-            <div className="mt-6">
-              <div className="alert alert-error" role="alert">
-                <span>{error ?? t("students.somethingWentWrong")}</span>
-              </div>
-
-              <div className="modal-action">
-                <button type="button" className="btn btn-ghost" onClick={reset}>
-                  {t("common.close")}
-                </button>
-
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  {t("students.chooseAnotherFile")}
-                </button>
-              </div>
-            </div>
-          )}
         </div>
 
-        {phase !== "importing" && (
-          <form method="dialog" className="modal-backdrop">
-            <button type="button" onClick={reset}>
-              {t("common.close")}
-            </button>
-          </form>
+        {phase === "preview" && (
+          <div className="mt-6">
+            <Alert tone="info" className="mb-4">
+              <span>
+                {t("students.usernamesFound", { count: rows.length })}
+              </span>
+            </Alert>
+
+            {rows.length > 0 ? (
+              <div className="max-h-80 overflow-auto rounded-box border border-base-300">
+                <table className="table table-sm">
+                  <thead>
+                    <tr>
+                      <th scope="col">#</th>
+                      <th scope="col">{t("students.githubUsernameColumn")}</th>
+                      <th scope="col">{t("students.nameColumn")}</th>
+                      <th scope="col">{t("students.emailColumn")}</th>
+                      <th scope="col">{t("students.sectionColumn")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, index) => (
+                      <tr key={row.username.toLowerCase()}>
+                        <td>{index + 1}</td>
+                        <td>
+                          <code>{row.username}</code>
+                        </td>
+                        <td className="opacity-70">
+                          {[row.first_name, row.last_name]
+                            .filter(Boolean)
+                            .join(" ")}
+                        </td>
+                        <td className="opacity-70">{row.email}</td>
+                        <td className="opacity-70">{row.section}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <Alert tone="warning">{t("students.noValidUsernames")}</Alert>
+            )}
+
+            <div className="modal-action">
+              <Button variant="ghost" onClick={reset}>
+                {t("common.cancel")}
+              </Button>
+
+              <Button
+                variant="primary"
+                disabled={rows.length === 0}
+                onClick={startImport}
+              >
+                {t("students.importCount", { count: rows.length })}
+              </Button>
+            </div>
+          </div>
         )}
-      </dialog>
+
+        {phase === "importing" && (
+          <div className="mt-6">
+            <p className="mb-2 font-medium">{progress.message}</p>
+
+            <progress
+              className="progress progress-primary w-full"
+              value={progress.processed}
+              max={progress.total || 1}
+            />
+
+            <div className="mt-2 flex justify-between text-sm opacity-70">
+              <span>
+                {t("students.progressProcessed", {
+                  processed: progress.processed,
+                  total: progress.total,
+                })}
+              </span>
+              <span>
+                {t("students.progressPercent", { percent: progressPercent })}
+              </span>
+            </div>
+
+            <Alert tone="info" className="mt-6">
+              <span>{t("students.keepTabOpen")}</span>
+            </Alert>
+          </div>
+        )}
+
+        {phase === "complete" && result && (
+          <div className="mt-6 space-y-4">
+            <Alert tone="success">
+              <span>
+                {t("students.addedCount", {
+                  count: result.addedStudents.length,
+                })}
+              </span>
+            </Alert>
+
+            {result.addedStudents.length > 0 && (
+              <ImportResultSection
+                title={t("students.resultAdded")}
+                rows={result.addedStudents.map((student) => ({
+                  key: student.username,
+                  label: student.username,
+                  detail: [student.first_name, student.last_name]
+                    .filter(Boolean)
+                    .join(" "),
+                }))}
+              />
+            )}
+
+            {result.skippedStudents.length > 0 && (
+              <ImportResultSection
+                title={t("students.resultSkipped")}
+                rows={result.skippedStudents.map((student) => ({
+                  key: student.username,
+                  label: student.username,
+                  detail: student.message ?? student.reason,
+                }))}
+              />
+            )}
+
+            {result.teamResults?.some(
+              (teamResult) => teamResult.status === "failed",
+            ) && (
+              <ImportResultSection
+                title={t("students.resultTeamFailures")}
+                rows={result.teamResults
+                  .filter((teamResult) => teamResult.status === "failed")
+                  .map((teamResult) => ({
+                    key: teamResult.username,
+                    label: teamResult.username,
+                    detail:
+                      teamResult.message ?? t("students.couldNotAddToTeam"),
+                  }))}
+              />
+            )}
+
+            {result.notInOrg && result.notInOrg.length > 0 && (
+              <ImportResultSection
+                title={t("students.resultNotInOrg")}
+                rows={result.notInOrg.map((username) => ({
+                  key: username,
+                  label: username,
+                  detail: t("students.notInOrgDetail"),
+                }))}
+              />
+            )}
+
+            <div className="modal-action">
+              <Button variant="primary" onClick={reset}>
+                {t("students.done")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {phase === "error" && (
+          <div className="mt-6">
+            <Alert tone="error">
+              <span>{error ?? t("students.somethingWentWrong")}</span>
+            </Alert>
+
+            <div className="modal-action">
+              <Button variant="ghost" onClick={reset}>
+                {t("common.close")}
+              </Button>
+
+              <Button
+                variant="primary"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {t("students.chooseAnotherFile")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
     </>
   )
 }

--- a/web/src/pages/submissions/SubmissionsControls.tsx
+++ b/web/src/pages/submissions/SubmissionsControls.tsx
@@ -1,6 +1,7 @@
 import { Search, X } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
+import { Button, Select } from "@/components/ui"
 import type {
   SubmissionFilters,
   SubmissionSort,
@@ -66,8 +67,9 @@ const SubmissionsControls = ({
       </label>
 
       {sections.length > 0 && (
-        <select
-          className="select select-bordered select-sm w-auto min-w-0 max-w-[10rem]"
+        <Select
+          selectSize="sm"
+          className="w-auto min-w-0 max-w-[10rem]"
           value={filters.section}
           onChange={(e) =>
             onFiltersChange({ ...filters, section: e.target.value })
@@ -80,11 +82,12 @@ const SubmissionsControls = ({
               {section}
             </option>
           ))}
-        </select>
+        </Select>
       )}
 
-      <select
-        className="select select-bordered select-sm w-auto min-w-0"
+      <Select
+        selectSize="sm"
+        className="w-auto min-w-0"
         value={filters.submission}
         onChange={(e) =>
           onFiltersChange({
@@ -105,11 +108,12 @@ const SubmissionsControls = ({
             {t("submissions.filters.notSubmitted")}
           </option>
         )}
-      </select>
+      </Select>
 
       {passingAvailable && (
-        <select
-          className="select select-bordered select-sm w-auto min-w-0"
+        <Select
+          selectSize="sm"
+          className="w-auto min-w-0"
           value={filters.passing}
           // Disabled when filtering to non-submitters: they have no grade, so a
           // passing/failing filter would always yield an empty table.
@@ -125,12 +129,13 @@ const SubmissionsControls = ({
           <option value="all">{t("submissions.filters.allGrades")}</option>
           <option value="passing">{t("submissions.filters.passing")}</option>
           <option value="failing">{t("submissions.filters.failing")}</option>
-        </select>
+        </Select>
       )}
 
       {acceptedAvailable && (
-        <select
-          className="select select-bordered select-sm w-auto min-w-0"
+        <Select
+          selectSize="sm"
+          className="w-auto min-w-0"
           value={filters.accepted}
           onChange={(e) =>
             onFiltersChange({
@@ -145,22 +150,19 @@ const SubmissionsControls = ({
           <option value="not-accepted">
             {t("submissions.filters.notAccepted")}
           </option>
-        </select>
+        </Select>
       )}
 
       {hasActiveFilter && (
-        <button
-          type="button"
-          className="btn btn-ghost btn-sm"
-          onClick={clearAll}
-        >
+        <Button variant="ghost" size="sm" onClick={clearAll}>
           <X aria-hidden="true" className="size-4" />{" "}
           {t("submissions.filters.clear")}
-        </button>
+        </Button>
       )}
 
-      <select
-        className="select select-bordered select-sm ml-auto w-auto min-w-0"
+      <Select
+        selectSize="sm"
+        className="ml-auto w-auto min-w-0"
         value={sort}
         onChange={(e) => onSortChange(e.target.value as SubmissionSort)}
         aria-label={t("submissions.filters.sortAria")}
@@ -171,7 +173,7 @@ const SubmissionsControls = ({
         <option value="name-desc">
           {t("submissions.filters.sortNameDesc")}
         </option>
-      </select>
+      </Select>
     </div>
   )
 }

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -19,6 +19,7 @@ import {
 import { studentRepoName, studentRepoUrl } from "@/util/studentRepo"
 import { safeHttpUrl } from "@/util/url"
 import Avatar from "@/components/avatar"
+import { Button, Modal } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
@@ -242,68 +243,61 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
 
   return (
     <>
-      <button
-        type="button"
-        className="btn btn-ghost btn-sm btn-square text-base-content/70 disabled:opacity-60"
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="text-base-content/70 disabled:opacity-60"
         disabled={resolving}
+        loading={resolving}
+        loadingLabel={t("submissions.table.review")}
         onClick={handleReview}
         aria-label={t("submissions.table.reviewAria")}
         title={t("submissions.table.review")}
       >
-        {resolving ? (
-          <span
-            className="loading loading-spinner loading-xs"
-            aria-hidden="true"
-          />
+        {!resolving && <MessageCircle aria-hidden="true" className="size-4" />}
+      </Button>
+      <Modal
+        dialogRef={dialogRef}
+        size="md"
+        hideCloseButton
+        aria-labelledby={titleId}
+      >
+        {errorMsg ? (
+          <>
+            <h3 id={titleId} className="text-lg font-bold">
+              {t("submissions.reviewModal.errorTitle")}
+            </h3>
+            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
+              {errorMsg}
+            </p>
+          </>
         ) : (
-          <MessageCircle aria-hidden="true" className="size-4" />
+          <>
+            <h3 id={titleId} className="text-lg font-bold">
+              {t("submissions.reviewModal.emptyTitle")}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-base-content/70">
+              {t("submissions.reviewModal.emptyBody_prefix")}{" "}
+              <span className="font-mono">{repo}</span>{" "}
+              {t("submissions.reviewModal.emptyBody_suffix")}
+            </p>
+          </>
         )}
-      </button>
-      <dialog ref={dialogRef} className="modal" aria-labelledby={titleId}>
-        <div className="modal-box max-w-md">
-          {errorMsg ? (
-            <>
-              <h3 id={titleId} className="text-lg font-bold">
-                {t("submissions.reviewModal.errorTitle")}
-              </h3>
-              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
-                {errorMsg}
-              </p>
-            </>
-          ) : (
-            <>
-              <h3 id={titleId} className="text-lg font-bold">
-                {t("submissions.reviewModal.emptyTitle")}
-              </h3>
-              <p className="mt-2 text-sm leading-6 text-base-content/70">
-                {t("submissions.reviewModal.emptyBody_prefix")}{" "}
-                <span className="font-mono">{repo}</span>{" "}
-                {t("submissions.reviewModal.emptyBody_suffix")}
-              </p>
-            </>
-          )}
-          <div className="modal-action">
-            <a
-              className="btn btn-ghost btn-sm"
-              href={`https://github.com/${org}/${repo}/pulls`}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t("submissions.reviewModal.openRepoPrs")}
-            </a>
-            <button
-              type="button"
-              className="btn btn-sm"
-              onClick={() => dialogRef.current?.close()}
-            >
-              {t("common.close")}
-            </button>
-          </div>
+        <div className="modal-action">
+          <a
+            className="btn btn-ghost btn-sm"
+            href={`https://github.com/${org}/${repo}/pulls`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {t("submissions.reviewModal.openRepoPrs")}
+          </a>
+          <Button size="sm" onClick={() => dialogRef.current?.close()}>
+            {t("common.close")}
+          </Button>
         </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>{t("common.close")}</button>
-        </form>
-      </dialog>
+      </Modal>
     </>
   )
 }
@@ -357,26 +351,25 @@ const RegradeButton = ({
 
   return (
     <>
-      <button
-        type="button"
-        className={`${ACTION_BTN} text-base-content/70 disabled:opacity-60`}
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="text-base-content/70 disabled:opacity-60"
         disabled={inFlight || blocked}
+        loading={inFlight}
+        loadingLabel={t("submissions.rowRegrade.title")}
         onClick={handleClick}
         aria-label={t("submissions.rowRegrade.aria", { owner })}
         title={title}
       >
-        {inFlight ? (
-          <span
-            className="loading loading-spinner loading-xs"
-            aria-hidden="true"
-          />
-        ) : (
+        {!inFlight && (
           <RefreshCw
             aria-hidden="true"
             className={`size-4 ${phase === "completed" ? "text-success" : phase === "failed" ? "text-error" : ""}`}
           />
         )}
-      </button>
+      </Button>
       <ConfirmModal
         open={confirmOpen}
         title={t("submissions.rowRegrade.confirmTitle", {
@@ -683,9 +676,11 @@ const SubmissionsTable = ({
                       <td>
                         <div className="flex items-center gap-1">
                           {isGroup && (
-                            <button
-                              type="button"
-                              className="btn btn-ghost btn-sm btn-square text-base-content/70"
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              shape="square"
+                              className="text-base-content/70"
                               onClick={() => setManageOwner(rest.owner)}
                               aria-label={t("submissions.table.membersAria")}
                               title={t("submissions.table.members")}
@@ -694,7 +689,7 @@ const SubmissionsTable = ({
                                 aria-hidden="true"
                                 className="size-4"
                               />
-                            </button>
+                            </Button>
                           )}
                           <ActionIconLink
                             href={repoHref}

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import type { RouterContext } from "@/types/router"
 import { TriangleAlert } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { RoleViewProvider } from "@/context/roleView/RoleViewProvider"
+import { Button } from "@/components/ui"
 
 const RootComponent = () => {
   // Scope "view as" to the current org (reset across orgs via the key); the
@@ -35,13 +36,13 @@ const RootErrorComponent = ({ error }: { error: Error }) => {
           {error?.message || t("error.unexpected")}
         </p>
       </div>
-      <button
-        type="button"
-        className="btn btn-primary btn-sm"
+      <Button
+        variant="primary"
+        size="sm"
         onClick={() => window.location.reload()}
       >
         {t("error.reload")}
-      </button>
+      </Button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

A full visual + structural pass on the web app, delivered as a stack of focused commits:

- **New "sumi" theme** (replaces the stock daisyUI `corporate`): a custom, minimalist ink-on-paper palette on neutral surfaces with a calm indigo accent (`#3e5da8`) and mid-chroma semantic colors tuned to pop while staying in harmony. Light (`sumi`) + dark (`sumi-dark`), both WCAG-AA. Typeface switched to Noto Sans for broad multi-language coverage.
- **Shared UI primitives** under `web/src/components/ui/` (Button, Card, Badge, Input, Select, Textarea, FormField, Modal, Alert; Spinner re-exported), with unit tests. Migrated the previously inline copy-pasted daisyUI classes across ~75 files onto them — buttons own their loading state, forms share one bordered convention + unified label/error markup, modals share one dialog shell, alerts use the soft house style.
- **Layout**: tighter PageShell padding and a single `flex flex-col gap-6` section rhythm applied uniformly (the org-homepage look, now everywhere).
- **Sidebar**: current GitHub org shown as a persistent chip above the profile menu; smaller profile avatar; hover affordance on the account menu.
- **Semantic tone standardization**: same message category → same tone across the app (not-yet-present → info, capability-gated → error, in-progress → info; risky-overwrite stays warning).
- **Theme switching** now cross-fades via the View Transitions API (smooth GPU cross-fade, graceful fallback, respects reduced-motion, no anti-flash regression). **Only user-initiated toggles cross-fade** — OS and cross-tab changes apply instantly so an external event can't abort a user's in-flight transition.

Client-only architecture is untouched — no backend/state/route changes.

## Review fixes

A multi-agent code review of this branch surfaced four actionable findings, all addressed in `fix(web): address theme/UI-primitive review findings`:

- **Alert tone single-source** — extracted `alertToneClass(tone, soft)` so `Alert` and `NotificationProvider` share one tone→class recipe instead of two hand-synced maps.
- **useTheme transition scope** — cross-fade only user toggles; OS/cross-tab changes apply instantly (no aborted in-flight View Transition).
- **useTheme runtime tests** — added `renderHook` coverage (resolve, first-apply-no-animate, VT branch + fallback, OS/storage listeners, persistence, listener cleanup); the prior test only guarded the anti-flash `index.html` contract.
- **Modal ref-driven test** — covers the imperative `dialogRef` path (`open` omitted → early-return branch).

Two **latent-only** primitive footguns (no reachable caller today) are tracked separately as hardening follow-ups in #170 rather than expanding this PR's scope.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx vitest run` — 846 tests pass (was 834; +12 from the review fixes, incl. new useTheme runtime + Modal ref-driven tests)
- [x] `npx eslint .` — 0 errors
- [x] `npx prettier --check src` clean
- [x] `npm run build` succeeds
- [x] Bugbot review — no bugs found
- [x] Multi-agent code review — 4 findings addressed; 2 latent items tracked in #170
- [x] Visual QA in light + dark, key pages (classrooms, submissions, a modal, a form)
- [x] Verify theme cross-fade + reduced-motion behavior in a supporting browser (confirm OS/cross-tab changes apply instantly, user toggles cross-fade)