### PR TITLE
fix(web): verify classroom50 config repo before listing an org

### DIFF
--- a/web/src/hooks/github/queries.test.ts
+++ b/web/src/hooks/github/queries.test.ts
@@ -2,14 +2,16 @@ import { describe, expect, it, vi } from "vitest"
 import {
   pagesAssignmentUrl,
   classroomsIndexUrl,
+  getClassroom50OrgSummary,
   listAllOrgMembers,
   listOrgAdmins,
   listOrgTeams,
   releasesQuery,
+  verifyClassroom50ConfigRepo,
 } from "./queries"
 import { GitHubAPIError } from "./errors"
 import type { GitHubClient } from "./client"
-import type { GitHubUser, GitHubRelease } from "./types"
+import type { GitHubOrgMembership, GitHubUser, GitHubRelease } from "./types"
 
 describe("pagesAssignmentUrl", () => {
   it("builds the plain classroom path when no secret is set", () => {
@@ -227,5 +229,78 @@ describe("releasesQuery", () => {
     ])
     const releases = await run({ request } as unknown as GitHubClient)
     expect(releases.map((r) => r.tag_name)).toEqual(["submit/2", "submit/1"])
+  })
+})
+
+const MARKER_PATH = "/contents/.github/workflows/autograde-runner.yaml"
+
+describe("verifyClassroom50ConfigRepo (name-collision guard)", () => {
+  it("returns true when the config-repo marker resolves", async () => {
+    const client = { request: vi.fn().mockResolvedValue({ type: "file" }) }
+    await expect(verifyClassroom50ConfigRepo(client, "acme")).resolves.toBe(
+      true,
+    )
+    expect(client.request).toHaveBeenCalledWith(
+      `/repos/acme/classroom50${MARKER_PATH}`,
+    )
+  })
+
+  it("returns false on a 404 (repo exists but isn't a config repo)", async () => {
+    const client = { request: vi.fn().mockRejectedValue(apiError(404)) }
+    await expect(verifyClassroom50ConfigRepo(client, "acme")).resolves.toBe(
+      false,
+    )
+  })
+
+  it("fails open (true) on a non-404 error so a blip never hides a real org", async () => {
+    const client = { request: vi.fn().mockRejectedValue(apiError(403)) }
+    await expect(verifyClassroom50ConfigRepo(client, "acme")).resolves.toBe(
+      true,
+    )
+  })
+})
+
+describe("getClassroom50OrgSummary (verifies config repo before 'ready')", () => {
+  const membership = (
+    role: "admin" | "member",
+    state: "active" | "pending" = "active",
+  ): GitHubOrgMembership =>
+    ({
+      state,
+      role,
+      organization: {
+        login: "acme",
+        id: 1,
+        avatar_url: "",
+        html_url: "https://github.com/acme",
+      },
+    }) as unknown as GitHubOrgMembership
+
+  it("is 'ready' when the repo exists AND carries the config marker", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue({ id: 1 }),
+    } as unknown as GitHubClient
+    const summary = await getClassroom50OrgSummary(client, membership("admin"))
+    expect(summary.classroom50.status).toBe("ready")
+    expect(summary.classroom50.canAccessRepo).toBe(true)
+  })
+
+  it("is 'not_classroom50' when a readable repo lacks the config marker (name collision)", async () => {
+    const client = {
+      request: vi.fn().mockImplementation((path: string) => {
+        if (path.includes("/contents/")) return Promise.reject(apiError(404))
+        return Promise.resolve({ id: 1 })
+      }),
+    } as unknown as GitHubClient
+    const summary = await getClassroom50OrgSummary(client, membership("admin"))
+    expect(summary.classroom50.status).toBe("not_classroom50")
+  })
+
+  it("is 'needs_setup' for an admin when the repo itself 404s", async () => {
+    const client = {
+      request: vi.fn().mockRejectedValue(apiError(404)),
+    } as unknown as GitHubClient
+    const summary = await getClassroom50OrgSummary(client, membership("admin"))
+    expect(summary.classroom50.status).toBe("needs_setup")
   })
 })

--- a/web/src/hooks/github/queries.test.ts
+++ b/web/src/hooks/github/queries.test.ts
@@ -12,6 +12,7 @@ import {
 import { GitHubAPIError } from "./errors"
 import type { GitHubClient } from "./client"
 import type { GitHubOrgMembership, GitHubUser, GitHubRelease } from "./types"
+import { CONFIG_REPO_MARKER_REL, ORG_GITHUB_DIR } from "@/skeleton/skeleton"
 
 describe("pagesAssignmentUrl", () => {
   it("builds the plain classroom path when no secret is set", () => {
@@ -232,7 +233,7 @@ describe("releasesQuery", () => {
   })
 })
 
-const MARKER_PATH = "/contents/.github/workflows/autograde-runner.yaml"
+const MARKER_PATH = `/contents/${ORG_GITHUB_DIR}/${CONFIG_REPO_MARKER_REL}`
 
 describe("verifyClassroom50ConfigRepo (name-collision guard)", () => {
   it("returns true when the config-repo marker resolves", async () => {
@@ -294,6 +295,18 @@ describe("getClassroom50OrgSummary (verifies config repo before 'ready')", () =>
     } as unknown as GitHubClient
     const summary = await getClassroom50OrgSummary(client, membership("admin"))
     expect(summary.classroom50.status).toBe("not_classroom50")
+  })
+
+  it("stays 'ready' when the marker probe fails open on a non-404 (readable repo, blip on the marker read)", async () => {
+    const client = {
+      request: vi.fn().mockImplementation((path: string) => {
+        if (path.includes("/contents/")) return Promise.reject(apiError(403))
+        return Promise.resolve({ id: 1 })
+      }),
+    } as unknown as GitHubClient
+    const summary = await getClassroom50OrgSummary(client, membership("admin"))
+    expect(summary.classroom50.status).toBe("ready")
+    expect(summary.classroom50.canAccessRepo).toBe(true)
   })
 
   it("is 'needs_setup' for an admin when the repo itself 404s", async () => {

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -884,6 +884,33 @@ export type Classroom50OrgSummary = {
 
 type Classroom50Status =
   "ready" | "needs_setup" | "no_access" | "not_classroom50" | "unknown"
+
+// A repo merely named `classroom50` isn't proof of a Classroom 50 org (the
+// project's own source repo has that name). The scaffold marker every genuine
+// config repo carries is — see SKELETON_PATHS.
+const CONFIG_REPO_MARKER_PATH = ".github/workflows/autograde-runner.yaml"
+
+// True when a readable `classroom50` repo is a real config repo, not a name
+// collision. A clean 404 on the marker means collision; any other error is
+// transient/permission, so fail open — hiding a real teacher's org behind a
+// read blip is worse than briefly showing one extra.
+export async function verifyClassroom50ConfigRepo(
+  client: { request: (path: string) => Promise<unknown> },
+  org: string,
+): Promise<boolean> {
+  try {
+    await client.request(
+      `/repos/${org}/classroom50/contents/${CONFIG_REPO_MARKER_PATH}`,
+    )
+    return true
+  } catch (error) {
+    if (error instanceof GitHubAPIError && error.status === 404) {
+      return false
+    }
+    return true
+  }
+}
+
 export async function getClassroom50OrgSummary(
   client: GitHubClient,
   membership: GitHubOrgMembership,
@@ -896,7 +923,9 @@ export async function getClassroom50OrgSummary(
   try {
     await client.request(`/repos/${org.login}/classroom50`)
     canAccessRepo = true
-    status = "ready"
+
+    const isConfigRepo = await verifyClassroom50ConfigRepo(client, org.login)
+    status = isConfigRepo ? "ready" : "not_classroom50"
 
     // The service-token read is deliberately NOT done here: this summary runs
     // for every org the user can see, so reading the token per org fans out an

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -16,6 +16,7 @@ import type {
   GitHubWorkflowRun,
 } from "./types"
 import type { Assignment } from "@/types/classroom"
+import { CONFIG_REPO_MARKER_REL, ORG_GITHUB_DIR } from "@/skeleton/skeleton"
 import { GitHubAPIError } from "./errors"
 import {
   COLLECT_SCORES_WORKFLOW,
@@ -885,15 +886,13 @@ export type Classroom50OrgSummary = {
 type Classroom50Status =
   "ready" | "needs_setup" | "no_access" | "not_classroom50" | "unknown"
 
-// A repo merely named `classroom50` isn't proof of a Classroom 50 org (the
-// project's own source repo has that name). The scaffold marker every genuine
-// config repo carries is — see SKELETON_PATHS.
-const CONFIG_REPO_MARKER_PATH = ".github/workflows/autograde-runner.yaml"
+const CONFIG_REPO_MARKER_PATH = `${ORG_GITHUB_DIR}/${CONFIG_REPO_MARKER_REL}`
 
 // True when a readable `classroom50` repo is a real config repo, not a name
-// collision. A clean 404 on the marker means collision; any other error is
-// transient/permission, so fail open — hiding a real teacher's org behind a
-// read blip is worse than briefly showing one extra.
+// collision (an org owning an unrelated repo named `classroom50`, e.g. this
+// project's own source). A clean 404 on the marker means collision; any other
+// error is transient/permission, so fail open — hiding a real teacher's org
+// behind a read blip is worse than briefly showing one extra.
 export async function verifyClassroom50ConfigRepo(
   client: { request: (path: string) => Promise<unknown> },
   org: string,

--- a/web/src/hooks/useOrgClassroom50Status.test.ts
+++ b/web/src/hooks/useOrgClassroom50Status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { probeOrgClassroom50Status } from "./useOrgClassroom50Status"
 import { GitHubAPIError } from "./github/errors"
+import { CONFIG_REPO_MARKER_REL, ORG_GITHUB_DIR } from "@/skeleton/skeleton"
 
 // The /$org/* gate redirects an admin to /setup only on "missing", and fails
 // open on any other shape. That safety hinges on this probe returning "missing"
@@ -50,7 +51,7 @@ describe("probeOrgClassroom50Status", () => {
     )
     expect(client.request).toHaveBeenCalledWith("/repos/acme/classroom50")
     expect(client.request).toHaveBeenCalledWith(
-      "/repos/acme/classroom50/contents/.github/workflows/autograde-runner.yaml",
+      `/repos/acme/classroom50/contents/${ORG_GITHUB_DIR}/${CONFIG_REPO_MARKER_REL}`,
     )
   })
 
@@ -69,6 +70,20 @@ describe("probeOrgClassroom50Status", () => {
 
     await expect(probeOrgClassroom50Status(client, "acme")).resolves.toBe(
       "missing",
+    )
+  })
+
+  it("returns 'ready' when the marker probe fails open on a non-404 (repo OK, blip on the marker read)", async () => {
+    // Distinct from the 403 rethrow below: there the repo GET itself fails; here
+    // the repo resolves and only the marker read blips. The helper fails open so
+    // a real teacher's org is never hidden behind a transient marker read.
+    const client = clientReturning(async (path: string) => {
+      if (path.includes("/contents/")) throw apiError(403)
+      return { id: 1 }
+    })
+
+    await expect(probeOrgClassroom50Status(client, "acme")).resolves.toBe(
+      "ready",
     )
   })
 

--- a/web/src/hooks/useOrgClassroom50Status.test.ts
+++ b/web/src/hooks/useOrgClassroom50Status.test.ts
@@ -27,18 +27,39 @@ function apiError(status: number) {
   })
 }
 
-function clientReturning(impl: () => Promise<unknown>) {
+function clientReturning(impl: (path: string) => Promise<unknown>) {
   return { request: vi.fn(impl) }
 }
 
+// A client that resolves the repo GET but 404s the marker file — the
+// name-collision shape (some org owns an unrelated repo literally named
+// `classroom50`).
+function clientNameCollision() {
+  return clientReturning(async (path: string) => {
+    if (path.includes("/contents/")) throw apiError(404)
+    return { id: 1 }
+  })
+}
+
 describe("probeOrgClassroom50Status", () => {
-  it("returns 'ready' when the config repo request resolves", async () => {
+  it("returns 'ready' when the repo resolves AND carries the config marker", async () => {
     const client = clientReturning(async () => ({ id: 1 }))
 
     await expect(probeOrgClassroom50Status(client, "acme")).resolves.toBe(
       "ready",
     )
     expect(client.request).toHaveBeenCalledWith("/repos/acme/classroom50")
+    expect(client.request).toHaveBeenCalledWith(
+      "/repos/acme/classroom50/contents/.github/workflows/autograde-runner.yaml",
+    )
+  })
+
+  it("returns 'missing' for a name collision (repo exists but has no config marker)", async () => {
+    const client = clientNameCollision()
+
+    await expect(probeOrgClassroom50Status(client, "acme")).resolves.toBe(
+      "missing",
+    )
   })
 
   it("returns 'missing' on a 404 (repo unset or private to me)", async () => {

--- a/web/src/hooks/useOrgClassroom50Status.ts
+++ b/web/src/hooks/useOrgClassroom50Status.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { GitHubAPIError, retryTransientGitHubError } from "./github/errors"
+import { verifyClassroom50ConfigRepo } from "./github/queries"
 
 export type OrgClassroom50Status = "ready" | "missing" | "unknown"
 
@@ -11,15 +12,18 @@ type OrgClassroom50Probe = "ready" | "missing"
 
 // Probe the `classroom50` config repo for one org. 404 = missing (unset or
 // private to me); any other error rethrows so the query stays "unknown" rather
-// than reporting a transient failure as missing. Pure over its client so the
-// 404-vs-rethrow contract the /$org/* gate depends on is unit-testable.
+// than reporting a transient failure as missing. A readable repo that lacks the
+// config marker is a name collision, reported "missing" so the /$org/* gate
+// doesn't render its folders as classrooms. Pure over its client so the
+// 404-vs-rethrow contract the gate depends on is unit-testable.
 export async function probeOrgClassroom50Status(
   client: { request: (path: string) => Promise<unknown> },
   org: string,
 ): Promise<OrgClassroom50Probe> {
   try {
     await client.request(`/repos/${org}/classroom50`)
-    return "ready"
+    const isConfigRepo = await verifyClassroom50ConfigRepo(client, org)
+    return isConfigRepo ? "ready" : "missing"
   } catch (error) {
     if (error instanceof GitHubAPIError && error.status === 404) {
       return "missing"

--- a/web/src/hooks/useOrgClassroom50Status.ts
+++ b/web/src/hooks/useOrgClassroom50Status.ts
@@ -12,10 +12,10 @@ type OrgClassroom50Probe = "ready" | "missing"
 
 // Probe the `classroom50` config repo for one org. 404 = missing (unset or
 // private to me); any other error rethrows so the query stays "unknown" rather
-// than reporting a transient failure as missing. A readable repo that lacks the
-// config marker is a name collision, reported "missing" so the /$org/* gate
-// doesn't render its folders as classrooms. Pure over its client so the
-// 404-vs-rethrow contract the gate depends on is unit-testable.
+// than reporting a transient failure as missing. A readable repo lacking the
+// config marker is reported "missing" (see verifyClassroom50ConfigRepo). Pure
+// over its client so the 404-vs-rethrow contract the gate depends on is
+// unit-testable.
 export async function probeOrgClassroom50Status(
   client: { request: (path: string) => Promise<unknown> },
   org: string,

--- a/web/src/skeleton/skeleton.ts
+++ b/web/src/skeleton/skeleton.ts
@@ -8,7 +8,7 @@
 // dotgithub/ is rewritten to .github/ at commit time; the source dir is named
 // `dotgithub` because `//go:embed` (no `all:`) skips dot-prefixed paths.
 const SKELETON_SOURCE_DIR = "dotgithub"
-const ORG_GITHUB_DIR = ".github"
+export const ORG_GITHUB_DIR = ".github"
 
 // Substituted with the config repo's default branch at commit time, so
 // publish-pages.yaml's push trigger fires.
@@ -44,6 +44,14 @@ export const SKELETON_PATHS = [
   "workflows/probe-token.yaml",
   "scripts/probe_token.py",
 ] as const
+
+// The scaffold marker used to tell a genuine config repo from an org that
+// merely owns a repo named `classroom50`. Typed as a SKELETON_PATHS member so a
+// rename that drops the workflow fails the build here instead of silently
+// hiding every real teacher's org behind a 404 (see verifyClassroom50ConfigRepo
+// in hooks/github/queries.ts).
+export const CONFIG_REPO_MARKER_REL: (typeof SKELETON_PATHS)[number] =
+  "workflows/autograde-runner.yaml"
 
 // Map a bundled module key to its org-relative skeleton path, e.g.
 //   .../skeleton/dotgithub/workflows/publish-pages.yaml -> workflows/publish-pages.yaml


### PR DESCRIPTION
## Summary
- The org list marked an org **ready** the moment `GET /repos/{org}/classroom50` returned 200, without confirming the repo is an actual Classroom 50 config repo. A repo merely *named* `classroom50` (e.g. the project's own source repo) was misclassified, and `listClassroomDirs` then surfaced its root folders (`cli`, `web`, `schemas`, …) as "classrooms".
- Added `verifyClassroom50ConfigRepo`: after the repo resolves, probe the scaffold marker `.github/workflows/autograde-runner.yaml`. A clean 404 means a name collision → `not_classroom50` (hidden). Any other error fails **open** so a transient/permission blip never hides a real teacher's org.
- Applied the same guard to the single-org gate (`probeOrgClassroom50Status`) so navigating directly to `/{org}/*` on a name-collision repo resolves `missing` instead of rendering bogus classrooms.
- The marker path is derived from `SKELETON_PATHS` via `CONFIG_REPO_MARKER_REL`, typed as a `SKELETON_PATHS` member so a scaffold rename fails `tsc` here instead of silently 404-ing every genuine config repo (which would hide every teacher's org — the exact failure the fail-open guards against).

## Test plan
- [x] `tsc -b` clean (the typed marker pins the probe to a real skeleton path at compile time)
- [x] `vitest run` — 855/855 pass. Cases for the marker helper (200 → true, 404 → false, other → fail-open), `getClassroom50OrgSummary` name-collision → `not_classroom50`, single-org probe collision → `missing`, and the marker-read non-404 fail-open through **both** call sites (repo 200 + marker 403 → stays `ready`/`ready`).
- [x] `eslint` + `prettier --check` clean on touched files
- [ ] Manual: an org owning an unrelated repo named `classroom50` no longer appears as a classroom on the home page

## Follow-up (not in this PR)
- The marker discriminator lives in `web/`; the Go CLIs (`gh teacher teardown`, init, roster) still classify a classroom by repo-existence alone. Promoting the marker into `cli/shared/contract` and probing it CLI-side would make both surfaces agree — worth a separate change.