### PR TITLE
feat(web): standardized client-side logger, dev rate-limit overlay, and app-wide logging coverage

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -32,11 +32,13 @@ export default defineConfig([
       // refactors. Revisit case-by-case.
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/exhaustive-deps": "warn",
-      // Stop stray debug `console.log` from shipping (a recurring source of
-      // GitHub API response bodies leaking to the production console). Allow
-      // `console.warn`/`console.error` for genuine diagnostics; DEV-only debug
-      // logging should be guarded by `import.meta.env.DEV`.
-      "no-console": ["warn", { allow: ["warn", "error"] }],
+      // Route all console output through `src/lib/logger.ts` (leveled,
+      // timestamped, scoped, call-site tagged). Raw `console` is forbidden
+      // everywhere else — the wrapper centralises formatting AND the privacy
+      // contract (a recurring source of GitHub API response bodies leaking to
+      // the production console). The logger module and the deliberate release
+      // banner in main.tsx are the only exceptions (per-file overrides below).
+      "no-console": "error",
       // Keep the accessibility invariants self-checking. Advisory
       // (warn) so the plugin's stricter defaults don't block the build on
       // pre-existing markup, but new violations (missing alt/label, invalid
@@ -91,6 +93,16 @@ export default defineConfig([
             'Prefer the accessible <Spinner> component over a bare `loading loading-spinner` span (it adds role="status" + an sr-only label). In-button spinners may stay inline if the button already has an accessible name.',
         },
       ],
+    },
+  },
+  // The only files allowed to touch `console` directly: the logger wrapper
+  // (it IS the console centralisation point) and the main.tsx release banner
+  // (a deliberate always-on marker so the deployed build is identifiable from
+  // the console — it must print even in prod, outside the leveled model).
+  {
+    files: ["src/lib/logger.ts", "src/main.tsx"],
+    rules: {
+      "no-console": "off",
     },
   },
   // Last: turn off ESLint rules that conflict with Prettier (formatting is

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,9 @@ import router from "./router"
 import { Spinner } from "@/components/Spinner"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { BASE_PATH, isAuthedPath } from "@/auth/authedPath"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("app")
 
 export function App() {
   const { status, token, user } = useGithubAuth()
@@ -13,6 +16,7 @@ export function App() {
 
   useEffect(() => {
     if (status === "loading") return
+    log.debug("auth status settled, invalidating router", { status })
     void router.invalidate()
   }, [status, token])
 
@@ -30,9 +34,11 @@ export function App() {
 
   useEffect(() => {
     if (!sessionEndedOnAuthedRoute) return
+    log.info("session ended on authed route, redirecting to /login")
     // Hard-redirect fallback: a rejected navigate() would leave the spinner up
     // forever (the effect won't re-run — its only dep is unchanged).
     router.navigate({ to: "/login" }).catch(() => {
+      log.warn("navigate to /login failed, hard-redirecting", { record: true })
       window.location.assign(`${BASE_PATH}/login`)
     })
   }, [sessionEndedOnAuthedRoute])

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -69,6 +69,9 @@ import {
   outOfOrgTemplateError,
 } from "@/util/templateAccessError"
 import { githubOrgOAuthPolicyUrl } from "@/auth/constants"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("mutations:assignments")
 
 // Kept byte-identical with the CLI's `gh student accept` (via prefixCommit) per
 // the synchronized-release rule. Carries no contract — the runner keys the
@@ -146,7 +149,7 @@ async function withAcceptStep<T>(
       throw err
     }
     if (err instanceof GitHubAPIError) {
-      console.error(`Accept step "${label}" failed:`, err)
+      log.error(`Accept step "${label}" failed`, { err })
 
       if (err.isRateLimited) {
         fail(
@@ -945,7 +948,7 @@ async function tryGrantTeamTemplateRead(
   } catch (err) {
     // Log the raw error so a dev-time bug isn't fully hidden behind the
     // user-facing warning string.
-    console.error("grantTeamTemplateRead failed (assignment saved):", err)
+    log.error("grantTeamTemplateRead failed (assignment saved)", { err })
     const detail = getErrorMessage(err)
     return (
       `Assignment "${slug}" was saved, but granting the classroom team read on ` +

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -132,10 +132,12 @@ async function withAcceptStep<T>(
 ): Promise<T> {
   const { id, label, actions, onStepUpdate, doneMessage } = params
 
+  log.info(`accept step: ${id} started`, { step: id })
   onStepUpdate?.({ id, status: "running", message: label })
 
   try {
     const result = await fn()
+    log.info(`accept step: ${id} complete`, { step: id })
     onStepUpdate?.({ id, status: "complete", message: doneMessage ?? label })
     return result
   } catch (err) {
@@ -145,6 +147,7 @@ async function withAcceptStep<T>(
     }
 
     if (err instanceof TemplateAccessError || err instanceof AcceptStepError) {
+      log.warn(`accept step "${label}" failed (typed)`, { step: id })
       onStepUpdate?.({ id, status: "error", error: err.message })
       throw err
     }
@@ -167,6 +170,7 @@ async function withAcceptStep<T>(
     }
     // Unexpected non-GitHub error (network/parse/etc.): surface it so the
     // checklist row leaves "running" instead of spinning forever.
+    log.error(`accept step "${label}" failed (unexpected)`, { err })
     onStepUpdate?.({
       id,
       status: "error",
@@ -544,6 +548,8 @@ export async function editAssignment(
   input: CreateAssignmentInput,
 ): Promise<CreateAssignmentResult> {
   const { org, classroom, slug } = input
+
+  log.info("edit assignment: started", { org, classroom, slug })
 
   // The archive guard is independent of the org ref read, so run them
   // concurrently — Promise.all rejects on the first rejection, so an archived
@@ -969,6 +975,11 @@ export async function createAssignment(
   client: GitHubClient,
   input: CreateAssignmentInput,
 ): Promise<CreateAssignmentResult> {
+  log.info("create assignment: started", {
+    org: input.org,
+    classroom: input.classroom,
+    slug: input.slug,
+  })
   // The archive guard, entry build, and org ref read are independent, so run
   // them concurrently — Promise.all rejects on the first rejection, so an
   // archived classroom still fails closed before any write.
@@ -1401,6 +1412,12 @@ export async function copyAssignmentToClassroom(
 ): Promise<CreateAssignmentResult> {
   const { org, source, targetClassroom } = input
 
+  log.info("copy assignment: started", {
+    org,
+    targetClassroom,
+    sourceSlug: source.slug,
+  })
+
   const entry = buildReusedEntry(source, {
     slug: input.targetSlug ?? source.slug,
     name: input.targetName ?? source.name,
@@ -1622,6 +1639,8 @@ export async function deleteAssignment(
   input: DeleteAssignmentInput,
 ) {
   const { org, classroom, assignment: slug } = input
+
+  log.info("delete assignment: started", { org, classroom, slug })
 
   // Refuse a delete into an archived classroom (write-path guard); run the
   // check concurrently with the ref read.
@@ -1937,6 +1956,8 @@ export async function acceptAssignment(params: {
   const { client, org, classroom, assignmentSlug, secret, onStepUpdate } =
     params
 
+  log.info("accept assignment: started", { org, classroom, assignmentSlug })
+
   const user = await withAcceptStep(
     {
       id: "account",
@@ -1988,7 +2009,11 @@ export async function acceptAssignment(params: {
   if (sourceOwner) {
     try {
       sourceOwnerId = (await getUser(client, sourceOwner)).id
-    } catch {
+    } catch (err) {
+      log.debug("accept: template owner id lookup failed (non-fatal)", {
+        sourceOwner,
+        err,
+      })
       sourceOwnerId = null
     }
   }
@@ -2131,6 +2156,12 @@ export async function acceptAssignment(params: {
     onStepUpdate,
   })
 
+  log.info("accept assignment: completed", {
+    org,
+    classroom,
+    assignmentSlug,
+    status: "created",
+  })
   return {
     status: "created",
     repo,

--- a/web/src/api/mutations/classrooms.ts
+++ b/web/src/api/mutations/classrooms.ts
@@ -21,6 +21,9 @@ import {
   type StaffTeamRefs,
 } from "@/hooks/github/mutations"
 import { prefixCommit } from "@/util/commit"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("mutations:classrooms")
 
 export type CreateClassroomResult = {
   previousCommitSha: string
@@ -33,6 +36,10 @@ export async function createClassroomFiles(
   client: GitHubClient,
   input: CreateClassroomInput,
 ): Promise<CreateClassroomResult> {
+  log.info("create classroom: started", {
+    org: input.org,
+    classroom: input.classroom,
+  })
   // Create (or adopt) the teams BEFORE scaffolding so their { id, slug } land in
   // classroom.json (mirrors the CLI). The students team grants rostered students
   // read on private org templates; the staff teams (instructor, ta) get
@@ -60,6 +67,11 @@ export async function createClassroomFiles(
         role: "maintainer",
       })
     } catch {
+      log.warn("create classroom: seeding creator as instructor failed", {
+        org: input.org,
+        classroom: input.classroom,
+        creator: input.creator,
+      })
       // Non-fatal; surface nothing — the classroom still scaffolds.
     }
   }
@@ -88,6 +100,11 @@ export async function createClassroomFiles(
     updatedRef = await updateRef(client, input.org, newCommit.sha)
   } catch (err) {
     if (!(err instanceof GitHubAPIError && err.status === 409)) {
+      log.warn("create classroom: scaffolding failed, rolling back teams", {
+        org: input.org,
+        classroom: input.classroom,
+        err,
+      })
       await rollbackCreatedTeams(client, input.org, {
         students: teamCreated ? team : undefined,
         staff: teams,
@@ -96,6 +113,11 @@ export async function createClassroomFiles(
     }
     throw err
   }
+
+  log.info("create classroom: completed", {
+    org: input.org,
+    classroom: input.classroom,
+  })
 
   return {
     previousCommitSha: ref.object.sha,
@@ -126,6 +148,10 @@ async function rollbackCreatedTeams(
     try {
       await deleteClassroomTeam(client, org, t)
     } catch {
+      log.warn("rollback: team delete failed (best-effort)", {
+        org,
+        teamSlug: t.slug,
+      })
       // Best-effort cleanup; surface the original scaffolding error.
     }
   }
@@ -148,6 +174,7 @@ export async function withGitConflictRetry<T>(
       if (!isConflict || attempt === attempts) {
         throw err
       }
+      log.debug("git conflict, retrying commit", { attempt })
       await sleep(300 * attempt + Math.random() * 400)
     }
   }
@@ -281,6 +308,11 @@ async function deleteClassroomTeamWithRetry(
       if (!isTransientDeleteError(err) || attempt === attempts) {
         throw err
       }
+      log.debug("team delete transient failure, retrying", {
+        org,
+        teamSlug: team.slug,
+        attempt,
+      })
       await sleep(300 * attempt + Math.random() * 400)
     }
   }
@@ -293,6 +325,8 @@ export async function deleteClassroom(
 ) {
   const { org, classroom, branch = "main" } = input
   const prefix = `${classroom}/`
+
+  log.info("delete classroom: started", { org, classroom })
 
   // Resolve the team refs from classroom.json BEFORE the deletion commit
   // removes the file. No team block (pre-feature) or a read failure yields no
@@ -309,6 +343,13 @@ export async function deleteClassroom(
     team = classroomJson.team
     staffTeams = classroomJson.teams ?? {}
   } catch {
+    log.debug(
+      "delete classroom: classroom.json unreadable, no teams to remove",
+      {
+        org,
+        classroom,
+      },
+    )
     team = undefined
     staffTeams = {}
   }
@@ -393,7 +434,13 @@ export async function deleteClassroom(
   for (const teamRef of refsToDelete) {
     try {
       await deleteClassroomTeamWithRetry(client, org, teamRef)
-    } catch {
+    } catch (err) {
+      log.warn("delete classroom: team delete failed", {
+        org,
+        teamSlug: teamRef.slug,
+        err,
+        record: true,
+      })
       failedTeamSlugs.push(teamRef.slug)
     }
   }
@@ -407,6 +454,13 @@ export async function deleteClassroom(
             ", ",
           )}; delete by hand at https://github.com/orgs/${org}/teams if they linger.`
       : undefined
+
+  log.info("delete classroom: completed", {
+    org,
+    classroom,
+    deletedPaths: entriesToDelete.length,
+    teamsFailed: failedTeamSlugs.length,
+  })
 
   return {
     deleted: true,

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -476,6 +476,7 @@ export async function enrollStudentInClassroom(
   input: AddStudentToClassroomInput,
 ) {
   const { org, classroom } = input
+  log.info("enroll student: started", { org, classroom })
   await assertClassroomNotArchived(client, org, classroom)
   // Resolve the classroom team (slug + id) once, concurrently with the commit.
   // Can reject on a transient read; attach a catch to avoid an unhandled
@@ -491,6 +492,11 @@ export async function enrollStudentInClassroom(
 
   const result = await addStudentToClassroomWithConflictRetry(client, {
     ...input,
+    enrolled: alreadyMember,
+  })
+  log.info("enroll student: roster row committed", {
+    org,
+    classroom,
     enrolled: alreadyMember,
   })
 
@@ -547,6 +553,11 @@ export async function enrollStudentInClassroom(
     )
   }
 
+  log.info("enroll student: completed", {
+    org,
+    classroom,
+    warnings: warnings.length,
+  })
   return {
     ...result,
     // Whether the student is now an active org member (team-added directly, no
@@ -625,6 +636,12 @@ export async function addStudentsToClassroom(
   if (normalizedRows.length === 0) {
     throw new Error("At least one GitHub username is required")
   }
+
+  log.info("bulk add students: started", {
+    org: input.org,
+    classroom: input.classroom,
+    total: normalizedRows.length,
+  })
 
   await assertClassroomNotArchived(client, input.org, input.classroom)
 
@@ -725,6 +742,10 @@ export async function addStudentsToClassroom(
       existingGithubIds.add(student.github_id)
       addedStudents.push(student)
     } catch (err) {
+      log.debug("bulk add: user lookup failed, skipping row", {
+        username,
+        err,
+      })
       skippedStudents.push({
         username,
         reason: "not_found",
@@ -787,6 +808,13 @@ export async function addStudentsToClassroom(
     message: "students.csv updated.",
   })
 
+  log.info("bulk add students: completed", {
+    org: input.org,
+    classroom: input.classroom,
+    added: addedStudents.length,
+    skipped: skippedStudents.length,
+  })
+
   return {
     previousCommitSha: ref.object.sha,
     baseTreeSha: commit.tree.sha,
@@ -829,6 +857,7 @@ export async function syncRosterFromTeam(
   input: { org: string; classroom: string },
 ): Promise<SyncRosterFromTeamResult> {
   const { org, classroom } = input
+  log.info("sync roster from team: started", { org, classroom })
   await assertClassroomNotArchived(client, org, classroom)
 
   const teamSlug = await resolveClassroomTeamSlug(client, org, classroom)
@@ -873,6 +902,10 @@ export async function syncRosterFromTeam(
     )
 
     if (missing.length === 0) {
+      log.info("sync roster from team: completed (up to date)", {
+        org,
+        classroom,
+      })
       return { addedUsernames: [], noop: true }
     }
 
@@ -919,6 +952,11 @@ export async function syncRosterFromTeam(
 
     await updateRef(client, org, newCommit.sha)
 
+    log.info("sync roster from team: completed", {
+      org,
+      classroom,
+      added: addedRows.length,
+    })
     return {
       addedUsernames: addedRows.map((r) => r.username),
       noop: false,
@@ -962,6 +1000,11 @@ export async function reconcileTeamFromOrgMembers(
   input: ReconcileTeamInput,
 ): Promise<ReconcileTeamResult> {
   const { org, classroom, usernames } = input
+  log.info("reconcile team from org members: started", {
+    org,
+    classroom,
+    candidates: usernames.length,
+  })
   await assertClassroomNotArchived(client, org, classroom)
 
   const added: string[] = []
@@ -1003,6 +1046,13 @@ export async function reconcileTeamFromOrgMembers(
     else failed.push({ login, message: result.detail })
   }
 
+  log.info("reconcile team from org members: completed", {
+    org,
+    classroom,
+    added: added.length,
+    skipped: skipped.length,
+    failed: failed.length,
+  })
   return { added, skipped, failed }
 }
 
@@ -1155,6 +1205,12 @@ export async function bulkEnrollStudentsInClassroom(
 
   const total = (bulkInput.rows ?? bulkInput.usernames ?? []).length
 
+  log.info("bulk enroll: started", {
+    org: bulkInput.org,
+    classroom: bulkInput.classroom,
+    total,
+  })
+
   onProgress?.({
     processed: 0,
     total,
@@ -1179,6 +1235,11 @@ export async function bulkEnrollStudentsInClassroom(
       bulkInput.classroom,
     )
   } catch (err) {
+    log.warn("bulk enroll: classroom team read failed, team adds will defer", {
+      org: bulkInput.org,
+      classroom: bulkInput.classroom,
+      err,
+    })
     teamSlugError = getErrorMessage(err)
   }
 
@@ -1254,6 +1315,15 @@ export async function bulkEnrollStudentsInClassroom(
     message: "Import complete",
   })
 
+  log.info("bulk enroll: completed", {
+    org: bulkInput.org,
+    classroom: bulkInput.classroom,
+    added: addResult.addedStudents.length,
+    skipped: addResult.skippedStudents.length,
+    notInOrg: notInOrg.length,
+    teamFailed: teamResults.filter((r) => r.status === "failed").length,
+  })
+
   return {
     ...addResult,
     teamResults,
@@ -1288,6 +1358,7 @@ export async function unenrollStudent(
   input: UnenrollStudentInput,
 ) {
   const { org, classroom, student: toRemoveStudent } = input
+  log.info("unenroll student: started", { org, classroom })
   await assertClassroomNotArchived(client, org, classroom)
   const normalizedUsername = toRemoveStudent?.username.trim()
   const normalizedEmail = toRemoveStudent?.email?.trim()
@@ -1422,6 +1493,11 @@ export async function unenrollStudent(
     }
   }
 
+  log.info("unenroll student: completed", {
+    org,
+    classroom,
+    warnings: warnings.length,
+  })
   return {
     previousCommitSha: ref.object.sha,
     baseTreeSha: commit.tree.sha,
@@ -1481,6 +1557,8 @@ export async function bulkUnenrollStudents(
   if (targets.length === 0) {
     return { removed: [], notFound: [], warnings: [] }
   }
+
+  log.info("bulk unenroll: started", { org, classroom, total: targets.length })
 
   // Same per-row match predicate as unenrollStudent (shared matchesRosterRow):
   // username/github_id.
@@ -1563,7 +1641,12 @@ export async function bulkUnenrollStudents(
   let teamSlug: string | undefined
   try {
     teamSlug = await teamSlugPromise
-  } catch {
+  } catch (err) {
+    log.warn("bulk unenroll: classroom team read failed, skipping team drops", {
+      org,
+      classroom,
+      err,
+    })
     teamSlug = undefined
   }
 
@@ -1582,6 +1665,7 @@ export async function bulkUnenrollStudents(
       try {
         await removeUserFromTeam(client, { org, teamSlug, username })
       } catch (err) {
+        log.error("team removal failed (student bulk-unenrolled)", { err })
         warnings.push(
           `${username} was removed from the roster, but removing them from the ` +
             `classroom team failed (${getErrorMessage(err)}); they may keep read ` +
@@ -1599,6 +1683,12 @@ export async function bulkUnenrollStudents(
         try {
           await removeOrgMembership(client, { org, username })
         } catch (err) {
+          log.error(
+            "org invite cancellation failed (student bulk-unenrolled)",
+            {
+              err,
+            },
+          )
           warnings.push(
             `${username} was removed from the roster, but cancelling their ` +
               `pending org invite failed (${getErrorMessage(err)}); retry from ` +
@@ -1618,6 +1708,14 @@ export async function bulkUnenrollStudents(
     processed: removed.length,
     total: removed.length,
     message: "Done",
+  })
+
+  log.info("bulk unenroll: completed", {
+    org,
+    classroom,
+    removed: removed.length,
+    notFound: notFound.length,
+    warnings: warnings.length,
   })
 
   return { removed, notFound, warnings, newCommitSha }

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -34,6 +34,9 @@ import { mapWithConcurrency } from "@/util/concurrency"
 import { escapeCsvFormulaInjection } from "@/util/csv"
 import { prefixCommit } from "@/util/commit"
 import { type Student } from "@/types/classroom"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("mutations:students")
 
 // Slug is authoritative in classroom.json: GitHub may assign a non-derived slug
 // on name collision. Only derive on 404/missing team block; propagate transient
@@ -123,7 +126,7 @@ async function tryAddUserToTeam(
     })
     return { ok: true }
   } catch (err) {
-    console.error(`team add failed (${context}):`, err)
+    log.error(`team add failed (${context})`, { err })
     return { ok: false, detail: getErrorMessage(err) }
   }
 }
@@ -444,7 +447,7 @@ export async function inviteByEmail(
           `If they should be on this classroom, add them by GitHub username.`,
       }
     }
-    console.error("org email invite failed:", err)
+    log.error("org email invite failed", { err })
     return {
       inviteWarning:
         `Sending the organization invite to ${normalizedEmail} failed ` +
@@ -511,7 +514,7 @@ export async function enrollStudentInClassroom(
         teamIds: teamId ? [teamId] : undefined,
       })
     } catch (err) {
-      console.error("org invite failed (student enrolled):", err)
+      log.error("org invite failed (student enrolled)", { err })
       const detail = getErrorMessage(err)
       warnings.push(
         `${result.student.username} was added to the roster, but sending their ` +
@@ -533,7 +536,7 @@ export async function enrollStudentInClassroom(
     if (!added.ok) enrollTeamFailed = added.detail
   } catch (err) {
     // Slug resolution failed (not the add itself).
-    console.error("team resolve failed (student enrolled):", err)
+    log.error("team resolve failed (student enrolled)", { err })
     enrollTeamFailed = getErrorMessage(err)
   }
   if (enrollTeamFailed) {
@@ -1376,7 +1379,7 @@ export async function unenrollStudent(
         username: normalizedUsername,
       })
     } catch (err) {
-      console.error("team removal failed (student unenrolled):", err)
+      log.error("team removal failed (student unenrolled)", { err })
       const detail = getErrorMessage(err)
       warnings.push(
         `${toRemoveStudent.username} was removed from the roster, but removing ` +
@@ -1409,7 +1412,7 @@ export async function unenrollStudent(
     try {
       await removeOrgMembership(client, { org, username: normalizedUsername })
     } catch (err) {
-      console.error("org invite cancellation failed (student unenrolled):", err)
+      log.error("org invite cancellation failed (student unenrolled)", { err })
       const detail = getErrorMessage(err)
       warnings.push(
         `${toRemoveStudent.username} was removed from the roster, but ` +

--- a/web/src/api/mutations/teardown.ts
+++ b/web/src/api/mutations/teardown.ts
@@ -24,6 +24,9 @@ import {
 } from "@/hooks/github/queries"
 import { CONFIG_REPO } from "@/hooks/github/orgChecks"
 import { mapWithConcurrency } from "@/util/concurrency"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("mutations:teardown")
 
 export class TeardownScopeError extends Error {
   constructor(message: string) {
@@ -77,6 +80,12 @@ async function collectClassroomTeams(
   try {
     dirs = await listClassroomDirs(client, org)
   } catch {
+    log.debug(
+      "teardown: no readable classroom dirs, skipping team collection",
+      {
+        org,
+      },
+    )
     // No readable classroom dirs (e.g. marker already partially gone) — nothing
     // to resolve; let the repo flow proceed.
     return []
@@ -97,6 +106,10 @@ async function collectClassroomTeams(
         }
       }
     } catch {
+      log.debug("teardown: classroom.json unreadable, no team ref", {
+        org,
+        classroom: dir.name,
+      })
       // Missing/unreadable classroom.json or no team block: contributes nothing.
     }
   })
@@ -209,6 +222,10 @@ async function withDeleteRetry(
         err.rateLimit.retryAfter !== null ? err.rateLimit.retryAfter * 1000 : 0
       const backoffMs = Math.min(8000, 500 * 2 ** attempt)
       const jitterMs = Math.floor(Math.random() * 250)
+      log.debug("teardown: delete retry backoff", {
+        attempt,
+        rateLimited: isRateLimited,
+      })
       await sleep(Math.max(retryAfterMs, backoffMs) + jitterMs)
     }
   }
@@ -303,6 +320,13 @@ export async function executeTeardown(
   const nonMarker = current.repoNames.filter((n) => n !== CONFIG_REPO)
   const marker = current.repoNames.filter((n) => n === CONFIG_REPO)
 
+  log.warn("teardown: STARTED (destructive, irreversible)", {
+    org: plan.org,
+    repos: nonMarker.length,
+    teams: current.teams.length,
+    record: true,
+  })
+
   let scopeWall = false
   let rateLimited = false
 
@@ -310,12 +334,18 @@ export async function executeTeardown(
     try {
       const outcome = await deleteRepoWithRetry(client, plan.org, repo)
       if (outcome === "deleted") {
+        log.info("teardown: repo deleted", { org: plan.org, repo })
         deleted.push(repo)
       } else {
         // Retries exhausted: a throttle is retryable; other transient failures
         // (5xx) go to `failed` so the marker is preserved (re-runnable). Repos
         // never see "permanent-failed" — a scope 403 rethrows below instead.
         if (outcome === "rate-limited") rateLimited = true
+        log.warn("teardown: repo delete failed", {
+          org: plan.org,
+          repo,
+          outcome,
+        })
         failed.push(repo)
       }
     } catch (err) {
@@ -323,6 +353,11 @@ export async function executeTeardown(
       if (err instanceof GitHubAPIError && err.isForbidden) {
         scopeWall = true
       }
+      log.error("teardown: repo delete errored", {
+        org: plan.org,
+        repo,
+        err,
+      })
       failed.push(repo)
     }
   }
@@ -332,8 +367,24 @@ export async function executeTeardown(
   // A scope 403 is unrecoverable; a throttle is retryable. Both abort before
   // the marker so the run stays re-runnable.
   const abortIfBlocked = () => {
-    if (scopeWall) throw new TeardownScopeError(DELETE_SCOPE_MESSAGE)
-    if (rateLimited) throw new TeardownRateLimitError(deleted, failed)
+    if (scopeWall) {
+      log.error("teardown aborted: missing delete_repo scope", {
+        org: plan.org,
+        deleted: deleted.length,
+        failed: failed.length,
+        record: true,
+      })
+      throw new TeardownScopeError(DELETE_SCOPE_MESSAGE)
+    }
+    if (rateLimited) {
+      log.warn("teardown aborted: rate limited (re-runnable)", {
+        org: plan.org,
+        deleted: deleted.length,
+        failed: failed.length,
+        record: true,
+      })
+      throw new TeardownRateLimitError(deleted, failed)
+    }
   }
 
   abortIfBlocked()
@@ -360,7 +411,20 @@ export async function executeTeardown(
     }
     abortIfBlocked()
     markerDeleted = deleted.includes(CONFIG_REPO)
+    if (markerDeleted) {
+      log.info("teardown: marker repo deleted", { org: plan.org })
+    }
   }
+
+  log.warn("teardown: completed", {
+    org: plan.org,
+    deleted: deleted.length,
+    failed: failed.length,
+    teamsDeleted: teamsDeleted.length,
+    teamsFailed: teamsFailed.length,
+    markerDeleted,
+    record: true,
+  })
 
   return { deleted, failed, teamsDeleted, teamsFailed, markerDeleted }
 }

--- a/web/src/api/mutations/users.ts
+++ b/web/src/api/mutations/users.ts
@@ -1,6 +1,9 @@
 import type { GitHubClient } from "@/hooks/github/client"
 import { getPendingOrgInvite } from "@/hooks/github/mutations"
 import type { GitHubOrgMembership } from "@/hooks/github/types"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("mutations:users")
 
 // Accept a pending org invitation for the authenticated user. Returns whether
 // the PATCH succeeded so callers can tell "now active" from a transient failure
@@ -13,7 +16,8 @@ export async function acceptPendingOrgInvite(
   try {
     await acceptPendingOrgInviteOrThrow(client, org)
     return { ok: true }
-  } catch {
+  } catch (err) {
+    log.debug("best-effort accept of pending org invite failed", { org, err })
     return { ok: false }
   }
 }

--- a/web/src/auth/github-user-api.ts
+++ b/web/src/auth/github-user-api.ts
@@ -1,4 +1,7 @@
 import type { GitHubUser } from "@/hooks/github/types"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("auth")
 
 // Carries the HTTP status so callers can branch on auth failures (401) without
 // string-matching the message — e.g. the session-expiry effect in useGithubAuth.
@@ -21,6 +24,7 @@ export async function fetchGithubUser(token: string): Promise<GitHubUser> {
   })
 
   if (!res.ok) {
+    log.warn("GET /user failed", { status: res.status })
     throw new GitHubUserFetchError(res.status)
   }
 
@@ -43,6 +47,7 @@ export async function fetchGithubUserWithScopes(
   })
 
   if (!res.ok) {
+    log.warn("GET /user (PAT validation) failed", { status: res.status })
     throw new GitHubUserFetchError(res.status)
   }
 

--- a/web/src/auth/github-user-api.ts
+++ b/web/src/auth/github-user-api.ts
@@ -1,7 +1,8 @@
 import type { GitHubUser } from "@/hooks/github/types"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_AUTH } from "@/lib/logScopes"
 
-const log = logger.scope("auth")
+const log = logger.scope(LOG_SCOPE_AUTH)
 
 // Carries the HTTP status so callers can branch on auth failures (401) without
 // string-matching the message — e.g. the session-expiry effect in useGithubAuth.

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -24,6 +24,7 @@ import {
 } from "./github-user-api"
 import { isDefinitiveGitHubStatus } from "@/hooks/github/errors"
 import router from "@/router"
+import { logger } from "@/lib/logger"
 import { deriveChallenge, generateVerifier, randomBase64Url } from "./pkce"
 import { missingScopes } from "./scopes"
 import {
@@ -43,6 +44,8 @@ import type { AuthStatus } from "@/types/router"
 // react-i18next's `t` we rely on (key + optional interpolation values).
 type Translate = (key: string, options?: Record<string, unknown>) => string
 
+const log = logger.scope("auth")
+
 function formatError(
   t: Translate,
   err: unknown,
@@ -53,6 +56,8 @@ function formatError(
   networkTarget: string = t("auth.errorNetworkProxyTarget"),
 ) {
   const message = err instanceof Error ? err.message : String(err)
+
+  log.debug("formatting auth error for display", { message })
 
   if (
     message.toLowerCase().includes("failed to fetch") ||
@@ -184,6 +189,7 @@ function useGithubAuthState() {
   // card shows a spinner (no interstitial success splash).
   const completeSignIn = useCallback(
     (data: { access_token: string; scope?: string }) => {
+      log.info("sign-in complete, token acquired")
       persistGithubToken(data.access_token, data.scope || "")
       setToken(data.access_token)
       setTokenScope(data.scope || "")
@@ -220,6 +226,7 @@ function useGithubAuthState() {
     setTokenScope(storedScope)
 
     if (storedToken) {
+      log.info("restored stored session")
       setToken(storedToken)
       setScreen("authed")
     }
@@ -260,17 +267,24 @@ function useGithubAuthState() {
     } = consumeOAuthSession()
 
     if (!returnedState || returnedState !== expectedState) {
+      log.error("OAuth state mismatch — possible CSRF, aborting sign-in", {
+        record: true,
+      })
       setError(t("auth.errorStateMismatch"))
       setScreen("config")
       return
     }
 
     if (!verifier || !callbackClientId) {
+      log.error("OAuth callback missing PKCE verifier/clientId", {
+        record: true,
+      })
       setError(t("auth.errorMissingPkce"))
       setScreen("config")
       return
     }
 
+    log.info("OAuth callback received, exchanging code")
     setClientId(callbackClientId)
     persistGithubClientId(callbackClientId)
 
@@ -292,6 +306,7 @@ function useGithubAuthState() {
           pendingReturnToRef.current = returnTo
         },
         onError: (err) => {
+          log.error("OAuth code exchange failed", { err, record: true })
           setError(formatError(t, err))
           setScreen("config")
         },
@@ -333,6 +348,7 @@ function useGithubAuthState() {
     const config = validateConfig()
     if (!config) return
 
+    log.info("starting web (PKCE) sign-in flow")
     setScreen("exchanging")
 
     const verifier = generateVerifier()
@@ -360,6 +376,7 @@ function useGithubAuthState() {
   }, [validateConfig])
 
   const failDeviceFlow = useCallback((message: string) => {
+    log.warn("device flow failed", { record: true })
     abortRef.current?.abort()
     abortRef.current = null
     setError(message)
@@ -430,6 +447,9 @@ function useGithubAuthState() {
         if (data.error === "authorization_pending") continue
 
         if (data.error === "slow_down") {
+          log.debug("device poll: slow_down, backing off", {
+            intervalSeconds: intervalSeconds + 5,
+          })
           intervalSeconds += 5
           continue
         }
@@ -466,10 +486,12 @@ function useGithubAuthState() {
     const config = validateConfig()
     if (!config) return
 
+    log.info("starting device sign-in flow")
     setError(null)
 
     requestDeviceCodeMutation.mutate(config, {
       onSuccess: (data) => {
+        log.info("device code issued, awaiting authorization")
         const intervalSeconds = data.interval || 5
         const expiresAt = Date.now() + data.expires_in! * 1000
 
@@ -552,6 +574,7 @@ function useGithubAuthState() {
 
       setPatError(null)
 
+      log.info("validating personal access token")
       validatePatMutation.mutate(token, {
         onSuccess: ({ scopes }) => {
           const result = classifyPatResult(scopes)
@@ -561,11 +584,15 @@ function useGithubAuthState() {
           // mid-operation, so block it at entry rather than sign in on a token
           // we can't vet.
           if (result.kind === "fine-grained") {
+            log.warn("PAT rejected: fine-grained (unverifiable scopes)")
             setPatError(t("auth.errorPatFineGrained"))
             return
           }
 
           if (result.kind === "missing") {
+            log.warn("PAT rejected: missing required scopes", {
+              missing: result.missing,
+            })
             setPatError(
               t("auth.errorPatMissingScopes", {
                 scopes: result.missing.join(", "),
@@ -578,9 +605,11 @@ function useGithubAuthState() {
         },
         onError: (err) => {
           if (err instanceof GitHubUserFetchError && err.status === 401) {
+            log.warn("PAT rejected: 401 (invalid token)")
             setPatError(t("auth.errorPatRejected401"))
             return
           }
+          log.error("PAT validation failed", { err, record: true })
           setPatError(formatError(t, err, "api.github.com"))
         },
       })
@@ -592,6 +621,13 @@ function useGithubAuthState() {
   // `expired` flags the involuntary case so /login can explain the redirect.
   const clearSession = useCallback(
     (expired: boolean) => {
+      if (expired) {
+        // Involuntary teardown (a live 401): warn + record so a user's
+        // diagnostics reflect why they were kicked out.
+        log.warn("session expired, signing out", { record: true })
+      } else {
+        log.info("signing out")
+      }
       abortRef.current?.abort()
       clearGithubToken()
       setToken(null)
@@ -690,6 +726,9 @@ function useGithubAuthState() {
     try {
       router.history.push(returnTo)
     } catch {
+      log.warn("invalid return-to path, falling back to home", {
+        record: true,
+      })
       router.history.push("/")
     }
   }, [status])

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -25,6 +25,7 @@ import {
 import { isDefinitiveGitHubStatus } from "@/hooks/github/errors"
 import router from "@/router"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_AUTH } from "@/lib/logScopes"
 import { deriveChallenge, generateVerifier, randomBase64Url } from "./pkce"
 import { missingScopes } from "./scopes"
 import {
@@ -44,7 +45,7 @@ import type { AuthStatus } from "@/types/router"
 // react-i18next's `t` we rely on (key + optional interpolation values).
 type Translate = (key: string, options?: Record<string, unknown>) => string
 
-const log = logger.scope("auth")
+const log = logger.scope(LOG_SCOPE_AUTH)
 
 function formatError(
   t: Translate,

--- a/web/src/components/dev/RateLimitOverlay.tsx
+++ b/web/src/components/dev/RateLimitOverlay.tsx
@@ -61,6 +61,9 @@ export function RateLimitOverlay() {
   // The total-call count captured when the current view loaded; per-view calls
   // are the delta since. Kept in state (not a ref) and rebased via the "derive
   // state during render" pattern so a route change resets it without an effect.
+  // Approximate ("~"): baseline (totalCalls) and pathname come from independent
+  // stores, so a call firing across a route change can land in either bucket —
+  // fine for a dev glance, not an accounting figure.
   const [view, setView] = useState({ path: pathname, baseline: totalCalls })
   if (view.path !== pathname) {
     setView({ path: pathname, baseline: totalCalls })
@@ -94,7 +97,7 @@ export function RateLimitOverlay() {
           title="Toggle GitHub rate-limit details"
         >
           <span className="opacity-60">this view</span>
-          <span>{callsThisView} calls</span>
+          <span>~{callsThisView} calls</span>
           <span className="opacity-40">{collapsed ? "▸" : "▾"}</span>
         </button>
         {!collapsed && (

--- a/web/src/components/dev/RateLimitOverlay.tsx
+++ b/web/src/components/dev/RateLimitOverlay.tsx
@@ -70,19 +70,20 @@ export function RateLimitOverlay() {
   }
   const callsThisView = totalCalls - view.baseline
 
-  // Tick once a second only while there's a reset to count down toward.
+  // Tick once a second only while there's a snapshot to count down toward. Keyed
+  // on whether a snapshot exists (not its identity) so a new snapshot object on
+  // every response doesn't tear down and re-arm the interval each time.
+  const hasSnapshot = snapshot !== null
   useEffect(() => {
-    if (!snapshot) return
+    if (!hasSnapshot) return
     const id = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(id)
-  }, [snapshot])
+  }, [hasSnapshot])
 
   const rateLimit = snapshot?.rateLimit ?? null
   const resetIn = secondsUntil(rateLimit?.reset ?? null, now)
   const tone = toneClass(rateLimit?.remaining ?? null, rateLimit?.limit ?? null)
 
-  // Portal to body so the bar is never inside the app's React root subtree —
-  // the app can't detect it via layout, scroll, or CSS descendant selectors.
   return createPortal(
     <div
       className="pointer-events-none fixed inset-x-0 bottom-0 z-[9999] flex justify-center"

--- a/web/src/components/dev/RateLimitOverlay.tsx
+++ b/web/src/components/dev/RateLimitOverlay.tsx
@@ -1,0 +1,131 @@
+// Dev-only overlay showing the latest GitHub rate-limit counters, so the data
+// that used to flood the console per-response is now glanceable and always
+// current instead. Mounted only under import.meta.env.DEV (see main.tsx), so it
+// never ships to production and needs no i18n (t()) — it's a developer tool.
+//
+// Rendered through a portal onto document.body (NOT inside the app's React root
+// subtree) and position:fixed, so from the website's perspective it doesn't
+// exist: it's outside the app's DOM tree, reserves no layout space, and can't be
+// matched by the app's own scroll containers or :has()/descendant selectors.
+
+import { useSyncExternalStore, useState, useEffect } from "react"
+import { createPortal } from "react-dom"
+import { useRouterState } from "@tanstack/react-router"
+
+import router from "@/router"
+import {
+  getApiCallCount,
+  getRateLimitSnapshot,
+  subscribeRateLimit,
+} from "@/lib/diagnostics/rateLimit"
+
+// Below this fraction of the limit remaining, warn; near-zero, danger. Mirrors
+// the "how close am I to a 429" question the overlay exists to answer.
+const WARN_FRACTION = 0.2
+const DANGER_FRACTION = 0.05
+
+function toneClass(remaining: number | null, limit: number | null): string {
+  if (remaining === null || limit === null || limit === 0)
+    return "text-base-content"
+  const frac = remaining / limit
+  if (frac <= DANGER_FRACTION) return "text-error"
+  if (frac <= WARN_FRACTION) return "text-warning"
+  return "text-success"
+}
+
+// Seconds until the rate-limit window resets (GitHub `reset` is epoch seconds).
+function secondsUntil(
+  resetEpochSec: number | null,
+  nowMs: number,
+): number | null {
+  if (resetEpochSec === null) return null
+  return Math.max(0, Math.round(resetEpochSec - nowMs / 1000))
+}
+
+export function RateLimitOverlay() {
+  const snapshot = useSyncExternalStore(
+    subscribeRateLimit,
+    getRateLimitSnapshot,
+  )
+  const totalCalls = useSyncExternalStore(subscribeRateLimit, getApiCallCount)
+  const [collapsed, setCollapsed] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
+
+  // Subscribe to the router directly (this overlay lives outside RouterProvider,
+  // mounted at the root) so a route change can rebase the per-view counter.
+  const pathname = useRouterState({
+    router,
+    select: (s) => s.location.pathname,
+  })
+
+  // The total-call count captured when the current view loaded; per-view calls
+  // are the delta since. Kept in state (not a ref) and rebased via the "derive
+  // state during render" pattern so a route change resets it without an effect.
+  const [view, setView] = useState({ path: pathname, baseline: totalCalls })
+  if (view.path !== pathname) {
+    setView({ path: pathname, baseline: totalCalls })
+  }
+  const callsThisView = totalCalls - view.baseline
+
+  // Tick once a second only while there's a reset to count down toward.
+  useEffect(() => {
+    if (!snapshot) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [snapshot])
+
+  const rateLimit = snapshot?.rateLimit ?? null
+  const resetIn = secondsUntil(rateLimit?.reset ?? null, now)
+  const tone = toneClass(rateLimit?.remaining ?? null, rateLimit?.limit ?? null)
+
+  // Portal to body so the bar is never inside the app's React root subtree —
+  // the app can't detect it via layout, scroll, or CSS descendant selectors.
+  return createPortal(
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-[9999] flex justify-center"
+      role="status"
+      aria-label="GitHub rate limit (dev)"
+    >
+      <div className="pointer-events-auto flex items-center gap-4 rounded-t-box border border-b-0 border-base-300 bg-base-100/95 px-4 py-1.5 font-mono text-xs shadow-lg backdrop-blur">
+        <button
+          type="button"
+          className="flex items-center gap-2 text-left"
+          onClick={() => setCollapsed((c) => !c)}
+          title="Toggle GitHub rate-limit details"
+        >
+          <span className="opacity-60">this view</span>
+          <span>{callsThisView} calls</span>
+          <span className="opacity-40">{collapsed ? "▸" : "▾"}</span>
+        </button>
+        {!collapsed && (
+          <div className="flex items-center gap-4">
+            <span>
+              <span className="opacity-60">rate-limit</span>{" "}
+              <span className={tone}>
+                {rateLimit?.remaining ?? "?"}/{rateLimit?.limit ?? "?"}
+              </span>
+            </span>
+            <span>
+              <span className="opacity-60">resource</span>{" "}
+              {rateLimit?.resource ?? "—"}
+            </span>
+            <span>
+              <span className="opacity-60">session total</span> {totalCalls}
+            </span>
+            <span>
+              <span className="opacity-60">resets in</span>{" "}
+              {resetIn === null ? "—" : `${resetIn}s`}
+            </span>
+            {rateLimit?.retryAfter != null && (
+              <span className="text-error">
+                <span className="opacity-60">retry-after</span>{" "}
+                {rateLimit.retryAfter}s
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/web/src/context/actions/ActionActivityProvider.tsx
+++ b/web/src/context/actions/ActionActivityProvider.tsx
@@ -7,6 +7,10 @@ import {
   type PropsWithChildren,
 } from "react"
 
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("context:actions")
+
 // A teacher action this session that triggered a workflow; the banner turns each
 // into a tracker bound to its run. Attribution anchors:
 //  - "sha":        a push run (publish-pages), matched by head_sha.
@@ -76,6 +80,7 @@ const loadState = (): PersistedState => {
       : []
     return { ops, dismissed }
   } catch {
+    log.warn("failed to load persisted action activity (corrupt storage)")
     return { ops: [], dismissed: [] }
   }
 }
@@ -84,6 +89,7 @@ const saveState = (state: PersistedState) => {
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
   } catch {
+    log.warn("failed to persist action activity (storage quota/write)")
     // Best-effort; in-memory tracking still works this mount.
   }
 }
@@ -101,6 +107,11 @@ export function ActionActivityProvider({ children }: PropsWithChildren) {
         id: nextOpId(),
         startedAt: Date.now(),
       }
+      log.info("action registered for run tracking", {
+        org: op.org,
+        label: op.label,
+        anchor: op.anchor.kind,
+      })
       setState((prev) => {
         const cutoff = Date.now() - OP_TTL_MS
         const ops = [...prev.ops.filter((o) => o.startedAt >= cutoff), full]

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -14,6 +14,9 @@ import {
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { missingScopes } from "@/auth/scopes"
 import { observeResponse } from "@/lib/diagnostics/observed"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("context:github")
 
 const GitHubClientContext = createContext<GitHubClient | null>(null)
 
@@ -44,6 +47,9 @@ export function GitHubProvider({
       // the guard redirects to /login instead of stranding the user on a dead
       // authed page. expireSession() no-ops once the token is cleared.
       if (signal.status === 401) {
+        log.warn("live 401 on API response, tearing down session", {
+          record: true,
+        })
         expireSession()
         return
       }
@@ -64,6 +70,7 @@ export function GitHubProvider({
 
   const client = useMemo(() => {
     if (!token) return null
+    log.debug("creating GitHub client for new token")
     return createGitHubClient({ token, onResponse })
   }, [token, onResponse])
 
@@ -105,6 +112,10 @@ export function useMissingScopes(): string[] {
 
   return useMemo(() => {
     if (!granted) return []
-    return missingScopes(granted)
+    const missing = missingScopes(granted)
+    if (missing.length > 0) {
+      log.debug("token is missing required scopes", { missing })
+    }
+    return missing
   }, [granted])
 }

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -13,6 +13,9 @@ import { AnimatePresence, motion } from "motion/react"
 import { toastVariants } from "@/lib/motion"
 import { Button, alertToneClass } from "@/components/ui"
 import { recordErrorToast } from "@/lib/activity/activityStore"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("context:notifications")
 
 export type ToastTone = "info" | "success" | "warning" | "error"
 
@@ -84,6 +87,14 @@ export function NotificationProvider({ children }: PropsWithChildren) {
       // double-listed.
       if (tone === "error" && typeof message === "string") {
         recordErrorToast(message)
+      } else {
+        // Error toasts are already recorded above; trace the rest at debug so a
+        // shown notification is visible in the log. Only a string message is
+        // logged (JSX has no clean label).
+        log.debug("toast shown", {
+          tone,
+          message: typeof message === "string" ? message : undefined,
+        })
       }
 
       // A keyed toast reuses its id so a replace updates in place; otherwise a

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -88,9 +88,8 @@ export function NotificationProvider({ children }: PropsWithChildren) {
       if (tone === "error" && typeof message === "string") {
         recordErrorToast(message)
       } else {
-        // Error toasts are already recorded above; trace the rest at debug so a
-        // shown notification is visible in the log. Only a string message is
-        // logged (JSX has no clean label).
+        // Non-error toasts: trace at debug so a shown notification is visible
+        // in the log.
         log.debug("toast shown", {
           tone,
           message: typeof message === "string" ? message : undefined,

--- a/web/src/context/roleView/RoleViewProvider.tsx
+++ b/web/src/context/roleView/RoleViewProvider.tsx
@@ -9,6 +9,9 @@ import {
   type PropsWithChildren,
 } from "react"
 import type { ViewAsRole } from "@/hooks/useClassroomRole"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("context:roleView")
 
 // "View as" preview: a client-side lens letting an instructor/owner preview the
 // app as a TA or student. Persisted per org+classroom in sessionStorage and
@@ -71,6 +74,11 @@ export function RoleViewProvider({
 
   const setViewAs = useCallback(
     (next: ViewAsRole | null) => {
+      log.info("view-as role changed", {
+        org,
+        classroom,
+        viewAs: next ?? "self",
+      })
       setViewAsState(next)
       if (typeof window === "undefined") return
       const key = keyFor(org, classroom)

--- a/web/src/hooks/github/client.test.ts
+++ b/web/src/hooks/github/client.test.ts
@@ -78,3 +78,56 @@ describe("createGitHubClient request timeout", () => {
     expect(DEFAULT_REQUEST_TIMEOUT_MS).toBe(15000)
   })
 })
+
+describe("createGitHubClient request logging", () => {
+  function stubJsonFetch(status = 200, body: unknown = { ok: true }): void {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    )
+  }
+
+  it("logs request + response debug lines with method/path, never the token", async () => {
+    stubJsonFetch()
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {})
+    const client = createGitHubClient({ token: "super-secret-token" })
+
+    await client.request("/rate_limit", { method: "GET" })
+
+    const lines = debug.mock.calls.map((c) => String(c[0]))
+    // A scoped request line and a scoped response line both fire.
+    expect(lines.some((l) => /\[github:client\].*request\b/.test(l))).toBe(true)
+    expect(lines.some((l) => /\[github:client\].*response\b/.test(l))).toBe(
+      true,
+    )
+    // The token must never appear in any logged line OR its context arg.
+    const serialized = JSON.stringify(debug.mock.calls)
+    expect(serialized).not.toContain("super-secret-token")
+
+    debug.mockRestore()
+  })
+
+  it("logs an api-error debug line (status/path, no body) on a failed response", async () => {
+    stubJsonFetch(404, { message: "Not Found", secret: "should-not-log" })
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {})
+    const client = createGitHubClient({ token: "t" })
+
+    await expect(
+      client.request("/missing", { method: "GET" }),
+    ).rejects.toThrow()
+
+    const apiError = debug.mock.calls.find((c) =>
+      /\[github:client\].*api error/.test(String(c[0])),
+    )
+    expect(apiError).toBeTruthy()
+    // The status is in the context; the raw body's non-message fields are not.
+    expect(JSON.stringify(apiError)).toContain("404")
+    expect(JSON.stringify(apiError)).not.toContain("should-not-log")
+
+    debug.mockRestore()
+  })
+})

--- a/web/src/hooks/github/client.test.ts
+++ b/web/src/hooks/github/client.test.ts
@@ -126,7 +126,9 @@ describe("createGitHubClient request logging", () => {
     expect(apiError).toBeTruthy()
     // The status is in the context; the raw body's non-message fields are not.
     expect(JSON.stringify(apiError)).toContain("404")
-    expect(JSON.stringify(apiError)).not.toContain("should-not-log")
+    // The raw response body must not appear in ANY logged call — not just the
+    // scrubbed `api error` line. Guards against a stray site logging `{ body }`.
+    expect(JSON.stringify(debug.mock.calls)).not.toContain("should-not-log")
 
     debug.mockRestore()
   })

--- a/web/src/hooks/github/client.ts
+++ b/web/src/hooks/github/client.ts
@@ -1,8 +1,9 @@
 import { GitHubAPIError, readGitHubRateLimitHeaders } from "./errors"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_GITHUB_CLIENT } from "@/lib/logScopes"
 import { countApiCall, publishRateLimit } from "@/lib/diagnostics/rateLimit"
 
-const log = logger.scope("github:client")
+const log = logger.scope(LOG_SCOPE_GITHUB_CLIENT)
 
 // Bound every request so a half-open GitHub connection can't pin a poll or
 // mutation forever (React Query imposes no request timeout; the banner uses
@@ -128,8 +129,6 @@ export function createGitHubClient(args: {
       } catch {
         body = text
       }
-
-      log.debug("body when request fail", { body })
 
       const message =
         typeof body === "object" &&

--- a/web/src/hooks/github/client.ts
+++ b/web/src/hooks/github/client.ts
@@ -78,14 +78,31 @@ export function createGitHubClient(args: {
         ? AbortSignal.any([options.signal, timeoutSignal])
         : (options.signal ?? timeoutSignal)
 
-    const res = await fetch(url, {
-      method: options.method ?? "GET",
-      headers,
-      body:
-        options.body === undefined ? undefined : JSON.stringify(options.body),
-      signal,
-      cache: options.method === "GET" ? "no-store" : undefined,
-    })
+    const method = options.method ?? "GET"
+    log.debug("request", { method, path })
+
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method,
+        headers,
+        body:
+          options.body === undefined ? undefined : JSON.stringify(options.body),
+        signal,
+        cache: options.method === "GET" ? "no-store" : undefined,
+      })
+    } catch (err) {
+      // A rejected fetch is an abort (caller cancel or our timeout) or a network
+      // failure. Distinguish so a timeout doesn't read as a mystery error; never
+      // log the token/headers/body — just method + path.
+      const aborted = err instanceof DOMException && err.name === "AbortError"
+      if (aborted) {
+        log.debug("request aborted", { method, path })
+      } else {
+        log.warn("request network error", { method, path })
+      }
+      throw err
+    }
 
     // Report the token's live state to the provider before any throw, so the
     // 401/403 revocation path still surfaces. `scopes` is the X-OAuth-Scopes
@@ -122,6 +139,15 @@ export function createGitHubClient(args: {
           ? body.message
           : `GitHub API request failed with ${res.status}`
 
+      // Trace the failure with non-sensitive fields only (never the body): the
+      // status, the endpoint, and GitHub's request id for support correlation.
+      log.debug("api error", {
+        method,
+        path,
+        status: res.status,
+        requestId: res.headers.get("x-github-request-id"),
+      })
+
       throw new GitHubAPIError({
         status: res.status,
         url,
@@ -135,6 +161,7 @@ export function createGitHubClient(args: {
       })
     }
 
+    log.debug("response", { method, path, status: res.status })
     return res
   }
 

--- a/web/src/hooks/github/client.ts
+++ b/web/src/hooks/github/client.ts
@@ -1,5 +1,6 @@
 import { GitHubAPIError, readGitHubRateLimitHeaders } from "./errors"
 import { logger } from "@/lib/logger"
+import { countApiCall, publishRateLimit } from "@/lib/diagnostics/rateLimit"
 
 const log = logger.scope("github:client")
 
@@ -48,6 +49,10 @@ export function createGitHubClient(args: {
     path: string,
     options: GitHubRequestOptions = { method: "GET" },
   ): Promise<Response> {
+    // Count every outbound call at the single choke point (covers request +
+    // requestRaw) — before the fetch, so a thrown/timed-out call still counts.
+    countApiCall()
+
     const url = path.startsWith("http")
       ? path
       : `${apiBaseUrl}${path.startsWith("/") ? path : `/${path}`}`
@@ -93,7 +98,9 @@ export function createGitHubClient(args: {
     })
 
     const rateLimit = readGitHubRateLimitHeaders(res)
-    log.debug("rate limit headers", { rateLimit })
+    // Publish to the dev rate-limit overlay instead of logging per-response
+    // (that flooded the console). No-op in prod (nothing subscribes).
+    publishRateLimit(rateLimit)
 
     if (!res.ok) {
       let body: unknown

--- a/web/src/hooks/github/client.ts
+++ b/web/src/hooks/github/client.ts
@@ -1,4 +1,7 @@
 import { GitHubAPIError, readGitHubRateLimitHeaders } from "./errors"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("github:client")
 
 // Bound every request so a half-open GitHub connection can't pin a poll or
 // mutation forever (React Query imposes no request timeout; the banner uses
@@ -90,9 +93,7 @@ export function createGitHubClient(args: {
     })
 
     const rateLimit = readGitHubRateLimitHeaders(res)
-    if (import.meta.env.DEV) {
-      console.warn("rate limit headers", rateLimit)
-    }
+    log.debug("rate limit headers", { rateLimit })
 
     if (!res.ok) {
       let body: unknown
@@ -104,9 +105,7 @@ export function createGitHubClient(args: {
         body = text
       }
 
-      if (import.meta.env.DEV) {
-        console.warn("body when request fail", body)
-      }
+      log.debug("body when request fail", { body })
 
       const message =
         typeof body === "object" &&

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -1,9 +1,13 @@
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_GITHUB_CLIENT } from "@/lib/logScopes"
 
 // Lazy so this module can be imported by logger.ts's dependency graph without a
-// top-level circular-init hazard (errors -> logger -> activityStore -> errors).
+// top-level circular-init hazard: logger.ts -> activityStore.ts -> errors.ts,
+// so at errors.ts eval time the `logger` export is still undefined. Verified:
+// an eager `logger.scope(...)` here throws "Cannot read properties of undefined
+// (reading 'scope')" on import. Keep lazy.
 let logInstance: ReturnType<typeof logger.scope> | null = null
-const log = () => (logInstance ??= logger.scope("github:client"))
+const log = () => (logInstance ??= logger.scope(LOG_SCOPE_GITHUB_CLIENT))
 
 export type GitHubRateLimit = {
   limit: number | null

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -1,3 +1,10 @@
+import { logger } from "@/lib/logger"
+
+// Lazy so this module can be imported by logger.ts's dependency graph without a
+// top-level circular-init hazard (errors -> logger -> activityStore -> errors).
+let logInstance: ReturnType<typeof logger.scope> | null = null
+const log = () => (logInstance ??= logger.scope("github:client"))
+
 export type GitHubRateLimit = {
   limit: number | null
   remaining: number | null
@@ -6,7 +13,6 @@ export type GitHubRateLimit = {
   resource: string | null
   retryAfter: number | null
 }
-
 export class GitHubAPIError extends Error {
   status: number
   url: string
@@ -140,6 +146,7 @@ export function parseSsoAuthorizationUrl(
     if (url.hostname !== "github.com") return null
     return url.toString()
   } catch {
+    log().debug("unparseable SSO authorization URL")
     return null
   }
 }
@@ -156,9 +163,16 @@ export function retryTransientGitHubError(
     error instanceof GitHubAPIError &&
     isDefinitiveGitHubStatus(error.status)
   ) {
+    log().debug("retry suppressed (definitive status)", {
+      status: error.status,
+    })
     return false
   }
-  return failureCount < 2
+  const willRetry = failureCount < 2
+  if (willRetry) {
+    log().debug("retrying transient error", { failureCount })
+  }
+  return willRetry
 }
 
 // Statuses that are DEFINITIVE for a GitHub read — retrying can't change the

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -23,9 +23,10 @@ import { repairRulesets } from "./rulesets"
 import { buildSkeletonFiles, type SkeletonFile } from "@/skeleton/skeleton"
 import { bytesToHex } from "@/util/hex"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_GITHUB_SETUP } from "@/lib/logScopes"
 
 const logWorkflows = logger.scope("github:workflows")
-const logSetup = logger.scope("github:setup")
+const logSetup = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
 const ASSIGNMENTS_TEMPLATE = {
   schema: "classroom50/assignments/v1",

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -22,6 +22,10 @@ import { prefixCommit } from "@/util/commit"
 import { repairRulesets } from "./rulesets"
 import { buildSkeletonFiles, type SkeletonFile } from "@/skeleton/skeleton"
 import { bytesToHex } from "@/util/hex"
+import { logger } from "@/lib/logger"
+
+const logWorkflows = logger.scope("github:workflows")
+const logSetup = logger.scope("github:setup")
 
 const ASSIGNMENTS_TEMPLATE = {
   schema: "classroom50/assignments/v1",
@@ -977,6 +981,7 @@ async function tryStep<T>({
 }): Promise<T | StepOutcome> {
   const { warningCodes } = options || {}
 
+  logSetup.info(`setup step: ${id} started`, { step: id })
   onStepUpdate?.({
     id,
     status: "running",
@@ -993,6 +998,12 @@ async function tryStep<T>({
         ? result.status
         : "complete"
 
+    logSetup.info(
+      `setup step: ${id} ${maybeStatus === "warning" ? "warning" : "complete"}`,
+      {
+        step: id,
+      },
+    )
     onStepUpdate?.({
       id,
       status: maybeStatus === "warning" ? "warning" : "complete",
@@ -1012,6 +1023,10 @@ async function tryStep<T>({
       err instanceof GitHubAPIError &&
       warningCodes?.some((code) => err.status === code)
     ) {
+      logSetup.warn(`setup step: ${id} warning`, {
+        step: id,
+        status: err.status,
+      })
       onStepUpdate?.({
         id,
         status: "warning",
@@ -1024,6 +1039,7 @@ async function tryStep<T>({
     }
 
     const message = err instanceof Error ? err.message : "Unknown error"
+    logSetup.error(`setup step: ${id} failed`, { step: id, err })
     onStepUpdate?.({
       id,
       status: "error",
@@ -1803,6 +1819,9 @@ export async function validateServiceToken(
   const trimmed = token.trim()
   if (!trimmed) throw new Error("Enter a token before saving.")
 
+  // NEVER log the token value — only the action + org.
+  logSetup.info("validating service token", { org })
+
   const tokenClient = createGitHubClient({ token: trimmed })
 
   const scopeHint =
@@ -1956,6 +1975,7 @@ export async function triggerScoreCollection(
     },
   )
 
+  logWorkflows.info("dispatched collect-scores", { org, classroom, sinceRunId })
   return { sinceRunId }
 }
 
@@ -2022,6 +2042,13 @@ export async function triggerRegrade(
     },
   )
 
+  logWorkflows.info("dispatched regrade", {
+    org,
+    classroom,
+    assignment,
+    owner: owner ?? "(all)",
+    sinceRunId,
+  })
   return { sinceRunId }
 }
 
@@ -2033,6 +2060,7 @@ export async function rerunFailedRun(
   org: string,
   runId: number,
 ): Promise<void> {
+  logWorkflows.info("re-running failed jobs", { org, runId })
   await client.request(
     `/repos/${org}/classroom50/actions/runs/${runId}/rerun-failed-jobs`,
     { method: "POST" },
@@ -2053,6 +2081,9 @@ export async function putRepoSecret(
   }>(`/repos/${owner}/${repo}/actions/secrets/public-key`)
 
   const encryptedValue = await encryptSecret(key.key, plaintext)
+
+  // Log the write, never the plaintext/encrypted value.
+  logSetup.info("writing repo Actions secret", { owner, repo, name })
 
   await client.request(`/repos/${owner}/${repo}/actions/secrets/${name}`, {
     method: "PUT",
@@ -2351,6 +2382,8 @@ export async function initClassroom50({
 }) {
   const results: Partial<Record<InitStepId, unknown>> = {}
 
+  logSetup.info("org setup: started", { org, plan })
+
   const buildResult = (status: "error" | "complete") => ({
     org,
     repo: "classroom50",
@@ -2403,6 +2436,7 @@ export async function initClassroom50({
   // continuing only cascades 404s and would report success on a
   // half-initialized org. Stop here.
   if (stepFailed(results.configRepo)) {
+    logSetup.error("org setup: aborted (config repo step failed)", { org })
     return buildResult("error")
   }
 
@@ -2414,6 +2448,7 @@ export async function initClassroom50({
 
   // skeleton (workflows + scripts) — same hard-prerequisite gate.
   if (stepFailed(results.skeleton)) {
+    logSetup.error("org setup: aborted (skeleton step failed)", { org })
     return buildResult("error")
   }
 
@@ -2447,6 +2482,7 @@ export async function initClassroom50({
     fn: () => repairRulesets(client, org),
   })
 
+  logSetup.info("org setup: completed", { org })
   return buildResult("complete")
 }
 

--- a/web/src/hooks/github/orgChecks.ts
+++ b/web/src/hooks/github/orgChecks.ts
@@ -12,6 +12,9 @@ import {
   type ClassifyResult,
   type MemberDefaultSetting,
 } from "@/orgPolicy/desiredState"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("github:orgChecks")
 
 export const CONFIG_REPO = "classroom50"
 
@@ -275,7 +278,7 @@ async function verifyOrgDefaults(
     }
   } catch (err) {
     // Read-back failed — don't manufacture success; report unverified.
-    console.warn(`${org}: org member-default read-back failed`, err)
+    log.warn("org member-default read-back failed", { org, err })
     return { ok: false, verified: false, unenforced: [] }
   }
 }

--- a/web/src/hooks/github/orgChecks.ts
+++ b/web/src/hooks/github/orgChecks.ts
@@ -222,6 +222,7 @@ export async function checkWorkflowPermissions(
         }
       }
     } catch {
+      log.warn("org workflow-permissions policy unreadable, treating as drift")
       // Org policy unreadable — treat the repo "read" as drift.
     }
 

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -29,6 +29,9 @@ import { decodeBase64Utf8 } from "@/util/github"
 import { classroomPagesSegment } from "@/util/secret"
 import type { GetAssignmentsFileInput } from "@/api/queries/assignments"
 import type { OrgRunner, OrgRunnersResult } from "@/util/runners"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("queries")
 
 export const githubKeys = {
   all: ["github"] as const,
@@ -326,6 +329,7 @@ export async function withFreshRepoRetry<T>(
       if (!shouldRetry(err) || attempt === attempts) {
         throw err
       }
+      log.debug("fresh-repo lag, retrying read", { attempt })
       await sleep(baseDelayMs * backoffFactor ** (attempt - 1))
     }
   }
@@ -701,6 +705,12 @@ export async function paginateAll<T>(
     page++
   }
 
+  if (page > MAX_PAGES) {
+    log.warn("pagination hit MAX_PAGES cap, results may be truncated", {
+      maxPages: MAX_PAGES,
+    })
+  }
+
   return all
 }
 
@@ -841,7 +851,8 @@ export async function orgPublishesClassroom50Pages(
     // page served with 200).
     const data = (await res.json()) as { classrooms?: unknown }
     return Array.isArray(data?.classrooms) ? "yes" : "no"
-  } catch {
+  } catch (err) {
+    log.warn("org Pages probe failed (indeterminate)", { org, err })
     // Network failure, timeout, DNS, CORS -> transient; never collapse to a
     // definitive "no" (that would hide a genuinely-enrolled student's org).
     return "indeterminate"
@@ -943,6 +954,7 @@ export async function verifyClassroom50ConfigRepo(
     if (error instanceof GitHubAPIError && error.status === 404) {
       return false
     }
+    log.warn("config-repo marker read failed, failing open", { org, error })
     return true
   }
 }

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -30,8 +30,9 @@ import { classroomPagesSegment } from "@/util/secret"
 import type { GetAssignmentsFileInput } from "@/api/queries/assignments"
 import type { OrgRunner, OrgRunnersResult } from "@/util/runners"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_QUERIES } from "@/lib/logScopes"
 
-const log = logger.scope("queries")
+const log = logger.scope(LOG_SCOPE_QUERIES)
 
 export const githubKeys = {
   all: ["github"] as const,

--- a/web/src/hooks/github/rulesets.ts
+++ b/web/src/hooks/github/rulesets.ts
@@ -9,8 +9,9 @@ import { paginateAll } from "./queries"
 import type { CheckVerdict } from "./orgChecks"
 import { readFailedDetail } from "./orgChecks"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_GITHUB_SETUP } from "@/lib/logScopes"
 
-const log = logger.scope("github:setup")
+const log = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
 const FEEDBACK_BASE_BRANCH = "feedback"
 

--- a/web/src/hooks/github/rulesets.ts
+++ b/web/src/hooks/github/rulesets.ts
@@ -8,6 +8,9 @@ import type { GitHubClient } from "./client"
 import { paginateAll } from "./queries"
 import type { CheckVerdict } from "./orgChecks"
 import { readFailedDetail } from "./orgChecks"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("github:setup")
 
 const FEEDBACK_BASE_BRANCH = "feedback"
 
@@ -140,7 +143,11 @@ export async function repairRulesets(
   let existing: Map<string, number>
   try {
     existing = await listOrgRulesets(client, org)
-  } catch {
+  } catch (err) {
+    log.warn("could not list org rulesets; skipping ruleset repair", {
+      org,
+      err,
+    })
     return {
       status: "warning",
       message: `${org}: could not list org rulesets; apply Feedback PR branch protections manually.`,
@@ -166,7 +173,8 @@ export async function repairRulesets(
         })
         created.push(body.name)
       }
-    } catch {
+    } catch (err) {
+      log.warn("ruleset apply failed", { org, ruleset: body.name, err })
       failed.push(body.name)
     }
   }

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -2,6 +2,9 @@ import { useQuery } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { jsonFileQuery } from "./github/queries"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("queries")
 
 // Canonical <classroom>/scores.json shape (classroom50/scores/v1), written by
 // the CLI's collect_scores.py — the GUI is a pure consumer. Keyed by slug →
@@ -93,6 +96,9 @@ function bucketToRows(bucket: AssignmentBucket): SubmissionRow[] {
   // A hand-edited or partial scores.json bucket can lack `entries`; degrade to
   // no rows instead of throwing in the react-query select (which would blank
   // the whole submissions view).
+  if (bucket && !Array.isArray(bucket.entries)) {
+    log.warn("scores.json bucket has no entries array; degrading to no rows")
+  }
   const entries = Array.isArray(bucket?.entries) ? bucket.entries : []
   return entries
     .filter(

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -3,8 +3,9 @@ import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { jsonFileQuery } from "./github/queries"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_QUERIES } from "@/lib/logScopes"
 
-const log = logger.scope("queries")
+const log = logger.scope(LOG_SCOPE_QUERIES)
 
 // Canonical <classroom>/scores.json shape (classroom50/scores/v1), written by
 // the CLI's collect_scores.py — the GUI is a pure consumer. Keyed by slug →

--- a/web/src/lib/diagnostics/rateLimit.test.ts
+++ b/web/src/lib/diagnostics/rateLimit.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { GitHubRateLimit } from "@/hooks/github/errors"
+import {
+  countApiCall,
+  getApiCallCount,
+  getRateLimitSnapshot,
+  publishRateLimit,
+  subscribeRateLimit,
+} from "./rateLimit"
+
+const sample = (remaining: number): GitHubRateLimit => ({
+  limit: 5000,
+  remaining,
+  used: 5000 - remaining,
+  reset: Math.floor(Date.now() / 1000) + 3600,
+  resource: "core",
+  retryAfter: null,
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("rateLimit store", () => {
+  it("returns the most recently published snapshot", () => {
+    publishRateLimit(sample(4999))
+    expect(getRateLimitSnapshot()?.rateLimit.remaining).toBe(4999)
+    publishRateLimit(sample(4998))
+    expect(getRateLimitSnapshot()?.rateLimit.remaining).toBe(4998)
+  })
+
+  it("stamps the snapshot with an observation time", () => {
+    const before = Date.now()
+    publishRateLimit(sample(100))
+    const at = getRateLimitSnapshot()?.at ?? 0
+    expect(at).toBeGreaterThanOrEqual(before)
+  })
+
+  it("notifies subscribers on publish and stops after unsubscribe", () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeRateLimit(listener)
+    publishRateLimit(sample(10))
+    publishRateLimit(sample(9))
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsubscribe()
+    publishRateLimit(sample(8))
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it("counts API calls monotonically and notifies subscribers", () => {
+    const before = getApiCallCount()
+    const listener = vi.fn()
+    const unsubscribe = subscribeRateLimit(listener)
+    countApiCall()
+    countApiCall()
+    expect(getApiCallCount()).toBe(before + 2)
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+})

--- a/web/src/lib/diagnostics/rateLimit.ts
+++ b/web/src/lib/diagnostics/rateLimit.ts
@@ -1,0 +1,52 @@
+// Latest observed GitHub rate-limit headers, for the dev-only RateLimitOverlay.
+// Module-level (not React state) because the publisher is the fetch client —
+// a plain function outside React, exactly like the Activity store's feeds. The
+// client calls publishRateLimit() on every response; the overlay reads it via
+// useSyncExternalStore.
+//
+// Dev-diagnostic only: this is not persisted and carries no PII — just the
+// x-ratelimit-* counters GitHub returns on every response.
+
+import type { GitHubRateLimit } from "@/hooks/github/errors"
+
+// The stored snapshot plus when we observed it (epoch ms), so the overlay can
+// show "as of Ns ago" and a reset countdown.
+export type RateLimitSnapshot = {
+  rateLimit: GitHubRateLimit
+  at: number
+}
+
+let current: RateLimitSnapshot | null = null
+const listeners = new Set<() => void>()
+
+// Monotonic count of GitHub API calls made through the client this session,
+// incremented at the client's single request choke point. The overlay reads it
+// and snapshots the value on each route change to derive "calls in this view".
+let apiCallCount = 0
+
+// Called by the GitHub client at its request choke point (covers request +
+// requestRaw). Monotonic; the overlay derives per-view counts by diffing.
+export function countApiCall(): void {
+  apiCallCount += 1
+  for (const l of listeners) l()
+}
+
+export function getApiCallCount(): number {
+  return apiCallCount
+}
+
+// Called by the GitHub client on every response. Replaces the old per-response
+// `log.debug("rate limit headers", …)` that flooded the console.
+export function publishRateLimit(rateLimit: GitHubRateLimit): void {
+  current = { rateLimit, at: Date.now() }
+  for (const l of listeners) l()
+}
+
+export function subscribeRateLimit(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getRateLimitSnapshot(): RateLimitSnapshot | null {
+  return current
+}

--- a/web/src/lib/logScopes.ts
+++ b/web/src/lib/logScopes.ts
@@ -1,4 +1,9 @@
-// Shared logger scope names for modules that log under the same scope from more
-// than one file, so a rename stays single-source. Leaf module (no imports) to
-// stay clear of the logger/errors init cycle. Single-file scopes stay inline.
+// Shared logger scope names for scopes used from more than one file, so a
+// rename stays single-source (this file's own doc rule: cross-file scopes are
+// extracted, single-file scopes stay inline at their call site). Leaf module
+// (no imports) to stay clear of the logger/errors init cycle.
 export const LOG_SCOPE_GITHUB_CLIENT = "github:client"
+export const LOG_SCOPE_GITHUB_SETUP = "github:setup"
+export const LOG_SCOPE_ROUTER = "router"
+export const LOG_SCOPE_AUTH = "auth"
+export const LOG_SCOPE_QUERIES = "queries"

--- a/web/src/lib/logScopes.ts
+++ b/web/src/lib/logScopes.ts
@@ -1,0 +1,4 @@
+// Shared logger scope names for modules that log under the same scope from more
+// than one file, so a rename stays single-source. Leaf module (no imports) to
+// stay clear of the logger/errors init cycle. Single-file scopes stay inline.
+export const LOG_SCOPE_GITHUB_CLIENT = "github:client"

--- a/web/src/lib/logger.test.ts
+++ b/web/src/lib/logger.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { logger } from "./logger"
+import { clearActivity, readActivity } from "@/lib/activity/activityStore"
+
+// Under Vitest import.meta.env.DEV === true, so the module's MIN_LEVEL is
+// "debug" and every level prints — letting us assert the full range here.
+
+type Spies = Record<
+  "debug" | "info" | "warn" | "error",
+  ReturnType<typeof vi.spyOn>
+>
+
+let spies: Spies
+
+beforeEach(() => {
+  spies = {
+    debug: vi.spyOn(console, "debug").mockImplementation(() => {}),
+    info: vi.spyOn(console, "info").mockImplementation(() => {}),
+    warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+    error: vi.spyOn(console, "error").mockImplementation(() => {}),
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearActivity()
+})
+
+const firstArg = (spy: ReturnType<typeof vi.spyOn>): string =>
+  String(spy.mock.calls[0]?.[0] ?? "")
+
+describe("logger", () => {
+  it("routes each level to the matching console method", () => {
+    logger.debug("d")
+    logger.info("i")
+    logger.warn("w")
+    logger.error("e")
+    expect(spies.debug).toHaveBeenCalledTimes(1)
+    expect(spies.info).toHaveBeenCalledTimes(1)
+    expect(spies.warn).toHaveBeenCalledTimes(1)
+    expect(spies.error).toHaveBeenCalledTimes(1)
+  })
+
+  it("prefixes an ISO timestamp and upper-case level", () => {
+    logger.warn("something happened")
+    const line = firstArg(spies.warn)
+    expect(line).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z WARN /)
+    expect(line).toContain("something happened")
+  })
+
+  it("includes the scope in brackets when scoped", () => {
+    logger.scope("mutations:students").error("boom")
+    expect(firstArg(spies.error)).toContain("[mutations:students]")
+  })
+
+  it("nests scopes with a colon", () => {
+    logger.scope("a").scope("b").info("hi")
+    expect(firstArg(spies.info)).toContain("[a:b]")
+  })
+
+  it("tags a call-site frame pointing at the caller, not logger.ts", () => {
+    logger.info("hi")
+    const line = firstArg(spies.info)
+    // A frame renders as "(file.tsx:line...)"; it must not point back at the
+    // wrapper module itself.
+    expect(line).not.toContain("logger.ts")
+    expect(line).toMatch(/\(logger\.test\.ts:\d+/)
+  })
+
+  it("prints structured context as a trailing object (never inline)", () => {
+    logger.warn("with ctx", { requestId: "ABCD:1", count: 3 })
+    const [, ctx] = spies.warn.mock.calls[0] ?? []
+    expect(ctx).toEqual({ requestId: "ABCD:1", count: 3 })
+  })
+
+  it("omits the trailing object when only control fields are passed", () => {
+    logger.error("no rest", { record: false, org: "acme" })
+    // org/record are consumed by the logger, not printed as context.
+    expect(spies.error.mock.calls[0]?.length).toBe(1)
+  })
+
+  it("does not record into the Activity store by default", () => {
+    logger.error("silent failure")
+    expect(readActivity()).toHaveLength(0)
+  })
+
+  it("records into the Activity store when record:true, scope-qualified", () => {
+    logger.scope("CreateClassroomPage").error("non-GitHub API error", {
+      record: true,
+      org: "acme",
+    })
+    const entries = readActivity()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].kind).toBe("error")
+    expect(entries[0].org).toBe("acme")
+    expect(entries[0].label).toBe("[CreateClassroomPage] non-GitHub API error")
+  })
+
+  it("does not record debug/info even with record:true (store is error/action)", () => {
+    logger.info("fyi", { record: true })
+    logger.debug("trace", { record: true })
+    expect(readActivity()).toHaveLength(0)
+  })
+
+  it("records a warn when record:true", () => {
+    logger.warn("read-back failed", { record: true, org: "acme" })
+    expect(readActivity()).toHaveLength(1)
+  })
+})

--- a/web/src/lib/logger.test.ts
+++ b/web/src/lib/logger.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { logger } from "./logger"
+import { GitHubAPIError } from "@/hooks/github/errors"
 import { clearActivity, readActivity } from "@/lib/activity/activityStore"
 
 // Under Vitest import.meta.env.DEV === true, so the module's MIN_LEVEL is
@@ -106,6 +107,53 @@ describe("logger", () => {
 
   it("records a warn when record:true", () => {
     logger.warn("read-back failed", { record: true, org: "acme" })
+    expect(readActivity()).toHaveLength(1)
+  })
+})
+
+describe("logger privacy + record path", () => {
+  it("never leaks a GitHubAPIError's body or ssoHeader passed as { err } context", () => {
+    const err = new GitHubAPIError({
+      status: 403,
+      url: "https://api.github.com/orgs/acme/repos",
+      message: "Forbidden",
+      body: { message: "Forbidden", secret: "should-not-log" },
+      rateLimit: {
+        limit: null,
+        remaining: null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+      ssoHeader:
+        "required; url=https://github.com/orgs/acme/sso?authorization_request=leaky-token",
+    })
+    logger.error("request failed", { err })
+    // The raw body and the SSO authorization_request token must not reach the
+    // console sink through a stray raw-error context value.
+    const serialized = JSON.stringify(spies.error.mock.calls)
+    expect(serialized).not.toContain("should-not-log")
+    expect(serialized).not.toContain("leaky-token")
+    // The safe, allow-listed fields still come through so the line is useful.
+    const [, ctx] = spies.error.mock.calls[0] ?? []
+    expect(JSON.stringify(ctx)).toContain("403")
+  })
+
+  it("attributes a recorded entry's source to the caller, not logger.ts", () => {
+    logger.scope("github:client").error("boom", { record: true })
+    const [entry] = readActivity()
+    expect(entry.source ?? "").not.toContain("logger.ts")
+    expect(entry.source ?? "").toMatch(/logger\.test\.ts:\d+/)
+  })
+
+  it("collapses a burst of identical recorded warns into one Activity entry", () => {
+    const log = logger.scope("github:client")
+    for (let i = 0; i < 5; i++) {
+      log.warn("session expired (401)", { record: true, org: "acme" })
+    }
+    // Same scope+message within the dedup window -> one entry, so a 401 burst
+    // can't evict genuine errors from the ring.
     expect(readActivity()).toHaveLength(1)
   })
 })

--- a/web/src/lib/logger.ts
+++ b/web/src/lib/logger.ts
@@ -79,6 +79,39 @@ function splitContext(context?: LogContext): {
   return { record: Boolean(record), org, rest }
 }
 
+// Error-shaped context values (a stray `{ err }`) carry sensitive fields the
+// privacy contract forbids in a log line: a GitHubAPIError exposes the raw
+// response `body` and the `ssoHeader` (an authorization_request token). Project
+// to an ALLOW-LIST of known non-sensitive scalar fields (matching the Activity
+// store's allow-list philosophy) so a caller can't leak by handing us the raw
+// error — anything not explicitly listed is dropped. Both the console sink and
+// the record path consume the sanitized context.
+const SAFE_ERROR_KEYS = new Set(["status", "requestId"])
+
+function sanitizeValue(value: unknown): unknown {
+  if (!(value instanceof Error)) return value
+  const safe: Record<string, unknown> = {
+    name: value.name,
+    message: value.message,
+  }
+  for (const [key, v] of Object.entries(value)) {
+    if (!SAFE_ERROR_KEYS.has(key)) continue
+    // Only scalars — never a nested object/array (could carry a body/header).
+    if (v === null || typeof v !== "object") safe[key] = v
+  }
+  return safe
+}
+
+function sanitizeContext(
+  rest: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(rest)) {
+    out[key] = sanitizeValue(value)
+  }
+  return out
+}
+
 function emit(
   level: LogLevel,
   scope: string | undefined,
@@ -89,6 +122,7 @@ function emit(
 
   const { record, org, rest } = splitContext(context)
   const site = callSite()
+  const safeRest = sanitizeContext(rest)
 
   const prefix = [
     new Date().toISOString(),
@@ -100,13 +134,13 @@ function emit(
     .join(" ")
 
   const line = `${prefix} ${message}`
-  const hasContext = Object.keys(rest).length > 0
+  const hasContext = Object.keys(safeRest).length > 0
   // Looked up lazily (not bound at module load) so it respects a console the
   // host swaps out — a test spy, or a wrapper installed after this module
   // loaded. `console.debug` exists in every target browser + node.
   const sink = console[CONSOLE_METHOD[level]]
   if (hasContext) {
-    sink(line, rest)
+    sink(line, safeRest)
   } else {
     sink(line)
   }
@@ -115,10 +149,24 @@ function emit(
   // snapshot reflects this line. Only meaningful for warn/error (the store is
   // an error/action record); label is the scope-qualified message.
   if (record && (level === "error" || level === "warn")) {
-    recordError(new Error(message), {
+    // Strip this module's frames from the fresh error's stack so the recorded
+    // entry's `source` resolves to the real caller (the same frame as `site`),
+    // not logger.ts — toActivityEntry prefers the error's own stack.
+    const recordErr = new Error(message)
+    if (recordErr.stack) {
+      recordErr.stack = recordErr.stack
+        .split("\n")
+        .filter((l) => !/logger\.(?:ts|js)/.test(l))
+        .join("\n")
+    }
+    recordError(recordErr, {
       org,
       label: scope ? `[${scope}] ${message}` : message,
       source: site,
+      // Collapse a burst of identical recorded lines (e.g. one warn per 401 in
+      // a multi-org read) into one Activity entry so the ring doesn't evict
+      // genuine errors — same window the mutation/toast paths use.
+      dedupKey: scope ? `log-${scope}-${message}` : `log-${message}`,
     })
   }
 }

--- a/web/src/lib/logger.ts
+++ b/web/src/lib/logger.ts
@@ -28,15 +28,6 @@ const LEVEL_WEIGHT: Record<LogLevel, number> = {
   error: 40,
 }
 
-// Each level maps to its own console method, so browser devtools can filter by
-// severity (Verbose/Info/Warnings/Errors) and errors get a captured stack.
-const CONSOLE_METHOD: Record<LogLevel, "debug" | "info" | "warn" | "error"> = {
-  debug: "debug",
-  info: "info",
-  warn: "warn",
-  error: "error",
-}
-
 // In a production build only warn/error print (matches the app's existing
 // DEV-gating of verbose console output); dev prints everything. `import.meta`
 // env is read once at module load — it's a compile-time constant under Vite.
@@ -55,18 +46,23 @@ export type LogContext = {
   [key: string]: unknown
 }
 
-// First app frame of the CURRENT call, so a line prints "where it came from"
-// even when no Error is passed. Reuses the activity store's frame extractor so
-// there's one notion of "app-origin frame". We drop the top frames that are
-// inside this module (logger.ts) to point at the real caller.
-function callSite(): string | undefined {
-  const stack = new Error().stack
-  if (!stack) return undefined
-  const external = stack
+// Drop this module's own frames from a stack so an origin resolves to the real
+// caller, not logger.ts. Shared by callSite() and the record path so the two
+// stay in lockstep.
+function stripLoggerFrames(stack: string): string {
+  return stack
     .split("\n")
     .filter((line) => !/logger\.(?:ts|js)/.test(line))
     .join("\n")
-  return sourceFromStack(external)
+}
+
+// First app frame of the CURRENT call, so a line prints "where it came from"
+// even when no Error is passed. Reuses the activity store's frame extractor so
+// there's one notion of "app-origin frame".
+function callSite(): string | undefined {
+  const stack = new Error().stack
+  if (!stack) return undefined
+  return sourceFromStack(stripLoggerFrames(stack))
 }
 
 function splitContext(context?: LogContext): {
@@ -135,10 +131,12 @@ function emit(
 
   const line = `${prefix} ${message}`
   const hasContext = Object.keys(safeRest).length > 0
-  // Looked up lazily (not bound at module load) so it respects a console the
-  // host swaps out — a test spy, or a wrapper installed after this module
-  // loaded. `console.debug` exists in every target browser + node.
-  const sink = console[CONSOLE_METHOD[level]]
+  // Indexed by level (which IS the console method name) and looked up lazily
+  // (not bound at module load) so it respects a console the host swaps out — a
+  // test spy, or a wrapper installed after this module loaded. Each level maps
+  // to its matching method so devtools can filter by severity. `console.debug`
+  // exists in every target browser + node.
+  const sink = console[level]
   if (hasContext) {
     sink(line, safeRest)
   } else {
@@ -154,10 +152,7 @@ function emit(
     // not logger.ts — toActivityEntry prefers the error's own stack.
     const recordErr = new Error(message)
     if (recordErr.stack) {
-      recordErr.stack = recordErr.stack
-        .split("\n")
-        .filter((l) => !/logger\.(?:ts|js)/.test(l))
-        .join("\n")
+      recordErr.stack = stripLoggerFrames(recordErr.stack)
     }
     recordError(recordErr, {
       org,

--- a/web/src/lib/logger.ts
+++ b/web/src/lib/logger.ts
@@ -1,0 +1,148 @@
+// The one sanctioned wrapper around `console` for the app. Everything else goes
+// through here so leveled, timestamped, call-site-tagged, scoped output is
+// centralised — and the `no-console` lint rule can forbid raw `console`
+// everywhere but this file (see eslint.config.js).
+//
+// Design for a no-backend SPA: there is nowhere to ship logs, so "logging" is
+// (a) developer-facing console output and (b) the session Activity store that
+// backs the "Copy diagnostics" snapshot. This wrapper unifies (a) and lets a
+// call opt into (b) via `{ record: true }`, so a single line both prints in dev
+// and lands in the diagnostics a user can paste into a bug report — without
+// double-recording the paths that already feed activity (MutationCache.onError,
+// the window handlers), which stay untouched.
+//
+// PRIVACY: `error`/`warn` may reach the recorded Activity store, which is an
+// allow-listed projection (see lib/activity/activityStore.ts). Never pass a raw
+// GitHub response body or the X-GitHub-SSO header as the message or context —
+// the same contract the store enforces.
+
+import { recordError, sourceFromStack } from "@/lib/activity/activityStore"
+
+export type LogLevel = "debug" | "info" | "warn" | "error"
+
+// Ordered so a threshold comparison ("at least warn") is a numeric one.
+const LEVEL_WEIGHT: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+}
+
+// Each level maps to its own console method, so browser devtools can filter by
+// severity (Verbose/Info/Warnings/Errors) and errors get a captured stack.
+const CONSOLE_METHOD: Record<LogLevel, "debug" | "info" | "warn" | "error"> = {
+  debug: "debug",
+  info: "info",
+  warn: "warn",
+  error: "error",
+}
+
+// In a production build only warn/error print (matches the app's existing
+// DEV-gating of verbose console output); dev prints everything. `import.meta`
+// env is read once at module load — it's a compile-time constant under Vite.
+const MIN_LEVEL: LogLevel = import.meta.env.DEV ? "debug" : "warn"
+
+// Structured context attached to a line. Kept to primitives + the known
+// activity fields so it stays greppable and never invites a raw object dump.
+export type LogContext = {
+  // Org this line pertains to — threaded into a recorded activity entry.
+  org?: string
+  // When true, an `error`/`warn` also records into the session Activity store
+  // so it surfaces in the diagnostics snapshot. Off by default: most call sites
+  // are dev-facing, and the mutation/window paths already record on their own.
+  record?: boolean
+  // Any other structured, non-sensitive fields to print alongside the message.
+  [key: string]: unknown
+}
+
+// First app frame of the CURRENT call, so a line prints "where it came from"
+// even when no Error is passed. Reuses the activity store's frame extractor so
+// there's one notion of "app-origin frame". We drop the top frames that are
+// inside this module (logger.ts) to point at the real caller.
+function callSite(): string | undefined {
+  const stack = new Error().stack
+  if (!stack) return undefined
+  const external = stack
+    .split("\n")
+    .filter((line) => !/logger\.(?:ts|js)/.test(line))
+    .join("\n")
+  return sourceFromStack(external)
+}
+
+function splitContext(context?: LogContext): {
+  record: boolean
+  org?: string
+  rest: Record<string, unknown>
+} {
+  if (!context) return { record: false, rest: {} }
+  const { record, org, ...rest } = context
+  return { record: Boolean(record), org, rest }
+}
+
+function emit(
+  level: LogLevel,
+  scope: string | undefined,
+  message: string,
+  context?: LogContext,
+): void {
+  if (LEVEL_WEIGHT[level] < LEVEL_WEIGHT[MIN_LEVEL]) return
+
+  const { record, org, rest } = splitContext(context)
+  const site = callSite()
+
+  const prefix = [
+    new Date().toISOString(),
+    level.toUpperCase(),
+    scope ? `[${scope}]` : undefined,
+    site ? `(${site})` : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  const line = `${prefix} ${message}`
+  const hasContext = Object.keys(rest).length > 0
+  // Looked up lazily (not bound at module load) so it respects a console the
+  // host swaps out — a test spy, or a wrapper installed after this module
+  // loaded. `console.debug` exists in every target browser + node.
+  const sink = console[CONSOLE_METHOD[level]]
+  if (hasContext) {
+    sink(line, rest)
+  } else {
+    sink(line)
+  }
+
+  // Opt-in mirror into the session Activity store so a user's diagnostics
+  // snapshot reflects this line. Only meaningful for warn/error (the store is
+  // an error/action record); label is the scope-qualified message.
+  if (record && (level === "error" || level === "warn")) {
+    recordError(new Error(message), {
+      org,
+      label: scope ? `[${scope}] ${message}` : message,
+      source: site,
+    })
+  }
+}
+
+export type Logger = {
+  debug(message: string, context?: LogContext): void
+  info(message: string, context?: LogContext): void
+  warn(message: string, context?: LogContext): void
+  error(message: string, context?: LogContext): void
+  // A child logger tagged with a nested scope, e.g.
+  // logger.scope("mutations").scope("students") → "mutations:students".
+  scope(name: string): Logger
+}
+
+function make(scope?: string): Logger {
+  return {
+    debug: (message, context) => emit("debug", scope, message, context),
+    info: (message, context) => emit("info", scope, message, context),
+    warn: (message, context) => emit("warn", scope, message, context),
+    error: (message, context) => emit("error", scope, message, context),
+    scope: (name) => make(scope ? `${scope}:${name}` : name),
+  }
+}
+
+// The app-wide logger. Prefer a scoped child at a module boundary
+// (`const log = logger.scope("mutations:students")`) so origin is greppable.
+export const logger: Logger = make()

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -20,6 +20,7 @@ import App from "./App"
 import { appVersion, formatAppVersion } from "./version"
 import { installDiagnosticsHandlers } from "./lib/diagnostics/globalHandlers"
 import { recordError } from "./lib/activity/activityStore"
+import { RateLimitOverlay } from "./components/dev/RateLimitOverlay"
 
 // Record every failed mutation as session activity. Mutations are the app's
 // real write operations (create/delete/dispatch/enroll), so a rejection here is
@@ -61,7 +62,10 @@ createRoot(document.getElementById("root")!).render(
               </NotificationProvider>
             </ActionActivityProvider>
             {import.meta.env.DEV && (
-              <ReactQueryDevtools initialIsOpen={false} />
+              <>
+                <ReactQueryDevtools initialIsOpen={false} />
+                <RateLimitOverlay />
+              </>
             )}
           </GitHubClientProviderFromAuth>
         </GitHubAuthProvider>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -40,8 +40,9 @@ installDiagnosticsHandlers()
 
 // Make the deployed release identifiable from the browser console (a static SPA
 // has no version in the URL or a server header). Deliberate release diagnostic,
-// not stray debug logging — hence the no-console exception.
-// eslint-disable-next-line no-console
+// not stray debug logging — it must print even in prod, so it stays a direct
+// console call (allowed for main.tsx in eslint.config.js) rather than going
+// through the DEV-gated logger.
 console.info(
   `Classroom 50 — ${formatAppVersion()} — built ${appVersion.buildDate}`,
 )

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -19,14 +19,14 @@ import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { githubKeys } from "@/hooks/github/queries"
 import { logger } from "@/lib/logger"
-
-const log = logger.scope("CreateAssignmentPage")
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import type {
   CreateAssignmentInput,
   CreateAssignmentResult,
 } from "@/api/mutations/assignments"
+
+const log = logger.scope("CreateAssignmentPage")
 
 const CreateAssignmentPage = () => {
   const { t } = useTranslation()

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -53,16 +53,11 @@ const CreateAssignmentPage = () => {
     mutationFn: (input) => createAssignment(client, input),
     onError: (err) => {
       if (err instanceof GitHubAPIError) {
-        switch (err.status) {
-          case 409:
-            break
-          case 404:
-            break
-          case 422:
-            break
-          default:
-            break
-        }
+        // Console-only trace (MutationCache already recorded this failure).
+        log.error("create assignment failed", {
+          status: err.status,
+          requestId: err.requestId,
+        })
       } else {
         log.error("non-GitHub API error", { err, record: true })
       }

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -18,6 +18,9 @@ import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvi
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { githubKeys } from "@/hooks/github/queries"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("CreateAssignmentPage")
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import type {
@@ -61,7 +64,7 @@ const CreateAssignmentPage = () => {
             break
         }
       } else {
-        console.error("non-GitHub API error:", err)
+        log.error("non-GitHub API error", { err, record: true })
       }
       setErrorMessage(err.message)
       window.scrollTo({ top: 0, behavior: "smooth" })

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -14,8 +14,6 @@ import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
 import { logger } from "@/lib/logger"
-
-const log = logger.scope("CreateClassroomPage")
 import RequireTeacher from "@/components/RequireTeacher"
 import CreateClassroomForm from "./classes/CreateClassroomForm"
 import { githubKeys } from "@/hooks/github/queries"
@@ -23,6 +21,8 @@ import type {
   CreateClassroomInput,
   CreateClassroomResult,
 } from "@/api/mutations/classrooms"
+
+const log = logger.scope("CreateClassroomPage")
 
 const CreateClassroomPage = () => {
   const { t } = useTranslation()

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -43,16 +43,11 @@ const CreateClassroomPage = () => {
     mutationFn: (input) => createClassroomFilesWithConflictRetry(client, input),
     onError: (err) => {
       if (err instanceof GitHubAPIError) {
-        switch (err.status) {
-          case 409:
-            break
-          case 404:
-            break
-          case 422:
-            break
-          default:
-            break
-        }
+        // Console-only trace (MutationCache already recorded this failure).
+        log.error("create classroom failed", {
+          status: err.status,
+          requestId: err.requestId,
+        })
       } else {
         log.error("non-GitHub API error", { err, record: true })
       }

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -13,6 +13,9 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("CreateClassroomPage")
 import RequireTeacher from "@/components/RequireTeacher"
 import CreateClassroomForm from "./classes/CreateClassroomForm"
 import { githubKeys } from "@/hooks/github/queries"
@@ -51,7 +54,7 @@ const CreateClassroomPage = () => {
             break
         }
       } else {
-        console.error("non-GitHub API error:", err)
+        log.error("non-GitHub API error", { err, record: true })
       }
       notify({
         tone: "error",

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -16,12 +16,15 @@ import {
   type BulkRemoveFromClassroomResult,
 } from "@/pages/orgMembers/bulkRemoveFromClassroom"
 import { ConfirmModal } from "@/components/modals"
+import { logger } from "@/lib/logger"
 import {
   BulkResultSection,
   type BulkPhase,
   type BulkProgress,
   type BulkResultView,
 } from "@/components/bulk/resultView"
+
+const log = logger.scope("orgMembers:BulkActionsBar")
 
 // A classroom option for the picker (the config-repo dir name/path).
 export type BulkClassroomOption = { name: string; path: string }
@@ -257,7 +260,7 @@ const BulkActionsBar = ({
       }
       setPhase("complete")
     } catch (err) {
-      console.error(err)
+      log.error("bulk action failed", { err, record: true })
       setError(
         err instanceof Error ? err.message : t("orgMembers.somethingWrong"),
       )

--- a/web/src/pages/orgMembers/bulkAddToClassroom.ts
+++ b/web/src/pages/orgMembers/bulkAddToClassroom.ts
@@ -6,6 +6,9 @@ import { isActiveMember } from "@/hooks/github/mutations"
 import { parseGitHubId } from "@/util/students"
 import type { GitHubUser } from "@/hooks/github/types"
 import type { OrgMemberRow } from "@/util/orgMembers"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("orgMembers:bulkAddToClassroom")
 
 // Per-row outcome of resolving a selection to a placeable current login BEFORE
 // the enroll engine runs. `skipped` = rows we intentionally don't send (not a
@@ -139,7 +142,8 @@ export async function bulkAddToClassroom(
     let login: string
     try {
       login = (await getUserById(client, id)).login
-    } catch {
+    } catch (err) {
+      log.debug("bulk add: id resolve failed, skipping row", { id, err })
       preSkipped.push({
         key: row.key,
         label: labelFor(row),

--- a/web/src/pages/orgMembers/bulkRemoveFromClassroom.ts
+++ b/web/src/pages/orgMembers/bulkRemoveFromClassroom.ts
@@ -4,6 +4,9 @@ import { getErrorMessage } from "@/hooks/github/mutations"
 import { studentKey } from "@/util/identity"
 import type { Student } from "@/types/classroom"
 import type { OrgMemberRow } from "@/util/orgMembers"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("orgMembers:bulkRemoveFromClassroom")
 
 export type BulkRemoveProgress = {
   processed: number
@@ -131,6 +134,12 @@ export async function bulkRemoveFromClassroom(
   } catch (err) {
     // A hard failure of the single roster write fails the whole batch (nothing
     // committed). Report each eligible row as failed.
+    log.warn("bulk remove from classroom failed (whole batch)", {
+      org,
+      classroom,
+      count: byStudent.length,
+      err,
+    })
     const detail = getErrorMessage(err)
     for (const { row } of byStudent) {
       outcomes.push({

--- a/web/src/pages/orgMembers/inviteMemberToOrg.ts
+++ b/web/src/pages/orgMembers/inviteMemberToOrg.ts
@@ -3,6 +3,9 @@ import { createOrgInvitation, getErrorMessage } from "@/hooks/github/mutations"
 import { getUserById } from "@/hooks/github/queries"
 import { parseGitHubId } from "@/util/students"
 import type { OrgMemberRow } from "@/util/orgMembers"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("orgMembers:inviteMemberToOrg")
 
 export type InviteToOrgResult = {
   // The current GitHub login resolved from the immutable id; undefined if the
@@ -28,10 +31,15 @@ export async function inviteMemberToOrg(
   let currentUsername: string | undefined
   try {
     currentUsername = (await getUserById(client, inviteeId)).login
-  } catch {
+  } catch (err) {
+    log.debug("invite: current-login lookup failed (inviting by id anyway)", {
+      org,
+      err,
+    })
     currentUsername = undefined
   }
 
+  log.info("inviting member to org", { org, inviteeId })
   try {
     await createOrgInvitation(client, { org, invitee_id: inviteeId })
   } catch (err) {

--- a/web/src/pages/orgMembers/removeMemberFromOrg.ts
+++ b/web/src/pages/orgMembers/removeMemberFromOrg.ts
@@ -6,6 +6,9 @@ import { getAuthenticatedUser } from "@/api/queries/users"
 import { isSameGitHubUser } from "@/util/students"
 import type { Student } from "@/types/classroom"
 import type { OrgMemberRow } from "@/util/orgMembers"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("orgMembers:removeMemberFromOrg")
 
 export type RemoveFromOrgResult = {
   // Classrooms the student was unenrolled from before org removal.
@@ -40,6 +43,11 @@ export async function removeMemberFromOrg(
   const student = rowToStudent(row)
   const unenrolledClassrooms: string[] = []
   const warnings: string[] = []
+
+  log.info("remove member from org: started", {
+    org,
+    classrooms: row.classrooms.length,
+  })
 
   // Defense-in-depth self-guard: the Members page hides this action for the
   // viewer, but that guard is UI-only and depends on the viewer query loading.
@@ -103,6 +111,11 @@ export async function removeMemberFromOrg(
       })
       unenrolledClassrooms.push(access.classroom)
     } catch (err) {
+      log.warn("remove member: per-classroom unenroll failed", {
+        org,
+        classroom: access.classroom,
+        err,
+      })
       warnings.push(
         t
           ? t("orgMembers.warnUnenrollFailed", {
@@ -122,12 +135,24 @@ export async function removeMemberFromOrg(
     await removeOrgMembership(client, { org, username: row.username })
     removed = true
   } catch (err) {
+    log.error("remove member: org membership DELETE failed", {
+      org,
+      err,
+      record: true,
+    })
     warnings.push(
       `Removing ${row.username} from the organization failed (${getErrorMessage(
         err,
       )}); retry from the organization's people page.`,
     )
   }
+
+  log.info("remove member from org: completed", {
+    org,
+    unenrolled: unenrolledClassrooms.length,
+    removed,
+    warnings: warnings.length,
+  })
 
   return { unenrolledClassrooms, warnings, removed }
 }

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -19,6 +19,9 @@ import {
 } from "@/api/mutations/teardown"
 import SettingsSection from "./SettingsSection"
 import { CalloutDiv, CalloutText } from "@/lib/motionComponents"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("orgSettings:TeardownSection")
 
 // Teardown / org reset: deletes ALL repos in the org (mirroring the CLI's
 // `gh teacher teardown`), marker-gated and behind a typed-org-name confirmation.
@@ -45,6 +48,7 @@ const TeardownSection = ({ org }: { org: string }) => {
       setOpen(true)
     },
     onError: (err) => {
+      log.warn("teardown plan failed", { org, err })
       setError(
         err instanceof TeardownMarkerError
           ? err.message

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -237,6 +237,7 @@ const RosterBulkActionsBar = ({
         if (outcome.state === "invited") invited.push({ key: row.key, label })
         else skipped.push({ key: row.key, label })
       } catch (err) {
+        log.debug("bulk resend: per-row invite failed", { err })
         failed.push({ key: row.key, label, detail: getErrorMessage(err) })
         if (err instanceof GitHubAPIError && err.isRateLimited) {
           rateLimited = true

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -23,6 +23,9 @@ import {
   type BulkResultView,
 } from "@/components/bulk/resultView"
 import type { TeamRosterRow } from "@/util/teamRoster"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("students:RosterBulkActionsBar")
 
 // The three "add students" affordances the toolbar surfaces (when nothing is
 // selected). The page owns the modals; the bar just triggers them, keeping the
@@ -183,7 +186,7 @@ const RosterBulkActionsBar = ({
       setPhase("complete")
       onDone("unenroll")
     } catch (err) {
-      console.error(err)
+      log.error("bulk unenroll failed", { err, record: true })
       setError(getErrorMessage(err))
       setPhase("error")
     }

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -12,6 +12,9 @@ import {
   type BulkImportResult,
   type ImportRosterRow,
 } from "@/api/mutations/students"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("students:UploadRoster")
 
 // Parse an uploaded roster into metadata rows. A CSV with a `username` header
 // column also honors first_name/last_name/name/email/section columns (case- and
@@ -226,7 +229,7 @@ const UploadRoster = ({
       setPhase("complete")
       onSuccess?.(importResult)
     } catch (err) {
-      console.error(err)
+      log.error("roster import failed", { err, record: true })
       setError(err instanceof Error ? err.message : t("students.importFailed"))
       setPhase("error")
     }

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -198,6 +198,7 @@ const UploadRoster = ({
       })
       setPhase("preview")
     } catch (err) {
+      log.warn("roster file read/parse failed", { err, record: true })
       setError(
         err instanceof Error ? err.message : t("students.couldNotReadFile"),
       )

--- a/web/src/pages/students/bulkUnenrollRoster.ts
+++ b/web/src/pages/students/bulkUnenrollRoster.ts
@@ -3,6 +3,9 @@ import { bulkUnenrollStudents } from "@/api/mutations/students"
 import { getErrorMessage } from "@/hooks/github/mutations"
 import { studentKey } from "@/util/identity"
 import { rowToStudent, type TeamRosterRow } from "@/util/teamRoster"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("students:bulkUnenrollRoster")
 
 export type BulkUnenrollRosterProgress = {
   processed: number
@@ -80,6 +83,12 @@ export async function bulkUnenrollRoster(
   } catch (err) {
     // A hard failure of the single roster write fails the whole batch (nothing
     // committed). Report each row as failed.
+    log.warn("bulk unenroll roster failed (whole batch)", {
+      org,
+      classroom,
+      count: byStudent.length,
+      err,
+    })
     const detail = getErrorMessage(err)
     const outcomes: BulkUnenrollRosterOutcome[] = byStudent.map(({ row }) => ({
       key: row.key,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -29,9 +29,10 @@ const RootComponent = () => {
 // this screen instead of a blank white page.
 const RootErrorComponent = ({ error }: { error: Error }) => {
   const { t } = useTranslation()
-  // Log once per distinct error (not per re-render). This is the app-wide
-  // boundary, and it's reached outside any useMutation, so record it into the
-  // diagnostics snapshot too.
+  // Log once per distinct error (effect deps [error]); the logger's record path
+  // dedups repeat records of the same message within its window, so StrictMode's
+  // double-invoke and re-renders collapse to one diagnostics entry. Reached
+  // outside any useMutation, so record it into the snapshot too.
   useEffect(() => {
     log.error("route error boundary triggered", { error, record: true })
   }, [error])

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -10,8 +10,9 @@ import { useTranslation } from "react-i18next"
 import { RoleViewProvider } from "@/context/roleView/RoleViewProvider"
 import { Button } from "@/components/ui"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_ROUTER } from "@/lib/logScopes"
 
-const log = logger.scope("router")
+const log = logger.scope(LOG_SCOPE_ROUTER)
 
 const RootComponent = () => {
   // Scope "view as" to the current org (reset across orgs via the key); the

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -5,9 +5,13 @@ import {
 } from "@tanstack/react-router"
 import type { RouterContext } from "@/types/router"
 import { TriangleAlert } from "lucide-react"
+import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { RoleViewProvider } from "@/context/roleView/RoleViewProvider"
 import { Button } from "@/components/ui"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("router")
 
 const RootComponent = () => {
   // Scope "view as" to the current org (reset across orgs via the key); the
@@ -25,6 +29,12 @@ const RootComponent = () => {
 // this screen instead of a blank white page.
 const RootErrorComponent = ({ error }: { error: Error }) => {
   const { t } = useTranslation()
+  // Log once per distinct error (not per re-render). This is the app-wide
+  // boundary, and it's reached outside any useMutation, so record it into the
+  // diagnostics snapshot too.
+  useEffect(() => {
+    log.error("route error boundary triggered", { error, record: true })
+  }, [error])
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-10 text-center">
       <div className="flex size-16 items-center justify-center rounded-2xl bg-error/10 text-error">

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -6,8 +6,9 @@ import { UpdateAvailableBanner } from "@/components/UpdateAvailableBanner"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { Spinner } from "@/components/Spinner"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_ROUTER } from "@/lib/logScopes"
 
-const log = logger.scope("router")
+const log = logger.scope(LOG_SCOPE_ROUTER)
 
 export const Route = createFileRoute("/_authed")({
   beforeLoad: ({ context, location }) => {

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -5,6 +5,9 @@ import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
 import { UpdateAvailableBanner } from "@/components/UpdateAvailableBanner"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { Spinner } from "@/components/Spinner"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("router")
 
 export const Route = createFileRoute("/_authed")({
   beforeLoad: ({ context, location }) => {
@@ -16,6 +19,9 @@ export const Route = createFileRoute("/_authed")({
       // round-tripping.
       const returnTo = location.pathname + location.searchStr
       const isRoot = location.pathname === "/"
+      log.info("auth guard: unauthenticated, redirecting to /login", {
+        from: location.pathname,
+      })
       throw redirect({
         to: "/login",
         search: isRoot ? undefined : { redirect: returnTo },

--- a/web/src/routes/auth/index.tsx
+++ b/web/src/routes/auth/index.tsx
@@ -1,11 +1,15 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { GitHubAuthCard } from "@/auth/GitHubAuthCard"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("router")
 
 export const Route = createFileRoute("/auth/")({
   component: GitHubAuthCard,
   beforeLoad: ({ context }) => {
     const { auth } = context
     if (auth.status === "authenticated") {
+      log.info("already authenticated, redirecting away from /auth to /")
       throw redirect({
         to: "/",
       })

--- a/web/src/routes/auth/index.tsx
+++ b/web/src/routes/auth/index.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { GitHubAuthCard } from "@/auth/GitHubAuthCard"
 import { logger } from "@/lib/logger"
+import { LOG_SCOPE_ROUTER } from "@/lib/logScopes"
 
-const log = logger.scope("router")
+const log = logger.scope(LOG_SCOPE_ROUTER)
 
 export const Route = createFileRoute("/auth/")({
   component: GitHubAuthCard,


### PR DESCRIPTION
## Summary

Introduces a standardized logging story for the client-side-only web app and instruments the codebase so behavior is traceable from logs. Closes #183.

Five commits:

- **`feat(web): add a standardized client-side logger`** — one sanctioned `console` wrapper (`src/lib/logger.ts`): levels (`debug`/`info`/`warn`/`error`), ISO timestamp, scoped children (`logger.scope("name")`), call-site tagging (reusing the activity store's frame extractor), and opt-in `{ record: true }` that feeds the diagnostics snapshot. `info`/`debug` are dev-only; `warn`/`error` print in prod. Migrated the 16 existing `console.*` sites and tightened the `no-console` ESLint rule to `error` (allowed only in `logger.ts` and the deliberate `main.tsx` release banner).
- **`feat(web): show GitHub rate-limit and per-view API call count in a dev overlay`** — replaces the per-response rate-limit `console.debug` flood with a dev-only sticky footer overlay: live rate-limit counters plus a per-view API-call counter (rebases on route change). Portaled to `document.body` so the app's layout never detects it; DEV-gated so it never ships.
- **`feat(web): add logging coverage across auth, client, mutations, and routing`** — balanced coverage per an agreed policy: auth lifecycle milestones; client request/response/abort/retry traces; **info-per-step** on multi-step orchestrators (assignment accept, org setup, teardown, bulk enroll/unenroll, sync/reconcile); workflow dispatches; provider + router/guard lifecycle; and the previously-silent lossy `catch` sites. New scopes: `auth`, `github:client`, `github:workflows`, `github:setup`, `queries`, `mutations:*`, `context:*`, `router`, `app`, and per-page scopes.
- **`fix(web): stop logging raw GitHub error body and SSO header to the console`** — a code review found the privacy contract was violated in practice: a stray `{ err }` context passed a raw `GitHubAPIError` (whose own-enumerable `body` and `X-GitHub-SSO` header the console expands) to `log.error`, printing at `error` level in prod. The logger now **sanitizes any `Error`-shaped context to an allow-list** (`name`/`message` + `status`/`requestId`), so the raw body and the SSO `authorization_request` token can never reach the console or the Activity store, regardless of call site. Also dropped the raw-body debug line in the client fail path, hardened the privacy test to assert the sentinel is absent from every logged call, deduped the record path so a 401 burst collapses to one Activity entry instead of evicting genuine errors, and fixed the recorded entry's `source` to point at the caller instead of `logger.ts`.
- **`refactor(web): de-duplicate logger internals and shared scope names`** — a simplification pass: a shared `stripLoggerFrames()` replaces the duplicated stack filter in `callSite()` and the record path; the redundant `CONSOLE_METHOD` identity map is dropped (`console[level]` is equivalent); the remaining cross-file log scopes (`github:setup`, `router`, `auth`, `queries`) are single-sourced in `logScopes.ts` per its own rule; and the dev overlay's tick effect is keyed on whether a snapshot exists (not its identity) so a new snapshot per response no longer re-arms the 1s interval. Behavior-preserving.

### Design notes / constraints honored

- **No double-recording:** `{ record: true }` is added only on error paths that don't already flow through `MutationCache.onError` (auth, providers, router, destructive helpers, hand-rolled runners). Mutation-routed errors stay console-only.
- **Privacy:** never logs the token, raw GitHub response bodies, the `X-GitHub-SSO` header, service-token plaintext, or student PII (email) — only orgs, slugs, statuses, counts, and request ids. The record path stores the message string, never the raw error object. The logger now **enforces** this at the seam: any `Error`-shaped context value is projected to an allow-list before it reaches the console sink or the record path, so a stray `{ err }` cannot leak a raw body or the SSO header.
- **Prod stays quiet:** `info`/`debug` are `import.meta.env.DEV`-only, matching the app's existing DEV-gating.
- Resolved a module-init circular import (`errors → logger → activityStore → errors`) by making the logger in `errors.ts` lazy (verified still required — an eager `logger.scope(...)` there throws on import).

## Test plan

- [x] `npm run check` green: `tsc -b`, `eslint` (0 errors; only pre-existing advisory warnings; no `no-console` violations), `prettier --check`, `vitest` (92 files, 1008 tests).
- [x] New tests: logger unit tests (`logger.test.ts`) including the allow-list sanitizer, recorded-source attribution, and record-path dedup; rate-limit store tests (`rateLimit.test.ts`); and client request-lifecycle logging tests asserting the token and error body never appear in **any** logged call.
- [ ] Manual: run `npm run dev`, confirm the dev overlay shows rate-limit + per-view call count and doesn't intercept clicks; confirm scoped/timestamped log lines appear for sign-in, a create/accept flow, and a route error.
