### PR TITLE
fix(web): split assignment due badge into date and countdown

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1370,8 +1370,6 @@
   "submissions": {
     "missingParams": "Missing organization, classroom, or assignment in the URL.",
     "dueDate": "Due {{date}}",
-    "dueIn": "Due {{date}} · {{relative}}",
-    "dueOverdue": "Due {{date}} · {{relative}}",
     "noDueDate": "No due date",
     "lateBadge_one": "{{count}} late",
     "lateBadge_other": "{{count}} late",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -2,13 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import Papa from "papaparse"
 
-import {
-  BarChart3,
-  CalendarClock,
-  Info,
-  LinkIcon,
-  RefreshCw,
-} from "lucide-react"
+import { BarChart3, Info, LinkIcon, RefreshCw } from "lucide-react"
 import { useParams, Navigate } from "@tanstack/react-router"
 
 import Breadcrumb from "@/components/breadcrumb"
@@ -482,22 +476,22 @@ const SubmissionsPageContent = () => {
         subtitle={
           <div className="flex flex-wrap items-center gap-2">
             {dueDate ? (
-              <Badge
-                tone={dueOverdue ? "error" : "info"}
-                size="md"
-                title={formatDueDateTime(dueDate)}
-              >
-                <CalendarClock aria-hidden="true" className="size-3.5" />
-                {dueOverdue
-                  ? t("submissions.dueOverdue", {
-                      date: formatDueDateTime(dueDate),
-                      relative: dueRelative,
-                    })
-                  : t("submissions.dueIn", {
-                      date: formatDueDateTime(dueDate),
-                      relative: dueRelative,
-                    })}
-              </Badge>
+              <>
+                <Badge
+                  tone={dueOverdue ? "error" : "info"}
+                  size="md"
+                  title={formatDueDateTime(dueDate)}
+                >
+                  {t("submissions.dueDate", {
+                    date: formatDueDateTime(dueDate),
+                  })}
+                </Badge>
+                {dueRelative && (
+                  <Badge tone={dueOverdue ? "error" : "warning"} size="md">
+                    {dueRelative}
+                  </Badge>
+                )}
+              </>
             ) : (
               <span>{t("submissions.noDueDate")}</span>
             )}


### PR DESCRIPTION
## Summary
- On the submissions page, split the single assignment due-date badge into two.
- Removed the calendar icon.
- The absolute date shows in an `info` badge (`Due {{date}}`); the relative countdown shows in a `warning` badge (`in 5 days` / `2 hours ago`).
- Both badges flip to `error` when the assignment is overdue.
- Dropped the now-orphaned `submissions.dueIn` / `submissions.dueOverdue` locale keys (reusing the existing `submissions.dueDate`).

## Test plan
- [x] `tsc -b`, eslint, and prettier clean on touched files
- [x] i18n key audit test passes
- [x] SubmissionsPage tests pass
- [ ] Visual check: due badge shows two pills, warning countdown; overdue shows both red