### PR TITLE
feat(web): detect offline and stop bouncing a valid session to /login

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import { logger } from "@/lib/logger"
 const log = logger.scope("app")
 
 export function App() {
-  const { status, token, user } = useGithubAuth()
+  const { status, token, user, isOnline } = useGithubAuth()
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -44,9 +44,14 @@ export function App() {
   }, [sessionEndedOnAuthedRoute])
 
   if (status === "loading" || sessionEndedOnAuthedRoute) {
+    // Offline with a stored token that can't be validated yet: explain the hold
+    // rather than showing a bare, indefinite "loading" spinner (the session is
+    // preserved and resumes when connectivity returns).
+    const label =
+      !isOnline && token ? t("auth.offlineHold") : t("common.loadingApp")
     return (
       <div className="min-h-screen grid place-items-center">
-        <Spinner size="lg" label={t("common.loadingApp")} />
+        <Spinner size="lg" label={label} />
       </div>
     )
   }

--- a/web/src/auth/GitHubAuthCard.test.ts
+++ b/web/src/auth/GitHubAuthCard.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveLoginAlert } from "./GitHubAuthCard"
+
+// Precedence for the sign-in form alert (#187): offline must win over a stale
+// error or the involuntary-expiry notice, because when offline the user never
+// signed out — showing "session expired" or a proxy error would misexplain it.
+describe("resolveLoginAlert", () => {
+  it("shows nothing when online with no error and no expiry", () => {
+    expect(
+      resolveLoginAlert({ isOnline: true, error: null, sessionExpired: false }),
+    ).toBeNull()
+  })
+
+  it("shows the offline alert when offline, even with a stale error present", () => {
+    expect(
+      resolveLoginAlert({
+        isOnline: false,
+        error: "Network error reaching the proxy",
+        sessionExpired: false,
+      }),
+    ).toBe("offline")
+  })
+
+  it("shows the offline alert when offline, even with a session-expired notice", () => {
+    expect(
+      resolveLoginAlert({
+        isOnline: false,
+        error: null,
+        sessionExpired: true,
+      }),
+    ).toBe("offline")
+  })
+
+  it("shows the error alert when online with a live sign-in error", () => {
+    expect(
+      resolveLoginAlert({
+        isOnline: true,
+        error: "That token was rejected by GitHub (401).",
+        sessionExpired: false,
+      }),
+    ).toBe("error")
+  })
+
+  it("prefers the error alert over the expiry notice when both are set online", () => {
+    expect(
+      resolveLoginAlert({
+        isOnline: true,
+        error: "Something went wrong",
+        sessionExpired: true,
+      }),
+    ).toBe("error")
+  })
+
+  it("shows the expiry notice when online with no error but the session expired", () => {
+    expect(
+      resolveLoginAlert({
+        isOnline: true,
+        error: null,
+        sessionExpired: true,
+      }),
+    ).toBe("expired")
+  })
+})

--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -24,6 +24,23 @@ function LoadingScreen({ label }: { label: string }) {
   )
 }
 
+// Which alert the sign-in form shows, in precedence order. Offline wins: the
+// user never signed out, so a stale error or expiry notice would misexplain the
+// state. Then a live sign-in error, then the involuntary-expiry notice. Pure so
+// the precedence is unit-testable without rendering the whole card.
+export type LoginAlertKind = "offline" | "error" | "expired" | null
+
+export function resolveLoginAlert(input: {
+  isOnline: boolean
+  error: string | null
+  sessionExpired: boolean
+}): LoginAlertKind {
+  if (!input.isOnline) return "offline"
+  if (input.error) return "error"
+  if (input.sessionExpired) return "expired"
+  return null
+}
+
 export function GitHubAuthCard() {
   const { t } = useTranslation()
   useDocumentTitle(t("auth.signInTitle"))
@@ -85,31 +102,30 @@ export function GitHubAuthCard() {
                 void auth.startWebFlow()
               }}
             >
-              {!auth.isOnline ? (
-                <Alert tone="warning" className="items-start text-sm">
-                  <AlertTriangle
-                    aria-hidden="true"
-                    className="size-4 shrink-0"
-                  />
-                  <span>{t("auth.offlineHold")}</span>
-                </Alert>
-              ) : auth.error ? (
-                <Alert tone="error" className="items-start text-sm">
-                  <AlertTriangle
-                    aria-hidden="true"
-                    className="size-4 shrink-0"
-                  />
-                  <span>{auth.error}</span>
-                </Alert>
-              ) : auth.sessionExpired ? (
-                <Alert tone="warning" className="items-start text-sm">
-                  <AlertTriangle
-                    aria-hidden="true"
-                    className="size-4 shrink-0"
-                  />
-                  <span>Your session expired — sign in again to continue.</span>
-                </Alert>
-              ) : null}
+              {(() => {
+                const alert = resolveLoginAlert({
+                  isOnline: auth.isOnline,
+                  error: auth.error,
+                  sessionExpired: auth.sessionExpired,
+                })
+                if (!alert) return null
+                const tone = alert === "error" ? "error" : "warning"
+                const message =
+                  alert === "offline"
+                    ? t("auth.offlineHold")
+                    : alert === "error"
+                      ? auth.error
+                      : "Your session expired — sign in again to continue."
+                return (
+                  <Alert tone={tone} className="items-start text-sm">
+                    <AlertTriangle
+                      aria-hidden="true"
+                      className="size-4 shrink-0"
+                    />
+                    <span>{message}</span>
+                  </Alert>
+                )
+              })()}
 
               <div className="space-y-3">
                 <Button

--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -85,7 +85,15 @@ export function GitHubAuthCard() {
                 void auth.startWebFlow()
               }}
             >
-              {auth.error ? (
+              {!auth.isOnline ? (
+                <Alert tone="warning" className="items-start text-sm">
+                  <AlertTriangle
+                    aria-hidden="true"
+                    className="size-4 shrink-0"
+                  />
+                  <span>{t("auth.offlineHold")}</span>
+                </Alert>
+              ) : auth.error ? (
                 <Alert tone="error" className="items-start text-sm">
                   <AlertTriangle
                     aria-hidden="true"

--- a/web/src/auth/github-user-api.ts
+++ b/web/src/auth/github-user-api.ts
@@ -1,4 +1,5 @@
 import type { GitHubUser } from "@/hooks/github/types"
+import { DEFAULT_REQUEST_TIMEOUT_MS } from "@/hooks/github/client"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_AUTH } from "@/lib/logScopes"
 
@@ -22,6 +23,12 @@ export async function fetchGithubUser(token: string): Promise<GitHubUser> {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",
     },
+    // Bare fetch has no built-in timeout: without this a hung/half-open
+    // connection (e.g. on reconnect) never settles, pinning the session-
+    // validation query "pending" and stranding the app on its loading spinner.
+    // A timeout aborts to a rejected fetch, which the query treats as a
+    // transient error and retries.
+    signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS),
   })
 
   if (!res.ok) {
@@ -45,6 +52,7 @@ export async function fetchGithubUserWithScopes(
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",
     },
+    signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS),
   })
 
   if (!res.ok) {

--- a/web/src/auth/useGithubAuth.recovery.test.ts
+++ b/web/src/auth/useGithubAuth.recovery.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest"
 import {
   classifyPatResult,
   recoverStrandedExchange,
+  resolveAuthStatus,
   shouldExpireOnUserError,
+  type AuthStatusInput,
 } from "./useGithubAuth"
 import { GitHubUserFetchError } from "./github-user-api"
 
@@ -87,5 +89,82 @@ describe("classifyPatResult", () => {
   it("accepts a comma+space delimited header the same as a space-delimited one", () => {
     const granted = "read:user, repo, workflow, admin:org, delete_repo"
     expect(classifyPatResult(granted)).toEqual({ kind: "ok", scopes: granted })
+  })
+})
+
+// The auth-status verdict for the router guard. Two headline invariants (#185):
+//   - An offline cold reload with a stored token but no cached user HOLDS at
+//     "loading" (session preserved) rather than bouncing to /login.
+//   - An already-validated session (cached user) stays "authenticated" while
+//     offline, so the app stays mounted and the OfflineBanner shows — a blip
+//     must not collapse a working session to a spinner.
+describe("resolveAuthStatus", () => {
+  const authed: AuthStatusInput = {
+    hasLoadedStoredAuth: true,
+    hasToken: true,
+    isOnline: true,
+    userQueryPending: false,
+    userQueryErrored: false,
+    hasUser: true,
+  }
+
+  it("is 'loading' until stored auth has been read", () => {
+    expect(resolveAuthStatus({ ...authed, hasLoadedStoredAuth: false })).toBe(
+      "loading",
+    )
+  })
+
+  it("is 'unauthenticated' with no token (even offline)", () => {
+    expect(
+      resolveAuthStatus({ ...authed, hasToken: false, isOnline: false }),
+    ).toBe("unauthenticated")
+  })
+
+  it("STAYS 'authenticated' when offline with a cached user (keep the app mounted, show the banner)", () => {
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        isOnline: false,
+        userQueryErrored: true,
+      }),
+    ).toBe("authenticated")
+  })
+
+  it("HOLDS at 'loading' when offline with a token but no cached user yet (cold reload — don't bounce to /login)", () => {
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        isOnline: false,
+        hasUser: false,
+        userQueryPending: true,
+      }),
+    ).toBe("loading")
+  })
+
+  it("also HOLDS at 'loading' when offline with no user and the paused query errored", () => {
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        isOnline: false,
+        hasUser: false,
+        userQueryErrored: true,
+      }),
+    ).toBe("loading")
+  })
+
+  it("is 'loading' while the user query is pending (online, first validation)", () => {
+    expect(
+      resolveAuthStatus({ ...authed, hasUser: false, userQueryPending: true }),
+    ).toBe("loading")
+  })
+
+  it("is 'unauthenticated' when online with a token but the first validation errored (e.g. a definitive 401 upstream)", () => {
+    expect(
+      resolveAuthStatus({ ...authed, hasUser: false, userQueryErrored: true }),
+    ).toBe("unauthenticated")
+  })
+
+  it("is 'authenticated' when online with a token and a resolved user", () => {
+    expect(resolveAuthStatus(authed)).toBe("authenticated")
   })
 })

--- a/web/src/auth/useGithubAuth.recovery.test.ts
+++ b/web/src/auth/useGithubAuth.recovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   classifyPatResult,
+  isTransientUserError,
   recoverStrandedExchange,
   resolveAuthStatus,
   shouldExpireOnUserError,
@@ -92,12 +93,15 @@ describe("classifyPatResult", () => {
   })
 })
 
-// The auth-status verdict for the router guard. Two headline invariants (#185):
+// The auth-status verdict for the router guard. Headline invariants (#185, #187):
 //   - An offline cold reload with a stored token but no cached user HOLDS at
 //     "loading" (session preserved) rather than bouncing to /login.
 //   - An already-validated session (cached user) stays "authenticated" while
-//     offline, so the app stays mounted and the OfflineBanner shows — a blip
-//     must not collapse a working session to a spinner.
+//     offline, so the app stays mounted and the OfflineBanner shows.
+//   - Only a definitive 401 signs the user out; a transient first-validation
+//     error (5xx / network / captive portal) HOLDS instead of bouncing a still-
+//     valid session to /login; a definitive non-401 (403 SSO/rate-limit) lets
+//     the app mount so its per-resource gates handle it (never an infinite hold).
 describe("resolveAuthStatus", () => {
   const authed: AuthStatusInput = {
     hasLoadedStoredAuth: true,
@@ -105,6 +109,8 @@ describe("resolveAuthStatus", () => {
     isOnline: true,
     userQueryPending: false,
     userQueryErrored: false,
+    userErrorExpiresToken: false,
+    userErrorIsTransient: false,
     hasUser: true,
   }
 
@@ -126,6 +132,7 @@ describe("resolveAuthStatus", () => {
         ...authed,
         isOnline: false,
         userQueryErrored: true,
+        userErrorIsTransient: true,
       }),
     ).toBe("authenticated")
   })
@@ -148,6 +155,7 @@ describe("resolveAuthStatus", () => {
         isOnline: false,
         hasUser: false,
         userQueryErrored: true,
+        userErrorIsTransient: true,
       }),
     ).toBe("loading")
   })
@@ -158,13 +166,104 @@ describe("resolveAuthStatus", () => {
     ).toBe("loading")
   })
 
-  it("is 'unauthenticated' when online with a token but the first validation errored (e.g. a definitive 401 upstream)", () => {
+  it("is 'unauthenticated' when the first validation is a definitive 401 (revoked/expired token)", () => {
     expect(
-      resolveAuthStatus({ ...authed, hasUser: false, userQueryErrored: true }),
+      resolveAuthStatus({
+        ...authed,
+        hasUser: false,
+        userQueryErrored: true,
+        userErrorExpiresToken: true,
+      }),
     ).toBe("unauthenticated")
+  })
+
+  it("a 401 signs out even offline (a known-dead token isn't worth holding for)", () => {
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        isOnline: false,
+        hasUser: false,
+        userQueryErrored: true,
+        userErrorExpiresToken: true,
+      }),
+    ).toBe("unauthenticated")
+  })
+
+  it("HOLDS at 'loading' on a transient online error (5xx/network) — don't bounce a still-valid session to /login (#187)", () => {
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        hasUser: false,
+        userQueryErrored: true,
+        userErrorIsTransient: true,
+      }),
+    ).toBe("loading")
+  })
+
+  it("also HOLDS on a captive-portal error (navigator.onLine true, network fetch failed) rather than bouncing to /login (#187)", () => {
+    // A captive portal reads as online, so isOnline is true; the fetch failure
+    // is transient (not a definitive GitHub status), so we hold, not bounce.
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        isOnline: true,
+        hasUser: false,
+        userQueryErrored: true,
+        userErrorIsTransient: true,
+      }),
+    ).toBe("loading")
+  })
+
+  it("resolves 'authenticated' on a definitive non-401 error (403 SSO/rate-limit) so the app mounts and its per-resource gates handle it (never an infinite hold) (#187)", () => {
+    // Token is valid (not a 401), but the error won't self-heal, so holding
+    // would strand the user on a spinner. Let them into the app instead.
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        hasUser: false,
+        userQueryErrored: true,
+        userErrorExpiresToken: false,
+        userErrorIsTransient: false,
+      }),
+    ).toBe("authenticated")
   })
 
   it("is 'authenticated' when online with a token and a resolved user", () => {
     expect(resolveAuthStatus(authed)).toBe("authenticated")
+  })
+})
+
+// Transient-vs-definitive classification for the /user validation error. A
+// definitive GitHub status (401/403/404) is NOT transient (retrying can't fix
+// it); a 5xx/429 or a bare network failure (no status) IS transient and should
+// self-heal on refetch/reconnect (#187 hold behavior).
+describe("isTransientUserError", () => {
+  it("treats a network error (non-GitHubUserFetchError) as transient", () => {
+    expect(isTransientUserError(new TypeError("Failed to fetch"))).toBe(true)
+  })
+
+  it("treats a 5xx as transient", () => {
+    expect(isTransientUserError(new GitHubUserFetchError(503))).toBe(true)
+  })
+
+  it("treats a 429 (rate limit) as transient", () => {
+    expect(isTransientUserError(new GitHubUserFetchError(429))).toBe(true)
+  })
+
+  it("does NOT treat a definitive 401 as transient", () => {
+    expect(isTransientUserError(new GitHubUserFetchError(401))).toBe(false)
+  })
+
+  it("does NOT treat a definitive 403 (SSO/blocked) as transient", () => {
+    expect(isTransientUserError(new GitHubUserFetchError(403))).toBe(false)
+  })
+
+  it("does NOT treat a definitive 404 as transient", () => {
+    expect(isTransientUserError(new GitHubUserFetchError(404))).toBe(false)
+  })
+
+  it("is false when there is no error", () => {
+    expect(isTransientUserError(undefined)).toBe(false)
+    expect(isTransientUserError(null)).toBe(false)
   })
 })

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -28,6 +28,7 @@ import { logger } from "@/lib/logger"
 import { LOG_SCOPE_AUTH } from "@/lib/logScopes"
 import { deriveChallenge, generateVerifier, randomBase64Url } from "./pkce"
 import { missingScopes } from "./scopes"
+import { useOnlineStatus } from "@/hooks/useOnlineStatus"
 import {
   clearGithubToken,
   consumeOAuthSession,
@@ -64,6 +65,11 @@ function formatError(
     message.toLowerCase().includes("failed to fetch") ||
     message.toLowerCase().includes("networkerror")
   ) {
+    // A fetch failure while the browser reports no network is the client being
+    // offline, not our proxy/GitHub being down — don't misattribute blame.
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      return t("auth.errorOffline")
+    }
     return t("auth.errorNetwork", { target: networkTarget })
   }
 
@@ -79,6 +85,43 @@ function formatError(
 // apart), so both are preserved.
 export function shouldExpireOnUserError(error: unknown): boolean {
   return error instanceof GitHubUserFetchError && error.status === 401
+}
+
+// State the auth status verdict depends on — structural so the decision stays a
+// pure, testable function (mirrors the repo's resolve* pattern).
+export type AuthStatusInput = {
+  hasLoadedStoredAuth: boolean
+  hasToken: boolean
+  isOnline: boolean
+  userQueryPending: boolean
+  userQueryErrored: boolean
+  hasUser: boolean
+}
+
+// Resolve the auth status for the router guard.
+//
+// Two offline cases, deliberately split:
+//   - Already validated this session (hasUser): stay "authenticated" even when
+//     offline. The app stays mounted on cached data and the OfflineBanner (in
+//     the _authed layout) explains the state — don't collapse a working session
+//     to a full-screen spinner on a network blip.
+//   - Not yet validated + offline (cold reload, no cached user): hold at
+//     "loading". The GET /user validation can't run offline, so an
+//     error/absent-user must NOT report "unauthenticated" and bounce a
+//     still-valid session to /login. We hold until connectivity returns and the
+//     query resolves.
+//
+// A genuine 401 tears the token down elsewhere (shouldExpireOnUserError),
+// clearing both `hasToken` and the cached user, so neither branch can mask a
+// truly dead token.
+export function resolveAuthStatus(input: AuthStatusInput): AuthStatus {
+  if (!input.hasLoadedStoredAuth) return "loading"
+  if (!input.hasToken) return "unauthenticated"
+  if (input.hasUser) return "authenticated"
+  if (!input.isOnline) return "loading"
+  if (input.userQueryPending) return "loading"
+  if (input.userQueryErrored) return "unauthenticated"
+  return "authenticated"
 }
 
 // Recover a stranded "exchanging" screen: with no ?code to exchange (fresh
@@ -130,6 +173,7 @@ function sleep(ms: number, signal: AbortSignal) {
 function useGithubAuthState() {
   const queryClient = useQueryClient()
   const { t } = useTranslation()
+  const isOnline = useOnlineStatus()
   const abortRef = useRef<AbortController | null>(null)
   // Deep link (#71) stashed at code-exchange, consumed by the status-driven
   // effect below so navigation runs against an authenticated router context.
@@ -688,32 +732,27 @@ function useGithubAuthState() {
     }
   }, [device, now])
 
-  const status = useMemo<AuthStatus>(() => {
-    if (!hasLoadedStoredAuth) {
-      return "loading"
-    }
-
-    if (!token) {
-      return "unauthenticated"
-    }
-
-    if (githubUserQuery.isLoading || githubUserQuery.isPending) {
-      return "loading"
-    }
-
-    if (githubUserQuery.isError || !githubUserQuery.data) {
-      return "unauthenticated"
-    }
-
-    return "authenticated"
-  }, [
-    hasLoadedStoredAuth,
-    token,
-    githubUserQuery.isLoading,
-    githubUserQuery.isPending,
-    githubUserQuery.isError,
-    githubUserQuery.data,
-  ])
+  const status = useMemo<AuthStatus>(
+    () =>
+      resolveAuthStatus({
+        hasLoadedStoredAuth,
+        hasToken: Boolean(token),
+        isOnline,
+        userQueryPending:
+          githubUserQuery.isLoading || githubUserQuery.isPending,
+        userQueryErrored: githubUserQuery.isError,
+        hasUser: Boolean(githubUserQuery.data),
+      }),
+    [
+      hasLoadedStoredAuth,
+      token,
+      isOnline,
+      githubUserQuery.isLoading,
+      githubUserQuery.isPending,
+      githubUserQuery.isError,
+      githubUserQuery.data,
+    ],
+  )
 
   // Navigate to the stashed deep link once status is "authenticated", so the
   // target _authed guard sees an authenticated context instead of bouncing
@@ -759,6 +798,7 @@ function useGithubAuthState() {
     expireSession,
     sessionExpired,
     status,
+    isOnline,
   }
 }
 

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -87,6 +87,21 @@ export function shouldExpireOnUserError(error: unknown): boolean {
   return error instanceof GitHubUserFetchError && error.status === 401
 }
 
+// A /user validation error that should self-heal on refetch/reconnect: a network
+// failure (no status — a TypeError from fetch, incl. a captive portal) or a
+// non-definitive GitHub status (5xx / 429). A definitive GitHub status
+// (401/403/404 per isDefinitiveGitHubStatus) is NOT transient — retrying can't
+// change it — so it must not hold at "loading" forever. `undefined`/`null` (no
+// error) is not transient.
+export function isTransientUserError(error: unknown): boolean {
+  if (!error) return false
+  if (error instanceof GitHubUserFetchError) {
+    return !isDefinitiveGitHubStatus(error.status)
+  }
+  // A non-GitHubUserFetchError reaching here is a fetch/network failure.
+  return true
+}
+
 // State the auth status verdict depends on — structural so the decision stays a
 // pure, testable function (mirrors the repo's resolve* pattern).
 export type AuthStatusInput = {
@@ -95,6 +110,15 @@ export type AuthStatusInput = {
   isOnline: boolean
   userQueryPending: boolean
   userQueryErrored: boolean
+  // The /user validation failed with a definitive 401 — the token is genuinely
+  // revoked/expired (shouldExpireOnUserError). Distinct from `userQueryErrored`,
+  // which is true for any failure including recoverable ones.
+  userErrorExpiresToken: boolean
+  // The error is transient (5xx / network / captive-portal / 429) rather than a
+  // definitive GitHub status — it should self-heal on refetch/reconnect, so we
+  // hold. A definitive non-401 (403 SSO/blocked, 404) is NOT transient: it won't
+  // clear on its own, so holding would strand the user on a spinner forever.
+  userErrorIsTransient: boolean
   hasUser: boolean
 }
 
@@ -108,19 +132,28 @@ export type AuthStatusInput = {
 //   - Not yet validated + offline (cold reload, no cached user): hold at
 //     "loading". The GET /user validation can't run offline, so an
 //     error/absent-user must NOT report "unauthenticated" and bounce a
-//     still-valid session to /login. We hold until connectivity returns and the
-//     query resolves.
+//     still-valid session to /login. We hold until connectivity returns.
 //
-// A genuine 401 tears the token down elsewhere (shouldExpireOnUserError),
-// clearing both `hasToken` and the cached user, so neither branch can mask a
-// truly dead token.
+// First-validation error triage (token present, no cached user yet):
+//   - Definitive 401 (userErrorExpiresToken): the token is dead — sign out.
+//   - Transient (5xx / network / captive-portal / 429): recoverable — hold at
+//     "loading" and let the refetch self-heal, rather than bouncing a still-
+//     valid session to /login (#185's regression).
+//   - Definitive non-401 (403 SSO/blocked, 404): the token is valid but this
+//     won't clear on its own; resolve to "authenticated" so the app mounts and
+//     its per-resource gates (scope/SSO banners) handle it — holding would
+//     strand the user on a spinner forever.
+//
+// The matching 401 teardown elsewhere clears `hasToken` + the cached user, so
+// no branch can mask a truly dead token.
 export function resolveAuthStatus(input: AuthStatusInput): AuthStatus {
   if (!input.hasLoadedStoredAuth) return "loading"
   if (!input.hasToken) return "unauthenticated"
   if (input.hasUser) return "authenticated"
+  if (input.userErrorExpiresToken) return "unauthenticated"
   if (!input.isOnline) return "loading"
   if (input.userQueryPending) return "loading"
-  if (input.userQueryErrored) return "unauthenticated"
+  if (input.userQueryErrored && input.userErrorIsTransient) return "loading"
   return "authenticated"
 }
 
@@ -741,6 +774,8 @@ function useGithubAuthState() {
         userQueryPending:
           githubUserQuery.isLoading || githubUserQuery.isPending,
         userQueryErrored: githubUserQuery.isError,
+        userErrorExpiresToken: shouldExpireOnUserError(githubUserQuery.error),
+        userErrorIsTransient: isTransientUserError(githubUserQuery.error),
         hasUser: Boolean(githubUserQuery.data),
       }),
     [
@@ -750,6 +785,7 @@ function useGithubAuthState() {
       githubUserQuery.isLoading,
       githubUserQuery.isPending,
       githubUserQuery.isError,
+      githubUserQuery.error,
       githubUserQuery.data,
     ],
   )

--- a/web/src/components/OfflineBanner.tsx
+++ b/web/src/components/OfflineBanner.tsx
@@ -1,0 +1,31 @@
+import { WifiOff } from "lucide-react"
+import { AnimatePresence } from "motion/react"
+import { useTranslation } from "react-i18next"
+
+import { AppBanner } from "@/components/AppBanner"
+import { useOnlineStatus } from "@/hooks/useOnlineStatus"
+
+// Global banner shown while the browser reports no network. Non-dismissible: it
+// reflects live connectivity, so it clears itself the moment the `online` event
+// fires (see useOnlineStatus) rather than needing a manual dismiss.
+export function OfflineBanner() {
+  const isOnline = useOnlineStatus()
+  const { t } = useTranslation()
+
+  return (
+    <AnimatePresence initial={false}>
+      {!isOnline ? (
+        <AppBanner
+          key="offline"
+          tone="warning"
+          icon={<WifiOff className="size-5" aria-hidden="true" />}
+          title={t("offline.title")}
+        >
+          <p className="text-base-content/70">{t("offline.body")}</p>
+        </AppBanner>
+      ) : null}
+    </AnimatePresence>
+  )
+}
+
+export default OfflineBanner

--- a/web/src/hooks/useOnlineStatus.test.ts
+++ b/web/src/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+
+import { useOnlineStatus } from "./useOnlineStatus"
+
+function setNavigatorOnLine(value: boolean) {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value,
+  })
+}
+
+describe("useOnlineStatus", () => {
+  afterEach(() => {
+    setNavigatorOnLine(true)
+    vi.restoreAllMocks()
+  })
+
+  it("seeds from navigator.onLine", () => {
+    setNavigatorOnLine(false)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(false)
+  })
+
+  it("flips to offline when the offline event fires", () => {
+    setNavigatorOnLine(true)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(true)
+
+    act(() => {
+      setNavigatorOnLine(false)
+      window.dispatchEvent(new Event("offline"))
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it("recovers to online when the online event fires", () => {
+    setNavigatorOnLine(false)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      setNavigatorOnLine(true)
+      window.dispatchEvent(new Event("online"))
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it("unsubscribes on unmount", () => {
+    const remove = vi.spyOn(window, "removeEventListener")
+    const { unmount } = renderHook(() => useOnlineStatus())
+    unmount()
+    expect(remove).toHaveBeenCalledWith("online", expect.any(Function))
+    expect(remove).toHaveBeenCalledWith("offline", expect.any(Function))
+  })
+})

--- a/web/src/hooks/useOnlineStatus.ts
+++ b/web/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,31 @@
+import { useSyncExternalStore } from "react"
+
+function subscribe(onChange: () => void) {
+  window.addEventListener("online", onChange)
+  window.addEventListener("offline", onChange)
+  return () => {
+    window.removeEventListener("online", onChange)
+    window.removeEventListener("offline", onChange)
+  }
+}
+
+function getSnapshot() {
+  return navigator.onLine
+}
+
+// SSR/tests without a navigator default to online so nothing renders an offline
+// state on the server.
+function getServerSnapshot() {
+  return true
+}
+
+// Live browser connectivity, driven by the online/offline events so an offline
+// state appears and clears without a reload. navigator.onLine is optimistic (a
+// captive portal reads as online), so treat only `false` as authoritative:
+// false means no network, true means "probably reachable" — never a claim that
+// a specific host is up (that's what the actual fetch is for).
+export function useOnlineStatus(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}
+
+export default useOnlineStatus

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -149,6 +149,8 @@
     "patCancel": "Cancel",
     "errorNetwork": "Network error reaching {{target}}; it may be down or unreachable.",
     "errorNetworkProxyTarget": "the Cloudflare Worker proxy",
+    "errorOffline": "You appear to be offline. Check your connection and try again — signing in needs a network connection.",
+    "offlineHold": "You're offline. Waiting for a connection to restore your session…",
     "errorStateMismatch": "State mismatch -- possible CSRF. Please try signing in again.",
     "errorMissingPkce": "Missing PKCE verifier or client ID. Please try signing in again.",
     "errorClientIdMissing": "GitHub OAuth client ID is not configured (VITE_GITHUB_CLIENT_ID).",
@@ -1133,6 +1135,10 @@
     "title": "A new version of Classroom 50 is available",
     "body": "Reload the page to get the latest version.",
     "action": "Reload now"
+  },
+  "offline": {
+    "title": "You're offline",
+    "body": "Classroom 50 works with live data from GitHub, so it needs a connection. This banner clears automatically when you're back online."
   },
   "skeletonDrift": {
     "title": "Classroom workflow files are out of date",

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
 import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
+import { OfflineBanner } from "@/components/OfflineBanner"
 import { UpdateAvailableBanner } from "@/components/UpdateAvailableBanner"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { Spinner } from "@/components/Spinner"
@@ -52,6 +53,7 @@ function AuthedLayout() {
 
   return (
     <>
+      <OfflineBanner />
       <ScopeWarningBanner />
       <SkeletonDriftBanner />
       <UpdateAvailableBanner />


### PR DESCRIPTION
## Summary

Fixes the offline experience reported in #185. Previously, an offline cold reload couldn't validate the stored token, so auth `status` flipped to `unauthenticated` and the `_authed` guard bounced a still-valid session to `/login` — showing a misleading "Cloudflare Worker proxy... down or unreachable" error when the real cause was no network.

- Add a `useOnlineStatus` hook (`navigator.onLine` seed + `online`/`offline` events; treats only `false` as authoritative).
- Split the auth-status verdict into a pure, tested `resolveAuthStatus`:
  - **Already validated this session (cached user):** stay `authenticated` while offline so the app stays mounted and the new `OfflineBanner` shows — a blip no longer collapses a working session to a spinner.
  - **Cold reload, offline, never validated:** hold at `loading` (session preserved, auto-recovers on reconnect) instead of bouncing to `/login`.
  - **First-validation error triage** (token present, no cached user): a definitive `401` signs out; a **transient** error (5xx / network / captive-portal) **holds** at `loading` and self-heals; a **definitive non-401** (403 SSO/rate-limit, 404) resolves `authenticated` so the app mounts and its per-resource gates handle it (never an infinite hold). This closes the reconnect path where a preserved-token error still bounced a valid session to `/login`.
- Add an `AbortSignal` timeout to the bare `GET /user` validation fetch so a hung/half-open reconnect can't strand the validation query on the loading spinner.
- Make `formatError` offline-aware: name the real cause instead of blaming the proxy.
- Add an app-wide `OfflineBanner` (reuses `AppBanner`, non-dismissible, clears on reconnect) mounted in the `_authed` layout, plus offline-aware copy on the login card and the app-shell loading screen. Login-card alert precedence (offline > error > expired) is extracted into a tested pure function.
- All user-facing strings go through `t()` (added to `en.json`).

Closes #185.

## Review

A multi-agent code review flagged one blocker (now fixed in the second commit): on the reconnect path this PR targets, a non-401 `GET /user` error (403 SSO/rate-limit, 5xx, captive portal) preserved the token yet still resolved `unauthenticated`, re-triggering the #185 bounce. Resolved via the first-validation error triage above; the pre-existing missing-timeout on the validation fetch was fixed alongside.

## Test plan

- [x] `npm run check` green (tsc, eslint, prettier, 1037 vitest tests; only pre-existing warnings).
- [x] Unit tests: `useOnlineStatus` (seed, online/offline transitions, unsubscribe); `resolveAuthStatus` (offline hold, stay-authenticated-with-cached-user, 401 signs out, transient/captive-portal holds, definitive-non-401 mounts); `isTransientUserError`; `resolveLoginAlert` precedence.
- [ ] Manual: offline while app is open + signed in -> OfflineBanner appears, clears on reconnect.
- [ ] Manual: go offline, then hard-reload -> "waiting for a connection" spinner, auto-recovers when back online (no bounce to /login).
- [ ] Manual: signed-out + offline -> login card shows the offline note rather than the proxy-down error.
- [ ] Manual: reconnect where /user returns 403/5xx -> no bounce to /login (holds or mounts per triage).