### PR TITLE
feat(web): animate inline alerts in/out

### DIFF
--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -5,7 +5,7 @@ import { Plus, Trash2, UsersRound } from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
 import { Spinner } from "@/components/Spinner"
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, AnimatedAlert, Button, Modal } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
@@ -412,17 +412,17 @@ export function GroupCollaboratorsModal({
         </div>
       ) : (
         <>
-          {saved && (
-            <Alert tone="success" className="mt-4 text-sm">
-              {t("components.modals.groupCollaborators.saved")}
-            </Alert>
-          )}
+          <AnimatedAlert tone="success" show={saved} className="mt-4 text-sm">
+            {t("components.modals.groupCollaborators.saved")}
+          </AnimatedAlert>
 
-          {submitError && (
-            <Alert tone="error" className="mt-4 text-sm">
-              {submitError}
-            </Alert>
-          )}
+          <AnimatedAlert
+            tone="error"
+            show={!!submitError}
+            className="mt-4 text-sm"
+          >
+            {submitError}
+          </AnimatedAlert>
 
           {!canManage && (
             <Alert tone="error" className="mt-4 text-sm">

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -3,7 +3,7 @@ import { useEffect, useId, type ReactNode, type RefObject } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 
-import { Alert, Button, Modal } from "@/components/ui"
+import { AnimatedAlert, Button, Modal } from "@/components/ui"
 
 // Shared chrome for the two reuse modals — close button, header, error/warning
 // alerts, Cancel/Reuse footer — so each supplies only its title, description,
@@ -66,18 +66,22 @@ export const ReuseModalShell = ({
 
       {children}
 
-      {errorMessage ? (
-        <Alert tone="error" className="mt-4 text-sm">
-          {errorMessage}
-        </Alert>
-      ) : null}
+      <AnimatedAlert
+        tone="error"
+        show={!!errorMessage}
+        className="mt-4 text-sm"
+      >
+        {errorMessage}
+      </AnimatedAlert>
 
-      {warning ? (
-        <Alert tone="warning" className="mt-4 items-start text-sm">
-          <TriangleAlert aria-hidden="true" className="size-4 shrink-0" />
-          <span>{warning}</span>
-        </Alert>
-      ) : null}
+      <AnimatedAlert
+        tone="warning"
+        show={!!warning}
+        className="mt-4 items-start text-sm"
+      >
+        <TriangleAlert aria-hidden="true" className="size-4 shrink-0" />
+        <span>{warning}</span>
+      </AnimatedAlert>
 
       <div className="modal-action">
         <Button variant="ghost" disabled={isPending} onClick={closeDialog}>

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -2,7 +2,7 @@ import { AlertTriangle } from "lucide-react"
 import { useEffect, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Alert, type ButtonVariant } from "@/components/ui"
+import { Button, AnimatedAlert, type ButtonVariant } from "@/components/ui"
 
 type ConfirmModalProps = {
   open: boolean
@@ -169,11 +169,9 @@ export function ConfirmModal({
               </div>
             ) : null}
 
-            {error ? (
-              <Alert tone="error" className="mt-4 text-sm">
-                {error}
-              </Alert>
-            ) : null}
+            <AnimatedAlert tone="error" show={!!error} className="mt-4 text-sm">
+              {error}
+            </AnimatedAlert>
 
             <div className="modal-action">
               <Button
@@ -238,11 +236,9 @@ export function ConfirmModal({
                 }}
               />
 
-              {error ? (
-                <Alert tone="error" className="text-sm">
-                  {error}
-                </Alert>
-              ) : null}
+              <AnimatedAlert tone="error" show={!!error} className="text-sm">
+                {error}
+              </AnimatedAlert>
             </div>
 
             <div className="modal-action">

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
-import { Alert, Button } from "@/components/ui"
+import { AnimatedAlert, Button } from "@/components/ui"
 import { useLanguage } from "@/hooks/useLanguage"
 import { useLanguageRegistry } from "@/hooks/useLanguageRegistry"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
@@ -490,11 +490,9 @@ export const LanguageSwitcher = ({
         </div>
       )}
 
-      {error && (
-        <Alert tone="error">
-          <span className="text-sm">{error}</span>
-        </Alert>
-      )}
+      <AnimatedAlert tone="error" show={!!error}>
+        <span className="text-sm">{error}</span>
+      </AnimatedAlert>
     </div>
   )
 }

--- a/web/src/components/ui/AnimatedAlert.test.tsx
+++ b/web/src/components/ui/AnimatedAlert.test.tsx
@@ -42,4 +42,21 @@ describe("AnimatedAlert", () => {
     expect(el.className).toContain("mt-4")
     expect(el.className).toContain("text-sm")
   })
+
+  it("keeps the exiting content when show flips false and children clear", () => {
+    // Callers usually clear the message string in the same render that flips
+    // `show` off. AnimatePresence animates out the snapshot it last rendered, so
+    // the text must not blank mid-collapse.
+    const { rerender } = render(
+      <AnimatedAlert tone="error" show>
+        original message
+      </AnimatedAlert>,
+    )
+    rerender(
+      <AnimatedAlert tone="error" show={false}>
+        {""}
+      </AnimatedAlert>,
+    )
+    expect(screen.getByRole("alert").textContent).toBe("original message")
+  })
 })

--- a/web/src/components/ui/AnimatedAlert.test.tsx
+++ b/web/src/components/ui/AnimatedAlert.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { AnimatedAlert } from "./AnimatedAlert"
+
+afterEach(cleanup)
+
+describe("AnimatedAlert", () => {
+  it("renders the wrapped Alert with tone + role when shown", () => {
+    render(
+      <AnimatedAlert tone="error" show>
+        boom
+      </AnimatedAlert>,
+    )
+    const el = screen.getByRole("alert")
+    expect(el.className).toContain("alert-error")
+    expect(el.className).toContain("alert-soft")
+    expect(el.textContent).toBe("boom")
+    // The collapse wrapper clips the margin/height animation.
+    expect(el.parentElement?.className).toContain("overflow-hidden")
+  })
+
+  it("renders nothing when not shown", () => {
+    render(
+      <AnimatedAlert tone="success" show={false}>
+        nope
+      </AnimatedAlert>,
+    )
+    expect(screen.queryByRole("alert")).toBeNull()
+    expect(screen.queryByText("nope")).toBeNull()
+  })
+
+  it("forwards role and className to the inner Alert", () => {
+    render(
+      <AnimatedAlert tone="warning" show role="status" className="mt-4 text-sm">
+        heads up
+      </AnimatedAlert>,
+    )
+    const el = screen.getByRole("status")
+    expect(el.className).toContain("alert-warning")
+    expect(el.className).toContain("mt-4")
+    expect(el.className).toContain("text-sm")
+  })
+})

--- a/web/src/components/ui/AnimatedAlert.tsx
+++ b/web/src/components/ui/AnimatedAlert.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react"
+import { AnimatePresence, motion } from "motion/react"
+
+import { collapseVariants } from "@/lib/motion"
+import { Alert, type AlertProps } from "./Alert"
+
+// The <Alert> primitive that animates its own mount/unmount. State-toggled
+// alerts (`show` flips on a mutation result) otherwise snap in and out and jerk
+// the content below them; this height-collapses on exit — the same
+// collapseVariants + AnimatePresence recipe as AppBanner — so the surrounding
+// layout reflows smoothly. The alert itself is an unchanged <Alert>, wrapped in
+// a padding-free `overflow-hidden` collapser (padding on the collapsing element
+// would keep a sliver visible at height 0). For always-rendered alerts (no
+// enter/exit moment) use <Alert> directly.
+
+export type AnimatedAlertProps = {
+  // Toggles the alert; false animates it out rather than unmounting abruptly.
+  show: boolean
+  children?: ReactNode
+} & AlertProps
+
+export function AnimatedAlert({
+  show,
+  children,
+  ...alertProps
+}: AnimatedAlertProps) {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          variants={collapseVariants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          className="overflow-hidden"
+        >
+          <Alert {...alertProps}>{children}</Alert>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+export default AnimatedAlert

--- a/web/src/components/ui/AnimatedAlert.tsx
+++ b/web/src/components/ui/AnimatedAlert.tsx
@@ -1,22 +1,16 @@
-import type { ReactNode } from "react"
 import { AnimatePresence, motion } from "motion/react"
 
 import { collapseVariants } from "@/lib/motion"
 import { Alert, type AlertProps } from "./Alert"
 
-// The <Alert> primitive that animates its own mount/unmount. State-toggled
-// alerts (`show` flips on a mutation result) otherwise snap in and out and jerk
-// the content below them; this height-collapses on exit — the same
-// collapseVariants + AnimatePresence recipe as AppBanner — so the surrounding
-// layout reflows smoothly. The alert itself is an unchanged <Alert>, wrapped in
-// a padding-free `overflow-hidden` collapser (padding on the collapsing element
-// would keep a sliver visible at height 0). For always-rendered alerts (no
-// enter/exit moment) use <Alert> directly.
+// <Alert> that height-collapses on mount/unmount so a toggled alert doesn't jerk
+// the layout. The collapser is padding-free (padding on the collapsing element
+// would keep a sliver visible at height 0). Always-rendered alerts should use
+// <Alert> directly.
 
 export type AnimatedAlertProps = {
   // Toggles the alert; false animates it out rather than unmounting abruptly.
   show: boolean
-  children?: ReactNode
 } & AlertProps
 
 export function AnimatedAlert({

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -33,6 +33,9 @@ export type { ModalProps, ModalSize } from "./Modal"
 export { Alert, alertToneClass } from "./Alert"
 export type { AlertProps, AlertTone } from "./Alert"
 
+export { AnimatedAlert } from "./AnimatedAlert"
+export type { AnimatedAlertProps } from "./AnimatedAlert"
+
 export { CopyableCode } from "./CopyableCode"
 export type { CopyableCodeProps } from "./CopyableCode"
 

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -6,7 +6,7 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import MissingParams from "@/components/MissingParams"
 import RequireTeacher from "@/components/RequireTeacher"
-import { Alert, Button } from "@/components/ui"
+import { AnimatedAlert, Button } from "@/components/ui"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import CreateAssignmentForm from "@/pages/assignments/CreateAssignmentForm"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -120,25 +120,27 @@ const CreateAssignmentPage = () => {
             hasRosterRows={emptyRoster.hasRosterRows}
           />
         ) : null}
-        {errorMessage ? <Alert tone="error">{errorMessage}</Alert> : <></>}
-        {warningMessage ? (
-          <Alert tone="warning" className="flex flex-col items-start gap-2">
-            <span>{warningMessage}</span>
-            <Button
-              size="sm"
-              onClick={() =>
-                navigate({
-                  to: "/$org/$classroom/assignments",
-                  params: { org, classroom },
-                })
-              }
-            >
-              {t("assignments.goToAssignments")}
-            </Button>
-          </Alert>
-        ) : (
-          <></>
-        )}
+        <AnimatedAlert tone="error" show={!!errorMessage}>
+          {errorMessage}
+        </AnimatedAlert>
+        <AnimatedAlert
+          tone="warning"
+          show={!!warningMessage}
+          className="flex flex-col items-start gap-2"
+        >
+          <span>{warningMessage}</span>
+          <Button
+            size="sm"
+            onClick={() =>
+              navigate({
+                to: "/$org/$classroom/assignments",
+                params: { org, classroom },
+              })
+            }
+          >
+            {t("assignments.goToAssignments")}
+          </Button>
+        </AnimatedAlert>
         <CreateAssignmentForm
           loading={createClassroomMutation.isPending}
           org={org}

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -6,7 +6,7 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { Spinner } from "@/components/Spinner"
-import { Alert, Button, Card } from "@/components/ui"
+import { Alert, AnimatedAlert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
@@ -181,11 +181,15 @@ const EditAssignmentPage = () => {
   return (
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("documentTitle.assignmentSettings")} />
-      {editError && <Alert tone="error">{editError}</Alert>}
-      {editSuccess && (
-        <Alert tone="success">{t("assignmentSettings.editSuccess")}</Alert>
-      )}
-      {editWarning && <Alert tone="warning">{editWarning}</Alert>}
+      <AnimatedAlert tone="error" show={!!editError}>
+        {editError}
+      </AnimatedAlert>
+      <AnimatedAlert tone="success" show={editSuccess}>
+        {t("assignmentSettings.editSuccess")}
+      </AnimatedAlert>
+      <AnimatedAlert tone="warning" show={!!editWarning}>
+        {editWarning}
+      </AnimatedAlert>
       <PageHeader title={t("assignmentSettings.heading")} />
       {isTeacher && archived && (
         <ArchivedClassroomNotice>

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query"
 import Papa from "papaparse"
 import { Activity } from "lucide-react"
 
-import { Alert, Card, Spinner, Button } from "@/components/ui"
+import { AnimatedAlert, Card, Spinner, Button } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { EmptyState } from "@/components/list"
@@ -154,11 +154,14 @@ const OrgActivityPage = () => {
           planName={orgPlanDetails?.plan?.name}
         />
 
-        {sourceError && (
-          <Alert tone="warning" className="mt-4 text-sm" role="status">
-            <span>{t("orgActivity.partialError")}</span>
-          </Alert>
-        )}
+        <AnimatedAlert
+          tone="warning"
+          show={!!sourceError}
+          className="mt-4 text-sm"
+          role="status"
+        >
+          <span>{t("orgActivity.partialError")}</span>
+        </AnimatedAlert>
 
         {items.length === 0 ? (
           loading ? (

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -10,7 +10,7 @@ import {
   UserPlus,
 } from "lucide-react"
 
-import { Alert, Button, Card, Spinner } from "@/components/ui"
+import { AnimatedAlert, Button, Card, Spinner } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -398,20 +398,26 @@ const OrgMembersPage = () => {
             }
           />
 
-          {notes.length > 0 ? (
-            <Alert tone="warning" className="mt-6 text-sm" role="status">
-              <span>{notes.join(" ")}</span>
-            </Alert>
-          ) : null}
+          <AnimatedAlert
+            tone="warning"
+            show={notes.length > 0}
+            className="mt-6 text-sm"
+            role="status"
+          >
+            <span>{notes.join(" ")}</span>
+          </AnimatedAlert>
 
-          {discrepancyCount > 0 ? (
-            <Alert tone="error" className="mt-6 text-sm" role="status">
-              <AlertTriangle className="size-4" aria-hidden="true" />
-              <span>
-                {t("orgMembers.discrepancy", { count: discrepancyCount })}
-              </span>
-            </Alert>
-          ) : null}
+          <AnimatedAlert
+            tone="error"
+            show={discrepancyCount > 0}
+            className="mt-6 text-sm"
+            role="status"
+          >
+            <AlertTriangle className="size-4" aria-hidden="true" />
+            <span>
+              {t("orgMembers.discrepancy", { count: discrepancyCount })}
+            </span>
+          </AnimatedAlert>
 
           <div className="mt-6 flex flex-wrap items-center gap-3">
             <label className="input input-bordered flex min-w-0 flex-1 items-center gap-2">

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -22,7 +22,7 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { isValidEmail } from "@/util/orgMembership"
 import { splitName, toStudent } from "@/util/roster"
-import { Alert, Button, Modal } from "@/components/ui"
+import { AnimatedAlert, Button, Modal } from "@/components/ui"
 
 type AddStudentProps = {
   org: string
@@ -225,17 +225,13 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
           form.handleSubmit()
         }}
       >
-        {warning && (
-          <Alert tone="warning" className="mt-4 text-sm">
-            {warning}
-          </Alert>
-        )}
+        <AnimatedAlert tone="warning" show={!!warning} className="mt-4 text-sm">
+          {warning}
+        </AnimatedAlert>
 
-        {success && (
-          <Alert tone="success" className="mt-4 text-sm">
-            {success}
-          </Alert>
-        )}
+        <AnimatedAlert tone="success" show={!!success} className="mt-4 text-sm">
+          {success}
+        </AnimatedAlert>
 
         <div className="mt-4 flex flex-col gap-3">
           <form.Field name="name">

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -12,7 +12,7 @@ import { isValidEmail } from "@/util/orgMembership"
 import { studentKey } from "@/util/roster"
 import type { Student } from "@/types/classroom"
 import type { StudentCsvRow } from "@/api/mutations/students"
-import { Alert, Button, Input } from "@/components/ui"
+import { AnimatedAlert, Button, Input } from "@/components/ui"
 
 export type EditStudentFormValues = {
   first_name: string
@@ -245,11 +245,9 @@ const EditStudentForm = ({
         ) : null}
       </div>
 
-      {error ? (
-        <Alert tone="error" className="mt-4 text-sm">
-          {error}
-        </Alert>
-      ) : null}
+      <AnimatedAlert tone="error" show={!!error} className="mt-4 text-sm">
+        {error}
+      </AnimatedAlert>
 
       <div className="modal-action">
         <Button variant="ghost" disabled={submitting} onClick={onCancel}>

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react"
 
 import { nameFromParts } from "@/util/students"
-import { Alert, Button, Card, Spinner } from "@/components/ui"
+import { Alert, AnimatedAlert, Button, Card, Spinner } from "@/components/ui"
 import Avatar from "@/components/avatar"
 import type { Student } from "@/types/classroom"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -538,37 +538,41 @@ const EnrolledStudents = ({
       {/* Pending-invites banner: clicking "Review" filters to pending so the
           teacher can select rows and bulk-resend (cancel + re-send).
           Dismissable for the session. */}
-      {!isLoading &&
-      !isError &&
-      !pendingHidden &&
-      !pendingDismissed &&
-      counts.pending > 0 ? (
-        <Alert tone="info" className="flex items-center justify-between gap-3">
-          <span className="flex items-center gap-2 text-sm">
-            <Send aria-hidden="true" className="size-4 shrink-0" />
-            {t("students.pendingBanner", { count: counts.pending })}
-          </span>
-          <div className="flex shrink-0 items-center gap-1">
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => setStatusFilter("pending")}
-            >
-              {t("students.pendingReview")}
-            </Button>
-            <Button
-              variant="ghost"
-              size="xs"
-              shape="square"
-              aria-label={t("students.dismiss")}
-              title={t("students.dismiss")}
-              onClick={() => setPendingDismissed(true)}
-            >
-              <X aria-hidden="true" className="size-4" />
-            </Button>
-          </div>
-        </Alert>
-      ) : null}
+      <AnimatedAlert
+        tone="info"
+        show={
+          !isLoading &&
+          !isError &&
+          !pendingHidden &&
+          !pendingDismissed &&
+          counts.pending > 0
+        }
+        className="flex items-center justify-between gap-3"
+      >
+        <span className="flex items-center gap-2 text-sm">
+          <Send aria-hidden="true" className="size-4 shrink-0" />
+          {t("students.pendingBanner", { count: counts.pending })}
+        </span>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => setStatusFilter("pending")}
+          >
+            {t("students.pendingReview")}
+          </Button>
+          <Button
+            variant="ghost"
+            size="xs"
+            shape="square"
+            aria-label={t("students.dismiss")}
+            title={t("students.dismiss")}
+            onClick={() => setPendingDismissed(true)}
+          >
+            <X aria-hidden="true" className="size-4" />
+          </Button>
+        </div>
+      </AnimatedAlert>
 
       {/* Non-owner: pending invites are owner-only. */}
       {!isLoading && !isError && pendingHidden ? (


### PR DESCRIPTION
## Summary

Conditionally-rendered inline `<Alert>` banners popped in/out abruptly — the primitive is a plain `<div>` with no enter/exit transition, so a state-toggled alert (e.g. the success/warning/error banners on Edit Assignment settings) snapped in and jerked the content below it on mount/unmount.

This adds a reusable **`AnimatedAlert`** primitive and migrates the conditional alert sites onto it.

- **`AnimatedAlert`** (`web/src/components/ui/AnimatedAlert.tsx`) wraps the existing `<Alert>` in `AnimatePresence` + `collapseVariants` (fade + height-collapse) inside a padding-free `overflow-hidden` collapser — the same fade+height-collapse recipe `AppBanner` uses. Both entrance and exit animate, and the surrounding layout reflows smoothly instead of jumping.
- **Reuses the primitive, no styling drift:** it extends `AlertProps` and forwards everything to `<Alert>` (which owns the `alertToneClass` recipe), so the alert is byte-for-byte identical.
- **Kept separate from `Alert` deliberately:** the animation changes *who controls mounting* (the component, via `show`, not the parent via `{cond && …}`), which `AnimatePresence` requires — a merged prop would create a silent footgun and pull `motion/react` into every always-on `<Alert>` consumer. `Alert` stays a dumb, dependency-free primitive.

## Animation choice

`collapseVariants` (fade + **height-collapse**) over the slide-only `calloutVariants`: inline alerts sit in normal flow and push page content, so the height must animate or the content below jumps. Matches the `AppBanner` precedent.

## Scope

Migrated the **state-toggled** alerts (toggle on their own boolean/string state): `EditAssignmentPage`, `CreateAssignmentPage`, `AddStudent`, `EditStudentForm`, `EnrolledStudents` (dismissible pending banner), `OrgMembersPage`, `OrgActivityPage`, `LanguageSwitcher`, and the modals.

**Left as plain `<Alert>`** (out of scope, would animate poorly):
- Always-rendered alerts (`MissingParams`, load errors, permission gates) — no enter/exit moment.
- Phase-state-machine swaps (`SubmissionsPage`, `UploadRoster`, bulk-action bars) — mutually-exclusive alerts inside a parent block that itself toggles; per-alert `AnimatePresence` would cause double-occupancy jank rather than a clean appear/disappear.

Reduced-motion users get no animation (inherited from the app-level `MotionConfig reducedMotion="user"`).

Closes #101.

## Notes on exit-content behavior

Callers usually clear the message string (`setEditError("")`) in the same render that flips `show` off. `AnimatePresence` animates out the **snapshot it last rendered**, so the exiting alert keeps its text through the collapse rather than blanking — verified empirically and locked in by a regression test (`keeps the exiting content when show flips false and children clear`).

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — 1041 passed (incl. 4 `AnimatedAlert` tests, one guarding exit-content)
- [x] `npx eslint` on touched files — no new warnings (2 pre-existing `setState`-in-effect warnings on `AddStudent`/`EditStudentForm` are unrelated)
- [x] `npx prettier --check` — clean
- [ ] Manual: toggle an Edit Assignment save success/error and confirm the banner collapses in/out smoothly
- [ ] Manual: verify with OS "reduce motion" enabled the alerts appear/disappear instantly
