### PR TITLE
feat(web): make activity banner reflect state and surface poll errors

### DIFF
--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -17,7 +17,7 @@ import {
 import { useTranslation } from "react-i18next"
 
 import { useActionActivity, type Tracker } from "@/hooks/useActionActivity"
-import { DURATION, EASE_OUT } from "@/lib/motion"
+import { collapseVariants, DURATION, EASE_OUT } from "@/lib/motion"
 
 // Compact elapsed duration ("8s", "1m 12s", "3m", "1h 5m"); "" for non-positive.
 function formatElapsed(ms: number): string {
@@ -247,10 +247,10 @@ const BannerBody = ({
         {showList && (
           <motion.ul
             key="list"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: DURATION.base, ease: EASE_OUT }}
+            variants={collapseVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
             className="flex w-full flex-col gap-1 overflow-hidden bg-base-100 p-2 text-base-content"
           >
             {trackers.map((tracker) => (

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -114,7 +114,9 @@ const TrackerRow = ({
       }`}
     >
       <StatusIcon phase={tracker.phase} tinted={!compact} />
-      <span className="min-w-0 flex-1 truncate text-sm">{tracker.label}</span>
+      <span className="min-w-0 flex-1 truncate text-sm">
+        {tracker.displayLabel}
+      </span>
       <ElapsedLabel tracker={tracker} now={now} />
       {tracker.htmlUrl && (
         <a
@@ -212,7 +214,7 @@ const BannerBody = ({
       >
         <StatusIcon phase={primaryPhase} />
         <span className="min-w-0 flex-1 truncate text-sm font-medium">
-          {primary?.label}
+          {primary?.displayLabel}
         </span>
         {attentionCount > 0 && (
           <span
@@ -241,27 +243,38 @@ const BannerBody = ({
         />
       </button>
 
-      {showList && (
-        <ul className="flex w-full flex-col gap-1 bg-base-100 p-2 text-base-content">
-          {trackers.map((tracker) => (
-            <li key={tracker.id}>
-              <TrackerRow
-                tracker={tracker}
-                onDismiss={dismiss}
-                onRetry={retry}
-                retrying={retrying.has(tracker.id)}
-                now={now}
-              />
-            </li>
-          ))}
-        </ul>
-      )}
+      <AnimatePresence initial={false}>
+        {showList && (
+          <motion.ul
+            key="list"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: DURATION.base, ease: EASE_OUT }}
+            className="flex w-full flex-col gap-1 overflow-hidden bg-base-100 p-2 text-base-content"
+          >
+            {trackers.map((tracker) => (
+              <li key={tracker.id}>
+                <TrackerRow
+                  tracker={tracker}
+                  onDismiss={dismiss}
+                  onRetry={retry}
+                  retrying={retrying.has(tracker.id)}
+                  now={now}
+                />
+              </li>
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
     </>
   )
 }
 
 export function ActionsBanner() {
-  const { trackers, anyFailed, dismiss, retry, retrying } = useActionActivity()
+  const { trackers, anyFailed, pollError, dismiss, retry, retrying } =
+    useActionActivity()
+  const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
 
   // Shared 1s clock so running rows tick in step. Runs only while something is
@@ -360,19 +373,27 @@ export function ActionsBanner() {
   }
 
   const body = (
-    <BannerBody
-      trackers={trackers}
-      primary={primary}
-      primaryPhase={primaryPhase}
-      attentionCount={attentionCount}
-      single={single}
-      showList={showList}
-      setExpanded={setExpanded}
-      dismiss={dismiss}
-      retry={retry}
-      retrying={retrying}
-      now={now}
-    />
+    <>
+      <BannerBody
+        trackers={trackers}
+        primary={primary}
+        primaryPhase={primaryPhase}
+        attentionCount={attentionCount}
+        single={single}
+        showList={showList}
+        setExpanded={setExpanded}
+        dismiss={dismiss}
+        retry={retry}
+        retrying={retrying}
+        now={now}
+      />
+      {pollError && (
+        <div className="flex items-center gap-2 border-t border-current/20 px-4 py-1.5 text-xs opacity-80">
+          <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+          <span>{t("actionsBanner.pollError")}</span>
+        </div>
+      )}
+    </>
   )
 
   return (

--- a/web/src/hooks/useActionActivity.ts
+++ b/web/src/hooks/useActionActivity.ts
@@ -60,8 +60,6 @@ const WORKFLOW_LABEL_KEY: Record<string, string> = {
 export type Tracker = {
   // Session op id, or `run-<id>` for a discovered run.
   id: string
-  // Base action label (the "what"), e.g. "Collecting scores".
-  label: string
   // Phase-wrapped label for display + aria-live, e.g. "Collecting scores…" ->
   // "Collecting scores — done". Announces state, not just the icon.
   displayLabel: string
@@ -353,7 +351,6 @@ export function useActionActivity(): ActionActivity {
       const times = run ? runTimes(run) : {}
       return {
         id: op.id,
-        label: op.label,
         displayLabel: phaseLabel(op.label, phase),
         phase,
         htmlUrl:
@@ -384,7 +381,6 @@ export function useActionActivity(): ActionActivity {
       const times = runTimes(r)
       return {
         id: `run-${r.id}`,
-        label,
         displayLabel: phaseLabel(label, "running"),
         phase: "running" as TrackerPhase,
         htmlUrl: r.html_url,

--- a/web/src/hooks/useActionActivity.ts
+++ b/web/src/hooks/useActionActivity.ts
@@ -15,6 +15,7 @@ import { useActiveOrg } from "@/hooks/useActiveOrg"
 import {
   isRunning,
   nowMs,
+  PHASE_LABEL_KEY,
   resolveOpRun,
   runTimes,
   runUrl,
@@ -42,6 +43,12 @@ const PENDING_TTL_MS = 5 * 60_000
 // the re-run as in_progress.
 const RETRY_OPTIMISTIC_MS = 20_000
 
+// Once EVERY tracker has succeeded (no failures, nothing running), briefly show
+// the all-green state, then auto-dismiss so the banner disappears on its own. A
+// failure present anywhere cancels this — failures stay until dismissed so the
+// teacher (and the Retry affordance) aren't hidden.
+const ALL_SUCCESS_DISMISS_MS = 8000
+
 // Generic label for a discovered run (cron, another teacher) matching no op.
 const WORKFLOW_LABEL_KEY: Record<string, string> = {
   "publish-pages.yaml": "actionsBanner.workflow.publishPages",
@@ -53,7 +60,11 @@ const WORKFLOW_LABEL_KEY: Record<string, string> = {
 export type Tracker = {
   // Session op id, or `run-<id>` for a discovered run.
   id: string
+  // Base action label (the "what"), e.g. "Collecting scores".
   label: string
+  // Phase-wrapped label for display + aria-live, e.g. "Collecting scores…" ->
+  // "Collecting scores — done". Announces state, not just the icon.
+  displayLabel: string
   phase: TrackerPhase
   // Run's GitHub URL; absent only for a still-pending op.
   htmlUrl?: string
@@ -73,6 +84,10 @@ export type ActionActivity = {
   org: string | undefined
   trackers: Tracker[]
   anyFailed: boolean
+  // True when the status poll is failing (rate limit, lost Actions read) while
+  // trackers are still shown — so the banner can say "retrying" instead of
+  // spinning silently forever.
+  pollError: boolean
   dismiss: (id: string) => void
   retry: (id: string) => void
   // Tracker ids with a retry in flight (spinner / disabled X).
@@ -85,6 +100,12 @@ export type ActionActivity = {
 // Terminal trackers persist as history until dismissed.
 export function useActionActivity(): ActionActivity {
   const { t } = useTranslation()
+  // Wrap a base label with its phase so display text reflects state.
+  const phaseLabel = useCallback(
+    (label: string, phase: TrackerPhase) =>
+      t(PHASE_LABEL_KEY[phase], { label }),
+    [t],
+  )
   const org = useActiveOrg()
   const client = useOptionalGitHubClient()
   const { operationsForOrg, lastRegisteredAt, isDismissed, dismiss, clearOp } =
@@ -333,6 +354,7 @@ export function useActionActivity(): ActionActivity {
       return {
         id: op.id,
         label: op.label,
+        displayLabel: phaseLabel(op.label, phase),
         phase,
         htmlUrl:
           run?.html_url ??
@@ -363,6 +385,7 @@ export function useActionActivity(): ActionActivity {
       return {
         id: `run-${r.id}`,
         label,
+        displayLabel: phaseLabel(label, "running"),
         phase: "running" as TrackerPhase,
         htmlUrl: r.html_url,
         runId: r.id,
@@ -459,10 +482,39 @@ export function useActionActivity(): ActionActivity {
 
   const anyFailed = trackers.some((tr) => tr.phase === "failed")
 
+  // All-green auto-dismiss: when every tracker has succeeded (no failed,
+  // running, or pending — discovered runs are always "running", so they gate
+  // this too, and every id here is a session op), flash the green state
+  // briefly, then clearOp each so the banner clears itself. clearOp (not
+  // dismiss) forgets the op entirely — it's terminal history the teacher never
+  // needs again — which also drops it from operationsForOrg so the idle poll
+  // can stop instead of ticking until the op's TTL. Keyed off the phase
+  // signature so a new/failed action cancels the pending timer.
+  const allSucceeded =
+    trackers.length > 0 && trackers.every((tr) => tr.phase === "success")
+  const successIds = allSucceeded ? trackers.map((tr) => tr.id) : []
+  const successSignature = successIds.join(",")
+  useEffect(() => {
+    if (successSignature === "") return
+    const ids = successSignature.split(",")
+    const timer = window.setTimeout(() => {
+      for (const id of ids) clearOp(id)
+    }, ALL_SUCCESS_DISMISS_MS)
+    return () => window.clearTimeout(timer)
+  }, [successSignature, clearOp])
+
+  // Poll is failing (403/429/5xx propagate from the fetch layer) and we have
+  // something on screen to keep fresh. Require >= 2 consecutive failures so a
+  // single transient blip doesn't flash the "retrying" hint. React Query keeps
+  // retrying on the poll interval, so it clears on its own once a fetch lands.
+  const pollError =
+    runsQuery.isError && runsQuery.failureCount >= 2 && trackers.length > 0
+
   return {
     org,
     trackers,
     anyFailed,
+    pollError,
     dismiss,
     retry,
     retrying,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -7,9 +7,17 @@
     "viewRun": "View run",
     "retry": "Retry",
     "retryFailed": "Couldn't re-run the action: {{detail}}",
+    "pollError": "Couldn't check status — retrying…",
     "dismiss": "Dismiss",
+    "state": {
+      "pending": "{{label}} — starting…",
+      "running": "{{label}}…",
+      "success": "{{label}} — done",
+      "failed": "{{label}} — failed"
+    },
     "workflow": {
       "publishPages": "Publishing to student site",
+      "publishClassroom": "Publishing “{{name}}” settings",
       "collectScores": "Collecting scores",
       "regrade": "Regrading",
       "generic": "GitHub Actions workflow"

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -64,7 +64,9 @@ const CreateClassroomPage = () => {
       if (org && result.newCommitSha) {
         register({
           org,
-          label: t("actionsBanner.workflow.publishPages"),
+          label: t("actionsBanner.workflow.publishClassroom", {
+            name: variables.classroom,
+          }),
           anchor: { kind: "sha", sha: result.newCommitSha },
         })
       }

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -77,7 +77,9 @@ const EditClassroomContent = ({
       if (org && result?.newCommitSha) {
         register({
           org,
-          label: t("actionsBanner.workflow.publishPages"),
+          label: t("actionsBanner.workflow.publishClassroom", {
+            name: cl?.name ?? classroom,
+          }),
           anchor: { kind: "sha", sha: result.newCommitSha },
         })
       }

--- a/web/src/util/actionActivity.test.ts
+++ b/web/src/util/actionActivity.test.ts
@@ -4,6 +4,7 @@ import {
   isFailureConclusion,
   isRunning,
   orgFromPathname,
+  PHASE_LABEL_KEY,
   resolveOpRun,
   runMatchesOp,
   runTimes,
@@ -13,6 +14,8 @@ import {
 } from "./actionActivity"
 import type { GitHubWorkflowRun } from "@/hooks/github/types"
 import type { ActionOperation } from "@/context/actions/ActionActivityProvider"
+import en from "@/locales/en.json"
+import { flattenBundle } from "@/i18n/customLocale"
 
 const run = (over: Partial<GitHubWorkflowRun>): GitHubWorkflowRun =>
   ({
@@ -295,6 +298,26 @@ describe("isFailureConclusion", () => {
   it("treats success/skipped/neutral and null as non-failures", () => {
     for (const c of ["success", "skipped", "neutral", null] as const) {
       expect(isFailureConclusion(c)).toBe(false)
+    }
+  })
+})
+
+describe("PHASE_LABEL_KEY", () => {
+  const baseKeys = flattenBundle(en)
+
+  it("maps every tracker phase to a distinct actionsBanner.state key", () => {
+    const keys = Object.values(PHASE_LABEL_KEY)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it("resolves every phase key to an en.json template carrying {{label}}", () => {
+    for (const phase of ["pending", "running", "success", "failed"] as const) {
+      const key = PHASE_LABEL_KEY[phase]
+      // Guards the dynamic t(PHASE_LABEL_KEY[phase], { label }) call site the
+      // static key audit skips: a rename/removal in en.json must fail here,
+      // not ship green and render a raw key to screen readers.
+      expect(baseKeys).toHaveProperty(key)
+      expect(baseKeys[key]).toContain("{{label}}")
     }
   })
 })

--- a/web/src/util/actionActivity.ts
+++ b/web/src/util/actionActivity.ts
@@ -141,3 +141,13 @@ export function trackerPhase(run: GitHubWorkflowRun | null): TrackerPhase {
   if (isRunning(run)) return "running"
   return isFailureConclusion(run.conclusion) ? "failed" : "success"
 }
+
+// The i18n key that wraps a base action label for a given phase, so the banner
+// text (and thus the aria-live announcement) reflects state, not just the icon
+// — a screen-reader user hears "…done" / "…failed", not the same string twice.
+export const PHASE_LABEL_KEY: Record<TrackerPhase, string> = {
+  pending: "actionsBanner.state.pending",
+  running: "actionsBanner.state.running",
+  success: "actionsBanner.state.success",
+  failed: "actionsBanner.state.failed",
+}


### PR DESCRIPTION
## Summary

Refines the global GitHub Actions activity banner (#97) so its text — not just its icon and color — communicates what is happening, closing an accessibility gap and several UX rough edges.

- **Phase-aware text (accessibility):** each tracker's label now reflects its phase via `actionsBanner.state.*` wrapper templates ("Collecting scores…" -> "…done" / "…failed"). Because the visible text changes on each transition, the existing `aria-live` region announces the new state to screen readers instead of repeating a static label.
- **Poll-error surfacing:** when the Actions poll is failing (rate limit / lost Actions read), the banner shows a "Couldn't check status — retrying…" strip instead of spinning silently forever. Gated on `failureCount >= 2` so a single transient blip doesn't flash; self-heals on the next successful poll.
- **Named classroom publishes:** create/edit classroom register `Publishing "<name>" settings` so concurrent publishes are distinguishable.
- **All-success auto-dismiss:** once every tracker has succeeded (no failures, nothing running), the green state shows briefly then clears itself. Failures stay sticky so the Retry affordance is never hidden.
- **Animated expand/collapse** of the multi-tracker list, reusing the shared `collapseVariants` and respecting the global reduced-motion config.

## Review & simplification fixes folded in

A multi-agent code review and a simplification pass surfaced and this PR includes:

- Auto-dismiss now calls `clearOp()` rather than `dismiss()`, so completed ops are forgotten and the poll can idle-stop — previously a silent background poll kept firing ~15s for up to 15 min after the banner vanished.
- The `PHASE_LABEL_KEY` test now asserts the keys actually resolve in `en.json` (with the `{{label}}` placeholder) rather than re-checking the map's own literals — guarding the dynamic `t()` key the static i18n audit skips.
- The expand animation reuses the shared `collapseVariants` from `lib/motion.ts` instead of inline motion props (matching the four existing consumers), and the vestigial `Tracker.label` field was dropped now that every consumer reads `displayLabel`.

## Test plan

- [x] `cd web && npx tsc -b` — clean
- [x] `npx vitest run` — 1043 passing
- [x] `npx eslint` / `npx prettier --check` on touched files — clean (no new warnings)
- [x] Manual: trigger collect-scores / regrade / assignment + classroom publish; confirm the label tracks pending -> running -> done, the banner auto-clears once all succeed, a failure stays with Retry, and forcing a poll 403 shows the retrying strip

Closes #97