### PR TITLE
fix(web): harden Modal close lock and Button form-submit type

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -93,14 +93,15 @@ export default defineConfig([
             'Prefer the accessible <Spinner> component over a bare `loading loading-spinner` span (it adds role="status" + an sr-only label). In-button spinners may stay inline if the button already has an accessible name.',
         },
         {
-          // A bare <button> inside a <form> defaults to type="submit"; our
-          // <Button> primitive defaults to type="button". A <Button> under a
-          // <form> without an explicit `type` is almost certainly a silently
-          // broken submit (or a click-handler button that should say
-          // type="button" to make the intent explicit). Descendant selector, so
-          // it catches nesting at any depth.
+          // Warn when a <Button> sits in a form without an explicit `type`: a
+          // bare <button> defaults to submit, our <Button> defaults to "button",
+          // so an unmarked one is a likely silent no-op submit. Advisory only —
+          // the Button default + form-submit tests are the real enforcement.
+          // Two deliberate limits: matches <form> AND `<Card as="form">` (the
+          // app uses the latter); same-file lexical only, so a <Button> in a
+          // child component rendered inside a form isn't reachable here.
           selector:
-            "JSXElement[openingElement.name.name='form'] JSXElement[openingElement.name.name='Button']:not(:has(JSXAttribute[name.name='type']))",
+            ":matches(JSXElement[openingElement.name.name='form'], JSXElement:has(JSXAttribute[name.name='as'][value.value='form'])) JSXOpeningElement[name.name='Button']:not(:has(JSXAttribute[name.name=/^(type|as|href)$/]))",
           message:
             'A <Button> inside a <form> needs an explicit `type`: add type="submit" for the submit action or type="button" for a click handler. The <Button> default is "button", which silently disables implicit form submit.',
         },

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -92,6 +92,18 @@ export default defineConfig([
           message:
             'Prefer the accessible <Spinner> component over a bare `loading loading-spinner` span (it adds role="status" + an sr-only label). In-button spinners may stay inline if the button already has an accessible name.',
         },
+        {
+          // A bare <button> inside a <form> defaults to type="submit"; our
+          // <Button> primitive defaults to type="button". A <Button> under a
+          // <form> without an explicit `type` is almost certainly a silently
+          // broken submit (or a click-handler button that should say
+          // type="button" to make the intent explicit). Descendant selector, so
+          // it catches nesting at any depth.
+          selector:
+            "JSXElement[openingElement.name.name='form'] JSXElement[openingElement.name.name='Button']:not(:has(JSXAttribute[name.name='type']))",
+          message:
+            'A <Button> inside a <form> needs an explicit `type`: add type="submit" for the submit action or type="button" for a click handler. The <Button> default is "button", which silently disables implicit form submit.',
+        },
       ],
     },
   },

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -85,6 +85,48 @@ describe("Button", () => {
     ).toBe("submit")
   })
 
+  // The type default is a footgun: a bare <button> in a <form> implicitly
+  // submits, but Button defaults to type="button". These lock the contract so a
+  // migration can't silently strip a form's submit — type="submit" fires
+  // onSubmit on click and Enter; the default does not.
+  it("fires the form onSubmit on click when type=submit", async () => {
+    const onSubmit = vi.fn((e) => e.preventDefault())
+    render(
+      <form onSubmit={onSubmit}>
+        <Button type="submit">Go</Button>
+      </form>,
+    )
+    await userEvent.click(screen.getByRole("button", { name: "Go" }))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("fires the form onSubmit on Enter in a field when type=submit", async () => {
+    const onSubmit = vi.fn((e) => e.preventDefault())
+    render(
+      <form onSubmit={onSubmit}>
+        <input aria-label="field" />
+        <Button type="submit">Go</Button>
+      </form>,
+    )
+    await userEvent.type(screen.getByLabelText("field"), "hi{Enter}")
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not submit the form on click with the default type", async () => {
+    const onSubmit = vi.fn((e) => e.preventDefault())
+    render(
+      <form onSubmit={onSubmit}>
+        {/* Intentionally no `type`: proving the default is "button" (no submit).
+            The no-restricted-syntax guard flags exactly this shape, so disable
+            it for the one line that asserts the footgun it guards against. */}
+        {/* eslint-disable-next-line no-restricted-syntax */}
+        <Button>Go</Button>
+      </form>,
+    )
+    await userEvent.click(screen.getByRole("button", { name: "Go" }))
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
   it("renders an anchor with the same recipe when given href", () => {
     render(
       <Button href="https://example.com" variant="ghost" size="sm">

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -85,10 +85,8 @@ describe("Button", () => {
     ).toBe("submit")
   })
 
-  // The type default is a footgun: a bare <button> in a <form> implicitly
-  // submits, but Button defaults to type="button". These lock the contract so a
-  // migration can't silently strip a form's submit — type="submit" fires
-  // onSubmit on click and Enter; the default does not.
+  // Lock the contract so a migration can't silently strip a form's submit:
+  // type="submit" fires onSubmit on click/Enter; the "button" default does not.
   it("fires the form onSubmit on click when type=submit", async () => {
     const onSubmit = vi.fn((e) => e.preventDefault())
     render(
@@ -116,9 +114,8 @@ describe("Button", () => {
     const onSubmit = vi.fn((e) => e.preventDefault())
     render(
       <form onSubmit={onSubmit}>
-        {/* Intentionally no `type`: proving the default is "button" (no submit).
-            The no-restricted-syntax guard flags exactly this shape, so disable
-            it for the one line that asserts the footgun it guards against. */}
+        {/* Intentionally no `type`: asserting the "button" default (no submit)
+            — the exact shape the guard flags. */}
         {/* eslint-disable-next-line no-restricted-syntax */}
         <Button>Go</Button>
       </form>,

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -92,6 +92,11 @@ export type ButtonProps = CommonProps &
     rel?: string
     download?: AnchorHTMLAttributes<HTMLAnchorElement>["download"]
     ref?: Ref<HTMLButtonElement | HTMLAnchorElement>
+    // Defaults to "button" (unlike a bare <button>, which defaults to "submit"
+    // inside a form). A submit button must pass type="submit" explicitly, or the
+    // eslint-plugin-react `button-has-type` rule / the form-submit test will flag
+    // the silent no-op.
+    type?: ButtonHTMLAttributes<HTMLButtonElement>["type"]
   }
 
 export function Button({

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -92,10 +92,8 @@ export type ButtonProps = CommonProps &
     rel?: string
     download?: AnchorHTMLAttributes<HTMLAnchorElement>["download"]
     ref?: Ref<HTMLButtonElement | HTMLAnchorElement>
-    // Defaults to "button" (unlike a bare <button>, which defaults to "submit"
-    // inside a form). A submit button must pass type="submit" explicitly, or the
-    // eslint-plugin-react `button-has-type` rule / the form-submit test will flag
-    // the silent no-op.
+    // Defaults to "button" (a bare <button> defaults to "submit" inside a
+    // form); a submit button must pass type="submit" explicitly.
     type?: ButtonHTMLAttributes<HTMLButtonElement>["type"]
   }
 

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -100,6 +100,35 @@ describe("Modal", () => {
     expect(cancel.defaultPrevented).toBe(false)
   })
 
+  it("holds the dialog open against open=false while closeDisabled, then closes when the lock releases", () => {
+    const { container, rerender } = render(
+      <Modal open closeDisabled aria-label="dlg">
+        x
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+    expect(dialog.open).toBe(true)
+
+    // A parent flipping open=false mid-submit must not dismiss the guarded
+    // dialog — the lock covers the programmatic close path, not just user
+    // dismissal.
+    rerender(
+      <Modal open={false} closeDisabled aria-label="dlg">
+        x
+      </Modal>,
+    )
+    expect(dialog.open).toBe(true)
+
+    // Once the submit finishes and the lock releases, the pending open=false
+    // takes effect and the dialog closes.
+    rerender(
+      <Modal open={false} aria-label="dlg">
+        x
+      </Modal>,
+    )
+    expect(dialog.open).toBe(false)
+  })
+
   it("stays closed in ref-driven mode until opened imperatively, and wires dialogRef", () => {
     const onClose = vi.fn()
     const dialogRef = createRef<HTMLDialogElement | null>()

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -71,8 +71,7 @@ export function Modal({
 
   // Keep the native dialog in sync with `open` (controlled mode). Skipped when
   // the caller drives the dialog through `dialogRef` and never passes `open`.
-  // `closeDisabled` holds the dialog open against a parent that flips
-  // `open=false` mid-submit — the same lock that vetoes user dismissal.
+  // Don't close while `closeDisabled` — a parent may flip open=false mid-submit.
   useEffect(() => {
     if (open === undefined) return
     const dialog = dialogRef?.current ?? internalRef.current

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -40,8 +40,9 @@ export type ModalProps = {
   // Hide the built-in top-right close X (some modals render their own header
   // affordance or must block dismissal while submitting).
   hideCloseButton?: boolean
-  // Disable the close X + backdrop close, and block Esc-dismiss, while a submit
-  // is in flight (see the onCancel guard below).
+  // Block dismissal while a submit is in flight: disables the close X + backdrop
+  // close, vetoes Esc (see the onCancel guard below), and holds the dialog open
+  // against a controlled `open=false` transition (see the open-sync effect).
   closeDisabled?: boolean
   "aria-labelledby"?: string
   "aria-label"?: string
@@ -70,13 +71,15 @@ export function Modal({
 
   // Keep the native dialog in sync with `open` (controlled mode). Skipped when
   // the caller drives the dialog through `dialogRef` and never passes `open`.
+  // `closeDisabled` holds the dialog open against a parent that flips
+  // `open=false` mid-submit — the same lock that vetoes user dismissal.
   useEffect(() => {
     if (open === undefined) return
     const dialog = dialogRef?.current ?? internalRef.current
     if (!dialog) return
     if (open && !dialog.open) dialog.showModal()
-    if (!open && dialog.open) dialog.close()
-  }, [open, dialogRef])
+    if (!open && dialog.open && !closeDisabled) dialog.close()
+  }, [open, dialogRef, closeDisabled])
 
   const setRefs = (node: HTMLDialogElement | null) => {
     internalRef.current = node

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -955,7 +955,12 @@ const CreateAssignmentForm = ({
       <div className="divider" />
       <div className="card-actions justify-end p-2">
         {onCancel && (
-          <Button variant="ghost" onClick={onCancel} disabled={loading}>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            disabled={loading}
+          >
             {readOnly ? t("assignments.form.back") : t("common.cancel")}
           </Button>
         )}

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -268,6 +268,7 @@ const CreateClassroomForm = ({
                               }
                             />
                             <Button
+                              type="button"
                               variant="ghost"
                               onClick={() =>
                                 secretField.handleChange(

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -355,7 +355,12 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
         </div>
 
         <div className="modal-action">
-          <Button variant="ghost" disabled={submitting} onClick={closeDialog}>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={submitting}
+            onClick={closeDialog}
+          >
             {t("common.close")}
           </Button>
           <form.Subscribe

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -250,7 +250,12 @@ const EditStudentForm = ({
       </AnimatedAlert>
 
       <div className="modal-action">
-        <Button variant="ghost" disabled={submitting} onClick={onCancel}>
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={submitting}
+          onClick={onCancel}
+        >
           {t("common.cancel")}
         </Button>
         <form.Subscribe


### PR DESCRIPTION
## Summary

Closes #170 — two forward-looking hardening items from the #169 review. Neither was a live defect, but both mechanisms were provable from the code and unguarded.

- **Modal `closeDisabled` now guards the programmatic close path.** The open-sync effect previously called `dialog.close()` unconditionally, so a parent flipping `open=false` while a submit was in flight would dismiss a modal the lock was protecting. It now checks `!closeDisabled` (added to the effect deps); the pending close applies once the lock releases. Doc comment updated to reflect the wider contract.
- **`Button` form-submit type footgun guarded.** A bare `<button>` in a `<form>` defaults to `type="submit"`; the `Button` primitive defaults to `type="button"`. Added a `no-restricted-syntax` eslint rule (repo's existing `warn` convention) that flags any `<Button>` descendant of a `<form>` lacking an explicit `type`, plus render tests asserting click/Enter submit behavior. Documented the default on `ButtonProps`.
- **Fixed three latent sites the new rule caught** — cancel/close buttons inside forms in `AddStudent`, `EditStudentForm`, and `CreateAssignmentForm` that relied on the implicit default. Made their `type="button"` explicit (no behavior change; the intent is now declared and robust).

## Test plan

- [x] `tsc -b` — clean
- [x] `eslint .` — 0 errors, 0 remaining form-button warnings
- [x] `prettier --check` — clean on all touched files
- [x] `vitest run` — 1047 passed (95 files), including 4 new tests:
  - Modal holds open against `open=false` while `closeDisabled`, then closes when the lock releases
  - Button `type="submit"` fires form `onSubmit` on click
  - Button `type="submit"` fires form `onSubmit` on Enter
  - Button default type does not submit