### PR TITLE
refactor(web): consolidate toolbars into one extensible Toolbar primitive

### DIFF
--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef, ReactNode, Ref } from "react"
 
-import { cx } from "./cx"
+import { cx, hasUtility } from "./cx"
 
 // The canonical text input. Wraps daisyUI `input input-bordered w-full` so the
 // two competing conventions (`input w-full` vs `input input-bordered`) converge
@@ -42,7 +42,7 @@ export function Input({
   // trailing `w-full` in the recipe would otherwise beat a per-site `w-32` (cx
   // doesn't merge Tailwind classes, and same-property source order is
   // unspecified).
-  const hasWidth = className ? /(?:^|\s)w-/.test(className) : false
+  const hasWidth = hasUtility("w-", className)
 
   // With a leading icon, the border lives on the wrapping <label> (daisyUI's
   // documented pattern) and the <input> is a bare grower — a single border

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef, Ref } from "react"
 
-import { cx } from "./cx"
+import { cx, hasUtility } from "./cx"
 
 // The canonical select. Wraps daisyUI `select select-bordered w-full` to match
 // the Input convention. `invalid` adds `select-error`; `selectSize` maps size
@@ -27,7 +27,7 @@ export function Select({
   children,
   ...props
 }: SelectProps) {
-  const hasWidth = className ? /(?:^|\s)w-/.test(className) : false
+  const hasWidth = hasUtility("w-", className)
   return (
     <select
       className={cx(

--- a/web/src/components/ui/Toolbar.test.tsx
+++ b/web/src/components/ui/Toolbar.test.tsx
@@ -105,6 +105,22 @@ describe("Toolbar.Search", () => {
     expect(label.className).not.toContain("input-sm")
   })
 
+  it("suppresses the default w-full when a caller passes w-auto with flex utilities", () => {
+    render(
+      <Toolbar.Search
+        value=""
+        onChange={() => {}}
+        ariaLabel="Search"
+        inputSize="md"
+        className="w-auto min-w-0 flex-1"
+      />,
+    )
+    const label = screen.getByLabelText("Search").closest("label")!
+    expect(label.className).not.toContain("w-full")
+    expect(label.className).toContain("w-auto")
+    expect(label.className).toContain("flex-1")
+  })
+
   it("applies an icon className override", () => {
     const { container } = render(
       <Toolbar.Search

--- a/web/src/components/ui/Toolbar.test.tsx
+++ b/web/src/components/ui/Toolbar.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach, vi } from "vitest"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
+
+import { Toolbar } from "./Toolbar"
+
+afterEach(cleanup)
+
+describe("Toolbar shell", () => {
+  it("renders the filter-bar container recipe by default", () => {
+    render(
+      <Toolbar data-testid="bar">
+        <span>x</span>
+      </Toolbar>,
+    )
+    const cls = screen.getByTestId("bar").className
+    expect(cls).toContain("flex")
+    expect(cls).toContain("flex-wrap")
+    expect(cls).toContain("items-center")
+    expect(cls).toContain("gap-2")
+    expect(cls).not.toContain("border-b")
+  })
+
+  it("merges a caller className with the default recipe", () => {
+    render(
+      <Toolbar data-testid="bar" className="mt-6">
+        <span>x</span>
+      </Toolbar>,
+    )
+    const cls = screen.getByTestId("bar").className
+    expect(cls).toContain("gap-2")
+    expect(cls).toContain("mt-6")
+  })
+
+  it("switches to the header chrome and wider gap when header is set", () => {
+    render(
+      <Toolbar data-testid="bar" header>
+        <span>x</span>
+      </Toolbar>,
+    )
+    const cls = screen.getByTestId("bar").className
+    expect(cls).toContain("border-b")
+    expect(cls).toContain("border-base-300")
+    expect(cls).toContain("px-6")
+    expect(cls).toContain("py-3")
+    expect(cls).toContain("gap-x-4")
+    expect(cls).toContain("gap-y-3")
+    expect(cls).not.toContain("gap-2")
+  })
+})
+
+describe("Toolbar.Search", () => {
+  it("renders a bordered search input with the label on the inner input", () => {
+    render(
+      <Toolbar.Search
+        value=""
+        onChange={() => {}}
+        ariaLabel="Search"
+        placeholder="Find"
+      />,
+    )
+    const input = screen.getByLabelText("Search")
+    expect(input.getAttribute("type")).toBe("search")
+    expect(input.getAttribute("placeholder")).toBe("Find")
+    // leadingIcon: the input is a bare grower, the label owns the border + width.
+    const label = input.closest("label")!
+    expect(label.className).toContain("input-bordered")
+    expect(label.className).toContain("input-sm")
+  })
+
+  it("fires onChange with the raw string value", () => {
+    const onChange = vi.fn()
+    render(<Toolbar.Search value="" onChange={onChange} ariaLabel="Search" />)
+    fireEvent.change(screen.getByLabelText("Search"), {
+      target: { value: "abc" },
+    })
+    expect(onChange).toHaveBeenCalledWith("abc")
+  })
+
+  it("lets a caller width override the default and applies inputSize", () => {
+    render(
+      <Toolbar.Search
+        value=""
+        onChange={() => {}}
+        ariaLabel="Search"
+        inputSize="md"
+        className="w-full sm:max-w-xs"
+      />,
+    )
+    const label = screen.getByLabelText("Search").closest("label")!
+    expect(label.className).toContain("w-full")
+    expect(label.className).not.toContain("min-w-[12rem]")
+    // md maps to no size modifier.
+    expect(label.className).not.toContain("input-sm")
+  })
+
+  it("applies an icon className override", () => {
+    const { container } = render(
+      <Toolbar.Search
+        value=""
+        onChange={() => {}}
+        ariaLabel="Search"
+        iconClassName="opacity-50"
+      />,
+    )
+    const icon = container.querySelector("svg")!
+    expect(icon.getAttribute("class")).toContain("opacity-50")
+  })
+})
+
+describe("Toolbar.FilterSelect", () => {
+  it("renders a labelled join select with the prefix", () => {
+    render(
+      <Toolbar.FilterSelect label="Type" aria-label="Type filter" value="all" onChange={() => {}}>
+        <option value="all">All</option>
+        <option value="a" disabled>
+          A
+        </option>
+      </Toolbar.FilterSelect>,
+    )
+    const select = screen.getByLabelText("Type filter")
+    expect(select.className).toContain("join-item")
+    expect(screen.getByText("Type")).not.toBeNull()
+    // Per-option disabled state rides through the wrapper.
+    const opt = screen.getByText("A") as HTMLOptionElement
+    expect(opt.disabled).toBe(true)
+  })
+
+  it("renders a bare select with no prefix or join when label is absent", () => {
+    render(
+      <Toolbar.FilterSelect aria-label="Status" value="all" onChange={() => {}}>
+        <option value="all">All</option>
+      </Toolbar.FilterSelect>,
+    )
+    const select = screen.getByLabelText("Status")
+    expect(select.className).not.toContain("join-item")
+    // No LabeledControl join wrapper.
+    expect(select.closest(".join")).toBeNull()
+  })
+
+  it("lets a caller width override the default on the label-less variant", () => {
+    render(
+      <Toolbar.FilterSelect
+        aria-label="Status"
+        value="all"
+        onChange={() => {}}
+        selectSize="md"
+        className="w-full sm:w-auto"
+      >
+        <option value="all">All</option>
+      </Toolbar.FilterSelect>,
+    )
+    const select = screen.getByLabelText("Status")
+    expect(select.className).toContain("w-full")
+    expect(select.className).not.toContain("select-sm")
+  })
+})
+
+describe("Toolbar.Trailing", () => {
+  it("renders an ml-auto group with children", () => {
+    render(
+      <Toolbar.Trailing data-testid="tr">
+        <button>Go</button>
+      </Toolbar.Trailing>,
+    )
+    expect(screen.getByTestId("tr").className).toContain("ml-auto")
+  })
+
+  it("renders nothing when it has no children", () => {
+    const { container } = render(<Toolbar.Trailing>{null}</Toolbar.Trailing>)
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe("Toolbar.Selection", () => {
+  const base = {
+    onToggleSelectAll: () => {},
+    selectAllAriaLabel: "Select all",
+    label: "3 selected",
+  }
+
+  it("reflects allSelected and fires onToggleSelectAll", () => {
+    const onToggle = vi.fn()
+    render(
+      <Toolbar.Selection
+        {...base}
+        allSelected
+        someSelected={false}
+        onToggleSelectAll={onToggle}
+      />,
+    )
+    const checkbox = screen.getByLabelText("Select all") as HTMLInputElement
+    expect(checkbox.checked).toBe(true)
+    fireEvent.click(checkbox)
+    expect(onToggle).toHaveBeenCalled()
+    expect(screen.getByText("3 selected")).not.toBeNull()
+  })
+
+  it("sets indeterminate when partially selected", () => {
+    render(
+      <Toolbar.Selection {...base} allSelected={false} someSelected />,
+    )
+    const checkbox = screen.getByLabelText("Select all") as HTMLInputElement
+    expect(checkbox.indeterminate).toBe(true)
+  })
+
+  it("shows children (selected actions) and hides idleActions when selected", () => {
+    render(
+      <Toolbar.Selection
+        {...base}
+        allSelected={false}
+        someSelected
+        aux={<span>aux-toggle</span>}
+        idleActions={<span>idle-actions</span>}
+      >
+        <button>Remove</button>
+      </Toolbar.Selection>,
+    )
+    expect(screen.getByText("Remove")).not.toBeNull()
+    expect(screen.getByText("aux-toggle")).not.toBeNull()
+    expect(screen.queryByText("idle-actions")).toBeNull()
+  })
+
+  it("shows idleActions and aux when nothing is selected", () => {
+    render(
+      <Toolbar.Selection
+        {...base}
+        label="10 members"
+        allSelected={false}
+        someSelected={false}
+        aux={<span>aux-toggle</span>}
+        idleActions={<span>idle-actions</span>}
+      />,
+    )
+    expect(screen.getByText("idle-actions")).not.toBeNull()
+    expect(screen.getByText("aux-toggle")).not.toBeNull()
+  })
+})

--- a/web/src/components/ui/Toolbar.test.tsx
+++ b/web/src/components/ui/Toolbar.test.tsx
@@ -122,7 +122,12 @@ describe("Toolbar.Search", () => {
 describe("Toolbar.FilterSelect", () => {
   it("renders a labelled join select with the prefix", () => {
     render(
-      <Toolbar.FilterSelect label="Type" aria-label="Type filter" value="all" onChange={() => {}}>
+      <Toolbar.FilterSelect
+        label="Type"
+        aria-label="Type filter"
+        value="all"
+        onChange={() => {}}
+      >
         <option value="all">All</option>
         <option value="a" disabled>
           A
@@ -208,9 +213,7 @@ describe("Toolbar.Selection", () => {
   })
 
   it("sets indeterminate when partially selected", () => {
-    render(
-      <Toolbar.Selection {...base} allSelected={false} someSelected />,
-    )
+    render(<Toolbar.Selection {...base} allSelected={false} someSelected />)
     const checkbox = screen.getByLabelText("Select all") as HTMLInputElement
     expect(checkbox.indeterminate).toBe(true)
   })

--- a/web/src/components/ui/Toolbar.test.tsx
+++ b/web/src/components/ui/Toolbar.test.tsx
@@ -32,6 +32,17 @@ describe("Toolbar shell", () => {
     expect(cls).toContain("mt-6")
   })
 
+  it("lets a caller gap override the default gap-2", () => {
+    render(
+      <Toolbar data-testid="bar" className="gap-3">
+        <span>x</span>
+      </Toolbar>,
+    )
+    const cls = screen.getByTestId("bar").className
+    expect(cls).not.toContain("gap-2")
+    expect(cls).toContain("gap-3")
+  })
+
   it("switches to the header chrome and wider gap when header is set", () => {
     render(
       <Toolbar data-testid="bar" header>

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,17 +1,14 @@
 import { Search } from "lucide-react"
 import type { ComponentPropsWithoutRef, ReactNode } from "react"
 
-import { cx } from "./cx"
+import { cx, hasUtility } from "./cx"
 import { Input, type InputSize } from "./Input"
 import { LabeledControl } from "./LabeledControl"
 import { Select, type SelectSize } from "./Select"
 
-// The shared toolbar shell + slots. One source for the filter/action-bar recipes
-// each page used to hand-roll: the `flex flex-wrap items-center gap-2` container,
-// the search input, the labelled select, the `ml-auto` trailing group, and the
-// selection-aware bulk-actions region. Pages compose the slots they need; the
-// shell stays presentational. `header` switches to the table-header chrome the
-// bulk bars use (border + wider gap) so both species share one shell.
+// The shared toolbar shell + slots that replace the per-page hand-rolled bars.
+// `header` swaps the filter-bar chrome for the bulk-bar table-header chrome so
+// both species share one shell.
 
 export type ToolbarProps = {
   header?: boolean
@@ -24,10 +21,9 @@ export function Toolbar({
   children,
   ...props
 }: ToolbarProps) {
-  // Let a caller override the default gap (mirrors Input/Select's width guard):
-  // cx doesn't merge Tailwind classes, so a stray default `gap-2` would beat a
-  // per-site `gap-3`.
-  const hasGap = className ? /(?:^|\s)gap-/.test(className) : false
+  // A caller gap (e.g. gap-3) overrides the default; without the guard cx would
+  // emit both, and Tailwind source order is unspecified.
+  const hasGap = hasUtility("gap-", className)
   return (
     <div
       className={cx(

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -24,13 +24,17 @@ export function Toolbar({
   children,
   ...props
 }: ToolbarProps) {
+  // Let a caller override the default gap (mirrors Input/Select's width guard):
+  // cx doesn't merge Tailwind classes, so a stray default `gap-2` would beat a
+  // per-site `gap-3`.
+  const hasGap = className ? /(?:^|\s)gap-/.test(className) : false
   return (
     <div
       className={cx(
         "flex flex-wrap items-center",
         header
           ? "gap-x-4 gap-y-3 border-b border-base-300 px-6 py-3"
-          : "gap-2",
+          : !hasGap && "gap-2",
         className,
       )}
       {...props}

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -70,7 +70,9 @@ function ToolbarSearch({
       type="search"
       inputSize={inputSize}
       className={className}
-      leadingIcon={<Search aria-hidden="true" className={cx("size-4", iconClassName)} />}
+      leadingIcon={
+        <Search aria-hidden="true" className={cx("size-4", iconClassName)} />
+      }
       placeholder={placeholder}
       value={value}
       onChange={(e) => onChange(e.target.value)}
@@ -117,7 +119,11 @@ export type ToolbarTrailingProps = {
   children?: ReactNode
 } & ComponentPropsWithoutRef<"div">
 
-function ToolbarTrailing({ className, children, ...props }: ToolbarTrailingProps) {
+function ToolbarTrailing({
+  className,
+  children,
+  ...props
+}: ToolbarTrailingProps) {
   if (!children) return null
   return (
     <div

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,0 +1,185 @@
+import { Search } from "lucide-react"
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+
+import { cx } from "./cx"
+import { Input, type InputSize } from "./Input"
+import { LabeledControl } from "./LabeledControl"
+import { Select, type SelectSize } from "./Select"
+
+// The shared toolbar shell + slots. One source for the filter/action-bar recipes
+// each page used to hand-roll: the `flex flex-wrap items-center gap-2` container,
+// the search input, the labelled select, the `ml-auto` trailing group, and the
+// selection-aware bulk-actions region. Pages compose the slots they need; the
+// shell stays presentational. `header` switches to the table-header chrome the
+// bulk bars use (border + wider gap) so both species share one shell.
+
+export type ToolbarProps = {
+  header?: boolean
+  children?: ReactNode
+} & ComponentPropsWithoutRef<"div">
+
+export function Toolbar({
+  header = false,
+  className,
+  children,
+  ...props
+}: ToolbarProps) {
+  return (
+    <div
+      className={cx(
+        "flex flex-wrap items-center",
+        header
+          ? "gap-x-4 gap-y-3 border-b border-base-300 px-6 py-3"
+          : "gap-2",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export type ToolbarSearchProps = {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  ariaLabel?: string
+  inputSize?: InputSize
+  // Overrides the default width recipe; relies on Input's own `hasWidth` guard,
+  // so a caller `w-full`/`min-w-0` wins over the default.
+  className?: string
+  iconClassName?: string
+}
+
+function ToolbarSearch({
+  value,
+  onChange,
+  placeholder,
+  ariaLabel,
+  inputSize = "sm",
+  className = "min-w-[12rem] flex-1 sm:max-w-xs",
+  iconClassName = "opacity-60",
+}: ToolbarSearchProps) {
+  return (
+    <Input
+      type="search"
+      inputSize={inputSize}
+      className={className}
+      leadingIcon={<Search aria-hidden="true" className={cx("size-4", iconClassName)} />}
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={ariaLabel}
+    />
+  )
+}
+
+export type ToolbarFilterSelectProps = {
+  // Optional: with a label the select gets the joined label-prefix recipe; without
+  // one it renders a bare sized Select (the inline bars have no visible prefix).
+  label?: string
+  selectSize?: SelectSize
+} & ComponentPropsWithoutRef<"select">
+
+function ToolbarFilterSelect({
+  label,
+  selectSize = "sm",
+  className,
+  children,
+  ...props
+}: ToolbarFilterSelectProps) {
+  if (!label) {
+    return (
+      <Select selectSize={selectSize} className={className} {...props}>
+        {children}
+      </Select>
+    )
+  }
+  return (
+    <LabeledControl label={label}>
+      <Select
+        selectSize={selectSize}
+        className={cx("join-item w-auto min-w-0", className)}
+        {...props}
+      >
+        {children}
+      </Select>
+    </LabeledControl>
+  )
+}
+
+export type ToolbarTrailingProps = {
+  children?: ReactNode
+} & ComponentPropsWithoutRef<"div">
+
+function ToolbarTrailing({ className, children, ...props }: ToolbarTrailingProps) {
+  if (!children) return null
+  return (
+    <div
+      className={cx("ml-auto flex flex-wrap items-center gap-2", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export type ToolbarSelectionProps = {
+  allSelected: boolean
+  someSelected: boolean
+  onToggleSelectAll: () => void
+  selectAllAriaLabel: string
+  label: ReactNode
+  // Rendered between the count and the actions, regardless of selection (e.g. the
+  // roster group-by-section toggle).
+  aux?: ReactNode
+  // The selection-revealed actions (shown when rows are selected).
+  children?: ReactNode
+  // The no-selection trailing group (e.g. the roster Add/Upload/Invite group).
+  idleActions?: ReactNode
+}
+
+function ToolbarSelection({
+  allSelected,
+  someSelected,
+  onToggleSelectAll,
+  selectAllAriaLabel,
+  label,
+  aux,
+  children,
+  idleActions,
+}: ToolbarSelectionProps) {
+  return (
+    <>
+      <label className="flex cursor-pointer items-center gap-3">
+        <input
+          type="checkbox"
+          className="checkbox checkbox-sm"
+          aria-label={selectAllAriaLabel}
+          checked={allSelected}
+          ref={(el) => {
+            if (el) el.indeterminate = someSelected && !allSelected
+          }}
+          onChange={onToggleSelectAll}
+        />
+        <span className="text-sm font-medium tabular-nums">{label}</span>
+      </label>
+      {aux}
+      {children ? (
+        <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
+          {children}
+        </div>
+      ) : (
+        idleActions
+      )}
+    </>
+  )
+}
+
+Toolbar.Search = ToolbarSearch
+Toolbar.FilterSelect = ToolbarFilterSelect
+Toolbar.Trailing = ToolbarTrailing
+Toolbar.Selection = ToolbarSelection
+
+export default Toolbar

--- a/web/src/components/ui/cx.ts
+++ b/web/src/components/ui/cx.ts
@@ -6,3 +6,13 @@
 export function cx(...parts: Array<string | false | null | undefined>): string {
   return parts.filter(Boolean).join(" ").trim()
 }
+
+// True when `className` already sets a utility in the given family (e.g. `w-`,
+// `gap-`), so a primitive can drop its default rather than emit both — cx can't
+// merge Tailwind classes and same-property source order is unspecified.
+export function hasUtility(
+  prefix: string,
+  className: string | null | undefined,
+): boolean {
+  return className ? new RegExp(`(?:^|\\s)${prefix}`).test(className) : false
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -60,3 +60,4 @@ export type {
 export { Spinner } from "@/components/Spinner"
 
 export { cx } from "./cx"
+export { hasUtility } from "./cx"

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -48,6 +48,15 @@ export type { StatCardProps } from "./StatCard"
 export { LabeledControl } from "./LabeledControl"
 export type { LabeledControlProps } from "./LabeledControl"
 
+export { Toolbar } from "./Toolbar"
+export type {
+  ToolbarProps,
+  ToolbarSearchProps,
+  ToolbarFilterSelectProps,
+  ToolbarTrailingProps,
+  ToolbarSelectionProps,
+} from "./Toolbar"
+
 export { Spinner } from "@/components/Spinner"
 
 export { cx } from "./cx"

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -13,13 +13,12 @@ import {
   Lock,
   Plus,
   RefreshCw,
-  Search,
 } from "lucide-react"
 import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
-import { Button, Card } from "@/components/ui"
+import { Button, Card, Toolbar } from "@/components/ui"
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
 import Spinner from "@/components/Spinner"
@@ -372,25 +371,19 @@ const OrgsPage = () => {
             />
 
             {hasAnyOrgs && (
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <label className="input input-bordered flex w-full items-center gap-2 sm:max-w-xs">
-                  <Search
-                    aria-hidden="true"
-                    className="size-4 text-base-content/50"
-                  />
-                  <input
-                    type="search"
-                    className="grow"
-                    placeholder={t("orgs.toolbar.searchPlaceholder")}
-                    aria-label={t("orgs.toolbar.searchLabel")}
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                  />
-                </label>
+              <Toolbar className="flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <Toolbar.Search
+                  inputSize="md"
+                  className="w-full sm:max-w-xs"
+                  iconClassName="text-base-content/50"
+                  placeholder={t("orgs.toolbar.searchPlaceholder")}
+                  ariaLabel={t("orgs.toolbar.searchLabel")}
+                  value={search}
+                  onChange={setSearch}
+                />
 
                 <div className="flex items-center gap-3">
-                  <select
-                    className="select select-bordered select-sm"
+                  <Toolbar.FilterSelect
                     aria-label={t("orgs.toolbar.sort.label")}
                     value={sortKey}
                     onChange={(e) => changeSort(e.target.value as OrgSortKey)}
@@ -400,7 +393,7 @@ const OrgsPage = () => {
                         {t(opt.labelKey)}
                       </option>
                     ))}
-                  </select>
+                  </Toolbar.FilterSelect>
 
                   <ViewToggle
                     viewMode={viewMode}
@@ -418,7 +411,7 @@ const OrgsPage = () => {
                     {t("orgs.newOrg.button")}
                   </Button>
                 </div>
-              </div>
+              </Toolbar>
             )}
 
             {noSearchResults ? (

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -384,6 +384,7 @@ const OrgsPage = () => {
 
                 <div className="flex items-center gap-3">
                   <Toolbar.FilterSelect
+                    className="w-auto"
                     aria-label={t("orgs.toolbar.sort.label")}
                     value={sortKey}
                     onChange={(e) => changeSort(e.target.value as OrgSortKey)}

--- a/web/src/pages/assignments/AssignmentsToolbar.tsx
+++ b/web/src/pages/assignments/AssignmentsToolbar.tsx
@@ -1,35 +1,12 @@
-import { Search, X } from "lucide-react"
+import { X } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Input, LabeledControl, Select } from "@/components/ui"
+import { Button, Toolbar } from "@/components/ui"
 import {
   DEFAULT_FILTERS,
   type AssignmentFilters,
   type AssignmentSort,
 } from "@/pages/assignments/assignmentList"
-
-// A select glued to a labelled prefix (the org/classroom toolbar convention)
-// via the shared LabeledControl primitive, so each dropdown reads as
-// "Type: All" and its purpose is clear at a glance.
-const LabeledSelect = ({
-  label,
-  className,
-  children,
-  ...props
-}: {
-  label: string
-  className?: string
-} & React.ComponentPropsWithoutRef<"select">) => (
-  <LabeledControl label={label}>
-    <Select
-      selectSize="sm"
-      className={`join-item w-auto min-w-0${className ? ` ${className}` : ""}`}
-      {...props}
-    >
-      {children}
-    </Select>
-  </LabeledControl>
-)
 
 // Search + type/due filters + sort for the teacher assignments table.
 // Controlled by TeacherAssignmentsView; emits query/filter/sort changes.
@@ -58,21 +35,15 @@ const AssignmentsToolbar = ({
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <Input
-        type="search"
-        inputSize="sm"
-        className="min-w-[12rem] flex-1 sm:max-w-xs"
-        leadingIcon={
-          <Search aria-hidden="true" className="size-4 opacity-60" />
-        }
+    <Toolbar>
+      <Toolbar.Search
         placeholder={t("assignments.toolbar.searchPlaceholder")}
         value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
-        aria-label={t("assignments.toolbar.searchAria")}
+        onChange={onQueryChange}
+        ariaLabel={t("assignments.toolbar.searchAria")}
       />
 
-      <LabeledSelect
+      <Toolbar.FilterSelect
         label={t("assignments.toolbar.typeLabel")}
         value={filters.type}
         onChange={(e) =>
@@ -88,9 +59,9 @@ const AssignmentsToolbar = ({
           {t("assignments.toolbar.typeIndividual")}
         </option>
         <option value="group">{t("assignments.toolbar.typeGroup")}</option>
-      </LabeledSelect>
+      </Toolbar.FilterSelect>
 
-      <LabeledSelect
+      <Toolbar.FilterSelect
         label={t("assignments.toolbar.dueLabel")}
         value={filters.due}
         onChange={(e) =>
@@ -105,7 +76,7 @@ const AssignmentsToolbar = ({
         <option value="has-due">{t("assignments.toolbar.dueHas")}</option>
         <option value="no-due">{t("assignments.toolbar.dueNone")}</option>
         <option value="overdue">{t("assignments.toolbar.dueOverdue")}</option>
-      </LabeledSelect>
+      </Toolbar.FilterSelect>
 
       {hasActiveFilter && (
         <Button variant="ghost" size="sm" onClick={clearAll}>
@@ -114,8 +85,8 @@ const AssignmentsToolbar = ({
         </Button>
       )}
 
-      <div className="ml-auto flex flex-wrap items-center gap-2">
-        <LabeledSelect
+      <Toolbar.Trailing>
+        <Toolbar.FilterSelect
           label={t("assignments.toolbar.sortLabel")}
           value={sort}
           onChange={(e) => onSortChange(e.target.value as AssignmentSort)}
@@ -132,9 +103,9 @@ const AssignmentsToolbar = ({
             {t("assignments.toolbar.sortDueDesc")}
           </option>
           <option value="type">{t("assignments.toolbar.sortType")}</option>
-        </LabeledSelect>
-      </div>
-    </div>
+        </Toolbar.FilterSelect>
+      </Toolbar.Trailing>
+    </Toolbar>
   )
 }
 

--- a/web/src/pages/orgActivity/ActivityToolbar.tsx
+++ b/web/src/pages/orgActivity/ActivityToolbar.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
-import { Download, FileText, Search, X } from "lucide-react"
+import { Download, FileText, X } from "lucide-react"
 
-import { Button, Input, LabeledControl, Select } from "@/components/ui"
+import { Button, Toolbar } from "@/components/ui"
 import type { TimelineSource, TimelineType } from "@/lib/activity/timeline"
 
 export type ActivityFilterState = {
@@ -22,21 +22,6 @@ const TYPE_ORDER: TimelineType[] = [
   "error",
   "action",
 ]
-
-// A labeled single-select in the shared toolbar prefix style ("Source: All").
-const LabeledSelect = ({
-  label,
-  children,
-  ...props
-}: {
-  label: string
-} & React.ComponentPropsWithoutRef<"select">) => (
-  <LabeledControl label={label}>
-    <Select selectSize="sm" className="join-item w-auto min-w-0" {...props}>
-      {children}
-    </Select>
-  </LabeledControl>
-)
 
 // Read/write a single-select value backed by a Set: "" = all (empty set), else a
 // one-element set.
@@ -79,21 +64,15 @@ export function ActivityToolbar({
   }
 
   return (
-    <div className="mt-6 flex flex-wrap items-center gap-2">
-      <Input
-        type="search"
-        inputSize="sm"
-        className="min-w-[12rem] flex-1 sm:max-w-xs"
-        leadingIcon={
-          <Search aria-hidden="true" className="size-4 opacity-60" />
-        }
+    <Toolbar className="mt-6">
+      <Toolbar.Search
         placeholder={t("orgActivity.searchPlaceholder")}
-        aria-label={t("orgActivity.searchLabel")}
+        ariaLabel={t("orgActivity.searchLabel")}
         value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
+        onChange={onQueryChange}
       />
 
-      <LabeledSelect
+      <Toolbar.FilterSelect
         label={t("orgActivity.filters.source")}
         value={selectValue(filters.sources)}
         aria-label={t("orgActivity.filters.source")}
@@ -107,9 +86,9 @@ export function ActivityToolbar({
             {t(`orgActivity.source.${s}`)}
           </option>
         ))}
-      </LabeledSelect>
+      </Toolbar.FilterSelect>
 
-      <LabeledSelect
+      <Toolbar.FilterSelect
         label={t("orgActivity.filters.type")}
         value={selectValue(filters.types)}
         aria-label={t("orgActivity.filters.type")}
@@ -123,7 +102,7 @@ export function ActivityToolbar({
             {t(`orgActivity.type.${ty}`)}
           </option>
         ))}
-      </LabeledSelect>
+      </Toolbar.FilterSelect>
 
       {hasActiveFilter && (
         <Button variant="ghost" size="sm" onClick={clearAll}>
@@ -132,7 +111,7 @@ export function ActivityToolbar({
         </Button>
       )}
 
-      <div className="ml-auto flex flex-wrap items-center gap-2">
+      <Toolbar.Trailing>
         <Button
           variant="outline"
           size="sm"
@@ -146,7 +125,7 @@ export function ActivityToolbar({
           <FileText aria-hidden="true" className="size-4" />
           {t("orgActivity.showDiagnostics")}
         </Button>
-      </div>
-    </div>
+      </Toolbar.Trailing>
+    </Toolbar>
   )
 }

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Plus, UserMinus, X } from "lucide-react"
 
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Toolbar } from "@/components/ui"
 import type { GitHubClient } from "@/hooks/github/client"
 import type { GitHubUser } from "@/hooks/github/types"
 import type { StudentCsvRow } from "@/api/mutations/students"
@@ -275,105 +275,98 @@ const BulkActionsBar = ({
 
   return (
     <>
-      <div
-        className={`flex flex-wrap items-center gap-x-4 gap-y-3 border-b border-base-300 px-6 py-3 transition-colors ${
-          hasSelection ? "bg-base-200/60" : ""
-        }`}
+      <Toolbar
+        header
+        className={`transition-colors ${hasSelection ? "bg-base-200/60" : ""}`}
       >
-        <label className="flex cursor-pointer items-center gap-3">
-          <input
-            type="checkbox"
-            className="checkbox checkbox-sm"
-            aria-label={t("orgMembers.bulk.selectAll")}
-            checked={allSelected}
-            ref={(el) => {
-              if (el) el.indeterminate = someSelected && !allSelected
-            }}
-            onChange={onToggleSelectAll}
-          />
-          <span className="text-sm font-medium tabular-nums">
-            {hasSelection
+        <Toolbar.Selection
+          allSelected={allSelected}
+          someSelected={someSelected}
+          onToggleSelectAll={onToggleSelectAll}
+          selectAllAriaLabel={t("orgMembers.bulk.selectAll")}
+          label={
+            hasSelection
               ? t("orgMembers.bulk.selectedCount", {
                   count: selectedRows.length,
                 })
-              : t("orgMembers.bulk.memberCount", { count: totalCount })}
-          </span>
-        </label>
-
-        {hasSelection ? (
-          <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
-            <label
-              htmlFor={`${titleId}-picker`}
-              className="text-sm text-base-content/60"
-            >
-              {t("orgMembers.bulk.classroomLabel")}
-            </label>
-            <select
-              id={`${titleId}-picker`}
-              className="select select-bordered select-sm max-w-[12rem]"
-              value={effectiveClassroom}
-              onChange={(e) => setClassroom(e.target.value)}
-              disabled={classrooms.length === 0}
-            >
-              {classrooms.length === 0 ? (
-                <option value="">{t("orgMembers.bulk.noClassrooms")}</option>
-              ) : (
-                classrooms.map((c) => (
-                  <option key={c.path} value={c.path}>
-                    {c.name}
-                  </option>
-                ))
-              )}
-            </select>
-
-            <div className="join">
-              <Button
-                variant="primary"
-                size="sm"
-                className="join-item"
-                disabled={!effectiveClassroom}
-                aria-label={t("orgMembers.bulk.addToClassroom", {
-                  classroom: effectiveClassroom,
-                })}
-                title={t("orgMembers.bulk.addToClassroom", {
-                  classroom: effectiveClassroom,
-                })}
-                onClick={() => setConfirmingAdd(true)}
+              : t("orgMembers.bulk.memberCount", { count: totalCount })
+          }
+        >
+          {hasSelection ? (
+            <>
+              <label
+                htmlFor={`${titleId}-picker`}
+                className="text-sm text-base-content/60"
               >
-                <Plus aria-hidden="true" className="size-4" />
-                {t("orgMembers.bulk.add")}
-              </Button>
+                {t("orgMembers.bulk.classroomLabel")}
+              </label>
+              <select
+                id={`${titleId}-picker`}
+                className="select select-bordered select-sm max-w-[12rem]"
+                value={effectiveClassroom}
+                onChange={(e) => setClassroom(e.target.value)}
+                disabled={classrooms.length === 0}
+              >
+                {classrooms.length === 0 ? (
+                  <option value="">{t("orgMembers.bulk.noClassrooms")}</option>
+                ) : (
+                  classrooms.map((c) => (
+                    <option key={c.path} value={c.path}>
+                      {c.name}
+                    </option>
+                  ))
+                )}
+              </select>
+
+              <div className="join">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  className="join-item"
+                  disabled={!effectiveClassroom}
+                  aria-label={t("orgMembers.bulk.addToClassroom", {
+                    classroom: effectiveClassroom,
+                  })}
+                  title={t("orgMembers.bulk.addToClassroom", {
+                    classroom: effectiveClassroom,
+                  })}
+                  onClick={() => setConfirmingAdd(true)}
+                >
+                  <Plus aria-hidden="true" className="size-4" />
+                  {t("orgMembers.bulk.add")}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="join-item text-error hover:bg-error/10"
+                  disabled={!effectiveClassroom}
+                  aria-label={t("orgMembers.bulk.removeFromClassroom", {
+                    classroom: effectiveClassroom,
+                  })}
+                  title={t("orgMembers.bulk.removeFromClassroom", {
+                    classroom: effectiveClassroom,
+                  })}
+                  onClick={() => setConfirmingRemove(true)}
+                >
+                  <UserMinus aria-hidden="true" className="size-4" />
+                  {t("orgMembers.bulk.remove")}
+                </Button>
+              </div>
+
               <Button
                 variant="ghost"
                 size="sm"
-                className="join-item text-error hover:bg-error/10"
-                disabled={!effectiveClassroom}
-                aria-label={t("orgMembers.bulk.removeFromClassroom", {
-                  classroom: effectiveClassroom,
-                })}
-                title={t("orgMembers.bulk.removeFromClassroom", {
-                  classroom: effectiveClassroom,
-                })}
-                onClick={() => setConfirmingRemove(true)}
+                shape="square"
+                aria-label={t("orgMembers.bulk.clearSelection")}
+                title={t("orgMembers.bulk.clearSelection")}
+                onClick={onClearSelection}
               >
-                <UserMinus aria-hidden="true" className="size-4" />
-                {t("orgMembers.bulk.remove")}
+                <X aria-hidden="true" className="size-4" />
               </Button>
-            </div>
-
-            <Button
-              variant="ghost"
-              size="sm"
-              shape="square"
-              aria-label={t("orgMembers.bulk.clearSelection")}
-              title={t("orgMembers.bulk.clearSelection")}
-              onClick={onClearSelection}
-            >
-              <X aria-hidden="true" className="size-4" />
-            </Button>
-          </div>
-        ) : null}
-      </div>
+            </>
+          ) : null}
+        </Toolbar.Selection>
+      </Toolbar>
 
       <ConfirmModal
         open={confirmingRemove}

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -593,7 +593,7 @@ const EnrolledStudents = ({
         <Toolbar className="gap-3">
           <Toolbar.Search
             inputSize="md"
-            className="min-w-0 flex-1"
+            className="w-auto min-w-0 flex-1"
             iconClassName="opacity-50"
             placeholder={t("students.searchPlaceholder")}
             ariaLabel={t("students.searchLabel")}

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -3,14 +3,13 @@ import {
   ChevronRight,
   Plus,
   RefreshCw,
-  Search,
   Send,
   Upload,
   X,
 } from "lucide-react"
 
 import { nameFromParts } from "@/util/students"
-import { Alert, AnimatedAlert, Button, Card, Spinner } from "@/components/ui"
+import { Alert, AnimatedAlert, Button, Card, Spinner, Toolbar } from "@/components/ui"
 import Avatar from "@/components/avatar"
 import type { Student } from "@/types/classroom"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -584,20 +583,19 @@ const EnrolledStudents = ({
       {/* Toolbar: search + status filter (group-by-section lives in the table
           header next to the count). Sync pinned far-right when applicable. */}
       {!isLoading && !isError && !isEmpty ? (
-        <div className="flex flex-wrap items-center gap-3">
-          <label className="input input-bordered flex min-w-0 flex-1 items-center gap-2">
-            <Search aria-hidden="true" className="size-4 opacity-50" />
-            <input
-              type="search"
-              className="grow"
-              placeholder={t("students.searchPlaceholder")}
-              aria-label={t("students.searchLabel")}
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-            />
-          </label>
-          <select
-            className="select select-bordered w-full sm:w-auto"
+        <Toolbar className="gap-3">
+          <Toolbar.Search
+            inputSize="md"
+            className="min-w-0 flex-1"
+            iconClassName="opacity-50"
+            placeholder={t("students.searchPlaceholder")}
+            ariaLabel={t("students.searchLabel")}
+            value={query}
+            onChange={setQuery}
+          />
+          <Toolbar.FilterSelect
+            selectSize="md"
+            className="w-full sm:w-auto"
             aria-label={t("students.filterByStatusLabel")}
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
@@ -607,10 +605,11 @@ const EnrolledStudents = ({
                 {o.label}
               </option>
             ))}
-          </select>
+          </Toolbar.FilterSelect>
           {sectionOptions.length > 0 ? (
-            <select
-              className="select select-bordered w-full sm:w-auto"
+            <Toolbar.FilterSelect
+              selectSize="md"
+              className="w-full sm:w-auto"
               aria-label={t("students.filterBySectionLabel")}
               value={effectiveSection}
               onChange={(e) => setSectionFilter(e.target.value)}
@@ -621,7 +620,7 @@ const EnrolledStudents = ({
                   {section === NO_SECTION ? t("students.noSection") : section}
                 </option>
               ))}
-            </select>
+            </Toolbar.FilterSelect>
           ) : null}
           {syncMutation.isPending || csvMissingCount > 0 ? (
             <Button
@@ -644,7 +643,7 @@ const EnrolledStudents = ({
               />
             </Button>
           ) : null}
-        </div>
+        </Toolbar>
       ) : null}
 
       {/* The list card. */}

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -9,7 +9,14 @@ import {
 } from "lucide-react"
 
 import { nameFromParts } from "@/util/students"
-import { Alert, AnimatedAlert, Button, Card, Spinner, Toolbar } from "@/components/ui"
+import {
+  Alert,
+  AnimatedAlert,
+  Button,
+  Card,
+  Spinner,
+  Toolbar,
+} from "@/components/ui"
 import Avatar from "@/components/avatar"
 import type { Student } from "@/types/classroom"
 import { useMutation, useQueryClient } from "@tanstack/react-query"

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -4,7 +4,7 @@ import { Plus, Send, Upload, UserMinus, X } from "lucide-react"
 
 import type { GitHubClient } from "@/hooks/github/client"
 import { ConfirmModal } from "@/components/modals"
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Toolbar } from "@/components/ui"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import { resendOrgInvitation, getErrorMessage } from "@/hooks/github/mutations"
 import {
@@ -333,120 +333,117 @@ const RosterBulkActionsBar = ({
 
   return (
     <>
-      <div
-        className={`flex flex-wrap items-center gap-x-4 gap-y-3 border-b border-base-300 px-6 py-3 transition-colors ${
-          hasSelection ? "bg-base-200/60" : ""
-        }`}
+      <Toolbar
+        header
+        className={`transition-colors ${hasSelection ? "bg-base-200/60" : ""}`}
       >
-        <label className="flex cursor-pointer items-center gap-3">
-          <input
-            type="checkbox"
-            className="checkbox checkbox-sm"
-            aria-label={t("students.bulk.selectAll")}
-            checked={allSelected}
-            ref={(el) => {
-              if (el) el.indeterminate = someSelected && !allSelected
-            }}
-            onChange={onToggleSelectAll}
-          />
-          <span className="text-sm font-medium tabular-nums">
-            {hasSelection
+        <Toolbar.Selection
+          allSelected={allSelected}
+          someSelected={someSelected}
+          onToggleSelectAll={onToggleSelectAll}
+          selectAllAriaLabel={t("students.bulk.selectAll")}
+          label={
+            hasSelection
               ? t("students.bulk.selectedCount", { count: selectedRows.length })
-              : t("students.bulk.studentCount", { count: totalCount })}
-          </span>
-        </label>
+              : t("students.bulk.studentCount", { count: totalCount })
+          }
+          aux={
+            canGroupBySection && onGroupBySectionChange ? (
+              <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm text-base-content/70">
+                <input
+                  type="checkbox"
+                  className="toggle toggle-sm"
+                  checked={Boolean(groupBySection)}
+                  onChange={(e) => onGroupBySectionChange(e.target.checked)}
+                />
+                {t("students.groupBySection")}
+              </label>
+            ) : null
+          }
+          idleActions={
+            addActions ? (
+              <div className="join ml-auto">
+                <Button
+                  size="sm"
+                  className="join-item"
+                  aria-label={t("students.addTitle")}
+                  title={t("students.addTitle")}
+                  onClick={addActions.onAddStudent}
+                >
+                  <Plus aria-hidden="true" className="size-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  className="join-item"
+                  aria-label={t("students.uploadRosterTitle")}
+                  title={t("students.uploadRosterTitle")}
+                  onClick={addActions.onUploadRoster}
+                >
+                  <Upload aria-hidden="true" className="size-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  className="join-item"
+                  aria-label={t("students.inviteStudents")}
+                  title={t("students.inviteStudents")}
+                  onClick={addActions.onInviteLinks}
+                >
+                  <Send aria-hidden="true" className="size-4" />
+                </Button>
+              </div>
+            ) : null
+          }
+        >
+          {hasSelection ? (
+            <>
+              <div className="join">
+                <Button
+                  size="sm"
+                  className="join-item"
+                  disabled={invitableSelected === 0}
+                  title={
+                    invitableSelected === 0
+                      ? t("students.bulk.inviteNoneInvitable")
+                      : t("students.bulk.inviteSelected", {
+                          count: invitableSelected,
+                        })
+                  }
+                  onClick={() => setConfirmingInvite(true)}
+                >
+                  <Send aria-hidden="true" className="size-4" />
+                  {t("students.bulk.invite")}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="join-item text-error hover:bg-error/10"
+                  aria-label={t("students.bulk.unenrollSelected", {
+                    count: selectedRows.length,
+                  })}
+                  title={t("students.bulk.unenrollSelected", {
+                    count: selectedRows.length,
+                  })}
+                  onClick={() => setConfirmingUnenroll(true)}
+                >
+                  <UserMinus aria-hidden="true" className="size-4" />
+                  {t("students.bulk.unenroll")}
+                </Button>
+              </div>
 
-        {canGroupBySection && onGroupBySectionChange ? (
-          <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm text-base-content/70">
-            <input
-              type="checkbox"
-              className="toggle toggle-sm"
-              checked={Boolean(groupBySection)}
-              onChange={(e) => onGroupBySectionChange(e.target.checked)}
-            />
-            {t("students.groupBySection")}
-          </label>
-        ) : null}
-
-        {hasSelection ? (
-          <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
-            <div className="join">
-              <Button
-                size="sm"
-                className="join-item"
-                disabled={invitableSelected === 0}
-                title={
-                  invitableSelected === 0
-                    ? t("students.bulk.inviteNoneInvitable")
-                    : t("students.bulk.inviteSelected", {
-                        count: invitableSelected,
-                      })
-                }
-                onClick={() => setConfirmingInvite(true)}
-              >
-                <Send aria-hidden="true" className="size-4" />
-                {t("students.bulk.invite")}
-              </Button>
               <Button
                 variant="ghost"
                 size="sm"
-                className="join-item text-error hover:bg-error/10"
-                aria-label={t("students.bulk.unenrollSelected", {
-                  count: selectedRows.length,
-                })}
-                title={t("students.bulk.unenrollSelected", {
-                  count: selectedRows.length,
-                })}
-                onClick={() => setConfirmingUnenroll(true)}
+                shape="square"
+                aria-label={t("students.bulk.clearSelection")}
+                title={t("students.bulk.clearSelection")}
+                onClick={onClearSelection}
               >
-                <UserMinus aria-hidden="true" className="size-4" />
-                {t("students.bulk.unenroll")}
+                <X aria-hidden="true" className="size-4" />
               </Button>
-            </div>
-
-            <Button
-              variant="ghost"
-              size="sm"
-              shape="square"
-              aria-label={t("students.bulk.clearSelection")}
-              title={t("students.bulk.clearSelection")}
-              onClick={onClearSelection}
-            >
-              <X aria-hidden="true" className="size-4" />
-            </Button>
-          </div>
-        ) : addActions ? (
-          <div className="join ml-auto">
-            <Button
-              size="sm"
-              className="join-item"
-              aria-label={t("students.addTitle")}
-              title={t("students.addTitle")}
-              onClick={addActions.onAddStudent}
-            >
-              <Plus aria-hidden="true" className="size-4" />
-            </Button>
-            <Button
-              size="sm"
-              className="join-item"
-              aria-label={t("students.uploadRosterTitle")}
-              title={t("students.uploadRosterTitle")}
-              onClick={addActions.onUploadRoster}
-            >
-              <Upload aria-hidden="true" className="size-4" />
-            </Button>
-            <Button
-              size="sm"
-              className="join-item"
-              aria-label={t("students.inviteStudents")}
-              title={t("students.inviteStudents")}
-              onClick={addActions.onInviteLinks}
-            >
-              <Send aria-hidden="true" className="size-4" />
-            </Button>
-          </div>
-        ) : null}
-      </div>
+            </>
+          ) : null}
+        </Toolbar.Selection>
+      </Toolbar>
 
       <ConfirmModal
         open={confirmingUnenroll}

--- a/web/src/pages/submissions/SubmissionsControls.tsx
+++ b/web/src/pages/submissions/SubmissionsControls.tsx
@@ -1,8 +1,8 @@
-import { Search, X } from "lucide-react"
+import { X } from "lucide-react"
 import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Input, LabeledControl, Select } from "@/components/ui"
+import { Button, Toolbar } from "@/components/ui"
 import type {
   StatusSelectValue,
   SubmissionFilters,
@@ -13,29 +13,6 @@ import {
   applyStatusSelection,
   statusSelectValue,
 } from "@/pages/submissions/dashboard"
-
-// A select glued to a labelled prefix (the org/classroom toolbar convention)
-// via the shared LabeledControl primitive, so each dropdown reads as
-// "Status: All" and its purpose is clear at a glance.
-const LabeledSelect = ({
-  label,
-  className,
-  children,
-  ...props
-}: {
-  label: string
-  className?: string
-} & React.ComponentPropsWithoutRef<"select">) => (
-  <LabeledControl label={label}>
-    <Select
-      selectSize="sm"
-      className={`join-item w-auto min-w-0${className ? ` ${className}` : ""}`}
-      {...props}
-    >
-      {children}
-    </Select>
-  </LabeledControl>
-)
 
 // Search + sort + filter controls for the assignment overview dashboard.
 // Controlled by SubmissionsPage; emits filter/sort/query changes. The
@@ -91,26 +68,20 @@ const SubmissionsControls = ({
     onFiltersChange(applyStatusSelection(filters, value))
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <Input
-        type="search"
-        inputSize="sm"
-        className="min-w-[12rem] flex-1 sm:max-w-xs"
-        leadingIcon={
-          <Search aria-hidden="true" className="size-4 opacity-60" />
-        }
+    <Toolbar>
+      <Toolbar.Search
         placeholder={
           isGroup
             ? t("submissions.filters.searchGroupPlaceholder")
             : t("submissions.filters.searchStudentPlaceholder")
         }
         value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
-        aria-label={t("submissions.filters.searchAria")}
+        onChange={onQueryChange}
+        ariaLabel={t("submissions.filters.searchAria")}
       />
 
       {sections.length > 0 && (
-        <LabeledSelect
+        <Toolbar.FilterSelect
           label={t("submissions.filters.sectionLabel")}
           className="max-w-[10rem]"
           value={filters.section}
@@ -125,10 +96,10 @@ const SubmissionsControls = ({
               {section}
             </option>
           ))}
-        </LabeledSelect>
+        </Toolbar.FilterSelect>
       )}
 
-      <LabeledSelect
+      <Toolbar.FilterSelect
         label={t("submissions.filters.submissionLabel")}
         value={statusValue}
         onChange={(e) => onStatusChange(e.target.value as StatusSelectValue)}
@@ -156,10 +127,10 @@ const SubmissionsControls = ({
             </option>
           </>
         )}
-      </LabeledSelect>
+      </Toolbar.FilterSelect>
 
       {passingAvailable && (
-        <LabeledSelect
+        <Toolbar.FilterSelect
           label={t("submissions.filters.passingLabel")}
           value={filters.passing}
           // Disabled when filtering to non-submitters: they have no grade, so a
@@ -176,7 +147,7 @@ const SubmissionsControls = ({
           <option value="all">{t("submissions.filters.allGrades")}</option>
           <option value="passing">{t("submissions.filters.passing")}</option>
           <option value="failing">{t("submissions.filters.failing")}</option>
-        </LabeledSelect>
+        </Toolbar.FilterSelect>
       )}
 
       {hasActiveFilter && (
@@ -186,8 +157,8 @@ const SubmissionsControls = ({
         </Button>
       )}
 
-      <div className="ml-auto flex flex-wrap items-center gap-2">
-        <LabeledSelect
+      <Toolbar.Trailing>
+        <Toolbar.FilterSelect
           label={t("submissions.filters.sortLabel")}
           value={sort}
           onChange={(e) => onSortChange(e.target.value as SubmissionSort)}
@@ -201,10 +172,10 @@ const SubmissionsControls = ({
           <option value="name-desc">
             {t("submissions.filters.sortNameDesc")}
           </option>
-        </LabeledSelect>
+        </Toolbar.FilterSelect>
         {trailing}
-      </div>
-    </div>
+      </Toolbar.Trailing>
+    </Toolbar>
   )
 }
 


### PR DESCRIPTION
## Summary

Consolidates the web app's hand-rolled filter/action bars behind one extensible, shared **`Toolbar`** primitive. Behavior-, style-, and i18n-preserving — no new UX. The win is deduplication (three copy-pasted `LabeledSelect` helpers, the repeated container/search/select recipes) and a single composition point for every current and future toolbar.

Plan: `docs/plans/2026-07-09-002-refactor-consolidate-toolbar-plan.md`
Closes #203.

## Design

`web/src/components/ui/Toolbar.tsx` — a compound component (shell + composable slots), mirroring the existing `Card`/`Card.Body` pattern:

- `Toolbar` — bar shell (`flex flex-wrap items-center gap-2`; `header` flag adds the bulk-bar chrome + wider gap; width/gap overrides honored via the same guard the `Input`/`Select` primitives use)
- `Toolbar.Search` — search-input recipe (size/width/icon overridable)
- `Toolbar.FilterSelect` — labelled-select recipe, optional label (label-less for the inline bars)
- `Toolbar.Trailing` — `ml-auto` action group (null-collapses when empty)
- `Toolbar.Selection` — selection-aware bulk region (select-all + count + `aux` / selected-actions / `idleActions` slots)

## Bars migrated (7)

- **Filter bars:** `SubmissionsControls`, `ActivityToolbar`, `AssignmentsToolbar` — deletes all three duplicated `LabeledSelect` helpers.
- **Inline bars:** `OrgsPage`, `EnrolledStudents` — off raw `<input>`/`<select>` onto the primitives.
- **Bulk bars:** `orgMembers/BulkActionsBar`, `students/RosterBulkActionsBar` — adopt the shared shell + `Toolbar.Selection`; orchestration, modals, and confirm flows untouched.

Out of scope: `ClassroomList` (already uses `LabeledControl`), folding `ViewToggle`/`NoSearchResults` into `Toolbar`, extracting bulk orchestration.

## Test plan

- [x] `tsc -b` — 0 errors
- [x] `vitest run` — 1099 tests pass (98 files), incl. the `keyAudit` i18n guard and the `OrgActivityPage` parity test unchanged
- [x] `eslint` — 0 errors on touched files
- [x] `prettier --check` — clean
- [x] New `Toolbar.test.tsx` covers the shell recipes, header chrome, gap/width overrides, label-less select, trailing null-collapse, and all selection states (indeterminate, aux, selected vs idle actions)
- [ ] Manual `npm run dev` spot-check of each migrated bar for visual parity