### PR TITLE
fix(web): stop unenrolled students and non-students from reappearing (#209)

### DIFF
--- a/web/src/hooks/useSuppressedLogins.test.ts
+++ b/web/src/hooks/useSuppressedLogins.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import { dropSuppressed } from "./useSuppressedLogins"
+
+// Set-backed stub matching the { has } shape the effects pass (a real
+// SuppressedLogins stores normalized logins, so the stub does too).
+const suppressing = (...logins: string[]) => {
+  const set = new Set(logins.map((l) => l.trim().toLowerCase()))
+  return { has: (login: string) => set.has(login) }
+}
+
+describe("dropSuppressed", () => {
+  it("keeps candidates that are not suppressed", () => {
+    expect(dropSuppressed(["alice", "bob"], suppressing("carol"))).toEqual([
+      "alice",
+      "bob",
+    ])
+  })
+
+  it("drops suppressed candidates", () => {
+    expect(dropSuppressed(["alice", "bob"], suppressing("alice"))).toEqual([
+      "bob",
+    ])
+  })
+
+  it("normalizes case and whitespace on the candidate side", () => {
+    // The just-unenrolled login was stored lowercased; a candidate arriving as
+    // "ALICE" or " alice " must still be recognized as suppressed.
+    expect(dropSuppressed(["ALICE", " bob "], suppressing("alice"))).toEqual([
+      " bob ",
+    ])
+  })
+
+  it("returns everything when nothing is suppressed", () => {
+    expect(dropSuppressed(["alice", "bob"], suppressing())).toEqual([
+      "alice",
+      "bob",
+    ])
+  })
+
+  it("returns an empty list when every candidate is suppressed", () => {
+    expect(
+      dropSuppressed(["alice", "bob"], suppressing("alice", "bob")),
+    ).toEqual([])
+  })
+})

--- a/web/src/hooks/useSuppressedLogins.ts
+++ b/web/src/hooks/useSuppressedLogins.ts
@@ -1,0 +1,53 @@
+import { useRef } from "react"
+
+// Session-scoped set of GitHub logins the teacher just unenrolled, used to stop
+// the roster's automatic backfills (auto-sync, auto-reconcile) from re-adding
+// someone they removed. Unenroll is classroom-scoped — it drops the CSV row and
+// classroom-team seat but leaves an active member's ORG membership intact — so a
+// removed student can momentarily be a live org member with no team seat, which
+// auto-reconcile would otherwise "fix" by team-adding them back (and auto-sync
+// re-appending the CSV row). GitHub's Contents API is eventually consistent, so
+// a refetch right after the CSV delete can also resurface the row. Remembering
+// the login across those windows blocks the loop.
+//
+// Lives above EnrolledStudents + AddStudent (shared parent) so a re-enroll from
+// the Add modal can `forget` the login it previously suppressed — otherwise a
+// legitimately re-added student would stay suppressed until reload. In-memory by
+// design: a full reload re-derives roster state and clears it (matching the
+// drift-banner dismissal), so a genuinely still-drifted student is one refresh —
+// or the explicit Sync/Reconcile — away.
+export type SuppressedLogins = {
+  remember: (logins: Iterable<string>) => void
+  forget: (logins: Iterable<string>) => void
+  has: (login: string) => boolean
+  clear: () => void
+}
+
+const normalize = (login: string) => login.trim().toLowerCase()
+
+// Filter `candidates` down to logins NOT currently suppressed. Pure so the
+// backfill effects' skip decision is unit-testable in isolation. Case- and
+// whitespace-insensitive on both sides, matching how logins are stored.
+export function dropSuppressed(
+  candidates: string[],
+  suppressed: { has: (login: string) => boolean },
+): string[] {
+  return candidates.filter((login) => !suppressed.has(normalize(login)))
+}
+
+export function useSuppressedLogins(): SuppressedLogins {
+  const ref = useRef<Set<string>>(new Set())
+  return {
+    remember: (logins) => {
+      for (const login of logins) {
+        const key = normalize(login)
+        if (key) ref.current.add(key)
+      }
+    },
+    forget: (logins) => {
+      for (const login of logins) ref.current.delete(normalize(login))
+    },
+    has: (login) => ref.current.has(login),
+    clear: () => ref.current.clear(),
+  }
+}

--- a/web/src/hooks/useTeamRoster.ts
+++ b/web/src/hooks/useTeamRoster.ts
@@ -61,6 +61,9 @@ export type UseTeamRosterResult = {
   // can sync (auto-synced on open). Opposite direction from `not_in_org` (on
   // CSV, not on team), which sync can't fix.
   csvMissingCount: number
+  // Lowercased logins of team members with no students.csv row — used to skip a
+  // just-unenrolled member (team-drop failed) from the automatic CSV backfill.
+  csvMissingLogins: string[]
   // Rostered students who are `not_in_org` (on students.csv with a username but
   // not a team/org member and not a pending invite) — the usernames
   // auto-reconcile feeds to reconcileTeamFromOrgMembers. It team-adds the ones
@@ -171,9 +174,17 @@ export function useTeamRoster(
 
   // CSV drift / reconcile are STUDENT-roster concepts: a staffer is never
   // synced into students.csv, so count only the student team against the CSV.
-  const csvMissingCount = useMemo(
-    () => teamMembersMissingFromCsv(members ?? [], students).length,
+  const csvMissing = useMemo(
+    () => teamMembersMissingFromCsv(members ?? [], students),
     [members, students],
+  )
+  const csvMissingCount = csvMissing.length
+  // Lowercased logins of those csv-missing team members, so the view can skip a
+  // just-unenrolled member (whose best-effort team-drop failed) from the
+  // automatic backfill rather than re-appending the student it just removed.
+  const csvMissingLogins = useMemo(
+    () => csvMissing.map((m) => m.login.toLowerCase()),
+    [csvMissing],
   )
 
   // Rostered `not_in_org` usernames — what auto-reconcile tries to team-add
@@ -207,6 +218,7 @@ export function useTeamRoster(
     pendingHidden,
     teamSlug,
     csvMissingCount,
+    csvMissingLogins,
     notInOrgUsernames: notInOrg,
     // isError folds in the staff-member fetches too, so a retry must re-run
     // every team-member query (student + instructor + ta), not just the

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -13,6 +13,7 @@ import { useParams } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 import useGetStudents, { useUpdateRosterCache } from "@/hooks/useGetStudents"
 import { useTeamRoster } from "@/hooks/useTeamRoster"
+import { useSuppressedLogins } from "@/hooks/useSuppressedLogins"
 import { invalidateInviteQueries } from "@/hooks/github/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import RequireTeacher from "@/components/RequireTeacher"
@@ -34,6 +35,11 @@ const StudentListContent = ({
   const client = useGitHubClient()
   const queryClient = useQueryClient()
   const updateRosterCache = useUpdateRosterCache(org, classroom)
+  // Session-unenrolled logins, owned here so both the roster (which remembers on
+  // unenroll and skips them in the auto-backfills) and the Add modal (which
+  // forgets a login on a successful re-enroll) share one set — otherwise a
+  // re-added student would stay suppressed until reload.
+  const suppressedLogins = useSuppressedLogins()
 
   // Which add-students affordance is open (all mutually exclusive modals).
   const [addOpen, setAddOpen] = useState(false)
@@ -114,6 +120,7 @@ const StudentListContent = ({
         students={students}
         org={org}
         classroom={classroom}
+        suppressedLogins={suppressedLogins}
         addActions={{
           onAddStudent: () => setAddOpen(true),
           onUploadRoster: () => setUploadOpen(true),
@@ -126,6 +133,10 @@ const StudentListContent = ({
         classroom={classroom}
         open={addOpen}
         onClose={() => setAddOpen(false)}
+        // A re-enroll must clear any earlier session-unenroll suppression for
+        // this login, else the auto-backfills would keep skipping the student
+        // the teacher just re-added.
+        onEnrolled={(username) => suppressedLogins.forget([username])}
       />
       <UploadRoster
         org={org}
@@ -140,6 +151,8 @@ const StudentListContent = ({
               ...current,
               ...result.addedStudents.map(toStudent),
             ])
+            // A re-uploaded student clears their earlier unenroll suppression.
+            suppressedLogins.forget(result.addedStudents.map((s) => s.username))
           }
           invalidateInviteQueries(queryClient, org)
         }}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -30,6 +30,7 @@ import {
   filterAndSortRows,
   filterNonSubmitters,
   hasAccepted,
+  rosterScopedRows,
   rowInSection,
   selectActiveWorkflowAction,
   showsNonSubmitters,
@@ -43,6 +44,7 @@ import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetStudents from "@/hooks/useGetStudents"
 import { useTeamRoster } from "@/hooks/useTeamRoster"
 import { rowToStudent } from "@/util/teamRoster"
+import { hasStudentEnrollment } from "@/util/rosterRoles"
 import type { Student } from "@/types/classroom"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
@@ -116,17 +118,25 @@ const SubmissionsPageContent = () => {
   // Team-driven usernames (Section 7): the classroom GitHub team is
   // authoritative for enrollment; students.csv enriches display only. The
   // dashboard consumes Student[], so map enrolled team rows into that shape.
+  // Restrict to rows carrying a STUDENT enrollment — a pure instructor/TA is an
+  // enrolled team member but not a gradee, and "Collect scores" already runs
+  // only against the student team, so excluding them keeps this roster in step
+  // with what's actually graded (a student who is also staff still counts).
   const { students: csvStudents } = useGetStudents(org, classroom)
   // Surface the team fetch's error/loading: a transient or permission failure
   // of the enrolled source of truth must render as error+retry, not an
   // authoritative empty roster.
   const {
     rows: teamRows,
+    isLoading: rosterLoading,
     isError: rosterError,
     refetch: refetchRoster,
   } = useTeamRoster(org ?? "", classroom ?? "", csvStudents)
   const students: Student[] = useMemo(
-    () => teamRows.filter((r) => r.state === "enrolled").map(rowToStudent),
+    () =>
+      teamRows
+        .filter((r) => r.state === "enrolled" && hasStudentEnrollment(r))
+        .map(rowToStudent),
     [teamRows],
   )
   // Gate Regrade all / Collect now on an empty roster: dispatching with no
@@ -169,10 +179,19 @@ const SubmissionsPageContent = () => {
     (a) => a.slug === assignment,
   )
   const isGroupAssignment = assignmentInfo?.mode === "group"
-  const scoresInfo = useMemo(
-    () => scoresData?.submissions?.[assignment ?? ""] || [],
-    [scoresData, assignment],
-  )
+  // Scores as written by the CLI collector, scoped to the CURRENT roster: a
+  // student unenrolled after a collect still has a record in scores.json (the
+  // collector never prunes and the web app doesn't mutate the file), so their
+  // stale grade would otherwise render here and skew the stats. Drop rows whose
+  // credited students are all off the roster — but only once it has resolved,
+  // so a transient load/permission failure can't blank a populated gradebook
+  // (the roster error surfaces its own retry above). `rosterScopedRows` keeps a
+  // group row with at least one still-enrolled member.
+  const rosterReady = !rosterLoading && !rosterError
+  const scoresInfo = useMemo(() => {
+    const rows = scoresData?.submissions?.[assignment ?? ""] || []
+    return rosterReady ? rosterScopedRows(rows, students) : rows
+  }, [scoresData, assignment, rosterReady, students])
 
   // Repos whose latest submission landed after the deadline. `late` is computed
   // upstream (collect_scores.py) from push time, not grade time.

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -179,14 +179,9 @@ const SubmissionsPageContent = () => {
     (a) => a.slug === assignment,
   )
   const isGroupAssignment = assignmentInfo?.mode === "group"
-  // Scores as written by the CLI collector, scoped to the CURRENT roster: a
-  // student unenrolled after a collect still has a record in scores.json (the
-  // collector never prunes and the web app doesn't mutate the file), so their
-  // stale grade would otherwise render here and skew the stats. Drop rows whose
-  // credited students are all off the roster — but only once it has resolved,
-  // so a transient load/permission failure can't blank a populated gradebook
-  // (the roster error surfaces its own retry above). `rosterScopedRows` keeps a
-  // group row with at least one still-enrolled member.
+  // Scope the collector's scores to the CURRENT roster (see rosterScopedRows).
+  // Gate on a resolved roster so a transient load/permission failure falls back
+  // to unscoped rows rather than blanking a populated gradebook.
   const rosterReady = !rosterLoading && !rosterError
   const scoresInfo = useMemo(() => {
     const rows = scoresData?.submissions?.[assignment ?? ""] || []

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -29,6 +29,9 @@ type AddStudentProps = {
   classroom: string
   open: boolean
   onClose: () => void
+  // Called with the enrolled GitHub login on a successful username enrollment,
+  // so the parent can clear any session-unenroll suppression for that login.
+  onEnrolled?: (username: string) => void
 }
 
 type AddStudentFormValues = {
@@ -42,7 +45,13 @@ type AddStudentFormValues = {
 // send org invite) and stores the email; email-only sends an email invite.
 // Either way the student joins the classroom team on accepting the invite. The
 // form collects every students.csv field (name, username, email, section).
-const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
+const AddStudent = ({
+  org,
+  classroom,
+  open,
+  onClose,
+  onEnrolled,
+}: AddStudentProps) => {
   const { team } = useEnsureTeam(org, classroom)
   const queryClient = useQueryClient()
   const githubClient = useGitHubClient()
@@ -118,6 +127,9 @@ const AddStudent = ({ org, classroom, open, onClose }: AddStudentProps) => {
       if (result.kind === "username") {
         // Show the new row immediately (see useUpdateRosterCache).
         updateRosterCache((current) => [...current, result.student])
+        // Clear any earlier unenroll suppression for this login so the roster's
+        // auto-backfills treat the re-added student as enrolled again.
+        onEnrolled?.(result.student.username)
         // Enrolled member -> seed the team-members cache so the row shows
         // enrolled at once; the invited path already shows a pending invite, so
         // just invalidate.

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -134,6 +134,7 @@ const EnrolledStudents = ({
     pendingHidden,
     teamSlug,
     csvMissingCount,
+    csvMissingLogins,
     notInOrgUsernames,
     refetch: refetchRoster,
   } = useTeamRoster(org, classroom, students)
@@ -330,38 +331,60 @@ const EnrolledStudents = ({
     },
   })
 
+  // Identities the teacher unenrolled this session (studentKey + lowercased
+  // username), so the automatic backfills below never re-add someone they just
+  // removed. Unenroll is classroom-scoped: it drops the CSV row + classroom-team
+  // membership but deliberately leaves ACTIVE org membership intact. That leaves
+  // a window where the student is a still-active org member with no team seat —
+  // which auto-reconcile would otherwise "fix" by team-adding them straight back
+  // (flipping them from removed to enrolled again, and their submissions from
+  // 0/0 to 0/1). The CSV Contents API is also eventually consistent, so a
+  // refetch right after the delete can resurface the row as not_in_org and feed
+  // that same loop. A ref (not state) so mutating it doesn't re-render; it
+  // persists across the re-navigation the loop rides on. A full page reload
+  // legitimately re-derives state and clears it (matching the drift-banner
+  // dismissal), so a genuinely still-drifted student is one refresh — or the
+  // explicit Sync/Reconcile — away.
+  const unenrolledRef = useRef<{ keys: Set<string>; logins: Set<string> }>({
+    keys: new Set(),
+    logins: new Set(),
+  })
+  const rememberUnenrolled = (
+    removed: Array<Pick<TeamRosterRow, "username">>,
+  ) => {
+    for (const row of removed) {
+      const login = row.username.trim().toLowerCase()
+      if (login) unenrolledRef.current.logins.add(login)
+    }
+  }
+  const rememberUnenrolledKey = (rowKey: string, username: string) => {
+    if (rowKey) unenrolledRef.current.keys.add(rowKey)
+    const login = username.trim().toLowerCase()
+    if (login) unenrolledRef.current.logins.add(login)
+  }
+
   // Auto-sync on open: append team members lacking a CSV row (fire once per
-  // drift episode; re-arm when count returns to 0).
-  //
-  // suppressAutoSyncRef blocks the NEXT drift episode after a teacher-initiated
-  // unenroll: bulkUnenrollStudents/unenrollStudent drop the CSV row first and
-  // then best-effort remove team membership, so a transient team-drop failure
-  // leaves a live team member with no CSV row (csvMissingCount > 0). Without
-  // this guard, auto-sync would immediately re-append that just-removed student,
-  // silently reversing the unenroll behind a soft warning toast. We only defer
-  // the AUTOMATIC backfill — the explicit Sync button (and a fresh page open)
-  // still runs it — so a real drift the teacher wants backfilled is one click
-  // away, but an unenroll no longer undoes itself on its own.
+  // drift episode; re-arm when count returns to 0). The effect filters out any
+  // csv-missing member the teacher just unenrolled whose best-effort team-drop
+  // failed — otherwise auto-sync would re-append the student it just removed.
+  // (The unenrolled set is read in the effect, not during render, so a ref is
+  // safe here; syncRosterFromTeam re-derives the authoritative set server-side.)
   const autoSyncedRef = useRef(false)
-  const suppressAutoSyncRef = useRef(false)
+  const csvMissingKey = csvMissingLogins.join(",")
   useEffect(() => {
     if (isLoading || isError) return
-    if (csvMissingCount === 0) {
+    const pending = csvMissingLogins.filter(
+      (login) => !unenrolledRef.current.logins.has(login),
+    )
+    if (pending.length === 0) {
       autoSyncedRef.current = false
-      return
-    }
-    if (suppressAutoSyncRef.current) {
-      // Consume the one-episode suppression: latch as if we synced so this
-      // drift episode is skipped, and let the next fresh episode auto-sync.
-      suppressAutoSyncRef.current = false
-      autoSyncedRef.current = true
       return
     }
     if (autoSyncedRef.current || syncMutation.isPending) return
     autoSyncedRef.current = true
     syncMutation.mutate()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [csvMissingCount, isLoading, isError])
+  }, [csvMissingKey, isLoading, isError])
 
   // Auto-reconcile on open: team-add rostered not_in_org usernames that are in
   // fact active org members (native invite / SSO).
@@ -396,18 +419,24 @@ const EnrolledStudents = ({
   })
 
   const autoReconciledRef = useRef(false)
-  const notInOrgCount = notInOrgUsernames.length
+  // The unenrolled filter runs in the effect (ref read after render) so a
+  // teacher's leftover active org membership isn't silently promoted back onto
+  // the team — the root of the "unenrolled student keeps coming back" loop.
+  const notInOrgKey = notInOrgUsernames.join(",")
   useEffect(() => {
     if (isLoading || isError) return
-    if (notInOrgCount === 0) {
+    const targets = notInOrgUsernames.filter(
+      (u) => !unenrolledRef.current.logins.has(u.trim().toLowerCase()),
+    )
+    if (targets.length === 0) {
       autoReconciledRef.current = false
       return
     }
     if (autoReconciledRef.current || reconcileMutation.isPending) return
     autoReconciledRef.current = true
-    reconcileMutation.mutate(notInOrgUsernames)
+    reconcileMutation.mutate(targets)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [notInOrgCount, isLoading, isError])
+  }, [notInOrgKey, isLoading, isError])
 
   const onRowMetadataSaved = (rowKey: string, updated: StudentCsvRow) => {
     updateRosterCache((current) => {
@@ -422,9 +451,12 @@ const EnrolledStudents = ({
 
   const onRowUnenrolled = (rowKey: string, teamWarning?: string) => {
     if (teamWarning) setWarning(rowKey, teamWarning)
-    // A failed team-drop would leave an orphaned team member; don't let the next
-    // auto-sync re-append the student the teacher just removed (see the effect).
-    suppressAutoSyncRef.current = true
+    // Remember this identity so the automatic backfills (auto-sync,
+    // auto-reconcile) don't re-add the student the teacher just removed — e.g.
+    // when a best-effort team-drop failed, or the CSV delete hasn't propagated
+    // and they resurface as not_in_org while still an active org member.
+    const removed = rows.find((r) => r.key === rowKey)
+    rememberUnenrolledKey(rowKey, removed?.username ?? "")
     updateRosterCache((current) =>
       current.filter((s) => studentKey(s) !== rowKey),
     )
@@ -439,15 +471,18 @@ const EnrolledStudents = ({
 
   // After a bulk run, clear the selection and refresh the caches the run
   // touched (roster team membership + pending invites).
-  const onBulkDone = (action: "unenroll" | "invite") => {
+  const onBulkDone = (
+    action: "unenroll" | "invite",
+    removed?: Array<Pick<TeamRosterRow, "username">>,
+  ) => {
     setSelectedKeys(new Set())
     invalidateInviteQueries()
     // Unenroll changes team membership; invite changes org-invite state and may
     // team-add an already-active member — refresh the enrolled roster for both.
     invalidateTeamRoster()
-    // After a bulk unenroll, defer the next auto-sync: a per-row team-drop that
-    // failed would otherwise make auto-sync re-append the just-removed student.
-    if (action === "unenroll") suppressAutoSyncRef.current = true
+    // After a bulk unenroll, remember the removed identities so the automatic
+    // backfills don't re-add them (see rememberUnenrolled / the effects).
+    if (action === "unenroll" && removed) rememberUnenrolled(removed)
   }
 
   const renderRow = (row: TeamRosterRow) => {
@@ -716,9 +751,11 @@ const EnrolledStudents = ({
               shape="square"
               disabled={syncMutation.isPending}
               onClick={() => {
-                // Explicit backfill: clear any post-unenroll suppression so the
-                // teacher's deliberate Sync always runs.
-                suppressAutoSyncRef.current = false
+                // Explicit backfill: clear the post-unenroll suppression so the
+                // teacher's deliberate Sync always runs (re-adding any drifted
+                // team members, even ones removed earlier this session).
+                unenrolledRef.current.logins.clear()
+                unenrolledRef.current.keys.clear()
                 syncMutation.mutate()
               }}
               aria-label={t("students.syncRosterTitle")}

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -34,6 +34,10 @@ import {
 } from "@/hooks/github/queries"
 import { useUpdateRosterCache } from "@/hooks/useGetStudents"
 import { useTeamRoster, useInvalidateTeamRoster } from "@/hooks/useTeamRoster"
+import {
+  dropSuppressed,
+  type SuppressedLogins,
+} from "@/hooks/useSuppressedLogins"
 import type { TeamRosterRow, RosterRole } from "@/util/teamRoster"
 import { STAFF_ROLES } from "@/types/classroom"
 import {
@@ -97,11 +101,16 @@ const EnrolledStudents = ({
   org,
   classroom,
   addActions,
+  suppressedLogins,
 }: {
   students: Student[]
   org: string
   classroom: string
   addActions?: AddStudentActions
+  // Session-unenrolled logins, owned by the parent so a re-enroll from the Add
+  // modal can clear a login this view suppressed. Shared, not local, so the two
+  // surfaces can't disagree on who's suppressed.
+  suppressedLogins: SuppressedLogins
 }) => {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
@@ -331,52 +340,17 @@ const EnrolledStudents = ({
     },
   })
 
-  // Identities the teacher unenrolled this session (studentKey + lowercased
-  // username), so the automatic backfills below never re-add someone they just
-  // removed. Unenroll is classroom-scoped: it drops the CSV row + classroom-team
-  // membership but deliberately leaves ACTIVE org membership intact. That leaves
-  // a window where the student is a still-active org member with no team seat —
-  // which auto-reconcile would otherwise "fix" by team-adding them straight back
-  // (flipping them from removed to enrolled again, and their submissions from
-  // 0/0 to 0/1). The CSV Contents API is also eventually consistent, so a
-  // refetch right after the delete can resurface the row as not_in_org and feed
-  // that same loop. A ref (not state) so mutating it doesn't re-render; it
-  // persists across the re-navigation the loop rides on. A full page reload
-  // legitimately re-derives state and clears it (matching the drift-banner
-  // dismissal), so a genuinely still-drifted student is one refresh — or the
-  // explicit Sync/Reconcile — away.
-  const unenrolledRef = useRef<{ keys: Set<string>; logins: Set<string> }>({
-    keys: new Set(),
-    logins: new Set(),
-  })
-  const rememberUnenrolled = (
-    removed: Array<Pick<TeamRosterRow, "username">>,
-  ) => {
-    for (const row of removed) {
-      const login = row.username.trim().toLowerCase()
-      if (login) unenrolledRef.current.logins.add(login)
-    }
-  }
-  const rememberUnenrolledKey = (rowKey: string, username: string) => {
-    if (rowKey) unenrolledRef.current.keys.add(rowKey)
-    const login = username.trim().toLowerCase()
-    if (login) unenrolledRef.current.logins.add(login)
-  }
-
   // Auto-sync on open: append team members lacking a CSV row (fire once per
-  // drift episode; re-arm when count returns to 0). The effect filters out any
+  // drift episode; re-arm when count returns to 0). dropSuppressed skips any
   // csv-missing member the teacher just unenrolled whose best-effort team-drop
   // failed — otherwise auto-sync would re-append the student it just removed.
-  // (The unenrolled set is read in the effect, not during render, so a ref is
-  // safe here; syncRosterFromTeam re-derives the authoritative set server-side.)
+  // (suppressedLogins is read in the effect, not during render;
+  // syncRosterFromTeam re-derives the authoritative set server-side.)
   const autoSyncedRef = useRef(false)
   const csvMissingKey = csvMissingLogins.join(",")
   useEffect(() => {
     if (isLoading || isError) return
-    const pending = csvMissingLogins.filter(
-      (login) => !unenrolledRef.current.logins.has(login),
-    )
-    if (pending.length === 0) {
+    if (dropSuppressed(csvMissingLogins, suppressedLogins).length === 0) {
       autoSyncedRef.current = false
       return
     }
@@ -419,15 +393,13 @@ const EnrolledStudents = ({
   })
 
   const autoReconciledRef = useRef(false)
-  // The unenrolled filter runs in the effect (ref read after render) so a
-  // teacher's leftover active org membership isn't silently promoted back onto
-  // the team — the root of the "unenrolled student keeps coming back" loop.
+  // dropSuppressed runs in the effect (read after render) so a teacher's
+  // leftover active org membership isn't silently promoted back onto the team —
+  // the root of the "unenrolled student keeps coming back" loop.
   const notInOrgKey = notInOrgUsernames.join(",")
   useEffect(() => {
     if (isLoading || isError) return
-    const targets = notInOrgUsernames.filter(
-      (u) => !unenrolledRef.current.logins.has(u.trim().toLowerCase()),
-    )
+    const targets = dropSuppressed(notInOrgUsernames, suppressedLogins)
     if (targets.length === 0) {
       autoReconciledRef.current = false
       return
@@ -451,12 +423,12 @@ const EnrolledStudents = ({
 
   const onRowUnenrolled = (rowKey: string, teamWarning?: string) => {
     if (teamWarning) setWarning(rowKey, teamWarning)
-    // Remember this identity so the automatic backfills (auto-sync,
-    // auto-reconcile) don't re-add the student the teacher just removed — e.g.
-    // when a best-effort team-drop failed, or the CSV delete hasn't propagated
-    // and they resurface as not_in_org while still an active org member.
+    // Remember this login so the automatic backfills (auto-sync, auto-reconcile)
+    // don't re-add the student the teacher just removed — e.g. when a
+    // best-effort team-drop failed, or the CSV delete hasn't propagated and they
+    // resurface as not_in_org while still an active org member.
     const removed = rows.find((r) => r.key === rowKey)
-    rememberUnenrolledKey(rowKey, removed?.username ?? "")
+    if (removed?.username) suppressedLogins.remember([removed.username])
     updateRosterCache((current) =>
       current.filter((s) => studentKey(s) !== rowKey),
     )
@@ -480,9 +452,12 @@ const EnrolledStudents = ({
     // Unenroll changes team membership; invite changes org-invite state and may
     // team-add an already-active member — refresh the enrolled roster for both.
     invalidateTeamRoster()
-    // After a bulk unenroll, remember the removed identities so the automatic
-    // backfills don't re-add them (see rememberUnenrolled / the effects).
-    if (action === "unenroll" && removed) rememberUnenrolled(removed)
+    // After a bulk unenroll, remember the removed logins so the automatic
+    // backfills don't re-add them (see the effects). Only confirmed-removed rows
+    // are passed (not selection misses), so a still-enrolled row isn't
+    // suppressed by mistake.
+    if (action === "unenroll" && removed)
+      suppressedLogins.remember(removed.map((r) => r.username))
   }
 
   const renderRow = (row: TeamRosterRow) => {
@@ -754,8 +729,7 @@ const EnrolledStudents = ({
                 // Explicit backfill: clear the post-unenroll suppression so the
                 // teacher's deliberate Sync always runs (re-adding any drifted
                 // team members, even ones removed earlier this session).
-                unenrolledRef.current.logins.clear()
-                unenrolledRef.current.keys.clear()
+                suppressedLogins.clear()
                 syncMutation.mutate()
               }}
               aria-label={t("students.syncRosterTitle")}

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -189,12 +189,18 @@ const RosterBulkActionsBar = ({
       })
       setResult(buildUnenrollResult(res, t))
       setPhase("complete")
-      // Pass the targeted rows so the page suppresses the automatic backfills
-      // from re-adding them (a still-active org member left by a
-      // classroom-scoped unenroll would otherwise be team-added back).
+      // Pass only the CONFIRMED-removed rows so the page suppresses the
+      // automatic backfills for exactly those (a still-active org member left by
+      // a classroom-scoped unenroll would otherwise be team-added back). Rows
+      // that matched nothing (already gone) are not suppressed.
+      const removedKeys = new Set(
+        res.outcomes.filter((o) => o.status === "removed").map((o) => o.key),
+      )
       onDone(
         "unenroll",
-        selectedRows.map((r) => ({ username: r.username })),
+        selectedRows
+          .filter((r) => removedKeys.has(r.key))
+          .map((r) => ({ username: r.username })),
       )
     } catch (err) {
       log.error("bulk unenroll failed", { err, record: true })

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -116,8 +116,13 @@ const RosterBulkActionsBar = ({
   onToggleSelectAll: () => void
   onClearSelection: () => void
   // Called after a run completes so the page can invalidate roster + invite
-  // caches. `action` distinguishes what changed.
-  onDone: (action: "unenroll" | "invite") => void
+  // caches. `action` distinguishes what changed; on an unenroll run the removed
+  // rows are passed so the page can suppress the automatic backfills from
+  // re-adding them.
+  onDone: (
+    action: "unenroll" | "invite",
+    removed?: Array<Pick<TeamRosterRow, "username">>,
+  ) => void
   // The "add students" triggers shown on the right when nothing is selected.
   addActions?: AddStudentActions
   // Group-by-section toggle, rendered in the header next to the count. Shown
@@ -184,7 +189,13 @@ const RosterBulkActionsBar = ({
       })
       setResult(buildUnenrollResult(res, t))
       setPhase("complete")
-      onDone("unenroll")
+      // Pass the targeted rows so the page suppresses the automatic backfills
+      // from re-adding them (a still-active org member left by a
+      // classroom-scoped unenroll would otherwise be team-added back).
+      onDone(
+        "unenroll",
+        selectedRows.map((r) => ({ username: r.username })),
+      )
     } catch (err) {
       log.error("bulk unenroll failed", { err, record: true })
       setError(getErrorMessage(err))

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -16,7 +16,9 @@ import {
   filterNonSubmitters,
   hasAccepted,
   nonSubmitterStatus,
+  rosterScopedRows,
   rowMatchesQuery,
+  rowOnRoster,
   rowPassState,
   scoreTone,
   selectActiveWorkflowAction,
@@ -56,6 +58,46 @@ const repo = (name: string): GitHubRepo => ({ name }) as GitHubRepo
 const filters = (over: Partial<SubmissionFilters> = {}): SubmissionFilters => ({
   ...DEFAULT_FILTERS,
   ...over,
+})
+
+describe("rowOnRoster / rosterScopedRows", () => {
+  const roster = [student({ username: "alice" }), student({ username: "bob" })]
+
+  it("keeps an individual row whose owner is on the roster", () => {
+    const logins = new Set(["alice", "bob"])
+    expect(rowOnRoster(row({ usernames: ["alice"] }), logins)).toBe(true)
+    expect(rowOnRoster(row({ usernames: ["carol"] }), logins)).toBe(false)
+  })
+
+  it("matches case-insensitively", () => {
+    expect(rowOnRoster(row({ usernames: ["ALICE"] }), new Set(["alice"]))).toBe(
+      true,
+    )
+  })
+
+  it("keeps a group row with at least one still-enrolled member", () => {
+    const logins = new Set(["alice"])
+    // bob unenrolled, alice still on the roster -> group stays visible.
+    expect(rowOnRoster(row({ usernames: ["alice", "bob"] }), logins)).toBe(true)
+    // all members unenrolled -> dropped.
+    expect(rowOnRoster(row({ usernames: ["bob", "carol"] }), logins)).toBe(
+      false,
+    )
+  })
+
+  it("drops rows credited only to since-unenrolled students", () => {
+    const rows = [
+      row({ owner: "alice", usernames: ["alice"] }),
+      row({ owner: "carol", usernames: ["carol"] }), // no longer on roster
+    ]
+    const out = rosterScopedRows(rows, roster)
+    expect(out.map((r) => r.owner)).toEqual(["alice"])
+  })
+
+  it("ignores blank roster usernames (never matches an empty login)", () => {
+    const rows = [row({ owner: "", usernames: [""] })]
+    expect(rosterScopedRows(rows, [student({ username: "" })])).toEqual([])
+  })
 })
 
 describe("rowPassState", () => {

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -9,6 +9,35 @@ import type { BadgeTone } from "@/components/ui"
 import { getName } from "@/util/students"
 import { studentRepoName } from "@/util/studentRepo"
 
+// Whether a row's grade still belongs to a current roster member. A row is
+// credited to `usernames` (group members, else [owner]); keep it when ANY
+// credited login is on the roster, so a group with at least one current member
+// still shows. Used to drop the grades of a since-unenrolled student: the CLI
+// collector writes scores.json and never prunes on unenroll, so the web app —
+// a pure consumer — filters the read against the live team roster rather than
+// mutating the file (grades stay intact on disk for history / re-enrollment).
+export function rowOnRoster(
+  row: SubmissionRow,
+  rosterLogins: Set<string>,
+): boolean {
+  return row.usernames.some((u) => rosterLogins.has(u.trim().toLowerCase()))
+}
+
+// Drop submission rows whose credited students are all off the current roster.
+// Single choke point so every downstream consumer (table, stats, average, late
+// count, CSV export) sees the same roster-scoped set.
+export function rosterScopedRows(
+  rows: SubmissionRow[],
+  students: Student[],
+): SubmissionRow[] {
+  const rosterLogins = new Set(
+    students
+      .map((s) => s.username.trim().toLowerCase())
+      .filter((u) => u.length > 0),
+  )
+  return rows.filter((row) => rowOnRoster(row, rosterLogins))
+}
+
 // `thresholdFraction` is the passing bar as a fraction of max, or `null` when
 // the assignment sets no threshold — then every row is "ungraded" (as is an
 // ungraded/zero-max row).


### PR DESCRIPTION
## Summary

Fixes #209, where a student the teacher unenrolled kept reappearing in the roster and in assignment submissions (submissions flipping `0/0` → `0/1`, "Not Accepted" rows returning), and where instructors/TAs were shown as students.

### Root causes

- **Roster resurrection loop.** Unenroll is classroom-scoped — it drops the CSV row + classroom-team seat but deliberately leaves an active member's **org** membership intact. Auto-reconcile then team-added that still-active org member straight back, and auto-sync re-appended the CSV row. GitHub's Contents API is eventually consistent, so a refetch right after the CSV delete could also resurface the row and re-feed the loop. The prior one-shot guard only covered auto-sync for a single drift episode and didn't survive re-navigation.
- **Submissions view.** It derived its roster from all enrolled team rows (so pure instructors/TAs appeared as students) and rendered every `scores.json` record (so a since-unenrolled student's stale grade lingered and skewed the stats).

### What changed

- **Track session-unenrolled logins and skip them in both automatic backfills** (auto-sync + auto-reconcile), so a removed student isn't silently re-added. The set lives in a shared `useSuppressedLogins` hook owned by the roster page, so a re-enroll from the **Add Student** or **Upload Roster** modals clears the login it suppressed — a re-added student is enrolled again immediately, not stuck until reload. A full reload or the explicit **Sync/Reconcile** action also clears it. Bulk unenroll suppresses only the **confirmed-removed** rows, not selection misses.
- **Restrict the submissions roster to student-enrollment rows** (`hasStudentEnrollment`) so pure instructors/TAs drop out, and **scope `scores.json` rows to current team members** (`rosterScopedRows`), gated on a resolved roster so a transient load/permission failure can't blank a populated gradebook. Client-side only — `scores.json` is left intact on disk for history and re-enrollment.

### Commits

1. `fix(web): hide non-student and unenrolled members from submissions` — the submissions half (`SubmissionsPage.tsx`, `submissions/dashboard.ts`).
2. `fix(web): stop auto-reconcile from re-adding unenrolled students` — the roster resurrection guard (`EnrolledStudents.tsx`, `useTeamRoster.ts`, `RosterBulkActionsBar.tsx`).
3. `fix(web): share unenroll-suppression set so re-adds and bulk misses behave` — applies multi-agent code-review findings: lift the suppression set to a shared hook with a `forget` on re-enroll, suppress only confirmed-removed bulk rows, drop dead state, extract the pure (unit-tested) `dropSuppressed` predicate, trim comments per AGENTS.md.

## Test plan

- [x] `tsc -b`, `eslint`, `prettier --check` clean on all touched files
- [x] Full web suite green (`vitest run`): 1145 passed, incl. new `rowOnRoster` / `rosterScopedRows` / `dropSuppressed` unit tests
- [ ] Manual: unenroll an active org member, navigate into an assignment and back / reload — student stays gone from the roster and submissions
- [ ] Manual: unenroll then re-add the same student via Add Student (or Upload Roster) in the same session — student is enrolled again, not stuck `not_in_org`
- [ ] Manual: unenroll then click the explicit **Sync**/**Reconcile** — student is re-added (deliberate action still works)
- [ ] Manual: an instructor/TA no longer appears as a student in the submissions table or stats

## Notes

- All commits are `fix(web): …` touching `web/**`, so release-please lands them as a web patch bump.
- Does **not** introduce an `inactive` marker in `scores.json` (a cross-tool schema + `collect_scores.py` change) — deliberately out of scope; the fix is a pure-consumer read filter.
- Context-parity note (from review): the web submissions roster is student-role-scoped while `collect_scores.py` grades the whole classroom team, so `scores.json` can legitimately hold records the web view suppresses (a non-student team member with a repo; pre-collect timing skew). Inherent to the client-side model and intended.
- Known test gap: the stateful auto-sync/auto-reconcile effect interaction (unenroll → re-add → skip) has no component-level test today; the extractable pure logic (`dropSuppressed`) is covered.