### PR TITLE
feat: sync instructors/TAs into roster.csv and add a best-effort role column

### DIFF
--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -13,8 +13,18 @@ import (
 
 // RosterColumns: canonical required column order. github_id is CLI-managed
 // (from `GET /users/{username}`); the immutable numeric ID defends against
-// mid-class username changes. Email may be empty.
-var RosterColumns = []string{"username", "first_name", "last_name", "email", "section", "github_id"}
+// mid-class username changes. Email may be empty. role is best-effort recorded
+// metadata (instructor/ta/student, or "") refreshed from the classroom's GitHub
+// teams on sync — the teams, not this column, remain the enrollment/role
+// authority; nothing reads it for logic.
+var RosterColumns = []string{"username", "first_name", "last_name", "email", "section", "github_id", "role"}
+
+// legacyRequiredColumns is the canonical prefix a pre-role roster.csv carries.
+// role was appended additively, so a file written before it (ending at
+// github_id) is still valid; ParseRoster tolerates a header missing exactly the
+// trailing role column and reads role as "". Everything before role is required
+// in order.
+var legacyRequiredColumns = RosterColumns[:len(RosterColumns)-1]
 
 // FullRosterHeader is the on-disk roster.csv header (RosterColumns,
 // comma-joined). The single shared fixture the Go, Python, and web suites
@@ -51,8 +61,12 @@ type RosterRow struct {
 	Email     string
 	Section   string
 	GitHubID  int64
+	// Role is best-effort recorded metadata: "instructor", "ta", "student", or
+	// "" (unknown / a pre-role file). Refreshed from team membership on sync;
+	// never consulted for enrollment decisions.
+	Role string
 	// Extra carries non-canonical columns keyed by header name, so a
-	// read/modify/write round-trips them. nil for a plain 6-column file.
+	// read/modify/write round-trips them. nil for a plain canonical file.
 	Extra map[string]string
 	// ExtraOrder is the on-disk order of Extra columns for deterministic
 	// encoding. INVARIANT: it lists exactly the keys of Extra.
@@ -60,7 +74,9 @@ type RosterRow struct {
 }
 
 // ParseRoster decodes the roster CSV. The header MUST begin with the canonical
-// RosterColumns in order; additional trailing columns are preserved verbatim in
+// RosterColumns in order; a file written before the trailing `role` column was
+// added (ending at github_id) is still accepted (role reads as ""). Additional
+// trailing columns beyond the canonical set are preserved verbatim in
 // RosterRow.Extra. Empty input is rejected.
 func ParseRoster(data []byte) ([]RosterRow, error) {
 	data = bytes.TrimPrefix(data, utf8BOM)
@@ -76,12 +92,28 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read header: %w", err)
 	}
-	// Header must begin with the canonical columns in order; anything after is
-	// an extra column carried through verbatim.
-	if len(header) < len(RosterColumns) || !equalSlices(header[:len(RosterColumns)], RosterColumns) {
+	// The header must begin with the canonical columns in order. `role` is a
+	// trailing additive column, so a legacy file that stops at github_id is
+	// accepted too; anything after the matched canonical prefix is an extra
+	// column carried through verbatim.
+	var canonicalLen int
+	switch {
+	case len(header) >= len(RosterColumns) && equalSlices(header[:len(RosterColumns)], RosterColumns):
+		canonicalLen = len(RosterColumns)
+	case len(header) == len(legacyRequiredColumns) && equalSlices(header, legacyRequiredColumns):
+		// Pre-role file: exactly the canonical columns through github_id, no
+		// trailing columns. role reads as "".
+		canonicalLen = len(legacyRequiredColumns)
+	case len(header) < len(RosterColumns) || !equalSlices(header[:len(legacyRequiredColumns)], legacyRequiredColumns):
 		return nil, fmt.Errorf("unexpected header: got %v, want %v followed by any optional columns", header, RosterColumns)
+	default:
+		// Header begins with the legacy prefix but the 7th column is not `role`
+		// — treat the whole tail (including that 7th column) as extras and read
+		// role as "". Keeps a pre-role file that already carried its own extra
+		// columns working.
+		canonicalLen = len(legacyRequiredColumns)
 	}
-	extraColumns := append([]string(nil), header[len(RosterColumns):]...)
+	extraColumns := append([]string(nil), header[canonicalLen:]...)
 	// Reject a malformed extra-column header rather than mangling it on
 	// round-trip: a duplicate clobbers on read and collapses on write; a name
 	// reusing a canonical one produces a file the web's header-keyed parser
@@ -113,7 +145,7 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 		if err != nil {
 			return nil, fmt.Errorf("line %d: %w", line, err)
 		}
-		row, err := recordToRow(record, extraColumns, line)
+		row, err := recordToRow(record, canonicalLen, extraColumns, line)
 		if err != nil {
 			return nil, err
 		}
@@ -122,12 +154,15 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 	return rows, nil
 }
 
-// ParseImportCSV decodes a teacher-supplied import CSV: the 6-column canonical
-// shape (github_id ignored; re-resolved) or the 5-column hand-edit shape.
+// ParseImportCSV decodes a teacher-supplied import CSV: the identity/metadata
+// columns through github_id (github_id ignored; re-resolved) or the 5-column
+// hand-edit shape without github_id. `role` is NOT an import column — it is
+// team-derived metadata written by sync, never hand-imported.
 //
-// Unlike ParseRoster, import rejects a wider file with extra trailing columns:
-// it re-resolves github_id and carries no extra state, so a wider file would
-// silently drop the tail. The error points at the canonical shape.
+// Unlike ParseRoster, import rejects a wider file with extra trailing columns
+// (including a stray role): it re-resolves github_id and carries no extra
+// state, so a wider file would silently drop the tail. The error points at the
+// canonical shape.
 func ParseImportCSV(data []byte) ([]RosterRow, error) {
 	data = bytes.TrimPrefix(data, utf8BOM)
 	r := csv.NewReader(bytes.NewReader(data))
@@ -141,14 +176,19 @@ func ParseImportCSV(data []byte) ([]RosterRow, error) {
 		return nil, fmt.Errorf("read header: %w", err)
 	}
 
-	if !equalSlices(header, RosterColumns) && !equalSlices(header, RosterColumns[:5]) {
-		// Common mistake: feeding a wider roster CSV straight into import.
-		if len(header) > len(RosterColumns) && equalSlices(header[:len(RosterColumns)], RosterColumns) {
+	// Import accepts the identity columns through github_id, or the 5-column
+	// form without it. role and any other trailing column are not import input.
+	importFull := legacyRequiredColumns      // username..github_id (6)
+	importShort := legacyRequiredColumns[:5] // username..section  (5)
+	if !equalSlices(header, importFull) && !equalSlices(header, importShort) {
+		// Common mistake: feeding a wider roster CSV (with role and/or legacy
+		// extra columns) straight into import.
+		if len(header) > len(importFull) && equalSlices(header[:len(importFull)], importFull) {
 			return nil, fmt.Errorf("unexpected header: got %v — import takes only the canonical %v (or its 5-column form without github_id). "+
 				"This looks like a roster with extra columns appended; drop the columns after github_id before importing "+
-				"(roster add/update preserve those columns, import does not)", header, RosterColumns[:5])
+				"(roster add/update preserve those columns, import does not)", header, importShort)
 		}
-		return nil, fmt.Errorf("unexpected header: got %v, want %v (with optional trailing github_id; github_id ignored on input — the CLI re-resolves it)", header, RosterColumns[:5])
+		return nil, fmt.Errorf("unexpected header: got %v, want %v (with optional trailing github_id; github_id ignored on input — the CLI re-resolves it)", header, importShort)
 	}
 	r.FieldsPerRecord = len(header)
 
@@ -183,9 +223,10 @@ func ParseImportCSV(data []byte) ([]RosterRow, error) {
 	return rows, nil
 }
 
-// recordToRow maps a data record onto a RosterRow. extraColumns (in header
-// order) name the values beyond the canonical 6, carried through Extra.
-func recordToRow(record, extraColumns []string, line int) (RosterRow, error) {
+// recordToRow maps a data record onto a RosterRow. canonicalLen is the matched
+// canonical prefix width (7 with role, 6 for a pre-role file); extraColumns (in
+// header order) name the values beyond it, carried through Extra.
+func recordToRow(record []string, canonicalLen int, extraColumns []string, line int) (RosterRow, error) {
 	if err := checkFieldLengths(line, record); err != nil {
 		return RosterRow{}, err
 	}
@@ -206,13 +247,18 @@ func recordToRow(record, extraColumns []string, line int) (RosterRow, error) {
 		}
 		row.GitHubID = id
 	}
+	// role is present only when the header carried the full canonical set; a
+	// pre-role file (canonicalLen == 6) leaves it "".
+	if canonicalLen == len(RosterColumns) {
+		row.Role = strings.TrimSpace(undefangCSVCell(record[len(RosterColumns)-1]))
+	}
 	if len(extraColumns) > 0 {
 		// Every row's extra order IS the header's, so share that slice instead
 		// of rebuilding an identical one per row. Read-only after parse.
 		row.Extra = make(map[string]string, len(extraColumns))
 		row.ExtraOrder = extraColumns
 		for i, name := range extraColumns {
-			row.Extra[name] = undefangCSVCell(record[len(RosterColumns)+i])
+			row.Extra[name] = undefangCSVCell(record[canonicalLen+i])
 		}
 	}
 	return row, nil
@@ -244,6 +290,7 @@ func EncodeRoster(rows []RosterRow) ([]byte, error) {
 			defangCSVCell(row.Email),
 			defangCSVCell(row.Section),
 			githubID,
+			defangCSVCell(row.Role),
 		}
 		for _, name := range extraColumns {
 			record = append(record, defangCSVCell(row.Extra[name]))
@@ -281,13 +328,18 @@ func collectExtraColumns(rows []RosterRow) []string {
 //
 // On replace, the existing row's Extra is carried over UNLESS the incoming row
 // supplies its own — so a CLI `roster add` (canonical fields only) never wipes
-// web-written extra columns.
+// web-written extra columns. The same guard applies to Role: an incoming empty
+// Role (a caller that doesn't know the team-derived role) preserves the
+// existing recorded role rather than blanking it.
 func UpsertRosterRow(rows []RosterRow, row RosterRow) ([]RosterRow, bool) {
 	for i := range rows {
 		if strings.EqualFold(rows[i].Username, row.Username) {
 			if row.Extra == nil && rows[i].Extra != nil {
 				row.Extra = rows[i].Extra
 				row.ExtraOrder = rows[i].ExtraOrder
+			}
+			if row.Role == "" && rows[i].Role != "" {
+				row.Role = rows[i].Role
 			}
 			rows[i] = row
 			return rows, true

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -7,19 +7,36 @@ import (
 )
 
 func TestParseRoster_Canonical(t *testing.T) {
-	in := []byte("username,first_name,last_name,email,section,github_id\n" +
-		"alice,Alice,Andersson,alice@example.edu,section-1,12345\n" +
-		"bob,Bob,Baker,,,67890\n" +
-		"carol,,,carol@example.edu,section-2,11111\n")
+	in := []byte("username,first_name,last_name,email,section,github_id,role\n" +
+		"alice,Alice,Andersson,alice@example.edu,section-1,12345,instructor\n" +
+		"bob,Bob,Baker,,,67890,ta\n" +
+		"carol,,,carol@example.edu,section-2,11111,student\n")
 
 	rows, err := ParseRoster(in)
 	if err != nil {
 		t.Fatalf("ParseRoster: %v", err)
 	}
 	want := []RosterRow{
-		{Username: "alice", FirstName: "Alice", LastName: "Andersson", Email: "alice@example.edu", Section: "section-1", GitHubID: 12345},
-		{Username: "bob", FirstName: "Bob", LastName: "Baker", Email: "", Section: "", GitHubID: 67890},
-		{Username: "carol", FirstName: "", LastName: "", Email: "carol@example.edu", Section: "section-2", GitHubID: 11111},
+		{Username: "alice", FirstName: "Alice", LastName: "Andersson", Email: "alice@example.edu", Section: "section-1", GitHubID: 12345, Role: "instructor"},
+		{Username: "bob", FirstName: "Bob", LastName: "Baker", Email: "", Section: "", GitHubID: 67890, Role: "ta"},
+		{Username: "carol", FirstName: "", LastName: "", Email: "carol@example.edu", Section: "section-2", GitHubID: 11111, Role: "student"},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("rows = %#v, want %#v", rows, want)
+	}
+}
+
+// A pre-role roster.csv (canonical columns ending at github_id, no role column)
+// must still parse — role was added additively — with Role reading as "".
+func TestParseRoster_LegacyNoRoleColumn(t *testing.T) {
+	in := []byte("username,first_name,last_name,email,section,github_id\n" +
+		"alice,Alice,Andersson,alice@example.edu,section-1,12345\n")
+	rows, err := ParseRoster(in)
+	if err != nil {
+		t.Fatalf("ParseRoster (pre-role file): %v", err)
+	}
+	want := []RosterRow{
+		{Username: "alice", FirstName: "Alice", LastName: "Andersson", Email: "alice@example.edu", Section: "section-1", GitHubID: 12345, Role: ""},
 	}
 	if !reflect.DeepEqual(rows, want) {
 		t.Fatalf("rows = %#v, want %#v", rows, want)
@@ -27,7 +44,7 @@ func TestParseRoster_Canonical(t *testing.T) {
 }
 
 func TestParseRoster_HeaderOnly(t *testing.T) {
-	in := []byte("username,first_name,last_name,email,section,github_id\n")
+	in := []byte("username,first_name,last_name,email,section,github_id,role\n")
 	rows, err := ParseRoster(in)
 	if err != nil {
 		t.Fatalf("ParseRoster: %v", err)
@@ -46,10 +63,10 @@ func TestParseRoster_RejectsBadInputs(t *testing.T) {
 		{"empty input", "", "empty"},
 		{"missing github_id column", "username,first_name,last_name,email,section\nalice,A,A,a@x,s\n", "unexpected header"},
 		{"missing email column", "username,first_name,last_name,section,github_id\nalice,A,A,s,1\n", "unexpected header"},
-		{"renamed first column", "user,first_name,last_name,email,section,github_id\nalice,A,A,,s,1\n", "unexpected header"},
-		{"username empty", "username,first_name,last_name,email,section,github_id\n,A,A,,s,1\n", "username column is empty"},
-		{"non-numeric github_id", "username,first_name,last_name,email,section,github_id\nalice,A,A,,s,nope\n", "invalid github_id"},
-		{"wrong field count", "username,first_name,last_name,email,section,github_id\nalice,A,A\n", "wrong number"},
+		{"renamed first column", "user,first_name,last_name,email,section,github_id,role\nalice,A,A,,s,1,student\n", "unexpected header"},
+		{"username empty", "username,first_name,last_name,email,section,github_id,role\n,A,A,,s,1,student\n", "username column is empty"},
+		{"non-numeric github_id", "username,first_name,last_name,email,section,github_id,role\nalice,A,A,,s,nope,student\n", "invalid github_id"},
+		{"wrong field count", "username,first_name,last_name,email,section,github_id,role\nalice,A,A\n", "wrong number"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -131,9 +148,9 @@ func TestParseImportCSV_Rejects(t *testing.T) {
 
 func TestEncodeRoster_RoundTrip(t *testing.T) {
 	original := []RosterRow{
-		{Username: "alice", FirstName: "Alice", LastName: "Andersson", Email: "alice@example.edu", Section: "section-1", GitHubID: 12345},
-		{Username: "bob", FirstName: "Bob, Jr.", LastName: `"Baker"`, Email: "bob+tag@example.org", Section: "section, 2", GitHubID: 67890},
-		{Username: "carol", FirstName: "", LastName: "", Email: "", Section: "", GitHubID: 11111},
+		{Username: "alice", FirstName: "Alice", LastName: "Andersson", Email: "alice@example.edu", Section: "section-1", GitHubID: 12345, Role: "instructor"},
+		{Username: "bob", FirstName: "Bob, Jr.", LastName: `"Baker"`, Email: "bob+tag@example.org", Section: "section, 2", GitHubID: 67890, Role: "ta"},
+		{Username: "carol", FirstName: "", LastName: "", Email: "", Section: "", GitHubID: 11111, Role: "student"},
 	}
 	encoded, err := EncodeRoster(original)
 	if err != nil {
@@ -141,7 +158,7 @@ func TestEncodeRoster_RoundTrip(t *testing.T) {
 	}
 
 	// Canonical column order, no quoting on the header row.
-	wantHeader := "username,first_name,last_name,email,section,github_id\n"
+	wantHeader := "username,first_name,last_name,email,section,github_id,role\n"
 	if !strings.HasPrefix(string(encoded), wantHeader) {
 		t.Fatalf("encoded output should start with canonical header.\ngot:\n%s\nwant prefix:\n%s", encoded, wantHeader)
 	}
@@ -157,7 +174,7 @@ func TestEncodeRoster_RoundTrip(t *testing.T) {
 }
 
 func TestEncodeRoster_EmptyGitHubID(t *testing.T) {
-	rows := []RosterRow{{Username: "alice", FirstName: "A", LastName: "A", Email: "a@x", Section: "s", GitHubID: 0}}
+	rows := []RosterRow{{Username: "alice", FirstName: "A", LastName: "A", Email: "a@x", Section: "s", GitHubID: 0, Role: "student"}}
 	encoded, err := EncodeRoster(rows)
 	if err != nil {
 		t.Fatalf("EncodeRoster: %v", err)
@@ -165,7 +182,7 @@ func TestEncodeRoster_EmptyGitHubID(t *testing.T) {
 	// GitHubID == 0 must serialize as an empty github_id column,
 	// not "0". ParseRoster reads "" as 0 but treats "0" as a valid
 	// numeric ID, so the encoded shape matters.
-	if !strings.Contains(string(encoded), "alice,A,A,a@x,s,\n") {
+	if !strings.Contains(string(encoded), "alice,A,A,a@x,s,,student\n") {
 		t.Errorf("GitHubID == 0 should encode as empty column, got:\n%s", encoded)
 	}
 }
@@ -462,6 +479,25 @@ func TestEncodeRoster_LeavesSafeCellsAlone(t *testing.T) {
 	}
 }
 
+// role is recorded metadata, refreshed from team membership; an upsert that
+// doesn't know the role (empty Role) must preserve the existing recorded role
+// rather than blanking it — mirroring the Extra-preservation guard.
+func TestUpsertRosterRow_PreservesRoleWhenIncomingEmpty(t *testing.T) {
+	rows := []RosterRow{{Username: "alice", GitHubID: 1, Role: "instructor"}}
+	updated, replaced := UpsertRosterRow(rows, RosterRow{Username: "alice", FirstName: "Alice", GitHubID: 1})
+	if !replaced {
+		t.Fatalf("expected replace")
+	}
+	if updated[0].Role != "instructor" {
+		t.Errorf("empty incoming Role should preserve existing role, got %q", updated[0].Role)
+	}
+	// A non-empty incoming role overrides (a re-sync that changed the role).
+	updated, _ = UpsertRosterRow(updated, RosterRow{Username: "alice", GitHubID: 1, Role: "ta"})
+	if updated[0].Role != "ta" {
+		t.Errorf("non-empty incoming Role should override, got %q", updated[0].Role)
+	}
+}
+
 func TestDedupeByUsername_LastWins(t *testing.T) {
 	rows := []RosterRow{
 		{Username: "Alice", FirstName: "first-A"},
@@ -531,7 +567,8 @@ func TestEncodeRoster_RoundTripsLegacyColumns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeRoster: %v", err)
 	}
-	wantHeader := "username,first_name,last_name,email,section,github_id," +
+	// role (now canonical) is inserted after github_id; the legacy tail follows.
+	wantHeader := "username,first_name,last_name,email,section,github_id,role," +
 		"enrollment_status,enrollment_method,email_hash,invite_token,invited_at,enrolled_at\n"
 	if !strings.HasPrefix(string(encoded), wantHeader) {
 		t.Fatalf("encoded header drifted.\ngot:\n%s\nwant prefix:\n%s", encoded, wantHeader)
@@ -564,7 +601,7 @@ func TestEncodeRoster_UnknownColumnsPreserveSourceOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeRoster: %v", err)
 	}
-	wantHeader := "username,first_name,last_name,email,section,github_id," +
+	wantHeader := "username,first_name,last_name,email,section,github_id,role," +
 		"invite_token,enrollment_status\n"
 	if !strings.HasPrefix(string(encoded), wantHeader) {
 		t.Fatalf("unknown columns not preserved in source order.\ngot:\n%s\nwant prefix:\n%s", encoded, wantHeader)
@@ -662,7 +699,7 @@ func TestParseRoster_RejectsFormulaTriggerExtraColumnName(t *testing.T) {
 // file. If you change RosterColumns, update the web app and the Python fixture
 // in lockstep.
 func TestFullRosterHeader(t *testing.T) {
-	const want = "username,first_name,last_name,email,section,github_id"
+	const want = "username,first_name,last_name,email,section,github_id,role"
 	if FullRosterHeader != want {
 		t.Fatalf("FullRosterHeader = %q, want %q", FullRosterHeader, want)
 	}

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -84,10 +84,12 @@ MAX_RESULT_BYTES = 10 * 1024 * 1024
 
 # Required roster columns written by `gh teacher classroom add`. Mirrors
 # RosterColumns in cli/gh-teacher/internal/configrepo/students_csv.go and the
-# web app's STUDENT_CSV_FIELDS. Just these six identity/metadata columns — an
-# earlier email-first tail was pruned across all three codebases (the classroom
-# GitHub team is the source of truth for enrollment).
-ROSTER_REQUIRED_COLUMNS = ("username", "first_name", "last_name", "email", "section", "github_id")
+# web app's STUDENT_CSV_FIELDS. Identity/metadata columns; `role`
+# (instructor/ta/student, or "") is best-effort recorded metadata refreshed from
+# the classroom's GitHub teams — the teams, not this column, remain the
+# enrollment authority. A pre-role file (ending at github_id) still reads fine:
+# DictReader is header-keyed and a missing column just yields "".
+ROSTER_REQUIRED_COLUMNS = ("username", "first_name", "last_name", "email", "section", "github_id", "role")
 
 # Per-classroom roster file. ROSTER_FILENAME is the current name; a reader
 # falls back to LEGACY_ROSTER_FILENAME for classrooms bootstrapped before the

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -77,8 +77,9 @@ def make_update(*, assignment: str = "hello", assignment_type: str = "individual
 
 
 def write_roster(path, rows: list[dict[str, str]]) -> None:
-    """Write a 6-column roster CSV at `path`. Each row dict only needs
-    the fields the test cares about; missing fields default to ''."""
+    """Write a roster CSV at `path` with the full canonical header (including
+    role). Each row dict only needs the fields the test cares about; missing
+    fields default to ''."""
     with path.open("w", newline="") as fh:
         writer = csv.DictWriter(fh, fieldnames=list(cs.ROSTER_REQUIRED_COLUMNS), extrasaction="ignore")
         writer.writeheader()
@@ -1257,14 +1258,14 @@ class TestLateness:
 
 
 def test_full_roster_header_matches_go_constant():
-    # The exact 6-column header must stay in lockstep with FullRosterHeader
+    # The exact 7-column header must stay in lockstep with FullRosterHeader
     # in cli/gh-teacher/internal/configrepo/students_csv.go (asserted there by
     # TestFullRosterHeader) and classroom50-web's STUDENT_CSV_FIELDS. If this
     # fails, a column or its order drifted between the codebases. Collection is
     # team-driven and only reads the roster for best-effort metadata, but the Go
     # download-metadata join and the web writer still share this header, so the
     # Python leg of the 3-way lockstep is retained.
-    assert cs.FULL_ROSTER_HEADER == "username,first_name,last_name,email,section,github_id"
+    assert cs.FULL_ROSTER_HEADER == "username,first_name,last_name,email,section,github_id,role"
 
 
 def test_roster_filename_matches_go_constant():
@@ -1337,6 +1338,31 @@ class TestRosterMetadataJoin:
         write_roster(tmp_path / "students.csv", [{"username": "alice", "first_name": "Old"}])
         results = self._collect(tmp_path, monkeypatch)
         assert results[0]["first_name"] == "New"
+
+    def test_role_column_tolerated_metadata_still_joins(self, tmp_path, monkeypatch):
+        # A roster.csv carrying the role column joins its display metadata
+        # normally; role is recorded metadata the collector does not consume.
+        write_roster(tmp_path / "roster.csv", [{
+            "username": "alice", "first_name": "Ada", "last_name": "Lovelace",
+            "email": "ada@uni.edu", "section": "A", "github_id": "1", "role": "instructor",
+        }])
+        results = self._collect(tmp_path, monkeypatch)
+        assert len(results) == 1
+        assert results[0]["first_name"] == "Ada"
+        assert results[0]["email"] == "ada@uni.edu"
+        # role is not surfaced onto the result entry (best-effort metadata only).
+        assert "role" not in results[0]
+
+    def test_legacy_pre_role_roster_still_joins(self, tmp_path, monkeypatch):
+        # A pre-role file (no role column) must still join — DictReader is
+        # header-keyed, so an absent role just doesn't appear.
+        path = tmp_path / "roster.csv"
+        with path.open("w", newline="") as fh:
+            fh.write("username,first_name,last_name,email,section,github_id\n")
+            fh.write("alice,Ada,Lovelace,ada@uni.edu,A,1\n")
+        results = self._collect(tmp_path, monkeypatch)
+        assert results[0]["first_name"] == "Ada"
+        assert results[0]["section"] == "A"
 
     def test_missing_roster_yields_blank_metadata_no_crash(self, tmp_path, monkeypatch):
         # Neither file present: best-effort, so collection still succeeds and

--- a/web/src/api/mutations/classrooms.ts
+++ b/web/src/api/mutations/classrooms.ts
@@ -13,6 +13,7 @@ import {
   ensureStaffTeams,
   addUserToTeam,
   isDeletableClassroomTeamRef,
+  isNonFastForward,
   updateRef,
   type ClassroomTeamRef,
   type EditClassroomInput,
@@ -160,9 +161,11 @@ async function rollbackCreatedTeams(
 export async function withGitConflictRetry<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
-  // A concurrent write to classroom50 main 409s the updateRef. fn re-reads the
-  // ref + file each attempt, so retrying is safe; jittered backoff lets the
-  // winning write land and avoids lock-step collisions between racing clients.
+  // A concurrent write to classroom50 main conflicts the updateRef: GitHub
+  // returns 409, or a 422 "not a fast forward" when the force:false ref PATCH
+  // loses the race. fn re-reads the ref + file each attempt, so retrying either
+  // is safe; jittered backoff lets the winning write land and avoids lock-step
+  // collisions between racing clients.
   const attempts = 4
   let lastError: unknown
   for (let attempt = 1; attempt <= attempts; attempt++) {
@@ -170,7 +173,9 @@ export async function withGitConflictRetry<T>(
       return await fn()
     } catch (err) {
       lastError = err
-      const isConflict = err instanceof GitHubAPIError && err.status === 409
+      const isConflict =
+        (err instanceof GitHubAPIError && err.status === 409) ||
+        isNonFastForward(err)
       if (!isConflict || attempt === attempts) {
         throw err
       }

--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -10,6 +10,7 @@ import {
   reconcileTeamFromOrgMembers,
   inviteRosterStudents,
   syncRosterFromTeam,
+  migrateRosterFile,
   updateStudent,
   updateStudentWithConflictRetry,
   parseStudentsCsv,
@@ -1867,5 +1868,143 @@ describe("inviteRosterStudents — fresh invites for not_in_org students", () =>
     // Only the one attempt that tripped the limit was POSTed; no further invites
     // were fired at the throttled endpoint.
     expect(invitations).toEqual([])
+  })
+})
+
+describe("migrateRosterFile — converge students.csv onto roster.csv", () => {
+  // A minimal client: contents reads for roster.csv/students.csv (present in
+  // `files`, else a real 404), plus the git-data write surface. Records the
+  // tree payload so a test can assert the upsert + delete.
+  const notFound = (path: string) =>
+    new GitHubAPIError({
+      status: 404,
+      url: path,
+      message: "Not Found",
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+    })
+
+  const makeMigrateClient = (files: Record<string, string>) => {
+    const committed: {
+      tree: { path: string; content?: string; sha?: string | null }[] | null
+    } = { tree: null }
+    let treePosted = false
+
+    const request = vi
+      .fn()
+      .mockImplementation((path: string, options?: { body?: unknown }) => {
+        if (path.includes("/contents/")) {
+          const match = path.match(/\/contents\/(.+?)(\?|$)/)
+          const rel = match ? decodeURIComponent(match[1]) : ""
+          const content = files[rel]
+          if (content == null) return Promise.reject(notFound(path))
+          return Promise.resolve({
+            type: "file",
+            encoding: "base64",
+            content: Buffer.from(content, "utf-8").toString("base64"),
+          })
+        }
+        if (path.includes("/git/ref/")) {
+          return Promise.resolve({ object: { sha: "base-sha" } })
+        }
+        if (path.includes("/git/commits/")) {
+          return Promise.resolve({ tree: { sha: "base-tree-sha" } })
+        }
+        if (path.endsWith("/git/trees")) {
+          treePosted = true
+          committed.tree =
+            (
+              options?.body as {
+                tree?: {
+                  path: string
+                  content?: string
+                  sha?: string | null
+                }[]
+              }
+            )?.tree ?? null
+          return Promise.resolve({ sha: "tree-sha" })
+        }
+        if (path.endsWith("/git/commits")) {
+          return Promise.resolve({ sha: "new-commit-sha" })
+        }
+        if (path.endsWith("/git/refs/heads/main")) {
+          return Promise.resolve({})
+        }
+        return Promise.reject(new Error(`unexpected request: ${path}`))
+      })
+
+    return {
+      client: { request } as unknown as GitHubClient,
+      committed,
+      treePosted: () => treePosted,
+    }
+  }
+
+  const LEGACY =
+    "username,first_name,last_name,email,section,github_id,role\nada,,,,,1,student\n"
+
+  it("renames students.csv to roster.csv (write new + delete legacy) in one commit", async () => {
+    const { client, committed } = makeMigrateClient({
+      "cs101/students.csv": LEGACY,
+    })
+
+    const result = await migrateRosterFile(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.migrated).toBe(true)
+    const upsert = committed.tree?.find((t) => t.path === "cs101/roster.csv")
+    expect(upsert?.content).toBe(LEGACY) // legacy bytes verbatim
+    const del = committed.tree?.find((t) => t.path === "cs101/students.csv")
+    expect(del?.sha).toBeNull() // deletion
+  })
+
+  it("is a no-op when roster.csv already exists", async () => {
+    const { client, treePosted } = makeMigrateClient({
+      "cs101/roster.csv": LEGACY,
+    })
+
+    const result = await migrateRosterFile(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.migrated).toBe(false)
+    expect(treePosted()).toBe(false)
+  })
+
+  it("prefers the existing roster.csv when both files are present (no rename)", async () => {
+    const { client, treePosted } = makeMigrateClient({
+      "cs101/roster.csv": LEGACY,
+      "cs101/students.csv": LEGACY,
+    })
+
+    const result = await migrateRosterFile(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.migrated).toBe(false)
+    expect(treePosted()).toBe(false)
+  })
+
+  it("does nothing when neither file exists (brand-new classroom)", async () => {
+    const { client, treePosted } = makeMigrateClient({})
+
+    const result = await migrateRosterFile(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.migrated).toBe(false)
+    expect(treePosted()).toBe(false)
   })
 })

--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -105,7 +105,7 @@ const makeClient = (opts: {
   return { client, committed }
 }
 
-const HEADER = "username,first_name,last_name,email,section,github_id\n"
+const HEADER = "username,first_name,last_name,email,section,github_id,role\n"
 
 // The web leg of the three-way roster header lockstep. The Go
 // (TestFullRosterHeader) and Python (test_full_roster_header_matches_go_constant)
@@ -117,7 +117,7 @@ const HEADER = "username,first_name,last_name,email,section,github_id\n"
 describe("roster.csv header lockstep (web leg)", () => {
   it("STUDENT_CSV_FIELDS matches the Go/Python header verbatim", () => {
     expect(STUDENT_CSV_FIELDS.join(",")).toBe(
-      "username,first_name,last_name,email,section,github_id",
+      "username,first_name,last_name,email,section,github_id,role",
     )
   })
 
@@ -992,6 +992,7 @@ describe("unenrollStudent — classroom-scoped, no active-member org removal", (
         email: "alice@x.edu",
         section: "",
         github_id: "42",
+        role: "",
       },
     })
 
@@ -1017,6 +1018,7 @@ describe("unenrollStudent — classroom-scoped, no active-member org removal", (
         email: "bob@x.edu",
         section: "",
         github_id: "43",
+        role: "",
       },
     })
 
@@ -1043,6 +1045,7 @@ describe("unenrollStudent — classroom-scoped, no active-member org removal", (
         email: "alice@x.edu",
         section: "",
         github_id: "42",
+        role: "",
       },
     })
 
@@ -1070,6 +1073,7 @@ describe("unenrollStudent — classroom-scoped, no active-member org removal", (
         email: "bob@x.edu",
         section: "",
         github_id: "43",
+        role: "",
       },
     })
 
@@ -1092,6 +1096,7 @@ describe("bulkUnenrollStudents — single-commit batch removal", () => {
     email: `${username}@x.edu`,
     section: "",
     github_id,
+    role: "",
   })
 
   it("drops every matched row in exactly ONE commit", async () => {
@@ -1176,6 +1181,7 @@ describe("bulkUnenrollStudents — single-commit batch removal", () => {
           email: "sam@x.edu",
           section: "",
           github_id: "",
+          role: "",
         },
       ],
     })
@@ -1471,14 +1477,14 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
   })
 
   // Regression: a roster hand-edited (or exported by a tool that drops empty
-  // trailing columns) has rows with only 5 fields — the empty `github_id`
-  // column omitted, e.g. `octocat,Grace,Hopper,g@x.edu,Section A`. Papa flags
-  // TooFewFields, but the row is benign (missing trailing field -> ""), so the
-  // parse must NOT throw and sync must still see the row's identity.
-  it("tolerates short rows missing the trailing github_id column", async () => {
+  // trailing columns) has rows with the empty trailing column omitted, e.g.
+  // `octocat,Grace,Hopper,g@x.edu,Section A,1` (the trailing `role` dropped).
+  // Papa flags TooFewFields, but the row is benign (missing trailing field ->
+  // ""), so the parse must NOT throw and sync must still see the row's identity.
+  it("tolerates short rows missing the trailing role column", async () => {
     const shortRows =
-      "octocat,Grace,Hopper,grace@example.edu,Section A\n" +
-      "torvalds,Linus,Torvalds,linus@example.edu,Section A\n"
+      "octocat,Grace,Hopper,grace@example.edu,Section A,1\n" +
+      "torvalds,Linus,Torvalds,linus@example.edu,Section A,2\n"
     const { client } = makeTeamClient({
       startingCsv: HEADER + shortRows,
       users: {},
@@ -1504,11 +1510,11 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
 describe("parseStudentsCsv — short-row tolerance is trailing-only", () => {
   const HEADER = STUDENT_CSV_FIELDS.join(",") + "\n"
 
-  it("parses a row missing the trailing github_id into correct fields", () => {
-    // 5 fields: the empty trailing github_id column omitted. The row must parse
-    // (not throw) AND keep every value in its own column, with github_id -> "".
+  it("parses a row missing the trailing role column into correct fields", () => {
+    // 6 fields: the empty trailing role column omitted. The row must parse
+    // (not throw) AND keep every value in its own column, with role -> "".
     const rows = parseStudentsCsv(
-      HEADER + "octocat,Grace,Hopper,grace@example.edu,Section A\n",
+      HEADER + "octocat,Grace,Hopper,grace@example.edu,Section A,42\n",
     )
     expect(rows).toEqual([
       {
@@ -1517,26 +1523,30 @@ describe("parseStudentsCsv — short-row tolerance is trailing-only", () => {
         last_name: "Hopper",
         email: "grace@example.edu",
         section: "Section A",
-        github_id: "",
+        github_id: "42",
+        role: "",
       },
     ])
   })
 
   it("throws on a row short by more than one column", () => {
-    // 4 fields — short by 2. A row this incomplete can't be a mere dropped
-    // trailing github_id; Papa would map its values into the wrong columns, so
-    // the trailing-only guard must reject it rather than silently misalign
-    // identity. (A row short by exactly one is inherently ambiguous and is
-    // treated as the optional trailing github_id being omitted — see above.)
+    // 5 fields — short by 2 (github_id AND role dropped). A row this incomplete
+    // can't be a mere dropped trailing column; Papa would map its values into
+    // the wrong columns, so the trailing-only guard must reject it rather than
+    // silently misalign identity. (A row short by exactly one is inherently
+    // ambiguous and is treated as the optional trailing column being omitted —
+    // see above.)
     expect(() =>
-      parseStudentsCsv(HEADER + "octocat,Grace,Hopper,grace@example.edu\n"),
+      parseStudentsCsv(
+        HEADER + "octocat,Grace,Hopper,grace@example.edu,Sec A\n",
+      ),
     ).toThrow(/roster\.csv/)
   })
 
   it("still rejects a TooManyFields (extra column) row as before", () => {
     expect(() =>
       parseStudentsCsv(
-        HEADER + "octocat,Grace,Hopper,g@x.edu,Sec A,42,extra\n",
+        HEADER + "octocat,Grace,Hopper,g@x.edu,Sec A,42,student,extra\n",
       ),
     ).toThrow(/roster\.csv/)
   })

--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -1219,7 +1219,10 @@ describe("bulkUnenrollStudents — single-commit batch removal", () => {
 // / syncRosterFromTeam end to end (CSV read+commit, /users/{login}, membership
 // GET, team-add PUT, team-members list). `users` maps login -> id/name/email;
 // `members` is the set of ACTIVE org-member logins (case-insensitive); `teamHas`
-// seeds the team-member list syncRosterFromTeam reads.
+// seeds the STUDENT team-member list, and `instructorHas`/`taHas` the staff
+// teams (matched by the derived `classroom50-cs101[-role]` slug suffix) that
+// syncRosterFromTeam now reads across all three teams.
+type TeamMemberSeed = { login: string; id: number; name?: string | null }
 const makeTeamClient = (opts: {
   startingCsv: string
   users: Record<
@@ -1227,7 +1230,9 @@ const makeTeamClient = (opts: {
     { id: number; name?: string | null; email?: string | null }
   >
   members?: string[]
-  teamHas?: { login: string; id: number; name?: string | null }[]
+  teamHas?: TeamMemberSeed[]
+  instructorHas?: TeamMemberSeed[]
+  taHas?: TeamMemberSeed[]
 }) => {
   const committed: { content: string | null } = { content: null }
   const memberSet = new Set((opts.members ?? []).map((m) => m.toLowerCase()))
@@ -1265,8 +1270,18 @@ const makeTeamClient = (opts: {
       }
       // Team members list (syncRosterFromTeam): GET .../teams/{slug}/members
       // (checked AFTER /memberships/ since "/members" is a substring of it).
+      // Route by the derived slug so the student vs instructor vs ta teams
+      // return their own seeded lists.
       if (path.includes("/teams/") && path.includes("/members")) {
-        const members = (opts.teamHas ?? []).map((m) => ({
+        const slug = decodeURIComponent(
+          path.split("/teams/")[1].split("/members")[0],
+        )
+        const seed = slug.endsWith("-instructor")
+          ? (opts.instructorHas ?? [])
+          : slug.endsWith("-ta")
+            ? (opts.taHas ?? [])
+            : (opts.teamHas ?? [])
+        const members = seed.map((m) => ({
           login: m.login,
           id: m.id,
           name: m.name ?? null,
@@ -1457,12 +1472,95 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
       last_name: "",
       email: "",
       section: "",
+      // Student-team member records the "student" role.
+      role: "student",
     })
   })
 
-  it("is a noop when every team member already has a CSV row", async () => {
+  it("syncs instructors and TAs with their role, not just students", async () => {
+    // The nice-classroom scenario: only an instructor and a TA, no students,
+    // and no roster.csv rows yet. Both must be appended with their role so the
+    // roster is populated from the staff teams alone.
     const { client, committed } = makeTeamClient({
-      startingCsv: HEADER + "grace,,,,,707\n",
+      startingCsv: HEADER,
+      users: {},
+      teamHas: [], // no student-team members
+      instructorHas: [{ login: "prof", id: 1 }],
+      taHas: [{ login: "helper", id: 2 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.noop).toBe(false)
+    expect(result.addedUsernames.sort()).toEqual(["helper", "prof"])
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows.find((r) => r.username === "prof")).toMatchObject({
+      github_id: "1",
+      role: "instructor",
+    })
+    expect(rows.find((r) => r.username === "helper")).toMatchObject({
+      github_id: "2",
+      role: "ta",
+    })
+  })
+
+  it("records the highest-precedence role for a member on multiple teams", async () => {
+    // An instructor who is also on the student team records "instructor"
+    // (instructor > ta > student), matching the roster view's primary role.
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER,
+      users: {},
+      teamHas: [{ login: "prof", id: 1 }], // also a student-team member
+      instructorHas: [{ login: "prof", id: 1 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.addedUsernames).toEqual(["prof"])
+    const rows = rowsFromCsv(committed.content!)
+    // One row, not one per team.
+    expect(rows.filter((r) => r.username === "prof")).toHaveLength(1)
+    expect(rows[0].role).toBe("instructor")
+  })
+
+  it("refreshes a role that changed (promotion) on an existing row", async () => {
+    // grace was recorded as a student; she's now on the instructor team. Sync
+    // updates her role in place without adding a row.
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + "grace,Grace,Hopper,g@x.edu,A,707,student\n",
+      users: {},
+      teamHas: [],
+      instructorHas: [{ login: "grace", id: 707 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.addedUsernames).toEqual([])
+    expect(result.noop).toBe(false)
+    const grace = rowsFromCsv(committed.content!).find(
+      (r) => r.username === "grace",
+    )
+    // role refreshed; teacher-owned metadata untouched.
+    expect(grace).toMatchObject({
+      role: "instructor",
+      first_name: "Grace",
+      email: "g@x.edu",
+      section: "A",
+    })
+  })
+
+  it("is a noop when every team member already has a CSV row with its role", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + "grace,,,,,707,student\n",
       users: {},
       teamHas: [{ login: "grace", id: 707 }],
     })
@@ -1474,6 +1572,29 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
 
     expect(result.noop).toBe(true)
     expect(committed.content).toBeNull()
+  })
+
+  // A pre-role row for an existing team member gets its recorded role refreshed
+  // in place (a role-only convergence), even though no member is missing.
+  it("refreshes a missing/stale role on an existing row without adding rows", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + "grace,,,,,707\n", // role column empty
+      users: {},
+      teamHas: [{ login: "grace", id: 707 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    // No member was missing, so nothing was appended...
+    expect(result.addedUsernames).toEqual([])
+    expect(result.noop).toBe(false)
+    // ...but the role was written, so a commit did happen.
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].role).toBe("student")
   })
 
   // Regression: a roster hand-edited (or exported by a tool that drops empty
@@ -1488,8 +1609,10 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
     const { client } = makeTeamClient({
       startingCsv: HEADER + shortRows,
       users: {},
-      // Both short-row students are already team members, so this is a noop —
-      // the point is that parsing the short rows doesn't throw.
+      // Both short-row students are already team members matched by id, so no
+      // member is missing — the point is that parsing the short rows doesn't
+      // throw. (Their empty role is refreshed to "student" in place, so this is
+      // not a no-op, but nothing is appended.)
       teamHas: [
         { login: "octocat", id: 1 },
         { login: "torvalds", id: 2 },
@@ -1501,9 +1624,9 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
       classroom: "cs101",
     })
 
-    // octocat/torvalds carry no CSV github_id but ARE matched by login, so
-    // they're already "claimed" — nothing to backfill, and no parse error.
-    expect(result.noop).toBe(true)
+    // octocat/torvalds are matched by id, so nothing is backfilled and the
+    // short rows parsed without error.
+    expect(result.addedUsernames).toEqual([])
   })
 })
 

--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -1234,6 +1234,9 @@ const makeTeamClient = (opts: {
   teamHas?: TeamMemberSeed[]
   instructorHas?: TeamMemberSeed[]
   taHas?: TeamMemberSeed[]
+  // When set, a members read for the instructor/ta team rejects with this
+  // non-404 status (to exercise the best-effort staff-read degradation).
+  staffReadRejects?: { role: "instructor" | "ta"; status: number }
 }) => {
   const committed: { content: string | null } = { content: null }
   const memberSet = new Set((opts.members ?? []).map((m) => m.toLowerCase()))
@@ -1277,6 +1280,25 @@ const makeTeamClient = (opts: {
         const slug = decodeURIComponent(
           path.split("/teams/")[1].split("/members")[0],
         )
+        const rejects = opts.staffReadRejects
+        if (rejects && slug.endsWith(`-${rejects.role}`)) {
+          return Promise.reject(
+            new GitHubAPIError({
+              status: rejects.status,
+              url: path,
+              message: "boom",
+              body: null,
+              rateLimit: {
+                limit: null,
+                remaining: null,
+                used: null,
+                reset: null,
+                resource: null,
+                retryAfter: null,
+              },
+            }),
+          )
+        }
         const seed = slug.endsWith("-instructor")
           ? (opts.instructorHas ?? [])
           : slug.endsWith("-ta")
@@ -1557,6 +1579,30 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
       email: "g@x.edu",
       section: "A",
     })
+  })
+
+  it("a non-404 failure on a staff-team read degrades to [] and still syncs students", async () => {
+    // The instructor-team read 500s; that must NOT fail the whole sync — the
+    // student-team member is still backfilled (staff reads are best-effort).
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER,
+      users: {},
+      teamHas: [{ login: "stu", id: 10 }],
+      instructorHas: [{ login: "prof", id: 1 }], // would be added, but read 500s
+      staffReadRejects: { role: "instructor", status: 500 },
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    // The student synced; the instructor (whose read failed) did not, but the
+    // sync as a whole succeeded rather than throwing.
+    expect(result.addedUsernames).toEqual(["stu"])
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows.map((r) => r.username)).toEqual(["stu"])
+    expect(rows[0].role).toBe("student")
   })
 
   it("is a noop when every team member already has a CSV row with its role", async () => {

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -899,10 +899,17 @@ async function listClassroomMembersWithRoles(
   org: string,
   slugs: { student: string; staff: Record<StaffRole, string> },
 ): Promise<MemberWithRole[]> {
+  // The student read stays strict (a transient failure there fails the sync so
+  // it retries against fresh state). The two staff reads are best-effort: a
+  // flaky or permission-blocked staff team degrades to [] rather than blocking
+  // an otherwise-fine student sync — listTeamMembers already treats a missing
+  // team (404) as [], so only a non-404 reject reaches the settle here.
   const [studentMembers, ...staffMemberLists] = await Promise.all([
     listTeamMembers(client, org, slugs.student),
     ...STAFF_ROLES.map((role) =>
-      listTeamMembers(client, org, slugs.staff[role]),
+      Promise.allSettled([
+        listTeamMembers(client, org, slugs.staff[role]),
+      ]).then(([r]) => (r.status === "fulfilled" ? r.value : [])),
     ),
   ])
 

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -20,6 +20,7 @@ import {
   type CreateClassroomResult,
 } from "./classrooms"
 import {
+  getRawFile,
   getRawFileWithFallback,
   getUser,
   listTeamMembers,
@@ -1077,6 +1078,93 @@ export async function syncRosterFromTeam(
       addedUsernames: addedRows.map((r) => r.username),
       noop: false,
     }
+  })
+}
+
+export type MigrateRosterFileResult = {
+  // True when a rename commit was made (legacy students.csv -> roster.csv).
+  migrated: boolean
+}
+
+// Read a config file's bytes, or null on a true 404. A non-404 propagates so a
+// transient API failure is never mistaken for "file absent".
+async function readFileOrNull(
+  client: GitHubClient,
+  org: string,
+  path: string,
+  ref: string,
+): Promise<string | null> {
+  try {
+    return await getRawFile(client, { org, path, ref })
+  } catch (err) {
+    if (err instanceof GitHubAPIError && err.status === 404) return null
+    throw err
+  }
+}
+
+// Converge a classroom bootstrapped before the students.csv -> roster.csv
+// rename onto roster.csv, so the file always physically exists. Mirrors the CLI
+// `gh teacher roster migrate`: if only the legacy students.csv is present, write
+// roster.csv with its bytes verbatim and delete students.csv in ONE tree commit.
+// Idempotent: a no-op when roster.csv already exists, and nothing-to-do when
+// neither file is present (a brand-new classroom's roster.csv is created by the
+// team sync instead). Runs inside the conflict-retry loop so a concurrent write
+// (e.g. an interleaved roster edit) is re-read rather than clobbered.
+export async function migrateRosterFile(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+): Promise<MigrateRosterFileResult> {
+  const { org, classroom } = input
+  const rosterFilePath = rosterPath(classroom)
+  const legacyPath = legacyRosterPath(classroom)
+
+  return withGitConflictRetry(async () => {
+    const ref = await getBranchRef(client, org)
+    const commit = await getCommit(client, org, ref.object.sha)
+
+    // Read both files' presence at the same commit. roster.csv present -> the
+    // classroom is already converged (or has both, and roster.csv is canonical);
+    // nothing to migrate.
+    const [rosterBytes, legacyBytes] = await Promise.all([
+      readFileOrNull(client, org, rosterFilePath, ref.object.sha),
+      readFileOrNull(client, org, legacyPath, ref.object.sha),
+    ])
+
+    if (rosterBytes !== null || legacyBytes === null) {
+      // roster.csv already exists, or neither file does — no rename to do.
+      return { migrated: false }
+    }
+
+    // Only the legacy file exists: write roster.csv with its bytes verbatim and
+    // delete students.csv in a single commit (mode 100644; sha:null deletes).
+    const tree = await createGitTree(client, {
+      org,
+      base_tree: commit.tree.sha,
+      tree: [
+        {
+          path: rosterFilePath,
+          mode: "100644",
+          type: "blob",
+          content: legacyBytes,
+        },
+        { path: legacyPath, mode: "100644", type: "blob", sha: null },
+      ],
+    })
+
+    const newCommit = await createGitCommit(client, {
+      org,
+      message: prefixCommit(`Migrate students.csv to roster.csv: ${classroom}`),
+      tree_sha: tree.sha,
+      parents: [ref.object.sha],
+    })
+
+    await updateRef(client, org, newCommit.sha)
+
+    log.info("migrate roster file: renamed students.csv -> roster.csv", {
+      org,
+      classroom,
+    })
+    return { migrated: true }
   })
 }
 

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -11,6 +11,7 @@ import {
   isActiveMember,
   removeOrgMembership,
   removeUserFromTeam,
+  staffTeamName,
   updateRef,
 } from "@/hooks/github/mutations"
 import {
@@ -34,7 +35,8 @@ import { mapWithConcurrency } from "@/util/concurrency"
 import { escapeCsvFormulaInjection } from "@/util/csv"
 import { prefixCommit } from "@/util/commit"
 import { rosterPath, legacyRosterPath } from "@/util/rosterPath"
-import { type Student } from "@/types/classroom"
+import { ROLE_RANK, type RosterRole } from "@/util/teamRoster"
+import { STAFF_ROLES, type StaffRole, type Student } from "@/types/classroom"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("mutations:students")
@@ -844,22 +846,104 @@ export async function addStudentsToClassroomWithConflictRetry(
 export type SyncRosterFromTeamResult = {
   // Team members newly appended to roster.csv as metadata rows.
   addedUsernames: string[]
-  // No missing members — nothing was committed.
+  // No missing members and no role changes — nothing was committed.
   noop: boolean
 }
 
-// Backfill roster.csv from the classroom team: ensure every active team
-// member has an IDENTITY row (username + github_id), appended in ONE commit. The
-// team is the source of truth for enrollment; the CSV holds only teacher-
-// supplied metadata, so this writes identity only and never fabricates
-// name/email/section from the GitHub profile — the teacher fills those in.
-// Never removes rows (CSV-only rows are drift, not deletions).
+// A single classroom member unioned across the student + staff teams, tagged
+// with their highest-precedence role (instructor > ta > student).
+type MemberWithRole = {
+  id: number
+  login: string
+  email?: string | null
+  role: RosterRole
+}
+
+// Resolve the student-team slug plus the two staff-team slugs from one
+// classroom.json read (slugs are authoritative there; GitHub may rewrite them
+// on name collision). Falls back to the derived name per team when the block
+// is absent — mirroring useTeamRoster's resolution so the sync sees exactly the
+// teams the roster view does.
+async function resolveClassroomTeamSlugs(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+): Promise<{ student: string; staff: Record<StaffRole, string> }> {
+  let json: Awaited<ReturnType<typeof getClassroomJson>> | null = null
+  try {
+    json = await getClassroomJson(client, { org, classroom })
+  } catch (err) {
+    // A missing classroom.json (404) -> derived slugs; a transient failure
+    // propagates so we don't sync against a wrong team.
+    if (!(err instanceof GitHubAPIError && err.isNotFound)) {
+      throw err
+    }
+  }
+  return {
+    student: json?.team?.slug || `classroom50-${classroom}`,
+    staff: {
+      instructor:
+        json?.teams?.instructor?.slug || staffTeamName(classroom, "instructor"),
+      ta: json?.teams?.ta?.slug || staffTeamName(classroom, "ta"),
+    },
+  }
+}
+
+// Union the student + staff team memberships into one member-per-github_id map,
+// each tagged with their highest-precedence role. A staff team that doesn't
+// exist yet (404) lists as empty (listTeamMembers already 404-tolerates), so a
+// classroom with no staff team simply contributes no staff rows.
+async function listClassroomMembersWithRoles(
+  client: GitHubClient,
+  org: string,
+  slugs: { student: string; staff: Record<StaffRole, string> },
+): Promise<MemberWithRole[]> {
+  const [studentMembers, ...staffMemberLists] = await Promise.all([
+    listTeamMembers(client, org, slugs.student),
+    ...STAFF_ROLES.map((role) =>
+      listTeamMembers(client, org, slugs.staff[role]),
+    ),
+  ])
+
+  const byId = new Map<number, MemberWithRole>()
+  const consider = (
+    member: { id: number; login: string; email?: string | null },
+    role: RosterRole,
+  ) => {
+    const existing = byId.get(member.id)
+    // Keep the highest-precedence role when a person is on several teams
+    // (e.g. an instructor also on the student team records "instructor").
+    if (existing && ROLE_RANK[existing.role] >= ROLE_RANK[role]) return
+    byId.set(member.id, {
+      id: member.id,
+      login: member.login,
+      email: member.email,
+      role,
+    })
+  }
+
+  for (const m of studentMembers) consider(m, "student")
+  STAFF_ROLES.forEach((role, i) => {
+    for (const m of staffMemberLists[i]) consider(m, role)
+  })
+
+  return [...byId.values()]
+}
+
+// Sync roster.csv from the classroom's GitHub teams: ensure every active member
+// of the student, instructor, and ta teams has an IDENTITY row (username +
+// github_id) carrying their recorded `role`, and refresh the role on rows whose
+// team-derived role has changed — all in ONE commit. The teams are the source
+// of truth for enrollment and role; the CSV holds teacher-supplied metadata
+// plus this best-effort role snapshot, so this writes identity + role only and
+// never fabricates name/email/section from the GitHub profile. Never removes
+// rows (CSV-only rows are drift, not deletions).
 //
-// The diff is recomputed INSIDE the retried closure (re-reading both team and
+// The diff is recomputed INSIDE the retried closure (re-reading both teams and
 // CSV each attempt) so a 409 retry or concurrent edit can't reintroduce or
-// duplicate rows. Uses the same github_id -> username fallback join as the
-// roster view when deciding "missing", so a pre-resolution row with an empty
-// github_id isn't treated as missing (which would append a duplicate).
+// duplicate rows. Uses the same github_id -> username -> email fallback join as
+// the roster view when deciding "missing", so a pre-resolution row with an
+// empty github_id isn't treated as missing (which would append a duplicate).
 export async function syncRosterFromTeam(
   client: GitHubClient,
   input: { org: string; classroom: string },
@@ -868,13 +952,13 @@ export async function syncRosterFromTeam(
   log.info("sync roster from team: started", { org, classroom })
   await assertClassroomNotArchived(client, org, classroom)
 
-  const teamSlug = await resolveClassroomTeamSlug(client, org, classroom)
+  const slugs = await resolveClassroomTeamSlugs(client, org, classroom)
 
   return withGitConflictRetry(async () => {
-    // Re-read team + CSV on every attempt so the diff is always against the
+    // Re-read teams + CSV on every attempt so the diff is always against the
     // latest state (a concurrent add/edit can't be clobbered or duplicated).
     const [members, ref] = await Promise.all([
-      listTeamMembers(client, org, teamSlug),
+      listClassroomMembersWithRoles(client, org, slugs),
       getBranchRef(client, org),
     ])
     const commit = await getCommit(client, org, ref.object.sha)
@@ -910,7 +994,27 @@ export async function syncRosterFromTeam(
         !(m.email ? emails.has(m.email.trim().toLowerCase()) : false),
     )
 
-    if (missing.length === 0) {
+    // Refresh the recorded role on existing rows whose team-derived role has
+    // changed (a promotion/demotion, or a first-ever role on a pre-role row).
+    // Matched by id, then login — the same identity join used above. This is
+    // the only in-place edit sync makes; name/email/section stay teacher-owned.
+    const roleById = new Map(members.map((m) => [String(m.id), m.role]))
+    const roleByLogin = new Map(
+      members.map((m) => [m.login.toLowerCase(), m.role]),
+    )
+    let roleChanges = 0
+    const reconciledStudents = currentStudents.map((s) => {
+      const role =
+        (s.github_id ? roleById.get(s.github_id.trim()) : undefined) ??
+        roleByLogin.get(s.username.trim().toLowerCase())
+      if (role && role !== s.role) {
+        roleChanges++
+        return { ...s, role }
+      }
+      return s
+    })
+
+    if (missing.length === 0 && roleChanges === 0) {
       log.info("sync roster from team: completed (up to date)", {
         org,
         classroom,
@@ -918,10 +1022,11 @@ export async function syncRosterFromTeam(
       return { addedUsernames: [], noop: true }
     }
 
-    // Identity-only rows: username + github_id. Name/email/section are left
-    // blank for the teacher to provide (via Edit or a roster upload). The team
-    // decides enrollment; the CSV holds only teacher-supplied metadata, so we
-    // never fabricate profile fields from the GitHub account here.
+    // Identity + role rows: username + github_id + role. Name/email/section are
+    // left blank for the teacher to provide (via Edit or a roster upload). The
+    // teams decide enrollment and role; the CSV holds only teacher-supplied
+    // metadata plus this role snapshot, so we never fabricate profile fields
+    // from the GitHub account here.
     const addedRows = missing.map((m) =>
       normalizeStudentRow({
         username: m.login,
@@ -930,10 +1035,11 @@ export async function syncRosterFromTeam(
         email: "",
         section: "",
         github_id: String(m.id),
+        role: m.role,
       }),
     )
 
-    const nextCsv = stringifyStudentsCsv([...currentStudents, ...addedRows])
+    const nextCsv = stringifyStudentsCsv([...reconciledStudents, ...addedRows])
 
     const tree = await createGitTree(client, {
       org,
@@ -951,7 +1057,7 @@ export async function syncRosterFromTeam(
     const newCommit = await createGitCommit(client, {
       org,
       message: prefixCommit(
-        `Sync ${addedRows.length} team member${
+        `Sync ${addedRows.length} member${
           addedRows.length === 1 ? "" : "s"
         } into roster: ${classroom}`,
       ),
@@ -965,6 +1071,7 @@ export async function syncRosterFromTeam(
       org,
       classroom,
       added: addedRows.length,
+      roleChanges,
     })
     return {
       addedUsernames: addedRows.map((r) => r.username),

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -139,6 +139,7 @@ export const STUDENT_CSV_FIELDS = [
   "email",
   "section",
   "github_id",
+  "role",
 ] as const
 type StudentCsvField = (typeof STUDENT_CSV_FIELDS)[number]
 
@@ -154,6 +155,10 @@ export function normalizeStudentRow(
     email: String(row.email ?? "").trim(),
     section: String(row.section ?? "").trim(),
     github_id: String(row.github_id ?? "").trim(),
+    // Best-effort recorded metadata (instructor/ta/student, or ""), refreshed
+    // from the classroom's GitHub teams on sync. A pre-role file has no role
+    // column, so this coerces to "".
+    role: String(row.role ?? "").trim(),
   }
 }
 

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -1147,8 +1147,10 @@ const SKELETON_COMMIT_ATTEMPTS = 3
 
 // A ref PATCH with force:false that loses a race returns 422 "Update is not a
 // fast forward". Treat that (and only that) as retryable; everything else is a
-// real error the caller should see.
-function isNonFastForward(err: unknown): boolean {
+// real error the caller should see. Exported so withGitConflictRetry treats a
+// lost force:false race as retryable too (not just a 409) — the roster mutation
+// family relies on that retry for concurrency safety.
+export function isNonFastForward(err: unknown): boolean {
   if (!(err instanceof GitHubAPIError) || err.status !== 422) return false
   const message =
     err.message + " " + (typeof err.body === "string" ? err.body : "")

--- a/web/src/hooks/useTeamRoster.ts
+++ b/web/src/hooks/useTeamRoster.ts
@@ -172,11 +172,24 @@ export function useTeamRoster(
   // Enrolled head counts by role for the header (students / instructors / TAs).
   const roleCounts = useMemo(() => enrolledCountsByRole(rows), [rows])
 
-  // CSV drift / reconcile are STUDENT-roster concepts: a staffer is never
-  // synced into roster.csv, so count only the student team against the CSV.
+  // CSV drift / reconcile: role is now recorded metadata, so every classroom
+  // member (student + instructor + ta) belongs in roster.csv. Count all three
+  // teams against the CSV so auto-sync also populates a staff-only classroom
+  // (an instructor/TA with no students still needs a roster.csv row).
+  const allTeamMembers = useMemo(() => {
+    const byId = new Map<number, GitHubUser>()
+    for (const m of [
+      ...(members ?? []),
+      ...(instructorMembers ?? []),
+      ...(taMembers ?? []),
+    ]) {
+      if (!byId.has(m.id)) byId.set(m.id, m)
+    }
+    return [...byId.values()]
+  }, [members, instructorMembers, taMembers])
   const csvMissing = useMemo(
-    () => teamMembersMissingFromCsv(members ?? [], students),
-    [members, students],
+    () => teamMembersMissingFromCsv(allTeamMembers, students),
+    [allTeamMembers, students],
   )
   const csvMissingCount = csvMissing.length
   // Lowercased logins of those csv-missing team members, so the view can skip a

--- a/web/src/pages/orgMembers/bulkRemoveFromClassroom.ts
+++ b/web/src/pages/orgMembers/bulkRemoveFromClassroom.ts
@@ -40,6 +40,7 @@ const rowToStudent = (row: OrgMemberRow): Student => ({
   email: row.email,
   section: "",
   github_id: row.github_id,
+  role: "",
 })
 
 // Remove selected members from ONE classroom in a SINGLE roster commit (drops

--- a/web/src/pages/orgMembers/removeMemberFromOrg.ts
+++ b/web/src/pages/orgMembers/removeMemberFromOrg.ts
@@ -28,6 +28,7 @@ const rowToStudent = (row: OrgMemberRow): Student => ({
   email: row.email,
   section: "",
   github_id: row.github_id,
+  role: "",
 })
 
 // Remove a student from the org without leaving any roster inconsistent:

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -23,6 +23,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   syncRosterFromTeam,
   reconcileTeamFromOrgMembers,
+  migrateRosterFile,
 } from "@/api/mutations/students"
 import { getErrorMessage } from "@/hooks/github/mutations"
 import { useToast } from "@/context/notifications/NotificationProvider"
@@ -313,6 +314,35 @@ const EnrolledStudents = ({
       : [{ value: "pending" as const, label: t("students.filterPending") }]),
     { value: "not_in_org", label: t("students.filterNotInOrg") },
   ]
+
+  // Auto-migrate on open: converge a classroom bootstrapped before the
+  // students.csv -> roster.csv rename so roster.csv always physically exists.
+  // Idempotent and cheap (a no-op once roster.csv is present), so fire once per
+  // mount; on an actual rename, refresh the roster read so it reads roster.csv.
+  const migrateMutation = useMutation({
+    mutationFn: () => migrateRosterFile(client, { org, classroom }),
+    onSuccess: (result) => {
+      if (result.migrated) {
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.csvFile(
+            org,
+            "classroom50",
+            rosterPath(classroom),
+          ),
+        })
+      }
+    },
+    // Best-effort convergence: a failure is non-fatal (reads still fall back to
+    // students.csv), so it's logged by the mutation layer, not surfaced.
+  })
+  const migratedRef = useRef(false)
+  useEffect(() => {
+    if (isLoading || isError) return
+    if (migratedRef.current || migrateMutation.isPending) return
+    migratedRef.current = true
+    migrateMutation.mutate()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, isError])
 
   // Explicit teacher-triggered CSV backfill (also auto-run on open).
   const syncMutation = useMutation({

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -317,32 +317,33 @@ const EnrolledStudents = ({
 
   // Auto-migrate on open: converge a classroom bootstrapped before the
   // students.csv -> roster.csv rename so roster.csv always physically exists.
-  // Idempotent and cheap (a no-op once roster.csv is present), so fire once per
-  // mount; on an actual rename, refresh the roster read so it reads roster.csv.
+  // Idempotent and cheap (a no-op once roster.csv is present). It runs BEFORE
+  // auto-sync (which gates on migrateSettledFor) so the two roster writers don't
+  // race on the ref. The rename changes only the file's path, not its content,
+  // and reads already fall back to students.csv, so there's no cache to
+  // invalidate — a plain invalidate here would refetch eventually-consistent
+  // bytes and needlessly re-arm auto-sync.
+  const [migrateSettledFor, setMigrateSettledFor] = useState<string | null>(
+    null,
+  )
   const migrateMutation = useMutation({
     mutationFn: () => migrateRosterFile(client, { org, classroom }),
-    onSuccess: (result) => {
-      if (result.migrated) {
-        void queryClient.invalidateQueries({
-          queryKey: githubKeys.csvFile(
-            org,
-            "classroom50",
-            rosterPath(classroom),
-          ),
-        })
-      }
-    },
+    onSettled: () => setMigrateSettledFor(classroom),
     // Best-effort convergence: a failure is non-fatal (reads still fall back to
-    // students.csv), so it's logged by the mutation layer, not surfaced.
+    // students.csv), so it's logged by the mutation layer, not surfaced — and
+    // onSettled still unblocks auto-sync so a migrate hiccup can't strand it.
   })
-  const migratedRef = useRef(false)
+  // Fire once per classroom (the component instance is reused across a
+  // $classroom param switch, so a boolean would skip later classrooms).
+  const migratedForRef = useRef<string | null>(null)
   useEffect(() => {
     if (isLoading || isError) return
-    if (migratedRef.current || migrateMutation.isPending) return
-    migratedRef.current = true
+    if (migratedForRef.current === classroom) return
+    migratedForRef.current = classroom
+    setMigrateSettledFor(null)
     migrateMutation.mutate()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, isError])
+  }, [classroom, isLoading, isError])
 
   // Explicit teacher-triggered CSV backfill (also auto-run on open).
   const syncMutation = useMutation({
@@ -368,15 +369,20 @@ const EnrolledStudents = ({
   })
 
   // Auto-sync on open: append team members lacking a CSV row (fire once per
-  // drift episode; re-arm when count returns to 0). dropSuppressed skips any
-  // csv-missing member the teacher just unenrolled whose best-effort team-drop
-  // failed — otherwise auto-sync would re-append the student it just removed.
-  // (suppressedLogins is read in the effect, not during render;
-  // syncRosterFromTeam re-derives the authoritative set server-side.)
+  // drift episode; re-arm when count returns to 0). Gated on migrate having
+  // settled for this classroom so the two roster writers run in sequence, not a
+  // race. dropSuppressed skips any csv-missing member the teacher just
+  // unenrolled whose best-effort team-drop failed — otherwise auto-sync would
+  // re-append the student it just removed. (suppressedLogins is read in the
+  // effect, not during render; syncRosterFromTeam re-derives the authoritative
+  // set server-side.)
   const autoSyncedRef = useRef(false)
   const csvMissingKey = csvMissingLogins.join(",")
   useEffect(() => {
     if (isLoading || isError) return
+    // Wait for the migrate pass to settle first (converges students.csv ->
+    // roster.csv) so sync's write can't race migrate's on the ref.
+    if (migrateSettledFor !== classroom) return
     if (dropSuppressed(csvMissingLogins, suppressedLogins).length === 0) {
       autoSyncedRef.current = false
       return
@@ -385,7 +391,7 @@ const EnrolledStudents = ({
     autoSyncedRef.current = true
     syncMutation.mutate()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [csvMissingKey, isLoading, isError])
+  }, [csvMissingKey, isLoading, isError, migrateSettledFor, classroom])
 
   // Auto-reconcile on open: team-add rostered not_in_org usernames that are in
   // fact active org members (native invite / SSO).

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -50,6 +50,7 @@ const student = (over: Partial<Student> = {}): Student => ({
   email: "alice@example.edu",
   section: "",
   github_id: "1",
+  role: "",
   ...over,
 })
 

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -171,10 +171,12 @@ export type AssignmentTest = {
   points: number
 }
 
-// The roster is just the 6 identity/metadata columns — the classroom GitHub
-// team is the source of truth for enrollment, so the email-first onboarding
-// lifecycle columns were pruned. A data contract shared with the gh-teacher CLI
-// and the Python collector; all three moved in lockstep.
+// The roster's identity/metadata columns — the classroom GitHub team is the
+// source of truth for enrollment, so the email-first onboarding lifecycle
+// columns were pruned. `role` is best-effort recorded metadata
+// (instructor/ta/student, or ""), refreshed from the classroom's GitHub teams
+// on sync; nothing reads it for logic. A data contract shared with the
+// gh-teacher CLI and the Python collector; all three moved in lockstep.
 export type Student = {
   username: string
   first_name: string
@@ -182,4 +184,5 @@ export type Student = {
   email: string
   section: string
   github_id: string
+  role: string
 }

--- a/web/src/util/orgMembers.test.ts
+++ b/web/src/util/orgMembers.test.ts
@@ -18,6 +18,7 @@ const student = (over: Partial<Student>): Student => ({
   email: "",
   section: "",
   github_id: "",
+  role: "",
   ...over,
 })
 

--- a/web/src/util/roster.test.ts
+++ b/web/src/util/roster.test.ts
@@ -15,6 +15,7 @@ const student = (overrides: Partial<Student> = {}): Student => ({
   email: "octocat@example.com",
   section: "",
   github_id: "583231",
+  role: "",
   ...overrides,
 })
 
@@ -56,7 +57,7 @@ describe("splitName", () => {
 })
 
 describe("toStudent", () => {
-  it("passes through the 6 identity/metadata columns", () => {
+  it("passes through the identity/metadata columns", () => {
     const row = {
       username: "x",
       first_name: "First",
@@ -64,6 +65,7 @@ describe("toStudent", () => {
       email: "x@y.io",
       section: "A",
       github_id: "9",
+      role: "student",
     }
     const s = toStudent(row)
     expect(s).toEqual(row)
@@ -90,6 +92,7 @@ describe("toStudent", () => {
       email: "",
       section: "",
       github_id: "",
+      role: "",
     })
     expect("enrollment_status" in s).toBe(false)
     expect("email_hash" in s).toBe(false)

--- a/web/src/util/students.ts
+++ b/web/src/util/students.ts
@@ -21,6 +21,7 @@ export const placeholderStudent = (username: string): Student => ({
   email: "",
   section: "",
   github_id: "",
+  role: "",
 })
 
 // The roster Student for a username, or a placeholder so callers always get one.

--- a/web/src/util/teamRoster.test.ts
+++ b/web/src/util/teamRoster.test.ts
@@ -235,7 +235,7 @@ describe("buildTeamRoster", () => {
     })
   })
 
-  it("rowToStudent projects all six Student fields from a roster row", () => {
+  it("rowToStudent projects all Student fields from a roster row", () => {
     const rows = buildTeamRoster({
       members: [member(101, "ada")],
       students: [
@@ -256,6 +256,8 @@ describe("buildTeamRoster", () => {
       email: "ada@uni.edu",
       section: "A",
       github_id: "101",
+      // primary role recorded from team membership (student team here)
+      role: "student",
     })
   })
 })

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -347,6 +347,9 @@ export function rowToStudent(row: TeamRosterRow): Student {
     email: row.email,
     section: row.section,
     github_id: row.github_id,
+    // Primary (highest-precedence) role as recorded metadata. roles is always
+    // non-empty and rank-sorted (instructor > ta > student).
+    role: row.roles[0],
   }
 }
 


### PR DESCRIPTION
## Summary

Populates `roster.csv` from **all** of a classroom's GitHub teams (not just students) and records each member's role, so a classroom with only an instructor + TA no longer shows an empty roster. Because Classroom 50 keeps all state in GitHub repos (no backend) and the roster column list is a hand-mirrored cross-tool contract, the change spans the Go CLI, the Python autograde skeleton, and the web app together.

- **`role` column** — adds `role` (`instructor` / `ta` / `student`, or `""`) as the 7th canonical roster column across the three mirrors — Go `RosterColumns`/`RosterRow`, web `STUDENT_CSV_FIELDS`/`Student`, Python `ROSTER_REQUIRED_COLUMNS` — with the three-way header parity pins updated in lockstep. Best-effort recorded metadata (like name/email): the GitHub team stays the enrollment/role authority; nothing reads `role` for logic.
- **Staff sync** — `syncRosterFromTeam` now reads the student + instructor + ta teams, unions members by `github_id`, and records each person's highest-precedence role (`instructor > ta > student`, matching the roster view's primary-role rule). Missing members are appended as identity+role rows; a row whose team-derived role changed is refreshed in place, all in one conflict-retried commit.
- **Web auto-migrate** — `migrateRosterFile` mirrors `gh teacher roster migrate`: when only the legacy `students.csv` exists, it writes `roster.csv` verbatim and deletes `students.csv` in one tree commit (no-op once `roster.csv` exists). A fire-once effect runs it on the roster page so `roster.csv` always physically exists.

Schema evolution is **additive**: a pre-role 6-column file still parses with `role=""` (Go tolerates the trailing-column-absent header; web/Python readers are header-keyed).

## Notable

- The two mount-time roster writers (auto-migrate + auto-sync) are **sequenced**, not raced: auto-sync waits for the migrate pass to settle per classroom. `withGitConflictRetry` also now retries a `422 "not a fast forward"` (a lost `force:false` ref PATCH), not just `409`, hardening the whole roster mutation family.
- Staff-team reads are best-effort: a non-404 failure on the instructor/ta read degrades to `[]` rather than failing an otherwise-fine student sync.
- Reviewed with `ce-code-review` (Ready with fixes, 0 P0/P1); the surfaced P2 mount-race findings are fixed in this branch. Two P3 advisories remain as documented residual risks (a stale pre-deploy tab dropping `role` on write; an inert email-join comment) — both bounded by the best-effort role semantics and self-heal on the next sync.

## Test plan

- [x] `cli/shared`: `go test ./...`
- [x] `cli/gh-teacher`: `go build ./... && go test ./...` (7-column round-trip + legacy 6-column tolerance + `role` defang/upsert-preservation; header parity pin)
- [x] Python skeleton: `pytest cli/gh-teacher/skeleton_tests` (416 pass; role-column tolerance + pre-role file + header-mirror pin)
- [x] web: `tsc -b && vitest run` (1161 pass; staff-sync role assignment/refresh, highest-precedence role, staff-read degradation, `migrateRosterFile` branches, 7-column contract) + eslint + prettier
- [ ] CI `golangci-lint` (not run locally)