### PR TITLE
fix(web): fix roster profile edit modal getting stuck and Save not disabling

### DIFF
--- a/web/src/pages/students/EditStudentForm.test.tsx
+++ b/web/src/pages/students/EditStudentForm.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactElement } from "react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}) as unknown,
+}))
+
+const updateStudentWithConflictRetry = vi.fn()
+vi.mock("@/api/mutations/students", () => ({
+  updateStudentWithConflictRetry: (...args: unknown[]) =>
+    updateStudentWithConflictRetry(...args),
+}))
+
+import EditStudentForm from "./EditStudentForm"
+import type { Student } from "@/types/classroom"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const student: Student = {
+  username: "octocat",
+  first_name: "Mona",
+  last_name: "Cat",
+  email: "mona@example.com",
+  section: "A",
+  github_id: "42",
+  role: "student",
+}
+
+const renderForm = (ui: ReactElement) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>{ui}</QueryClientProvider>,
+  )
+
+// #: a successful save unmounts the form (parent leaves edit mode) while
+// react-form's isSubmitting is still true for that render, so the parent never
+// received the trailing false. The unmount cleanup must push false so the
+// parent's mirrored `submitting` (folded into the modal's `busy` guard) can't
+// stay stuck true and wedge the modal shut.
+describe("EditStudentForm submitting propagation", () => {
+  it("reports submitting false on unmount after a successful save", async () => {
+    updateStudentWithConflictRetry.mockResolvedValue({
+      student: { ...student, first_name: "Renamed" },
+    })
+    const user = userEvent.setup()
+    const onSubmittingChange = vi.fn<(submitting: boolean) => void>()
+    // Mirror the parent: unmount the form when the save reports success.
+    const onSaved = vi.fn(() => unmount())
+
+    const { unmount } = renderForm(
+      <EditStudentForm
+        org="acme"
+        classroom="cs50"
+        student={student}
+        onCancel={() => {}}
+        onSaved={onSaved}
+        onSubmittingChange={onSubmittingChange}
+      />,
+    )
+
+    await user.click(screen.getByText("students.saveChanges"))
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1))
+    // Whatever the intermediate transitions, the LAST signal the parent hears
+    // is false — the modal's busy latch clears.
+    await waitFor(() =>
+      expect(onSubmittingChange.mock.calls.at(-1)?.[0]).toBe(false),
+    )
+  })
+
+  it("reports submitting false on a plain unmount (cancel / row switch)", () => {
+    const onSubmittingChange = vi.fn<(submitting: boolean) => void>()
+    const { unmount } = renderForm(
+      <EditStudentForm
+        org="acme"
+        classroom="cs50"
+        student={student}
+        onCancel={() => {}}
+        onSaved={() => {}}
+        onSubmittingChange={onSubmittingChange}
+      />,
+    )
+    onSubmittingChange.mockClear()
+    unmount()
+    expect(onSubmittingChange).toHaveBeenLastCalledWith(false)
+  })
+})
+
+// The Save button must be disabled for the WHOLE in-flight write, not just flip
+// at the end. Clicking submit should synchronously (within the submit tick)
+// mark the form submitting and disable the button until the mutation settles.
+describe("EditStudentForm in-flight Save button", () => {
+  it("disables Save while the write is in flight", async () => {
+    let resolveWrite: (v: unknown) => void = () => {}
+    updateStudentWithConflictRetry.mockImplementation(
+      () => new Promise((resolve) => (resolveWrite = resolve)),
+    )
+    const user = userEvent.setup()
+    const onSubmittingChange = vi.fn<(submitting: boolean) => void>()
+
+    renderForm(
+      <EditStudentForm
+        org="acme"
+        classroom="cs50"
+        student={student}
+        onCancel={() => {}}
+        onSaved={() => {}}
+        onSubmittingChange={onSubmittingChange}
+      />,
+    )
+
+    const button = screen
+      .getByRole("button", { name: /saveChanges|saving/ })
+      .closest("button") as HTMLButtonElement
+
+    expect(button.disabled).toBe(false)
+    await user.click(button)
+
+    // In flight: the mutation promise is unsettled, the button is disabled.
+    await waitFor(() => expect(button.disabled).toBe(true))
+    expect(onSubmittingChange.mock.calls.at(-1)?.[0]).toBe(true)
+
+    // Settle so the test doesn't leak a pending promise.
+    resolveWrite({ student })
+    await waitFor(() =>
+      expect(onSubmittingChange.mock.calls.at(-1)?.[0]).toBe(false),
+    )
+  })
+
+  // The real bug: the roster modal recreates the `student` object every render
+  // (rowToStudent(row)) and passes a stable `resetSignal`. A parent re-render
+  // mid-submit (e.g. from the submitting flag flowing up) must NOT re-run the
+  // form-reset effect — form.reset() clears isSubmitting, re-enabling Save while
+  // the write is still running. Keying the reset on `resetSignal` alone fixes
+  // it; this pins that a fresh `student` identity mid-flight keeps Save disabled.
+  it("keeps Save disabled when the parent recreates `student` mid-flight", async () => {
+    let resolveWrite: (v: unknown) => void = () => {}
+    updateStudentWithConflictRetry.mockImplementation(
+      () => new Promise((resolve) => (resolveWrite = resolve)),
+    )
+    const user = userEvent.setup()
+
+    // A stable resetSignal across the re-render, mirroring the modal (same
+    // row.key + open + editingProfile) while `student` gets a new identity.
+    const props = {
+      org: "acme",
+      classroom: "cs50",
+      resetSignal: "octocat:true:true",
+      onCancel: () => {},
+      onSaved: () => {},
+    }
+    const client = new QueryClient()
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <EditStudentForm {...props} student={{ ...student }} />
+      </QueryClientProvider>,
+    )
+
+    const button = screen
+      .getByRole("button", { name: /saveChanges|saving/ })
+      .closest("button") as HTMLButtonElement
+
+    await user.click(button)
+    await waitFor(() => expect(button.disabled).toBe(true))
+
+    // Parent re-renders with a brand-new `student` object (same values) — as the
+    // modal does on every render. The button must stay disabled.
+    rerender(
+      <QueryClientProvider client={client}>
+        <EditStudentForm {...props} student={{ ...student }} />
+      </QueryClientProvider>,
+    )
+    expect(button.disabled).toBe(true)
+
+    resolveWrite({ student })
+    await waitFor(() => expect(button.disabled).toBe(false))
+  })
+})

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -111,18 +111,27 @@ const EditStudentForm = ({
     },
   })
 
-  // Reset to the student's CURRENT values whenever the parent signals (open) or
-  // the target student changes; a parent keeping the form mounted across rows
-  // would otherwise show mount-time values that go stale after a save.
+  // Reset to the student's CURRENT values only when the parent deliberately
+  // signals it (open, or a switch to a different row/edit session). `defaults`
+  // is intentionally NOT a dependency: parents recreate the `student` object
+  // every render (e.g. the roster modal's `rowToStudent(row)`), so keying on it
+  // would re-run mid-submit — `form.reset` clears `isSubmitting`, so the Save
+  // button would flicker back to enabled while the write is in flight.
   useEffect(() => {
     setError(null)
     form.reset(defaults())
-  }, [resetSignal, form, defaults])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetSignal])
 
   const submitting = form.state.isSubmitting
 
+  // On a successful save the parent unmounts this form (leaves edit mode) while
+  // `submitting` is still true for that render, so the parent never sees the
+  // trailing false — leaving its mirrored flag stuck true and the modal
+  // non-closeable. Reset it on unmount so `busy` always clears.
   useEffect(() => {
     onSubmittingChange?.(submitting)
+    return () => onSubmittingChange?.(false)
   }, [submitting, onSubmittingChange])
 
   return (

--- a/web/src/pages/students/EnrolledStudents.section.test.ts
+++ b/web/src/pages/students/EnrolledStudents.section.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { groupStudentsBySection } from "./EnrolledStudents"
+import {
+  groupStudentsBySection,
+  nextSelectedKeyAfterSave,
+} from "./EnrolledStudents"
 import type { Student } from "@/types/classroom"
 
 const student = (username: string, section?: string): Student =>
@@ -36,5 +39,31 @@ describe("groupStudentsBySection", () => {
 
   it("returns an empty array for no students", () => {
     expect(groupStudentsBySection([])).toEqual([])
+  })
+})
+
+describe("nextSelectedKeyAfterSave", () => {
+  it("keeps the selection when the key is unchanged (common case)", () => {
+    expect(nextSelectedKeyAfterSave("42", "42", "42")).toBe("42")
+  })
+
+  it("follows the saved row's selection to its new key so the modal stays open", () => {
+    // An email-keyed row whose email was edited: the modal must track the new
+    // key instead of snapping shut on a now-missing old key.
+    expect(nextSelectedKeyAfterSave("old@x.io", "old@x.io", "new@x.io")).toBe(
+      "new@x.io",
+    )
+  })
+
+  it("leaves an unrelated selection alone when a different row moves keys", () => {
+    expect(nextSelectedKeyAfterSave("42", "old@x.io", "new@x.io")).toBe("42")
+  })
+
+  it("does nothing when nothing is selected", () => {
+    expect(nextSelectedKeyAfterSave(null, "old@x.io", "new@x.io")).toBeNull()
+  })
+
+  it("ignores an empty new key (never selects nothing by accident)", () => {
+    expect(nextSelectedKeyAfterSave("42", "42", "")).toBe("42")
   })
 })

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -97,6 +97,21 @@ export function groupStudentsBySection<T extends { section?: string }>(
     .map(([section, group]) => ({ section, students: group }))
 }
 
+// After a metadata save, where should the open detail modal's selection point?
+// An edit can't change an editable row's identity (rows key on
+// github_id/username; the form edits only name/email/section), so this is
+// normally a no-op — but if the key ever moves, follow it so the modal stays on
+// the same person instead of snapping shut. Only re-points the row that was
+// saved; any other selection is left alone.
+export function nextSelectedKeyAfterSave(
+  prev: string | null,
+  savedRowKey: string,
+  nextRowKey: string,
+): string | null {
+  if (!nextRowKey || nextRowKey === savedRowKey) return prev
+  return prev === savedRowKey ? nextRowKey : prev
+}
+
 const EnrolledStudents = ({
   students = [],
   parseProblems = [],
@@ -443,6 +458,9 @@ const EnrolledStudents = ({
       const exists = current.some((s) => studentKey(s) === rowKey)
       return exists ? next : [...next, toStudent(updated)]
     })
+    // Follow the row's key if a save ever moved it, so the open modal stays put.
+    const nextKey = studentKey(updated)
+    setSelectedKey((prev) => nextSelectedKeyAfterSave(prev, rowKey, nextKey))
     invalidateInviteQueries()
   }
 


### PR DESCRIPTION
## Summary

Fixes two teacher-facing bugs in the classroom roster detail modal's profile edit flow:

- **Save button not disabled during the write.** The modal recomputes `rowToStudent(row)` on every render, giving `EditStudentForm`'s `student` prop a new identity each time. That made the form-reset effect (keyed on `defaults`, which tracks `student`) re-run on every render — including mid-submit, when the submitting flag flows up and re-renders the modal. `form.reset()` clears `isSubmitting`, so Save flickered back to enabled while the write was still in flight. The effect now keys on `resetSignal` only, its intended single deliberate trigger.
- **Modal couldn't be dismissed after a save.** On success the parent unmounts the form while `isSubmitting` is still true, so the parent's mirrored `submitting` flag never received the trailing `false` — leaving `busy` stuck true and the close X / backdrop / Escape all inert (a page refresh was the only way out). The submitting effect now resets the flag on unmount.
- **Hardening:** `onRowMetadataSaved` now follows a row's key if a save ever moves it, so the open modal can't snap shut on a now-missing key (a defensive guard extracted as the pure `nextSelectedKeyAfterSave`).

A side benefit of keying the reset on `resetSignal`: a background roster refetch can no longer clobber a teacher's in-progress edits.

## Test plan

- [x] New `EditStudentForm.test.tsx`: Save stays disabled while the write is in flight, **stays disabled when the parent recreates `student` mid-flight** (reproduces the reported bug — verified red before the fix), and reports `submitting=false` on unmount (save + plain unmount).
- [x] New `nextSelectedKeyAfterSave` cases in `EnrolledStudents.section.test.ts`.
- [x] `tsc -b` clean, `prettier --check` clean, `eslint` 0 errors.
- [x] Full suite green: 106 files / 1226 tests.