### PR TITLE
refactor(web): classroom-scoped resolve-once role boundary

### DIFF
--- a/web/src/components/RequireTeacher.tsx
+++ b/web/src/components/RequireTeacher.tsx
@@ -1,24 +1,32 @@
 import { type ReactNode } from "react"
 import { useParams } from "@tanstack/react-router"
 import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
-import { useClassroomRole, isInstructorRole } from "@/hooks/useClassroomRole"
+import {
+  useClassroomRole,
+  isInstructorRole,
+  isStaffRole,
+} from "@/hooks/useClassroomRole"
 import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useOptionalClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import NotFound from "@/components/NotFound"
 import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 
 // What a guarded surface requires:
 // - "staff": any classroom staff (owner/instructor/ta) — for classroom CONTENT
-//   (roster, authoring, submissions). Backed by config-repo access.
+//   (roster, authoring, submissions).
 // - "instructor": owner OR instructor of THIS classroom (excludes TAs) — for
-//   classroom SETTINGS. Needs a `$classroom` route param.
+//   classroom SETTINGS.
 // - "owner": org admin only — for ORG-wide settings/setup, where TA and
 //   instructor can't be distinguished without a classroom context.
 export type RequireRole = "staff" | "instructor" | "owner"
 
-// Gate page content by role. While the role resolves we show a spinner (never
-// flash a 404 at a real teacher), then children or NotFound. Access is
-// GitHub-enforced underneath; this UX guard 404s rather than 403s by design.
-// Default `allow: "staff"` preserves the original behavior.
+// Gate page content by role. Classroom-scoped surfaces sit under the
+// $org/$classroom boundary, which has already resolved the role and blocked
+// non-members — so this guard just applies the `allow` filter over the resolved
+// context, no spinner or blocked-handling of its own. Org-level surfaces (no
+// classroom in scope) have no boundary, so they fall back to the coarse
+// config-repo verdict. Access is GitHub-enforced underneath; this UX guard 404s
+// rather than 403s by design. Default `allow: "staff"`.
 const RequireTeacher = ({
   children,
   allow = "staff",
@@ -26,42 +34,50 @@ const RequireTeacher = ({
   children: ReactNode
   allow?: RequireRole
 }) => {
-  if (allow === "staff") return <RequireStaff>{children}</RequireStaff>
-  return <RequireElevated allow={allow}>{children}</RequireElevated>
+  const resolved = useOptionalClassroomRoleContext()
+
+  // Under the classroom boundary: the role is resolved and non-blocked. Apply
+  // the allow filter directly.
+  if (resolved) {
+    const permitted =
+      allow === "owner"
+        ? resolved.role === "owner"
+        : allow === "instructor"
+          ? isInstructorRole(resolved.role)
+          : isStaffRole(resolved.role)
+    return permitted ? <>{children}</> : <NotFound />
+  }
+
+  // Org-level (no classroom boundary): coarse config-repo verdict.
+  return <RequireOrgTeacher allow={allow}>{children}</RequireOrgTeacher>
 }
 
-// Staff gate: any config-repo access (owner/instructor/ta). Used for classroom
-// content TAs may see.
-const RequireStaff = ({ children }: { children: ReactNode }) => {
-  const { org } = useParams({ strict: false })
-  const { showTeacherUi, roleResolved } = useCourseTeacherAccess(org)
-
-  if (!roleResolved) return <RoleResolvingFallback />
-  if (!showTeacherUi) return <NotFound />
-  return <>{children}</>
-}
-
-// Elevated gate: "instructor" (owner OR instructor of this classroom) or
-// "owner" (org admin). Resolves the full classroom role; TAs are excluded.
-const RequireElevated = ({
+// Org-level fallback for surfaces rendered outside a classroom boundary (org
+// settings/members/activity, create-classroom). `staff` uses the coarse
+// config-repo verdict (any teacher); `owner`/`instructor` resolve the org-scoped
+// role (no classroom => owner-vs-student) so owner-only org surfaces still
+// require an org admin — preserving the prior RequireElevated behavior.
+const RequireOrgTeacher = ({
   children,
   allow,
 }: {
   children: ReactNode
-  allow: "instructor" | "owner"
+  allow: RequireRole
 }) => {
   const { org, classroom } = useParams({ strict: false })
   const { user } = useGithubAuth()
+  const coarse = useCourseTeacherAccess(org)
   const { role, isLoading } = useClassroomRole(org, classroom, user?.login)
 
-  // `unresolved` means a signal is still in flight or hit a transient error —
-  // hold the spinner rather than flash NotFound at a real instructor/owner.
-  if (isLoading || role === "unresolved") return <RoleResolvingFallback />
+  if (allow === "staff") {
+    if (!coarse.roleResolved) return <RoleResolvingFallback />
+    if (!coarse.showTeacherUi) return <NotFound />
+    return <>{children}</>
+  }
 
-  // "instructor" allows owner OR instructor; "owner" is owner-only.
+  if (isLoading || role === "unresolved") return <RoleResolvingFallback />
   const permitted =
     allow === "owner" ? role === "owner" : isInstructorRole(role)
-
   if (!permitted) return <NotFound />
   return <>{children}</>
 }

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -38,6 +38,7 @@ import {
   isStaffRole,
   type ViewAsRole,
 } from "@/hooks/useClassroomRole"
+import { useOptionalClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { useRoleView } from "@/context/roleView/RoleViewProvider"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetOrgMembership from "@/hooks/useGetOrgMembership"
@@ -372,7 +373,15 @@ const AssignmentSidebarMenu = ({
     org,
     studentRepoNameForSecret,
   )
-  const { actualRole } = useClassroomRole(org, classroom, user?.login)
+  const { actualRole: hookActualRole } = useClassroomRole(
+    org,
+    classroom,
+    user?.login,
+  )
+  // Prefer the boundary-resolved role when under a classroom (this menu only
+  // renders on classroom routes, but the hook stays as a defensive fallback).
+  const ctxRole = useOptionalClassroomRoleContext()
+  const actualRole = ctxRole?.actualRole ?? hookActualRole
   const isActuallyStaff = isStaffRole(actualRole) && actualRole !== "unresolved"
   const { data: classroomMeta } = useGetClassroom(org, classroom, {
     enabled: isActuallyStaff,
@@ -550,7 +559,9 @@ export const TeacherSidebarMenu = ({
   // instructor-only; gating on this makes "View as student/TA" faithfully hide
   // what a real student/TA wouldn't see. `unresolved` is permissive (no flash).
   const { user } = useGithubAuth()
-  const { role: classroomRole } = useClassroomRole(org, classroom, user?.login)
+  const { role: hookRole } = useClassroomRole(org, classroom, user?.login)
+  const ctxRole = useOptionalClassroomRoleContext()
+  const classroomRole = ctxRole?.role ?? hookRole
   const showStaffItems = showTeacherUi && isStaffRole(classroomRole)
   const canEditSettings =
     classroomRole === "owner" || classroomRole === "instructor"
@@ -625,12 +636,19 @@ export const SidebarFooter = () => {
   // often undefined (the snapshot then reports "unknown" with a reason).
   const { data: orgPlanDetails } = useGetOrgPlanDetails(org)
   // Precise classroom role (Instructor vs TA); respects the "view as" preview.
-  // `actualRole` is the real (preview-independent) role.
+  // `actualRole` is the real (preview-independent) role. On a classroom route
+  // the boundary already resolved this, so prefer the context; the hook remains
+  // the org-route fallback (and covers a classroom route not yet wrapped).
   const {
-    role: classroomRole,
-    actualRole: actualClassroomRole,
-    isLoading: classroomRoleLoading,
+    role: hookClassroomRole,
+    actualRole: hookActualClassroomRole,
+    isLoading: hookClassroomRoleLoading,
   } = useClassroomRole(org, classroom, user?.login)
+  const ctxRole = useOptionalClassroomRoleContext()
+  const classroomRole = ctxRole?.role ?? hookClassroomRole
+  const actualClassroomRole = ctxRole?.actualRole ?? hookActualClassroomRole
+  // A resolved context role is never loading.
+  const classroomRoleLoading = ctxRole ? false : hookClassroomRoleLoading
   const { viewAs, setViewAs } = useRoleView()
   // Offer "View as" only to a real owner/instructor in a classroom (the roles
   // with something lower to preview).

--- a/web/src/context/classroomRole/ClassroomRoleProvider.test.tsx
+++ b/web/src/context/classroomRole/ClassroomRoleProvider.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest"
+import { render, renderHook, screen, cleanup } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+import {
+  ClassroomRoleProvider,
+  useClassroomRoleContext,
+  useOptionalClassroomRoleContext,
+} from "./ClassroomRoleProvider"
+
+afterEach(cleanup)
+
+const wrapper =
+  (role: "owner" | "instructor" | "ta" | "student", actualRole = role) =>
+  ({ children }: { children: ReactNode }) => (
+    <ClassroomRoleProvider value={{ role, actualRole }}>
+      {children}
+    </ClassroomRoleProvider>
+  )
+
+describe("ClassroomRoleProvider", () => {
+  it("provides the resolved role + actualRole to the throwing accessor", () => {
+    const { result } = renderHook(() => useClassroomRoleContext(), {
+      wrapper: wrapper("ta", "owner"),
+    })
+    expect(result.current.role).toBe("ta")
+    expect(result.current.actualRole).toBe("owner")
+  })
+
+  it("throwing accessor throws outside the provider", () => {
+    // Suppress the expected error render noise.
+    const spy = () => renderHook(() => useClassroomRoleContext())
+    expect(spy).toThrow(/must be used under the \$org\/\$classroom boundary/)
+  })
+
+  it("non-throwing accessor returns the value inside the provider", () => {
+    const { result } = renderHook(() => useOptionalClassroomRoleContext(), {
+      wrapper: wrapper("student"),
+    })
+    expect(result.current?.role).toBe("student")
+  })
+
+  it("non-throwing accessor returns null outside the provider", () => {
+    const { result } = renderHook(() => useOptionalClassroomRoleContext())
+    expect(result.current).toBeNull()
+  })
+
+  it("renders children", () => {
+    render(
+      <ClassroomRoleProvider value={{ role: "owner", actualRole: "owner" }}>
+        <span>child</span>
+      </ClassroomRoleProvider>,
+    )
+    expect(screen.getByText("child")).toBeTruthy()
+  })
+})

--- a/web/src/context/classroomRole/ClassroomRoleProvider.tsx
+++ b/web/src/context/classroomRole/ClassroomRoleProvider.tsx
@@ -24,10 +24,7 @@ export function ClassroomRoleProvider({
   value: ResolvedClassroomRole
   children: ReactNode
 }) {
-  const memoized = useMemo(
-    () => value,
-    [value.role, value.actualRole],
-  )
+  const memoized = useMemo(() => value, [value.role, value.actualRole])
   return (
     <ClassroomRoleContext.Provider value={memoized}>
       {children}

--- a/web/src/context/classroomRole/ClassroomRoleProvider.tsx
+++ b/web/src/context/classroomRole/ClassroomRoleProvider.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react"
+
+import type { EffectiveRole } from "@/hooks/useClassroomRole"
+
+// The viewer's resolved classroom role, provided once by the classroom layout
+// boundary (routes/_authed/$org/$classroom/route.tsx). By the time this value
+// exists the boundary has already gated on resolution and blocked non-members,
+// so `role`/`actualRole` are never "unresolved" or "blocked" — descendants get
+// a settled role and need no per-page resolution-window handling.
+//
+// `role` is the effective (view-as-applied) role; `actualRole` is the real one
+// (for the drawer's "View as" preview gate).
+export type ResolvedClassroomRole = {
+  role: Exclude<EffectiveRole, "unresolved" | "blocked">
+  actualRole: Exclude<EffectiveRole, "unresolved" | "blocked">
+}
+
+const ClassroomRoleContext = createContext<ResolvedClassroomRole | null>(null)
+
+export function ClassroomRoleProvider({
+  value,
+  children,
+}: {
+  value: ResolvedClassroomRole
+  children: ReactNode
+}) {
+  const memoized = useMemo(
+    () => value,
+    [value.role, value.actualRole],
+  )
+  return (
+    <ClassroomRoleContext.Provider value={memoized}>
+      {children}
+    </ClassroomRoleContext.Provider>
+  )
+}
+
+// Read the resolved role. Throws outside the boundary — a page under
+// $org/$classroom always has one, so a missing provider is a wiring bug.
+export function useClassroomRoleContext(): ResolvedClassroomRole {
+  const value = useContext(ClassroomRoleContext)
+  if (!value) {
+    throw new Error(
+      "useClassroomRoleContext must be used under the $org/$classroom boundary",
+    )
+  }
+  return value
+}
+
+// Non-throwing read for components that straddle org and classroom scope (the
+// drawer). Returns null outside a classroom boundary, so the caller can fall
+// back to its org-level behavior instead of crashing.
+export function useOptionalClassroomRoleContext(): ResolvedClassroomRole | null {
+  return useContext(ClassroomRoleContext)
+}

--- a/web/src/hooks/useClassroomRole.test.ts
+++ b/web/src/hooks/useClassroomRole.test.ts
@@ -13,22 +13,21 @@ const base: ClassroomRoleInput = {
   org: "acme",
   classroom: "cs101",
   isOwner: false,
-  staffRoleResolved: true,
-  isStaff: true,
   instructor: "non-member",
   ta: "non-member",
+  student: "member",
 }
 
 describe("resolveClassroomRole", () => {
-  it("owner outranks everything and needs no staff/team read", () => {
+  it("owner outranks everything and needs no team read", () => {
     expect(
       resolveClassroomRole({
         ...base,
         isOwner: true,
-        // even with unresolved staff/team signals, owner short-circuits
-        staffRoleResolved: false,
+        // even with unresolved team signals, owner short-circuits
         instructor: "unresolved",
         ta: "unresolved",
+        student: "unresolved",
       }),
     ).toBe("owner")
   })
@@ -49,32 +48,24 @@ describe("resolveClassroomRole", () => {
     expect(resolveClassroomRole({ ...base, ta: "member" })).toBe("ta")
   })
 
-  it("student when staff (repo access) but in neither staff team", () => {
+  it("student when on the student team and neither staff team", () => {
     expect(resolveClassroomRole(base)).toBe("student")
   })
 
-  it("student when not staff (no config-repo access), ignoring stale team signal", () => {
-    expect(
-      resolveClassroomRole({
-        ...base,
-        isStaff: false,
-        instructor: "member",
-      }),
-    ).toBe("student")
+  it("blocked when on none of the classroom's teams (not owner)", () => {
+    expect(resolveClassroomRole({ ...base, student: "non-member" })).toBe(
+      "blocked",
+    )
+  })
+
+  it("config-repo access is no longer an input — student-team membership decides", () => {
+    // A former "staff repo access but no team" case now hinges on team
+    // membership alone: student team => student.
+    expect(resolveClassroomRole({ ...base, student: "member" })).toBe("student")
   })
 
   describe("fail-closed (unresolved) on transient signals we depend on", () => {
-    it("unresolved when the staff (repo) verdict isn't resolved and not an owner", () => {
-      expect(
-        resolveClassroomRole({
-          ...base,
-          isOwner: undefined,
-          staffRoleResolved: false,
-        }),
-      ).toBe("unresolved")
-    })
-
-    it("unresolved when staff but a team read is in flight", () => {
+    it("unresolved when a staff team read is in flight (might be staff)", () => {
       expect(resolveClassroomRole({ ...base, instructor: "unresolved" })).toBe(
         "unresolved",
       )
@@ -83,23 +74,41 @@ describe("resolveClassroomRole", () => {
       )
     })
 
-    it("does NOT go unresolved on a team read when a higher role already matched", () => {
-      // instructor member resolves before the ta-unresolved is considered
+    it("does NOT trust a student match while a staff signal is still in flight", () => {
+      // student member but instructor unresolved => hold, don't render student
+      expect(
+        resolveClassroomRole({
+          ...base,
+          instructor: "unresolved",
+          student: "member",
+        }),
+      ).toBe("unresolved")
+    })
+
+    it("does NOT go unresolved when a higher role already matched", () => {
       expect(
         resolveClassroomRole({
           ...base,
           instructor: "member",
           ta: "unresolved",
+          student: "unresolved",
         }),
       ).toBe("instructor")
     })
 
-    it("holds unresolved on a CLASSROOM route while ownership is still loading (don't flash a real owner as student)", () => {
-      // isOwner undefined + no team match => hold rather than demote.
+    it("unresolved when the student read is in flight (staff definitively out)", () => {
+      expect(resolveClassroomRole({ ...base, student: "unresolved" })).toBe(
+        "unresolved",
+      )
+    })
+
+    it("holds unresolved on a classroom route while ownership is still loading", () => {
+      // isOwner undefined + no staff match yet => hold rather than decide.
       expect(
         resolveClassroomRole({
           ...base,
           isOwner: undefined,
+          student: "non-member",
         }),
       ).toBe("unresolved")
     })
@@ -113,17 +122,19 @@ describe("resolveClassroomRole", () => {
         }),
       ).toBe("instructor")
       expect(
-        resolveClassroomRole({
-          ...base,
-          isOwner: undefined,
-          ta: "member",
-        }),
+        resolveClassroomRole({ ...base, isOwner: undefined, ta: "member" }),
       ).toBe("ta")
     })
 
-    it("demotes to student on a classroom route only once ownership is known (isOwner false)", () => {
-      // staff (repo access) but in neither team AND a definitive non-owner.
+    it("resolves student/blocked only once ownership is known (isOwner false)", () => {
       expect(resolveClassroomRole({ ...base, isOwner: false })).toBe("student")
+      expect(
+        resolveClassroomRole({
+          ...base,
+          isOwner: false,
+          student: "non-member",
+        }),
+      ).toBe("blocked")
     })
   })
 
@@ -162,23 +173,25 @@ describe("resolveClassroomRole", () => {
 })
 
 describe("role predicates", () => {
-  it("isStaffRole: owner/instructor/ta/unresolved true; student false", () => {
+  it("isStaffRole: owner/instructor/ta/unresolved true; student/blocked false", () => {
     expect(isStaffRole("owner")).toBe(true)
     expect(isStaffRole("instructor")).toBe(true)
     expect(isStaffRole("ta")).toBe(true)
     expect(isStaffRole("unresolved")).toBe(true) // permissive: let page load
     expect(isStaffRole("student")).toBe(false)
+    expect(isStaffRole("blocked")).toBe(false)
   })
 
-  it("isInstructorRole: owner/instructor/unresolved true; ta/student false", () => {
+  it("isInstructorRole: owner/instructor/unresolved true; ta/student/blocked false", () => {
     expect(isInstructorRole("owner")).toBe(true)
     expect(isInstructorRole("instructor")).toBe(true)
     expect(isInstructorRole("unresolved")).toBe(true)
     expect(isInstructorRole("ta")).toBe(false)
     expect(isInstructorRole("student")).toBe(false)
+    expect(isInstructorRole("blocked")).toBe(false)
   })
 
-  it("isResolvedInstructorOrOwner: owner/instructor true; unresolved/ta/student false", () => {
+  it("isResolvedInstructorOrOwner: owner/instructor true; unresolved/ta/student/blocked false", () => {
     expect(isResolvedInstructorOrOwner("owner")).toBe(true)
     expect(isResolvedInstructorOrOwner("instructor")).toBe(true)
     // The distinction from isInstructorRole: unresolved is NOT permissive here,
@@ -186,14 +199,16 @@ describe("role predicates", () => {
     expect(isResolvedInstructorOrOwner("unresolved")).toBe(false)
     expect(isResolvedInstructorOrOwner("ta")).toBe(false)
     expect(isResolvedInstructorOrOwner("student")).toBe(false)
+    expect(isResolvedInstructorOrOwner("blocked")).toBe(false)
   })
 
-  it("roleLabelKey: owner+instructor => nav.roleInstructor, ta => nav.roleTa, student => nav.roleStudent, unresolved => null", () => {
+  it("roleLabelKey: owner+instructor => nav.roleInstructor, ta => nav.roleTa, student => nav.roleStudent, unresolved/blocked => null", () => {
     expect(roleLabelKey("owner")).toBe("nav.roleInstructor")
     expect(roleLabelKey("instructor")).toBe("nav.roleInstructor")
     expect(roleLabelKey("ta")).toBe("nav.roleTa")
     expect(roleLabelKey("student")).toBe("nav.roleStudent")
     expect(roleLabelKey("unresolved")).toBeNull()
+    expect(roleLabelKey("blocked")).toBeNull()
   })
 })
 
@@ -225,6 +240,11 @@ describe("applyViewAs (#221 downgrade-only preview)", () => {
 
   it("does not clamp an unresolved role (guard still resolving)", () => {
     expect(applyViewAs("unresolved", "student")).toBe("unresolved")
+  })
+
+  it("does not clamp a blocked role (no classroom to preview)", () => {
+    expect(applyViewAs("blocked", "student")).toBe("blocked")
+    expect(applyViewAs("blocked", "ta")).toBe("blocked")
   })
 
   it("a preview equal to or above the actual role is a no-op", () => {

--- a/web/src/hooks/useClassroomRole.ts
+++ b/web/src/hooks/useClassroomRole.ts
@@ -113,13 +113,15 @@ export type ViewAsRole = "ta" | "student"
 // intentionally absent — we never clamp an in-flight role (still showing a
 // spinner) nor a blocked one (the classroom is hidden; there's nothing to
 // preview).
-const ROLE_RANK: Record<Exclude<EffectiveRole, "unresolved" | "blocked">, number> =
-  {
-    owner: 3,
-    instructor: 2,
-    ta: 1,
-    student: 0,
-  }
+const ROLE_RANK: Record<
+  Exclude<EffectiveRole, "unresolved" | "blocked">,
+  number
+> = {
+  owner: 3,
+  instructor: 2,
+  ta: 1,
+  student: 0,
+}
 
 // Apply a "view as" preview to an actual role. DOWNGRADE-ONLY: the preview can
 // only lower the effective role, never raise it, so it can't be abused to gain
@@ -234,7 +236,8 @@ export function useClassroomRole(
   // authoritative slug lives in the private classroom.json they can't read).
   // Classroom creation rejects names that GitHub would re-slugify, so the
   // heuristic is authoritative; a miss safe-degrades to a 404 => non-member.
-  const studentSlug = org && classroom ? classroomTeamSlugHeuristic(classroom) : ""
+  const studentSlug =
+    org && classroom ? classroomTeamSlugHeuristic(classroom) : ""
 
   const instructorQuery = useQuery({
     ...teamMembershipQuery(

--- a/web/src/hooks/useClassroomRole.ts
+++ b/web/src/hooks/useClassroomRole.ts
@@ -1,10 +1,9 @@
 import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { orgMembershipQuery } from "./github/queries"
-import { useGitHubRepo } from "./github/hooks"
 import { GitHubAPIError, retryTransientGitHubError } from "./github/errors"
-import { resolveTeacherVerdict } from "./useCourseTeacherAccess"
 import { staffTeamName } from "./github/mutations"
+import { classroomTeamSlugHeuristic } from "@/util/orgMembership"
 import { useRoleView } from "@/context/roleView/RoleViewProvider"
 import type { GitHubClient } from "./github/client"
 import type { StaffRole } from "@/types/classroom"
@@ -16,74 +15,72 @@ import type { StaffRole } from "@/types/classroom"
 // so callers treat it as "don't redirect; let the page load" rather than
 // demoting a real staff member on a blip.
 export type EffectiveRole =
-  "owner" | "instructor" | "ta" | "student" | "unresolved"
+  "owner" | "instructor" | "ta" | "student" | "blocked" | "unresolved"
 
 // A tri-state membership signal: definitively in / definitively out / couldn't
 // tell (transient). Mirrors the fail-closed posture of resolveTeacherVerdict.
 export type Membership = "member" | "non-member" | "unresolved"
 
 // Structural inputs so the verdict is a pure, unit-testable function (no React
-// Query). Each signal is pre-reduced to its tri-state.
+// Query). Each signal is pre-reduced to its tri-state. Classroom role is decided
+// by TEAM MEMBERSHIP alone — org-wide config-repo access no longer decides it.
 export type ClassroomRoleInput = {
   org: string | undefined
   classroom: string | undefined
   // org admin? (true => owner). undefined when not yet known.
   isOwner: boolean | undefined
-  // Can the viewer read the classroom50 config repo at all? (staff gate)
-  staffRoleResolved: boolean
-  isStaff: boolean
-  // Team memberships.
+  // Per-classroom team memberships (the single source of truth for access).
   instructor: Membership
   ta: Membership
+  student: Membership
 }
 
-// Pure role resolution. Owner short-circuits (org admin outranks everything).
-// Otherwise the viewer must be staff (config-repo access) AND in a staff team
-// to be instructor/ta; a definitive "not staff" makes them a student. Anything
-// still in flight yields `unresolved`.
+// Pure role resolution from GitHub team membership. Owner (org admin)
+// short-circuits. Otherwise a positive staff-team match wins; before trusting a
+// student match or declaring `blocked`, the higher-priority staff signals must
+// be settled (a student-team member who might also be staff must not render as a
+// plain student while instructor/ta are still in flight). A non-owner on none of
+// the classroom's teams is `blocked` — team membership, not config-repo access,
+// grants classroom access. Anything still in flight yields `unresolved`.
 export function resolveClassroomRole(input: ClassroomRoleInput): EffectiveRole {
-  const { org, classroom, isOwner, staffRoleResolved, isStaff } = input
+  const { org, classroom, isOwner, instructor, ta, student } = input
 
   if (!org) return "student"
 
   // Owner (org admin) outranks all and isn't classroom-scoped: resolve before
   // the classroom check so an owner on an org-level route isn't misclassified.
-  // While in flight (undefined) fall through.
   if (isOwner === true) return "owner"
 
-  // Refine the CLASSROOM role (instructor/ta), which needs a classroom. A
-  // non-owner on an org-level route has no finer role; hold `unresolved` while
-  // ownership is still resolving so we don't flash NotFound.
+  // Non-owner roles need a classroom. On an org-level route, hold `unresolved`
+  // while ownership resolves so we don't flash a wrong verdict.
   if (!classroom) return isOwner === undefined ? "unresolved" : "student"
 
-  // Need the staff (config-repo) verdict before deciding non-owner roles.
-  if (!staffRoleResolved) return "unresolved"
+  // A confirmed staff-team membership is definitive and outranks the (slower)
+  // owner read, so resolve a confirmed instructor/ta immediately.
+  if (instructor === "member") return "instructor"
+  if (ta === "member") return "ta"
 
-  // Staff team membership is definitive and outranks the (slower) owner read, so
-  // resolve a confirmed instructor/ta before waiting on ownership. Only positive
-  // matches are safe while isOwner is unknown — a demotion below must wait.
-  if (isStaff) {
-    if (input.instructor === "member") return "instructor"
-    if (input.ta === "member") return "ta"
-    if (input.instructor === "unresolved" || input.ta === "unresolved") {
-      return "unresolved"
-    }
-  }
+  // Before trusting a student match or declaring blocked, the higher-priority
+  // signals must be settled — a student-team member who might also be staff must
+  // not resolve to `student` (or `blocked`) while instructor/ta are in flight.
+  if (instructor === "unresolved" || ta === "unresolved") return "unresolved"
 
-  // Ownership not yet known: don't demote. An owner needs no staff/team signal,
-  // so hold `unresolved` rather than falling through to `student`.
+  // Ownership not yet known: don't decide a non-owner role yet. An owner needs
+  // no team signal, so hold `unresolved` rather than mis-blocking a pending owner.
   if (isOwner === undefined) return "unresolved"
 
-  // A non-staff non-owner is a student, regardless of any stale team signal.
-  if (!isStaff) return "student"
+  // Staff teams are definitively non-member. Decide from the student team.
+  if (student === "member") return "student"
+  if (student === "unresolved") return "unresolved"
 
-  // Staff (reads the config repo) but in neither staff team — treat as student;
-  // owners are handled above.
-  return "student"
+  // On none of the classroom's teams (and not owner): no access to this
+  // classroom. Config-repo access does not grant classroom access.
+  return "blocked"
 }
 
 // Whether a role may see/do instructor-or-TA classroom content. `unresolved` is
-// permissive on purpose: the guard treats it as "let the page load".
+// permissive on purpose: the guard treats it as "let the page load". `blocked`
+// is never staff (fail-closed: no team in this classroom => no access).
 export function isStaffRole(role: EffectiveRole): boolean {
   return (
     role === "owner" ||
@@ -112,30 +109,34 @@ export function isResolvedInstructorOrOwner(role: EffectiveRole): boolean {
 // verifying what each role sees — never escalates.
 export type ViewAsRole = "ta" | "student"
 
-// Rank for the downgrade-only clamp. `unresolved` is intentionally absent — we
-// never clamp an in-flight role (the guard is still showing a spinner).
-const ROLE_RANK: Record<Exclude<EffectiveRole, "unresolved">, number> = {
-  owner: 3,
-  instructor: 2,
-  ta: 1,
-  student: 0,
-}
+// Rank for the downgrade-only clamp. `unresolved` and `blocked` are
+// intentionally absent — we never clamp an in-flight role (still showing a
+// spinner) nor a blocked one (the classroom is hidden; there's nothing to
+// preview).
+const ROLE_RANK: Record<Exclude<EffectiveRole, "unresolved" | "blocked">, number> =
+  {
+    owner: 3,
+    instructor: 2,
+    ta: 1,
+    student: 0,
+  }
 
 // Apply a "view as" preview to an actual role. DOWNGRADE-ONLY: the preview can
 // only lower the effective role, never raise it, so it can't be abused to gain
-// access. `unresolved`/no-preview pass through unchanged.
+// access. `unresolved`/`blocked`/no-preview pass through unchanged (a blocked
+// viewer has no classroom to preview).
 export function applyViewAs(
   actual: EffectiveRole,
   viewAs: ViewAsRole | null,
 ): EffectiveRole {
-  if (!viewAs || actual === "unresolved") return actual
+  if (!viewAs || actual === "unresolved" || actual === "blocked") return actual
   // Applies only when it ranks strictly below the actual role; else a no-op.
   return ROLE_RANK[viewAs] < ROLE_RANK[actual] ? viewAs : actual
 }
 
 // Translation key for the human role label: owner + instructor =>
 // "nav.roleInstructor", ta => "nav.roleTa", student => "nav.roleStudent",
-// unresolved => null (so callers show a skeleton mid-load). Pass through t().
+// unresolved/blocked => null (mid-load skeleton, or no classroom access). t().
 export function roleLabelKey(role: EffectiveRole): string | null {
   switch (role) {
     case "owner":
@@ -146,6 +147,7 @@ export function roleLabelKey(role: EffectiveRole): string | null {
     case "student":
       return "nav.roleStudent"
     case "unresolved":
+    case "blocked":
       return null
   }
 }
@@ -226,18 +228,13 @@ export function useClassroomRole(
     retry: retryTransientGitHubError,
   })
 
-  const staffRepoQuery = useGitHubRepo(org, "classroom50", {
-    retry: retryTransientGitHubError,
-  })
-  const staff = resolveTeacherVerdict({
-    org,
-    isSuccess: staffRepoQuery.isSuccess,
-    permissions: staffRepoQuery.data?.permissions,
-    error: staffRepoQuery.error,
-  })
-
   const teamRole = (role: StaffRole) =>
     org && classroom ? staffTeamName(classroom, role) : ""
+  // Student team slug: the heuristic the student themselves can derive (the
+  // authoritative slug lives in the private classroom.json they can't read).
+  // Classroom creation rejects names that GitHub would re-slugify, so the
+  // heuristic is authoritative; a miss safe-degrades to a 404 => non-member.
+  const studentSlug = org && classroom ? classroomTeamSlugHeuristic(classroom) : ""
 
   const instructorQuery = useQuery({
     ...teamMembershipQuery(
@@ -250,6 +247,10 @@ export function useClassroomRole(
   })
   const taQuery = useQuery({
     ...teamMembershipQuery(client, org ?? "", teamRole("ta"), username ?? ""),
+    enabled: Boolean(org && classroom && username),
+  })
+  const studentQuery = useQuery({
+    ...teamMembershipQuery(client, org ?? "", studentSlug, username ?? ""),
     enabled: Boolean(org && classroom && username),
   })
 
@@ -266,17 +267,18 @@ export function useClassroomRole(
         ? false
         : undefined
 
+  // Classroom role is decided by team membership alone (config-repo access no
+  // longer gates it — that repo is org-wide and can't tell classrooms apart).
   const actualRole = resolveClassroomRole({
     org,
     classroom,
     isOwner,
-    staffRoleResolved: staff.roleResolved,
-    isStaff: staff.isTeacher,
     instructor: membershipFromQuery(
       instructorQuery.isSuccess,
       instructorQuery.error,
     ),
     ta: membershipFromQuery(taQuery.isSuccess, taQuery.error),
+    student: membershipFromQuery(studentQuery.isSuccess, studentQuery.error),
   })
 
   // Apply the "view as" preview (downgrade-only; never escalates).
@@ -287,9 +289,9 @@ export function useClassroomRole(
   // pin the guard's spinner.
   const isLoading =
     ownerQuery.fetchStatus === "fetching" ||
-    staffRepoQuery.fetchStatus === "fetching" ||
     instructorQuery.fetchStatus === "fetching" ||
-    taQuery.fetchStatus === "fetching"
+    taQuery.fetchStatus === "fetching" ||
+    studentQuery.fetchStatus === "fetching"
 
   return { role, actualRole, isLoading }
 }

--- a/web/src/pages/AssignmentIndexPage.tsx
+++ b/web/src/pages/AssignmentIndexPage.tsx
@@ -1,27 +1,23 @@
 import { Navigate, useParams } from "@tanstack/react-router"
-import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
-import RoleResolvingFallback from "@/components/RoleResolvingFallback"
+import { isStaffRole } from "@/hooks/useClassroomRole"
+import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 
 // The bare assignment route has no view of its own: it forwards to the
-// role-appropriate landing (teachers → submissions gradebook, students → their
-// own submission). Wait for the role to resolve so we never bounce a teacher
-// through the student page (or vice versa).
+// role-appropriate landing (staff → submissions gradebook, students → their
+// own submission). The $org/$classroom boundary already resolved the role, so
+// we forward immediately with no resolution-window handling of our own.
 const AssignmentIndexPage = () => {
   const { org, classroom, assignment } = useParams({ strict: false })
-  const { showTeacherUi, roleResolved } = useCourseTeacherAccess(org)
+  const { role } = useClassroomRoleContext()
 
   if (!org || !classroom || !assignment) {
     return <Navigate to="/" />
   }
 
-  if (!roleResolved) {
-    return <RoleResolvingFallback className="min-h-screen" />
-  }
-
   return (
     <Navigate
       to={
-        showTeacherUi
+        isStaffRole(role)
           ? "/$org/$classroom/assignments/$assignment/submissions"
           : "/$org/$classroom/assignments/$assignment/submission"
       }

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -25,13 +25,12 @@ import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetStudents from "@/hooks/useGetStudents"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
-import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
 import {
-  useClassroomRole,
   roleLabelKey,
   isResolvedInstructorOrOwner,
+  isStaffRole,
 } from "@/hooks/useClassroomRole"
-import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { isClassroomArchived } from "@/types/classroom"
 import { OrgRepos } from "./ClassesPage"
 
@@ -118,15 +117,12 @@ const TeacherAssignmentsView = ({
     org,
     classroom,
   )
-  const { user } = useGithubAuth()
-  const { role: myRole } = useClassroomRole(org, classroom, user?.login)
+  const { role: myRole } = useClassroomRoleContext()
   const myRoleLabelKey = roleLabelKey(myRole)
   const myRoleLabel = myRoleLabelKey ? t(myRoleLabelKey) : null
   const archived = isClassroomArchived(classroomData ?? {})
-  // Gate the owner-only team roster on a resolved owner/instructor. Enabling it
-  // for a TA (or during the unresolved window) fires org members/invitations
-  // reads that 403 for a non-owner. The empty-roster warning is an owner/
-  // instructor affordance, so a TA simply doesn't get it.
+  // The empty-roster warning is an owner/instructor affordance; a TA doesn't get
+  // it. Role is already resolved by the boundary, so this gates directly.
   const emptyRoster = useEmptyRosterWarning(org, classroom, {
     enabled: isResolvedInstructorOrOwner(myRole),
   })
@@ -264,26 +260,18 @@ const AssignmentsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.assignments"))
   const { org, classroom } = useParams({ strict: false })
-  const {
-    isTeacher,
-    isStudent,
-    isLoading: roleLoading,
-  } = useCourseTeacherAccess(org)
+  // Role is resolved once by the $org/$classroom boundary (blocked/unresolved
+  // never reach here). Staff (owner/instructor/ta) get the teacher view; a
+  // student gets the student view.
+  const { role } = useClassroomRoleContext()
 
   return (
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("nav.assignments")} />
-      {roleLoading && (
-        <div className="space-y-4">
-          <div className="skeleton skeleton-shimmer h-6 w-48" />
-          <div className="skeleton skeleton-shimmer h-4 w-32" />
-          <div className="skeleton skeleton-shimmer h-64 w-full rounded-box" />
-        </div>
-      )}
-      {!roleLoading && isTeacher && org && classroom && (
+      {isStaffRole(role) && org && classroom && (
         <TeacherAssignmentsView org={org} classroom={classroom} />
       )}
-      {!roleLoading && isStudent && org && classroom && (
+      {role === "student" && org && classroom && (
         <StudentAssignmentsView org={org} classroom={classroom} />
       )}
     </PageShell>

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -8,7 +8,8 @@ import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { Spinner } from "@/components/Spinner"
 import { Alert, AnimatedAlert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
-import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
+import { isStaffRole } from "@/hooks/useClassroomRole"
+import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import useGetPublicAssignment from "@/hooks/useGetPublicAssignment"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
@@ -166,7 +167,11 @@ const EditAssignmentPage = () => {
   useDocumentTitle(t("documentTitle.assignmentSettings"))
   const { org, classroom, assignment } = useParams({ strict: false })
   const router = useRouter()
-  const { isTeacher, isStudent } = useCourseTeacherAccess(org)
+  // Role is resolved once by the $org/$classroom boundary; staff edit the
+  // assignment, a student manages group collaborators.
+  const { role } = useClassroomRoleContext()
+  const isTeacher = isStaffRole(role)
+  const isStudent = role === "student"
   const { data: assignments } = useGetClassroomAssignments(org, classroom)
   const { data: classroomData } = useGetClassroom(org, classroom)
   const archived = isClassroomArchived(classroomData ?? {})

--- a/web/src/pages/StudentListPage.test.tsx
+++ b/web/src/pages/StudentListPage.test.tsx
@@ -10,9 +10,9 @@ vi.mock("react-i18next", async (importOriginal) => {
   }
 })
 
-const useClassroomRole = vi.fn()
-vi.mock("@/hooks/useClassroomRole", () => ({
-  useClassroomRole: (...args: unknown[]) => useClassroomRole(...args),
+const useClassroomRoleContext = vi.fn()
+vi.mock("@/context/classroomRole/ClassroomRoleProvider", () => ({
+  useClassroomRoleContext: () => useClassroomRoleContext(),
 }))
 
 vi.mock("@/auth/useGithubAuth", () => ({
@@ -66,12 +66,6 @@ vi.mock("@/context/github/GitHubProvider", () => ({
 vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({}),
 }))
-vi.mock("@/components/RoleResolvingFallback", () => ({
-  default: () => <div data-testid="role-fallback" />,
-}))
-vi.mock("@/components/NotFound", () => ({
-  default: () => <div data-testid="not-found" />,
-}))
 
 import { StudentListContent } from "./StudentListPage"
 
@@ -80,8 +74,8 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-const setRole = (role: string, isLoading = false) =>
-  useClassroomRole.mockReturnValue({ role, actualRole: role, isLoading })
+const setRole = (role: string) =>
+  useClassroomRoleContext.mockReturnValue({ role, actualRole: role })
 
 const renderContent = () =>
   render(<StudentListContent org="acme" classroom="cs101" />)
@@ -107,26 +101,5 @@ describe("StudentListContent role branch", () => {
     setRole("instructor")
     renderContent()
     expect(screen.getByTestId("enrolled-students")).toBeTruthy()
-  })
-
-  it("shows the role-resolving fallback while loading or unresolved", () => {
-    setRole("unresolved", true)
-    renderContent()
-    expect(screen.getByTestId("role-fallback")).toBeTruthy()
-    expect(screen.queryByTestId("enrolled-students")).toBeNull()
-    expect(screen.queryByTestId("ta-roster-view")).toBeNull()
-
-    cleanup()
-    setRole("unresolved", false)
-    renderContent()
-    expect(screen.getByTestId("role-fallback")).toBeTruthy()
-  })
-
-  it("shows NotFound for a downgraded non-staff preview (e.g. student)", () => {
-    setRole("student")
-    renderContent()
-    expect(screen.getByTestId("not-found")).toBeTruthy()
-    expect(screen.queryByTestId("enrolled-students")).toBeNull()
-    expect(screen.queryByTestId("ta-roster-view")).toBeNull()
   })
 })

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -17,11 +17,8 @@ import { useSuppressedLogins } from "@/hooks/useSuppressedLogins"
 import { invalidateInviteQueries } from "@/hooks/github/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import RequireTeacher from "@/components/RequireTeacher"
-import NotFound from "@/components/NotFound"
-import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 import TaRosterView from "@/pages/students/TaRosterView"
-import { useClassroomRole } from "@/hooks/useClassroomRole"
-import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { CONFIG_REPO } from "@/hooks/github/orgChecks"
 import { toStudent } from "@/util/roster"
 import { rosterPath } from "@/util/rosterPath"
@@ -36,23 +33,12 @@ export const StudentListContent = ({
   org: string
   classroom: string
 }) => {
-  const { user } = useGithubAuth()
-  const { role, isLoading: roleLoading } = useClassroomRole(
-    org,
-    classroom,
-    user?.login,
-  )
+  // Role is resolved once by the $org/$classroom boundary; a blocked/unresolved
+  // viewer never reaches here, and RequireTeacher (allow="staff") has already
+  // excluded a plain student. "View as TA" surfaces as role === "ta".
+  const { role } = useClassroomRoleContext()
 
-  // Resolve the viewer's effective role before subscribing to any owner-only
-  // data. TAs get a read-only roster.csv view; the owner-only hooks below never
-  // run for them (R6). "View as TA" downgrades role to "ta", so an owner
-  // previewing as TA sees this same view. A downgraded non-staff preview (e.g.
-  // "View as student") is not authorized here and gets NotFound rather than the
-  // owner UI.
-  if (roleLoading || role === "unresolved") return <RoleResolvingFallback />
   if (role === "ta") return <TaRosterView org={org} classroom={classroom} />
-  if (role !== "owner" && role !== "instructor") return <NotFound />
-
   return <OwnerRosterContent org={org} classroom={classroom} />
 }
 

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -45,10 +45,10 @@ import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetStudents from "@/hooks/useGetStudents"
 import { useTeamRoster } from "@/hooks/useTeamRoster"
 import {
-  useClassroomRole,
   isResolvedInstructorOrOwner,
+  isStaffRole,
 } from "@/hooks/useClassroomRole"
-import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { rowToStudent } from "@/util/teamRoster"
 import { hasStudentEnrollment } from "@/util/rosterRoles"
 import type { Student } from "@/types/classroom"
@@ -60,8 +60,6 @@ import useTriggerScoreCollection from "@/hooks/useTriggerScoreCollection"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import { RegradeCoordinatorProvider } from "@/context/regrade/RegradeCoordinator"
 import useGetLastCollectScoresRun from "@/hooks/useGetLastCollectScoresRun"
-import { useCourseTeacherAccess } from "@/hooks/useCourseTeacherAccess"
-import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 import {
   COLLECT_SCORES_WORKFLOW,
   REGRADE_WORKFLOW,
@@ -139,14 +137,10 @@ const SubmissionsPageContent = () => {
   // to empty and would blank the whole gradebook. Source their enrollment from
   // roster.csv instead (rows recorded as role "student"). Keys off the
   // effective role, so "View as TA" exercises the same path.
-  const { user } = useGithubAuth()
-  const { role } = useClassroomRole(org, classroom, user?.login)
+  const { role } = useClassroomRoleContext()
   const isTaView = role === "ta"
-  // Gate the owner-only team roster on a RESOLVED non-TA role. Enabling on
-  // `!isTaView` alone also fires during the `unresolved` window (role starts
-  // unresolved, so isTaView is briefly false), launching owner-only requests
-  // that then 403 for a TA — disabling after the role resolves can't cancel an
-  // already-dispatched fetch. Hold the queries until the role is known.
+  // Gate the owner-only team roster on a RESOLVED non-TA role. The boundary
+  // already resolved the role, so this is simply owner/instructor.
   const teamRosterEnabled = isResolvedInstructorOrOwner(role)
   const csvEnrollment = useMemo(
     () => csvStudentEnrollment(csvStudents),
@@ -169,12 +163,7 @@ const SubmissionsPageContent = () => {
   // the team roster; owner/instructor keep the team-driven source unchanged. A
   // still-loading or failed roster.csv read must surface as loading/error —
   // never an authoritative empty roster that would blank a populated gradebook.
-  // The classroom-role-unresolved window counts as loading too: a disabled
-  // team-roster query reports isLoading:false, so without this a TA (isTaView
-  // still false while unresolved) would read rosterReady=true against an empty
-  // team roster and rosterScopedRows would drop every submission.
-  const rosterLoading =
-    role === "unresolved" || (isTaView ? csvStudentsLoading : teamRosterLoading)
+  const rosterLoading = isTaView ? csvStudentsLoading : teamRosterLoading
   const rosterError = isTaView ? csvStudentsError : teamRosterError
   // The retry on the roster error alert must re-run whichever source backs the
   // current view: roster.csv for a TA, the team roster otherwise.
@@ -826,19 +815,16 @@ const SubmissionsPageContent = () => {
 }
 
 // The teacher gradebook. Students who land here directly (e.g. an old link) are
-// redirected to their own submission view; we wait for the role to resolve so a
-// real teacher never bounces, and avoid firing teacher-only reads for a student.
+// redirected to their own submission view. The $org/$classroom boundary has
+// already resolved the role and gated blocked/loading, so staff render the
+// gradebook and a plain student bounces to their per-assignment page.
 const SubmissionsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.submissions"))
   const { org, classroom, assignment } = useParams({ strict: false })
-  const { showTeacherUi, roleResolved } = useCourseTeacherAccess(org)
+  const { role } = useClassroomRoleContext()
 
-  if (!roleResolved) {
-    return <RoleResolvingFallback className="min-h-screen" />
-  }
-
-  if (!showTeacherUi && org && classroom && assignment) {
+  if (!isStaffRole(role) && org && classroom && assignment) {
     return (
       <Navigate
         to="/$org/$classroom/assignments/$assignment/submission"

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AuthIndexRouteImport } from './routes/auth/index'
 import { Route as AuthedIndexRouteImport } from './routes/_authed/index'
 import { Route as AuthedOrgRouteRouteImport } from './routes/_authed/$org/route'
 import { Route as AuthedOrgIndexRouteImport } from './routes/_authed/$org/index'
+import { Route as AuthedOrgClassroomRouteRouteImport } from './routes/_authed/$org/$classroom/route'
 import { Route as AuthedOrgSetupIndexRouteImport } from './routes/_authed/$org/setup/index'
 import { Route as AuthedOrgSettingsIndexRouteImport } from './routes/_authed/$org/settings/index'
 import { Route as AuthedOrgPublishedIndexRouteImport } from './routes/_authed/$org/published/index'
@@ -75,6 +76,11 @@ const AuthedOrgIndexRoute = AuthedOrgIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AuthedOrgRouteRoute,
 } as any)
+const AuthedOrgClassroomRouteRoute = AuthedOrgClassroomRouteRouteImport.update({
+  id: '/$classroom',
+  path: '/$classroom',
+  getParentRoute: () => AuthedOrgRouteRoute,
+} as any)
 const AuthedOrgSetupIndexRoute = AuthedOrgSetupIndexRouteImport.update({
   id: '/setup/',
   path: '/setup/',
@@ -106,9 +112,9 @@ const AuthedOrgActivityIndexRoute = AuthedOrgActivityIndexRouteImport.update({
   getParentRoute: () => AuthedOrgRouteRoute,
 } as any)
 const AuthedOrgClassroomIndexRoute = AuthedOrgClassroomIndexRouteImport.update({
-  id: '/$classroom/',
-  path: '/$classroom/',
-  getParentRoute: () => AuthedOrgRouteRoute,
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthedOrgClassroomRouteRoute,
 } as any)
 const AuthedOrgClassesNewIndexRoute =
   AuthedOrgClassesNewIndexRouteImport.update({
@@ -118,63 +124,63 @@ const AuthedOrgClassesNewIndexRoute =
   } as any)
 const AuthedOrgClassroomRosterIndexRoute =
   AuthedOrgClassroomRosterIndexRouteImport.update({
-    id: '/$classroom/roster/',
-    path: '/$classroom/roster/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/roster/',
+    path: '/roster/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomOnboardIndexRoute =
   AuthedOrgClassroomOnboardIndexRouteImport.update({
-    id: '/$classroom/onboard/',
-    path: '/$classroom/onboard/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/onboard/',
+    path: '/onboard/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomEditIndexRoute =
   AuthedOrgClassroomEditIndexRouteImport.update({
-    id: '/$classroom/edit/',
-    path: '/$classroom/edit/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/edit/',
+    path: '/edit/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsIndexRoute =
   AuthedOrgClassroomAssignmentsIndexRouteImport.update({
-    id: '/$classroom/assignments/',
-    path: '/$classroom/assignments/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/assignments/',
+    path: '/assignments/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsNewIndexRoute =
   AuthedOrgClassroomAssignmentsNewIndexRouteImport.update({
-    id: '/$classroom/assignments/new/',
-    path: '/$classroom/assignments/new/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/assignments/new/',
+    path: '/assignments/new/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsAssignmentIndexRoute =
   AuthedOrgClassroomAssignmentsAssignmentIndexRouteImport.update({
-    id: '/$classroom/assignments/$assignment/',
-    path: '/$classroom/assignments/$assignment/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/assignments/$assignment/',
+    path: '/assignments/$assignment/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute =
   AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRouteImport.update({
-    id: '/$classroom/assignments/$assignment/submissions/',
-    path: '/$classroom/assignments/$assignment/submissions/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/assignments/$assignment/submissions/',
+    path: '/assignments/$assignment/submissions/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute =
   AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRouteImport.update({
-    id: '/$classroom/assignments/$assignment/submission/',
-    path: '/$classroom/assignments/$assignment/submission/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/assignments/$assignment/submission/',
+    path: '/assignments/$assignment/submission/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute =
   AuthedOrgClassroomAssignmentsAssignmentEditIndexRouteImport.update({
-    id: '/$classroom/assignments/$assignment/edit/',
-    path: '/$classroom/assignments/$assignment/edit/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/assignments/$assignment/edit/',
+    path: '/assignments/$assignment/edit/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute =
   AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRouteImport.update({
-    id: '/$classroom/assignments/$assignment/accept/',
-    path: '/$classroom/assignments/$assignment/accept/',
-    getParentRoute: () => AuthedOrgRouteRoute,
+    id: '/assignments/$assignment/accept/',
+    path: '/assignments/$assignment/accept/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -184,6 +190,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/$org': typeof AuthedOrgRouteRouteWithChildren
   '/auth/': typeof AuthIndexRoute
+  '/$org/$classroom': typeof AuthedOrgClassroomRouteRouteWithChildren
   '/$org/': typeof AuthedOrgIndexRoute
   '/$org/$classroom/': typeof AuthedOrgClassroomIndexRoute
   '/$org/activity/': typeof AuthedOrgActivityIndexRoute
@@ -239,6 +246,7 @@ export interface FileRoutesById {
   '/_authed/$org': typeof AuthedOrgRouteRouteWithChildren
   '/_authed/': typeof AuthedIndexRoute
   '/auth/': typeof AuthIndexRoute
+  '/_authed/$org/$classroom': typeof AuthedOrgClassroomRouteRouteWithChildren
   '/_authed/$org/': typeof AuthedOrgIndexRoute
   '/_authed/$org/$classroom/': typeof AuthedOrgClassroomIndexRoute
   '/_authed/$org/activity/': typeof AuthedOrgActivityIndexRoute
@@ -268,6 +276,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/$org'
     | '/auth/'
+    | '/$org/$classroom'
     | '/$org/'
     | '/$org/$classroom/'
     | '/$org/activity/'
@@ -322,6 +331,7 @@ export interface FileRouteTypes {
     | '/_authed/$org'
     | '/_authed/'
     | '/auth/'
+    | '/_authed/$org/$classroom'
     | '/_authed/$org/'
     | '/_authed/$org/$classroom/'
     | '/_authed/$org/activity/'
@@ -409,6 +419,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedOrgIndexRouteImport
       parentRoute: typeof AuthedOrgRouteRoute
     }
+    '/_authed/$org/$classroom': {
+      id: '/_authed/$org/$classroom'
+      path: '/$classroom'
+      fullPath: '/$org/$classroom'
+      preLoaderRoute: typeof AuthedOrgClassroomRouteRouteImport
+      parentRoute: typeof AuthedOrgRouteRoute
+    }
     '/_authed/$org/setup/': {
       id: '/_authed/$org/setup/'
       path: '/setup'
@@ -453,10 +470,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authed/$org/$classroom/': {
       id: '/_authed/$org/$classroom/'
-      path: '/$classroom'
+      path: '/'
       fullPath: '/$org/$classroom/'
       preLoaderRoute: typeof AuthedOrgClassroomIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/classes/new/': {
       id: '/_authed/$org/classes/new/'
@@ -467,91 +484,83 @@ declare module '@tanstack/react-router' {
     }
     '/_authed/$org/$classroom/roster/': {
       id: '/_authed/$org/$classroom/roster/'
-      path: '/$classroom/roster'
+      path: '/roster'
       fullPath: '/$org/$classroom/roster/'
       preLoaderRoute: typeof AuthedOrgClassroomRosterIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/onboard/': {
       id: '/_authed/$org/$classroom/onboard/'
-      path: '/$classroom/onboard'
+      path: '/onboard'
       fullPath: '/$org/$classroom/onboard/'
       preLoaderRoute: typeof AuthedOrgClassroomOnboardIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/edit/': {
       id: '/_authed/$org/$classroom/edit/'
-      path: '/$classroom/edit'
+      path: '/edit'
       fullPath: '/$org/$classroom/edit/'
       preLoaderRoute: typeof AuthedOrgClassroomEditIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/': {
       id: '/_authed/$org/$classroom/assignments/'
-      path: '/$classroom/assignments'
+      path: '/assignments'
       fullPath: '/$org/$classroom/assignments/'
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/new/': {
       id: '/_authed/$org/$classroom/assignments/new/'
-      path: '/$classroom/assignments/new'
+      path: '/assignments/new'
       fullPath: '/$org/$classroom/assignments/new/'
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsNewIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/$assignment/': {
       id: '/_authed/$org/$classroom/assignments/$assignment/'
-      path: '/$classroom/assignments/$assignment'
+      path: '/assignments/$assignment'
       fullPath: '/$org/$classroom/assignments/$assignment/'
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/$assignment/submissions/': {
       id: '/_authed/$org/$classroom/assignments/$assignment/submissions/'
-      path: '/$classroom/assignments/$assignment/submissions'
+      path: '/assignments/$assignment/submissions'
       fullPath: '/$org/$classroom/assignments/$assignment/submissions/'
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/$assignment/submission/': {
       id: '/_authed/$org/$classroom/assignments/$assignment/submission/'
-      path: '/$classroom/assignments/$assignment/submission'
+      path: '/assignments/$assignment/submission'
       fullPath: '/$org/$classroom/assignments/$assignment/submission/'
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/$assignment/edit/': {
       id: '/_authed/$org/$classroom/assignments/$assignment/edit/'
-      path: '/$classroom/assignments/$assignment/edit'
+      path: '/assignments/$assignment/edit'
       fullPath: '/$org/$classroom/assignments/$assignment/edit/'
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentEditIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/$assignment/accept/': {
       id: '/_authed/$org/$classroom/assignments/$assignment/accept/'
-      path: '/$classroom/assignments/$assignment/accept'
+      path: '/assignments/$assignment/accept'
       fullPath: '/$org/$classroom/assignments/$assignment/accept/'
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRouteImport
-      parentRoute: typeof AuthedOrgRouteRoute
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
   }
 }
 
-interface AuthedOrgRouteRouteChildren {
-  AuthedOrgIndexRoute: typeof AuthedOrgIndexRoute
+interface AuthedOrgClassroomRouteRouteChildren {
   AuthedOrgClassroomIndexRoute: typeof AuthedOrgClassroomIndexRoute
-  AuthedOrgActivityIndexRoute: typeof AuthedOrgActivityIndexRoute
-  AuthedOrgClassesIndexRoute: typeof AuthedOrgClassesIndexRoute
-  AuthedOrgMembersIndexRoute: typeof AuthedOrgMembersIndexRoute
-  AuthedOrgPublishedIndexRoute: typeof AuthedOrgPublishedIndexRoute
-  AuthedOrgSettingsIndexRoute: typeof AuthedOrgSettingsIndexRoute
-  AuthedOrgSetupIndexRoute: typeof AuthedOrgSetupIndexRoute
   AuthedOrgClassroomAssignmentsIndexRoute: typeof AuthedOrgClassroomAssignmentsIndexRoute
   AuthedOrgClassroomEditIndexRoute: typeof AuthedOrgClassroomEditIndexRoute
   AuthedOrgClassroomOnboardIndexRoute: typeof AuthedOrgClassroomOnboardIndexRoute
   AuthedOrgClassroomRosterIndexRoute: typeof AuthedOrgClassroomRosterIndexRoute
-  AuthedOrgClassesNewIndexRoute: typeof AuthedOrgClassesNewIndexRoute
   AuthedOrgClassroomAssignmentsAssignmentIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentIndexRoute
   AuthedOrgClassroomAssignmentsNewIndexRoute: typeof AuthedOrgClassroomAssignmentsNewIndexRoute
   AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute
@@ -560,33 +569,55 @@ interface AuthedOrgRouteRouteChildren {
   AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute
 }
 
+const AuthedOrgClassroomRouteRouteChildren: AuthedOrgClassroomRouteRouteChildren =
+  {
+    AuthedOrgClassroomIndexRoute: AuthedOrgClassroomIndexRoute,
+    AuthedOrgClassroomAssignmentsIndexRoute:
+      AuthedOrgClassroomAssignmentsIndexRoute,
+    AuthedOrgClassroomEditIndexRoute: AuthedOrgClassroomEditIndexRoute,
+    AuthedOrgClassroomOnboardIndexRoute: AuthedOrgClassroomOnboardIndexRoute,
+    AuthedOrgClassroomRosterIndexRoute: AuthedOrgClassroomRosterIndexRoute,
+    AuthedOrgClassroomAssignmentsAssignmentIndexRoute:
+      AuthedOrgClassroomAssignmentsAssignmentIndexRoute,
+    AuthedOrgClassroomAssignmentsNewIndexRoute:
+      AuthedOrgClassroomAssignmentsNewIndexRoute,
+    AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute:
+      AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute,
+    AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute:
+      AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute,
+    AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute:
+      AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute,
+    AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute:
+      AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute,
+  }
+
+const AuthedOrgClassroomRouteRouteWithChildren =
+  AuthedOrgClassroomRouteRoute._addFileChildren(
+    AuthedOrgClassroomRouteRouteChildren,
+  )
+
+interface AuthedOrgRouteRouteChildren {
+  AuthedOrgClassroomRouteRoute: typeof AuthedOrgClassroomRouteRouteWithChildren
+  AuthedOrgIndexRoute: typeof AuthedOrgIndexRoute
+  AuthedOrgActivityIndexRoute: typeof AuthedOrgActivityIndexRoute
+  AuthedOrgClassesIndexRoute: typeof AuthedOrgClassesIndexRoute
+  AuthedOrgMembersIndexRoute: typeof AuthedOrgMembersIndexRoute
+  AuthedOrgPublishedIndexRoute: typeof AuthedOrgPublishedIndexRoute
+  AuthedOrgSettingsIndexRoute: typeof AuthedOrgSettingsIndexRoute
+  AuthedOrgSetupIndexRoute: typeof AuthedOrgSetupIndexRoute
+  AuthedOrgClassesNewIndexRoute: typeof AuthedOrgClassesNewIndexRoute
+}
+
 const AuthedOrgRouteRouteChildren: AuthedOrgRouteRouteChildren = {
+  AuthedOrgClassroomRouteRoute: AuthedOrgClassroomRouteRouteWithChildren,
   AuthedOrgIndexRoute: AuthedOrgIndexRoute,
-  AuthedOrgClassroomIndexRoute: AuthedOrgClassroomIndexRoute,
   AuthedOrgActivityIndexRoute: AuthedOrgActivityIndexRoute,
   AuthedOrgClassesIndexRoute: AuthedOrgClassesIndexRoute,
   AuthedOrgMembersIndexRoute: AuthedOrgMembersIndexRoute,
   AuthedOrgPublishedIndexRoute: AuthedOrgPublishedIndexRoute,
   AuthedOrgSettingsIndexRoute: AuthedOrgSettingsIndexRoute,
   AuthedOrgSetupIndexRoute: AuthedOrgSetupIndexRoute,
-  AuthedOrgClassroomAssignmentsIndexRoute:
-    AuthedOrgClassroomAssignmentsIndexRoute,
-  AuthedOrgClassroomEditIndexRoute: AuthedOrgClassroomEditIndexRoute,
-  AuthedOrgClassroomOnboardIndexRoute: AuthedOrgClassroomOnboardIndexRoute,
-  AuthedOrgClassroomRosterIndexRoute: AuthedOrgClassroomRosterIndexRoute,
   AuthedOrgClassesNewIndexRoute: AuthedOrgClassesNewIndexRoute,
-  AuthedOrgClassroomAssignmentsAssignmentIndexRoute:
-    AuthedOrgClassroomAssignmentsAssignmentIndexRoute,
-  AuthedOrgClassroomAssignmentsNewIndexRoute:
-    AuthedOrgClassroomAssignmentsNewIndexRoute,
-  AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute:
-    AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute,
-  AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute:
-    AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute,
-  AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute:
-    AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute,
-  AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute:
-    AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute,
 }
 
 const AuthedOrgRouteRouteWithChildren = AuthedOrgRouteRoute._addFileChildren(

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -11,7 +11,6 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ClassesRouteImport } from './routes/classes'
-import { Route as AssignmentsRouteImport } from './routes/assignments'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as AuthIndexRouteImport } from './routes/auth/index'
 import { Route as AuthedIndexRouteImport } from './routes/_authed/index'
@@ -45,11 +44,6 @@ const LoginRoute = LoginRouteImport.update({
 const ClassesRoute = ClassesRouteImport.update({
   id: '/classes',
   path: '/classes',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AssignmentsRoute = AssignmentsRouteImport.update({
-  id: '/assignments',
-  path: '/assignments',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthedRoute = AuthedRouteImport.update({
@@ -185,7 +179,6 @@ const AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthedIndexRoute
-  '/assignments': typeof AssignmentsRoute
   '/classes': typeof ClassesRoute
   '/login': typeof LoginRoute
   '/$org': typeof AuthedOrgRouteRouteWithChildren
@@ -212,7 +205,6 @@ export interface FileRoutesByFullPath {
   '/$org/$classroom/assignments/$assignment/submissions/': typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute
 }
 export interface FileRoutesByTo {
-  '/assignments': typeof AssignmentsRoute
   '/classes': typeof ClassesRoute
   '/login': typeof LoginRoute
   '/': typeof AuthedIndexRoute
@@ -240,7 +232,6 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_authed': typeof AuthedRouteWithChildren
-  '/assignments': typeof AssignmentsRoute
   '/classes': typeof ClassesRoute
   '/login': typeof LoginRoute
   '/_authed/$org': typeof AuthedOrgRouteRouteWithChildren
@@ -271,7 +262,6 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/assignments'
     | '/classes'
     | '/login'
     | '/$org'
@@ -298,7 +288,6 @@ export interface FileRouteTypes {
     | '/$org/$classroom/assignments/$assignment/submissions/'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/assignments'
     | '/classes'
     | '/login'
     | '/'
@@ -325,7 +314,6 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/_authed'
-    | '/assignments'
     | '/classes'
     | '/login'
     | '/_authed/$org'
@@ -355,7 +343,6 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   AuthedRoute: typeof AuthedRouteWithChildren
-  AssignmentsRoute: typeof AssignmentsRoute
   ClassesRoute: typeof ClassesRoute
   LoginRoute: typeof LoginRoute
   AuthIndexRoute: typeof AuthIndexRoute
@@ -375,13 +362,6 @@ declare module '@tanstack/react-router' {
       path: '/classes'
       fullPath: '/classes'
       preLoaderRoute: typeof ClassesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/assignments': {
-      id: '/assignments'
-      path: '/assignments'
-      fullPath: '/assignments'
-      preLoaderRoute: typeof AssignmentsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authed': {
@@ -639,7 +619,6 @@ const AuthedRouteWithChildren =
 
 const rootRouteChildren: RootRouteChildren = {
   AuthedRoute: AuthedRouteWithChildren,
-  AssignmentsRoute: AssignmentsRoute,
   ClassesRoute: ClassesRoute,
   LoginRoute: LoginRoute,
   AuthIndexRoute: AuthIndexRoute,

--- a/web/src/routes/_authed/$org/$classroom/route.tsx
+++ b/web/src/routes/_authed/$org/$classroom/route.tsx
@@ -39,8 +39,7 @@ function ClassroomLayout() {
   )
 
   const onUngatedRoute = useRouterState({
-    select: (s) =>
-      s.matches.some((m) => UNGATED_ROUTE_IDS.includes(m.routeId)),
+    select: (s) => s.matches.some((m) => UNGATED_ROUTE_IDS.includes(m.routeId)),
   })
 
   // Pre-enrollment flows must reach a teamless user — never gate them.

--- a/web/src/routes/_authed/$org/$classroom/route.tsx
+++ b/web/src/routes/_authed/$org/$classroom/route.tsx
@@ -1,0 +1,61 @@
+import {
+  createFileRoute,
+  Outlet,
+  useParams,
+  useRouterState,
+} from "@tanstack/react-router"
+
+import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useClassroomRole } from "@/hooks/useClassroomRole"
+import NotFound from "@/components/NotFound"
+import RoleResolvingFallback from "@/components/RoleResolvingFallback"
+import { ClassroomRoleProvider } from "@/context/classroomRole/ClassroomRoleProvider"
+
+export const Route = createFileRoute("/_authed/$org/$classroom")({
+  component: ClassroomLayout,
+})
+
+// Pre-enrollment entry points that must render for a viewer with no team in the
+// classroom yet (they exist to get such a user enrolled). Matched by route id,
+// not a path suffix, so an assignment slug named "onboard"/"accept" can't
+// collide and a route rename can't silently re-gate them.
+const UNGATED_ROUTE_IDS = [
+  "/_authed/$org/$classroom/onboard/",
+  "/_authed/$org/$classroom/assignments/$assignment/accept/",
+]
+
+// Resolve the viewer's classroom role once for the whole classroom subtree and
+// provide it to descendants. Holds a single loading fallback until the role is
+// known, and renders NotFound for a viewer on none of the classroom's teams
+// (`blocked`) — so no descendant page re-resolves role or handles the
+// resolution window. The onboard/accept entry points render outside the gate.
+function ClassroomLayout() {
+  const { org, classroom } = useParams({ from: "/_authed/$org/$classroom" })
+  const { user } = useGithubAuth()
+  const { role, actualRole, isLoading } = useClassroomRole(
+    org,
+    classroom,
+    user?.login,
+  )
+
+  const onUngatedRoute = useRouterState({
+    select: (s) =>
+      s.matches.some((m) => UNGATED_ROUTE_IDS.includes(m.routeId)),
+  })
+
+  // Pre-enrollment flows must reach a teamless user — never gate them.
+  if (onUngatedRoute) return <Outlet />
+
+  if (isLoading || role === "unresolved" || actualRole === "unresolved") {
+    return <RoleResolvingFallback />
+  }
+
+  // No team in this classroom (and not owner): the app hides the classroom.
+  if (role === "blocked" || actualRole === "blocked") return <NotFound />
+
+  return (
+    <ClassroomRoleProvider value={{ role, actualRole }}>
+      <Outlet />
+    </ClassroomRoleProvider>
+  )
+}

--- a/web/src/routes/assignments.tsx
+++ b/web/src/routes/assignments.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router"
-import AssignmentsPage from "@/pages/AssignmentsPage"
-
-export const Route = createFileRoute("/assignments")({
-  component: AssignmentsPage,
-})


### PR DESCRIPTION
> Stacked on #225 — targets `feat/ta-roster-view-csv`. Rebase onto `main` once #225 merges.

## Summary

Resolve the viewer's classroom role **once**, at a new `$org/$classroom` layout boundary, and provide it to every page and guard below — replacing the per-page role resolution that produced two shipped timing bugs. Also makes **GitHub team membership the single source of truth for classroom access**: a viewer on none of a classroom's teams is now `blocked`.

- **Resolve once + provide.** A new `$org/$classroom/route.tsx` layout resolves the role, holds one loading fallback until it's settled, and provides `{ role, actualRole }` (never `unresolved`/`blocked` for descendants) via a new context — a throwing accessor for pages under the boundary, a non-throwing one for the drawer (which also renders on org routes). The onboard and assignment-accept flows are exempt by route id so a not-yet-enrolled (teamless) user can still enroll.
- **Team-membership access model.** `resolveClassroomRole` now decides from team membership alone: org owner short-circuits; else instructor / ta / student team; **none of the three → `blocked` → NotFound**. Org-wide `classroom50` config-repo access no longer decides classroom access (it can't tell classrooms apart — a TA of class A previously passed the staff gate for class B). The student team is read via the same self-membership primitive as instructor/ta (a read a student can make); creation already rejects divergent team slugs, and a slug miss safe-degrades to non-member.
- **Full migration.** Both route guards and every classroom-scoped consumer (roster, assignments, submissions, assignment index/edit, drawer) read the resolved context; the guard branches at runtime on the `classroom` param (context under the boundary, coarse config-repo verdict for org-level surfaces). The scattered per-page resolution-window guards are deleted — the boundary guarantees a settled role, so the `unresolved`-window bug class is structurally gone.

Origin plan (local, `docs/` is gitignored): `docs/plans/2026-07-12-001-refactor-classroom-role-boundary-plan.md`.

## Notable decisions

- **Deliberate access tightening (please confirm):** a user with `classroom50` config-repo access but no team in a given classroom is now `blocked` there (previously treated as staff/student). This is the intended point of the change — team membership, not repo access, grants classroom access — but it does change behavior for any setup that relied on the old coarse gate.
- **`blocked` is a terminal, fail-closed role** — never staff/instructor, no label, and `applyViewAs` can't escalate out of it. Every `EffectiveRole` enumeration handles it.
- Owner still transcends classrooms (org admin sees all); TA/owner/instructor rendering is unchanged in outcome; the github.com cross-classroom visibility leak remains accepted risk (out of scope).
- The client-side role gate is a UX/visibility boundary, not a server-enforced one — GitHub's API remains the real authorization boundary.

## Test plan

- [x] `npm run check` green (tsc + eslint + prettier + vitest); 1308 tests pass.
- [x] New/updated unit tests: `resolveClassroomRole` across all six outcomes incl. `blocked` and the staff-settled-before-student ordering; the `blocked` predicate/label/view-as audit; the `ClassroomRoleProvider` throwing + non-throwing accessors; updated `StudentListPage` role-branch tests against the context.
- [x] Multi-persona code review (`depth:full`, access-boundary focus): one P2 fixed — the orphan top-level `/assignments` route would crash under the throwing context, so it was removed (it never functioned). Re-review found no other off-boundary consumers.
- [ ] Manual: as a TA of class A, open class B (no team there) → NotFound; open class A → TA views. As a student, open your classroom → student view; a staff-only route → NotFound. Owner opens any classroom → full access. "View as TA/student" still works.
- [ ] Manual: confirm the onboard and assignment-accept flows still render for a not-yet-enrolled user (not NotFound'd by the boundary).