### PR TITLE
fix(cli): auto-install pytest + pytest-json-report for python autograding

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -36,6 +36,7 @@ history is unavailable or baseline == commit).
 from __future__ import annotations
 
 import datetime
+import importlib.util
 import io
 import json
 import os
@@ -1275,21 +1276,15 @@ _PYTEST_DEPS = {"pytest": "pytest", "pytest_jsonreport": "pytest-json-report"}
 
 def _ensure_pytest(cwd: pathlib.Path, timeout: int) -> None:
     """Best-effort: make pytest + pytest-json-report importable before a
-    `python` test runs. Idempotent -- probes each dep against the grading
-    interpreter and installs only what's missing, so a teacher-pinned version
-    (from a setup command or requirements.txt) is left untouched. Never raises:
-    a locked-down or offline runner degrades to _grade_python's fallback
-    scoring rather than erroring the whole submission. Lives here (not in the
-    workflow) because runner.py is fetched from Pages each run, so the fix
-    reaches every classroom on next submission with no per-repo edit."""
-    missing = []
-    for module, package in _PYTEST_DEPS.items():
-        probe = f"{shlex.quote(sys.executable)} -c {shlex.quote(f'import {module}')}"
-        try:
-            if _run_command(probe, cwd, timeout).returncode != 0:
-                missing.append(package)
-        except (subprocess.SubprocessError, OSError):
-            missing.append(package)
+    `python` test runs. Idempotent -- installs only the deps missing from the
+    grading interpreter, so a teacher-pinned version (from a setup command or
+    requirements.txt) is left untouched. Never raises: a locked-down or offline
+    runner degrades to _grade_python's fallback scoring rather than erroring the
+    whole submission. Lives here (not in the workflow) because runner.py is
+    fetched from Pages each run, so the fix reaches every classroom on next
+    submission with no per-repo edit."""
+    missing = [package for module, package in _PYTEST_DEPS.items()
+               if importlib.util.find_spec(module) is None]
     if not missing:
         return
     install = (f"{shlex.quote(sys.executable)} -m pip install --quiet "

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -1267,22 +1267,17 @@ def _run_setup(setup: str, cwd: pathlib.Path, timeout: int) -> str | None:
     return None
 
 
-# import name -> pip package. actions/setup-python provisions only bare
-# CPython, so a `python` test with no install step has neither pytest nor the
-# JSON-report plugin -- the historical cause of `pytest: not found` (exit 127)
-# and silent all-or-nothing scoring (issue #212).
+# import name -> pip package for the pytest deps bare setup-python omits (#212).
 _PYTEST_DEPS = {"pytest": "pytest", "pytest_jsonreport": "pytest-json-report"}
+
+# Floor for the auto-install budget: the 10s default per-test timeout is too
+# small for a cold install, which would silently no-op the #212 fix.
+PIP_INSTALL_TIMEOUT = 120
 
 
 def _ensure_pytest(cwd: pathlib.Path, timeout: int) -> None:
-    """Best-effort: make pytest + pytest-json-report importable before a
-    `python` test runs. Idempotent -- installs only the deps missing from the
-    grading interpreter, so a teacher-pinned version (from a setup command or
-    requirements.txt) is left untouched. Never raises: a locked-down or offline
-    runner degrades to _grade_python's fallback scoring rather than erroring the
-    whole submission. Lives here (not in the workflow) because runner.py is
-    fetched from Pages each run, so the fix reaches every classroom on next
-    submission with no per-repo edit."""
+    """Best-effort, idempotent install of the pytest deps missing from the
+    grading interpreter; never raises (offline runner falls back to #212)."""
     missing = [package for module, package in _PYTEST_DEPS.items()
                if importlib.util.find_spec(module) is None]
     if not missing:
@@ -1290,18 +1285,17 @@ def _ensure_pytest(cwd: pathlib.Path, timeout: int) -> None:
     install = (f"{shlex.quote(sys.executable)} -m pip install --quiet "
                + " ".join(shlex.quote(p) for p in missing))
     try:
-        _run_command(install, cwd, timeout)
+        # Own budget, not the per-test timeout: the 10s default is too small
+        # for a cold install and would leave the deps missing.
+        _run_command(install, cwd, max(timeout, PIP_INSTALL_TIMEOUT))
     except (subprocess.SubprocessError, OSError):
         pass
 
 
 def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
                   points: int, name: str) -> dict[str, Any]:
-    """Run a pytest command and split `points` across discovered cases (GitHub
-    Classroom's points/num_tests model) via pytest-json-report. Auto-installs
-    pytest + the plugin when absent (see _ensure_pytest); falls back to
-    all-or-nothing exit-code scoring only when a report still isn't produced
-    (e.g. an offline runner couldn't install the plugin)."""
+    """Split `points` across cases via pytest-json-report (deps auto-installed
+    by _ensure_pytest), falling back to exit-code scoring when no report."""
     _ensure_pytest(cwd, timeout)
     report_dir = pathlib.Path(tempfile.mkdtemp(prefix="classroom50-pytest-"))
     report = report_dir / "report.json"
@@ -1344,9 +1338,8 @@ def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
             detail += "\n" + _clip(rp.stdout or rp.stderr)
         return _make_outcome(name, points, passed, detail, score=score)
 
-    # Fallback: no parseable report -> all-or-nothing on the exit code. Reached
-    # only when pytest-json-report still isn't loadable (e.g. an offline runner
-    # blocked _ensure_pytest's install).
+    # Fallback: no parseable report -> all-or-nothing on the exit code
+    # (e.g. an offline runner couldn't load pytest-json-report).
     passed = rp.returncode == 0
     detail = (f"pytest exit {rp.returncode} "
               f"(no JSON report from pytest-json-report; scored on exit code)")

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -1266,12 +1266,48 @@ def _run_setup(setup: str, cwd: pathlib.Path, timeout: int) -> str | None:
     return None
 
 
+# import name -> pip package. actions/setup-python provisions only bare
+# CPython, so a `python` test with no install step has neither pytest nor the
+# JSON-report plugin -- the historical cause of `pytest: not found` (exit 127)
+# and silent all-or-nothing scoring (issue #212).
+_PYTEST_DEPS = {"pytest": "pytest", "pytest_jsonreport": "pytest-json-report"}
+
+
+def _ensure_pytest(cwd: pathlib.Path, timeout: int) -> None:
+    """Best-effort: make pytest + pytest-json-report importable before a
+    `python` test runs. Idempotent -- probes each dep against the grading
+    interpreter and installs only what's missing, so a teacher-pinned version
+    (from a setup command or requirements.txt) is left untouched. Never raises:
+    a locked-down or offline runner degrades to _grade_python's fallback
+    scoring rather than erroring the whole submission. Lives here (not in the
+    workflow) because runner.py is fetched from Pages each run, so the fix
+    reaches every classroom on next submission with no per-repo edit."""
+    missing = []
+    for module, package in _PYTEST_DEPS.items():
+        probe = f"{shlex.quote(sys.executable)} -c {shlex.quote(f'import {module}')}"
+        try:
+            if _run_command(probe, cwd, timeout).returncode != 0:
+                missing.append(package)
+        except (subprocess.SubprocessError, OSError):
+            missing.append(package)
+    if not missing:
+        return
+    install = (f"{shlex.quote(sys.executable)} -m pip install --quiet "
+               + " ".join(shlex.quote(p) for p in missing))
+    try:
+        _run_command(install, cwd, timeout)
+    except (subprocess.SubprocessError, OSError):
+        pass
+
+
 def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
                   points: int, name: str) -> dict[str, Any]:
     """Run a pytest command and split `points` across discovered cases (GitHub
-    Classroom's points/num_tests model) via pytest-json-report. Falls back to
-    all-or-nothing exit-code scoring when no JSON report is produced (e.g. the
-    plugin isn't installed)."""
+    Classroom's points/num_tests model) via pytest-json-report. Auto-installs
+    pytest + the plugin when absent (see _ensure_pytest); falls back to
+    all-or-nothing exit-code scoring only when a report still isn't produced
+    (e.g. an offline runner couldn't install the plugin)."""
+    _ensure_pytest(cwd, timeout)
     report_dir = pathlib.Path(tempfile.mkdtemp(prefix="classroom50-pytest-"))
     report = report_dir / "report.json"
     # Skip appending when the teacher's command already configures the plugin
@@ -1313,10 +1349,12 @@ def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
             detail += "\n" + _clip(rp.stdout or rp.stderr)
         return _make_outcome(name, points, passed, detail, score=score)
 
-    # Fallback: no parseable report -> all-or-nothing on the exit code.
+    # Fallback: no parseable report -> all-or-nothing on the exit code. Reached
+    # only when pytest-json-report still isn't loadable (e.g. an offline runner
+    # blocked _ensure_pytest's install).
     passed = rp.returncode == 0
     detail = (f"pytest exit {rp.returncode} "
-              f"(no JSON report; install pytest-json-report for per-case scoring)")
+              f"(no JSON report from pytest-json-report; scored on exit code)")
     if not passed:
         detail += "\n" + _clip(rp.stdout or rp.stderr)
     return _make_outcome(name, points, passed, detail)

--- a/cli/gh-teacher/skeleton_tests/test_runner_grade_python.py
+++ b/cli/gh-teacher/skeleton_tests/test_runner_grade_python.py
@@ -1,0 +1,122 @@
+"""Tests for runner.py's pytest grading path.
+
+Focus is _ensure_pytest (issue #212): actions/setup-python provides only bare
+CPython, so a `python` test must have pytest + pytest-json-report installed
+before it runs. _ensure_pytest probes each dep against the grading interpreter
+and installs only what's missing, best-effort, without breaking per-case
+scoring when the report is present.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from conftest import _load_module, _SCRIPTS_DIR
+
+runner = _load_module("runner", _SCRIPTS_DIR / "runner.py")
+
+
+def _completed(returncode: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args="", returncode=returncode,
+                                       stdout="", stderr="")
+
+
+class _CommandRecorder:
+    """Stand-in for runner._run_command. Answers `import <module>` probes from
+    `importable` and records every command it's asked to run."""
+
+    def __init__(self, importable):
+        self.importable = set(importable)
+        self.commands: list[str] = []
+
+    def __call__(self, command, cwd, timeout, stdin=""):
+        self.commands.append(command)
+        for module in ("pytest_jsonreport", "pytest"):
+            if f"import {module}" in command:
+                return _completed(0 if module in self.importable else 1)
+        return _completed(0)
+
+    @property
+    def installs(self) -> list[str]:
+        return [c for c in self.commands if "pip install" in c]
+
+
+def _run_ensure(monkeypatch, importable):
+    rec = _CommandRecorder(importable)
+    monkeypatch.setattr(runner, "_run_command", rec)
+    runner._ensure_pytest(cwd=None, timeout=30)
+    return rec
+
+
+def test_skips_install_when_both_present(monkeypatch):
+    rec = _run_ensure(monkeypatch, {"pytest", "pytest_jsonreport"})
+    assert rec.installs == []
+
+
+def test_installs_only_pytest_when_plugin_present(monkeypatch):
+    rec = _run_ensure(monkeypatch, {"pytest_jsonreport"})
+    assert len(rec.installs) == 1
+    assert "pytest" in rec.installs[0]
+    assert "pytest-json-report" not in rec.installs[0]
+
+
+def test_installs_only_plugin_when_pytest_present(monkeypatch):
+    rec = _run_ensure(monkeypatch, {"pytest"})
+    assert len(rec.installs) == 1
+    assert "pytest-json-report" in rec.installs[0]
+    # The bare `pytest` token must not appear as a standalone install target.
+    assert " pytest " not in f" {rec.installs[0]} "
+
+
+def test_installs_both_when_both_missing(monkeypatch):
+    rec = _run_ensure(monkeypatch, set())
+    assert len(rec.installs) == 1
+    assert "pytest" in rec.installs[0]
+    assert "pytest-json-report" in rec.installs[0]
+
+
+def test_swallows_install_failure(monkeypatch):
+    def boom(command, cwd, timeout, stdin=""):
+        if "pip install" in command:
+            raise OSError("no network")
+        return _completed(1)
+
+    monkeypatch.setattr(runner, "_run_command", boom)
+    # Must not raise -- an offline runner degrades to fallback scoring.
+    runner._ensure_pytest(cwd=None, timeout=30)
+
+
+def test_swallows_probe_failure(monkeypatch):
+    def boom(command, cwd, timeout, stdin=""):
+        raise subprocess.SubprocessError("probe blew up")
+
+    monkeypatch.setattr(runner, "_run_command", boom)
+    runner._ensure_pytest(cwd=None, timeout=30)
+
+
+def test_grade_python_per_case_scoring_unaffected(monkeypatch, tmp_path):
+    """_ensure_pytest runs before grading, but a produced report.json still
+    drives per-case scoring -- the auto-install must not change the happy
+    path."""
+    monkeypatch.setattr(runner, "_ensure_pytest",
+                        lambda cwd, timeout: None)
+
+    def fake_run(command, cwd, timeout, stdin=""):
+        # Write the report the runner asked for via --json-report-file=...
+        for token in command.split():
+            if token.startswith("--json-report-file="):
+                path = token.split("=", 1)[1].strip("'\"")
+                import json
+                import pathlib
+                pathlib.Path(path).write_text(
+                    json.dumps({"summary": {"total": 4, "passed": 3}}))
+        return _completed(1)
+
+    monkeypatch.setattr(runner, "_run_command", fake_run)
+    spec = {"name": "pytest suite", "type": "python", "run": "python -m pytest -q"}
+    outcome = runner._grade_python(spec, cwd=tmp_path, timeout=30,
+                                   points=8, name="pytest suite")
+    # 3/4 cases -> 6 points, capped below full credit since not all passed.
+    assert outcome["score"] == 6
+    assert outcome["passed"] is False
+    assert "3/4" in outcome["detail"]

--- a/cli/gh-teacher/skeleton_tests/test_runner_grade_python.py
+++ b/cli/gh-teacher/skeleton_tests/test_runner_grade_python.py
@@ -1,11 +1,5 @@
-"""Tests for runner.py's pytest grading path.
-
-Focus is _ensure_pytest (issue #212): actions/setup-python provides only bare
-CPython, so a `python` test must have pytest + pytest-json-report installed
-before it runs. _ensure_pytest checks each dep against the grading interpreter
-and installs only what's missing, best-effort, without breaking per-case
-scoring when the report is present.
-"""
+"""Tests for runner.py's pytest grading path (_ensure_pytest, issue #212):
+install the pytest deps missing from the grading interpreter, best-effort."""
 
 from __future__ import annotations
 
@@ -24,14 +18,16 @@ def _completed(returncode: int) -> subprocess.CompletedProcess[str]:
 
 
 class _InstallRecorder:
-    """Stand-in for runner._run_command that records the install commands it's
-    asked to run (the only thing _ensure_pytest still shells out for)."""
+    """Stand-in for runner._run_command that records the install commands (and
+    their timeouts) it's asked to run."""
 
     def __init__(self):
         self.installs: list[str] = []
+        self.timeouts: list[int] = []
 
     def __call__(self, command, cwd, timeout, stdin=""):
         self.installs.append(command)
+        self.timeouts.append(timeout)
         return _completed(0)
 
 
@@ -73,6 +69,34 @@ def test_installs_both_when_both_missing(monkeypatch):
     assert "pytest-json-report" in rec.installs[0]
 
 
+def test_install_targets_grading_interpreter(monkeypatch):
+    import shlex
+    import sys
+    rec = _run_ensure(monkeypatch, set())
+    # The fix rests on installing into the interpreter that grades (sys.executable),
+    # not whatever `python` the run command resolves from PATH.
+    assert rec.installs[0].startswith(f"{shlex.quote(sys.executable)} -m pip install")
+
+
+def test_install_uses_its_own_timeout_floor(monkeypatch):
+    # A cold install can't fit the 10s default per-test timeout; _ensure_pytest
+    # must floor the install budget at PIP_INSTALL_TIMEOUT so the fix isn't a no-op.
+    monkeypatch.setattr(runner.importlib.util, "find_spec", lambda module: None)
+    rec = _InstallRecorder()
+    monkeypatch.setattr(runner, "_run_command", rec)
+    runner._ensure_pytest(cwd=None, timeout=10)
+    assert rec.timeouts == [runner.PIP_INSTALL_TIMEOUT]
+
+
+def test_install_keeps_larger_test_timeout(monkeypatch):
+    # A teacher-set timeout above the floor is respected, not clamped down.
+    monkeypatch.setattr(runner.importlib.util, "find_spec", lambda module: None)
+    rec = _InstallRecorder()
+    monkeypatch.setattr(runner, "_run_command", rec)
+    runner._ensure_pytest(cwd=None, timeout=runner.PIP_INSTALL_TIMEOUT + 60)
+    assert rec.timeouts == [runner.PIP_INSTALL_TIMEOUT + 60]
+
+
 def test_swallows_install_failure(monkeypatch):
     monkeypatch.setattr(runner.importlib.util, "find_spec", lambda module: None)
 
@@ -81,6 +105,18 @@ def test_swallows_install_failure(monkeypatch):
 
     monkeypatch.setattr(runner, "_run_command", boom)
     # Must not raise -- an offline runner degrades to fallback scoring.
+    runner._ensure_pytest(cwd=None, timeout=30)
+
+
+def test_swallows_install_timeout(monkeypatch):
+    # A bounded install that times out is the realistic failure; TimeoutExpired
+    # is a SubprocessError, so the except tuple must swallow it too.
+    monkeypatch.setattr(runner.importlib.util, "find_spec", lambda module: None)
+
+    def slow(command, cwd, timeout, stdin=""):
+        raise subprocess.TimeoutExpired(cmd="pip", timeout=timeout)
+
+    monkeypatch.setattr(runner, "_run_command", slow)
     runner._ensure_pytest(cwd=None, timeout=30)
 
 

--- a/cli/gh-teacher/skeleton_tests/test_runner_grade_python.py
+++ b/cli/gh-teacher/skeleton_tests/test_runner_grade_python.py
@@ -2,13 +2,15 @@
 
 Focus is _ensure_pytest (issue #212): actions/setup-python provides only bare
 CPython, so a `python` test must have pytest + pytest-json-report installed
-before it runs. _ensure_pytest probes each dep against the grading interpreter
+before it runs. _ensure_pytest checks each dep against the grading interpreter
 and installs only what's missing, best-effort, without breaking per-case
 scoring when the report is present.
 """
 
 from __future__ import annotations
 
+import json
+import pathlib
 import subprocess
 
 from conftest import _load_module, _SCRIPTS_DIR
@@ -21,28 +23,24 @@ def _completed(returncode: int) -> subprocess.CompletedProcess[str]:
                                        stdout="", stderr="")
 
 
-class _CommandRecorder:
-    """Stand-in for runner._run_command. Answers `import <module>` probes from
-    `importable` and records every command it's asked to run."""
+class _InstallRecorder:
+    """Stand-in for runner._run_command that records the install commands it's
+    asked to run (the only thing _ensure_pytest still shells out for)."""
 
-    def __init__(self, importable):
-        self.importable = set(importable)
-        self.commands: list[str] = []
+    def __init__(self):
+        self.installs: list[str] = []
 
     def __call__(self, command, cwd, timeout, stdin=""):
-        self.commands.append(command)
-        for module in ("pytest_jsonreport", "pytest"):
-            if f"import {module}" in command:
-                return _completed(0 if module in self.importable else 1)
+        self.installs.append(command)
         return _completed(0)
-
-    @property
-    def installs(self) -> list[str]:
-        return [c for c in self.commands if "pip install" in c]
 
 
 def _run_ensure(monkeypatch, importable):
-    rec = _CommandRecorder(importable)
+    importable = set(importable)
+    monkeypatch.setattr(
+        runner.importlib.util, "find_spec",
+        lambda module: object() if module in importable else None)
+    rec = _InstallRecorder()
     monkeypatch.setattr(runner, "_run_command", rec)
     runner._ensure_pytest(cwd=None, timeout=30)
     return rec
@@ -76,21 +74,13 @@ def test_installs_both_when_both_missing(monkeypatch):
 
 
 def test_swallows_install_failure(monkeypatch):
+    monkeypatch.setattr(runner.importlib.util, "find_spec", lambda module: None)
+
     def boom(command, cwd, timeout, stdin=""):
-        if "pip install" in command:
-            raise OSError("no network")
-        return _completed(1)
+        raise OSError("no network")
 
     monkeypatch.setattr(runner, "_run_command", boom)
     # Must not raise -- an offline runner degrades to fallback scoring.
-    runner._ensure_pytest(cwd=None, timeout=30)
-
-
-def test_swallows_probe_failure(monkeypatch):
-    def boom(command, cwd, timeout, stdin=""):
-        raise subprocess.SubprocessError("probe blew up")
-
-    monkeypatch.setattr(runner, "_run_command", boom)
     runner._ensure_pytest(cwd=None, timeout=30)
 
 
@@ -106,8 +96,6 @@ def test_grade_python_per_case_scoring_unaffected(monkeypatch, tmp_path):
         for token in command.split():
             if token.startswith("--json-report-file="):
                 path = token.split("=", 1)[1].strip("'\"")
-                import json
-                import pathlib
                 pathlib.Path(path).write_text(
                     json.dumps({"summary": {"total": 4, "passed": 3}}))
         return _completed(1)

--- a/web/src/hooks/useSkeletonDrift.ts
+++ b/web/src/hooks/useSkeletonDrift.ts
@@ -3,7 +3,8 @@ import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { findStaleSkeletonFiles } from "./github/mutations"
 import { githubKeys } from "./github/queries"
-import { useOrgRole } from "@/context/orgRole/OrgRoleProvider"
+import useGetOwnOrgMembership from "@/hooks/useGetOwnOrgMembership"
+import { resolveOrgRole } from "@/util/resolveRole"
 import { can } from "@/util/capabilities"
 
 // State subset the verdict depends on — structural so the fail-open logic stays
@@ -32,7 +33,15 @@ export function resolveSkeletonDrift(input: SkeletonDriftInput): boolean {
 // dead-end their CTA on a NotFound.
 export function useSkeletonDrift(org: string | undefined) {
   const client = useGitHubClient()
-  const { orgRole } = useOrgRole()
+  // Resolve the role from the membership read, not useOrgRole(): this banner
+  // mounts above the OrgRoleProvider, so the context would always be unresolved.
+  const membership = useGetOwnOrgMembership(org)
+  const orgRole = resolveOrgRole({
+    isSuccess: membership.isSuccess,
+    role: membership.data?.role,
+    state: membership.data?.state,
+    error: membership.error,
+  })
   const isOwner = can("manageOrg", { orgRole })
 
   const query = useQuery({

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -796,7 +796,7 @@
       "exitCode": "Required Exit Code",
       "exitCodeHint": "Leave empty to require a successful exit (0).",
       "pythonNote_prefix": "The run command should invoke pytest (e.g.",
-      "pythonNote_suffix": ") against test files in the assignment template. Points are split across the cases pytest discovers.",
+      "pythonNote_suffix": ") against test files in the assignment template. pytest and pytest-json-report are installed automatically. Points are split across the cases pytest discovers.",
       "timeout": "Timeout (seconds)",
       "timeoutHint": "0 = default (10s)",
       "points": "Points",

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -104,10 +104,11 @@ Or set the whole array at once with `gh teacher assignment add ... --tests <file
     "run": "./hello", "input": "Alice\n", "expected": "^hello,\\s+Alice\\b",
     "comparison": "regex", "points": 2 },
   { "name": "pytest suite", "type": "python",
-    "setup": "pip install --quiet pytest pytest-json-report",
     "run": "python -m pytest -q", "timeout": 120, "points": 10 }
 ]
 ```
+
+> The runner auto-installs `pytest` and `pytest-json-report` for `python` tests, so no `setup` install line is needed. Add one (e.g. `"setup": "pip install --quiet pytest==8.* pytest-json-report"`) only to pin a version — the runner leaves an already-importable version untouched.
 
 ### How it flows
 
@@ -121,7 +122,7 @@ Test commands are teacher-authored shell, executed at the same privilege as a ha
 |---|---|---|
 | `io` | stdout of `run` matches `expected` per `comparison` | `input` / `input-file`, `expected` / `expected-file`, `comparison` |
 | `run` | exit code of `run` equals `exit-code` (default 0) | `exit-code` |
-| `python` | pytest passes; points split across cases as `points × passed/total` (needs `pytest-json-report`; without it, all-or-nothing on exit code) | — |
+| `python` | pytest passes; points split across cases as `points × passed/total`. The runner auto-installs `pytest` + `pytest-json-report`; if a report still can't be produced (e.g. an offline runner), it falls back to all-or-nothing on the exit code | — |
 
 ### Fields
 


### PR DESCRIPTION
## Summary

Fixes #212. Pytest autograding failed out of the box with `pytest: not found` (exit 127) and no per-case scoring, because `actions/setup-python` provisions only bare CPython — nothing in the pipeline installed `pytest` or the `pytest-json-report` plugin.

- The runner now idempotently ensures both deps are importable before running a `python` test. It probes each against the grading interpreter (`sys.executable`) and installs only what's missing, so a teacher-pinned version (setup command / requirements.txt) is left untouched.
- The install gets its own budget (`PIP_INSTALL_TIMEOUT`, 120s), not the per-test timeout: the 10s default is too small for a cold install, so borrowing it would silently no-op the fix, and a large teacher-set timeout would otherwise be charged twice against the 15-min job ceiling.
- Install is best-effort: an offline/locked-down runner degrades to the existing exit-code fallback scoring instead of erroring the whole submission.
- The fix lives in `runner.py` (not the workflow) — it's fetched from Pages on every submission, so it reaches every classroom on next submission with no per-repo or workflow edit.
- Docs updated: the manual `pip install` is dropped from the wiki example and the web form note, kept only as an optional version-pin escape hatch.

## Test plan

- [x] `python3 -m pytest cli/gh-teacher/skeleton_tests -q` — 424 passed. New in `test_runner_grade_python.py`: skip-when-present, install-only-missing each, install-both, install-targets-`sys.executable`, install-timeout-floor + larger-timeout-respected, swallowed install failure (`OSError`) and swallowed install timeout (`TimeoutExpired`), per-case scoring regression guard.
- [x] `python3 -m pytest cli/gh-teacher/autograders_tests -q` — 289 passed (incl. the pre-existing exit-code fallback test).
- [x] `npm run check` (web) — tsc clean, prettier clean, vitest green.
- [ ] Sanity-check on a real classroom submission with a `python` test and no setup command.

## Known follow-up (out of scope)

`_grade_python` derives score/pass solely from the `pytest-json-report` summary with no independent expected-case count, and pytest runs in the student checkout with no collection confinement — so a student repo-root `conftest.py` could deselect failing cases (`total == passed` → full credit). This scoring code is pre-existing and untouched here, but auto-installing the plugin makes the summary path the default, amplifying exposure. Tracking separately as a grading-integrity hardening issue rather than blocking this fix.