### PR TITLE
docs: fix stale and inaccurate code comments

### DIFF
--- a/cli/gh-teacher/autograder_cmd.go
+++ b/cli/gh-teacher/autograder_cmd.go
@@ -208,7 +208,7 @@ func fetchFileContent(client githubapi.Client, owner, repo, path, ref string) ([
 	if body.Encoding != "base64" {
 		return nil, fmt.Errorf("GET %s: unexpected encoding %q (want base64)", apiPath, body.Encoding)
 	}
-	// GitHub wraps base64 at 76 chars; strip whitespace before decoding.
+	// GitHub wraps base64 at 60 chars; strip whitespace before decoding.
 	clean := strings.Map(func(r rune) rune {
 		if r == '\n' || r == '\r' || r == ' ' || r == '\t' {
 			return -1

--- a/cli/shared/gittree/gittree.go
+++ b/cli/shared/gittree/gittree.go
@@ -40,7 +40,7 @@ import (
 // descendant of the current branch tip. CommitWithRebase retries on it.
 var ErrNonFastForward = errors.New("non-fast-forward ref update")
 
-// rebaseAttempts: 5 tries at 200ms × 2^n backoff (~6.2s) — absorbs concurrent
+// rebaseAttempts: 5 tries at 200ms × 2^n backoff (~3s) — absorbs concurrent
 // CLI invocations, fails fast on a wedged repo.
 const rebaseAttempts = 5
 

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -398,8 +398,8 @@ type AddStudentToClassroomInput = {
   last_name?: string
   email?: string
   section?: string
-  // Write the new row directly as `enrolled` (vs `invited`); set when the
-  // student is already an active org member, so they aren't stranded.
+  // Student is already an active org member: skip the invite and drive the
+  // team-add / optimistic-seed path. Not written to the roster row.
   enrolled?: boolean
 }
 export async function enrollStudentInClassroom(
@@ -415,9 +415,9 @@ export async function enrollStudentInClassroom(
   const teamPromise = resolveClassroomTeam(client, org, classroom)
   teamPromise.catch(() => {})
 
-  // Already an active member -> write the row enrolled directly (no invite is
-  // sent, so reconcile would never confirm them). Best-effort: a failed read
-  // falls back to the normal "invited" path.
+  // Already an active member -> skip the org invite and add to the team
+  // directly (an invite would be a no-op, so reconcile would never confirm
+  // them). Best-effort: a failed read falls back to sending the invite.
   const normalizedUsername = input.username.trim()
   const alreadyMember = await isActiveMember(client, org, normalizedUsername)
 


### PR DESCRIPTION
## Summary

Audited every comment across the codebase (web/, cli/, scripts/, schemas/, CI) for factual accuracy and staleness. Comment discipline is high, so this is a small, surgical set of fixes — four comments in three files that no longer matched the code they annotate:

- **`web/src/api/mutations/students.ts`** — Two comments claimed the `enrolled` input writes an `enrolled`-vs-`invited` *status onto the roster row*. That's stale: the roster is team-driven, `STUDENT_CSV_FIELDS` has no status column, and `normalizeStudentRow` never reads the flag. It actually skips the org invite and drives the team-add / optimistic-seed path. Reworded to match.
- **`cli/shared/gittree/gittree.go`** — Rebase-backoff total said `~6.2s`; the loop sleeps only between the 5 attempts (`BackoffDelay(0..3)` = 200+400+800+1600 = ~3s). Corrected to `~3s`, consistent with the identical sibling comment in `gh-student/internal/classroomcfg/commit.go`.
- **`cli/gh-teacher/autograder_cmd.go`** — Said GitHub wraps base64 at `76 chars`; the contents API wraps at `60` (matches the authoritative `DecodeContentsBase64` note in `ghutil.go`). Corrected to `60`.

Comment-only, behavior-neutral. Python, schemas, shell, and CI comments were all verified accurate — no changes needed there.

## Test plan

- [x] `web`: `npm run check` — tsc + eslint (0 errors) + prettier clean + 1356 tests pass
- [x] `cli`: all three Go modules build, `go vet` clean, `gofmt` clean, full `go test ./...` passes (incl. `gittree`, `ghutil`, `gh-teacher`)
- [x] No behavior change — diff is comments only