### PR TITLE
feat: grant students push (not admin) on individual assignment repos

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -92,10 +92,11 @@ func acceptCmd() *cobra.Command {
 			"`.classroom50.yaml` and the autograde workflow are written in a\n" +
 			"single Tree commit, then verified.\n\n" +
 			"Re-running is safe and self-healing: an already-accepted repo\n" +
-			"that is fully provisioned is left untouched, but one whose\n" +
-			"setup never finished (a prior run interrupted after the repo\n" +
-			"was created but before the control files landed) is repaired by\n" +
-			"re-running the idempotent provisioning. accept only reports\n" +
+			"that is fully provisioned is left in place (its founder role is\n" +
+			"reconciled best-effort), but one whose setup never finished (a\n" +
+			"prior run interrupted after the repo was created but before the\n" +
+			"control files landed) is repaired by re-running the idempotent\n" +
+			"provisioning. accept only reports\n" +
 			"success once both control files are confirmed present, so an\n" +
 			"\"accepted\" repo always autogrades.",
 		Example: "  gh student accept cs50 cs50-fall-2026 hello\n" +
@@ -223,15 +224,22 @@ func acceptOrgInvite(client githubapi.Client, org string) (AcceptStatus, error) 
 	return AcceptStatus{StatusCode: http.StatusOK}, nil
 }
 
-// checkAcceptableMode gates `gh student accept` by assignment mode: individual
-// and group (and empty, defaulting to individual) are accepted; an unrecognized
-// mode is rejected. A group-shaped entry (max_group_size >= 2) whose mode isn't
-// `group` is also rejected: the founder would be under-privileged (push, not
-// admin) and unable to run `gh student invite`. Pure helper, unit-testable.
-func checkAcceptableMode(assignment, mode string, maxGroupSize int) error {
+// checkAcceptableMode rejects an unrecognized mode (which can't map to a repo
+// role). Pure helper, unit-testable. Group-shape coherence is a separate,
+// fresh-create-only check (assertModeCoherentForCreate).
+func checkAcceptableMode(assignment, mode string) error {
 	if mode != "" && mode != contract.ModeIndividual && mode != contract.ModeGroup {
 		return fmt.Errorf("assignment %q has unsupported mode %q", assignment, mode)
 	}
+	return nil
+}
+
+// assertModeCoherentForCreate rejects a group-shaped entry (max_group_size >= 2)
+// whose mode isn't `group`: fresh-founding it would under-privilege the founder
+// (push, not admin) and break `gh student invite`. Enforced only on a fresh
+// create — a healthy already-accepted repo must still reconcile/heal even if a
+// later-published entry drifted incoherent. Pure helper, unit-testable.
+func assertModeCoherentForCreate(assignment, mode string, maxGroupSize int) error {
 	if maxGroupSize > 0 && mode != contract.ModeGroup {
 		return fmt.Errorf("assignment %q has max_group_size %d but mode %q (want %q) — its published metadata is inconsistent; ask your instructor to re-run `gh teacher assignment add`",
 			assignment, maxGroupSize, mode, contract.ModeGroup)
@@ -266,7 +274,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	// The first accepter accepts a group assignment normally: the repo is
 	// created under their name and they add teammates via
 	// `gh student invite <org>/<repo> <teammate>`. Only an unknown mode errors.
-	if err := checkAcceptableMode(assignment, entry.Mode, entry.MaxGroupSize); err != nil {
+	if err := checkAcceptableMode(assignment, entry.Mode); err != nil {
 		return err
 	}
 	// A template, when present, must be complete. A template-less assignment
@@ -342,6 +350,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 		classroom:      classroom,
 		assignment:     assignment,
 		mode:           entry.Mode,
+		maxGroupSize:   entry.MaxGroupSize,
 		secret:         secret,
 		username:       username,
 		ownerID:        &ownerID,
@@ -366,6 +375,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 type acceptRepoParams struct {
 	org, classroom, assignment string
 	mode                       string
+	maxGroupSize               int
 	secret                     string
 	username, repoName, branch string
 	ownerID                    *int64
@@ -382,19 +392,12 @@ type acceptRepoParams struct {
 // provisioning, runs the idempotent provisioning when it does, and emits the
 // final report. It is the self-healing fork:
 //
-//   - alreadyExisted + marker present → already accepted; reconcile only the
-//     founder's collaborator role (downgrades a repo granted admin under an
-//     older release to the mode's least-privilege role), then leave untouched.
+//   - alreadyExisted + marker present → already accepted; best-effort reconcile
+//     of the founder's role (heals a stale admin grant down), then report.
 //   - alreadyExisted + marker missing → half-finished prior accept; re-run
 //     the idempotent provisioning to repair it.
 //   - freshly created → provision normally.
 func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writer, p acceptRepoParams) error {
-	// An existing repo with .classroom50.yaml present is already accepted, so
-	// skip the (heavier) file-provisioning — but still reconcile the founder's
-	// role: a repo accepted under an older release holds admin, and the
-	// idempotent PUT downgrades it to the mode's least-privilege role. A
-	// missing marker means a half-finished prior accept; fall through to
-	// re-provision and repair.
 	if p.alreadyExisted {
 		provisioned, perr := repoFileExists(client, p.org, p.repoName, classroomcfg.MetadataPath)
 		if perr != nil {
@@ -402,9 +405,11 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			return perr
 		}
 		if provisioned {
-			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode)); err != nil {
-				p.createSp.Fail(p.createMsg)
-				return err
+			// Already accepted: reconcile the role best-effort. The repo is
+			// already healthy, so a transient/SSO-403/left-org failure must not
+			// fail a re-run that previously always succeeded — warn and report.
+			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode)); err != nil && verbose {
+				u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 			}
 			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
 			return reportAlreadyAccepted(u, out, p.fullName, p.htmlURL)
@@ -415,6 +420,13 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 		p.createSp.Stop(fmt.Sprintf("Found incomplete setup: %s", p.fullName))
 	} else {
 		p.createSp.Stop(fmt.Sprintf("Created %s", p.fullName))
+	}
+
+	// Fresh create (or heal of a never-finished accept): a group-shaped entry
+	// whose mode isn't group would found the repo under-privileged, so reject
+	// incoherent metadata here — not on the already-accepted path above.
+	if err := assertModeCoherentForCreate(p.assignment, p.mode, p.maxGroupSize); err != nil {
+		return err
 	}
 
 	// Provision (or repair) the repo. Every step is idempotent, so this is
@@ -766,13 +778,9 @@ func founderPermission(mode string) string {
 	return "push"
 }
 
-// inviteFounder sets username's collaborator role on org/repoName to permission
-// and verifies it took effect. The student is repo `admin` the moment they
-// create the repo (GitHub grants the creator admin), so for an individual
-// assignment this is an explicit self-demotion to `push`; the PUT is an
-// idempotent upsert. Because a silently-ignored downgrade would otherwise look
-// identical to success, we read the effective permission back and fail loudly
-// if the student is still over-privileged.
+// inviteFounder sets username's collaborator role and verifies it took effect.
+// A repo creator holds admin, so an individual self-downgrade GitHub silently
+// ignores would otherwise look identical to success.
 func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string) error {
 	if _, err := githubapi.SetCollaborator(client, org, repoName, username, permission); err != nil {
 		return err
@@ -789,15 +797,9 @@ func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, or
 	return nil
 }
 
-// verifyFounderPermission reads username's effective permission back and errors
-// if it doesn't match the role we just set. This catches the case that
-// motivates the whole demotion: the creator holds admin, and if GitHub ever
-// ignores the self-downgrade the student would silently keep it.
-//
-// GET .../collaborators/{username}/permission reports the legacy role in
-// `permission` (admin/write/read/none), where our `push` grant reads back as
-// `write` and `maintain` as `write`; the granular role is in `role_name`. We
-// compare against both so a `push`→`write` mapping isn't misread as a failure.
+// verifyFounderPermission reads the effective permission back and errors if it
+// doesn't match the role we set (permissionSatisfies handles GitHub's legacy
+// role collapse), so a silently-ignored downgrade fails loud instead.
 func verifyFounderPermission(client githubapi.Client, org, repoName, username, want string) error {
 	path := fmt.Sprintf("repos/%s/%s/collaborators/%s/permission",
 		url.PathEscape(org), url.PathEscape(repoName), url.PathEscape(username))
@@ -815,19 +817,25 @@ func verifyFounderPermission(client githubapi.Client, org, repoName, username, w
 		username, want, org, repoName, got.Permission, got.RoleName, want)
 }
 
-// permissionSatisfies reports whether the effective permission (legacy
-// `permission` + granular `role_name`) matches the role we set. The legacy
-// field collapses maintain→write and triage→read, so `push` is satisfied by a
-// legacy `write`; `admin` requires admin.
+// permissionSatisfies reports whether the read-back matches the role we set.
+// role_name is authoritative when present: a push target accepts push/write
+// but must reject the more-privileged maintain/admin, which the legacy field
+// would otherwise hide (GitHub collapses maintain→write, admin→admin).
 func permissionSatisfies(legacy, roleName, want string) bool {
-	if roleName == want {
-		return true
+	if roleName != "" {
+		switch want {
+		case "admin":
+			return roleName == "admin"
+		case "push":
+			return roleName == "push" || roleName == "write"
+		default:
+			return roleName == want
+		}
 	}
 	switch want {
 	case "admin":
 		return legacy == "admin"
 	case "push":
-		// A push grant reads back as the legacy "write" role.
 		return legacy == "write"
 	default:
 		return legacy == want

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -225,8 +225,7 @@ func acceptOrgInvite(client githubapi.Client, org string) (AcceptStatus, error) 
 }
 
 // checkAcceptableMode rejects an unrecognized mode (which can't map to a repo
-// role). Pure helper, unit-testable. Group-shape coherence is a separate,
-// fresh-create-only check (assertModeCoherentForCreate).
+// role). Group-shape coherence is a separate check (assertModeCoherentForCreate).
 func checkAcceptableMode(assignment, mode string) error {
 	if mode != "" && mode != contract.ModeIndividual && mode != contract.ModeGroup {
 		return fmt.Errorf("assignment %q has unsupported mode %q", assignment, mode)
@@ -236,9 +235,8 @@ func checkAcceptableMode(assignment, mode string) error {
 
 // assertModeCoherentForCreate rejects a group-shaped entry (max_group_size >= 2)
 // whose mode isn't `group`: fresh-founding it would under-privilege the founder
-// (push, not admin) and break `gh student invite`. Enforced only on a fresh
-// create — a healthy already-accepted repo must still reconcile/heal even if a
-// later-published entry drifted incoherent. Pure helper, unit-testable.
+// and break `gh student invite`. Only on fresh create — a healthy repo must
+// still reconcile even if a later-published entry drifted incoherent.
 func assertModeCoherentForCreate(assignment, mode string, maxGroupSize int) error {
 	if maxGroupSize > 0 && mode != contract.ModeGroup {
 		return fmt.Errorf("assignment %q has max_group_size %d but mode %q (want %q) — its published metadata is inconsistent; ask your instructor to re-run `gh teacher assignment add`",

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -766,17 +766,70 @@ func founderPermission(mode string) string {
 	return "push"
 }
 
-// inviteFounder upserts username as an org/repoName collaborator at permission.
-// The PUT is idempotent, so a re-run after a role change upserts to the new
-// role (e.g. downgrading a repo granted admin under an older release).
+// inviteFounder sets username's collaborator role on org/repoName to permission
+// and verifies it took effect. The student is repo `admin` the moment they
+// create the repo (GitHub grants the creator admin), so for an individual
+// assignment this is an explicit self-demotion to `push`; the PUT is an
+// idempotent upsert. Because a silently-ignored downgrade would otherwise look
+// identical to success, we read the effective permission back and fail loudly
+// if the student is still over-privileged.
 func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string) error {
 	if _, err := githubapi.SetCollaborator(client, org, repoName, username, permission); err != nil {
 		return err
 	}
 
+	if err := verifyFounderPermission(client, org, repoName, username, permission); err != nil {
+		return err
+	}
+
 	if verbose {
-		u.Detail("invited %s to %s/%s with %s permission", username, org, repoName, permission)
+		u.Detail("set %s to %s on %s/%s", username, permission, org, repoName)
 	}
 
 	return nil
+}
+
+// verifyFounderPermission reads username's effective permission back and errors
+// if it doesn't match the role we just set. This catches the case that
+// motivates the whole demotion: the creator holds admin, and if GitHub ever
+// ignores the self-downgrade the student would silently keep it.
+//
+// GET .../collaborators/{username}/permission reports the legacy role in
+// `permission` (admin/write/read/none), where our `push` grant reads back as
+// `write` and `maintain` as `write`; the granular role is in `role_name`. We
+// compare against both so a `push`→`write` mapping isn't misread as a failure.
+func verifyFounderPermission(client githubapi.Client, org, repoName, username, want string) error {
+	path := fmt.Sprintf("repos/%s/%s/collaborators/%s/permission",
+		url.PathEscape(org), url.PathEscape(repoName), url.PathEscape(username))
+	var got struct {
+		Permission string `json:"permission"`
+		RoleName   string `json:"role_name"`
+	}
+	if err := client.Get(path, &got); err != nil {
+		return fmt.Errorf("verifying %s's permission on %s/%s: %w", username, org, repoName, err)
+	}
+	if permissionSatisfies(got.Permission, got.RoleName, want) {
+		return nil
+	}
+	return fmt.Errorf("expected %s to have %q access on %s/%s after setup, but GitHub reports %q (role %q) — a repo creator holds admin and a self-downgrade may be blocked by org policy; ask your instructor to set your access to %q",
+		username, want, org, repoName, got.Permission, got.RoleName, want)
+}
+
+// permissionSatisfies reports whether the effective permission (legacy
+// `permission` + granular `role_name`) matches the role we set. The legacy
+// field collapses maintain→write and triage→read, so `push` is satisfied by a
+// legacy `write`; `admin` requires admin.
+func permissionSatisfies(legacy, roleName, want string) bool {
+	if roleName == want {
+		return true
+	}
+	switch want {
+	case "admin":
+		return legacy == "admin"
+	case "push":
+		// A push grant reads back as the legacy "write" role.
+		return legacy == "write"
+	default:
+		return legacy == want
+	}
 }

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -87,7 +87,7 @@ func acceptCmd() *cobra.Command {
 			"student repo.\n\n" +
 			"If the student has a pending org invite it is auto-accepted first.\n" +
 			"After creating the repo, the student is added as a collaborator on\n" +
-			"their own repo (`write` for an individual assignment; `admin` for a\n" +
+			"their own repo (`push` for an individual assignment; `admin` for a\n" +
 			"group assignment, so the founder can add teammates), and\n" +
 			"`.classroom50.yaml` and the autograde workflow are written in a\n" +
 			"single Tree commit, then verified.\n\n" +
@@ -224,11 +224,17 @@ func acceptOrgInvite(client githubapi.Client, org string) (AcceptStatus, error) 
 }
 
 // checkAcceptableMode gates `gh student accept` by assignment mode: individual
-// and group (and empty, defaulting to individual) are accepted; only an
-// unrecognized mode is rejected. Pure helper so the group seam is unit-testable.
-func checkAcceptableMode(assignment, mode string) error {
+// and group (and empty, defaulting to individual) are accepted; an unrecognized
+// mode is rejected. A group-shaped entry (max_group_size >= 2) whose mode isn't
+// `group` is also rejected: the founder would be under-privileged (push, not
+// admin) and unable to run `gh student invite`. Pure helper, unit-testable.
+func checkAcceptableMode(assignment, mode string, maxGroupSize int) error {
 	if mode != "" && mode != contract.ModeIndividual && mode != contract.ModeGroup {
 		return fmt.Errorf("assignment %q has unsupported mode %q", assignment, mode)
+	}
+	if maxGroupSize > 0 && mode != contract.ModeGroup {
+		return fmt.Errorf("assignment %q has max_group_size %d but mode %q (want %q) — its published metadata is inconsistent; ask your instructor to re-run `gh teacher assignment add`",
+			assignment, maxGroupSize, mode, contract.ModeGroup)
 	}
 	return nil
 }
@@ -260,7 +266,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	// The first accepter accepts a group assignment normally: the repo is
 	// created under their name and they add teammates via
 	// `gh student invite <org>/<repo> <teammate>`. Only an unknown mode errors.
-	if err := checkAcceptableMode(assignment, entry.Mode); err != nil {
+	if err := checkAcceptableMode(assignment, entry.Mode, entry.MaxGroupSize); err != nil {
 		return err
 	}
 	// A template, when present, must be complete. A template-less assignment
@@ -376,14 +382,19 @@ type acceptRepoParams struct {
 // provisioning, runs the idempotent provisioning when it does, and emits the
 // final report. It is the self-healing fork:
 //
-//   - alreadyExisted + marker present → already accepted, leave untouched.
+//   - alreadyExisted + marker present → already accepted; reconcile only the
+//     founder's collaborator role (downgrades a repo granted admin under an
+//     older release to the mode's least-privilege role), then leave untouched.
 //   - alreadyExisted + marker missing → half-finished prior accept; re-run
 //     the idempotent provisioning to repair it.
 //   - freshly created → provision normally.
 func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writer, p acceptRepoParams) error {
-	// An existing repo with .classroom50.yaml present is already accepted —
-	// leave it untouched. A missing marker means a half-finished prior
-	// accept; fall through to re-provision and repair.
+	// An existing repo with .classroom50.yaml present is already accepted, so
+	// skip the (heavier) file-provisioning — but still reconcile the founder's
+	// role: a repo accepted under an older release holds admin, and the
+	// idempotent PUT downgrades it to the mode's least-privilege role. A
+	// missing marker means a half-finished prior accept; fall through to
+	// re-provision and repair.
 	if p.alreadyExisted {
 		provisioned, perr := repoFileExists(client, p.org, p.repoName, classroomcfg.MetadataPath)
 		if perr != nil {
@@ -391,6 +402,10 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			return perr
 		}
 		if provisioned {
+			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode)); err != nil {
+				p.createSp.Fail(p.createMsg)
+				return err
+			}
 			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
 			return reportAlreadyAccepted(u, out, p.fullName, p.htmlURL)
 		}
@@ -430,8 +445,7 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 // student repo to a healthy, autogradable state and is safe to re-run:
 //
 //  1. Grant the founder their repo role (PUT collaborators is an upsert):
-//     `write` for an individual assignment, `admin` for group (only an admin
-//     can manage collaborators for the founder-driven invite flow).
+//     `push` for an individual assignment, `admin` for group.
 //  2. Land .classroom50.yaml + the autograde shim in one Tree commit,
 //     riding out GitHub's post-create git-data lag.
 //  3. Verify the accept marker is readable before declaring success, so
@@ -441,11 +455,9 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 // paths. Mirrors the GUI's provisionAcceptedRepo so CLI and GUI heal a
 // half-finished accept identically.
 func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p acceptRepoParams, cfg classroomcfg.Config) error {
-	// Individual founders get `write` (least privilege — enough to push and
-	// trigger autograding, but not to delete/transfer the repo or manage
-	// collaborators). Group founders keep `admin` so they can add teammates
-	// via `gh student invite`, which only an admin can do. The org-level
-	// lockdown in `gh teacher init` defangs the admin's org-wide danger.
+	// Individual founders get least-privilege `push` (enough to push and
+	// trigger autograding); group founders get `admin` (needed to manage
+	// collaborators for `gh student invite`). See founderPermission.
 	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode)); err != nil {
 		return err
 	}
@@ -744,22 +756,19 @@ func defaultBranchOrMain(branch string) string {
 	return branch
 }
 
-// founderPermission is the repo collaborator role granted to the founder on
-// accept: `write` for an individual assignment (least privilege — enough to
-// push and trigger autograding), `admin` for group (only an admin can manage
-// collaborators for `gh student invite`). An empty/unknown mode defaults to
-// individual, matching checkAcceptableMode.
+// founderPermission maps an assignment mode to the founder's accept-time repo
+// role: least-privilege `push` for individual, `admin` for group (which needs
+// to manage collaborators for `gh student invite`).
 func founderPermission(mode string) string {
 	if mode == contract.ModeGroup {
 		return "admin"
 	}
-	return "write"
+	return "push"
 }
 
-// inviteFounder grants username the given collaborator permission on
-// org/repoName. PUT collaborators is an upsert, so re-running is a no-op — and
-// a re-run after a permission change (e.g. a group founder who was previously
-// granted admin) upserts to the new role.
+// inviteFounder upserts username as an org/repoName collaborator at permission.
+// The PUT is idempotent, so a re-run after a role change upserts to the new
+// role (e.g. downgrading a repo granted admin under an older release).
 func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string) error {
 	if _, err := githubapi.SetCollaborator(client, org, repoName, username, permission); err != nil {
 		return err

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -86,10 +86,11 @@ func acceptCmd() *cobra.Command {
 			"propagate on the next submission without ever touching the\n" +
 			"student repo.\n\n" +
 			"If the student has a pending org invite it is auto-accepted first.\n" +
-			"After creating the repo, the student is added as an `admin`\n" +
-			"collaborator (so they can manage collaborators for group\n" +
-			"assignments), and `.classroom50.yaml` and the autograde\n" +
-			"workflow are written in a single Tree commit, then verified.\n\n" +
+			"After creating the repo, the student is added as a collaborator on\n" +
+			"their own repo (`write` for an individual assignment; `admin` for a\n" +
+			"group assignment, so the founder can add teammates), and\n" +
+			"`.classroom50.yaml` and the autograde workflow are written in a\n" +
+			"single Tree commit, then verified.\n\n" +
 			"Re-running is safe and self-healing: an already-accepted repo\n" +
 			"that is fully provisioned is left untouched, but one whose\n" +
 			"setup never finished (a prior run interrupted after the repo\n" +
@@ -334,6 +335,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 		org:            org,
 		classroom:      classroom,
 		assignment:     assignment,
+		mode:           entry.Mode,
 		secret:         secret,
 		username:       username,
 		ownerID:        &ownerID,
@@ -357,6 +359,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 // Pages fetch.
 type acceptRepoParams struct {
 	org, classroom, assignment string
+	mode                       string
 	secret                     string
 	username, repoName, branch string
 	ownerID                    *int64
@@ -426,7 +429,9 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 // provisionAcceptedRepo brings a just-created (or partially-provisioned)
 // student repo to a healthy, autogradable state and is safe to re-run:
 //
-//  1. Grant the founder `admin` (PUT collaborators is an upsert).
+//  1. Grant the founder their repo role (PUT collaborators is an upsert):
+//     `write` for an individual assignment, `admin` for group (only an admin
+//     can manage collaborators for the founder-driven invite flow).
 //  2. Land .classroom50.yaml + the autograde shim in one Tree commit,
 //     riding out GitHub's post-create git-data lag.
 //  3. Verify the accept marker is readable before declaring success, so
@@ -436,11 +441,12 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 // paths. Mirrors the GUI's provisionAcceptedRepo so CLI and GUI heal a
 // half-finished accept identically.
 func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p acceptRepoParams, cfg classroomcfg.Config) error {
-	// Founder stays repo `admin` (upsert) so they can manage collaborators —
-	// a group founder adds teammates via `gh student invite`, which only an
-	// admin can do. The org-level lockdown in `gh teacher init` defangs the
-	// admin's delete/transfer/visibility powers org-wide.
-	if err := inviteUserAsAdmin(client, u, verbose, p.username, p.org, p.repoName); err != nil {
+	// Individual founders get `write` (least privilege — enough to push and
+	// trigger autograding, but not to delete/transfer the repo or manage
+	// collaborators). Group founders keep `admin` so they can add teammates
+	// via `gh student invite`, which only an admin can do. The org-level
+	// lockdown in `gh teacher init` defangs the admin's org-wide danger.
+	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode)); err != nil {
 		return err
 	}
 
@@ -738,20 +744,29 @@ func defaultBranchOrMain(branch string) string {
 	return branch
 }
 
-// inviteUserAsAdmin keeps username as a repo `admin` collaborator on
-// org/repoName. PUT collaborators is an upsert, so re-running is a no-op.
-// Admin (not maintain) is required because only an admin can manage
-// collaborator access — a group founder uses `gh student invite` to add
-// teammates. The org-level member-privilege lockdown in `gh teacher init`
-// removes the org-wide danger of repo-admin (no delete/transfer/visibility
-// change), so admin-on-own-repo is safe.
-func inviteUserAsAdmin(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName string) error {
-	if _, err := githubapi.SetCollaborator(client, org, repoName, username, "admin"); err != nil {
+// founderPermission is the repo collaborator role granted to the founder on
+// accept: `write` for an individual assignment (least privilege — enough to
+// push and trigger autograding), `admin` for group (only an admin can manage
+// collaborators for `gh student invite`). An empty/unknown mode defaults to
+// individual, matching checkAcceptableMode.
+func founderPermission(mode string) string {
+	if mode == contract.ModeGroup {
+		return "admin"
+	}
+	return "write"
+}
+
+// inviteFounder grants username the given collaborator permission on
+// org/repoName. PUT collaborators is an upsert, so re-running is a no-op — and
+// a re-run after a permission change (e.g. a group founder who was previously
+// granted admin) upserts to the new role.
+func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string) error {
+	if _, err := githubapi.SetCollaborator(client, org, repoName, username, permission); err != nil {
 		return err
 	}
 
 	if verbose {
-		u.Detail("invited %s to %s/%s with admin permission", username, org, repoName)
+		u.Detail("invited %s to %s/%s with %s permission", username, org, repoName, permission)
 	}
 
 	return nil

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -384,17 +384,24 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 		}
 	}
 
-	t.Run("already accepted (marker present) -> untouched, no provisioning", func(t *testing.T) {
+	t.Run("already accepted (marker present) -> reconciles founder role, no file re-provision", func(t *testing.T) {
+		var collaboratorPerm string
 		var collaboratorPut, treeWrite bool
 		mux := http.NewServeMux()
 		mux.HandleFunc(markerPath, func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"type": "file"})
 		})
-		// Any provisioning call here is a bug — the repo is already done.
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, _ *http.Request) {
+		// The founder role is reconciled (idempotent PUT downgrades a repo
+		// granted admin under an older release); capture the permission.
+		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, r *http.Request) {
 			collaboratorPut = true
+			var body map[string]any
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			collaboratorPerm, _ = body["permission"].(string)
 			w.WriteHeader(http.StatusNoContent)
 		})
+		// Any file re-provision (tree commit) here is a bug — the repo is done.
 		mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/trees", func(w http.ResponseWriter, _ *http.Request) {
 			treeWrite = true
 			_ = json.NewEncoder(w).Encode(map[string]string{"sha": "t"})
@@ -407,8 +414,15 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 		if err != nil {
 			t.Fatalf("acceptIntoRepo: unexpected error: %v", err)
 		}
-		if collaboratorPut || treeWrite {
-			t.Errorf("an already-provisioned repo must be left untouched (collaboratorPut=%v treeWrite=%v)", collaboratorPut, treeWrite)
+		if !collaboratorPut {
+			t.Errorf("an already-provisioned repo must still reconcile the founder role (no collaborator PUT issued)")
+		}
+		// baseParams leaves mode empty (individual): reconcile downgrades to push.
+		if collaboratorPerm != "push" {
+			t.Errorf("reconciled individual founder permission = %q, want \"push\" (heals a stale admin grant down)", collaboratorPerm)
+		}
+		if treeWrite {
+			t.Errorf("an already-provisioned repo must not re-provision files (unexpected tree write)")
 		}
 		if !strings.Contains(out.String(), "already accepted") {
 			t.Errorf("expected an already-accepted report on stdout:\n%s", out.String())
@@ -512,78 +526,89 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 		}
 	})
 
-	t.Run("freshly created (not alreadyExisted) -> provisions and reports accepted", func(t *testing.T) {
-		var (
-			collaboratorPut  bool
-			collaboratorPerm string
-			treeWrite        bool
-			refPatched       bool
-		)
-		mux := http.NewServeMux()
-		// Fresh create skips the fork's marker probe; the marker is only
-		// read by the post-provision verifyProvisioned, and must be
-		// present (the commit just landed it).
-		mux.HandleFunc(markerPath, func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]any{"type": "file"})
-		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, r *http.Request) {
-			collaboratorPut = true
-			var body map[string]any
-			raw, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(raw, &body)
-			collaboratorPerm, _ = body["permission"].(string)
-			w.WriteHeader(http.StatusNoContent)
-		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/branches/main", func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]any{"commit": map[string]any{"sha": "stable"}})
-		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
-			switch r.Method {
-			case http.MethodGet:
-				_ = json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": "parent"}})
-			case http.MethodPatch:
-				refPatched = true
-				w.WriteHeader(http.StatusOK)
-			}
-		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/commits/parent", func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]any{"tree": map[string]string{"sha": "parent-tree"}})
-		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/blobs", func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]string{"sha": "blob"})
-		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/trees", func(w http.ResponseWriter, _ *http.Request) {
-			treeWrite = true
-			_ = json.NewEncoder(w).Encode(map[string]string{"sha": "tree"})
-		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/commits", func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]string{"sha": "commit"})
-		})
-		server := httptest.NewServer(mux)
-		t.Cleanup(server.Close)
+	t.Run("freshly created (not alreadyExisted) -> provisions with the mode's role", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			mode     string
+			wantPerm string
+		}{
+			{"individual grants push", "", "push"},
+			{"group grants admin", "group", "admin"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var (
+					collaboratorPut  bool
+					collaboratorPerm string
+					treeWrite        bool
+					refPatched       bool
+				)
+				mux := http.NewServeMux()
+				// Fresh create skips the fork's marker probe; the marker is only
+				// read by the post-provision verifyProvisioned, and must be
+				// present (the commit just landed it).
+				mux.HandleFunc(markerPath, func(w http.ResponseWriter, _ *http.Request) {
+					_ = json.NewEncoder(w).Encode(map[string]any{"type": "file"})
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, r *http.Request) {
+					collaboratorPut = true
+					var body map[string]any
+					raw, _ := io.ReadAll(r.Body)
+					_ = json.Unmarshal(raw, &body)
+					collaboratorPerm, _ = body["permission"].(string)
+					w.WriteHeader(http.StatusNoContent)
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/branches/main", func(w http.ResponseWriter, _ *http.Request) {
+					_ = json.NewEncoder(w).Encode(map[string]any{"commit": map[string]any{"sha": "stable"}})
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
+					switch r.Method {
+					case http.MethodGet:
+						_ = json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": "parent"}})
+					case http.MethodPatch:
+						refPatched = true
+						w.WriteHeader(http.StatusOK)
+					}
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/commits/parent", func(w http.ResponseWriter, _ *http.Request) {
+					_ = json.NewEncoder(w).Encode(map[string]any{"tree": map[string]string{"sha": "parent-tree"}})
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/blobs", func(w http.ResponseWriter, _ *http.Request) {
+					_ = json.NewEncoder(w).Encode(map[string]string{"sha": "blob"})
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/trees", func(w http.ResponseWriter, _ *http.Request) {
+					treeWrite = true
+					_ = json.NewEncoder(w).Encode(map[string]string{"sha": "tree"})
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/git/commits", func(w http.ResponseWriter, _ *http.Request) {
+					_ = json.NewEncoder(w).Encode(map[string]string{"sha": "commit"})
+				})
+				server := httptest.NewServer(mux)
+				t.Cleanup(server.Close)
 
-		p := baseParams()
-		p.alreadyExisted = false
-		var out bytes.Buffer
-		err := acceptIntoRepo(newTestRESTClient(t, server), ui.NewForced(&out, false), false, &out, p)
-		if err != nil {
-			t.Fatalf("acceptIntoRepo (fresh): unexpected error: %v", err)
-		}
-		if !collaboratorPut || !treeWrite || !refPatched {
-			t.Errorf("fresh path must provision (collaboratorPut=%v treeWrite=%v refPatched=%v)", collaboratorPut, treeWrite, refPatched)
-		}
-		// baseParams leaves mode empty (individual): the founder gets
-		// least-privilege `write`, not `admin`.
-		if collaboratorPerm != "write" {
-			t.Errorf("individual founder permission = %q, want \"write\"", collaboratorPerm)
-		}
-		// A first-time accept reports "Assignment accepted:", NOT the
-		// "already accepted" wording the alreadyExisted branches use.
-		if !strings.Contains(out.String(), "Assignment accepted:") {
-			t.Errorf("a fresh accept should report 'Assignment accepted:':\n%s", out.String())
-		}
-		if strings.Contains(out.String(), "already accepted") {
-			t.Errorf("a fresh accept must not use the already-accepted wording:\n%s", out.String())
+				p := baseParams()
+				p.alreadyExisted = false
+				p.mode = tc.mode
+				var out bytes.Buffer
+				err := acceptIntoRepo(newTestRESTClient(t, server), ui.NewForced(&out, false), false, &out, p)
+				if err != nil {
+					t.Fatalf("acceptIntoRepo (fresh): unexpected error: %v", err)
+				}
+				if !collaboratorPut || !treeWrite || !refPatched {
+					t.Errorf("fresh path must provision (collaboratorPut=%v treeWrite=%v refPatched=%v)", collaboratorPut, treeWrite, refPatched)
+				}
+				if collaboratorPerm != tc.wantPerm {
+					t.Errorf("mode %q founder permission = %q, want %q", tc.mode, collaboratorPerm, tc.wantPerm)
+				}
+				// A first-time accept reports "Assignment accepted:", NOT the
+				// "already accepted" wording the alreadyExisted branches use.
+				if !strings.Contains(out.String(), "Assignment accepted:") {
+					t.Errorf("a fresh accept should report 'Assignment accepted:':\n%s", out.String())
+				}
+				if strings.Contains(out.String(), "already accepted") {
+					t.Errorf("a fresh accept must not use the already-accepted wording:\n%s", out.String())
+				}
+			})
 		}
 	})
 }

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -444,6 +444,59 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 		}
 	})
 
+	t.Run("already accepted group repo -> reconciles founder to admin", func(t *testing.T) {
+		var collaboratorPerm string
+		mux := http.NewServeMux()
+		mux.HandleFunc(markerPath, func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"type": "file"})
+		})
+		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice/permission", func(w http.ResponseWriter, _ *http.Request) {
+			writePermissionReadback(w, collaboratorPerm)
+		})
+		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]any
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			collaboratorPerm, _ = body["permission"].(string)
+			w.WriteHeader(http.StatusNoContent)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		p := baseParams()
+		p.mode = "group"
+		var out bytes.Buffer
+		if err := acceptIntoRepo(newTestRESTClient(t, server), ui.NewForced(&out, false), false, &out, p); err != nil {
+			t.Fatalf("acceptIntoRepo (group already-accepted): unexpected error: %v", err)
+		}
+		// A group founder must stay admin on reconcile, else `gh student invite` breaks.
+		if collaboratorPerm != "admin" {
+			t.Errorf("reconciled group founder permission = %q, want \"admin\"", collaboratorPerm)
+		}
+	})
+
+	t.Run("already accepted repo still reports success when the best-effort reconcile fails", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(markerPath, func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"type": "file"})
+		})
+		// Reconcile fails (e.g. transient 5xx / SSO 403 / departed founder): a
+		// healthy already-accepted repo must NOT fail the re-run over it.
+		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		var out bytes.Buffer
+		if err := acceptIntoRepo(newTestRESTClient(t, server), ui.NewForced(&out, false), false, &out, baseParams()); err != nil {
+			t.Fatalf("a healthy already-accepted repo must not fail when the reconcile errs: %v", err)
+		}
+		if !strings.Contains(out.String(), "already accepted") {
+			t.Errorf("expected an already-accepted report despite the reconcile failure:\n%s", out.String())
+		}
+	})
+
 	t.Run("half-provisioned (marker missing) -> re-provisions and repairs", func(t *testing.T) {
 		var (
 			markerReads     int

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -16,6 +16,18 @@ import (
 	"github.com/foundation50/gh-student/internal/ui"
 )
 
+// writePermissionReadback answers GET .../collaborators/{u}/permission with the
+// effective role GitHub would report for a grant of `set`: push collapses to
+// the legacy "write" role, admin stays admin. Lets the accept tests satisfy
+// inviteFounder's post-grant verification.
+func writePermissionReadback(w http.ResponseWriter, set string) {
+	legacy, role := set, set
+	if set == "push" {
+		legacy, role = "write", "push"
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"permission": legacy, "role_name": role})
+}
+
 func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 	tmpl := assignments.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "main"}
 
@@ -393,6 +405,9 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 		})
 		// The founder role is reconciled (idempotent PUT downgrades a repo
 		// granted admin under an older release); capture the permission.
+		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice/permission", func(w http.ResponseWriter, _ *http.Request) {
+			writePermissionReadback(w, collaboratorPerm)
+		})
 		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, r *http.Request) {
 			collaboratorPut = true
 			var body map[string]any
@@ -447,7 +462,10 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusNotFound)
 		})
-		// Provisioning: admin grant.
+		// Provisioning: role grant (baseParams mode is empty -> push).
+		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice/permission", func(w http.ResponseWriter, _ *http.Request) {
+			writePermissionReadback(w, "push")
+		})
 		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, _ *http.Request) {
 			collaboratorPut = true
 			w.WriteHeader(http.StatusNoContent)
@@ -549,6 +567,9 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 				// present (the commit just landed it).
 				mux.HandleFunc(markerPath, func(w http.ResponseWriter, _ *http.Request) {
 					_ = json.NewEncoder(w).Encode(map[string]any{"type": "file"})
+				})
+				mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice/permission", func(w http.ResponseWriter, _ *http.Request) {
+					writePermissionReadback(w, collaboratorPerm)
 				})
 				mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, r *http.Request) {
 					collaboratorPut = true

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -514,9 +514,10 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 
 	t.Run("freshly created (not alreadyExisted) -> provisions and reports accepted", func(t *testing.T) {
 		var (
-			collaboratorPut bool
-			treeWrite       bool
-			refPatched      bool
+			collaboratorPut  bool
+			collaboratorPerm string
+			treeWrite        bool
+			refPatched       bool
 		)
 		mux := http.NewServeMux()
 		// Fresh create skips the fork's marker probe; the marker is only
@@ -525,8 +526,12 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 		mux.HandleFunc(markerPath, func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"type": "file"})
 		})
-		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, _ *http.Request) {
+		mux.HandleFunc("/repos/"+org+"/"+repoName+"/collaborators/alice", func(w http.ResponseWriter, r *http.Request) {
 			collaboratorPut = true
+			var body map[string]any
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			collaboratorPerm, _ = body["permission"].(string)
 			w.WriteHeader(http.StatusNoContent)
 		})
 		mux.HandleFunc("/repos/"+org+"/"+repoName+"/branches/main", func(w http.ResponseWriter, _ *http.Request) {
@@ -566,6 +571,11 @@ func TestAcceptIntoRepo_SelfHealFork(t *testing.T) {
 		}
 		if !collaboratorPut || !treeWrite || !refPatched {
 			t.Errorf("fresh path must provision (collaboratorPut=%v treeWrite=%v refPatched=%v)", collaboratorPut, treeWrite, refPatched)
+		}
+		// baseParams leaves mode empty (individual): the founder gets
+		// least-privilege `write`, not `admin`.
+		if collaboratorPerm != "write" {
+			t.Errorf("individual founder permission = %q, want \"write\"", collaboratorPerm)
 		}
 		// A first-time accept reports "Assignment accepted:", NOT the
 		// "already accepted" wording the alreadyExisted branches use.

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -70,10 +70,9 @@ func TestAssertModeCoherentForCreate(t *testing.T) {
 	}
 }
 
-// TestPermissionSatisfies pins the read-back decision, including the boundary
-// the guard exists to enforce: a `maintain` founder (which GitHub's legacy
-// field collapses to "write") must FAIL a `push` target, so an ignored
-// self-downgrade to a still-over-privileged role is caught, not passed green.
+// TestPermissionSatisfies pins the read-back decision, incl. the guard's
+// boundary: a `maintain` founder (legacy collapses to "write") must FAIL a
+// `push` target, so an ignored self-downgrade isn't passed green.
 func TestPermissionSatisfies(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -103,11 +102,8 @@ func TestPermissionSatisfies(t *testing.T) {
 }
 
 // TestFounderPermission pins the mode→role mapping: individual (and
-// empty/unknown, which default to individual) gets least-privilege `push` —
-// enough to push and trigger autograding but not to delete/transfer the repo
-// or manage collaborators — while group gets `admin` so the founder can add
-// teammates via `gh student invite`. A regression here either over-privileges
-// individual students or silently breaks the group-invite flow.
+// empty/unknown, which default to individual) gets least-privilege `push`,
+// group gets `admin` so the founder can add teammates via `gh student invite`.
 func TestFounderPermission(t *testing.T) {
 	cases := []struct {
 		mode string
@@ -127,10 +123,9 @@ func TestFounderPermission(t *testing.T) {
 	}
 }
 
-// TestInviteFounder pins the founder grant + verification: accept PUTs the
-// student at the requested role, then reads the effective permission back and
-// succeeds only when it matches (a push grant reads back as the legacy `write`
-// role). Asserts the exact PUT path/body so a wrong verb/path/role regresses.
+// TestInviteFounder pins the grant + verification: accept PUTs the student at
+// the requested role, then succeeds only when the read-back matches (a push
+// grant reads back as legacy `write`). Asserts the exact PUT path/body.
 func TestInviteFounder(t *testing.T) {
 	const (
 		org      = "cs50"
@@ -187,9 +182,8 @@ func TestInviteFounder(t *testing.T) {
 }
 
 // TestInviteFounder_VerificationFails proves the demotion is verified, not
-// fire-and-forget: when the read-back still reports admin after we set push
-// (the self-downgrade was ignored), inviteFounder returns an actionable error
-// rather than silently reporting success.
+// fire-and-forget: a read-back still reporting admin after a push grant must
+// return an actionable error, not silently report success.
 func TestInviteFounder_VerificationFails(t *testing.T) {
 	const (
 		org      = "cs50"

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/foundation50/gh-student/internal/ui"
@@ -68,45 +69,95 @@ func TestFounderPermission(t *testing.T) {
 	}
 }
 
-// TestInviteFounder pins the founder collaborator grant: accept must PUT the
-// student as a collaborator at the requested permission. Assert the exact PUT
-// path and request body so a regression to a wrong verb/path/role is caught.
+// TestInviteFounder pins the founder grant + verification: accept PUTs the
+// student at the requested role, then reads the effective permission back and
+// succeeds only when it matches (a push grant reads back as the legacy `write`
+// role). Asserts the exact PUT path/body so a wrong verb/path/role regresses.
 func TestInviteFounder(t *testing.T) {
 	const (
 		org      = "cs50"
 		repoName = "cs50-fall-2026-hello-alice"
 		username = "alice"
 	)
-	wantPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
+	collabPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
+	permPath := collabPath + "/permission"
 
-	for _, permission := range []string{"push", "admin"} {
-		t.Run(permission, func(t *testing.T) {
-			var gotPath, gotMethod string
+	// want is the role we set; legacyBack is what GitHub reports on the
+	// read-back (push collapses to the legacy "write" role).
+	cases := []struct {
+		want      string
+		legacyBack string
+	}{
+		{"push", "write"},
+		{"admin", "admin"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			var gotPutPath, gotMethod string
 			var gotBody map[string]any
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				gotPath = r.URL.Path
+			mux := http.NewServeMux()
+			mux.HandleFunc(permPath, func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"permission": tc.legacyBack, "role_name": tc.want})
+			})
+			mux.HandleFunc(collabPath, func(w http.ResponseWriter, r *http.Request) {
+				gotPutPath = r.URL.Path
 				gotMethod = r.Method
 				raw, _ := io.ReadAll(r.Body)
 				_ = json.Unmarshal(raw, &gotBody)
-				w.WriteHeader(http.StatusNoContent) // 204: added directly
-			}))
+				w.WriteHeader(http.StatusNoContent) // 204: updated directly
+			})
+			server := httptest.NewServer(mux)
 			t.Cleanup(server.Close)
 			client := newTestRESTClient(t, server)
 
 			var out bytes.Buffer
-			if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, permission); err != nil {
+			if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, tc.want); err != nil {
 				t.Fatalf("inviteFounder returned error: %v", err)
 			}
 
 			if gotMethod != http.MethodPut {
 				t.Errorf("method = %q, want PUT", gotMethod)
 			}
-			if gotPath != wantPath {
-				t.Errorf("path = %q, want %q", gotPath, wantPath)
+			if gotPutPath != collabPath {
+				t.Errorf("path = %q, want %q", gotPutPath, collabPath)
 			}
-			if perm := gotBody["permission"]; perm != permission {
-				t.Errorf("collaborator permission = %v, want %q", perm, permission)
+			if perm := gotBody["permission"]; perm != tc.want {
+				t.Errorf("collaborator permission = %v, want %q", perm, tc.want)
 			}
 		})
+	}
+}
+
+// TestInviteFounder_VerificationFails proves the demotion is verified, not
+// fire-and-forget: when the read-back still reports admin after we set push
+// (the self-downgrade was ignored), inviteFounder returns an actionable error
+// rather than silently reporting success.
+func TestInviteFounder_VerificationFails(t *testing.T) {
+	const (
+		org      = "cs50"
+		repoName = "cs50-fall-2026-hello-alice"
+		username = "alice"
+	)
+	collabPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(collabPath+"/permission", func(w http.ResponseWriter, _ *http.Request) {
+		// The downgrade didn't take — student is still admin.
+		_ = json.NewEncoder(w).Encode(map[string]any{"permission": "admin", "role_name": "admin"})
+	})
+	mux.HandleFunc(collabPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := newTestRESTClient(t, server)
+
+	var out bytes.Buffer
+	err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "push")
+	if err == nil {
+		t.Fatalf("expected an error when the effective permission stays admin after a push grant, got nil")
+	}
+	if !strings.Contains(err.Error(), "push") || !strings.Contains(err.Error(), "admin") {
+		t.Errorf("error should name the wanted (push) and actual (admin) roles, got: %v", err)
 	}
 }

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -13,32 +13,90 @@ import (
 )
 
 // TestCheckAcceptableMode pins the accept mode gate: individual, group, and
-// empty (defaults to individual) are accepted; an unknown mode errors; and a
-// group-shaped entry (max_group_size >= 2) whose mode isn't `group` is rejected
-// as inconsistent metadata (the founder would be under-privileged).
+// empty (defaults to individual) are accepted; only an unknown mode errors.
+// Group-shape coherence is a separate check (TestAssertModeCoherentForCreate).
 func TestCheckAcceptableMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		mode    string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"individual", "individual", false},
+		{"group", "group", false},
+		{"unknown mode", "team", true},
+		{"uppercase group is not canonical", "GROUP", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkAcceptableMode("hello", tc.mode)
+			if tc.wantErr && err == nil {
+				t.Errorf("mode %q: expected an error, got nil", tc.mode)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("mode %q: unexpected error %v", tc.mode, err)
+			}
+		})
+	}
+}
+
+// TestAssertModeCoherentForCreate pins the fresh-create coherence gate: a
+// group-shaped entry (max_group_size >= 2) whose mode isn't `group` is rejected
+// (the founder would be under-privileged), while coherent and non-group-shaped
+// entries pass. This gate must NOT run on the already-accepted reconcile path.
+func TestAssertModeCoherentForCreate(t *testing.T) {
 	cases := []struct {
 		name         string
 		mode         string
 		maxGroupSize int
 		wantErr      bool
 	}{
-		{"empty", "", 0, false},
-		{"individual", "individual", 0, false},
-		{"group", "group", 3, false},
-		{"unknown mode", "team", 0, true},
-		{"uppercase group is not canonical", "GROUP", 0, true},
+		{"individual no size", "individual", 0, false},
+		{"group with size", "group", 3, false},
+		{"empty no size", "", 0, false},
 		{"group size but empty mode is inconsistent", "", 3, true},
 		{"group size but individual mode is inconsistent", "individual", 2, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := checkAcceptableMode("hello", tc.mode, tc.maxGroupSize)
+			err := assertModeCoherentForCreate("hello", tc.mode, tc.maxGroupSize)
 			if tc.wantErr && err == nil {
 				t.Errorf("mode %q size %d: expected an error, got nil", tc.mode, tc.maxGroupSize)
 			}
 			if !tc.wantErr && err != nil {
 				t.Errorf("mode %q size %d: unexpected error %v", tc.mode, tc.maxGroupSize, err)
+			}
+		})
+	}
+}
+
+// TestPermissionSatisfies pins the read-back decision, including the boundary
+// the guard exists to enforce: a `maintain` founder (which GitHub's legacy
+// field collapses to "write") must FAIL a `push` target, so an ignored
+// self-downgrade to a still-over-privileged role is caught, not passed green.
+func TestPermissionSatisfies(t *testing.T) {
+	cases := []struct {
+		name     string
+		legacy   string
+		roleName string
+		want     string
+		ok       bool
+	}{
+		{"push grant reads role_name push", "write", "push", "push", true},
+		{"push grant reads role_name write", "write", "write", "push", true},
+		{"maintain must fail a push target", "write", "maintain", "push", false},
+		{"admin must fail a push target", "admin", "admin", "push", false},
+		{"read must fail a push target", "read", "read", "push", false},
+		{"admin grant reads role_name admin", "admin", "admin", "admin", true},
+		{"push must fail an admin target", "write", "push", "admin", false},
+		{"empty role_name falls back to legacy write for push", "write", "", "push", true},
+		{"empty role_name falls back to legacy admin for admin", "admin", "", "admin", true},
+		{"empty role_name legacy write must fail admin", "write", "", "admin", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := permissionSatisfies(tc.legacy, tc.roleName, tc.want); got != tc.ok {
+				t.Errorf("permissionSatisfies(%q,%q,%q) = %v, want %v", tc.legacy, tc.roleName, tc.want, got, tc.ok)
 			}
 		})
 	}

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -38,12 +38,35 @@ func TestCheckAcceptableMode(t *testing.T) {
 	}
 }
 
-// TestInviteUserAsAdmin pins the founder-admin grant: accept must keep the
-// student as an `admin` collaborator (not the old `maintain`), because only an
-// admin can manage collaborators for the founder-driven group-invite flow. A
-// regression to a weaker permission silently breaks `gh student invite`, so
-// assert the exact PUT path and request body.
-func TestInviteUserAsAdmin(t *testing.T) {
+// TestFounderPermission pins the mode→role mapping: individual (and
+// empty/unknown, which default to individual) gets least-privilege `write` —
+// enough to push and trigger autograding but not to delete/transfer the repo
+// or manage collaborators — while group keeps `admin` so the founder can add
+// teammates via `gh student invite`. A regression here either over-privileges
+// individual students or silently breaks the group-invite flow.
+func TestFounderPermission(t *testing.T) {
+	cases := []struct {
+		mode string
+		want string
+	}{
+		{"individual", "write"},
+		{"", "write"},
+		{"team", "write"}, // unknown modes default to individual (least privilege)
+		{"group", "admin"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mode, func(t *testing.T) {
+			if got := founderPermission(tc.mode); got != tc.want {
+				t.Errorf("founderPermission(%q) = %q, want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInviteFounder pins the founder collaborator grant: accept must PUT the
+// student as a collaborator at the requested permission. Assert the exact PUT
+// path and request body so a regression to a wrong verb/path/role is caught.
+func TestInviteFounder(t *testing.T) {
 	const (
 		org      = "cs50"
 		repoName = "cs50-fall-2026-hello-alice"
@@ -51,30 +74,34 @@ func TestInviteUserAsAdmin(t *testing.T) {
 	)
 	wantPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
 
-	var gotPath, gotMethod string
-	var gotBody map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		gotMethod = r.Method
-		raw, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(raw, &gotBody)
-		w.WriteHeader(http.StatusNoContent) // 204: added directly
-	}))
-	t.Cleanup(server.Close)
-	client := newTestRESTClient(t, server)
+	for _, permission := range []string{"write", "admin"} {
+		t.Run(permission, func(t *testing.T) {
+			var gotPath, gotMethod string
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotMethod = r.Method
+				raw, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(raw, &gotBody)
+				w.WriteHeader(http.StatusNoContent) // 204: added directly
+			}))
+			t.Cleanup(server.Close)
+			client := newTestRESTClient(t, server)
 
-	var out bytes.Buffer
-	if err := inviteUserAsAdmin(client, ui.NewForced(&out, false), false, username, org, repoName); err != nil {
-		t.Fatalf("inviteUserAsAdmin returned error: %v", err)
-	}
+			var out bytes.Buffer
+			if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, permission); err != nil {
+				t.Fatalf("inviteFounder returned error: %v", err)
+			}
 
-	if gotMethod != http.MethodPut {
-		t.Errorf("method = %q, want PUT", gotMethod)
-	}
-	if gotPath != wantPath {
-		t.Errorf("path = %q, want %q", gotPath, wantPath)
-	}
-	if perm := gotBody["permission"]; perm != "admin" {
-		t.Errorf("collaborator permission = %v, want \"admin\" (regression to maintain/push breaks gh student invite)", perm)
+			if gotMethod != http.MethodPut {
+				t.Errorf("method = %q, want PUT", gotMethod)
+			}
+			if gotPath != wantPath {
+				t.Errorf("path = %q, want %q", gotPath, wantPath)
+			}
+			if perm := gotBody["permission"]; perm != permission {
+				t.Errorf("collaborator permission = %v, want %q", perm, permission)
+			}
+		})
 	}
 }

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -11,37 +11,42 @@ import (
 	"github.com/foundation50/gh-student/internal/ui"
 )
 
-// TestCheckAcceptableMode pins the lifted accept seam: group is now accepted
-// (previously rejected), individual and empty are accepted, and only an
-// unrecognized mode errors.
+// TestCheckAcceptableMode pins the accept mode gate: individual, group, and
+// empty (defaults to individual) are accepted; an unknown mode errors; and a
+// group-shaped entry (max_group_size >= 2) whose mode isn't `group` is rejected
+// as inconsistent metadata (the founder would be under-privileged).
 func TestCheckAcceptableMode(t *testing.T) {
 	cases := []struct {
-		mode    string
-		wantErr bool
+		name         string
+		mode         string
+		maxGroupSize int
+		wantErr      bool
 	}{
-		{"", false},
-		{"individual", false},
-		{"group", false},
-		{"team", true},
-		{"GROUP", true}, // case-sensitive; the canonical value is lowercase
+		{"empty", "", 0, false},
+		{"individual", "individual", 0, false},
+		{"group", "group", 3, false},
+		{"unknown mode", "team", 0, true},
+		{"uppercase group is not canonical", "GROUP", 0, true},
+		{"group size but empty mode is inconsistent", "", 3, true},
+		{"group size but individual mode is inconsistent", "individual", 2, true},
 	}
 	for _, tc := range cases {
-		t.Run(tc.mode, func(t *testing.T) {
-			err := checkAcceptableMode("hello", tc.mode)
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkAcceptableMode("hello", tc.mode, tc.maxGroupSize)
 			if tc.wantErr && err == nil {
-				t.Errorf("mode %q: expected an error, got nil", tc.mode)
+				t.Errorf("mode %q size %d: expected an error, got nil", tc.mode, tc.maxGroupSize)
 			}
 			if !tc.wantErr && err != nil {
-				t.Errorf("mode %q: unexpected error %v", tc.mode, err)
+				t.Errorf("mode %q size %d: unexpected error %v", tc.mode, tc.maxGroupSize, err)
 			}
 		})
 	}
 }
 
 // TestFounderPermission pins the mode→role mapping: individual (and
-// empty/unknown, which default to individual) gets least-privilege `write` —
+// empty/unknown, which default to individual) gets least-privilege `push` —
 // enough to push and trigger autograding but not to delete/transfer the repo
-// or manage collaborators — while group keeps `admin` so the founder can add
+// or manage collaborators — while group gets `admin` so the founder can add
 // teammates via `gh student invite`. A regression here either over-privileges
 // individual students or silently breaks the group-invite flow.
 func TestFounderPermission(t *testing.T) {
@@ -49,9 +54,9 @@ func TestFounderPermission(t *testing.T) {
 		mode string
 		want string
 	}{
-		{"individual", "write"},
-		{"", "write"},
-		{"team", "write"}, // unknown modes default to individual (least privilege)
+		{"individual", "push"},
+		{"", "push"},
+		{"team", "push"}, // unknown modes default to individual (least privilege)
 		{"group", "admin"},
 	}
 	for _, tc := range cases {
@@ -74,7 +79,7 @@ func TestInviteFounder(t *testing.T) {
 	)
 	wantPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
 
-	for _, permission := range []string{"write", "admin"} {
+	for _, permission := range []string{"push", "admin"} {
 		t.Run(permission, func(t *testing.T) {
 			var gotPath, gotMethod string
 			var gotBody map[string]any

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -85,7 +85,7 @@ func TestInviteFounder(t *testing.T) {
 	// want is the role we set; legacyBack is what GitHub reports on the
 	// read-back (push collapses to the legacy "write" role).
 	cases := []struct {
-		want      string
+		want       string
 		legacyBack string
 	}{
 		{"push", "write"},

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import {
+  addFounderCollaborator,
   assertAssignmentModeCoherent,
   buildReusedEntry,
   copyAssignmentToClassroom,
@@ -1186,7 +1187,117 @@ describe("permissionSatisfies — verified founder demotion (issue #213)", () =>
     expect(permissionSatisfies("admin", "admin", "push")).toBe(false)
   })
 
+  it("rejects a maintain read-back for a push target (the guard's boundary)", () => {
+    // GitHub collapses maintain->legacy "write", so legacy alone would pass;
+    // the authoritative role_name must catch the still-over-privileged founder.
+    expect(permissionSatisfies("write", "maintain", "push")).toBe(false)
+  })
+
+  it("rejects a push read-back for an admin target (group under-grant)", () => {
+    expect(permissionSatisfies("write", "push", "admin")).toBe(false)
+  })
+
+  it("falls back to the legacy field when role_name is absent", () => {
+    expect(permissionSatisfies("write", undefined, "push")).toBe(true)
+    expect(permissionSatisfies("admin", undefined, "admin")).toBe(true)
+    expect(permissionSatisfies("write", undefined, "admin")).toBe(false)
+  })
+
   it("rejects an under-grant (read only) for a push target", () => {
     expect(permissionSatisfies("read", "read", "push")).toBe(false)
+  })
+})
+
+// Drives addFounderCollaborator end-to-end (PUT grant -> read-back -> throw),
+// the web mirror of gh-student's TestInviteFounder / _VerificationFails: the
+// pure permissionSatisfies is unit-tested above, but this pins the wiring
+// (getRepoPermissionForUser -> compare -> throw) that isolation can't reach.
+describe("addFounderCollaborator — grant + read-back verification (issue #213)", () => {
+  const owner = "cs50"
+  const repo = "cs50-fall-2026-hello-alice"
+  const username = "alice"
+  const collabPath = `/repos/${owner}/${repo}/collaborators/${username}`
+  const permPath = `${collabPath}/permission`
+
+  // A mock client that records the collaborator PUT body and answers the
+  // permission read-back with `readback`.
+  function makeClient(readback: { permission?: string; role_name?: string }) {
+    const put = vi.fn()
+    const request = vi.fn(async (path: string, opts?: { method?: string }) => {
+      if (path === collabPath && opts?.method === "PUT") {
+        put(opts)
+        return undefined
+      }
+      if (path === permPath) return readback
+      throw new Error(`unexpected request: ${opts?.method ?? "GET"} ${path}`)
+    })
+    return { client: { request } as unknown as GitHubClient, request, put }
+  }
+
+  it("PUTs push and succeeds when the read-back satisfies", async () => {
+    const { client, request } = makeClient({
+      permission: "write",
+      role_name: "push",
+    })
+    await expect(
+      addFounderCollaborator({
+        client,
+        owner,
+        repo,
+        username,
+        permission: "push",
+      }),
+    ).resolves.toBeUndefined()
+    expect(request).toHaveBeenCalledWith(collabPath, {
+      method: "PUT",
+      body: { permission: "push" },
+    })
+  })
+
+  it("PUTs admin for a group founder", async () => {
+    const { client, request } = makeClient({
+      permission: "admin",
+      role_name: "admin",
+    })
+    await addFounderCollaborator({
+      client,
+      owner,
+      repo,
+      username,
+      permission: "admin",
+    })
+    expect(request).toHaveBeenCalledWith(collabPath, {
+      method: "PUT",
+      body: { permission: "admin" },
+    })
+  })
+
+  it("throws when the read-back still reports admin after a push grant", async () => {
+    const { client } = makeClient({ permission: "admin", role_name: "admin" })
+    await expect(
+      addFounderCollaborator({
+        client,
+        owner,
+        repo,
+        username,
+        permission: "push",
+      }),
+    ).rejects.toThrow(/"push"/)
+  })
+
+  it("throws when the read-back is maintain for a push grant (the guard's boundary)", async () => {
+    const { client } = makeClient({
+      permission: "write",
+      role_name: "maintain",
+    })
+    await expect(
+      addFounderCollaborator({
+        client,
+        owner,
+        repo,
+        username,
+        permission: "push",
+      }),
+    ).rejects.toThrow(/"push"/)
   })
 })

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -4,6 +4,7 @@ import {
   buildReusedEntry,
   copyAssignmentToClassroom,
   editAssignment,
+  founderPermission,
   nextAvailableSlug,
   preserveUnmanagedAssignmentKeys,
   resolveTemplate,
@@ -1126,5 +1127,24 @@ describe("resolveTemplate (create/edit blocking path)", () => {
     const result = await resolveTemplate(client, ORG, ref(ORG, "tmpl"))
 
     expect(result.template?.repo).toBe("tmpl")
+  })
+})
+
+// Mirrors gh-student's TestFounderPermission: individual (and empty/unknown,
+// which default to individual) gets least-privilege `write` — enough to push
+// and trigger autograding but not to delete/transfer the repo or manage
+// collaborators — while group keeps `admin` for the founder-driven invite flow.
+describe("founderPermission — accept-time repo role (issue #213)", () => {
+  it("grants write for individual assignments", () => {
+    expect(founderPermission("individual")).toBe("write")
+  })
+
+  it("grants admin for group assignments (founder manages collaborators)", () => {
+    expect(founderPermission("group")).toBe("admin")
+  })
+
+  it("defaults an absent or unknown mode to write (least privilege)", () => {
+    expect(founderPermission(undefined)).toBe("write")
+    expect(founderPermission("team")).toBe("write")
   })
 })

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -1136,7 +1136,7 @@ describe("resolveTemplate (create/edit blocking path)", () => {
 // Mirrors gh-student's TestFounderPermission: individual gets least-privilege
 // `push` (enough to push and trigger autograding, not to delete/transfer or
 // manage collaborators); group gets `admin` for the founder-driven invite flow.
-describe("founderPermission — accept-time repo role (issue #213)", () => {
+describe("founderPermission — accept-time repo role", () => {
   it("grants push for individual assignments", () => {
     expect(founderPermission("individual")).toBe("push")
   })
@@ -1146,10 +1146,10 @@ describe("founderPermission — accept-time repo role (issue #213)", () => {
   })
 })
 
-// Mirrors gh-student's checkAcceptableMode group-coherence gate: a group-shaped
-// entry (max_group_size >= 2) whose mode isn't `group` is rejected so the
-// founder isn't silently under-privileged (push instead of admin).
-describe("assertAssignmentModeCoherent (issue #213 / review #3)", () => {
+// Mirrors gh-student's assertModeCoherentForCreate: a group-shaped entry
+// (max_group_size >= 2) whose mode isn't `group` is rejected so the founder
+// isn't silently under-privileged (push instead of admin).
+describe("assertAssignmentModeCoherent", () => {
   it("accepts a coherent group entry", () => {
     expect(() => assertAssignmentModeCoherent("hw", "group", 3)).not.toThrow()
   })
@@ -1173,7 +1173,7 @@ describe("assertAssignmentModeCoherent (issue #213 / review #3)", () => {
 // permissionSatisfies decides whether the read-back after the grant matches the
 // role we set, accounting for GitHub collapsing push -> legacy "write". Guards
 // the verified self-demotion (a repo creator is admin until this downgrades it).
-describe("permissionSatisfies — verified founder demotion (issue #213)", () => {
+describe("permissionSatisfies — verified founder demotion", () => {
   it("accepts a push grant that reads back as legacy write", () => {
     expect(permissionSatisfies("write", "write", "push")).toBe(true)
     expect(permissionSatisfies("write", "push", "push")).toBe(true)
@@ -1209,10 +1209,8 @@ describe("permissionSatisfies — verified founder demotion (issue #213)", () =>
 })
 
 // Drives addFounderCollaborator end-to-end (PUT grant -> read-back -> throw),
-// the web mirror of gh-student's TestInviteFounder / _VerificationFails: the
-// pure permissionSatisfies is unit-tested above, but this pins the wiring
-// (getRepoPermissionForUser -> compare -> throw) that isolation can't reach.
-describe("addFounderCollaborator — grant + read-back verification (issue #213)", () => {
+// the web mirror of gh-student's TestInviteFounder / _VerificationFails.
+describe("addFounderCollaborator — grant + read-back verification", () => {
   const owner = "cs50"
   const repo = "cs50-fall-2026-hello-alice"
   const username = "alice"

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -7,6 +7,7 @@ import {
   editAssignment,
   founderPermission,
   nextAvailableSlug,
+  permissionSatisfies,
   preserveUnmanagedAssignmentKeys,
   resolveTemplate,
   verifyTemplateAccess,
@@ -1165,5 +1166,27 @@ describe("assertAssignmentModeCoherent (issue #213 / review #3)", () => {
     expect(() => assertAssignmentModeCoherent("hw", "individual", 2)).toThrow(
       /max_group_size 2 but mode "individual"/,
     )
+  })
+})
+
+// permissionSatisfies decides whether the read-back after the grant matches the
+// role we set, accounting for GitHub collapsing push -> legacy "write". Guards
+// the verified self-demotion (a repo creator is admin until this downgrades it).
+describe("permissionSatisfies — verified founder demotion (issue #213)", () => {
+  it("accepts a push grant that reads back as legacy write", () => {
+    expect(permissionSatisfies("write", "write", "push")).toBe(true)
+    expect(permissionSatisfies("write", "push", "push")).toBe(true)
+  })
+
+  it("accepts an admin grant that reads back as admin", () => {
+    expect(permissionSatisfies("admin", "admin", "admin")).toBe(true)
+  })
+
+  it("rejects a still-admin read-back after a push grant (downgrade ignored)", () => {
+    expect(permissionSatisfies("admin", "admin", "push")).toBe(false)
+  })
+
+  it("rejects an under-grant (read only) for a push target", () => {
+    expect(permissionSatisfies("read", "read", "push")).toBe(false)
   })
 })

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import {
+  assertAssignmentModeCoherent,
   buildReusedEntry,
   copyAssignmentToClassroom,
   editAssignment,
@@ -1130,21 +1131,39 @@ describe("resolveTemplate (create/edit blocking path)", () => {
   })
 })
 
-// Mirrors gh-student's TestFounderPermission: individual (and empty/unknown,
-// which default to individual) gets least-privilege `write` — enough to push
-// and trigger autograding but not to delete/transfer the repo or manage
-// collaborators — while group keeps `admin` for the founder-driven invite flow.
+// Mirrors gh-student's TestFounderPermission: individual gets least-privilege
+// `push` (enough to push and trigger autograding, not to delete/transfer or
+// manage collaborators); group gets `admin` for the founder-driven invite flow.
 describe("founderPermission — accept-time repo role (issue #213)", () => {
-  it("grants write for individual assignments", () => {
-    expect(founderPermission("individual")).toBe("write")
+  it("grants push for individual assignments", () => {
+    expect(founderPermission("individual")).toBe("push")
   })
 
   it("grants admin for group assignments (founder manages collaborators)", () => {
     expect(founderPermission("group")).toBe("admin")
   })
+})
 
-  it("defaults an absent or unknown mode to write (least privilege)", () => {
-    expect(founderPermission(undefined)).toBe("write")
-    expect(founderPermission("team")).toBe("write")
+// Mirrors gh-student's checkAcceptableMode group-coherence gate: a group-shaped
+// entry (max_group_size >= 2) whose mode isn't `group` is rejected so the
+// founder isn't silently under-privileged (push instead of admin).
+describe("assertAssignmentModeCoherent (issue #213 / review #3)", () => {
+  it("accepts a coherent group entry", () => {
+    expect(() => assertAssignmentModeCoherent("hw", "group", 3)).not.toThrow()
+  })
+
+  it("accepts an individual entry with no group size", () => {
+    expect(() =>
+      assertAssignmentModeCoherent("hw", "individual", undefined),
+    ).not.toThrow()
+    expect(() =>
+      assertAssignmentModeCoherent("hw", "individual", 0),
+    ).not.toThrow()
+  })
+
+  it("rejects a group-shaped size with a non-group mode", () => {
+    expect(() => assertAssignmentModeCoherent("hw", "individual", 2)).toThrow(
+      /max_group_size 2 but mode "individual"/,
+    )
   })
 })

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -59,6 +59,7 @@ import {
   getBranchRefRepo,
   getCommitByRepo,
   getRepo,
+  getRepoPermissionForUser,
   withFreshRepoRetry,
 } from "@/hooks/github/queries"
 import { getAuthenticatedUser } from "../queries/users"
@@ -1709,7 +1710,10 @@ export async function deleteAssignment(
 
 // Grant the founder their repo role: `push` for individual (least privilege),
 // `admin` for group (needed to manage collaborators for `gh student invite`).
-// CLI-aligned with founderPermission in gh-student's accept.go.
+// The student is repo admin the moment they create it, so for individual this
+// is an explicit self-demotion; we read the effective permission back and throw
+// if it didn't take, since a silently-ignored downgrade looks like success.
+// CLI-aligned with inviteFounder in gh-student's accept.go.
 async function addFounderCollaborator(params: {
   client: GitHubClient
   owner: string
@@ -1725,6 +1729,36 @@ async function addFounderCollaborator(params: {
       permission,
     },
   })
+
+  const effective = await getRepoPermissionForUser({
+    client,
+    org: owner,
+    repo,
+    username,
+  })
+
+  if (
+    !permissionSatisfies(effective.permission, effective.role_name, permission)
+  ) {
+    throw new Error(
+      `Expected ${username} to have "${permission}" access on ${owner}/${repo}, but GitHub reports "${effective.permission}" (role "${effective.role_name}") — a repo creator holds admin and a self-downgrade may be blocked by org policy. Ask your instructor to set your access to "${permission}".`,
+    )
+  }
+}
+
+// Whether the effective permission (legacy `permission` + granular `role_name`)
+// matches the role we set. The legacy field collapses maintain->write and
+// triage->read, so a `push` grant reads back as legacy `write`. Mirrors
+// gh-student's permissionSatisfies.
+export function permissionSatisfies(
+  legacy: string | undefined,
+  roleName: string | undefined,
+  want: "push" | "admin",
+): boolean {
+  if (roleName === want) return true
+  if (want === "admin") return legacy === "admin"
+  // push grant reads back as the legacy "write" role.
+  return legacy === "write"
 }
 
 // Maps assignment mode to the founder's repo role: least-privilege `push` for

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1707,23 +1707,35 @@ export async function deleteAssignment(
   }
 }
 
-// Grant the student `admin` (not `maintain`) on their own repo. Intentional and
-// CLI-aligned: only an admin can manage collaborators for the founder-driven
-// group-invite flow (`gh student invite`).
-async function addAdminCollaborator(params: {
+// Grant the founder their repo role on their own repo. `write` for an
+// individual assignment (least privilege — enough to push and trigger
+// autograding, but not to delete/transfer the repo or manage collaborators);
+// `admin` for group, because only an admin can manage collaborators for the
+// founder-driven group-invite flow (`gh student invite`). CLI-aligned with
+// founderPermission in gh-student's accept.go.
+async function addFounderCollaborator(params: {
   client: GitHubClient
   owner: string
   repo: string
   username: string
+  permission: "write" | "admin"
 }) {
-  const { client, owner, repo, username } = params
+  const { client, owner, repo, username, permission } = params
 
   await client.request(`/repos/${owner}/${repo}/collaborators/${username}`, {
     method: "PUT",
     body: {
-      permission: "admin",
+      permission,
     },
   })
+}
+
+// founderPermission maps an assignment mode to the founder's repo role:
+// least-privilege `write` for individual (and any unknown/absent mode), `admin`
+// for group. Mirrors gh-student's founderPermission so CLI and GUI grant the
+// same access.
+export function founderPermission(mode: string | undefined): "write" | "admin" {
+  return mode === "group" ? "admin" : "write"
 }
 
 async function patchRepoSurface(
@@ -1881,14 +1893,16 @@ type AcceptAssignmentResult = {
 }
 
 // Provision a just-created (or partially-provisioned) student repo: patch its
-// surface, grant the student admin, and land the .classroom50.yaml + autograde
-// shim through GitHub's post-generate lag. Every step is idempotent, so it's
-// safe to re-run when healing a repo whose earlier accept failed mid-flow.
+// surface, grant the student their repo role (write for individual, admin for
+// group), and land the .classroom50.yaml + autograde shim through GitHub's
+// post-generate lag. Every step is idempotent, so it's safe to re-run when
+// healing a repo whose earlier accept failed mid-flow.
 async function provisionAcceptedRepo(params: {
   client: GitHubClient
   org: string
   repo: GitHubRepo
   username: string
+  mode: string | undefined
   branch: string
   metadataYaml: string
   autogradeYaml: string
@@ -1899,6 +1913,7 @@ async function provisionAcceptedRepo(params: {
     org,
     repo,
     username,
+    mode,
     branch,
     metadataYaml,
     autogradeYaml,
@@ -1915,11 +1930,12 @@ async function provisionAcceptedRepo(params: {
     },
     async () => {
       await patchRepoSurface(client, org, repo.name)
-      await addAdminCollaborator({
+      await addFounderCollaborator({
         client,
         owner: org,
         repo: repo.name,
         username,
+        permission: founderPermission(mode),
       })
     },
   )
@@ -2130,6 +2146,7 @@ export async function acceptAssignment(params: {
       org,
       repo: created.repo,
       username,
+      mode: assignment.mode,
       branch: created.repo.default_branch || sourceBranch,
       metadataYaml,
       autogradeYaml,
@@ -2155,6 +2172,7 @@ export async function acceptAssignment(params: {
     org,
     repo,
     username,
+    mode: assignment.mode,
     branch: targetBranch,
     metadataYaml,
     autogradeYaml,

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1,5 +1,5 @@
 import type { GitHubClient } from "@/hooks/github/client"
-import type { Assignment } from "@/types/classroom"
+import type { Assignment, AssignmentMode } from "@/types/classroom"
 import {
   GROUP_SIZE_MAX,
   GROUP_SIZE_MIN,
@@ -1707,18 +1707,15 @@ export async function deleteAssignment(
   }
 }
 
-// Grant the founder their repo role on their own repo. `write` for an
-// individual assignment (least privilege — enough to push and trigger
-// autograding, but not to delete/transfer the repo or manage collaborators);
-// `admin` for group, because only an admin can manage collaborators for the
-// founder-driven group-invite flow (`gh student invite`). CLI-aligned with
-// founderPermission in gh-student's accept.go.
+// Grant the founder their repo role: `push` for individual (least privilege),
+// `admin` for group (needed to manage collaborators for `gh student invite`).
+// CLI-aligned with founderPermission in gh-student's accept.go.
 async function addFounderCollaborator(params: {
   client: GitHubClient
   owner: string
   repo: string
   username: string
-  permission: "write" | "admin"
+  permission: "push" | "admin"
 }) {
   const { client, owner, repo, username, permission } = params
 
@@ -1730,12 +1727,25 @@ async function addFounderCollaborator(params: {
   })
 }
 
-// founderPermission maps an assignment mode to the founder's repo role:
-// least-privilege `write` for individual (and any unknown/absent mode), `admin`
-// for group. Mirrors gh-student's founderPermission so CLI and GUI grant the
-// same access.
-export function founderPermission(mode: string | undefined): "write" | "admin" {
-  return mode === "group" ? "admin" : "write"
+// Maps assignment mode to the founder's repo role: least-privilege `push` for
+// individual, `admin` for group. Mirrors gh-student's founderPermission.
+export function founderPermission(mode: AssignmentMode): "push" | "admin" {
+  return mode === "group" ? "admin" : "push"
+}
+
+// Rejects a group-shaped entry (max_group_size >= 2) whose mode isn't `group`:
+// its published metadata is inconsistent and the founder would be
+// under-privileged. Mirrors gh-student's checkAcceptableMode.
+export function assertAssignmentModeCoherent(
+  slug: string,
+  mode: AssignmentMode,
+  maxGroupSize: number | undefined,
+): void {
+  if ((maxGroupSize ?? 0) > 0 && mode !== "group") {
+    throw new Error(
+      `Assignment "${slug}" has max_group_size ${maxGroupSize} but mode "${mode}" (want "group") — its published metadata is inconsistent. Ask your instructor to re-run assignment setup.`,
+    )
+  }
 }
 
 async function patchRepoSurface(
@@ -1893,7 +1903,7 @@ type AcceptAssignmentResult = {
 }
 
 // Provision a just-created (or partially-provisioned) student repo: patch its
-// surface, grant the student their repo role (write for individual, admin for
+// surface, grant the student their repo role (push for individual, admin for
 // group), and land the .classroom50.yaml + autograde shim through GitHub's
 // post-generate lag. Every step is idempotent, so it's safe to re-run when
 // healing a repo whose earlier accept failed mid-flow.
@@ -1902,7 +1912,7 @@ async function provisionAcceptedRepo(params: {
   org: string
   repo: GitHubRepo
   username: string
-  mode: string | undefined
+  mode: AssignmentMode
   branch: string
   metadataYaml: string
   autogradeYaml: string
@@ -2020,6 +2030,16 @@ export async function acceptAssignment(params: {
     () => fetchAssignmentFromPages(org, classroom, assignmentSlug, secret),
   )
 
+  // A group-shaped entry (max_group_size >= 2) whose mode isn't `group` has
+  // inconsistent published metadata: the founder would be under-privileged
+  // (push, not admin) and unable to add teammates. CLI-aligned with
+  // checkAcceptableMode in gh-student's accept.go.
+  assertAssignmentModeCoherent(
+    assignment.slug,
+    assignment.mode,
+    assignment.max_group_size,
+  )
+
   const sourceOwner = assignment.template?.owner
   const sourceRepo = assignment.template?.repo
   const sourceBranch = assignment.template?.branch ?? "main"
@@ -2118,8 +2138,16 @@ export async function acceptAssignment(params: {
     const provisioned = hasMetadata && hasWorkflow
 
     if (provisioned) {
-      // Genuinely already accepted — mark the remaining steps complete so the
-      // checklist doesn't look stuck.
+      // Genuinely already accepted — reconcile only the founder's role (an
+      // older release granted admin; the idempotent PUT downgrades it to the
+      // mode's least-privilege role), then mark the remaining steps complete.
+      await addFounderCollaborator({
+        client,
+        owner: org,
+        repo: created.repo.name,
+        username,
+        permission: founderPermission(assignment.mode),
+      })
       onStepUpdate?.({
         id: "repo",
         status: "complete",

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1767,8 +1767,7 @@ export function founderPermission(mode: AssignmentMode): "push" | "admin" {
 }
 
 // Rejects a group-shaped entry (max_group_size >= 2) whose mode isn't `group`:
-// its published metadata is inconsistent and the founder would be
-// under-privileged. Mirrors gh-student's checkAcceptableMode.
+// the founder would be under-privileged. Mirrors gh-student's assertModeCoherentForCreate.
 export function assertAssignmentModeCoherent(
   slug: string,
   mode: AssignmentMode,
@@ -1935,11 +1934,8 @@ type AcceptAssignmentResult = {
   cloneCommand: string
 }
 
-// Provision a just-created (or partially-provisioned) student repo: patch its
-// surface, grant the student their repo role (push for individual, admin for
-// group), and land the .classroom50.yaml + autograde shim through GitHub's
-// post-generate lag. Every step is idempotent, so it's safe to re-run when
-// healing a repo whose earlier accept failed mid-flow.
+// Provision (or heal) a just-created student repo — grant the founder role,
+// land the control files. Idempotent, so safe to re-run mid-flow.
 async function provisionAcceptedRepo(params: {
   client: GitHubClient
   org: string
@@ -2161,10 +2157,8 @@ export async function acceptAssignment(params: {
     const provisioned = hasMetadata && hasWorkflow
 
     if (provisioned) {
-      // Genuinely already accepted and healthy: reconcile the founder's role
-      // best-effort (heals a stale admin grant down). A transient/SSO-403/
-      // left-org failure must not fail a re-run that previously always
-      // succeeded, so swallow it and report already-accepted.
+      // Healthy already-accepted: reconcile the founder role best-effort. A
+      // transient failure must not fail a re-run that previously succeeded.
       try {
         await addFounderCollaborator({
           client,

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1708,13 +1708,10 @@ export async function deleteAssignment(
   }
 }
 
-// Grant the founder their repo role: `push` for individual (least privilege),
-// `admin` for group (needed to manage collaborators for `gh student invite`).
-// The student is repo admin the moment they create it, so for individual this
-// is an explicit self-demotion; we read the effective permission back and throw
-// if it didn't take, since a silently-ignored downgrade looks like success.
-// CLI-aligned with inviteFounder in gh-student's accept.go.
-async function addFounderCollaborator(params: {
+// Grant the founder their repo role and verify it took: a repo creator holds
+// admin, so an individual self-downgrade GitHub silently ignores looks like
+// success. CLI-aligned with inviteFounder in gh-student's accept.go.
+export async function addFounderCollaborator(params: {
   client: GitHubClient
   owner: string
   repo: string
@@ -1746,18 +1743,20 @@ async function addFounderCollaborator(params: {
   }
 }
 
-// Whether the effective permission (legacy `permission` + granular `role_name`)
-// matches the role we set. The legacy field collapses maintain->write and
-// triage->read, so a `push` grant reads back as legacy `write`. Mirrors
-// gh-student's permissionSatisfies.
+// Whether the read-back matches the role we set. role_name is authoritative
+// when present: a push target accepts push/write but must reject the
+// more-privileged maintain/admin the legacy field would hide (GitHub collapses
+// maintain->write, admin->admin). Mirrors gh-student's permissionSatisfies.
 export function permissionSatisfies(
   legacy: string | undefined,
   roleName: string | undefined,
   want: "push" | "admin",
 ): boolean {
-  if (roleName === want) return true
+  if (roleName) {
+    if (want === "admin") return roleName === "admin"
+    return roleName === "push" || roleName === "write"
+  }
   if (want === "admin") return legacy === "admin"
-  // push grant reads back as the legacy "write" role.
   return legacy === "write"
 }
 
@@ -2064,16 +2063,6 @@ export async function acceptAssignment(params: {
     () => fetchAssignmentFromPages(org, classroom, assignmentSlug, secret),
   )
 
-  // A group-shaped entry (max_group_size >= 2) whose mode isn't `group` has
-  // inconsistent published metadata: the founder would be under-privileged
-  // (push, not admin) and unable to add teammates. CLI-aligned with
-  // checkAcceptableMode in gh-student's accept.go.
-  assertAssignmentModeCoherent(
-    assignment.slug,
-    assignment.mode,
-    assignment.max_group_size,
-  )
-
   const sourceOwner = assignment.template?.owner
   const sourceRepo = assignment.template?.repo
   const sourceBranch = assignment.template?.branch ?? "main"
@@ -2172,16 +2161,25 @@ export async function acceptAssignment(params: {
     const provisioned = hasMetadata && hasWorkflow
 
     if (provisioned) {
-      // Genuinely already accepted — reconcile only the founder's role (an
-      // older release granted admin; the idempotent PUT downgrades it to the
-      // mode's least-privilege role), then mark the remaining steps complete.
-      await addFounderCollaborator({
-        client,
-        owner: org,
-        repo: created.repo.name,
-        username,
-        permission: founderPermission(assignment.mode),
-      })
+      // Genuinely already accepted and healthy: reconcile the founder's role
+      // best-effort (heals a stale admin grant down). A transient/SSO-403/
+      // left-org failure must not fail a re-run that previously always
+      // succeeded, so swallow it and report already-accepted.
+      try {
+        await addFounderCollaborator({
+          client,
+          owner: org,
+          repo: created.repo.name,
+          username,
+          permission: founderPermission(assignment.mode),
+        })
+      } catch (err) {
+        log.debug("accept: best-effort role reconcile failed (non-fatal)", {
+          org,
+          repo: created.repo.name,
+          err,
+        })
+      }
       onStepUpdate?.({
         id: "repo",
         status: "complete",
@@ -2196,7 +2194,14 @@ export async function acceptAssignment(params: {
       }
     }
 
-    // Half-finished prior accept — re-provision to repair it.
+    // Half-finished prior accept — re-provision to repair it. Re-founding a
+    // group-shaped-but-non-group entry would under-privilege the founder, so
+    // reject incoherent metadata here (not on the healthy path above).
+    assertAssignmentModeCoherent(
+      assignment.slug,
+      assignment.mode,
+      assignment.max_group_size,
+    )
     onStepUpdate?.({
       id: "repo",
       status: "complete",
@@ -2223,6 +2228,14 @@ export async function acceptAssignment(params: {
   }
 
   const repo = created.repo
+
+  // Fresh create: reject a group-shaped-but-non-group entry that would found
+  // the repo under-privileged (mirrors the half-finished path above).
+  assertAssignmentModeCoherent(
+    assignment.slug,
+    assignment.mode,
+    assignment.max_group_size,
+  )
 
   const targetBranch =
     created.kind === "fallback-empty"

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -1444,10 +1444,10 @@ export async function getRepoPermissionForUser(params: {
   org: string
   repo: string
   username: string
-}) {
+}): Promise<{ permission?: string; role_name?: string }> {
   const { client, org, repo, username } = params
 
-  return client.request(
+  return client.request<{ permission?: string; role_name?: string }>(
     `/repos/${org}/${repo}/collaborators/${username}/permission`,
   )
 }

--- a/web/src/hooks/github/rulesets.ts
+++ b/web/src/hooks/github/rulesets.ts
@@ -46,7 +46,8 @@ type OrgRulesetBody = {
 
 // OrganizationAdmin (actor_id 1) is the org-owner role — the teacher — so they
 // can merge the Feedback PR and force-push/delete in a pinch, while students
-// (maintain, no bypass) cannot.
+// (a repo `push` or `admin` collaborator, but never OrganizationAdmin) get no
+// bypass entry and stay bound by the rules.
 const ADMIN_BYPASS: RulesetBypassActor[] = [
   { actor_id: 1, actor_type: "OrganizationAdmin", bypass_mode: "always" },
 ]


### PR DESCRIPTION
## Summary

Closes #213.

When a student accepts an assignment, `gh student accept` (and the web accept flow) previously added them as an **admin** collaborator on their own repo. Admin lets them delete/transfer the repo, change its visibility, and manage collaborators — more than a student needs for an individual assignment.

This grants the founder the least privilege that still works:

- **Individual** assignments → `push`. Per GitHub's [repository roles](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization), the write/`push` role can push and *"create, edit, run, re-run, and cancel GitHub Actions workflows"* — so autograding (push + workflow re-run) is fully preserved, while delete/transfer/visibility/collaborator-management are not granted. We send GitHub's documented request value `push` (not the undocumented `write` alias), matching `gh student invite` and the rest of the repo.
- **Group** assignments → `admin` (unchanged). Only an admin can manage collaborators, which the group founder needs for `gh student invite`.

The mode→role decision lives in a single `founderPermission` helper mirrored across the Go CLI (`cli/gh-student/accept.go`) and the web app (`web/src/api/mutations/assignments.ts`).

**Re-accept reconciles the role.** The collaborator PUT is an idempotent upsert, and it now runs on *every* accept — including when the repo is already fully provisioned — so a repo granted `admin` under an older release is healed *down* to its least-privilege role. (File re-provisioning is still skipped for an already-complete repo; only the role is reconciled.)

**The self-demotion is verified.** A repo creator holds `admin` the moment they create the repo, so the individual `push` grant is a self-downgrade GitHub can silently ignore. After the PUT we read the effective permission back and fail loud if the student is still over-privileged (`verifyFounderPermission` / `permissionSatisfies`, mirrored web-side); `role_name` is authoritative so a `maintain` founder can't sneak past a `push` target. On the healthy re-accept path this reconcile is best-effort — a transient/SSO-403/departed-founder failure must not fail a re-run that previously always succeeded.

**Consistent metadata is enforced.** A group-shaped entry (`max_group_size >= 2`) whose published `mode` isn't `group` is now rejected at accept time (mirrored `assertModeCoherentForCreate` / `assertAssignmentModeCoherent`), so a group founder can't silently land on `push` and then be unable to run `gh student invite`. The gate runs only on fresh-create/heal, not the healthy reconcile path.

The `gh teacher init` org lockdown (no member delete/transfer/visibility-change) already defanged the org-wide danger of repo-admin; this narrows the per-repo grant too.

Out of scope (issue's "less important" follow-up): a teacher-facing checkbox to opt individual assignments into admin.

## Changes

- `cli/gh-student/accept.go`: thread assignment `mode` into provisioning; `founderPermission` returns `push`/`admin`; reconcile + verify the founder role on the already-provisioned re-accept path (best-effort); `assertModeCoherentForCreate` rejects incoherent group metadata on fresh create; rename `inviteUserAsAdmin` → `inviteFounder`; update `accept --help` text.
- `web/src/api/mutations/assignments.ts`: mirror all of the above — `founderPermission` (`push`/`admin`, typed `AssignmentMode`), reconcile + verify on the already-accepted branch, exported `assertAssignmentModeCoherent` and `permissionSatisfies`, rename `addAdminCollaborator` → `addFounderCollaborator`.
- `web/src/hooks/github/{queries,rulesets}.ts`: type `getRepoPermissionForUser`'s return; fix a stale comment that described students as `maintain`.
- Tests: mode→role mapping and coherence gate (CLI + web); `permissionSatisfies` boundaries (`maintain` fails a `push` target); `inviteFounder` / `addFounderCollaborator` PUT body per role plus read-back verification; end-to-end assertions that a fresh individual accept grants `push`, a fresh group accept grants `admin`, a re-accept reconciles an existing repo down to `push`, and a best-effort reconcile failure still reports already-accepted.
- Comment cleanup: trim over-length doc comments to the repo's `<=2`-line style, drop `issue`/`review` references from test names, and correct the `assertAssignmentModeCoherent` cross-reference to name its real Go mirror (`assertModeCoherentForCreate`).

## Test plan

- [x] `cd cli/gh-student && go build ./... && go test ./...` — pass
- [x] `cd cli/gh-student && go vet ./...` — clean; `gofmt` clean
- [x] web `tsc -b` — pass
- [x] web `vitest run` — pass (`assignments.test.ts`: 68 pass)
- [x] `eslint` + `prettier --check` on touched web files — clean
- [ ] Manual: accept an individual assignment, confirm student is `push` and can push + re-run the autograde workflow
- [ ] Manual: accept a group assignment, confirm founder is `admin` and `gh student invite` works
- [ ] Manual: re-accept an assignment created under the old release, confirm the role reconciles from `admin` down to `push`