### PR TITLE
fix: support non-main default branches in org setup and submit

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -821,12 +821,11 @@ func resolveConfigRepoBranch(client githubapi.Client, org string) (string, error
 	return defaultBranchOrMain(repo.DefaultBranch), nil
 }
 
-// defaultBranchOrMain guards against an empty default_branch in the
-// (HasTemplate-guaranteed non-empty) template ref; the empty-repo path has no
-// such guarantee, so an empty value would flow into WaitForStableBranch("")
-// and 404-loop to an opaque "did not stabilize" failure, leaving a
-// created-but-shimless repo. "main" is GitHub's default for an auto_init repo
-// and matches what `gh student submit` pushes to.
+// defaultBranchOrMain guards against an empty default_branch in a create/GET
+// response: an empty value flowing into WaitForStableBranch("") would 404-loop
+// to an opaque "did not stabilize" failure, leaving a created-but-shimless
+// repo. "main" is GitHub's default for an auto_init repo and matches what
+// `gh student submit` pushes to.
 func defaultBranchOrMain(branch string) string {
 	if branch == "" {
 		return "main"

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -365,10 +365,19 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 
 	// Render the default shim now that the assignment repo's default branch is
 	// known: `on: push: branches` targets commitBranch, and the reusable-workflow
-	// `uses:` ref targets the config repo's actual default branch (best-effort;
-	// defaults to main when it can't be read).
+	// `uses:` ref targets the config repo's actual default branch. On a read
+	// failure, fall back to the assignment repo's own branch (commitBranch), not
+	// a hardcoded `main` — a wrong `@main` ref would 404 the runner and silently
+	// skip grading on a master-default org.
 	if useDefaultShim {
-		shim = renderEmbeddedShim(org, commitBranch, resolveConfigRepoBranch(client, org))
+		configBranch, cbErr := resolveConfigRepoBranch(client, org)
+		if cbErr != nil {
+			if verbose {
+				u.Detail("could not read %s/classroom50 default branch (%v); pinning shim to %q", org, cbErr, commitBranch)
+			}
+			configBranch = commitBranch
+		}
+		shim = renderEmbeddedShim(org, commitBranch, configBranch)
 	}
 
 	repoName := reponame.Name(classroom, assignment, username)
@@ -727,6 +736,15 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 	if genBranch == "" {
 		genBranch = created.DefaultBranch
 	}
+	// Both echoes can briefly omit default_branch right after generate; confirm
+	// with a GET before falling back to `main`, so the shim's push-trigger branch
+	// matches the repo's real default rather than a wrong `main`.
+	if genBranch == "" {
+		var fresh GeneratedRepo
+		if getErr := client.Get(patchPath, &fresh); getErr == nil {
+			genBranch = fresh.DefaultBranch
+		}
+	}
 	return updated.HTMLURL, updated.FullName, defaultBranchOrMain(genBranch), false, nil
 }
 
@@ -789,17 +807,18 @@ func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, ve
 }
 
 // resolveConfigRepoBranch returns the org's classroom50 config repo default
-// branch for the shim's reusable-workflow `uses:` ref. Best-effort: any failure
-// (or empty value) falls back to "main". This keeps the shim's `@<branch>` ref
-// valid even when a config-repo rename to main could not land.
-func resolveConfigRepoBranch(client githubapi.Client, org string) string {
+// branch for the shim's reusable-workflow `uses:` ref. A read failure is
+// returned as an error so the caller can fall back to the assignment repo's own
+// branch rather than a wrong `@main` ref that would 404 the runner; an empty
+// value falls back to "main" (an auto_init repo's default).
+func resolveConfigRepoBranch(client githubapi.Client, org string) (string, error) {
 	var repo struct {
 		DefaultBranch string `json:"default_branch"`
 	}
 	if err := client.Get(fmt.Sprintf("repos/%s/classroom50", url.PathEscape(org)), &repo); err != nil {
-		return defaultConfigRepoBranch
+		return "", err
 	}
-	return defaultBranchOrMain(repo.DefaultBranch)
+	return defaultBranchOrMain(repo.DefaultBranch), nil
 }
 
 // defaultBranchOrMain guards against an empty default_branch in the

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -736,14 +736,13 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 	if genBranch == "" {
 		genBranch = created.DefaultBranch
 	}
-	// Both echoes can briefly omit default_branch right after generate; confirm
-	// with a GET before falling back to `main`, so the shim's push-trigger branch
-	// matches the repo's real default rather than a wrong `main`.
-	if genBranch == "" {
-		var fresh GeneratedRepo
-		if getErr := client.Get(patchPath, &fresh); getErr == nil {
-			genBranch = fresh.DefaultBranch
-		}
+	// The generate/PATCH echoes can report a stale default_branch (empty, or a
+	// default `main`) before the real branch settles, so confirm with a GET and
+	// prefer its value — otherwise a `master`-default template can send the shim
+	// commit at a nonexistent `heads/main` ref. A read failure keeps the echo.
+	var fresh GeneratedRepo
+	if getErr := client.Get(patchPath, &fresh); getErr == nil && fresh.DefaultBranch != "" {
+		genBranch = fresh.DefaultBranch
 	}
 	return updated.HTMLURL, updated.FullName, defaultBranchOrMain(genBranch), false, nil
 }

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -736,14 +736,13 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 	if genBranch == "" {
 		genBranch = created.DefaultBranch
 	}
-	// The generate/PATCH echoes can report a stale default_branch (empty, or a
-	// default `main`) before the real branch settles, so confirm with a GET and
-	// prefer its value — otherwise a `master`-default template can send the shim
-	// commit at a nonexistent `heads/main` ref. A read failure keeps the echo.
-	var fresh GeneratedRepo
-	if getErr := client.Get(patchPath, &fresh); getErr == nil && fresh.DefaultBranch != "" {
-		genBranch = fresh.DefaultBranch
-	}
+	// The generate/PATCH echoes (and an immediate GET) can report a stale
+	// default_branch: right after generate GitHub reports the org default
+	// (`main`) while the template's real branch (e.g. `master`) hasn't been
+	// copied yet. Wait for the branch to actually materialize and use that, so a
+	// `master`-default template doesn't pin the shim + commit at a `heads/main`
+	// ref that never exists.
+	genBranch = githubapi.ResolveSettledDefaultBranch(client, org, newRepoName, defaultBranchOrMain(genBranch))
 	return updated.HTMLURL, updated.FullName, defaultBranchOrMain(genBranch), false, nil
 }
 

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -44,15 +44,32 @@ var embeddedShimContent string
 
 // shimOrgPlaceholder is substituted in embeddedShimContent at accept time so
 // each student repo's shim references the correct org's reusable
-// autograde-runner workflow.
-const shimOrgPlaceholder = "{{ORG}}"
+// autograde-runner workflow. shimBranchPlaceholder is the student repo's
+// default branch (the shim's push trigger); shimConfigBranchPlaceholder is the
+// config repo's default branch (the reusable-workflow ref), which may not be
+// `main` if a config-repo rename could not land.
+const (
+	shimOrgPlaceholder          = "{{ORG}}"
+	shimBranchPlaceholder       = "{{BRANCH}}"
+	shimConfigBranchPlaceholder = "{{CONFIG_BRANCH}}"
+	defaultConfigRepoBranch     = "main"
+)
 
-// renderEmbeddedShim returns the embedded shim with the org placeholder
-// substituted. The shim never changes after accept — runtime customization,
-// runner edits, and teacher overrides all flow through the runner workflow +
-// assignments.json on the teacher's side.
-func renderEmbeddedShim(org string) string {
-	return strings.ReplaceAll(embeddedShimContent, shimOrgPlaceholder, org)
+// renderEmbeddedShim returns the embedded shim with the org, submission-branch,
+// and config-branch placeholders substituted. The shim never changes after
+// accept — runtime customization, runner edits, and teacher overrides all flow
+// through the runner workflow + assignments.json on the teacher's side.
+func renderEmbeddedShim(org, branch, configBranch string) string {
+	if branch == "" {
+		branch = defaultConfigRepoBranch
+	}
+	if configBranch == "" {
+		configBranch = defaultConfigRepoBranch
+	}
+	out := strings.ReplaceAll(embeddedShimContent, shimOrgPlaceholder, org)
+	out = strings.ReplaceAll(out, shimBranchPlaceholder, branch)
+	out = strings.ReplaceAll(out, shimConfigBranchPlaceholder, configBranch)
+	return out
 }
 
 func acceptCmd() *cobra.Command {
@@ -284,15 +301,16 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 			assignment, entry.Template.Owner, entry.Template.Repo, entry.Template.Branch)
 	}
 
-	// 2) Resolve the autograder shim *before* creating the repo so a
-	//    non-default-autograder fetch failure doesn't leave a half-baked repo
-	//    on the teacher's org. The default autograder uses the embedded shim
-	//    (no Pages fetch); other names fetch from Pages.
+	// 2) Resolve the autograder shim. A non-default (Pages-fetched) autograder
+	//    is teacher-authored and resolved up front so a fetch failure doesn't
+	//    leave a half-baked repo. The default (embedded) shim is rendered AFTER
+	//    the repo is created, because its `on: push: branches` must match the
+	//    assignment repo's actual default branch (which GitHub, not the template,
+	//    decides) and its `uses:` ref must match the config repo's branch.
 	autograderName := entry.ResolveAutograder()
+	useDefaultShim := autograderName == contract.DefaultAutograderName
 	var shim string
-	if autograderName == contract.DefaultAutograderName {
-		shim = renderEmbeddedShim(org)
-	} else {
+	if !useDefaultShim {
 		workflow, err := assignments.FetchAutograderWorkflow(cmd.Context(), org, classroom, secret, autograderName)
 		if err != nil {
 			return err
@@ -317,8 +335,11 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	createSp := u.Spinner(createMsg)
 	createSp.Start()
 	if hasTemplate {
-		htmlURL, fullName, alreadyExisted, err = createTemplatedPrivateAssignmentRepoInOrg(client, u, verbose, username, classroom, assignment, org, *entry.Template)
-		commitBranch = entry.Template.Branch
+		var genBranch string
+		htmlURL, fullName, genBranch, alreadyExisted, err = createTemplatedPrivateAssignmentRepoInOrg(client, u, verbose, username, classroom, assignment, org, *entry.Template)
+		// The generated repo's own default branch — not the template's branch —
+		// is where control files land and what the shim must trigger on.
+		commitBranch = genBranch
 		// Resolve the template owner's immutable id best-effort so a rename
 		// of the template org/user doesn't break submit's instructor-file
 		// re-fetch. A failed lookup is non-fatal — leave owner_id null.
@@ -340,6 +361,14 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	if err != nil {
 		createSp.Fail(createMsg)
 		return err
+	}
+
+	// Render the default shim now that the assignment repo's default branch is
+	// known: `on: push: branches` targets commitBranch, and the reusable-workflow
+	// `uses:` ref targets the config repo's actual default branch (best-effort;
+	// defaults to main when it can't be read).
+	if useDefaultShim {
+		shim = renderEmbeddedShim(org, commitBranch, resolveConfigRepoBranch(client, org))
 	}
 
 	repoName := reponame.Name(classroom, assignment, username)
@@ -637,7 +666,7 @@ type GeneratedRepo struct {
 // cross-org visibility message (template not readable by the student).
 // 422-already-exists → alreadyExisted=true and the PATCH is skipped so
 // re-runs don't disturb an existing repo.
-func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, verbose bool, username, classroom, assignment, org string, tmpl assignments.TemplateRef) (htmlURL, fullName string, alreadyExisted bool, err error) {
+func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, verbose bool, username, classroom, assignment, org string, tmpl assignments.TemplateRef) (htmlURL, fullName, defaultBranch string, alreadyExisted bool, err error) {
 	newRepoName := reponame.Name(classroom, assignment, username)
 	createBody, err := json.Marshal(map[string]any{
 		"owner":   org,
@@ -645,7 +674,7 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 		"private": true,
 	})
 	if err != nil {
-		return "", "", false, fmt.Errorf("error encoding json for template: %w", err)
+		return "", "", "", false, fmt.Errorf("error encoding json for template: %w", err)
 	}
 
 	createPath := fmt.Sprintf("repos/%s/%s/generate", url.PathEscape(tmpl.Owner), url.PathEscape(tmpl.Repo))
@@ -658,16 +687,16 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 				if is422AlreadyExists(httpErr) {
 					getPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(newRepoName))
 					if getErr := client.Get(getPath, &created); getErr != nil {
-						return "", "", false, fmt.Errorf("POST %s returned 422 and follow-up GET %s failed: %w", createPath, getPath, getErr)
+						return "", "", "", false, fmt.Errorf("POST %s returned 422 and follow-up GET %s failed: %w", createPath, getPath, getErr)
 					}
-					return created.HTMLURL, created.FullName, true, nil
+					return created.HTMLURL, created.FullName, defaultBranchOrMain(created.DefaultBranch), true, nil
 				}
 			case http.StatusNotFound:
-				return "", "", false, fmt.Errorf("template `%s/%s` is not accessible to you — ask your instructor to make it public or grant your account access",
+				return "", "", "", false, fmt.Errorf("template `%s/%s` is not accessible to you — ask your instructor to make it public or grant your account access",
 					tmpl.Owner, tmpl.Repo)
 			}
 		}
-		return "", "", false, fmt.Errorf("POST %s: %w", createPath, err)
+		return "", "", "", false, fmt.Errorf("POST %s: %w", createPath, err)
 	}
 
 	patchBody, err := json.Marshal(map[string]any{
@@ -676,14 +705,14 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 		"has_wiki":     false,
 	})
 	if err != nil {
-		return "", "", false, fmt.Errorf("patch body encode error: %w", err)
+		return "", "", "", false, fmt.Errorf("patch body encode error: %w", err)
 	}
 
 	patchPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(newRepoName))
 
 	var updated GeneratedRepo
 	if err := client.Patch(patchPath, bytes.NewReader(patchBody), &updated); err != nil {
-		return "", "", false, fmt.Errorf("created %s/%s, but failed to disable issues/projects/wiki: %w", org, newRepoName, err)
+		return "", "", "", false, fmt.Errorf("created %s/%s, but failed to disable issues/projects/wiki: %w", org, newRepoName, err)
 	}
 
 	if verbose {
@@ -691,7 +720,14 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 			updated.FullName, updated.HTMLURL)
 	}
 
-	return updated.HTMLURL, updated.FullName, false, nil
+	// Prefer the PATCH response's default_branch, falling back to the generate
+	// response — a template generated into a `master`-defaulting org yields a
+	// `master` repo regardless of the template's own branch name.
+	genBranch := updated.DefaultBranch
+	if genBranch == "" {
+		genBranch = created.DefaultBranch
+	}
+	return updated.HTMLURL, updated.FullName, defaultBranchOrMain(genBranch), false, nil
 }
 
 // createEmptyPrivateAssignmentRepoInOrg creates an empty private repo for a
@@ -752,8 +788,21 @@ func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, ve
 	return updated.HTMLURL, updated.FullName, defaultBranchOrMain(updated.DefaultBranch), false, nil
 }
 
+// resolveConfigRepoBranch returns the org's classroom50 config repo default
+// branch for the shim's reusable-workflow `uses:` ref. Best-effort: any failure
+// (or empty value) falls back to "main". This keeps the shim's `@<branch>` ref
+// valid even when a config-repo rename to main could not land.
+func resolveConfigRepoBranch(client githubapi.Client, org string) string {
+	var repo struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := client.Get(fmt.Sprintf("repos/%s/classroom50", url.PathEscape(org)), &repo); err != nil {
+		return defaultConfigRepoBranch
+	}
+	return defaultBranchOrMain(repo.DefaultBranch)
+}
+
 // defaultBranchOrMain guards against an empty default_branch in the
-// create/GET response. The templated path takes its branch from the
 // (HasTemplate-guaranteed non-empty) template ref; the empty-repo path has no
 // such guarantee, so an empty value would flow into WaitForStableBranch("")
 // and 404-loop to an opaque "did not stabilize" failure, leaving a

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -52,6 +52,9 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 				"default_branch": "main",
 			})
 		})
+		mux.HandleFunc("/repos/o/cs-principles-hello-alice/branches", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "main"}})
+		})
 		server := httptest.NewServer(mux)
 		t.Cleanup(server.Close)
 		client := newTestRESTClient(t, server)
@@ -91,6 +94,9 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 				"default_branch": "master",
 			})
 		})
+		mux.HandleFunc("/repos/o/cs-principles-hello-alice/branches", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "master"}})
+		})
 		server := httptest.NewServer(mux)
 		t.Cleanup(server.Close)
 
@@ -104,24 +110,29 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		}
 	})
 
-	t.Run("empty default_branch in both echoes: confirming GET resolves it", func(t *testing.T) {
-		var confirmGets int
+	t.Run("stale default_branch: settles to the branch that materializes", func(t *testing.T) {
+		var branchesGets int
 		mux := http.NewServeMux()
 		mux.HandleFunc("/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
+			// Generate echoes the transient org default `main`, but the template
+			// really produces `master`.
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"full_name": "o/cs-principles-hello-alice",
-				"html_url":  "https://github.com/o/cs-principles-hello-alice",
+				"full_name":      "o/cs-principles-hello-alice",
+				"html_url":       "https://github.com/o/cs-principles-hello-alice",
+				"default_branch": "main",
 			})
 		})
+		mux.HandleFunc("/repos/o/cs-principles-hello-alice/branches", func(w http.ResponseWriter, _ *http.Request) {
+			branchesGets++
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "master"}})
+		})
 		mux.HandleFunc("/repos/o/cs-principles-hello-alice", func(w http.ResponseWriter, r *http.Request) {
-			// PATCH and the initial echoes omit default_branch; the confirming GET
-			// (issued only when both are empty) returns the settled branch.
 			body := map[string]string{
 				"full_name": "o/cs-principles-hello-alice",
 				"html_url":  "https://github.com/o/cs-principles-hello-alice",
 			}
 			if r.Method == http.MethodGet {
-				confirmGets++
+				// The settled repo reports the real branch.
 				body["default_branch"] = "master"
 			}
 			_ = json.NewEncoder(w).Encode(body)
@@ -134,11 +145,11 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if confirmGets == 0 {
-			t.Error("expected a confirming GET when both echoes omit default_branch")
+		if branchesGets == 0 {
+			t.Error("expected the settle-resolver to poll the branches endpoint")
 		}
 		if branch != "master" {
-			t.Errorf("branch = %q, want master from the confirming GET", branch)
+			t.Errorf("branch = %q, want master (the branch that materialized, not the stale main echo)", branch)
 		}
 	})
 

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -37,8 +37,9 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		mux.HandleFunc("/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
 			generated = true
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"full_name": "o/cs-principles-hello-alice",
-				"html_url":  "https://github.com/o/cs-principles-hello-alice",
+				"full_name":      "o/cs-principles-hello-alice",
+				"html_url":       "https://github.com/o/cs-principles-hello-alice",
+				"default_branch": "main",
 			})
 		})
 		mux.HandleFunc("/repos/o/cs-principles-hello-alice", func(w http.ResponseWriter, r *http.Request) {
@@ -46,8 +47,9 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 				patched = true
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"full_name": "o/cs-principles-hello-alice",
-				"html_url":  "https://github.com/o/cs-principles-hello-alice",
+				"full_name":      "o/cs-principles-hello-alice",
+				"html_url":       "https://github.com/o/cs-principles-hello-alice",
+				"default_branch": "main",
 			})
 		})
 		server := httptest.NewServer(mux)
@@ -55,12 +57,15 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		client := newTestRESTClient(t, server)
 
 		var out bytes.Buffer
-		htmlURL, fullName, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
+		htmlURL, fullName, branch, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if already {
 			t.Error("alreadyExisted = true, want false on a fresh create")
+		}
+		if branch != "main" {
+			t.Errorf("branch = %q, want main", branch)
 		}
 		if !generated || !patched {
 			t.Errorf("generated=%v patched=%v, want both true", generated, patched)
@@ -92,7 +97,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		client := newTestRESTClient(t, server)
 
 		var out bytes.Buffer
-		_, fullName, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
+		_, fullName, _, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -117,7 +122,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		client := newTestRESTClient(t, server)
 
 		var out bytes.Buffer
-		_, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
+		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
 		if err == nil || !strings.Contains(err.Error(), "not accessible to you") {
 			t.Fatalf("err = %v, want the cross-org 'not accessible' message", err)
 		}

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -75,6 +75,73 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		}
 	})
 
+	t.Run("master-default org: generated repo's branch (not the template's) is returned", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"full_name":      "o/cs-principles-hello-alice",
+				"html_url":       "https://github.com/o/cs-principles-hello-alice",
+				"default_branch": "master",
+			})
+		})
+		mux.HandleFunc("/repos/o/cs-principles-hello-alice", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"full_name":      "o/cs-principles-hello-alice",
+				"html_url":       "https://github.com/o/cs-principles-hello-alice",
+				"default_branch": "master",
+			})
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		var out bytes.Buffer
+		_, _, branch, _, err := createTemplatedPrivateAssignmentRepoInOrg(newTestRESTClient(t, server), ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if branch != "master" {
+			t.Errorf("branch = %q, want master (the generated repo's default branch)", branch)
+		}
+	})
+
+	t.Run("empty default_branch in both echoes: confirming GET resolves it", func(t *testing.T) {
+		var confirmGets int
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"full_name": "o/cs-principles-hello-alice",
+				"html_url":  "https://github.com/o/cs-principles-hello-alice",
+			})
+		})
+		mux.HandleFunc("/repos/o/cs-principles-hello-alice", func(w http.ResponseWriter, r *http.Request) {
+			// PATCH and the initial echoes omit default_branch; the confirming GET
+			// (issued only when both are empty) returns the settled branch.
+			body := map[string]string{
+				"full_name": "o/cs-principles-hello-alice",
+				"html_url":  "https://github.com/o/cs-principles-hello-alice",
+			}
+			if r.Method == http.MethodGet {
+				confirmGets++
+				body["default_branch"] = "master"
+			}
+			_ = json.NewEncoder(w).Encode(body)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		var out bytes.Buffer
+		_, _, branch, _, err := createTemplatedPrivateAssignmentRepoInOrg(newTestRESTClient(t, server), ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if confirmGets == 0 {
+			t.Error("expected a confirming GET when both echoes omit default_branch")
+		}
+		if branch != "master" {
+			t.Errorf("branch = %q, want master from the confirming GET", branch)
+		}
+	})
+
 	t.Run("422 already-exists short-circuits to alreadyExisted via follow-up GET", func(t *testing.T) {
 		var patchAttempted bool
 		mux := http.NewServeMux()

--- a/cli/gh-student/accept_shim_test.go
+++ b/cli/gh-student/accept_shim_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -104,4 +107,48 @@ func TestRenderEmbeddedShim_BranchSubstitution(t *testing.T) {
 	if !strings.Contains(def, "autograde-runner.yaml@main") {
 		t.Errorf("empty configBranch should default to main, got:\n%s", def)
 	}
+}
+
+func TestResolveConfigRepoBranch(t *testing.T) {
+	newServer := func(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+		server := httptest.NewServer(handler)
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	t.Run("returns the config repo's actual default branch (master)", func(t *testing.T) {
+		server := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "master"})
+		})
+		got, err := resolveConfigRepoBranch(newTestRESTClient(t, server), "o")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "master" {
+			t.Errorf("got %q, want master", got)
+		}
+	})
+
+	t.Run("empty default_branch falls back to main", func(t *testing.T) {
+		server := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": ""})
+		})
+		got, err := resolveConfigRepoBranch(newTestRESTClient(t, server), "o")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "main" {
+			t.Errorf("got %q, want main", got)
+		}
+	})
+
+	t.Run("a read failure is returned as an error (never a silent main)", func(t *testing.T) {
+		server := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := resolveConfigRepoBranch(newTestRESTClient(t, server), "o")
+		if err == nil {
+			t.Fatal("expected an error on a failed config-repo read")
+		}
+	})
 }

--- a/cli/gh-student/accept_shim_test.go
+++ b/cli/gh-student/accept_shim_test.go
@@ -7,14 +7,15 @@ import (
 
 func TestRenderEmbeddedShim(t *testing.T) {
 	// The embedded shim is the universal one-body-fits-all that gh student
-	// accept drops into every student repo. {{ORG}} is the only per-classroom
-	// customization; everything else is fixed.
-	got := renderEmbeddedShim("cs50-fall-2026")
+	// accept drops into every student repo. {{ORG}}, the submission branch, and
+	// the config-repo branch are the per-repo substitutions; everything else is
+	// fixed.
+	got := renderEmbeddedShim("cs50-fall-2026", "main", "main")
 
 	// Trigger contract: branch pushes auto-grade; manual submit/* tag pushes
 	// still work (the runner detects which fired and creates or reuses the tag).
 	for _, want := range []string{
-		"branches: [main]",
+		`branches: ["main"]`,
 		`tags: ["submit/*"]`,
 	} {
 		if !strings.Contains(got, want) {
@@ -30,9 +31,11 @@ func TestRenderEmbeddedShim(t *testing.T) {
 		t.Errorf("embedded shim missing %q\nfull:\n%s", wantUses, got)
 	}
 
-	// Placeholder must be fully substituted.
-	if strings.Contains(got, "{{ORG}}") {
-		t.Errorf("embedded shim still contains unsubstituted {{ORG}}:\n%s", got)
+	// Placeholders must be fully substituted.
+	for _, ph := range []string{"{{ORG}}", "{{BRANCH}}", "{{CONFIG_BRANCH}}"} {
+		if strings.Contains(got, ph) {
+			t.Errorf("embedded shim still contains unsubstituted %s:\n%s", ph, got)
+		}
 	}
 
 	// Caller's job-level permissions must include both writes the runner's
@@ -68,7 +71,7 @@ func TestRenderEmbeddedShim_OrgSubstitution(t *testing.T) {
 	// matching anything else.
 	for _, org := range []string{"cs50-fall-2026", "foundation50", "very-long-org-name-2026"} {
 		t.Run(org, func(t *testing.T) {
-			got := renderEmbeddedShim(org)
+			got := renderEmbeddedShim(org, "main", "main")
 			wantUses := `uses: "` + org + `/classroom50/.github/workflows/autograde-runner.yaml@main"`
 			if !strings.Contains(got, wantUses) {
 				t.Errorf("expected %q in shim, got:\n%s", wantUses, got)
@@ -77,5 +80,28 @@ func TestRenderEmbeddedShim_OrgSubstitution(t *testing.T) {
 				t.Errorf("placeholder leak for %q:\n%s", org, got)
 			}
 		})
+	}
+}
+
+func TestRenderEmbeddedShim_BranchSubstitution(t *testing.T) {
+	// A master-default assignment repo must trigger on `master`; a config repo
+	// that stayed on `master` (rename didn't land) must be referenced via
+	// `@master` so the reusable-workflow ref resolves.
+	got := renderEmbeddedShim("cs50", "master", "master")
+	if !strings.Contains(got, `branches: ["master"]`) {
+		t.Errorf("expected branches: [\"master\"], got:\n%s", got)
+	}
+	wantUses := `uses: "cs50/classroom50/.github/workflows/autograde-runner.yaml@master"`
+	if !strings.Contains(got, wantUses) {
+		t.Errorf("expected %q, got:\n%s", wantUses, got)
+	}
+
+	// Empty branch/configBranch default to main.
+	def := renderEmbeddedShim("cs50", "", "")
+	if !strings.Contains(def, `branches: ["main"]`) {
+		t.Errorf("empty branch should default to main, got:\n%s", def)
+	}
+	if !strings.Contains(def, "autograde-runner.yaml@main") {
+		t.Errorf("empty configBranch should default to main, got:\n%s", def)
 	}
 }

--- a/cli/gh-student/embed/autograde-shim.yaml
+++ b/cli/gh-student/embed/autograde-shim.yaml
@@ -12,9 +12,9 @@
 # This file should not be edited.
 #
 # Triggers:
-#   • push to main      — every commit grades (except the acceptance
-#                         commit, which the runner detects and skips);
-#                         the runner creates the
+#   • push to the repo's default branch — every commit grades (except
+#                         the acceptance commit, which the runner detects
+#                         and skips); the runner creates the
 #                         submit/<UTC-timestamp>-<short-sha> tag itself
 #   • push of submit/*  — manual or web-UI tag pushes work too;
 #                         the runner reuses the pushed tag
@@ -23,16 +23,16 @@ name: Autograde
 
 on:
   push:
-    branches: [main]
+    branches: ["{{BRANCH}}"]
     tags: ["submit/*"]
 
 jobs:
   grade:
-    # `uses:` quoted so the unsubstituted {{ORG}} placeholder
-    # parses as a plain string rather than a YAML flow mapping —
+    # `uses:` quoted so the unsubstituted {{ORG}}/{{CONFIG_BRANCH}} placeholders
+    # parse as a plain string rather than a YAML flow mapping —
     # actionlint and any other YAML pre-flight tool can validate
     # the embed before substitution.
-    uses: "{{ORG}}/classroom50/.github/workflows/autograde-runner.yaml@main"
+    uses: "{{ORG}}/classroom50/.github/workflows/autograde-runner.yaml@{{CONFIG_BRANCH}}"
     permissions:
       contents: write
       statuses: write

--- a/cli/gh-student/internal/githubapi/shared.go
+++ b/cli/gh-student/internal/githubapi/shared.go
@@ -1,6 +1,8 @@
 package githubapi
 
 import (
+	"time"
+
 	"github.com/cli/go-gh/v2/pkg/api"
 
 	"github.com/foundation50/classroom50-cli-shared/ghutil"
@@ -35,6 +37,13 @@ func SetCollaborator(c Client, owner, repo, username, permission string) (int, e
 // a templated-repo creation, smoothing replication lag.
 func WaitForStableBranch(c Client, owner, repo, branch string) error {
 	return ghutil.WaitForStableBranch(rest(c), owner, repo, branch)
+}
+
+// ResolveSettledDefaultBranch waits out the async template-copy lag and returns
+// the branch that actually materialized (not the transiently-reported
+// default_branch), falling back to `fallback`.
+func ResolveSettledDefaultBranch(c Client, owner, repo, fallback string) string {
+	return ghutil.ResolveSettledDefaultBranch(rest(c), owner, repo, fallback, 20, 250*time.Millisecond)
 }
 
 // UploadBlobs uploads file contents as git blobs, returning their tree

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -1,6 +1,6 @@
 // Package submitcmd implements `gh student submit`: snapshot the current
-// branch and push it as a new commit on the assignment repo's main, so the
-// autograde workflow tags and grades the submission. Extracted command
+// branch and push it as a new commit on the assignment repo's default branch,
+// so the autograde workflow tags and grades the submission. Extracted command
 // package; only NewCmd is exported. Consumes the internal/* seams (githubapi,
 // classroomcfg, identity, localgit) + the shared ghutil helper, never main.
 package submitcmd
@@ -38,11 +38,11 @@ func NewCmd() *cobra.Command {
 		Use:   "submit",
 		Short: "Submit the current assignment to its remote",
 		Long: "Snapshot the current branch and push it as a new commit on top\n" +
-			"of the assignment repo's `main` branch. The autograde workflow\n" +
-			"in the student repo listens for pushes to main and (a) creates\n" +
-			"its own `submit/<UTC-timestamp>-<short-sha>` tag at the pushed\n" +
-			"commit and (b) publishes a scored Release at that tag a minute\n" +
-			"or two later.\n\n" +
+			"of the assignment repo's default branch. The autograde workflow\n" +
+			"in the student repo listens for pushes to that branch and (a)\n" +
+			"creates its own `submit/<UTC-timestamp>-<short-sha>` tag at the\n" +
+			"pushed commit and (b) publishes a scored Release at that tag a\n" +
+			"minute or two later.\n\n" +
 			"Before snapshotting, the latest instructor `.gitignore` and\n" +
 			"`.github/` (both optional) are fetched from the template repo\n" +
 			"recorded in `.classroom50.yaml` so any teacher-side updates\n" +
@@ -75,10 +75,7 @@ func NewCmd() *cobra.Command {
 }
 
 func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool, out io.Writer, errOut io.Writer) error {
-	const (
-		remote = "origin"
-		branch = "main"
-	)
+	const remote = "origin"
 
 	u := ui.New(errOut)
 
@@ -114,6 +111,15 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 		return fmt.Errorf("parse remote URL: %w", err)
 	}
 	repoHTMLURL := fmt.Sprintf("https://github.com/%s/%s", repoOwner, repoName)
+
+	// Push to the assignment repo's actual default branch (which GitHub, not
+	// Classroom 50, may have named `master`) so the autograde shim — which
+	// triggers on that branch — fires. A failed lookup is fatal: silently
+	// falling back to `main` would push to the wrong branch and skip grading.
+	branch, err := resolveRepoDefaultBranch(client, repoOwner, repoName)
+	if err != nil {
+		return err
+	}
 
 	tmpRoot, err := os.MkdirTemp("", "classroom50-submit-*")
 	if err != nil {
@@ -262,6 +268,23 @@ func resolveAssignmentName(ctx context.Context, org, classroom, secret, slug str
 // assignmentNameTimeout caps the cosmetic post-push name lookup so a slow
 // Pages CDN can't stall the terminal after the submission already landed.
 const assignmentNameTimeout = 3 * time.Second
+
+// resolveRepoDefaultBranch reads the assignment repo's default branch. A GET
+// failure is returned as an error (submitting to the wrong branch would skip
+// grading); an empty value falls back to "main" (matches an auto_init repo).
+func resolveRepoDefaultBranch(client githubapi.Client, owner, repo string) (string, error) {
+	var resp struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
+	if err := client.Get(path, &resp); err != nil {
+		return "", fmt.Errorf("resolve default branch for %s/%s: %w", owner, repo, err)
+	}
+	if resp.DefaultBranch == "" {
+		return "main", nil
+	}
+	return resp.DefaultBranch, nil
+}
 
 func gitOutput(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)

--- a/cli/gh-student/internal/submitcmd/submit_test.go
+++ b/cli/gh-student/internal/submitcmd/submit_test.go
@@ -1,8 +1,13 @@
 package submitcmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/foundation50/gh-student/internal/githubtest"
 )
 
 func TestParseGitHubRemote(t *testing.T) {
@@ -62,4 +67,51 @@ func TestParseGitHubRemote_ErrorMentionsShape(t *testing.T) {
 	if !strings.Contains(err.Error(), "git@github.com") {
 		t.Errorf("error should hint at expected shape, got %q", err)
 	}
+}
+
+func TestResolveRepoDefaultBranch(t *testing.T) {
+	newClient := func(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+		server := httptest.NewServer(handler)
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	t.Run("returns the repo's actual default branch (master)", func(t *testing.T) {
+		server := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/repos/o/repo" {
+				t.Errorf("unexpected path %s", r.URL.Path)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "master"})
+		})
+		got, err := resolveRepoDefaultBranch(githubtest.NewTestClient(t, server), "o", "repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "master" {
+			t.Errorf("got %q, want master", got)
+		}
+	})
+
+	t.Run("empty default_branch falls back to main", func(t *testing.T) {
+		server := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": ""})
+		})
+		got, err := resolveRepoDefaultBranch(githubtest.NewTestClient(t, server), "o", "repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "main" {
+			t.Errorf("got %q, want main", got)
+		}
+	})
+
+	t.Run("a failed GET is fatal (never silently pushes to main)", func(t *testing.T) {
+		server := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := resolveRepoDefaultBranch(githubtest.NewTestClient(t, server), "o", "repo")
+		if err == nil {
+			t.Fatal("expected an error on a failed default-branch lookup")
+		}
+	})
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -492,6 +492,14 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			return fmt.Errorf("template `%s/%s` is private and outside the org %s — students can't be granted access to it, so `gh student accept` would fail. Copy it into %s and reference the copy, or make the template public",
 				ref.Owner, ref.Repo, org, org)
 		}
+		// Working assumption is `main`. A non-main template default branch is
+		// supported (student repos inherit it), but warn so the teacher knows
+		// autograde/submit will key off that branch, not `main`.
+		if ref.Branch != "main" {
+			_, _ = fmt.Fprintf(errOut,
+				"Warning: template %s/%s uses default branch %q, not \"main\". The assignment will use %q; students' repos and autograding key off that branch.\n",
+				ref.Owner, ref.Repo, ref.Branch, ref.Branch)
+		}
 		resolved = &ref
 	}
 

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
@@ -611,6 +611,72 @@ func archivedClassroomAddServer(t *testing.T, fix *testCmdFixture) *httptest.Ser
 	return server
 }
 
+// TestRunAssignmentAdd_WarnsOnNonMainTemplateBranch pins the U7 warning:
+// a template whose default branch isn't `main` still succeeds, but the teacher
+// is warned that the assignment (and student autograding) key off that branch.
+func TestRunAssignmentAdd_WarnsOnNonMainTemplateBranch(t *testing.T) {
+	// A dedicated server whose template probe reports a master default branch.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/o/classroom50", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "main"})
+	})
+	mux.HandleFunc("/repos/o/classroom50/contents/cs-principles/assignments.json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":     "file",
+			"content":  base64.StdEncoding.EncodeToString([]byte(helloAssignments(""))),
+			"encoding": "base64",
+		})
+	})
+	mux.HandleFunc("/repos/cs50/hello-template", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "default_branch": "master"})
+	})
+	mux.HandleFunc("/repos/o/classroom50/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": "parent-sha"}})
+	})
+	mux.HandleFunc("/repos/o/classroom50/git/commits/parent-sha", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"tree": map[string]string{"sha": "parent-tree"}})
+	})
+	mux.HandleFunc("/repos/o/classroom50/git/blobs", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"sha": "blob-sha"})
+	})
+	mux.HandleFunc("/repos/o/classroom50/git/trees", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"sha": "new-tree-sha"})
+	})
+	mux.HandleFunc("/repos/o/classroom50/git/commits", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"sha": "new-commit-sha"})
+	})
+	masterServer := httptest.NewServer(mux)
+	t.Cleanup(masterServer.Close)
+	client := githubtest.NewTestClient(t, masterServer)
+
+	var stdout, stderr bytes.Buffer
+	if err := runAssignmentAdd(client, &stdout, &stderr, helloAddParams()); err != nil {
+		t.Fatalf("runAssignmentAdd(master template): %v", err)
+	}
+	if !strings.Contains(stderr.String(), `default branch "master"`) {
+		t.Errorf("expected a non-main branch warning, stderr = %q", stderr.String())
+	}
+}
+
+// TestRunAssignmentAdd_NoWarnOnMainTemplateBranch is the negative: a `main`
+// template default branch adds no warning.
+func TestRunAssignmentAdd_NoWarnOnMainTemplateBranch(t *testing.T) {
+	server, _ := newTestCmdServer(t, helloAssignments(""), false)
+	client := githubtest.NewTestClient(t, server)
+
+	var stdout, stderr bytes.Buffer
+	if err := runAssignmentAdd(client, &stdout, &stderr, helloAddParams()); err != nil {
+		t.Fatalf("runAssignmentAdd(main template): %v", err)
+	}
+	if strings.Contains(stderr.String(), "not \"main\"") {
+		t.Errorf("main template should not warn, stderr = %q", stderr.String())
+	}
+}
+
 // TestRunAssignmentAdd_RefusesArchivedTarget pins the add-path archived
 // refusal branch (assignment.go ensureClassroomActive): `assignment add`
 // into an archived (active:false) classroom is refused and lands no blob,

--- a/cli/gh-teacher/internal/audit/audit.go
+++ b/cli/gh-teacher/internal/audit/audit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/foundation50/gh-teacher/internal/configrepo"
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 	"github.com/foundation50/gh-teacher/internal/orgpolicy"
 	"github.com/foundation50/gh-teacher/internal/ui"
@@ -124,6 +125,12 @@ type auditReport struct {
 	DefaultBranchRec string `json:"default_branch_recommendation,omitempty"`
 	// RepositoryDefaultsURL is the settings page for the default-branch fix.
 	RepositoryDefaultsURL string `json:"repository_defaults_url,omitempty"`
+	// ConfigRepoBranchRec: advisory-only. When set, the classroom50 config
+	// repo's default branch (this value) isn't `main`; recommended, never a
+	// failure. Renameable in the web app; hand-fix link here.
+	ConfigRepoBranchRec string `json:"config_repo_branch_recommendation,omitempty"`
+	// ConfigRepoBranchesURL is the config repo's branches settings page.
+	ConfigRepoBranchesURL string `json:"config_repo_branches_url,omitempty"`
 	// SettingsURL is the org member-privileges page every item lives on.
 	SettingsURL string `json:"settings_url"`
 }
@@ -179,6 +186,17 @@ func buildAuditReport(client githubapi.Client, org, plan string) auditReport {
 	if rec := orgpolicy.OrgDefaultBranchRecommendation(live); rec != "" {
 		report.DefaultBranchRec = rec
 		report.RepositoryDefaultsURL = orgpolicy.OrgRepositoryDefaultsURL(org)
+	}
+
+	// Advisory-only: the classroom50 config repo drifted off `main`. Renameable
+	// in the web app; here we only recommend + link. A read failure (e.g. repo
+	// not yet initialized) simply omits the recommendation — it never gates the
+	// verdict.
+	if branch, err := configrepo.ResolveConfigRepoBranch(client, org); err == nil {
+		if rec := orgpolicy.ConfigRepoDefaultBranchRecommendation(branch); rec != "" {
+			report.ConfigRepoBranchRec = rec
+			report.ConfigRepoBranchesURL = orgpolicy.ConfigRepoBranchesURL(org)
+		}
 	}
 	return report
 }
@@ -258,10 +276,17 @@ func (r *auditReport) renderHuman(u *ui.UI) {
 	}
 
 	// Advisory recommendation — highly recommended, never a failure.
-	if r.DefaultBranchRec != "" {
+	if r.DefaultBranchRec != "" || r.ConfigRepoBranchRec != "" {
 		u.Heading("Recommended (not required)")
+	}
+	if r.DefaultBranchRec != "" {
 		u.Detail("Your org's default branch name for new repositories is %q; we recommend %q so new repos (including student assignment repos) match Classroom 50's convention. Existing repos are unaffected.",
 			r.DefaultBranchRec, orgpolicy.RecommendedOrgDefaultBranch)
 		u.Detail("Change it at %s", r.RepositoryDefaultsURL)
+	}
+	if r.ConfigRepoBranchRec != "" {
+		u.Detail("The classroom50 config repo's default branch is %q, not %q; everything still works (reads/writes target the real branch), but renaming it matches Classroom 50's convention. The web app can rename it for you.",
+			r.ConfigRepoBranchRec, orgpolicy.RecommendedOrgDefaultBranch)
+		u.Detail("Rename it at %s", r.ConfigRepoBranchesURL)
 	}
 }

--- a/cli/gh-teacher/internal/audit/audit.go
+++ b/cli/gh-teacher/internal/audit/audit.go
@@ -119,6 +119,11 @@ type auditReport struct {
 	// ManualUnreadable: web-UI-only settings with no REST field; audit can't
 	// confirm them and asks the teacher to eyeball them.
 	ManualUnreadable []orgpolicy.ManualStep `json:"manual_unreadable"`
+	// DefaultBranchRec: advisory-only. When set, the org's default repository
+	// branch name (this value) isn't `main`; recommended, never a failure.
+	DefaultBranchRec string `json:"default_branch_recommendation,omitempty"`
+	// RepositoryDefaultsURL is the settings page for the default-branch fix.
+	RepositoryDefaultsURL string `json:"repository_defaults_url,omitempty"`
 	// SettingsURL is the org member-privileges page every item lives on.
 	SettingsURL string `json:"settings_url"`
 }
@@ -168,6 +173,13 @@ func buildAuditReport(client githubapi.Client, org, plan string) auditReport {
 	// Any drift fails (match the web GUI). The per-setting Critical flag is
 	// still surfaced for ordering/labeling but no longer gates the verdict.
 	report.LockdownComplete = len(report.Unenforced) == 0
+
+	// Advisory-only: the org default branch name isn't `main`. Never gates the
+	// verdict (GitHub has no API to set it — only a hand-fix reminder).
+	if rec := orgpolicy.OrgDefaultBranchRecommendation(live); rec != "" {
+		report.DefaultBranchRec = rec
+		report.RepositoryDefaultsURL = orgpolicy.OrgRepositoryDefaultsURL(org)
+	}
 	return report
 }
 
@@ -243,5 +255,13 @@ func (r *auditReport) renderHuman(u *ui.UI) {
 		for i, m := range r.ManualUnreadable {
 			u.Numbered(i+1, "%s", m.Setting)
 		}
+	}
+
+	// Advisory recommendation — highly recommended, never a failure.
+	if r.DefaultBranchRec != "" {
+		u.Heading("Recommended (not required)")
+		u.Detail("Your org's default branch name for new repositories is %q; we recommend %q so new repos (including student assignment repos) match Classroom 50's convention. Existing repos are unaffected.",
+			r.DefaultBranchRec, orgpolicy.RecommendedOrgDefaultBranch)
+		u.Detail("Change it at %s", r.RepositoryDefaultsURL)
 	}
 }

--- a/cli/gh-teacher/internal/audit/audit_test.go
+++ b/cli/gh-teacher/internal/audit/audit_test.go
@@ -94,6 +94,56 @@ func TestBuildAuditReport_NoRecommendationWhenDefaultBranchIsMain(t *testing.T) 
 	}
 }
 
+func TestBuildAuditReport_RecommendsNonMainConfigRepoBranch(t *testing.T) {
+	live := orgLiveFromSettings("team")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/repos/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"default_branch": "master"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(live)
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	report := buildAuditReport(client, "cs50-fall-2026", "team")
+
+	// Advisory only — a non-main config-repo branch never fails the lockdown.
+	if !report.LockdownComplete {
+		t.Errorf("LockdownComplete = false; a non-main config-repo branch must not fail the audit")
+	}
+	if report.ConfigRepoBranchRec != "master" {
+		t.Errorf("ConfigRepoBranchRec = %q, want %q", report.ConfigRepoBranchRec, "master")
+	}
+	if !strings.Contains(report.ConfigRepoBranchesURL, "/classroom50/settings/branches") {
+		t.Errorf("ConfigRepoBranchesURL = %q, want the config repo branches page", report.ConfigRepoBranchesURL)
+	}
+}
+
+func TestBuildAuditReport_NoConfigRepoRecommendationWhenUnreadable(t *testing.T) {
+	// A config-repo read failure (e.g. repo not initialized) must omit the
+	// recommendation without failing the audit — it's advisory.
+	live := orgLiveFromSettings("team")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/repos/") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(live)
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	report := buildAuditReport(client, "cs50-fall-2026", "team")
+	if report.ConfigRepoBranchRec != "" {
+		t.Errorf("ConfigRepoBranchRec = %q, want empty when the config repo can't be read", report.ConfigRepoBranchRec)
+	}
+	if !report.LockdownComplete {
+		t.Errorf("a config-repo read failure must not fail the lockdown verdict")
+	}
+}
+
 func TestBuildAuditReport_CriticalDriftFails(t *testing.T) {
 	// A teacher who re-checked "delete or transfer repositories" leaves a
 	// critical lockdown field un-set: audit must flag it and report the

--- a/cli/gh-teacher/internal/audit/audit_test.go
+++ b/cli/gh-teacher/internal/audit/audit_test.go
@@ -56,6 +56,44 @@ func TestBuildAuditReport_AllEnforced(t *testing.T) {
 	}
 }
 
+func TestBuildAuditReport_RecommendsNonMainDefaultBranch(t *testing.T) {
+	live := orgLiveFromSettings("team")
+	live["default_repository_branch"] = "master"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(live)
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	report := buildAuditReport(client, "cs50-fall-2026", "team")
+
+	// Advisory only — a non-main default branch never fails the lockdown.
+	if !report.LockdownComplete {
+		t.Errorf("LockdownComplete = false; a non-main default branch must not fail the audit")
+	}
+	if report.DefaultBranchRec != "master" {
+		t.Errorf("DefaultBranchRec = %q, want %q", report.DefaultBranchRec, "master")
+	}
+	if !strings.Contains(report.RepositoryDefaultsURL, "/settings/repository-defaults") {
+		t.Errorf("RepositoryDefaultsURL = %q, want the repository-defaults settings page", report.RepositoryDefaultsURL)
+	}
+}
+
+func TestBuildAuditReport_NoRecommendationWhenDefaultBranchIsMain(t *testing.T) {
+	live := orgLiveFromSettings("team")
+	live["default_repository_branch"] = "main"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(live)
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	report := buildAuditReport(client, "cs50-fall-2026", "team")
+	if report.DefaultBranchRec != "" {
+		t.Errorf("DefaultBranchRec = %q, want empty when already main", report.DefaultBranchRec)
+	}
+}
+
 func TestBuildAuditReport_CriticalDriftFails(t *testing.T) {
 	// A teacher who re-checked "delete or transfer repositories" leaves a
 	// critical lockdown field un-set: audit must flag it and report the

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -246,6 +246,30 @@ type ManualStep struct {
 	URL     string `json:"url"`
 }
 
+// RecommendedOrgDefaultBranch is the org "Repository default branch name" we
+// recommend. GitHub exposes no REST field to set it (PATCH /orgs ignores
+// default_repository_branch — it's web-UI-only), so this is surfaced as an
+// advisory recommendation, never an enforced/critical setting.
+const RecommendedOrgDefaultBranch = "main"
+
+// OrgDefaultBranchRecommendation returns the org's current default branch name
+// when it differs from RecommendedOrgDefaultBranch (so callers can advise a
+// hand-fix), or "" when it already matches / is unset / unreadable. `live` is
+// the raw GET /orgs/{org} map.
+func OrgDefaultBranchRecommendation(live map[string]any) string {
+	branch, ok := live["default_repository_branch"].(string)
+	if !ok || branch == "" || branch == RecommendedOrgDefaultBranch {
+		return ""
+	}
+	return branch
+}
+
+// OrgRepositoryDefaultsURL is the org settings page where the default branch
+// name is changed (the one setting with no REST write path).
+func OrgRepositoryDefaultsURL(org string) string {
+	return fmt.Sprintf("https://github.com/organizations/%s/settings/repository-defaults", org)
+}
+
 // ManualHardeningSteps is the canonical list of the four member-privilege
 // settings with no REST API (single-sourced so init's reminder, init's JSON,
 // and audit's list can't drift). Each instruction is verb-first with the

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -264,6 +264,24 @@ func OrgDefaultBranchRecommendation(live map[string]any) string {
 	return branch
 }
 
+// ConfigRepoDefaultBranchRecommendation returns the config repo's current
+// default branch when it differs from RecommendedOrgDefaultBranch (so callers
+// can advise renaming it), or "" when it already matches / is unset / couldn't
+// be read. Unlike the org-default recommendation this branch IS API-renameable,
+// but the CLI audit is read-only, so both surface it identically as advice.
+func ConfigRepoDefaultBranchRecommendation(branch string) string {
+	if branch == "" || branch == RecommendedOrgDefaultBranch {
+		return ""
+	}
+	return branch
+}
+
+// ConfigRepoBranchesURL is the config repo's branches settings page where a
+// teacher can rename the default branch to `main`.
+func ConfigRepoBranchesURL(org string) string {
+	return fmt.Sprintf("https://github.com/%s/classroom50/settings/branches", org)
+}
+
 // OrgRepositoryDefaultsURL is the org settings page where the default branch
 // name is changed (the one setting with no REST write path).
 func OrgRepositoryDefaultsURL(org string) string {

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy_test.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy_test.go
@@ -200,3 +200,23 @@ func TestOrgDefaultBranchRecommendation(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigRepoDefaultBranchRecommendation(t *testing.T) {
+	cases := []struct {
+		name   string
+		branch string
+		want   string
+	}{
+		{"master recommends renaming", "master", "master"},
+		{"develop recommends renaming", "develop", "develop"},
+		{"main is fine", "main", ""},
+		{"empty is fine", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ConfigRepoDefaultBranchRecommendation(tc.branch); got != tc.want {
+				t.Errorf("ConfigRepoDefaultBranchRecommendation = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy_test.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy_test.go
@@ -178,3 +178,25 @@ func TestManualHardeningSteps(t *testing.T) {
 		}
 	}
 }
+
+func TestOrgDefaultBranchRecommendation(t *testing.T) {
+	cases := []struct {
+		name string
+		live map[string]any
+		want string
+	}{
+		{"master recommends switching", map[string]any{"default_repository_branch": "master"}, "master"},
+		{"develop recommends switching", map[string]any{"default_repository_branch": "develop"}, "develop"},
+		{"main is fine", map[string]any{"default_repository_branch": "main"}, ""},
+		{"missing field is fine", map[string]any{}, ""},
+		{"empty string is fine", map[string]any{"default_repository_branch": ""}, ""},
+		{"non-string is fine", map[string]any{"default_repository_branch": 42}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := OrgDefaultBranchRecommendation(tc.live); got != tc.want {
+				t.Errorf("OrgDefaultBranchRecommendation = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -66,7 +66,7 @@ SCORES_SCHEMA_V1 = "classroom50/scores/v1"
 RESULT_SCHEMA_V1 = "classroom50/result/v1"
 
 # Trigger contract: only `submit/*` tag releases count as submissions
-# (created by autograde-runner.yaml on push to `main`).
+# (created by autograde-runner.yaml on push to the repo's default branch).
 SUBMIT_TAG_PREFIX = "submit/"
 
 RFC3339_RE = re.compile(

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
@@ -73,8 +73,9 @@ ASSIGNMENTS_SCHEMA_V1 = "classroom50/assignments/v1"
 # prefix aligned with autograde-runner.yaml and collect_scores.py.
 SUBMIT_TAG_PREFIX = "submit/"
 
-# Branch whose HEAD we re-tag. Submissions are graded off `main` (the autograde
-# shim's `on.push.branches`), so that's the ref we regrade.
+# Fallback submission branch when a repo's default branch can't be read.
+# Submissions grade off the repo's default branch (the autograde shim's
+# `on.push.branches`); `main` is only the fallback for a repo with no default.
 SUBMISSION_BRANCH = "main"
 
 # How often (every N repos) the fan-out logs incremental progress, so a run
@@ -365,10 +366,35 @@ def build_submit_tag(sha: str) -> str:
     return f"{SUBMIT_TAG_PREFIX}{stamp}-{sha[:7]}"
 
 
+def repo_default_branch(api_url: str, org: str, repo: str, token: str) -> str | None:
+    """The repo's default branch (which GitHub may have named `master`), or None
+    when the repo doesn't exist (404) — the student hasn't accepted."""
+    try:
+        body = _http_get(
+            _repo_url(api_url, org, repo), token, accept="application/vnd.github+json"
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+    data = json.loads(body.decode("utf-8"))
+    branch = data.get("default_branch") if isinstance(data, dict) else None
+    if isinstance(branch, str) and branch:
+        return branch
+    return SUBMISSION_BRANCH
+
+
 def main_head_sha(api_url: str, org: str, repo: str, token: str) -> str | None:
-    """The commit SHA at `repo`'s main branch HEAD, or None when the repo
-    or branch doesn't exist (404) — the student hasn't accepted/pushed."""
-    url = f"{_repo_url(api_url, org, repo)}/git/ref/heads/{urllib.parse.quote(SUBMISSION_BRANCH)}"
+    """The commit SHA at `repo`'s default-branch HEAD, or None when the repo
+    or branch doesn't exist (404) — the student hasn't accepted/pushed.
+
+    Resolves the repo's actual default branch first (it may be `master`), so a
+    non-main repo is regraded off its real HEAD rather than a nonexistent
+    `main`."""
+    branch = repo_default_branch(api_url, org, repo, token)
+    if branch is None:
+        return None
+    url = f"{_repo_url(api_url, org, repo)}/git/ref/heads/{urllib.parse.quote(branch)}"
     try:
         body = _http_get(url, token, accept="application/vnd.github+json")
     except urllib.error.HTTPError as exc:
@@ -379,7 +405,7 @@ def main_head_sha(api_url: str, org: str, repo: str, token: str) -> str | None:
     obj = ref.get("object") if isinstance(ref, dict) else None
     sha = obj.get("sha") if isinstance(obj, dict) else None
     if not isinstance(sha, str) or not sha:
-        raise ValueError(f"git/ref/heads/{SUBMISSION_BRANCH} returned no object.sha")
+        raise ValueError(f"git/ref/heads/{branch} returned no object.sha")
     return sha
 
 

--- a/cli/gh-teacher/skeleton_tests/test_regrade_repos.py
+++ b/cli/gh-teacher/skeleton_tests/test_regrade_repos.py
@@ -161,6 +161,33 @@ def test_main_head_sha_parses_object_sha(monkeypatch):
     assert rr.main_head_sha("https://api", "cs50", "repo", "tok") == "1234abcd"
 
 
+def test_main_head_sha_resolves_master_default_branch(monkeypatch):
+    # A master-default student repo must be regraded off heads/master, not a
+    # nonexistent heads/main.
+    seen = {}
+
+    def fake_get(url, token, *, accept, _retries=3):
+        if url.endswith("/repos/cs50/repo"):
+            return json.dumps({"default_branch": "master"}).encode("utf-8")
+        seen["ref_url"] = url
+        return json.dumps({"object": {"sha": "cafe"}}).encode("utf-8")
+
+    monkeypatch.setattr(rr, "_http_get", fake_get)
+    assert rr.main_head_sha("https://api", "cs50", "repo", "tok") == "cafe"
+    assert seen["ref_url"].endswith("/git/ref/heads/master")
+
+
+def test_main_head_sha_returns_none_when_repo_missing(monkeypatch):
+    # 404 on the repo read (student never accepted) → None, no ref read.
+    def fake_get(url, token, *, accept, _retries=3):
+        if url.endswith("/repos/cs50/repo"):
+            raise _http_error(404)
+        raise AssertionError("ref read should not happen when the repo is 404")
+
+    monkeypatch.setattr(rr, "_http_get", fake_get)
+    assert rr.main_head_sha("https://api", "cs50", "repo", "tok") is None
+
+
 def test_existing_submit_tag_matches_sha(monkeypatch):
     body = json.dumps(
         [

--- a/cli/shared/ghutil/ghutil.go
+++ b/cli/shared/ghutil/ghutil.go
@@ -124,6 +124,53 @@ func WaitForStableBranch(client *api.RESTClient, owner, repo, branch string) err
 	return fmt.Errorf("branch %s/%s:%s did not stabilize", owner, repo, branch)
 }
 
+// ResolveSettledDefaultBranch waits out GitHub's async template-copy lag and
+// returns the branch that actually materialized. Right after POST .../generate,
+// GET /repos reports a transient default_branch (the org default, e.g. `main`)
+// while the real branch (copied from the template, e.g. `master`) hasn't been
+// created yet — so trusting default_branch, or an immediate confirming GET,
+// can pin a `heads/main` that never exists. This polls the repo's branch list
+// until at least one ref exists, then returns the live default_branch when it
+// names a real branch, else the sole/first materialized branch. Falls back to
+// `fallback` if nothing materializes within the window.
+// ResolveSettledDefaultBranch waits out GitHub's async template-copy lag and
+// returns the branch that actually materialized. Right after POST .../generate,
+// GET /repos reports a transient default_branch (the org default, e.g. `main`)
+// while the real branch (copied from the template, e.g. `master`) hasn't been
+// created yet — so trusting default_branch, or an immediate confirming GET,
+// can pin a `heads/main` that never exists. This polls the repo's branch list
+// up to `attempts` times (sleeping `delay*(i+1)` between tries) until at least
+// one ref exists, then returns the live default_branch when it names a real
+// branch, else the first materialized branch. Falls back to `fallback` if
+// nothing materializes within the window.
+func ResolveSettledDefaultBranch(client *api.RESTClient, owner, repo, fallback string, attempts int, delay time.Duration) string {
+	repoPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
+	branchesPath := fmt.Sprintf("repos/%s/%s/branches?per_page=100", url.PathEscape(owner), url.PathEscape(repo))
+	for i := range attempts {
+		var branches []struct {
+			Name string `json:"name"`
+		}
+		if err := client.Get(branchesPath, &branches); err == nil && len(branches) > 0 {
+			names := make(map[string]bool, len(branches))
+			for _, b := range branches {
+				names[b.Name] = true
+			}
+			// Prefer the live default_branch when it names a branch that exists;
+			// otherwise fall back to the first materialized branch.
+			var repoResp struct {
+				DefaultBranch string `json:"default_branch"`
+			}
+			if err := client.Get(repoPath, &repoResp); err == nil &&
+				repoResp.DefaultBranch != "" && names[repoResp.DefaultBranch] {
+				return repoResp.DefaultBranch
+			}
+			return branches[0].Name
+		}
+		time.Sleep(delay * time.Duration(i+1))
+	}
+	return fallback
+}
+
 // CurrentUser returns the authenticated user's login and immutable numeric ID
 // via GET /user. Callers needing only the login can ignore the id (e.g.
 // whoami); gh-student's identity.Fetch uses both to build the noreply email.

--- a/cli/shared/ghutil/ghutil_test.go
+++ b/cli/shared/ghutil/ghutil_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 )
@@ -215,4 +216,58 @@ func TestWaitForStableBranch(t *testing.T) {
 	if err := WaitForStableBranch(newTestRESTClient(t, server), "o", "r", "main"); err != nil {
 		t.Fatalf("WaitForStableBranch: %v", err)
 	}
+}
+
+// TestResolveSettledDefaultBranch pins the async-copy-lag resolution the accept
+// flow relies on: it must return the branch that actually materialized, not a
+// transiently-reported default_branch, and fall back when nothing appears.
+func TestResolveSettledDefaultBranch(t *testing.T) {
+	t.Run("returns the settled default when it names a real branch", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/o/r/branches", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "master"}})
+		})
+		mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "master"})
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		got := ResolveSettledDefaultBranch(newTestRESTClient(t, server), "o", "r", "main", 5, time.Millisecond)
+		if got != "master" {
+			t.Errorf("got %q, want master", got)
+		}
+	})
+
+	t.Run("returns the materialized branch when default_branch is stale", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/o/r/branches", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "master"}})
+		})
+		mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, _ *http.Request) {
+			// Stale: names a branch (`main`) that doesn't exist yet.
+			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "main"})
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		got := ResolveSettledDefaultBranch(newTestRESTClient(t, server), "o", "r", "main", 5, time.Millisecond)
+		if got != "master" {
+			t.Errorf("got %q, want master (the only materialized branch)", got)
+		}
+	})
+
+	t.Run("falls back when no branch materializes", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/o/r/branches", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]string{})
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		got := ResolveSettledDefaultBranch(newTestRESTClient(t, server), "o", "r", "fallback-br", 2, time.Millisecond)
+		if got != "fallback-br" {
+			t.Errorf("got %q, want fallback-br", got)
+		}
+	})
 }

--- a/web/src/api/github/queries.ts
+++ b/web/src/api/github/queries.ts
@@ -1,6 +1,21 @@
 import type { GitHubClient } from "@/hooks/github/client"
-import type { GitHubBranchRef, GitHubCommitRef } from "@/hooks/github/types"
+import type {
+  GitHubBranchRef,
+  GitHubCommitRef,
+  GitHubRepo,
+} from "@/hooks/github/types"
 import type { Classroom } from "@/types/classroom"
+
+// The classroom50 config repo's default branch. Org policy can seed a new repo
+// on `master`, so config-repo reads/writes must target the real branch, not a
+// hardcoded `main`. Falls back to `main` only when the value is empty.
+export async function getConfigRepoBranch(
+  client: GitHubClient,
+  org: string,
+): Promise<string> {
+  const repo = await client.request<GitHubRepo>(`/repos/${org}/classroom50`)
+  return repo.default_branch || "main"
+}
 
 export function getBranchRef(
   client: GitHubClient,

--- a/web/src/api/github/queries.ts
+++ b/web/src/api/github/queries.ts
@@ -23,7 +23,7 @@ export function getBranchRef(
   branch?: string,
 ) {
   return client.request<GitHubBranchRef>(
-    `/repos/${org}/classroom50/git/ref/heads/${branch ?? "main"}`,
+    `/repos/${org}/classroom50/git/ref/heads/${encodeURIComponent(branch ?? "main")}`,
   )
 }
 

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -10,6 +10,7 @@ import {
   nextAvailableSlug,
   permissionSatisfies,
   preserveUnmanagedAssignmentKeys,
+  resolveAutograderWorkflow,
   resolveTemplate,
   verifyTemplateAccess,
 } from "./assignments"
@@ -1297,5 +1298,49 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         permission: "push",
       }),
     ).rejects.toThrow(/"push"/)
+  })
+})
+
+// The default autograder shim is templated by the assignment repo's default
+// branch (its push trigger) and the config repo's branch (its reusable-workflow
+// ref), so autograde fires on a master-default repo and the @<branch> ref
+// resolves even if the config-repo rename to main did not land.
+describe("resolveAutograderWorkflow default shim branch templating", () => {
+  it("templates the push-trigger branch and the runner ref (master)", async () => {
+    const yaml = await resolveAutograderWorkflow({
+      org: "cs50",
+      classroom: "cs101",
+      autograder: "default",
+      branch: "master",
+      configBranch: "master",
+    })
+    expect(yaml).toContain("branches: [master]")
+    expect(yaml).toContain(
+      'uses: "cs50/classroom50/.github/workflows/autograde-runner.yaml@master"',
+    )
+  })
+
+  it("defaults to main when no branch is supplied", async () => {
+    const yaml = await resolveAutograderWorkflow({
+      org: "cs50",
+      classroom: "cs101",
+      autograder: "default",
+    })
+    expect(yaml).toContain("branches: [main]")
+    expect(yaml).toContain("autograde-runner.yaml@main")
+  })
+
+  it("does not fetch from Pages for the default autograder", async () => {
+    // Passing no client proves the default path never makes a network call
+    // (a Pages fetch would dereference the undefined client and throw).
+    await expect(
+      resolveAutograderWorkflow({
+        org: "cs50",
+        classroom: "cs101",
+        autograder: undefined,
+        branch: "main",
+        configBranch: "main",
+      }),
+    ).resolves.toContain("branches: [main]")
   })
 })

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -1312,27 +1312,20 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
   })
 })
 
-// createAssignmentRepo trusts GitHub's POST .../generate response, whose
-// default_branch can be a stale `main` before the real branch (e.g. `master`
-// from a master-default template) settles. A confirming GET fixes it so the
-// downstream commit targets the repo's actual default branch.
-describe("createAssignmentRepo generated default-branch confirmation", () => {
-  it("confirms the real default branch when generate reports a stale main", async () => {
+// createAssignmentRepo returns the POST .../generate response verbatim. The
+// generated repo's real branch is resolved later (in the commit retry), because
+// the template copy is async — right after generate, default_branch is still a
+// transient value and no ref exists yet.
+describe("createAssignmentRepo", () => {
+  it("returns the generated repo from the generate response", async () => {
     const paths: string[] = []
     const client: GitHubClient = {
       request: <T>(path: string, opts?: { method?: string }) => {
         paths.push(`${opts?.method ?? "GET"} ${path}`)
         if (path.endsWith("/generate")) {
-          // Stale echo: claims main, but the repo really defaults to master.
           return Promise.resolve({
             name: "hw1-alice",
             default_branch: "main",
-          } as T)
-        }
-        if (path === "/repos/acme/hw1-alice") {
-          return Promise.resolve({
-            name: "hw1-alice",
-            default_branch: "master",
           } as T)
         }
         return Promise.reject(new Error(`unexpected: ${path}`))
@@ -1350,35 +1343,35 @@ describe("createAssignmentRepo generated default-branch confirmation", () => {
     })
 
     expect(result.kind).toBe("generated")
-    expect(result.repo.default_branch).toBe("master")
-    expect(paths).toContain("GET /repos/acme/hw1-alice")
+    expect(result.repo.name).toBe("hw1-alice")
+    // No extra confirming GET — the generate response is used directly.
+    expect(paths).toEqual(["POST /repos/acme/master-template/generate"])
   })
 
-  it("keeps the generate branch when the confirming read fails", async () => {
+  it("returns already-accepted on a 422 (repo exists)", async () => {
     const client: GitHubClient = {
       request: <T>(path: string) => {
         if (path.endsWith("/generate"))
-          return Promise.resolve({
-            name: "hw1-alice",
-            default_branch: "develop",
-          } as T)
-        // getRepo is 404-tolerant → returns null → keep the echo.
-        return Promise.reject(
-          new GitHubAPIError({
-            status: 404,
-            url: path,
-            message: "Not Found",
-            body: null,
-            rateLimit: {
-              limit: null,
-              remaining: null,
-              used: null,
-              reset: null,
-              resource: null,
-              retryAfter: null,
-            },
-          }),
-        ) as Promise<T>
+          return Promise.reject(
+            new GitHubAPIError({
+              status: 422,
+              url: path,
+              message: "Unprocessable",
+              body: null,
+              rateLimit: {
+                limit: null,
+                remaining: null,
+                used: null,
+                reset: null,
+                resource: null,
+                retryAfter: null,
+              },
+            }),
+          ) as Promise<T>
+        return Promise.resolve({
+          name: "hw1-alice",
+          default_branch: "master",
+        } as T)
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
     }
@@ -1392,8 +1385,8 @@ describe("createAssignmentRepo generated default-branch confirmation", () => {
       fallbackBranch: "main",
     })
 
-    expect(result.kind).toBe("generated")
-    expect(result.repo.default_branch).toBe("develop")
+    expect(result.kind).toBe("already-accepted")
+    expect(result.repo.default_branch).toBe("master")
   })
 })
 

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -5,6 +5,7 @@ import {
   assertAssignmentModeCoherent,
   buildReusedEntry,
   copyAssignmentToClassroom,
+  createAssignmentRepo,
   editAssignment,
   founderPermission,
   nextAvailableSlug,
@@ -1308,6 +1309,91 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         permission: "push",
       }),
     ).rejects.toThrow(/"push"/)
+  })
+})
+
+// createAssignmentRepo trusts GitHub's POST .../generate response, whose
+// default_branch can be a stale `main` before the real branch (e.g. `master`
+// from a master-default template) settles. A confirming GET fixes it so the
+// downstream commit targets the repo's actual default branch.
+describe("createAssignmentRepo generated default-branch confirmation", () => {
+  it("confirms the real default branch when generate reports a stale main", async () => {
+    const paths: string[] = []
+    const client: GitHubClient = {
+      request: <T>(path: string, opts?: { method?: string }) => {
+        paths.push(`${opts?.method ?? "GET"} ${path}`)
+        if (path.endsWith("/generate")) {
+          // Stale echo: claims main, but the repo really defaults to master.
+          return Promise.resolve({
+            name: "hw1-alice",
+            default_branch: "main",
+          } as T)
+        }
+        if (path === "/repos/acme/hw1-alice") {
+          return Promise.resolve({
+            name: "hw1-alice",
+            default_branch: "master",
+          } as T)
+        }
+        return Promise.reject(new Error(`unexpected: ${path}`))
+      },
+      requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    }
+
+    const result = await createAssignmentRepo({
+      client,
+      templateOwner: "acme",
+      templateRepo: "master-template",
+      owner: "acme",
+      name: "hw1-alice",
+      fallbackBranch: "main",
+    })
+
+    expect(result.kind).toBe("generated")
+    expect(result.repo.default_branch).toBe("master")
+    expect(paths).toContain("GET /repos/acme/hw1-alice")
+  })
+
+  it("keeps the generate branch when the confirming read fails", async () => {
+    const client: GitHubClient = {
+      request: <T>(path: string) => {
+        if (path.endsWith("/generate"))
+          return Promise.resolve({
+            name: "hw1-alice",
+            default_branch: "develop",
+          } as T)
+        // getRepo is 404-tolerant → returns null → keep the echo.
+        return Promise.reject(
+          new GitHubAPIError({
+            status: 404,
+            url: path,
+            message: "Not Found",
+            body: null,
+            rateLimit: {
+              limit: null,
+              remaining: null,
+              used: null,
+              reset: null,
+              resource: null,
+              retryAfter: null,
+            },
+          }),
+        ) as Promise<T>
+      },
+      requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    }
+
+    const result = await createAssignmentRepo({
+      client,
+      templateOwner: "acme",
+      templateRepo: "starter",
+      owner: "acme",
+      name: "hw1-alice",
+      fallbackBranch: "main",
+    })
+
+    expect(result.kind).toBe("generated")
+    expect(result.repo.default_branch).toBe("develop")
   })
 })
 

--- a/web/src/api/mutations/assignments.test.ts
+++ b/web/src/api/mutations/assignments.test.ts
@@ -364,6 +364,9 @@ describe("editAssignment (preserved-entry integration)", () => {
 
     const request = vi.fn(async (url: string, init?: { method?: string }) => {
       const method = init?.method ?? "GET"
+      if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(url)) {
+        return { default_branch: "main" }
+      }
       if (method === "GET" && url.includes("/git/ref/heads/main")) {
         return { object: { sha: "refsha" } }
       }
@@ -503,6 +506,9 @@ describe("editAssignment (preserved-entry integration)", () => {
     let capturedContent = ""
     const request = vi.fn(async (url: string, init?: { method?: string }) => {
       const method = init?.method ?? "GET"
+      if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(url)) {
+        return { default_branch: "main" }
+      }
       if (method === "GET" && url.includes("/git/ref/heads/main")) {
         return { object: { sha: "refsha" } }
       }
@@ -645,6 +651,8 @@ describe("editAssignment (preserved-entry integration)", () => {
     const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64")
 
     const request = vi.fn(async (url: string) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(url))
+        return { default_branch: "main" }
       if (url.includes("/git/ref/heads/main")) return { object: { sha: "s" } }
       if (url.includes("/git/commits/s")) return { tree: { sha: "t" } }
       if (url.includes("/contents/cs50/assignments.json")) {
@@ -714,6 +722,8 @@ describe("copyAssignmentToClassroom (reuse fork guard)", () => {
   // guard throws before any commit, so no write routes are needed.
   function makeClient(repo: unknown): GitHubClient {
     const request = vi.fn(async (url: string) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(url))
+        return { default_branch: "main" }
       if (url.includes("/git/ref/heads/main")) return { object: { sha: "s" } }
       if (url.includes("/repos/")) return repo
       throw new Error(`unexpected request: ${url}`)
@@ -1314,7 +1324,7 @@ describe("resolveAutograderWorkflow default shim branch templating", () => {
       branch: "master",
       configBranch: "master",
     })
-    expect(yaml).toContain("branches: [master]")
+    expect(yaml).toContain('branches: ["master"]')
     expect(yaml).toContain(
       'uses: "cs50/classroom50/.github/workflows/autograde-runner.yaml@master"',
     )
@@ -1326,8 +1336,21 @@ describe("resolveAutograderWorkflow default shim branch templating", () => {
       classroom: "cs101",
       autograder: "default",
     })
-    expect(yaml).toContain("branches: [main]")
+    expect(yaml).toContain('branches: ["main"]')
     expect(yaml).toContain("autograde-runner.yaml@main")
+  })
+
+  it("quotes a YAML-hostile branch name so it stays a string", async () => {
+    // An unquoted `branches: [off]` would parse as boolean false; quoting keeps
+    // it a branch name. Matches the CLI embed's quoted form.
+    const yaml = await resolveAutograderWorkflow({
+      org: "cs50",
+      classroom: "cs101",
+      autograder: "default",
+      branch: "off",
+      configBranch: "main",
+    })
+    expect(yaml).toContain('branches: ["off"]')
   })
 
   it("does not fetch from Pages for the default autograder", async () => {
@@ -1341,6 +1364,6 @@ describe("resolveAutograderWorkflow default shim branch templating", () => {
         branch: "main",
         configBranch: "main",
       }),
-    ).resolves.toContain("branches: [main]")
+    ).resolves.toContain('branches: ["main"]')
   })
 })

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1806,17 +1806,21 @@ function pagesAutograderUrl(params: {
   return `https://${org}.github.io/classroom50/${segment}/autograders/${name}.yaml`
 }
 
-function defaultAutograderWorkflow(org: string) {
+function defaultAutograderWorkflow(
+  org: string,
+  branch: string,
+  configBranch: string,
+) {
   return `name: Autograde
 
 on:
   push:
-    branches: [main]
+    branches: [${branch}]
     tags: ["submit/*"]
 
 jobs:
   grade:
-    uses: "${org}/classroom50/.github/workflows/autograde-runner.yaml@main"
+    uses: "${org}/classroom50/.github/workflows/autograde-runner.yaml@${configBranch}"
     permissions:
       contents: write
       statuses: write
@@ -1827,25 +1831,59 @@ jobs:
 `
 }
 
+// Whether an autograder name uses the built-in default shim (templated by
+// branch here) vs a teacher-authored one fetched from Pages (branch-agnostic).
+function isDefaultAutograder(autograder?: string): boolean {
+  return !autograder || autograder === "default"
+}
+
+// The config repo's default branch, for the default shim's reusable-workflow
+// `uses:` ref. Best-effort: any failure (or empty value) falls back to "main",
+// keeping the shim's `@<branch>` ref valid even if a config-repo rename to main
+// could not land.
+async function resolveConfigRepoDefaultBranch(
+  client: GitHubClient,
+  org: string,
+): Promise<string> {
+  try {
+    const repo = await getRepo(client, org, "classroom50")
+    return repo?.default_branch || "main"
+  } catch {
+    return "main"
+  }
+}
+
 export async function resolveAutograderWorkflow(params: {
   org: string
   classroom: string
   autograder?: string
   secret?: string
+  // The assignment repo's default branch (the shim's push trigger) and the
+  // config repo's default branch (the reusable-workflow ref). Only used for the
+  // built-in default shim; teacher-authored autograders are branch-agnostic.
+  branch?: string
+  configBranch?: string
 }): Promise<string> {
-  const { org, classroom, autograder, secret } = params
-  if (!autograder || autograder === "default") {
-    return defaultAutograderWorkflow(org)
+  const { org, classroom, autograder, secret, branch, configBranch } = params
+  if (isDefaultAutograder(autograder)) {
+    return defaultAutograderWorkflow(
+      org,
+      branch || "main",
+      configBranch || "main",
+    )
   }
+  // Narrowed: isDefaultAutograder returns true for undefined/"default", so a
+  // non-default autograder name is a non-empty string here.
+  const autograderName = autograder as string
 
   const workflow = await fetchTextWithFriendlyErrors(
-    pagesAutograderUrl({ org, classroom, name: autograder, secret }),
-    `autograder ${autograder}`,
+    pagesAutograderUrl({ org, classroom, name: autograderName, secret }),
+    `autograder ${autograderName}`,
   )
 
   if (!workflow.includes("jobs:")) {
     throw new Error(
-      `Autograder ${autograder} may be malformed YAML. Ask your instructor to check the file in the config repo.`,
+      `Autograder ${autograderName} may be malformed YAML. Ask your instructor to check the file in the config repo.`,
     )
   }
 
@@ -2078,7 +2116,7 @@ export async function acceptAssignment(params: {
     }
   }
 
-  const autogradeYaml = await withAcceptStep(
+  let autogradeYaml = await withAcceptStep(
     {
       id: "autograder",
       label: "Resolving the autograder",
@@ -2092,6 +2130,9 @@ export async function acceptAssignment(params: {
         classroom,
         autograder: assignment.autograder,
         secret,
+        // Preliminary branch; the default shim is re-rendered post-create with
+        // the assignment repo's actual default branch (below).
+        branch: sourceBranch || "main",
       }),
   )
 
@@ -2132,6 +2173,20 @@ export async function acceptAssignment(params: {
         fallbackBranch: sourceBranch || "main",
       }),
   )
+
+  // The default shim's push-trigger branch must match the assignment repo's
+  // actual default branch (which GitHub, not the template, decides — a `main`
+  // template generated into a `master`-default org yields a `master` repo), and
+  // its reusable-workflow `uses:` ref must match the config repo's branch. Both
+  // are only knowable after the repo exists, so re-render here.
+  if (isDefaultAutograder(assignment.autograder)) {
+    const resolvedBranch =
+      created.kind === "fallback-empty"
+        ? created.branch
+        : created.repo.default_branch || sourceBranch || "main"
+    const configBranch = await resolveConfigRepoDefaultBranch(client, org)
+    autogradeYaml = defaultAutograderWorkflow(org, resolvedBranch, configBranch)
+  }
 
   if (created.kind === "already-accepted") {
     // The repo exists, but a prior accept may have failed AFTER creating it but

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -7,7 +7,12 @@ import {
   PASS_THRESHOLD_MIN,
   assertAssignmentMode,
 } from "@/types/classroom"
-import { getBranchRef, getClassroomJson, getCommit } from "../github/queries"
+import {
+  getBranchRef,
+  getClassroomJson,
+  getCommit,
+  getConfigRepoBranch,
+} from "../github/queries"
 import { getUser } from "@/hooks/github/queries"
 import { GitHubAPIError } from "@/hooks/github/errors"
 
@@ -555,10 +560,11 @@ export async function editAssignment(
   // The archive guard is independent of the org ref read, so run them
   // concurrently — Promise.all rejects on the first rejection, so an archived
   // classroom still fails closed before any write.
-  const [, ref] = await Promise.all([
+  const [, configBranch] = await Promise.all([
     assertClassroomNotArchived(client, org, classroom),
-    getBranchRef(client, org),
+    getConfigRepoBranch(client, org),
   ])
+  const ref = await getBranchRef(client, org, configBranch)
   const commit = await getCommit(client, org, ref.object.sha)
 
   const assignmentsFilePath = `${classroom}/assignments.json`
@@ -620,7 +626,12 @@ export async function editAssignment(
     tree_sha: tree.sha,
     parents: [ref.object.sha],
   })
-  const updatedRef = await updateRef(client, input.org, newCommit.sha)
+  const updatedRef = await updateRef(
+    client,
+    input.org,
+    newCommit.sha,
+    configBranch,
+  )
 
   // Grant the (possibly changed) in-org private template a team read — a
   // non-fatal warning, never thrown (the edit already committed). needsTeamGrant
@@ -989,11 +1000,13 @@ export async function createAssignment(
   // The archive guard, entry build, and org ref read are independent, so run
   // them concurrently — Promise.all rejects on the first rejection, so an
   // archived classroom still fails closed before any write.
-  const [, { entry: assignmentBody, needsTeamGrant }, ref] = await Promise.all([
-    assertClassroomNotArchived(client, input.org, input.classroom),
-    buildAssignmentEntry(client, input),
-    getBranchRef(client, input.org),
-  ])
+  const [, { entry: assignmentBody, needsTeamGrant }, configBranch] =
+    await Promise.all([
+      assertClassroomNotArchived(client, input.org, input.classroom),
+      buildAssignmentEntry(client, input),
+      getConfigRepoBranch(client, input.org),
+    ])
+  const ref = await getBranchRef(client, input.org, configBranch)
 
   const commit = await getCommit(client, input.org, ref.object.sha)
 
@@ -1037,7 +1050,12 @@ export async function createAssignment(
     tree_sha: tree.sha,
     parents: [ref.object.sha],
   })
-  const updatedRef = await updateRef(client, input.org, newCommit.sha)
+  const updatedRef = await updateRef(
+    client,
+    input.org,
+    newCommit.sha,
+    configBranch,
+  )
 
   let templateGrantWarning: string | undefined
   if (needsTeamGrant && assignmentBody.template) {
@@ -1433,13 +1451,14 @@ export async function copyAssignmentToClassroom(
   // run them concurrently — one fewer serial round-trip per retry attempt.
   // Promise.all rejects on the first rejection, so an archived classroom or bad
   // template throws before any write.
-  const [, repo, ref] = await Promise.all([
+  const [, repo, configBranch] = await Promise.all([
     assertClassroomNotArchived(client, org, targetClassroom),
     entry.template
       ? getRepo(client, entry.template.owner, entry.template.repo)
       : Promise.resolve(null),
-    getBranchRef(client, org),
+    getConfigRepoBranch(client, org),
   ])
+  const ref = await getBranchRef(client, org, configBranch)
 
   // Re-check the template live (mirrors create): public/missing -> no grant;
   // private in-org -> needs grant; private out-of-org -> refuse.
@@ -1524,7 +1543,7 @@ export async function copyAssignmentToClassroom(
     tree_sha: tree.sha,
     parents: [ref.object.sha],
   })
-  const updatedRef = await updateRef(client, org, newCommit.sha)
+  const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
 
   let templateGrantWarning: string | undefined
   if (needsTeamGrant && entry.template) {
@@ -1650,10 +1669,11 @@ export async function deleteAssignment(
 
   // Refuse a delete into an archived classroom (write-path guard); run the
   // check concurrently with the ref read.
-  const [, ref] = await Promise.all([
+  const [, configBranch] = await Promise.all([
     assertClassroomNotArchived(client, org, classroom),
-    getBranchRef(client, org),
+    getConfigRepoBranch(client, org),
   ])
+  const ref = await getBranchRef(client, org, configBranch)
   const commit = await getCommit(client, org, ref.object.sha)
 
   const assignmentsFilePath = `${classroom}/assignments.json`
@@ -1697,7 +1717,12 @@ export async function deleteAssignment(
     tree_sha: tree.sha,
     parents: [ref.object.sha],
   })
-  const updatedRef = await updateRef(client, input.org, newCommit.sha)
+  const updatedRef = await updateRef(
+    client,
+    input.org,
+    newCommit.sha,
+    configBranch,
+  )
 
   return {
     previousCommitSha: ref.object.sha,
@@ -1815,7 +1840,7 @@ function defaultAutograderWorkflow(
 
 on:
   push:
-    branches: [${branch}]
+    branches: ["${branch}"]
     tags: ["submit/*"]
 
 jobs:
@@ -1838,18 +1863,20 @@ function isDefaultAutograder(autograder?: string): boolean {
 }
 
 // The config repo's default branch, for the default shim's reusable-workflow
-// `uses:` ref. Best-effort: any failure (or empty value) falls back to "main",
-// keeping the shim's `@<branch>` ref valid even if a config-repo rename to main
-// could not land.
+// `uses:` ref. On a read failure, fall back to `fallbackBranch` (the assignment
+// repo's own branch) rather than a hardcoded `main` — a wrong `@main` ref would
+// 404 the runner and silently skip grading on a master-default org. A 404
+// (getRepo returns null) or empty value falls back to `main`.
 async function resolveConfigRepoDefaultBranch(
   client: GitHubClient,
   org: string,
+  fallbackBranch: string,
 ): Promise<string> {
   try {
     const repo = await getRepo(client, org, "classroom50")
     return repo?.default_branch || "main"
   } catch {
-    return "main"
+    return fallbackBranch
   }
 }
 
@@ -2184,7 +2211,11 @@ export async function acceptAssignment(params: {
       created.kind === "fallback-empty"
         ? created.branch
         : created.repo.default_branch || sourceBranch || "main"
-    const configBranch = await resolveConfigRepoDefaultBranch(client, org)
+    const configBranch = await resolveConfigRepoDefaultBranch(
+      client,
+      org,
+      resolvedBranch,
+    )
     autogradeYaml = defaultAutograderWorkflow(org, resolvedBranch, configBranch)
   }
 

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1082,30 +1082,6 @@ const extractTemplate = (template: string) => {
   if (!/\//.test(template)) return template
   return template.split("/")?.[1] ?? template
 }
-// GitHub's POST .../generate response reports a stale/default `default_branch`
-// (often `main`) before the generated repo's real branch settles — so a
-// `master`-default template can yield a response claiming `main` while the only
-// branch is `master`, sending the downstream commit at a nonexistent `heads/main`
-// ref (a 409/404 stabilize loop). Confirm the real branch with a follow-up GET,
-// falling back to the generate response's value when the read is unavailable.
-async function confirmGeneratedDefaultBranch(
-  client: GitHubClient,
-  owner: string,
-  name: string,
-  generated: GitHubRepo,
-): Promise<GitHubRepo> {
-  try {
-    const confirmed = await getRepo(client, owner, name)
-    const branch = confirmed?.default_branch
-    if (branch && branch !== generated.default_branch) {
-      return { ...generated, default_branch: branch }
-    }
-  } catch {
-    // Fall through: keep the generate response's branch on a read failure.
-  }
-  return generated
-}
-
 export async function createAssignmentRepo(params: {
   client: GitHubClient
   templateOwner?: string
@@ -1138,7 +1114,7 @@ export async function createAssignmentRepo(params: {
 
       return {
         kind: "generated",
-        repo: await confirmGeneratedDefaultBranch(client, owner, name, repo),
+        repo,
       }
     } catch (err) {
       if (!(err instanceof GitHubAPIError)) {
@@ -1974,11 +1950,32 @@ async function commitAcceptFilesWithFreshRepoRetry(params: {
   branch: string
   metadataYaml: string
   autogradeYaml: string
+  // Rebuild the autograde shim for the branch that actually materialized. The
+  // default shim's push-trigger branch must match the generated repo's real
+  // default branch, which is only known after GitHub's async template copy
+  // settles (see below). Omitted for branch-agnostic (teacher-authored) shims.
+  rerenderShimForBranch?: (branch: string) => string
 }) {
-  const { client, owner, repo, branch, metadataYaml, autogradeYaml } = params
+  const {
+    client,
+    owner,
+    repo,
+    branch,
+    metadataYaml,
+    autogradeYaml,
+    rerenderShimForBranch,
+  } = params
 
   await withFreshRepoRetry(async () => {
-    const ref = await getBranchRefRepo(client, owner, repo, branch)
+    // A freshly template-generated repo's real branch (copied from the template,
+    // e.g. `master`) only materializes after GitHub finishes the async copy —
+    // until then `default_branch` transiently reports the org default (`main`)
+    // and no ref exists. Re-resolve the live default branch each attempt so we
+    // commit to the branch that actually appears, not a pre-guessed `main` that
+    // may never exist. Fall back to the caller's branch while it's still empty.
+    const live = await getRepo(client, owner, repo)
+    const targetBranch = live?.default_branch || branch
+    const ref = await getBranchRefRepo(client, owner, repo, targetBranch)
     const parentSha = ref.object.sha
     const currentCommit = await getCommitByRepo(client, owner, repo, parentSha)
     const baseTreeSha = currentCommit.tree?.sha
@@ -1987,13 +1984,20 @@ async function commitAcceptFilesWithFreshRepoRetry(params: {
       throw freshRepoNotReadyError(owner, repo)
     }
 
+    // Re-render the default shim's push trigger for the branch that actually
+    // materialized (targetBranch), so autograde fires on the repo's real
+    // default branch rather than a transiently-reported `main`.
+    const shim = rerenderShimForBranch
+      ? rerenderShimForBranch(targetBranch)
+      : autogradeYaml
+
     const tree = await createTreeForAssignment({
       client,
       owner,
       repo,
       baseTreeSha,
       metadataYaml,
-      autogradeYaml,
+      autogradeYaml: shim,
     })
 
     const commit = await createCommitForAssignment({
@@ -2011,7 +2015,7 @@ async function commitAcceptFilesWithFreshRepoRetry(params: {
       client,
       owner,
       repo,
-      branch,
+      branch: targetBranch,
       commitSha: commit.sha,
     })
   })
@@ -2034,6 +2038,7 @@ async function provisionAcceptedRepo(params: {
   branch: string
   metadataYaml: string
   autogradeYaml: string
+  rerenderShimForBranch?: (branch: string) => string
   onStepUpdate?: OnAcceptStepUpdate
 }) {
   const {
@@ -2045,6 +2050,7 @@ async function provisionAcceptedRepo(params: {
     branch,
     metadataYaml,
     autogradeYaml,
+    rerenderShimForBranch,
     onStepUpdate,
   } = params
 
@@ -2086,6 +2092,7 @@ async function provisionAcceptedRepo(params: {
         branch,
         metadataYaml,
         autogradeYaml,
+        rerenderShimForBranch,
       }),
   )
 }
@@ -2230,6 +2237,11 @@ export async function acceptAssignment(params: {
   // template generated into a `master`-default org yields a `master` repo), and
   // its reusable-workflow `uses:` ref must match the config repo's branch. Both
   // are only knowable after the repo exists, so re-render here.
+  //
+  // The generated repo's real branch lags GitHub's async template copy, so the
+  // branch resolved here may still be the transient `main`. rerenderShim lets
+  // the commit step rebuild the shim once the true branch materializes.
+  let rerenderShim: ((branch: string) => string) | undefined
   if (isDefaultAutograder(assignment.autograder)) {
     const resolvedBranch =
       created.kind === "fallback-empty"
@@ -2241,6 +2253,8 @@ export async function acceptAssignment(params: {
       resolvedBranch,
     )
     autogradeYaml = defaultAutograderWorkflow(org, resolvedBranch, configBranch)
+    rerenderShim = (branch: string) =>
+      defaultAutograderWorkflow(org, branch, configBranch)
   }
 
   if (created.kind === "already-accepted") {
@@ -2321,6 +2335,7 @@ export async function acceptAssignment(params: {
       branch: created.repo.default_branch || sourceBranch,
       metadataYaml,
       autogradeYaml,
+      rerenderShimForBranch: rerenderShim,
       onStepUpdate,
     })
 
@@ -2355,6 +2370,7 @@ export async function acceptAssignment(params: {
     branch: targetBranch,
     metadataYaml,
     autogradeYaml,
+    rerenderShimForBranch: rerenderShim,
     onStepUpdate,
   })
 

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -1082,6 +1082,30 @@ const extractTemplate = (template: string) => {
   if (!/\//.test(template)) return template
   return template.split("/")?.[1] ?? template
 }
+// GitHub's POST .../generate response reports a stale/default `default_branch`
+// (often `main`) before the generated repo's real branch settles — so a
+// `master`-default template can yield a response claiming `main` while the only
+// branch is `master`, sending the downstream commit at a nonexistent `heads/main`
+// ref (a 409/404 stabilize loop). Confirm the real branch with a follow-up GET,
+// falling back to the generate response's value when the read is unavailable.
+async function confirmGeneratedDefaultBranch(
+  client: GitHubClient,
+  owner: string,
+  name: string,
+  generated: GitHubRepo,
+): Promise<GitHubRepo> {
+  try {
+    const confirmed = await getRepo(client, owner, name)
+    const branch = confirmed?.default_branch
+    if (branch && branch !== generated.default_branch) {
+      return { ...generated, default_branch: branch }
+    }
+  } catch {
+    // Fall through: keep the generate response's branch on a read failure.
+  }
+  return generated
+}
+
 export async function createAssignmentRepo(params: {
   client: GitHubClient
   templateOwner?: string
@@ -1114,7 +1138,7 @@ export async function createAssignmentRepo(params: {
 
       return {
         kind: "generated",
-        repo,
+        repo: await confirmGeneratedDefaultBranch(client, owner, name, repo),
       }
     } catch (err) {
       if (!(err instanceof GitHubAPIError)) {

--- a/web/src/api/mutations/classrooms.ts
+++ b/web/src/api/mutations/classrooms.ts
@@ -1,7 +1,12 @@
 import type { GitHubClient } from "@/hooks/github/client"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import type { GitHubMoveBranch } from "@/hooks/github/types"
-import { getBranchRef, getClassroomJson, getCommit } from "../github/queries"
+import {
+  getBranchRef,
+  getClassroomJson,
+  getCommit,
+  getConfigRepoBranch,
+} from "../github/queries"
 import { sleep } from "@/hooks/github/queries"
 import { isClassroomArchived } from "@/types/classroom"
 import {
@@ -84,7 +89,8 @@ export async function createClassroomFiles(
   // just-created teams rather than deleting them out from under the retry.
   let ref, commit, tree, newCommit, updatedRef
   try {
-    ref = await getBranchRef(client, input.org)
+    const configBranch = await getConfigRepoBranch(client, input.org)
+    ref = await getBranchRef(client, input.org, configBranch)
     commit = await getCommit(client, input.org, ref.object.sha)
     tree = await createTree(client, {
       ...input,
@@ -98,7 +104,7 @@ export async function createClassroomFiles(
       tree_sha: tree.sha,
       parents: [ref.object.sha],
     })
-    updatedRef = await updateRef(client, input.org, newCommit.sha)
+    updatedRef = await updateRef(client, input.org, newCommit.sha, configBranch)
   } catch (err) {
     if (!(err instanceof GitHubAPIError && err.status === 409)) {
       log.warn("create classroom: scaffolding failed, rolling back teams", {

--- a/web/src/api/mutations/students.test.ts
+++ b/web/src/api/mutations/students.test.ts
@@ -69,6 +69,8 @@ const makeClient = (opts: {
   const request = vi
     .fn()
     .mockImplementation((path: string, options?: { body?: unknown }) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(path))
+        return { default_branch: "main" }
       if (path.includes("/contents/") && path.includes("roster.csv")) {
         return Promise.resolve(csvFile())
       }
@@ -191,6 +193,8 @@ describe("roster write target — commits roster.csv, never students.csv", () =>
     const request = vi
       .fn()
       .mockImplementation((path: string, options?: { body?: unknown }) => {
+        if (/\/repos\/[^/]+\/classroom50$/.test(path))
+          return { default_branch: "main" }
         // Un-migrated classroom: roster.csv 404s, only students.csv exists.
         if (path.includes("/contents/") && path.includes("roster.csv")) {
           return Promise.reject(
@@ -316,6 +320,8 @@ describe("roster write target — commits roster.csv, never students.csv", () =>
     const request = vi
       .fn()
       .mockImplementation((path: string, options?: { body?: unknown }) => {
+        if (/\/repos\/[^/]+\/classroom50$/.test(path))
+          return { default_branch: "main" }
         if (path.includes("/contents/") && path.includes("roster.csv")) {
           rosterContentsReads++
           // First read 404s (lag); the tree-confirmed re-read succeeds.
@@ -505,6 +511,8 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
     const request = vi
       .fn()
       .mockImplementation((path: string, options?: { body?: unknown }) => {
+        if (/\/repos\/[^/]+\/classroom50$/.test(path))
+          return { default_branch: "main" }
         if (path.endsWith("/git/trees")) {
           state.csvWritten = true
           return Promise.resolve({ sha: "tree-sha" })
@@ -654,6 +662,8 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
       .fn()
       .mockImplementation(
         (path: string, options?: { body?: unknown; method?: string }) => {
+          if (/\/repos\/[^/]+\/classroom50$/.test(path))
+            return { default_branch: "main" }
           if (path.endsWith("/git/trees")) {
             state.csvWritten = true
             return Promise.resolve({ sha: "tree-sha" })
@@ -1137,6 +1147,8 @@ describe("updateStudent — edit a roster row's teacher-facing fields in place",
       return Promise.reject(new Error(`unexpected requestRaw: ${path}`))
     })
     const request = vi.fn().mockImplementation((path: string) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(path))
+        return { default_branch: "main" }
       if (path.includes("/git/trees")) {
         committed.content = "should-not-write"
       }
@@ -1323,6 +1335,8 @@ describe("updateStudent — edit a roster row's teacher-facing fields in place",
     const request = vi
       .fn()
       .mockImplementation((path: string, options?: { body?: unknown }) => {
+        if (/\/repos\/[^/]+\/classroom50$/.test(path))
+          return { default_branch: "main" }
         if (path.includes("/contents/") && path.includes("roster.csv")) {
           return Promise.resolve({
             type: "file",
@@ -1378,6 +1392,8 @@ describe("updateStudent — edit a roster row's teacher-facing fields in place",
     const request = vi
       .fn()
       .mockImplementation((path: string, options?: { body?: unknown }) => {
+        if (/\/repos\/[^/]+\/classroom50$/.test(path))
+          return { default_branch: "main" }
         if (path.includes("/contents/") && path.includes("roster.csv")) {
           // On retry, serve the already-committed CSV if present.
           const csv = committed.content ?? HEADER + aliceRow
@@ -1473,6 +1489,8 @@ describe("unenrollStudent — classroom-scoped, no active-member org removal", (
       .fn()
       .mockImplementation(
         (path: string, options?: { method?: string; body?: unknown }) => {
+          if (/\/repos\/[^/]+\/classroom50$/.test(path))
+            return { default_branch: "main" }
           if (path.includes("/contents/") && path.includes("roster.csv")) {
             const csv = committed.content ?? opts.startingCsv
             return Promise.resolve({
@@ -1821,6 +1839,8 @@ const makeTeamClient = (opts: {
   const request = vi
     .fn()
     .mockImplementation((path: string, options?: { method?: string }) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(path))
+        return { default_branch: "main" }
       if (path.includes("/contents/") && path.includes("roster.csv")) {
         const csv = committed.content ?? opts.startingCsv
         return Promise.resolve({
@@ -2639,6 +2659,8 @@ const makeInviteClient = (opts: {
   const request = vi
     .fn()
     .mockImplementation((path: string, options?: { method?: string }) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(path))
+        return { default_branch: "main" }
       if (path.startsWith("/users/")) {
         const login = decodeURIComponent(path.slice("/users/".length))
         const u = opts.users?.[login]
@@ -3046,6 +3068,8 @@ describe("migrateRosterFile — converge students.csv onto roster.csv", () => {
     const request = vi
       .fn()
       .mockImplementation((path: string, options?: { body?: unknown }) => {
+        if (/\/repos\/[^/]+\/classroom50$/.test(path))
+          return { default_branch: "main" }
         if (path.includes("/contents/")) {
           const match = path.match(/\/contents\/(.+?)(\?|$)/)
           const rel = match ? decodeURIComponent(match[1]) : ""
@@ -3276,6 +3300,8 @@ const makeRoleChangeClient = (opts: {
     .mockImplementation(
       (path: string, options?: { method?: string; body?: unknown }) => {
         const method = options?.method ?? "GET"
+        if (/\/repos\/[^/]+\/classroom50$/.test(path))
+          return { default_branch: "main" }
         // Authenticated viewer (getAuthenticatedUser) for the self-demote guard.
         if (path === "/user") {
           return Promise.resolve({ id: 1, login: viewerLogin })

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -35,7 +35,12 @@ import {
   REPO_READ_CONCURRENCY,
 } from "@/hooks/github/queries"
 import { getAuthenticatedUser } from "@/api/queries/users"
-import { getBranchRef, getClassroomJson, getCommit } from "../github/queries"
+import {
+  getBranchRef,
+  getClassroomJson,
+  getCommit,
+  getConfigRepoBranch,
+} from "../github/queries"
 import { GitHubAPIError, isDefinitiveGitHubStatus } from "@/hooks/github/errors"
 import { isSameGitHubUser, parseGitHubId } from "@/util/students"
 import { studentKey, rosterClaimSet } from "@/util/identity"
@@ -235,7 +240,8 @@ export async function addStudentToClassroom(
 
   await assertClassroomNotArchived(client, input.org, input.classroom)
 
-  const ref = await getBranchRef(client, input.org)
+  const configBranch = await getConfigRepoBranch(client, input.org)
+  const ref = await getBranchRef(client, input.org, configBranch)
   const commit = await getCommit(client, input.org, ref.object.sha)
 
   const studentsFilePath = rosterPath(input.classroom)
@@ -291,7 +297,12 @@ export async function addStudentToClassroom(
     parents: [ref.object.sha],
   })
 
-  const updatedRef = await updateRef(client, input.org, newCommit.sha)
+  const updatedRef = await updateRef(
+    client,
+    input.org,
+    newCommit.sha,
+    configBranch,
+  )
 
   return {
     previousCommitSha: ref.object.sha,
@@ -598,7 +609,8 @@ export async function addStudentsToClassroom(
     message: "Reading current roster.csv...",
   })
 
-  const ref = await getBranchRef(client, input.org)
+  const configBranch = await getConfigRepoBranch(client, input.org)
+  const ref = await getBranchRef(client, input.org, configBranch)
   const commit = await getCommit(client, input.org, ref.object.sha)
 
   const studentsFilePath = rosterPath(input.classroom)
@@ -741,7 +753,12 @@ export async function addStudentsToClassroom(
     parents: [ref.object.sha],
   })
 
-  const updatedRef = await updateRef(client, input.org, newCommit.sha)
+  const updatedRef = await updateRef(
+    client,
+    input.org,
+    newCommit.sha,
+    configBranch,
+  )
 
   input.onProgress?.({
     processed: normalizedRows.length,
@@ -936,10 +953,12 @@ export async function syncRosterFromTeam(
   return withGitConflictRetry(async () => {
     // Re-read teams + CSV on every attempt so the diff is always against the
     // latest state (a concurrent add/edit can't be clobbered or duplicated).
-    const [{ members, fullyRead, pendingRoleKeys }, ref] = await Promise.all([
-      listClassroomMembersWithRoles(client, org, slugs),
-      getBranchRef(client, org),
-    ])
+    const [{ members, fullyRead, pendingRoleKeys }, configBranch] =
+      await Promise.all([
+        listClassroomMembersWithRoles(client, org, slugs),
+        getConfigRepoBranch(client, org),
+      ])
+    const ref = await getBranchRef(client, org, configBranch)
     const commit = await getCommit(client, org, ref.object.sha)
 
     const studentsFilePath = rosterPath(classroom)
@@ -1083,7 +1102,7 @@ export async function syncRosterFromTeam(
       parents: [ref.object.sha],
     })
 
-    await updateRef(client, org, newCommit.sha)
+    await updateRef(client, org, newCommit.sha, configBranch)
 
     log.info("sync roster from team: completed", {
       org,
@@ -1141,7 +1160,8 @@ export async function writeRosterRoles(
   if (roleByLogin.size === 0) return { changed: 0 }
 
   return withGitConflictRetry(async () => {
-    const ref = await getBranchRef(client, org)
+    const configBranch = await getConfigRepoBranch(client, org)
+    const ref = await getBranchRef(client, org, configBranch)
     const commit = await getCommit(client, org, ref.object.sha)
     const studentsFilePath = rosterPath(classroom)
     const currentCsv = await getRawFileWithFallbackSource(client, {
@@ -1189,7 +1209,7 @@ export async function writeRosterRoles(
       tree_sha: tree.sha,
       parents: [ref.object.sha],
     })
-    await updateRef(client, org, newCommit.sha)
+    await updateRef(client, org, newCommit.sha, configBranch)
     log.info("write roster roles: committed", { org, classroom, changed })
     return { changed }
   })
@@ -1233,7 +1253,8 @@ export async function migrateRosterFile(
   const legacyPath = legacyRosterPath(classroom)
 
   return withGitConflictRetry(async () => {
-    const ref = await getBranchRef(client, org)
+    const configBranch = await getConfigRepoBranch(client, org)
+    const ref = await getBranchRef(client, org, configBranch)
     const commit = await getCommit(client, org, ref.object.sha)
 
     // Read both files' presence at the same commit. roster.csv present -> the
@@ -1264,7 +1285,7 @@ export async function migrateRosterFile(
       parents: [ref.object.sha],
     })
 
-    await updateRef(client, org, newCommit.sha)
+    await updateRef(client, org, newCommit.sha, configBranch)
 
     log.info("migrate roster file: renamed students.csv -> roster.csv", {
       org,
@@ -2194,7 +2215,8 @@ export async function unenrollStudent(
   const viewerPromise = getAuthenticatedUser(client)
   viewerPromise.catch(() => {})
 
-  const ref = await getBranchRef(client, org)
+  const configBranch = await getConfigRepoBranch(client, org)
+  const ref = await getBranchRef(client, org, configBranch)
   const commit = await getCommit(client, org, ref.object.sha)
 
   const studentsFilePath = rosterPath(classroom)
@@ -2238,7 +2260,7 @@ export async function unenrollStudent(
     parents: [ref.object.sha],
   })
 
-  const updatedRef = await updateRef(client, org, newCommit.sha)
+  const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
 
   // Commit landed, so every org-side step below is a non-fatal warning.
   const warnings: string[] = []
@@ -2390,7 +2412,8 @@ export async function bulkUnenrollStudents(
   let newCommitSha: string | undefined
 
   await withGitConflictRetry(async () => {
-    const ref = await getBranchRef(client, org)
+    const configBranch = await getConfigRepoBranch(client, org)
+    const ref = await getBranchRef(client, org, configBranch)
     const commit = await getCommit(client, org, ref.object.sha)
     const currentCsv = await getRawFileWithFallbackSource(client, {
       org,
@@ -2429,7 +2452,7 @@ export async function bulkUnenrollStudents(
       tree_sha: tree.sha,
       parents: [ref.object.sha],
     })
-    await updateRef(client, org, newCommit.sha)
+    await updateRef(client, org, newCommit.sha, configBranch)
     newCommitSha = newCommit.sha
   })
 
@@ -2564,7 +2587,8 @@ export async function updateStudent(
 
   await assertClassroomNotArchived(client, org, classroom)
 
-  const ref = await getBranchRef(client, org)
+  const configBranch = await getConfigRepoBranch(client, org)
+  const ref = await getBranchRef(client, org, configBranch)
   const commit = await getCommit(client, org, ref.object.sha)
 
   const studentsFilePath = rosterPath(classroom)
@@ -2658,7 +2682,7 @@ export async function updateStudent(
     parents: [ref.object.sha],
   })
 
-  const updatedRef = await updateRef(client, org, newCommit.sha)
+  const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
 
   return {
     previousCommitSha: ref.object.sha,

--- a/web/src/hooks/github/mutations.test.ts
+++ b/web/src/hooks/github/mutations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   buildClassroomUpdate,
   editClassroom,
+  ensureClassroom50Repo,
   ensurePages,
   ensureSkeletonFiles,
   ensureWorkflowPermissions,
@@ -112,6 +113,9 @@ describe("editClassroom archived read-only guard", () => {
       return Promise.reject(new Error(`unexpected requestRaw: ${path}`))
     })
     const request = vi.fn().mockImplementation((path: string) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(path)) {
+        return Promise.resolve({ default_branch: "main" })
+      }
       if (path.endsWith("/git/ref/heads/main")) {
         return Promise.resolve({ object: { sha: "base-sha" } })
       }
@@ -675,6 +679,120 @@ describe("findStaleSkeletonFiles", () => {
     const byPath = Object.fromEntries(stale.map((f) => [f.path, f.exists]))
     expect(byPath[drifted]).toBe(true)
     expect(byPath[missing]).toBe(false)
+  })
+
+  // A master-default config repo: the tree read must resolve heads/master, not
+  // heads/main. This is the #233 regression — a hardcoded heads/main 404s here.
+  it("reads the config repo's actual default branch (master) for the tree", async () => {
+    const refBranches: string[] = []
+    const request = vi.fn(async (url: string) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(url)) {
+        return { default_branch: "master" }
+      }
+      const m = url.match(/\/git\/ref\/heads\/([^/?]+)/)
+      if (m) {
+        refBranches.push(decodeURIComponent(m[1]))
+        return { object: { sha: "refsha" } }
+      }
+      if (url.includes("/git/commits/")) return { tree: { sha: "treesha" } }
+      if (url.includes("/git/trees/")) return { truncated: false, tree: [] }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    await findStaleSkeletonFiles({ request } as unknown as GitHubClient, org)
+    expect(refBranches).toContain("master")
+    expect(refBranches).not.toContain("main")
+  })
+})
+
+// U1: the config repo is normalized to `main` (guarded rename) and the org
+// default-branch setting is steered to `main`, both best-effort.
+describe("ensureClassroom50Repo branch normalization", () => {
+  const org = "acme"
+
+  function makeClient(opts: {
+    existingDefaultBranch?: string | null
+    renameFails?: boolean
+  }) {
+    const calls: string[] = []
+    const request = vi.fn(async (url: string, o?: { method?: string }) => {
+      const method = o?.method ?? "GET"
+      calls.push(`${method} ${url}`)
+      if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(url)) {
+        if (opts.existingDefaultBranch === null) {
+          throw new GitHubAPIError({
+            status: 404,
+            url,
+            message: "Not Found",
+            body: null,
+            rateLimit: {
+              limit: null,
+              remaining: null,
+              used: null,
+              reset: null,
+              resource: null,
+              retryAfter: null,
+            },
+          })
+        }
+        return { default_branch: opts.existingDefaultBranch ?? "main" }
+      }
+      if (method === "POST" && url.endsWith("/repos")) {
+        return { default_branch: opts.existingDefaultBranch ?? "main" }
+      }
+      if (
+        method === "POST" &&
+        url.includes("/branches/") &&
+        url.endsWith("/rename")
+      ) {
+        if (opts.renameFails) {
+          throw new GitHubAPIError({
+            status: 403,
+            url,
+            message: "Forbidden",
+            body: null,
+            rateLimit: {
+              limit: null,
+              remaining: null,
+              used: null,
+              reset: null,
+              resource: null,
+              retryAfter: null,
+            },
+          })
+        }
+        return { default_branch: "main" }
+      }
+      throw new Error(`unexpected request: ${method} ${url}`)
+    })
+    return { client: { request } as unknown as GitHubClient, calls }
+  }
+
+  it("renames the branch to main when an existing repo defaults to master", async () => {
+    const { client, calls } = makeClient({ existingDefaultBranch: "master" })
+    const result = await ensureClassroom50Repo(client, org)
+    expect(
+      calls.some(
+        (c) => c === `POST /repos/${org}/classroom50/branches/master/rename`,
+      ),
+    ).toBe(true)
+    expect(result.repo.default_branch).toBe("main")
+  })
+
+  it("does NOT call rename when the repo already defaults to main", async () => {
+    const { client, calls } = makeClient({ existingDefaultBranch: "main" })
+    await ensureClassroom50Repo(client, org)
+    expect(calls.some((c) => c.includes("/rename"))).toBe(false)
+  })
+
+  it("swallows a rename failure and still resolves", async () => {
+    const { client } = makeClient({
+      existingDefaultBranch: "master",
+      renameFails: true,
+    })
+    const result = await ensureClassroom50Repo(client, org)
+    // Rename failed, so the reported branch stays master (defense-in-depth
+    // reads resolve it); the step does not throw.
+    expect(result.repo.default_branch).toBe("master")
   })
 })
 

--- a/web/src/hooks/github/mutations.test.ts
+++ b/web/src/hooks/github/mutations.test.ts
@@ -9,6 +9,7 @@ import {
   ensureWorkflowPermissions,
   findStaleSkeletonFiles,
   gitBlobSha,
+  renameConfigRepoToMain,
   resendOrgInvitation,
   triggerRegrade,
   validateServiceToken,
@@ -808,6 +809,70 @@ describe("ensureClassroom50Repo branch normalization", () => {
     // Rename failed, so the reported branch stays master (defense-in-depth
     // reads resolve it); the step does not throw.
     expect(result.repo.default_branch).toBe("master")
+  })
+})
+
+// The audit pane's on-demand rename: unlike ensureClassroom50Repo this DOES
+// rename an existing non-main repo (the teacher confirmed the shim-breaking
+// risk in a modal). A no-op when already main; a failure propagates so the
+// modal can surface it.
+describe("renameConfigRepoToMain", () => {
+  const org = "acme"
+
+  function makeClient(opts: { defaultBranch: string; renameFails?: boolean }) {
+    const calls: string[] = []
+    const request = vi.fn(async (url: string, o?: { method?: string }) => {
+      const method = o?.method ?? "GET"
+      calls.push(`${method} ${url}`)
+      if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(url)) {
+        return { default_branch: opts.defaultBranch }
+      }
+      if (method === "POST" && url.endsWith("/rename")) {
+        if (opts.renameFails) {
+          throw new GitHubAPIError({
+            status: 403,
+            url,
+            message: "Forbidden",
+            body: null,
+            rateLimit: {
+              limit: null,
+              remaining: null,
+              used: null,
+              reset: null,
+              resource: null,
+              retryAfter: null,
+            },
+          })
+        }
+        return { default_branch: "main" }
+      }
+      throw new Error(`unexpected request: ${method} ${url}`)
+    })
+    return { client: { request } as unknown as GitHubClient, calls }
+  }
+
+  it("renames a master default branch to main", async () => {
+    const { client, calls } = makeClient({ defaultBranch: "master" })
+    const result = await renameConfigRepoToMain(client, org)
+    expect(result).toEqual({ renamed: true, from: "master" })
+    expect(calls).toContain(
+      `POST /repos/${org}/classroom50/branches/master/rename`,
+    )
+  })
+
+  it("is a no-op (no request) when already on main", async () => {
+    const { client, calls } = makeClient({ defaultBranch: "main" })
+    const result = await renameConfigRepoToMain(client, org)
+    expect(result).toEqual({ renamed: false, from: "main" })
+    expect(calls.some((c) => c.includes("/rename"))).toBe(false)
+  })
+
+  it("propagates a rename failure so the caller can surface it", async () => {
+    const { client } = makeClient({
+      defaultBranch: "master",
+      renameFails: true,
+    })
+    await expect(renameConfigRepoToMain(client, org)).rejects.toThrow()
   })
 })
 

--- a/web/src/hooks/github/mutations.test.ts
+++ b/web/src/hooks/github/mutations.test.ts
@@ -711,6 +711,7 @@ describe("ensureClassroom50Repo branch normalization", () => {
 
   function makeClient(opts: {
     existingDefaultBranch?: string | null
+    createdDefaultBranch?: string
     renameFails?: boolean
   }) {
     const calls: string[] = []
@@ -737,7 +738,7 @@ describe("ensureClassroom50Repo branch normalization", () => {
         return { default_branch: opts.existingDefaultBranch ?? "main" }
       }
       if (method === "POST" && url.endsWith("/repos")) {
-        return { default_branch: opts.existingDefaultBranch ?? "main" }
+        return { default_branch: opts.createdDefaultBranch ?? "main" }
       }
       if (
         method === "POST" &&
@@ -767,8 +768,12 @@ describe("ensureClassroom50Repo branch normalization", () => {
     return { client: { request } as unknown as GitHubClient, calls }
   }
 
-  it("renames the branch to main when an existing repo defaults to master", async () => {
-    const { client, calls } = makeClient({ existingDefaultBranch: "master" })
+  it("renames a freshly-created repo to main when GitHub seeds it on master", async () => {
+    // existing 404 -> created via POST /repos on master -> rename fires.
+    const { client, calls } = makeClient({
+      existingDefaultBranch: null,
+      createdDefaultBranch: "master",
+    })
     const result = await ensureClassroom50Repo(client, org)
     expect(
       calls.some(
@@ -778,15 +783,25 @@ describe("ensureClassroom50Repo branch normalization", () => {
     expect(result.repo.default_branch).toBe("main")
   })
 
+  it("does NOT rename an EXISTING master repo (may have student repos referencing it)", async () => {
+    const { client, calls } = makeClient({ existingDefaultBranch: "master" })
+    const result = await ensureClassroom50Repo(client, org)
+    // Skip the rename to avoid stranding already-accepted repos' frozen shim
+    // refs; the branch stays master and reads/writes resolve it.
+    expect(calls.some((c) => c.includes("/rename"))).toBe(false)
+    expect(result.repo.default_branch).toBe("master")
+  })
+
   it("does NOT call rename when the repo already defaults to main", async () => {
     const { client, calls } = makeClient({ existingDefaultBranch: "main" })
     await ensureClassroom50Repo(client, org)
     expect(calls.some((c) => c.includes("/rename"))).toBe(false)
   })
 
-  it("swallows a rename failure and still resolves", async () => {
+  it("swallows a rename failure on a fresh repo and still resolves", async () => {
     const { client } = makeClient({
-      existingDefaultBranch: "master",
+      existingDefaultBranch: null,
+      createdDefaultBranch: "master",
       renameFails: true,
     })
     const result = await ensureClassroom50Repo(client, org)

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -1171,18 +1171,31 @@ export async function createOrgRepo(client: GitHubClient, org: string) {
   })
 }
 
-// Rename the config repo's default branch to `main` when GitHub seeded it with
-// something else (an org whose default-branch-name policy is `master` etc.).
-// Best-effort and guarded: no API call when the branch is already `main`, and a
-// failure (missing admin, protected branch, enterprise lock) is swallowed so
-// setup proceeds — the downstream reads resolve the real branch regardless.
+// Rename the config repo's default branch to `main` (org policy can seed it as
+// `master`). Guarded (skips when already main) and best-effort; failure swallowed.
+// `freshlyCreated` gates the rename: an existing config repo may already have
+// student repos whose frozen shim `uses:@<branch>` ref would dangle after a
+// rename, so we only auto-rename a brand-new repo and warn otherwise.
 async function normalizeConfigRepoBranch(
   client: GitHubClient,
   org: string,
   repo: GitHubRepo,
+  freshlyCreated: boolean,
 ): Promise<GitHubRepo> {
   const current = repo.default_branch
   if (!current || current === CONFIG_REPO_BRANCH) {
+    return repo
+  }
+
+  if (!freshlyCreated) {
+    // Existing repo on a non-main branch: renaming now could strand the
+    // `@<branch>` reusable-workflow ref frozen in already-accepted student
+    // repos. Leave it (reads/writes resolve the real branch) and let the audit
+    // recommendation nudge the teacher to fix the org default by hand.
+    logSetup.warn(
+      "config repo default branch is not main; skipping rename on an existing repo (may have student repos referencing it)",
+      { org, current },
+    )
     return repo
   }
 
@@ -1210,12 +1223,12 @@ export async function ensureClassroom50Repo(client: GitHubClient, org: string) {
   const existing = await getRepo(client, org, "classroom50")
 
   if (existing) {
-    const repo = await normalizeConfigRepoBranch(client, org, existing)
+    const repo = await normalizeConfigRepoBranch(client, org, existing, false)
     return { status: "complete" as const, created: false, repo }
   }
 
   const created = await createOrgRepo(client, org)
-  const repo = await normalizeConfigRepoBranch(client, org, created)
+  const repo = await normalizeConfigRepoBranch(client, org, created, true)
 
   return { status: "complete" as const, created: true, repo }
 }

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -28,6 +28,11 @@ import { LOG_SCOPE_GITHUB_SETUP } from "@/lib/logScopes"
 const logWorkflows = logger.scope("github:workflows")
 const logSetup = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
+// The branch Classroom 50 standardizes the config repo (and its skeleton
+// workflows/Pages/branch protection) on. New config repos are normalized to
+// this; the org default-branch setting is steered here too.
+const CONFIG_REPO_BRANCH = "main"
+
 const ASSIGNMENTS_TEMPLATE = {
   schema: "classroom50/assignments/v1",
   assignments: [],
@@ -285,9 +290,14 @@ export function createCommitForAssignment(params: {
   )
 }
 
-export function updateRef(client: GitHubClient, org: string, sha: string) {
+export function updateRef(
+  client: GitHubClient,
+  org: string,
+  sha: string,
+  branch = "main",
+) {
   return client.request<GitHubMoveBranch>(
-    `/repos/${org}/classroom50/git/refs/heads/main`,
+    `/repos/${org}/classroom50/git/refs/heads/${encodeURIComponent(branch)}`,
     {
       method: "PATCH",
       body: {
@@ -1149,7 +1159,7 @@ export type InitStepStatus =
   "pending" | "running" | "complete" | "warning" | "error" | "skipped"
 
 export async function createOrgRepo(client: GitHubClient, org: string) {
-  return client.request(`/orgs/${org}/repos`, {
+  return client.request<GitHubRepo>(`/orgs/${org}/repos`, {
     method: "POST",
     body: {
       name: "classroom50",
@@ -1161,14 +1171,73 @@ export async function createOrgRepo(client: GitHubClient, org: string) {
   })
 }
 
+// Rename the config repo's default branch to `main` when GitHub seeded it with
+// something else (an org whose default-branch-name policy is `master` etc.).
+// Best-effort and guarded: no API call when the branch is already `main`, and a
+// failure (missing admin, protected branch, enterprise lock) is swallowed so
+// setup proceeds — the downstream reads resolve the real branch regardless.
+async function normalizeConfigRepoBranch(
+  client: GitHubClient,
+  org: string,
+  repo: GitHubRepo,
+): Promise<GitHubRepo> {
+  const current = repo.default_branch
+  if (!current || current === CONFIG_REPO_BRANCH) {
+    return repo
+  }
+
+  try {
+    const renamed = await client.request<GitHubRepo>(
+      `/repos/${org}/${CONFIG_REPO}/branches/${encodePathPart(current)}/rename`,
+      { method: "POST", body: { new_name: CONFIG_REPO_BRANCH } },
+    )
+    logSetup.info("config repo default branch renamed to main", {
+      org,
+      from: current,
+    })
+    return renamed
+  } catch (err) {
+    logSetup.warn("config repo branch rename to main failed (continuing)", {
+      org,
+      from: current,
+      err,
+    })
+    return repo
+  }
+}
+
+// Best-effort: steer the org's default repository branch name to `main` so
+// future repos (config repo re-creates, student assignment repos) seed on
+// `main`. Only affects future repos and needs org-owner rights (can be
+// enterprise-locked), so any failure is swallowed — it never blocks setup.
+async function ensureOrgDefaultBranch(
+  client: GitHubClient,
+  org: string,
+): Promise<void> {
+  try {
+    await client.request(`/orgs/${org}`, {
+      method: "PATCH",
+      body: { default_repository_branch: CONFIG_REPO_BRANCH },
+    })
+    logSetup.info("org default repository branch set to main", { org })
+  } catch (err) {
+    logSetup.warn("could not set org default repository branch (continuing)", {
+      org,
+      err,
+    })
+  }
+}
+
 export async function ensureClassroom50Repo(client: GitHubClient, org: string) {
   const existing = await getRepo(client, org, "classroom50")
 
   if (existing) {
-    return { status: "complete" as const, created: false, repo: existing }
+    const repo = await normalizeConfigRepoBranch(client, org, existing)
+    return { status: "complete" as const, created: false, repo }
   }
 
-  const repo = await createOrgRepo(client, org)
+  const created = await createOrgRepo(client, org)
+  const repo = await normalizeConfigRepoBranch(client, org, created)
 
   return { status: "complete" as const, created: true, repo }
 }
@@ -1185,11 +1254,11 @@ export type GitHubTreeResponse = {
 async function listTargetRepoBlobs(
   client: GitHubClient,
   org: string,
-  branch = "main",
+  branch: string,
 ): Promise<Map<string, string>> {
   const ref = await client.request<{
     object: { sha: string }
-  }>(`/repos/${org}/${CONFIG_REPO}/git/ref/heads/${branch}`)
+  }>(`/repos/${org}/${CONFIG_REPO}/git/ref/heads/${encodePathPart(branch)}`)
 
   const commit = await client.request<{
     tree: { sha: string }
@@ -1258,13 +1327,21 @@ export async function findStaleSkeletonFiles(
   client: GitHubClient,
   org: string,
 ): Promise<StaleSkeletonFile[]> {
-  // The tree read and the default-branch read are independent — overlap them.
-  const [existingBlobs, repo] = await Promise.all([
-    listTargetRepoBlobs(client, org),
-    client.request<GitHubRepo>(`/repos/${org}/${CONFIG_REPO}`),
-  ])
-  // Use the config repo's actual default branch (org policy can rename `main`).
-  const defaultBranch = repo.default_branch || "main"
+  return (await findStaleSkeleton(client, org)).stale
+}
+
+// Like findStaleSkeletonFiles but also returns the config repo's resolved
+// default branch, so the write path commits onto the same branch it diffed
+// against. The repo read must precede the tree read — the tree read needs the
+// branch name, which org policy can set to something other than `main`.
+async function findStaleSkeleton(
+  client: GitHubClient,
+  org: string,
+): Promise<{ stale: StaleSkeletonFile[]; branch: string }> {
+  const repo = await client.request<GitHubRepo>(`/repos/${org}/${CONFIG_REPO}`)
+  const defaultBranch = repo.default_branch || CONFIG_REPO_BRANCH
+
+  const existingBlobs = await listTargetRepoBlobs(client, org, defaultBranch)
 
   // From the bundled skeleton — no runtime fetch from the CLI repo.
   const bundled = buildSkeletonFiles(defaultBranch)
@@ -1281,7 +1358,7 @@ export async function findStaleSkeletonFiles(
       stale.push({ ...file, exists: true })
     }
   })
-  return stale
+  return { stale, branch: defaultBranch }
 }
 
 // Commits missing skeleton files and refreshes drifted ones. Overwriting an
@@ -1295,7 +1372,7 @@ export async function ensureSkeletonFiles(
   org: string,
   confirmOverwrite?: (paths: string[]) => Promise<boolean>,
 ) {
-  const stale = await findStaleSkeletonFiles(client, org)
+  const { stale, branch: configBranch } = await findStaleSkeleton(client, org)
 
   if (stale.length === 0) {
     return { status: "complete" as const, created: [], skippedOverwrite: [] }
@@ -1355,7 +1432,7 @@ export async function ensureSkeletonFiles(
     }
     changed = stillStale.map((f) => f.path)
 
-    const branch = await getBranchRef(client, org)
+    const branch = await getBranchRef(client, org, configBranch)
     const commit = await getCommit(client, org, branch.object.sha)
 
     const tree = await createTreeRepo(client, {
@@ -1383,7 +1460,7 @@ export async function ensureSkeletonFiles(
         client,
         owner: org,
         repo: "classroom50",
-        branch: "main",
+        branch: configBranch,
         commitSha: newCommit.sha,
       })
       break
@@ -2491,6 +2568,9 @@ export async function initClassroom50({
     id: "orgDefaults",
     onStepUpdate,
     fn: async () => {
+      // Steer the org's default branch name to main (best-effort; only affects
+      // future repos). Runs alongside the member-privilege defaults repair.
+      await ensureOrgDefaultBranch(client, org)
       const result = await repairOrgDefaults(client, org, plan)
       // Forward the whole result (not just status/message) so the board can list
       // the specific unenforced settings, and warn on ANY unenforced field so it
@@ -2568,7 +2648,9 @@ export async function initClassroom50({
   results.branchProtection = await tryStep({
     id: "branchProtection",
     onStepUpdate,
-    fn: () => ensureBranchProtection(client, org, "classroom50", "main"),
+    // Omit the branch so ensureBranchProtection resolves the config repo's
+    // actual default branch (org policy can seed it as `master`).
+    fn: () => ensureBranchProtection(client, org, "classroom50"),
   })
 
   results.rulesets = await tryStep({
@@ -2740,7 +2822,13 @@ export async function editClassroom(
 ) {
   const { org, slug, term, name, active } = input
 
-  const ref = await getBranchRef(client, org)
+  // Resolve the config repo's default branch once; org policy can seed it as
+  // something other than `main`, so both the ref read and the write must target
+  // the real branch.
+  const configBranch =
+    (await getRepo(client, org, "classroom50"))?.default_branch || "main"
+
+  const ref = await getBranchRef(client, org, configBranch)
 
   const commit = await getCommit(client, org, ref.object.sha)
 
@@ -2801,7 +2889,7 @@ export async function editClassroom(
     classroom: slug,
   })
 
-  const updatedRef = await updateRef(client, org, newCommit.sha)
+  const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
 
   return {
     previousCommitSha: ref.object.sha,

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -11,7 +11,12 @@ import {
 } from "./types"
 import { GitHubAPIError } from "./errors"
 import sodium from "libsodium-wrappers"
-import { getBranchRef, getClassroomJson, getCommit } from "@/api/github/queries"
+import {
+  getBranchRef,
+  getClassroomJson,
+  getCommit,
+  getConfigRepoBranch,
+} from "@/api/github/queries"
 import type { CreateClassroomInput } from "@/api/mutations/classrooms"
 import type { StaffRole } from "@/types/classroom"
 import { isClassroomArchived, STAFF_ROLES } from "@/types/classroom"
@@ -1329,8 +1334,7 @@ async function findStaleSkeleton(
   client: GitHubClient,
   org: string,
 ): Promise<{ stale: StaleSkeletonFile[]; branch: string }> {
-  const repo = await client.request<GitHubRepo>(`/repos/${org}/${CONFIG_REPO}`)
-  const defaultBranch = repo.default_branch || CONFIG_REPO_BRANCH
+  const defaultBranch = await getConfigRepoBranch(client, org)
 
   const existingBlobs = await listTargetRepoBlobs(client, org, defaultBranch)
 
@@ -2636,8 +2640,8 @@ export async function initClassroom50({
   results.branchProtection = await tryStep({
     id: "branchProtection",
     onStepUpdate,
-    // Omit the branch so ensureBranchProtection resolves the config repo's
-    // actual default branch (org policy can seed it as `master`).
+    // No branch: ensureBranchProtection resolves the config repo's actual
+    // default branch, since org policy can seed it as `master`.
     fn: () => ensureBranchProtection(client, org, "classroom50"),
   })
 
@@ -2810,11 +2814,9 @@ export async function editClassroom(
 ) {
   const { org, slug, term, name, active } = input
 
-  // Resolve the config repo's default branch once; org policy can seed it as
-  // something other than `main`, so both the ref read and the write must target
-  // the real branch.
-  const configBranch =
-    (await getRepo(client, org, "classroom50"))?.default_branch || "main"
+  // Org policy can seed the config repo on a non-`main` branch, so both the ref
+  // read and the write must target the real branch.
+  const configBranch = await getConfigRepoBranch(client, org)
 
   const ref = await getBranchRef(client, org, configBranch)
 

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -1238,6 +1238,28 @@ export async function ensureClassroom50Repo(client: GitHubClient, org: string) {
   return { status: "complete" as const, created: true, repo }
 }
 
+// Rename the classroom50 config repo's default branch to `main` on demand (the
+// audit pane's one-click fix for a repo that drifted onto `master`). Unlike
+// normalizeConfigRepoBranch this runs on an EXISTING repo, so the caller must
+// warn first: already-accepted student repos pin the old branch in their frozen
+// autograde-shim `uses:@<branch>` ref and would stop grading after the rename.
+// A no-op (already `main`) resolves without a request.
+export async function renameConfigRepoToMain(
+  client: GitHubClient,
+  org: string,
+): Promise<{ renamed: boolean; from: string }> {
+  const current =
+    (await getRepo(client, org, "classroom50"))?.default_branch || "main"
+  if (current === CONFIG_REPO_BRANCH) {
+    return { renamed: false, from: current }
+  }
+  await client.request(
+    `/repos/${org}/${CONFIG_REPO}/branches/${encodePathPart(current)}/rename`,
+    { method: "POST", body: { new_name: CONFIG_REPO_BRANCH } },
+  )
+  return { renamed: true, from: current }
+}
+
 export type GitHubTreeResponse = {
   tree: Array<{
     path: string

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -30,7 +30,7 @@ const logSetup = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
 // The branch Classroom 50 standardizes the config repo (and its skeleton
 // workflows/Pages/branch protection) on. New config repos are normalized to
-// this; the org default-branch setting is steered here too.
+// this via a guarded rename.
 const CONFIG_REPO_BRANCH = "main"
 
 const ASSIGNMENTS_TEMPLATE = {
@@ -1203,28 +1203,6 @@ async function normalizeConfigRepoBranch(
       err,
     })
     return repo
-  }
-}
-
-// Best-effort: steer the org's default repository branch name to `main` so
-// future repos (config repo re-creates, student assignment repos) seed on
-// `main`. Only affects future repos and needs org-owner rights (can be
-// enterprise-locked), so any failure is swallowed — it never blocks setup.
-async function ensureOrgDefaultBranch(
-  client: GitHubClient,
-  org: string,
-): Promise<void> {
-  try {
-    await client.request(`/orgs/${org}`, {
-      method: "PATCH",
-      body: { default_repository_branch: CONFIG_REPO_BRANCH },
-    })
-    logSetup.info("org default repository branch set to main", { org })
-  } catch (err) {
-    logSetup.warn("could not set org default repository branch (continuing)", {
-      org,
-      err,
-    })
   }
 }
 
@@ -2568,9 +2546,6 @@ export async function initClassroom50({
     id: "orgDefaults",
     onStepUpdate,
     fn: async () => {
-      // Steer the org's default branch name to main (best-effort; only affects
-      // future repos). Runs alongside the member-privilege defaults repair.
-      await ensureOrgDefaultBranch(client, org)
       const result = await repairOrgDefaults(client, org, plan)
       // Forward the whole result (not just status/message) so the board can list
       // the specific unenforced settings, and warn on ANY unenforced field so it

--- a/web/src/hooks/github/orgChecks.test.ts
+++ b/web/src/hooks/github/orgChecks.test.ts
@@ -172,6 +172,51 @@ describe("checkBranchProtection", () => {
       "unenforced",
     )
   })
+
+  it("resolves the config repo's real default branch (master), not main", async () => {
+    const requested: string[] = []
+    const client: GitHubClient = {
+      request: <T>(path: string) => {
+        requested.push(path)
+        if (path === "/repos/acme/classroom50")
+          return Promise.resolve({ default_branch: "master" } as T)
+        if (path.includes("/branches/master/protection"))
+          return Promise.resolve({
+            allow_force_pushes: { enabled: false },
+            allow_deletions: { enabled: false },
+          } as T)
+        return Promise.reject(new Error(`unexpected request: ${path}`))
+      },
+      requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    }
+    expect((await checkBranchProtection(client, "acme")).state).toBe("enforced")
+    expect(
+      requested.some((p) => p.includes("/branches/master/protection")),
+    ).toBe(true)
+    expect(requested.some((p) => p.includes("/branches/main/"))).toBe(false)
+  })
+
+  it("honors an explicit branch argument over the repo default", async () => {
+    const requested: string[] = []
+    const client: GitHubClient = {
+      request: <T>(path: string) => {
+        requested.push(path)
+        if (path.includes("/branches/develop/protection"))
+          return Promise.resolve({
+            allow_force_pushes: { enabled: false },
+            allow_deletions: { enabled: false },
+          } as T)
+        return Promise.reject(new Error(`unexpected request: ${path}`))
+      },
+      requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    }
+    expect(
+      (await checkBranchProtection(client, "acme", "classroom50", "develop"))
+        .state,
+    ).toBe("enforced")
+    // No repo read when the branch is given explicitly.
+    expect(requested.some((p) => p === "/repos/acme/classroom50")).toBe(false)
+  })
 })
 
 describe("checkReusableWorkflowAccess", () => {

--- a/web/src/hooks/github/orgChecks.ts
+++ b/web/src/hooks/github/orgChecks.ts
@@ -85,6 +85,24 @@ export async function checkOrgDefaultBranch(
   }
 }
 
+// The classroom50 config repo's live default branch. Returns it so the audit can
+// recommend renaming to `main` when it drifted (org policy can seed a repo on
+// `master`). null when the read failed or the repo doesn't exist yet — the
+// recommendation is advisory and suppressed in both cases.
+export async function checkConfigRepoDefaultBranch(
+  client: GitHubClient,
+  org: string,
+): Promise<string | null> {
+  try {
+    const repo = await client.request<{ default_branch?: string }>(
+      `/repos/${org}/${CONFIG_REPO}`,
+    )
+    return repo.default_branch ?? null
+  } catch {
+    return null
+  }
+}
+
 type OrgActionsPermissions = {
   enabled_repositories: "all" | "none" | "selected"
   allowed_actions?: "all" | "local_only" | "selected"
@@ -142,16 +160,20 @@ type BranchProtection = {
 }
 
 // branchProtection: GET /repos/{org}/{repo}/branches/{branch}/protection —
-// enforced when force-pushes and deletions are both disabled.
+// enforced when force-pushes and deletions are both disabled. When no branch is
+// given, resolves the repo's actual default branch (org policy can seed the
+// config repo on `master`), falling back to `main` only if that read fails.
 export async function checkBranchProtection(
   client: GitHubClient,
   org: string,
   repo: string = CONFIG_REPO,
-  branch: string = "main",
+  branch?: string,
 ): Promise<CheckVerdict> {
   try {
+    const targetBranch =
+      branch ?? (await resolveRepoDefaultBranch(client, org, repo))
     const protection = await client.request<BranchProtection>(
-      `/repos/${org}/${repo}/branches/${encodeURIComponent(branch)}/protection`,
+      `/repos/${org}/${repo}/branches/${encodeURIComponent(targetBranch)}/protection`,
     )
     const enforced =
       protection.allow_force_pushes?.enabled === false &&
@@ -159,6 +181,24 @@ export async function checkBranchProtection(
     return { state: enforced ? "enforced" : "unenforced" }
   } catch (err) {
     return unreadableFrom(err)
+  }
+}
+
+// The repo's live default branch, falling back to `main` when the read fails —
+// so a branch-relative check/audit targets the real branch even on a `master`
+// config repo, without letting an advisory read outage throw.
+async function resolveRepoDefaultBranch(
+  client: GitHubClient,
+  org: string,
+  repo: string,
+): Promise<string> {
+  try {
+    const data = await client.request<{ default_branch?: string }>(
+      `/repos/${org}/${repo}`,
+    )
+    return data.default_branch || "main"
+  } catch {
+    return "main"
   }
 }
 

--- a/web/src/hooks/github/orgChecks.ts
+++ b/web/src/hooks/github/orgChecks.ts
@@ -18,6 +18,12 @@ const log = logger.scope("github:orgChecks")
 
 export const CONFIG_REPO = "classroom50"
 
+// The org "Repository default branch name" we recommend. Not enforceable via
+// API (PATCH /orgs ignores default_repository_branch — it's a web-UI-only
+// setting), so this is surfaced as an advisory recommendation, never a
+// failing/critical concern.
+export const RECOMMENDED_ORG_DEFAULT_BRANCH = "main"
+
 // A concern's read-only state: enforced means the live value already matches
 // the desired policy; unenforced means it drifted; unreadable means the read
 // itself failed (permission/transient) so the verdict is inconclusive.
@@ -60,6 +66,24 @@ export async function checkOrgDefaults(
     return { verdict: { state }, classification }
   } catch (err) {
     return { verdict: unreadableFrom(err) }
+  }
+}
+
+// The org's live "Repository default branch name" (default_repository_branch on
+// GET /orgs/{org}). Returns the value so the audit can recommend switching to
+// `main` when it differs. null when the org read failed (recommendation is then
+// suppressed — it's advisory, not worth surfacing on a read outage).
+export async function checkOrgDefaultBranch(
+  client: GitHubClient,
+  org: string,
+): Promise<string | null> {
+  try {
+    const live = await client.request<{ default_repository_branch?: string }>(
+      `/orgs/${org}`,
+    )
+    return live.default_repository_branch ?? null
+  } catch {
+    return null
   }
 }
 

--- a/web/src/hooks/github/orgChecks.ts
+++ b/web/src/hooks/github/orgChecks.ts
@@ -18,10 +18,8 @@ const log = logger.scope("github:orgChecks")
 
 export const CONFIG_REPO = "classroom50"
 
-// The org "Repository default branch name" we recommend. Not enforceable via
-// API (PATCH /orgs ignores default_repository_branch — it's a web-UI-only
-// setting), so this is surfaced as an advisory recommendation, never a
-// failing/critical concern.
+// The org "Repository default branch name" we recommend. Not API-writable
+// (PATCH /orgs ignores it), so it's surfaced as an advisory recommendation only.
 export const RECOMMENDED_ORG_DEFAULT_BRANCH = "main"
 
 // A concern's read-only state: enforced means the live value already matches

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -883,6 +883,8 @@
       "okPrefixPublicInOrg": "Public template, branch",
       "okPrefixPrivateInOrg": "Private template, branch",
       "okSuffix": ". Students can access it.",
+      "nonMainBranch_1": "This template's default branch is",
+      "nonMainBranch_2": ", not \"main\". The assignment will use it, and student autograding keys off that branch.",
       "okVerify_1": "Reachable in {{owner}} (branch",
       "okVerify_2": "). If {{owner}} restricts third-party apps, students can't copy it until an owner approves Classroom 50.",
       "notVisible": "{{owner}}/{{repo}} isn't visible to you. Make it public or copy it into {{org}}.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1157,6 +1157,10 @@
       "confirmManually": "Confirm manually",
       "recommended": "Recommended",
       "defaultBranchRec": "Your org's default branch name for new repositories is \"{{current}}\". We recommend \"main\" so new repos (including student assignment repos) match Classroom 50's convention. Existing repos are unaffected and keep working.",
+      "configBranchRec": "The classroom50 config repo's default branch is \"{{current}}\", not \"main\". Everything still works (reads and writes target the real branch), but renaming it to \"main\" matches Classroom 50's convention.",
+      "renameToMain": "Rename to main",
+      "renameModalTitle": "Rename the config repo's default branch to main?",
+      "renameModalBody": "This renames the classroom50 config repo's default branch to \"main\". If any students have already accepted assignments, their autograde workflow pins the current branch name and will stop grading until they re-accept or you re-point their shim. Prefer this only before students accept, or be ready to re-run their setup.",
       "memberPermsToggle": "Member permissions we configure",
       "memberPermsHint": "The full list of organization member privileges Classroom 50 sets, including the ones already in place. Drifted ones are called out above."
     },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1155,6 +1155,10 @@
       "confirmByHand": "Confirm by hand",
       "confirmByHandBody": "GitHub exposes no API to read these settings, so we can't verify them automatically — confirm each one on the member privileges page.",
       "confirmManually": "Confirm manually",
+      "recommendedTitle": "Recommended",
+      "recommendedBody": "Not required, but we highly recommend these — GitHub exposes no API to set them, so change them by hand.",
+      "recommended": "Recommended",
+      "defaultBranchRec": "Your org's default branch name for new repositories is \"{{current}}\". We recommend \"main\" so new repos (including student assignment repos) match Classroom 50's convention. Existing repos are unaffected and keep working.",
       "memberPermsToggle": "Member permissions we configure",
       "memberPermsHint": "The full list of organization member privileges Classroom 50 sets, including the ones already in place. Drifted ones are called out above."
     },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1155,8 +1155,6 @@
       "confirmByHand": "Confirm by hand",
       "confirmByHandBody": "GitHub exposes no API to read these settings, so we can't verify them automatically — confirm each one on the member privileges page.",
       "confirmManually": "Confirm manually",
-      "recommendedTitle": "Recommended",
-      "recommendedBody": "Not required, but we highly recommend these — GitHub exposes no API to set them, so change them by hand.",
       "recommended": "Recommended",
       "defaultBranchRec": "Your org's default branch name for new repositories is \"{{current}}\". We recommend \"main\" so new repos (including student assignment repos) match Classroom 50's convention. Existing repos are unaffected and keep working.",
       "memberPermsToggle": "Member permissions we configure",

--- a/web/src/orgPolicy/audit.test.ts
+++ b/web/src/orgPolicy/audit.test.ts
@@ -103,6 +103,39 @@ describe("buildOrgAuditReport", () => {
     expect(report.defaultVerdicts.every((v) => v.enforced)).toBe(true)
   })
 
+  it("recommends switching a non-main org default branch without failing", async () => {
+    const report = await buildOrgAuditReport(
+      makeClient({
+        orgDefaults: driftedDefaults((live) => {
+          live.default_repository_branch = "master"
+        }),
+      }),
+      "acme",
+      "team",
+    )
+    // Advisory only — a non-main default branch never fails the verdict.
+    expect(report.verdict).toBe("ok")
+    expect(report.recommendations).toHaveLength(1)
+    expect(report.recommendations[0].id).toBe("orgDefaultBranch")
+    expect(report.recommendations[0].detail).toBe("master")
+    expect(report.recommendations[0].settingsUrl).toContain(
+      "/settings/repository-defaults",
+    )
+  })
+
+  it("no recommendation when the org default branch is already main", async () => {
+    const report = await buildOrgAuditReport(
+      makeClient({
+        orgDefaults: driftedDefaults((live) => {
+          live.default_repository_branch = "main"
+        }),
+      }),
+      "acme",
+      "team",
+    )
+    expect(report.recommendations).toHaveLength(0)
+  })
+
   it("verdict fail when a critical member-default drifts", async () => {
     const report = await buildOrgAuditReport(
       makeClient({

--- a/web/src/orgPolicy/audit.test.ts
+++ b/web/src/orgPolicy/audit.test.ts
@@ -33,6 +33,9 @@ function httpError(status: number): GitHubAPIError {
 
 type Routes = {
   orgDefaults?: Record<string, unknown> | GitHubAPIError
+  // The classroom50 config repo's default branch (or an error to simulate an
+  // unreadable/uninitialized repo). Defaults to "main" (no recommendation).
+  configRepoBranch?: string | GitHubAPIError
 }
 
 // A fully-enforced fake org: every check returns its desired value, both
@@ -52,6 +55,11 @@ function makeClient(overrides: Routes = {}): GitHubClient {
         if (overrides.orgDefaults instanceof GitHubAPIError)
           return reject(overrides.orgDefaults)
         return ok(overrides.orgDefaults ?? enforcedDefaults)
+      }
+      if (path === "/repos/acme/classroom50") {
+        if (overrides.configRepoBranch instanceof GitHubAPIError)
+          return reject(overrides.configRepoBranch)
+        return ok({ default_branch: overrides.configRepoBranch ?? "main" })
       }
       if (path.endsWith("/actions/permissions"))
         return ok({ enabled_repositories: "all", allowed_actions: "all" })
@@ -134,6 +142,65 @@ describe("buildOrgAuditReport", () => {
       "team",
     )
     expect(report.recommendations).toHaveLength(0)
+  })
+
+  it("recommends renaming a non-main config repo branch without failing", async () => {
+    const report = await buildOrgAuditReport(
+      makeClient({ configRepoBranch: "master" }),
+      "acme",
+      "team",
+    )
+    // Advisory only — a drifted config-repo branch never fails the verdict.
+    expect(report.verdict).toBe("ok")
+    const rec = report.recommendations.find(
+      (r) => r.id === "configRepoDefaultBranch",
+    )
+    expect(rec).toBeDefined()
+    expect(rec?.detail).toBe("master")
+    expect(rec?.settingsUrl).toBe(
+      "https://github.com/acme/classroom50/settings/branches",
+    )
+  })
+
+  it("no config-repo recommendation when it is already main or unreadable", async () => {
+    const onMain = await buildOrgAuditReport(
+      makeClient({ configRepoBranch: "main" }),
+      "acme",
+      "team",
+    )
+    expect(
+      onMain.recommendations.some((r) => r.id === "configRepoDefaultBranch"),
+    ).toBe(false)
+
+    // A read failure (e.g. repo not initialized) suppresses the advisory rec.
+    const unreadable = await buildOrgAuditReport(
+      makeClient({ configRepoBranch: httpError(404) }),
+      "acme",
+      "team",
+    )
+    expect(unreadable.verdict).toBe("ok")
+    expect(
+      unreadable.recommendations.some(
+        (r) => r.id === "configRepoDefaultBranch",
+      ),
+    ).toBe(false)
+  })
+
+  it("lists the config-repo rename recommendation first (it's the actionable one)", async () => {
+    const report = await buildOrgAuditReport(
+      makeClient({
+        configRepoBranch: "master",
+        orgDefaults: driftedDefaults((live) => {
+          live.default_repository_branch = "master"
+        }),
+      }),
+      "acme",
+      "team",
+    )
+    expect(report.recommendations.map((r) => r.id)).toEqual([
+      "configRepoDefaultBranch",
+      "orgDefaultBranch",
+    ])
   })
 
   it("verdict fail when a critical member-default drifts", async () => {

--- a/web/src/orgPolicy/audit.ts
+++ b/web/src/orgPolicy/audit.ts
@@ -6,11 +6,13 @@ import type { GitHubClient } from "@/hooks/github/client"
 import {
   checkBranchProtection,
   checkOrgActions,
+  checkOrgDefaultBranch,
   checkOrgDefaults,
   checkOrgPrCreation,
   checkPages,
   checkReusableWorkflowAccess,
   checkWorkflowPermissions,
+  RECOMMENDED_ORG_DEFAULT_BRANCH,
   type CheckVerdict,
 } from "@/hooks/github/orgChecks"
 import { checkRulesets } from "@/hooks/github/rulesets"
@@ -61,6 +63,21 @@ export type OrgAuditReport = {
   concerns: ConcernCheck[]
   // The four API-less settings the teacher confirms by hand; never fail.
   manualUnreadable: ManualStep[]
+  // Advisory recommendations that never affect `verdict` — e.g. the org's
+  // default repository branch name isn't `main`. Not enforceable via API, so
+  // surfaced as a "highly recommended, not required" hand-fix.
+  recommendations: OrgRecommendation[]
+}
+
+// A non-blocking, highly-recommended hand-fix surfaced by the audit. Distinct
+// from ConcernCheck (which fails the verdict) and ManualStep (member-privilege
+// settings we can't read): a recommendation is read from the live org but is
+// advisory only.
+export type OrgRecommendation = {
+  id: "orgDefaultBranch"
+  title: string
+  detail: string
+  settingsUrl: string
 }
 
 const CONCERN_TITLES: Record<ConcernId, string> = {
@@ -130,6 +147,7 @@ export async function buildOrgAuditReport(
     reusableAccess,
     pages,
     rulesets,
+    orgDefaultBranch,
   ] = await Promise.all([
     checkOrgDefaults(client, org, plan),
     checkOrgActions(client, org),
@@ -139,6 +157,7 @@ export async function buildOrgAuditReport(
     checkReusableWorkflowAccess(client, org),
     checkPages(client, org),
     checkRulesets(client, org),
+    checkOrgDefaultBranch(client, org),
   ])
 
   const readOk = defaults.verdict.state !== "unreadable"
@@ -173,6 +192,21 @@ export async function buildOrgAuditReport(
   // Sort alphabetically by title for predictable scanning.
   concerns.sort((a, b) => a.title.localeCompare(b.title))
 
+  // Advisory-only: the org default branch name isn't `main`. Never affects the
+  // verdict (GitHub has no API to set it, so we can't "fix it" — only remind).
+  const recommendations: OrgRecommendation[] = []
+  if (
+    orgDefaultBranch !== null &&
+    orgDefaultBranch !== RECOMMENDED_ORG_DEFAULT_BRANCH
+  ) {
+    recommendations.push({
+      id: "orgDefaultBranch",
+      title: "Repository default branch",
+      detail: orgDefaultBranch,
+      settingsUrl: `https://github.com/organizations/${org}/settings/repository-defaults`,
+    })
+  }
+
   return {
     org,
     plan,
@@ -183,5 +217,6 @@ export async function buildOrgAuditReport(
     defaultVerdicts,
     concerns,
     manualUnreadable: manualHardeningSteps(org),
+    recommendations,
   }
 }

--- a/web/src/orgPolicy/audit.ts
+++ b/web/src/orgPolicy/audit.ts
@@ -69,10 +69,8 @@ export type OrgAuditReport = {
   recommendations: OrgRecommendation[]
 }
 
-// A non-blocking, highly-recommended hand-fix surfaced by the audit. Distinct
-// from ConcernCheck (which fails the verdict) and ManualStep (member-privilege
-// settings we can't read): a recommendation is read from the live org but is
-// advisory only.
+// A non-blocking, highly-recommended hand-fix surfaced by the audit (never
+// affects the verdict) — e.g. the org default branch name isn't `main`.
 export type OrgRecommendation = {
   id: "orgDefaultBranch"
   title: string

--- a/web/src/orgPolicy/audit.ts
+++ b/web/src/orgPolicy/audit.ts
@@ -5,6 +5,7 @@
 import type { GitHubClient } from "@/hooks/github/client"
 import {
   checkBranchProtection,
+  checkConfigRepoDefaultBranch,
   checkOrgActions,
   checkOrgDefaultBranch,
   checkOrgDefaults,
@@ -70,13 +71,25 @@ export type OrgAuditReport = {
 }
 
 // A non-blocking, highly-recommended hand-fix surfaced by the audit (never
-// affects the verdict) — e.g. the org default branch name isn't `main`.
-export type OrgRecommendation = {
-  id: "orgDefaultBranch"
-  title: string
-  detail: string
-  settingsUrl: string
-}
+// affects the verdict). Two kinds:
+//   - orgDefaultBranch: the org's default-branch *setting* isn't `main`. Not
+//     API-writable (PATCH /orgs ignores it), so hand-fix only.
+//   - configRepoDefaultBranch: the classroom50 config *repo* drifted off `main`.
+//     API-renameable, so the pane offers a one-click rename (behind a warning:
+//     already-accepted student shims pin the old branch).
+export type OrgRecommendation =
+  | {
+      id: "orgDefaultBranch"
+      title: string
+      detail: string
+      settingsUrl: string
+    }
+  | {
+      id: "configRepoDefaultBranch"
+      title: string
+      detail: string
+      settingsUrl: string
+    }
 
 const CONCERN_TITLES: Record<ConcernId, string> = {
   orgDefaults: "Member-privilege lockdown",
@@ -146,6 +159,7 @@ export async function buildOrgAuditReport(
     pages,
     rulesets,
     orgDefaultBranch,
+    configRepoDefaultBranch,
   ] = await Promise.all([
     checkOrgDefaults(client, org, plan),
     checkOrgActions(client, org),
@@ -156,6 +170,7 @@ export async function buildOrgAuditReport(
     checkPages(client, org),
     checkRulesets(client, org),
     checkOrgDefaultBranch(client, org),
+    checkConfigRepoDefaultBranch(client, org),
   ])
 
   const readOk = defaults.verdict.state !== "unreadable"
@@ -190,9 +205,24 @@ export async function buildOrgAuditReport(
   // Sort alphabetically by title for predictable scanning.
   concerns.sort((a, b) => a.title.localeCompare(b.title))
 
-  // Advisory-only: the org default branch name isn't `main`. Never affects the
-  // verdict (GitHub has no API to set it, so we can't "fix it" — only remind).
+  // Advisory-only recommendations — never affect the verdict.
   const recommendations: OrgRecommendation[] = []
+  // The classroom50 config repo drifted off `main`. API-renameable, so the pane
+  // offers a one-click rename (guarded: it may strand student shim refs). Listed
+  // first — it's the actionable one.
+  if (
+    configRepoDefaultBranch !== null &&
+    configRepoDefaultBranch !== RECOMMENDED_ORG_DEFAULT_BRANCH
+  ) {
+    recommendations.push({
+      id: "configRepoDefaultBranch",
+      title: "Config repo default branch",
+      detail: configRepoDefaultBranch,
+      settingsUrl: `https://github.com/${org}/classroom50/settings/branches`,
+    })
+  }
+  // The org default branch *setting* isn't `main`. GitHub has no API to set it,
+  // so we can't "fix it" — only remind.
   if (
     orgDefaultBranch !== null &&
     orgDefaultBranch !== RECOMMENDED_ORG_DEFAULT_BRANCH

--- a/web/src/orgPolicy/repair.test.ts
+++ b/web/src/orgPolicy/repair.test.ts
@@ -33,7 +33,10 @@ function httpError(status: number): GitHubAPIError {
   })
 }
 
-function makeClient(): { client: GitHubClient; calls: Recorded[] } {
+function makeClient(configRepoBranch = "main"): {
+  client: GitHubClient
+  calls: Recorded[]
+} {
   const calls: Recorded[] = []
   const request = vi
     .fn()
@@ -45,6 +48,10 @@ function makeClient(): { client: GitHubClient; calls: Recorded[] } {
         const live: Record<string, unknown> = {}
         for (const s of memberDefaultSettings("team")) live[s.field] = s.value
         return Promise.resolve(live)
+      }
+      // ensureBranchProtection resolves the config repo's real default branch.
+      if (method === "GET" && path === "/repos/acme/classroom50") {
+        return Promise.resolve({ default_branch: configRepoBranch })
       }
       if (method === "GET" && path.includes("/rulesets")) {
         return Promise.resolve([
@@ -91,6 +98,17 @@ describe("repairConcern", () => {
     const { client, calls } = makeClient()
     await repairConcern(client, "acme", "branchProtection", "team")
     expect(writePaths(calls)).toContain(
+      "PUT /repos/acme/classroom50/branches/main/protection",
+    )
+  })
+
+  it("branchProtection targets the config repo's real default branch (master)", async () => {
+    const { client, calls } = makeClient("master")
+    await repairConcern(client, "acme", "branchProtection", "team")
+    expect(writePaths(calls)).toContain(
+      "PUT /repos/acme/classroom50/branches/master/protection",
+    )
+    expect(writePaths(calls)).not.toContain(
       "PUT /repos/acme/classroom50/branches/main/protection",
     )
   })

--- a/web/src/orgPolicy/repair.ts
+++ b/web/src/orgPolicy/repair.ts
@@ -65,12 +65,9 @@ export async function repairConcern(
       await ensureOrgCanCreatePullRequests(client, org)
       return { unfixableFields: [] }
     case "branchProtection": {
-      const result = await ensureBranchProtection(
-        client,
-        org,
-        CONFIG_REPO,
-        "main",
-      )
+      // No branch: ensureBranchProtection resolves the config repo's actual
+      // default branch, since org policy can seed it as `master`.
+      const result = await ensureBranchProtection(client, org, CONFIG_REPO)
       if (result.status === "warning") {
         // branch_not_found means the repo is still initializing — transient, so
         // the UI offers a retry rather than flipping to manual setup.

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -176,6 +176,47 @@ const TemplateVerificationNote = ({
 
   const fallbackOrg = org ?? t("assignments.template.fallbackOrg")
 
+  // Working assumption is `main`. When a verified template resolves to another
+  // default branch, the assignment (and student autograding) key off that
+  // branch — warn without blocking. Only kinds that carry a resolved branch.
+  const resolvedBranch =
+    "branch" in verification ? verification.branch : undefined
+  const nonMainNote =
+    resolvedBranch && resolvedBranch !== "main" ? (
+      <Note tone="warning" icon={Info}>
+        {t("assignments.template.nonMainBranch_1")}{" "}
+        <Code>{resolvedBranch}</Code>
+        {t("assignments.template.nonMainBranch_2")}
+      </Note>
+    ) : null
+
+  const verdict = renderTemplateVerdict({
+    verification,
+    t,
+    fallbackOrg,
+    teamHasAccess,
+  })
+
+  if (!nonMainNote) return verdict
+  return (
+    <>
+      {verdict}
+      {nonMainNote}
+    </>
+  )
+}
+
+function renderTemplateVerdict({
+  verification,
+  t,
+  fallbackOrg,
+  teamHasAccess,
+}: {
+  verification: Exclude<TemplateAccessVerification, { kind: "empty" }>
+  t: ReturnType<typeof useTranslation>["t"]
+  fallbackOrg: string
+  teamHasAccess?: boolean
+}): ReactNode {
   switch (verification.kind) {
     case "ok": {
       // Students can't read an in-org private template directly; the classroom

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -311,6 +311,48 @@ function AuditBody({
         </div>
       )}
 
+      {report.recommendations.length > 0 && (
+        <div className="mt-6">
+          <h3 className="text-sm font-semibold">
+            {t("orgSettings.audit.recommendedTitle")}
+          </h3>
+          <p className="mt-1 text-xs text-base-content/70">
+            {t("orgSettings.audit.recommendedBody")}
+          </p>
+          <div className="mt-2 grid gap-2">
+            {report.recommendations.map((rec) => (
+              <div
+                key={rec.id}
+                className="flex items-start justify-between gap-4 rounded-lg border border-warning/40 bg-warning/5 p-3"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-base-content/80">
+                    {rec.title}
+                  </div>
+                  <p className="mt-0.5 text-xs text-base-content/70">
+                    {t("orgSettings.audit.defaultBranchRec", {
+                      current: rec.detail,
+                    })}
+                  </p>
+                  <a
+                    href={rec.settingsUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+                  >
+                    {t("orgSettings.audit.viewOnGitHub")}
+                    <ExternalLink aria-hidden="true" className="size-3" />
+                  </a>
+                </div>
+                <span className="badge badge-warning badge-soft shrink-0">
+                  {t("orgSettings.audit.recommended")}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {report.defaultVerdicts.length > 0 && (
         <div className="mt-6">
           <button

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -256,6 +256,46 @@ function AuditBody({
         </div>
       </CalloutDiv>
 
+      {report.recommendations.length > 0 && (
+        <div className="mt-4">
+          <div className="grid gap-2">
+            {report.recommendations.map((rec) => (
+              <div
+                key={rec.id}
+                className="flex items-start justify-between gap-4 rounded-lg border border-warning/40 bg-warning/5 p-3"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5 text-sm font-semibold text-base-content/80">
+                    <TriangleAlert
+                      aria-hidden="true"
+                      className="size-4 shrink-0 text-warning"
+                    />
+                    {rec.title}
+                  </div>
+                  <p className="mt-0.5 text-xs text-base-content/70">
+                    {t("orgSettings.audit.defaultBranchRec", {
+                      current: rec.detail,
+                    })}
+                  </p>
+                  <a
+                    href={rec.settingsUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+                  >
+                    {t("orgSettings.audit.viewOnGitHub")}
+                    <ExternalLink aria-hidden="true" className="size-3" />
+                  </a>
+                </div>
+                <span className="badge badge-warning badge-soft shrink-0">
+                  {t("orgSettings.audit.recommended")}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mt-4 grid gap-2">
         {report.concerns.map((c) => (
           <ConcernRow
@@ -304,48 +344,6 @@ function AuditBody({
                 </div>
                 <span className="badge badge-warning badge-soft shrink-0">
                   {t("orgSettings.audit.confirmManually")}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {report.recommendations.length > 0 && (
-        <div className="mt-6">
-          <h3 className="text-sm font-semibold">
-            {t("orgSettings.audit.recommendedTitle")}
-          </h3>
-          <p className="mt-1 text-xs text-base-content/70">
-            {t("orgSettings.audit.recommendedBody")}
-          </p>
-          <div className="mt-2 grid gap-2">
-            {report.recommendations.map((rec) => (
-              <div
-                key={rec.id}
-                className="flex items-start justify-between gap-4 rounded-lg border border-warning/40 bg-warning/5 p-3"
-              >
-                <div className="min-w-0">
-                  <div className="text-sm font-semibold text-base-content/80">
-                    {rec.title}
-                  </div>
-                  <p className="mt-0.5 text-xs text-base-content/70">
-                    {t("orgSettings.audit.defaultBranchRec", {
-                      current: rec.detail,
-                    })}
-                  </p>
-                  <a
-                    href={rec.settingsUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
-                  >
-                    {t("orgSettings.audit.viewOnGitHub")}
-                    <ExternalLink aria-hidden="true" className="size-3" />
-                  </a>
-                </div>
-                <span className="badge badge-warning badge-soft shrink-0">
-                  {t("orgSettings.audit.recommended")}
                 </span>
               </div>
             ))}

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -12,7 +12,9 @@ import {
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { githubKeys } from "@/hooks/github/queries"
+import { renameConfigRepoToMain } from "@/hooks/github/mutations"
 import { Button, Spinner } from "@/components/ui"
+import { ConfirmModal } from "@/components/modals"
 import PlanBadge from "@/components/PlanBadge"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import useGetOrgAudit from "@/hooks/useGetOrgAudit"
@@ -23,6 +25,7 @@ import type {
   ConcernCheck,
   ConcernId,
   OrgAuditReport,
+  OrgRecommendation,
 } from "@/orgPolicy/audit"
 import { REPAIRABLE_CONCERNS, repairConcern } from "@/orgPolicy/repair"
 import type { RepairResult } from "@/orgPolicy/repair"
@@ -208,20 +211,82 @@ export function ConcernRow({
   )
 }
 
+function RecommendationRow({
+  rec,
+  canFix,
+  fixing,
+  onRenameConfigRepo,
+}: {
+  rec: OrgRecommendation
+  canFix: boolean
+  fixing: boolean
+  onRenameConfigRepo: () => void
+}) {
+  const { t } = useTranslation()
+  const isConfigRepo = rec.id === "configRepoDefaultBranch"
+  return (
+    <div className="flex items-start justify-between gap-4 rounded-lg border border-warning/40 bg-warning/5 p-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5 text-sm font-semibold text-base-content/80">
+          <TriangleAlert
+            aria-hidden="true"
+            className="size-4 shrink-0 text-warning"
+          />
+          {rec.title}
+        </div>
+        <p className="mt-0.5 text-xs text-base-content/70">
+          {isConfigRepo
+            ? t("orgSettings.audit.configBranchRec", { current: rec.detail })
+            : t("orgSettings.audit.defaultBranchRec", { current: rec.detail })}
+        </p>
+        <a
+          href={rec.settingsUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+        >
+          {t("orgSettings.audit.viewOnGitHub")}
+          <ExternalLink aria-hidden="true" className="size-3" />
+        </a>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {isConfigRepo && canFix && (
+          <Button
+            variant="primary"
+            size="xs"
+            loading={fixing}
+            disabled={fixing}
+            onClick={onRenameConfigRepo}
+          >
+            {fixing ? null : t("orgSettings.audit.renameToMain")}
+          </Button>
+        )}
+        <span className="badge badge-warning badge-soft">
+          {t("orgSettings.audit.recommended")}
+        </span>
+      </div>
+    </div>
+  )
+}
+
 function AuditBody({
   report,
   canFix,
   fixingId,
+  fixingConfigBranch,
   enterprisePinned,
   unresolvedConcerns,
   onFix,
+  onRenameConfigRepo,
 }: {
   report: OrgAuditReport
   canFix: boolean
   fixingId: ConcernId | null
+  fixingConfigBranch: boolean
   enterprisePinned: Set<string>
   unresolvedConcerns: Map<ConcernId, string>
   onFix: (id: ConcernId) => void
+  onRenameConfigRepo: () => void
 }) {
   const { t } = useTranslation()
   const banner = VERDICT_BANNER[report.verdict]
@@ -260,37 +325,13 @@ function AuditBody({
         <div className="mt-4">
           <div className="grid gap-2">
             {report.recommendations.map((rec) => (
-              <div
+              <RecommendationRow
                 key={rec.id}
-                className="flex items-start justify-between gap-4 rounded-lg border border-warning/40 bg-warning/5 p-3"
-              >
-                <div className="min-w-0">
-                  <div className="flex items-center gap-1.5 text-sm font-semibold text-base-content/80">
-                    <TriangleAlert
-                      aria-hidden="true"
-                      className="size-4 shrink-0 text-warning"
-                    />
-                    {rec.title}
-                  </div>
-                  <p className="mt-0.5 text-xs text-base-content/70">
-                    {t("orgSettings.audit.defaultBranchRec", {
-                      current: rec.detail,
-                    })}
-                  </p>
-                  <a
-                    href={rec.settingsUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
-                  >
-                    {t("orgSettings.audit.viewOnGitHub")}
-                    <ExternalLink aria-hidden="true" className="size-3" />
-                  </a>
-                </div>
-                <span className="badge badge-warning badge-soft shrink-0">
-                  {t("orgSettings.audit.recommended")}
-                </span>
-              </div>
+                rec={rec}
+                canFix={canFix}
+                fixing={fixingConfigBranch}
+                onRenameConfigRepo={onRenameConfigRepo}
+              />
             ))}
           </div>
         </div>
@@ -478,6 +519,19 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
     ? (fixMutation.variables ?? null)
     : null
 
+  // Renaming the config repo to `main` is a separate flow: it's a recommendation
+  // (not a concern) and destructive to already-accepted student shims, so it's
+  // gated behind a confirm modal rather than an inline Fix-it.
+  const [confirmRename, setConfirmRename] = useState(false)
+  const renameMutation = useMutation({
+    mutationFn: () => renameConfigRepoToMain(client, org),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgAuditPrefix(org),
+      })
+    },
+  })
+
   return (
     <SettingsSection
       title={t("orgSettings.audit.title")}
@@ -544,14 +598,27 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
           report={report}
           canFix={Boolean(isOwner)}
           fixingId={fixingId}
+          fixingConfigBranch={renameMutation.isPending}
           enterprisePinned={enterprisePinned}
           unresolvedConcerns={unresolvedConcerns}
           onFix={(id) => {
             if (!fixMutation.isPending)
               void runFix(() => fixMutation.mutateAsync(id))
           }}
+          onRenameConfigRepo={() => setConfirmRename(true)}
         />
       )}
+
+      <ConfirmModal
+        open={confirmRename}
+        title={t("orgSettings.audit.renameModalTitle")}
+        description={t("orgSettings.audit.renameModalBody")}
+        confirmLabel={t("orgSettings.audit.renameToMain")}
+        dangerous
+        needsConfirm={false}
+        onConfirm={() => renameMutation.mutateAsync().then(() => undefined)}
+        onClose={() => setConfirmRename(false)}
+      />
     </SettingsSection>
   )
 }

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -80,7 +80,7 @@ The instructor's autograder workflow has a YAML syntax error. `gh student` valid
 
 ## Submit pushed a commit but the teacher doesn't see new work
 
-`gh student submit` pushes to the assignment repo's `main` branch (hardcoded for now). If your template uses `master` or `develop`, the first submit creates a new `main` branch alongside it. Make sure the assignment repo's default branch on GitHub is the one you (and the teacher's download flow) expect.
+`gh student submit` pushes to the assignment repo's actual default branch (resolved from the repo — `master`, `develop`, or `main`), and the autograde workflow triggers on that same branch, so grading fires regardless of the branch name. If a submission still isn't graded, confirm the push landed on the repo's default branch on GitHub and that the autograde workflow ran under the repo's Actions tab.
 
 ## `gh teacher download` clones nothing
 

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -13,7 +13,7 @@ Run `gh student <command> --help` for the live flag list. Errors always go to st
 | `gh student logout` | Log out of GitHub via `gh auth logout`. |
 | `gh student accept <org> <classroom> <assignment>` | Accept an assignment: auto-accept any pending org invite, create a private repo (a copy of the assignment's template, or an empty repo if the assignment is template-less), keep the student as `admin` (so a group founder can `gh student invite` teammates), write `.classroom50.yaml`, and print clone instructions. |
 | `gh student invite <org>/<repo> <user>` | Invite a classmate or TA to the repo with `push` permission. For group assignments, the founder uses this to add each teammate. |
-| `gh student submit` | Snapshot the current branch and push it as a new commit on top of the assignment repo's `main` branch (refreshing the instructor's `.gitignore` and `.github/` from the template first, when the assignment has one). The autograde workflow tags and grades automatically. |
+| `gh student submit` | Snapshot the current branch and push it as a new commit on top of the assignment repo's default branch (refreshing the instructor's `.gitignore` and `.github/` from the template first, when the assignment has one). The autograde workflow tags and grades automatically. |
 
 ## `gh student accept`
 
@@ -67,7 +67,7 @@ Invites a classmate or TA to a repo with `push` permission. Calls `PUT /repos/{o
 gh student submit
 ```
 
-Run from inside a cloned assignment repo. Snapshots the current working tree and pushes it as a new commit on top of `main`. The autograde workflow in the student repo listens for the push, creates its own `submit/<UTC-timestamp>-<short-sha>` tag, and publishes a scored Release at that tag a minute or two later.
+Run from inside a cloned assignment repo. Snapshots the current working tree and pushes it as a new commit on top of the repo's default branch (which may be `master` if the template used it). The autograde workflow in the student repo listens for the push, creates its own `submit/<UTC-timestamp>-<short-sha>` tag, and publishes a scored Release at that tag a minute or two later.
 
 Functionally equivalent to `git commit -am "Submit" && git push`, with the template `.gitignore`/`.github/` refresh as the only delta (skipped for a template-less assignment) — submit doesn't manage tags, manifests, or the autograde workflow shim itself.
 
@@ -83,7 +83,7 @@ The commit is authored with the user's GitHub login and noreply email (`<id>+<lo
 
 Tagging is the runner's job — the autograde workflow's first step creates `submit/<UTC-timestamp>-<short-sha>` at the just-pushed SHA. That gives each submission an immutable history entry plus its own Release without `gh student submit` having to know anything about tags. The one exception is the **acceptance commit** (the commit `gh student accept` lands to set the repo up): it fires the workflow but has no work to grade, so the runner detects it and skips tagging, grading, and the release. Your first real `gh student submit` is always graded.
 
-The hardcoded `main` push target means templates whose default branch is `master`/`develop` end up with a separate `main` after the first submit.
+`gh student submit` pushes to the assignment repo's **actual default branch** (resolved from the repo, not hardcoded), so a template whose default branch is `master`/`develop` grades correctly without a stray `main` branch appearing. The autograde workflow's push trigger targets that same branch.
 
 **Feedback PR timing.** If your teacher enabled feedback, a single long-lived **Feedback** pull request appears on your **first submission that adds work** — not at accept time. (GitHub can't open a pull request with no changes to show, and right after accepting there's nothing yet.) Unlike GitHub Classroom — which opens the feedback PR the moment you accept — Classroom 50 waits for real work, so the diff your teacher reviews never includes the setup files (`.classroom50.yaml`, the autograde workflow). A side benefit: if you ever change those setup files, it stands out in the diff. The one PR is reused for every later submission.
 


### PR DESCRIPTION
The unifying defect: Classroom 50 hardcoded `main` as a branch name in several places, so any repo whose default branch is `master` (or any non-`main` name) broke — org setup 404'd on the skeleton step, and the student submit → autograde loop silently never fired.

Governing principle: **`main` is the working assumption. When a repo's default branch isn't `main`, use the actual default branch and warn (or offer to fix it).**

## Summary

**Org setup (#233)**
- Normalize the `classroom50` config repo to `main` after creation (guarded rename via `POST .../branches/{old}/rename`, **skipped when already `main`**; failure is swallowed). Only a **freshly-created** repo is auto-renamed — an existing repo is left alone (its branch may be pinned by already-accepted student shims).
- Defense-in-depth: thread the config repo's actual `default_branch` through the skeleton diff/commit, branch protection, and `editClassroom` writes so setup succeeds even against a pre-existing `master` repo. This is the direct fix for the "Not Found" skeleton failure.

**Config repo default branch — read, recommend & one-click rename**
- The read-only **drift auditor** detects when the `classroom50` config repo's own default branch isn't `main` and surfaces a **highly-recommended, non-blocking** recommendation (listed above the org-default one — it's the actionable one).
- In the **web audit pane** this comes with a one-click **"Rename to main"** button behind a confirm modal that warns already-accepted students' autograde shims pin the old branch and may stop grading until re-accepted. The rename is a guarded no-op when already `main`.
- The **`gh teacher audit`** CLI mirrors the read-only recommendation with a deep link to the repo's branches page (read-only, so it recommends rather than renames).
- Fixed the branch-protection audit/repair, which hardcoded `main`: `checkBranchProtection` and the "Fix it" repair now resolve the config repo's real default branch, so a `master`-default repo is no longer mis-audited or mis-repaired.

**Org default branch — read & recommend, can't set**
- GitHub's `PATCH /orgs/{org}` **silently ignores** `default_repository_branch` (verified against a live org: returns 200, value unchanged — it's a web-UI-only setting), so it can't be set programmatically. We *can* read it via `GET /orgs/{org}`.
- The drift auditor (web audit pane **and** `gh teacher audit`) reads the live value and, when it isn't `main`, surfaces a **highly-recommended, non-blocking** hand-fix with a deep link to the repository-defaults page. It never fails the audit verdict. Web/CLI desired-state mirrors kept in parity.

**Accept-time branch resolution — the async template-copy lag**
- A template `generate` is **asynchronous**: right after `POST .../generate`, GitHub reports a *transient* `default_branch` (the org default, `main`) and an empty branch list, while the template's real branch (e.g. `master`) is copied a moment later. Trusting that early value (or a single immediate confirming GET, which also reads the transient `main`) pinned the accept commit + the shim's push trigger to a `heads/main` ref **that never exists** — so accept 404'd on "Setting up autograding" and, even when it didn't, the shim triggered on the wrong branch.
- **Web:** re-resolve the branch from the repo's live state *inside* the commit retry (once the copy settles), and re-render the default shim's `on.push.branches` trigger for that confirmed branch.
- **CLI:** new shared `ghutil.ResolveSettledDefaultBranch` polls the branch list until a ref materializes (preferring the live `default_branch` when it names a real branch), used in the templated-create path so `gh student accept` and the web app share one algorithm.
- Root cause confirmed with runtime instrumentation: the retry probe showed the loop polling `main` while the repo materialized `["master"]` on the 2nd attempt; the fix self-corrects to the real branch.

**Student submit → autograde (#49)**
- Template the autograde shim's push-trigger branch (`{{BRANCH}}`) and reusable-workflow ref (`{{CONFIG_BRANCH}}`) on both the CLI embed shim and the web `defaultAutograderWorkflow`.
- Render the default shim **after** the assignment repo's real default branch is known — using the *generated* repo's branch, not the template's.
- `gh student submit` pushes to the repo's actual default branch (a failed lookup is fatal, never a silent `main` fallback).
- Keep the shim's `@<config-branch>` ref valid even if the config-repo rename to `main` didn't land.
- `regrade_repos.py`'s first-grade fallback resolves each student repo's default branch before tagging.

**Warning (templates)**
- Both `gh teacher assignment add` and the web create-assignment template field warn (without blocking) when a chosen template's default branch isn't `main`.

**Docs**
- Updated the known-limitation notes in `wiki/gh-student.md` and `wiki/Troubleshooting.md`.

## Notes
- No schema changes, no new persisted config field — the default branch is always resolved live from the repo's settled state.
- The already-accepted heal path is forward-only (doesn't re-render an existing shim). Dynamic resolution alone closes #233/#49; the config-repo rename (auto for fresh repos, one-click for drifted ones) and the org-default recommendation are additive.
- `getBranchRef` now `encodeURIComponent`s the branch it interpolates (it was raw once a variable branch flowed through it), matching the sibling ref paths.

## Test plan
- [x] `web`: `npm run check` — tsc + eslint (0 errors) + prettier + **1394 vitest** pass
- [x] `web`: i18n audit (`audit_i18n.py`) PASS
- [x] `cli/gh-student`: `go build ./... && go test ./...` (incl. the settled-branch resolution tests)
- [x] `cli/gh-teacher`: `go build ./... && go test ./...` (incl. new audit + orgpolicy recommendation tests)
- [x] `cli/shared`: `go build ./... && go test ./...` (new `ResolveSettledDefaultBranch` tests)
- [x] skeleton: `python3 -m pytest cli/gh-teacher/skeleton_tests -q` — **426** pass
- [x] Regression proofs: config-repo rename against a `master` repo + skeleton reads (#233); shim `branches: ["master"]` + submit push target + regrade `heads/master` (#49); audit reads a non-main org default and a non-main config-repo branch and recommends switching (one-click rename in the web pane) without failing the verdict; branch-protection audit/repair targets the real `master` branch; **live end-to-end accept against a `master`-default template lands both control files on `master` with the shim triggering on `master`**
- [ ] `golangci-lint run` per module (not installed locally; runs in CI)

Closes #49
Closes #233