### PR TITLE
feat(web): surface pending org invitations on the home page

### DIFF
--- a/web/src/hooks/useGetOrgs.ts
+++ b/web/src/hooks/useGetOrgs.ts
@@ -23,7 +23,7 @@ const useGetOrgs = () => {
   const client = useGitHubClient()
   const memberships = useOrgMemberships(client)
 
-  return useQuery({
+  const summaries = useQuery({
     queryKey: ["orgs", "active-summaries"],
     enabled: memberships.data !== undefined,
     queryFn: () => {
@@ -38,6 +38,15 @@ const useGetOrgs = () => {
     },
     staleTime: 10 * 60 * 1000,
   })
+
+  return {
+    ...summaries,
+    // The summaries query is disabled until memberships resolve; a disabled
+    // query reports isLoading=false, so fold in the memberships fetch to keep
+    // the page's spinner covering the whole chain (no empty-state flash).
+    isLoading: memberships.isLoading || summaries.isLoading,
+    isFetching: memberships.isFetching || summaries.isFetching,
+  }
 }
 
 // Orgs the viewer has been invited to but hasn't joined yet. Pending members

--- a/web/src/hooks/useGetOrgs.ts
+++ b/web/src/hooks/useGetOrgs.ts
@@ -1,29 +1,56 @@
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useQuery } from "@tanstack/react-query"
+import type { GitHubClient } from "@/hooks/github/client"
+import type { GitHubOrgMembership } from "@/hooks/github/types"
 import {
   getClassroom50OrgSummary,
   listAuthedOrgMemberships,
 } from "./github/queries"
 
+// One fetch of /user/memberships/orgs backs both the active-org list and the
+// pending-invite list, so the two hooks share a cache entry instead of racing
+// duplicate calls.
+export const orgMembershipsQueryKey = ["orgs", "memberships"]
+
+const useOrgMemberships = (client: GitHubClient) =>
+  useQuery({
+    queryKey: orgMembershipsQueryKey,
+    queryFn: () => listAuthedOrgMemberships(client),
+    staleTime: 10 * 60 * 1000,
+  })
+
 const useGetOrgs = () => {
   const client = useGitHubClient()
-  return useQuery({
-    queryKey: ["orgs"],
-    queryFn: async () => {
-      const memberships = await listAuthedOrgMemberships(client)
+  const memberships = useOrgMemberships(client)
 
-      const activeMemberships = memberships.filter(
+  return useQuery({
+    queryKey: ["orgs", "active-summaries"],
+    enabled: memberships.data !== undefined,
+    queryFn: () => {
+      const active = (memberships.data ?? []).filter(
         (membership) => membership.state === "active",
       )
-
       return Promise.all(
-        activeMemberships.map((membership) =>
+        active.map((membership) =>
           getClassroom50OrgSummary(client, membership),
         ),
       )
     },
     staleTime: 10 * 60 * 1000,
   })
+}
+
+// Orgs the viewer has been invited to but hasn't joined yet. Pending members
+// can't read the org's classroom50 config repo, so we surface the raw
+// membership (org avatar/name/description + invited role) without the
+// classroom50 status probe that getClassroom50OrgSummary does for active orgs.
+export const usePendingOrgInvites = () => {
+  const client = useGitHubClient()
+  const { data, ...rest } = useOrgMemberships(client)
+  const pending: GitHubOrgMembership[] = (data ?? []).filter(
+    (membership) => membership.state === "pending",
+  )
+  return { ...rest, data: pending }
 }
 
 export default useGetOrgs

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -660,6 +660,22 @@
       "openOnGitHub": "Open {{org}} on GitHub",
       "open": "Open",
       "updatedAgo": "Updated {{when}}"
+    },
+    "invites": {
+      "summary_one": "You have {{count}} pending invitation",
+      "summary_other": "You have {{count}} pending invitations",
+      "pendingBadge": "Invited",
+      "roleAdmin": "Owner",
+      "roleMember": "Member",
+      "roleAdminHint": "You're invited as an owner — you'll be able to set up classrooms, assignments, and manage this organization.",
+      "roleMemberHint": "You're invited as a member — accept to join and see this organization's classrooms and assignments.",
+      "accept": "Accept invitation",
+      "acceptOpen": "Accept & Open",
+      "accepting": "Accepting…",
+      "accepted": "Joined {{org}}.",
+      "acceptError": "Couldn't accept the invitation to {{org}}. It may need SSO authorization on GitHub, or try again.",
+      "viewOnGitHub": "View invite on GitHub",
+      "openInviteOnGitHub": "Open the {{org}} invitation on GitHub"
     }
   },
   "assignments": {

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -1,24 +1,34 @@
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
+import { acceptAndVerifyOrgMembership } from "@/api/mutations/users"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Classroom50OrgSummary } from "@/hooks/github/queries"
-import useGetOrgs from "@/hooks/useGetOrgs"
+import type { GitHubOrgMembership } from "@/hooks/github/types"
+import useGetOrgs, {
+  orgMembershipsQueryKey,
+  usePendingOrgInvites,
+} from "@/hooks/useGetOrgs"
 import useOrgLastModified from "@/hooks/useOrgLastModified"
-import { useQueryClient } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Link, useNavigate } from "@tanstack/react-router"
 import {
   ChevronDown,
   ExternalLink,
   Info,
   Lock,
+  MailOpen,
   Plus,
   RefreshCw,
+  ShieldCheck,
+  User,
 } from "lucide-react"
 import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
-import { Button, Card, Toolbar } from "@/components/ui"
+import { Badge, Button, Card, Toolbar } from "@/components/ui"
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
 import Spinner from "@/components/Spinner"
@@ -81,6 +91,135 @@ function MissingOrgNotice({
           {t("orgs.missingNotice.manageOauth")}
           <ExternalLink aria-hidden="true" className="size-4" />
         </a>
+      </div>
+    </details>
+  )
+}
+
+// A single pending org invitation: org identity from the membership record
+// (avatar/name/description) plus an inline accept-and-verify. Pending members
+// can't read the classroom50 repo, so there's no status probe here — accepting
+// moves the org into the active list, where the classroom50 summary is built.
+function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
+  const { t } = useTranslation()
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { notify } = useToast()
+  const org = invite.organization
+  const isOwner = invite.role === "admin"
+
+  const accept = useMutation({
+    mutationFn: () => acceptAndVerifyOrgMembership(client, org.login),
+    onSuccess: () => {
+      notify({
+        tone: "success",
+        message: t("orgs.invites.accepted", { org: org.login }),
+      })
+      queryClient.invalidateQueries({ queryKey: orgMembershipsQueryKey })
+      queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      navigate({ to: "/$org", params: { org: org.login } })
+    },
+    onError: () => {
+      notify({
+        tone: "error",
+        message: t("orgs.invites.acceptError", { org: org.login }),
+      })
+    },
+  })
+
+  return (
+    <Card
+      as={EnterDiv}
+      radius="xl"
+      shadow={false}
+      className="col-span-12 border-warning/40 bg-warning/5 md:col-span-6"
+    >
+      <Card.Body className="justify-between">
+        <div className="flex gap-4">
+          <img
+            src={org.avatar_url}
+            alt=""
+            className="size-12 rounded-xl border border-base-300"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="truncate text-lg font-bold">{org.login}</h2>
+              <Badge tone="warning" size="sm">
+                {t("orgs.invites.pendingBadge")}
+              </Badge>
+              {isOwner ? (
+                <Badge tone="primary" size="sm" className="gap-1">
+                  <ShieldCheck aria-hidden="true" className="size-3" />
+                  {t("orgs.invites.roleAdmin")}
+                </Badge>
+              ) : (
+                <Badge tone="neutral" size="sm" className="gap-1">
+                  <User aria-hidden="true" className="size-3" />
+                  {t("orgs.invites.roleMember")}
+                </Badge>
+              )}
+            </div>
+            {org.description && (
+              <p className="mt-1 line-clamp-2 text-sm text-base-content/70">
+                {org.description}
+              </p>
+            )}
+            <p className="mt-1 text-xs text-base-content/50">
+              {isOwner
+                ? t("orgs.invites.roleAdminHint")
+                : t("orgs.invites.roleMemberHint")}
+            </p>
+          </div>
+        </div>
+
+        <Card.Actions className="mt-5 items-center justify-end gap-2">
+          <GitHubLink
+            href={`https://github.com/orgs/${org.login}/invitation`}
+            label={t("orgs.invites.viewOnGitHub")}
+            title={t("orgs.invites.openInviteOnGitHub", { org: org.login })}
+            className="shrink-0"
+            showLogo={false}
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            loading={accept.isPending}
+            loadingLabel={t("orgs.invites.accepting")}
+            onClick={() => accept.mutate()}
+          >
+            {t("orgs.invites.acceptOpen")}
+          </Button>
+        </Card.Actions>
+      </Card.Body>
+    </Card>
+  )
+}
+
+// Collapsed by default so a stack of invites doesn't dominate the home page;
+// the summary announces the count and expands to the accept cards.
+function PendingInvites({ invites }: { invites: GitHubOrgMembership[] }) {
+  const { t } = useTranslation()
+  if (invites.length === 0) return null
+  return (
+    <details className="group rounded-xl border border-warning/40 bg-warning/5">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-sm">
+        <MailOpen aria-hidden="true" className="size-4 shrink-0 text-warning" />
+        <span className="min-w-0 flex-1 truncate font-medium text-base-content">
+          {t("orgs.invites.summary", { count: invites.length })}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className="size-4 shrink-0 text-base-content/50 transition-transform group-open:rotate-180"
+        />
+      </summary>
+
+      <div className="border-t border-warning/20 p-4">
+        <div className="grid grid-cols-12 gap-4">
+          {invites.map((invite) => (
+            <PendingInviteCard key={invite.organization.id} invite={invite} />
+          ))}
+        </div>
       </div>
     </details>
   )
@@ -266,6 +405,7 @@ const OrgsPage = () => {
   useDocumentTitle(t("documentTitle.organizations"))
   const queryClient = useQueryClient()
   const { data: orgs = [], isLoading, isFetching } = useGetOrgs()
+  const { data: pendingInvites = [] } = usePendingOrgInvites()
 
   const { viewMode, sortKey, changeView, changeSort } =
     useListPrefsState(orgListPrefs)
@@ -344,6 +484,8 @@ const OrgsPage = () => {
     queryClient.invalidateQueries({ queryKey: ["orgs"] })
 
   const hasAnyOrgs = cl50Orgs.length > 0
+  const hasInvites = pendingInvites.length > 0
+  const hasContent = hasAnyOrgs || hasInvites
   const noSearchResults = hasAnyOrgs && sorted.length === 0
 
   return (
@@ -370,7 +512,9 @@ const OrgsPage = () => {
               onRefresh={handleRefresh}
             />
 
-            {hasAnyOrgs && (
+            {hasInvites && <PendingInvites invites={pendingInvites} />}
+
+            {hasContent && (
               <Toolbar className="flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <Toolbar.Search
                   inputSize="md"
@@ -461,7 +605,7 @@ const OrgsPage = () => {
                   </Button>
                 }
               />
-            ) : (
+            ) : hasInvites ? null : (
               <EmptyState
                 title={t("orgs.emptyTitle")}
                 body={t("orgs.emptyBody")}


### PR DESCRIPTION
Closes #238

## Summary

- A student/TA/instructor with a **pending** org invite who hadn't joined yet landed on an **empty** home page. Root cause: `useGetOrgs` fetched `/user/memberships/orgs` (which returns both `active` and `pending`) but discarded anything not `active`.
- Surface pending invites in a **collapsible disclosure** above the toolbar (under the "Not seeing your organization?" notice): a summary line "You have {N} pending invitation(s)" that expands to one card per invite.
- Each card shows org **avatar / name / description**, an **"Invited"** badge, the invited **role clearly distinguished** (Owner vs Member, distinct color + icon + explanation), a **"View invite on GitHub"** link to `https://github.com/orgs/{org}/invitation`, and an **"Accept & Open"** button that accept-verifies membership then navigates into the org.

## Implementation notes

- Split the single `/user/memberships/orgs` fetch into a shared query so the active-org list and the pending-invite list use **one cache entry** (no duplicate calls). `useGetOrgs` keeps its existing shape; added `usePendingOrgInvites`.
- Reuses the existing verified-accept path (`acceptAndVerifyOrgMembership`) used by the onboarding / accept-assignment flows. On success it invalidates the org/membership queries so the org moves into the active list, and navigates to `/$org`.
- Deliberately **skips** the per-org `classroom50` status probe for pending invites (a pending member can't read that repo).
- All new user-facing strings go through `t()` (pluralized summary via i18next `_one`/`_other`).

## Code review fix

- **fix(web): keep orgs spinner during memberships fetch** — splitting `useGetOrgs` into a memberships query + a summaries query `enabled` only after memberships resolve meant the (disabled) summaries query reported `isLoading=false`, so the page skipped its spinner and flashed the empty state on cold load. Folded the memberships loading/fetching state back into `useGetOrgs` so the spinner covers the whole fetch chain.

## Test plan

- [x] `tsc -b`, `eslint`, `prettier --check` pass on touched files
- [x] `vitest run` green (1412 tests), i18n key audit green
- [ ] Manual: as a user with a pending invite, home page shows the disclosure; expand → "Accept & Open" joins + opens the org
- [ ] Manual: Owner vs Member invites render distinctly; "View invite on GitHub" points at the org invitation page
- [ ] Manual: cold load shows the spinner (no empty-state flash) before orgs/invites appear