### PR TITLE
fix(web): count only role=student in classroom student stats

### DIFF
--- a/web/src/hooks/useClassroomSummaries.test.tsx
+++ b/web/src/hooks/useClassroomSummaries.test.tsx
@@ -40,8 +40,9 @@ describe("useClassroomSummaries", () => {
       archived: false,
       loading: false,
     })
-    // Count is no longer sourced here — it's collected by the list's probes.
-    expect(result.current[0].studentCount).toBeUndefined()
+    // Count is no longer sourced here — the type has no studentCount; it's
+    // collected by ClassroomList's probes for the sort only.
+    expect(result.current[0]).not.toHaveProperty("studentCount")
   })
 
   it("keeps a row (with {path}) when classroom.json is unreadable", () => {

--- a/web/src/hooks/useClassroomSummaries.test.tsx
+++ b/web/src/hooks/useClassroomSummaries.test.tsx
@@ -4,7 +4,6 @@ import { renderHook } from "@testing-library/react"
 
 import type { GitHubFileListing } from "@/hooks/github/types"
 
-// Drive classroom.json reads: each dir resolves to a minimal classroom.
 const useQueriesMock = vi.fn()
 vi.mock("@tanstack/react-query", () => ({
   useQueries: (arg: unknown) => useQueriesMock(arg),
@@ -16,21 +15,6 @@ vi.mock("@/hooks/github/queries", () => ({
   jsonFileQuery: () => ({}),
 }))
 
-// Per-classroom authoritative count, keyed by classroom path so each dir can
-// resolve to a distinct student count.
-const countByPath: Record<string, number | undefined> = {}
-const studentCountMock = vi.fn(
-  (_org: string | undefined, classroom: string | undefined) => ({
-    studentCount: classroom ? countByPath[classroom] : undefined,
-    isLoading: false,
-    isError: false,
-  }),
-)
-vi.mock("@/hooks/useStudentCount", () => ({
-  default: (...a: [string | undefined, string | undefined]) =>
-    studentCountMock(...a),
-}))
-
 import useClassroomSummaries from "./useClassroomSummaries"
 
 const dir = (path: string): GitHubFileListing =>
@@ -38,46 +22,35 @@ const dir = (path: string): GitHubFileListing =>
 
 beforeEach(() => {
   useQueriesMock.mockReset()
-  studentCountMock.mockClear()
-  for (const k of Object.keys(countByPath)) delete countByPath[k]
 })
 
-describe("useClassroomSummaries student-count sort", () => {
-  it("uses the role-aware count, not the total roster length", () => {
-    // classroom.json resolves for both dirs.
+describe("useClassroomSummaries", () => {
+  it("lifts classroom.json fields and does not compute a student count", () => {
     useQueriesMock.mockReturnValue([
-      { data: { name: "CS 101" }, isPending: false },
-      { data: { name: "CS 202" }, isPending: false },
+      { data: { name: "CS 101", term: "F26" }, isPending: false },
     ])
-    countByPath["cs101"] = 11 // 11 students even if roster.csv has 14 rows
-    countByPath["cs202"] = 3
 
     const { result } = renderHook(() =>
-      useClassroomSummaries("acme", [dir("cs101"), dir("cs202")], true),
+      useClassroomSummaries("acme", [dir("cs101")]),
     )
-    expect(result.current[0].studentCount).toBe(11)
-    expect(result.current[1].studentCount).toBe(3)
-  })
-
-  it("keeps studentCount undefined for an unresolved count", () => {
-    useQueriesMock.mockReturnValue([{ data: { name: "CS 101" }, isPending: false }])
-    countByPath["cs101"] = undefined // team roster not resolved yet
-
-    const { result } = renderHook(() =>
-      useClassroomSummaries("acme", [dir("cs101")], true),
-    )
+    expect(result.current[0]).toMatchObject({
+      path: "cs101",
+      name: "CS 101",
+      term: "F26",
+      archived: false,
+      loading: false,
+    })
+    // Count is no longer sourced here — it's collected by the list's probes.
     expect(result.current[0].studentCount).toBeUndefined()
   })
 
-  it("does not fetch counts when the sort is inactive", () => {
-    useQueriesMock.mockReturnValue([{ data: { name: "CS 101" }, isPending: false }])
+  it("keeps a row (with {path}) when classroom.json is unreadable", () => {
+    useQueriesMock.mockReturnValue([{ data: undefined, isPending: false }])
 
     const { result } = renderHook(() =>
-      useClassroomSummaries("acme", [dir("cs101")], false),
+      useClassroomSummaries("acme", [dir("cs404")]),
     )
-    expect(result.current[0].studentCount).toBeUndefined()
-    // useStudentCount is still called (hook rules), but with undefined args so
-    // its internal queries stay disabled — no team-count fan-out.
-    expect(studentCountMock).toHaveBeenCalledWith(undefined, undefined)
+    expect(result.current[0].path).toBe("cs404")
+    expect(result.current[0].name).toBeUndefined()
   })
 })

--- a/web/src/hooks/useClassroomSummaries.test.tsx
+++ b/web/src/hooks/useClassroomSummaries.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+import type { GitHubFileListing } from "@/hooks/github/types"
+
+// Drive classroom.json reads: each dir resolves to a minimal classroom.
+const useQueriesMock = vi.fn()
+vi.mock("@tanstack/react-query", () => ({
+  useQueries: (arg: unknown) => useQueriesMock(arg),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+vi.mock("@/hooks/github/queries", () => ({
+  jsonFileQuery: () => ({}),
+}))
+
+// Per-classroom authoritative count, keyed by classroom path so each dir can
+// resolve to a distinct student count.
+const countByPath: Record<string, number | undefined> = {}
+const studentCountMock = vi.fn(
+  (_org: string | undefined, classroom: string | undefined) => ({
+    studentCount: classroom ? countByPath[classroom] : undefined,
+    isLoading: false,
+    isError: false,
+  }),
+)
+vi.mock("@/hooks/useStudentCount", () => ({
+  default: (...a: [string | undefined, string | undefined]) =>
+    studentCountMock(...a),
+}))
+
+import useClassroomSummaries from "./useClassroomSummaries"
+
+const dir = (path: string): GitHubFileListing =>
+  ({ path, type: "dir", name: path }) as GitHubFileListing
+
+beforeEach(() => {
+  useQueriesMock.mockReset()
+  studentCountMock.mockClear()
+  for (const k of Object.keys(countByPath)) delete countByPath[k]
+})
+
+describe("useClassroomSummaries student-count sort", () => {
+  it("uses the role-aware count, not the total roster length", () => {
+    // classroom.json resolves for both dirs.
+    useQueriesMock.mockReturnValue([
+      { data: { name: "CS 101" }, isPending: false },
+      { data: { name: "CS 202" }, isPending: false },
+    ])
+    countByPath["cs101"] = 11 // 11 students even if roster.csv has 14 rows
+    countByPath["cs202"] = 3
+
+    const { result } = renderHook(() =>
+      useClassroomSummaries("acme", [dir("cs101"), dir("cs202")], true),
+    )
+    expect(result.current[0].studentCount).toBe(11)
+    expect(result.current[1].studentCount).toBe(3)
+  })
+
+  it("keeps studentCount undefined for an unresolved count", () => {
+    useQueriesMock.mockReturnValue([{ data: { name: "CS 101" }, isPending: false }])
+    countByPath["cs101"] = undefined // team roster not resolved yet
+
+    const { result } = renderHook(() =>
+      useClassroomSummaries("acme", [dir("cs101")], true),
+    )
+    expect(result.current[0].studentCount).toBeUndefined()
+  })
+
+  it("does not fetch counts when the sort is inactive", () => {
+    useQueriesMock.mockReturnValue([{ data: { name: "CS 101" }, isPending: false }])
+
+    const { result } = renderHook(() =>
+      useClassroomSummaries("acme", [dir("cs101")], false),
+    )
+    expect(result.current[0].studentCount).toBeUndefined()
+    // useStudentCount is still called (hook rules), but with undefined args so
+    // its internal queries stay disabled — no team-count fan-out.
+    expect(studentCountMock).toHaveBeenCalledWith(undefined, undefined)
+  })
+})

--- a/web/src/hooks/useClassroomSummaries.ts
+++ b/web/src/hooks/useClassroomSummaries.ts
@@ -1,14 +1,10 @@
 import { useQueries } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { csvFileQuery, jsonFileQuery } from "@/hooks/github/queries"
-import { rosterPath, legacyRosterPath } from "@/util/rosterPath"
+import { jsonFileQuery } from "@/hooks/github/queries"
+import useStudentCount from "@/hooks/useStudentCount"
 import type { GitHubFileListing } from "@/hooks/github/types"
-import {
-  isClassroomArchived,
-  type Classroom,
-  type Student,
-} from "@/types/classroom"
+import { isClassroomArchived, type Classroom } from "@/types/classroom"
 
 export type ClassroomSummary = {
   // The classroom directory slug. Always present, even when classroom.json
@@ -27,12 +23,13 @@ export type ClassroomSummary = {
   loading: boolean
 }
 
-// Lifts each classroom's classroom.json (and optionally its roster) to the
-// parent so the My Classrooms list can search/sort/filter before rendering.
-// Reuses useGetClassroom's jsonFileQuery cache keys and useGetStudents'
-// csvFileQuery keys, so no duplicate requests vs. the per-card reads. Roster
-// fetches are gated behind `withStudentCounts` (only true when the
-// student-count sort is active) to avoid an unnecessary fan-out otherwise.
+// Lifts each classroom's classroom.json to the parent so the My Classrooms list
+// can search/sort/filter before rendering the cards. Reuses useGetClassroom's
+// jsonFileQuery cache keys, so no duplicate requests vs. the per-card reads.
+// When the student-count sort is active, it also fetches the authoritative
+// role-aware student count per classroom (same useStudentCount the cards use),
+// gated behind `withStudentCounts` so the team-membership fan-out only happens
+// then.
 //
 // jsonFileQuery/csvFileQuery use retry:false, so a dir with a missing/malformed
 // classroom.json resolves to data===undefined: we keep {path} and mark the rest
@@ -55,30 +52,27 @@ const useClassroomSummaries = (
     ),
   })
 
-  const rosterResults = useQueries({
-    queries: dirs.map((dir) => ({
-      ...csvFileQuery<Student>(
-        client,
-        org ?? "",
-        "classroom50",
-        rosterPath(dir.path),
-        undefined,
-        legacyRosterPath(dir.path),
-      ),
-      enabled: withStudentCounts && Boolean(org && dir.path),
-    })),
-  })
+  // Authoritative role-aware student count per classroom, from the single
+  // useStudentCount source (R5) — never roster.csv row count, which includes
+  // staff. dirs is a stable-length listing for a mounted list (it changes only
+  // on create/delete, which remounts), so a hook-per-dir is safe here.
+  const studentCounts = dirs.map((dir) =>
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useStudentCount(
+      withStudentCounts ? org : undefined,
+      withStudentCounts ? dir.path : undefined,
+    ),
+  )
 
   return dirs.map((dir, i) => {
     const cl = classroomResults[i]?.data
-    const roster = rosterResults[i]?.data
     return {
       path: dir.path,
       name: cl?.name,
       short_name: cl?.short_name,
       term: cl?.term,
       archived: isClassroomArchived(cl ?? {}),
-      studentCount: withStudentCounts ? roster?.length : undefined,
+      studentCount: withStudentCounts ? studentCounts[i]?.studentCount : undefined,
       loading: classroomResults[i]?.isPending ?? false,
     }
   })

--- a/web/src/hooks/useClassroomSummaries.ts
+++ b/web/src/hooks/useClassroomSummaries.ts
@@ -15,9 +15,6 @@ export type ClassroomSummary = {
   // Archived lifecycle derived from classroom.json's `active` flag via
   // isClassroomArchived; an unresolved/errored read is treated as active.
   archived: boolean
-  // studentCount undefined while pending/unreadable (or when counts aren't
-  // requested); callers pin undefined to the bottom in name order.
-  studentCount?: number
   // Distinct from a resolved-but-empty classroom.json read.
   loading: boolean
 }
@@ -30,7 +27,8 @@ export type ClassroomSummary = {
 // needs an authoritative role-aware count (useStudentCount), and calling a hook
 // per dir in this hook would violate the Rules of Hooks when the classroom list
 // grows/shrinks without a remount. ClassroomList collects those counts via
-// keyed probe components instead and merges them in (see useStudentCountsByDir).
+// keyed probe components instead and merges them in (see StudentCountProbes and
+// useStudentCount).
 //
 // jsonFileQuery uses retry:false, so a dir with a missing/malformed
 // classroom.json resolves to data===undefined: we keep {path} and mark the rest

--- a/web/src/hooks/useClassroomSummaries.ts
+++ b/web/src/hooks/useClassroomSummaries.ts
@@ -2,7 +2,6 @@ import { useQueries } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { jsonFileQuery } from "@/hooks/github/queries"
-import useStudentCount from "@/hooks/useStudentCount"
 import type { GitHubFileListing } from "@/hooks/github/types"
 import { isClassroomArchived, type Classroom } from "@/types/classroom"
 
@@ -26,18 +25,19 @@ export type ClassroomSummary = {
 // Lifts each classroom's classroom.json to the parent so the My Classrooms list
 // can search/sort/filter before rendering the cards. Reuses useGetClassroom's
 // jsonFileQuery cache keys, so no duplicate requests vs. the per-card reads.
-// When the student-count sort is active, it also fetches the authoritative
-// role-aware student count per classroom (same useStudentCount the cards use),
-// gated behind `withStudentCounts` so the team-membership fan-out only happens
-// then.
 //
-// jsonFileQuery/csvFileQuery use retry:false, so a dir with a missing/malformed
+// The student-count sort's per-classroom counts are NOT fetched here: that sort
+// needs an authoritative role-aware count (useStudentCount), and calling a hook
+// per dir in this hook would violate the Rules of Hooks when the classroom list
+// grows/shrinks without a remount. ClassroomList collects those counts via
+// keyed probe components instead and merges them in (see useStudentCountsByDir).
+//
+// jsonFileQuery uses retry:false, so a dir with a missing/malformed
 // classroom.json resolves to data===undefined: we keep {path} and mark the rest
 // optional rather than dropping a real classroom from the list.
 const useClassroomSummaries = (
   org: string | undefined,
   dirs: GitHubFileListing[],
-  withStudentCounts: boolean,
 ): ClassroomSummary[] => {
   const client = useGitHubClient()
 
@@ -52,18 +52,6 @@ const useClassroomSummaries = (
     ),
   })
 
-  // Authoritative role-aware student count per classroom, from the single
-  // useStudentCount source (R5) — never roster.csv row count, which includes
-  // staff. dirs is a stable-length listing for a mounted list (it changes only
-  // on create/delete, which remounts), so a hook-per-dir is safe here.
-  const studentCounts = dirs.map((dir) =>
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useStudentCount(
-      withStudentCounts ? org : undefined,
-      withStudentCounts ? dir.path : undefined,
-    ),
-  )
-
   return dirs.map((dir, i) => {
     const cl = classroomResults[i]?.data
     return {
@@ -72,7 +60,6 @@ const useClassroomSummaries = (
       short_name: cl?.short_name,
       term: cl?.term,
       archived: isClassroomArchived(cl ?? {}),
-      studentCount: withStudentCounts ? studentCounts[i]?.studentCount : undefined,
       loading: classroomResults[i]?.isPending ?? false,
     }
   })

--- a/web/src/hooks/useStudentCount.test.tsx
+++ b/web/src/hooks/useStudentCount.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+import type { RoleCounts } from "@/util/rosterRoles"
+import type { UseTeamRosterResult } from "@/hooks/useTeamRoster"
+
+const getStudents = vi.fn()
+const teamRoster = vi.fn()
+
+vi.mock("@/hooks/useGetStudents", () => ({
+  default: (...args: unknown[]) => getStudents(...args),
+}))
+vi.mock("@/hooks/useTeamRoster", () => ({
+  useTeamRoster: (...args: unknown[]) => teamRoster(...args),
+}))
+
+import useStudentCount from "./useStudentCount"
+
+const roleCounts = (student: number): RoleCounts => ({
+  instructor: 0,
+  ta: 0,
+  student,
+})
+
+// Minimal team-roster result: only the fields useStudentCount reads.
+const rosterResult = (
+  overrides: Partial<UseTeamRosterResult>,
+): UseTeamRosterResult =>
+  ({
+    roleCounts: roleCounts(0),
+    isLoading: false,
+    isError: false,
+    ...overrides,
+  }) as UseTeamRosterResult
+
+beforeEach(() => {
+  getStudents.mockReset()
+  teamRoster.mockReset()
+  getStudents.mockReturnValue({ students: [], isLoading: false })
+})
+
+describe("useStudentCount", () => {
+  it("returns roleCounts.student, not the total roster row count", () => {
+    // A roster with staff rows; team membership resolves 11 student-role members.
+    getStudents.mockReturnValue({
+      students: new Array(14).fill({}),
+      isLoading: false,
+    })
+    teamRoster.mockReturnValue(rosterResult({ roleCounts: roleCounts(11) }))
+
+    const { result } = renderHook(() => useStudentCount("org", "cs101"))
+    expect(result.current.studentCount).toBe(11)
+  })
+
+  it("counts a student-who-is-also-staff once (roleCounts already unions)", () => {
+    // roleCounts.student tallies every row carrying the student role, including
+    // student+instructor, exactly once — the wrapper passes it through.
+    teamRoster.mockReturnValue(rosterResult({ roleCounts: roleCounts(3) }))
+
+    const { result } = renderHook(() => useStudentCount("org", "cs101"))
+    expect(result.current.studentCount).toBe(3)
+  })
+
+  it("is undefined while the team roster is loading", () => {
+    teamRoster.mockReturnValue(
+      rosterResult({ roleCounts: roleCounts(5), isLoading: true }),
+    )
+
+    const { result } = renderHook(() => useStudentCount("org", "cs101"))
+    expect(result.current.studentCount).toBeUndefined()
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it("surfaces isError without returning a wrong numeric count", () => {
+    teamRoster.mockReturnValue(
+      rosterResult({ roleCounts: roleCounts(0), isError: true }),
+    )
+
+    const { result } = renderHook(() => useStudentCount("org", "cs101"))
+    expect(result.current.isError).toBe(true)
+    // Not undefined-from-loading (loading is false); the caller keys on isError
+    // rather than trusting the 0 as a real count.
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("returns 0 (not undefined) for a resolved staff-only classroom", () => {
+    teamRoster.mockReturnValue(rosterResult({ roleCounts: roleCounts(0) }))
+
+    const { result } = renderHook(() => useStudentCount("org", "cs101"))
+    expect(result.current.studentCount).toBe(0)
+  })
+
+  it("passes roster students through to useTeamRoster as the metadata arg", () => {
+    const students = [{ username: "octocat" }]
+    getStudents.mockReturnValue({ students, isLoading: false })
+    teamRoster.mockReturnValue(rosterResult({ roleCounts: roleCounts(1) }))
+
+    renderHook(() => useStudentCount("org", "cs101"))
+    expect(teamRoster).toHaveBeenCalledWith("org", "cs101", students)
+  })
+})

--- a/web/src/hooks/useStudentCount.ts
+++ b/web/src/hooks/useStudentCount.ts
@@ -1,0 +1,44 @@
+import useGetStudents from "@/hooks/useGetStudents"
+import { useTeamRoster } from "@/hooks/useTeamRoster"
+
+export type StudentCount = {
+  // Enrolled student-role head count, or undefined while the authoritative
+  // source resolves. Distinct from a resolved 0 (a staff-only classroom).
+  studentCount: number | undefined
+  isLoading: boolean
+  // A role-count read failed; callers degrade gracefully instead of showing a
+  // wrong number (a bare `?? 0` would render a misleading "0 students").
+  isError: boolean
+}
+
+// Authoritative student count: enrolled members holding the student role, from
+// the same team-membership source the Roster page uses. Callers that only need
+// the number use this instead of the full useTeamRoster result.
+//
+// Fan-out: useTeamRoster fires several GitHub reads per classroom (student + 2
+// staff team members, owner-gated invitations, org members). Rendered once per
+// card on the My Classrooms list, this is a real per-card cost — kept in check
+// by owner-gated reads, 404->[] staff reads, and shared query-key caching. The
+// roster.csv `role` column is deliberately NOT used; it is stale/absent on
+// legacy files, whereas team membership is the source of truth.
+const useStudentCount = (
+  org: string | undefined,
+  classroom: string | undefined,
+): StudentCount => {
+  const { students } = useGetStudents(org, classroom)
+  // students is only the metadata arg useTeamRoster needs to enrich rows; the
+  // count derives solely from roleCounts.student, never from the CSV rows.
+  const { roleCounts, isLoading, isError } = useTeamRoster(
+    org ?? "",
+    classroom ?? "",
+    students,
+  )
+
+  return {
+    studentCount: isLoading ? undefined : roleCounts.student,
+    isLoading,
+    isError,
+  }
+}
+
+export default useStudentCount

--- a/web/src/pages/AssignmentsPage.test.tsx
+++ b/web/src/pages/AssignmentsPage.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: { count?: number }) =>
+        opts && "count" in opts ? `${key}:${opts.count}` : key,
+    }),
+  }
+})
+
+// Router Link needs a RouterProvider; stub it to a plain anchor so the header's
+// New Assignment button renders without router context.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    useParams: () => ({ org: "acme", classroom: "cs101" }),
+  }
+})
+
+const studentCount = vi.fn()
+const getStudents = vi.fn()
+const getClassroom = vi.fn()
+const getAssignments = vi.fn()
+
+vi.mock("@/hooks/useStudentCount", () => ({
+  default: (...a: unknown[]) => studentCount(...a),
+}))
+vi.mock("@/hooks/useGetStudents", () => ({
+  default: (...a: unknown[]) => getStudents(...a),
+}))
+vi.mock("@/hooks/useGetClassroom", () => ({
+  default: (...a: unknown[]) => getClassroom(...a),
+}))
+vi.mock("@/hooks/useGetClassAssignments", () => ({
+  default: (...a: unknown[]) => getAssignments(...a),
+}))
+vi.mock("@/hooks/useEmptyRosterWarning", () => ({
+  default: () => ({ show: false, hasRosterRows: false }),
+}))
+vi.mock("@/context/classroomRole/ClassroomRoleProvider", () => ({
+  useClassroomRoleContext: () => ({ role: "instructor" }),
+}))
+// Stub the heavy children so the test targets only the header subtitle.
+vi.mock("@/pages/assignments/AssignmentsTable", () => ({ default: () => null }))
+vi.mock("@/pages/assignments/AssignmentsToolbar", () => ({
+  default: () => null,
+}))
+
+import { TeacherAssignmentsView } from "./AssignmentsPage"
+
+beforeEach(() => {
+  studentCount.mockReset()
+  getStudents.mockReset()
+  getClassroom.mockReset()
+  getAssignments.mockReset()
+  getStudents.mockReturnValue({ students: [] })
+  getClassroom.mockReturnValue({ data: { name: "CS 101" }, isLoading: false })
+  getAssignments.mockReturnValue({
+    data: { assignments: [] },
+    isLoading: false,
+  })
+})
+
+afterEach(cleanup)
+
+describe("Assignments header student count", () => {
+  it("renders the role-aware count, not the total roster row count", () => {
+    getStudents.mockReturnValue({ students: new Array(14).fill({}) })
+    studentCount.mockReturnValue({
+      studentCount: 11,
+      isLoading: false,
+      isError: false,
+    })
+    render(<TeacherAssignmentsView org="acme" classroom="cs101" />)
+    expect(screen.getByText(/assignments\.studentCount:11/)).toBeTruthy()
+  })
+
+  it("shows the loading placeholder until the count resolves", () => {
+    studentCount.mockReturnValue({
+      studentCount: undefined,
+      isLoading: true,
+      isError: false,
+    })
+    render(<TeacherAssignmentsView org="acme" classroom="cs101" />)
+    expect(screen.getByText("…")).toBeTruthy()
+  })
+
+  it("shows the placeholder on a role-count error, not a wrong number", () => {
+    studentCount.mockReturnValue({
+      studentCount: undefined,
+      isLoading: false,
+      isError: true,
+    })
+    render(<TeacherAssignmentsView org="acme" classroom="cs101" />)
+    expect(screen.getByText("…")).toBeTruthy()
+    expect(screen.queryByText(/assignments\.studentCount/)).toBeNull()
+  })
+})

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -23,7 +23,7 @@ import { ClaimInstructorNotice } from "./classes/ClaimInstructorNotice"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { ReuseFromClassroomModal } from "@/components/modals/ReuseFromClassroomModal"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
-import useGetStudents from "@/hooks/useGetStudents"
+import useStudentCount from "@/hooks/useStudentCount"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
@@ -96,7 +96,7 @@ const NewAssignmentButton = ({
   )
 }
 
-const TeacherAssignmentsView = ({
+export const TeacherAssignmentsView = ({
   org,
   classroom,
 }: {
@@ -106,10 +106,14 @@ const TeacherAssignmentsView = ({
   const { t } = useTranslation()
   const { data: classData, isLoading: assignmentsLoading } =
     useGetClassroomAssignments(org, classroom)
-  const { students, isLoading: studentsLoading } = useGetStudents(
-    org,
-    classroom,
-  )
+  // Authoritative student-role count for the header and the table denominator,
+  // so neither counts instructors/TAs. The count comes from team membership
+  // (one source); roster.csv identity is fetched by useStudentCount internally.
+  const {
+    studentCount,
+    isLoading: studentsLoading,
+    isError: studentCountError,
+  } = useStudentCount(org, classroom)
   const { data: classroomData, isLoading: classroomLoading } = useGetClassroom(
     org,
     classroom,
@@ -156,9 +160,9 @@ const TeacherAssignmentsView = ({
         subtitle={
           <>
             {classroomData?.term ? `${classroomData?.term} • ` : ""}
-            {studentsLoading
+            {studentsLoading || studentCountError
               ? "…"
-              : t("assignments.studentCount", { count: students.length })}
+              : t("assignments.studentCount", { count: studentCount ?? 0 })}
           </>
         }
         action={
@@ -215,7 +219,7 @@ const TeacherAssignmentsView = ({
           org={org}
           classroom={classroom}
           assignments={hasAssignments ? visible : sourceAssignments}
-          students={students}
+          studentCount={studentCount}
           loading={assignmentsLoading}
           archived={archived}
         />

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+import type { Assignment } from "@/types/classroom"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    useNavigate: () => () => {},
+  }
+})
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+
+const scores = vi.fn()
+vi.mock("@/hooks/useGetScores", () => ({
+  default: (...a: unknown[]) => scores(...a),
+}))
+
+import AssignmentsTable from "./AssignmentsTable"
+
+const wrap = (ui: ReactNode) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+const assignment = (over: Partial<Assignment> = {}): Assignment =>
+  ({ slug: "hw1", name: "HW 1", mode: "individual", ...over }) as Assignment
+
+// The submission cell renders "<submitted> / <denominator>" as sibling text
+// nodes; read the row's textContent to assert the rendered ratio.
+const ratioText = () =>
+  screen.getByText("assignments.table.colSubmissions").closest("table")
+    ?.textContent ?? ""
+
+beforeEach(() => {
+  scores.mockReset()
+})
+
+afterEach(cleanup)
+
+describe("AssignmentsTable submission denominator", () => {
+  it("uses the student-role count as the denominator, not roster rows", () => {
+    scores.mockReturnValue({ data: { submissions: { hw1: [{}, {}, {}] } } })
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment()]}
+        studentCount={11}
+      />,
+    )
+    // 3 submitted out of 11 students (not the 14 roster rows).
+    expect(ratioText()).toContain("3 / 11")
+  })
+
+  it("clamps so a non-student submission can't push the ratio above 100%", () => {
+    // 5 submission repos but only 3 student-role members: display clamps to 3/3.
+    scores.mockReturnValue({
+      data: { submissions: { hw1: [{}, {}, {}, {}, {}] } },
+    })
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment()]}
+        studentCount={3}
+      />,
+    )
+    expect(ratioText()).toContain("3 / 3")
+    expect(ratioText()).not.toContain("5 / 3")
+  })
+
+  it("renders 0 / 0 without dividing by zero when there are no students", () => {
+    scores.mockReturnValue({ data: { submissions: { hw1: [{}] } } })
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment()]}
+        studentCount={0}
+      />,
+    )
+    expect(ratioText()).toContain("0 / 0")
+  })
+
+  it("leaves group assignments as a submitted count, no roster denominator", () => {
+    scores.mockReturnValue({ data: { submissions: { hw1: [{}, {}] } } })
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment({ mode: "group" })]}
+        studentCount={11}
+      />,
+    )
+    expect(ratioText()).toContain("assignments.table.groupsSubmitted")
+    expect(ratioText()).not.toContain("/ 11")
+  })
+})

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -17,7 +17,7 @@ import {
   type DeleteAssignmentInput,
 } from "@/api/mutations/assignments"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import type { Assignment, Student } from "@/types/classroom"
+import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 import { Button } from "@/components/ui"
 
@@ -161,14 +161,16 @@ const AssignmentsTable = ({
   org,
   classroom,
   assignments,
-  students = [],
+  studentCount,
   loading = false,
   archived = false,
 }: {
   org: string
   classroom: string
   assignments?: Assignment[]
-  students?: Student[]
+  // Authoritative student-role count (from useStudentCount), the denominator for
+  // the submission ratio. undefined while the count is still resolving.
+  studentCount?: number
   loading?: boolean
   // When archived, hide per-row mutating actions (edit/reuse/delete); viewing
   // stays available.
@@ -293,15 +295,22 @@ const AssignmentsTable = ({
                       )
                     }
 
+                    // Denominator is the authoritative student-role count, not
+                    // the roster row count (which includes staff). The
+                    // numerator is a repo-count from scores.json with no role
+                    // join, so a submission from a non-student repo could push
+                    // it past the denominator — clamp the displayed fraction and
+                    // the bar to 100% (KTD4). undefined count reads as 0 until it
+                    // resolves.
+                    const denominator = studentCount ?? 0
+                    const shown = Math.min(submitted, denominator)
                     return (
                       <>
-                        {submitted} / {students.length}{" "}
+                        {shown} / {denominator}{" "}
                         <progress
                           className="progress progress-info w-56"
                           value={
-                            students.length === 0
-                              ? 0
-                              : (submitted / students.length) * 100
+                            denominator === 0 ? 0 : (shown / denominator) * 100
                           }
                           max="100"
                         ></progress>

--- a/web/src/pages/classes/ClassroomCard.test.tsx
+++ b/web/src/pages/classes/ClassroomCard.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+// i18n as identity, but expand the count-bearing keys so we can assert the
+// number that actually reaches the label (interpolation is what matters here).
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: { count?: number }) =>
+        opts && "count" in opts ? `${key}:${opts.count}` : key,
+    }),
+  }
+})
+
+const studentCount = vi.fn()
+const assignments = vi.fn()
+
+vi.mock("@/hooks/useStudentCount", () => ({
+  default: (...a: unknown[]) => studentCount(...a),
+}))
+vi.mock("@/hooks/useGetClassAssignments", () => ({
+  default: (...a: unknown[]) => assignments(...a),
+}))
+
+import { ClassroomStats } from "./ClassroomCard"
+
+beforeEach(() => {
+  studentCount.mockReset()
+  assignments.mockReset()
+  // Assignments resolved with none, so the assignment stat never confuses the
+  // student-stat assertions below.
+  assignments.mockReturnValue({
+    data: { assignments: [] },
+    isPending: false,
+    isError: false,
+    error: null,
+  })
+})
+
+afterEach(cleanup)
+
+describe("ClassroomStats student count", () => {
+  it("renders the role-aware student count, not total roster rows", () => {
+    // 11 students even though the roster carries 14 rows (staff included).
+    studentCount.mockReturnValue({
+      studentCount: 11,
+      isLoading: false,
+      isError: false,
+    })
+    render(<ClassroomStats org="acme" slug="cs101" />)
+    expect(screen.getByText("classes.studentCount:11")).toBeTruthy()
+  })
+
+  it("renders the noStudents string when the count is zero", () => {
+    studentCount.mockReturnValue({
+      studentCount: 0,
+      isLoading: false,
+      isError: false,
+    })
+    render(<ClassroomStats org="acme" slug="cs101" />)
+    expect(screen.getByText("classes.noStudents")).toBeTruthy()
+  })
+
+  it("shows the loading label until the count resolves", () => {
+    studentCount.mockReturnValue({
+      studentCount: undefined,
+      isLoading: true,
+      isError: false,
+    })
+    render(<ClassroomStats org="acme" slug="cs101" />)
+    expect(screen.getByText("classes.card.loadingStudents")).toBeTruthy()
+  })
+
+  it("shows counts-unavailable on a role-count error, never a wrong 0", () => {
+    studentCount.mockReturnValue({
+      studentCount: undefined,
+      isLoading: false,
+      isError: true,
+    })
+    render(<ClassroomStats org="acme" slug="cs101" />)
+    expect(screen.getByText("classes.card.countsUnavailable")).toBeTruthy()
+    expect(screen.queryByText("classes.noStudents")).toBeNull()
+  })
+})

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -10,7 +10,7 @@ import { githubKeys } from "@/hooks/github/queries"
 import { GitHubAPIError } from "@/hooks/github/errors"
 import type { GitHubFileListing } from "@/hooks/github/types"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
-import useGetStudents from "@/hooks/useGetStudents"
+import useStudentCount from "@/hooks/useStudentCount"
 import {
   classroomDisplayName,
   type ClassroomSummary,
@@ -47,10 +47,11 @@ type ClassroomCardProps = {
 // no assignments.json); a non-404 error sets assignmentsError so the caller can
 // show "Counts unavailable".
 function useCardCounts(org: string, classroom: string) {
-  const { students, isLoading: studentsLoading } = useGetStudents(
-    org,
-    classroom,
-  )
+  const {
+    studentCount,
+    isLoading: studentsLoading,
+    isError: studentsError,
+  } = useStudentCount(org, classroom)
   const assignmentsQuery = useGetClassroomAssignments(org, classroom)
   // A missing assignments.json 404s (a brand-new classroom has none), which is
   // the normal zero case — not a failure. Only a non-404 error is "unavailable".
@@ -58,7 +59,10 @@ function useCardCounts(org: string, classroom: string) {
     assignmentsQuery.error instanceof GitHubAPIError &&
     assignmentsQuery.error.status === 404
   return {
-    studentCount: studentsLoading ? undefined : students.length,
+    // undefined while the authoritative team count resolves; on error the caller
+    // shows "counts unavailable" rather than a misleading 0 (R6).
+    studentCount: studentsLoading ? undefined : studentCount,
+    studentsError,
     // Optional-chain `assignments` too: jsonFileQuery does no shape validation,
     // so a file that parses without an `assignments` array must not throw.
     assignmentCount: assignmentsQuery.isPending
@@ -484,22 +488,22 @@ function ClassroomBadges({ summary }: { summary: ClassroomSummary }) {
   )
 }
 
-function ClassroomStats({ org, slug }: { org: string; slug: string }) {
+export function ClassroomStats({ org, slug }: { org: string; slug: string }) {
   const { t } = useTranslation()
-  const { studentCount, assignmentCount, assignmentsError } = useCardCounts(
-    org,
-    slug,
-  )
+  const { studentCount, studentsError, assignmentCount, assignmentsError } =
+    useCardCounts(org, slug)
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
       <CountStat
         icon={<UsersRound aria-hidden="true" className="size-4" />}
-        loading={studentCount === undefined}
+        loading={studentCount === undefined && !studentsError}
         loadingLabel={t("classes.card.loadingStudents")}
         label={
-          studentCount === 0
-            ? t("classes.noStudents")
-            : t("classes.studentCount", { count: studentCount ?? 0 })
+          studentsError
+            ? t("classes.card.countsUnavailable")
+            : studentCount === 0
+              ? t("classes.noStudents")
+              : t("classes.studentCount", { count: studentCount ?? 0 })
         }
       />
       <CountStat

--- a/web/src/pages/classes/ClassroomList.test.tsx
+++ b/web/src/pages/classes/ClassroomList.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, act } from "@testing-library/react"
+import type { ClassroomSummary } from "@/hooks/useClassroomSummaries"
+import type { GitHubFileListing } from "@/hooks/github/types"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return { ...actual, Link: ({ children }: { children?: unknown }) => children }
+})
+
+// Drive the sort key; changeSort is captured so a test can flip it at runtime.
+let sortKey = "name-asc"
+const changeSort = vi.fn((k: string) => {
+  sortKey = k
+})
+vi.mock("@/lib/listPrefs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/listPrefs")>()
+  return {
+    ...actual,
+    useListPrefsState: () => ({
+      viewMode: "grid",
+      sortKey,
+      changeView: () => {},
+      changeSort,
+    }),
+  }
+})
+
+const summaries = vi.fn()
+vi.mock("@/hooks/useClassroomSummaries", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/hooks/useClassroomSummaries")>()
+  return {
+    ...actual,
+    default: (...a: unknown[]) => summaries(...a),
+    // keep the real classroomDisplayName
+  }
+})
+
+// Cards render the display name so we can assert sort order from the DOM.
+vi.mock("@/pages/classes/ClassroomCard", () => ({
+  ClassroomCard: ({ summary }: { summary: ClassroomSummary }) => (
+    <div data-testid="card">{summary.name ?? summary.path}</div>
+  ),
+  ClassroomRow: ({ summary }: { summary: ClassroomSummary }) => (
+    <div data-testid="card">{summary.name ?? summary.path}</div>
+  ),
+}))
+
+// Capture the probe props (paths + onCount) instead of running real probes.
+let probeProps: {
+  paths: string[]
+  onCount: (path: string, count: number | undefined) => void
+} | null = null
+const probesRendered = vi.fn()
+vi.mock("@/pages/classes/StudentCountProbes", () => ({
+  StudentCountProbes: (props: {
+    paths: string[]
+    onCount: (path: string, count: number | undefined) => void
+  }) => {
+    probesRendered()
+    probeProps = props
+    return null
+  },
+}))
+
+import ClassroomList from "./ClassroomList"
+
+const summary = (over: Partial<ClassroomSummary>): ClassroomSummary => ({
+  path: over.path ?? "p",
+  name: over.name,
+  archived: over.archived ?? false,
+  loading: over.loading ?? false,
+  ...over,
+})
+const dir = (path: string): GitHubFileListing =>
+  ({ path, type: "dir", name: path }) as GitHubFileListing
+
+const cardNames = () =>
+  screen.getAllByTestId("card").map((el) => el.textContent)
+
+beforeEach(() => {
+  sortKey = "name-asc"
+  changeSort.mockClear()
+  probesRendered.mockClear()
+  probeProps = null
+  summaries.mockReturnValue([
+    summary({ path: "cs101", name: "Alpha" }),
+    summary({ path: "cs202", name: "Beta" }),
+    summary({ path: "cs303", name: "Gamma" }),
+  ])
+})
+
+afterEach(cleanup)
+
+describe("ClassroomList student-count sort", () => {
+  it("does not render probes (no fan-out) for a non-count sort", () => {
+    render(<ClassroomList org="acme" dirs={[dir("cs101")]} />)
+    expect(probesRendered).not.toHaveBeenCalled()
+  })
+
+  it("renders probes only for the filtered/visible classrooms when sorting by count", () => {
+    sortKey = "student-count"
+    // Beta is archived; the default "active" filter should exclude it, so no
+    // probe (and thus no team-membership fan-out) fires for it.
+    summaries.mockReturnValue([
+      summary({ path: "cs101", name: "Alpha" }),
+      summary({ path: "cs202", name: "Beta", archived: true }),
+      summary({ path: "cs303", name: "Gamma" }),
+    ])
+    render(
+      <ClassroomList
+        org="acme"
+        dirs={[dir("cs101"), dir("cs202"), dir("cs303")]}
+      />,
+    )
+    expect(probeProps?.paths).toEqual(["cs101", "cs303"])
+  })
+
+  it("orders by reported count high-to-low, pinning unknown counts to the bottom", () => {
+    sortKey = "student-count"
+    render(
+      <ClassroomList
+        org="acme"
+        dirs={[dir("cs101"), dir("cs202"), dir("cs303")]}
+      />,
+    )
+    // Report: Alpha=5, Beta=20, Gamma never reports (unknown -> bottom).
+    act(() => {
+      probeProps?.onCount("cs101", 5)
+      probeProps?.onCount("cs202", 20)
+    })
+    expect(cardNames()).toEqual(["Beta", "Alpha", "Gamma"])
+  })
+
+  it("keeps an errored classroom (undefined) in the unknown bucket, not as a real 0", () => {
+    sortKey = "student-count"
+    render(
+      <ClassroomList
+        org="acme"
+        dirs={[dir("cs101"), dir("cs202"), dir("cs303")]}
+      />,
+    )
+    // Alpha genuinely has 0 students; Gamma errored (reported undefined). A real
+    // 0 sorts among known counts (above unknown); the errored one drops to the
+    // bottom in name order.
+    act(() => {
+      probeProps?.onCount("cs101", 0)
+      probeProps?.onCount("cs202", 3)
+      probeProps?.onCount("cs303", undefined)
+    })
+    expect(cardNames()).toEqual(["Beta", "Alpha", "Gamma"])
+  })
+})

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/classroomListPrefs"
 import { useListPrefsState } from "@/lib/listPrefs"
 import { ClassroomCard, ClassroomRow } from "@/pages/classes/ClassroomCard"
+import { StudentCountProbes } from "@/pages/classes/StudentCountProbes"
 
 type ClassFilter = "active" | "archived" | "all"
 
@@ -42,10 +43,32 @@ const ClassroomList = ({
   const [termFilter, setTermFilter] = useState<string>("all")
   const [search, setSearch] = useState("")
 
-  const summaries = useClassroomSummaries(
-    org,
-    dirs,
-    sortKey === "student-count",
+  const summariesRaw = useClassroomSummaries(org, dirs)
+
+  // Role-aware student counts for the sort, collected via keyed probes (see
+  // StudentCountProbes) only while the student-count sort is active. Merge them
+  // onto the summaries so the sort and search/filter operate on one shape.
+  const sortByStudents = sortKey === "student-count"
+  const [studentCounts, setStudentCounts] = useState<
+    Record<string, number | undefined>
+  >({})
+  const handleStudentCount = useCallback(
+    (path: string, count: number | undefined) => {
+      setStudentCounts((prev) =>
+        prev[path] === count ? prev : { ...prev, [path]: count },
+      )
+    },
+    [],
+  )
+  const summaries = useMemo(
+    () =>
+      sortByStudents
+        ? summariesRaw.map((s) => ({
+            ...s,
+            studentCount: studentCounts[s.path],
+          }))
+        : summariesRaw,
+    [summariesRaw, sortByStudents, studentCounts],
   )
 
   // Distinct non-empty terms across the (resolved) classrooms, for the term
@@ -131,6 +154,13 @@ const ClassroomList = ({
 
   return (
     <div className="space-y-4">
+      {sortByStudents && (
+        <StudentCountProbes
+          org={org}
+          paths={dirs.map((d) => d.path)}
+          onCount={handleStudentCount}
+        />
+      )}
       <div className="flex flex-wrap items-center gap-2 rounded-xl border border-base-300 bg-base-100 p-2">
         <label className="input input-sm input-bordered flex min-w-48 flex-1 items-center gap-2">
           <Search aria-hidden="true" className="size-4 text-base-content/50" />

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -43,11 +43,12 @@ const ClassroomList = ({
   const [termFilter, setTermFilter] = useState<string>("all")
   const [search, setSearch] = useState("")
 
-  const summariesRaw = useClassroomSummaries(org, dirs)
+  const summaries = useClassroomSummaries(org, dirs)
 
   // Role-aware student counts for the sort, collected via keyed probes (see
-  // StudentCountProbes) only while the student-count sort is active. Merge them
-  // onto the summaries so the sort and search/filter operate on one shape.
+  // StudentCountProbes) only while the student-count sort is active. Kept in a
+  // path-keyed record and read by the comparator, so filtering/search operate on
+  // the base summary shape (which has no count) and only the sort consults it.
   const sortByStudents = sortKey === "student-count"
   const [studentCounts, setStudentCounts] = useState<
     Record<string, number | undefined>
@@ -59,16 +60,6 @@ const ClassroomList = ({
       )
     },
     [],
-  )
-  const summaries = useMemo(
-    () =>
-      sortByStudents
-        ? summariesRaw.map((s) => ({
-            ...s,
-            studentCount: studentCounts[s.path],
-          }))
-        : summariesRaw,
-    [summariesRaw, sortByStudents, studentCounts],
   )
 
   // Distinct non-empty terms across the (resolved) classrooms, for the term
@@ -116,11 +107,12 @@ const ClassroomList = ({
           (a, b) => (a.term ?? "").localeCompare(b.term ?? "") || byName(a, b),
         )
       case "student-count":
-        // Known counts high-to-low; unresolved/unknown pinned to the bottom in
-        // stable name order so rows don't reshuffle as rosters resolve.
+        // Known counts high-to-low; unresolved/unknown (or errored, reported as
+        // undefined by the probe) pinned to the bottom in stable name order so
+        // rows don't reshuffle as rosters resolve.
         return list.sort((a, b) => {
-          const ca = a.studentCount
-          const cb = b.studentCount
+          const ca = studentCounts[a.path]
+          const cb = studentCounts[b.path]
           if (ca !== undefined && cb !== undefined)
             return cb - ca || byName(a, b)
           if (ca !== undefined) return -1
@@ -131,7 +123,7 @@ const ClassroomList = ({
       default:
         return list.sort(byName)
     }
-  }, [filtered, sortKey])
+  }, [filtered, sortKey, studentCounts])
 
   // While a card is "busy" (its menu or a destructive confirm modal is open),
   // freeze the rendered order so an async re-sort (e.g. a roster resolving under
@@ -157,7 +149,7 @@ const ClassroomList = ({
       {sortByStudents && (
         <StudentCountProbes
           org={org}
-          paths={dirs.map((d) => d.path)}
+          paths={filtered.map((s) => s.path)}
           onCount={handleStudentCount}
         />
       )}

--- a/web/src/pages/classes/StudentCountProbes.test.tsx
+++ b/web/src/pages/classes/StudentCountProbes.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, cleanup, waitFor } from "@testing-library/react"
+
+const studentCount = vi.fn()
+vi.mock("@/hooks/useStudentCount", () => ({
+  default: (...a: [string, string]) => studentCount(...a),
+}))
+
+import { StudentCountProbes } from "./StudentCountProbes"
+
+beforeEach(() => {
+  studentCount.mockReset()
+})
+
+afterEach(cleanup)
+
+describe("StudentCountProbes", () => {
+  it("reports the role-aware count per classroom via onCount", async () => {
+    // Distinct role-aware counts per path (not roster row counts).
+    studentCount.mockImplementation((_org: string, path: string) => ({
+      studentCount: path === "cs101" ? 11 : 3,
+      isLoading: false,
+      isError: false,
+    }))
+    const onCount = vi.fn()
+
+    render(
+      <StudentCountProbes
+        org="acme"
+        paths={["cs101", "cs202"]}
+        onCount={onCount}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(onCount).toHaveBeenCalledWith("cs101", 11)
+      expect(onCount).toHaveBeenCalledWith("cs202", 3)
+    })
+  })
+
+  it("passes each classroom path through to useStudentCount", () => {
+    studentCount.mockReturnValue({
+      studentCount: 0,
+      isLoading: false,
+      isError: false,
+    })
+    render(
+      <StudentCountProbes org="acme" paths={["cs101"]} onCount={() => {}} />,
+    )
+    expect(studentCount).toHaveBeenCalledWith("acme", "cs101")
+  })
+
+  it("renders no probes (no fan-out) when there are no paths", () => {
+    render(<StudentCountProbes org="acme" paths={[]} onCount={() => {}} />)
+    expect(studentCount).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/pages/classes/StudentCountProbes.test.tsx
+++ b/web/src/pages/classes/StudentCountProbes.test.tsx
@@ -55,4 +55,38 @@ describe("StudentCountProbes", () => {
     render(<StudentCountProbes org="acme" paths={[]} onCount={() => {}} />)
     expect(studentCount).not.toHaveBeenCalled()
   })
+
+  it("reports undefined while the count is loading", async () => {
+    studentCount.mockReturnValue({
+      studentCount: undefined,
+      isLoading: true,
+      isError: false,
+    })
+    const onCount = vi.fn()
+    render(
+      <StudentCountProbes org="acme" paths={["cs101"]} onCount={onCount} />,
+    )
+    await waitFor(() =>
+      expect(onCount).toHaveBeenCalledWith("cs101", undefined),
+    )
+  })
+
+  it("reports undefined on error, never the errored 0, so the sort treats it as unknown", async () => {
+    // A settled team-membership error resolves studentCount to 0 with
+    // isError:true; the probe must NOT report that 0 (it would sort as a real
+    // zero-student classroom instead of pinning to the unknown bucket).
+    studentCount.mockReturnValue({
+      studentCount: 0,
+      isLoading: false,
+      isError: true,
+    })
+    const onCount = vi.fn()
+    render(
+      <StudentCountProbes org="acme" paths={["cs101"]} onCount={onCount} />,
+    )
+    await waitFor(() =>
+      expect(onCount).toHaveBeenCalledWith("cs101", undefined),
+    )
+    expect(onCount).not.toHaveBeenCalledWith("cs101", 0)
+  })
 })

--- a/web/src/pages/classes/StudentCountProbes.tsx
+++ b/web/src/pages/classes/StudentCountProbes.tsx
@@ -1,0 +1,48 @@
+import { memo, useEffect } from "react"
+
+import useStudentCount from "@/hooks/useStudentCount"
+
+// Role-aware student counts for the classroom-list sort, collected without
+// violating the Rules of Hooks. useStudentCount can't be called in a loop inside
+// useClassroomSummaries because the classroom list grows/shrinks (create/delete)
+// without remounting, which would change the hook count between renders. Instead
+// each classroom gets a keyed probe component: React mounts/unmounts a whole
+// component as the list changes, so each probe calls its hooks exactly once.
+//
+// Rendered only when the student-count sort is active (the caller gates it), so
+// the team-membership fan-out doesn't happen otherwise. Probes render nothing.
+
+const StudentCountProbe = memo(function StudentCountProbe({
+  org,
+  path,
+  onCount,
+}: {
+  org: string
+  path: string
+  onCount: (path: string, count: number | undefined) => void
+}) {
+  const { studentCount } = useStudentCount(org, path)
+  useEffect(() => {
+    onCount(path, studentCount)
+  }, [path, studentCount, onCount])
+  return null
+})
+
+// Mounts one probe per classroom directory. onCount fires as each resolves.
+export function StudentCountProbes({
+  org,
+  paths,
+  onCount,
+}: {
+  org: string
+  paths: string[]
+  onCount: (path: string, count: number | undefined) => void
+}) {
+  return (
+    <>
+      {paths.map((path) => (
+        <StudentCountProbe key={path} org={org} path={path} onCount={onCount} />
+      ))}
+    </>
+  )
+}

--- a/web/src/pages/classes/StudentCountProbes.tsx
+++ b/web/src/pages/classes/StudentCountProbes.tsx
@@ -21,10 +21,13 @@ const StudentCountProbe = memo(function StudentCountProbe({
   path: string
   onCount: (path: string, count: number | undefined) => void
 }) {
-  const { studentCount } = useStudentCount(org, path)
+  const { studentCount, isError } = useStudentCount(org, path)
   useEffect(() => {
-    onCount(path, studentCount)
-  }, [path, studentCount, onCount])
+    // Report undefined on error so the sort pins the classroom to the unknown
+    // bucket (bottom) rather than treating a failed read as an authoritative 0,
+    // matching the card/header degradation (R6).
+    onCount(path, isError ? undefined : studentCount)
+  }, [path, studentCount, isError, onCount])
   return null
 })
 


### PR DESCRIPTION
## Summary

Fixes #240. The "My Classrooms" card (and other surfaces) showed a **Students** count that included instructors and TAs, because it read the full `roster.csv` row count and roster.csv now carries staff rows. This switches every classroom student count to derive **authoritatively from GitHub team membership** via a new `useStudentCount` hook — the same `roleCounts.student` source the Roster page already uses — so staff are excluded and the count is correct even when the roster.csv `role` column is stale or absent.

Four surfaces migrated:

- **My Classrooms card** stat (the issue) — `ClassroomCard`
- **"Sort by student count"** ordering — `ClassroomList` via keyed count probes
- **Assignments page header** "Students" subtitle — `AssignmentsPage`
- **Assignments table** submission-ratio denominator — `AssignmentsTable`

## Notes / decisions

- **One source (repo convention):** all counts flow through `useStudentCount` / `roleCounts.student`; no second role-counting path was introduced.
- **Sort counts via keyed probes:** the classroom list can grow/shrink without remounting, so calling `useStudentCount` in a loop would break the Rules of Hooks. Counts are collected by keyed `StudentCountProbe` components mounted only while the student-count sort is active, and only for the **filtered/visible** classrooms so the team-membership fan-out doesn't cover hidden rows.
- **Submission ratio clamp:** the submission numerator is a repo-count from `scores.json` with no role join, so the ratio is clamped to the student denominator rather than letting a non-student repo push it past 100%.
- **Graceful error UX (R6):** on a role-count read error the card shows "counts unavailable", the Assignments header shows a placeholder, and the sort pins the classroom to the unknown bucket — never a wrong "0".

## Review fixes (post code review)

A code review pass surfaced findings that are now addressed:

- **#1** the sort probe dropped `isError` and would have sorted a failed-to-load classroom as a real `0`; it now reports `undefined` on error (unknown bucket).
- **#7** the sort probed every classroom dir; it now probes only the filtered set, cutting the fan-out on large/filtered lists.
- **#5** `studentCount` was split-owned across the summaries hook and the list; the comparator now reads counts directly and the field is off the base type.
- **#4** fixed a stale comment referencing a symbol that never existed.
- **#2 / #3** added `ClassroomList` tests (probe gating/scoping, count ordering, errored→unknown) and probe loading/error-emission tests.

## Test plan

- [x] `useStudentCount` unit tests (role-aware count, dual-role once, loading, error, staff-only 0)
- [x] `ClassroomCard` / `ClassroomList` / `AssignmentsPage` / `AssignmentsTable` / `StudentCountProbes` / `useClassroomSummaries` tests
- [x] Full suite green: 1440 tests / 124 files
- [x] `tsc -b`, `eslint` (0 errors), `prettier --check` all green
- [ ] Manual: card, Assignments header, and Roster page show the same student number for a classroom whose roster includes instructors/TAs

Plan: `docs/plans/2026-07-13-001-fix-student-count-role-aware-plan.md`.