### PR TITLE
fix: keep classroom creator on the instructor team only

### DIFF
--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -217,11 +217,13 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 		return err
 	}
 
-	// GitHub auto-adds the authenticated creator as a maintainer of every team
-	// the create POST makes, so the acting teacher lands on the students and both
-	// staff teams — but their only intended role is instructor. Drop them from
-	// the students and TA teams so the team-driven roster doesn't count the owner
-	// as an enrolled student/TA. Best-effort, mirroring the web.
+	// The acting teacher must never hold a student or TA role — mixed roles
+	// aren't allowed, and the team-driven roster would otherwise count the owner
+	// as an enrolled student/TA. GitHub silently adds the creator as a maintainer
+	// of every team the create POST makes, so drop them from the students and TA
+	// teams unconditionally (not gated on created-vs-adopted: an owner on an
+	// adopted students/TA team is the same mixed-role state we clear). Best-effort,
+	// mirroring the web.
 	dropCreatorFromNonInstructorTeams(client, errOut, org, login, team.Slug, staffTeams)
 
 	files, err := classroomScaffold(org, shortName, name, term, secret, nil, nil, &team, staffTeams)
@@ -293,11 +295,13 @@ func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName st
 }
 
 // dropCreatorFromNonInstructorTeams removes the acting teacher from the students
-// team and the TA team, undoing GitHub's implicit "creator becomes maintainer"
-// grant on team create so the owner's only role is instructor. Best-effort and
-// idempotent (RemoveTeamMembership treats 404 as success): a failure warns but
-// leaves the owner harmlessly on the team. A no-op when the login couldn't be
-// resolved.
+// team and the TA team so the owner's only role is instructor — mixed roles
+// aren't allowed. Unconditional by design: GitHub auto-adds the creator on teams
+// it creates, and an owner already sitting on an adopted students/TA team is the
+// same mixed-role state we clear, so neither case should be preserved.
+// Best-effort and idempotent (RemoveTeamMembership treats 404 as success): a
+// failure warns but leaves the owner on the team, where the roster's per-role
+// badges surface it. A no-op when the login couldn't be resolved.
 func dropCreatorFromNonInstructorTeams(client githubapi.Client, errOut io.Writer, org, login, studentsSlug string, staffTeams *configrepo.StaffTeamsRef) {
 	if login == "" {
 		return

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -212,10 +212,17 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	// Create (or adopt) the staff teams (instructor, ta), grant each write on
 	// the config repo, and seed the acting teacher as instructor maintainer,
 	// mirroring the web.
-	staffTeams, err := seedStaffTeams(client, errOut, org, shortName)
+	staffTeams, login, err := seedStaffTeams(client, errOut, org, shortName)
 	if err != nil {
 		return err
 	}
+
+	// GitHub auto-adds the authenticated creator as a maintainer of every team
+	// the create POST makes, so the acting teacher lands on the students and both
+	// staff teams — but their only intended role is instructor. Drop them from
+	// the students and TA teams so the team-driven roster doesn't count the owner
+	// as an enrolled student/TA. Best-effort, mirroring the web.
+	dropCreatorFromNonInstructorTeams(client, errOut, org, login, team.Slug, staffTeams)
 
 	files, err := classroomScaffold(org, shortName, name, term, secret, nil, nil, &team, staffTeams)
 	if err != nil {
@@ -258,29 +265,56 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 
 // seedStaffTeams creates (or adopts) the instructor + ta teams, grants each
 // write on the config repo, and adds the acting teacher as instructor
-// maintainer — shared by `classroom add` and `classroom migrate`. The
-// maintainer add is best-effort: a CurrentUser/membership failure warns but
-// doesn't fail creation (the teacher can self-add via the web).
-func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName string) (*configrepo.StaffTeamsRef, error) {
+// maintainer — shared by `classroom add` and `classroom migrate`. Returns the
+// resolved acting login (empty when it couldn't be read) so the caller can drop
+// that same user from the non-instructor teams. The maintainer add is
+// best-effort: a CurrentUser/membership failure warns but doesn't fail creation
+// (the teacher can self-add via the web).
+func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName string) (*configrepo.StaffTeamsRef, string, error) {
 	staffTeams, err := configrepo.EnsureStaffTeams(client, org, shortName)
 	if err != nil {
-		return nil, fmt.Errorf("create staff teams: %w", err)
+		return nil, "", fmt.Errorf("create staff teams: %w", err)
 	}
 	if staffTeams.Instructor == nil {
-		return staffTeams, nil
+		return staffTeams, "", nil
 	}
 	login, _, uerr := githubapi.CurrentUser(client)
 	if uerr != nil || login == "" {
 		// Surface the skip so a silent CurrentUser failure isn't invisible.
 		_, _ = fmt.Fprintf(errOut, "Warning: created the instructor team but couldn't resolve your GitHub login to add you (%v); add yourself at https://github.com/orgs/%s/teams/%s.\n",
 			uerr, org, staffTeams.Instructor.Slug)
-		return staffTeams, nil
+		return staffTeams, "", nil
 	}
 	if merr := configrepo.AddTeamMembershipWithRole(client, org, staffTeams.Instructor.Slug, login, configrepo.TeamMaintainer); merr != nil {
 		_, _ = fmt.Fprintf(errOut, "Warning: created the instructor team but couldn't add you (%s) to it (%v); add yourself at https://github.com/orgs/%s/teams/%s.\n",
 			login, merr, org, staffTeams.Instructor.Slug)
 	}
-	return staffTeams, nil
+	return staffTeams, login, nil
+}
+
+// dropCreatorFromNonInstructorTeams removes the acting teacher from the students
+// team and the TA team, undoing GitHub's implicit "creator becomes maintainer"
+// grant on team create so the owner's only role is instructor. Best-effort and
+// idempotent (RemoveTeamMembership treats 404 as success): a failure warns but
+// leaves the owner harmlessly on the team. A no-op when the login couldn't be
+// resolved.
+func dropCreatorFromNonInstructorTeams(client githubapi.Client, errOut io.Writer, org, login, studentsSlug string, staffTeams *configrepo.StaffTeamsRef) {
+	if login == "" {
+		return
+	}
+	slugs := []string{studentsSlug}
+	if staffTeams != nil && staffTeams.TA != nil {
+		slugs = append(slugs, staffTeams.TA.Slug)
+	}
+	for _, slug := range slugs {
+		if slug == "" {
+			continue
+		}
+		if err := configrepo.RemoveTeamMembership(client, org, slug, login); err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: couldn't remove you (%s) from team %s (%v); you were auto-added when it was created — remove yourself at https://github.com/orgs/%s/teams/%s if you don't want to appear on its roster.\n",
+				login, slug, err, org, slug)
+		}
+	}
 }
 
 // classroomSummary is the per-classroom view for `classroom list --json`: the

--- a/cli/gh-teacher/internal/classroom/classroom_cmd_test.go
+++ b/cli/gh-teacher/internal/classroom/classroom_cmd_test.go
@@ -491,7 +491,7 @@ func TestSeedStaffTeams_MaintainerAddFailureIsBestEffort(t *testing.T) {
 	client := githubtest.NewTestClient(t, server)
 
 	var errOut bytes.Buffer
-	refs, err := seedStaffTeams(client, &errOut, "o", "cs-principles")
+	refs, _, err := seedStaffTeams(client, &errOut, "o", "cs-principles")
 	if err != nil {
 		t.Fatalf("seedStaffTeams must not fail on a best-effort maintainer-add error: %v", err)
 	}
@@ -500,6 +500,112 @@ func TestSeedStaffTeams_MaintainerAddFailureIsBestEffort(t *testing.T) {
 	}
 	if !strings.Contains(errOut.String(), "couldn't add you") {
 		t.Errorf("stderr = %q, want a best-effort maintainer-add warning", errOut.String())
+	}
+}
+
+// TestDropCreatorFromNonInstructorTeams_RemovesStudentsAndTA pins that the
+// creator is dropped from the students and TA teams (undoing GitHub's implicit
+// creator-as-maintainer grant on team create) but NEVER from the instructor
+// team — the owner's only intended role.
+func TestDropCreatorFromNonInstructorTeams_RemovesStudentsAndTA(t *testing.T) {
+	var deleted []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/orgs/o/teams/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/memberships/") {
+			deleted = append(deleted, r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	staffTeams := &configrepo.StaffTeamsRef{
+		Instructor: &configrepo.TeamRef{ID: 1, Slug: "classroom50-cs-principles-instructor"},
+		TA:         &configrepo.TeamRef{ID: 2, Slug: "classroom50-cs-principles-ta"},
+	}
+
+	var errOut bytes.Buffer
+	dropCreatorFromNonInstructorTeams(client, &errOut, "o", "teacher", "classroom50-cs-principles", staffTeams)
+
+	want := []string{
+		"/orgs/o/teams/classroom50-cs-principles/memberships/teacher",
+		"/orgs/o/teams/classroom50-cs-principles-ta/memberships/teacher",
+	}
+	if len(deleted) != len(want) {
+		t.Fatalf("DELETEs = %v, want %v", deleted, want)
+	}
+	for _, w := range want {
+		found := false
+		for _, d := range deleted {
+			if d == w {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing DELETE %s (got %v)", w, deleted)
+		}
+	}
+	for _, d := range deleted {
+		if strings.Contains(d, "-instructor/") {
+			t.Errorf("must not drop the creator from the instructor team, got %s", d)
+		}
+	}
+}
+
+// TestDropCreatorFromNonInstructorTeams_BestEffort pins that a removal failure
+// warns but does not panic/fail — the owner is left harmlessly on the team.
+func TestDropCreatorFromNonInstructorTeams_BestEffort(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/orgs/o/teams/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/memberships/") {
+			http.Error(w, `{"message":"forbidden"}`, http.StatusForbidden)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	staffTeams := &configrepo.StaffTeamsRef{
+		Instructor: &configrepo.TeamRef{ID: 1, Slug: "classroom50-cs-principles-instructor"},
+		TA:         &configrepo.TeamRef{ID: 2, Slug: "classroom50-cs-principles-ta"},
+	}
+
+	var errOut bytes.Buffer
+	dropCreatorFromNonInstructorTeams(client, &errOut, "o", "teacher", "classroom50-cs-principles", staffTeams)
+
+	if !strings.Contains(errOut.String(), "couldn't remove you") {
+		t.Errorf("stderr = %q, want a best-effort removal warning", errOut.String())
+	}
+}
+
+// TestDropCreatorFromNonInstructorTeams_NoLogin pins that an unresolved login
+// (empty string) is a no-op — nothing to remove, no request.
+func TestDropCreatorFromNonInstructorTeams_NoLogin(t *testing.T) {
+	var hit bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	staffTeams := &configrepo.StaffTeamsRef{
+		Instructor: &configrepo.TeamRef{ID: 1, Slug: "classroom50-cs-principles-instructor"},
+		TA:         &configrepo.TeamRef{ID: 2, Slug: "classroom50-cs-principles-ta"},
+	}
+
+	var errOut bytes.Buffer
+	dropCreatorFromNonInstructorTeams(client, &errOut, "o", "", "classroom50-cs-principles", staffTeams)
+
+	if hit {
+		t.Errorf("an empty login must make no request, but the server was hit")
 	}
 }
 

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -235,10 +235,14 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 
 	// Create (or adopt) staff teams + config-repo write grant + instructor
 	// seed, same as `classroom add`.
-	staffTeams, err := seedStaffTeams(client, errOut, plan.TargetOrg, plan.ShortName)
+	staffTeams, login, err := seedStaffTeams(client, errOut, plan.TargetOrg, plan.ShortName)
 	if err != nil {
 		return err
 	}
+
+	// Undo GitHub's implicit creator-as-maintainer grant on the students + TA
+	// teams so the owner's only role is instructor, same as `classroom add`.
+	dropCreatorFromNonInstructorTeams(client, errOut, plan.TargetOrg, login, team.Slug, staffTeams)
 
 	build := func(parentSHA string) (map[string]string, error) {
 		exists, err := configrepo.ContentsExists(client, plan.TargetOrg, configrepo.ConfigRepoName, plan.ShortName, parentSHA)

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -240,8 +240,8 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 		return err
 	}
 
-	// Undo GitHub's implicit creator-as-maintainer grant on the students + TA
-	// teams so the owner's only role is instructor, same as `classroom add`.
+	// Drop the acting teacher from the students + TA teams so their only role is
+	// instructor — mixed roles aren't allowed, same as `classroom add`.
 	dropCreatorFromNonInstructorTeams(client, errOut, plan.TargetOrg, login, team.Slug, staffTeams)
 
 	build := func(parentSHA string) (map[string]string, error) {

--- a/cli/gh-teacher/internal/classroom/migrate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_test.go
@@ -611,6 +611,12 @@ func (s *migrateE2EState) dispatch(t *testing.T, w http.ResponseWriter, r *http.
 		w.WriteHeader(http.StatusOK)
 		writeJSON(t, w, map[string]any{"state": "active"})
 
+	// Target-side: membership DELETE — dropping the creator from the
+	// students + TA teams (undoing GitHub's implicit creator-as-maintainer
+	// grant on team create). Idempotent; 204 = removed.
+	case strings.HasPrefix(path, "/orgs/"+s.targetOrg()+"/teams/") && strings.Contains(path, "/memberships/") && r.Method == http.MethodDelete:
+		w.WriteHeader(http.StatusNoContent)
+
 	default:
 		t.Errorf("unexpected path %q method %s", path, r.Method)
 		http.NotFound(w, r)

--- a/cli/gh-teacher/internal/classroom/migrate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -251,6 +253,14 @@ func TestRunMigrate_NonDryRun_HappyPath(t *testing.T) {
 		}
 	}
 
+	// The creator is dropped from the students + TA teams (mixed roles aren't
+	// allowed) but NEVER the instructor team — the owner's only role.
+	sort.Strings(state.membershipDeleted)
+	wantDropped := []string{"classroom50-classroom50test", "classroom50-classroom50test-ta"}
+	if !reflect.DeepEqual(state.membershipDeleted, wantDropped) {
+		t.Errorf("membership DELETEs = %v, want %v (students + ta, never instructor)", state.membershipDeleted, wantDropped)
+	}
+
 	// Final stdout line is parseable; commit SHA appears.
 	if !strings.Contains(stdout.String(), "cs50-fall-2026/classroom50/classroom50test: migrated from classroom 95884") {
 		t.Errorf("stdout missing parseable migration result line:\n%s", stdout.String())
@@ -389,11 +399,12 @@ type migrateE2EState struct {
 	existingDirs     map[string]bool // <short-name> → already exists in target classroom50 (default false)
 
 	// Captured side-effects.
-	generated        map[string]bool   // "owner/repo" → was generated
-	markedAsTemplate map[string]bool   // "owner/repo" → got is_template PATCH
-	uploadedFiles    map[string]string // git tree path → blob content
-	commitsCreated   int
-	teamsCreated     int // count of POST /orgs/{org}/teams (students + staff)
+	generated         map[string]bool   // "owner/repo" → was generated
+	markedAsTemplate  map[string]bool   // "owner/repo" → got is_template PATCH
+	uploadedFiles     map[string]string // git tree path → blob content
+	commitsCreated    int
+	teamsCreated      int      // count of POST /orgs/{org}/teams (students + staff)
+	membershipDeleted []string // slugs that received a DELETE .../memberships/{user}
 
 	parentSHA     string
 	parentTreeSHA string
@@ -612,9 +623,14 @@ func (s *migrateE2EState) dispatch(t *testing.T, w http.ResponseWriter, r *http.
 		writeJSON(t, w, map[string]any{"state": "active"})
 
 	// Target-side: membership DELETE — dropping the creator from the
-	// students + TA teams (undoing GitHub's implicit creator-as-maintainer
-	// grant on team create). Idempotent; 204 = removed.
+	// students + TA teams (they must not hold a student/TA role). Idempotent;
+	// 204 = removed. Record the targeted slug so the test can assert WHICH
+	// teams are dropped (students + ta, never instructor).
 	case strings.HasPrefix(path, "/orgs/"+s.targetOrg()+"/teams/") && strings.Contains(path, "/memberships/") && r.Method == http.MethodDelete:
+		if slug, _, ok := strings.Cut(strings.TrimPrefix(path, "/orgs/"+s.targetOrg()+"/teams/"), "/memberships/"); ok {
+			// dispatch runs under s.mu (see handler), so append directly.
+			s.membershipDeleted = append(s.membershipDeleted, slug)
+		}
 		w.WriteHeader(http.StatusNoContent)
 
 	default:

--- a/web/src/api/mutations/classrooms.test.ts
+++ b/web/src/api/mutations/classrooms.test.ts
@@ -120,6 +120,9 @@ describe("createClassroomFiles creator team cleanup", () => {
   const routingClient = (opts: {
     onDelete: (path: string) => void
     deleteThrows?: boolean
+    // When true, the students-team create POST returns 422 so the flow adopts a
+    // pre-existing team (created: false) instead of creating it.
+    adoptStudentsTeam?: boolean
   }): GitHubClient => {
     const request = vi.fn(
       async (path: string, options?: GitHubRequestOptions) => {
@@ -130,9 +133,20 @@ describe("createClassroomFiles creator team cleanup", () => {
           if (opts.deleteThrows) throw apiError(403)
           return undefined
         }
-        // Team create/adopt -> { id, slug } derived from the POSTed name.
+        // Adopt path: the students-team GET returns the pre-existing secret team.
+        if (
+          method === "GET" &&
+          /\/orgs\/[^/]+\/teams\/classroom50-cs101$/.test(path)
+        ) {
+          return { id: 7, slug: "classroom50-cs101", privacy: "secret" }
+        }
+        // Team create/adopt -> { id, slug } derived from the POSTed name. When
+        // adoptStudentsTeam is set, the students team POST 422s (already exists).
         if (method === "POST" && /\/orgs\/[^/]+\/teams$/.test(path)) {
           const name = (options?.body as { name?: string })?.name ?? "team"
+          if (opts.adoptStudentsTeam && name === "classroom50-cs101") {
+            throw apiError(422)
+          }
           return { id: 1, slug: name }
         }
         // Config-repo read (getConfigRepoBranch).
@@ -211,5 +225,26 @@ describe("createClassroomFiles creator team cleanup", () => {
     await createClassroomFiles(client, { ...input, creator: undefined })
 
     expect(deleted).toHaveLength(0)
+  })
+
+  it("still drops the creator from an ADOPTED students team (mixed roles aren't allowed)", async () => {
+    // The students team already exists (POST 422 -> adopt). Mixed roles are
+    // disallowed, so the creator must be dropped regardless of whether we
+    // created or adopted the team — the drop is intentionally not gated on the
+    // created flag.
+    const deleted: string[] = []
+    const client = routingClient({
+      onDelete: (p) => deleted.push(p),
+      adoptStudentsTeam: true,
+    })
+
+    await createClassroomFiles(client, input)
+
+    expect(deleted).toContain(
+      "/orgs/acme/teams/classroom50-cs101/memberships/prof",
+    )
+    expect(deleted).toContain(
+      "/orgs/acme/teams/classroom50-cs101-ta/memberships/prof",
+    )
   })
 })

--- a/web/src/api/mutations/classrooms.test.ts
+++ b/web/src/api/mutations/classrooms.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { assertClassroomNotArchived } from "./classrooms"
+import { assertClassroomNotArchived, createClassroomFiles } from "./classrooms"
 import { GitHubAPIError, type GitHubRateLimit } from "@/hooks/github/errors"
-import type { GitHubClient } from "@/hooks/github/client"
+import type { GitHubClient, GitHubRequestOptions } from "@/hooks/github/client"
 
 // assertClassroomNotArchived is the authoritative write-path guard fanned out
 // across ~11 assignment + roster mutations, so its branch matrix is
@@ -102,5 +102,114 @@ describe("assertClassroomNotArchived", () => {
       assertClassroomNotArchived(client, "acme", "cs101"),
     ).rejects.toThrow(/couldn't verify/i)
     expect(client.requestRaw).toHaveBeenCalledTimes(2)
+  })
+})
+
+// createClassroomFiles provisions three secret teams (students, instructor, ta).
+// GitHub auto-adds the authenticated creator as a maintainer of every team it
+// creates, so the flow must drop the creator from the students + ta teams
+// (leaving them only on instructor) — else the team-driven roster counts the
+// owner as an enrolled student/TA. These tests route client.request by
+// path+method, record the membership DELETEs, and assert exactly which teams the
+// creator is removed from.
+describe("createClassroomFiles creator team cleanup", () => {
+  // A routing client that satisfies the whole create flow (team create + grant +
+  // membership PUT/DELETE, then the git scaffolding calls). `onDelete` records
+  // each membership DELETE; `deleteThrows` makes every DELETE reject so the
+  // best-effort path can be exercised.
+  const routingClient = (opts: {
+    onDelete: (path: string) => void
+    deleteThrows?: boolean
+  }): GitHubClient => {
+    const request = vi.fn(
+      async (path: string, options?: GitHubRequestOptions) => {
+        const method = options?.method ?? "GET"
+
+        if (method === "DELETE" && path.includes("/memberships/")) {
+          opts.onDelete(path)
+          if (opts.deleteThrows) throw apiError(403)
+          return undefined
+        }
+        // Team create/adopt -> { id, slug } derived from the POSTed name.
+        if (method === "POST" && /\/orgs\/[^/]+\/teams$/.test(path)) {
+          const name = (options?.body as { name?: string })?.name ?? "team"
+          return { id: 1, slug: name }
+        }
+        // Config-repo read (getConfigRepoBranch).
+        if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(path)) {
+          return { default_branch: "main" }
+        }
+        // Branch ref (getBranchRef).
+        if (path.includes("/git/ref/heads/")) {
+          return { object: { sha: "base-sha" } }
+        }
+        // Commit (getCommit).
+        if (path.includes("/git/commits/")) {
+          return { tree: { sha: "tree-sha" } }
+        }
+        // createTree.
+        if (method === "POST" && path.endsWith("/git/trees")) {
+          return { sha: "new-tree-sha" }
+        }
+        // createCommit.
+        if (method === "POST" && path.endsWith("/git/commits")) {
+          return { sha: "new-commit-sha" }
+        }
+        // updateRef.
+        if (method === "PATCH" && path.includes("/git/refs/heads/")) {
+          return { object: { sha: "new-commit-sha" } }
+        }
+        // Repo-grant PUT, instructor membership PUT, and anything else.
+        return undefined
+      },
+    )
+    return { request, requestRaw: vi.fn() } as unknown as GitHubClient
+  }
+
+  const input = {
+    org: "acme",
+    classroom: "cs101",
+    term: "2026",
+    creator: "prof",
+  }
+
+  it("removes the creator from the students and ta teams but never instructor", async () => {
+    const deleted: string[] = []
+    const client = routingClient({ onDelete: (p) => deleted.push(p) })
+
+    await createClassroomFiles(client, input)
+
+    expect(deleted).toContain(
+      "/orgs/acme/teams/classroom50-cs101/memberships/prof",
+    )
+    expect(deleted).toContain(
+      "/orgs/acme/teams/classroom50-cs101-ta/memberships/prof",
+    )
+    expect(deleted).not.toContain(
+      "/orgs/acme/teams/classroom50-cs101-instructor/memberships/prof",
+    )
+  })
+
+  it("still completes when a creator-drop DELETE fails (best-effort)", async () => {
+    const deleted: string[] = []
+    const client = routingClient({
+      onDelete: (p) => deleted.push(p),
+      deleteThrows: true,
+    })
+
+    await expect(createClassroomFiles(client, input)).resolves.toMatchObject({
+      newCommitSha: "new-commit-sha",
+    })
+    // Both drops were attempted even though each threw.
+    expect(deleted).toHaveLength(2)
+  })
+
+  it("does not attempt any creator drop when no creator is supplied", async () => {
+    const deleted: string[] = []
+    const client = routingClient({ onDelete: (p) => deleted.push(p) })
+
+    await createClassroomFiles(client, { ...input, creator: undefined })
+
+    expect(deleted).toHaveLength(0)
   })
 })

--- a/web/src/api/mutations/classrooms.ts
+++ b/web/src/api/mutations/classrooms.ts
@@ -17,6 +17,7 @@ import {
   ensureClassroomTeam,
   ensureStaffTeams,
   addUserToTeam,
+  removeUserFromTeam,
   isDeletableClassroomTeamRef,
   isNonFastForward,
   updateRef,
@@ -79,6 +80,35 @@ export async function createClassroomFiles(
         creator: input.creator,
       })
       // Non-fatal; surface nothing — the classroom still scaffolds.
+    }
+  }
+
+  // GitHub auto-adds the authenticated creator as a maintainer of every team the
+  // create-team POST makes, so the creator lands on the students and both staff
+  // teams — but their only intended role is instructor. Drop them from the
+  // students and TA teams so the team-driven roster doesn't count the owner as an
+  // enrolled student/TA. Best-effort and idempotent (404 = already absent); a
+  // failure just leaves them harmlessly on a team.
+  if (input.creator) {
+    const dropSlugs = [team.slug, teams.ta?.slug].filter(
+      (slug): slug is string => Boolean(slug),
+    )
+    for (const teamSlug of dropSlugs) {
+      try {
+        await removeUserFromTeam(client, {
+          org: input.org,
+          teamSlug,
+          username: input.creator,
+        })
+      } catch {
+        log.warn("create classroom: dropping creator from team failed", {
+          org: input.org,
+          classroom: input.classroom,
+          creator: input.creator,
+          teamSlug,
+        })
+        // Non-fatal; the classroom still scaffolds.
+      }
     }
   }
 

--- a/web/src/api/mutations/classrooms.ts
+++ b/web/src/api/mutations/classrooms.ts
@@ -83,12 +83,15 @@ export async function createClassroomFiles(
     }
   }
 
-  // GitHub auto-adds the authenticated creator as a maintainer of every team the
-  // create-team POST makes, so the creator lands on the students and both staff
-  // teams — but their only intended role is instructor. Drop them from the
-  // students and TA teams so the team-driven roster doesn't count the owner as an
-  // enrolled student/TA. Best-effort and idempotent (404 = already absent); a
-  // failure just leaves them harmlessly on a team.
+  // The creator must never hold a student or TA role — mixed roles aren't
+  // allowed, and the team-driven roster would otherwise count the owner as an
+  // enrolled student/TA. GitHub silently adds the creator as a maintainer of
+  // every team the create POST makes, so drop them from the students and TA
+  // teams unconditionally: the drop is deliberately NOT gated on whether we
+  // created vs adopted the team — an owner sitting on an adopted students/TA
+  // team is exactly the mixed-role state we're clearing. Best-effort and
+  // idempotent (404 = already absent); a failure just leaves them on a team,
+  // where the roster's per-role badges surface it for manual cleanup.
   if (input.creator) {
     const dropSlugs = [team.slug, teams.ta?.slug].filter(
       (slug): slug is string => Boolean(slug),

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -18,6 +18,7 @@ import {
   Toolbar,
 } from "@/components/ui"
 import Avatar from "@/components/avatar"
+import { RoleBadges } from "./RoleBadges"
 import type { Student } from "@/types/classroom"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { syncRosterFromTeam, migrateRosterFile } from "@/api/mutations/students"
@@ -46,11 +47,9 @@ import { roleForOrgRole } from "@/util/teamRoster"
 import { STAFF_ROLES } from "@/types/classroom"
 import {
   ROLE_LABEL_KEY,
-  ROLE_BADGE_TONE,
   STATE_BADGE_TONE,
   STATE_LABEL_KEY,
   hasStudentEnrollment,
-  primaryRole,
 } from "@/util/rosterRoles"
 import {
   filterRosterRows,
@@ -635,27 +634,16 @@ const EnrolledStudents = ({
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {(() => {
-            // Enrolled/pending rows assert a role (the team is the authority),
-            // shown as the highest-precedence badge (instructor > ta > student;
-            // student uses the neutral ghost). Needs-attention rows have no
-            // team role yet, so they render no role badge.
+            // Enrolled/pending rows assert role(s) (the team is the authority),
+            // shown as one badge per role via RoleBadges. Needs-attention rows
+            // have no team role yet, so they render no role badge.
             if (
               row.state === "needs_attention_in_org" ||
               row.state === "needs_attention_not_in_org"
             ) {
               return null
             }
-            const role = primaryRole(row)
-            return (
-              <Badge
-                size="sm"
-                tone={ROLE_BADGE_TONE[role]}
-                ghost={role === "student"}
-                className="shrink-0"
-              >
-                {t(ROLE_LABEL_KEY[role])}
-              </Badge>
-            )
+            return <RoleBadges roles={row.roles} />
           })()}
           {row.section.trim() ? (
             <span className="badge badge-sm badge-info badge-soft shrink-0">

--- a/web/src/pages/students/RoleBadges.test.tsx
+++ b/web/src/pages/students/RoleBadges.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+import { RoleBadges } from "./RoleBadges"
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("RoleBadges", () => {
+  it("renders a chip per role for a mixed-team member (instructor + student)", () => {
+    render(<RoleBadges roles={["student", "instructor"]} />)
+    expect(screen.getByText("students.roleInstructor")).toBeTruthy()
+    expect(screen.getByText("students.roleStudent")).toBeTruthy()
+  })
+
+  it("renders exactly one chip for a single-role member", () => {
+    const { container } = render(<RoleBadges roles={["student"]} />)
+    expect(screen.getByText("students.roleStudent")).toBeTruthy()
+    expect(screen.queryByText("students.roleInstructor")).toBeNull()
+    // One badge element, not a collapsed-then-duplicated render.
+    expect(container.querySelectorAll(".badge")).toHaveLength(1)
+  })
+
+  it("orders chips by precedence (instructor before ta before student)", () => {
+    const { container } = render(
+      <RoleBadges roles={["student", "ta", "instructor"]} />,
+    )
+    const labels = [...container.querySelectorAll(".badge")].map(
+      (el) => el.textContent,
+    )
+    expect(labels).toEqual([
+      "students.roleInstructor",
+      "students.roleTa",
+      "students.roleStudent",
+    ])
+  })
+
+  it("renders nothing for an empty role list", () => {
+    const { container } = render(<RoleBadges roles={[]} />)
+    expect(container.querySelectorAll(".badge")).toHaveLength(0)
+  })
+})

--- a/web/src/pages/students/RoleBadges.tsx
+++ b/web/src/pages/students/RoleBadges.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "@/components/ui"
+import {
+  ROLE_BADGE_TONE,
+  ROLE_LABEL_KEY,
+  sortRolesByRank,
+} from "@/util/rosterRoles"
+import type { RosterRole } from "@/util/teamRoster"
+
+// One badge per classroom role a member holds, highest-precedence first
+// (instructor > ta > student; student renders as the neutral ghost chip). A
+// person on more than one team (e.g. an instructor who is also a student) shows
+// a chip for each, making a "mixed team" membership visible at a glance rather
+// than collapsing to a single primary role. Uses the shared role presentation
+// maps so the roster row and any other role-badge surface can't drift.
+export function RoleBadges({ roles }: { roles: RosterRole[] }) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      {sortRolesByRank(roles).map((role) => (
+        <Badge
+          key={role}
+          size="sm"
+          tone={ROLE_BADGE_TONE[role]}
+          ghost={role === "student"}
+          className="shrink-0"
+        >
+          {t(ROLE_LABEL_KEY[role])}
+        </Badge>
+      ))}
+    </>
+  )
+}

--- a/web/src/util/rosterRoles.test.ts
+++ b/web/src/util/rosterRoles.test.ts
@@ -3,7 +3,6 @@ import {
   countByRole,
   enrolledCountsByRole,
   hasStudentEnrollment,
-  primaryRole,
   sortRolesByRank,
 } from "./rosterRoles"
 import type {
@@ -39,18 +38,6 @@ describe("hasStudentEnrollment", () => {
   })
   it("is true for a student who is also staff (unenroll drops only the student side)", () => {
     expect(hasStudentEnrollment(row(["instructor", "student"]))).toBe(true)
-  })
-})
-
-describe("primaryRole", () => {
-  it("returns the sole role", () => {
-    expect(primaryRole(row(["student"]))).toBe("student")
-    expect(primaryRole(row(["ta"]))).toBe("ta")
-  })
-  it("picks the highest-precedence role (instructor > ta > student)", () => {
-    expect(primaryRole(row(["student", "instructor"]))).toBe("instructor")
-    expect(primaryRole(row(["student", "ta"]))).toBe("ta")
-    expect(primaryRole(row(["ta", "instructor", "student"]))).toBe("instructor")
   })
 })
 

--- a/web/src/util/rosterRoles.ts
+++ b/web/src/util/rosterRoles.ts
@@ -49,14 +49,6 @@ export const STATE_LABEL_KEY: Record<TeamRosterRowState, string> = {
   needs_attention_not_in_org: "students.statusNeedsAttentionNotInOrg",
 }
 
-// A row's single highest-precedence role for the primary badge (instructor >
-// ta > student). Roles are stored ROLE_RANK-sorted (see addRole in teamRoster),
-// so the first is the highest; this is a named accessor so callers don't reach
-// into roles[0] and re-encode the sort assumption.
-export function primaryRole(row: Pick<TeamRosterRow, "roles">): RosterRole {
-  return sortRolesByRank(row.roles)[0]
-}
-
 // Whether a row carries a student enrollment (a roster.csv row + student-team
 // membership). True for a plain student AND for a student who is also staff.
 // The single definition of "can be unenrolled": unenroll drops only the student


### PR DESCRIPTION
Fixes #242

## Summary

**Policy: a classroom member holds exactly one role — mixed roles are not allowed.** This PR enforces that at creation and surfaces any pre-existing violations.

1. **Fix — enforce single role at creation.** GitHub's [`POST /orgs/{org}/teams`](https://docs.github.com/en/rest/teams/teams) auto-adds the authenticated creator as a **maintainer** of every team it creates. Classroom creation POSTs all three per-classroom `secret` teams (students, instructor, TA) as the org owner, so the owner silently landed on all three. Because the roster is GitHub-team-driven (`web/src/hooks/useTeamRoster.ts`, CLI `ListTeamMembers`), the owner wrongly appeared as an enrolled **student** and a **TA**, inflated by-role counts, and triggered spurious `roster.csv` backfill. After provisioning, the creator is now dropped from the students and TA teams, leaving them only on instructor. The drop is **unconditional by design** (not gated on created-vs-adopted): an owner sitting on a pre-existing students/TA team is the same disallowed mixed-role state, so it's cleared too. Best-effort and idempotent (404 = success), so a hiccup never fails classroom creation.

2. **Visibility — surface pre-existing violations.** The roster row collapsed a member to a single highest-precedence badge, hiding when someone holds multiple roles. It now renders one chip per role (new `RoleBadges` component), so any mixed-role member that predates this fix is visible at a glance for manual cleanup. Presentation-only — the row data already unions roles, and the route-level single-role resolution boundary is untouched.

## Changes

- **web** (`web/src/api/mutations/classrooms.ts`): after the instructor add, best-effort `removeUserFromTeam` for the students (`team.slug`) and TA (`teams.ta?.slug`) teams; failures `log.warn` and are non-fatal.
- **cli** (`classroom.go`, `migrate.go`): `seedStaffTeams` now returns the resolved acting login; new `dropCreatorFromNonInstructorTeams` helper (via `configrepo.RemoveTeamMembership`) called from both `classroom add` and `classroom migrate` so they stay in parity. No-op when the login can't be resolved; warns on failure.
- **web** (`web/src/pages/students/RoleBadges.tsx`, used in `EnrolledStudents.tsx`): render all of a member's roles as chips (instructor > ta > student order), reusing the shared role presentation maps. Removes the now-unused `primaryRole` helper.

## Notes / scope

- The drop is **intentionally unconditional** (not gated on the created flag). Mixed roles are disallowed, so a creator on an adopted students/TA team must also be cleared. Code comments state this so a future change doesn't re-introduce created-gating.
- The explicit instructor add is kept — it's still needed on the adopted-team (422) path where GitHub does not auto-add.
- Removing team membership does **not** touch org membership or the owner's org-admin power.
- **Existing** classrooms created before this fix keep the owner on all three teams; the fix only corrects new/migrated classrooms. The role chips make those pre-existing mixed-role members visible so an owner can clean them up by hand; a dedicated reconcile could automate this later.
- No schema changes.

## Test plan

- [x] web: `tsc -b` clean, eslint clean, prettier clean, full vitest suite (1446 tests) passes.
  - `classrooms.test.ts`: creator removed from students + TA but not instructor; still completes when a drop DELETE fails; no drop without a creator; **creator still dropped from an ADOPTED students team** (mixed roles disallowed).
  - `RoleBadges.test.tsx`: mixed-role member renders a chip per role; single-role renders exactly one; precedence ordering; empty roles render nothing.
- [x] cli: `go build ./...` + `go test ./...` pass, `golangci-lint` 0 issues.
  - `dropCreatorFromNonInstructorTeams`: removes students + TA, never instructor; best-effort on a 403; empty-login no-op.
  - `migrate_test.go`: E2E now asserts the membership DELETE targets **students + TA, never instructor**.