### PR TITLE
feat(web): list created repos on the submissions dashboard

### DIFF
--- a/web/src/hooks/useGetRepoCollaborators.ts
+++ b/web/src/hooks/useGetRepoCollaborators.ts
@@ -21,7 +21,7 @@ const useGetRepoCollaborators = (
         `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repoName)}/collaborators?affiliation=direct`,
       )
     },
-    staleTime: 10 * 60 * 1000,
+    staleTime: 60 * 1000,
     enabled: Boolean(org && repoName) && (options?.enabled ?? true),
   })
 }

--- a/web/src/hooks/useGroupRepoMembers.test.tsx
+++ b/web/src/hooks/useGroupRepoMembers.test.tsx
@@ -69,6 +69,25 @@ describe("useGroupRepoMemberLogins", () => {
     )
   })
 
+  it("keeps the union from surviving repos when one repo's read fails", async () => {
+    // mapWithConcurrency is all-or-nothing; the hook wraps each read so a single
+    // repo's 404/403/429 can't void the whole union (#245 regression guard).
+    request.mockImplementation((url: string) =>
+      url.includes("cs101-hw1-alice")
+        ? Promise.reject(new Error("404"))
+        : Promise.resolve([user("carol")]),
+    )
+    const { result } = renderHook(
+      () =>
+        useGroupRepoMemberLogins("acme", [
+          { owner: "alice", repoName: "cs101-hw1-alice" },
+          { owner: "dave", repoName: "cs101-hw1-dave" },
+        ]),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect([...result.current].sort()).toEqual(["carol"]))
+  })
+
   it("does not fetch when there are no group repos", () => {
     const { result } = renderHook(() => useGroupRepoMemberLogins("acme", []), {
       wrapper: wrapper(makeClient()),

--- a/web/src/hooks/useGroupRepoMembers.test.tsx
+++ b/web/src/hooks/useGroupRepoMembers.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+const request = vi.fn()
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request }),
+}))
+
+import { useGroupRepoMemberLogins } from "./useGroupRepoMembers"
+import { githubKeys } from "./github/queries"
+import type { GitHubUser } from "./github/types"
+
+const user = (login: string): GitHubUser => ({ login }) as GitHubUser
+
+const makeClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+const wrapper =
+  (client: QueryClient) =>
+  ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+
+beforeEach(() => {
+  request.mockReset()
+})
+
+describe("useGroupRepoMemberLogins", () => {
+  it("returns the lowercased union of collaborators across all group repos", async () => {
+    request.mockImplementation((url: string) =>
+      url.includes("cs101-hw1-alice")
+        ? Promise.resolve([user("Alice"), user("Bob")])
+        : Promise.resolve([user("carol")]),
+    )
+    const { result } = renderHook(
+      () =>
+        useGroupRepoMemberLogins("acme", [
+          { owner: "alice", repoName: "cs101-hw1-alice" },
+          { owner: "dave", repoName: "cs101-hw1-dave" },
+        ]),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() =>
+      expect([...result.current].sort()).toEqual(["alice", "bob", "carol"]),
+    )
+  })
+
+  it("primes the shared per-repo collaborators cache the rows/modal read", async () => {
+    request.mockResolvedValue([user("alice")])
+    const client = makeClient()
+    renderHook(
+      () =>
+        useGroupRepoMemberLogins("acme", [
+          { owner: "alice", repoName: "cs101-hw1-alice" },
+        ]),
+      { wrapper: wrapper(client) },
+    )
+    await waitFor(() =>
+      expect(
+        client.getQueryData(
+          githubKeys.collaborators("acme", "cs101-hw1-alice"),
+        ),
+      ).toEqual([user("alice")]),
+    )
+  })
+
+  it("does not fetch when there are no group repos", () => {
+    const { result } = renderHook(() => useGroupRepoMemberLogins("acme", []), {
+      wrapper: wrapper(makeClient()),
+    })
+    expect(request).not.toHaveBeenCalled()
+    expect(result.current.size).toBe(0)
+  })
+})

--- a/web/src/hooks/useGroupRepoMembers.ts
+++ b/web/src/hooks/useGroupRepoMembers.ts
@@ -39,17 +39,26 @@ export function useGroupRepoMemberLogins(
         repoNames,
         REPO_READ_CONCURRENCY,
         async (repo) => {
-          // affiliation=direct excludes org-inherited access (owners/admins),
-          // matching useGetRepoCollaborators so both share one cache entry.
-          const collaborators = await client.request<GitHubUser[]>(
-            `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators?affiliation=direct`,
-          )
-          // Prime the per-repo cache the rows and Members modal read from.
-          queryClient.setQueryData(
-            githubKeys.collaborators(org, repo),
-            collaborators,
-          )
-          for (const c of collaborators) logins.add(c.login.toLowerCase())
+          // Tolerate a single repo's failure (deleted repo 404, 403, or 429
+          // after retries): mapWithConcurrency is all-or-nothing, so an
+          // unhandled rejection would void the whole union and re-list every
+          // teammate as "no group" — the exact #245 state this exists to fix.
+          // Degrade to "that repo's members unknown" instead.
+          try {
+            // affiliation=direct excludes org-inherited access (owners/admins),
+            // matching useGetRepoCollaborators so both share one cache entry.
+            const collaborators = await client.request<GitHubUser[]>(
+              `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators?affiliation=direct`,
+            )
+            // Prime the per-repo cache the rows and Members modal read from.
+            queryClient.setQueryData(
+              githubKeys.collaborators(org, repo),
+              collaborators,
+            )
+            for (const c of collaborators) logins.add(c.login.toLowerCase())
+          } catch {
+            // Leave this repo's members out of the union; other repos still count.
+          }
         },
       )
       return logins

--- a/web/src/hooks/useGroupRepoMembers.ts
+++ b/web/src/hooks/useGroupRepoMembers.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { githubKeys, REPO_READ_CONCURRENCY } from "./github/queries"
+import type { GitHubUser } from "./github/types"
+import { mapWithConcurrency } from "@/util/concurrency"
+
+type GroupRepoRef = { owner: string; repoName: string }
+
+// Eagerly (but bounded) fetch collaborators for the given group repos and return
+// the union of member logins (lowercased). Populates the shared
+// githubKeys.collaborators cache so the group rows' avatars and the Members
+// modal read the same data, and so the submissions dashboard can drop every
+// group member — not just founders — from the "no group" non-submitter list,
+// keeping the view accurate on load without opening each modal (#245).
+//
+// The reads run through mapWithConcurrency at REPO_READ_CONCURRENCY so a class
+// with many groups doesn't fan out one simultaneous request per repo (secondary
+// rate limits); the trade is ~N throttled collaborator reads per assignment
+// load, cached 1 min like the modal's own fetch.
+export function useGroupRepoMemberLogins(
+  org: string,
+  repos: GroupRepoRef[],
+): Set<string> {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  const repoNames = repos.map((r) => r.repoName)
+  // Stable key over the repo set (sorted) so the batch only refires when the set
+  // of group repos changes, not on every render.
+  const repoKey = [...repoNames].sort().join(",")
+
+  const { data } = useQuery({
+    queryKey: [...githubKeys.all, "group-collaborators", org, repoKey] as const,
+    queryFn: async () => {
+      const logins = new Set<string>()
+      await mapWithConcurrency(
+        repoNames,
+        REPO_READ_CONCURRENCY,
+        async (repo) => {
+          // affiliation=direct excludes org-inherited access (owners/admins),
+          // matching useGetRepoCollaborators so both share one cache entry.
+          const collaborators = await client.request<GitHubUser[]>(
+            `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators?affiliation=direct`,
+          )
+          // Prime the per-repo cache the rows and Members modal read from.
+          queryClient.setQueryData(
+            githubKeys.collaborators(org, repo),
+            collaborators,
+          )
+          for (const c of collaborators) logins.add(c.login.toLowerCase())
+        },
+      )
+      return logins
+    },
+    staleTime: 60 * 1000,
+    enabled: Boolean(org) && repoNames.length > 0,
+  })
+
+  const empty = useMemo(() => new Set<string>(), [])
+  return data ?? empty
+}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -190,6 +190,10 @@ const SubmissionsPageContent = () => {
     return rosterReady ? rosterScopedRows(rows, students) : rows
   }, [scoresData, assignment, rosterReady, students])
 
+  // Org repo list drives repo-existence signals (individual acceptance below and
+  // group-repo enumeration here).
+  const { data: orgRepos } = useGetOrgRepos(org ?? "")
+
   // Repos whose latest submission landed after the deadline. `late` is computed
   // upstream (collect_scores.py) from push time, not grade time.
   const lateCount = scoresInfo.filter((row) => row.late).length
@@ -202,23 +206,48 @@ const SubmissionsPageContent = () => {
     ? formatRelativeToNow(dueDeadlineInstant(dueDate) ?? new Date(dueDate))
     : null
 
+  // Group repos that already exist for this assignment, derived from the org
+  // repo list (empty for individual assignments). Named after the founder, so
+  // the `owner` segment is a roster login when the founder is enrolled. Computed
+  // here so both the non-submitter list (to avoid double-listing a founder who
+  // has a repo) and the group-repo rows below share one derivation.
+  const groupRepoList = useMemo(
+    () =>
+      isGroupAssignment
+        ? existingGroupRepos(
+            orgRepos,
+            classroom ?? "",
+            assignment ?? "",
+            new Set(),
+          )
+        : [],
+    [isGroupAssignment, orgRepos, classroom, assignment],
+  )
+  const groupRepoFounders = useMemo(
+    () => new Set(groupRepoList.map((repo) => repo.owner)),
+    [groupRepoList],
+  )
+
   // Roster students with no submission. "Credited" = login appears in any row's
   // `usernames` (member_usernames for groups, else [owner]), so group teammates
   // aren't falsely flagged. For groups, uncredited students surface as
   // "No group · not submitted" (see #174) — a student who never joined a
   // submitting group has no repo, so the row makes the omission explicit
-  // instead of vanishing. Gated on scores having loaded — until then scoresInfo
-  // is empty and would flag the whole roster.
+  // instead of vanishing. A founder whose group repo exists but hasn't submitted
+  // is excluded here — they already appear as a group-repo row (#245), so listing
+  // them as "no group" too would double-count them. Gated on scores having
+  // loaded — until then scoresInfo is empty and would flag the whole roster.
   const scoresLoaded = scoresData !== undefined
   const nonSubmitters = useMemo(() => {
     if (!scoresLoaded) return []
     const credited = new Set(
       scoresInfo.flatMap((row) => row.usernames.map((u) => u.toLowerCase())),
     )
-    return students.filter(
-      (student) => !credited.has(student.username.toLowerCase()),
-    )
-  }, [scoresLoaded, scoresInfo, students])
+    return students.filter((student) => {
+      const login = student.username.toLowerCase()
+      return !credited.has(login) && !groupRepoFounders.has(login)
+    })
+  }, [scoresLoaded, scoresInfo, students, groupRepoFounders])
 
   // Dashboard controls — all client-side over already-loaded data.
   const [query, setQuery] = useState("")
@@ -243,7 +272,6 @@ const SubmissionsPageContent = () => {
 
   // Deterministic acceptance from the org repo list (see acceptedUsernames);
   // individual assignments only, so gated on acceptedAvailable.
-  const { data: orgRepos } = useGetOrgRepos(org ?? "")
   const acceptedSet = useMemo(
     () =>
       acceptedUsernames(orgRepos, classroom ?? "", assignment ?? "", students),
@@ -261,16 +289,8 @@ const SubmissionsPageContent = () => {
     [scoresInfo],
   )
   const unsubmittedGroupRepos = useMemo(
-    () =>
-      isGroupAssignment
-        ? existingGroupRepos(
-            orgRepos,
-            classroom ?? "",
-            assignment ?? "",
-            submittedGroupOwners,
-          ).filter((repo) => !repo.submitted)
-        : [],
-    [isGroupAssignment, orgRepos, classroom, assignment, submittedGroupOwners],
+    () => groupRepoList.filter((repo) => !submittedGroupOwners.has(repo.owner)),
+    [groupRepoList, submittedGroupOwners],
   )
 
   // Section filtering: distinct sections for the dropdown, plus a username ->

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -31,6 +31,7 @@ import {
   filterAndSortRows,
   filterNonSubmitters,
   hasAccepted,
+  reconcileNonSubmitters,
   rosterScopedRows,
   rowInSection,
   selectActiveWorkflowAction,
@@ -258,13 +259,7 @@ const SubmissionsPageContent = () => {
   const scoresLoaded = scoresData !== undefined
   const nonSubmitters = useMemo(() => {
     if (!scoresLoaded) return []
-    const credited = new Set(
-      scoresInfo.flatMap((row) => row.usernames.map((u) => u.toLowerCase())),
-    )
-    return students.filter((student) => {
-      const login = student.username.toLowerCase()
-      return !credited.has(login) && !groupRepoFounders.has(login)
-    })
+    return reconcileNonSubmitters(students, scoresInfo, groupRepoFounders)
   }, [scoresLoaded, scoresInfo, students, groupRepoFounders])
 
   // Dashboard controls — all client-side over already-loaded data.

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -27,6 +27,7 @@ import {
   classAverage,
   computeStats,
   distinctSections,
+  existingGroupRepos,
   filterAndSortRows,
   filterNonSubmitters,
   hasAccepted,
@@ -44,6 +45,7 @@ import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetStudents from "@/hooks/useGetStudents"
 import { useTeamRoster } from "@/hooks/useTeamRoster"
 import { rowToStudent } from "@/util/teamRoster"
+import { getName } from "@/util/students"
 import { hasStudentEnrollment } from "@/util/rosterRoles"
 import type { Student } from "@/types/classroom"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
@@ -249,6 +251,28 @@ const SubmissionsPageContent = () => {
   )
   const acceptedAvailable = !isGroupAssignment && orgRepos != null
 
+  // Group repos that exist but have no submission yet: for group assignments the
+  // repo is named after the founder (not each member), so acceptance can't be
+  // derived per student — instead surface every group repo from the org list
+  // (#245) so teachers can see teams that formed before anyone pushes. Submitted
+  // groups already show as score rows, so drop them here.
+  const submittedGroupOwners = useMemo(
+    () => new Set(scoresInfo.map((row) => row.owner.toLowerCase())),
+    [scoresInfo],
+  )
+  const unsubmittedGroupRepos = useMemo(
+    () =>
+      isGroupAssignment
+        ? existingGroupRepos(
+            orgRepos,
+            classroom ?? "",
+            assignment ?? "",
+            submittedGroupOwners,
+          ).filter((repo) => !repo.submitted)
+        : [],
+    [isGroupAssignment, orgRepos, classroom, assignment, submittedGroupOwners],
+  )
+
   // Section filtering: distinct sections for the dropdown, plus a username ->
   // section lookup so submitted rows (which carry only logins) can be matched.
   const sections = useMemo(() => distinctSections(students), [students])
@@ -363,6 +387,21 @@ const SubmissionsPageContent = () => {
         : [],
     [effectiveFilters, nonSubmitters, query, acceptedSet],
   )
+
+  // Group repos without a submission, gated like non-submitters (hidden while a
+  // narrowing filter other than "not submitted" is active) and matched against
+  // the search by founder login or roster name. Section isn't filtered — a group
+  // repo carries no single section.
+  const visibleGroupRepos = useMemo(() => {
+    if (!showsNonSubmitters(effectiveFilters)) return []
+    const q = query.trim().toLowerCase()
+    if (!q) return unsubmittedGroupRepos
+    return unsubmittedGroupRepos.filter((repo) => {
+      if (repo.owner.includes(q)) return true
+      const name = getName(repo.owner, students).toLowerCase()
+      return name.length > 0 && name.includes(q)
+    })
+  }, [effectiveFilters, query, unsubmittedGroupRepos, students])
 
   const collectScores = useTriggerScoreCollection(org)
   const regradeAll = useTriggerRegrade({ org, classroom, assignment })
@@ -687,6 +726,7 @@ const SubmissionsPageContent = () => {
         scores={visibleRows}
         students={students}
         nonSubmitters={visibleNonSubmitters}
+        unsubmittedGroupRepos={visibleGroupRepos}
         isGroup={isGroupAssignment}
         org={org}
         classroom={classroom}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -52,6 +52,7 @@ import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import { QueryErrorAlert } from "@/components/QueryErrorAlert"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
+import { useGroupRepoMemberLogins } from "@/hooks/useGroupRepoMembers"
 import useTriggerScoreCollection from "@/hooks/useTriggerScoreCollection"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import { RegradeCoordinatorProvider } from "@/context/regrade/RegradeCoordinator"
@@ -208,9 +209,15 @@ const SubmissionsPageContent = () => {
 
   // Group repos that already exist for this assignment, derived from the org
   // repo list (empty for individual assignments). Named after the founder, so
-  // the `owner` segment is a roster login when the founder is enrolled. Computed
-  // here so both the non-submitter list (to avoid double-listing a founder who
-  // has a repo) and the group-repo rows below share one derivation.
+  // the `owner` segment is a roster login when the founder is enrolled. Sibling
+  // assignment slugs are passed so a repo of a slug-extending sibling
+  // ("hw1-bonus" under "hw1") isn't mis-attributed here. Computed once so both
+  // the non-submitter list (to avoid double-listing a member who has a repo) and
+  // the group-repo rows below share one derivation.
+  const siblingSlugs = useMemo(
+    () => (assignmentData?.assignments ?? []).map((a) => a.slug),
+    [assignmentData],
+  )
   const groupRepoList = useMemo(
     () =>
       isGroupAssignment
@@ -218,14 +225,24 @@ const SubmissionsPageContent = () => {
             orgRepos,
             classroom ?? "",
             assignment ?? "",
-            new Set(),
+            siblingSlugs,
           )
         : [],
-    [isGroupAssignment, orgRepos, classroom, assignment],
+    [isGroupAssignment, orgRepos, classroom, assignment, siblingSlugs],
   )
+  // Members of every existing group repo, fetched (bounded) and reconciled so
+  // the "no group" list is accurate on load: the union of founders (known from
+  // the repo name) plus each repo's collaborators means a teammate on a
+  // formed-but-unsubmitted group isn't also listed as "no group" (#245). The
+  // fetch is throttled and shares the collaborators cache with the rows/modal.
+  const groupRepoMembers = useGroupRepoMemberLogins(org ?? "", groupRepoList)
   const groupRepoFounders = useMemo(
-    () => new Set(groupRepoList.map((repo) => repo.owner)),
-    [groupRepoList],
+    () =>
+      new Set([
+        ...groupRepoList.map((repo) => repo.owner),
+        ...groupRepoMembers,
+      ]),
+    [groupRepoList, groupRepoMembers],
   )
 
   // Roster students with no submission. "Credited" = login appears in any row's
@@ -233,10 +250,11 @@ const SubmissionsPageContent = () => {
   // aren't falsely flagged. For groups, uncredited students surface as
   // "No group · not submitted" (see #174) — a student who never joined a
   // submitting group has no repo, so the row makes the omission explicit
-  // instead of vanishing. A founder whose group repo exists but hasn't submitted
-  // is excluded here — they already appear as a group-repo row (#245), so listing
-  // them as "no group" too would double-count them. Gated on scores having
-  // loaded — until then scoresInfo is empty and would flag the whole roster.
+  // instead of vanishing. A member of an existing group repo (its founder, or
+  // any cached collaborator) is excluded here — they already appear as that
+  // group's row (#245), so listing them as "no group" too would double-count
+  // them. Gated on scores having loaded — until then scoresInfo is empty and
+  // would flag the whole roster.
   const scoresLoaded = scoresData !== undefined
   const nonSubmitters = useMemo(() => {
     if (!scoresLoaded) return []

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -1,0 +1,372 @@
+import { UsersRound } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import GitHub from "@/assets/github.svg?react"
+import { getName, getInitials } from "@/util/students"
+import { studentRepoName, studentRepoUrl } from "@/util/studentRepo"
+import Avatar from "@/components/avatar"
+import { Badge, Button } from "@/components/ui"
+import { nonSubmitterStatus } from "@/pages/submissions/dashboard"
+import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
+import type { Student } from "@/types/classroom"
+
+// Secondary avatar line: the GitHub login plus the section (e.g.
+// "octocat · Period 3"), dropping whichever piece is missing. The login is
+// omitted when `name` is empty — Avatar's primary line already falls back to
+// the login there, so repeating it in the subtitle would duplicate it.
+export const identitySubtitle = (
+  name?: string,
+  login?: string,
+  section?: string,
+) => {
+  const showLogin = name?.trim() ? login?.trim() : undefined
+  return [showLogin, section?.trim()].filter(Boolean).join(" · ") || undefined
+}
+
+type IconComponent = React.ComponentType<{ className?: string }>
+
+// Icon action in the Actions cell: an external link when a URL is present, else
+// a dimmed non-clickable button (with a "no … yet" label) to keep the row
+// aligned. Both render through the shared ghost-square Button recipe.
+export const ActionIconLink = ({
+  href,
+  icon: Icon,
+  label,
+  title,
+  emptyLabel,
+  emptyTitle,
+}: {
+  href: string | null | undefined
+  icon: IconComponent
+  label: string
+  title: string
+  emptyLabel: string
+  emptyTitle: string
+}) =>
+  href ? (
+    <Button
+      as="a"
+      variant="ghost"
+      size="sm"
+      shape="square"
+      className="text-base-content/70"
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={label}
+      title={title}
+    >
+      <Icon className="size-4" />
+    </Button>
+  ) : (
+    <Button
+      variant="ghost"
+      size="sm"
+      shape="square"
+      className="text-base-content/30"
+      disabled
+      aria-label={emptyLabel}
+      title={emptyTitle}
+    >
+      <Icon className="size-4" />
+    </Button>
+  )
+
+// Per-row status chip for a roster student with no submission: distinguishes
+// accepted-but-not-submitted, never-accepted, and (group) no-group from a flat
+// "Not submitted", so a teacher can nudge accepters vs chase non-accepters.
+const NonSubmitterStatusBadge = ({
+  username,
+  isGroup,
+  acceptedUsernames,
+}: {
+  username: string
+  isGroup: boolean
+  acceptedUsernames?: Set<string>
+}) => {
+  const { t } = useTranslation()
+  const status = nonSubmitterStatus(username, { isGroup, acceptedUsernames })
+  switch (status) {
+    case "accepted-not-submitted":
+      return (
+        <Badge tone="warning" className="whitespace-nowrap">
+          {t("submissions.table.acceptedAwaiting")}
+        </Badge>
+      )
+    case "not-accepted":
+      return (
+        <Badge ghost className="whitespace-nowrap">
+          {t("submissions.table.notAccepted")}
+        </Badge>
+      )
+    case "no-group":
+      return (
+        <Badge
+          ghost
+          className="whitespace-nowrap"
+          title={t("submissions.table.noGroupTitle")}
+        >
+          {t("submissions.table.noGroup")}
+        </Badge>
+      )
+    default:
+      return (
+        <Badge ghost className="whitespace-nowrap">
+          {t("submissions.table.notSubmitted")}
+        </Badge>
+      )
+  }
+}
+
+// Compact group identity: shared repo + stacked avatars. Renders from the
+// scores.json `usernames` snapshot and never fetches (enabled: false) to avoid a
+// per-row GitHub call; reads the shared collaborators cache so avatars upgrade to
+// live data once the Members modal populates it.
+const MAX_VISIBLE_AVATARS = 4
+
+export const GroupMembers = ({
+  org,
+  repoName,
+  usernames,
+  students,
+  repoHref,
+  repoLabel,
+}: {
+  org: string
+  repoName: string
+  usernames: string[]
+  students: Student[]
+  repoHref: string
+  repoLabel: string
+}) => {
+  const { t } = useTranslation()
+  // enabled: false — reads the cache the Members modal populates, never fetches.
+  const { data: liveCollaborators } = useGetRepoCollaborators(org, repoName, {
+    enabled: false,
+  })
+  const memberLogins =
+    liveCollaborators && liveCollaborators.length > 0
+      ? liveCollaborators.map((c) => c.login)
+      : usernames
+
+  const visible = memberLogins.slice(0, MAX_VISIBLE_AVATARS)
+  const overflow = memberLogins.length - visible.length
+
+  return (
+    <div className="flex flex-col gap-2">
+      <a
+        className="flex items-center gap-1.5 link link-hover w-fit font-medium"
+        href={repoHref}
+        target="_blank"
+        rel="noreferrer"
+        title={t("submissions.table.openGroupRepo")}
+      >
+        <GitHub aria-hidden="true" className="size-4 shrink-0" />
+        <span className="font-mono text-sm">{repoLabel}</span>
+      </a>
+
+      <div className="avatar-group -space-x-3">
+        {visible.map((username) => {
+          const name = getName(username, students)
+          return (
+            <div
+              key={username}
+              className="avatar avatar-placeholder"
+              title={name ? `${name} (${username})` : username}
+            >
+              <div className="bg-base-200 text-primary rounded-full w-7 border-2 border-base-100">
+                <span className="text-xs">
+                  {getInitials(username, students) ||
+                    username.at(0)?.toUpperCase()}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+
+        {overflow > 0 && (
+          <div
+            className="avatar avatar-placeholder"
+            title={memberLogins.slice(MAX_VISIBLE_AVATARS).join(", ")}
+          >
+            <div className="bg-neutral text-neutral-content rounded-full w-7 border-2 border-base-100">
+              <span className="text-xs">+{overflow}</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Shared action cluster for a group repo: Members button (opens the manage
+// modal) + the repo link. Used by both the submitted score row and the
+// awaiting group-repo row so the two never drift (one recipe, one source).
+export const GroupActionControls = ({
+  repo,
+  repoHref,
+  onManage,
+}: {
+  repo: string
+  repoHref: string
+  onManage: () => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="text-base-content/70"
+        onClick={onManage}
+        aria-label={t("submissions.table.membersAria")}
+        title={t("submissions.table.members")}
+      >
+        <UsersRound aria-hidden="true" className="size-4" />
+      </Button>
+      <ActionIconLink
+        href={repoHref}
+        icon={GitHub}
+        label={t("submissions.table.openRepoLabel", { repo })}
+        title={t("submissions.table.viewRepo")}
+        emptyLabel={t("submissions.table.openRepoLabel", { repo })}
+        emptyTitle={t("submissions.table.viewRepo")}
+      />
+    </>
+  )
+}
+
+// A roster student with no submission row: identity + status badge, plus a repo
+// link when they accepted an individual assignment (a repo exists to open).
+export const NonSubmitterRow = ({
+  student,
+  students,
+  isGroup,
+  acceptedUsernames,
+  org,
+  classroom,
+  assignment,
+  onProfile,
+}: {
+  student: Student
+  students: Student[]
+  isGroup: boolean
+  acceptedUsernames?: Set<string>
+  org: string
+  classroom: string
+  assignment: string
+  onProfile: (username: string) => void
+}) => {
+  const { t } = useTranslation()
+  const accepted =
+    !isGroup &&
+    Boolean(
+      student.username &&
+      acceptedUsernames?.has(student.username.toLowerCase()),
+    )
+  const repo = accepted
+    ? studentRepoName(classroom, assignment, student.username)
+    : null
+  const repoHref = accepted
+    ? studentRepoUrl(org, classroom, assignment, student.username)
+    : null
+  return (
+    <tr>
+      <td>
+        <Avatar
+          name={getName(student.username, students)}
+          initials={getInitials(student.username, students)}
+          github={student.username || student.email}
+          subtitle={identitySubtitle(
+            getName(student.username, students),
+            student.username,
+            student.section,
+          )}
+          onClick={
+            student.username ? () => onProfile(student.username) : undefined
+          }
+        />
+      </td>
+      <td>
+        <NonSubmitterStatusBadge
+          username={student.username}
+          isGroup={isGroup}
+          acceptedUsernames={acceptedUsernames}
+        />
+      </td>
+      <td>—</td>
+      <td>—</td>
+      <td>
+        {repo && repoHref ? (
+          <ActionIconLink
+            href={repoHref}
+            icon={GitHub}
+            label={t("submissions.table.openRepoLabel", { repo })}
+            title={t("submissions.table.viewRepo")}
+            emptyLabel={t("submissions.table.openRepoLabel", { repo })}
+            emptyTitle={t("submissions.table.viewRepo")}
+          />
+        ) : (
+          "—"
+        )}
+      </td>
+    </tr>
+  )
+}
+
+// A group repo that exists but has no submission yet: repo + members (from the
+// collaborators cache) with an "awaiting submission" badge and the shared group
+// actions. Fetching is lazy — the Members modal loads collaborators on demand,
+// so a class with many formed-but-unpushed groups doesn't fan out one request
+// per row on mount (#245).
+export const GroupRepoRow = ({
+  org,
+  classroom,
+  assignment,
+  owner,
+  repoName,
+  students,
+  onManage,
+}: {
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+  repoName: string
+  students: Student[]
+  onManage: () => void
+}) => {
+  const { t } = useTranslation()
+  const repoHref = studentRepoUrl(org, classroom, assignment, owner)
+  return (
+    <tr>
+      <td>
+        <GroupMembers
+          org={org}
+          repoName={repoName}
+          usernames={[]}
+          students={students}
+          repoHref={repoHref}
+          repoLabel={repoName}
+        />
+      </td>
+      <td>
+        <Badge tone="warning" className="whitespace-nowrap">
+          {t("submissions.table.acceptedAwaiting")}
+        </Badge>
+      </td>
+      <td>—</td>
+      <td>—</td>
+      <td>
+        <div className="flex items-center gap-1">
+          <GroupActionControls
+            repo={repoName}
+            repoHref={repoHref}
+            onManage={onManage}
+          />
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -99,7 +99,6 @@ describe("SubmissionsTable non-submitter repo links", () => {
           {
             owner: "team-rocket",
             repoName: "cs101-hw1-team-rocket",
-            submitted: false,
           },
         ]}
       />,
@@ -110,12 +109,15 @@ describe("SubmissionsTable non-submitter repo links", () => {
     expect(link.getAttribute("href")).toBe(
       "https://github.com/acme/cs101-hw1-team-rocket",
     )
-    // Live collaborators fetch is enabled for a group repo with no submission.
+    // The empty-state row must not render alongside group-repo rows.
+    expect(screen.queryByText("submissions.table.emptyNoDataTitle")).toBeNull()
+    // Members are loaded lazily (via the Members modal), not eagerly per row,
+    // so the row's collaborators query stays cache-only (enabled: false).
     expect(collaborators).toHaveBeenCalledWith(
       "acme",
       "cs101-hw1-team-rocket",
       {
-        enabled: true,
+        enabled: false,
       },
     )
   })

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) =>
+        opts && "repo" in opts ? `${key}:${String(opts.repo)}` : key,
+    }),
+  }
+})
+
+// The row's hooks/modals fetch from GitHub or need providers; stub them so the
+// test targets only the table's row rendering.
+const collaborators = vi.fn()
+vi.mock("@/hooks/useGetRepoCollaborators", () => ({
+  default: (...a: unknown[]) => collaborators(...a),
+}))
+vi.mock("@/hooks/useGetFeedbackPr", () => ({
+  default: () => ({ refetch: vi.fn() }),
+}))
+vi.mock("@/hooks/useTriggerRegrade", () => ({
+  default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),
+}))
+vi.mock("@/components/modals/GroupCollaboratorsModal", () => ({
+  GroupCollaboratorsModal: () => null,
+}))
+vi.mock("@/components/modals/StudentProfileModal", () => ({
+  StudentProfileModal: () => null,
+}))
+
+import SubmissionsTable from "./SubmissionsTable"
+import type { Student } from "@/types/classroom"
+
+const student = (over: Partial<Student> = {}): Student => ({
+  username: "alice",
+  first_name: "Alice",
+  last_name: "A",
+  email: "alice@example.com",
+  section: "",
+  github_id: "1",
+  role: "student",
+  ...over,
+})
+
+beforeEach(() => {
+  collaborators.mockReset()
+  collaborators.mockReturnValue({ data: undefined })
+})
+
+afterEach(cleanup)
+
+const baseProps = {
+  scores: [],
+  students: [student()],
+  org: "acme",
+  classroom: "cs101",
+  assignment: "hw1",
+}
+
+describe("SubmissionsTable non-submitter repo links", () => {
+  it("links to the repo for an accepted-not-submitted individual", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set(["alice"])}
+      />,
+    )
+    const link = screen.getByRole("link", {
+      name: "submissions.table.openRepoLabel:cs101-hw1-alice",
+    })
+    expect(link.getAttribute("href")).toBe(
+      "https://github.com/acme/cs101-hw1-alice",
+    )
+  })
+
+  it("shows no repo link for a never-accepted individual", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set()}
+      />,
+    )
+    expect(screen.queryByRole("link")).toBeNull()
+  })
+
+  it("renders unsubmitted group repos with a repo link even with no roster match", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        students={[]}
+        isGroup
+        unsubmittedGroupRepos={[
+          {
+            owner: "team-rocket",
+            repoName: "cs101-hw1-team-rocket",
+            submitted: false,
+          },
+        ]}
+      />,
+    )
+    const link = screen.getByRole("link", {
+      name: "submissions.table.openRepoLabel:cs101-hw1-team-rocket",
+    })
+    expect(link.getAttribute("href")).toBe(
+      "https://github.com/acme/cs101-hw1-team-rocket",
+    )
+    // Live collaborators fetch is enabled for a group repo with no submission.
+    expect(collaborators).toHaveBeenCalledWith(
+      "acme",
+      "cs101-hw1-team-rocket",
+      {
+        enabled: true,
+      },
+    )
+  })
+})

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -6,7 +6,6 @@ import {
   RefreshCw,
   ScrollText,
   SearchX,
-  UsersRound,
 } from "lucide-react"
 import { Fragment, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -22,14 +21,21 @@ import { studentRepoName, studentRepoUrl } from "@/util/studentRepo"
 import { safeHttpUrl } from "@/util/url"
 import Avatar from "@/components/avatar"
 import { Badge, Button, Modal } from "@/components/ui"
-import { nonSubmitterStatus, scoreTone } from "@/pages/submissions/dashboard"
+import { scoreTone } from "@/pages/submissions/dashboard"
 import type { GroupRepo } from "@/pages/submissions/dashboard"
+import {
+  ActionIconLink,
+  GroupActionControls,
+  GroupMembers,
+  GroupRepoRow,
+  NonSubmitterRow,
+  identitySubtitle,
+} from "@/pages/submissions/SubmissionsRows"
 import { ConfirmModal } from "@/components/modals"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
 import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
 import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
-import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import type { Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
@@ -39,15 +45,6 @@ const formatDateTime = (datetime: string) =>
     dateStyle: "medium",
     timeStyle: "short",
   })
-
-// Secondary avatar line: the GitHub login plus the section (e.g.
-// "octocat · Period 3"), dropping whichever piece is missing. The login is
-// omitted when `name` is empty — Avatar's primary line already falls back to
-// the login there, so repeating it in the subtitle would duplicate it.
-const identitySubtitle = (name?: string, login?: string, section?: string) => {
-  const showLogin = name?.trim() ? login?.trim() : undefined
-  return [showLogin, section?.trim()].filter(Boolean).join(" · ") || undefined
-}
 
 // Score chip via the shared scoreTone recipe (one mapping for table + history):
 // success/error tone for graded rows, neutral ghost for ungraded.
@@ -77,97 +74,7 @@ const ScoreBadge = ({
 // Per-row status chip for a roster student with no submission: distinguishes
 // accepted-but-not-submitted, never-accepted, and (group) no-group from a flat
 // "Not submitted", so a teacher can nudge accepters vs chase non-accepters.
-const NonSubmitterStatusBadge = ({
-  username,
-  isGroup,
-  acceptedUsernames,
-}: {
-  username: string
-  isGroup: boolean
-  acceptedUsernames?: Set<string>
-}) => {
-  const { t } = useTranslation()
-  const status = nonSubmitterStatus(username, { isGroup, acceptedUsernames })
-  switch (status) {
-    case "accepted-not-submitted":
-      return (
-        <Badge tone="warning" className="whitespace-nowrap">
-          {t("submissions.table.acceptedAwaiting")}
-        </Badge>
-      )
-    case "not-accepted":
-      return (
-        <Badge ghost className="whitespace-nowrap">
-          {t("submissions.table.notAccepted")}
-        </Badge>
-      )
-    case "no-group":
-      return (
-        <Badge
-          ghost
-          className="whitespace-nowrap"
-          title={t("submissions.table.noGroupTitle")}
-        >
-          {t("submissions.table.noGroup")}
-        </Badge>
-      )
-    default:
-      return (
-        <Badge ghost className="whitespace-nowrap">
-          {t("submissions.table.notSubmitted")}
-        </Badge>
-      )
-  }
-}
-
-// Icon action in the Actions cell: an external link when a URL is present, else
-// a dimmed non-clickable button (with a "no … yet" label) to keep the row
-// aligned. Both render through the shared ghost-square Button recipe.
 type IconComponent = React.ComponentType<{ className?: string }>
-
-const ActionIconLink = ({
-  href,
-  icon: Icon,
-  label,
-  title,
-  emptyLabel,
-  emptyTitle,
-}: {
-  href: string | null | undefined
-  icon: IconComponent
-  label: string
-  title: string
-  emptyLabel: string
-  emptyTitle: string
-}) =>
-  href ? (
-    <Button
-      as="a"
-      variant="ghost"
-      size="sm"
-      shape="square"
-      className="text-base-content/70"
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      aria-label={label}
-      title={title}
-    >
-      <Icon className="size-4" />
-    </Button>
-  ) : (
-    <Button
-      variant="ghost"
-      size="sm"
-      shape="square"
-      className="text-base-content/30"
-      disabled
-      aria-label={emptyLabel}
-      title={emptyTitle}
-    >
-      <Icon className="size-4" />
-    </Button>
-  )
 
 // Inline commit/details link in the expanded history row: external link when a
 // URL is present, else dimmed non-clickable text (label shown beside the icon,
@@ -197,92 +104,6 @@ const HistoryLink = ({
       {label}
     </span>
   )
-
-// Compact group identity: shared repo + stacked avatars. Renders from the
-// scores.json `usernames` snapshot; by default never fetches (reads the shared
-// collaborators cache so avatars upgrade once the Members modal populates it).
-// A group repo with no submission yet has no `usernames`, so it opts into a live
-// collaborators fetch via `fetchMembers`.
-const MAX_VISIBLE_AVATARS = 4
-
-const GroupMembers = ({
-  org,
-  repoName,
-  usernames,
-  students,
-  repoHref,
-  repoLabel,
-  fetchMembers = false,
-}: {
-  org: string
-  repoName: string
-  usernames: string[]
-  students: Student[]
-  repoHref: string
-  repoLabel: string
-  // Fetch collaborators live rather than only reading the modal-populated cache.
-  // Needed for a group repo with no submission yet: `usernames` (from
-  // scores.json) is empty, so members are only known from the repo itself.
-  fetchMembers?: boolean
-}) => {
-  const { t } = useTranslation()
-  const { data: liveCollaborators } = useGetRepoCollaborators(org, repoName, {
-    enabled: fetchMembers,
-  })
-  const memberLogins =
-    liveCollaborators && liveCollaborators.length > 0
-      ? liveCollaborators.map((c) => c.login)
-      : usernames
-
-  const visible = memberLogins.slice(0, MAX_VISIBLE_AVATARS)
-  const overflow = memberLogins.length - visible.length
-
-  return (
-    <div className="flex flex-col gap-2">
-      <a
-        className="flex items-center gap-1.5 link link-hover w-fit font-medium"
-        href={repoHref}
-        target="_blank"
-        rel="noreferrer"
-        title={t("submissions.table.openGroupRepo")}
-      >
-        <GitHub aria-hidden="true" className="size-4 shrink-0" />
-        <span className="font-mono text-sm">{repoLabel}</span>
-      </a>
-
-      <div className="avatar-group -space-x-3">
-        {visible.map((username) => {
-          const name = getName(username, students)
-          return (
-            <div
-              key={username}
-              className="avatar avatar-placeholder"
-              title={name ? `${name} (${username})` : username}
-            >
-              <div className="bg-base-200 text-primary rounded-full w-7 border-2 border-base-100">
-                <span className="text-xs">
-                  {getInitials(username, students) ||
-                    username.at(0)?.toUpperCase()}
-                </span>
-              </div>
-            </div>
-          )
-        })}
-
-        {overflow > 0 && (
-          <div
-            className="avatar avatar-placeholder"
-            title={memberLogins.slice(MAX_VISIBLE_AVATARS).join(", ")}
-          >
-            <div className="bg-neutral text-neutral-content rounded-full w-7 border-2 border-base-100">
-              <span className="text-xs">+{overflow}</span>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
 
 // Review action: links to the open Feedback PR (opened by the autograde
 // workflow) when one exists, else opens an info modal. The PR is the source of
@@ -806,33 +627,26 @@ const SubmissionsTable = ({
                       <td>
                         <div className="flex items-center gap-1">
                           {isGroup && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              shape="square"
-                              className="text-base-content/70"
-                              onClick={() => setManageOwner(rest.owner)}
-                              aria-label={t("submissions.table.membersAria")}
-                              title={t("submissions.table.members")}
-                            >
-                              <UsersRound
-                                aria-hidden="true"
-                                className="size-4"
-                              />
-                            </Button>
+                            <GroupActionControls
+                              repo={repo}
+                              repoHref={repoHref}
+                              onManage={() => setManageOwner(rest.owner)}
+                            />
                           )}
-                          <ActionIconLink
-                            href={repoHref}
-                            icon={GitHub}
-                            label={t("submissions.table.openRepoLabel", {
-                              repo,
-                            })}
-                            title={t("submissions.table.viewRepo")}
-                            emptyLabel={t("submissions.table.openRepoLabel", {
-                              repo,
-                            })}
-                            emptyTitle={t("submissions.table.viewRepo")}
-                          />
+                          {!isGroup && (
+                            <ActionIconLink
+                              href={repoHref}
+                              icon={GitHub}
+                              label={t("submissions.table.openRepoLabel", {
+                                repo,
+                              })}
+                              title={t("submissions.table.viewRepo")}
+                              emptyLabel={t("submissions.table.openRepoLabel", {
+                                repo,
+                              })}
+                              emptyTitle={t("submissions.table.viewRepo")}
+                            />
+                          )}
                           <ActionIconLink
                             href={safeHttpUrl(rest.commit)}
                             icon={GitCommitHorizontal}
@@ -881,120 +695,31 @@ const SubmissionsTable = ({
                 )
               },
             )}
-            {nonSubmitters.map((student) => {
-              const accepted =
-                !isGroup &&
-                Boolean(
-                  student.username &&
-                  acceptedUsernames?.has(student.username.toLowerCase()),
-                )
-              const repo = accepted
-                ? studentRepoName(classroom, assignment, student.username)
-                : null
-              const repoHref = accepted
-                ? studentRepoUrl(org, classroom, assignment, student.username)
-                : null
-              return (
-                <tr
-                  key={`missing-${student.username || student.email || student.github_id}`}
-                >
-                  <td>
-                    <Avatar
-                      name={getName(student.username, students)}
-                      initials={getInitials(student.username, students)}
-                      github={student.username || student.email}
-                      subtitle={identitySubtitle(
-                        getName(student.username, students),
-                        student.username,
-                        student.section,
-                      )}
-                      onClick={
-                        student.username
-                          ? () => setProfileUsername(student.username)
-                          : undefined
-                      }
-                    />
-                  </td>
-                  <td>
-                    <NonSubmitterStatusBadge
-                      username={student.username}
-                      isGroup={isGroup}
-                      acceptedUsernames={acceptedUsernames}
-                    />
-                  </td>
-                  <td>—</td>
-                  <td>—</td>
-                  <td>
-                    {repo && repoHref ? (
-                      <ActionIconLink
-                        href={repoHref}
-                        icon={GitHub}
-                        label={t("submissions.table.openRepoLabel", { repo })}
-                        title={t("submissions.table.viewRepo")}
-                        emptyLabel={t("submissions.table.openRepoLabel", {
-                          repo,
-                        })}
-                        emptyTitle={t("submissions.table.viewRepo")}
-                      />
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                </tr>
-              )
-            })}
-            {unsubmittedGroupRepos.map(({ owner, repoName }) => {
-              const repoHref = studentRepoUrl(org, classroom, assignment, owner)
-              return (
-                <tr key={`group-${repoName}`}>
-                  <td>
-                    <GroupMembers
-                      org={org}
-                      repoName={repoName}
-                      usernames={[]}
-                      students={students}
-                      repoHref={repoHref}
-                      repoLabel={repoName}
-                      fetchMembers
-                    />
-                  </td>
-                  <td>
-                    <Badge tone="warning" className="whitespace-nowrap">
-                      {t("submissions.table.acceptedAwaiting")}
-                    </Badge>
-                  </td>
-                  <td>—</td>
-                  <td>—</td>
-                  <td>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        shape="square"
-                        className="text-base-content/70"
-                        onClick={() => setManageOwner(owner)}
-                        aria-label={t("submissions.table.membersAria")}
-                        title={t("submissions.table.members")}
-                      >
-                        <UsersRound aria-hidden="true" className="size-4" />
-                      </Button>
-                      <ActionIconLink
-                        href={repoHref}
-                        icon={GitHub}
-                        label={t("submissions.table.openRepoLabel", {
-                          repo: repoName,
-                        })}
-                        title={t("submissions.table.viewRepo")}
-                        emptyLabel={t("submissions.table.openRepoLabel", {
-                          repo: repoName,
-                        })}
-                        emptyTitle={t("submissions.table.viewRepo")}
-                      />
-                    </div>
-                  </td>
-                </tr>
-              )
-            })}
+            {nonSubmitters.map((student) => (
+              <NonSubmitterRow
+                key={`missing-${student.username || student.email || student.github_id}`}
+                student={student}
+                students={students}
+                isGroup={isGroup}
+                acceptedUsernames={acceptedUsernames}
+                org={org}
+                classroom={classroom}
+                assignment={assignment}
+                onProfile={setProfileUsername}
+              />
+            ))}
+            {unsubmittedGroupRepos.map(({ owner, repoName }) => (
+              <GroupRepoRow
+                key={`group-${repoName}`}
+                org={org}
+                classroom={classroom}
+                assignment={assignment}
+                owner={owner}
+                repoName={repoName}
+                students={students}
+                onManage={() => setManageOwner(owner)}
+              />
+            ))}
           </tbody>
         </table>
       </EnterDiv>

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -23,6 +23,7 @@ import { safeHttpUrl } from "@/util/url"
 import Avatar from "@/components/avatar"
 import { Badge, Button, Modal } from "@/components/ui"
 import { nonSubmitterStatus, scoreTone } from "@/pages/submissions/dashboard"
+import type { GroupRepo } from "@/pages/submissions/dashboard"
 import { ConfirmModal } from "@/components/modals"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
@@ -198,9 +199,10 @@ const HistoryLink = ({
   )
 
 // Compact group identity: shared repo + stacked avatars. Renders from the
-// scores.json `usernames` snapshot and never fetches (enabled: false) to avoid a
-// per-row GitHub call; reads the shared collaborators cache so avatars upgrade to
-// live data once the Members modal populates it.
+// scores.json `usernames` snapshot; by default never fetches (reads the shared
+// collaborators cache so avatars upgrade once the Members modal populates it).
+// A group repo with no submission yet has no `usernames`, so it opts into a live
+// collaborators fetch via `fetchMembers`.
 const MAX_VISIBLE_AVATARS = 4
 
 const GroupMembers = ({
@@ -210,6 +212,7 @@ const GroupMembers = ({
   students,
   repoHref,
   repoLabel,
+  fetchMembers = false,
 }: {
   org: string
   repoName: string
@@ -217,11 +220,14 @@ const GroupMembers = ({
   students: Student[]
   repoHref: string
   repoLabel: string
+  // Fetch collaborators live rather than only reading the modal-populated cache.
+  // Needed for a group repo with no submission yet: `usernames` (from
+  // scores.json) is empty, so members are only known from the repo itself.
+  fetchMembers?: boolean
 }) => {
   const { t } = useTranslation()
-  // enabled: false — reads the cache the Members modal populates, never fetches.
   const { data: liveCollaborators } = useGetRepoCollaborators(org, repoName, {
-    enabled: false,
+    enabled: fetchMembers,
   })
   const memberLogins =
     liveCollaborators && liveCollaborators.length > 0
@@ -552,6 +558,7 @@ const SubmissionsTable = ({
   scores,
   students,
   nonSubmitters = [],
+  unsubmittedGroupRepos = [],
   isGroup = false,
   org,
   classroom,
@@ -566,6 +573,9 @@ const SubmissionsTable = ({
   scores: SubmissionRow[]
   students: Student[]
   nonSubmitters?: Student[]
+  // Group repos that exist but have no submission yet (group assignments only).
+  // Rendered as extra rows so teachers see teams that formed before any push.
+  unsubmittedGroupRepos?: GroupRepo[]
   isGroup?: boolean
   org: string
   classroom: string
@@ -638,51 +648,53 @@ const SubmissionsTable = ({
             </tr>
           </thead>
           <tbody>
-            {!scores?.length && !nonSubmitters.length && (
-              <tr>
-                <td colSpan={5} className="py-10 text-center">
-                  <div className="mx-auto flex max-w-sm flex-col items-center gap-2">
-                    {filtered ? (
-                      <>
-                        <SearchX
-                          aria-hidden="true"
-                          className="size-8 text-base-content/40"
-                        />
-                        <p className="font-medium">
-                          {t("submissions.table.emptyFilteredTitle")}
-                        </p>
-                        <p className="text-sm text-base-content/70">
-                          {t("submissions.table.emptyFilteredBody")}
-                        </p>
-                        {onClearFilters && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="mt-1"
-                            onClick={onClearFilters}
-                          >
-                            {t("submissions.table.emptyClearFilters")}
-                          </Button>
-                        )}
-                      </>
-                    ) : (
-                      <>
-                        <Inbox
-                          aria-hidden="true"
-                          className="size-8 text-base-content/40"
-                        />
-                        <p className="font-medium">
-                          {t("submissions.table.emptyNoDataTitle")}
-                        </p>
-                        <p className="text-sm text-base-content/70">
-                          {t("submissions.table.emptyNoDataBody")}
-                        </p>
-                      </>
-                    )}
-                  </div>
-                </td>
-              </tr>
-            )}
+            {!scores?.length &&
+              !nonSubmitters.length &&
+              !unsubmittedGroupRepos.length && (
+                <tr>
+                  <td colSpan={5} className="py-10 text-center">
+                    <div className="mx-auto flex max-w-sm flex-col items-center gap-2">
+                      {filtered ? (
+                        <>
+                          <SearchX
+                            aria-hidden="true"
+                            className="size-8 text-base-content/40"
+                          />
+                          <p className="font-medium">
+                            {t("submissions.table.emptyFilteredTitle")}
+                          </p>
+                          <p className="text-sm text-base-content/70">
+                            {t("submissions.table.emptyFilteredBody")}
+                          </p>
+                          {onClearFilters && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="mt-1"
+                              onClick={onClearFilters}
+                            >
+                              {t("submissions.table.emptyClearFilters")}
+                            </Button>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          <Inbox
+                            aria-hidden="true"
+                            className="size-8 text-base-content/40"
+                          />
+                          <p className="font-medium">
+                            {t("submissions.table.emptyNoDataTitle")}
+                          </p>
+                          <p className="text-sm text-base-content/70">
+                            {t("submissions.table.emptyNoDataBody")}
+                          </p>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )}
             {scores.map(
               ({
                 usernames,
@@ -869,40 +881,120 @@ const SubmissionsTable = ({
                 )
               },
             )}
-            {nonSubmitters.map((student) => (
-              <tr
-                key={`missing-${student.username || student.email || student.github_id}`}
-                className="opacity-60"
-              >
-                <td>
-                  <Avatar
-                    name={getName(student.username, students)}
-                    initials={getInitials(student.username, students)}
-                    github={student.username || student.email}
-                    subtitle={identitySubtitle(
-                      getName(student.username, students),
-                      student.username,
-                      student.section,
+            {nonSubmitters.map((student) => {
+              const accepted =
+                !isGroup &&
+                Boolean(
+                  student.username &&
+                  acceptedUsernames?.has(student.username.toLowerCase()),
+                )
+              const repo = accepted
+                ? studentRepoName(classroom, assignment, student.username)
+                : null
+              const repoHref = accepted
+                ? studentRepoUrl(org, classroom, assignment, student.username)
+                : null
+              return (
+                <tr
+                  key={`missing-${student.username || student.email || student.github_id}`}
+                >
+                  <td>
+                    <Avatar
+                      name={getName(student.username, students)}
+                      initials={getInitials(student.username, students)}
+                      github={student.username || student.email}
+                      subtitle={identitySubtitle(
+                        getName(student.username, students),
+                        student.username,
+                        student.section,
+                      )}
+                      onClick={
+                        student.username
+                          ? () => setProfileUsername(student.username)
+                          : undefined
+                      }
+                    />
+                  </td>
+                  <td>
+                    <NonSubmitterStatusBadge
+                      username={student.username}
+                      isGroup={isGroup}
+                      acceptedUsernames={acceptedUsernames}
+                    />
+                  </td>
+                  <td>—</td>
+                  <td>—</td>
+                  <td>
+                    {repo && repoHref ? (
+                      <ActionIconLink
+                        href={repoHref}
+                        icon={GitHub}
+                        label={t("submissions.table.openRepoLabel", { repo })}
+                        title={t("submissions.table.viewRepo")}
+                        emptyLabel={t("submissions.table.openRepoLabel", {
+                          repo,
+                        })}
+                        emptyTitle={t("submissions.table.viewRepo")}
+                      />
+                    ) : (
+                      "—"
                     )}
-                    onClick={
-                      student.username
-                        ? () => setProfileUsername(student.username)
-                        : undefined
-                    }
-                  />
-                </td>
-                <td>
-                  <NonSubmitterStatusBadge
-                    username={student.username}
-                    isGroup={isGroup}
-                    acceptedUsernames={acceptedUsernames}
-                  />
-                </td>
-                <td>—</td>
-                <td>—</td>
-                <td>—</td>
-              </tr>
-            ))}
+                  </td>
+                </tr>
+              )
+            })}
+            {unsubmittedGroupRepos.map(({ owner, repoName }) => {
+              const repoHref = studentRepoUrl(org, classroom, assignment, owner)
+              return (
+                <tr key={`group-${repoName}`}>
+                  <td>
+                    <GroupMembers
+                      org={org}
+                      repoName={repoName}
+                      usernames={[]}
+                      students={students}
+                      repoHref={repoHref}
+                      repoLabel={repoName}
+                      fetchMembers
+                    />
+                  </td>
+                  <td>
+                    <Badge tone="warning" className="whitespace-nowrap">
+                      {t("submissions.table.acceptedAwaiting")}
+                    </Badge>
+                  </td>
+                  <td>—</td>
+                  <td>—</td>
+                  <td>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        shape="square"
+                        className="text-base-content/70"
+                        onClick={() => setManageOwner(owner)}
+                        aria-label={t("submissions.table.membersAria")}
+                        title={t("submissions.table.members")}
+                      >
+                        <UsersRound aria-hidden="true" className="size-4" />
+                      </Button>
+                      <ActionIconLink
+                        href={repoHref}
+                        icon={GitHub}
+                        label={t("submissions.table.openRepoLabel", {
+                          repo: repoName,
+                        })}
+                        title={t("submissions.table.viewRepo")}
+                        emptyLabel={t("submissions.table.openRepoLabel", {
+                          repo: repoName,
+                        })}
+                        emptyTitle={t("submissions.table.viewRepo")}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </EnterDiv>

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -71,9 +71,6 @@ const ScoreBadge = ({
   )
 }
 
-// Per-row status chip for a roster student with no submission: distinguishes
-// accepted-but-not-submitted, never-accepted, and (group) no-group from a flat
-// "Not submitted", so a teacher can nudge accepters vs chase non-accepters.
 type IconComponent = React.ComponentType<{ className?: string }>
 
 // Inline commit/details link in the expanded history row: external link when a

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -17,6 +17,7 @@ import {
   filterNonSubmitters,
   hasAccepted,
   nonSubmitterStatus,
+  reconcileNonSubmitters,
   rosterScopedRows,
   rowMatchesQuery,
   rowOnRoster,
@@ -442,6 +443,46 @@ describe("existingGroupRepos", () => {
   it("returns an empty list for null/undefined repos", () => {
     expect(existingGroupRepos(null, "cs101", "hw1")).toEqual([])
     expect(existingGroupRepos(undefined, "cs101", "hw1")).toEqual([])
+  })
+})
+
+describe("reconcileNonSubmitters", () => {
+  const roster = [
+    student({ username: "alice" }),
+    student({ username: "bob" }),
+    student({ username: "carol" }),
+  ]
+
+  it("excludes students credited on a score row", () => {
+    const out = reconcileNonSubmitters(
+      roster,
+      [{ usernames: ["alice"] }],
+      new Set(),
+    )
+    expect(out.map((s) => s.username).sort()).toEqual(["bob", "carol"])
+  })
+
+  it("excludes a group-repo member so they aren't double-listed as no-group (#245)", () => {
+    // bob is a teammate on a formed-but-unsubmitted group repo (no score row
+    // yet); he must not surface as "no group".
+    const out = reconcileNonSubmitters(roster, [], new Set(["bob"]))
+    expect(out.map((s) => s.username).sort()).toEqual(["alice", "carol"])
+  })
+
+  it("re-lists a teammate as no-group when the member set is empty (fetch failed)", () => {
+    // Guards the failure-mode contract: an empty groupRepoMembers (e.g. the
+    // bounded fetch errored) degrades to listing everyone uncredited.
+    const out = reconcileNonSubmitters(roster, [], new Set())
+    expect(out.map((s) => s.username).sort()).toEqual(["alice", "bob", "carol"])
+  })
+
+  it("matches credit and membership case-insensitively", () => {
+    const out = reconcileNonSubmitters(
+      [student({ username: "Alice" }), student({ username: "Bob" })],
+      [{ usernames: ["ALICE"] }],
+      new Set(["bob"]),
+    )
+    expect(out).toEqual([])
   })
 })
 

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -389,25 +389,37 @@ describe("existingGroupRepos", () => {
   ]
 
   it("lists group repos for the exact classroom+assignment, keyed by founder", () => {
-    const out = existingGroupRepos(repos, "cs101", "hw1", new Set())
+    const out = existingGroupRepos(repos, "cs101", "hw1")
     expect(out.map((r) => r.owner).sort()).toEqual(["alice", "bob-team"])
   })
 
-  it("marks repos with a recorded submission as submitted", () => {
-    const out = existingGroupRepos(repos, "cs101", "hw1", new Set(["alice"]))
-    const alice = out.find((r) => r.owner === "alice")
-    const bob = out.find((r) => r.owner === "bob-team")
-    expect(alice?.submitted).toBe(true)
-    expect(bob?.submitted).toBe(false)
+  it("returns the repo name alongside the founder", () => {
+    const out = existingGroupRepos([repo("cs101-hw1-alice")], "cs101", "hw1")
+    expect(out).toEqual([{ owner: "alice", repoName: "cs101-hw1-alice" }])
+  })
+
+  it("rejects a slug-extending sibling assignment's repos (hw1 vs hw1-bonus)", () => {
+    const out = existingGroupRepos(
+      [repo("cs101-hw1-alice"), repo("cs101-hw1-bonus-alice")],
+      "cs101",
+      "hw1",
+      ["hw1", "hw1-bonus"],
+    )
+    // Without the sibling guard, `bonus-alice` would leak in as a phantom row.
+    expect(out.map((r) => r.owner)).toEqual(["alice"])
+  })
+
+  it("keeps a sibling repo when the sibling slug isn't a prefix extension", () => {
+    // `hw1b` is not `hw1-<something>`, so it never shares the `cs101-hw1-` prefix.
+    const out = existingGroupRepos([repo("cs101-hw1-alice")], "cs101", "hw1", [
+      "hw1",
+      "hw1b",
+    ])
+    expect(out.map((r) => r.owner)).toEqual(["alice"])
   })
 
   it("rejects a bare `<classroom>-<assignment>-` with an empty owner segment", () => {
-    const out = existingGroupRepos(
-      [repo("cs101-hw1-")],
-      "cs101",
-      "hw1",
-      new Set(),
-    )
+    const out = existingGroupRepos([repo("cs101-hw1-")], "cs101", "hw1")
     expect(out).toEqual([])
   })
 
@@ -416,30 +428,20 @@ describe("existingGroupRepos", () => {
       [repo("CS101-HW1-TeamRocket")],
       "cs101",
       "hw1",
-      new Set(["teamrocket"]),
     )
     expect(out).toEqual([
-      {
-        owner: "teamrocket",
-        repoName: "cs101-hw1-teamrocket",
-        submitted: true,
-      },
+      { owner: "teamrocket", repoName: "cs101-hw1-teamrocket" },
     ])
   })
 
   it("does not match a numeric-adjacent slug (hw1 vs hw10)", () => {
-    const out = existingGroupRepos(
-      [repo("cs101-hw10-team")],
-      "cs101",
-      "hw1",
-      new Set(),
-    )
+    const out = existingGroupRepos([repo("cs101-hw10-team")], "cs101", "hw1")
     expect(out).toEqual([])
   })
 
   it("returns an empty list for null/undefined repos", () => {
-    expect(existingGroupRepos(null, "cs101", "hw1", new Set())).toEqual([])
-    expect(existingGroupRepos(undefined, "cs101", "hw1", new Set())).toEqual([])
+    expect(existingGroupRepos(null, "cs101", "hw1")).toEqual([])
+    expect(existingGroupRepos(undefined, "cs101", "hw1")).toEqual([])
   })
 })
 

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -12,6 +12,7 @@ import {
   buildSectionLookup,
   computeStats,
   distinctSections,
+  existingGroupRepos,
   filterAndSortRows,
   filterNonSubmitters,
   hasAccepted,
@@ -375,6 +376,70 @@ describe("acceptedUsernames / hasAccepted / acceptedRosterCount", () => {
   it("counts roster students who accepted", () => {
     const set = acceptedUsernames(repos, "cs101", "hw1", roster)
     expect(acceptedRosterCount(roster, set)).toBe(2)
+  })
+})
+
+describe("existingGroupRepos", () => {
+  const repos = [
+    repo("cs101-hw1-alice"),
+    repo("cs101-hw1-bob-team"),
+    repo("cs101-hw2-alice"),
+    repo("cs101-hw1"),
+    repo("unrelated-repo"),
+  ]
+
+  it("lists group repos for the exact classroom+assignment, keyed by founder", () => {
+    const out = existingGroupRepos(repos, "cs101", "hw1", new Set())
+    expect(out.map((r) => r.owner).sort()).toEqual(["alice", "bob-team"])
+  })
+
+  it("marks repos with a recorded submission as submitted", () => {
+    const out = existingGroupRepos(repos, "cs101", "hw1", new Set(["alice"]))
+    const alice = out.find((r) => r.owner === "alice")
+    const bob = out.find((r) => r.owner === "bob-team")
+    expect(alice?.submitted).toBe(true)
+    expect(bob?.submitted).toBe(false)
+  })
+
+  it("rejects a bare `<classroom>-<assignment>-` with an empty owner segment", () => {
+    const out = existingGroupRepos(
+      [repo("cs101-hw1-")],
+      "cs101",
+      "hw1",
+      new Set(),
+    )
+    expect(out).toEqual([])
+  })
+
+  it("is case-insensitive on the repo name and founder", () => {
+    const out = existingGroupRepos(
+      [repo("CS101-HW1-TeamRocket")],
+      "cs101",
+      "hw1",
+      new Set(["teamrocket"]),
+    )
+    expect(out).toEqual([
+      {
+        owner: "teamrocket",
+        repoName: "cs101-hw1-teamrocket",
+        submitted: true,
+      },
+    ])
+  })
+
+  it("does not match a numeric-adjacent slug (hw1 vs hw10)", () => {
+    const out = existingGroupRepos(
+      [repo("cs101-hw10-team")],
+      "cs101",
+      "hw1",
+      new Set(),
+    )
+    expect(out).toEqual([])
+  })
+
+  it("returns an empty list for null/undefined repos", () => {
+    expect(existingGroupRepos(null, "cs101", "hw1", new Set())).toEqual([])
+    expect(existingGroupRepos(undefined, "cs101", "hw1", new Set())).toEqual([])
   })
 })
 

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -199,7 +199,8 @@ export const DEFAULT_SORT: SubmissionSort = "recent"
 // a `<classroom>-<assignment>-` prefix: prefix-stripping over-matches a sibling
 // whose slug extends this one (assignment "hw" would capture `cs-hw-bonus-alice`
 // from "hw-bonus"), polluting the set and risking a 404 when the modal rebuilds
-// a URL. (See docs/solutions/.../forward-only-cross-binary-repo-name-contract.md.)
+// a URL. (existingGroupRepos below must reverse-parse and so guards this
+// explicitly against the sibling assignment list.)
 //
 // Group assignments are excluded (repo named after the owner, not each member),
 // so callers offer the accepted filter for individual assignments only.
@@ -229,41 +230,42 @@ export function hasAccepted(username: string, accepted: Set<string>): boolean {
 }
 
 // An existing group repo derived from the org repo list, keyed by its founder
-// (the `<owner>` segment of `<classroom>-<assignment>-<owner>`). `submitted` is
-// true when a graded push already recorded scores for it — the dashboard folds
-// submitted groups into the normal score rows and surfaces only the rest, so a
-// teacher can see teams that formed but haven't pushed yet (#245).
-export type GroupRepo = { owner: string; repoName: string; submitted: boolean }
+// (the `<owner>` segment of `<classroom>-<assignment>-<owner>`).
+export type GroupRepo = { owner: string; repoName: string }
 
 // Group repos that exist for the assignment. Unlike individual acceptance, the
 // founder logins aren't known up front (group repos are named after whoever
 // created the group), so we must reverse-parse the `<classroom>-<assignment>-`
-// prefix rather than forward-construct per student. The sibling-slug hazard the
-// individual path avoids (assignment "hw" capturing "cs-hw-bonus-alice") is not
-// a false positive here: `cs-hw-bonus-alice` yields founder `bonus-alice`, a
-// real distinct repo, so it simply isn't matched as a submitted owner unless it
-// truly is one. Empty owner segments (a bare `<classroom>-<assignment>-`) are
-// rejected. `submittedOwners` is the set of lowercased founders that already
-// have a score row.
+// prefix rather than forward-construct per student. Prefix-stripping alone
+// over-matches a sibling whose slug extends this one (assignment "hw1" capturing
+// `cs101-hw1-bonus-alice` from "hw1-bonus"), so reject any repo that belongs to
+// a longer sibling assignment: `siblingSlugs` is the classroom's other slugs, and
+// a repo under `<classroom>-<sibling>-` where `<sibling>` extends `<assignment>-`
+// is that sibling's, not ours. Empty owner segments (a bare
+// `<classroom>-<assignment>-`) are rejected.
 export function existingGroupRepos(
   repos: GitHubRepo[] | null | undefined,
   classroom: string,
   assignment: string,
-  submittedOwners: Set<string>,
+  siblingSlugs: string[] = [],
 ): GroupRepo[] {
   if (!repos) return []
   const prefix = `${classroom}-${assignment}-`.toLowerCase()
+  // Prefixes of sibling assignments whose slug strictly extends this one; a repo
+  // under any of these was created for the sibling, not this assignment.
+  const overlapPrefixes = siblingSlugs
+    .map((slug) => slug.toLowerCase())
+    .filter((slug) => slug !== assignment.toLowerCase())
+    .map((slug) => `${classroom}-${slug}-`.toLowerCase())
+    .filter((siblingPrefix) => siblingPrefix.startsWith(prefix))
   const out: GroupRepo[] = []
   for (const repo of repos) {
     const name = repo.name.toLowerCase()
     if (!name.startsWith(prefix)) continue
+    if (overlapPrefixes.some((sibling) => name.startsWith(sibling))) continue
     const owner = name.slice(prefix.length)
     if (!owner) continue
-    out.push({
-      owner,
-      repoName: name,
-      submitted: submittedOwners.has(owner),
-    })
+    out.push({ owner, repoName: name })
   }
   return out
 }

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -228,6 +228,46 @@ export function hasAccepted(username: string, accepted: Set<string>): boolean {
   return accepted.has(username.trim().toLowerCase())
 }
 
+// An existing group repo derived from the org repo list, keyed by its founder
+// (the `<owner>` segment of `<classroom>-<assignment>-<owner>`). `submitted` is
+// true when a graded push already recorded scores for it — the dashboard folds
+// submitted groups into the normal score rows and surfaces only the rest, so a
+// teacher can see teams that formed but haven't pushed yet (#245).
+export type GroupRepo = { owner: string; repoName: string; submitted: boolean }
+
+// Group repos that exist for the assignment. Unlike individual acceptance, the
+// founder logins aren't known up front (group repos are named after whoever
+// created the group), so we must reverse-parse the `<classroom>-<assignment>-`
+// prefix rather than forward-construct per student. The sibling-slug hazard the
+// individual path avoids (assignment "hw" capturing "cs-hw-bonus-alice") is not
+// a false positive here: `cs-hw-bonus-alice` yields founder `bonus-alice`, a
+// real distinct repo, so it simply isn't matched as a submitted owner unless it
+// truly is one. Empty owner segments (a bare `<classroom>-<assignment>-`) are
+// rejected. `submittedOwners` is the set of lowercased founders that already
+// have a score row.
+export function existingGroupRepos(
+  repos: GitHubRepo[] | null | undefined,
+  classroom: string,
+  assignment: string,
+  submittedOwners: Set<string>,
+): GroupRepo[] {
+  if (!repos) return []
+  const prefix = `${classroom}-${assignment}-`.toLowerCase()
+  const out: GroupRepo[] = []
+  for (const repo of repos) {
+    const name = repo.name.toLowerCase()
+    if (!name.startsWith(prefix)) continue
+    const owner = name.slice(prefix.length)
+    if (!owner) continue
+    out.push({
+      owner,
+      repoName: name,
+      submitted: submittedOwners.has(owner),
+    })
+  }
+  return out
+}
+
 // Per-row status for a roster student with no submission row. Distinguishes the
 // three states that would otherwise collapse into a flat "Not submitted":
 //   - no-group: group assignment — the student isn't credited on any submitting

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -270,6 +270,27 @@ export function existingGroupRepos(
   return out
 }
 
+// Roster students with no submission, with group-repo members excluded (#245).
+// "Credited" = login appears in any score row's `usernames` (member_usernames
+// for groups, else [owner]). A login in `groupRepoMembers` (an existing group
+// repo's founder or a fetched collaborator) is also excluded — they already
+// appear as that group's repo row, so listing them as "no group" too would
+// double-count them. Pure derivation extracted from SubmissionsPage so the
+// reconciliation is unit-testable.
+export function reconcileNonSubmitters(
+  students: Student[],
+  scoreRows: { usernames: string[] }[],
+  groupRepoMembers: Set<string>,
+): Student[] {
+  const credited = new Set(
+    scoreRows.flatMap((row) => row.usernames.map((u) => u.toLowerCase())),
+  )
+  return students.filter((student) => {
+    const login = student.username.toLowerCase()
+    return !credited.has(login) && !groupRepoMembers.has(login)
+  })
+}
+
 // Per-row status for a roster student with no submission row. Distinguishes the
 // three states that would otherwise collapse into a flat "Not submitted":
 //   - no-group: group assignment — the student isn't credited on any submitting


### PR DESCRIPTION
## Summary

Closes #245. Teachers can see every created assignment repository in the submissions dashboard — with a repo link and, for groups, the team members — even before any submission is pushed. Everything stays 100% client-side, derived from data the dashboard already fetches (org repo list + `scores.json` + collaborators).

- **Individual assignments:** `accepted-not-submitted` rows link to the student's repo (previously a bare `—`).
- **Group assignments:** render a row per existing group repo (from the org repo list, prefix-matched by `<classroom>-<assignment>-` with a guard against slug-extending sibling assignments like `hw1` vs `hw1-bonus`) with a repo link, member avatars, and a Members button.
- **Accurate "no group" reconciliation:** collaborators for all existing group repos are fetched up front (bounded at `REPO_READ_CONCURRENCY`, cached briefly) and unioned with founders, so a teammate on a formed-but-unsubmitted group is never also listed as "Not in a credited group". The fetch shares one cache with the group rows and the Members modal, and **tolerates a single repo's failure** (a deleted-repo 404, 403, or 429) so one bad read degrades to "that repo's members unknown" instead of voiding the whole union and re-flashing every teammate as "no group".
- Rows render at full opacity now that a status badge communicates their state.
- No new i18n keys (reused `acceptedAwaiting`, `openRepoLabel`, `viewRepo`, `members`, `membersAria`).

## Structure

- `dashboard.ts` — `existingGroupRepos()`: pure prefix-match derivation, sibling-guarded, keyed by founder. `reconcileNonSubmitters()`: pure, unit-tested derivation of the roster's non-submitters with group-repo members excluded (extracted from `SubmissionsPage` so the #245 reconciliation is testable).
- `useGroupRepoMembers.ts` — bounded, cache-sharing collaborator fetch + member-login union used for reconciliation; each per-repo read is fault-tolerant so the union survives a single failure.
- `SubmissionsRows.tsx` — extracted `NonSubmitterRow`, `GroupRepoRow`, `GroupActionControls`, `GroupMembers`, `ActionIconLink` (keeps `SubmissionsTable.tsx` under ~1k lines and de-duplicates the group action cell).

## Trade-off

Always-accurate group reconciliation costs ~N throttled collaborator reads per assignment view (N = number of group repos), cached ~1 min. Concurrency is bounded to avoid secondary-rate-limit bursts; total request volume is the deliberate cost of accuracy on load. A single failing read no longer aborts the batch — the union just omits that repo's members.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx vitest run` passing (new: `existingGroupRepos` sibling-slug/enumeration tests, `reconcileNonSubmitters` credit/membership/empty-set/case tests, `useGroupRepoMembers` union/cache-priming/partial-failure/no-fetch tests, `SubmissionsTable` repo-link + empty-state + cache-only assertions)
- [x] `npx eslint` + `npx prettier --check` clean on touched files
- [ ] Manual: group assignment with an accepted-but-not-submitted repo shows a single group-repo row with members (no duplicate "no group" row); individual accepted-not-submitted rows link to the repo
