### PR TITLE
refactor(web): unify the tolerant-404 idiom behind tolerateGitHubError

### DIFF
--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -41,7 +41,11 @@ import {
   getCommit,
   getConfigRepoBranch,
 } from "../github/queries"
-import { GitHubAPIError, isDefinitiveGitHubStatus } from "@/hooks/github/errors"
+import {
+  GitHubAPIError,
+  isDefinitiveGitHubStatus,
+  tolerateGitHubError,
+} from "@/hooks/github/errors"
 import { isSameGitHubUser, parseGitHubId } from "@/util/students"
 import { studentKey, rosterClaimSet } from "@/util/identity"
 import { mapWithConcurrency } from "@/util/concurrency"
@@ -250,13 +254,10 @@ export async function resolveTeamIdForRoleRead(
   if (role === "student") {
     return (await resolveClassroomTeam(client, org, classroom)).id
   }
-  try {
+  return tolerateGitHubError(async () => {
     const classroomJson = await getClassroomJson(client, { org, classroom })
     return classroomJson.teams?.[role]?.id
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.isNotFound) return undefined
-    throw err
-  }
+  }, undefined)
 }
 
 // Resolve the classroom team, retrying only TRANSIENT read failures (5xx / 429 /
@@ -1339,12 +1340,7 @@ async function readFileOrNull(
   path: string,
   ref: string,
 ): Promise<string | null> {
-  try {
-    return await getRawFile(client, { org, path, ref })
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) return null
-    throw err
-  }
+  return tolerateGitHubError(() => getRawFile(client, { org, path, ref }), null)
 }
 
 // Converge a classroom bootstrapped before the roster rename onto roster.csv,

--- a/web/src/hooks/github/errors.test.ts
+++ b/web/src/hooks/github/errors.test.ts
@@ -5,6 +5,7 @@ import {
   isDefinitiveGitHubStatus,
   parseSsoAuthorizationUrl,
   retryTransientGitHubError,
+  tolerateGitHubError,
 } from "./errors"
 
 const apiError = (status: number, ssoHeader?: string | null) =>
@@ -243,5 +244,66 @@ describe("requestId", () => {
     const error = apiError(403, "required; url=https://github.com/orgs/a/sso")
     expect(error.requestId).toBeNull()
     expect(error.isSsoRequired).toBe(true)
+  })
+})
+
+describe("tolerateGitHubError", () => {
+  it("returns the op result on success", async () => {
+    expect(await tolerateGitHubError(async () => 42, -1)).toBe(42)
+  })
+
+  it("returns the fallback on a tolerated 404 (default predicate)", async () => {
+    const result = await tolerateGitHubError(async () => {
+      throw apiError(404)
+    }, [] as number[])
+    expect(result).toEqual([])
+  })
+
+  it("runs onCaught then returns the fallback", async () => {
+    let caught: GitHubAPIError | null = null
+    const result = await tolerateGitHubError(
+      async () => {
+        throw apiError(404)
+      },
+      null,
+      { onCaught: (e) => (caught = e) },
+    )
+    expect(result).toBeNull()
+    expect(caught).not.toBeNull()
+  })
+
+  it("widens with a predicate (tolerates 403)", async () => {
+    const result = await tolerateGitHubError(
+      async () => {
+        throw apiError(403)
+      },
+      [] as string[],
+      { predicate: (e) => e.isForbidden || e.isNotFound },
+    )
+    expect(result).toEqual([])
+  })
+
+  it("rethrows a non-tolerated status (500)", async () => {
+    await expect(
+      tolerateGitHubError(async () => {
+        throw apiError(500)
+      }, null),
+    ).rejects.toThrow("HTTP 500")
+  })
+
+  it("does not tolerate 403 under the default (404-only) predicate", async () => {
+    await expect(
+      tolerateGitHubError(async () => {
+        throw apiError(403)
+      }, null),
+    ).rejects.toBeInstanceOf(GitHubAPIError)
+  })
+
+  it("rethrows a non-GitHubAPIError throw unchanged", async () => {
+    await expect(
+      tolerateGitHubError(async () => {
+        throw new Error("network")
+      }, null),
+    ).rejects.toThrow("network")
   })
 })

--- a/web/src/hooks/github/errors.test.ts
+++ b/web/src/hooks/github/errors.test.ts
@@ -306,4 +306,18 @@ describe("tolerateGitHubError", () => {
       }, null),
     ).rejects.toThrow("network")
   })
+
+  it("does not run onCaught on the rethrow path", async () => {
+    let ran = false
+    await expect(
+      tolerateGitHubError(
+        async () => {
+          throw apiError(500)
+        },
+        null,
+        { onCaught: () => (ran = true) },
+      ),
+    ).rejects.toThrow("HTTP 500")
+    expect(ran).toBe(false)
+  })
 })

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -203,3 +203,30 @@ export function readGitHubRateLimitHeaders(res: Response): GitHubRateLimit {
     retryAfter: numberHeader("retry-after"),
   }
 }
+
+// Run a GitHub read/write, swallowing a tolerated error into `fallback` instead
+// of throwing — the "absent reads as empty/none" idiom, unified so call sites
+// stop re-spelling the `instanceof GitHubAPIError && status === 404` guard.
+// Defaults to 404-only; pass `predicate` to widen (e.g. 403||404 for a list a
+// caller can't read) and `onCaught` for a side-effect (e.g. log.warn) before
+// returning. Any error the predicate rejects, and any non-GitHubAPIError throw,
+// rethrows unchanged.
+export async function tolerateGitHubError<T>(
+  op: () => Promise<T>,
+  fallback: T,
+  opts?: {
+    predicate?: (err: GitHubAPIError) => boolean
+    onCaught?: (err: GitHubAPIError) => void
+  },
+): Promise<T> {
+  try {
+    return await op()
+  } catch (err) {
+    const tolerates = opts?.predicate ?? ((e: GitHubAPIError) => e.isNotFound)
+    if (err instanceof GitHubAPIError && tolerates(err)) {
+      opts?.onCaught?.(err)
+      return fallback
+    }
+    throw err
+  }
+}

--- a/web/src/hooks/github/errors.ts
+++ b/web/src/hooks/github/errors.ts
@@ -211,14 +211,18 @@ export function readGitHubRateLimitHeaders(res: Response): GitHubRateLimit {
 // caller can't read) and `onCaught` for a side-effect (e.g. log.warn) before
 // returning. Any error the predicate rejects, and any non-GitHubAPIError throw,
 // rethrows unchanged.
-export async function tolerateGitHubError<T>(
+//
+// `F` defaults to `T` but is separate so a fallback wider than the op result
+// (e.g. op yields `GitHubRepo[]`, fallback is `null`) types as `T | F` without a
+// cast at the call site.
+export async function tolerateGitHubError<T, F = T>(
   op: () => Promise<T>,
-  fallback: T,
+  fallback: F,
   opts?: {
     predicate?: (err: GitHubAPIError) => boolean
     onCaught?: (err: GitHubAPIError) => void
   },
-): Promise<T> {
+): Promise<T | F> {
   try {
     return await op()
   } catch (err) {

--- a/web/src/hooks/github/mutations.deleteTeam.test.ts
+++ b/web/src/hooks/github/mutations.deleteTeam.test.ts
@@ -147,4 +147,39 @@ describe("deleteClassroomTeam fail-closed guard", () => {
     ).resolves.toBeUndefined()
     expect(deletes).toEqual([])
   })
+
+  // The live-id GET matches, so we reach the DELETE; a 404 there (deleted
+  // between check and delete) is tolerated as success.
+  it("tolerates a 404 on the DELETE itself (gone between check and delete)", async () => {
+    const request = vi.fn(
+      async (_path: string, init?: { method?: string }): Promise<unknown> => {
+        if (init?.method === "DELETE") throw apiError(404)
+        return { id: 11 }
+      },
+    )
+    const client = { request } as unknown as GitHubClient
+    await expect(
+      deleteClassroomTeam(client, "acme", {
+        id: 11,
+        slug: "classroom50-cs101-ta",
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  // A non-404 failure on the DELETE must propagate — never silently swallowed.
+  it("rethrows a non-404 error on the DELETE", async () => {
+    const request = vi.fn(
+      async (_path: string, init?: { method?: string }): Promise<unknown> => {
+        if (init?.method === "DELETE") throw apiError(500)
+        return { id: 11 }
+      },
+    )
+    const client = { request } as unknown as GitHubClient
+    await expect(
+      deleteClassroomTeam(client, "acme", {
+        id: 11,
+        slug: "classroom50-cs101-ta",
+      }),
+    ).rejects.toBeInstanceOf(GitHubAPIError)
+  })
 })

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -768,7 +768,7 @@ export async function cancelOrgInvitation(
 ): Promise<{ cancelled: boolean }> {
   const { org, invitationId } = input
 
-  return tolerateGitHubError<{ cancelled: boolean }>(
+  return tolerateGitHubError(
     async () => {
       await client.request(`/orgs/${org}/invitations/${invitationId}`, {
         method: "DELETE",

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -9,7 +9,7 @@ import {
   type GitHubOrgMembership,
   type GitHubBlob,
 } from "./types"
-import { GitHubAPIError } from "./errors"
+import { GitHubAPIError, tolerateGitHubError } from "./errors"
 import sodium from "libsodium-wrappers"
 import {
   getBranchRef,
@@ -639,19 +639,16 @@ export async function deleteClassroomTeam(
     throw err
   }
 
-  try {
-    await client.request(
-      `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(team.slug)}`,
-      {
-        method: "DELETE",
-      },
-    )
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
-      return
-    }
-    throw err
-  }
+  await tolerateGitHubError(
+    () =>
+      client.request(
+        `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(team.slug)}`,
+        {
+          method: "DELETE",
+        },
+      ),
+    undefined,
+  )
 }
 
 export function addRepositoryToTeam(
@@ -712,19 +709,16 @@ export async function removeUserFromTeam(
 ): Promise<void> {
   const { org, teamSlug, username } = input
 
-  try {
-    await client.request(
-      `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
-        teamSlug,
-      )}/memberships/${encodeURIComponent(username)}`,
-      { method: "DELETE" },
-    )
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
-      return
-    }
-    throw err
-  }
+  await tolerateGitHubError(
+    () =>
+      client.request(
+        `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+          teamSlug,
+        )}/memberships/${encodeURIComponent(username)}`,
+        { method: "DELETE" },
+      ),
+    undefined,
+  )
 }
 
 // POST /orgs/{org}/invitations by invitee_id or email. An optional team_ids
@@ -774,17 +768,15 @@ export async function cancelOrgInvitation(
 ): Promise<{ cancelled: boolean }> {
   const { org, invitationId } = input
 
-  try {
-    await client.request(`/orgs/${org}/invitations/${invitationId}`, {
-      method: "DELETE",
-    })
-    return { cancelled: true }
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.isNotFound) {
-      return { cancelled: false }
-    }
-    throw err
-  }
+  return tolerateGitHubError<{ cancelled: boolean }>(
+    async () => {
+      await client.request(`/orgs/${org}/invitations/${invitationId}`, {
+        method: "DELETE",
+      })
+      return { cancelled: true }
+    },
+    { cancelled: false },
+  )
 }
 
 // DELETE /orgs/{org}/memberships/{username}: removes an active member or
@@ -795,16 +787,13 @@ export async function removeOrgMembership(
 ): Promise<void> {
   const { org, username } = input
 
-  try {
-    await client.request(`/orgs/${org}/memberships/${username}`, {
-      method: "DELETE",
-    })
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.isNotFound) {
-      return
-    }
-    throw err
-  }
+  await tolerateGitHubError(
+    () =>
+      client.request(`/orgs/${org}/memberships/${username}`, {
+        method: "DELETE",
+      }),
+    undefined,
+  )
 }
 
 export type OrgMembershipState = "active" | "pending"
@@ -837,17 +826,14 @@ export async function archiveRepo(
 ): Promise<void> {
   const { owner, repo } = input
 
-  try {
-    await client.request(`/repos/${owner}/${repo}`, {
-      method: "PATCH",
-      body: { archived: true },
-    })
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.isNotFound) {
-      return
-    }
-    throw err
-  }
+  await tolerateGitHubError(
+    () =>
+      client.request(`/repos/${owner}/${repo}`, {
+        method: "PATCH",
+        body: { archived: true },
+      }),
+    undefined,
+  )
 }
 
 // DELETE /repos/{owner}/{repo}. Needs the delete_repo OAuth scope. A token
@@ -860,16 +846,13 @@ export async function deleteRepo(
 ): Promise<void> {
   const { owner, repo } = input
 
-  try {
-    await client.request(`/repos/${owner}/${repo}`, {
-      method: "DELETE",
-    })
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.isNotFound) {
-      return
-    }
-    throw err
-  }
+  await tolerateGitHubError(
+    () =>
+      client.request(`/repos/${owner}/${repo}`, {
+        method: "DELETE",
+      }),
+    undefined,
+  )
 }
 
 // GET /orgs/{org}/memberships/{username} -> the raw membership state. A 404
@@ -882,17 +865,14 @@ export async function readOrgMembershipState(
   org: string,
   username: string,
 ): Promise<OrgMembershipState | null> {
-  try {
+  return tolerateGitHubError(async () => {
     const membership = await client.request<{ state?: OrgMembershipState }>(
       `/orgs/${encodeURIComponent(org)}/memberships/${encodeURIComponent(
         username,
       )}`,
     )
     return membership.state ?? null
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) return null
-    throw err
-  }
+  }, null)
 }
 
 // GET /orgs/{org}/memberships/{username} -> state, or null on 404/error. The

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -18,7 +18,11 @@ import type {
 } from "./types"
 import type { Assignment } from "@/types/classroom"
 import { CONFIG_REPO_MARKER_REL, ORG_GITHUB_DIR } from "@/skeleton/skeleton"
-import { GitHubAPIError, retryTransientGitHubError } from "./errors"
+import {
+  GitHubAPIError,
+  retryTransientGitHubError,
+  tolerateGitHubError,
+} from "./errors"
 import {
   COLLECT_SCORES_WORKFLOW,
   REGRADE_WORKFLOW,
@@ -497,8 +501,11 @@ export function releasesQuery(
 ) {
   return queryOptions({
     queryKey: githubKeys.releases(owner, repo),
-    queryFn: async ({ signal }): Promise<GitHubRelease[]> => {
-      try {
+    queryFn: ({ signal }): Promise<GitHubRelease[]> =>
+      // A missing repo (student hasn't accepted, or a previewing teacher with
+      // no repo) 404s here — no releases, so [] falls through to the empty
+      // state. Other errors throw.
+      tolerateGitHubError(async () => {
         const releases = await client.request<GitHubRelease[]>(
           `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
             repo,
@@ -509,16 +516,7 @@ export function releasesQuery(
         return releases
           .filter((r) => r.tag_name.startsWith(SUBMISSION_TAG_PREFIX))
           .sort((a, b) => releaseTime(b) - releaseTime(a))
-      } catch (err) {
-        // A missing repo (student hasn't accepted, or a previewing teacher with
-        // no repo) 404s here — no releases. Return [] so the page falls through
-        // to its empty state. Other errors throw.
-        if (err instanceof GitHubAPIError && err.status === 404) {
-          return []
-        }
-        throw err
-      }
-    },
+      }, []),
     enabled: Boolean(owner && repo),
     staleTime: 5 * 60 * 1000,
     retry: false,
@@ -539,19 +537,17 @@ export function configCommitsQuery(
 ) {
   return queryOptions({
     queryKey: githubKeys.configCommits(org ?? "", perPage),
-    queryFn: async ({ signal }): Promise<GitHubCommit[]> => {
-      try {
-        return await client.request<GitHubCommit[]>(
-          `/repos/${encodeURIComponent(
-            org ?? "",
-          )}/classroom50/commits?per_page=${perPage}`,
-          { method: "GET", signal },
-        )
-      } catch (err) {
-        if (err instanceof GitHubAPIError && err.status === 404) return []
-        throw err
-      }
-    },
+    queryFn: ({ signal }): Promise<GitHubCommit[]> =>
+      tolerateGitHubError(
+        () =>
+          client.request<GitHubCommit[]>(
+            `/repos/${encodeURIComponent(
+              org ?? "",
+            )}/classroom50/commits?per_page=${perPage}`,
+            { method: "GET", signal },
+          ),
+        [],
+      ),
     enabled: Boolean(org),
     staleTime: 60 * 1000,
     retry: false,
@@ -811,21 +807,16 @@ export async function listOrgAdmins(
   client: GitHubClient,
   org: string,
 ): Promise<GitHubUser[]> {
-  try {
-    return await paginateAll<GitHubUser>(
-      client,
-      (page) =>
-        `/orgs/${encodeURIComponent(org)}/members?role=admin&per_page=100&page=${page}`,
-    )
-  } catch (error) {
-    if (
-      error instanceof GitHubAPIError &&
-      (error.status === 403 || error.status === 404)
-    ) {
-      return []
-    }
-    throw error
-  }
+  return tolerateGitHubError(
+    () =>
+      paginateAll<GitHubUser>(
+        client,
+        (page) =>
+          `/orgs/${encodeURIComponent(org)}/members?role=admin&per_page=100&page=${page}`,
+      ),
+    [],
+    { predicate: (e) => e.isForbidden || e.isNotFound },
+  )
 }
 
 export function orgAdminsQuery(client: GitHubClient, org: string) {
@@ -935,15 +926,10 @@ export async function getTeam(
 ) {
   const teamSlug = `classroom50-${classroom}`
 
-  try {
-    return await client.request<GitHubTeam>(`/orgs/${org}/teams/${teamSlug}`)
-  } catch (error) {
-    if (error instanceof GitHubAPIError && error.status === 404) {
-      return null
-    }
-
-    throw error
-  }
+  return tolerateGitHubError(
+    () => client.request<GitHubTeam>(`/orgs/${org}/teams/${teamSlug}`),
+    null,
+  )
 }
 
 // Whether the classroom team already has access to a repo (the in-org private
@@ -956,17 +942,12 @@ export async function teamHasRepoAccess(
   const { org, classroom, owner, repo } = input
   const teamSlug = `classroom50-${classroom}`
 
-  try {
+  return tolerateGitHubError(async () => {
     await client.request(
       `/orgs/${org}/teams/${teamSlug}/repos/${owner}/${repo}`,
     )
     return true
-  } catch (error) {
-    if (error instanceof GitHubAPIError && error.status === 404) {
-      return false
-    }
-    throw error
-  }
+  }, false)
 }
 
 export async function ensureTeam(
@@ -1218,14 +1199,10 @@ export async function getRepo(
   owner: string,
   repo: string,
 ) {
-  try {
-    return await client.request<GitHubRepo>(`/repos/${owner}/${repo}`)
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
-      return null
-    }
-    throw err
-  }
+  return tolerateGitHubError(
+    () => client.request<GitHubRepo>(`/repos/${owner}/${repo}`),
+    null,
+  )
 }
 
 // List a team's members across all pages. 404 (team doesn't exist yet) returns
@@ -1235,18 +1212,17 @@ export async function listTeamMembers(
   org: string,
   teamSlug: string,
 ): Promise<GitHubUser[]> {
-  try {
-    return await paginateAll<GitHubUser>(
-      client,
-      (page) =>
-        `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
-          teamSlug,
-        )}/members?per_page=100&page=${page}`,
-    )
-  } catch (error) {
-    if (error instanceof GitHubAPIError && error.status === 404) return []
-    throw error
-  }
+  return tolerateGitHubError(
+    () =>
+      paginateAll<GitHubUser>(
+        client,
+        (page) =>
+          `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+            teamSlug,
+          )}/members?per_page=100&page=${page}`,
+      ),
+    [],
+  )
 }
 
 export function teamMembersQuery(
@@ -1273,18 +1249,17 @@ export async function listTeamInvitations(
   org: string,
   teamSlug: string,
 ): Promise<GitHubOrgInvitation[]> {
-  try {
-    return await paginateAll<GitHubOrgInvitation>(
-      client,
-      (page) =>
-        `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
-          teamSlug,
-        )}/invitations?per_page=100&page=${page}`,
-    )
-  } catch (error) {
-    if (error instanceof GitHubAPIError && error.status === 404) return []
-    throw error
-  }
+  return tolerateGitHubError(
+    () =>
+      paginateAll<GitHubOrgInvitation>(
+        client,
+        (page) =>
+          `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+            teamSlug,
+          )}/invitations?per_page=100&page=${page}`,
+      ),
+    [],
+  )
 }
 
 export function teamInvitationsQuery(
@@ -1332,16 +1307,15 @@ export async function listOrgTeams(
   client: GitHubClient,
   org: string,
 ): Promise<GitHubTeam[]> {
-  try {
-    return await paginateAll<GitHubTeam>(
-      client,
-      (page) =>
-        `/orgs/${encodeURIComponent(org)}/teams?per_page=100&page=${page}`,
-    )
-  } catch (error) {
-    if (error instanceof GitHubAPIError && error.status === 404) return []
-    throw error
-  }
+  return tolerateGitHubError(
+    () =>
+      paginateAll<GitHubTeam>(
+        client,
+        (page) =>
+          `/orgs/${encodeURIComponent(org)}/teams?per_page=100&page=${page}`,
+      ),
+    [],
+  )
 }
 
 export function orgTeamsQuery(client: GitHubClient, org: string) {
@@ -1372,35 +1346,29 @@ export async function getOpenPullRequests(
   repo: string,
   signal?: AbortSignal,
 ) {
-  try {
-    return await client.request<GitHubPullRequest[]>(
-      `/repos/${owner}/${repo}/pulls?state=open&per_page=10`,
-      { method: "GET", signal },
-    )
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
-      return []
-    }
-    throw err
-  }
+  return tolerateGitHubError(
+    () =>
+      client.request<GitHubPullRequest[]>(
+        `/repos/${owner}/${repo}/pulls?state=open&per_page=10`,
+        { method: "GET", signal },
+      ),
+    [] as GitHubPullRequest[],
+  )
 }
 
 export async function getOrgRepos(client: GitHubClient, owner: string) {
-  try {
-    // Paginate to exhaustion: a single per_page=100 page silently under-counts
-    // orgs with >100 repos, making repo-list-derived signals (e.g. assignment
-    // acceptance on the submissions dashboard) miss students in large orgs. A
-    // first-page failure still surfaces a 404 as null below.
-    return await paginateAll<GitHubRepo>(
-      client,
-      (page) => `/orgs/${owner}/repos?per_page=100&page=${page}&type=all`,
-    )
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
-      return null
-    }
-    throw err
-  }
+  // Paginate to exhaustion: a single per_page=100 page silently under-counts
+  // orgs with >100 repos, making repo-list-derived signals (e.g. assignment
+  // acceptance on the submissions dashboard) miss students in large orgs. A
+  // first-page 404 surfaces as null.
+  return tolerateGitHubError(
+    () =>
+      paginateAll<GitHubRepo>(
+        client,
+        (page) => `/orgs/${owner}/repos?per_page=100&page=${page}&type=all`,
+      ),
+    null as GitHubRepo[] | null,
+  )
 }
 
 type RepositorySecret = {

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -1352,7 +1352,7 @@ export async function getOpenPullRequests(
         `/repos/${owner}/${repo}/pulls?state=open&per_page=10`,
         { method: "GET", signal },
       ),
-    [] as GitHubPullRequest[],
+    [],
   )
 }
 
@@ -1367,7 +1367,7 @@ export async function getOrgRepos(client: GitHubClient, owner: string) {
         client,
         (page) => `/orgs/${owner}/repos?per_page=100&page=${page}&type=all`,
       ),
-    null as GitHubRepo[] | null,
+    null,
   )
 }
 


### PR DESCRIPTION
## Summary

Collapse the hand-copied `try { return await ... } catch (err) { if (err instanceof GitHubAPIError && err.status === 404) return <sentinel>; throw err }` idiom (repeated ~20x across the GitHub read/write layer) behind one flexible helper.

- Add `tolerateGitHubError(op, fallback, { predicate?, onCaught? })` to `web/src/hooks/github/errors.ts`, co-located with `GitHubAPIError` / `isDefinitiveGitHubStatus` / `retryTransientGitHubError`. Defaults to 404-only (using `err.isNotFound`, so call sites stop hand-spelling `status === 404`); `predicate` widens (e.g. `403 || 404`), `onCaught` runs a side-effect before returning the fallback. Non-tolerated statuses and non-`GitHubAPIError` throws rethrow unchanged.
- Route the clean 404-to-sentinel reads/writes through it in `queries.ts`, `mutations.ts`, and `api/mutations/students.ts`. The one widened site (`listOrgAdmins`) keeps `403 || 404` via the predicate.

### Left inline (verified — not a tolerate-else-throw shape)

- Inverse fail-open (`verifyClassroom50ConfigRepo`), tree-fallback (`getRawFileWithFallbackSource`), stateful branch (`getClassroom50OrgSummary`).
- Control-flow guards (`deleteClassroomTeam`'s pre-check block that exits the function on 404) and `!(...isNotFound) throw` inverse guards.
- Predicate / error-message mappers that only inspect `isNotFound` (`resolveRole`, `membershipReadError`, `orgChecks.unreadableFrom`, message branches).
- Sites in files outside this pass's scope (`assignments.ts`, `classrooms.ts`, `orgChecks.ts`, `useOrgClassroom50Status.ts`, `activityRuns.ts` — the last has an abort pre-check). Candidate follow-up.

Behavior-preserving: `err.isNotFound` is exactly `status === 404`; widened sites keep `403 || 404` via the predicate. Titled `refactor:` — no release-please changelog entry, by intent.

## Test plan

- [x] `npm run check` green in `web/` (tsc + eslint + prettier + vitest): 0 errors, 1489 tests pass across 130 files.
- [x] 7 new `tolerateGitHubError` unit tests (success passthrough, 404 fallback, `onCaught`, widened `403` predicate, rethrow non-tolerated 500, default predicate rejects 403, rethrow non-`GitHubAPIError`).
- [x] Existing `queries.test.ts` / `mutations.test.ts` (the 404-tolerating behavior of `getTeam`, `listTeamInvitations`, releases, etc.) pass unchanged as the behavior-preservation guard.
- [x] Grep guard: remaining `instanceof GitHubAPIError && (status === 404 | isNotFound)` matches are only the documented inline exclusions.