### PR TITLE
fix(web): distinguish assignment load failures

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1528,6 +1528,14 @@
     "errorTitle": "Could not accept assignment",
     "errorGeneric": "Something went wrong while accepting the assignment.",
     "errorRetryHint": "This is safe to retry — address anything noted above if you can, then use the button below. Some errors (rate limits, GitHub hiccups) just need a moment before retrying.",
+    "loadError": {
+      "badge": "Assignment temporarily unavailable",
+      "title": "Couldn't load assignment",
+      "body": "Classroom 50 couldn't load the published assignment information. Check your connection and try again.",
+      "hint": "If this keeps happening, ask your instructor to confirm that the assignment was published successfully.",
+      "retry": "Try again",
+      "retrying": "Trying again"
+    },
     "openRepository": "Open repository",
     "goToClassroom": "Go to my classroom",
     "editCollaborators": "Edit collaborators",

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+const pagesAssignmentsMock = vi.fn()
+const refetchAssignments = vi.fn()
+
+vi.mock("@/hooks/usePagesAssignments", () => ({
+  default: (org?: string, classroom?: string, secret?: string) =>
+    pagesAssignmentsMock(org, classroom, secret),
+}))
+
+vi.mock("@/hooks/useGetRepo", () => ({
+  default: () => ({ data: null, isLoading: false }),
+}))
+
+vi.mock("@/hooks/useGetOwnOrgMembership", () => ({
+  default: () => ({
+    data: { state: "active" },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/useAcceptAndVerifyMembership", () => ({
+  useAcceptAndVerifyMembership: () => ({
+    isActive: true,
+    isError: false,
+    error: null,
+    retry: vi.fn(),
+  }),
+}))
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({
+    user: { id: 1, login: "student", name: "Test Student" },
+  }),
+}))
+
+vi.mock("@/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+vi.mock("@/components/LanguageDialog", () => ({
+  LanguageDialog: () => null,
+}))
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useParams: () => ({
+      org: "VNU-HUS",
+      classroom: "classroom50-pilot-2026",
+      assignment: "hello-python",
+    }),
+    useSearch: () => ({ k: "dkybs3e9" }),
+    Link: ({ children }: { children: ReactNode }) => <a href="/">{children}</a>,
+  }
+})
+
+import AcceptAssignmentPage from "./AcceptAssignmentPage"
+
+const renderPage = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <AcceptAssignmentPage />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  pagesAssignmentsMock.mockReset()
+  refetchAssignments.mockReset()
+})
+
+describe("AcceptAssignmentPage assignment manifest states", () => {
+  it("shows a retryable load error instead of misreporting a missing assignment", () => {
+    pagesAssignmentsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+      error: new TypeError("Failed to fetch"),
+      refetch: refetchAssignments,
+    })
+
+    renderPage()
+
+    expect(screen.queryByText("accept.loadError.title")).not.toBeNull()
+    expect(screen.queryByText("accept.notFound.title")).toBeNull()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "accept.loadError.retry" }),
+    )
+    expect(refetchAssignments).toHaveBeenCalledTimes(1)
+    expect(pagesAssignmentsMock).toHaveBeenCalledWith(
+      "VNU-HUS",
+      "classroom50-pilot-2026",
+      "dkybs3e9",
+    )
+  })
+
+  it("keeps not-found for a successfully loaded manifest without the slug", () => {
+    pagesAssignmentsMock.mockReturnValue({
+      data: [{ slug: "different-assignment" }],
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+      error: null,
+      refetch: refetchAssignments,
+    })
+
+    renderPage()
+
+    expect(screen.queryByText("accept.notFound.title")).not.toBeNull()
+    expect(screen.queryByText("accept.loadError.title")).toBeNull()
+  })
+
+  it("keeps usable cached data when only a background refetch failed", () => {
+    pagesAssignmentsMock.mockReturnValue({
+      data: [
+        {
+          slug: "hello-python",
+          name: "Hello Python",
+          mode: "individual",
+        },
+      ],
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+      error: new TypeError("Background refetch failed"),
+      refetch: refetchAssignments,
+    })
+
+    renderPage()
+
+    expect(screen.queryByText("Hello Python")).not.toBeNull()
+    expect(screen.queryByText("accept.loadError.title")).toBeNull()
+    expect(screen.queryByText("accept.notFound.title")).toBeNull()
+  })
+
+  it("keeps a paused initial query pending instead of reporting not-found", () => {
+    pagesAssignmentsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isPending: true,
+      isFetching: false,
+      error: null,
+      refetch: refetchAssignments,
+    })
+
+    renderPage()
+
+    expect(screen.queryByText("accept.loadingAssignment")).not.toBeNull()
+    expect(screen.queryByText("accept.loadError.title")).toBeNull()
+    expect(screen.queryByText("accept.notFound.title")).toBeNull()
+  })
+})

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -215,6 +215,65 @@ const AssignmentNotFound = ({
   )
 }
 
+const AssignmentLoadError = ({
+  user,
+  onRetry,
+  retrying,
+}: {
+  user: GitHubUser | null
+  onRetry: () => void
+  retrying: boolean
+}) => {
+  const { t } = useTranslation()
+  return (
+    <AcceptLayout>
+      <AcceptCard>
+        <Card.Body className="gap-8">
+          <div>
+            <span className="badge badge-warning badge-soft gap-2">
+              <AlertTriangle aria-hidden="true" className="size-4" />
+              {t("accept.loadError.badge")}
+            </span>
+
+            <h1 className="mt-6 text-2xl font-bold">
+              {t("accept.loadError.title")}
+            </h1>
+
+            <p className="mt-2 text-base text-base-content/70">
+              {t("accept.loadError.body")}
+            </p>
+          </div>
+
+          <Alert tone="warning" className="items-start">
+            <AlertTriangle aria-hidden="true" className="size-5 shrink-0" />
+            <div>{t("accept.loadError.hint")}</div>
+          </Alert>
+
+          <Button
+            variant="primary"
+            className="w-full"
+            loading={retrying}
+            loadingLabel={t("accept.loadError.retrying")}
+            onClick={onRetry}
+          >
+            {t("accept.loadError.retry")}
+          </Button>
+
+          <div className="divider my-0" />
+
+          <div className="space-y-3">
+            <div className="label p-0 text-base font-semibold">
+              {t("accept.signedInAs")}
+            </div>
+
+            <UserInfo user={user} />
+          </div>
+        </Card.Body>
+      </AcceptCard>
+    </AcceptLayout>
+  )
+}
+
 const modeLabelKey: Record<string, string> = {
   individual: "accept.modeIndividual",
   group: "accept.modeGroup",
@@ -529,8 +588,13 @@ const AcceptAssignmentPage = () => {
   const { user } = useGithubAuth()
   const username = user?.login
 
-  const { data: assignmentsData, isLoading: loadingAssignments } =
-    usePagesAssignments(org, classroom, secret)
+  const {
+    data: assignmentsData,
+    isPending: pendingAssignments,
+    isFetching: fetchingAssignments,
+    error: assignmentsError,
+    refetch: refetchAssignments,
+  } = usePagesAssignments(org, classroom, secret)
   const {
     data: orgInvite,
     isLoading: loadingOrgMembership,
@@ -599,7 +663,7 @@ const AcceptAssignmentPage = () => {
     },
   })
 
-  if (loadingAssignments || isLoadingRepo || loadingOrgMembership) {
+  if (pendingAssignments || isLoadingRepo || loadingOrgMembership) {
     return (
       <AcceptLayout>
         <Spinner size="xl" label={t("accept.loadingAssignment")} />
@@ -671,6 +735,20 @@ const AcceptAssignmentPage = () => {
       <AcceptLayout>
         <Spinner size="xl" label={t("accept.loadingAssignment")} />
       </AcceptLayout>
+    )
+  }
+
+  // A failed Pages request is not evidence that the assignment slug is absent.
+  // Keep transport/HTTP/JSON errors retryable and reserve "not found" for a
+  // successfully loaded manifest that genuinely lacks the requested slug.
+  // Do not render the raw error: fetch errors can contain the capability URL.
+  if (assignmentsError && assignmentsData === undefined) {
+    return (
+      <AssignmentLoadError
+        user={user}
+        retrying={fetchingAssignments}
+        onRetry={() => void refetchAssignments()}
+      />
     )
   }
 


### PR DESCRIPTION
## Summary

- distinguish assignment-manifest load failures from a successfully loaded manifest that lacks the requested slug
- give students a safe retry action without rendering the capability URL or raw fetch error
- preserve usable cached assignment data after a background-refetch failure and keep paused initial queries in a pending state
- add focused regression coverage for load-error, true not-found, cached-data, and paused-query states

## Root cause and impact

`AcceptAssignmentPage` previously consumed only `data` and `isLoading` from `usePagesAssignments`. When the GitHub Pages request failed because of HTTP, network, CORS, or JSON errors, React Query exposed an error with no data, but the page treated that state as a missing assignment and rendered “Assignment not found.” Students therefore received a false diagnosis and had no way to retry without reloading the route.

The page now reserves “not found” for a successful manifest that genuinely lacks the slug. Initial load failures get a sanitized retry screen; raw errors are intentionally not displayed because an HTTP error may contain the capability URL.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Verification

- Confirmed the new load-error regression failed on the pre-fix implementation.
- `cd web && npm run check` — 131 test files and 1,486 tests passed.
- `cd web && npm run build` — production build succeeded.
- `python3 web/src/locales/audit_i18n.py` — passed with zero missing keys.
- Fresh correctness review and security review completed with no remaining actionable findings.

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - Web: `cd web && npm run check`
- [x] No cross-binary contract changed.
- [x] No CLI command or flag changed.
- [x] My commit follows Conventional Commits.
