### PR TITLE
refactor(web): single-source the per-classroom team slug

### DIFF
--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -64,7 +64,7 @@ var StaffTeamRepoPermissions = map[StaffRole]string{
 }
 
 // staffTeamName derives the staff-role team name: `classroom50-<short>-<role>`.
-// Mirrors the web's staffTeamName. The short-name is canonical, so slug == name.
+// Mirrors the web's classroomTeamSlug(short, role). The short-name is canonical, so slug == name.
 func staffTeamName(shortName string, role StaffRole) string {
 	return "classroom50-" + shortName + "-" + string(role)
 }

--- a/web/src/api/mutations/assignments.ts
+++ b/web/src/api/mutations/assignments.ts
@@ -15,6 +15,7 @@ import {
 } from "../github/queries"
 import { getUser } from "@/hooks/github/queries"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import { GitHubAPIError } from "@/hooks/github/errors"
 
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
@@ -977,7 +978,7 @@ async function tryGrantTeamTemplateRead(
     return (
       `Assignment "${slug}" was saved, but granting the classroom team read on ` +
       `the private template ${template.owner}/${template.repo} failed (${detail}). ` +
-      `Students can't accept it until the classroom50-${classroom} team is granted ` +
+      `Students can't accept it until the ${classroomTeamSlug(classroom)} team is granted ` +
       `read on that repo — grant the team read on ${template.owner}/${template.repo} ` +
       `directly in GitHub (Settings -> Collaborators and teams), then students can accept.`
     )

--- a/web/src/api/mutations/students.ts
+++ b/web/src/api/mutations/students.ts
@@ -14,7 +14,6 @@ import {
   readOrgMembershipState,
   removeUserFromTeam,
   setOrgMembershipRole,
-  staffTeamName,
   updateRef,
   type GitTreeEntry,
 } from "@/hooks/github/mutations"
@@ -61,6 +60,7 @@ import {
 } from "@/util/rosterCsv"
 import { rosterPath, legacyRosterPath } from "@/util/rosterPath"
 import { ROLE_RANK, orgRoleForRole, type RosterRole } from "@/util/teamRoster"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import { memberIdentitySets } from "@/util/identity"
 import {
   classifyRosterUpload,
@@ -236,7 +236,7 @@ async function resolveClassroomTeam(
       throw err
     }
   }
-  return { slug: `classroom50-${classroom}` }
+  return { slug: classroomTeamSlug(classroom) }
 }
 
 // Read-only resolution of the GitHub team id for a role from classroom.json —
@@ -940,11 +940,12 @@ async function resolveClassroomTeamSlugs(
     }
   }
   return {
-    student: json?.team?.slug || `classroom50-${classroom}`,
+    student: json?.team?.slug || classroomTeamSlug(classroom),
     staff: {
       instructor:
-        json?.teams?.instructor?.slug || staffTeamName(classroom, "instructor"),
-      ta: json?.teams?.ta?.slug || staffTeamName(classroom, "ta"),
+        json?.teams?.instructor?.slug ||
+        classroomTeamSlug(classroom, "instructor"),
+      ta: json?.teams?.ta?.slug || classroomTeamSlug(classroom, "ta"),
     },
   }
 }

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -445,7 +445,7 @@ export function isDeletableClassroomTeamRef(
 ): team is ClassroomTeamRef {
   return (
     typeof team?.slug === "string" &&
-    team.slug.startsWith("classroom50-") &&
+    team.slug.startsWith(`${CONFIG_REPO}-`) &&
     Number.isInteger(team.id) &&
     (team.id as number) > 0
   )

--- a/web/src/hooks/github/mutations.ts
+++ b/web/src/hooks/github/mutations.ts
@@ -24,6 +24,7 @@ import { STUDENT_CSV_FIELDS } from "@/api/mutations/students"
 import { getRepo } from "./queries"
 import { checkPages, repairOrgDefaults } from "./orgChecks"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import { prefixCommit } from "@/util/commit"
 import { repairRulesets } from "./rulesets"
 import { buildSkeletonFiles, type SkeletonFile } from "@/skeleton/skeleton"
@@ -516,19 +517,13 @@ export async function ensureClassroomTeam(
   classroom: string,
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   assertCanonicalTeamShortName(classroom)
-  return ensureSecretTeamByName(client, org, `classroom50-${classroom}`)
+  return ensureSecretTeamByName(client, org, classroomTeamSlug(classroom))
 }
 
 // The per-classroom staff team refs persisted under classroom.json `teams`.
 export type StaffTeamRefs = {
   instructor?: ClassroomTeamRef
   ta?: ClassroomTeamRef
-}
-
-// The team name (== slug, given the canonical-short-name guard) for a staff
-// role: `classroom50-<classroom>-<role>`.
-export function staffTeamName(classroom: string, role: StaffRole): string {
-  return `classroom50-${classroom}-${role}`
 }
 
 // Create (or adopt) the per-classroom STAFF team for `role`, a `secret` team
@@ -541,7 +536,7 @@ export async function ensureClassroomRoleTeam(
   role: StaffRole,
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   assertCanonicalTeamShortName(classroom)
-  return ensureSecretTeamByName(client, org, staffTeamName(classroom, role))
+  return ensureSecretTeamByName(client, org, classroomTeamSlug(classroom, role))
 }
 
 // Grant a team `push` (write) on the org's `classroom50` config repo, so its

--- a/web/src/hooks/github/queries.ts
+++ b/web/src/hooks/github/queries.ts
@@ -19,6 +19,7 @@ import type {
 import type { Assignment } from "@/types/classroom"
 import { CONFIG_REPO_MARKER_REL, ORG_GITHUB_DIR } from "@/skeleton/skeleton"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import {
   GitHubAPIError,
   retryTransientGitHubError,
@@ -925,7 +926,7 @@ export async function getTeam(
   org: string,
   classroom: string,
 ) {
-  const teamSlug = `classroom50-${classroom}`
+  const teamSlug = classroomTeamSlug(classroom)
 
   return tolerateGitHubError(
     () => client.request<GitHubTeam>(`/orgs/${org}/teams/${teamSlug}`),
@@ -941,7 +942,7 @@ export async function teamHasRepoAccess(
   input: { org: string; classroom: string; owner: string; repo: string },
 ): Promise<boolean> {
   const { org, classroom, owner, repo } = input
-  const teamSlug = `classroom50-${classroom}`
+  const teamSlug = classroomTeamSlug(classroom)
 
   return tolerateGitHubError(async () => {
     await client.request(
@@ -961,7 +962,7 @@ export async function ensureTeam(
   if (existingTeam) return existingTeam
 
   try {
-    return await createTeam(client, { org, name: `classroom50-${classroom}` })
+    return await createTeam(client, { org, name: classroomTeamSlug(classroom) })
   } catch (error) {
     if (error instanceof GitHubAPIError && error.status === 422) {
       const team = await getTeam(client, org, classroom)

--- a/web/src/hooks/useClassroomRole.ts
+++ b/web/src/hooks/useClassroomRole.ts
@@ -2,8 +2,7 @@ import { useCallback } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { GitHubAPIError, retryTransientGitHubError } from "./github/errors"
-import { staffTeamName } from "./github/mutations"
-import { classroomTeamSlugHeuristic } from "@/util/orgMembership"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import { useRoleView } from "@/context/roleView/RoleViewProvider"
 import {
   resolveClassroomRole,
@@ -79,9 +78,8 @@ export function useClassroomRole(
   const { viewAs } = useRoleView()
 
   const teamSlug = (role: StaffRole) =>
-    org && classroom ? staffTeamName(classroom, role) : ""
-  const studentSlug =
-    org && classroom ? classroomTeamSlugHeuristic(classroom) : ""
+    org && classroom ? classroomTeamSlug(classroom, role) : ""
+  const studentSlug = org && classroom ? classroomTeamSlug(classroom) : ""
 
   const enabled = Boolean(org && classroom && username)
   const instructorQuery = useQuery({

--- a/web/src/hooks/useOrgMembersOverview.ts
+++ b/web/src/hooks/useOrgMembersOverview.ts
@@ -11,7 +11,7 @@ import {
 } from "@/hooks/github/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import useGetClasses from "@/hooks/useGetClasses"
-import { classroomTeamSlugHeuristic } from "@/util/orgMembership"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import { toStudent } from "@/util/roster"
 import { rosterPath, legacyRosterPath } from "@/util/rosterPath"
 import {
@@ -34,7 +34,7 @@ export type OrgMembersOverview = {
   isLoading: boolean
   isError: boolean
   // classroom path -> resolved GitHub team slug (classroom.json.team.slug, else
-  // the classroom50-<classroom> heuristic). The SAME slug teamMembersByClassroom
+  // the derived classroomTeamSlug). The SAME slug teamMembersByClassroom
   // keys from, so optimistic team-cache writes on the Members page target the
   // cache this hook reads (a collided classroom's real slug can differ).
   teamSlugByClassroom: Map<string, string>
@@ -101,13 +101,13 @@ const useOrgMembersOverview = (org: string | undefined): OrgMembersOverview => {
   // Live members of each classroom's `classroom50-<classroom>` team — the
   // enrollment source of truth, cross-referenced against CSV-derived access to
   // surface drift. Slug resolves from classroom.json when present (GitHub may
-  // slugify a collided name differently), else the heuristic.
+  // slugify a collided name differently), else the derived classroomTeamSlug.
   const teamSlugs = useMemo(
     () =>
       classroomNames.map(
         (name, i) =>
           (metaQueries[i]?.data as Classroom | undefined)?.team?.slug ||
-          classroomTeamSlugHeuristic(name),
+          classroomTeamSlug(name),
       ),
     // metaQueries is a fresh array each render; depend on the stable signature.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/hooks/useTeamRoster.ts
+++ b/web/src/hooks/useTeamRoster.ts
@@ -12,8 +12,7 @@ import {
   orgMembersAllQuery,
 } from "@/hooks/github/queries"
 import { GitHubAPIError } from "@/hooks/github/errors"
-import { staffTeamName } from "@/hooks/github/mutations"
-import { classroomTeamSlugHeuristic } from "@/util/orgMembership"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import {
   buildTeamRoster,
   countByState,
@@ -110,15 +109,14 @@ export function useTeamRoster(
   const isOwner = can("manageOrg", { orgRole })
 
   const { data: classroomJson } = useGetClassroom(org, classroom)
-  const teamSlug =
-    classroomJson?.team?.slug || classroomTeamSlugHeuristic(classroom)
-  // Staff team slugs: prefer the classroom's stored slug, else the heuristic
-  // (same precedence as the student slug above).
+  const teamSlug = classroomJson?.team?.slug || classroomTeamSlug(classroom)
+  // Staff team slugs: prefer the classroom's stored slug, else the derived
+  // classroomTeamSlug (same precedence as the student slug above).
   const instructorSlug =
     classroomJson?.teams?.instructor?.slug ||
-    staffTeamName(classroom, "instructor")
+    classroomTeamSlug(classroom, "instructor")
   const taSlug =
-    classroomJson?.teams?.ta?.slug || staffTeamName(classroom, "ta")
+    classroomJson?.teams?.ta?.slug || classroomTeamSlug(classroom, "ta")
 
   const {
     data: members,
@@ -375,8 +373,7 @@ export function useInvalidateTeamRoster(
 ): () => void {
   const queryClient = useQueryClient()
   const { data: classroomJson } = useGetClassroom(org, classroom)
-  const teamSlug =
-    classroomJson?.team?.slug || classroomTeamSlugHeuristic(classroom)
+  const teamSlug = classroomJson?.team?.slug || classroomTeamSlug(classroom)
 
   return useCallback(() => {
     void queryClient.invalidateQueries({
@@ -404,8 +401,7 @@ export function useSeedTeamMember(
 ): (member: OptimisticMember) => void {
   const queryClient = useQueryClient()
   const { data: classroomJson } = useGetClassroom(org, classroom)
-  const teamSlug =
-    classroomJson?.team?.slug || classroomTeamSlugHeuristic(classroom)
+  const teamSlug = classroomJson?.team?.slug || classroomTeamSlug(classroom)
 
   return useCallback(
     (member: OptimisticMember) => {

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -21,6 +21,7 @@ import { useToast } from "@/context/notifications/NotificationProvider"
 import { useGitHubViewer } from "@/hooks/github/hooks"
 import { githubKeys, invalidateInviteQueries } from "@/hooks/github/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import useOrgMembersOverview from "@/hooks/useOrgMembersOverview"
 import type { OrgMemberRow } from "@/util/orgMembers"
 import { githubOrgPeopleUrl } from "@/util/orgUrl"
@@ -110,12 +111,12 @@ const OrgMembersPage = () => {
   }
 
   // Resolved GitHub team slug for a classroom (classroom.json.team.slug, else
-  // the classroom50-<classroom> heuristic). Must match the key
+  // the derived classroomTeamSlug). Must match the key
   // useOrgMembersOverview reads the team cache under, or optimistic writes below
   // target a cache nobody reads (a name-collision classroom's real slug differs
   // from the heuristic) and reintroduce the false "unprovisioned" flash.
   const teamSlugFor = (classroom: string) =>
-    teamSlugByClassroom.get(classroom) ?? `classroom50-${classroom}`
+    teamSlugByClassroom.get(classroom) ?? classroomTeamSlug(classroom)
 
   // Invalidate the non-racy caches a roster write touches: classroom.json and,
   // unless suppressed, the CSV. The team-members query is deliberately NOT

--- a/web/src/pages/classes/ClaimInstructorNotice.test.tsx
+++ b/web/src/pages/classes/ClaimInstructorNotice.test.tsx
@@ -36,8 +36,6 @@ vi.mock("@/hooks/github/mutations", () => ({
   ensureClassroomRoleTeam: (...a: unknown[]) => ensureTeamMock(...a),
   grantTeamConfigRepoWrite: (...a: unknown[]) => grantWriteMock(...a),
   addUserToTeam: (...a: unknown[]) => addUserMock(...a),
-  staffTeamName: (classroom: string, role: string) =>
-    `classroom50-${classroom}-${role}`,
 }))
 
 import { ClaimInstructorNotice } from "./ClaimInstructorNotice"

--- a/web/src/pages/classes/ClaimInstructorNotice.tsx
+++ b/web/src/pages/classes/ClaimInstructorNotice.tsx
@@ -7,11 +7,11 @@ import { useToast } from "@/context/notifications/NotificationProvider"
 import { useOrgRole } from "@/context/orgRole/OrgRoleProvider"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { can } from "@/util/capabilities"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import {
   addUserToTeam,
   ensureClassroomRoleTeam,
   grantTeamConfigRepoWrite,
-  staffTeamName,
 } from "@/hooks/github/mutations"
 import { githubKeys } from "@/hooks/github/queries"
 import { Alert, Button } from "@/components/ui"
@@ -65,7 +65,7 @@ export function ClaimInstructorNotice({
       queryClient.invalidateQueries({
         queryKey: githubKeys.teamMembers(
           org,
-          staffTeamName(classroom, "instructor"),
+          classroomTeamSlug(classroom, "instructor"),
         ),
       })
       // Re-resolve the viewer's classroom role: their instructor-team membership
@@ -74,7 +74,7 @@ export function ClaimInstructorNotice({
         queryKey: [
           "team-membership",
           org,
-          staffTeamName(classroom, "instructor"),
+          classroomTeamSlug(classroom, "instructor"),
           username,
         ],
       })

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -15,13 +15,13 @@ import {
   getUser,
 } from "@/hooks/github/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import {
   addUserToTeam,
   ensureClassroomRoleTeam,
   removeUserFromTeam,
   resendOrgInvitation,
   cancelOrgInvitation,
-  staffTeamName,
   grantTeamConfigRepoWrite,
 } from "@/hooks/github/mutations"
 import {
@@ -194,7 +194,7 @@ const AddStaff = ({
       queryClient.invalidateQueries({
         queryKey: githubKeys.teamMembers(
           org,
-          staffTeamName(classroom, addedRole),
+          classroomTeamSlug(classroom, addedRole),
         ),
       })
       // Record the new staffer's role in roster.csv now (best-effort).
@@ -297,7 +297,7 @@ const StaffRoleList = ({
   const { t } = useTranslation()
   const client = useGitHubClient()
   const teamSlug = useMemo(
-    () => staffTeamName(classroom, role),
+    () => classroomTeamSlug(classroom, role),
     [classroom, role],
   )
   const membersQuery = useQuery(teamMembersQuery(client, org, teamSlug))
@@ -372,7 +372,7 @@ const StaffMemberRow = ({
   const queryClient = useQueryClient()
   const { notify } = useToast()
   const [confirmingRemove, setConfirmingRemove] = useState(false)
-  const teamSlug = staffTeamName(classroom, role)
+  const teamSlug = classroomTeamSlug(classroom, role)
 
   const roleLabel = t(ROLE_LABEL_KEY[role])
   const rolePlural =
@@ -495,7 +495,7 @@ const PendingStaffRow = ({
   const client = useGitHubClient()
   const queryClient = useQueryClient()
   const { notify } = useToast()
-  const teamSlug = staffTeamName(classroom, role)
+  const teamSlug = classroomTeamSlug(classroom, role)
   const who = invite.login || invite.email || String(invite.id)
 
   const invalidate = () => {

--- a/web/src/util/orgMembership.test.ts
+++ b/web/src/util/orgMembership.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest"
-import {
-  classroomTeamSlugHeuristic,
-  isValidEmail,
-  normalizeEmail,
-} from "./orgMembership"
+import { isValidEmail, normalizeEmail } from "./orgMembership"
 
 describe("normalizeEmail", () => {
   it("lowercases and trims", () => {
@@ -27,13 +23,5 @@ describe("isValidEmail", () => {
     expect(isValidEmail("nope")).toBe(false)
     expect(isValidEmail("a@b")).toBe(false)
     expect(isValidEmail("a @b.com")).toBe(false)
-  })
-})
-
-describe("classroomTeamSlugHeuristic", () => {
-  it("derives classroom50-<classroom>", () => {
-    expect(classroomTeamSlugHeuristic("cs-principles")).toBe(
-      "classroom50-cs-principles",
-    )
   })
 })

--- a/web/src/util/orgMembership.ts
+++ b/web/src/util/orgMembership.ts
@@ -1,15 +1,6 @@
-// Email + classroom-team-slug helpers shared by the CSV write path
-// (students.ts) and the student org-membership flow (/onboard and accept
-// pages). Survivors of the team-as-source-of-truth rework.
-
-// The classroom team slug a STUDENT derives (the authoritative slug is in the
-// private classroom.json they can't read). Safe-degrade: on a slug collision the
-// derived slug 404s and the membership read reports "not a member", so a miss
-// never grants false access. The teacher side reads the real slug via
-// resolveClassroomTeam.
-export function classroomTeamSlugHeuristic(classroom: string): string {
-  return `classroom50-${classroom}`
-}
+// Email helpers shared by the CSV write path (students.ts) and the student
+// org-membership flow (/onboard and accept pages). Survivors of the
+// team-as-source-of-truth rework.
 
 // Canonical form for email comparison. Lowercase + trim only: deliberately do
 // NOT strip Gmail-style `+tags` or dots — those are provider-specific and would

--- a/web/src/util/teamSlug.test.ts
+++ b/web/src/util/teamSlug.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { classroomTeamSlug } from "./teamSlug"
+
+// Byte-identity guard: these strings are a cross-tool contract (CLI + schema
+// hand-mirror them). A change here that isn't mirrored breaks membership reads
+// and template grants, so pin the exact wire form.
+describe("classroomTeamSlug", () => {
+  it("students team drops the role suffix", () => {
+    expect(classroomTeamSlug("cs-principles")).toBe("classroom50-cs-principles")
+    expect(classroomTeamSlug("cs101", "student")).toBe("classroom50-cs101")
+  })
+
+  it("staff roles append the role suffix", () => {
+    expect(classroomTeamSlug("cs101", "instructor")).toBe(
+      "classroom50-cs101-instructor",
+    )
+    expect(classroomTeamSlug("cs101", "ta")).toBe("classroom50-cs101-ta")
+  })
+})

--- a/web/src/util/teamSlug.ts
+++ b/web/src/util/teamSlug.ts
@@ -1,11 +1,9 @@
 import { CONFIG_REPO } from "@/util/configRepo"
 import type { StaffRole } from "@/types/classroom"
 
-// The roles a per-classroom GitHub team can back. Broader than StaffRole because
-// it also covers the students team — which is a real team but NOT a staff role
-// (it carries no `-<role>` suffix and isn't stored under classroom.json.teams).
-// Keeping StaffRole as the sole "who is a teacher" authority, this just layers
-// `student` on top; a future head-ta added to StaffRole is picked up for free.
+// Roles a per-classroom team can back. Broader than StaffRole: also the students
+// team, a real team but not a staff role (no `-<role>` suffix, absent from
+// classroom.json.teams). Layered on StaffRole so a future head-ta flows in free.
 export type ClassroomTeamRole = "student" | StaffRole
 
 // The single derivation of a per-classroom team's slug (== name, given the

--- a/web/src/util/teamSlug.ts
+++ b/web/src/util/teamSlug.ts
@@ -1,0 +1,30 @@
+import { CONFIG_REPO } from "@/util/configRepo"
+import type { StaffRole } from "@/types/classroom"
+
+// The roles a per-classroom GitHub team can back. Broader than StaffRole because
+// it also covers the students team — which is a real team but NOT a staff role
+// (it carries no `-<role>` suffix and isn't stored under classroom.json.teams).
+// Keeping StaffRole as the sole "who is a teacher" authority, this just layers
+// `student` on top; a future head-ta added to StaffRole is picked up for free.
+export type ClassroomTeamRole = "student" | StaffRole
+
+// The single derivation of a per-classroom team's slug (== name, given the
+// canonical-short-name guard). Student drops the role suffix
+// (`classroom50-<classroom>`); each staff role appends it
+// (`classroom50-<classroom>-<role>`). A byte-mirror of the CLI/schema team
+// convention — a cross-tool contract with no compile-time link across Go and
+// TypeScript, so keep it in lockstep.
+//
+// Safe-degrade for students: the authoritative slug lives in the private
+// classroom.json a student can't read, so a student derives it. On a slug
+// collision the derived slug 404s and the membership read reports "not a
+// member", so a miss never grants false access; the teacher side reads the real
+// slug from classroom.json.
+export function classroomTeamSlug(
+  classroom: string,
+  role: ClassroomTeamRole = "student",
+): string {
+  return role === "student"
+    ? `${CONFIG_REPO}-${classroom}`
+    : `${CONFIG_REPO}-${classroom}-${role}`
+}


### PR DESCRIPTION
## Summary

Track T2 of the architecture-layering roadmap: single-source the per-classroom GitHub team slug.

- Introduces one pure helper `classroomTeamSlug(classroom, role = "student")` in `web/src/util/teamSlug.ts`, built from the T1 `CONFIG_REPO` constant and keyed by `ClassroomTeamRole = "student" | StaffRole`. Student drops the role suffix (`classroom50-<c>`); staff roles append it (`classroom50-<c>-<role>`).
- Replaces the hand-built `classroom50-${classroom}[-${role}]` literal across ~15 sites and removes both prior builders — `classroomTeamSlugHeuristic` (was in `util/orgMembership.ts`) and `staffTeamName` (was in the heavy `hooks/github/mutations.ts`).
- Produced strings stay **byte-identical** — this slug is a cross-tool contract hand-mirrored by the Go CLI and the JSON schema. A new `util/teamSlug.test.ts` pins the exact wire form.
- Reuses `StaffRole` as the sole "who is a teacher" authority, so a future `head-ta` added there flows into the slug helper for free.
- Refreshes a stale cross-tool comment in the Go mirror (`cli/.../team.go`) that referenced the renamed web symbol. Comment-only; no CLI behavior or release-track change.

Scoped superset of the roadmap's T2 (which covered only the student slug and treated staff slugs as already-centralized) — both builders now share one home.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` — 0 errors
- [x] `prettier --check` — clean
- [x] `vitest run` — 1494/1494 pass
- [x] Grep confirms zero remaining `classroom50-${classroom}` literals and no lingering `staffTeamName` / `classroomTeamSlugHeuristic` importers in `web/`
- [x] `/ce-code-review` — 8 reviewers clean; only comment-drift fixes applied