### PR TITLE
fix(web): stop no-cycle guard test timing out in CI

### DIFF
--- a/web/src/github-core/noCycleGuard.test.ts
+++ b/web/src/github-core/noCycleGuard.test.ts
@@ -8,24 +8,36 @@ import { fileURLToPath } from "node:url"
 // (no parser/resolver → it resolved zero @/* edges and passed green while a
 // cycle existed), and a future eslint-plugin-import-x bump could re-break the
 // rule/resolver wiring while the co-scoped no-unresolved tripwire stays green.
-// Nothing else in CI would notice. This writes a two-file cycle INSIDE the
-// guarded scope, runs eslint, and asserts import-x/no-cycle fires by rule id
-// (not just a non-zero exit — a no-unresolved failure must not masquerade as a
-// no-cycle pass).
+// Nothing else in CI would notice. This writes a two-file cycle plus a clean
+// control INSIDE the guarded scope, runs eslint once, and asserts
+// import-x/no-cycle fires by rule id on the cycle files but not the control
+// (a non-zero exit alone isn't enough — a no-unresolved failure must not
+// masquerade as a no-cycle pass, and a globally-broken eslint must not read as
+// a real catch).
 
 const CORE_DIR = fileURLToPath(new URL(".", import.meta.url))
+const WEB_ROOT = fileURLToPath(new URL("../..", import.meta.url))
+const ESLINT_BIN = fileURLToPath(
+  new URL("../../node_modules/.bin/eslint", import.meta.url),
+)
 
-type EslintMessage = { ruleId: string | null }
-type EslintFileResult = { messages: EslintMessage[] }
+// Spawning eslint (Node startup + the TS project resolver) is inherently slow,
+// especially cold on CI — well past vitest's 5s default. Give it room.
+const TIMEOUT_MS = 60_000
 
-// Run eslint over `paths` and return every rule id it reported. `npx eslint`
-// exits non-zero when errors are found, so execFileSync throwing is expected;
+type EslintFileResult = {
+  filePath: string
+  messages: { ruleId: string | null }[]
+}
+
+// Run eslint over `paths` and return a { basename -> ruleIds[] } map. eslint
+// exits non-zero when it finds errors, so execFileSync throwing is expected;
 // the JSON report is on stdout either way.
-function ruleIdsFor(paths: string[]): string[] {
+function ruleIdsByFile(paths: string[]): Record<string, string[]> {
   let stdout: string
   try {
-    stdout = execFileSync("npx", ["eslint", "--format", "json", ...paths], {
-      cwd: fileURLToPath(new URL("../..", import.meta.url)),
+    stdout = execFileSync(ESLINT_BIN, ["--format", "json", ...paths], {
+      cwd: WEB_ROOT,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     })
@@ -33,36 +45,50 @@ function ruleIdsFor(paths: string[]): string[] {
     stdout = (err as { stdout?: string }).stdout ?? ""
   }
   const results = JSON.parse(stdout) as EslintFileResult[]
-  return results.flatMap((r) => r.messages.map((m) => m.ruleId ?? ""))
+  const out: Record<string, string[]> = {}
+  for (const r of results) {
+    out[r.filePath.split("/").pop() ?? r.filePath] = r.messages.map(
+      (m) => m.ruleId ?? "",
+    )
+  }
+  return out
 }
 
 describe("data-layer no-cycle guard is live", () => {
-  it("reports import-x/no-cycle on a cycle inside the guarded scope", () => {
-    // Temp dir under src/github-core so the guard's files glob matches it.
-    const dir = mkdtempSync(`${CORE_DIR}__nocycle_probe_`)
-    try {
-      writeFileSync(
-        `${dir}/a.ts`,
-        `import { b } from "./b"\nexport const a = () => b()\n`,
-      )
-      writeFileSync(
-        `${dir}/b.ts`,
-        `import { a } from "./a"\nexport const b = () => a()\n`,
-      )
+  it(
+    "reports import-x/no-cycle on a cycle inside the guarded scope",
+    { timeout: TIMEOUT_MS },
+    () => {
+      // Temp dir under src/github-core so the guard's files glob matches it.
+      const dir = mkdtempSync(`${CORE_DIR}__nocycle_probe_`)
+      try {
+        writeFileSync(
+          `${dir}/a.ts`,
+          `import { b } from "./b"\nexport const a = () => b()\n`,
+        )
+        writeFileSync(
+          `${dir}/b.ts`,
+          `import { a } from "./a"\nexport const b = () => a()\n`,
+        )
+        // Positive control: a non-cyclic file in the same scope must NOT report
+        // no-cycle — guards against a globally-broken eslint erroring on
+        // everything, which would make the cycle assertion a false pass.
+        writeFileSync(`${dir}/c.ts`, `export const c = () => 1\n`)
 
-      const cycleIds = ruleIdsFor([`${dir}/a.ts`, `${dir}/b.ts`])
-      expect(
-        cycleIds,
-        "The no-cycle guard did not fire on a real cycle in src/github-core — it has gone inert (check the parser/resolver wiring and files glob in eslint.config.js).",
-      ).toContain("import-x/no-cycle")
+        const byFile = ruleIdsByFile([
+          `${dir}/a.ts`,
+          `${dir}/b.ts`,
+          `${dir}/c.ts`,
+        ])
 
-      // Positive control: a non-cyclic file in the same scope must NOT report
-      // no-cycle. Guards against a globally-broken eslint that errors on
-      // everything (which would make the assertion above a false pass).
-      writeFileSync(`${dir}/c.ts`, `export const c = () => 1\n`)
-      expect(ruleIdsFor([`${dir}/c.ts`])).not.toContain("import-x/no-cycle")
-    } finally {
-      rmSync(dir, { recursive: true, force: true })
-    }
-  })
+        expect(
+          byFile["a.ts"],
+          "The no-cycle guard did not fire on a real cycle in src/github-core — it has gone inert (check the parser/resolver wiring and files glob in eslint.config.js).",
+        ).toContain("import-x/no-cycle")
+        expect(byFile["c.ts"] ?? []).not.toContain("import-x/no-cycle")
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    },
+  )
 })


### PR DESCRIPTION
## Summary

The no-cycle guard liveness test added in #255 (`web/src/github-core/noCycleGuard.test.ts`) timed out on CI and turned `main` red after merge:

> `Test timed out in 5000ms` — `noCycleGuard.test.ts:40`

Root cause: the test spawned `npx eslint` **twice** (the cycle case + the positive control) under vitest's **5s default** test timeout. Locally each cold `npx eslint` (Node startup + the TS project resolver) is ~0.6–1.3s and squeaks under 5s; on a colder CI runner the two invocations combined exceed it.

## Fix

- **One eslint invocation instead of two** — lint all three fixture files (`a.ts`/`b.ts` cycle + `c.ts` clean control) in a single run and partition rule ids by file path from the JSON report.
- **Invoke the local eslint bin directly** (`node_modules/.bin/eslint`) instead of `npx` — drops the npx resolution overhead.
- **Explicit 60s `testTimeout`** for the inherently-slow shell-out (same spirit as other meta-tests that shell out / read the tree).

Test now runs in ~0.4s locally. The guard-liveness guarantee is unchanged: it still asserts `import-x/no-cycle` fires by **rule id** on the cycle files and not on the control, and the negative control (disable the rule → the test fails) still holds.

## Test plan
- [x] `vitest run` — 1495/1495 pass; the guard test runs in ~0.4s (was timing out at 5s)
- [x] Negative control: set `import-x/no-cycle` to `off` → the test fails as expected
- [x] `tsc -b`, `eslint`, `prettier --check` clean on the changed file