### PR TITLE
refactor(web): single-source + restructure the role vocabulary (P5b)

### DIFF
--- a/web/src/context/orgRole/OrgRoleProvider.test.tsx
+++ b/web/src/context/orgRole/OrgRoleProvider.test.tsx
@@ -87,10 +87,10 @@ describe("OrgRoleProvider", () => {
     ).toBe("member")
   })
 
-  it("member on a definitive 403/404", () => {
-    expect(renderWithMembership({ error: apiError(404) })).toBe("member")
+  it("non-member on a definitive 403/404", () => {
+    expect(renderWithMembership({ error: apiError(404) })).toBe("non-member")
     cleanup()
-    expect(renderWithMembership({ error: apiError(403) })).toBe("member")
+    expect(renderWithMembership({ error: apiError(403) })).toBe("non-member")
   })
 
   it("unresolved while loading / on a transient error (fail-closed)", () => {
@@ -106,10 +106,10 @@ describe("OrgRoleProvider", () => {
     expect(screen.getByTestId("role").textContent).toBe("unresolved")
     expect(screen.getByTestId("error").textContent).toBe("true")
     cleanup()
-    // A definitive 403 resolves to `member` (roleResolved), so it is NOT an
+    // A definitive 403 resolves to `non-member` (roleResolved), so it is NOT an
     // error strand even though the query technically errored.
     renderWithMembership({ isError: true, error: apiError(403) })
-    expect(screen.getByTestId("role").textContent).toBe("member")
+    expect(screen.getByTestId("role").textContent).toBe("non-member")
     expect(screen.getByTestId("error").textContent).toBe("false")
   })
 })

--- a/web/src/context/orgRole/OrgRoleProvider.tsx
+++ b/web/src/context/orgRole/OrgRoleProvider.tsx
@@ -6,21 +6,22 @@ import {
   type PropsWithChildren,
 } from "react"
 import useGetOwnOrgMembership from "@/hooks/useGetOwnOrgMembership"
-import { resolveOrgRole, type OrgRole } from "@/util/resolveRole"
+import { resolveOrgRole, type GitHubOrgRole } from "@/util/resolveRole"
 
 // Org-wide capability, resolved ONCE at the $org boundary and shared with org-
 // level routes (settings, members, activity, create-classroom) that have no
-// classroom in scope. `owner` = active org admin; `member` = definitive
-// non-admin; `unresolved` = a transient read (fail-closed — never demote a real
-// owner on a blip). The finer classroom role layers on top of this at the
-// classroom boundary (see ClassroomRoleProvider).
+// classroom in scope. `owner` = active org admin; `member` = confirmed non-admin
+// member; `non-member` = definitive outsider (403/404); `unresolved` = a
+// transient read (fail-closed — never demote a real owner on a blip). The finer
+// classroom role layers on top of this at the classroom boundary (see
+// ClassroomRoleProvider).
 type OrgRoleContextValue = {
-  orgRole: OrgRole
+  orgRole: GitHubOrgRole
   // The membership read settled in a transient error (retries exhausted) with
   // the role still `unresolved` — the owner gate shows a retryable error surface
   // instead of holding a spinner forever (mirrors the classroom gates). A
   // definitive 403/404 is NOT `isError` here (resolveOrgRole already reduced it
-  // to `member`, so the role resolved).
+  // to `non-member`, so the role resolved).
   isError: boolean
   // Re-run the membership read (the error surface's retry).
   retry: () => void

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -238,7 +238,9 @@ const RosterMemberModal = ({
     canManage && isSelf && row.state === "enrolled" && Boolean(row.username)
   const selectedRole = pendingRole ?? currentRole
   const roleChanged = selectedRole !== currentRole
-  const roleGrantsOwner = selectedRole === "instructor"
+  // Single-sourced with the write mapping: a role grants org owner iff its
+  // invite carries the "admin" org role (currently only instructor).
+  const roleGrantsOwner = orgRoleForRole(selectedRole) === "admin"
   const canApplyRole = roleChanged && (!roleGrantsOwner || roleOwnerConfirmed)
 
   const handleAssignRole = async () => {

--- a/web/src/util/capabilities.test.ts
+++ b/web/src/util/capabilities.test.ts
@@ -18,6 +18,7 @@ describe("can — org capabilities", () => {
   it("manageOrg: only an org owner", () => {
     expect(can("manageOrg", { orgRole: "owner" })).toBe(true)
     expect(can("manageOrg", { orgRole: "member" })).toBe(false)
+    expect(can("manageOrg", { orgRole: "non-member" })).toBe(false)
     expect(can("manageOrg", { orgRole: "unresolved" })).toBe(false)
     // Classroom role is irrelevant to org capabilities.
     for (const classroomRole of classroomRoles) {

--- a/web/src/util/capabilities.test.ts
+++ b/web/src/util/capabilities.test.ts
@@ -6,7 +6,7 @@ import type { EffectiveRole, OrgRole } from "./resolveRole"
 // scattered role-literal checks used to encode. Includes the KTD-4 rule (org
 // owner is NOT a classroom instructor) and the deny-by-default posture.
 
-const orgRoles: OrgRole[] = ["owner", "member", "unresolved"]
+const orgRoles: OrgRole[] = ["owner", "member", "non-member", "unresolved"]
 const classroomRoles: EffectiveRole[] = [
   "instructor",
   "ta",
@@ -92,6 +92,12 @@ describe("can — claimInstructor (KTD-4 self-repair)", () => {
   it("never offered to a non-owner or mid-resolution", () => {
     expect(
       can("claimInstructor", { orgRole: "member", classroomRole: "student" }),
+    ).toBe(false)
+    expect(
+      can("claimInstructor", {
+        orgRole: "non-member",
+        classroomRole: "student",
+      }),
     ).toBe(false)
     expect(
       can("claimInstructor", { orgRole: "owner", classroomRole: "unresolved" }),

--- a/web/src/util/resolveRole.test.ts
+++ b/web/src/util/resolveRole.test.ts
@@ -139,7 +139,7 @@ describe("resolveOrgRole", () => {
   })
 
   for (const status of [403, 404]) {
-    it(`member on a definitive ${status}`, () => {
+    it(`non-member on a definitive ${status}`, () => {
       expect(
         resolveOrgRole({
           isSuccess: false,
@@ -147,7 +147,7 @@ describe("resolveOrgRole", () => {
           state: undefined,
           error: apiError(status),
         }),
-      ).toBe("member")
+      ).toBe("non-member")
     })
   }
 

--- a/web/src/util/resolveRole.ts
+++ b/web/src/util/resolveRole.ts
@@ -1,16 +1,29 @@
 import { GitHubAPIError } from "@/github-core/errors"
 import type {
+  ResolvedRole,
+  GitHubOrgRole,
+  GitHubTeamMembership,
+  ViewAsRole,
+  // Deprecated aliases re-exported below for existing importers.
   EffectiveRole,
   OrgRole,
   Membership,
-  ViewAsRole,
 } from "@/util/roles"
 import { ROLE_RANK } from "@/util/roles"
 
 // Role types are single-sourced in util/roles; re-exported here because the
 // resolution logic below is their primary consumer and guards/UI reach for the
-// type alongside these resolvers.
-export type { EffectiveRole, OrgRole, Membership, ViewAsRole }
+// type alongside these resolvers. The deprecated aliases stay exported so
+// existing importers of this module don't churn in the overhaul PR.
+export type {
+  ResolvedRole,
+  GitHubOrgRole,
+  GitHubTeamMembership,
+  ViewAsRole,
+  EffectiveRole,
+  OrgRole,
+  Membership,
+}
 
 // Structural inputs so the verdict is a pure, unit-testable function (no React
 // Query). Each signal is pre-reduced to its tri-state.
@@ -18,16 +31,16 @@ export type ClassroomRoleInput = {
   org: string | undefined
   classroom: string | undefined
   // Per-classroom team memberships (instructor > ta > student precedence).
-  instructor: Membership
-  ta: Membership
-  student: Membership
+  instructor: GitHubTeamMembership
+  ta: GitHubTeamMembership
+  student: GitHubTeamMembership
 }
 
 // Pure classroom role from the three per-classroom teams (instructor > ta >
 // student). Fail posture is asymmetric: an in-flight ELEVATION read holds
 // (`unresolved`, fail-closed); an in-flight students read can't grant access so
 // it falls through to the safe `student` default (fail-open). See inline notes.
-export function resolveClassroomRole(input: ClassroomRoleInput): EffectiveRole {
+export function resolveClassroomRole(input: ClassroomRoleInput): ResolvedRole {
   const { org, classroom, instructor, ta, student } = input
 
   if (!org || !classroom) return "student"
@@ -53,28 +66,31 @@ export function resolveClassroomRole(input: ClassroomRoleInput): EffectiveRole {
   return "student"
 }
 
-// Reduce an org-membership read to the org-wide capability. An active admin is
-// `owner`; a definitive non-admin (success non-admin, or 403/404) is `member`;
-// anything in flight/transient is `unresolved` (fail-closed — never demote a
-// real owner on a blip).
+// Reduce an org-membership read to the viewer's org standing. An active admin is
+// `owner`; a successful read of a non-admin active membership is `member`; a
+// definitive 403/404 is `non-member` (outsider); anything in flight/transient is
+// `unresolved` (fail-closed — never demote a real owner on a blip).
 export function resolveOrgRole(input: {
   isSuccess: boolean
   role: string | undefined
   state: string | undefined
   error: unknown
-}): OrgRole {
+}): GitHubOrgRole {
   const { isSuccess, role, state, error } = input
   if (state === "active" && role === "admin") return "owner"
-  const definitiveNonOwner =
-    isSuccess ||
-    (error instanceof GitHubAPIError && (error.isForbidden || error.isNotFound))
-  return definitiveNonOwner ? "member" : "unresolved"
+  if (isSuccess) return "member"
+  if (
+    error instanceof GitHubAPIError &&
+    (error.isForbidden || error.isNotFound)
+  )
+    return "non-member"
+  return "unresolved"
 }
 
 // Whether a classroom role may see/do instructor-or-TA classroom content.
 // `unresolved` is permissive on purpose: the guard treats it as "let the page
 // load".
-export function isStaffRole(role: EffectiveRole): boolean {
+export function isStaffRole(role: ResolvedRole): boolean {
   return role === "instructor" || role === "ta" || role === "unresolved"
 }
 
@@ -82,9 +98,9 @@ export function isStaffRole(role: EffectiveRole): boolean {
 // only lower the effective role, never raise it, so it can't be abused to gain
 // access. `unresolved`/no-preview pass through unchanged.
 export function applyViewAs(
-  actual: EffectiveRole,
+  actual: ResolvedRole,
   viewAs: ViewAsRole | null,
-): EffectiveRole {
+): ResolvedRole {
   if (!viewAs || actual === "unresolved") return actual
   // Applies only when it ranks strictly below the actual role; else a no-op.
   return ROLE_RANK[viewAs] < ROLE_RANK[actual] ? viewAs : actual
@@ -92,7 +108,7 @@ export function applyViewAs(
 
 // Translation key for the human role label; null while `unresolved` so callers
 // show a skeleton mid-load. Pass through t().
-export function roleLabelKey(role: EffectiveRole): string | null {
+export function roleLabelKey(role: ResolvedRole): string | null {
   switch (role) {
     case "instructor":
       return "nav.roleInstructor"
@@ -110,7 +126,7 @@ export function roleLabelKey(role: EffectiveRole): string | null {
 export function membershipFromQuery(
   isSuccess: boolean,
   error: unknown,
-): Membership {
+): GitHubTeamMembership {
   if (isSuccess) return "member"
   if (error instanceof GitHubAPIError && error.isNotFound) {
     return "non-member"

--- a/web/src/util/resolveRole.ts
+++ b/web/src/util/resolveRole.ts
@@ -1,22 +1,16 @@
 import { GitHubAPIError } from "@/github-core/errors"
+import type {
+  EffectiveRole,
+  OrgRole,
+  Membership,
+  ViewAsRole,
+} from "@/util/roles"
+import { ROLE_RANK } from "@/util/roles"
 
-// The viewer's effective role WITHIN a classroom, used by route guards and UI
-// visibility. Precedence (highest first): instructor > ta > student. Org-admin
-// status is NOT a classroom role (see resolveClassroomRole for the KTD-4
-// rationale). `unresolved` is a fail-closed sentinel: a needed signal hit a
-// transient error, so callers treat it as "don't redirect; let the page load"
-// rather than demoting a real staff member on a blip.
-export type EffectiveRole = "instructor" | "ta" | "student" | "unresolved"
-
-// The viewer's ORG-wide capability, independent of any classroom. `owner` (org
-// admin) gates org settings, member management, and classroom creation.
-// `unresolved` is the same fail-closed sentinel as EffectiveRole.
-export type OrgRole = "owner" | "member" | "unresolved"
-
-// A tri-state membership signal: definitively in / definitively out / couldn't
-// tell (transient). Fail-closed: a blip reads as `unresolved`, never as a
-// definitive verdict (see membershipFromQuery).
-export type Membership = "member" | "non-member" | "unresolved"
+// Role types are single-sourced in util/roles; re-exported here because the
+// resolution logic below is their primary consumer and guards/UI reach for the
+// type alongside these resolvers.
+export type { EffectiveRole, OrgRole, Membership, ViewAsRole }
 
 // Structural inputs so the verdict is a pure, unit-testable function (no React
 // Query). Each signal is pre-reduced to its tri-state.
@@ -82,18 +76,6 @@ export function resolveOrgRole(input: {
 // load".
 export function isStaffRole(role: EffectiveRole): boolean {
   return role === "instructor" || role === "ta" || role === "unresolved"
-}
-
-// The roles an instructor can preview the app AS. A client-side lens for
-// verifying what each role sees — never escalates.
-export type ViewAsRole = "ta" | "student"
-
-// Rank for the downgrade-only clamp. `unresolved` is intentionally absent — we
-// never clamp an in-flight role (the guard is still showing a spinner).
-const ROLE_RANK: Record<Exclude<EffectiveRole, "unresolved">, number> = {
-  instructor: 2,
-  ta: 1,
-  student: 0,
 }
 
 // Apply a "view as" preview to an actual role. DOWNGRADE-ONLY: the preview can

--- a/web/src/util/roles.ts
+++ b/web/src/util/roles.ts
@@ -1,0 +1,74 @@
+import type { StaffRole } from "@/types/classroom"
+
+// Single home for Classroom-50's PRODUCT role vocabulary and the app<->GitHub
+// role mappings. The one contract-frozen literal — `StaffRole`
+// ("instructor"|"ta") — stays in types/classroom.ts because it mirrors the
+// persisted `teams` schema shape; everything derived from it lives here. Adding
+// a role (e.g. "head-ta") is then: add the literal to StaffRole (the contract),
+// then extend the maps below — the unions, rank, and slug role pick it up.
+//
+// Product terms (instructor/ta/student, owner) are distinct from GitHub WIRE
+// terms (team member/maintainer; org admin/direct_member). The two directions of
+// the admin<->owner correspondence are the only place that mapping lives.
+
+// A person's classroom role(s). "student" = classroom team; instructor/ta = the
+// per-classroom staff teams. A row can carry several (an instructor also on the
+// student team), unioned across teams.
+export type RosterRole = StaffRole | "student"
+
+// The role suffix in a per-classroom team slug: `classroom50-<classroom>` for
+// "student", `classroom50-<classroom>-<role>` for staff. Same set as RosterRole;
+// named distinctly for the slug-building call site.
+export type ClassroomTeamRole = "student" | StaffRole
+
+// The viewer's effective role WITHIN a classroom (route guards + UI visibility).
+// Precedence (highest first): instructor > ta > student. `unresolved` is a
+// fail-closed sentinel: a needed signal hit a transient error, so callers treat
+// it as "don't redirect; let the page load" rather than demoting a real staffer.
+export type EffectiveRole = RosterRole | "unresolved"
+
+// The viewer's ORG-wide capability, independent of any classroom. `owner` (the
+// product name for GitHub's org `admin`) gates org settings, member management,
+// and classroom creation. `unresolved` is the same fail-closed sentinel.
+export type OrgRole = "owner" | "member" | "unresolved"
+
+// A tri-state membership signal: definitively in / out / couldn't tell
+// (transient). Fail-closed: a blip reads as `unresolved`, never definitive.
+export type Membership = "member" | "non-member" | "unresolved"
+
+// The roles an instructor can preview the app AS. A client-side lens; never
+// escalates (see applyViewAs).
+export type ViewAsRole = "ta" | "student"
+
+// Precedence for the primary badge / role sort and the view-as downgrade clamp:
+// instructor > ta > student. One rank map for both the roster presentation and
+// the guard clamp (previously duplicated across teamRoster + resolveRole).
+export const ROLE_RANK: Record<RosterRole, number> = {
+  instructor: 2,
+  ta: 1,
+  student: 0,
+}
+
+// Sort a role set by precedence (highest first). Pure; returns a new array.
+export function sortRolesByRank(roles: RosterRole[]): RosterRole[] {
+  return [...roles].sort((a, b) => ROLE_RANK[b] - ROLE_RANK[a])
+}
+
+// --- The app<->GitHub org-role mapping (both directions, single-sourced) ---
+// Security-sensitive: this is the ONLY place "who becomes an org owner" is
+// decided, so a missed hand-copy can't silently mis-scope admin access.
+
+// WRITE: the GitHub org membership role an invite/role-change carries for a
+// classroom role. An instructor becomes an org OWNER (wire "admin"); student/ta
+// are plain members ("direct_member").
+export function orgRoleForRole(role: RosterRole): "admin" | "direct_member" {
+  return role === "instructor" ? "admin" : "direct_member"
+}
+
+// READ (inverse): the classroom role implied by an existing invitation's GitHub
+// org role. "admin" grants org OWNER, i.e. an instructor; anything else
+// re-invites as a plain student (org role alone can't distinguish TA from
+// student, and student is the safe default a re-invite lands on).
+export function roleForOrgRole(orgRole: string): RosterRole {
+  return orgRole === "admin" ? "instructor" : "student"
+}

--- a/web/src/util/roles.ts
+++ b/web/src/util/roles.ts
@@ -1,67 +1,92 @@
 import type { StaffRole } from "@/types/classroom"
 
-// Single home for Classroom-50's PRODUCT role vocabulary and the app<->GitHub
-// role mappings. The one contract-frozen literal — `StaffRole`
-// ("instructor"|"ta") — stays in types/classroom.ts because it mirrors the
-// persisted `teams` schema shape; everything derived from it lives here. Adding
-// a role (e.g. "head-ta") is then: add the literal to StaffRole (the contract),
-// then extend the maps below — the unions, rank, and slug role pick it up.
+// Single home for Classroom-50's role vocabulary and the app<->GitHub role
+// mappings. There are exactly three concepts here — keep them distinct:
+//
+//   1. GitHubOrgRole      — the viewer's standing in the GitHub org
+//                           (owner | member | non-member). Owner is the product
+//                           name for GitHub's org `admin`.
+//   2. ClassroomRole      — the viewer's in-app role within a classroom
+//                           (instructor | ta | student), backed by GitHub teams.
+//   3. GitHubTeamMembership — a low-level "is the viewer on THIS team?" probe
+//                           result. It FEEDS classroom-role resolution but is not
+//                           itself a role; "member" here means "on this team",
+//                           NOT "in the org" (so it is not GitHubOrgRole).
+//
+// Each carries an `unresolved` fail-closed sentinel: a needed signal hit a
+// transient error, so callers hold ("don't redirect / don't demote") rather than
+// act on a blip. The one contract-frozen literal, StaffRole ("instructor"|"ta"),
+// lives in types/classroom.ts (it mirrors the persisted `teams` schema shape);
+// everything here derives from it, so adding a role (e.g. "head-ta") is: add the
+// literal to StaffRole (the contract — also its schema + CLI mirror), then extend
+// the maps below. The unions, rank, and slug role pick it up automatically.
 //
 // Product terms (instructor/ta/student, owner) are distinct from GitHub WIRE
-// terms (team member/maintainer; org admin/direct_member). The two directions of
-// the admin<->owner correspondence are the only place that mapping lives.
+// terms (team member/maintainer; org admin/direct_member); the two directions of
+// the admin<->owner correspondence live only in this file (orgRoleForRole /
+// roleForOrgRole).
 
-// A person's classroom role(s). "student" = classroom team; instructor/ta = the
-// per-classroom staff teams. A row can carry several (an instructor also on the
-// student team), unioned across teams.
-export type RosterRole = StaffRole | "student"
+// --- 1. GitHub org standing -------------------------------------------------
 
-// The role suffix in a per-classroom team slug: `classroom50-<classroom>` for
-// "student", `classroom50-<classroom>-<role>` for staff. Same set as RosterRole;
-// named distinctly for the slug-building call site.
-export type ClassroomTeamRole = "student" | StaffRole
+// The viewer's standing in the GitHub org, independent of any classroom. `owner`
+// (the product name for GitHub's org `admin`) gates org settings, member
+// management, and classroom creation; `member` is a confirmed non-owner member;
+// `non-member` is a definitive outsider (403/404). `unresolved` is fail-closed —
+// a transient blip, never demote a real owner.
+export type GitHubOrgRole = "owner" | "member" | "non-member" | "unresolved"
 
-// The viewer's effective role WITHIN a classroom (route guards + UI visibility).
-// Precedence (highest first): instructor > ta > student. `unresolved` is a
-// fail-closed sentinel: a needed signal hit a transient error, so callers treat
-// it as "don't redirect; let the page load" rather than demoting a real staffer.
-export type EffectiveRole = RosterRole | "unresolved"
+// --- 2. Classroom role ------------------------------------------------------
 
-// The viewer's ORG-wide capability, independent of any classroom. `owner` (the
-// product name for GitHub's org `admin`) gates org settings, member management,
-// and classroom creation. `unresolved` is the same fail-closed sentinel.
-export type OrgRole = "owner" | "member" | "unresolved"
+// The sole non-staff classroom role. Named for symmetry with StaffRole so
+// ClassroomRole reads as "student or staff".
+export type StudentRole = "student"
 
-// A tri-state membership signal: definitively in / out / couldn't tell
-// (transient). Fail-closed: a blip reads as `unresolved`, never definitive.
-export type Membership = "member" | "non-member" | "unresolved"
+// A person's role WITHIN a classroom: student (classroom team) or a StaffRole
+// (instructor/ta staff teams). The single base the other classroom-role shapes
+// derive from. A person can hold several (an instructor also on the student
+// team), so roster rows carry a set of these.
+export type ClassroomRole = StudentRole | StaffRole
 
-// The roles an instructor can preview the app AS. A client-side lens; never
-// escalates (see applyViewAs).
-export type ViewAsRole = "ta" | "student"
+// A resolved classroom role for guards/UI: the base plus the fail-closed
+// sentinel. Precedence (highest first): instructor > ta > student. `unresolved`
+// means "let the page load; don't redirect" rather than demoting a real staffer.
+export type ResolvedRole = ClassroomRole | "unresolved"
+
+// The roles an instructor can preview the app AS — a client-side lens that never
+// escalates (see applyViewAs). Derived as ClassroomRole minus "instructor" so it
+// can't drift: you can't preview as the top role.
+export type ViewAsRole = Exclude<ClassroomRole, "instructor">
 
 // Precedence for the primary badge / role sort and the view-as downgrade clamp:
-// instructor > ta > student. One rank map for both the roster presentation and
-// the guard clamp (previously duplicated across teamRoster + resolveRole).
-export const ROLE_RANK: Record<RosterRole, number> = {
+// instructor > ta > student. One rank map for both roster presentation and the
+// guard clamp.
+export const ROLE_RANK: Record<ClassroomRole, number> = {
   instructor: 2,
   ta: 1,
   student: 0,
 }
 
 // Sort a role set by precedence (highest first). Pure; returns a new array.
-export function sortRolesByRank(roles: RosterRole[]): RosterRole[] {
+export function sortRolesByRank(roles: ClassroomRole[]): ClassroomRole[] {
   return [...roles].sort((a, b) => ROLE_RANK[b] - ROLE_RANK[a])
 }
 
-// --- The app<->GitHub org-role mapping (both directions, single-sourced) ---
+// --- 3. Team-membership probe primitive -------------------------------------
+
+// The result of a single "is the viewer on THIS team?" probe: definitively on /
+// off / couldn't tell (transient). Fail-closed: a blip reads as `unresolved`,
+// never a definitive verdict. Feeds ClassroomRole resolution (one probe per
+// per-classroom staff/student team); "member" means "on this team".
+export type GitHubTeamMembership = "member" | "non-member" | "unresolved"
+
+// --- The app<->GitHub org-role mapping (both directions, single-sourced) -----
 // Security-sensitive: this is the ONLY place "who becomes an org owner" is
 // decided, so a missed hand-copy can't silently mis-scope admin access.
 
 // WRITE: the GitHub org membership role an invite/role-change carries for a
 // classroom role. An instructor becomes an org OWNER (wire "admin"); student/ta
 // are plain members ("direct_member").
-export function orgRoleForRole(role: RosterRole): "admin" | "direct_member" {
+export function orgRoleForRole(role: ClassroomRole): "admin" | "direct_member" {
   return role === "instructor" ? "admin" : "direct_member"
 }
 
@@ -69,6 +94,20 @@ export function orgRoleForRole(role: RosterRole): "admin" | "direct_member" {
 // org role. "admin" grants org OWNER, i.e. an instructor; anything else
 // re-invites as a plain student (org role alone can't distinguish TA from
 // student, and student is the safe default a re-invite lands on).
-export function roleForOrgRole(orgRole: string): RosterRole {
+export function roleForOrgRole(orgRole: string): ClassroomRole {
   return orgRole === "admin" ? "instructor" : "student"
 }
+
+// --- Backward-compatible aliases (deprecated) -------------------------------
+// The names below were the pre-overhaul vocabulary. Kept so existing importers
+// (and the resolveRole/teamRoster re-export surfaces) don't churn in this PR;
+// remove in a follow-up repoint pass.
+
+/** @deprecated Use GitHubOrgRole. */
+export type OrgRole = GitHubOrgRole
+/** @deprecated Use GitHubTeamMembership. */
+export type Membership = GitHubTeamMembership
+/** @deprecated Use ClassroomRole. */
+export type RosterRole = ClassroomRole
+/** @deprecated Use ResolvedRole. */
+export type EffectiveRole = ResolvedRole

--- a/web/src/util/roles.ts
+++ b/web/src/util/roles.ts
@@ -1,30 +1,13 @@
 import type { StaffRole } from "@/types/classroom"
 
 // Single home for Classroom-50's role vocabulary and the app<->GitHub role
-// mappings. There are exactly three concepts here — keep them distinct:
-//
-//   1. GitHubOrgRole      — the viewer's standing in the GitHub org
-//                           (owner | member | non-member). Owner is the product
-//                           name for GitHub's org `admin`.
-//   2. ClassroomRole      — the viewer's in-app role within a classroom
-//                           (instructor | ta | student), backed by GitHub teams.
-//   3. GitHubTeamMembership — a low-level "is the viewer on THIS team?" probe
-//                           result. It FEEDS classroom-role resolution but is not
-//                           itself a role; "member" here means "on this team",
-//                           NOT "in the org" (so it is not GitHubOrgRole).
-//
-// Each carries an `unresolved` fail-closed sentinel: a needed signal hit a
-// transient error, so callers hold ("don't redirect / don't demote") rather than
-// act on a blip. The one contract-frozen literal, StaffRole ("instructor"|"ta"),
-// lives in types/classroom.ts (it mirrors the persisted `teams` schema shape);
-// everything here derives from it, so adding a role (e.g. "head-ta") is: add the
-// literal to StaffRole (the contract — also its schema + CLI mirror), then extend
-// the maps below. The unions, rank, and slug role pick it up automatically.
-//
-// Product terms (instructor/ta/student, owner) are distinct from GitHub WIRE
-// terms (team member/maintainer; org admin/direct_member); the two directions of
-// the admin<->owner correspondence live only in this file (orgRoleForRole /
-// roleForOrgRole).
+// mappings. Three distinct concepts live below, each in its own section:
+// GitHubOrgRole (org standing), ClassroomRole (in-app role), and
+// GitHubTeamMembership (a per-team probe result that feeds ClassroomRole).
+// Every union derives from the one contract-frozen literal StaffRole (in
+// types/classroom.ts, mirroring the persisted `teams` schema), so adding a role
+// starts there. The admin<->owner correspondence lives only here
+// (orgRoleForRole / roleForOrgRole).
 
 // --- 1. GitHub org standing -------------------------------------------------
 

--- a/web/src/util/rosterRoles.ts
+++ b/web/src/util/rosterRoles.ts
@@ -10,9 +10,8 @@ import {
 // Single source of truth for how a classroom role is presented and ranked.
 // Shared by the Roster view and the classroom Settings staff section so the two
 // surfaces can't drift on tone or precedence (AGENTS.md: one recipe, one source).
-// ROLE_RANK and sortRolesByRank live in teamRoster (next to the row type they
-// order) and are re-exported here so UI callers have one import for all role
-// presentation.
+// ROLE_RANK and sortRolesByRank are single-sourced in util/roles and re-exported
+// here (via teamRoster) so UI callers have one import for all role presentation.
 export { ROLE_RANK, sortRolesByRank }
 
 // i18n key per role for row badges and filter labels.

--- a/web/src/util/rosterRoles.ts
+++ b/web/src/util/rosterRoles.ts
@@ -1,17 +1,12 @@
 import type { BadgeTone } from "@/components/ui"
-import {
-  ROLE_RANK,
-  sortRolesByRank,
-  type RosterRole,
-  type TeamRosterRow,
-  type TeamRosterRowState,
-} from "@/util/teamRoster"
+import { ROLE_RANK, sortRolesByRank, type RosterRole } from "@/util/roles"
+import type { TeamRosterRow, TeamRosterRowState } from "@/util/teamRoster"
 
 // Single source of truth for how a classroom role is presented and ranked.
 // Shared by the Roster view and the classroom Settings staff section so the two
 // surfaces can't drift on tone or precedence (AGENTS.md: one recipe, one source).
 // ROLE_RANK and sortRolesByRank are single-sourced in util/roles and re-exported
-// here (via teamRoster) so UI callers have one import for all role presentation.
+// here so UI callers have one import for all role presentation.
 export { ROLE_RANK, sortRolesByRank }
 
 // i18n key per role for row badges and filter labels.

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -2,6 +2,24 @@ import type { Student } from "@/types/classroom"
 import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
 import type { GitHubUser, GitHubOrgInvitation } from "@/github-core/types"
 import { rosterClaimSet } from "@/util/identity"
+import {
+  type RosterRole,
+  ROLE_RANK,
+  sortRolesByRank,
+  orgRoleForRole,
+  roleForOrgRole,
+} from "@/util/roles"
+
+// Role vocabulary is single-sourced in util/roles. Re-exported here because the
+// roster row logic below is its primary consumer and callers naturally reach for
+// these alongside TeamRosterRow; roles.ts stays the definition home.
+export {
+  type RosterRole,
+  ROLE_RANK,
+  sortRolesByRank,
+  orgRoleForRole,
+  roleForOrgRole,
+}
 
 // Team-driven roster: the classroom GitHub team is the source of truth for
 // enrollment and role, not roster.csv. Enrolled/pending rows come from team
@@ -29,37 +47,6 @@ export type TeamRosterRowState =
   | "pending"
   | "needs_attention_in_org"
   | "needs_attention_not_in_org"
-
-// A person's classroom role(s). "student" = classroom team; "instructor"/"ta"
-// = the per-classroom staff teams. A person can hold several (an instructor
-// also on the student team), so a row carries a set, unioned across teams.
-export type RosterRole = StaffRole | "student"
-
-// Precedence for the primary badge / role sort: instructor > ta > student.
-// Exported so the shared role-presentation module (rosterRoles) re-exports it
-// rather than defining a second copy.
-export const ROLE_RANK: Record<RosterRole, number> = {
-  instructor: 2,
-  ta: 1,
-  student: 0,
-}
-
-// The GitHub org membership role an invite/role-change carries for a classroom
-// role: an instructor becomes an org OWNER ("admin"); student/ta are plain
-// members. One source for this security-sensitive mapping (who gets org owner)
-// so a missed hand-copy can't silently mis-scope admin access.
-export function orgRoleForRole(role: RosterRole): "admin" | "direct_member" {
-  return role === "instructor" ? "admin" : "direct_member"
-}
-
-// Inverse of orgRoleForRole: the classroom role implied by a GitHub org
-// membership role on an existing invitation. "admin" means the invite grants
-// org OWNER, i.e. an instructor; anything else re-invites as a plain student
-// (org role alone can't distinguish TA from student, and student is the safe
-// default a re-invite lands on — a TA re-invite would just be re-assigned).
-export function roleForOrgRole(orgRole: string): RosterRole {
-  return orgRole === "admin" ? "instructor" : "student"
-}
 
 export type TeamRosterRow = {
   // Stable identity for React keys and joins: github_id || login || email.
@@ -375,13 +362,6 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
 function addRole(row: TeamRosterRow, role: RosterRole): void {
   if (row.roles.includes(role)) return
   row.roles = sortRolesByRank([...row.roles, role])
-}
-
-// Sort a role set by precedence (highest first). Pure; returns a new array.
-// Lives here beside ROLE_RANK (its only dependency) so the rank comparator has
-// a single home; rosterRoles re-exports it for UI callers.
-export function sortRolesByRank(roles: RosterRole[]): RosterRole[] {
-  return [...roles].sort((a, b) => ROLE_RANK[b] - ROLE_RANK[a])
 }
 
 // Display name for sorting: "Last, First" folded to a comparable string, else


### PR DESCRIPTION
## Summary

**P5b** of the web-architecture-boundaries plan. Two commits that together make the role vocabulary a single, legible home, plus a review-follow-up commit:

1. **Single-source** (`fcc577c`): unify the role literals that were duplicated across `resolveRole.ts`, `teamRoster.ts`, `types/classroom.ts` into `util/roles.ts`; fold the duplicated `ROLE_RANK`; co-locate the `admin<->owner` mapping (both directions).
2. **Three-concept restructure** (`92c919e`): the vocabulary had grown to 6 overlapping unions. Collapse to **three named concepts**, each in its own headed section.
3. **Review follow-ups** (`0746beb`): tidy low-risk `/ce-code-review` findings (see below).

## The three concepts

- **`GitHubOrgRole`** = `owner | member | non-member | unresolved` (was `OrgRole`) — the viewer's standing in the GitHub org, now carrying insider/outsider. `owner` = product name for GitHub `admin`.
- **`ClassroomRole`** = `StudentRole | StaffRole` (`StudentRole = "student"`) — the single base replacing `RosterRole` and the dead `ClassroomTeamRole` (zero importers; `classroomTeamSlug` keeps its own copy). `ResolvedRole` (was `EffectiveRole`) = `ClassroomRole | "unresolved"`; `ViewAsRole = Exclude<ClassroomRole, "instructor">` (derived, can't drift).
- **`GitHubTeamMembership`** = `member | non-member | unresolved` (was `Membership`) — kept **distinct**, NOT merged into `GitHubOrgRole`: it's the low-level per-*team* probe result where `"member"` = "on this team", which feeds classroom-role resolution.

## The one deliberate behavior change (verified capability-neutral)

`resolveOrgRole` now returns `non-member` on a definitive 403/404 instead of collapsing it into `member`. Every consumer of a `GitHubOrgRole` value reads only `=== "owner"` (capability grant) or `=== "unresolved"` (spinner/pending) — none branches on `member` vs `non-member` — so no `can()` outcome, guard, or label changes. The 4 tests that asserted the old collapse are updated to the more precise contract.

## Safety / invariants

- Both `unresolved` fail-closed sentinels stay load-bearing.
- `ROLE_RANK` and the `admin<->owner` mapping remain single-sourced in `roles.ts`.
- Role-name string literals are byte-identical (contract-frozen); `StaffRole` stays in `types/classroom.ts`.
- Old names (`OrgRole`/`Membership`/`RosterRole`/`EffectiveRole`) kept as `@deprecated` aliases so no call site churns; a repoint pass is a future follow-up.
- `head-ta` remains structure-only — adding it for real is a contract change (`StaffRole` + `classroom-v1.schema.json` + the Go mirror), out of scope.

## Review follow-ups (`0746beb`)

Applied low-risk `/ce-code-review` findings, no behavior change:

- `rosterRoles.ts` imports `ROLE_RANK`/`sortRolesByRank` straight from `util/roles` instead of hopping through `teamRoster` (collapses a 3-file re-export chase to one hop).
- `capabilities.test.ts` now covers the new `non-member` org role in the `orgRoles` matrix fixture + an explicit `claimInstructor` non-member deny.
- Trimmed `roles.ts`'s multi-paragraph header to a short orientation (AGENTS.md: avoid multi-paragraph block comments).

## Test plan

- [x] `tsc -b` clean
- [x] `eslint .` — 0 errors (32 pre-existing warnings)
- [x] `prettier --check` clean
- [x] `vitest run` — pass
- [x] capability-neutrality of the `member`/`non-member` split verified by enumerating every `GitHubOrgRole` consumer
- [x] `/ce-code-review` — complete; verdict **Ready to merge** (0 P0/P1; 3 low-risk findings applied in `0746beb`; the `member`->`non-member` split independently confirmed capability-neutral by correctness/security/api-contract/adversarial)