### PR TITLE
fix(web): show write-access assignment repositories

### DIFF
--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -50,6 +50,8 @@ export const githubKeys = {
   orgMembership: (org: string) =>
     [...githubKeys.all, "org-membership", org] as const,
 
+  orgRepos: (org: string) => [...githubKeys.all, "org-repos", org] as const,
+
   orgMembers: (org: string) => ["orgs", "list", "members", org] as const,
 
   // Distinct from `orgMembers` (page-1 via listOrgMembers): this keys the

--- a/web/src/hooks/useGetMyOrgRepos.ts
+++ b/web/src/hooks/useGetMyOrgRepos.ts
@@ -1,12 +1,12 @@
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useQuery } from "@tanstack/react-query"
-import { getOrgRepos } from "@/github-core/queries"
+import { getOrgRepos, githubKeys } from "@/github-core/queries"
 
 const useGetOrgRepos = (org: string) => {
   const client = useGitHubClient()
 
   return useQuery({
-    queryKey: ["orgs", org, "repos"],
+    queryKey: githubKeys.orgRepos(org),
     queryFn: () => getOrgRepos(client, org),
     // Drives the "Accepted" count from repo existence; keep it fresh so a tab
     // refocus reflects newly accepted assignments instead of a 10-min cache.

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1457,7 +1457,7 @@
       "group": "Group",
       "openRepo": "Open repo",
       "emptyTitle": "No assignment repos yet",
-      "emptyBody": "Repositories you can maintain will appear here once assignments have been created for this organization."
+      "emptyBody": "Repositories you can write to will appear here once assignments have been created for this organization."
     },
     "form": {
       "basicInfo": "Basic Information",

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import type { GitHubRepo } from "@/github-core/types"
+
+const acceptAssignment = vi.fn()
+
+vi.mock("@/domain/assignments", () => ({
+  acceptAssignment: (...args: unknown[]) => acceptAssignment(...args),
+}))
+vi.mock("@/hooks/usePagesAssignments", () => ({
+  default: () => ({
+    data: [
+      {
+        slug: "hello-python",
+        name: "Hello Python",
+        mode: "individual",
+        autograder: "default",
+      },
+    ],
+    isLoading: false,
+  }),
+}))
+vi.mock("@/hooks/useGetRepo", () => ({
+  default: () => ({ data: null, isLoading: false }),
+}))
+vi.mock("@/hooks/useGetOwnOrgMembership", () => ({
+  default: () => ({
+    data: { state: "active" },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+vi.mock("@/hooks/mutations/useAcceptAndVerifyMembership", () => ({
+  useAcceptAndVerifyMembership: () => ({
+    isActive: true,
+    isError: false,
+    error: null,
+    retry: vi.fn(),
+  }),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({
+    user: { id: 1, login: "student", name: "Test Student" },
+  }),
+}))
+vi.mock("@/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: () => undefined,
+}))
+vi.mock("@/components/LanguageDialog", () => ({
+  LanguageDialog: () => null,
+}))
+vi.mock("@/components/modals/GroupCollaboratorsModal", () => ({
+  GroupCollaboratorsModal: () => null,
+}))
+vi.mock("canvas-confetti", () => ({ default: vi.fn() }))
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useParams: () => ({
+      org: "acme",
+      classroom: "cs101",
+      assignment: "hello-python",
+    }),
+    useSearch: () => ({ k: "test-secret" }),
+    Link: ({ children }: { children: ReactNode }) => <a href="/">{children}</a>,
+  }
+})
+
+import AcceptAssignmentPage from "./AcceptAssignmentPage"
+
+const acceptedRepo: GitHubRepo = {
+  id: 1,
+  name: "cs101-hello-python-student",
+  full_name: "acme/cs101-hello-python-student",
+  private: true,
+  default_branch: "main",
+  ssh_url: "git@github.com:acme/cs101-hello-python-student.git",
+  html_url: "https://github.com/acme/cs101-hello-python-student",
+  permissions: {
+    admin: false,
+    maintain: false,
+    push: true,
+    pull: true,
+  },
+}
+
+const orgReposKey = ["github", "org-repos", "acme"] as const
+
+const renderPage = (client: QueryClient) =>
+  render(
+    <QueryClientProvider client={client}>
+      <AcceptAssignmentPage />
+    </QueryClientProvider>,
+  )
+
+beforeEach(() => {
+  acceptAssignment.mockReset()
+})
+
+afterEach(cleanup)
+
+describe("AcceptAssignmentPage repository cache", () => {
+  it.each(["created", "already-accepted"] as const)(
+    "refreshes an inactive organization-repository query after %s",
+    async (status) => {
+      const client = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, gcTime: Infinity },
+          mutations: { retry: false },
+        },
+      })
+      let resolveRefresh!: (repos: GitHubRepo[]) => void
+      const refresh = new Promise<GitHubRepo[]>((resolve) => {
+        resolveRefresh = resolve
+      })
+      const listRepos = vi
+        .fn<() => Promise<GitHubRepo[]>>()
+        .mockResolvedValueOnce([])
+        .mockImplementationOnce(() => refresh)
+
+      await client.prefetchQuery({
+        queryKey: orgReposKey,
+        queryFn: listRepos,
+      })
+      expect(
+        client
+          .getQueryCache()
+          .find({
+            queryKey: orgReposKey,
+            exact: true,
+          })
+          ?.getObserversCount(),
+      ).toBe(0)
+      acceptAssignment.mockResolvedValue({
+        status,
+        repo: acceptedRepo,
+        cloneCommand: "gh repo clone acme/repo",
+      })
+
+      renderPage(client)
+      fireEvent.click(
+        screen.getByRole("button", { name: "accept.acceptButton" }),
+      )
+
+      await waitFor(() => expect(acceptAssignment).toHaveBeenCalledTimes(1))
+      await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(2))
+      expect(screen.queryByText("accept.openRepository")).not.toBeNull()
+
+      resolveRefresh([acceptedRepo])
+      await waitFor(() =>
+        expect(client.getQueryData(orgReposKey)).toEqual([acceptedRepo]),
+      )
+    },
+  )
+})

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -12,10 +12,11 @@ import { Spinner } from "@/components/Spinner"
 import { Alert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubUser } from "@/github-core/types"
+import { githubKeys } from "@/github-core/queries"
 import { Link, useParams, useSearch } from "@tanstack/react-router"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useGithubAuth } from "@/auth/useGithubAuth"
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import confetti from "canvas-confetti"
@@ -525,6 +526,7 @@ const AcceptAssignmentPage = () => {
   const search = useSearch({ strict: false }) as { k?: string }
   const secret = typeof search.k === "string" ? search.k : undefined
   const client = useGitHubClient()
+  const queryClient = useQueryClient()
 
   const { user } = useGithubAuth()
   const username = user?.login
@@ -595,6 +597,14 @@ const AcceptAssignmentPage = () => {
       // milestone, so skip the confetti.
       if (result.status === "created") {
         fireConfetti()
+      }
+
+      if (org) {
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.orgRepos(org),
+          exact: true,
+          refetchType: "all",
+        })
       }
     },
   })

--- a/web/src/pages/ClassesPage.test.tsx
+++ b/web/src/pages/ClassesPage.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import type { GitHubRepo } from "@/github-core/types"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+const getOrgRepos = vi.fn()
+
+vi.mock("@/hooks/useGetMyOrgRepos", () => ({
+  default: (...args: unknown[]) => getOrgRepos(...args),
+}))
+vi.mock("@/hooks/useDotClassroom50", () => ({
+  default: () => ({}),
+}))
+vi.mock("@/hooks/useGetPublicAssignment", () => ({
+  default: () => ({ assignment: undefined }),
+}))
+
+import { OrgRepos } from "./ClassesPage"
+
+type Permissions = NonNullable<GitHubRepo["permissions"]>
+
+const rolePermissions = {
+  read: {
+    admin: false,
+    maintain: false,
+    push: false,
+    pull: true,
+  },
+  write: {
+    admin: false,
+    maintain: false,
+    push: true,
+    pull: true,
+  },
+  maintain: {
+    admin: false,
+    maintain: true,
+    push: true,
+    pull: true,
+  },
+  admin: {
+    admin: true,
+    maintain: true,
+    push: true,
+    pull: true,
+  },
+} satisfies Record<"read" | "write" | "maintain" | "admin", Permissions>
+
+let nextId = 1
+
+const repo = (
+  name: string,
+  role: keyof typeof rolePermissions,
+): GitHubRepo => ({
+  id: nextId++,
+  name,
+  full_name: `acme/${name}`,
+  private: true,
+  default_branch: "main",
+  ssh_url: `git@github.com:acme/${name}.git`,
+  html_url: `https://github.com/acme/${name}`,
+  permissions: rolePermissions[role],
+})
+
+beforeEach(() => {
+  nextId = 1
+  getOrgRepos.mockReset()
+})
+
+afterEach(cleanup)
+
+describe("OrgRepos", () => {
+  it("shows write-or-higher repos only for the selected classroom", () => {
+    getOrgRepos.mockReturnValue({
+      data: [
+        repo("cs-a1-writer", "write"),
+        repo("cs-a2-maintainer", "maintain"),
+        repo("cs-a3-admin", "admin"),
+        repo("cs-a4-reader", "read"),
+        repo("cs101-a1-sibling", "admin"),
+      ],
+    })
+
+    render(<OrgRepos org="acme" classroom="cs" />)
+
+    expect(screen.getByRole("heading", { name: "cs-a1-writer" })).toBeTruthy()
+    expect(
+      screen.getByRole("heading", { name: "cs-a2-maintainer" }),
+    ).toBeTruthy()
+    expect(screen.getByRole("heading", { name: "cs-a3-admin" })).toBeTruthy()
+    expect(screen.queryByRole("heading", { name: "cs-a4-reader" })).toBeNull()
+    expect(
+      screen.queryByRole("heading", { name: "cs101-a1-sibling" }),
+    ).toBeNull()
+  })
+})

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -261,17 +261,17 @@ export const OrgRepos = ({
 
   if (!repos) return <></>
 
-  let maintainRepos = repos.filter((repo) => repo.permissions?.maintain)
+  let writableRepos = repos.filter((repo) => repo.permissions?.push)
   if (classroom) {
     // Classroom repos are `<classroom>-<assignment>-<user>`, so require the
     // trailing "-" to avoid matching a sibling classroom whose name extends
     // this one (e.g. "cs" wrongly matching "cs101-a1-bob").
-    maintainRepos = maintainRepos.filter((repo) =>
+    writableRepos = writableRepos.filter((repo) =>
       repo.name.startsWith(`${classroom}-`),
     )
   }
 
-  if (maintainRepos.length === 0) {
+  if (writableRepos.length === 0) {
     return (
       <div className="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center">
         <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-full bg-base-200">
@@ -294,7 +294,7 @@ export const OrgRepos = ({
 
   return (
     <div className="grid grid-cols-12 gap-4">
-      {maintainRepos.map((repo) => (
+      {writableRepos.map((repo) => (
         <RepoCard key={repo.id ?? repo.full_name} org={org} repo={repo} />
       ))}
     </div>


### PR DESCRIPTION
## Summary

- show assignment repositories when the signed-in student has Write access, while preserving Maintain/Admin visibility
- single-source the organization-repository query key under the authenticated GitHub cache namespace
- refresh inactive organization-repository data after fresh or repeated acceptance without blocking the success UI
- update the empty-state copy and add focused regression coverage

Follow-up to #231. Closes #258.

## Root cause and impact

#231 correctly reduced individual assignment students from Admin to Write/Push, but the student classroom page continued filtering with `permissions.maintain`. Valid accepted repositories were therefore hidden for individual students.

The organization-repository query also used an ad hoc key outside the `["github"]` namespace cleared at sign-out. The shared key now participates in session teardown before inactive refetching is enabled.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Verification

- Confirmed the visibility regression test failed before the predicate fix.
- Confirmed the inactive-cache tests failed before invalidation.
- Confirmed the non-blocking success test failed while invalidation was awaited.
- `cd web && npm run check` — 135 test files / 1,498 tests passed.
- `cd web && npm run build` — production build succeeded.
- `python3 web/src/locales/audit_i18n.py` — passed with zero missing keys.
- Fresh correctness and security reviews completed; all findings were fixed.

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - Web: `cd web && npm run check`
- [x] No cross-binary contract changed.
- [x] No CLI command or flag changed.
- [x] My commit follows Conventional Commits.
