### PR TITLE
refactor(web): converge inline DaisyUI recipes on ui/ primitives (P6)

### DIFF
--- a/web/src/auth/GitHubDevicePrompt.tsx
+++ b/web/src/auth/GitHubDevicePrompt.tsx
@@ -107,8 +107,11 @@ export function GitHubDevicePrompt({
             {t("auth.deviceStep2Title")}
           </h2>
 
-          <a
-            className="btn btn-outline btn-primary btn-sm mt-3 w-full"
+          <Button
+            as="a"
+            variant="outline"
+            size="sm"
+            className="mt-3 w-full"
             href={device.verificationUri}
             target="_blank"
             rel="noopener noreferrer"
@@ -118,7 +121,7 @@ export function GitHubDevicePrompt({
           >
             <ExternalLink aria-hidden="true" className="size-4" />
             {t("auth.deviceOpenUri", { uri: device.verificationUri })}
-          </a>
+          </Button>
 
           <p className="mt-2 text-xs leading-relaxed text-base-content/70">
             {t("auth.deviceStep2Hint")}

--- a/web/src/components/EmptyRosterNotice.tsx
+++ b/web/src/components/EmptyRosterNotice.tsx
@@ -1,6 +1,7 @@
-import { Link } from "@tanstack/react-router"
 import { Info, UserPlus } from "lucide-react"
 import { useTranslation } from "react-i18next"
+
+import { RouterButton } from "@/components/ui"
 
 // Empty/unenrolled-roster notice. Owns the daisyUI alert shell + ARIA so the
 // assignments list and create pages can't drift in markup; copy adapts to
@@ -42,16 +43,18 @@ export const EmptyRosterNotice = ({
           )}
         </span>
       </div>
-      <Link
+      <RouterButton
         to="/$org/$classroom/roster"
         params={{ org, classroom }}
-        className="btn btn-sm btn-info whitespace-nowrap sm:shrink-0"
+        variant="info"
+        size="sm"
+        className="whitespace-nowrap sm:shrink-0"
       >
         <UserPlus className="size-4" aria-hidden="true" />
         {hasRosterRows
           ? t("components.notices.emptyRoster.manageRoster")
           : t("components.notices.emptyRoster.addStudents")}
-      </Link>
+      </RouterButton>
     </div>
   )
 }

--- a/web/src/components/MembershipError.tsx
+++ b/web/src/components/MembershipError.tsx
@@ -2,7 +2,8 @@ import { AlertTriangle, UserPlus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
-import { Card, CopyableDetails, Button } from "@/components/ui"
+import { Card, CopyableDetails, Button, Badge } from "@/components/ui"
+import type { BadgeTone } from "@/components/ui"
 
 // Distinct membership-failure causes the student flow (onboarding + accept) can
 // hit; each maps to a title/body and at least one recovery action.
@@ -135,20 +136,21 @@ export const MembershipError = ({
     generic: "membership.generic.title",
   }[cause]
 
-  const badgeTone = {
-    ssoWithUrl: "badge-warning",
-    ssoUrlless: "badge-warning",
-    notAMember: "badge-error",
-    generic: "badge-error",
-  }[cause]
+  const badgeToneByCause: Record<MembershipErrorCause, BadgeTone> = {
+    ssoWithUrl: "warning",
+    ssoUrlless: "warning",
+    notAMember: "error",
+    generic: "error",
+  }
+  const badgeTone = badgeToneByCause[cause]
 
   return (
     <Card.Body className="gap-6">
       <div>
-        <span className={`badge ${badgeTone} badge-soft gap-2`}>
+        <Badge tone={badgeTone} size="md" className="gap-2">
           <AlertTriangle aria-hidden="true" className="size-4" />
           {t("membership.badge")}
-        </span>
+        </Badge>
         <h1 className="mt-6 text-2xl font-bold">{t(titleKey)}</h1>
         <p className="mt-2 text-base text-base-content/70">
           {cause === "ssoWithUrl" || cause === "ssoUrlless" ? (
@@ -186,13 +188,15 @@ export const MembershipError = ({
             </p>
 
             {cause === "ssoWithUrl" && ssoUrl && (
-              <a
+              <Button
+                as="a"
                 href={ssoUrl}
-                className="btn btn-primary btn-sm"
+                variant="primary"
+                size="sm"
                 rel="noopener noreferrer"
               >
                 {t("membership.ssoRequired.authorizeButton")}
-              </a>
+              </Button>
             )}
 
             {cause === "generic" && onRetry && (

--- a/web/src/components/NotFound.tsx
+++ b/web/src/components/NotFound.tsx
@@ -1,8 +1,8 @@
-import { Link } from "@tanstack/react-router"
 import { FileQuestion } from "lucide-react"
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 
+import { RouterButton } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 
 // Rendered by role/visibility-gated pages when the user can't access a resource.
@@ -34,9 +34,9 @@ const NotFound = ({ title, message }: { title?: string; message?: string }) => {
         </h1>
         <p className="mt-1 max-w-md text-base-content/70">{resolvedMessage}</p>
       </div>
-      <Link to="/" className="btn btn-primary btn-sm">
+      <RouterButton to="/" variant="primary" size="sm">
         {t("common.goToDashboard")}
-      </Link>
+      </RouterButton>
     </div>
   )
 }

--- a/web/src/components/PermissionErrorBoundary.test.tsx
+++ b/web/src/components/PermissionErrorBoundary.test.tsx
@@ -7,10 +7,18 @@ vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
   return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
 })
-// The friendly message renders a router <Link>; stub it to avoid a router.
-vi.mock("@tanstack/react-router", () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
-}))
+// The friendly message renders a RouterButton (createLink) that needs a router
+// context; stub just that primitive to a plain anchor so the boundary renders
+// without a RouterProvider. Spread the barrel so Alert et al. stay real.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({ children }: { children: React.ReactNode }) => (
+      <a>{children}</a>
+    ),
+  }
+})
 
 import { PermissionErrorBoundary } from "./PermissionErrorBoundary"
 

--- a/web/src/components/PermissionErrorBoundary.tsx
+++ b/web/src/components/PermissionErrorBoundary.tsx
@@ -1,9 +1,8 @@
 import { Component, type ErrorInfo, type ReactNode } from "react"
-import { Link } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { ShieldAlert } from "lucide-react"
 import { GitHubAPIError } from "@/github-core/errors"
-import { Alert } from "@/components/ui"
+import { Alert, RouterButton } from "@/components/ui"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("permission-error-boundary")
@@ -19,8 +18,8 @@ function isPermissionError(error: unknown): boolean {
   )
 }
 
-// The translated fallback UI. A function component so it can use hooks (t, Link)
-// that the class boundary can't.
+// The translated fallback UI. A function component so it can use hooks (t,
+// RouterButton) that the class boundary can't.
 function PermissionDeniedMessage() {
   const { t } = useTranslation()
   return (
@@ -32,9 +31,9 @@ function PermissionDeniedMessage() {
         <h1 className="text-lg font-bold">{t("permissionDenied.title")}</h1>
         <p className="text-sm">{t("permissionDenied.message")}</p>
       </Alert>
-      <Link to="/" className="btn btn-primary btn-sm">
+      <RouterButton to="/" variant="primary" size="sm">
         {t("permissionDenied.back")}
-      </Link>
+      </RouterButton>
     </div>
   )
 }

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -5,7 +5,14 @@ import { Plus, Trash2, UsersRound } from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
 import { Spinner } from "@/components/Spinner"
-import { Alert, AnimatedAlert, Button, Modal } from "@/components/ui"
+import {
+  Alert,
+  AnimatedAlert,
+  Badge,
+  Button,
+  Input,
+  Modal,
+} from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
@@ -464,9 +471,9 @@ export function GroupCollaboratorsModal({
                       students={students}
                     />
                   </span>
-                  <span className="badge badge-primary badge-soft badge-sm">
+                  <Badge tone="primary">
                     {t("components.modals.groupCollaborators.ownerBadge")}
-                  </span>
+                  </Badge>
                 </li>
               )}
 
@@ -582,8 +589,8 @@ export function GroupCollaboratorsModal({
 
             {canManage && !isFull && (
               <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-                <input
-                  className="input input-bordered flex-1"
+                <Input
+                  className="flex-1"
                   placeholder={t(
                     "components.modals.groupCollaborators.addPlaceholder",
                   )}

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -4,7 +4,7 @@ import { useId } from "react"
 import { useTranslation } from "react-i18next"
 
 import PlanBadge from "@/components/PlanBadge"
-import { Modal } from "@/components/ui"
+import { Button, Modal } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import { classifyPlan } from "@/lib/orgPlan"
@@ -115,15 +115,17 @@ function NewOrgModal({
       )}
 
       <div className="modal-action">
-        <a
+        <Button
+          as="a"
           href="https://github.com/organizations/new"
           target="_blank"
           rel="noreferrer"
-          className="btn btn-ghost btn-sm"
+          variant="ghost"
+          size="sm"
         >
           {t("orgs.newOrg.createOnGitHub")}
           <ExternalLink aria-hidden="true" className="size-4" />
-        </a>
+        </Button>
       </div>
     </Modal>
   )

--- a/web/src/components/modals/StudentProfileModal.tsx
+++ b/web/src/components/modals/StudentProfileModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { ExternalLink } from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
-import { Modal } from "@/components/ui"
+import { Badge, Button, Modal } from "@/components/ui"
 import type { Student } from "@/types/classroom"
 import { getName, getInitials } from "@/util/students"
 
@@ -88,9 +88,7 @@ export const StudentProfileModal = ({
             {name}
           </h3>
           {student.section?.trim() ? (
-            <span className="badge badge-sm badge-ghost">
-              {student.section.trim()}
-            </span>
+            <Badge ghost>{student.section.trim()}</Badge>
           ) : null}
         </div>
       </div>
@@ -110,8 +108,11 @@ export const StudentProfileModal = ({
       </dl>
 
       {repoUrl ? (
-        <a
-          className="btn btn-outline btn-sm mt-4 w-full"
+        <Button
+          as="a"
+          variant="outline"
+          size="sm"
+          className="mt-4 w-full"
           href={repoUrl}
           target="_blank"
           rel="noreferrer"
@@ -120,7 +121,7 @@ export const StudentProfileModal = ({
           <GitHub aria-hidden="true" className="size-4" />{" "}
           {t("components.modals.studentProfile.openRepo")}
           <ExternalLink aria-hidden="true" className="size-3.5" />
-        </a>
+        </Button>
       ) : null}
     </Modal>
   )

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -2,7 +2,12 @@ import { AlertTriangle } from "lucide-react"
 import { useEffect, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, AnimatedAlert, type ButtonVariant } from "@/components/ui"
+import {
+  Button,
+  AnimatedAlert,
+  Input,
+  type ButtonVariant,
+} from "@/components/ui"
 
 type ConfirmModalProps = {
   open: boolean
@@ -217,10 +222,10 @@ export function ConfirmModal({
                 {t("components.confirmModal.typeToConfirm_suffix")}
               </p>
 
-              <input
+              <Input
                 ref={confirmInputRef}
                 type="text"
-                className="input input-bordered w-full font-mono"
+                className="font-mono"
                 value={typedText}
                 disabled={isSubmitting}
                 autoFocus

--- a/web/src/components/ui/RouterButton.test.tsx
+++ b/web/src/components/ui/RouterButton.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router"
+
+import { RouterButton } from "./RouterButton"
+
+afterEach(cleanup)
+
+// `to` is typed against the app's generated route tree (module augmentation),
+// but this suite renders an isolated in-memory tree, so relax the path type to
+// a plain string for the ad-hoc `/target` route. Behavior is unaffected.
+const TestButton = RouterButton as (props: {
+  to: string
+  variant?: "primary"
+  size?: "sm"
+  className?: string
+  children?: React.ReactNode
+}) => React.ReactElement
+
+// RouterButton is createLink(Button): a router <Link> that wears the Button
+// recipe. These lock that it renders an <a> with the resolved href and the
+// same variant/size mapping Button uses, so the ~ handful of Link-as-button
+// sites converge on one primitive instead of hand-written `<Link class="btn">`.
+function renderInRouter(node: React.ReactNode) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <>{node}</>,
+  })
+  const targetRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/target",
+    component: () => <div>target</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  })
+  render(<RouterProvider router={router} />)
+}
+
+describe("RouterButton", () => {
+  it("renders an anchor with the resolved href", async () => {
+    renderInRouter(<TestButton to="/target">Go</TestButton>)
+    const link = await screen.findByRole("link", { name: "Go" })
+    expect(link.tagName).toBe("A")
+    expect(link.getAttribute("href")).toBe("/target")
+  })
+
+  it("wears the Button recipe (variant + size map to daisyUI modifiers)", async () => {
+    renderInRouter(
+      <TestButton to="/target" variant="primary" size="sm">
+        Styled
+      </TestButton>,
+    )
+    const cls = (await screen.findByRole("link", { name: "Styled" })).className
+    expect(cls).toContain("btn")
+    expect(cls).toContain("btn-primary")
+    expect(cls).toContain("btn-sm")
+  })
+
+  it("keeps the className escape hatch for layout utilities", async () => {
+    renderInRouter(
+      <TestButton to="/target" className="w-full">
+        Wide
+      </TestButton>,
+    )
+    expect(
+      (await screen.findByRole("link", { name: "Wide" })).className,
+    ).toContain("w-full")
+  })
+})

--- a/web/src/components/ui/RouterButton.tsx
+++ b/web/src/components/ui/RouterButton.tsx
@@ -1,0 +1,32 @@
+import { createLink, type LinkComponent } from "@tanstack/react-router"
+
+import { Button, type ButtonProps } from "./Button"
+
+// A TanStack Router link that wears the Button recipe — the single source for
+// "a router link styled as a button" (View roster, Go home, etc.). Built via
+// createLink so it keeps type-safe routing props (`to`, `params`, `search`,
+// `preload`, active state) while reusing Button's variant/size/shape mapping,
+// instead of hand-writing `<Link className="btn ...">` at each call site.
+//
+// Button already renders an <a> under `as="a"` (daisyUI styles anchors like
+// buttons), so we force that here and let createLink own the href + navigation.
+// A RouterButton never submits a form and needs no `type`; drop the button-only
+// props that don't apply to an anchor.
+type RouterButtonHostProps = Omit<
+  ButtonProps,
+  "as" | "href" | "type" | "ref" | "loading" | "loadingLabel"
+>
+
+const RouterButtonHost = (props: RouterButtonHostProps) => (
+  <Button as="a" {...props} />
+)
+
+const CreatedRouterButton = createLink(RouterButtonHost)
+
+// No default preload override — the app configures no defaultPreload, so plain
+// <Link>s don't preload; matching that keeps this a purely cosmetic convergence
+// (a caller can still opt in per-site via the standard `preload` prop).
+export const RouterButton: LinkComponent<typeof RouterButtonHost> =
+  CreatedRouterButton
+
+export default RouterButton

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -10,6 +10,8 @@ export type {
   ButtonShape,
 } from "./Button"
 
+export { RouterButton } from "./RouterButton"
+
 export { Card, CardBody, CardTitle, CardActions } from "./Card"
 export type { CardProps } from "./Card"
 

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -12,7 +12,7 @@ import {
   type AssignmentFilters,
   type AssignmentSort,
 } from "@/pages/assignments/assignmentList"
-import { Button } from "@/components/ui"
+import { Badge, Button } from "@/components/ui"
 import { NoSearchResults } from "@/components/list"
 import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
@@ -151,9 +151,9 @@ export const TeacherAssignmentsView = ({
           <span className="flex items-center gap-2">
             {classroomData?.name || classroomData?.short_name || classroom}
             {myRoleLabel ? (
-              <span className="badge badge-soft badge-primary badge-sm align-middle">
+              <Badge tone="primary" className="align-middle">
                 {myRoleLabel}
-              </span>
+              </Badge>
             ) : null}
           </span>
         }
@@ -167,9 +167,9 @@ export const TeacherAssignmentsView = ({
         }
         action={
           archived ? (
-            <span className="badge badge-soft badge-neutral">
+            <Badge tone="neutral" size="md">
               {t("assignments.archived")}
-            </span>
+            </Badge>
           ) : (
             <NewAssignmentButton org={org} classroom={classroom} />
           )

--- a/web/src/pages/OnboardingPage.tsx
+++ b/web/src/pages/OnboardingPage.tsx
@@ -7,7 +7,7 @@ import {
   UserPlus,
 } from "lucide-react"
 import { Spinner } from "@/components/Spinner"
-import { Button, Card } from "@/components/ui"
+import { Badge, Button, Card, RouterButton } from "@/components/ui"
 import {
   MembershipError,
   classifyMembershipError,
@@ -71,10 +71,10 @@ const NotInvited = ({
     <OnboardShell>
       <EnterDiv className="card-body gap-6">
         <div>
-          <span className="badge badge-ghost badge-soft gap-2">
+          <Badge ghost size="md" className="gap-2">
             <Mail aria-hidden="true" className="size-4" />
             {t("getStarted.badge")}
-          </span>
+          </Badge>
           <h1 className="mt-6 text-2xl font-bold">
             {t("getStarted.notInvited.title")}
           </h1>
@@ -127,10 +127,10 @@ const AllSet = ({
     <OnboardShell>
       <EnterDiv className="card-body gap-6">
         <div>
-          <span className="badge badge-primary badge-soft gap-2">
+          <Badge tone="primary" size="md" className="gap-2">
             <Mail aria-hidden="true" className="size-4" />
             {t("getStarted.badge")}
-          </span>
+          </Badge>
           <h1 className="mt-6 text-2xl font-bold">
             {t("getStarted.active.title")}
           </h1>
@@ -152,24 +152,21 @@ const AllSet = ({
           </div>
         </div>
         {returning && returnTo ? (
-          <button
-            type="button"
-            className="btn btn-primary w-full"
-            onClick={onContinue}
-          >
+          <Button variant="primary" className="w-full" onClick={onContinue}>
             {t("getStarted.continueToAssignment")}
-          </button>
+          </Button>
         ) : (
           org &&
           classroom && (
-            <Link
+            <RouterButton
               to="/$org/$classroom"
               params={{ org, classroom }}
-              className="btn btn-primary w-full"
+              variant="primary"
+              className="w-full"
             >
               {t("getStarted.active.goToClassroom")}
               <ArrowRight aria-hidden="true" className="size-4" />
-            </Link>
+            </RouterButton>
           )
         )}
       </EnterDiv>

--- a/web/src/pages/OrgActivityPage.test.tsx
+++ b/web/src/pages/OrgActivityPage.test.tsx
@@ -15,9 +15,13 @@ vi.mock("@/components/PageShell", () => ({
     <div>{children}</div>
   ),
 }))
-vi.mock("@tanstack/react-router", () => ({
-  useParams: () => ({ org: "acme" }),
-}))
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useParams: () => ({ org: "acme" }),
+  }
+})
 vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
 vi.mock("react-i18next", async (importActual) => {
   const actual = await importActual<typeof import("react-i18next")>()

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -10,7 +10,15 @@ import {
   UserPlus,
 } from "lucide-react"
 
-import { AnimatedAlert, Button, Card, Spinner } from "@/components/ui"
+import {
+  AnimatedAlert,
+  Badge,
+  Button,
+  Card,
+  Input,
+  Select,
+  Spinner,
+} from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -411,19 +419,19 @@ const OrgMembersPage = () => {
           </AnimatedAlert>
 
           <div className="mt-6 flex flex-wrap items-center gap-3">
-            <label className="input input-bordered flex min-w-0 flex-1 items-center gap-2">
-              <Search aria-hidden="true" className="size-4 opacity-50" />
-              <input
-                type="search"
-                className="grow"
-                placeholder={t("orgMembers.searchPlaceholder")}
-                aria-label={t("orgMembers.searchLabel")}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-              />
-            </label>
-            <select
-              className="select select-bordered w-full sm:w-auto sm:min-w-[14rem]"
+            <Input
+              leadingIcon={
+                <Search aria-hidden="true" className="size-4 opacity-50" />
+              }
+              className="min-w-0 flex-1"
+              type="search"
+              placeholder={t("orgMembers.searchPlaceholder")}
+              aria-label={t("orgMembers.searchLabel")}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <Select
+              className="w-full sm:w-auto sm:min-w-[14rem]"
               aria-label={t("orgMembers.filterByClassroomLabel")}
               value={classroomFilter}
               onChange={(e) => setClassroomFilter(e.target.value)}
@@ -437,7 +445,7 @@ const OrgMembersPage = () => {
                   {c.name}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
 
           <Card className="mt-4 w-full overflow-hidden">
@@ -561,8 +569,9 @@ const OrgMembersPage = () => {
                           })}
                         </span>
                         {row.unprovisionedClassrooms.length > 0 ? (
-                          <span
-                            className="badge badge-sm badge-warning badge-soft gap-1"
+                          <Badge
+                            tone="warning"
+                            className="gap-1"
                             title={t("orgMembers.unprovisionedTitle", {
                               classrooms:
                                 row.unprovisionedClassrooms.join(", "),
@@ -573,7 +582,7 @@ const OrgMembersPage = () => {
                               className="size-3"
                             />
                             {t("orgMembers.unprovisionedBadge")}
-                          </span>
+                          </Badge>
                         ) : null}
                         <ClassificationBadge row={row} isOwner={isOwner(row)} />
                         <ChevronRight

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Button } from "@/components/ui"
+import { Button, Input } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -419,12 +419,11 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
                   ? t("orgSettings.serviceToken.enterNewLabel")
                   : t("orgSettings.serviceToken.enterLabel")}
               </label>
-              <input
+              <Input
                 id="service-token"
                 ref={tokenInputRef}
                 type="password"
                 placeholder={t("orgSettings.serviceToken.placeholder")}
-                className="input input-bordered w-full"
                 autoComplete="off"
                 value={serviceToken}
                 onChange={(e) => {

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 import { ArrowLeft, ArrowRight, CheckCircle2 } from "lucide-react"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useTranslation } from "react-i18next"
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { Spinner } from "@/components/Spinner"
-import { Alert, Button, Card } from "@/components/ui"
+import { Alert, Button, Card, RouterButton } from "@/components/ui"
 import { QueryErrorAlert } from "@/components/QueryErrorAlert"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useIsOrgOwner } from "@/context/orgRole/useIsOrgOwner"
@@ -120,14 +120,14 @@ const OrgSteps = ({
                 {t("setup.allSetBody")}
               </p>
             </div>
-            <Link className="btn btn-primary" to="/$org" params={{ org }}>
+            <RouterButton variant="primary" to="/$org" params={{ org }}>
               <span className="truncate">
                 {t("setup.goToOrg", {
                   org: org || t("setup.yourOrganization"),
                 })}
               </span>
               <ArrowRight aria-hidden="true" className="size-4 shrink-0" />
-            </Link>
+            </RouterButton>
           </EnterDiv>
         )}
       </Card.Body>

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -17,7 +17,7 @@ import { enterExit, staggerTransition } from "@/lib/motion"
 
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
-import { Button } from "@/components/ui"
+import { Badge, Button, type BadgeTone } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import RequireTeacher from "@/components/RequireTeacher"
 import useGetClasses from "@/hooks/useGetClasses"
@@ -52,15 +52,16 @@ type Resource = {
 
 const KIND_BADGE: Record<
   ResourceKind,
-  { labelKey: string; className: string }
+  { labelKey: string; tone: BadgeTone; ghost?: boolean }
 > = {
   engine: {
     labelKey: "published.kind.engine",
-    className: "badge-ghost",
+    tone: "neutral",
+    ghost: true,
   },
   data: {
     labelKey: "published.kind.data",
-    className: "badge-primary badge-soft",
+    tone: "primary",
   },
 }
 
@@ -159,33 +160,25 @@ function StatusBadge({ url }: { url: string }) {
 
   if (status === "public") {
     return (
-      <span ref={ref} className="badge badge-success badge-soft badge-sm gap-1">
+      <Badge tone="success" className="gap-1">
         <Globe aria-hidden="true" className="size-3" />
         {t("published.status.public")}
-      </span>
+      </Badge>
     )
   }
 
   if (status === "missing") {
     return (
-      <span
-        ref={ref}
-        className="badge badge-ghost badge-sm"
-        title={t("published.status.notPublishedTitle")}
-      >
+      <Badge ghost title={t("published.status.notPublishedTitle")}>
         {t("published.status.notPublished")}
-      </span>
+      </Badge>
     )
   }
 
   return (
-    <span
-      ref={ref}
-      className="badge badge-warning badge-soft badge-sm"
-      title={t("published.status.unreachableTitle")}
-    >
+    <Badge tone="warning" title={t("published.status.unreachableTitle")}>
       {t("published.status.unreachable")}
-    </span>
+    </Badge>
   )
 }
 
@@ -199,14 +192,10 @@ function ResourceRow({ resource }: { resource: Resource }) {
           <span className="font-semibold text-base-content">
             {resource.label}
           </span>
-          <span className={`badge badge-sm ${badge.className}`}>
+          <Badge tone={badge.tone} ghost={badge.ghost}>
             {t(badge.labelKey)}
-          </span>
-          {resource.optional && (
-            <span className="badge badge-ghost badge-sm">
-              {t("published.optional")}
-            </span>
-          )}
+          </Badge>
+          {resource.optional && <Badge ghost>{t("published.optional")}</Badge>}
         </div>
         <p className="mt-1 text-sm text-base-content/70">
           {resource.description}
@@ -219,16 +208,18 @@ function ResourceRow({ resource }: { resource: Resource }) {
         <StatusBadge url={resource.url} />
         <div className="flex items-center gap-1">
           <CopyButton value={resource.url} />
-          <a
+          <Button
+            as="a"
+            variant="ghost"
+            size="xs"
             href={resource.url}
             target="_blank"
             rel="noreferrer"
-            className="btn btn-ghost btn-xs"
             aria-label={t("published.openUrl")}
             title={t("published.openUrl")}
           >
             <ExternalLink aria-hidden="true" className="size-3.5" />
-          </a>
+          </Button>
         </div>
       </div>
     </div>
@@ -321,14 +312,12 @@ function ClassroomResources({
           <div className="flex items-center gap-2">
             <h3 className="truncate font-semibold">{classroom}</h3>
             {secret ? (
-              <span className="badge badge-warning badge-soft badge-sm gap-1">
+              <Badge tone="warning" className="gap-1">
                 <ShieldAlert aria-hidden="true" className="size-3" />
                 {t("published.unlisted")}
-              </span>
+              </Badge>
             ) : (
-              <span className="badge badge-ghost badge-sm">
-                {t("published.publicPath")}
-              </span>
+              <Badge ghost>{t("published.publicPath")}</Badge>
             )}
           </div>
           <p className="text-xs text-base-content/70">

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -25,7 +25,7 @@ import { safeHttpUrl } from "@/util/url"
 import type { GitHubRelease } from "@/github-core/types"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
-import { Alert, Card } from "@/components/ui"
+import { Alert, Badge, Button, Card } from "@/components/ui"
 
 // Strips the `submit/` tag prefix for a friendlier label, falling back to the
 // release name when present.
@@ -50,15 +50,18 @@ const ReleaseRow = ({ release }: { release: GitHubRelease }) => {
         </p>
       </div>
       {href ? (
-        <a
+        <Button
+          as="a"
+          variant="outline"
+          size="sm"
           href={href}
           target="_blank"
           rel="noreferrer"
-          className="btn btn-sm btn-outline shrink-0"
+          className="shrink-0"
         >
           <FileText aria-hidden="true" className="size-4" />
           {t("submissions.student.viewGrade")}
-        </a>
+        </Button>
       ) : (
         <span className="text-sm text-base-content/70">
           {t("submissions.student.unavailable")}
@@ -77,24 +80,26 @@ const AssignmentMeta = ({ assignment }: { assignment?: Assignment }) => {
   return (
     <div className="mt-2 flex flex-wrap items-center gap-2">
       {assignment.mode === "group" ? (
-        <span className="badge badge-ghost badge-sm gap-1">
+        <Badge ghost className="gap-1">
           <UsersRound aria-hidden="true" className="size-3.5" />{" "}
           {t("submissions.student.modeGroup")}
-        </span>
+        </Badge>
       ) : assignment.mode === "individual" ? (
-        <span className="badge badge-ghost badge-sm gap-1">
+        <Badge ghost className="gap-1">
           <UserRound aria-hidden="true" className="size-3.5" />{" "}
           {t("submissions.student.modeIndividual")}
-        </span>
+        </Badge>
       ) : null}
-      <span
-        className={`badge badge-sm gap-1 ${overdue ? "badge-error badge-soft" : "badge-ghost"}`}
+      <Badge
+        tone={overdue ? "error" : "neutral"}
+        ghost={!overdue}
+        className="gap-1"
       >
         <CalendarClock aria-hidden="true" className="size-3.5" />
         {due
           ? t("submissions.dueDate", { date: formatDueDateTime(due) })
           : t("submissions.noDueDate")}
-      </span>
+      </Badge>
     </div>
   )
 }
@@ -181,15 +186,17 @@ const SubmissionBody = ({
         <Alert tone="info">
           <div>{t("submissions.student.noGradedYet")}</div>
         </Alert>
-        <a
+        <Button
+          as="a"
+          variant="outline"
+          size="sm"
           href={studentRepo.html_url}
           target="_blank"
           rel="noreferrer"
-          className="btn btn-sm btn-outline"
         >
           <ExternalLink aria-hidden="true" className="size-4" />
           {t("submissions.student.openMyRepo")}
-        </a>
+        </Button>
       </EnterDiv>
     )
   }
@@ -200,15 +207,17 @@ const SubmissionBody = ({
         <p className="text-sm text-base-content/70">
           {t("submissions.student.releasesIntro")}
         </p>
-        <a
+        <Button
+          as="a"
+          variant="outline"
+          size="sm"
           href={studentRepo.html_url}
           target="_blank"
           rel="noreferrer"
-          className="btn btn-sm btn-outline"
         >
           <ExternalLink aria-hidden="true" className="size-4" />
           {t("submissions.student.openMyRepo")}
-        </a>
+        </Button>
       </div>
 
       <Card as={EnterDiv} bordered={false} className="border border-base-200">

--- a/web/src/pages/assignments/AdvancedRuntimeFields.tsx
+++ b/web/src/pages/assignments/AdvancedRuntimeFields.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react"
 import { orgRunnersQuery } from "@/github-core/queries"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
-import { Button, HelpTooltip } from "@/components/ui"
+import { Button, HelpTooltip, Input } from "@/components/ui"
 import {
   isKnownHostedRunnerLabel,
   isRunnerLabelShapeValid,
@@ -128,13 +128,12 @@ export const LanguageVersionField = ({
             />
             <div className="dropdown w-full max-w-xs">
               <div className="join w-full">
-                <input
+                <Input
                   id={field.name}
                   name={field.name}
-                  type="text"
                   autoComplete="off"
                   spellCheck={false}
-                  className="input join-item w-full"
+                  className="join-item w-full"
                   placeholder={t(
                     "assignments.form.runtime.versionPlaceholder",
                     { version: meta.placeholder },
@@ -251,13 +250,12 @@ export const RunnerField = ({
         label={t("assignments.form.runner.label")}
         help={t("assignments.form.runner.tip")}
       />
-      <input
+      <Input
         id={field.name}
         name={field.name}
-        type="text"
         autoComplete="off"
         spellCheck={false}
-        className="input w-full max-w-xs"
+        className="w-full max-w-xs"
         placeholder="ubuntu-latest"
         value={rawValue}
         onBlur={normalizeOnBlur(field, (value) =>
@@ -298,11 +296,10 @@ export const ContainerFields = ({ form }: { form: AssignmentForm }) => {
               label={t("assignments.form.dockerImage")}
               help={t("assignments.form.dockerImageTip")}
             />
-            <input
+            <Input
               id={field.name}
               name={field.name}
-              type="text"
-              className="input w-full max-w-xs"
+              className="w-full max-w-xs"
               placeholder={t("assignments.form.dockerImagePlaceholder")}
               value={field.state.value}
               onBlur={normalizeOnBlur(field)}
@@ -320,11 +317,10 @@ export const ContainerFields = ({ form }: { form: AssignmentForm }) => {
               label={t("assignments.form.containerUser")}
               help={t("assignments.form.containerUserTip")}
             />
-            <input
+            <Input
               id={field.name}
               name={field.name}
-              type="text"
-              className="input w-full max-w-xs"
+              className="w-full max-w-xs"
               placeholder={t("assignments.form.containerUserPlaceholder")}
               value={field.state.value}
               onBlur={normalizeOnBlur(field)}
@@ -353,13 +349,11 @@ export const AptField = ({ form }: { form: AssignmentForm }) => {
               label={t("assignments.form.runtime.aptLabel")}
               help={t("assignments.form.runtime.aptTip")}
             />
-            <input
+            <Input
               id={field.name}
               name={field.name}
-              type="text"
               autoComplete="off"
               spellCheck={false}
-              className="input w-full"
               placeholder={t("assignments.form.runtime.aptPlaceholder")}
               value={field.state.value}
               onBlur={normalizeOnBlur(field, (value) =>

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -20,7 +20,7 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
-import { Button } from "@/components/ui"
+import { Badge, Button } from "@/components/ui"
 
 const DeleteAssignmentButton = ({
   org,
@@ -266,11 +266,15 @@ const AssignmentsTable = ({
                     })
                   }
                 >
-                  <span className="badge badge-soft max-xl:text-xs xl:text-sm whitespace-nowrap w-full">
+                  <Badge
+                    tone="neutral"
+                    size="md"
+                    className="max-xl:text-xs xl:text-sm whitespace-nowrap w-full"
+                  >
                     {assignment.due
                       ? formatDueDate(assignment.due)
                       : t("assignments.table.noDueDate")}
-                  </span>
+                  </Badge>
                 </td>
                 <td
                   onClick={() =>

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from "i18next"
 import { Pencil, Trash } from "lucide-react"
 import type { AssignmentForm } from "./CreateAssignmentForm"
 
-import { Button, Card, Input, Select } from "@/components/ui"
+import { Badge, Button, Card, Input, Select, Textarea } from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import { emptyTestDraft, validateTestDraft } from "@/util/assignmentTests"
 import type { AssignmentTestComparison } from "@/types/classroom"
@@ -248,9 +248,9 @@ const AutogradingTestModal = ({
                           >
                             {t("assignments.autograder.input")}
                           </label>
-                          <textarea
+                          <Textarea
                             id={field.name}
-                            className="textarea w-full font-mono"
+                            className="font-mono"
                             value={field.state.value}
                             onBlur={field.handleBlur}
                             onChange={(e) => field.handleChange(e.target.value)}
@@ -272,9 +272,9 @@ const AutogradingTestModal = ({
                           >
                             {t("assignments.autograder.expectedOutput")}
                           </label>
-                          <textarea
+                          <Textarea
                             id={field.name}
-                            className="textarea w-full font-mono"
+                            className="font-mono"
                             value={field.state.value}
                             onBlur={field.handleBlur}
                             onChange={(e) => field.handleChange(e.target.value)}
@@ -282,7 +282,7 @@ const AutogradingTestModal = ({
                               "assignments.autograder.expectedOutputPlaceholder",
                             )}
                             rows={5}
-                            aria-invalid={field.state.meta.errors.length > 0}
+                            invalid={field.state.meta.errors.length > 0}
                             aria-describedby={
                               field.state.meta.errors.length > 0
                                 ? `${field.name}-error`
@@ -586,9 +586,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                         </td>
 
                         <td>
-                          <span className="badge badge-ghost badge-soft">
-                            {typeBadge(test.type, t)}
-                          </span>
+                          <Badge ghost>{typeBadge(test.type, t)}</Badge>
                         </td>
 
                         <td>
@@ -600,9 +598,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                         </td>
 
                         <td>
-                          <span className="badge badge-primary badge-soft">
-                            {test.points}
-                          </span>
+                          <Badge tone="primary">{test.points}</Badge>
                         </td>
 
                         <td>

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -5,7 +5,7 @@ import type { TFunction } from "i18next"
 import { slugify } from "@/util/slug"
 import { AlertTriangle } from "lucide-react"
 import AutogradingTestsPane from "./AutogradingTestsPane"
-import { Button, Card } from "@/components/ui"
+import { Button, Card, FormField, Input, Textarea } from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
   testToDraft,
@@ -432,119 +432,114 @@ const CreateAssignmentForm = ({
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <form.Field name="name">
                 {(field) => (
-                  <div>
-                    <label htmlFor={field.name} className="label font-bold">
-                      {t("assignments.form.name")}
-                      <span className="text-error">*</span>
-                    </label>
-                    <input
-                      id={field.name}
-                      name={field.name}
-                      type="text"
-                      required
-                      aria-required="true"
-                      className="input w-full"
-                      placeholder={t("assignments.form.namePlaceholder")}
-                      value={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => {
-                        field.handleChange(e.target.value)
-                        if (!edit && !slugTouched) {
-                          form.setFieldValue("slug", slugify(e.target.value))
-                        }
-                      }}
-                    />
-                  </div>
+                  <FormField
+                    htmlFor={field.name}
+                    required
+                    label={t("assignments.form.name")}
+                  >
+                    {({ id }) => (
+                      <Input
+                        id={id}
+                        name={field.name}
+                        required
+                        aria-required="true"
+                        placeholder={t("assignments.form.namePlaceholder")}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
+                          if (!edit && !slugTouched) {
+                            form.setFieldValue("slug", slugify(e.target.value))
+                          }
+                        }}
+                      />
+                    )}
+                  </FormField>
                 )}
               </form.Field>
 
               <form.Field name="slug">
-                {(field) => (
-                  <div>
-                    <label
+                {(field) => {
+                  const slugError =
+                    !edit && field.state.meta.errors.length > 0
+                      ? String(field.state.meta.errors[0])
+                      : undefined
+                  return (
+                    <FormField
                       htmlFor={field.name}
-                      className="label font-bold flex items-center gap-1.5"
-                    >
-                      {t("assignments.form.slug")}
-                      {!edit && <span className="text-error">*</span>}
-                      <HelpTooltip
-                        help={t(
-                          edit
-                            ? "assignments.form.slugEditHelp"
-                            : "assignments.form.slugHelp",
-                        )}
-                      />
-                    </label>
-                    <input
-                      id={field.name}
-                      name={field.name}
-                      type="text"
                       required={!edit}
-                      aria-required={!edit}
-                      // The slug is the assignment's repo-path identity; renaming
-                      // isn't supported, so it's shown read-only in edit mode.
-                      disabled={edit}
-                      aria-invalid={!edit && field.state.meta.errors.length > 0}
-                      aria-describedby={
-                        !edit && field.state.meta.errors.length > 0
-                          ? `${field.name}-error`
-                          : undefined
-                      }
-                      className="input w-full"
-                      placeholder={t("assignments.form.slugPlaceholder")}
-                      value={field.state.value}
-                      onBlur={(e) => {
-                        // Normalize on blur so what the teacher sees is what's
-                        // saved (the repo path segment). An emptied slug falls
-                        // back to the name-derived default, so leaving the field
-                        // blank restores the auto-generated slug.
-                        const normalized = slugify(e.target.value)
-                        field.handleChange(
-                          normalized || slugify(form.state.values.name),
-                        )
-                        field.handleBlur()
-                      }}
-                      onChange={(e) => {
-                        // Clearing the slug re-arms auto-fill from the name;
-                        // any non-empty edit latches it off so a deliberate
-                        // slug isn't clobbered by later name edits.
-                        setSlugTouched(e.target.value.trim() !== "")
-                        field.handleChange(e.target.value)
-                      }}
-                    />
-                    {!edit && field.state.meta.errors.length > 0 && (
-                      <p
-                        id={`${field.name}-error`}
-                        className="text-error text-sm mt-1.5"
-                        role="alert"
-                      >
-                        {String(field.state.meta.errors[0])}
-                      </p>
-                    )}
-                  </div>
-                )}
+                      help={t(
+                        edit
+                          ? "assignments.form.slugEditHelp"
+                          : "assignments.form.slugHelp",
+                      )}
+                      label={t("assignments.form.slug")}
+                      error={slugError}
+                    >
+                      {({ id, describedById, invalid }) => (
+                        <Input
+                          id={id}
+                          name={field.name}
+                          required={!edit}
+                          aria-required={!edit}
+                          // The slug is the assignment's repo-path identity;
+                          // renaming isn't supported, so it's read-only on edit.
+                          disabled={edit}
+                          invalid={invalid}
+                          aria-describedby={describedById}
+                          placeholder={t("assignments.form.slugPlaceholder")}
+                          value={field.state.value}
+                          onBlur={(e) => {
+                            // Normalize on blur so what the teacher sees is
+                            // what's saved (the repo path segment). An emptied
+                            // slug falls back to the name-derived default, so
+                            // leaving it blank restores the auto slug.
+                            const normalized = slugify(e.target.value)
+                            field.handleChange(
+                              normalized || slugify(form.state.values.name),
+                            )
+                            field.handleBlur()
+                          }}
+                          onChange={(e) => {
+                            // Clearing the slug re-arms auto-fill from the name;
+                            // any non-empty edit latches it off so a deliberate
+                            // slug isn't clobbered by later name edits.
+                            setSlugTouched(e.target.value.trim() !== "")
+                            field.handleChange(e.target.value)
+                          }}
+                        />
+                      )}
+                    </FormField>
+                  )
+                }}
               </form.Field>
             </div>
 
             <form.Field name="description">
               {(field) => (
-                <div className="mt-4">
-                  <label htmlFor={field.name} className="label font-bold mb-2">
-                    {t("assignments.form.description")}
-                    <span className="ml-1.5 font-normal text-base-content/60">
-                      ({t("assignments.form.optional")})
-                    </span>
-                  </label>
-                  <textarea
-                    id={field.name}
-                    name={field.name}
-                    className="textarea w-full"
-                    placeholder={t("assignments.form.descriptionPlaceholder")}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </div>
+                <FormField
+                  htmlFor={field.name}
+                  className="mt-4"
+                  label={
+                    <>
+                      {t("assignments.form.description")}
+                      <span className="ml-1.5 font-normal text-base-content/60">
+                        ({t("assignments.form.optional")})
+                      </span>
+                    </>
+                  }
+                >
+                  {({ id }) => (
+                    <Textarea
+                      id={id}
+                      name={field.name}
+                      placeholder={t("assignments.form.descriptionPlaceholder")}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  )}
+                </FormField>
               )}
             </form.Field>
 
@@ -612,11 +607,11 @@ const CreateAssignmentForm = ({
                               htmlFor={field.name}
                               label={t("assignments.form.maxGroupSize")}
                             />
-                            <input
+                            <Input
                               id={field.name}
                               name={field.name}
                               type="number"
-                              className="input validator w-full sm:max-w-[8rem]"
+                              className="validator w-full sm:max-w-[8rem]"
                               placeholder="#"
                               min={GROUP_SIZE_MIN}
                               max={GROUP_SIZE_MAX}
@@ -684,11 +679,11 @@ const CreateAssignmentForm = ({
                       />
                       {dueDateEnabled ? (
                         <div className="mt-2 ml-[3.75rem]">
-                          <input
+                          <Input
                             id={field.name}
                             name={field.name}
                             type="datetime-local"
-                            className="input w-full sm:max-w-xs"
+                            className="w-full sm:max-w-xs"
                             aria-label={t("assignments.form.dueDate", {
                               tz: tzShort,
                             })}
@@ -820,11 +815,9 @@ const CreateAssignmentForm = ({
                       label={t("assignments.form.setupCommand")}
                       help={t("assignments.form.setupCommandTip")}
                     />
-                    <input
+                    <Input
                       id={field.name}
                       name={field.name}
-                      type="text"
-                      className="input w-full"
                       placeholder={t(
                         "assignments.form.setupCommandPlaceholder",
                       )}
@@ -853,10 +846,10 @@ const CreateAssignmentForm = ({
                           result: "hello.py",
                         })}
                       />
-                      <textarea
+                      <Textarea
                         id={field.name}
                         name={field.name}
-                        className="textarea w-full font-mono"
+                        className="font-mono"
                         rows={4}
                         spellCheck={false}
                         placeholder={"*\n!hello.py"}
@@ -917,7 +910,7 @@ const CreateAssignmentForm = ({
                           return (
                             <div className="mt-3">
                               <div className="flex items-center gap-2">
-                                <input
+                                <Input
                                   id={field.name}
                                   name={field.name}
                                   type="number"
@@ -925,7 +918,7 @@ const CreateAssignmentForm = ({
                                   min={PASS_THRESHOLD_MIN}
                                   max={PASS_THRESHOLD_MAX}
                                   step={1}
-                                  className="input w-28"
+                                  className="w-28"
                                   value={field.state.value}
                                   onBlur={field.handleBlur}
                                   onChange={(e) =>

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -23,7 +23,7 @@ import {
   type StringField,
 } from "./formFieldHelpers"
 import { InlineNote, InlineCode as Code } from "@/components/InlineNote"
-import { HelpTooltip } from "@/components/ui"
+import { FormField, Input } from "@/components/ui"
 import {
   templateForkNoteView,
   templateRestrictedNoteView,
@@ -112,32 +112,35 @@ export const TemplateField = ({
 
   return (
     <>
-      <label
+      <FormField
         htmlFor={field.name}
-        className="label font-bold mb-2 flex items-center gap-1.5"
+        help={t("assignments.template.help")}
+        label={
+          <>
+            <GitHub
+              aria-hidden="true"
+              className="size-4 text-base-content/30 opacity-70"
+            />
+            {t("assignments.template.label")}
+            <span className="font-normal text-base-content/60">
+              ({t("assignments.form.optional")})
+            </span>
+          </>
+        }
       >
-        <GitHub
-          aria-hidden="true"
-          className="size-4 text-base-content/30 opacity-70"
-        />
-        {t("assignments.template.label")}
-        <span className="font-normal text-base-content/60">
-          ({t("assignments.form.optional")})
-        </span>
-        <HelpTooltip help={t("assignments.template.help")} />
-      </label>
-      <input
-        id={field.name}
-        name={field.name}
-        type="text"
-        autoComplete="off"
-        spellCheck={false}
-        placeholder={t("assignments.template.placeholder")}
-        className="input w-full"
-        value={rawValue}
-        onBlur={normalizeOnBlur(field)}
-        onChange={(e) => field.handleChange(e.target.value)}
-      />
+        {({ id }) => (
+          <Input
+            id={id}
+            name={field.name}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={t("assignments.template.placeholder")}
+            value={rawValue}
+            onBlur={normalizeOnBlur(field)}
+            onChange={(e) => field.handleChange(e.target.value)}
+          />
+        )}
+      </FormField>
 
       <TemplateVerificationNote
         verification={verification}

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { NoSearchResults, ViewToggle } from "@/components/list"
-import { Button, LabeledControl } from "@/components/ui"
+import { Button, Input, LabeledControl, Select } from "@/components/ui"
 import useClassroomSummaries, {
   classroomDisplayName,
   type ClassroomSummary,
@@ -154,17 +154,21 @@ const ClassroomList = ({
         />
       )}
       <div className="flex flex-wrap items-center gap-2 rounded-xl border border-base-300 bg-base-100 p-2">
-        <label className="input input-sm input-bordered flex min-w-48 flex-1 items-center gap-2">
-          <Search aria-hidden="true" className="size-4 text-base-content/50" />
-          <input
-            type="search"
-            className="grow"
-            placeholder={t("classes.toolbar.searchPlaceholder")}
-            aria-label={t("classes.toolbar.searchLabel")}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-        </label>
+        <Input
+          inputSize="sm"
+          leadingIcon={
+            <Search
+              aria-hidden="true"
+              className="size-4 text-base-content/50"
+            />
+          }
+          className="min-w-48 flex-1"
+          type="search"
+          placeholder={t("classes.toolbar.searchPlaceholder")}
+          aria-label={t("classes.toolbar.searchLabel")}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
 
         <div
           role="group"
@@ -187,8 +191,9 @@ const ClassroomList = ({
 
         {showTermFilter && (
           <LabeledControl label={t("classes.toolbar.termPrefix")}>
-            <select
-              className="select select-bordered select-sm join-item"
+            <Select
+              selectSize="sm"
+              className="join-item w-auto"
               aria-label={t("classes.toolbar.termLabel")}
               value={activeTerm}
               onChange={(e) => setTermFilter(e.target.value)}
@@ -199,13 +204,14 @@ const ClassroomList = ({
                   {term}
                 </option>
               ))}
-            </select>
+            </Select>
           </LabeledControl>
         )}
 
         <LabeledControl label={t("classes.toolbar.sortPrefix")}>
-          <select
-            className="select select-bordered select-sm join-item"
+          <Select
+            selectSize="sm"
+            className="join-item w-auto"
             aria-label={t("classes.toolbar.sort.label")}
             value={sortKey}
             onChange={(e) => changeSort(e.target.value as ClassroomSortKey)}
@@ -215,7 +221,7 @@ const ClassroomList = ({
                 {t(opt.labelKey)}
               </option>
             ))}
-          </select>
+          </Select>
         </LabeledControl>
 
         <ViewToggle

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -231,7 +231,7 @@ const StaffRoleList = ({
     <div>
       <div className="flex items-center gap-2 mb-2">
         <h4 className="font-bold">{rolePlural}</h4>
-        <span className="badge badge-sm badge-ghost">{members.length}</span>
+        <Badge ghost>{members.length}</Badge>
       </div>
       {membersQuery.isLoading ? (
         <div className="flex items-center gap-2 text-sm text-base-content/70">
@@ -346,13 +346,13 @@ const StaffMemberRow = ({
           className="size-6 rounded-full shrink-0"
         />
         <span className="truncate text-sm">@{member.login}</span>
-        <span
-          className={`badge badge-xs shrink-0 ${
-            role === "instructor" ? "badge-primary" : "badge-secondary"
-          } badge-soft`}
+        <Badge
+          size="xs"
+          tone={role === "instructor" ? "primary" : "secondary"}
+          className="shrink-0"
         >
           {roleLabel}
-        </span>
+        </Badge>
       </a>
       <Button
         variant="ghost"

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Plus, UserMinus, X } from "lucide-react"
 
-import { Alert, Button, Modal, Toolbar } from "@/components/ui"
+import { Alert, Button, Modal, Select, Toolbar } from "@/components/ui"
 import type { GitHubClient } from "@/github-core/client"
 import type { GitHubUser } from "@/github-core/types"
 import type { StudentCsvRow } from "@/domain/students"
@@ -300,9 +300,10 @@ const BulkActionsBar = ({
               >
                 {t("orgMembers.bulk.classroomLabel")}
               </label>
-              <select
+              <Select
                 id={`${titleId}-picker`}
-                className="select select-bordered select-sm max-w-[12rem]"
+                selectSize="sm"
+                className="max-w-[12rem] w-auto"
                 value={effectiveClassroom}
                 onChange={(e) => setClassroom(e.target.value)}
                 disabled={classrooms.length === 0}
@@ -316,7 +317,7 @@ const BulkActionsBar = ({
                     </option>
                   ))
                 )}
-              </select>
+              </Select>
 
               <div className="join">
                 <Button

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, ChevronRight, UserPlus, X } from "lucide-react"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import { Button, Modal } from "@/components/ui"
+import { Badge, Button, Modal } from "@/components/ui"
 import { removeMemberFromOrg } from "@/domain/orgMembers/removeMemberFromOrg"
 import {
   ClassificationBadge,
@@ -181,13 +181,15 @@ const MemberDetailModal = ({
                   <span className="font-medium">
                     {access.classroom}
                     {access.archived ? (
-                      <span className="badge badge-xs badge-ghost ml-2">
+                      <Badge size="xs" ghost className="ml-2">
                         {t("orgMembers.archived")}
-                      </span>
+                      </Badge>
                     ) : null}
                     {access.state === "unprovisioned" && !access.archived ? (
-                      <span
-                        className="badge badge-xs badge-warning badge-soft ml-2 gap-1"
+                      <Badge
+                        size="xs"
+                        tone="warning"
+                        className="ml-2 gap-1"
                         title={t("orgMembers.unprovisionedAccessTitle")}
                       >
                         <AlertTriangle
@@ -195,14 +197,14 @@ const MemberDetailModal = ({
                           className="size-2.5"
                         />
                         {t("orgMembers.unprovisionedAccessBadge")}
-                      </span>
+                      </Badge>
                     ) : null}
                   </span>
                   <span className="flex items-center gap-2 text-base-content/70">
                     {access.section ? (
-                      <span className="badge badge-xs badge-ghost">
+                      <Badge size="xs" ghost>
                         {access.section}
-                      </span>
+                      </Badge>
                     ) : null}
                     <ChevronRight
                       aria-hidden="true"

--- a/web/src/pages/orgMembers/memberPresentation.tsx
+++ b/web/src/pages/orgMembers/memberPresentation.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { AlertTriangle, Info, ShieldCheck } from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
+import { Badge } from "@/components/ui"
 import type { GitHubClient } from "@/github-core/client"
 import type { NotifyInput } from "@/context/notifications/NotificationProvider"
 import { inviteMemberToOrg } from "@/domain/orgMembers/inviteMemberToOrg"
@@ -50,35 +51,31 @@ export const ClassificationBadge = ({
   const { t } = useTranslation()
   if (row.classification === "on-roster-not-member") {
     return (
-      <span className="badge badge-sm badge-error badge-soft gap-1">
+      <Badge tone="error" className="gap-1">
         <AlertTriangle aria-hidden="true" className="size-3" />{" "}
         {t("orgMembers.badgeNotMember")}
-      </span>
+      </Badge>
     )
   }
   // An owner/admin is labeled "Owner", not "Member" — takes precedence over the
   // no-roster badge (an owner with no classroom is still an owner).
   if (isOwner) {
     return (
-      <span className="badge badge-sm badge-info badge-soft gap-1">
+      <Badge tone="info" className="gap-1">
         <ShieldCheck aria-hidden="true" className="size-3" />{" "}
         {t("orgMembers.badgeOwner")}
-      </span>
+      </Badge>
     )
   }
   if (row.classification === "member-no-roster") {
     return (
-      <span className="badge badge-sm badge-ghost gap-1">
+      <Badge ghost className="gap-1">
         <Info aria-hidden="true" className="size-3" />{" "}
         {t("orgMembers.badgeNoClassroom")}
-      </span>
+      </Badge>
     )
   }
-  return (
-    <span className="badge badge-sm badge-success badge-soft">
-      {t("orgMembers.badgeMember")}
-    </span>
-  )
+  return <Badge tone="success">{t("orgMembers.badgeMember")}</Badge>
 }
 
 // Shared invite flow for the inline row button and the detail modal. Errors are

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -13,7 +13,7 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { githubKeys } from "@/github-core/queries"
 import { renameConfigRepoToMain } from "@/github-core/mutations"
-import { Button, Spinner } from "@/components/ui"
+import { Badge, Button, Spinner, type BadgeTone } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import PlanBadge from "@/components/PlanBadge"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
@@ -73,10 +73,13 @@ const CONCERN_STATE_LABEL: Record<CheckState, string> = {
   unreadable: "orgSettings.audit.stateUnreadable",
 }
 
-const CONCERN_STATE_BADGE: Record<CheckState, string> = {
-  enforced: "badge-success",
-  unenforced: "badge-error",
-  unreadable: "badge-neutral badge-ghost",
+const CONCERN_STATE_BADGE: Record<
+  CheckState,
+  { tone: BadgeTone; ghost?: boolean }
+> = {
+  enforced: { tone: "success" },
+  unenforced: { tone: "error" },
+  unreadable: { tone: "neutral", ghost: true },
 }
 
 // What a Fix-it result means for the pane, derived purely from the RepairResult
@@ -171,15 +174,17 @@ export function ConcernRow({
             </Button>
           )}
           {unresolvedMessage !== undefined && (
-            <span className="badge badge-warning badge-soft">
+            <Badge tone="warning">
               {t("orgSettings.audit.needsManualSetup")}
-            </span>
+            </Badge>
           )}
-          <span
-            className={`badge ${CONCERN_STATE_BADGE[concern.verdict.state]}`}
+          <Badge
+            {...CONCERN_STATE_BADGE[concern.verdict.state]}
+            size="md"
+            soft={false}
           >
             {t(CONCERN_STATE_LABEL[concern.verdict.state])}
-          </span>
+          </Badge>
         </div>
       </div>
 
@@ -260,9 +265,7 @@ function RecommendationRow({
             {fixing ? null : t("orgSettings.audit.renameToMain")}
           </Button>
         )}
-        <span className="badge badge-warning badge-soft">
-          {t("orgSettings.audit.recommended")}
-        </span>
+        <Badge tone="warning">{t("orgSettings.audit.recommended")}</Badge>
       </div>
     </div>
   )
@@ -382,9 +385,9 @@ function AuditBody({
                     <ExternalLink aria-hidden="true" className="size-3" />
                   </a>
                 </div>
-                <span className="badge badge-warning badge-soft shrink-0">
+                <Badge tone="warning" className="shrink-0">
                   {t("orgSettings.audit.confirmManually")}
-                </span>
+                </Badge>
               </div>
             ))}
           </div>

--- a/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
+++ b/web/src/pages/orgSettings/UnenforcedDefaultsList.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { TriangleAlert } from "lucide-react"
 
+import { Badge } from "@/components/ui"
 import type { UnenforcedDefaultItem } from "./orgDefaultsStepData"
 
 // The per-field list of settings needing a manual fix, shared by the setup step
@@ -26,9 +27,9 @@ export const UnenforcedDefaultsList = ({
               <span className="text-base-content/70"> — {d.manualFix}</span>
             )}
             {d.pinned && (
-              <span className="ml-1 badge badge-ghost badge-xs align-middle">
+              <Badge size="xs" ghost className="ml-1 align-middle">
                 {t("orgSettings.audit.requiresManualFix")}
-              </span>
+              </Badge>
             )}
           </span>
         </li>

--- a/web/src/pages/orgSettings/initStepBoard.tsx
+++ b/web/src/pages/orgSettings/initStepBoard.tsx
@@ -19,7 +19,7 @@ import {
   isOrgDefaultsStepData,
   unenforcedDefaultItems,
 } from "./orgDefaultsStepData"
-import { Spinner } from "@/components/ui"
+import { Badge, Spinner, type BadgeTone } from "@/components/ui"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Shared init "badge board" used by the org setup wizard (OrgSetupPage) and the
@@ -188,13 +188,16 @@ export function applyStepUpdate(
   }
 }
 
-const STATUS_BADGE_CLASS: Record<InitStepStatus, string> = {
-  complete: "badge-success",
-  warning: "badge-warning",
-  error: "badge-error",
-  pending: "badge-neutral badge-ghost",
-  running: "badge-neutral badge-ghost",
-  skipped: "badge-neutral badge-ghost",
+const STATUS_BADGE_PROPS: Record<
+  InitStepStatus,
+  { tone: BadgeTone; ghost?: boolean }
+> = {
+  complete: { tone: "success" },
+  warning: { tone: "warning" },
+  error: { tone: "error" },
+  pending: { tone: "neutral", ghost: true },
+  running: { tone: "neutral", ghost: true },
+  skipped: { tone: "neutral", ghost: true },
 }
 
 const STATUS_ICON: Record<InitStepStatus, ReactNode> = {
@@ -268,9 +271,14 @@ export const InitStep = ({
             </p>
           </div>
         </div>
-        <span className={`badge shrink-0 ${STATUS_BADGE_CLASS[status]}`}>
+        <Badge
+          {...STATUS_BADGE_PROPS[status]}
+          size="md"
+          soft={false}
+          className="shrink-0"
+        >
           {STATUS_ICON[status]}
-        </span>
+        </Badge>
       </button>
 
       {open && (

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -8,7 +8,7 @@ import { useEnrollOrInviteStudent } from "@/hooks/mutations/useEnrollOrInviteStu
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { StudentAlreadyEnrolledError } from "@/domain/students"
 import { isValidEmail } from "@/util/orgMembership"
-import { AnimatedAlert, Button, Modal } from "@/components/ui"
+import { AnimatedAlert, Button, Input, Modal } from "@/components/ui"
 
 type AddStudentProps = {
   org: string
@@ -165,49 +165,47 @@ const AddStudent = ({
         <div className="mt-4 flex flex-col gap-3">
           <form.Field name="name">
             {(field) => (
-              <label className="input input-bordered flex w-full items-center gap-2">
-                <UserRound
-                  className="size-4 text-base-content/50"
-                  aria-hidden="true"
-                />
-                <input
-                  id={field.name}
-                  name={field.name}
-                  type="text"
-                  className="grow"
-                  placeholder={t("students.namePlaceholder")}
-                  aria-label={t("students.namePlaceholder")}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              </label>
+              <Input
+                leadingIcon={
+                  <UserRound
+                    className="size-4 text-base-content/50"
+                    aria-hidden="true"
+                  />
+                }
+                id={field.name}
+                name={field.name}
+                type="text"
+                placeholder={t("students.namePlaceholder")}
+                aria-label={t("students.namePlaceholder")}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
             )}
           </form.Field>
 
           <form.Field name="username">
             {(field) => (
               <div>
-                <label className="input input-bordered flex w-full items-center gap-2">
-                  <GitHub className="size-4 opacity-40" aria-hidden="true" />
-                  <input
-                    id={field.name}
-                    name={field.name}
-                    type="text"
-                    className="grow"
-                    placeholder={t("students.usernamePlaceholder")}
-                    aria-label={t("students.usernameAria")}
-                    aria-invalid={field.state.meta.errors.length > 0}
-                    aria-describedby={
-                      field.state.meta.errors.length > 0
-                        ? `${field.name}-error`
-                        : undefined
-                    }
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </label>
+                <Input
+                  leadingIcon={
+                    <GitHub className="size-4 opacity-40" aria-hidden="true" />
+                  }
+                  id={field.name}
+                  name={field.name}
+                  type="text"
+                  placeholder={t("students.usernamePlaceholder")}
+                  aria-label={t("students.usernameAria")}
+                  aria-invalid={field.state.meta.errors.length > 0}
+                  aria-describedby={
+                    field.state.meta.errors.length > 0
+                      ? `${field.name}-error`
+                      : undefined
+                  }
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
                 {field.state.meta.errors.length > 0 && (
                   <p
                     id={`${field.name}-error`}
@@ -224,29 +222,28 @@ const AddStudent = ({
           <form.Field name="email">
             {(field) => (
               <div>
-                <label className="input input-bordered flex w-full items-center gap-2">
-                  <Mail
-                    className="size-4 text-base-content/50"
-                    aria-hidden="true"
-                  />
-                  <input
-                    id={field.name}
-                    name={field.name}
-                    type="email"
-                    className="grow"
-                    placeholder={t("students.emailPlaceholder")}
-                    aria-label={t("students.emailAria")}
-                    aria-invalid={field.state.meta.errors.length > 0}
-                    aria-describedby={
-                      field.state.meta.errors.length > 0
-                        ? `${field.name}-error`
-                        : undefined
-                    }
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </label>
+                <Input
+                  leadingIcon={
+                    <Mail
+                      className="size-4 text-base-content/50"
+                      aria-hidden="true"
+                    />
+                  }
+                  id={field.name}
+                  name={field.name}
+                  type="email"
+                  placeholder={t("students.emailPlaceholder")}
+                  aria-label={t("students.emailAria")}
+                  aria-invalid={field.state.meta.errors.length > 0}
+                  aria-describedby={
+                    field.state.meta.errors.length > 0
+                      ? `${field.name}-error`
+                      : undefined
+                  }
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
                 {field.state.meta.errors.length > 0 && (
                   <p
                     id={`${field.name}-error`}
@@ -262,23 +259,22 @@ const AddStudent = ({
 
           <form.Field name="section">
             {(field) => (
-              <label className="input input-bordered flex w-full items-center gap-2">
-                <Users
-                  className="size-4 text-base-content/50"
-                  aria-hidden="true"
-                />
-                <input
-                  id={field.name}
-                  name={field.name}
-                  type="text"
-                  className="grow"
-                  placeholder={t("students.sectionPlaceholder")}
-                  aria-label={t("students.sectionAria")}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              </label>
+              <Input
+                leadingIcon={
+                  <Users
+                    className="size-4 text-base-content/50"
+                    aria-hidden="true"
+                  />
+                }
+                id={field.name}
+                name={field.name}
+                type="text"
+                placeholder={t("students.sectionPlaceholder")}
+                aria-label={t("students.sectionAria")}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
             )}
           </form.Field>
         </div>

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -599,9 +599,9 @@ const EnrolledStudents = ({
             return <RoleBadges roles={row.roles} />
           })()}
           {row.section.trim() ? (
-            <span className="badge badge-sm badge-info badge-soft shrink-0">
+            <Badge tone="info" className="shrink-0">
               {row.section.trim()}
-            </span>
+            </Badge>
           ) : null}
           {row.state !== "enrolled" ? (
             <Badge
@@ -987,9 +987,7 @@ const EnrolledStudents = ({
                           ? t("students.noSection")
                           : section}
                       </h3>
-                      <span className="badge badge-ghost badge-sm">
-                        {group.length}
-                      </span>
+                      <Badge ghost>{group.length}</Badge>
                     </div>
                     <motion.ul
                       className="divide-y divide-base-300"

--- a/web/src/pages/students/InviteLinksModal.tsx
+++ b/web/src/pages/students/InviteLinksModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Check, Copy } from "lucide-react"
 
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
-import { Button, Modal } from "@/components/ui"
+import { Button, Input, Modal } from "@/components/ui"
 
 // A single copyable link row (read-only input + copy button).
 const CopyLinkField = ({
@@ -27,13 +27,14 @@ const CopyLinkField = ({
       <span className="text-sm font-medium">{label}</span>
       <span className="text-xs text-base-content/70">{hint}</span>
       <div className="join mt-1 w-full">
-        <input
+        <Input
+          inputSize="sm"
           type="text"
           readOnly
           value={url}
           aria-label={ariaLabel}
           onFocus={(event) => event.currentTarget.select()}
-          className="input input-sm input-bordered join-item w-full font-mono text-xs"
+          className="join-item w-full font-mono text-xs"
         />
         <Button
           size="sm"

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -5,7 +5,7 @@ import { Upload } from "lucide-react"
 import Papa from "papaparse"
 import { bulkEnrollStudentsInClassroom } from "@/domain/students"
 import type { GitHubClient } from "@/github-core/client"
-import { Alert, Button, Modal, Select, Spinner } from "@/components/ui"
+import { Alert, Badge, Button, Modal, Select, Spinner } from "@/components/ui"
 import {
   applyRosterRoleChange,
   bulkInviteByEmail,
@@ -208,7 +208,7 @@ const PreflightBucket = ({
       className={`flex items-center justify-between gap-2 rounded-box border px-4 py-2.5 ${toneClass}`}
     >
       <span className="text-sm">{title}</span>
-      <span className="badge badge-sm">{count}</span>
+      <Badge>{count}</Badge>
     </div>
   )
 }

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -333,12 +333,9 @@ const SubmissionHistory = ({
             size="sm"
           />
           {s.late ? (
-            <span
-              className="badge badge-sm badge-error badge-soft"
-              title={t("submissions.table.lateHistoryTitle")}
-            >
+            <Badge tone="error" title={t("submissions.table.lateHistoryTitle")}>
               {t("submissions.table.late")}
-            </span>
+            </Badge>
           ) : null}
           {isGroup && s.submittedBy ? (
             <span className="text-base-content/70">
@@ -601,12 +598,12 @@ const SubmissionsTable = ({
                               {formatDateTime(datetime)}
                             </span>
                             {late ? (
-                              <span
-                                className="badge badge-sm badge-error badge-soft"
+                              <Badge
+                                tone="error"
                                 title={t("submissions.table.lateRowTitle")}
                               >
                                 {t("submissions.table.late")}
-                              </span>
+                              </Badge>
                             ) : null}
                           </div>
                           {rest.gradedAt && rest.gradedAt !== datetime ? (


### PR DESCRIPTION
## Summary

P6 of the web architecture refactor: converge the ~37 files that still hand-write DaisyUI class recipes (`btn …`, `badge …`, `input …`, `select …`, `textarea …`) onto the shared typed primitives in `components/ui/` (`Button`, `Badge`, `Input`, `Select`, `Textarea`, `FormField`). One recipe, one source.

- **New `RouterButton` primitive** (`createLink(Button)`) — the single source for "a router link styled as a button", replacing hand-written `<Link className="btn …">`. Keeps type-safe routing props (`to`/`params`/`search`) while reusing `Button`'s variant/size/shape mapping. Covered by a new render test.
- **Badge sweep** — status `<span>` chips and computed tone/class maps (`KIND_BADGE`, `STATUS_BADGE`, `CONCERN_STATE_BADGE`, …) translated to typed `tone`/`ghost`/`size` props.
- **Button sweep** — inline `btn` recipes → `<Button variant/size/shape>`; external anchors → `<Button as="a">`.
- **Form sweep** — `label`+`input`/`textarea` pairs → `<FormField>` + `<Input>`/`<Textarea>`; icon-input `<label className="input">` shells → `<Input leadingIcon>`; `<select>` → `<Select>`.

Behavior-preserving cosmetic convergence: refs, event handlers, `aria-*`, value/onChange contracts, and per-site layout utilities (`w-full`, `join-item`, `font-mono`, …) are kept via the `className` escape hatch. The slug/number inputs preserve their exact validation, `disabled`-on-edit, and `Number()` casting behavior.

## Deliberately left as-is (don't map cleanly)

- Radio/checkbox styled as buttons (`<input type="radio" className="join-item btn">`) — `Button` renders `<button>`/`<a>`, not an input.
- Interactive `<label>`/`<div>` badges (hover/`onClick`/`aria-expanded` a `<span>` can't carry).
- Trailing-suffix inputs (e.g. the OrgSettings "… days" field) — no trailing slot on `Input`.
- Anchors/`<Link className="btn">` inside contexts where element semantics matter, and a decorative `<span className="btn">` nested inside a `<button>` (avoids invalid nested-button HTML).

## Test plan

- [x] `tsc -b` clean
- [x] Full `vitest` green (137 files, 1503 tests; +3 new `RouterButton` tests)
- [x] `eslint` on changed files: 0 errors (only pre-existing warnings remain)
- [x] `prettier --check` clean
- [x] Bugbot: no bugs
- [ ] Visual spot-check of the converged badges/buttons/forms in the running app