### PR TITLE
fix(cli): tolerate a malformed pre-existing roster.csv row on write

### DIFF
--- a/cli/gh-teacher/internal/configrepo/roster.go
+++ b/cli/gh-teacher/internal/configrepo/roster.go
@@ -56,8 +56,9 @@ func ResolveConfigRepoBranch(client githubapi.Client, org string) (string, error
 // classroom bootstrapped before the rename still reads. Missing both → points
 // the teacher at `gh teacher classroom add`.
 //
-// Read-only callers use this; write callers use LoadRosterWithSource so they
-// can converge the legacy file onto roster.csv in the same commit.
+// Read-only callers use this; write callers use LoadRosterWithSourceLenient so
+// they can converge the legacy file onto roster.csv in the same commit and
+// tolerate a pre-existing malformed row instead of aborting.
 func LoadRoster(client githubapi.Client, org, classroom, parentSHA string) ([]RosterRow, error) {
 	rows, _, err := LoadRosterWithSource(client, org, classroom, parentSHA)
 	return rows, err
@@ -68,8 +69,21 @@ func LoadRoster(client githubapi.Client, org, classroom, parentSHA string) ([]Ro
 // when only the legacy file exists. Write paths use the source to decide
 // whether the same commit must also delete the legacy file (see
 // RosterWriteChange), so a first edit of an un-migrated classroom converges it
-// onto roster.csv rather than leaving a stale legacy copy behind.
+// onto roster.csv rather than leaving a stale legacy copy behind. Parses
+// strictly; write commands use LoadRosterWithSourceLenient.
 func LoadRosterWithSource(client githubapi.Client, org, classroom, parentSHA string) (rows []RosterRow, sourcePath string, err error) {
+	return loadRosterWithSource(client, org, classroom, parentSHA, false)
+}
+
+// LoadRosterWithSourceLenient is LoadRosterWithSource for the read-modify-write
+// path: it parses leniently (ParseRosterLenient) so a pre-existing malformed row
+// can't block a legitimate edit of another and round-trips untouched. Write
+// commands (add/update/remove/import) use it; read-only callers stay strict.
+func LoadRosterWithSourceLenient(client githubapi.Client, org, classroom, parentSHA string) (rows []RosterRow, sourcePath string, err error) {
+	return loadRosterWithSource(client, org, classroom, parentSHA, true)
+}
+
+func loadRosterWithSource(client githubapi.Client, org, classroom, parentSHA string, lenient bool) (rows []RosterRow, sourcePath string, err error) {
 	path := RosterFilePath(classroom)
 	data, ok, err := ReadFileContents(client, org, ConfigRepoName, path, parentSHA)
 	if err != nil {
@@ -88,7 +102,11 @@ func LoadRosterWithSource(client githubapi.Client, org, classroom, parentSHA str
 		}
 		path, data = legacyPath, legacyData
 	}
-	parsed, err := ParseRoster(data)
+	parse := ParseRoster
+	if lenient {
+		parse = ParseRosterLenient
+	}
+	parsed, err := parse(data)
 	if err != nil {
 		return nil, "", fmt.Errorf("%s/%s/%s: %w", org, ConfigRepoName, path, err)
 	}
@@ -119,16 +137,22 @@ func RosterWriteChange(classroom, sourcePath string, rows []RosterRow) (gittree.
 func DedupeByUsername(rows []RosterRow) []RosterRow {
 	latest := make(map[string]RosterRow, len(rows))
 	order := make([]string, 0, len(rows))
+	var rawRows []RosterRow
 	for _, row := range rows {
+		if row.isRaw() {
+			// Preserved rows have no username to key on; keep each distinct.
+			rawRows = append(rawRows, row)
+			continue
+		}
 		key := strings.ToLower(row.Username)
 		if _, seen := latest[key]; !seen {
 			order = append(order, key)
 		}
 		latest[key] = row
 	}
-	out := make([]RosterRow, 0, len(order))
+	out := make([]RosterRow, 0, len(order)+len(rawRows))
 	for _, key := range order {
 		out = append(out, latest[key])
 	}
-	return out
+	return append(out, rawRows...)
 }

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -71,14 +71,37 @@ type RosterRow struct {
 	// ExtraOrder is the on-disk order of Extra columns for deterministic
 	// encoding. INVARIANT: it lists exactly the keys of Extra.
 	ExtraOrder []string
+	// raw is the original CSV record of a row that failed strict validation but
+	// was preserved by ParseRosterLenient, so a write can round-trip it instead
+	// of dropping a student. When set, the parsed fields are unpopulated:
+	// EncodeRoster writes raw verbatim; mutation helpers skip it (no username).
+	raw []string
 }
+
+// isRaw reports whether the row is a preserved-but-unparsed record.
+func (r RosterRow) isRaw() bool { return r.raw != nil }
 
 // ParseRoster decodes the roster CSV. The header MUST begin with the canonical
 // RosterColumns in order; a file written before the trailing `role` column was
 // added (ending at github_id) is still accepted (role reads as ""). Additional
 // trailing columns beyond the canonical set are preserved verbatim in
-// RosterRow.Extra. Empty input is rejected.
+// RosterRow.Extra. Empty input is rejected. Any malformed data row is an error.
 func ParseRoster(data []byte) ([]RosterRow, error) {
+	return parseRoster(data, false)
+}
+
+// ParseRosterLenient is ParseRoster for the read-modify-write path: a malformed
+// data row (empty username, wrong field count) is preserved verbatim as a raw
+// RosterRow instead of aborting, so a write command can round-trip pre-existing
+// bad data. Header and empty-input errors still hard-fail — a broken header
+// can't be safely round-tripped.
+func ParseRosterLenient(data []byte) ([]RosterRow, error) {
+	return parseRoster(data, true)
+}
+
+// parseRoster is the shared core; lenient preserves a bad row as raw rather
+// than erroring (see ParseRoster / ParseRosterLenient).
+func parseRoster(data []byte, lenient bool) ([]RosterRow, error) {
 	data = bytes.TrimPrefix(data, utf8BOM)
 	r := csv.NewReader(bytes.NewReader(data))
 	// Read header without field-count enforcement so a renamed/short header
@@ -133,8 +156,12 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 		}
 		seenExtra[name] = true
 	}
-	// Fix the field count to the full header width so a short/long row errors.
-	r.FieldsPerRecord = len(header)
+	// Strict mode fixes the field count so a short/long row errors; lenient
+	// leaves it unenforced so a mis-widthed row still reads into a preservable
+	// record.
+	if !lenient {
+		r.FieldsPerRecord = len(header)
+	}
 
 	var rows []RosterRow
 	for line := 2; ; line++ {
@@ -143,10 +170,18 @@ func ParseRoster(data []byte) ([]RosterRow, error) {
 			break
 		}
 		if err != nil {
+			if lenient {
+				// A quoting-level error yields no usable record to preserve.
+				continue
+			}
 			return nil, fmt.Errorf("line %d: %w", line, err)
 		}
 		row, err := recordToRow(record, canonicalLen, extraColumns, line)
 		if err != nil {
+			if lenient {
+				rows = append(rows, RosterRow{raw: record})
+				continue
+			}
 			return nil, err
 		}
 		rows = append(rows, row)
@@ -227,6 +262,12 @@ func ParseImportCSV(data []byte) ([]RosterRow, error) {
 // canonical prefix width (7 with role, 6 for a pre-role file); extraColumns (in
 // header order) name the values beyond it, carried through Extra.
 func recordToRow(record []string, canonicalLen int, extraColumns []string, line int) (RosterRow, error) {
+	// Guard the width before indexing: lenient parsing leaves FieldsPerRecord
+	// unenforced, so a mis-widthed row reaches here — error (the caller
+	// preserves it raw) rather than panicking on an out-of-range index.
+	if want := canonicalLen + len(extraColumns); len(record) != want {
+		return RosterRow{}, fmt.Errorf("line %d: wrong number of fields (got %d, want %d)", line, len(record), want)
+	}
 	if err := checkFieldLengths(line, record); err != nil {
 		return RosterRow{}, err
 	}
@@ -278,6 +319,19 @@ func EncodeRoster(rows []RosterRow) ([]byte, error) {
 		return nil, fmt.Errorf("write header: %w", err)
 	}
 	for _, row := range rows {
+		if row.isRaw() {
+			// Preserve a lenient-parsed malformed row verbatim (defanged). Its
+			// width may differ from the header; the write path re-reads
+			// leniently, so a mismatch round-trips.
+			record := make([]string, len(row.raw))
+			for i, cell := range row.raw {
+				record[i] = defangCSVCell(cell)
+			}
+			if err := w.Write(record); err != nil {
+				return nil, fmt.Errorf("write preserved row: %w", err)
+			}
+			continue
+		}
 		githubID := ""
 		if row.GitHubID != 0 {
 			githubID = strconv.FormatInt(row.GitHubID, 10)
@@ -333,6 +387,9 @@ func collectExtraColumns(rows []RosterRow) []string {
 // existing recorded role rather than blanking it.
 func UpsertRosterRow(rows []RosterRow, row RosterRow) ([]RosterRow, bool) {
 	for i := range rows {
+		if rows[i].isRaw() {
+			continue // preserved malformed row: no usable username to match
+		}
 		if strings.EqualFold(rows[i].Username, row.Username) {
 			if row.Extra == nil && rows[i].Extra != nil {
 				row.Extra = rows[i].Extra
@@ -352,6 +409,9 @@ func UpsertRosterRow(rows []RosterRow, row RosterRow) ([]RosterRow, bool) {
 // whether a row was removed.
 func RemoveRosterRow(rows []RosterRow, username string) ([]RosterRow, bool) {
 	for i := range rows {
+		if rows[i].isRaw() {
+			continue // preserved malformed row: no usable username to match
+		}
 		if strings.EqualFold(rows[i].Username, username) {
 			return append(rows[:i], rows[i+1:]...), true
 		}
@@ -373,6 +433,9 @@ type RosterPatch struct {
 // matched, and whether any value changed (so the caller can no-op).
 func UpdateRosterRow(rows []RosterRow, username string, p RosterPatch) (out []RosterRow, found, changed bool) {
 	for i := range rows {
+		if rows[i].isRaw() {
+			continue // preserved malformed row: no usable username to match
+		}
 		if !strings.EqualFold(rows[i].Username, username) {
 			continue
 		}

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -1,6 +1,7 @@
 package configrepo
 
 import (
+	"bytes"
 	"reflect"
 	"strings"
 	"testing"
@@ -713,5 +714,85 @@ func TestFullRosterHeader(t *testing.T) {
 	gotHeader, _, _ := strings.Cut(string(encoded), "\n")
 	if gotHeader != want {
 		t.Fatalf("EncodeRoster header = %q, want %q", gotHeader, want)
+	}
+}
+
+// TestParseRosterLenient_PreservesMalformedRow is the parser-level guard for
+// issue #207: the read-modify-write path must not abort on a pre-existing
+// malformed row (here an empty username on line 2). ParseRosterLenient keeps the
+// bad row verbatim while parsing the good rows normally, so a write command can
+// round-trip it.
+func TestParseRosterLenient_PreservesMalformedRow(t *testing.T) {
+	in := []byte("username,first_name,last_name,email,section,github_id,role\n" +
+		",Ghost,G,,,,\n" + // empty username: strict ParseRoster rejects this
+		"alice,Alice,A,alice@example.edu,s1,12345,student\n")
+
+	// Strict parse still rejects, proving lenient is the behavior change.
+	if _, err := ParseRoster(in); err == nil {
+		t.Fatal("strict ParseRoster must still reject an empty-username row")
+	}
+
+	rows, err := ParseRosterLenient(in)
+	if err != nil {
+		t.Fatalf("ParseRosterLenient: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows (1 preserved raw + alice), got %d: %#v", len(rows), rows)
+	}
+	if !rows[0].isRaw() {
+		t.Errorf("row 0 should be preserved raw, got %#v", rows[0])
+	}
+	if rows[1].isRaw() || rows[1].Username != "alice" || rows[1].GitHubID != 12345 {
+		t.Errorf("row 1 should be the parsed alice, got %#v", rows[1])
+	}
+}
+
+// TestParseRosterLenient_RoundTripsMalformedRow proves the preserved row
+// survives a lenient parse -> EncodeRoster -> lenient parse cycle unchanged, so
+// a write command never drops or corrupts a student it didn't touch.
+func TestParseRosterLenient_RoundTripsMalformedRow(t *testing.T) {
+	in := []byte("username,first_name,last_name,email,section,github_id,role\n" +
+		",Ghost,G,,,,\n" +
+		"alice,Alice,A,alice@example.edu,s1,12345,student\n")
+
+	rows, err := ParseRosterLenient(in)
+	if err != nil {
+		t.Fatalf("ParseRosterLenient: %v", err)
+	}
+	encoded, err := EncodeRoster(rows)
+	if err != nil {
+		t.Fatalf("EncodeRoster: %v", err)
+	}
+	if !bytes.Equal(encoded, in) {
+		t.Fatalf("round-trip changed the file.\ngot:\n%s\nwant:\n%s", encoded, in)
+	}
+
+	// A subsequent lenient parse yields the same shape (raw row still raw).
+	rows2, err := ParseRosterLenient(encoded)
+	if err != nil {
+		t.Fatalf("ParseRosterLenient (re-read): %v", err)
+	}
+	if len(rows2) != 2 || !rows2[0].isRaw() || rows2[1].Username != "alice" {
+		t.Fatalf("re-read shape changed: %#v", rows2)
+	}
+}
+
+// TestParseRosterLenient_PreservesWrongFieldCount: a short/long row is also
+// preserved verbatim (strict mode rejects it as a field-count error).
+func TestParseRosterLenient_PreservesWrongFieldCount(t *testing.T) {
+	in := []byte("username,first_name,last_name,email,section,github_id,role\n" +
+		"alice,A,A\n" + // too few fields
+		"bob,Bob,B,bob@example.edu,s1,2,student\n")
+
+	if _, err := ParseRoster(in); err == nil {
+		t.Fatal("strict ParseRoster must still reject a wrong-field-count row")
+	}
+
+	rows, err := ParseRosterLenient(in)
+	if err != nil {
+		t.Fatalf("ParseRosterLenient: %v", err)
+	}
+	if len(rows) != 2 || !rows[0].isRaw() || rows[1].Username != "bob" {
+		t.Fatalf("want a preserved raw row + bob, got %#v", rows)
 	}
 }

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -314,7 +314,7 @@ func runRosterAdd(client githubapi.Client, out, errOut io.Writer, org, classroom
 
 	var action string
 	build := func(parentSHA string) (configwrite.CommitChange, error) {
-		rows, sourcePath, err := configrepo.LoadRosterWithSource(client, org, classroom, parentSHA)
+		rows, sourcePath, err := configrepo.LoadRosterWithSourceLenient(client, org, classroom, parentSHA)
 		if err != nil {
 			return configwrite.CommitChange{}, err
 		}
@@ -380,7 +380,7 @@ func runRosterUpdate(client githubapi.Client, out io.Writer, org, classroom, use
 	var noChange bool
 	build := func(parentSHA string) (configwrite.CommitChange, error) {
 		noChange = false
-		rows, sourcePath, err := configrepo.LoadRosterWithSource(client, org, classroom, parentSHA)
+		rows, sourcePath, err := configrepo.LoadRosterWithSourceLenient(client, org, classroom, parentSHA)
 		if err != nil {
 			return configwrite.CommitChange{}, err
 		}
@@ -419,7 +419,7 @@ func runRosterRemove(client githubapi.Client, out io.Writer, org, classroom, use
 
 	var removed bool
 	build := func(parentSHA string) (configwrite.CommitChange, error) {
-		rows, sourcePath, err := configrepo.LoadRosterWithSource(client, org, classroom, parentSHA)
+		rows, sourcePath, err := configrepo.LoadRosterWithSourceLenient(client, org, classroom, parentSHA)
 		if err != nil {
 			return configwrite.CommitChange{}, err
 		}
@@ -511,7 +511,7 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 		updated int
 	)
 	build := func(parentSHA string) (configwrite.CommitChange, error) {
-		rows, sourcePath, err := configrepo.LoadRosterWithSource(client, org, classroom, parentSHA)
+		rows, sourcePath, err := configrepo.LoadRosterWithSourceLenient(client, org, classroom, parentSHA)
 		if err != nil {
 			return configwrite.CommitChange{}, err
 		}

--- a/cli/gh-teacher/internal/roster/roster_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/roster_cmd_test.go
@@ -521,3 +521,105 @@ func TestRosterUpdateCmdPatchBuilder(t *testing.T) {
 		}
 	})
 }
+
+// TestRunRosterRemove_PreservesMalformedRow is the command-level guard for issue
+// #207 on the simplest write path (remove needs no user-lookup/invite mocks): a
+// pre-existing malformed row (empty username on line 2) must not block the
+// command, and must round-trip untouched into the written file.
+func TestRunRosterRemove_PreservesMalformedRow(t *testing.T) {
+	roster := "username,first_name,last_name,email,section,github_id,role\n" +
+		",Ghost,G,,,,\n" + // malformed: empty username, strict parse would abort
+		"alice,Alice,A,a@x.edu,s1,1,student\n" +
+		"bob,Bob,B,b@x.edu,s1,2,student\n"
+
+	mock := &rosterWriteMock{files: map[string]string{"cs-principles/roster.csv": roster}}
+	server := httptest.NewServer(mock.handler(t))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	var out bytes.Buffer
+	if err := runRosterRemove(client, &out, "o", "cs-principles", "alice"); err != nil {
+		t.Fatalf("runRosterRemove must tolerate a malformed pre-existing row: %v", err)
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("got %d blobs POSTed, want 1", len(mock.blobs))
+	}
+	// The written file must still carry the untouched malformed row and bob.
+	if !strings.Contains(mock.blobs[0], ",Ghost,G,,,,") {
+		t.Errorf("malformed row was dropped or rewritten:\n%s", mock.blobs[0])
+	}
+	rows, err := configrepo.ParseRosterLenient([]byte(mock.blobs[0]))
+	if err != nil {
+		t.Fatalf("re-parse written roster: %v\n%s", err, mock.blobs[0])
+	}
+	var haveBob, haveAlice bool
+	for _, r := range rows {
+		switch r.Username {
+		case "bob":
+			haveBob = true
+		case "alice":
+			haveAlice = true
+		}
+	}
+	if !haveBob || haveAlice {
+		t.Errorf("want bob kept and alice removed, got %#v", rows)
+	}
+}
+
+// rosterAddMock extends the write mock with the user-lookup and org-invite
+// endpoints runRosterAdd calls. No classroom.json is served, so the team step
+// warns-and-skips (returns nil) — keeping the test focused on the commit path.
+type rosterAddMock struct{ *rosterWriteMock }
+
+func (m *rosterAddMock) handler(t *testing.T) http.Handler {
+	t.Helper()
+	base := m.rosterWriteMock.handler(t).(*http.ServeMux)
+	base.HandleFunc("/users/", func(w http.ResponseWriter, r *http.Request) {
+		login := strings.TrimPrefix(r.URL.Path, "/users/")
+		_ = json.NewEncoder(w).Encode(map[string]any{"login": login, "id": 999})
+	})
+	base.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+	return base
+}
+
+// TestRunRosterAdd_PreservesMalformedRow is the direct reproduction of issue
+// #207: `roster add` over a roster whose line 2 has an empty username must
+// succeed (previously it failed with "line 2: username column is empty") and
+// preserve the malformed row.
+func TestRunRosterAdd_PreservesMalformedRow(t *testing.T) {
+	roster := "username,first_name,last_name,email,section,github_id,role\n" +
+		",Ghost,G,,,,\n" + // the malformed row from the issue
+		"alice,Alice,A,a@x.edu,s1,1,student\n"
+
+	mock := &rosterAddMock{&rosterWriteMock{files: map[string]string{"ai26/roster.csv": roster}}}
+	server := httptest.NewServer(mock.handler(t))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	if err := runRosterAdd(client, &out, &errOut, "o", "ai26", "aristotea", "", "", "", ""); err != nil {
+		t.Fatalf("runRosterAdd must tolerate a malformed pre-existing row: %v", err)
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("got %d blobs POSTed, want 1", len(mock.blobs))
+	}
+	if !strings.Contains(mock.blobs[0], ",Ghost,G,,,,") {
+		t.Errorf("malformed row was dropped or rewritten:\n%s", mock.blobs[0])
+	}
+	rows, err := configrepo.ParseRosterLenient([]byte(mock.blobs[0]))
+	if err != nil {
+		t.Fatalf("re-parse written roster: %v\n%s", err, mock.blobs[0])
+	}
+	var haveNew bool
+	for _, r := range rows {
+		if r.Username == "aristotea" {
+			haveNew = true
+		}
+	}
+	if !haveNew {
+		t.Errorf("added student aristotea missing from written roster: %#v", rows)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #207. `gh teacher roster add ORG CLASS USERNAME` (and `update`/`remove`/`import`) failed with `line 2: username column is empty` when the existing `roster.csv` had a malformed row — even though `add` only appends and never touches that row.

Every roster write command reads the current file through the strict `ParseRoster`, which aborts on the first malformed data row. This made one bad row (an empty username, a wrong field count) block every legitimate edit.

- Adds a lenient read path (`ParseRosterLenient` / `LoadRosterWithSourceLenient`) used only by the write commands. A malformed row is preserved verbatim as an unexported `raw []string` on `RosterRow` and round-trips untouched; header/empty-input errors still hard-fail.
- `EncodeRoster` writes preserved rows verbatim (still defanged for CSV-injection safety). `UpsertRosterRow` / `UpdateRosterRow` / `RemoveRosterRow` / `DedupeByUsername` skip preserved rows (they have no username to match).
- Read-only callers (`roster list`) stay strict.

This mirrors the repo's existing "tolerate AND preserve unknown data" pattern (`RosterRow.Extra`, `classroom.json` Extra).

## Test plan

- [x] `TestParseRosterLenient_*`: preserves an empty-username row and a wrong-field-count row; lenient parse → `EncodeRoster` → lenient parse round-trips byte-for-byte. Strict `ParseRoster` still rejects both.
- [x] `TestRunRosterAdd_PreservesMalformedRow`: direct #207 reproduction — add over an empty-username line 2 now succeeds and preserves the row.
- [x] `TestRunRosterRemove_PreservesMalformedRow`: shared write path.
- [x] `go build ./...`, `go test ./...`, `golangci-lint run` all clean.