### PR TITLE
refactor(web): make can() the single classroom-gate; retire isStaffRole + coarse role booleans (authz T-A)

### DIFF
--- a/web/src/components/RequireTeacher.test.tsx
+++ b/web/src/components/RequireTeacher.test.tsx
@@ -55,10 +55,7 @@ const ctx = (over: Record<string, unknown> = {}) => ({
   isLoading: false,
   isError: false,
   retry: () => {},
-  isTeacher: true,
-  isStudent: false,
   roleResolved: true,
-  showTeacherUi: true,
   ...over,
 })
 
@@ -81,7 +78,7 @@ describe("RequireTeacher — staff gate on a classroom", () => {
   it("a student is 404'd from staff content", () => {
     paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
     classroomCtxMock.mockReturnValue(
-      ctx({ role: "student", actualRole: "student", showTeacherUi: false }),
+      ctx({ role: "student", actualRole: "student" }),
     )
     render(<RequireTeacher allow="staff">{child}</RequireTeacher>)
     expect(shown()).toBe("notfound")
@@ -90,7 +87,7 @@ describe("RequireTeacher — staff gate on a classroom", () => {
   it("holds the spinner while unresolved, never flashes NotFound (R5)", () => {
     paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
     classroomCtxMock.mockReturnValue(
-      ctx({ roleResolved: false, showTeacherUi: false }),
+      ctx({ role: "unresolved", roleResolved: false }),
     )
     render(<RequireTeacher allow="staff">{child}</RequireTeacher>)
     expect(shown()).toBe("spinner")
@@ -102,7 +99,6 @@ describe("RequireTeacher — staff gate on a classroom", () => {
       ctx({
         role: "unresolved",
         roleResolved: false,
-        showTeacherUi: false,
         isError: true,
       }),
     )

--- a/web/src/components/drawer/TeacherSidebarMenu.test.tsx
+++ b/web/src/components/drawer/TeacherSidebarMenu.test.tsx
@@ -5,9 +5,8 @@ import type { ReactNode } from "react"
 
 // The drawer's classroom nav affordances (Roster, Settings) are gated via the
 // real can() policy off the resolved classroom role. Mock only the role signal
-// + the router/i18n/asset boundaries the module needs to load — can() and
-// isStaffRole stay REAL so this pins the role -> can() wiring the pure policy
-// tests can't reach.
+// + the router/i18n/asset boundaries the module needs to load — can() stays
+// REAL so this pins the role -> can() wiring the pure policy tests can't reach.
 const classroomCtxMock = vi.fn()
 
 vi.mock("@/context/classroomRole/ClassroomRoleProvider", () => ({
@@ -53,10 +52,7 @@ const ctx = (over: Record<string, unknown> = {}) => ({
   isLoading: false,
   isError: false,
   retry: () => {},
-  isTeacher: true,
-  isStudent: false,
   roleResolved: true,
-  showTeacherUi: true,
   ...over,
 })
 
@@ -99,7 +95,7 @@ describe("TeacherSidebarMenu — RBAC nav affordances via can()", () => {
     // role is the preview-clamped one; showStaffItems/canEditSettings key off it,
     // so a real instructor previewing as a student sees the student surface.
     classroomCtxMock.mockReturnValue(
-      ctx({ role: "student", actualRole: "instructor", showTeacherUi: false }),
+      ctx({ role: "student", actualRole: "instructor" }),
     )
     renderMenu()
     expect(hasRoster()).toBe(false)
@@ -108,7 +104,7 @@ describe("TeacherSidebarMenu — RBAC nav affordances via can()", () => {
 
   it("a student sees neither Roster nor Settings", () => {
     classroomCtxMock.mockReturnValue(
-      ctx({ role: "student", actualRole: "student", showTeacherUi: false }),
+      ctx({ role: "student", actualRole: "student" }),
     )
     renderMenu()
     expect(hasRoster()).toBe(false)
@@ -117,7 +113,7 @@ describe("TeacherSidebarMenu — RBAC nav affordances via can()", () => {
 
   it("shows skeleton placeholders (never staff items) while the role is unresolved", () => {
     classroomCtxMock.mockReturnValue(
-      ctx({ role: "unresolved", roleResolved: false, showTeacherUi: false }),
+      ctx({ role: "unresolved", roleResolved: false }),
     )
     renderMenu()
     expect(hasSkeleton()).toBe(true)

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -40,7 +40,7 @@ import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import { can } from "@/util/capabilities"
 import { orgFooterRoleLabel } from "./footerRoleLabel"
-import { roleLabelKey, isStaffRole, type ViewAsRole } from "@/util/resolveRole"
+import { roleLabelKey, type ViewAsRole } from "@/util/resolveRole"
 import { useRoleView } from "@/context/roleView/RoleViewProvider"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
@@ -348,7 +348,10 @@ const AssignmentSidebarMenu = ({
 }) => {
   const { collapsed } = useSidebarCollapse()
   const { t } = useTranslation()
-  const { showTeacherUi, roleResolved, actualRole } = useClassroomRoleContext()
+  const { role, roleResolved, actualRole } = useClassroomRoleContext()
+  const showTeacherUi = can("viewClassroomStaffContent", {
+    classroomRole: role,
+  })
   const matchRoute = useMatchRoute()
   const { user } = useGithubAuth()
 
@@ -374,7 +377,9 @@ const AssignmentSidebarMenu = ({
     org,
     studentRepoNameForSecret,
   )
-  const isActuallyStaff = isStaffRole(actualRole) && actualRole !== "unresolved"
+  const isActuallyStaff = can("viewClassroomStaffContent", {
+    classroomRole: actualRole,
+  })
   const { data: classroomMeta } = useGetClassroom(org, classroom, {
     enabled: isActuallyStaff,
   })
@@ -546,19 +551,12 @@ export const TeacherSidebarMenu = ({
   selected: string
 }) => {
   // Placeholder while pending so items never flash in then out.
-  const {
-    showTeacherUi,
-    roleResolved,
-    role: classroomRole,
-  } = useClassroomRoleContext()
-  // Finer, preview-aware classroom role. Roster is staff-only, Settings
-  // instructor-only; gating on this makes "View as student/TA" faithfully hide
-  // what a real student/TA wouldn't see. showTeacherUi already implies a
-  // resolved instructor|ta role (see ClassroomRoleProvider: it's isStaffRole &&
-  // roleResolved), so the can() conjunct routes the staff-content decision
-  // through the central policy without changing the truth table.
-  const showStaffItems =
-    showTeacherUi && can("viewClassroomStaffContent", { classroomRole })
+  const { roleResolved, role: classroomRole } = useClassroomRoleContext()
+  // Staff nav (Roster staff-only, Settings instructor-only) gates on the
+  // preview-aware classroom role through the central can() policy, so "View as
+  // student/TA" faithfully hides what a real student/TA wouldn't see. can()
+  // already denies `unresolved`, so no separate resolved conjunct is needed.
+  const showStaffItems = can("viewClassroomStaffContent", { classroomRole })
   const canEditSettings = can("editClassroomSettings", {
     classroomRole,
   })

--- a/web/src/context/classroomRole/ClassroomRoleProvider.test.tsx
+++ b/web/src/context/classroomRole/ClassroomRoleProvider.test.tsx
@@ -3,8 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
 
 // Drive the provider from a mocked useClassroomRole (the fine role) + auth user,
-// so the test controls exactly what the boundary resolves. The provider derives
-// the coarse verdict purely from the fine role.
+// so the test controls exactly what the boundary resolves. The provider exposes
+// the fine role + roleResolved; permission verdicts are derived at call sites
+// via can() (covered in capabilities.test.ts + TeacherSidebarMenu.test.tsx).
 const classroomRoleMock = vi.fn()
 
 vi.mock("@/hooks/useClassroomRole", async (importOriginal) => {
@@ -27,9 +28,6 @@ const Probe = () => {
     <div>
       <span data-testid="role">{ctx.role}</span>
       <span data-testid="actualRole">{ctx.actualRole}</span>
-      <span data-testid="isTeacher">{String(ctx.isTeacher)}</span>
-      <span data-testid="showTeacherUi">{String(ctx.showTeacherUi)}</span>
-      <span data-testid="isStudent">{String(ctx.isStudent)}</span>
       <span data-testid="roleResolved">{String(ctx.roleResolved)}</span>
       <span data-testid="isError">{String(ctx.isError)}</span>
     </div>
@@ -49,7 +47,7 @@ afterEach(() => {
 })
 
 describe("ClassroomRoleProvider", () => {
-  it("supplies role/actualRole and the derived coarse verdict to children", () => {
+  it("supplies role/actualRole to children", () => {
     classroomRoleMock.mockReturnValue({
       role: "instructor",
       actualRole: "instructor",
@@ -58,8 +56,7 @@ describe("ClassroomRoleProvider", () => {
     renderProvider()
     expect(screen.getByTestId("role").textContent).toBe("instructor")
     expect(screen.getByTestId("actualRole").textContent).toBe("instructor")
-    expect(screen.getByTestId("isTeacher").textContent).toBe("true")
-    expect(screen.getByTestId("showTeacherUi").textContent).toBe("true")
+    expect(screen.getByTestId("roleResolved").textContent).toBe("true")
   })
 
   it("resolves the classroom role exactly once per mount (single useClassroomRole call)", () => {
@@ -72,36 +69,10 @@ describe("ClassroomRoleProvider", () => {
     expect(classroomRoleMock).toHaveBeenCalledTimes(1)
   })
 
-  it("a TA is staff (sees teacher content)", () => {
-    classroomRoleMock.mockReturnValue({
-      role: "ta",
-      actualRole: "ta",
-      isLoading: false,
-    })
-    renderProvider()
-    expect(screen.getByTestId("isTeacher").textContent).toBe("true")
-    expect(screen.getByTestId("showTeacherUi").textContent).toBe("true")
-    expect(screen.getByTestId("isStudent").textContent).toBe("false")
-  })
-
-  // The coarse verdict is DERIVED from the fine role, so a student never gets
-  // teacher UI regardless of any org-level config-repo access.
-  it("a student gets NO teacher UI", () => {
-    classroomRoleMock.mockReturnValue({
-      role: "student",
-      actualRole: "student",
-      isLoading: false,
-    })
-    renderProvider()
-    expect(screen.getByTestId("role").textContent).toBe("student")
-    expect(screen.getByTestId("isTeacher").textContent).toBe("false")
-    expect(screen.getByTestId("showTeacherUi").textContent).toBe("false")
-    expect(screen.getByTestId("isStudent").textContent).toBe("true")
-  })
-
-  it("the viewAs clamp flows through the resolved role: a clamped student hides teacher UI", () => {
-    // useClassroomRole already returns the preview-clamped `role`; the derived
-    // verdict follows it, so a clamped student sees no teacher UI.
+  it("exposes the preview-clamped role and the real actualRole", () => {
+    // useClassroomRole already returns the preview-clamped `role`; the provider
+    // passes both through so call sites can gate UI on `role` and query-enables
+    // on `actualRole`.
     classroomRoleMock.mockReturnValue({
       role: "student",
       actualRole: "instructor",
@@ -110,20 +81,18 @@ describe("ClassroomRoleProvider", () => {
     renderProvider()
     expect(screen.getByTestId("role").textContent).toBe("student")
     expect(screen.getByTestId("actualRole").textContent).toBe("instructor")
-    expect(screen.getByTestId("showTeacherUi").textContent).toBe("false")
-    expect(screen.getByTestId("isStudent").textContent).toBe("true")
+    expect(screen.getByTestId("roleResolved").textContent).toBe("true")
   })
 
-  it("holds unresolved as fail-closed (no teacher UI, not resolved)", () => {
+  it("holds unresolved as fail-closed (roleResolved false)", () => {
     classroomRoleMock.mockReturnValue({
       role: "unresolved",
       actualRole: "unresolved",
       isLoading: true,
     })
     renderProvider()
+    expect(screen.getByTestId("role").textContent).toBe("unresolved")
     expect(screen.getByTestId("roleResolved").textContent).toBe("false")
-    expect(screen.getByTestId("isTeacher").textContent).toBe("false")
-    expect(screen.getByTestId("isStudent").textContent).toBe("false")
   })
 
   it("passes the elevation-read error state through to the context", () => {

--- a/web/src/context/classroomRole/ClassroomRoleProvider.tsx
+++ b/web/src/context/classroomRole/ClassroomRoleProvider.tsx
@@ -6,14 +6,14 @@ import {
 } from "react"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useClassroomRole } from "@/hooks/useClassroomRole"
-import { isStaffRole, type ResolvedRole } from "@/util/resolveRole"
+import { type ResolvedRole } from "@/util/resolveRole"
 
 // The single authoritative effective-role signal for the current classroom,
 // resolved ONCE at the $org/$classroom boundary and shared with every child
-// page + guard. Carries both the fine classroom role (instructor/ta/student)
-// and the coarse staff verdict (showTeacherUi/isStudent/...) DERIVED from that
-// fine role, so the two can't diverge. Preview-aware fields respect the
-// downgrade-only "view as" lens; `actualRole` is the real one.
+// page + guard. Carries the fine classroom role (instructor/ta/student) plus
+// the `roleResolved` load signal; permission verdicts are derived at call sites
+// through the central `can()` policy off `role` (preview-aware; `actualRole` is
+// the real one).
 export type ClassroomRoleContextValue = {
   role: ResolvedRole
   actualRole: ResolvedRole
@@ -24,20 +24,19 @@ export type ClassroomRoleContextValue = {
   isError: boolean
   // Re-run the classroom team reads (the error surface's retry).
   retry: () => void
-  // Coarse staff verdict, DERIVED from the fine role (not a separate config-repo
-  // read) so it can't diverge from `role`. Preview-aware via `role`.
-  isTeacher: boolean
-  isStudent: boolean
+  // Whether the fine role has settled (not `unresolved`) — the spinner-vs-render
+  // signal. NOT a permission verdict: gate access via can(), gate loading state
+  // via this.
   roleResolved: boolean
-  showTeacherUi: boolean
 }
 
 const ClassroomRoleContext = createContext<ClassroomRoleContextValue | null>(
   null,
 )
 
-// Resolve the classroom role from the three per-classroom team reads and derive
-// the coarse staff verdict from it. One resolution per classroom mount.
+// Resolve the classroom role from the three per-classroom team reads. One
+// resolution per classroom mount; permission verdicts come from can() at the
+// call site off `role`.
 function useClassroomRoleResolution(
   org: string | undefined,
   classroom: string | undefined,
@@ -50,13 +49,7 @@ function useClassroomRoleResolution(
     user?.login,
   )
 
-  // DERIVE the coarse staff verdict from the resolved fine role (which already
-  // folds in team membership AND the "view as" clamp) so the two can't diverge.
-  // `unresolved` is the fail-closed sentinel (not resolved, no teacher UI, not
-  // yet a definitive student).
   const roleResolved = role !== "unresolved"
-  const isTeacher = isStaffRole(role) && roleResolved
-  const isStudent = role === "student"
 
   return {
     role,
@@ -64,10 +57,7 @@ function useClassroomRoleResolution(
     isLoading,
     isError,
     retry: refetch,
-    isTeacher,
-    isStudent,
     roleResolved,
-    showTeacherUi: isTeacher,
   }
 }
 
@@ -92,10 +82,7 @@ export function ClassroomRoleProvider({
       resolved.isLoading,
       resolved.isError,
       resolved.retry,
-      resolved.isTeacher,
-      resolved.isStudent,
       resolved.roleResolved,
-      resolved.showTeacherUi,
     ],
   )
   return (

--- a/web/src/hooks/useClassroomRole.test.ts
+++ b/web/src/hooks/useClassroomRole.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
   resolveClassroomRole,
-  isStaffRole,
   applyViewAs,
   roleLabelKey,
   type ClassroomRoleInput,
@@ -38,11 +37,6 @@ describe("resolveClassroomRole (KTD-4: owner is not a classroom role)", () => {
 })
 
 describe("role predicates stay wired", () => {
-  it("isStaffRole", () => {
-    expect(isStaffRole("ta")).toBe(true)
-    expect(isStaffRole("instructor")).toBe(true)
-    expect(isStaffRole("student")).toBe(false)
-  })
   it("roleLabelKey", () => {
     expect(roleLabelKey("instructor")).toBe("nav.roleInstructor")
     expect(roleLabelKey("unresolved")).toBeNull()

--- a/web/src/pages/AssignmentIndexPage.tsx
+++ b/web/src/pages/AssignmentIndexPage.tsx
@@ -1,5 +1,6 @@
 import { Navigate, useParams } from "@tanstack/react-router"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
+import { can } from "@/util/capabilities"
 import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 
 // The bare assignment route has no view of its own: it forwards to the
@@ -8,7 +9,7 @@ import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 // through the student page (or vice versa).
 const AssignmentIndexPage = () => {
   const { org, classroom, assignment } = useParams({ strict: false })
-  const { showTeacherUi, roleResolved } = useClassroomRoleContext()
+  const { role, roleResolved } = useClassroomRoleContext()
 
   if (!org || !classroom || !assignment) {
     return <Navigate to="/" />
@@ -21,7 +22,7 @@ const AssignmentIndexPage = () => {
   return (
     <Navigate
       to={
-        showTeacherUi
+        can("viewClassroomStaffContent", { classroomRole: role })
           ? "/$org/$classroom/assignments/$assignment/submissions"
           : "/$org/$classroom/assignments/$assignment/submission"
       }

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -28,6 +28,7 @@ import useGetClassroom from "@/hooks/useGetClassroom"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { roleLabelKey } from "@/util/resolveRole"
+import { can } from "@/util/capabilities"
 import { isClassroomArchived } from "@/types/classroom"
 import { OrgRepos } from "./ClassesPage"
 
@@ -257,7 +258,9 @@ const AssignmentsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.assignments"))
   const { org, classroom } = useParams({ strict: false })
-  const { isTeacher, isStudent, roleResolved } = useClassroomRoleContext()
+  const { role, roleResolved } = useClassroomRoleContext()
+  const isStaff = can("viewClassroomStaffContent", { classroomRole: role })
+  const isStudent = role === "student"
 
   return (
     <PageShell selected="assignments">
@@ -272,7 +275,7 @@ const AssignmentsPage = () => {
           <div className="skeleton skeleton-shimmer h-64 w-full rounded-box" />
         </div>
       )}
-      {roleResolved && isTeacher && org && classroom && (
+      {roleResolved && isStaff && org && classroom && (
         <TeacherAssignmentsView org={org} classroom={classroom} />
       )}
       {roleResolved && isStudent && org && classroom && (

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "@/components/Spinner"
 import { Alert, AnimatedAlert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
+import { can } from "@/util/capabilities"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import useGetPublicAssignment from "@/hooks/useGetPublicAssignment"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
@@ -166,7 +167,9 @@ const EditAssignmentPage = () => {
   useDocumentTitle(t("documentTitle.assignmentSettings"))
   const { org, classroom, assignment } = useParams({ strict: false })
   const router = useRouter()
-  const { isTeacher, isStudent } = useClassroomRoleContext()
+  const { role } = useClassroomRoleContext()
+  const isStaff = can("viewClassroomStaffContent", { classroomRole: role })
+  const isStudent = role === "student"
   const { data: assignments } = useGetClassroomAssignments(org, classroom)
   const { data: classroomData } = useGetClassroom(org, classroom)
   const archived = isClassroomArchived(classroomData ?? {})
@@ -191,7 +194,7 @@ const EditAssignmentPage = () => {
         {editWarning}
       </AnimatedAlert>
       <PageHeader title={t("assignmentSettings.heading")} />
-      {isTeacher && archived && (
+      {isStaff && archived && (
         <ArchivedClassroomNotice>
           {t("assignmentSettings.archivedNotice_prefix")}{" "}
           <Link
@@ -204,7 +207,7 @@ const EditAssignmentPage = () => {
           {t("assignmentSettings.archivedNotice_suffix")}
         </ArchivedClassroomNotice>
       )}
-      {isTeacher && org && classroom && assignment && (
+      {isStaff && org && classroom && assignment && (
         <EditAssignmentForm
           org={org}
           classroom={classroom}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -59,6 +59,7 @@ import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import { RegradeCoordinatorProvider } from "@/context/regrade/RegradeCoordinator"
 import useGetLastCollectScoresRun from "@/hooks/useGetLastCollectScoresRun"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
+import { can } from "@/util/capabilities"
 import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 import {
   COLLECT_SCORES_WORKFLOW,
@@ -837,13 +838,18 @@ const SubmissionsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.submissions"))
   const { org, classroom, assignment } = useParams({ strict: false })
-  const { showTeacherUi, roleResolved } = useClassroomRoleContext()
+  const { role, roleResolved } = useClassroomRoleContext()
 
   if (!roleResolved) {
     return <RoleResolvingFallback className="min-h-screen" />
   }
 
-  if (!showTeacherUi && org && classroom && assignment) {
+  if (
+    !can("viewClassroomStaffContent", { classroomRole: role }) &&
+    org &&
+    classroom &&
+    assignment
+  ) {
     return (
       <Navigate
         to="/$org/$classroom/assignments/$assignment/submission"

--- a/web/src/util/resolveRole.test.ts
+++ b/web/src/util/resolveRole.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest"
 import {
   resolveClassroomRole,
   resolveOrgRole,
-  isStaffRole,
   applyViewAs,
   roleLabelKey,
   membershipFromQuery,
@@ -200,13 +199,6 @@ describe("membershipFromQuery", () => {
 })
 
 describe("role predicates", () => {
-  it("isStaffRole: instructor/ta/unresolved true; student false", () => {
-    expect(isStaffRole("instructor")).toBe(true)
-    expect(isStaffRole("ta")).toBe(true)
-    expect(isStaffRole("unresolved")).toBe(true) // permissive: let page load
-    expect(isStaffRole("student")).toBe(false)
-  })
-
   it("roleLabelKey: instructor => nav.roleInstructor, ta => nav.roleTa, student => nav.roleStudent, unresolved => null", () => {
     expect(roleLabelKey("instructor")).toBe("nav.roleInstructor")
     expect(roleLabelKey("ta")).toBe("nav.roleTa")

--- a/web/src/util/resolveRole.ts
+++ b/web/src/util/resolveRole.ts
@@ -74,13 +74,6 @@ export function resolveOrgRole(input: {
   return "unresolved"
 }
 
-// Whether a classroom role may see/do instructor-or-TA classroom content.
-// `unresolved` is permissive on purpose: the guard treats it as "let the page
-// load".
-export function isStaffRole(role: ResolvedRole): boolean {
-  return role === "instructor" || role === "ta" || role === "unresolved"
-}
-
 // Apply a "view as" preview to an actual role. DOWNGRADE-ONLY: the preview can
 // only lower the effective role, never raise it, so it can't be abused to gain
 // access. `unresolved`/no-preview pass through unchanged.


### PR DESCRIPTION
## Summary

Phase-1 track T-A of the authz single-source-of-truth plan: make the central `can()` policy the *only* classroom permission surface.

- **Retire `isStaffRole`.** Its `unresolved`-is-permissive sentinel was the opposite of `can()`'s fail-closed posture (a latent footgun for any future unguarded caller). Replaced its two production call sites (`ClassroomRoleProvider`, drawer) with `can("viewClassroomStaffContent", { classroomRole })` — which already denies `unresolved` — and deleted the helper + its sentinel test.
- **Remove the coarse role booleans** (`isTeacher` / `isStudent` / `showTeacherUi`) from the classroom-role context. Page bodies (`AssignmentsPage`, `SubmissionsPage`, `AssignmentIndexPage`, `EditAssignmentPage`) and the drawer now read the fine `role` and derive the verdict via `can()` at the call site. The context keeps only `role` / `actualRole` / `isLoading` / `isError` / `retry` / `roleResolved` (a load signal, not a permission verdict).

Result: `can()` is the single classroom-gate; there's no second "coarse verdict" vocabulary to keep in sync.

**Out of scope (untouched):** the `useOrgStaff`-derived `isStaff`/`isNonStaff` locals in `ClassesPage`/drawer are the *org-level* staff signal (T-E's track), not the classroom context.

Behavior-preserving.

## Test plan

- [x] `tsc -b` clean
- [x] Full `vitest` green (138 files, 1517 tests)
- [x] `prettier --check` + `eslint` clean (0 errors; pre-existing a11y warnings only)
- [x] Bugbot: no bugs
- [x] grep: no `isStaffRole` anywhere; no context reads of `isTeacher`/`isStudent`/`showTeacherUi` remain