### PR TITLE
refactor(web): single-source the wire-level org-owner test (authz T-B)

### DIFF
--- a/web/src/github-core/queries.test.ts
+++ b/web/src/github-core/queries.test.ts
@@ -636,4 +636,21 @@ describe("getClassroom50OrgSummary (verifies config repo before 'ready')", () =>
     const summary = await getClassroom50OrgSummary(client, membership("admin"))
     expect(summary.classroom50.status).toBe("needs_setup")
   })
+
+  // Pins the active-state half of the owner test: only isOwnerGitHubOrgRole
+  // (bare admin) routes through the shared helper; the `state === "active"`
+  // premise stays inline, so a pending admin must NOT be treated as an owner.
+  it("denies canInitialize to a pending admin (active-state premise, not just role)", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue({ id: 1 }),
+    } as unknown as GitHubClient
+    const summary = await getClassroom50OrgSummary(
+      client,
+      membership("admin", "pending"),
+    )
+    // Repo is readable+marked, so status is 'ready' regardless of role, but the
+    // pending state must still gate initialization off.
+    expect(summary.classroom50.status).toBe("ready")
+    expect(summary.classroom50.canInitialize).toBe(false)
+  })
 })

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -22,6 +22,7 @@ import type { Assignment } from "@/types/classroom"
 import { CONFIG_REPO_MARKER_REL, ORG_GITHUB_DIR } from "@/skeleton/skeleton"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { classroomTeamSlug } from "@/util/teamSlug"
+import { isOwnerGitHubOrgRole } from "@/util/roles"
 import {
   GitHubAPIError,
   retryTransientGitHubError,
@@ -1115,11 +1116,13 @@ export async function getClassroom50OrgSummary(
   const org = membership.organization
 
   // The one owner test for this summary: an active org admin. Single-sourced
-  // here so the needs_setup branch and the canInitialize flag can't drift.
-  // (Can't route through resolveOrgRole/can — those live in util/resolveRole,
-  // which imports github-core/errors, so importing it here would cycle.)
+  // here so the needs_setup branch and the canInitialize flag can't drift. The
+  // owner half routes through isOwnerGitHubOrgRole (roles.ts imports only a
+  // type, so it's cycle-free here); the active-state premise stays inline
+  // because it's specific to this summary. (Can't route through resolveOrgRole/
+  // can — those live in util/resolveRole, which imports github-core/errors.)
   const isActiveAdmin =
-    membership.state === "active" && membership.role === "admin"
+    membership.state === "active" && isOwnerGitHubOrgRole(membership.role)
 
   let canAccessRepo = false
   let status: Classroom50Status

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -1114,6 +1114,13 @@ export async function getClassroom50OrgSummary(
 ): Promise<Classroom50OrgSummary> {
   const org = membership.organization
 
+  // The one owner test for this summary: an active org admin. Single-sourced
+  // here so the needs_setup branch and the canInitialize flag can't drift.
+  // (Can't route through resolveOrgRole/can — those live in util/resolveRole,
+  // which imports github-core/errors, so importing it here would cycle.)
+  const isActiveAdmin =
+    membership.state === "active" && membership.role === "admin"
+
   let canAccessRepo = false
   let status: Classroom50Status
 
@@ -1133,7 +1140,7 @@ export async function getClassroom50OrgSummary(
     if (error instanceof GitHubAPIError && error.status === 404) {
       canAccessRepo = false
 
-      if (membership.state === "active" && membership.role === "admin") {
+      if (isActiveAdmin) {
         // An admin who can't see classroom50 hasn't initialized it yet.
         status = "needs_setup"
       } else {
@@ -1159,8 +1166,7 @@ export async function getClassroom50OrgSummary(
     classroom50: {
       status,
       canAccessRepo,
-      canInitialize:
-        membership.state === "active" && membership.role === "admin",
+      canInitialize: isActiveAdmin,
       pagesUrl: `https://${org.login}.github.io/${CONFIG_REPO}/`,
     },
   }

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -2,6 +2,7 @@ import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { acceptAndVerifyOrgMembership } from "@/domain/users"
+import { isOwnerGitHubOrgRole } from "@/util/roles"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
@@ -107,7 +108,7 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
   const navigate = useNavigate()
   const { notify } = useToast()
   const org = invite.organization
-  const isOwner = invite.role === "admin"
+  const isOwner = isOwnerGitHubOrgRole(invite.role)
 
   const accept = useMutation({
     mutationFn: () => acceptAndVerifyOrgMembership(client, org.login),
@@ -231,7 +232,7 @@ function useOrgAffordances(summary: Classroom50OrgSummary) {
   const { org, membership, classroom50 } = summary
   const isReady = classroom50.status === "ready"
   const noAccess = classroom50.status === "no_access"
-  const isAdmin = membership.role === "admin"
+  const isAdmin = isOwnerGitHubOrgRole(membership.role)
   // useGetOrgs only surfaces active memberships, so every summary here is an
   // active member.
   const isActiveMember = membership.state === "active"

--- a/web/src/util/roles.ts
+++ b/web/src/util/roles.ts
@@ -82,3 +82,14 @@ export function githubOrgRoleForRole(
 export function roleForGitHubOrgRole(githubOrgRole: string): ClassroomRole {
   return githubOrgRole === "admin" ? "instructor" : "student"
 }
+
+// Whether a GitHub org membership wire-role denotes an org OWNER. GitHub's org
+// membership role is `admin` (owner) or `member`; `owner` is our product name
+// for `admin`. The single home for the wire-level owner test, so pages reading
+// a raw membership/invite payload don't hand-copy `role === "admin"`. (For a
+// resolved viewer role use resolveOrgRole/can("manageOrg"); this is for raw
+// wire objects — a pending invite's role, a per-org summary — that don't go
+// through the provider.)
+export function isOwnerGitHubOrgRole(githubOrgRole: string): boolean {
+  return githubOrgRole === "admin"
+}

--- a/web/src/util/teamRoster.test.ts
+++ b/web/src/util/teamRoster.test.ts
@@ -8,6 +8,7 @@ import {
   teamMembersMissingFromCsv,
   rowsNeedingBackfill,
 } from "./teamRoster"
+import { isOwnerGitHubOrgRole } from "@/util/roles"
 import { enrolledCountsByRole } from "./rosterRoles"
 import type { Student } from "@/types/classroom"
 import { STAFF_ROLES } from "@/types/classroom"
@@ -662,5 +663,14 @@ describe("githubOrgRoleForRole / roleForGitHubOrgRole — classroom<->org role m
     expect(roleForGitHubOrgRole(githubOrgRoleForRole("instructor"))).toBe(
       "instructor",
     )
+  })
+})
+
+describe("isOwnerGitHubOrgRole — wire org-role owner test", () => {
+  it("only `admin` is an owner; member/absent/unknown are not", () => {
+    expect(isOwnerGitHubOrgRole("admin")).toBe(true)
+    expect(isOwnerGitHubOrgRole("member")).toBe(false)
+    expect(isOwnerGitHubOrgRole("")).toBe(false)
+    expect(isOwnerGitHubOrgRole("direct_member")).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Phase-1 track T-B: single-source the scattered `role === "admin"` org-owner checks — but split by what each site actually tests (they are NOT one decision).

- **New `isOwnerGitHubOrgRole(wireRole)`** in `util/roles.ts` — the single home for the *wire-level* owner test, alongside the existing `githubOrgRoleForRole`/`roleForGitHubOrgRole` mappers. (Reads as an owner test, rather than borrowing the classroom-role mapper for an org-owner question.)
- **`queries.ts`** — the two raw-payload sites (the `needs_setup` branch and the `canInitialize` flag) share one local `const isActiveAdmin = membership.state === "active" && isOwnerGitHubOrgRole(membership.role)`. The **owner half routes through `isOwnerGitHubOrgRole`** (`util/roles` imports only a type, so it's cycle-free from `github-core/queries`); the **active-state premise stays inline** because it's specific to this summary. It can't route through `resolveOrgRole`/`can` — those live in `util/resolveRole`, which imports `github-core/errors`, so *that* import would cycle. (The earlier revision hand-copied `role === "admin"` here with a comment that over-broadly blamed the cycle on the new helper too; corrected.)
- **`OrgsPage.tsx`** — the pending-invite owner badge (`:110`, which has *no* active-state premise) and the per-org summary (`:234`) both now use `isOwnerGitHubOrgRole(...)`, so neither wrongly imposes an active-state requirement and both read as owner tests.

**Left untouched (correct as-is):** write-side `githubOrgRoleForRole(role) === "admin"`, API-payload `role: "admin"` writes, and the repo-permission `admin`/`push` axis in `domain/assignments.ts` (that's the decision-gated T-D, a different access dimension). The plan's original `OrgMembersPage.tsx:327` citation was a mis-cite (a per-row owner-id-set check, not a role literal) and was dropped.

Behavior-preserving.

## Test plan

- [x] `tsc -b` clean (confirms no import cycle from routing `queries.ts` through `util/roles`)
- [x] Full `vitest` green (+`isOwnerGitHubOrgRole` unit test; +regression test pinning `canInitialize: false` for a pending admin, so the active-state half of the owner test can't be silently dropped)
- [x] `prettier --check` + `eslint` clean
- [x] Bugbot: no bugs