### PR TITLE
refactor(web): name the org-staff verdict honestly, retire isTeacher/isStudent aliases (authz T-E)

### DIFF
--- a/web/src/components/drawer/footerRoleLabel.test.ts
+++ b/web/src/components/drawer/footerRoleLabel.test.ts
@@ -7,7 +7,7 @@ const base = {
   isOwner: false,
   ownerPending: false,
   ownerError: false,
-  isStudent: false,
+  isNonStaff: false,
   roleLoading: false,
 }
 
@@ -19,12 +19,11 @@ describe("orgFooterRoleLabel", () => {
     })
   })
 
-  it("owner on no staff team (isStudent from the team signal) still => Instructor", () => {
-    // The isNonStaff->isStudent rename: an org owner on no staff team now reads
-    // isStudent:true, but owner precedence must still label them Instructor, not
-    // Student. This is what keeps the renamed sentinel safe in the footer.
+  it("owner on no staff team (isNonStaff from the team signal) still => Instructor", () => {
+    // An org owner on no classroom staff team reads isNonStaff:true, but owner
+    // precedence must still label them Instructor, not Student.
     expect(
-      orgFooterRoleLabel({ ...base, isOwner: true, isStudent: true }),
+      orgFooterRoleLabel({ ...base, isOwner: true, isNonStaff: true }),
     ).toEqual({
       labelKey: "nav.roleInstructor",
       pending: false,
@@ -38,8 +37,8 @@ describe("orgFooterRoleLabel", () => {
     })
   })
 
-  it("definitive non-owner student => Student", () => {
-    expect(orgFooterRoleLabel({ ...base, isStudent: true })).toEqual({
+  it("definitive non-owner non-staff => Student", () => {
+    expect(orgFooterRoleLabel({ ...base, isNonStaff: true })).toEqual({
       labelKey: "nav.roleStudent",
       pending: false,
     })
@@ -54,9 +53,9 @@ describe("orgFooterRoleLabel", () => {
 
   it("owner-pending with an org in scope => pending spinner, no premature label", () => {
     expect(
-      orgFooterRoleLabel({ ...base, ownerPending: true, isStudent: true }),
+      orgFooterRoleLabel({ ...base, ownerPending: true, isNonStaff: true }),
     ).toEqual({
-      // isStudent must NOT win while owner is still pending (would flash Student
+      // isNonStaff must NOT win while owner is still pending (would flash Student
       // at a real owner mid-load).
       labelKey: null,
       pending: true,
@@ -74,7 +73,7 @@ describe("orgFooterRoleLabel", () => {
 
   it("settled owner-error + config 404 => blank, not Student (don't mislabel a real owner)", () => {
     expect(
-      orgFooterRoleLabel({ ...base, ownerError: true, isStudent: true }),
+      orgFooterRoleLabel({ ...base, ownerError: true, isNonStaff: true }),
     ).toEqual({
       // A settled owner-error means the verdict is untrustworthy; suppress the
       // Student fallback. Not pending (error is settled), so no spinner.
@@ -85,7 +84,7 @@ describe("orgFooterRoleLabel", () => {
 
   it("config-repo role loading => pending, Student suppressed until it resolves", () => {
     expect(
-      orgFooterRoleLabel({ ...base, roleLoading: true, isStudent: true }),
+      orgFooterRoleLabel({ ...base, roleLoading: true, isNonStaff: true }),
     ).toEqual({
       labelKey: null,
       pending: true,

--- a/web/src/components/drawer/footerRoleLabel.ts
+++ b/web/src/components/drawer/footerRoleLabel.ts
@@ -16,7 +16,7 @@ export type OrgFooterLabelInput = {
   // not trustworthy, so it neither grants "Instructor" nor falls back to
   // "Student".
   ownerError: boolean
-  isStudent: boolean
+  isNonStaff: boolean
   roleLoading: boolean
 }
 
@@ -33,7 +33,7 @@ export function orgFooterRoleLabel(input: OrgFooterLabelInput): OrgFooterLabel {
     isOwner,
     ownerPending,
     ownerError,
-    isStudent,
+    isNonStaff,
     roleLoading,
   } = input
 
@@ -42,7 +42,7 @@ export function orgFooterRoleLabel(input: OrgFooterLabelInput): OrgFooterLabel {
   let labelKey: OrgFooterLabel["labelKey"] = null
   if (isOrgSetup || isOwner) {
     labelKey = "nav.roleInstructor"
-  } else if (!ownerUnsettled && !roleLoading && isStudent) {
+  } else if (!ownerUnsettled && !roleLoading && isNonStaff) {
     labelKey = "nav.roleStudent"
   }
 

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -625,7 +625,7 @@ export const SidebarFooter = () => {
     from: "/_authed/$org/setup/",
     shouldThrow: false,
   })
-  const { isNonStaff: isStudent, isLoading: roleLoading } = useOrgStaff(org)
+  const { isNonStaff, isLoading: roleLoading } = useOrgStaff(org)
   // Org plan for the About-dialog diagnostics snapshot. Cached and shared with
   // the setup/audit panes; `plan` is only visible to org owners, so this is
   // often undefined (the snapshot then reports "unknown" with a reason).
@@ -702,7 +702,7 @@ export const SidebarFooter = () => {
       isOwner,
       ownerPending,
       ownerError,
-      isStudent,
+      isNonStaff,
       roleLoading,
     })
     roleLabelText = orgLabel.labelKey ? t(orgLabel.labelKey) : null
@@ -1030,10 +1030,10 @@ export const SidebarContent = ({ selected }: { selected: string }) => {
 export const MyClasses = ({ settings = false, selected = "" }) => {
   const { org } = useParams({ strict: false })
   const { t } = useTranslation()
-  const { isStaff: showTeacherUi, roleResolved } = useOrgStaff(org)
+  const { isStaff, roleResolved } = useOrgStaff(org)
   // Members/Activity/Settings are owner-only surfaces, so their route access
   // stays gated on can("manageOrg") (RequireOwner). Their sidebar SHORTCUTS,
-  // though, are shown only to a staff owner (`showTeacherUi && isOwner`): an org
+  // though, are shown only to a staff owner (`isStaff && isOwner`): an org
   // owner on no staff team deliberately loses the shortcut clutter but keeps the
   // routes reachable (and regains the nav by claiming instructor / joining a
   // staff team). Team membership is the source of truth for org-staff chrome.
@@ -1045,9 +1045,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
   const onActivity = selected === "activity"
   if (!org) return null
 
-  const classesLabel = showTeacherUi
-    ? t("nav.myClasses")
-    : t("nav.myAssignments")
+  const classesLabel = isStaff ? t("nav.myClasses") : t("nav.myAssignments")
 
   return (
     <div className="py-4">
@@ -1069,7 +1067,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
             </Link>
           </Tip>
         )}
-        {showTeacherUi && (
+        {isStaff && (
           <Tip label={t("nav.published")}>
             <Link to="/$org/published" params={{ org }}>
               <SidebarItemBody
@@ -1080,7 +1078,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
             </Link>
           </Tip>
         )}
-        {showTeacherUi && isOwner && (
+        {isStaff && isOwner && (
           <Tip label={t("nav.members")}>
             <Link to="/$org/members" params={{ org }}>
               <SidebarItemBody
@@ -1091,7 +1089,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
             </Link>
           </Tip>
         )}
-        {showTeacherUi && isOwner && (
+        {isStaff && isOwner && (
           <Tip label={t("nav.activity")}>
             <Link to="/$org/activity" params={{ org }}>
               <SidebarItemBody
@@ -1102,7 +1100,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
             </Link>
           </Tip>
         )}
-        {showTeacherUi && isOwner && (
+        {isStaff && isOwner && (
           <Tip label={t("nav.settings")}>
             <Link to="/$org/settings" params={{ org }}>
               <SidebarItemBody

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -306,11 +306,7 @@ const ClassesPage = () => {
   useDocumentTitle(t("documentTitle.classes"))
   const { org } = useParams({ strict: false })
   const { classes } = useGetClasses(org)
-  const {
-    isStaff: isTeacher,
-    isNonStaff: isStudent,
-    isLoading: roleLoading,
-  } = useOrgStaff(org)
+  const { isStaff, isNonStaff, isLoading: roleLoading } = useOrgStaff(org)
   const { data: membership, isLoading: loadingMembership } =
     useGetOwnOrgMembership(org)
   const { githubOrgRole } = useGitHubOrgRole()
@@ -330,11 +326,11 @@ const ClassesPage = () => {
     <PageShell page="classes" selected="assignments">
       <PageHeader
         loading={roleLoading}
-        title={isTeacher ? t("classes.myClasses") : t("classes.myAssignments")}
+        title={isStaff ? t("classes.myClasses") : t("classes.myAssignments")}
         subtitle={<p className="max-w-2xl">{t("classes.manageSubtitle")}</p>}
       />
 
-      {isStudent && !isMember && !loadingMembership && (
+      {isNonStaff && !isMember && !loadingMembership && (
         <JoinOrgCard org={org} />
       )}
       {isOwner && <OrgPreflightNotice org={org} />}
@@ -349,13 +345,11 @@ const ClassesPage = () => {
         </div>
       ) : (
         <>
-          {classes.length === 0 && isTeacher && (
-            <CreateClassroomPane org={org} />
-          )}
-          {isTeacher && classes.length > 0 && (
+          {classes.length === 0 && isStaff && <CreateClassroomPane org={org} />}
+          {isStaff && classes.length > 0 && (
             <ClassroomList org={org} dirs={classes} />
           )}
-          {isStudent && isMember && <OrgRepos org={org} />}
+          {isNonStaff && isMember && <OrgRepos org={org} />}
         </>
       )}
     </PageShell>


### PR DESCRIPTION
## Summary

Final Phase-1 track (T-E): retire the leftover "teacher/student" aliases of the org-level staff verdict, so `useOrgStaff`'s `isStaff`/`isNonStaff` are read by their true names.

- `ClassesPage`: `isStaff: isTeacher` / `isNonStaff: isStudent` → `isStaff` / `isNonStaff`.
- `drawer` footer: `isNonStaff: isStudent` → `isNonStaff`.
- `drawer` `MyClasses`: `isStaff: showTeacherUi` → `isStaff`.
- `footerRoleLabel` helper + test: `isStudent` param → `isNonStaff`.

Left `AssignmentSidebarMenu`'s local `showTeacherUi` untouched — that's a `can()`-derived *classroom*-role local (from T-A), not an org-staff alias.

## Recon correction

The plan's second half of T-E — "centralize owner precedence over the org-staff signal" (G7) — **did not hold up against the code**, so it was dropped:

- Owner-precedence ("owner ⇒ Instructor label") is **already centralized** in the pure, unit-tested `footerRoleLabel` helper — the only place it's applied.
- The three `useOrgStaff` consumers combine owner + staff as **orthogonal** signals for genuinely different purposes: `ClassesPage` gates only the preflight notice on `can("manageOrg")`; `MyClasses` gates owner-only *shortcuts* on `isStaff && isOwner`; the footer delegates to the label helper.

There was no scattered owner-precedence to fold into a `useOrgStaffOrOwner()` hook, so T-E reduced to the alias cleanup. This completes the authz Phase 1.

Behavior-preserving.

## Test plan

- [x] `tsc -b` clean
- [x] Full `vitest` green (138 files, 1519 tests)
- [x] `prettier --check` + `eslint` clean (0 errors; pre-existing a11y warnings only)
- [x] Bugbot: no bugs
- [x] grep: no `isStaff: isTeacher` / `isNonStaff: isStudent` / `isStaff: showTeacherUi` aliases remain