### PR TITLE
docs(web): comment cleanup pass over the authz module (post-refactor)

### DIFF
--- a/web/src/authz/capabilities.ts
+++ b/web/src/authz/capabilities.ts
@@ -28,7 +28,6 @@ export type CapabilityInput = {
 }
 
 // Central policy: the single source of truth mapping roles to capabilities.
-// Mirrors the semantics that were previously scattered as role-literal checks.
 // Fail-closed and self-contained: an `unresolved` role is denied here (it does
 // NOT rely on callers to separately gate the sentinel). Route guards still pair
 // a `resolved` signal to decide spinner-vs-NotFound, but a consumer that reads

--- a/web/src/authz/roles.ts
+++ b/web/src/authz/roles.ts
@@ -1,13 +1,11 @@
 import type { StaffRole } from "@/types/classroom"
 
 // Single home for Classroom-50's role vocabulary and the app<->GitHub role
-// mappings. Three distinct concepts live below, each in its own section:
-// GitHubOrgRole (org standing), ClassroomRole (in-app role), and
-// GitHubTeamMembership (a per-team probe result that feeds ClassroomRole).
-// Every union derives from the one contract-frozen literal StaffRole (in
-// types/classroom.ts, mirroring the persisted `teams` schema), so adding a role
-// starts there. The admin<->owner correspondence lives only here
-// (githubOrgRoleForRole / roleForGitHubOrgRole).
+// mappings. Three concepts, each in its own section below: GitHubOrgRole (org
+// standing), ClassroomRole (in-app role), and GitHubTeamMembership (a per-team
+// probe result that feeds ClassroomRole). Every union derives from the
+// contract-frozen StaffRole (types/classroom.ts, mirroring the persisted `teams`
+// schema), so adding a role starts there.
 
 // --- 1. GitHub org standing -------------------------------------------------
 
@@ -20,9 +18,8 @@ export type GitHubOrgRole = "owner" | "member" | "non-member" | "unresolved"
 
 // --- 2. Classroom role ------------------------------------------------------
 
-// The sole non-staff classroom role. Named for symmetry with StaffRole so
-// ClassroomRole reads as "student or staff". Not exported — it's a building
-// block for ClassroomRole, which is the public type.
+// The sole non-staff classroom role. Internal — a building block for the public
+// ClassroomRole below.
 type StudentRole = "student"
 
 // A person's role WITHIN a classroom: student (classroom team) or a StaffRole
@@ -41,16 +38,14 @@ export type ResolvedRole = ClassroomRole | "unresolved"
 // can't drift: you can't preview as the top role.
 export type ViewAsRole = Exclude<ClassroomRole, "instructor">
 
-// Precedence for the primary badge / role sort and the view-as downgrade clamp:
-// instructor > ta > student. One rank map for both roster presentation and the
-// guard clamp.
+// Role precedence (instructor > ta > student), shared by the primary-badge/
+// roster sort and the view-as downgrade clamp so the two can't disagree.
 export const ROLE_RANK: Record<ClassroomRole, number> = {
   instructor: 2,
   ta: 1,
   student: 0,
 }
 
-// Sort a role set by precedence (highest first). Pure; returns a new array.
 export function sortRolesByRank(roles: ClassroomRole[]): ClassroomRole[] {
   return [...roles].sort((a, b) => ROLE_RANK[b] - ROLE_RANK[a])
 }
@@ -64,33 +59,29 @@ export function sortRolesByRank(roles: ClassroomRole[]): ClassroomRole[] {
 export type GitHubTeamMembership = "member" | "non-member" | "unresolved"
 
 // --- The app<->GitHub org-role mapping (both directions, single-sourced) -----
-// Security-sensitive: this is the ONLY place "who becomes an org owner" is
-// decided, so a missed hand-copy can't silently mis-scope admin access.
+// The ONLY place the admin<->owner correspondence is decided (GitHub wire
+// "admin" == product "owner", i.e. instructor). Security-sensitive: a missed
+// hand-copy elsewhere could silently mis-scope owner access, so all three
+// helpers below live here.
 
-// WRITE: the GitHub org membership role an invite/role-change carries for a
-// classroom role. An instructor becomes an org OWNER (wire "admin"); student/ta
-// are plain members ("direct_member").
+// WRITE: the org membership role an invite/role-change carries. Only instructor
+// maps to owner ("admin"); student/ta are "direct_member".
 export function githubOrgRoleForRole(
   role: ClassroomRole,
 ): "admin" | "direct_member" {
   return role === "instructor" ? "admin" : "direct_member"
 }
 
-// READ (inverse): the classroom role implied by an existing invitation's GitHub
-// org role. "admin" grants org OWNER, i.e. an instructor; anything else
-// re-invites as a plain student (org role alone can't distinguish TA from
-// student, and student is the safe default a re-invite lands on).
+// READ (inverse): the classroom role an existing invite's org role implies.
+// Anything but "admin" re-invites as a plain student — org role alone can't tell
+// TA from student, and student is the safe default.
 export function roleForGitHubOrgRole(githubOrgRole: string): ClassroomRole {
   return githubOrgRole === "admin" ? "instructor" : "student"
 }
 
-// Whether a GitHub org membership wire-role denotes an org OWNER. GitHub's org
-// membership role is `admin` (owner) or `member`; `owner` is our product name
-// for `admin`. The single home for the wire-level owner test, so pages reading
-// a raw membership/invite payload don't hand-copy `role === "admin"`. (For a
-// resolved viewer role use resolveOrgRole/can("manageOrg"); this is for raw
-// wire objects — a pending invite's role, a per-org summary — that don't go
-// through the provider.)
+// The wire-level owner test, for callers holding a raw membership/invite payload
+// (a pending invite, a per-org summary) that never reaches the provider. For a
+// resolved viewer role, use resolveOrgRole / can("manageOrg") instead.
 export function isOwnerGitHubOrgRole(githubOrgRole: string): boolean {
   return githubOrgRole === "admin"
 }

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -121,9 +121,9 @@ const SubmissionsPageContent = () => {
   // last fetch (1s < 1min < 1hr). UI-only; the fetch cadence is unchanged.
   const now = useLiveNow(scoresUpdatedAt || null)
   const { data: assignmentData } = useGetClassroomAssignments(org, classroom)
-  // Team-driven usernames (Section 7): the classroom GitHub team is
-  // authoritative for enrollment; roster.csv enriches display only. The
-  // dashboard consumes Student[], so map enrolled team rows into that shape.
+  // Team-driven usernames: the classroom GitHub team is authoritative for
+  // enrollment; roster.csv enriches display only. The dashboard consumes
+  // Student[], so map enrolled team rows into that shape.
   // Restrict to rows carrying a STUDENT enrollment — a pure instructor/TA is an
   // enrolled team member but not a gradee, and "Collect scores" already runs
   // only against the student team, so excluding them keeps this roster in step

--- a/web/src/pages/orgActivity/TimelineRow.tsx
+++ b/web/src/pages/orgActivity/TimelineRow.tsx
@@ -27,9 +27,8 @@ function formatDetail(item: TimelineItem, t: TFunction): string | undefined {
 }
 
 // One source/status -> tone decision, shared by the icon chip and the Badge, so
-// the two never drift (AGENTS.md one-recipe-one-source). Maps to a DaisyUI
-// semantic color used both as the Badge tone and, via `${tone}`, the chip's
-// bg-<tone>/10 text-<tone> classes.
+// the two never drift. Maps to a DaisyUI semantic color used both as the Badge
+// tone and, via `${tone}`, the chip's bg-<tone>/10 text-<tone> classes.
 function itemTone(item: TimelineItem): BadgeTone {
   if (item.status === "error") return "error"
   if (item.status === "running") return "warning"

--- a/web/src/util/classroomRoleUI.ts
+++ b/web/src/util/classroomRoleUI.ts
@@ -26,8 +26,9 @@ export const ROLE_BADGE_TONE: Record<ClassroomRole, BadgeTone> = {
 }
 
 // Enrollment-state badge tone + i18n label, single-sourced so the roster row
-// list and the member modal render the same status chip (AGENTS.md: one recipe,
-// one source — this pair drifted once when hand-synced).
+// list (EnrolledStudents) and the member modal (RosterMemberModal) render the
+// same status chip (AGENTS.md: one recipe, one source — they were hand-synced
+// before and drifted once on a renamed key).
 export const STATE_BADGE_TONE: Record<TeamRosterRowState, BadgeTone> = {
   enrolled: "success",
   pending: "warning",

--- a/web/src/util/classroomRoleUI.ts
+++ b/web/src/util/classroomRoleUI.ts
@@ -4,7 +4,7 @@ import type { TeamRosterRow, TeamRosterRowState } from "@/util/teamRoster"
 
 // Single source of truth for how a classroom role is presented and ranked.
 // Shared by the Roster view and the classroom Settings staff section so the two
-// surfaces can't drift on tone or precedence (AGENTS.md: one recipe, one source).
+// surfaces can't drift on tone or precedence.
 // ROLE_RANK and sortRolesByRank are single-sourced in the authz module and
 // re-exported here so UI callers have one import for all role presentation.
 export { ROLE_RANK, sortRolesByRank }
@@ -27,8 +27,8 @@ export const ROLE_BADGE_TONE: Record<ClassroomRole, BadgeTone> = {
 
 // Enrollment-state badge tone + i18n label, single-sourced so the roster row
 // list (EnrolledStudents) and the member modal (RosterMemberModal) render the
-// same status chip (AGENTS.md: one recipe, one source — they were hand-synced
-// before and drifted once on a renamed key).
+// same status chip (they were hand-synced before and drifted once on a renamed
+// key).
 export const STATE_BADGE_TONE: Record<TeamRosterRowState, BadgeTone> = {
   enrolled: "success",
   pending: "warning",

--- a/web/src/util/classroomRoleUI.ts
+++ b/web/src/util/classroomRoleUI.ts
@@ -27,8 +27,7 @@ export const ROLE_BADGE_TONE: Record<ClassroomRole, BadgeTone> = {
 
 // Enrollment-state badge tone + i18n label, single-sourced so the roster row
 // list and the member modal render the same status chip (AGENTS.md: one recipe,
-// one source — previously hand-synced across EnrolledStudents + RosterMemberModal
-// and already drifted once on a renamed key).
+// one source — this pair drifted once when hand-synced).
 export const STATE_BADGE_TONE: Record<TeamRosterRowState, BadgeTone> = {
   enrolled: "success",
   pending: "warning",


### PR DESCRIPTION
## Summary

Final wrap-up of the authz refactor: a comment cleanup pass over the `authz/` module and surface, against the AGENTS.md comment rules (terse, explain *why* not *what*, say it once, no redundant narration).

**Stale/inaccurate cross-references (the audit's findings):**
- `SubmissionsPage.tsx` — dropped a dangling `(Section 7)` cross-reference (a stale pointer into a plan doc a reader can't resolve); kept the accurate rationale.
- `util/classroomRoleUI.ts` — the state-badge comment: first over-trimmed, then restored so it still names *which* two surfaces stay in sync (`EnrolledStudents` + `RosterMemberModal`) and *what* drifted (a renamed key) — the load-bearing specifics. Trimming words must not cost information.

**AGENTS.md pass over the `authz/` module:**
- `authz/roles.ts` — the admin↔owner mapping was restated four times (file header + section header + each of the 3 mapper functions). Consolidated the security-sensitive rationale into the section header (said once); each function keeps only its distinct contract. Trimmed the `StudentRole` / `ROLE_RANK` / `sortRolesByRank` narration that restated the code.
- `authz/capabilities.ts` — dropped the "previously scattered as role-literal checks" historical narration from the `can()` doc; kept the fail-closed rationale.

Kept every genuine "why" (fail-closed/fail-open posture, security-sensitivity, downgrade-only view-as, the barrel-boundary rationale in `index.ts`). The broader audit confirmed the rest of the 34-file authz surface had **no** stale-symbol or moved-path comments.

Comment-only; no behavior change.

## Test plan

- [x] `tsc -b` clean
- [x] `prettier --check` + `eslint` clean on touched files
- [x] authz tests green (3 files, 39 tests)
- [x] Comment-only diff — no logic touched