### PR TITLE
fix(web): set safe QueryClient defaultOptions for queries

### DIFF
--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -789,17 +789,18 @@ export function listAllOrgMembers(client: GitHubClient, org: string) {
 // The active org-member list (all pages) as a shared query. Single source for
 // the `orgMembersAll` cache both the classroom roster (needs-attention
 // in-org/not-in-org split) and the org Members page read, so the two can't
-// drift on cache key, fetcher, or freshness. Kept short (30s): membership
-// classification must react quickly to an invite accepted or a member removed
-// in another tab/session, and the list is cheap to refetch. Since the two
-// needs-attention states only affect a CSV-only row's sub-label (never
-// enrollment, which is team-driven), a brief staleness is display-only.
+// drift on cache key, fetcher, or freshness. Kept short (30s) and refetched on
+// focus so classification reacts quickly to an invite accepted or a member
+// removed in another tab/session; the affected sub-label is display-only
+// (never enrollment, which is team-driven), so brief staleness is harmless.
 export const ORG_MEMBERS_STALE_MS = 30 * 1000
 export function orgMembersAllQuery(client: GitHubClient, org: string) {
   return queryOptions({
     queryKey: githubKeys.orgMembersAll(org),
     queryFn: () => listAllOrgMembers(client, org),
     enabled: Boolean(org),
+    // Override the global refetchOnWindowFocus:false — see freshness note above.
+    refetchOnWindowFocus: true,
     staleTime: ORG_MEMBERS_STALE_MS,
   })
 }

--- a/web/src/hooks/useGetMyOrgRepos.ts
+++ b/web/src/hooks/useGetMyOrgRepos.ts
@@ -8,8 +8,9 @@ const useGetOrgRepos = (org: string) => {
   return useQuery({
     queryKey: githubKeys.orgRepos(org),
     queryFn: () => getOrgRepos(client, org),
-    // Drives the "Accepted" count from repo existence; keep it fresh so a tab
-    // refocus reflects newly accepted assignments instead of a 10-min cache.
+    // Drives the "Accepted" count; refetch on tab refocus (overriding the global
+    // refetchOnWindowFocus:false) so it reflects newly accepted assignments.
+    refetchOnWindowFocus: true,
     staleTime: 20 * 1000,
   })
 }

--- a/web/src/hooks/useGetRepo.ts
+++ b/web/src/hooks/useGetRepo.ts
@@ -13,6 +13,10 @@ const useGetRepo = (
     queryKey: ["github", "repo", org, path],
     queryFn: () => getRepo(client, org ?? "", path),
     enabled: Boolean(org && path) && (options?.enabled ?? true),
+    // Existence check that gates the accept flow; the accept mutation invalidates
+    // the orgRepos key, not this one, so refetch per mount rather than inheriting
+    // the global 30s floor and serving a stale "repo not created" on revisit.
+    staleTime: 0,
   })
 }
 

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -178,8 +178,9 @@ const useGetScores = (
       `${classroom ?? ""}/scores.json`,
     ),
     select: normalizeScores,
-    // Submissions land continuously; keep scores fresh so a tab refocus
-    // refetches rather than serving a 10-min-stale count.
+    // Submissions land continuously, so refetch on tab refocus (overriding the
+    // global refetchOnWindowFocus:false) rather than serving a stale count.
+    refetchOnWindowFocus: true,
     staleTime: 20 * 1000,
   })
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -20,14 +20,32 @@ import App from "./App"
 import { appVersion, formatAppVersion } from "./version"
 import { installDiagnosticsHandlers } from "./lib/diagnostics/globalHandlers"
 import { recordError } from "./lib/activity/activityStore"
+import { retryTransientGitHubError } from "./github-core/errors"
 import { RateLimitOverlay } from "./components/dev/RateLimitOverlay"
 
-// Record every failed mutation as session activity. Mutations are the app's
-// real write operations (create/delete/dispatch/enroll), so a rejection here is
-// a genuine, user-affecting failure — unlike the benign existence-check 404s on
-// the read path, which are caught and turned into verdicts and so never reach
-// this cache. The mutationId dedups against a matching error toast.
+// Safe query defaults so a new `useQuery` can't silently inherit React Query's
+// aggressive built-ins (staleTime:0 + refetchOnWindowFocus:true + retry:3). Every
+// read here hits the GitHub API, where those defaults are hazards: focus-refetch
+// storms and 3x-retrying a definitive 4xx (a 403 blocked / 404 not-a-member reads
+// as a role verdict, not a transient error). This makes the app's convention
+// (each hook sets its own staleTime; nothing wants focus-refetch; fail-closed
+// retry) the enforced baseline. Per-query options still override — polling hooks
+// (useActionActivity) set their own refetchInterval/retry and are unaffected.
 const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: retryTransientGitHubError,
+      // A small floor, not a cache: enough to dedupe a burst of mounts without
+      // holding stale data. Hooks that want longer freshness set their own.
+      staleTime: 30_000,
+    },
+  },
+  // Record every failed mutation as session activity. Mutations are the app's
+  // real write operations (create/delete/dispatch/enroll), so a rejection here is
+  // a genuine, user-affecting failure — unlike the benign existence-check 404s on
+  // the read path, which are caught and turned into verdicts and so never reach
+  // this cache. The mutationId dedups against a matching error toast.
   mutationCache: new MutationCache({
     onError: (error, _variables, _context, mutation) => {
       recordError(error, { dedupKey: `mutation-${mutation.mutationId}` })


### PR DESCRIPTION
## Summary

Tier-1 quick win from the codebase re-assessment plan (item A). The `QueryClient` set only a `mutationCache` and **no `defaultOptions.queries`**, so any `useQuery` that didn't opt out inherited React Query's aggressive built-ins: `staleTime: 0` + `refetchOnWindowFocus: true` + `retry: 3`.

Every read in this app hits the GitHub API, where those defaults are hazards:
- **focus-refetch storms** — refetching many org/team/repo reads on every window focus;
- **retrying definitive 4xx** — a 403 (blocked) / 404 (not a member) is a *role verdict*, not a transient error, and shouldn't be retried 3x.

The app already handles this correctly *by convention* — nearly every hook sets its own generous `staleTime` and fail-closed `retry` — but a new hook that forgot would silently get the hazardous defaults. This makes the convention the enforced baseline:

```
defaultOptions: {
  queries: {
    refetchOnWindowFocus: false,
    retry: retryTransientGitHubError,   // fail-closed: definitive 4xx don't retry
    staleTime: 30_000,                  // small dedupe floor, not a cache
  },
}
```

Per-query options still override, so nothing that opts in changes — e.g. `useActionActivity`'s `refetchInterval` / `retry:false` / `staleTime:0` polling is unaffected. Also makes the standing `useGetOwnOrgMembership` refetch-on-focus deferred item moot.

## Preserving per-hook freshness (review follow-up)

A code review surfaced the flip side of the plan's "verify no query relies on the old aggressive defaults" obligation: three reads leaned on the *old* built-ins for freshness and were silently overridden by the new global defaults. Restored with explicit per-query overrides (which win over the global baseline):

- **`useGetScores`**, **`useGetMyOrgRepos`**, **`orgMembersAllQuery`** — set `refetchOnWindowFocus: true`. Their comments already documented relying on a tab refocus to reflect newly landed submissions / newly accepted assignments / another-tab member changes; the global `refetchOnWindowFocus: false` would have defeated that.
- **`useGetRepo`** — set `staleTime: 0`. It's the accept-flow repo-existence check, but the accept mutation invalidates the `orgRepos` key, not the per-repo key — so under the global 30s floor a revisit within 30s could show a stale "repo will be created" for a repo that already exists.

Everything else still inherits the safe global baseline; the `retry` shift (to fail-closed `retryTransientGitHubError`) needed no per-hook exceptions.

## Test plan

- [x] `tsc -b` clean
- [x] Full `vitest` green (139 files, 1520 tests) — confirms no query's behavior regressed (per-query overrides hold)
- [x] `eslint` + `prettier` clean
- [x] Bugbot: no bugs