### PR TITLE
fix(cli): single-source the assignment-repo naming formula

### DIFF
--- a/cli/gh-student/internal/reponame/reponame.go
+++ b/cli/gh-student/internal/reponame/reponame.go
@@ -1,11 +1,8 @@
-// Package reponame owns the gh-student-facing assignment-repo naming API,
-// delegating to the single cross-binary source in cli/shared/contract
-// (AssignmentRepoName / AssignmentRepoPrefix). Kept as a thin named seam so the
-// gh-student commands that build or parse a repo name read from one place; the
-// formula itself is shared with gh-teacher's download command and mirrored by
-// runner.py::username_from_repo. Changing the shape (in contract) silently makes
-// `gh teacher download` return zero repos and misidentifies every submission in
-// scores.json.
+// Package reponame is the gh-student-facing assignment-repo naming API — a thin
+// named seam so gh-student commands read the repo-name formula from one place.
+// It delegates to the single cross-binary source in cli/shared/contract
+// (AssignmentRepoName / AssignmentRepoPrefix), where the shape and its
+// keep-byte-identical contract are documented.
 package reponame
 
 import "github.com/foundation50/classroom50-cli-shared/contract"

--- a/cli/gh-student/internal/reponame/reponame.go
+++ b/cli/gh-student/internal/reponame/reponame.go
@@ -1,31 +1,24 @@
-// Package reponame owns the canonical assignment-repo naming formula, a
-// cross-binary contract shared with cli/gh-teacher (which rebuilds the prefix
-// by hand in download.go — separate go.mod, no shared symbol) and
-// runner.py::username_from_repo. Changing the shape here silently makes
-// `gh teacher download` return zero repos and misidentifies every submission
-// in scores.json, so it lives in one named seam consumed by every gh-student
-// command that builds or parses a repo name.
+// Package reponame owns the gh-student-facing assignment-repo naming API,
+// delegating to the single cross-binary source in cli/shared/contract
+// (AssignmentRepoName / AssignmentRepoPrefix). Kept as a thin named seam so the
+// gh-student commands that build or parse a repo name read from one place; the
+// formula itself is shared with gh-teacher's download command and mirrored by
+// runner.py::username_from_repo. Changing the shape (in contract) silently makes
+// `gh teacher download` return zero repos and misidentifies every submission in
+// scores.json.
 package reponame
 
-import (
-	"fmt"
-	"strings"
-)
+import "github.com/foundation50/classroom50-cli-shared/contract"
 
 // Name is the canonical lowercased <classroom>-<assignment>-<username>
 // assignment-repo name.
 func Name(classroom, assignment, username string) string {
-	return Prefix(classroom, assignment) + strings.ToLower(username)
+	return contract.AssignmentRepoName(classroom, assignment, username)
 }
 
-// Prefix is the single source of the group/individual repo-name prefix
-// `<classroom>-<assignment>-` (all lowercased). Both the producer (Name) and
-// the consumer (group-membership's owner recovery, which strips this prefix)
-// derive from it, so the `<classroom>-<assignment>-<owner>` shape can only
-// change in one place.
+// Prefix is the group/individual repo-name prefix `<classroom>-<assignment>-`
+// (all lowercased). Both the producer (Name) and the consumer
+// (group-membership's owner recovery, which strips this prefix) derive from it.
 func Prefix(classroom, assignment string) string {
-	return fmt.Sprintf("%s-%s-",
-		strings.ToLower(classroom),
-		strings.ToLower(assignment),
-	)
+	return contract.AssignmentRepoPrefix(classroom, assignment)
 }

--- a/cli/gh-student/internal/reponame/reponame_test.go
+++ b/cli/gh-student/internal/reponame/reponame_test.go
@@ -1,0 +1,28 @@
+package reponame
+
+import "testing"
+
+// reponame delegates to cli/shared/contract; these pin the gh-student-facing API
+// so a refactor of the delegation can't silently change the repo-name shape that
+// `gh student accept` and group-membership owner recovery depend on.
+func TestName(t *testing.T) {
+	if got := Name("CS101", "HW1", "Alice"); got != "cs101-hw1-alice" {
+		t.Errorf("Name = %q, want %q", got, "cs101-hw1-alice")
+	}
+}
+
+func TestPrefix(t *testing.T) {
+	if got := Prefix("CS101", "HW1"); got != "cs101-hw1-" {
+		t.Errorf("Prefix = %q, want %q", got, "cs101-hw1-")
+	}
+}
+
+// Name must equal Prefix + lowercased username so the owner is recoverable by
+// stripping the prefix (the group-membership consumer relies on this).
+func TestNameIsPrefixPlusOwner(t *testing.T) {
+	prefix := Prefix("cs101", "hw1")
+	name := Name("cs101", "hw1", "Bob")
+	if name != prefix+"bob" {
+		t.Errorf("Name = %q, want %q", name, prefix+"bob")
+	}
+}

--- a/cli/gh-teacher/autograders_tests/test_runner.py
+++ b/cli/gh-teacher/autograders_tests/test_runner.py
@@ -80,6 +80,22 @@ class TestUsernameFromRepo:
             "fallback",
         ) == "alice-the-second"
 
+    def test_shared_fixture_parity(self):
+        # Same golden cases the Go contract test asserts, so the naming formula
+        # and this mirror can't drift: recover each fixture owner by stripping
+        # the <classroom>-<assignment>- prefix from the fixture repo name.
+        fixture = (_REPO_ROOT / "cli" / "shared" / "testdata"
+                   / "assignment_repo_name_cases.json")
+        cases = json.loads(fixture.read_text())["cases"]
+        assert cases, "shared fixture has no cases"
+        for case in cases:
+            assert ag.username_from_repo(
+                f"owner/{case['name']}",
+                case["classroom"],
+                case["assignment"],
+                "fallback",
+            ) == case["owner"], case["name"]
+
 
 # ---------------------------------------------------------------------------
 # URL construction

--- a/cli/gh-teacher/internal/download/download.go
+++ b/cli/gh-teacher/internal/download/download.go
@@ -365,12 +365,18 @@ func loadRosterMetadata(client githubapi.Client, org, classroom, branch string, 
 	return byLogin
 }
 
+// matchesAssignmentPrefix reports whether repo is an assignment repo for
+// <classroom>/<assignment> — its lowercased name starts with the repo-name
+// prefix. This is how downloadByPattern selects repos to clone, kept as a pure
+// helper so the selection can be tested in isolation.
+func matchesAssignmentPrefix(name, classroom, assignment string) bool {
+	return strings.HasPrefix(strings.ToLower(name), contract.AssignmentRepoPrefix(classroom, assignment))
+}
+
 // downloadByPattern: page through <org>'s repos and clone every one whose
 // name starts with <classroom>-<assignment>-. Skips the team lookup,
 // result.json refresh, and scores.csv summary (all depend on the config repo).
 func downloadByPattern(client githubapi.Client, out, errOut io.Writer, org, classroom, assignment, dir string, quiet, verbose bool) error {
-	// Deterministic head of the assignment repo name — single-sourced with
-	// gh-student via cli/shared/contract.
 	prefix := contract.AssignmentRepoPrefix(classroom, assignment)
 
 	repos, err := orgrepos.ListNames(client, org)
@@ -380,7 +386,7 @@ func downloadByPattern(client githubapi.Client, out, errOut io.Writer, org, clas
 
 	var matched []string
 	for _, name := range repos {
-		if strings.HasPrefix(strings.ToLower(name), prefix) {
+		if matchesAssignmentPrefix(name, classroom, assignment) {
 			matched = append(matched, name)
 		}
 	}

--- a/cli/gh-teacher/internal/download/download.go
+++ b/cli/gh-teacher/internal/download/download.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cli/go-gh/v2/pkg/auth"
 	"github.com/spf13/cobra"
 
+	"github.com/foundation50/classroom50-cli-shared/contract"
 	"github.com/foundation50/classroom50-cli-shared/ghui"
 	"github.com/foundation50/gh-teacher/internal/assignment"
 	"github.com/foundation50/gh-teacher/internal/cliutil"
@@ -368,9 +369,9 @@ func loadRosterMetadata(client githubapi.Client, org, classroom, branch string, 
 // name starts with <classroom>-<assignment>-. Skips the team lookup,
 // result.json refresh, and scores.csv summary (all depend on the config repo).
 func downloadByPattern(client githubapi.Client, out, errOut io.Writer, org, classroom, assignment, dir string, quiet, verbose bool) error {
-	// Deterministic head of assignmentRepoName — cross-binary contract with
-	// cli/gh-student/accept.go.
-	prefix := strings.ToLower(classroom) + "-" + strings.ToLower(assignment) + "-"
+	// Deterministic head of the assignment repo name — single-sourced with
+	// gh-student via cli/shared/contract.
+	prefix := contract.AssignmentRepoPrefix(classroom, assignment)
 
 	repos, err := orgrepos.ListNames(client, org)
 	if err != nil {
@@ -459,15 +460,11 @@ func assignmentIsGroup(assignments assignment.AssignmentsJSON, slug string) bool
 }
 
 // assignmentRepoName: canonical lowercased <classroom>-<assignment>-<username>
-// repo name. Cross-binary contract — mirrors reponame.Name in
-// cli/gh-student/internal/reponame. The two modules share no symbols; the
-// formula's shape IS the contract.
+// repo name. Delegates to the single cross-binary source in cli/shared/contract
+// (also used by gh-student via internal/reponame, and mirrored by
+// runner.py::username_from_repo).
 func assignmentRepoName(classroom, assignment, username string) string {
-	return fmt.Sprintf("%s-%s-%s",
-		strings.ToLower(classroom),
-		strings.ToLower(assignment),
-		strings.ToLower(username),
-	)
+	return contract.AssignmentRepoName(classroom, assignment, username)
 }
 
 // targetExists distinguishes "missing" from "other error" so a

--- a/cli/gh-teacher/internal/download/download_test.go
+++ b/cli/gh-teacher/internal/download/download_test.go
@@ -39,6 +39,32 @@ func TestAssignmentRepoName(t *testing.T) {
 	}
 }
 
+// TestMatchesAssignmentPrefix pins the repo-selection downloadByPattern uses:
+// canonical and mixed-case assignment repos match; the config repo, a different
+// assignment, and a near-miss prefix do not.
+func TestMatchesAssignmentPrefix(t *testing.T) {
+	cases := []struct {
+		name, classroom, assignment string
+		want                        bool
+	}{
+		{"cs-principles-hello-alice", "cs-principles", "hello", true},
+		{"CS-Principles-Hello-Alice", "cs-principles", "hello", true}, // repo name cased differently
+		{"cs-principles-hello-ada-l", "cs-principles", "hello", true}, // hyphenated username
+		{"cs-principles-goodbye-alice", "cs-principles", "hello", false},
+		{"classroom50", "cs-principles", "hello", false},                // config repo
+		{"cs-principles-hello", "cs-principles", "hello", false},        // prefix without trailing "-<owner>"
+		{"cs-principles-hello2-alice", "cs-principles", "hello", false}, // near-miss: no "-" boundary
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchesAssignmentPrefix(tc.name, tc.classroom, tc.assignment); got != tc.want {
+				t.Fatalf("matchesAssignmentPrefix(%q,%q,%q) = %v, want %v",
+					tc.name, tc.classroom, tc.assignment, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAssignmentRegistered(t *testing.T) {
 	file := assignment.AssignmentsJSON{
 		Schema: contract.AssignmentsSchemaV1,

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -646,9 +646,9 @@ def collect_classroom(
 
 
 def assignment_repo_name(classroom: str, assignment: str, username: str) -> str:
-    """Canonical student-repo name. Cross-binary contract — mirrors
-    `assignmentRepoName` in cli/gh-student/accept.go; changing the shape here
-    without updating Go silently breaks the collect loop."""
+    """Canonical student-repo name. Mirrors the formula single-sourced in
+    cli/shared/contract (AssignmentRepoName); keep byte-identical or the
+    collect loop misidentifies submissions."""
     return f"{classroom.lower()}-{assignment.lower()}-{username.lower()}"
 
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/regrade_repos.py
@@ -738,10 +738,9 @@ def _assert_same_host(next_url: str, api_url: str) -> str:
 
 
 def assignment_repo_name(classroom: str, assignment: str, username: str) -> str:
-    """Canonical student-repo name. Cross-binary contract — mirrors
-    `assignment_repo_name` in collect_scores.py and `assignmentRepoName` in
-    cli/gh-student/accept.go; changing the shape here without updating the
-    others silently breaks the regrade fan-out."""
+    """Canonical student-repo name. Mirrors the formula single-sourced in
+    cli/shared/contract (AssignmentRepoName); keep byte-identical or the
+    regrade fan-out misidentifies submissions."""
     return f"{classroom.lower()}-{assignment.lower()}-{username.lower()}"
 
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -172,9 +172,9 @@ def runtime_root() -> pathlib.Path:
 def username_from_repo(repository: str, classroom: str, assignment: str, actor: str) -> str:
     """Derive the student username from `<owner>/<classroom>-<assignment>-<username>`.
 
-    Mirrors `assignmentRepoName` in cli/gh-student/accept.go (lowercased
-    throughout). Falls back to GITHUB_ACTOR when the repo name doesn't follow
-    the convention (e.g. hand-created test repos).
+    Mirrors the naming formula single-sourced in cli/shared/contract
+    (AssignmentRepoName); keep byte-identical. Falls back to GITHUB_ACTOR when
+    the repo name doesn't follow the convention (e.g. hand-created test repos).
     """
     if "/" in repository:
         _, repo = repository.split("/", 1)

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1011,9 +1011,8 @@ class TestGroupCollectClassroom:
 
 class TestAssignmentRepoName:
     def test_lowercases_all_three_components(self):
-        # Cross-binary contract with assignmentRepoName in
-        # cli/gh-student/accept.go — drift makes the collect
-        # releases/latest call 404 for every student.
+        # Cross-binary contract single-sourced in cli/shared/contract — drift
+        # makes the collect releases/latest call 404 for every student.
         assert (
             cs.assignment_repo_name("CS-Principles", "Hello", "Alice")
             == "cs-principles-hello-alice"
@@ -1026,6 +1025,19 @@ class TestAssignmentRepoName:
             cs.assignment_repo_name("cs-principles", "hello-world", "ada-l")
             == "cs-principles-hello-world-ada-l"
         )
+
+    def test_shared_fixture_parity(self):
+        # Same golden cases the Go contract test asserts, so this mirror can't
+        # drift from the single source in cli/shared/contract.
+        repo_root = pathlib.Path(__file__).resolve().parents[3]
+        fixture = (repo_root / "cli" / "shared" / "testdata"
+                   / "assignment_repo_name_cases.json")
+        cases = json.loads(fixture.read_text())["cases"]
+        assert cases, "shared fixture has no cases"
+        for case in cases:
+            assert cs.assignment_repo_name(
+                case["classroom"], case["assignment"], case["username"]
+            ) == case["name"], case["name"]
 
 
 # Due-date / lateness ---------------------------------------------------------

--- a/cli/gh-teacher/skeleton_tests/test_regrade_repos.py
+++ b/cli/gh-teacher/skeleton_tests/test_regrade_repos.py
@@ -29,6 +29,20 @@ def test_assignment_repo_name_lowercases():
     )
 
 
+def test_assignment_repo_name_shared_fixture_parity():
+    # Same golden cases the Go contract test asserts, so this mirror can't
+    # drift from the single source in cli/shared/contract.
+    repo_root = pathlib.Path(__file__).resolve().parents[3]
+    fixture = (repo_root / "cli" / "shared" / "testdata"
+               / "assignment_repo_name_cases.json")
+    cases = json.loads(fixture.read_text())["cases"]
+    assert cases, "shared fixture has no cases"
+    for case in cases:
+        assert rr.assignment_repo_name(
+            case["classroom"], case["assignment"], case["username"]
+        ) == case["name"], case["name"]
+
+
 def test_build_submit_tag_shape():
     tag = rr.build_submit_tag("abcdef1234567890")
     assert tag.startswith("submit/")

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -113,10 +113,9 @@ func PrefixCommit(message string) string {
 // `<classroom>-<assignment>-` (all lowercased). Both the producer
 // (AssignmentRepoName) and consumers that strip it to recover the owner derive
 // from this, so the `<classroom>-<assignment>-<owner>` shape can only change in
-// one place. Cross-binary: gh-student (via internal/reponame) builds and parses
-// repo names with it, gh-teacher's download command matches repos by this
-// prefix, and runner.py::username_from_repo mirrors the shape by value (NO
-// compile-time link — keep byte-identical). A drift here silently makes
+// one place. Cross-binary with NO compile-time link — keep byte-identical with
+// the Python mirrors: runner.py::username_from_repo, and assignment_repo_name in
+// collect_scores.py and regrade_repos.py. A drift here silently makes
 // `gh teacher download` return zero repos and misidentifies every submission.
 func AssignmentRepoPrefix(classroom, assignment string) string {
 	return fmt.Sprintf("%s-%s-",

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -14,6 +14,11 @@
 // but the cross-language check stays manual.
 package contract
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	// ConfigRepoName is the per-org classroom config repo. Hardcoded across
 	// student repos and the collect-scores workflow — part of the public contract.
@@ -102,4 +107,26 @@ func RequiredOAuthScopes() []string {
 // preserved verbatim.
 func PrefixCommit(message string) string {
 	return CommitPrefix + " " + message
+}
+
+// AssignmentRepoPrefix is the single source of the assignment-repo name prefix
+// `<classroom>-<assignment>-` (all lowercased). Both the producer
+// (AssignmentRepoName) and consumers that strip it to recover the owner derive
+// from this, so the `<classroom>-<assignment>-<owner>` shape can only change in
+// one place. Cross-binary: gh-student (via internal/reponame) builds and parses
+// repo names with it, gh-teacher's download command matches repos by this
+// prefix, and runner.py::username_from_repo mirrors the shape by value (NO
+// compile-time link — keep byte-identical). A drift here silently makes
+// `gh teacher download` return zero repos and misidentifies every submission.
+func AssignmentRepoPrefix(classroom, assignment string) string {
+	return fmt.Sprintf("%s-%s-",
+		strings.ToLower(classroom),
+		strings.ToLower(assignment),
+	)
+}
+
+// AssignmentRepoName is the canonical lowercased
+// `<classroom>-<assignment>-<username>` assignment-repo name.
+func AssignmentRepoName(classroom, assignment, username string) string {
+	return AssignmentRepoPrefix(classroom, assignment) + strings.ToLower(username)
 }

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -54,6 +54,31 @@ func TestContractLiterals(t *testing.T) {
 	}
 }
 
+// TestAssignmentRepoName pins the assignment-repo naming formula — the
+// cross-binary contract that gh-student (via internal/reponame) and gh-teacher
+// (download) both build/parse and runner.py::username_from_repo mirrors by
+// value. A shape change here silently makes `gh teacher download` return zero
+// repos and misidentifies every submission, so this is the oracle. Covers the
+// lowercasing of all three segments and the prefix/name relationship.
+func TestAssignmentRepoName(t *testing.T) {
+	if got := AssignmentRepoPrefix("CS101", "HW1"); got != "cs101-hw1-" {
+		t.Errorf("AssignmentRepoPrefix = %q, want %q", got, "cs101-hw1-")
+	}
+	if got := AssignmentRepoName("CS101", "HW1", "Alice"); got != "cs101-hw1-alice" {
+		t.Errorf("AssignmentRepoName = %q, want %q", got, "cs101-hw1-alice")
+	}
+	// Name must be exactly Prefix + lowercased username, so a consumer that
+	// strips the prefix recovers the owner.
+	prefix := AssignmentRepoPrefix("cs101", "hw1")
+	name := AssignmentRepoName("cs101", "hw1", "bob")
+	if !strings.HasPrefix(name, prefix) {
+		t.Errorf("AssignmentRepoName %q does not start with AssignmentRepoPrefix %q", name, prefix)
+	}
+	if owner := strings.TrimPrefix(name, prefix); owner != "bob" {
+		t.Errorf("owner recovered from %q = %q, want %q", name, owner, "bob")
+	}
+}
+
 // TestRequiredOAuthScopes pins the unified CLI scope set (issue #246): both
 // binaries request exactly these, and delete_repo stays out (opt-in for
 // teardown). This list is the behavior oracle for the login command and the

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -1,6 +1,9 @@
 package contract
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -54,12 +57,10 @@ func TestContractLiterals(t *testing.T) {
 	}
 }
 
-// TestAssignmentRepoName pins the assignment-repo naming formula — the
-// cross-binary contract that gh-student (via internal/reponame) and gh-teacher
-// (download) both build/parse and runner.py::username_from_repo mirrors by
-// value. A shape change here silently makes `gh teacher download` return zero
-// repos and misidentifies every submission, so this is the oracle. Covers the
-// lowercasing of all three segments and the prefix/name relationship.
+// TestAssignmentRepoName pins the lowercasing of all three segments and the
+// prefix/name relationship (owner is recoverable by stripping the prefix).
+// Cross-language agreement with the Python mirrors is enforced separately by
+// TestAssignmentRepoName_SharedFixtureParity.
 func TestAssignmentRepoName(t *testing.T) {
 	if got := AssignmentRepoPrefix("CS101", "HW1"); got != "cs101-hw1-" {
 		t.Errorf("AssignmentRepoPrefix = %q, want %q", got, "cs101-hw1-")
@@ -76,6 +77,47 @@ func TestAssignmentRepoName(t *testing.T) {
 	}
 	if owner := strings.TrimPrefix(name, prefix); owner != "bob" {
 		t.Errorf("owner recovered from %q = %q, want %q", name, owner, "bob")
+	}
+}
+
+// sharedRepoNameCasesPath locates the cross-language golden fixture, also
+// consumed by the Python mirror tests (runner.py, collect_scores.py,
+// regrade_repos.py), relative to this package.
+const sharedRepoNameCasesPath = "../testdata/assignment_repo_name_cases.json"
+
+// TestAssignmentRepoName_SharedFixtureParity runs the shared golden cases so the
+// Go formula and the by-value Python mirrors can't drift: a one-sided edit fails
+// on the other language's copy of these same cases.
+func TestAssignmentRepoName_SharedFixtureParity(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Clean(sharedRepoNameCasesPath))
+	if err != nil {
+		t.Fatalf("read shared fixture: %v", err)
+	}
+	var doc struct {
+		Cases []struct {
+			Classroom  string `json:"classroom"`
+			Assignment string `json:"assignment"`
+			Username   string `json:"username"`
+			Name       string `json:"name"`
+			Owner      string `json:"owner"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse shared fixture: %v", err)
+	}
+	if len(doc.Cases) == 0 {
+		t.Fatal("shared fixture has no cases")
+	}
+	for _, c := range doc.Cases {
+		if got := AssignmentRepoName(c.Classroom, c.Assignment, c.Username); got != c.Name {
+			t.Errorf("AssignmentRepoName(%q,%q,%q) = %q, want %q",
+				c.Classroom, c.Assignment, c.Username, got, c.Name)
+		}
+		// owner is the tail the Python mirror recovers by stripping the prefix.
+		prefix := AssignmentRepoPrefix(c.Classroom, c.Assignment)
+		if owner := strings.TrimPrefix(c.Name, prefix); owner != c.Owner {
+			t.Errorf("owner recovered from %q = %q, want %q", c.Name, owner, c.Owner)
+		}
 	}
 }
 

--- a/cli/shared/testdata/assignment_repo_name_cases.json
+++ b/cli/shared/testdata/assignment_repo_name_cases.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Shared golden fixture pinning the assignment-repo naming formula <classroom>-<assignment>-<username> (all three segments lowercased) to identical output across every implementation: Go contract.AssignmentRepoName/AssignmentRepoPrefix (cli/shared/contract) and the by-value Python mirrors username_from_repo (runner.py), assignment_repo_name (collect_scores.py, regrade_repos.py). There is NO compile-time link across languages, so each side asserts these same cases and a one-sided edit fails on the other side. Each case gives the components and the expected repo name; owner is the expected tail recovered by stripping the <classroom>-<assignment>- prefix (runner.py::username_from_repo). A drift here silently makes `gh teacher download` return zero repos and misidentifies every submission.",
+  "cases": [
+    { "classroom": "CS101", "assignment": "HW1", "username": "Alice", "name": "cs101-hw1-alice", "owner": "alice" },
+    { "classroom": "cs-principles", "assignment": "hello", "username": "alice", "name": "cs-principles-hello-alice", "owner": "alice" },
+    { "classroom": "cs-principles", "assignment": "hello-world", "username": "ada-l", "name": "cs-principles-hello-world-ada-l", "owner": "ada-l" },
+    { "classroom": "CS-Principles", "assignment": "Hello", "username": "alice-the-second", "name": "cs-principles-hello-alice-the-second", "owner": "alice-the-second" }
+  ]
+}


### PR DESCRIPTION
## Summary

Tier-1 item B from the codebase re-assessment plan — the one genuine latent correctness bug. The `<classroom>-<assignment>-<username>` assignment-repo naming formula was **forked across three Go/Python surfaces**, coupled only by "keep in lockstep" comments:

- canonical in `cli/gh-student/internal/reponame/reponame.go`,
- hand-rebuilt **twice** in `cli/gh-teacher/internal/download/download.go` (the `downloadByPattern` prefix + `assignmentRepoName`),
- and by-value in **three** Python skeleton scripts: `runner.py::username_from_repo`, `collect_scores.py::assignment_repo_name`, and `regrade_repos.py::assignment_repo_name`.

Because gh-teacher and gh-student are separate go.mods with no shared symbol — and the Python copies have no compile-time link at all — a shape change to one silently makes `gh teacher download` return **zero repos** and misidentifies every submission in `scores.json`, with no compile error.

**Fix:** move the formula into `cli/shared/contract` (`AssignmentRepoName` / `AssignmentRepoPrefix`) — the existing home for cross-binary constants both CLIs already depend on.

- `gh-student/reponame` now **delegates** to it, preserving its public `Name`/`Prefix` API so `accept.go` / `invitecmd` consumers don't change.
- `gh-teacher/download.go` delegates both hand-built sites; the repo-selection prefix match is extracted into a testable `matchesAssignmentPrefix` helper.
- The Python mirrors stay by-value (no compile-time link is possible across the skeleton boundary), but are now guarded against drift.

**Cross-language drift is now caught, not just commented.** A shared golden fixture `cli/shared/testdata/assignment_repo_name_cases.json` is asserted by **both languages** — the Go `contract_test.go` parity test and a `shared_fixture` test in each of the three Python mirror suites (`test_runner.py`, `test_collect_scores.py`, `test_regrade_repos.py`) — mirroring the existing `allowed_files`/`control_path` fixture pattern. A one-sided edit to the formula now fails on the other language's copy of the same cases (verified: corrupting the fixture fails both the Go and Python parity tests). The three Python docstrings, which previously pointed at the now-non-authoritative `accept.go`, are repointed at `cli/shared/contract`.

Behavior-preserving: the formula is byte-identical, just single-sourced.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` green in all three modules (shared, gh-student, gh-teacher)
- [x] `python3 -m pytest` green for the three touched Python suites (skeleton_tests: 230 passed; autograders_tests runner: 170 passed)
- [x] Negative check: corrupting the shared fixture fails both the Go and Python parity tests (drift is caught)
- [x] `gofmt` clean on all touched files