### PR TITLE
fix(web): treat an org owner as org-staff so a fresh org isn't stranded

### DIFF
--- a/web/src/authz/resolveRole.ts
+++ b/web/src/authz/resolveRole.ts
@@ -121,9 +121,10 @@ export function membershipFromQuery(
 // (Published page, "My Classes" nav, ClassesPage): staff = confirmed member of
 // >=1 classroom staff team in the org, derived from the viewer's own team
 // memberships (see useOrgStaff). Fail-closed tri-state: a transient/in-flight
-// read holds `unresolved` rather than demoting a real staffer. Deliberately
-// ignores org-owner status: an owner on no staff team is non-staff here and
-// recovers via ClaimInstructor (owner-scoped UI stays gated on can("manageOrg")).
+// read holds `unresolved` rather than demoting a real staffer. This pure verdict
+// is team-only; useOrgStaff additionally grants staff to an org owner (so a
+// freshly-configured org with no teams isn't stranded) — owner precedence lives
+// in the hook, not this type.
 export type OrgStaffVerdict = {
   isStaff: boolean
   // Definitively-resolved AND not staff — the org-less "treat as a plain member/

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -1027,11 +1027,11 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
   const { t } = useTranslation()
   const { isStaff, roleResolved } = useOrgStaff(org)
   // Members/Activity/Settings are owner-only surfaces, so their route access
-  // stays gated on can("manageOrg") (RequireOwner). Their sidebar SHORTCUTS,
-  // though, are shown only to a staff owner (`isStaff && isOwner`): an org
-  // owner on no staff team deliberately loses the shortcut clutter but keeps the
-  // routes reachable (and regains the nav by claiming instructor / joining a
-  // staff team). Team membership is the source of truth for org-staff chrome.
+  // stays gated on can("manageOrg") (RequireOwner). Their sidebar SHORTCUTS are
+  // shown to a staff owner (`isStaff && isOwner`); since useOrgStaff now treats
+  // an org owner as staff, a fresh owner on no staff team keeps the shortcuts
+  // (and the routes). Team membership is the source of truth for non-owner
+  // org-staff chrome.
   const { githubOrgRole } = useGitHubOrgRole()
   const isOwner = can("manageOrg", { githubOrgRole })
   const onSettings = settings || selected === "settings"

--- a/web/src/hooks/useOrgStaff.test.tsx
+++ b/web/src/hooks/useOrgStaff.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest"
 import { renderHook } from "@testing-library/react"
 
 const useQueryMock = vi.fn()
+let githubOrgRoleMock = "member"
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (arg: unknown) => useQueryMock(arg),
@@ -12,6 +13,9 @@ vi.mock("@/context/github/GitHubProvider", () => ({
 }))
 vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => ({ user: { login: "teacher1" } }),
+}))
+vi.mock("@/context/githubOrgRole/GitHubOrgRoleProvider", () => ({
+  useGitHubOrgRole: () => ({ githubOrgRole: githubOrgRoleMock }),
 }))
 // myTeamsQuery is a pure options factory; the mock returns a marker the mocked
 // useQuery ignores (it returns whatever useQueryMock is set to).
@@ -44,6 +48,7 @@ const teams = (over: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   useQueryMock.mockReset()
+  githubOrgRoleMock = "member"
 })
 
 describe("useOrgStaff — team-based org-staff signal", () => {
@@ -121,5 +126,53 @@ describe("useOrgStaff — team-based org-staff signal", () => {
     const { result } = renderHook(() => useOrgStaff("acme"))
     result.current.refetch()
     expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats an org owner as staff even with no teams (fresh org)", () => {
+    githubOrgRoleMock = "owner"
+    // Empty successful listing: no classroom staff team at all.
+    useQueryMock.mockReturnValue(teams({ data: [], isSuccess: true }))
+    const { result } = renderHook(() => useOrgStaff("acme"))
+    expect(result.current).toMatchObject({
+      isStaff: true,
+      isNonStaff: false,
+      roleResolved: true,
+      isError: false,
+    })
+  })
+
+  it("resolves an owner immediately, without waiting on the teams read", () => {
+    githubOrgRoleMock = "owner"
+    // Teams read still in flight — the owner should resolve as staff anyway,
+    // never pinned on the spinner.
+    useQueryMock.mockReturnValue(teams({ fetchStatus: "fetching" }))
+    const { result } = renderHook(() => useOrgStaff("acme"))
+    expect(result.current.isStaff).toBe(true)
+    expect(result.current.roleResolved).toBe(true)
+    expect(result.current.isNonStaff).toBe(false)
+    // A resolved owner is not "loading" even while an irrelevant teams read is
+    // in flight — ClassesPage gates its whole render on isLoading.
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("holds fail-closed while the org role is unresolved (no owner flash)", () => {
+    githubOrgRoleMock = "unresolved"
+    // Org read in flight AND teams read in flight: not yet staff via the owner
+    // path, falls back to the team-based hold rather than flashing staff.
+    useQueryMock.mockReturnValue(teams({ fetchStatus: "fetching" }))
+    const { result } = renderHook(() => useOrgStaff("acme"))
+    expect(result.current.isStaff).toBe(false)
+    expect(result.current.roleResolved).toBe(false)
+    expect(result.current.isNonStaff).toBe(false)
+  })
+
+  it("keeps a non-owner on a staff team as staff regardless of org role", () => {
+    githubOrgRoleMock = "member"
+    useQueryMock.mockReturnValue(
+      teams({ data: [team("classroom50-cs101-ta")], isSuccess: true }),
+    )
+    const { result } = renderHook(() => useOrgStaff("acme"))
+    expect(result.current.isStaff).toBe(true)
+    expect(result.current.isNonStaff).toBe(false)
   })
 })

--- a/web/src/hooks/useOrgStaff.ts
+++ b/web/src/hooks/useOrgStaff.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { myTeamsQuery } from "@/github-core/queries"
 import { parseClassroomTeamSlug } from "@/util/teamSlug"
-import type { OrgStaffVerdict } from "@/authz"
+import { can, type OrgStaffVerdict } from "@/authz"
 
 export type UseOrgStaffResult = OrgStaffVerdict & {
   isLoading: boolean
@@ -13,42 +14,61 @@ export type UseOrgStaffResult = OrgStaffVerdict & {
 
 // Org-level "staff of any classroom" signal for surfaces with NO classroom in
 // scope (Published page, "My Classes" nav, ClassesPage): staff iff the viewer is
-// a confirmed member of >=1 classroom's instructor/ta team in this org.
+// an org owner OR a confirmed member of >=1 classroom's instructor/ta team in
+// this org.
 //
-// Derived DIRECTLY from the viewer's own team memberships (GET /user/teams, a
-// self-scoped read that returns secret teams they belong to) — NOT from the
-// config repo. This is the key property: a student can't read the config-repo
-// class listing (404), but they CAN list their own teams, so the signal never
-// hinges on config-repo access and a non-staff viewer cleanly resolves to
-// non-staff rather than an unresolvable error. Replaces the config-repo
-// `.pull`-as-teacher heuristic (owner-scoped UI stays gated on can("manageOrg");
-// an owner on no staff team recovers via ClaimInstructor).
+// The team signal is derived DIRECTLY from the viewer's own team memberships
+// (GET /user/teams, a self-scoped read that returns secret teams they belong
+// to) — NOT from the config repo. This is the key property: a student can't read
+// the config-repo class listing (404), but they CAN list their own teams, so the
+// signal never hinges on config-repo access and a non-staff viewer cleanly
+// resolves to non-staff rather than an unresolvable error. Team membership is the
+// source of truth for NON-owners (a read-only config-repo collaborator is not
+// staff).
 //
-// Fail-closed tri-state: a confirmed staff team in this org => staff; a
-// successful listing with no matching team => definitive non-staff; a
-// transient/in-flight read => unresolved (hold; never demote a real staffer).
+// An org owner is staff here regardless of team membership: a freshly-configured
+// org has no classroom teams yet, and the owner still needs the org-staff chrome
+// (My Classrooms, the create-classroom CTA, the owner nav shortcuts) to bootstrap
+// their first classroom. Creating it seeds the owner onto its instructor team, so
+// the team signal takes over naturally afterward.
+//
+// Fail-closed tri-state: a confirmed owner or staff team => staff; a successful
+// listing (non-owner) with no matching team => definitive non-staff; a
+// transient/in-flight read => unresolved (hold; never demote a real staffer, and
+// never flash staff chrome before the org role resolves).
 export function useOrgStaff(org: string | undefined): UseOrgStaffResult {
   const client = useGitHubClient()
   const { user } = useGithubAuth()
+  const { githubOrgRole } = useGitHubOrgRole()
   const username = user?.login
 
   const enabled = Boolean(org && username)
   const teamsQuery = useQuery({ ...myTeamsQuery(client), enabled })
 
-  // Staff iff any of the viewer's teams IN THIS ORG parses to a classroom staff
-  // slug (classroom50-<classroom>-<instructor|ta>). Cross-org teams are filtered
-  // out by organization.login; the student team (no role suffix) parses to null.
-  const isStaff = Boolean(
-    teamsQuery.data?.some(
-      (team) =>
-        team.organization.login === org && parseClassroomTeamSlug(team.slug),
-    ),
-  )
+  // An org owner is staff for org-level chrome regardless of team membership.
+  // `unresolved` (in-flight org read) is denied by can(), so a fresh load falls
+  // back to the team-based hold below rather than flashing staff.
+  const isOwner = can("manageOrg", { githubOrgRole })
 
-  // Resolve only on a definitively-successful listing (or a confirmed staff
-  // team). A transient/in-flight read holds unresolved so a real staffer is
-  // never demoted on a blip.
-  const roleResolved = enabled && (isStaff || teamsQuery.isSuccess)
+  // Staff iff owner, or any of the viewer's teams IN THIS ORG parses to a
+  // classroom staff slug (classroom50-<classroom>-<instructor|ta>). Cross-org
+  // teams are filtered out by organization.login; the student team (no role
+  // suffix) parses to null.
+  const isStaff =
+    isOwner ||
+    Boolean(
+      teamsQuery.data?.some(
+        (team) =>
+          team.organization.login === org && parseClassroomTeamSlug(team.slug),
+      ),
+    )
+
+  // Resolve on a confirmed owner or staff team, or a definitively-successful
+  // listing. An owner resolves immediately (keyed on `org`, not the teams
+  // `enabled`/success) so a fresh owner isn't pinned on a spinner waiting for a
+  // teams read they don't need. A non-owner's transient/in-flight read holds
+  // unresolved so a real staffer is never demoted on a blip.
+  const roleResolved = Boolean(org) && (isStaff || teamsQuery.isSuccess)
   const verdict: OrgStaffVerdict = {
     isStaff,
     isNonStaff: roleResolved && !isStaff,
@@ -58,7 +78,9 @@ export function useOrgStaff(org: string | undefined): UseOrgStaffResult {
   // A disabled hook (org-less route, no viewer) is NOT loading — it has nothing
   // to resolve; callers gate on roleResolved. Keying on fetchStatus avoids
   // pinning a permanent spinner on org-less surfaces (the footer role label).
-  const isLoading = teamsQuery.fetchStatus === "fetching"
+  // Once resolved (e.g. an owner, who needs no teams read), we're not loading
+  // even if an irrelevant teams read is still in flight.
+  const isLoading = !roleResolved && teamsQuery.fetchStatus === "fetching"
 
   // Surface a settled error (the teams read exhausted retries) with the role
   // still unresolved, so the gate offers retry instead of a stuck spinner.


### PR DESCRIPTION
## Summary

Fixes #280. A GitHub org **owner** who has just set up Classroom 50 but has **not created any classrooms yet** was stranded on the non-staff view: the page read "My Assignments", there was no "Create classroom" CTA, and the Published / Members / Activity / Settings sidebar shortcuts were hidden.

Root cause is a regression from #265 (P5d): `useOrgStaff` derives `isStaff` purely from classroom staff-team membership, and a brand-new org has no such teams, so `isStaff = false` even for the owner. The documented recovery (`ClaimInstructorNotice`) is classroom-scoped and needs an existing classroom, so a zero-classroom org had no recovery surface.

## What changed

- **`useOrgStaff`** now grants org-staff to an org **owner** (`can("manageOrg", { githubOrgRole })`), folded in at the single verdict source so `ClassesPage`, the drawer `MyClasses` nav, `RequireOrgStaff`, and the footer label all update for free. Reads the already-mounted org-role context — no new fetch.
  - The owner resolves **immediately** (keyed on `org`, not the teams read) and no longer reports `isLoading` once resolved, so a fresh owner isn't held on `ClassesPage`'s skeleton while an irrelevant teams read finishes.
  - **Non-owner behavior is unchanged** — team membership stays the source of truth (a read-only config-repo collaborator still resolves non-staff, preserving the #265 fix).
- Fail-closed preserved: a transient/in-flight org-role read (`unresolved`) is denied by `can()`, so staff chrome never flashes before the role resolves.
- Updated now-stale comments in `useOrgStaff.ts`, `authz/resolveRole.ts` (`OrgStaffVerdict`), and `drawer/index.tsx` that claimed an owner-on-no-staff-team is non-staff.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx vitest run` — 1524 passed (139 files)
- [x] `npx eslint` / `npx prettier --check` clean on touched files (pre-existing drawer a11y warnings only)
- [x] New `useOrgStaff.test.tsx` coverage: owner + no teams -> staff; owner resolves immediately and isn't loading; owner with `unresolved` org role holds fail-closed; non-owner on a staff team unchanged
- [ ] Manual: as an org owner in a fresh org (config repo present, zero classrooms), the org home shows "My Classrooms", the create-classroom CTA, and the Published/Members/Activity/Settings nav; `/$org/published` loads rather than 404s