### PR TITLE
fix(web): let org owners accept assignments despite residual admin

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -152,6 +152,11 @@ func acceptCmd() *cobra.Command {
 				return err
 			}
 
+			// An org owner who creates the repo holds admin and can't
+			// self-downgrade to the push we grant; tolerate that residual admin
+			// at the founder read-back so an owner can still accept.
+			isOwner := status.Role == "admin"
+
 			switch status.StatusCode {
 			case http.StatusOK:
 				// Auto-accept a pending org invite first.
@@ -162,7 +167,7 @@ func acceptCmd() *cobra.Command {
 					}
 					switch acceptStatus.StatusCode {
 					case http.StatusOK:
-						return acceptAssignment(cmd, client, u, out, org, classroom, assignment, secret)
+						return acceptAssignment(cmd, client, u, out, org, classroom, assignment, secret, isOwner)
 					case http.StatusNotFound:
 						return fmt.Errorf("%s: no membership found for accept", org)
 					case http.StatusForbidden:
@@ -181,7 +186,7 @@ func acceptCmd() *cobra.Command {
 				return fmt.Errorf("%s: unknown status received (%d)", org, status.StatusCode)
 			}
 
-			return acceptAssignment(cmd, client, u, out, org, classroom, assignment, secret)
+			return acceptAssignment(cmd, client, u, out, org, classroom, assignment, secret, isOwner)
 		},
 	}
 
@@ -191,6 +196,7 @@ func acceptCmd() *cobra.Command {
 
 type OrgStatus struct {
 	State      string
+	Role       string
 	StatusCode int
 }
 
@@ -199,6 +205,7 @@ func checkOrgStatus(client githubapi.Client, org string) (OrgStatus, error) {
 	path := fmt.Sprintf("user/memberships/orgs/%s", url.PathEscape(org))
 	var resp struct {
 		State string `json:"state"`
+		Role  string `json:"role"`
 	}
 	if err := client.Get(path, &resp); err != nil {
 		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok {
@@ -212,6 +219,7 @@ func checkOrgStatus(client githubapi.Client, org string) (OrgStatus, error) {
 
 	return OrgStatus{
 		State:      resp.State,
+		Role:       resp.Role,
 		StatusCode: http.StatusOK,
 	}, nil
 }
@@ -262,7 +270,7 @@ func assertModeCoherentForCreate(assignment, mode string, maxGroupSize int) erro
 	return nil
 }
 
-func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out io.Writer, org, classroom, assignment, secret string) error {
+func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out io.Writer, org, classroom, assignment, secret string, isOwner bool) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	// The acceptor owns the repo, so capture their immutable id and the
@@ -399,6 +407,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 		fullName:       fullName,
 		htmlURL:        htmlURL,
 		alreadyExisted: alreadyExisted,
+		isOwner:        isOwner,
 		createSp:       createSp,
 		createMsg:      createMsg,
 	})
@@ -420,8 +429,11 @@ type acceptRepoParams struct {
 	shim, autograderName       string
 	fullName, htmlURL          string
 	alreadyExisted             bool
-	createSp                   *ghui.Spinner
-	createMsg                  string
+	// isOwner tolerates an org owner's unavoidable residual admin at the
+	// founder read-back (they can't self-downgrade to push).
+	isOwner   bool
+	createSp  *ghui.Spinner
+	createMsg string
 }
 
 // acceptIntoRepo decides whether a just-created-or-existing repo needs
@@ -444,7 +456,7 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			// Already accepted: reconcile the role best-effort. The repo is
 			// already healthy, so a transient/SSO-403/left-org failure must not
 			// fail a re-run that previously always succeeded — warn and report.
-			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode)); err != nil && verbose {
+			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode), p.isOwner); err != nil && verbose {
 				u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 			}
 			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
@@ -506,7 +518,7 @@ func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p ac
 	// Individual founders get least-privilege `push` (enough to push and
 	// trigger autograding); group founders get `admin` (needed to manage
 	// collaborators for `gh student invite`). See founderPermission.
-	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode)); err != nil {
+	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode), p.isOwner); err != nil {
 		return err
 	}
 
@@ -843,13 +855,14 @@ func founderPermission(mode string) string {
 
 // inviteFounder sets username's collaborator role and verifies it took effect.
 // A repo creator holds admin, so an individual self-downgrade GitHub silently
-// ignores would otherwise look identical to success.
-func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string) error {
+// ignores would otherwise look identical to success. isOwner tolerates an
+// org owner's unavoidable residual admin (admin already covers push).
+func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string, isOwner bool) error {
 	if _, err := githubapi.SetCollaborator(client, org, repoName, username, permission); err != nil {
 		return err
 	}
 
-	if err := verifyFounderPermission(client, org, repoName, username, permission); err != nil {
+	if err := verifyFounderPermission(client, org, repoName, username, permission, isOwner); err != nil {
 		return err
 	}
 
@@ -863,7 +876,7 @@ func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, or
 // verifyFounderPermission reads the effective permission back and errors if it
 // doesn't match the role we set (permissionSatisfies handles GitHub's legacy
 // role collapse), so a silently-ignored downgrade fails loud instead.
-func verifyFounderPermission(client githubapi.Client, org, repoName, username, want string) error {
+func verifyFounderPermission(client githubapi.Client, org, repoName, username, want string, isOwner bool) error {
 	path := fmt.Sprintf("repos/%s/%s/collaborators/%s/permission",
 		url.PathEscape(org), url.PathEscape(repoName), url.PathEscape(username))
 	var got struct {
@@ -873,7 +886,7 @@ func verifyFounderPermission(client githubapi.Client, org, repoName, username, w
 	if err := client.Get(path, &got); err != nil {
 		return fmt.Errorf("verifying %s's permission on %s/%s: %w", username, org, repoName, err)
 	}
-	if permissionSatisfies(got.Permission, got.RoleName, want) {
+	if permissionSatisfies(got.Permission, got.RoleName, want, isOwner) {
 		return nil
 	}
 	return fmt.Errorf("expected %s to have %q access on %s/%s after setup, but GitHub reports %q (role %q) — a repo creator holds admin and a self-downgrade may be blocked by org policy; ask your instructor to set your access to %q",
@@ -883,13 +896,18 @@ func verifyFounderPermission(client githubapi.Client, org, repoName, username, w
 // permissionSatisfies reports whether the read-back matches the role we set.
 // role_name is authoritative when present: a push target accepts push/write
 // but must reject the more-privileged maintain/admin, which the legacy field
-// would otherwise hide (GitHub collapses maintain→write, admin→admin).
-func permissionSatisfies(legacy, roleName, want string) bool {
+// would otherwise hide (GitHub collapses maintain→write, admin→admin). isOwner
+// relaxes a push want to also accept admin: an org owner who created the repo
+// can't self-downgrade, and admin is a superset of push.
+func permissionSatisfies(legacy, roleName, want string, isOwner bool) bool {
 	if roleName != "" {
 		switch want {
 		case "admin":
 			return roleName == "admin"
 		case "push":
+			if isOwner && roleName == "admin" {
+				return true
+			}
 			return roleName == "push" || roleName == "write"
 		default:
 			return roleName == want
@@ -899,6 +917,9 @@ func permissionSatisfies(legacy, roleName, want string) bool {
 	case "admin":
 		return legacy == "admin"
 	case "push":
+		if isOwner && legacy == "admin" {
+			return true
+		}
 		return legacy == "write"
 	default:
 		return legacy == want

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -70,6 +70,52 @@ func TestAssertModeCoherentForCreate(t *testing.T) {
 	}
 }
 
+// TestCheckOrgStatus pins the wire -> OrgStatus decode that is the sole source
+// of isOwner: an "admin" role must surface so an org owner is tolerated at the
+// founder read-back, and a 404 must degrade to a StatusCode-only result.
+func TestCheckOrgStatus(t *testing.T) {
+	const org = "cs50"
+	cases := []struct {
+		name       string
+		status     int
+		body       string
+		wantState  string
+		wantRole   string
+		wantStatus int
+	}{
+		{"active owner", http.StatusOK, `{"state":"active","role":"admin"}`, "active", "admin", http.StatusOK},
+		{"active member", http.StatusOK, `{"state":"active","role":"member"}`, "active", "member", http.StatusOK},
+		{"pending owner keeps role", http.StatusOK, `{"state":"pending","role":"admin"}`, "pending", "admin", http.StatusOK},
+		{"not a member", http.StatusNotFound, `{}`, "", "", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/user/memberships/orgs/"+org, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			})
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+			client := newTestRESTClient(t, server)
+
+			got, err := checkOrgStatus(client, org)
+			if err != nil {
+				t.Fatalf("checkOrgStatus returned error: %v", err)
+			}
+			if got.State != tc.wantState {
+				t.Errorf("State = %q, want %q", got.State, tc.wantState)
+			}
+			if got.Role != tc.wantRole {
+				t.Errorf("Role = %q, want %q", got.Role, tc.wantRole)
+			}
+			if got.StatusCode != tc.wantStatus {
+				t.Errorf("StatusCode = %d, want %d", got.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}
+
 // TestPermissionSatisfies pins the read-back decision, incl. the guard's
 // boundary: a `maintain` founder (legacy collapses to "write") must FAIL a
 // `push` target, so an ignored self-downgrade isn't passed green. isOwner
@@ -96,6 +142,7 @@ func TestPermissionSatisfies(t *testing.T) {
 		{"owner admin satisfies a push target", "admin", "admin", "push", true, true},
 		{"owner admin (legacy only) satisfies a push target", "admin", "", "push", true, true},
 		{"owner still fails a maintain push target", "write", "maintain", "push", true, false},
+		{"owner does not leak into an admin target", "write", "maintain", "admin", true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -72,30 +72,35 @@ func TestAssertModeCoherentForCreate(t *testing.T) {
 
 // TestPermissionSatisfies pins the read-back decision, incl. the guard's
 // boundary: a `maintain` founder (legacy collapses to "write") must FAIL a
-// `push` target, so an ignored self-downgrade isn't passed green.
+// `push` target, so an ignored self-downgrade isn't passed green. isOwner
+// relaxes a push target to accept the org owner's unavoidable residual admin.
 func TestPermissionSatisfies(t *testing.T) {
 	cases := []struct {
 		name     string
 		legacy   string
 		roleName string
 		want     string
+		isOwner  bool
 		ok       bool
 	}{
-		{"push grant reads role_name push", "write", "push", "push", true},
-		{"push grant reads role_name write", "write", "write", "push", true},
-		{"maintain must fail a push target", "write", "maintain", "push", false},
-		{"admin must fail a push target", "admin", "admin", "push", false},
-		{"read must fail a push target", "read", "read", "push", false},
-		{"admin grant reads role_name admin", "admin", "admin", "admin", true},
-		{"push must fail an admin target", "write", "push", "admin", false},
-		{"empty role_name falls back to legacy write for push", "write", "", "push", true},
-		{"empty role_name falls back to legacy admin for admin", "admin", "", "admin", true},
-		{"empty role_name legacy write must fail admin", "write", "", "admin", false},
+		{"push grant reads role_name push", "write", "push", "push", false, true},
+		{"push grant reads role_name write", "write", "write", "push", false, true},
+		{"maintain must fail a push target", "write", "maintain", "push", false, false},
+		{"admin must fail a push target", "admin", "admin", "push", false, false},
+		{"read must fail a push target", "read", "read", "push", false, false},
+		{"admin grant reads role_name admin", "admin", "admin", "admin", false, true},
+		{"push must fail an admin target", "write", "push", "admin", false, false},
+		{"empty role_name falls back to legacy write for push", "write", "", "push", false, true},
+		{"empty role_name falls back to legacy admin for admin", "admin", "", "admin", false, true},
+		{"empty role_name legacy write must fail admin", "write", "", "admin", false, false},
+		{"owner admin satisfies a push target", "admin", "admin", "push", true, true},
+		{"owner admin (legacy only) satisfies a push target", "admin", "", "push", true, true},
+		{"owner still fails a maintain push target", "write", "maintain", "push", true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := permissionSatisfies(tc.legacy, tc.roleName, tc.want); got != tc.ok {
-				t.Errorf("permissionSatisfies(%q,%q,%q) = %v, want %v", tc.legacy, tc.roleName, tc.want, got, tc.ok)
+			if got := permissionSatisfies(tc.legacy, tc.roleName, tc.want, tc.isOwner); got != tc.ok {
+				t.Errorf("permissionSatisfies(%q,%q,%q,%v) = %v, want %v", tc.legacy, tc.roleName, tc.want, tc.isOwner, got, tc.ok)
 			}
 		})
 	}
@@ -164,7 +169,7 @@ func TestInviteFounder(t *testing.T) {
 			client := newTestRESTClient(t, server)
 
 			var out bytes.Buffer
-			if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, tc.want); err != nil {
+			if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, tc.want, false); err != nil {
 				t.Fatalf("inviteFounder returned error: %v", err)
 			}
 
@@ -205,11 +210,40 @@ func TestInviteFounder_VerificationFails(t *testing.T) {
 	client := newTestRESTClient(t, server)
 
 	var out bytes.Buffer
-	err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "push")
+	err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "push", false)
 	if err == nil {
 		t.Fatalf("expected an error when the effective permission stays admin after a push grant, got nil")
 	}
 	if !strings.Contains(err.Error(), "push") || !strings.Contains(err.Error(), "admin") {
 		t.Errorf("error should name the wanted (push) and actual (admin) roles, got: %v", err)
+	}
+}
+
+// TestInviteFounder_OwnerTolerated proves an org owner can accept: the
+// self-downgrade to push is silently ignored (owner keeps admin), but with
+// isOwner set the read-back tolerates that residual admin instead of failing.
+func TestInviteFounder_OwnerTolerated(t *testing.T) {
+	const (
+		org      = "cs50"
+		repoName = "cs50-fall-2026-hello-alice"
+		username = "alice"
+	)
+	collabPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(collabPath+"/permission", func(w http.ResponseWriter, _ *http.Request) {
+		// Owner can't self-downgrade; GitHub still reports admin.
+		_ = json.NewEncoder(w).Encode(map[string]any{"permission": "admin", "role_name": "admin"})
+	})
+	mux.HandleFunc(collabPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := newTestRESTClient(t, server)
+
+	var out bytes.Buffer
+	if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "push", true); err != nil {
+		t.Fatalf("owner push grant reading back as admin should be tolerated, got: %v", err)
 	}
 }

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1227,6 +1227,10 @@ describe("permissionSatisfies — verified founder demotion", () => {
   it("still rejects a maintain read-back for a push target even for an owner", () => {
     expect(permissionSatisfies("write", "maintain", "push", true)).toBe(false)
   })
+
+  it("does not let isOwner leak into an admin target", () => {
+    expect(permissionSatisfies("write", "maintain", "admin", true)).toBe(false)
+  })
 })
 
 // Drives addFounderCollaborator end-to-end (PUT grant -> read-back -> throw),

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1218,6 +1218,15 @@ describe("permissionSatisfies — verified founder demotion", () => {
   it("rejects an under-grant (read only) for a push target", () => {
     expect(permissionSatisfies("read", "read", "push")).toBe(false)
   })
+
+  it("tolerates an owner's unavoidable admin for a push target when isOwner", () => {
+    expect(permissionSatisfies("admin", "admin", "push", true)).toBe(true)
+    expect(permissionSatisfies("admin", undefined, "push", true)).toBe(true)
+  })
+
+  it("still rejects a maintain read-back for a push target even for an owner", () => {
+    expect(permissionSatisfies("write", "maintain", "push", true)).toBe(false)
+  })
 })
 
 // Drives addFounderCollaborator end-to-end (PUT grant -> read-back -> throw),
@@ -1309,6 +1318,27 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         permission: "push",
       }),
     ).rejects.toThrow(/"push"/)
+  })
+
+  it("resolves for an org owner whose read-back stays admin after a push grant", async () => {
+    const { client, request } = makeClient({
+      permission: "admin",
+      role_name: "admin",
+    })
+    await expect(
+      addFounderCollaborator({
+        client,
+        owner,
+        repo,
+        username,
+        permission: "push",
+        isOwner: true,
+      }),
+    ).resolves.toBeUndefined()
+    expect(request).toHaveBeenCalledWith(collabPath, {
+      method: "PUT",
+      body: { permission: "push" },
+    })
   })
 })
 

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -1737,15 +1737,18 @@ export async function deleteAssignment(
 
 // Grant the founder their repo role and verify it took: a repo creator holds
 // admin, so an individual self-downgrade GitHub silently ignores looks like
-// success. CLI-aligned with inviteFounder in gh-student's accept.go.
+// success. isOwner tolerates an unavoidable residual admin (an org owner can't
+// self-downgrade), since admin already covers push. CLI-aligned with
+// inviteFounder in gh-student's accept.go.
 export async function addFounderCollaborator(params: {
   client: GitHubClient
   owner: string
   repo: string
   username: string
   permission: "push" | "admin"
+  isOwner?: boolean
 }) {
-  const { client, owner, repo, username, permission } = params
+  const { client, owner, repo, username, permission, isOwner = false } = params
 
   await client.request(`/repos/${owner}/${repo}/collaborators/${username}`, {
     method: "PUT",
@@ -1762,7 +1765,12 @@ export async function addFounderCollaborator(params: {
   })
 
   if (
-    !permissionSatisfies(effective.permission, effective.role_name, permission)
+    !permissionSatisfies(
+      effective.permission,
+      effective.role_name,
+      permission,
+      isOwner,
+    )
   ) {
     throw new Error(
       `Expected ${username} to have "${permission}" access on ${owner}/${repo}, but GitHub reports "${effective.permission}" (role "${effective.role_name}") — a repo creator holds admin and a self-downgrade may be blocked by org policy. Ask your instructor to set your access to "${permission}".`,
@@ -1773,17 +1781,23 @@ export async function addFounderCollaborator(params: {
 // Whether the read-back matches the role we set. role_name is authoritative
 // when present: a push target accepts push/write but must reject the
 // more-privileged maintain/admin the legacy field would hide (GitHub collapses
-// maintain->write, admin->admin). Mirrors gh-student's permissionSatisfies.
+// maintain->write, admin->admin). isOwner relaxes a push want to also accept
+// admin: an org owner who created the repo can't self-downgrade (org policy
+// blocks it), and admin is a superset of push. Mirrors gh-student's
+// permissionSatisfies.
 export function permissionSatisfies(
   legacy: string | undefined,
   roleName: string | undefined,
   want: "push" | "admin",
+  isOwner = false,
 ): boolean {
   if (roleName) {
     if (want === "admin") return roleName === "admin"
+    if (isOwner && roleName === "admin") return true
     return roleName === "push" || roleName === "write"
   }
   if (want === "admin") return legacy === "admin"
+  if (isOwner && legacy === "admin") return true
   return legacy === "write"
 }
 
@@ -2040,6 +2054,7 @@ async function provisionAcceptedRepo(params: {
   branch: string
   metadataYaml: string
   autogradeYaml: string
+  isOwner?: boolean
   rerenderShimForBranch?: (branch: string) => string
   onStepUpdate?: OnAcceptStepUpdate
 }) {
@@ -2052,6 +2067,7 @@ async function provisionAcceptedRepo(params: {
     branch,
     metadataYaml,
     autogradeYaml,
+    isOwner = false,
     rerenderShimForBranch,
     onStepUpdate,
   } = params
@@ -2072,6 +2088,7 @@ async function provisionAcceptedRepo(params: {
         repo: repo.name,
         username,
         permission: founderPermission(mode),
+        isOwner,
       })
     },
   )
@@ -2134,7 +2151,7 @@ export async function acceptAssignment(params: {
   // can't create their repo). Verifying here means a SAML-SSO-gated 403 surfaces
   // as an actionable step failure right away (with the SSO/HTTP status) instead
   // of a confusing downstream repo/access failure.
-  await withAcceptStep(
+  const membership = await withAcceptStep(
     {
       id: "membership",
       label: "Confirming your classroom membership",
@@ -2145,6 +2162,11 @@ export async function acceptAssignment(params: {
     },
     () => acceptAndVerifyOrgMembership(client, org),
   )
+
+  // An org owner who creates the repo holds admin and can't self-downgrade to
+  // the push we grant (org policy blocks it); tolerate that residual admin at
+  // the founder read-back so an owner can still accept.
+  const isOwner = membership.role === "admin"
 
   const assignment = await withAcceptStep(
     {
@@ -2292,6 +2314,7 @@ export async function acceptAssignment(params: {
           repo: created.repo.name,
           username,
           permission: founderPermission(assignment.mode),
+          isOwner,
         })
       } catch (err) {
         log.debug("accept: best-effort role reconcile failed (non-fatal)", {
@@ -2337,6 +2360,7 @@ export async function acceptAssignment(params: {
       branch: created.repo.default_branch || sourceBranch,
       metadataYaml,
       autogradeYaml,
+      isOwner,
       rerenderShimForBranch: rerenderShim,
       onStepUpdate,
     })
@@ -2372,6 +2396,7 @@ export async function acceptAssignment(params: {
     branch: targetBranch,
     metadataYaml,
     autogradeYaml,
+    isOwner,
     rerenderShimForBranch: rerenderShim,
     onStepUpdate,
   })

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -71,6 +71,7 @@ import {
 } from "@/github-core/queries"
 import { getAuthenticatedUser } from "./queries/users"
 import { acceptAndVerifyOrgMembership } from "./users"
+import { isOwnerGitHubOrgRole } from "@/authz"
 import {
   TemplateAccessError,
   inOrgTemplateError,
@@ -2166,7 +2167,7 @@ export async function acceptAssignment(params: {
   // An org owner who creates the repo holds admin and can't self-downgrade to
   // the push we grant (org policy blocks it); tolerate that residual admin at
   // the founder read-back so an owner can still accept.
-  const isOwner = membership.role === "admin"
+  const isOwner = isOwnerGitHubOrgRole(membership.role)
 
   const assignment = await withAcceptStep(
     {


### PR DESCRIPTION
## Problem

An org owner accepting an individual assignment hit a hard failure on the **access** step:

> Expected rongxin-liu to have "push" access on rongxin-test/test-test-rongxin-liu, but GitHub reports "admin" (role "admin") — a repo creator holds admin and a self-downgrade may be blocked by org policy. Ask your instructor to set your access to "push".

Accept grants the founder least-privilege `push`, then reads the permission back and rejects anything more privileged. When the accepting user is an **org owner**, they created the repo and hold `admin`; GitHub/org policy silently ignores their self-downgrade to `push`, so the read-back stays `admin` and the verification throws. Regular students should still fail this check (a genuine mis-grant), so the guard can't just be loosened globally.

## Fix

Thread an `isOwner` signal (org-membership `role === "admin"`) down to the founder read-back. When the accepting user is the org owner, an `admin` read-back satisfies a `push` grant (admin ⊇ push). Everyone else keeps the strict least-privilege guard. The grant itself is unchanged — still `push`; only the verification tolerates the owner's unavoidable residual admin.

Kept web + `gh-student` CLI in parity:

- **web** (`web/src/domain/assignments.ts`): `permissionSatisfies` gains an `isOwner` param; `addFounderCollaborator` and `provisionAcceptedRepo` thread it through; `acceptAssignment` derives `isOwner` from the membership already returned by `acceptAndVerifyOrgMembership` (no extra request) and passes it to all three founder-grant call sites.
- **cli** (`cli/gh-student/accept.go`): `permissionSatisfies` / `verifyFounderPermission` / `inviteFounder` mirror the tolerance; `checkOrgStatus` decodes `role` and `isOwner` flows through `acceptRepoParams`.
- **tests**: owner-tolerant cases added (and the student-strict cases kept) in both `assignments.test.ts` and `accept_test.go`.

## Verification

- web: `tsc -b` clean, `vitest` domain suite 77/77, eslint + prettier clean on touched files.
- cli: `go build ./...`, `go test ./...` all pass, `gofmt -l` clean, `go vet ./...` clean.