### PR TITLE
feat: grant TA staff team read on templates at setup, not only at collect-scores

### DIFF
--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -642,7 +642,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	// students can generate from it. Idempotent. The team slug comes from
 	// classroom.json; a classroom with no team gets an actionable message.
 	if resolved != nil && templatePrivate && inOrg {
-		if err := grantClassroomTeamTemplateRead(client, out, org, classroom, branch, slug, resolved.Owner, resolved.Repo,
+		if err := grantClassroomTeamTemplateRead(client, out, errOut, org, classroom, branch, slug, resolved.Owner, resolved.Repo,
 			grantContext{verb: "committed", classroomNoun: "classroom", rerunHint: ", then re-run `gh teacher assignment add`"}); err != nil {
 			return err
 		}

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -341,8 +341,8 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 // grantStaffTeamTemplateRead best-effort grants the classroom's TA staff team
 // read on a private, org-owned template. Non-blocking by design (see
 // grantClassroomTeamTemplateRead): a missing TA team is a clean skip and a
-// grant failure only warns. The permission is gated on StaffTeamRepoPermissions
-// so setup-time and collect-scores grants can't diverge.
+// grant failure only warns. StaffTeamRepoPermissions is a presence gate here —
+// the TA team is granted read (GrantTeamRepoRead) only when the role is mapped.
 func grantStaffTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, tmplOwner, tmplRepo string) {
 	if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; !ok {
 		return

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -339,10 +339,9 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 }
 
 // grantStaffTeamTemplateRead best-effort grants the classroom's TA staff team
-// read on a private, org-owned template. Non-blocking by design (see
-// grantClassroomTeamTemplateRead): a missing TA team is a clean skip and a
-// grant failure only warns. StaffTeamRepoPermissions is a presence gate here —
-// the TA team is granted read (GrantTeamRepoRead) only when the role is mapped.
+// read on a private, org-owned template (see grantClassroomTeamTemplateRead for
+// the non-blocking rationale). StaffTeamRepoPermissions is a presence gate here:
+// grant the TA team read only when the role is mapped.
 func grantStaffTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, tmplOwner, tmplRepo string) {
 	if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; !ok {
 		return

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -297,7 +297,7 @@ func grantReusedTemplateAccess(client githubapi.Client, out, errOut io.Writer, o
 			slug, tmpl.Owner, tmpl.Repo, classroom, org)
 		return nil
 	}
-	return grantClassroomTeamTemplateRead(client, out, org, classroom, branch, slug, tmpl.Owner, tmpl.Repo, grantContext{verb: "reused", classroomNoun: "target classroom"})
+	return grantClassroomTeamTemplateRead(client, out, errOut, org, classroom, branch, slug, tmpl.Owner, tmpl.Repo, grantContext{verb: "reused", classroomNoun: "target classroom"})
 }
 
 // grantContext carries per-caller wording for grantClassroomTeamTemplateRead's
@@ -312,7 +312,13 @@ type grantContext struct {
 // grants it read on a private, org-owned template (idempotent). Shared by add
 // and reuse; the caller decides WHEN and supplies the wording. A classroom with
 // no team yields an actionable error, not a 404 on a guessed slug.
-func grantClassroomTeamTemplateRead(client githubapi.Client, out io.Writer, org, classroom, branch, slug, tmplOwner, tmplRepo string, ctx grantContext) error {
+//
+// After the student grant it best-effort grants the classroom's TA staff team
+// the same read, so a base-permission-`none` TA (an org member on the TA team)
+// can read the private template without waiting for a collect-scores run. That
+// grant is non-blocking: its failure warns to errOut but never fails an
+// operation that already succeeded for students (collect-scores re-affirms it).
+func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, slug, tmplOwner, tmplRepo string, ctx grantContext) error {
 	team, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
 		return fmt.Errorf("assignment %s, but reading the %s team failed: %w", ctx.verb, ctx.classroomNoun, err)
@@ -328,7 +334,35 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out io.Writer, org,
 	if granted {
 		_, _ = fmt.Fprintf(out, "%s: granted classroom team %s read on private template %s/%s\n", org, team.Slug, tmplOwner, tmplRepo)
 	}
+	grantStaffTeamTemplateRead(client, out, errOut, org, classroom, branch, tmplOwner, tmplRepo)
 	return nil
+}
+
+// grantStaffTeamTemplateRead best-effort grants the classroom's TA staff team
+// read on a private, org-owned template. Non-blocking by design (see
+// grantClassroomTeamTemplateRead): a missing TA team is a clean skip and a
+// grant failure only warns. The permission is gated on StaffTeamRepoPermissions
+// so setup-time and collect-scores grants can't diverge.
+func grantStaffTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, tmplOwner, tmplRepo string) {
+	if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; !ok {
+		return
+	}
+	taTeam, ok, err := configrepo.ResolveClassroomStaffTeam(client, org, classroom, branch, configrepo.RoleTA)
+	if err != nil {
+		_, _ = fmt.Fprintf(errOut, "Warning: could not read the TA staff team to grant read on private template %s/%s (%v); TAs get read at the next collect-scores run.\n", tmplOwner, tmplRepo, err)
+		return
+	}
+	if !ok {
+		return // no TA team recorded (older classroom) — clean skip
+	}
+	granted, err := configrepo.GrantTeamRepoRead(client, org, taTeam.Slug, tmplOwner, tmplRepo)
+	if err != nil {
+		_, _ = fmt.Fprintf(errOut, "Warning: could not grant TA staff team %s read on private template %s/%s (%v); TAs get read at the next collect-scores run.\n", taTeam.Slug, tmplOwner, tmplRepo, err)
+		return
+	}
+	if granted {
+		_, _ = fmt.Fprintf(out, "%s: granted TA staff team %s read on private template %s/%s\n", org, taTeam.Slug, tmplOwner, tmplRepo)
+	}
 }
 
 // templateVisibility probes a template repo for the reuse grant decision:

--- a/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
@@ -24,6 +24,8 @@ type reuseFixture struct {
 	treePath  string
 	// grantedRepo records a PUT classroom-team repo grant target, if any.
 	grantedRepo string
+	// grantedTATeam records a PUT TA-staff-team repo grant target, if any.
+	grantedTATeam string
 }
 
 // reuseServerConfig parameterizes the mock: the source/target classroom
@@ -45,6 +47,10 @@ type reuseServerConfig struct {
 	// template branch (warn, no grant). The source assignments body must
 	// reference the same owner.
 	templateOwner string
+	// taGrantStatus overrides the TA-staff-team grant PUT response; 0 =>
+	// the default 204 (success). Set to e.g. 500 to exercise the TA-grant
+	// failure path (which must warn, not fail the reuse).
+	taGrantStatus int
 }
 
 func newReuseServer(t *testing.T, cfg reuseServerConfig) (*httptest.Server, *reuseFixture) {
@@ -103,6 +109,24 @@ func newReuseServer(t *testing.T, cfg reuseServerConfig) (*httptest.Server, *reu
 			}
 			fix.mu.Lock()
 			fix.grantedRepo = "o/hello-template"
+			fix.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	// TA-staff-team grant: GET probe + PUT grant. Fires only when the target
+	// classroom.json records a `teams.ta` block (older classrooms skip it).
+	mux.HandleFunc("/orgs/o/teams/classroom50-dst-ta/repos/o/hello-template", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPut:
+			if cfg.taGrantStatus != 0 {
+				w.WriteHeader(cfg.taGrantStatus)
+				return
+			}
+			fix.mu.Lock()
+			fix.grantedTATeam = "o/hello-template"
 			fix.mu.Unlock()
 			w.WriteHeader(http.StatusNoContent)
 		}
@@ -195,6 +219,25 @@ func targetClassroomBody(active *bool) string {
 	}
 	if active != nil {
 		doc["active"] = *active
+	}
+	b, _ := json.Marshal(doc)
+	return string(b)
+}
+
+// targetClassroomBodyWithTA is targetClassroomBody plus a recorded TA staff
+// team, so the reuse grant path also grants the TA team read on a private
+// in-org template.
+func targetClassroomBodyWithTA() string {
+	doc := map[string]any{
+		"schema":     "classroom50/classroom/v1",
+		"name":       "Dst",
+		"short_name": "dst",
+		"term":       "",
+		"org":        "o",
+		"team":       map[string]any{"id": 7, "slug": "classroom50-dst"},
+		"teams": map[string]any{
+			"ta": map[string]any{"id": 9, "slug": "classroom50-dst-ta"},
+		},
 	}
 	b, _ := json.Marshal(doc)
 	return string(b)
@@ -633,5 +676,87 @@ func TestRunAssignmentReuse_InPlaceWithSlug(t *testing.T) {
 	file := decodeReuse(t, fix)
 	if _, ok := assignment.FindAssignment(file.Assignments, "hello-redux"); !ok {
 		t.Errorf("expected in-place copy under hello-redux, got %d entries", len(file.Assignments))
+	}
+}
+
+// TestRunAssignmentReuse_GrantsTATeam: when the target classroom records a TA
+// staff team, a private in-org template grants both the student team and the
+// TA team read.
+func TestRunAssignmentReuse_GrantsTATeam(t *testing.T) {
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceAssignmentsBody(),
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBodyWithTA(),
+		templatePrivate:   true,
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	if err := runAssignmentReuse(client, &out, &errOut, baseReuseParams()); err != nil {
+		t.Fatalf("runAssignmentReuse: %v", err)
+	}
+	fix.mu.Lock()
+	student, ta := fix.grantedRepo, fix.grantedTATeam
+	fix.mu.Unlock()
+	if student != "o/hello-template" {
+		t.Errorf("student team grant = %q, want o/hello-template", student)
+	}
+	if ta != "o/hello-template" {
+		t.Errorf("TA team grant = %q, want o/hello-template", ta)
+	}
+}
+
+// TestRunAssignmentReuse_NoTATeamSkips: a classroom with no recorded TA team
+// (older classroom) grants only the student team; no TA grant fires and no
+// error surfaces.
+func TestRunAssignmentReuse_NoTATeamSkips(t *testing.T) {
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceAssignmentsBody(),
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBody(nil), // no teams.ta
+		templatePrivate:   true,
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	if err := runAssignmentReuse(client, &out, &errOut, baseReuseParams()); err != nil {
+		t.Fatalf("runAssignmentReuse: %v", err)
+	}
+	fix.mu.Lock()
+	student, ta := fix.grantedRepo, fix.grantedTATeam
+	fix.mu.Unlock()
+	if student != "o/hello-template" {
+		t.Errorf("student team grant = %q, want o/hello-template", student)
+	}
+	if ta != "" {
+		t.Errorf("no TA grant expected, got %q", ta)
+	}
+}
+
+// TestRunAssignmentReuse_TAGrantFailureIsNonFatal: when the student grant
+// succeeds but the TA grant PUT fails, the reuse still succeeds (student
+// success stands) and a warning is emitted to stderr.
+func TestRunAssignmentReuse_TAGrantFailureIsNonFatal(t *testing.T) {
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceAssignmentsBody(),
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBodyWithTA(),
+		templatePrivate:   true,
+		taGrantStatus:     http.StatusInternalServerError,
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	if err := runAssignmentReuse(client, &out, &errOut, baseReuseParams()); err != nil {
+		t.Fatalf("runAssignmentReuse should not fail on a TA-grant error, got %v", err)
+	}
+	fix.mu.Lock()
+	student := fix.grantedRepo
+	fix.mu.Unlock()
+	if student != "o/hello-template" {
+		t.Errorf("student team grant = %q, want o/hello-template", student)
+	}
+	if !strings.Contains(errOut.String(), "TA staff team") {
+		t.Errorf("expected a TA-grant warning on stderr, got %q", errOut.String())
 	}
 }

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -273,6 +273,17 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// the grant, `student accept` 404s generating from it. Gate on the TARGET
 	// repo's visibility, use the team's authoritative slug, and track failures
 	// so the exit code reflects a template students can't yet accept.
+	//
+	// The TA staff team gets the same read (best-effort) so a base-permission-
+	// `none` TA can read the template without waiting for collect-scores. The
+	// TA slug comes from the just-created staffTeams (classroom.json isn't
+	// committed until CommitTree above, so it can't be re-resolved here). A TA-
+	// grant failure only warns — it's not a student blocker, so it never adds to
+	// grantFailures or changes the exit code.
+	taSlug := ""
+	if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; ok && staffTeams != nil && staffTeams.TA != nil {
+		taSlug = staffTeams.TA.Slug
+	}
 	var grantFailures int
 	for i := range resolved {
 		rt := resolved[i]
@@ -289,6 +300,19 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 		if granted {
 			_, _ = fmt.Fprintf(out, "%s: granted classroom team %s read on private template %s/%s\n",
 				plan.TargetOrg, team.Slug, rt.Template.Owner, rt.Template.Repo)
+		}
+		if taSlug == "" {
+			continue
+		}
+		taGranted, taErr := configrepo.GrantTeamRepoRead(client, plan.TargetOrg, taSlug, rt.Template.Owner, rt.Template.Repo)
+		if taErr != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: %s: could not grant TA staff team %s read on private template %s/%s (%v); TAs get read at the next collect-scores run.\n",
+				plan.TargetOrg, taSlug, rt.Template.Owner, rt.Template.Repo, taErr)
+			continue
+		}
+		if taGranted {
+			_, _ = fmt.Fprintf(out, "%s: granted TA staff team %s read on private template %s/%s\n",
+				plan.TargetOrg, taSlug, rt.Template.Owner, rt.Template.Repo)
 		}
 	}
 

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -277,9 +277,11 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// The TA staff team gets the same read (best-effort) so a base-permission-
 	// `none` TA can read the template without waiting for collect-scores. The
 	// TA slug comes from the just-created staffTeams (classroom.json isn't
-	// committed until CommitTree above, so it can't be re-resolved here). A TA-
-	// grant failure only warns — it's not a student blocker, so it never adds to
-	// grantFailures or changes the exit code.
+	// committed until CommitTree above, so it can't be re-resolved here).
+	// StaffTeamRepoPermissions is a presence gate: grant the TA team read only
+	// when the role is mapped. A TA-grant failure only warns — it's not a
+	// student blocker, so it never adds to grantFailures or changes the exit
+	// code.
 	taSlug := ""
 	if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; ok && staffTeams != nil && staffTeams.TA != nil {
 		taSlug = staffTeams.TA.Slug

--- a/cli/gh-teacher/internal/classroom/migrate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_test.go
@@ -671,6 +671,8 @@ func (s *migrateE2EState) dispatch(t *testing.T, w http.ResponseWriter, r *http.
 		case http.MethodPut:
 			rest := strings.TrimPrefix(path, "/orgs/"+s.targetOrg()+"/teams/")
 			if slug, repoPath, ok := strings.Cut(rest, "/repos/"); ok && strings.HasSuffix(repoPath, "/readability") {
+				// The `-ta` suffix is how the mock tells the TA staff team's
+				// template grant from the student team's.
 				if s.failTAGrant && strings.HasSuffix(slug, "-ta") {
 					w.WriteHeader(http.StatusInternalServerError)
 					return

--- a/cli/gh-teacher/internal/classroom/migrate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_test.go
@@ -262,6 +262,11 @@ func TestRunMigrate_NonDryRun_HappyPath(t *testing.T) {
 	if got := state.templateGrants["classroom50-classroom50test-ta"]; got != "cs50-fall-2026/readability" {
 		t.Errorf("TA team template grant = %q, want cs50-fall-2026/readability", got)
 	}
+	// Only the TA staff team is eagerly granted (StaffTeamRepoPermissions gate);
+	// the instructor team must NOT get template read.
+	if got, ok := state.templateGrants["classroom50-classroom50test-instructor"]; ok {
+		t.Errorf("instructor team must not be granted template read, got %q", got)
+	}
 
 	// The creator is dropped from the students + TA teams (mixed roles aren't
 	// allowed) but NEVER the instructor team — the owner's only role.
@@ -277,6 +282,37 @@ func TestRunMigrate_NonDryRun_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "1 generated, 0 reused, 0 skipped") {
 		t.Errorf("stdout missing action counts:\n%s", stdout.String())
+	}
+}
+
+// TestRunMigrate_NonDryRun_TAGrantFailureIsNonFatal: when the student grant
+// succeeds but the TA staff-team grant PUT fails, migrate still succeeds
+// (student success stands) and only warns — the TA failure must never add to
+// grantFailures or flip the exit code. Mirrors the reuse/web non-blocking tests.
+func TestRunMigrate_NonDryRun_TAGrantFailureIsNonFatal(t *testing.T) {
+	state := newMigrateE2EState(realExportClassroom(), []classroomAssignmentDetail{realExportReadabilityAssignment()})
+	state.failTAGrant = true
+	server := httptest.NewServer(state.handler(t))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := runMigrate(githubtest.NewTestClient(t, server), &stdout, &stderr, migrateOptions{
+		Source: "95884",
+		Target: "cs50-fall-2026",
+		DryRun: false,
+	})
+	if err != nil {
+		t.Fatalf("runMigrate must not fail on a TA-grant error: %v\nstderr:\n%s", err, stderr.String())
+	}
+	// Student grant still landed; migration completed.
+	if got := state.templateGrants["classroom50-classroom50test"]; got != "cs50-fall-2026/readability" {
+		t.Errorf("student team grant = %q, want cs50-fall-2026/readability", got)
+	}
+	if state.commitsCreated != 1 {
+		t.Errorf("commits created = %d, want 1 (migration still completes)", state.commitsCreated)
+	}
+	if !strings.Contains(stderr.String(), "could not grant TA staff team") {
+		t.Errorf("expected a TA-grant warning on stderr, got:\n%s", stderr.String())
 	}
 }
 
@@ -407,6 +443,9 @@ type migrateE2EState struct {
 	// flip these before handing the state to httptest.
 	sourceIsTemplate map[string]bool // "owner/repo" → is_template (default true)
 	existingDirs     map[string]bool // <short-name> → already exists in target classroom50 (default false)
+	// failTAGrant, when true, makes the TA staff-team template-grant PUT return
+	// 500 so a test can assert the failure is non-blocking (warns, no exit change).
+	failTAGrant bool
 
 	// Captured side-effects.
 	generated         map[string]bool   // "owner/repo" → was generated
@@ -632,6 +671,10 @@ func (s *migrateE2EState) dispatch(t *testing.T, w http.ResponseWriter, r *http.
 		case http.MethodPut:
 			rest := strings.TrimPrefix(path, "/orgs/"+s.targetOrg()+"/teams/")
 			if slug, repoPath, ok := strings.Cut(rest, "/repos/"); ok && strings.HasSuffix(repoPath, "/readability") {
+				if s.failTAGrant && strings.HasSuffix(slug, "-ta") {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
 				s.templateGrants[slug] = repoPath
 			}
 			w.WriteHeader(http.StatusNoContent)

--- a/cli/gh-teacher/internal/classroom/migrate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_test.go
@@ -253,6 +253,16 @@ func TestRunMigrate_NonDryRun_HappyPath(t *testing.T) {
 		}
 	}
 
+	// The private migrated template grants read to BOTH the student classroom
+	// team and the TA staff team (eager grant at migrate, not only at
+	// collect-scores).
+	if got := state.templateGrants["classroom50-classroom50test"]; got != "cs50-fall-2026/readability" {
+		t.Errorf("student team template grant = %q, want cs50-fall-2026/readability", got)
+	}
+	if got := state.templateGrants["classroom50-classroom50test-ta"]; got != "cs50-fall-2026/readability" {
+		t.Errorf("TA team template grant = %q, want cs50-fall-2026/readability", got)
+	}
+
 	// The creator is dropped from the students + TA teams (mixed roles aren't
 	// allowed) but NEVER the instructor team — the owner's only role.
 	sort.Strings(state.membershipDeleted)
@@ -405,6 +415,9 @@ type migrateE2EState struct {
 	commitsCreated    int
 	teamsCreated      int      // count of POST /orgs/{org}/teams (students + staff)
 	membershipDeleted []string // slugs that received a DELETE .../memberships/{user}
+	// templateGrants records team-slug → repo grants (PUT .../teams/{slug}/repos/{owner}/{repo})
+	// so a test can assert which teams got read on a private migrated template.
+	templateGrants map[string]string
 
 	parentSHA     string
 	parentTreeSHA string
@@ -420,6 +433,7 @@ func newMigrateE2EState(classroom classroomDetail, assignments []classroomAssign
 		generated:        map[string]bool{},
 		markedAsTemplate: map[string]bool{},
 		uploadedFiles:    map[string]string{},
+		templateGrants:   map[string]string{},
 		parentSHA:        "parent-sha-1",
 		parentTreeSHA:    "parent-tree-1",
 		commitSHA:        "new-commit-sha",
@@ -595,6 +609,7 @@ func (s *migrateE2EState) dispatch(t *testing.T, w http.ResponseWriter, r *http.
 		case http.MethodGet:
 			w.WriteHeader(http.StatusNotFound)
 		case http.MethodPut:
+			s.templateGrants["classroom50-classroom50test"] = strings.TrimPrefix(path, "/orgs/"+s.targetOrg()+"/teams/classroom50-classroom50test/repos/")
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Errorf("unexpected method %s on %s", r.Method, path)
@@ -608,11 +623,17 @@ func (s *migrateE2EState) dispatch(t *testing.T, w http.ResponseWriter, r *http.
 
 	// Target-side: staff-team config-repo grant probe/PUT and membership
 	// PUT (add instructor maintainer). Both live under a staff-team slug.
+	// A staff-team grant on the private template repo (readability) is the
+	// eager TA-team template read; record it so a test can assert it fired.
 	case strings.HasPrefix(path, "/orgs/"+s.targetOrg()+"/teams/") && strings.Contains(path, "/repos/"):
 		switch r.Method {
 		case http.MethodGet:
 			w.WriteHeader(http.StatusNotFound)
 		case http.MethodPut:
+			rest := strings.TrimPrefix(path, "/orgs/"+s.targetOrg()+"/teams/")
+			if slug, repoPath, ok := strings.Cut(rest, "/repos/"); ok && strings.HasSuffix(repoPath, "/readability") {
+				s.templateGrants[slug] = repoPath
+			}
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Errorf("unexpected method %s on %s", r.Method, path)

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -50,15 +50,18 @@ const (
 // StaffRoles is every staff role, in a stable order (instructor first).
 var StaffRoles = []StaffRole{RoleInstructor, RoleTA}
 
-// StaffTeamRepoPermissions maps a staff role to the repo permission
-// collect-scores grants that role's team on each student assignment repo and on
-// private in-org templates. Source of truth for the collector's hand-mirrored
-// STAFF_TEAM_PERMISSIONS (collect_scores.py) — keep the two in lockstep.
+// StaffTeamRepoPermissions maps a staff role to the repo permission a staff
+// team gets on each student assignment repo and on private in-org templates.
+// The TA-team template read is applied at TWO points, both reading this map so
+// they can't diverge: eagerly at assignment add/reuse and classroom migrate
+// (see grantStaffTeamTemplateRead / migrate.go), and again as an idempotent
+// re-affirm at collect-scores. Source of truth for the collector's
+// hand-mirrored STAFF_TEAM_PERMISSIONS (collect_scores.py) — keep in lockstep.
 //
 // A role absent from this map is granted nothing (the instructor team already
-// gets its access at classroom setup, so only the TA team needs a collect-time
-// grant today). Adding a future head-TA write team is a one-line addition here
-// and in the mirror.
+// gets its access at classroom setup, so only the TA team needs a grant today).
+// Adding a future head-TA write team is a one-line addition here and in the
+// mirror.
 var StaffTeamRepoPermissions = map[StaffRole]string{
 	RoleTA: "pull",
 }

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -55,15 +55,15 @@ var StaffRoles = []StaffRole{RoleInstructor, RoleTA}
 // The TA-team template read is applied at TWO points: eagerly at assignment
 // add/reuse and classroom migrate (see grantStaffTeamTemplateRead / migrate.go),
 // and again as an idempotent re-affirm at collect-scores. The eager sites use
-// this map as a presence gate (grant only roles listed here); collect-scores
-// additionally reads the value. Source of truth for the collector's
+// this map only as a presence gate and hardcode read (GrantTeamRepoRead);
+// collect-scores reads the value. Source of truth for the collector's
 // hand-mirrored STAFF_TEAM_PERMISSIONS (collect_scores.py) — keep in lockstep.
 //
 // A role absent from this map is granted nothing (the instructor team already
 // gets its access at classroom setup, so only the TA team needs a grant today).
-// Adding a future head-TA write team is a one-line addition here and in the
-// mirror — but note the eager sites currently hardcode read (GrantTeamRepoRead);
-// a non-read staff permission would also need those sites to consume the value.
+// Adding a future non-read staff permission is a one-line addition here and in
+// the mirror, but would also need the eager sites to consume the value instead
+// of hardcoding read.
 var StaffTeamRepoPermissions = map[StaffRole]string{
 	RoleTA: "pull",
 }

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -52,16 +52,18 @@ var StaffRoles = []StaffRole{RoleInstructor, RoleTA}
 
 // StaffTeamRepoPermissions maps a staff role to the repo permission a staff
 // team gets on each student assignment repo and on private in-org templates.
-// The TA-team template read is applied at TWO points, both reading this map so
-// they can't diverge: eagerly at assignment add/reuse and classroom migrate
-// (see grantStaffTeamTemplateRead / migrate.go), and again as an idempotent
-// re-affirm at collect-scores. Source of truth for the collector's
+// The TA-team template read is applied at TWO points: eagerly at assignment
+// add/reuse and classroom migrate (see grantStaffTeamTemplateRead / migrate.go),
+// and again as an idempotent re-affirm at collect-scores. The eager sites use
+// this map as a presence gate (grant only roles listed here); collect-scores
+// additionally reads the value. Source of truth for the collector's
 // hand-mirrored STAFF_TEAM_PERMISSIONS (collect_scores.py) — keep in lockstep.
 //
 // A role absent from this map is granted nothing (the instructor team already
 // gets its access at classroom setup, so only the TA team needs a grant today).
 // Adding a future head-TA write team is a one-line addition here and in the
-// mirror.
+// mirror — but note the eager sites currently hardcode read (GrantTeamRepoRead);
+// a non-read staff permission would also need those sites to consume the value.
 var StaffTeamRepoPermissions = map[StaffRole]string{
 	RoleTA: "pull",
 }

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -71,10 +71,12 @@ RESULT_SCHEMA_V1 = "classroom50/result/v1"
 # (created by autograde-runner.yaml on push to the repo's default branch).
 SUBMIT_TAG_PREFIX = "submit/"
 
-# Repo permission the collect-time grant gives each staff role's team. Hand-
-# mirrored from Go StaffTeamRepoPermissions (source of truth; parity-tested) —
-# keep in lockstep. A role absent here gets nothing (the instructor team is
-# granted at classroom setup, so only TA needs a collect-time grant today).
+# Repo permission the grant gives each staff role's team. Hand-mirrored from Go
+# StaffTeamRepoPermissions (source of truth; parity-tested) — keep in lockstep.
+# The TA-team template read is granted eagerly at assignment add/reuse and
+# classroom migrate (Go side); this collect-time grant is the idempotent
+# re-affirm. A role absent here gets nothing (the instructor team is granted at
+# classroom setup, so only TA needs a grant today).
 STAFF_TEAM_PERMISSIONS = {"ta": "pull"}
 
 RFC3339_RE = re.compile(

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -74,9 +74,10 @@ SUBMIT_TAG_PREFIX = "submit/"
 # Repo permission the grant gives each staff role's team. Hand-mirrored from Go
 # StaffTeamRepoPermissions (source of truth; parity-tested) — keep in lockstep.
 # The TA-team template read is granted eagerly at assignment add/reuse and
-# classroom migrate (Go side); this collect-time grant is the idempotent
-# re-affirm. A role absent here gets nothing (the instructor team is granted at
-# classroom setup, so only TA needs a grant today).
+# classroom migrate (Go side, which hardcodes read there); this collect-time
+# grant reads the value below and is the idempotent re-affirm. A role absent
+# here gets nothing (the instructor team is granted at classroom setup, so only
+# TA needs a grant today).
 STAFF_TEAM_PERMISSIONS = {"ta": "pull"}
 
 RFC3339_RE = re.compile(

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -707,6 +707,159 @@ describe("editAssignment (preserved-entry integration)", () => {
   })
 })
 
+describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
+  const ORG = "cs50"
+  const CLASSROOM = "cs50"
+  const SLUG = "hw1"
+  const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64")
+
+  // Drives editAssignment down the in-org-private-template grant path and
+  // records every team-repo PUT so a test can assert which teams got read on
+  // the template. classroomJson controls the recorded team/teams block.
+  function makeGrantClient(opts: {
+    classroomJson: Record<string, unknown>
+    taGrantThrows?: boolean
+  }): { client: GitHubClient; grants: () => string[] } {
+    const grants: string[] = []
+    const tmplRepo = {
+      name: "tmpl-v2",
+      full_name: `${ORG}/tmpl-v2`,
+      private: true,
+      is_template: true,
+      default_branch: "main",
+    }
+    const assignmentsFile = {
+      schema: "classroom50/assignments/v1",
+      assignments: [
+        {
+          slug: SLUG,
+          name: "Homework 1",
+          mode: "individual",
+          autograder: "default",
+          feedback_pr: true,
+          template: { owner: ORG, repo: "tmpl", branch: "main" },
+        },
+      ],
+    }
+
+    const request = vi.fn(async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? "GET"
+      // Team-repo grant PUT: /orgs/{org}/teams/{slug}/repos/{owner}/{repo}
+      const grantMatch = url.match(/\/orgs\/[^/]+\/teams\/([^/]+)\/repos\//)
+      if (method === "PUT" && grantMatch) {
+        if (grantMatch[1].endsWith("-ta") && opts.taGrantThrows) {
+          throw new GitHubAPIError({
+            status: 500,
+            url,
+            message: "boom",
+            body: null,
+            rateLimit: {
+              limit: null,
+              remaining: null,
+              used: null,
+              reset: null,
+              resource: null,
+              retryAfter: null,
+            },
+          })
+        }
+        grants.push(grantMatch[1])
+        return {}
+      }
+      if (/\/repos\/[^/]+\/classroom50$/.test(url))
+        return { default_branch: "main" }
+      if (url.includes("/git/ref/heads/main")) return { object: { sha: "s" } }
+      if (url.includes("/git/commits/s")) return { tree: { sha: "t" } }
+      if (url.includes("/contents/cs50/assignments.json")) {
+        return {
+          type: "file",
+          encoding: "base64",
+          content: b64(JSON.stringify(assignmentsFile)),
+        }
+      }
+      if (url.includes(`/repos/${ORG}/tmpl-v2`)) return tmplRepo
+      if (url.endsWith("/git/trees")) return { sha: "newtree" }
+      if (url.endsWith("/git/commits")) return { sha: "newcommit" }
+      if (method === "PATCH" && url.includes("/git/refs/heads/main"))
+        return { object: { sha: "newcommit" } }
+      throw new Error(`unexpected request: ${method} ${url}`)
+    })
+
+    // getClassroomJson (requestRaw) returns the recorded team block; the
+    // archive guard reads the same body (active by default).
+    const requestRaw = vi.fn(async () => JSON.stringify(opts.classroomJson))
+
+    return {
+      client: { request, requestRaw } as unknown as GitHubClient,
+      grants: () => grants,
+    }
+  }
+
+  function editInput() {
+    return {
+      org: ORG,
+      classroom: CLASSROOM,
+      slug: SLUG,
+      name: "Homework 1",
+      description: "",
+      template_repo: "tmpl-v2",
+      due_date: "",
+      mode: "individual",
+      max_group_size: 0,
+      tests: [],
+    } as unknown as Parameters<typeof editAssignment>[1]
+  }
+
+  it("grants both the student team and the TA staff team on a private in-org template", async () => {
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+      },
+    })
+
+    const result = await editAssignment(client, editInput())
+
+    expect(result.templateGrantWarning).toBeUndefined()
+    expect(grants()).toEqual(["classroom50-cs50", "classroom50-cs50-ta"])
+  })
+
+  it("grants only the student team when no TA team is recorded", async () => {
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+      },
+    })
+
+    const result = await editAssignment(client, editInput())
+
+    expect(result.templateGrantWarning).toBeUndefined()
+    expect(grants()).toEqual(["classroom50-cs50"])
+  })
+
+  it("keeps the edit successful when the TA grant fails (non-blocking)", async () => {
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+      },
+      taGrantThrows: true,
+    })
+
+    const result = await editAssignment(client, editInput())
+
+    // Student grant landed; TA failure did not surface as a save warning.
+    expect(result.templateGrantWarning).toBeUndefined()
+    expect(grants()).toEqual(["classroom50-cs50"])
+  })
+})
+
 describe("copyAssignmentToClassroom (reuse fork guard)", () => {
   const ORG = "acme"
   const emptyRateLimit = {

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -927,9 +927,11 @@ async function grantTeamTemplateRead(
   template: NonNullable<Assignment["template"]>,
 ) {
   let teamSlug: string | undefined
+  let taTeamSlug: string | undefined
   try {
     const classroomJson = await getClassroomJson(client, { org, classroom })
     teamSlug = classroomJson.team?.slug
+    taTeamSlug = classroomJson.teams?.ta?.slug
   } catch (err) {
     // 404 = no classroom.json (pre-feature) is a genuine "no team"; fall
     // through. Anything else is transient and must not be misread as "no team".
@@ -955,6 +957,31 @@ async function grantTeamTemplateRead(
     repo: template.repo,
     permission: "pull",
   })
+
+  // Best-effort: grant the TA staff team the same read so a base-permission-
+  // `none` TA can read the private template without waiting for collect-scores
+  // (mirrors the CLI). Non-blocking — the student grant above is what gates
+  // `student accept`; a TA-grant failure only warns and collect-scores
+  // re-affirms it. A classroom with no recorded TA team is a clean skip.
+  if (taTeamSlug) {
+    try {
+      await addRepositoryToTeam(client, {
+        org,
+        teamSlug: taTeamSlug,
+        owner: template.owner,
+        repo: template.repo,
+        permission: "pull",
+      })
+    } catch (err) {
+      log.warn("granting TA staff team template read failed (non-fatal)", {
+        org,
+        classroom,
+        taTeamSlug,
+        template: `${template.owner}/${template.repo}`,
+        err,
+      })
+    }
+  }
 }
 
 // Grant the template read but never throw: the commit already landed, so a


### PR DESCRIPTION
Closes #287.

## What

Grants the per-classroom TA staff team (`classroom50-<short>-ta`) `pull` on private in-org assignment templates **eagerly, at setup** — not only lazily at collect-scores time.

Before this change, a TA who is a base-permission-`none` org member on the TA team could not read a private in-org template until the first collect-scores (autograding) run — or ever, if a class never ran autograding. The student classroom team was already granted template read eagerly; this brings the TA team to parity.

## Where

The TA grant is applied at the same points the student team is granted, best-effort and non-blocking:

- **Go CLI** — `assignment add`, `assignment reuse` (via the shared `grantClassroomTeamTemplateRead` → new `grantStaffTeamTemplateRead`), and `classroom migrate`.
- **Web** — create / edit / reuse (via `grantTeamTemplateRead`).
- **Permission gate** — the eager sites use `StaffTeamRepoPermissions` (Go) as a **presence gate** and grant read; the collect-scores collector reads the map's value and re-affirms idempotently. `StaffTeamRepoPermissions` (Go) is the source of truth, mirrored by `STAFF_TEAM_PERMISSIONS` (Python collector) and parity-tested. No collector logic change — comments only.

## Semantics

- Only **private + in-org** templates are granted (public and out-of-org are skipped, unchanged rule).
- A classroom with no recorded `teams.ta` (older/pre-staff-teams classroom) is a **clean skip**.
- The TA grant is **non-blocking**: it runs after the student grant and only warns on failure — it never fails an operation that already succeeded for students, and never changes a command's exit code. Collect-scores re-affirms it later.

## Tests

- Go: coverage for TA-grant-fires / no-TA-team-skip / TA-failure-is-non-fatal on the reuse path; migrate now covers both the happy-path grant **and** the non-blocking TA-failure path, plus a negative assertion that the instructor team is never granted template read. Full `gh-teacher` suite green.
- Web: 3 integration tests (both teams granted / student-only when no TA team / edit stays successful when the TA grant fails); `tsc`, eslint, prettier clean.
- Python: `collect_scores` suite green; Go↔Python permission-map parity tests unchanged and passing.

## Review

Reviewed with a multi-persona code review (correctness, security, adversarial, maintainability, testing, standards) — no correctness or security issues. Addressed the actionable findings: corrected an overstated "grants can't diverge" comment (the eager sites gate on presence and hardcode read; only collect-scores reads the value), added the missing migrate non-blocking test, and added the instructor-not-granted assertion. A simplification pass trimmed duplicated rationale comments (behavior-preserving).