### PR TITLE
refactor(web): move classroom-lifecycle mutations into hooks/mutations/ (Tier-2F U9, batch 1)

### DIFF
--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -12,6 +12,13 @@ export const githubKeys = {
   orgMembership: (org: string) =>
     [...githubKeys.all, "org-membership", org] as const,
 
+  // The authenticated viewer's OWN membership in an org (GET
+  // /user/memberships/orgs/{org}) — distinct from `orgMembership` above (the
+  // org-scoped membership read). Single-sourced here because both the read
+  // (useGetOwnOrgMembership) and the accept-invite invalidation key it.
+  ownOrgMembership: (org: string | undefined) =>
+    [...githubKeys.all, "memberships", "orgs", org] as const,
+
   orgRepos: (org: string) => [...githubKeys.all, "org-repos", org] as const,
 
   orgMembers: (org: string) => ["orgs", "list", "members", org] as const,

--- a/web/src/hooks/mutations/useAcceptAndVerifyMembership.ts
+++ b/web/src/hooks/mutations/useAcceptAndVerifyMembership.ts
@@ -1,17 +1,9 @@
 import { useEffect } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { githubKeys } from "@/github-core/queries"
 import { acceptAndVerifyOrgMembership } from "@/domain/users"
 import type { GitHubOrgMembership } from "@/github-core/types"
-
-// The shared membership query key, read by useGetOwnOrgMembership on both the
-// /onboard and accept pages. Kept here so success can seed it directly.
-const membershipQueryKey = (org?: string) => [
-  "github",
-  "memberships",
-  "orgs",
-  org,
-]
 
 export type UseAcceptAndVerifyMembershipResult = {
   isActive: boolean
@@ -38,10 +30,11 @@ export function useAcceptAndVerifyMembership(input: {
   const mutation = useMutation({
     mutationFn: () => acceptAndVerifyOrgMembership(client, org ?? ""),
     onSuccess: (membership: GitHubOrgMembership) => {
-      // Seed the shared membership query with the active membership the verify
-      // read, so this page's redirect gate and the accept page's read agree
-      // immediately instead of racing a lagged re-fetch.
-      queryClient.setQueryData(membershipQueryKey(org), membership)
+      // Seed the shared membership query (githubKeys.ownOrgMembership, read by
+      // useGetOwnOrgMembership on the /onboard and accept pages) with the active
+      // membership the verify read, so this page's redirect gate and the accept
+      // page's read agree immediately instead of racing a lagged re-fetch.
+      queryClient.setQueryData(githubKeys.ownOrgMembership(org), membership)
     },
   })
 

--- a/web/src/hooks/mutations/useAcceptOrgInvite.test.ts
+++ b/web/src/hooks/mutations/useAcceptOrgInvite.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+const acceptAndVerifyOrgMembership = vi.fn(() => Promise.resolve())
+const acceptPendingOrgInvite = vi.fn(() => Promise.resolve())
+
+vi.mock("@/domain/users", () => ({
+  acceptAndVerifyOrgMembership: () => acceptAndVerifyOrgMembership(),
+  acceptPendingOrgInvite: () => acceptPendingOrgInvite(),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+vi.mock("@/hooks/useGetOrgs", () => ({
+  orgMembershipsQueryKey: ["orgs", "memberships"],
+}))
+
+import { useAcceptOrgInvite } from "./useAcceptOrgInvite"
+import { useAcceptPendingOrgInvite } from "./useAcceptPendingOrgInvite"
+
+const ORG = "acme"
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+beforeEach(() => {
+  acceptAndVerifyOrgMembership.mockClear()
+  acceptPendingOrgInvite.mockClear()
+})
+
+describe("useAcceptOrgInvite", () => {
+  it("accepts + verifies, then invalidates memberships and orgs on success", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useAcceptOrgInvite(ORG), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(acceptAndVerifyOrgMembership).toHaveBeenCalled()
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["orgs", "memberships"],
+    })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["orgs"] })
+  })
+})
+
+describe("useAcceptPendingOrgInvite", () => {
+  it("accepts the pending invite, then invalidates the org membership + orgs keys", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useAcceptPendingOrgInvite(ORG), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(acceptPendingOrgInvite).toHaveBeenCalled()
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["github", "memberships", "orgs", ORG],
+    })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["orgs"] })
+  })
+})

--- a/web/src/hooks/mutations/useAcceptOrgInvite.test.ts
+++ b/web/src/hooks/mutations/useAcceptOrgInvite.test.ts
@@ -21,6 +21,7 @@ vi.mock("@/hooks/useGetOrgs", () => ({
 
 import { useAcceptOrgInvite } from "./useAcceptOrgInvite"
 import { useAcceptPendingOrgInvite } from "./useAcceptPendingOrgInvite"
+import { githubKeys } from "@/github-core/queries"
 
 const ORG = "acme"
 
@@ -70,7 +71,7 @@ describe("useAcceptPendingOrgInvite", () => {
 
     expect(acceptPendingOrgInvite).toHaveBeenCalled()
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: ["github", "memberships", "orgs", ORG],
+      queryKey: githubKeys.ownOrgMembership(ORG),
     })
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ["orgs"] })
   })

--- a/web/src/hooks/mutations/useAcceptOrgInvite.ts
+++ b/web/src/hooks/mutations/useAcceptOrgInvite.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { acceptAndVerifyOrgMembership } from "@/domain/users"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { orgMembershipsQueryKey } from "@/hooks/useGetOrgs"
+
+// Accept a pending org invitation and verify membership landed. Hook owns the
+// membership + orgs-list invalidation (data-consistency that must run even if
+// the invite card unmounts); the success toast + navigation and the error toast
+// stay at the call site via mutate(_, { onSuccess, onError }) (see ./README.md).
+export function useAcceptOrgInvite(org: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => acceptAndVerifyOrgMembership(client, org),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: orgMembershipsQueryKey })
+      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+    },
+  })
+}
+
+export default useAcceptOrgInvite

--- a/web/src/hooks/mutations/useAcceptPendingOrgInvite.ts
+++ b/web/src/hooks/mutations/useAcceptPendingOrgInvite.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { acceptPendingOrgInvite } from "@/domain/users"
+import { githubKeys } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
 // Accept a pending org invite from the classes page's "join org" card (a
@@ -14,7 +15,7 @@ export function useAcceptPendingOrgInvite(org: string) {
     mutationFn: () => acceptPendingOrgInvite(client, org),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["github", "memberships", "orgs", org],
+        queryKey: githubKeys.ownOrgMembership(org),
       })
       void queryClient.invalidateQueries({ queryKey: ["orgs"] })
     },

--- a/web/src/hooks/mutations/useAcceptPendingOrgInvite.ts
+++ b/web/src/hooks/mutations/useAcceptPendingOrgInvite.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { acceptPendingOrgInvite } from "@/domain/users"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Accept a pending org invite from the classes page's "join org" card (a
+// best-effort accept, unlike useAcceptOrgInvite's accept-and-verify). Hook owns
+// the membership + orgs-list invalidation; the call site keeps its own UI
+// (the inline error alert reads mutation.isError off the returned result).
+export function useAcceptPendingOrgInvite(org: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => acceptPendingOrgInvite(client, org),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["github", "memberships", "orgs", org],
+      })
+      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+    },
+  })
+}
+
+export default useAcceptPendingOrgInvite

--- a/web/src/hooks/mutations/useArchiveClassroom.test.ts
+++ b/web/src/hooks/mutations/useArchiveClassroom.test.ts
@@ -8,6 +8,20 @@ import { createElement } from "react"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 
+// Capture the options passed to useMutation so we can assert the serialization
+// scope without depending on mutation timing.
+let lastMutationScopeId: string | undefined
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>()
+  return {
+    ...actual,
+    useMutation: ((options: Parameters<typeof actual.useMutation>[0]) => {
+      lastMutationScopeId = options.scope?.id
+      return actual.useMutation(options)
+    }) as typeof actual.useMutation,
+  }
+})
+
 // Drives editClassroomWithConflictRetry; switchable to fail so we can assert the
 // optimistic flip rolls back.
 let editShouldFail = false
@@ -101,5 +115,25 @@ describe("useArchiveClassroom", () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
     })
+  })
+
+  it("cancels in-flight reads of the classroom.json key before flipping", async () => {
+    // The flicker fix: a late read of classroom.json must be cancelled so it
+    // can't resolve after and overwrite the optimistic flip.
+    const { queryClient, result } = setup()
+    const cancel = vi.spyOn(queryClient, "cancelQueries")
+
+    result.current.mutate(false)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(cancel).toHaveBeenCalledWith({ queryKey: classroomKey })
+  })
+
+  it("scopes the mutation per classroom so concurrent toggles serialize", () => {
+    // A shared scope id makes React Query run same-classroom toggles one at a
+    // time, so a second toggle's onMutate snapshot can't capture the first's
+    // optimistic value (the stale-rollback race).
+    setup()
+    expect(lastMutationScopeId).toBe(`archive-classroom:${ORG}:${SLUG}`)
   })
 })

--- a/web/src/hooks/mutations/useArchiveClassroom.test.ts
+++ b/web/src/hooks/mutations/useArchiveClassroom.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// Drives editClassroomWithConflictRetry; switchable to fail so we can assert the
+// optimistic flip rolls back.
+let editShouldFail = false
+const editClassroom = vi.fn((_client: unknown, input: { active?: boolean }) => {
+  if (editShouldFail) return Promise.reject(new Error("boom"))
+  return Promise.resolve(input)
+})
+
+vi.mock("@/domain/classrooms", () => ({
+  editClassroomWithConflictRetry: (client: unknown, input: unknown) =>
+    editClassroom(client, input as { active?: boolean }),
+}))
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useArchiveClassroom } from "./useArchiveClassroom"
+
+const ORG = "acme"
+const SLUG = "cs101"
+const classroomKey = githubKeys.jsonFile(
+  ORG,
+  CONFIG_REPO,
+  `${SLUG}/classroom.json`,
+)
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  // Seed the cached classroom.json so we can observe the optimistic flip.
+  queryClient.setQueryData(classroomKey, { short_name: SLUG, active: true })
+  const wrapper = ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+  const { result } = renderHook(() => useArchiveClassroom(ORG, SLUG), {
+    wrapper,
+  })
+  return { queryClient, result }
+}
+
+beforeEach(() => {
+  editShouldFail = false
+  editClassroom.mockClear()
+})
+
+describe("useArchiveClassroom", () => {
+  it("optimistically flips the cached active on mutate and keeps it on success", async () => {
+    const { queryClient, result } = setup()
+
+    result.current.mutate(false)
+
+    // Optimistic flip is applied synchronously in onMutate.
+    await waitFor(() =>
+      expect(
+        (queryClient.getQueryData(classroomKey) as { active: boolean }).active,
+      ).toBe(false),
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(editClassroom).toHaveBeenCalledWith(expect.anything(), {
+      org: ORG,
+      slug: SLUG,
+      active: false,
+    })
+    // Stays flipped after success (no clobbering invalidate on the exact key).
+    expect(
+      (queryClient.getQueryData(classroomKey) as { active: boolean }).active,
+    ).toBe(false)
+  })
+
+  it("rolls back the optimistic flip when the write fails", async () => {
+    editShouldFail = true
+    const { queryClient, result } = setup()
+
+    result.current.mutate(false)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    // Rolled back to the pre-mutate snapshot.
+    expect(
+      (queryClient.getQueryData(classroomKey) as { active: boolean }).active,
+    ).toBe(true)
+  })
+
+  it("invalidates the config-repo list key on settle", async () => {
+    const { queryClient, result } = setup()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    result.current.mutate(false)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
+    })
+  })
+})

--- a/web/src/hooks/mutations/useArchiveClassroom.ts
+++ b/web/src/hooks/mutations/useArchiveClassroom.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { editClassroomWithConflictRetry } from "@/domain/classrooms"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// Archive / unarchive a classroom (toggles the `active` flag via the
+// conflict-retried edit). Hook owns the full optimistic cache chain so both the
+// list card and the detail form update instantly and consistently:
+// cancelQueries -> snapshot -> optimistic flip -> rollback on error -> settle
+// with a list invalidation. Toasts stay at the call site (see ./README.md).
+//
+// We do NOT invalidate the exact `classroom.json` key we flipped: GitHub's
+// Contents API is read-after-write eventual, so an immediate refetch can read
+// the pre-write body and clobber the optimistic value. The flip stays
+// authoritative and the per-query staleTime reconciles later; the list key is
+// a different query, safe to invalidate so the Active/Archived/All partition
+// updates.
+export function useArchiveClassroom(org: string, classroom: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  const classroomKey = githubKeys.jsonFile(
+    org,
+    CONFIG_REPO,
+    `${classroom}/classroom.json`,
+  )
+
+  return useMutation({
+    mutationFn: (active: boolean) =>
+      editClassroomWithConflictRetry(client, { org, slug: classroom, active }),
+    onMutate: async (active: boolean) => {
+      // Cancel in-flight reads of this classroom.json so a late response can't
+      // overwrite the optimistic flip (the missing step that let the card snap
+      // back to the pre-write state).
+      await queryClient.cancelQueries({ queryKey: classroomKey })
+      const prev = queryClient.getQueryData(classroomKey)
+      queryClient.setQueryData(
+        classroomKey,
+        (current: Record<string, unknown> | undefined) =>
+          current ? { ...current, active } : current,
+      )
+      return { prev }
+    },
+    onError: (_err, _active, ctx) => {
+      // Roll back the optimistic flip so a failed write can't strand the view
+      // in the wrong lifecycle state. Toast is the call site's job.
+      if (ctx) queryClient.setQueryData(classroomKey, ctx.prev)
+    },
+    onSettled: () => {
+      // Repartition the classes list (Active/Archived/All) — a different query
+      // than the per-classroom classroom.json flipped above.
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
+      })
+    },
+  })
+}
+
+export default useArchiveClassroom

--- a/web/src/hooks/mutations/useArchiveClassroom.ts
+++ b/web/src/hooks/mutations/useArchiveClassroom.ts
@@ -26,6 +26,13 @@ export function useArchiveClassroom(org: string, classroom: string) {
   )
 
   return useMutation({
+    // Serialize toggles on this classroom: without a scope, two rapid
+    // archive/unarchive taps run concurrently and their onMutate snapshots nest
+    // — toggle B captures A's optimistic value as `prev`, so if both writes fail
+    // B rolls back to A's optimistic state (persistently wrong until staleTime),
+    // not the true original. A shared scope id makes React Query run same-key
+    // toggles one at a time, so each snapshot sees a settled state.
+    scope: { id: `archive-classroom:${org}:${classroom}` },
     mutationFn: (active: boolean) =>
       editClassroomWithConflictRetry(client, { org, slug: classroom, active }),
     onMutate: async (active: boolean) => {

--- a/web/src/hooks/mutations/useArchiveClassroom.ts
+++ b/web/src/hooks/mutations/useArchiveClassroom.ts
@@ -5,10 +5,9 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Archive / unarchive a classroom (toggles the `active` flag via the
-// conflict-retried edit). Hook owns the full optimistic cache chain so both the
-// list card and the detail form update instantly and consistently:
-// cancelQueries -> snapshot -> optimistic flip -> rollback on error -> settle
-// with a list invalidation. Toasts stay at the call site (see ./README.md).
+// conflict-retried edit). Shared by the list card and the detail form, so the
+// hook owns the full optimistic cache chain and both surfaces stay consistent.
+// Toasts stay at the call site (see ./README.md).
 //
 // We do NOT invalidate the exact `classroom.json` key we flipped: GitHub's
 // Contents API is read-after-write eventual, so an immediate refetch can read

--- a/web/src/hooks/mutations/useDeleteClassroom.test.ts
+++ b/web/src/hooks/mutations/useDeleteClassroom.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+let deleteResult: { deleted: boolean; teamDeleteWarning?: boolean } = {
+  deleted: true,
+}
+const deleteClassroom = vi.fn(() => Promise.resolve(deleteResult))
+
+vi.mock("@/domain/classrooms", () => ({
+  deleteClassroom: () => deleteClassroom(),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useDeleteClassroom } from "./useDeleteClassroom"
+
+const ORG = "acme"
+const SLUG = "cs101"
+const listKey = githubKeys.jsonFile(ORG, CONFIG_REPO, "")
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  // Seed a cached dir listing so we can observe the optimistic drop.
+  queryClient.setQueryData(listKey, [
+    { path: SLUG, type: "dir" },
+    { path: "other", type: "dir" },
+  ])
+  const wrapper = ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+  const { result } = renderHook(() => useDeleteClassroom(ORG, SLUG), {
+    wrapper,
+  })
+  return { queryClient, result }
+}
+
+beforeEach(() => {
+  deleteResult = { deleted: true }
+  deleteClassroom.mockClear()
+})
+
+describe("useDeleteClassroom", () => {
+  it("optimistically drops the deleted dir from the cached listing on success", async () => {
+    const { queryClient, result } = setup()
+
+    result.current.mutate({ org: ORG, classroom: SLUG })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const list = queryClient.getQueryData(listKey) as { path: string }[]
+    expect(list.map((e) => e.path)).toEqual(["other"])
+  })
+
+  it("does NOT drop from the listing on a no-op deletion (deleted:false)", async () => {
+    deleteResult = { deleted: false }
+    const { queryClient, result } = setup()
+
+    result.current.mutate({ org: ORG, classroom: SLUG })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const list = queryClient.getQueryData(listKey) as { path: string }[]
+    expect(list.map((e) => e.path)).toEqual([SLUG, "other"])
+  })
+
+  it("invalidates the config-repo list key on settle", async () => {
+    const { queryClient, result } = setup()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    result.current.mutate({ org: ORG, classroom: SLUG })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
+    })
+  })
+})

--- a/web/src/hooks/mutations/useDeleteClassroom.test.ts
+++ b/web/src/hooks/mutations/useDeleteClassroom.test.ts
@@ -25,6 +25,11 @@ import { useDeleteClassroom } from "./useDeleteClassroom"
 const ORG = "acme"
 const SLUG = "cs101"
 const listKey = githubKeys.jsonFile(ORG, CONFIG_REPO, "")
+const classroomKey = githubKeys.jsonFile(
+  ORG,
+  CONFIG_REPO,
+  `${SLUG}/classroom.json`,
+)
 
 function setup() {
   const queryClient = new QueryClient({
@@ -70,15 +75,52 @@ describe("useDeleteClassroom", () => {
     expect(list.map((e) => e.path)).toEqual([SLUG, "other"])
   })
 
-  it("invalidates the config-repo list key on settle", async () => {
+  it("does NOT invalidate the optimistically-edited listing key on a real deletion", async () => {
+    // The optimistic drop is authoritative; re-invalidating the listing key we
+    // just edited would refetch GitHub's read-after-write-eventual Contents API
+    // and could re-add the just-deleted dir (a flicker).
+    const { result } = setup()
+    const invalidate = vi.spyOn(QueryClient.prototype, "invalidateQueries")
+
+    result.current.mutate({ org: ORG, classroom: SLUG })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: listKey })
+    invalidate.mockRestore()
+  })
+
+  it("evicts the deleted classroom's own config query on a real deletion", async () => {
+    const { queryClient, result } = setup()
+    // Seed the per-classroom config read so we can observe its removal.
+    queryClient.setQueryData(classroomKey, { short_name: SLUG, active: true })
+
+    result.current.mutate({ org: ORG, classroom: SLUG })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(queryClient.getQueryData(classroomKey)).toBeUndefined()
+  })
+
+  it("invalidates the listing key on a no-op deletion to reconcile", async () => {
+    deleteResult = { deleted: false }
     const { queryClient, result } = setup()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
 
     result.current.mutate({ org: ORG, classroom: SLUG })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: listKey })
+  })
+
+  it("returns teamDeleteWarning to the call site on a real deletion", async () => {
+    deleteResult = { deleted: true, teamDeleteWarning: true }
+    const { result } = setup()
+
+    result.current.mutate({ org: ORG, classroom: SLUG })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual({
+      deleted: true,
+      teamDeleteWarning: true,
     })
   })
 })

--- a/web/src/hooks/mutations/useDeleteClassroom.ts
+++ b/web/src/hooks/mutations/useDeleteClassroom.ts
@@ -7,32 +7,47 @@ import { CONFIG_REPO } from "@/util/configRepo"
 import type { GitHubFileListing } from "@/github-core/types"
 
 // Delete a classroom (removes its config-repo dir + best-effort team cleanup).
-// On a real deletion the hook optimistically drops the dir from the cached
-// listing so a list view leaves at once (the Contents API is read-after-write
-// eventual, so an immediate refetch can still return the just-deleted dir),
-// then invalidates to reconcile; a { deleted: false } no-op skips the drop. The
-// result (deleted / teamDeleteWarning) is returned so each call site decides
+// The result (deleted / teamDeleteWarning) is returned so each call site decides
 // its own toast/navigation (see ./README.md).
+//
+// On a real deletion the optimistic list drop is authoritative — we do NOT
+// invalidate the dir-listing key we just edited. `jsonFile(org, CONFIG_REPO)`
+// resolves to that exact listing key (path defaults to ""), and GitHub's
+// Contents API is read-after-write eventual, so an immediate refetch can still
+// return the just-deleted dir and re-add the card (a flicker). The optimistic
+// drop stays authoritative and the per-query staleTime reconciles later; we
+// remove the deleted classroom's own classroom.json query so its now-404 body
+// isn't served stale. A { deleted: false } no-op changed nothing, so it falls
+// through to a plain list invalidate to reconcile against whatever is there.
 export function useDeleteClassroom(org: string, classroom: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
+
+  const listKey = githubKeys.jsonFile(org, CONFIG_REPO, "")
 
   return useMutation({
     mutationFn: (input: DeleteClassroomInput) => deleteClassroom(client, input),
     onSuccess: (result) => {
       if (result.deleted) {
-        const listKey = githubKeys.jsonFile(org, CONFIG_REPO, "")
         queryClient.setQueryData(
           listKey,
           (prev: GitHubFileListing[] | undefined) =>
             prev ? prev.filter((entry) => entry.path !== classroom) : prev,
         )
+        // Evict the deleted classroom's own config read (now a 404) so a later
+        // view can't serve its stale body. Distinct from the listing key above.
+        void queryClient.removeQueries({
+          queryKey: githubKeys.jsonFile(
+            org,
+            CONFIG_REPO,
+            `${classroom}/classroom.json`,
+          ),
+        })
+        return
       }
-    },
-    onSettled: () => {
-      void queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
-      })
+      // No-op delete: nothing was optimistically changed, so reconcile the
+      // listing against the server.
+      void queryClient.invalidateQueries({ queryKey: listKey })
     },
   })
 }

--- a/web/src/hooks/mutations/useDeleteClassroom.ts
+++ b/web/src/hooks/mutations/useDeleteClassroom.ts
@@ -7,15 +7,12 @@ import { CONFIG_REPO } from "@/util/configRepo"
 import type { GitHubFileListing } from "@/github-core/types"
 
 // Delete a classroom (removes its config-repo dir + best-effort team cleanup).
-// Hook owns the cache reconcile that must always run: on a real deletion it
-// optimistically drops the dir from the cached listing so a list view leaves at
-// once (the Contents API is read-after-write eventual, so an immediate refetch
-// can still return the just-deleted dir), then invalidates to reconcile.
-// deleteClassroom returns { deleted: false } as a no-op (dir already gone) — the
-// hook still invalidates but skips the optimistic drop. The result (deleted /
-// teamDeleteWarning) is returned so the call site decides its own
-// toast/navigation (see ./README.md); a detail view that navigates away can
-// ignore the optimistic drop entirely.
+// On a real deletion the hook optimistically drops the dir from the cached
+// listing so a list view leaves at once (the Contents API is read-after-write
+// eventual, so an immediate refetch can still return the just-deleted dir),
+// then invalidates to reconcile; a { deleted: false } no-op skips the drop. The
+// result (deleted / teamDeleteWarning) is returned so each call site decides
+// its own toast/navigation (see ./README.md).
 export function useDeleteClassroom(org: string, classroom: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()

--- a/web/src/hooks/mutations/useDeleteClassroom.ts
+++ b/web/src/hooks/mutations/useDeleteClassroom.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { deleteClassroom } from "@/domain/classrooms"
+import type { DeleteClassroomInput } from "@/domain/classrooms"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { CONFIG_REPO } from "@/util/configRepo"
+import type { GitHubFileListing } from "@/github-core/types"
+
+// Delete a classroom (removes its config-repo dir + best-effort team cleanup).
+// Hook owns the cache reconcile that must always run: on a real deletion it
+// optimistically drops the dir from the cached listing so a list view leaves at
+// once (the Contents API is read-after-write eventual, so an immediate refetch
+// can still return the just-deleted dir), then invalidates to reconcile.
+// deleteClassroom returns { deleted: false } as a no-op (dir already gone) — the
+// hook still invalidates but skips the optimistic drop. The result (deleted /
+// teamDeleteWarning) is returned so the call site decides its own
+// toast/navigation (see ./README.md); a detail view that navigates away can
+// ignore the optimistic drop entirely.
+export function useDeleteClassroom(org: string, classroom: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: DeleteClassroomInput) => deleteClassroom(client, input),
+    onSuccess: (result) => {
+      if (result.deleted) {
+        const listKey = githubKeys.jsonFile(org, CONFIG_REPO, "")
+        queryClient.setQueryData(
+          listKey,
+          (prev: GitHubFileListing[] | undefined) =>
+            prev ? prev.filter((entry) => entry.path !== classroom) : prev,
+        )
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
+      })
+    },
+  })
+}
+
+export default useDeleteClassroom

--- a/web/src/hooks/useGetOwnOrgMembership.ts
+++ b/web/src/hooks/useGetOwnOrgMembership.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { getPendingOrgInvite } from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
 import { retryTransientGitHubError } from "@/github-core/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
@@ -14,7 +15,7 @@ const useGetOwnOrgMembership = (org: string | undefined) => {
   const client = useGitHubClient()
 
   return useQuery({
-    queryKey: ["github", "memberships", "orgs", org],
+    queryKey: githubKeys.ownOrgMembership(org),
     queryFn: () => getPendingOrgInvite(client, org ?? ""),
     staleTime: 10 * 60 * 1000,
     retry: retryTransientGitHubError,

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -14,9 +14,7 @@ import { useOrgStaff } from "@/hooks/useOrgStaff"
 import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { can } from "@/authz"
 import useGetOwnOrgMembership from "@/hooks/useGetOwnOrgMembership"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { acceptPendingOrgInvite } from "@/domain/users"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useAcceptPendingOrgInvite } from "@/hooks/mutations/useAcceptPendingOrgInvite"
 import OrgPreflightNotice from "@/pages/orgSettings/OrgPreflightNotice"
 import ClassroomList from "@/pages/classes/ClassroomList"
 import { OrgRepos } from "@/components/org/OrgRepos"
@@ -54,19 +52,9 @@ const CreateClassroomPane = ({ org }: { org: string }) => {
 
 const JoinOrgCard = ({ org }: { org: string }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const run = useSafeSubmit()
 
-  const mutation = useMutation({
-    mutationFn: () => acceptPendingOrgInvite(client, org),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["github", "memberships", "orgs", org],
-      })
-      queryClient.invalidateQueries({ queryKey: ["orgs"] })
-    },
-  })
+  const mutation = useAcceptPendingOrgInvite(org)
 
   return (
     <Card dashed>

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -1,18 +1,14 @@
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
-import { acceptAndVerifyOrgMembership } from "@/domain/users"
 import { isOwnerGitHubOrgRole } from "@/authz"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useAcceptOrgInvite } from "@/hooks/mutations/useAcceptOrgInvite"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import type { GitHubOrgMembership } from "@/github-core/types"
-import useGetOrgs, {
-  orgMembershipsQueryKey,
-  usePendingOrgInvites,
-} from "@/hooks/useGetOrgs"
+import useGetOrgs, { usePendingOrgInvites } from "@/hooks/useGetOrgs"
 import useOrgLastModified from "@/hooks/useOrgLastModified"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
   ChevronDown,
@@ -103,31 +99,12 @@ function MissingOrgNotice({
 // moves the org into the active list, where the classroom50 summary is built.
 function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
   const { t } = useTranslation()
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { notify } = useToast()
   const org = invite.organization
   const isOwner = isOwnerGitHubOrgRole(invite.role)
 
-  const accept = useMutation({
-    mutationFn: () => acceptAndVerifyOrgMembership(client, org.login),
-    onSuccess: () => {
-      notify({
-        tone: "success",
-        message: t("orgs.invites.accepted", { org: org.login }),
-      })
-      queryClient.invalidateQueries({ queryKey: orgMembershipsQueryKey })
-      queryClient.invalidateQueries({ queryKey: ["orgs"] })
-      navigate({ to: "/$org", params: { org: org.login } })
-    },
-    onError: () => {
-      notify({
-        tone: "error",
-        message: t("orgs.invites.acceptError", { org: org.login }),
-      })
-    },
-  })
+  const accept = useAcceptOrgInvite(org.login)
 
   return (
     <Card
@@ -187,7 +164,23 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
             size="sm"
             loading={accept.isPending}
             loadingLabel={t("orgs.invites.accepting")}
-            onClick={() => accept.mutate()}
+            onClick={() =>
+              accept.mutate(undefined, {
+                onSuccess: () => {
+                  notify({
+                    tone: "success",
+                    message: t("orgs.invites.accepted", { org: org.login }),
+                  })
+                  navigate({ to: "/$org", params: { org: org.login } })
+                },
+                onError: () => {
+                  notify({
+                    tone: "error",
+                    message: t("orgs.invites.acceptError", { org: org.login }),
+                  })
+                },
+              })
+            }
           >
             {t("orgs.invites.acceptOpen")}
           </Button>

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -1,15 +1,9 @@
-import {
-  deleteClassroom,
-  editClassroomWithConflictRetry,
-} from "@/domain/classrooms"
 import { ConfirmModal } from "@/components/modals"
 import { Button, Card } from "@/components/ui"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import { githubKeys } from "@/github-core/queries"
-import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError } from "@/github-core/errors"
-import type { GitHubFileListing } from "@/github-core/types"
+import { useArchiveClassroom } from "@/hooks/mutations/useArchiveClassroom"
+import { useDeleteClassroom } from "@/hooks/mutations/useDeleteClassroom"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useStudentCount from "@/hooks/useStudentCount"
 import {
@@ -18,7 +12,6 @@ import {
 } from "@/hooks/useClassroomSummaries"
 import { EnterDiv } from "@/lib/motionComponents"
 import { classroomConfigTreeUrl } from "@/util/orgUrl"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import {
   Archive,
@@ -116,9 +109,7 @@ function ClassroomMenu({
   onMenuOpenChange?: (open: boolean) => void
 }) {
   const { t } = useTranslation()
-  const client = useGitHubClient()
   const { notify } = useToast()
-  const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
   const [archiveOpen, setArchiveOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -205,115 +196,8 @@ function ClassroomMenu({
     items[next]?.focus()
   }
 
-  const archiveMutation = useMutation({
-    mutationFn: (active: boolean) =>
-      editClassroomWithConflictRetry(client, { org, slug, active }),
-    onMutate: (active: boolean) => {
-      const key = githubKeys.jsonFile(
-        org,
-        CONFIG_REPO,
-        `${slug}/classroom.json`,
-      )
-      const prev = queryClient.getQueryData(key)
-      // Optimistically flip the cached active so the card repartitions at once.
-      queryClient.setQueryData(
-        key,
-        (current: Record<string, unknown> | undefined) =>
-          current ? { ...current, active } : current,
-      )
-      // Do NOT invalidate this exact key (GitHub contents is read-after-write
-      // eventual). Repartition the list via the list-level key instead.
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
-      })
-      return { key, prev }
-    },
-    onError: (err, _active, ctx) => {
-      // Roll back the optimistic flip so a failed write can't strand the card
-      // in the wrong tab.
-      if (ctx) queryClient.setQueryData(ctx.key, ctx.prev)
-      notify({
-        tone: "error",
-        message: t(
-          archived ? "classes.unarchiveFailed" : "classes.archiveFailed",
-          {
-            classroom: slug,
-            error:
-              err instanceof Error
-                ? err.message
-                : t("classes.somethingWentWrong"),
-          },
-        ),
-      })
-    },
-    onSuccess: (_r, active) => {
-      notify({
-        tone: "success",
-        durationMs: 5000,
-        message: active
-          ? t("classes.unarchivedToast", { classroom: slug })
-          : t("classes.archivedToast", { classroom: slug }),
-      })
-    },
-  })
-
-  const deleteMutation = useMutation({
-    mutationFn: () => deleteClassroom(client, { org, classroom: slug }),
-    onSuccess: (result) => {
-      // deleteClassroom returns { deleted: false } as a no-op (e.g. the dir was
-      // already gone). Don't claim success in that case.
-      if (!result.deleted) {
-        notify({
-          tone: "warning",
-          message: t("classes.deleteNoop", { classroom: slug }),
-        })
-        queryClient.invalidateQueries({
-          queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
-        })
-        return
-      }
-      // Optimistically drop the dir from the cached listing so the card leaves
-      // at once — the Contents API is read-after-write eventual, so an immediate
-      // refetch can still return the just-deleted dir. Then invalidate to
-      // reconcile.
-      const listKey = githubKeys.jsonFile(org, CONFIG_REPO, "")
-      queryClient.setQueryData(
-        listKey,
-        (prev: GitHubFileListing[] | undefined) =>
-          prev ? prev.filter((entry) => entry.path !== slug) : prev,
-      )
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
-      })
-      // The list flow stays put (no navigate), so it is the natural place to
-      // finally surface the non-fatal team-cleanup warning that the edit page
-      // silently dropped.
-      if (result.teamDeleteWarning) {
-        notify({
-          tone: "warning",
-          message: t("classes.deleteTeamWarning", { classroom: slug }),
-        })
-      } else {
-        notify({
-          tone: "success",
-          durationMs: 5000,
-          message: t("classes.deletedToast", { classroom: slug }),
-        })
-      }
-    },
-    onError: (err) => {
-      notify({
-        tone: "error",
-        message: t("classes.deleteFailed", {
-          classroom: slug,
-          error:
-            err instanceof Error
-              ? err.message
-              : t("classes.somethingWentWrong"),
-        }),
-      })
-    },
-  })
+  const archiveMutation = useArchiveClassroom(org, slug)
+  const deleteMutation = useDeleteClassroom(org, slug)
 
   const menuItem =
     "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-base-200"
@@ -443,7 +327,34 @@ function ClassroomMenu({
         needsConfirm={false}
         dangerous={false}
         onConfirm={async () => {
-          await archiveMutation.mutateAsync(archived)
+          await archiveMutation.mutateAsync(archived, {
+            onSuccess: (_r, active) => {
+              notify({
+                tone: "success",
+                durationMs: 5000,
+                message: active
+                  ? t("classes.unarchivedToast", { classroom: slug })
+                  : t("classes.archivedToast", { classroom: slug }),
+              })
+            },
+            onError: (err) => {
+              notify({
+                tone: "error",
+                message: t(
+                  archived
+                    ? "classes.unarchiveFailed"
+                    : "classes.archiveFailed",
+                  {
+                    classroom: slug,
+                    error:
+                      err instanceof Error
+                        ? err.message
+                        : t("classes.somethingWentWrong"),
+                  },
+                ),
+              })
+            },
+          })
         }}
         onClose={() => setArchiveOpen(false)}
       />
@@ -465,7 +376,51 @@ function ClassroomMenu({
         cancelLabel={t("classes.deleteClassroomCancel")}
         dangerous
         onConfirm={async () => {
-          await deleteMutation.mutateAsync()
+          await deleteMutation.mutateAsync(
+            { org, classroom: slug },
+            {
+              onSuccess: (result) => {
+                // deleteClassroom returns { deleted: false } as a no-op (e.g.
+                // the dir was already gone). Don't claim success in that case.
+                if (!result.deleted) {
+                  notify({
+                    tone: "warning",
+                    message: t("classes.deleteNoop", { classroom: slug }),
+                  })
+                  return
+                }
+                // The list flow stays put (no navigate), so it is the natural
+                // place to surface the non-fatal team-cleanup warning that the
+                // edit page silently drops.
+                if (result.teamDeleteWarning) {
+                  notify({
+                    tone: "warning",
+                    message: t("classes.deleteTeamWarning", {
+                      classroom: slug,
+                    }),
+                  })
+                } else {
+                  notify({
+                    tone: "success",
+                    durationMs: 5000,
+                    message: t("classes.deletedToast", { classroom: slug }),
+                  })
+                }
+              },
+              onError: (err) => {
+                notify({
+                  tone: "error",
+                  message: t("classes.deleteFailed", {
+                    classroom: slug,
+                    error:
+                      err instanceof Error
+                        ? err.message
+                        : t("classes.somethingWentWrong"),
+                  }),
+                })
+              },
+            },
+          )
         }}
         onClose={() => setDeleteOpen(false)}
       />

--- a/web/src/pages/classes/EditClassroomForm.test.tsx
+++ b/web/src/pages/classes/EditClassroomForm.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+// i18n as identity so we can assert on raw keys.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+const notify = vi.fn()
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify }),
+}))
+
+// The hook under the call site: mutateAsync resolves with whatever the current
+// test sets, so we can drive the teamDeleteWarning branch.
+let deleteResult: { deleted: boolean; teamDeleteWarning?: boolean } = {
+  deleted: true,
+}
+const mutateAsync = vi.fn(() => Promise.resolve(deleteResult))
+vi.mock("@/hooks/mutations/useDeleteClassroom", () => ({
+  useDeleteClassroom: () => ({ mutateAsync }),
+}))
+
+import { DeleteClassroomButton } from "./EditClassroomForm"
+
+const ORG = "acme"
+const SLUG = "cs101"
+
+// Walks the ConfirmModal from trigger to confirmed: open, acknowledge the
+// dangerous prompt, type the required "<org>/<slug>" phrase, confirm.
+async function confirmDelete() {
+  const user = userEvent.setup()
+  await user.click(screen.getByLabelText("classes.deleteClassroomAria"))
+  await user.click(screen.getByText("components.confirmModal.yesContinue"))
+  const input = await screen.findByRole("textbox")
+  await user.type(input, `${ORG}/${SLUG}`)
+  await user.click(screen.getByText("classes.deleteClassroomConfirm"))
+}
+
+beforeEach(() => {
+  deleteResult = { deleted: true }
+  mutateAsync.mockClear()
+  notify.mockClear()
+})
+
+afterEach(cleanup)
+
+describe("EditClassroomForm DeleteClassroomButton", () => {
+  it("surfaces the team-cleanup warning toast when teamDeleteWarning is set", async () => {
+    deleteResult = { deleted: true, teamDeleteWarning: true }
+    const onDeleteClassroom = vi.fn()
+    render(
+      <DeleteClassroomButton
+        org={ORG}
+        classroom={SLUG}
+        onDeleteClassroom={onDeleteClassroom}
+      />,
+    )
+
+    await confirmDelete()
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tone: "warning",
+          message: "classes.deleteTeamWarning",
+        }),
+      ),
+    )
+    expect(onDeleteClassroom).toHaveBeenCalled()
+  })
+
+  it("does not toast a warning when teamDeleteWarning is absent, but still navigates", async () => {
+    deleteResult = { deleted: true }
+    const onDeleteClassroom = vi.fn()
+    render(
+      <DeleteClassroomButton
+        org={ORG}
+        classroom={SLUG}
+        onDeleteClassroom={onDeleteClassroom}
+      />,
+    )
+
+    await confirmDelete()
+
+    await waitFor(() => expect(onDeleteClassroom).toHaveBeenCalled())
+    expect(notify).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -37,6 +37,7 @@ const DeleteClassroomButton = ({
   onDeleteClassroom: () => void
 }) => {
   const { t } = useTranslation()
+  const { notify } = useToast()
   const [open, setOpen] = useState(false)
   const deleteClassroomMutation = useDeleteClassroom(org, classroom)
 
@@ -73,10 +74,18 @@ const DeleteClassroomButton = ({
         cancelLabel={t("classes.deleteClassroomCancel")}
         dangerous
         onConfirm={async () => {
-          await deleteClassroomMutation.mutateAsync({
+          const result = await deleteClassroomMutation.mutateAsync({
             org,
             classroom,
           })
+          // Surface the non-fatal team-cleanup warning (the classroom dir was
+          // still deleted); the toast rides along to the destination page.
+          if (result.teamDeleteWarning) {
+            notify({
+              tone: "warning",
+              message: t("classes.deleteTeamWarning", { classroom }),
+            })
+          }
           onDeleteClassroom()
         }}
         onClose={() => setOpen(false)}

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -1,16 +1,12 @@
-import {
-  deleteClassroom,
-  editClassroomWithConflictRetry,
-  type DeleteClassroomInput,
-} from "@/domain/classrooms"
 import { ConfirmModal } from "@/components/modals"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
+import { useArchiveClassroom } from "@/hooks/mutations/useArchiveClassroom"
+import { useDeleteClassroom } from "@/hooks/mutations/useDeleteClassroom"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { useForm } from "@tanstack/react-form"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { Archive, ArchiveRestore, Trash2 } from "lucide-react"
 import { GitHubLink } from "@/components/GitHubLink"
@@ -41,12 +37,8 @@ const DeleteClassroomButton = ({
   onDeleteClassroom: () => void
 }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
   const [open, setOpen] = useState(false)
-  const deleteClassroomMutation = useMutation({
-    mutationFn: (input: DeleteClassroomInput) => deleteClassroom(client, input),
-    onSuccess: () => onDeleteClassroom(),
-  })
+  const deleteClassroomMutation = useDeleteClassroom(org, classroom)
 
   return (
     <>
@@ -108,44 +100,14 @@ const ArchiveClassroomButton = ({
   archived: boolean
 }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
   const { notify } = useToast()
-  const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
 
   // A pure archive/unarchive write: editClassroom preserves name/term when
-  // omitted, so we send only `active` — no refetch, no stale name/term.
-  const archiveMutation = useMutation({
-    mutationFn: (active: boolean) =>
-      editClassroomWithConflictRetry(client, {
-        org,
-        slug: classroom,
-        active,
-      }),
-    onSuccess: (_result, active) => {
-      // Optimistically flip the cached classroom.json `active` so the button,
-      // read-only fieldset, and badges update immediately. GitHub's contents API
-      // is read-after-write eventual, so we do NOT invalidate this exact key: an
-      // immediate refetch can read the pre-write body and clobber the optimistic
-      // flip. The optimistic value stays authoritative; the staleTime refetch
-      // reconciles later.
-      const key = githubKeys.jsonFile(
-        org,
-        CONFIG_REPO,
-        `${classroom}/classroom.json`,
-      )
-      queryClient.setQueryData(
-        key,
-        (prev: Record<string, unknown> | undefined) =>
-          prev ? { ...prev, active } : prev,
-      )
-      // Repartition the classes list (Active/Archived/All) — a different query
-      // than the per-classroom classroom.json above.
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
-      })
-    },
-  })
+  // omitted, so we send only `active`. The hook owns the optimistic flip +
+  // rollback + list invalidation; the success/error toasts stay at the call
+  // site below.
+  const archiveMutation = useArchiveClassroom(org, classroom)
 
   return (
     <>

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -27,7 +27,7 @@ type EditClassroomFormProps = {
   cl?: Classroom
 }
 
-const DeleteClassroomButton = ({
+export const DeleteClassroomButton = ({
   org,
   classroom,
   onDeleteClassroom,


### PR DESCRIPTION
## Summary

**Tier-2 Phase F, U9 — batch 1 of 3** ([plan](docs/plans/2026-07-15-005-refactor-tier2-structural-debt-plan.md)). Converts the inline `useMutation` sites in the four classroom-lifecycle surfaces (`ClassroomCard`, `EditClassroomForm`, `ClassesPage`, `OrgsPage`) into named `hooks/mutations/` hooks, per the `hooks/mutations/README.md` convention: **data-consistency effects (optimistic cache ops, invalidation) live in the hook; UI effects (toasts, navigation) stay at the call site** via `mutate(vars, { onSuccess, onError })`.

New hooks:
- `useArchiveClassroom` — shared by the list card and the detail form
- `useDeleteClassroom` — shared by both, returns `{ deleted, teamDeleteWarning }` so each call site drives its own toast/navigation
- `useAcceptOrgInvite` (OrgsPage) / `useAcceptPendingOrgInvite` (ClassesPage)

### One deliberate behavior change (not pure refactor)
`useArchiveClassroom` adopts the **canonical optimistic template** — `cancelQueries → snapshot → setQueryData → onError rollback → onSettled invalidate` — which **fixes a latent bug** in `ClassroomCard`'s old inline archive: it did `setQueryData` in `onMutate` *without* `cancelQueries`, so an in-flight list read could resolve late and overwrite the optimistic flip (the classic "UI snaps back" flicker). The list card and the detail form keep their deliberately-different, and correct, render strategies (optimistic for the multi-item list; invalidate-and-navigate for the single detail view) — I researched the TanStack guidance and this divergence is textbook-correct, so I did **not** force-standardize them.

### Included ce-code-review fixes (2nd commit)
A full multi-agent review ran on this branch; the `fix(review)` commit addresses the actionable findings:
- **Query-key drift (P1):** the own-membership key `["github","memberships","orgs",org]` was hand-written in two places (`useGetOwnOrgMembership` + the accept hook). Promoted to `githubKeys.ownOrgMembership(org)` and single-sourced; the test asserts the factory key.
- **teamDeleteWarning (P1):** `EditClassroomForm`'s delete now surfaces the non-fatal team-cleanup warning before navigating (the pre-refactor inline delete silently dropped it).
- Trimmed the hook doc comments to why-not-what per AGENTS.md.

### Follow-up ce-code-review fixes (3rd commit)
A second multi-agent review pass (9 reviewers) ran on the branch; the `fix(web): stop delete hook clobbering its own optimistic drop` commit addresses the actionable findings:
- **Delete self-clobber (P2, cross-reviewer: races + adversarial):** `useDeleteClassroom` was optimistically dropping the deleted dir from the listing and then invalidating `jsonFile(org, CONFIG_REPO)` in `onSettled` — which resolves to that *exact* listing key (path defaults to `""`), forcing a refetch of GitHub's read-after-write-eventual Contents API that can re-add the just-deleted card (a flicker). This was the mirror-image mistake the archive hook deliberately avoids. The optimistic drop is now authoritative; we `removeQueries` the deleted classroom's own `classroom.json` (now 404) and only invalidate the listing on a `{ deleted: false }` no-op.
- **Third un-single-sourced key (P2):** the single-sourcing missed a *third* hand-written copy of the own-membership key in `useAcceptAndVerifyMembership` (`setQueryData` seed). Routed through `githubKeys.ownOrgMembership(org)` so a future factory change can't silently desync the seed from the read.
- **Concurrent archive toggles (P2, now fixed):** added `scope: { id: \`archive-classroom:${org}:${classroom}\` }` so two rapid toggles serialize — the second can no longer snapshot the first's optimistic value and roll back to a persistently-wrong state (previously listed below as a residual risk).
- **Tests:** new `EditClassroomForm.test.tsx` asserts the `teamDeleteWarning` toast surfaces; delete-hook tests pin the no-clobber contract + `classroom.json` eviction + `teamDeleteWarning` passthrough; archive-hook tests pin `cancelQueries` and the serialization scope.

**Cleared, not fixed (verified false positives / benign):** a `P1` claim that the *archive* `onSettled` invalidate clobbers the flipped `classroom.json` was dropped — verified against React Query's `partialMatchKey` that the list key does **not** prefix-match the per-classroom key. The archive `onSettled` firing on the error path is confirmed benign for the same reason (it targets a different key than the rolled-back one).

**Documented residual risk (not fixed — narrow):** none outstanding from the review. The two previously-noted risks (racing archive toggles; archive `onSettled`-on-error) are now respectively fixed (mutation scoping) and verified benign.

## Scope note
U9 is batched into 3 PRs by feature; this is batch 1 (classroom lifecycle). Batches 2 (students) and 3 (org-setup/staff) follow. The infra hooks `useGitHubOperation` / `useActionActivity` are intentionally excluded (generic dispatch / polling, not per-write ops), and `useGithubAuth` (U11) + `SkeletonDriftBanner` (U10) are separate units.

## Test plan

- [x] 4 new hooks + hook test files (optimistic flip + rollback + settle behavior; list-drop vs no-op + no-clobber contract + `classroom.json` eviction + `teamDeleteWarning` passthrough; `cancelQueries` + serialization scope; invite invalidations) plus a new `EditClassroomForm.test.tsx` for the team-warning surfacing
- [x] `tsc -b` clean; full `vitest` green (145 files, 1548 tests) — existing component tests confirm behavior preserved
- [x] Zero inline `useMutation` remaining in the 4 converted files
- [x] `eslint .` + `arch:validate` + `prettier --check` clean
- [x] Two full `ce-code-review` passes (correctness/reliability/adversarial/maintainability/races/…) — actionable findings applied across the 2nd and 3rd commits; no P0
