### PR TITLE
refactor(web): move student/assignment mutations into hooks/mutations/ (Tier-2F U9, batch 2)

### DIFF
--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -10,6 +10,7 @@ export {
   resolveTemplate,
   type AcceptStepId,
   type AcceptStepStatus,
+  type OnAcceptStepUpdate,
   type TemplateAccessVerification,
 } from "./assignments/accessPrimitives"
 export {

--- a/web/src/hooks/mutations/studentMutations.test.ts
+++ b/web/src/hooks/mutations/studentMutations.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+
+// Domain/github-core writes are mocked so each hook test asserts only the
+// hook's own responsibility: that it delegates to the right fn and (where it
+// owns cache reconcile) invalidates the right keys.
+const cancelOrgInvitation = vi.fn((..._a: unknown[]) => Promise.resolve())
+const acceptAssignment = vi.fn((..._a: unknown[]) =>
+  Promise.resolve({ status: "created", repo: {}, cloneCommand: "" }),
+)
+const deleteAssignment = vi.fn((..._a: unknown[]) => Promise.resolve())
+const unenrollStudent = vi.fn((..._a: unknown[]) =>
+  Promise.resolve({ removed: true }),
+)
+const updateStudentWithConflictRetry = vi.fn((..._a: unknown[]) =>
+  Promise.resolve({ student: {} }),
+)
+const invalidateInviteQueries = vi.fn((..._a: unknown[]) => {})
+
+vi.mock("@/github-core/mutations", () => ({
+  cancelOrgInvitation: (client: unknown, input: unknown) =>
+    cancelOrgInvitation(client, input),
+}))
+vi.mock("@/domain/assignments", () => ({
+  acceptAssignment: (params: unknown) => acceptAssignment(params),
+  deleteAssignment: (client: unknown, input: unknown) =>
+    deleteAssignment(client, input),
+}))
+vi.mock("@/domain/students", () => ({
+  unenrollStudent: (client: unknown, input: unknown) =>
+    unenrollStudent(client, input),
+  updateStudentWithConflictRetry: (client: unknown, input: unknown) =>
+    updateStudentWithConflictRetry(client, input),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+// invalidateInviteQueries is a real re-export from the queries barrel; spy it
+// but keep githubKeys intact (the accept test asserts a real key).
+vi.mock("@/github-core/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/github-core/queries")>()
+  return {
+    ...actual,
+    invalidateInviteQueries: (queryClient: unknown, org: unknown) =>
+      invalidateInviteQueries(queryClient, org),
+  }
+})
+
+import { useDismissFailedInvite } from "./useDismissFailedInvite"
+import { useAcceptAssignment } from "./useAcceptAssignment"
+import { useDeleteAssignment } from "./useDeleteAssignment"
+import { useUnenrollStudent } from "./useUnenrollStudent"
+import { useUpdateStudent } from "./useUpdateStudent"
+
+const ORG = "acme"
+const CLASSROOM = "cs101"
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useDismissFailedInvite", () => {
+  it("cancels the invite and invalidates the invite queries on success", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useDismissFailedInvite(ORG), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate(42)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(cancelOrgInvitation).toHaveBeenCalledWith(expect.anything(), {
+      org: ORG,
+      invitationId: 42,
+    })
+    expect(invalidateInviteQueries).toHaveBeenCalledWith(queryClient, ORG)
+  })
+})
+
+describe("useAcceptAssignment", () => {
+  it("accepts and invalidates the org-repos query on success", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const onStepUpdate = vi.fn()
+    const { result } = renderHook(
+      () =>
+        useAcceptAssignment({
+          org: ORG,
+          classroom: CLASSROOM,
+          assignmentSlug: "hw1",
+          onStepUpdate,
+        }),
+      { wrapper: wrapperWith(queryClient) },
+    )
+
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(acceptAssignment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org: ORG,
+        classroom: CLASSROOM,
+        assignmentSlug: "hw1",
+        onStepUpdate,
+      }),
+    )
+    expect(invalidate).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: githubKeys.orgRepos(ORG) }),
+    )
+  })
+})
+
+describe("thin passthrough hooks delegate to their domain fn", () => {
+  it("useDeleteAssignment delegates the input", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useDeleteAssignment(), {
+      wrapper: wrapperWith(queryClient),
+    })
+    const input = { org: ORG, classroom: CLASSROOM, assignment: "hw1" }
+    result.current.mutate(input)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(deleteAssignment).toHaveBeenCalledWith(expect.anything(), input)
+  })
+
+  it("useUnenrollStudent binds org/classroom and passes the student", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useUnenrollStudent(ORG, CLASSROOM), {
+      wrapper: wrapperWith(queryClient),
+    })
+    const student = { username: "alice" } as never
+    result.current.mutate(student)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(unenrollStudent).toHaveBeenCalledWith(expect.anything(), {
+      org: ORG,
+      classroom: CLASSROOM,
+      student,
+    })
+  })
+
+  it("useUpdateStudent delegates the full input", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useUpdateStudent(), {
+      wrapper: wrapperWith(queryClient),
+    })
+    const input = {
+      org: ORG,
+      classroom: CLASSROOM,
+      key: "id:1",
+      patch: { first_name: "A", last_name: "B", email: "", section: "" },
+    } as never
+    result.current.mutate(input)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(updateStudentWithConflictRetry).toHaveBeenCalledWith(
+      expect.anything(),
+      input,
+    )
+  })
+})

--- a/web/src/hooks/mutations/studentMutations.test.ts
+++ b/web/src/hooks/mutations/studentMutations.test.ts
@@ -10,18 +10,22 @@ import { githubKeys } from "@/github-core/queries"
 // Domain/github-core writes are mocked so each hook test asserts only the
 // hook's own responsibility: that it delegates to the right fn and (where it
 // owns cache reconcile) invalidates the right keys.
-const cancelOrgInvitation = vi.fn((..._a: unknown[]) => Promise.resolve())
-const acceptAssignment = vi.fn((..._a: unknown[]) =>
+const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+)
+const acceptAssignment = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve({ status: "created", repo: {}, cloneCommand: "" }),
 )
-const deleteAssignment = vi.fn((..._a: unknown[]) => Promise.resolve())
-const unenrollStudent = vi.fn((..._a: unknown[]) =>
+const deleteAssignment = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+)
+const unenrollStudent = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve({ removed: true }),
 )
-const updateStudentWithConflictRetry = vi.fn((..._a: unknown[]) =>
-  Promise.resolve({ student: {} }),
-)
-const invalidateInviteQueries = vi.fn((..._a: unknown[]) => {})
+const updateStudentWithConflictRetry = vi.fn<
+  (...args: unknown[]) => Promise<unknown>
+>(() => Promise.resolve({ student: {} }))
+const invalidateInviteQueries = vi.fn<(...args: unknown[]) => void>(() => {})
 
 vi.mock("@/github-core/mutations", () => ({
   cancelOrgInvitation: (client: unknown, input: unknown) =>

--- a/web/src/hooks/mutations/useAcceptAssignment.ts
+++ b/web/src/hooks/mutations/useAcceptAssignment.ts
@@ -9,6 +9,11 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 // the viewer's repo list; the confetti, per-step progress state, and error UI
 // stay at the call site (steps are driven via the onStepUpdate callback the
 // caller passes). Mirrors useEnrollOrInviteStudent's data-callback shape.
+//
+// Params are bound at hook-call time (not at mutate()) because onStepUpdate
+// closes over the page's step state and the one call site's params are stable;
+// onStepUpdate is required here (the domain fn takes it optional) since the page
+// always drives the progress UI.
 export function useAcceptAssignment(params: {
   org: string
   classroom: string
@@ -31,13 +36,11 @@ export function useAcceptAssignment(params: {
         onStepUpdate,
       }),
     onSuccess: () => {
-      if (org) {
-        void queryClient.invalidateQueries({
-          queryKey: githubKeys.orgRepos(org),
-          exact: true,
-          refetchType: "all",
-        })
-      }
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgRepos(org),
+        exact: true,
+        refetchType: "all",
+      })
     },
   })
 }

--- a/web/src/hooks/mutations/useAcceptAssignment.ts
+++ b/web/src/hooks/mutations/useAcceptAssignment.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { acceptAssignment } from "@/domain/assignments"
+import type { OnAcceptStepUpdate } from "@/domain/assignments"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Accept an assignment (provision the student repo, land control files). Hook
+// owns the org-repos invalidation on success so the accepted repo shows up in
+// the viewer's repo list; the confetti, per-step progress state, and error UI
+// stay at the call site (steps are driven via the onStepUpdate callback the
+// caller passes). Mirrors useEnrollOrInviteStudent's data-callback shape.
+export function useAcceptAssignment(params: {
+  org: string
+  classroom: string
+  assignmentSlug: string
+  secret?: string
+  onStepUpdate: OnAcceptStepUpdate
+}) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+  const { org, classroom, assignmentSlug, secret, onStepUpdate } = params
+
+  return useMutation({
+    mutationFn: () =>
+      acceptAssignment({
+        client,
+        org,
+        classroom,
+        assignmentSlug,
+        secret,
+        onStepUpdate,
+      }),
+    onSuccess: () => {
+      if (org) {
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.orgRepos(org),
+          exact: true,
+          refetchType: "all",
+        })
+      }
+    },
+  })
+}
+
+export default useAcceptAssignment

--- a/web/src/hooks/mutations/useDeleteAssignment.ts
+++ b/web/src/hooks/mutations/useDeleteAssignment.ts
@@ -3,11 +3,9 @@ import { deleteAssignment } from "@/domain/assignments"
 import type { DeleteAssignmentInput } from "@/domain/assignments"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
-// Delete an assignment from a classroom. A thin write-boundary hook: the cache
-// reconcile is the caller's job (the assignments list refetches via the
-// onDeleteAssignment callback the call site passes to mutate), so the hook only
-// binds the client and delegates. Lives here so the write op is discoverable in
-// hooks/mutations/ rather than inline in a table row (see ./README.md).
+// Delete an assignment from a classroom. Thin write-boundary passthrough: the
+// assignments list refetches via the onDeleteAssignment callback the call site
+// passes, so the hook only binds the client and delegates.
 export function useDeleteAssignment() {
   const client = useGitHubClient()
 

--- a/web/src/hooks/mutations/useDeleteAssignment.ts
+++ b/web/src/hooks/mutations/useDeleteAssignment.ts
@@ -1,0 +1,20 @@
+import { useMutation } from "@tanstack/react-query"
+import { deleteAssignment } from "@/domain/assignments"
+import type { DeleteAssignmentInput } from "@/domain/assignments"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Delete an assignment from a classroom. A thin write-boundary hook: the cache
+// reconcile is the caller's job (the assignments list refetches via the
+// onDeleteAssignment callback the call site passes to mutate), so the hook only
+// binds the client and delegates. Lives here so the write op is discoverable in
+// hooks/mutations/ rather than inline in a table row (see ./README.md).
+export function useDeleteAssignment() {
+  const client = useGitHubClient()
+
+  return useMutation({
+    mutationFn: (input: DeleteAssignmentInput) =>
+      deleteAssignment(client, input),
+  })
+}
+
+export default useDeleteAssignment

--- a/web/src/hooks/mutations/useDismissFailedInvite.ts
+++ b/web/src/hooks/mutations/useDismissFailedInvite.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { cancelOrgInvitation } from "@/github-core/mutations"
+import { invalidateInviteQueries } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Dismiss a failed/expired org invitation: cancel it on GitHub (removes it from
+// the failed list; the mutation treats a 404 as success) and refresh the
+// invite-status queries. Hook owns the invalidation; the error toast stays at
+// the call site (see ./README.md). Sibling of useReinviteFailedInvite.
+export function useDismissFailedInvite(org: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (invitationId: number) =>
+      cancelOrgInvitation(client, { org, invitationId }),
+    onSuccess: () => invalidateInviteQueries(queryClient, org),
+  })
+}
+
+export default useDismissFailedInvite

--- a/web/src/hooks/mutations/useUnenrollStudent.ts
+++ b/web/src/hooks/mutations/useUnenrollStudent.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query"
+import { unenrollStudent } from "@/domain/students"
+import type { UnenrollStudentInput } from "@/domain/students"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Unenroll one student from a classroom. Thin write-boundary hook: the roster
+// modal owns the cache reconcile + toasts around the call, so the hook binds
+// org/classroom and delegates the per-call `student`. Lives in hooks/mutations/
+// so the write op is discoverable rather than inline in the modal.
+export function useUnenrollStudent(org: string, classroom: string) {
+  const client = useGitHubClient()
+
+  return useMutation({
+    mutationFn: (student: UnenrollStudentInput["student"]) =>
+      unenrollStudent(client, { org, classroom, student }),
+  })
+}
+
+export default useUnenrollStudent

--- a/web/src/hooks/mutations/useUnenrollStudent.ts
+++ b/web/src/hooks/mutations/useUnenrollStudent.ts
@@ -3,10 +3,9 @@ import { unenrollStudent } from "@/domain/students"
 import type { UnenrollStudentInput } from "@/domain/students"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
-// Unenroll one student from a classroom. Thin write-boundary hook: the roster
-// modal owns the cache reconcile + toasts around the call, so the hook binds
-// org/classroom and delegates the per-call `student`. Lives in hooks/mutations/
-// so the write op is discoverable rather than inline in the modal.
+// Unenroll one student from a classroom. Thin write-boundary passthrough: the
+// roster modal owns the cache reconcile + toasts, so the hook binds
+// org/classroom and delegates the per-call `student`.
 export function useUnenrollStudent(org: string, classroom: string) {
   const client = useGitHubClient()
 

--- a/web/src/hooks/mutations/useUpdateStudent.ts
+++ b/web/src/hooks/mutations/useUpdateStudent.ts
@@ -4,10 +4,8 @@ import type { UpdateStudentInput } from "@/domain/students"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
 // Update (or upsert) one student's roster row, conflict-retried. Thin
-// write-boundary hook: the edit form owns the form->input shaping, the result
-// handoff (onSaved), and error UI, so the hook binds the client and delegates
-// the per-call UpdateStudentInput. Lives in hooks/mutations/ so the write op is
-// discoverable rather than inline in the form.
+// write-boundary passthrough: the edit form owns the form->input shaping, the
+// onSaved handoff, and error UI, so the hook delegates the per-call input.
 export function useUpdateStudent() {
   const client = useGitHubClient()
 

--- a/web/src/hooks/mutations/useUpdateStudent.ts
+++ b/web/src/hooks/mutations/useUpdateStudent.ts
@@ -1,0 +1,20 @@
+import { useMutation } from "@tanstack/react-query"
+import { updateStudentWithConflictRetry } from "@/domain/students"
+import type { UpdateStudentInput } from "@/domain/students"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Update (or upsert) one student's roster row, conflict-retried. Thin
+// write-boundary hook: the edit form owns the form->input shaping, the result
+// handoff (onSaved), and error UI, so the hook binds the client and delegates
+// the per-call UpdateStudentInput. Lives in hooks/mutations/ so the write op is
+// discoverable rather than inline in the form.
+export function useUpdateStudent() {
+  const client = useGitHubClient()
+
+  return useMutation({
+    mutationFn: (input: UpdateStudentInput) =>
+      updateStudentWithConflictRetry(client, input),
+  })
+}
+
+export default useUpdateStudent

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -12,19 +12,13 @@ import { Spinner } from "@/components/Spinner"
 import { Alert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubUser } from "@/github-core/types"
-import { githubKeys } from "@/github-core/queries"
 import { Link, useParams, useSearch } from "@tanstack/react-router"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useAcceptAssignment } from "@/hooks/mutations/useAcceptAssignment"
 import { useGithubAuth } from "@/auth/useGithubAuth"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import confetti from "canvas-confetti"
-import {
-  acceptAssignment,
-  type AcceptStepId,
-  type AcceptStepStatus,
-} from "@/domain/assignments"
+import { type AcceptStepId, type AcceptStepStatus } from "@/domain/assignments"
 import { useAcceptAndVerifyMembership } from "@/hooks/mutations/useAcceptAndVerifyMembership"
 import {
   classifyMembershipError,
@@ -525,8 +519,6 @@ const AcceptAssignmentPage = () => {
   // loosely so the page works if mounted without the typed route in tests.
   const search = useSearch({ strict: false }) as { k?: string }
   const secret = typeof search.k === "string" ? search.k : undefined
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
 
   const { user } = useGithubAuth()
   const username = user?.login
@@ -572,42 +564,36 @@ const AcceptAssignmentPage = () => {
     enabled: Boolean(isPending && org),
   })
 
-  const acceptMutation = useMutation({
-    mutationFn: () => {
-      setSteps(initialStepState)
-      return acceptAssignment({
-        client,
-        org: org ?? "",
-        classroom: classroom ?? "",
-        assignmentSlug: assignment ?? "",
-        secret,
-        onStepUpdate: (update) =>
-          setSteps((prev) => ({
-            ...prev,
-            [update.id]: {
-              status: update.status,
-              message: update.message,
-              error: update.error,
-            },
-          })),
-      })
-    },
-    onSuccess: (result) => {
-      // Celebrate a freshly created repo; an already-accepted repo isn't a new
-      // milestone, so skip the confetti.
-      if (result.status === "created") {
-        fireConfetti()
-      }
-
-      if (org) {
-        void queryClient.invalidateQueries({
-          queryKey: githubKeys.orgRepos(org),
-          exact: true,
-          refetchType: "all",
-        })
-      }
-    },
+  const acceptMutation = useAcceptAssignment({
+    org: org ?? "",
+    classroom: classroom ?? "",
+    assignmentSlug: assignment ?? "",
+    secret,
+    onStepUpdate: (update) =>
+      setSteps((prev) => ({
+        ...prev,
+        [update.id]: {
+          status: update.status,
+          message: update.message,
+          error: update.error,
+        },
+      })),
   })
+
+  // Reset the per-step progress UI, run the accept, and celebrate a freshly
+  // created repo. Step-reset + confetti are UI effects, so they live at the
+  // call site; the hook owns the org-repos invalidation. Both accept buttons
+  // (initial + repair rerun) go through this.
+  const runAcceptFlow = () => {
+    setSteps(initialStepState)
+    return acceptMutation.mutateAsync(undefined, {
+      onSuccess: (result) => {
+        if (result.status === "created") {
+          fireConfetti()
+        }
+      },
+    })
+  }
 
   if (loadingAssignments || isLoadingRepo || loadingOrgMembership) {
     return (
@@ -814,9 +800,7 @@ const AcceptAssignmentPage = () => {
                   variant="primary"
                   className="w-full text-lg p-5"
                   disabled={!username || acceptMutation.isPending}
-                  onClick={() =>
-                    void runAccept(() => acceptMutation.mutateAsync())
-                  }
+                  onClick={() => void runAccept(() => runAcceptFlow())}
                 >
                   {t("accept.acceptButton")}
                 </Button>
@@ -829,7 +813,7 @@ const AcceptAssignmentPage = () => {
                   disabled={!username || acceptMutation.isPending}
                   onRerun={() => {
                     setRepairOpen(false)
-                    void runAccept(() => acceptMutation.mutateAsync())
+                    void runAccept(() => runAcceptFlow())
                   }}
                   open={repairOpen}
                   onToggle={setRepairOpen}

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -12,12 +12,8 @@ import { ConfirmModal } from "@/components/modals"
 import { ReuseAssignmentModal } from "@/components/modals/ReuseAssignmentModal"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import {
-  deleteAssignment,
-  type DeleteAssignmentInput,
-} from "@/domain/assignments"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useQueryClient } from "@tanstack/react-query"
+import { useDeleteAssignment } from "@/hooks/mutations/useDeleteAssignment"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 import { Badge, Button } from "@/components/ui"
@@ -34,13 +30,8 @@ const DeleteAssignmentButton = ({
   onDeleteAssignment: () => void
 }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
   const [open, setOpen] = useState(false)
-  const deleteAssignmentMutation = useMutation({
-    mutationFn: (input: DeleteAssignmentInput) =>
-      deleteAssignment(client, input),
-    onSuccess: () => onDeleteAssignment(),
-  })
+  const deleteAssignmentMutation = useDeleteAssignment()
 
   return (
     <>

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -1,12 +1,10 @@
 import { Mail, UserRound, Users } from "lucide-react"
 import { revalidateLogic, useForm } from "@tanstack/react-form"
-import { useMutation } from "@tanstack/react-query"
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import GitHub from "@/assets/github.svg?react"
-import { updateStudentWithConflictRetry } from "@/domain/students"
+import { useUpdateStudent } from "@/hooks/mutations/useUpdateStudent"
 import { getErrorMessage } from "@/github-core/errorMessage"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { isValidEmail } from "@/util/orgMembership"
 import { studentKey } from "@/util/roster"
@@ -51,7 +49,6 @@ const EditStudentForm = ({
   // the GitHub identity elsewhere (e.g. the roster detail modal's header).
   showGitHubPanel?: boolean
 }) => {
-  const client = useGitHubClient()
   const runSave = useSafeSubmit()
   const { t } = useTranslation()
   const [error, setError] = useState<string | null>(null)
@@ -66,27 +63,7 @@ const EditStudentForm = ({
     [student],
   )
 
-  const updateMutation = useMutation({
-    mutationFn: (value: EditStudentFormValues) =>
-      updateStudentWithConflictRetry(client, {
-        org,
-        classroom,
-        key: studentKey(student),
-        patch: {
-          first_name: value.first_name.trim(),
-          last_name: value.last_name.trim(),
-          email: value.email.trim(),
-          section: value.section.trim(),
-        },
-        // Seed a row if none exists yet (a team member — often staff — added on
-        // GitHub before the roster synced their blank row), so editing upserts.
-        identity: {
-          github_id: student.github_id,
-          username: student.username,
-          email: student.email,
-        },
-      }),
-  })
+  const updateMutation = useUpdateStudent()
 
   const form = useForm({
     defaultValues: defaults(),
@@ -108,7 +85,25 @@ const EditStudentForm = ({
       // rejection, so capture the error inside fn before it propagates.
       await runSave(async () => {
         try {
-          const result = await updateMutation.mutateAsync(value)
+          const result = await updateMutation.mutateAsync({
+            org,
+            classroom,
+            key: studentKey(student),
+            patch: {
+              first_name: value.first_name.trim(),
+              last_name: value.last_name.trim(),
+              email: value.email.trim(),
+              section: value.section.trim(),
+            },
+            // Seed a row if none exists yet (a team member — often staff — added
+            // on GitHub before the roster synced their blank row), so editing
+            // upserts.
+            identity: {
+              github_id: student.github_id,
+              username: student.username,
+              email: student.email,
+            },
+          })
           onSaved(result.student)
         } catch (err) {
           setError(getErrorMessage(err))

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -20,9 +20,9 @@ import {
 import Avatar from "@/components/avatar"
 import { RoleBadges } from "./RoleBadges"
 import type { Student } from "@/types/classroom"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import type { RosterCsvProblem } from "@/domain/students"
-import { cancelOrgInvitation } from "@/github-core/mutations"
+import { useDismissFailedInvite } from "@/hooks/mutations/useDismissFailedInvite"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -189,19 +189,9 @@ const EnrolledStudents = ({
     invalidateInviteQueriesForOrg(queryClient, org)
 
   // Dismiss a failed/expired invitation: cancel it on GitHub (removes it from
-  // the failed list) and refresh. 404 is treated as success by the mutation.
-  const dismissFailedInvite = useMutation({
-    mutationFn: (invitationId: number) =>
-      cancelOrgInvitation(client, { org, invitationId }),
-    onSuccess: () => invalidateInviteQueries(),
-    onError: (err) =>
-      notify({
-        tone: "error",
-        message: t("students.failedInviteDismissError", {
-          error: getErrorMessage(err),
-        }),
-      }),
-  })
+  // the failed list) and refresh. The hook owns the invite-query invalidation;
+  // the error toast stays here so it skips on unmount.
+  const dismissFailedInvite = useDismissFailedInvite(org)
 
   // Re-invite a failed/expired invitation: dismiss the dead one, then re-issue
   // an equivalent fresh invite — same classroom role (instructor -> org OWNER),
@@ -797,7 +787,17 @@ const EnrolledStudents = ({
                         reinviteFailedInvite.isPending ||
                         dismissFailedInvite.isPending
                       }
-                      onClick={() => dismissFailedInvite.mutate(inv.id)}
+                      onClick={() =>
+                        dismissFailedInvite.mutate(inv.id, {
+                          onError: (err) =>
+                            notify({
+                              tone: "error",
+                              message: t("students.failedInviteDismissError", {
+                                error: getErrorMessage(err),
+                              }),
+                            }),
+                        })
+                      }
                     >
                       {t("students.dismiss")}
                     </Button>

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -10,18 +10,16 @@ import {
   XCircle,
 } from "lucide-react"
 
-import { useMutation } from "@tanstack/react-query"
-
 import Avatar from "@/components/avatar"
 import GitHub from "@/assets/github.svg?react"
 import EditStudentForm from "@/pages/students/EditStudentForm"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useUnenrollStudent } from "@/hooks/mutations/useUnenrollStudent"
 import {
   assignRosterMemberRole,
   applyClassroomRoleChange,
   inviteRosterStudents,
   resolveTeamIdForRoleRead,
-  unenrollStudent,
   type StudentCsvRow,
 } from "@/domain/students"
 import {
@@ -122,10 +120,7 @@ const RosterMemberModal = ({
   const [pendingRole, setPendingRole] = useState<ClassroomRole | null>(null)
   const [roleOwnerConfirmed, setRoleOwnerConfirmed] = useState(false)
 
-  const unenrollMutation = useMutation({
-    mutationFn: (student: ReturnType<typeof rowToStudent>) =>
-      unenrollStudent(client, { org, classroom, student }),
-  })
+  const unenrollMutation = useUnenrollStudent(org, classroom)
 
   // `resending` covers an in-flight invite/resend; folding it into `busy` keeps
   // the modal non-closeable (button, backdrop, Escape) while a write is pending,


### PR DESCRIPTION
## Summary

**Tier-2 Phase F, U9 — batch 2 of 3** ([plan](docs/plans/2026-07-15-005-refactor-tier2-structural-debt-plan.md)). Converts the inline `useMutation` sites in the five student/assignment surfaces into named `hooks/mutations/` hooks, per the `hooks/mutations/README.md` convention (data-consistency in the hook; UI effects at the call site).

| Hook | Call site | Shape |
|------|-----------|-------|
| `useDismissFailedInvite` | `EnrolledStudents` | owns the invite-query invalidation; error toast moved to the call-site `mutate(..., { onError })` |
| `useAcceptAssignment` | `AcceptAssignmentPage` | owns the org-repos invalidation; confetti + per-step progress reset stay at the call site via a small `runAcceptFlow` helper + per-call `onSuccess` |
| `useDeleteAssignment` | `AssignmentsTable` | thin passthrough — the assignments list refetches via the existing `onDeleteAssignment` parent callback |
| `useUnenrollStudent` | `RosterMemberModal` | thin passthrough — the modal owns reconcile/toasts |
| `useUpdateStudent` | `EditStudentForm` | thin passthrough — the form owns the `value -> UpdateStudentInput` shaping + `onSaved` handoff |

The three thin passthroughs have no cache-consistency to relocate (a parent callback already reconciles), but they're still extracted so every write op is discoverable at the `hooks/mutations/` boundary — moving toward the plan's zero-inline-`useMutation` DoD.

Also exports `OnAcceptStepUpdate` from the `domain/assignments` barrel (needed by the accept hook).

### Included ce-code-review fixes (2nd commit)
A full multi-agent review ran on this branch — **no P0/P1; correctness found zero issues** (behavior verified point-by-point, including the AcceptAssignmentPage rewiring). The `fix(review)` commit:
- Drops a dead `if (org)` guard in `useAcceptAssignment` (leftover from the old `string | undefined` inline) and documents the deliberate hook-call param binding + required `onStepUpdate`.
- Trims the three thin-passthrough hook comments to one line (why-not-what per AGENTS.md).

Reviewers also noted a **benign side-fix**: `AssignmentsTable` delete previously invalidated *twice* (inline `onSuccess` + the call-site callback); it now fires once.

## Scope note
This is batch 2 of U9's 3 feature-grouped PRs (batch 1 = classroom lifecycle, #296, merged). Batch 3 (org-setup/staff) follows. The infra hooks `useGitHubOperation` / `useActionActivity` remain intentionally excluded; `SkeletonDriftBanner` (U10) and `useGithubAuth` (U11) are separate units.

## Test plan

- [x] 5 focused hook tests (invalidation-key assertions for the two substantive hooks; delegation assertions for the passthroughs)
- [x] `tsc -b` clean; full `vitest` green (146 files, 1553 tests) — existing component tests confirm behavior preserved
- [x] Zero inline `useMutation` in the 5 converted files
- [x] `eslint .` + `arch:validate` + `prettier --check` clean
- [x] Full `ce-code-review` (correctness/reliability/adversarial/maintainability) — findings applied; no P0/P1