### PR TITLE
refactor(web): move org-setup/staff mutations into hooks/mutations/ (Tier-2F U9, batch 3)

### DIFF
--- a/web/src/hooks/mutations/orgSetupMutations.test.ts
+++ b/web/src/hooks/mutations/orgSetupMutations.test.ts
@@ -6,6 +6,7 @@ import type { PropsWithChildren } from "react"
 import { createElement } from "react"
 
 import { githubKeys } from "@/github-core/queries"
+import type { ConcernId } from "@/orgPolicy/audit"
 
 const renameConfigRepoToMain = vi.fn<(...args: unknown[]) => Promise<void>>(
   () => Promise.resolve(),
@@ -132,21 +133,25 @@ describe("useCancelStaffInvite", () => {
 })
 
 describe("useRepairOrgPolicyConcern", () => {
-  it("repairs the concern and invalidates only the org-audit prefix", async () => {
+  it("repairs the concern, runs onRepaired, and invalidates the org-audit prefix", async () => {
     const queryClient = freshClient()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const onRepaired = vi.fn()
     const { result } = renderHook(
-      () => useRepairOrgPolicyConcern(ORG, "Team"),
+      () => useRepairOrgPolicyConcern(ORG, "Team", onRepaired),
       { wrapper: wrapperWith(queryClient) },
     )
-    result.current.mutate("some-concern" as never)
+    const concernId: ConcernId = "orgDefaults"
+    result.current.mutate(concernId)
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(repairConcern).toHaveBeenCalledWith(
       expect.anything(),
       ORG,
-      "some-concern",
+      concernId,
       "Team",
     )
+    // onRepaired (durable persist) runs in the hook, unmount-safe.
+    expect(onRepaired).toHaveBeenCalledWith({}, concernId)
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.orgAuditPrefix(ORG),
     })
@@ -154,10 +159,11 @@ describe("useRepairOrgPolicyConcern", () => {
 })
 
 describe("useRunOrgSetup", () => {
-  it("delegates to initClassroom50 (thin orchestration wrapper, no invalidation)", async () => {
+  it("delegates to initClassroom50 and runs the caller's invalidate in the hook (unmount-safe)", async () => {
     const queryClient = freshClient()
     const onStepUpdate = vi.fn()
     const confirmSkeletonOverwrite = vi.fn()
+    const invalidate = vi.fn()
     const { result } = renderHook(
       () =>
         useRunOrgSetup({
@@ -165,6 +171,7 @@ describe("useRunOrgSetup", () => {
           plan: "Team",
           onStepUpdate,
           confirmSkeletonOverwrite,
+          invalidate,
         }),
       { wrapper: wrapperWith(queryClient) },
     )
@@ -173,5 +180,8 @@ describe("useRunOrgSetup", () => {
     expect(initClassroom50).toHaveBeenCalledWith(
       expect.objectContaining({ org: ORG, plan: "Team", onStepUpdate }),
     )
+    // Invalidation runs in the hook's onSuccess (fires regardless of caller
+    // unmount), receiving the queryClient + init result.
+    expect(invalidate).toHaveBeenCalledWith(queryClient, { status: "ok" })
   })
 })

--- a/web/src/hooks/mutations/orgSetupMutations.test.ts
+++ b/web/src/hooks/mutations/orgSetupMutations.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+
+const renameConfigRepoToMain = vi.fn<(...args: unknown[]) => Promise<void>>(
+  () => Promise.resolve(),
+)
+const removeUserFromTeam = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+)
+const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+)
+const repairConcern = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve({}),
+)
+const initClassroom50 = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve({ status: "ok" }),
+)
+const syncRosterAfterStaffChange = vi.fn<(...args: unknown[]) => void>(() => {})
+
+vi.mock("@/github-core/mutations", () => ({
+  renameConfigRepoToMain: (client: unknown, org: unknown) =>
+    renameConfigRepoToMain(client, org),
+  removeUserFromTeam: (client: unknown, input: unknown) =>
+    removeUserFromTeam(client, input),
+  cancelOrgInvitation: (client: unknown, input: unknown) =>
+    cancelOrgInvitation(client, input),
+  initClassroom50: (params: unknown) => initClassroom50(params),
+}))
+vi.mock("@/orgPolicy/repair", () => ({
+  repairConcern: (client: unknown, org: unknown, id: unknown, plan: unknown) =>
+    repairConcern(client, org, id, plan),
+}))
+vi.mock("@/hooks/mutations/useAddStaffMember", () => ({
+  syncRosterAfterStaffChange: (...a: unknown[]) =>
+    syncRosterAfterStaffChange(...a),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useRenameConfigRepoToMain } from "./useRenameConfigRepoToMain"
+import { useRemoveStaffMember } from "./useRemoveStaffMember"
+import { useCancelStaffInvite } from "./useCancelStaffInvite"
+import { useRepairOrgPolicyConcern } from "./useRepairOrgPolicyConcern"
+import { useRunOrgSetup } from "./useRunOrgSetup"
+
+const ORG = "acme"
+const CLASSROOM = "cs101"
+const TEAM = "classroom50-cs101-ta"
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useRenameConfigRepoToMain", () => {
+  it("renames then invalidates the org-audit prefix", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useRenameConfigRepoToMain(ORG), {
+      wrapper: wrapperWith(queryClient),
+    })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(renameConfigRepoToMain).toHaveBeenCalledWith(expect.anything(), ORG)
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.orgAuditPrefix(ORG),
+    })
+  })
+})
+
+describe("useRemoveStaffMember", () => {
+  it("removes the user, invalidates team members + invitations, and syncs the roster", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(
+      () => useRemoveStaffMember(ORG, CLASSROOM, TEAM),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate("alice")
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(removeUserFromTeam).toHaveBeenCalledWith(expect.anything(), {
+      org: ORG,
+      teamSlug: TEAM,
+      username: "alice",
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.teamMembers(ORG, TEAM),
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.teamInvitations(ORG, TEAM),
+    })
+    expect(syncRosterAfterStaffChange).toHaveBeenCalled()
+  })
+})
+
+describe("useCancelStaffInvite", () => {
+  it("cancels the invite and invalidates the bound team's queries", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useCancelStaffInvite(ORG, TEAM), {
+      wrapper: wrapperWith(queryClient),
+    })
+    result.current.mutate(99)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(cancelOrgInvitation).toHaveBeenCalledWith(expect.anything(), {
+      org: ORG,
+      invitationId: 99,
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.teamInvitations(ORG, TEAM),
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.teamMembers(ORG, TEAM),
+    })
+  })
+})
+
+describe("useRepairOrgPolicyConcern", () => {
+  it("repairs the concern and invalidates only the org-audit prefix", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(
+      () => useRepairOrgPolicyConcern(ORG, "Team"),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate("some-concern" as never)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(repairConcern).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG,
+      "some-concern",
+      "Team",
+    )
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.orgAuditPrefix(ORG),
+    })
+  })
+})
+
+describe("useRunOrgSetup", () => {
+  it("delegates to initClassroom50 (thin orchestration wrapper, no invalidation)", async () => {
+    const queryClient = freshClient()
+    const onStepUpdate = vi.fn()
+    const confirmSkeletonOverwrite = vi.fn()
+    const { result } = renderHook(
+      () =>
+        useRunOrgSetup({
+          org: ORG,
+          plan: "Team",
+          onStepUpdate,
+          confirmSkeletonOverwrite,
+        }),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(initClassroom50).toHaveBeenCalledWith(
+      expect.objectContaining({ org: ORG, plan: "Team", onStepUpdate }),
+    )
+  })
+})

--- a/web/src/hooks/mutations/orgSetupMutations.test.ts
+++ b/web/src/hooks/mutations/orgSetupMutations.test.ts
@@ -17,6 +17,9 @@ const removeUserFromTeam = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
 const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
   Promise.resolve(),
 )
+const resendOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+)
 const repairConcern = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve({}),
 )
@@ -24,6 +27,12 @@ const initClassroom50 = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve({ status: "ok" }),
 )
 const syncRosterAfterStaffChange = vi.fn<(...args: unknown[]) => void>(() => {})
+const getUser = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve({ id: 4242 }),
+)
+const resolveTeamIdForRoleRead = vi.fn<
+  (...args: unknown[]) => Promise<unknown>
+>(() => Promise.resolve(7))
 
 vi.mock("@/github-core/mutations", () => ({
   renameConfigRepoToMain: (client: unknown, org: unknown) =>
@@ -32,7 +41,18 @@ vi.mock("@/github-core/mutations", () => ({
     removeUserFromTeam(client, input),
   cancelOrgInvitation: (client: unknown, input: unknown) =>
     cancelOrgInvitation(client, input),
+  resendOrgInvitation: (client: unknown, input: unknown) =>
+    resendOrgInvitation(client, input),
   initClassroom50: (params: unknown) => initClassroom50(params),
+}))
+vi.mock("@/github-core/queries", async (importOriginal) => ({
+  // Keep the real githubKeys (assertions build query keys from it); override
+  // only the network read the resend hook performs.
+  ...(await importOriginal<typeof import("@/github-core/queries")>()),
+  getUser: (client: unknown, login: unknown) => getUser(client, login),
+}))
+vi.mock("@/domain/students", () => ({
+  resolveTeamIdForRoleRead: (...a: unknown[]) => resolveTeamIdForRoleRead(...a),
 }))
 vi.mock("@/orgPolicy/repair", () => ({
   repairConcern: (client: unknown, org: unknown, id: unknown, plan: unknown) =>
@@ -49,6 +69,7 @@ vi.mock("@/context/github/GitHubProvider", () => ({
 import { useRenameConfigRepoToMain } from "./useRenameConfigRepoToMain"
 import { useRemoveStaffMember } from "./useRemoveStaffMember"
 import { useCancelStaffInvite } from "./useCancelStaffInvite"
+import { useResendStaffInvite } from "./useResendStaffInvite"
 import { useRepairOrgPolicyConcern } from "./useRepairOrgPolicyConcern"
 import { useRunOrgSetup } from "./useRunOrgSetup"
 
@@ -132,6 +153,66 @@ describe("useCancelStaffInvite", () => {
   })
 })
 
+describe("useResendStaffInvite", () => {
+  const ROLE = "ta" as const
+
+  it("resolves invitee id + team, resends carrying the team, and invalidates", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(
+      () => useResendStaffInvite(ORG, CLASSROOM, ROLE, TEAM),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate({
+      login: "bob",
+      invitationId: 12,
+      emailOnlyMessage: "EMAIL_ONLY",
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(getUser).toHaveBeenCalledWith(expect.anything(), "bob")
+    expect(resolveTeamIdForRoleRead).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG,
+      CLASSROOM,
+      ROLE,
+    )
+    expect(resendOrgInvitation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        org: ORG,
+        username: "bob",
+        inviteeId: 4242,
+        invitationId: 12,
+        teamIds: [7],
+      }),
+    )
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.teamInvitations(ORG, TEAM),
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.teamMembers(ORG, TEAM),
+    })
+  })
+
+  it("throws the caller-supplied emailOnlyMessage when login is null (t()-free)", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(
+      () => useResendStaffInvite(ORG, CLASSROOM, ROLE, TEAM),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate({
+      login: null,
+      invitationId: 12,
+      emailOnlyMessage: "EMAIL_ONLY",
+    })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe("EMAIL_ONLY")
+    // The email-only guard short-circuits before any network read.
+    expect(getUser).not.toHaveBeenCalled()
+    expect(resendOrgInvitation).not.toHaveBeenCalled()
+  })
+})
+
 describe("useRepairOrgPolicyConcern", () => {
   it("repairs the concern, runs onRepaired, and invalidates the org-audit prefix", async () => {
     const queryClient = freshClient()
@@ -153,6 +234,25 @@ describe("useRepairOrgPolicyConcern", () => {
     // onRepaired (durable persist) runs in the hook, unmount-safe.
     expect(onRepaired).toHaveBeenCalledWith({}, concernId)
     expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.orgAuditPrefix(ORG),
+    })
+  })
+
+  it("does not run onRepaired or invalidate when the repair rejects", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const onRepaired = vi.fn()
+    repairConcern.mockRejectedValueOnce(new Error("boom"))
+    const { result } = renderHook(
+      () => useRepairOrgPolicyConcern(ORG, "Team", onRepaired),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate("orgDefaults" as ConcernId)
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    // onSuccess never fires on rejection, so neither the durable persist nor
+    // the audit invalidation runs.
+    expect(onRepaired).not.toHaveBeenCalled()
+    expect(invalidate).not.toHaveBeenCalledWith({
       queryKey: githubKeys.orgAuditPrefix(ORG),
     })
   })
@@ -183,5 +283,72 @@ describe("useRunOrgSetup", () => {
     // Invalidation runs in the hook's onSuccess (fires regardless of caller
     // unmount), receiving the queryClient + init result.
     expect(invalidate).toHaveBeenCalledWith(queryClient, { status: "ok" })
+  })
+
+  it("skips initClassroom50 on the org-absent path but still runs invalidate", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.fn()
+    const { result } = renderHook(
+      () =>
+        useRunOrgSetup({
+          org: undefined,
+          plan: "Team",
+          onStepUpdate: vi.fn(),
+          invalidate,
+        }),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    // Matches the pre-refactor early return: no init call, undefined result.
+    expect(initClassroom50).not.toHaveBeenCalled()
+    expect(invalidate).toHaveBeenCalledWith(queryClient, undefined)
+  })
+
+  it("supports a caller invalidate that guards on result.status (RerunOrgSetup shape)", async () => {
+    // RerunOrgSetup passes an invalidate that skips on a status-"error"
+    // outcome; OrgSetupPage's is unconditional. Exercise the guarded shape's
+    // both branches directly against the callback the hook drives.
+    const queryClient = freshClient()
+    const doInvalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const guardedInvalidate = (
+      qc: typeof queryClient,
+      result: { status?: string } | undefined,
+    ) => {
+      if (result && result.status === "error") return
+      qc.invalidateQueries({ queryKey: githubKeys.orgAuditPrefix(ORG) })
+      qc.invalidateQueries({ queryKey: ["orgs"] })
+    }
+
+    initClassroom50.mockResolvedValueOnce({ status: "error" })
+    const errRun = renderHook(
+      () =>
+        useRunOrgSetup({
+          org: ORG,
+          onStepUpdate: vi.fn(),
+          invalidate: guardedInvalidate,
+        }),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    errRun.result.current.mutate()
+    await waitFor(() => expect(errRun.result.current.isSuccess).toBe(true))
+    expect(doInvalidate).not.toHaveBeenCalled()
+
+    initClassroom50.mockResolvedValueOnce({ status: "ok" })
+    const okRun = renderHook(
+      () =>
+        useRunOrgSetup({
+          org: ORG,
+          onStepUpdate: vi.fn(),
+          invalidate: guardedInvalidate,
+        }),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    okRun.result.current.mutate()
+    await waitFor(() => expect(okRun.result.current.isSuccess).toBe(true))
+    expect(doInvalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.orgAuditPrefix(ORG),
+    })
+    expect(doInvalidate).toHaveBeenCalledWith({ queryKey: ["orgs"] })
   })
 })

--- a/web/src/hooks/mutations/useCancelStaffInvite.ts
+++ b/web/src/hooks/mutations/useCancelStaffInvite.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { cancelOrgInvitation } from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Cancel a pending staff org invitation. Hook owns the invitations + members
+// invalidation for the bound team (mirroring the resend hook's local
+// invalidate); the toasts stay at the call site (see ./README.md).
+export function useCancelStaffInvite(org: string, teamSlug: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (invitationId: number) =>
+      cancelOrgInvitation(client, { org, invitationId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.teamInvitations(org, teamSlug),
+      })
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.teamMembers(org, teamSlug),
+      })
+    },
+  })
+}
+
+export default useCancelStaffInvite

--- a/web/src/hooks/mutations/useCancelStaffInvite.ts
+++ b/web/src/hooks/mutations/useCancelStaffInvite.ts
@@ -4,8 +4,8 @@ import { githubKeys } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
 // Cancel a pending staff org invitation. Hook owns the invitations + members
-// invalidation for the bound team (mirroring the resend hook's local
-// invalidate); the toasts stay at the call site (see ./README.md).
+// invalidation for the bound team; the toasts stay at the call site (see
+// ./README.md).
 export function useCancelStaffInvite(org: string, teamSlug: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()

--- a/web/src/hooks/mutations/useRemoveStaffMember.ts
+++ b/web/src/hooks/mutations/useRemoveStaffMember.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { removeUserFromTeam } from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
+import { syncRosterAfterStaffChange } from "@/hooks/mutations/useAddStaffMember"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Remove a staff member from a classroom's role team. Hook owns the
+// team-members + team-invitations invalidation and the best-effort roster sync;
+// the success/error toasts stay at the call site (see ./README.md).
+export function useRemoveStaffMember(
+  org: string,
+  classroom: string,
+  teamSlug: string,
+) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (username: string) =>
+      removeUserFromTeam(client, { org, teamSlug, username }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.teamMembers(org, teamSlug),
+      })
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.teamInvitations(org, teamSlug),
+      })
+      void syncRosterAfterStaffChange(client, queryClient, org, classroom)
+    },
+  })
+}
+
+export default useRemoveStaffMember

--- a/web/src/hooks/mutations/useRenameConfigRepoToMain.ts
+++ b/web/src/hooks/mutations/useRenameConfigRepoToMain.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { renameConfigRepoToMain } from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Rename the config repo's default branch to `main`. Hook owns the audit-prefix
+// invalidation so the recommendation clears; the confirm modal + any UI stay at
+// the call site (see ./README.md).
+export function useRenameConfigRepoToMain(org: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => renameConfigRepoToMain(client, org),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgAuditPrefix(org),
+      })
+    },
+  })
+}
+
+export default useRenameConfigRepoToMain

--- a/web/src/hooks/mutations/useRepairOrgPolicyConcern.ts
+++ b/web/src/hooks/mutations/useRepairOrgPolicyConcern.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import type { ConcernId } from "@/orgPolicy/audit"
+import { repairConcern } from "@/orgPolicy/repair"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Repair a single API-repairable org-policy concern. Thin: the hook owns ONLY
+// the audit-prefix invalidation. classifyRepairOutcome and the enterprise-pin /
+// unresolved-concern / transient-notice component state stay at the call site
+// via a per-call onSuccess (see ./README.md).
+export function useRepairOrgPolicyConcern(org: string, plan?: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: ConcernId) => repairConcern(client, org, id, plan),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgAuditPrefix(org),
+      })
+    },
+  })
+}
+
+export default useRepairOrgPolicyConcern

--- a/web/src/hooks/mutations/useRepairOrgPolicyConcern.ts
+++ b/web/src/hooks/mutations/useRepairOrgPolicyConcern.ts
@@ -1,20 +1,30 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import type { ConcernId } from "@/orgPolicy/audit"
-import { repairConcern } from "@/orgPolicy/repair"
+import { repairConcern, type RepairResult } from "@/orgPolicy/repair"
 import { githubKeys } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
-// Repair a single API-repairable org-policy concern. Thin: the hook owns ONLY
-// the audit-prefix invalidation. classifyRepairOutcome and the enterprise-pin /
-// unresolved-concern / transient-notice component state stay at the call site
-// via a per-call onSuccess (see ./README.md).
-export function useRepairOrgPolicyConcern(org: string, plan?: string) {
+// Repair a single API-repairable org-policy concern. The hook owns the
+// always-run data-consistency effects: the audit-prefix invalidation AND the
+// caller's `onRepaired` (which records the persistent "didn't stick" outcome to
+// the per-org store). Both run in the hook's onSuccess so a mid-repair unmount
+// (e.g. an org switch remounting the pane) can't drop the durable write.
+// Pure component-state (enterprise-pin / unresolved-concern / transient-notice
+// setState) stays at the call site's per-call onSuccess (skipped on unmount).
+export function useRepairOrgPolicyConcern(
+  org: string,
+  plan: string | undefined,
+  // Data-consistency follow-up: persist the classified outcome. Runs in the
+  // hook (unmount-safe), NOT the call site.
+  onRepaired: (result: RepairResult, id: ConcernId) => void,
+) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (id: ConcernId) => repairConcern(client, org, id, plan),
-    onSuccess: () => {
+    onSuccess: (result, id) => {
+      onRepaired(result, id)
       void queryClient.invalidateQueries({
         queryKey: githubKeys.orgAuditPrefix(org),
       })

--- a/web/src/hooks/mutations/useResendStaffInvite.ts
+++ b/web/src/hooks/mutations/useResendStaffInvite.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { resendOrgInvitation } from "@/github-core/mutations"
+import { githubKeys, getUser } from "@/github-core/queries"
+import { resolveTeamIdForRoleRead } from "@/domain/students"
+import { githubOrgRoleForRole } from "@/util/teamRoster"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import type { StaffRole } from "@/types/classroom"
+
+// Resend a pending staff org invitation. The multi-step data logic — resolve
+// the invitee's immutable id (org invites don't carry it) and the role's team,
+// then re-send the invite carrying that team — lives in the mutationFn. Hook
+// owns the invitations + members invalidation for the bound team; the toasts
+// stay at the call site (see ./README.md).
+//
+// Hooks are t()-free: an email-only invite (no login) can't be resolved to a
+// numeric invitee id, so the caller passes the pre-translated `emailOnlyMessage`
+// the hook throws in that case.
+export function useResendStaffInvite(
+  org: string,
+  classroom: string,
+  role: StaffRole,
+  teamSlug: string,
+) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: {
+      login: string | null
+      invitationId: number
+      emailOnlyMessage: string
+    }) => {
+      if (!input.login) throw new Error(input.emailOnlyMessage)
+      const inviteeId = (await getUser(client, input.login)).id
+      const teamId = await resolveTeamIdForRoleRead(
+        client,
+        org,
+        classroom,
+        role,
+      )
+      await resendOrgInvitation(client, {
+        org,
+        username: input.login,
+        inviteeId,
+        invitationId: input.invitationId,
+        teamIds: teamId ? [teamId] : undefined,
+        // Preserve the original org role: an instructor invite is org OWNER.
+        role: githubOrgRoleForRole(role),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.teamInvitations(org, teamSlug),
+      })
+      queryClient.invalidateQueries({
+        queryKey: githubKeys.teamMembers(org, teamSlug),
+      })
+    },
+  })
+}
+
+export default useResendStaffInvite

--- a/web/src/hooks/mutations/useRunOrgSetup.ts
+++ b/web/src/hooks/mutations/useRunOrgSetup.ts
@@ -1,0 +1,37 @@
+import { useMutation } from "@tanstack/react-query"
+import { initClassroom50, type InitStepUpdate } from "@/github-core/mutations"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Run (or re-run) org setup: the idempotent initClassroom50 that applies
+// lockdown, rulesets, and repo settings. THIN — owns only the init call, no
+// invalidation, because the two call sites (RerunOrgSetup, OrgSetupPage)
+// invalidate differently and branch on data.status "error" into different
+// component state. Each keeps its own onSuccess + step-reset wrapper; the hook's
+// mutationFn just calls initClassroom50 (see ./README.md).
+//
+// Callbacks are bound at hook-call time (they close over the page's step state
+// and modal); org/plan are stable per render.
+export function useRunOrgSetup(params: {
+  org: string | undefined
+  plan?: string
+  onStepUpdate: (update: InitStepUpdate) => void
+  confirmSkeletonOverwrite?: (paths: string[]) => Promise<boolean>
+}) {
+  const client = useGitHubClient()
+  const { org, plan, onStepUpdate, confirmSkeletonOverwrite } = params
+
+  return useMutation({
+    mutationFn: () => {
+      if (!org) return Promise.resolve(undefined)
+      return initClassroom50({
+        client,
+        org,
+        plan,
+        onStepUpdate,
+        confirmSkeletonOverwrite,
+      })
+    },
+  })
+}
+
+export default useRunOrgSetup

--- a/web/src/hooks/mutations/useRunOrgSetup.ts
+++ b/web/src/hooks/mutations/useRunOrgSetup.ts
@@ -1,27 +1,40 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import type { QueryClient } from "@tanstack/react-query"
 import { initClassroom50, type InitStepUpdate } from "@/github-core/mutations"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
+type InitResult = Awaited<ReturnType<typeof initClassroom50>> | undefined
+
 // Run (or re-run) org setup: the idempotent initClassroom50 that applies
-// lockdown, rulesets, and repo settings. THIN — owns only the init call, no
-// invalidation, because the two call sites (RerunOrgSetup, OrgSetupPage)
-// invalidate differently and branch on data.status "error" into different
-// component state. Each keeps its own onSuccess + step-reset wrapper; the hook's
-// mutationFn just calls initClassroom50 (see ./README.md).
-//
-// Callbacks are bound at hook-call time (they close over the page's step state
-// and modal); org/plan are stable per render.
+// lockdown, rulesets, and repo settings. The hook owns the cache invalidation
+// (via the caller-supplied `invalidate`) in its OWN onSuccess — NOT at the call
+// site — because init runs ~10 sequential steps and the user can navigate away
+// mid-run: a per-call mutate() onSuccess is dropped on unmount (react-query
+// gates it on hasListeners()), which would silently skip the post-setup refetch.
+// The hook-level onSuccess always runs. The two call sites invalidate different
+// key sets, so `invalidate` is a callback rather than a fixed key list; it
+// receives the result to branch on data.status. UI setState (step board,
+// done/failed/next) stays at the call site's per-call onSuccess (correctly
+// skipped on unmount). Callbacks bind at hook-call time (they close over page
+// state); org/plan are stable per render.
 export function useRunOrgSetup(params: {
   org: string | undefined
   plan?: string
   onStepUpdate: (update: InitStepUpdate) => void
   confirmSkeletonOverwrite?: (paths: string[]) => Promise<boolean>
+  // Always-run cache reconcile (unmount-safe). Receives the init result so a
+  // caller can invalidate only on a non-error outcome.
+  invalidate: (queryClient: QueryClient, result: InitResult) => void
 }) {
   const client = useGitHubClient()
-  const { org, plan, onStepUpdate, confirmSkeletonOverwrite } = params
+  const queryClient = useQueryClient()
+  const { org, plan, onStepUpdate, confirmSkeletonOverwrite, invalidate } =
+    params
 
   return useMutation({
     mutationFn: () => {
+      // Resolve undefined when org is absent (callers branch on the result);
+      // matches the pre-refactor early return.
       if (!org) return Promise.resolve(undefined)
       return initClassroom50({
         client,
@@ -31,6 +44,7 @@ export function useRunOrgSetup(params: {
         confirmSkeletonOverwrite,
       })
     },
+    onSuccess: (result) => invalidate(queryClient, result),
   })
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1070,6 +1070,7 @@
       "auditing": "Auditing organization policy…",
       "auditError": "Couldn't run the policy audit. Try re-checking.",
       "fixError": "Couldn't apply the fix. You may lack owner permissions, or an enterprise policy blocks this change.",
+      "renameError": "Couldn't rename the config repo's default branch. You may lack owner permissions, or the rename didn't go through — try again.",
       "fixTransient": "That didn't go through — this can be a temporary rate limit, or the repository may still be initializing. Try again in a moment.",
       "needsManualSetup": "Needs manual setup",
       "couldntAutoConfigure": "We couldn't set this automatically. This can happen when an enterprise or organization policy manages the setting, or when the account lacks permission. Set it manually on the linked page.",

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -13,7 +13,6 @@ import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import { useState } from "react"
 import { type InitStepId, type InitStepUpdate } from "@/github-core/mutations"
-import { useQueryClient } from "@tanstack/react-query"
 import useRunOrgSetup from "@/hooks/mutations/useRunOrgSetup"
 import { OrgSettingsPane } from "./OrgSettingsPage"
 import { EnterDiv } from "@/lib/motionComponents"
@@ -144,7 +143,6 @@ const NotTeamOrEnterpriseNotice = () => {
 const OrgSetupPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.setup"))
-  const queryClient = useQueryClient()
 
   const { org } = useParams({ strict: false })
   const [steps, setSteps] =
@@ -170,11 +168,17 @@ const OrgSetupPage = () => {
       setSteps((steps) => applyStepUpdate(steps, update))
     },
     confirmSkeletonOverwrite,
+    // Unmount-safe: the org-list refetch runs in the hook's onSuccess (init is
+    // long-running and the user can navigate away). Always invalidate — even on
+    // a status-"error" outcome — matching the prior unconditional invalidate.
+    invalidate: (queryClient) => {
+      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+    },
   })
 
   // Reset the board before the init call (must run before mutateAsync), then
-  // run setup. Invalidation + the status-"error" advance branch stay here via
-  // the per-call onSuccess.
+  // run setup. Only the step-advance setState stays here (skipped on unmount);
+  // the cache invalidation lives in the hook so it survives an unmount.
   const runSetupFlow = () => {
     // Reset the board before a (re-)run so a prior run's per-step results —
     // including the orgDefaults unenforced-settings list — can't linger on an
@@ -182,9 +186,6 @@ const OrgSetupPage = () => {
     setSteps(initialInitSteps)
     return mutation.mutateAsync(undefined, {
       onSuccess: (data) => {
-        queryClient.invalidateQueries({
-          queryKey: ["orgs"],
-        })
         // Don't advance if a prerequisite step failed; initClassroom50 resolves
         // with status "error" rather than throwing.
         if (data && data.status === "error") {

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -12,13 +12,9 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import { useState } from "react"
-import {
-  initClassroom50,
-  type InitStepId,
-  type InitStepUpdate,
-} from "@/github-core/mutations"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { type InitStepId, type InitStepUpdate } from "@/github-core/mutations"
+import { useQueryClient } from "@tanstack/react-query"
+import useRunOrgSetup from "@/hooks/mutations/useRunOrgSetup"
 import { OrgSettingsPane } from "./OrgSettingsPage"
 import { EnterDiv } from "@/lib/motionComponents"
 import {
@@ -149,7 +145,6 @@ const OrgSetupPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.setup"))
   const queryClient = useQueryClient()
-  const githubClient = useGitHubClient()
 
   const { org } = useParams({ strict: false })
   const [steps, setSteps] =
@@ -168,39 +163,39 @@ const OrgSetupPage = () => {
   const { overwritePaths, resolveOverwrite, confirmSkeletonOverwrite } =
     useSkeletonOverwriteConfirm()
 
-  const mutation = useMutation({
-    mutationFn: async () => {
-      if (!org) {
-        return
-      }
-      // Reset the board before a (re-)run so a prior run's per-step results —
-      // including the orgDefaults unenforced-settings list — can't linger on an
-      // error path that emits no fresh data. Mirrors RerunOrgSetup.
-      setSteps(initialInitSteps)
-      return initClassroom50({
-        client: githubClient,
-        org,
-        plan: orgPlanDetails?.plan?.name,
-        onStepUpdate: (update) => {
-          setSteps((steps) => applyStepUpdate(steps, update))
-        },
-        confirmSkeletonOverwrite,
-      })
+  const mutation = useRunOrgSetup({
+    org,
+    plan: orgPlanDetails?.plan?.name,
+    onStepUpdate: (update) => {
+      setSteps((steps) => applyStepUpdate(steps, update))
     },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({
-        queryKey: ["orgs"],
-      })
-      // Don't advance if a prerequisite step failed; initClassroom50 resolves
-      // with status "error" rather than throwing.
-      if (data && data.status === "error") {
-        return
-      }
-      // Stay on step 1 after setup so the teacher can review per-step results;
-      // they advance with the explicit "Next" button.
-      setNextStep(true)
-    },
+    confirmSkeletonOverwrite,
   })
+
+  // Reset the board before the init call (must run before mutateAsync), then
+  // run setup. Invalidation + the status-"error" advance branch stay here via
+  // the per-call onSuccess.
+  const runSetupFlow = () => {
+    // Reset the board before a (re-)run so a prior run's per-step results —
+    // including the orgDefaults unenforced-settings list — can't linger on an
+    // error path that emits no fresh data. Mirrors RerunOrgSetup.
+    setSteps(initialInitSteps)
+    return mutation.mutateAsync(undefined, {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries({
+          queryKey: ["orgs"],
+        })
+        // Don't advance if a prerequisite step failed; initClassroom50 resolves
+        // with status "error" rather than throwing.
+        if (data && data.status === "error") {
+          return
+        }
+        // Stay on step 1 after setup so the teacher can review per-step
+        // results; they advance with the explicit "Next" button.
+        setNextStep(true)
+      },
+    })
+  }
 
   // Owner gate via the shared fail-closed verdict. /setup is NOT behind
   // RequireOwner, so this page owns the pending/error/deny branches: hold a
@@ -231,7 +226,10 @@ const OrgSetupPage = () => {
       {!ownerPending && !isError && isOwner && (
         <OrgSteps
           steps={steps}
-          mutation={mutation}
+          mutation={{
+            isPending: mutation.isPending,
+            mutateAsync: runSetupFlow,
+          }}
           nextStep={nextStep}
           org={org}
           setStage={setCurrentStage}

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -1,29 +1,17 @@
 import { useMemo, useState } from "react"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import { Loader2, Send, ShieldCheck, UserPlus, X, XCircle } from "lucide-react"
 import { GitHubLink } from "@/components/GitHubLink"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { ConfirmModal } from "@/components/modals"
-import {
-  githubKeys,
-  teamMembersQuery,
-  teamInvitationsQuery,
-  getUser,
-} from "@/github-core/queries"
+import { teamMembersQuery, teamInvitationsQuery } from "@/github-core/queries"
 import { classroomTeamSlug } from "@/util/teamSlug"
-import {
-  removeUserFromTeam,
-  resendOrgInvitation,
-  cancelOrgInvitation,
-} from "@/github-core/mutations"
-import { resolveTeamIdForRoleRead } from "@/domain/students"
-import { githubOrgRoleForRole } from "@/util/teamRoster"
-import {
-  useAddStaffMember,
-  syncRosterAfterStaffChange,
-} from "@/hooks/mutations/useAddStaffMember"
+import { useAddStaffMember } from "@/hooks/mutations/useAddStaffMember"
+import useRemoveStaffMember from "@/hooks/mutations/useRemoveStaffMember"
+import useResendStaffInvite from "@/hooks/mutations/useResendStaffInvite"
+import useCancelStaffInvite from "@/hooks/mutations/useCancelStaffInvite"
 import { GitHubAPIError } from "@/github-core/errors"
 import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
 import type { GitHubUser, GitHubOrgInvitation } from "@/github-core/types"
@@ -284,8 +272,6 @@ const StaffMemberRow = ({
   disabled: boolean
 }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const { notify } = useToast()
   const [confirmingRemove, setConfirmingRemove] = useState(false)
   const teamSlug = classroomTeamSlug(classroom, role)
@@ -296,41 +282,7 @@ const StaffMemberRow = ({
       ? t("classes.staff.roleInstructorPlural")
       : t("classes.staff.roleTaPlural")
 
-  const removeMutation = useMutation({
-    mutationFn: () =>
-      removeUserFromTeam(client, { org, teamSlug, username: member.login }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.teamMembers(org, teamSlug),
-      })
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.teamInvitations(org, teamSlug),
-      })
-      // Clear the removed staffer's stale role from roster.csv now
-      // (best-effort) so the roster stops showing them with a role.
-      void syncRosterAfterStaffChange(client, queryClient, org, classroom)
-      notify({
-        tone: "success",
-        durationMs: 4000,
-        message: t("classes.staff.removedToast", {
-          login: member.login,
-          role: rolePlural,
-        }),
-      })
-    },
-    onError: (err) => {
-      notify({
-        tone: "error",
-        message: t("classes.staff.removeFailed", {
-          login: member.login,
-          error:
-            err instanceof Error
-              ? err.message
-              : t("classes.somethingWentWrong"),
-        }),
-      })
-    },
-  })
+  const removeMutation = useRemoveStaffMember(org, classroom, teamSlug)
 
   return (
     <li className="flex items-center justify-between gap-2 rounded-md border border-base-200 px-2 py-1.5">
@@ -383,7 +335,30 @@ const StaffMemberRow = ({
         confirmLabel={t("classes.staff.removeRole", { role: roleLabel })}
         onConfirm={async () => {
           setConfirmingRemove(false)
-          await removeMutation.mutateAsync()
+          await removeMutation.mutateAsync(member.login, {
+            onSuccess: () => {
+              notify({
+                tone: "success",
+                durationMs: 4000,
+                message: t("classes.staff.removedToast", {
+                  login: member.login,
+                  role: rolePlural,
+                }),
+              })
+            },
+            onError: (err) => {
+              notify({
+                tone: "error",
+                message: t("classes.staff.removeFailed", {
+                  login: member.login,
+                  error:
+                    err instanceof Error
+                      ? err.message
+                      : t("classes.somethingWentWrong"),
+                }),
+              })
+            },
+          })
         }}
         onClose={() => setConfirmingRemove(false)}
       />
@@ -408,87 +383,12 @@ const PendingStaffRow = ({
   disabled: boolean
 }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const { notify } = useToast()
   const teamSlug = classroomTeamSlug(classroom, role)
   const who = invite.login || invite.email || String(invite.id)
 
-  const invalidate = () => {
-    queryClient.invalidateQueries({
-      queryKey: githubKeys.teamInvitations(org, teamSlug),
-    })
-    queryClient.invalidateQueries({
-      queryKey: githubKeys.teamMembers(org, teamSlug),
-    })
-  }
-
-  const resendMutation = useMutation({
-    mutationFn: async () => {
-      if (!invite.login) throw new Error(t("classes.staff.resendEmailOnly"))
-      // Resolve the invitee's immutable id (org invites don't carry it) and the
-      // role's team, so the re-sent invite lands them on the staff team.
-      const inviteeId = (await getUser(client, invite.login)).id
-      const teamId = await resolveTeamIdForRoleRead(
-        client,
-        org,
-        classroom,
-        role,
-      )
-      await resendOrgInvitation(client, {
-        org,
-        username: invite.login,
-        inviteeId,
-        invitationId: invite.id,
-        teamIds: teamId ? [teamId] : undefined,
-        // Preserve the original org role: an instructor invite is org OWNER.
-        role: githubOrgRoleForRole(role),
-      })
-    },
-    onSuccess: () => {
-      invalidate()
-      notify({
-        tone: "success",
-        durationMs: 4000,
-        message: t("classes.staff.resentToast", { who }),
-      })
-    },
-    onError: (err) =>
-      notify({
-        tone: "error",
-        message: t("classes.staff.resendFailed", {
-          who,
-          error:
-            err instanceof Error
-              ? err.message
-              : t("classes.somethingWentWrong"),
-        }),
-      }),
-  })
-
-  const cancelMutation = useMutation({
-    mutationFn: () =>
-      cancelOrgInvitation(client, { org, invitationId: invite.id }),
-    onSuccess: () => {
-      invalidate()
-      notify({
-        tone: "success",
-        durationMs: 4000,
-        message: t("classes.staff.cancelledToast", { who }),
-      })
-    },
-    onError: (err) =>
-      notify({
-        tone: "error",
-        message: t("classes.staff.cancelFailed", {
-          who,
-          error:
-            err instanceof Error
-              ? err.message
-              : t("classes.somethingWentWrong"),
-        }),
-      }),
-  })
+  const resendMutation = useResendStaffInvite(org, classroom, role, teamSlug)
+  const cancelMutation = useCancelStaffInvite(org, teamSlug)
 
   const busy = resendMutation.isPending || cancelMutation.isPending
 
@@ -509,7 +409,34 @@ const PendingStaffRow = ({
             size="xs"
             title={t("classes.staff.resend")}
             disabled={disabled || busy}
-            onClick={() => resendMutation.mutate()}
+            onClick={() =>
+              resendMutation.mutate(
+                {
+                  login: invite.login,
+                  invitationId: invite.id,
+                  emailOnlyMessage: t("classes.staff.resendEmailOnly"),
+                },
+                {
+                  onSuccess: () =>
+                    notify({
+                      tone: "success",
+                      durationMs: 4000,
+                      message: t("classes.staff.resentToast", { who }),
+                    }),
+                  onError: (err) =>
+                    notify({
+                      tone: "error",
+                      message: t("classes.staff.resendFailed", {
+                        who,
+                        error:
+                          err instanceof Error
+                            ? err.message
+                            : t("classes.somethingWentWrong"),
+                      }),
+                    }),
+                },
+              )
+            }
           >
             {resendMutation.isPending ? (
               <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
@@ -524,7 +451,27 @@ const PendingStaffRow = ({
           className="text-error"
           title={t("classes.staff.cancelInvite")}
           disabled={disabled || busy}
-          onClick={() => cancelMutation.mutate()}
+          onClick={() =>
+            cancelMutation.mutate(invite.id, {
+              onSuccess: () =>
+                notify({
+                  tone: "success",
+                  durationMs: 4000,
+                  message: t("classes.staff.cancelledToast", { who }),
+                }),
+              onError: (err) =>
+                notify({
+                  tone: "error",
+                  message: t("classes.staff.cancelFailed", {
+                    who,
+                    error:
+                      err instanceof Error
+                        ? err.message
+                        : t("classes.somethingWentWrong"),
+                  }),
+                }),
+            })
+          }
         >
           {cancelMutation.isPending ? (
             <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -12,6 +12,7 @@ import { useAddStaffMember } from "@/hooks/mutations/useAddStaffMember"
 import useRemoveStaffMember from "@/hooks/mutations/useRemoveStaffMember"
 import useResendStaffInvite from "@/hooks/mutations/useResendStaffInvite"
 import useCancelStaffInvite from "@/hooks/mutations/useCancelStaffInvite"
+import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { GitHubAPIError } from "@/github-core/errors"
 import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
 import type { GitHubUser, GitHubOrgInvitation } from "@/github-core/types"
@@ -390,6 +391,10 @@ const PendingStaffRow = ({
   const resendMutation = useResendStaffInvite(org, classroom, role, teamSlug)
   const cancelMutation = useCancelStaffInvite(org, teamSlug)
 
+  // One latch per row so a same-tick double-click, or resend racing cancel on
+  // the same invite, can't start two overlapping writes before isPending flips.
+  const submit = useSafeSubmit()
+
   const busy = resendMutation.isPending || cancelMutation.isPending
 
   return (
@@ -410,31 +415,33 @@ const PendingStaffRow = ({
             title={t("classes.staff.resend")}
             disabled={disabled || busy}
             onClick={() =>
-              resendMutation.mutate(
-                {
-                  login: invite.login,
-                  invitationId: invite.id,
-                  emailOnlyMessage: t("classes.staff.resendEmailOnly"),
-                },
-                {
-                  onSuccess: () =>
-                    notify({
-                      tone: "success",
-                      durationMs: 4000,
-                      message: t("classes.staff.resentToast", { who }),
-                    }),
-                  onError: (err) =>
-                    notify({
-                      tone: "error",
-                      message: t("classes.staff.resendFailed", {
-                        who,
-                        error:
-                          err instanceof Error
-                            ? err.message
-                            : t("classes.somethingWentWrong"),
+              void submit(() =>
+                resendMutation.mutateAsync(
+                  {
+                    login: invite.login,
+                    invitationId: invite.id,
+                    emailOnlyMessage: t("classes.staff.resendEmailOnly"),
+                  },
+                  {
+                    onSuccess: () =>
+                      notify({
+                        tone: "success",
+                        durationMs: 4000,
+                        message: t("classes.staff.resentToast", { who }),
                       }),
-                    }),
-                },
+                    onError: (err) =>
+                      notify({
+                        tone: "error",
+                        message: t("classes.staff.resendFailed", {
+                          who,
+                          error:
+                            err instanceof Error
+                              ? err.message
+                              : t("classes.somethingWentWrong"),
+                        }),
+                      }),
+                  },
+                ),
               )
             }
           >
@@ -452,25 +459,27 @@ const PendingStaffRow = ({
           title={t("classes.staff.cancelInvite")}
           disabled={disabled || busy}
           onClick={() =>
-            cancelMutation.mutate(invite.id, {
-              onSuccess: () =>
-                notify({
-                  tone: "success",
-                  durationMs: 4000,
-                  message: t("classes.staff.cancelledToast", { who }),
-                }),
-              onError: (err) =>
-                notify({
-                  tone: "error",
-                  message: t("classes.staff.cancelFailed", {
-                    who,
-                    error:
-                      err instanceof Error
-                        ? err.message
-                        : t("classes.somethingWentWrong"),
+            void submit(() =>
+              cancelMutation.mutateAsync(invite.id, {
+                onSuccess: () =>
+                  notify({
+                    tone: "success",
+                    durationMs: 4000,
+                    message: t("classes.staff.cancelledToast", { who }),
                   }),
-                }),
-            })
+                onError: (err) =>
+                  notify({
+                    tone: "error",
+                    message: t("classes.staff.cancelFailed", {
+                      who,
+                      error:
+                        err instanceof Error
+                          ? err.message
+                          : t("classes.somethingWentWrong"),
+                    }),
+                  }),
+              }),
+            )
           }
         >
           {cancelMutation.isPending ? (

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -485,15 +485,33 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
     isError,
   } = useGetOrgAudit(org, planDetails?.plan?.name)
 
-  const fixMutation = useRepairOrgPolicyConcern(org, planDetails?.plan?.name)
+  // Persist the classified Fix-it outcome to the per-org store — a DURABLE
+  // write, so it runs in the hook's onSuccess (via onRepaired below), NOT the
+  // call site, to survive a mid-repair unmount.
+  const persistRepairOutcome = (result: RepairResult, id: ConcernId) => {
+    const outcome = classifyRepairOutcome(result)
+    if (outcome.pinnedFields.length > 0) {
+      mergeUnresolved(org, { fields: outcome.pinnedFields })
+    }
+    if (outcome.unresolvedConcern !== null) {
+      mergeUnresolved(org, { concerns: [id] })
+    }
+  }
+
+  const fixMutation = useRepairOrgPolicyConcern(
+    org,
+    planDetails?.plan?.name,
+    persistRepairOutcome,
+  )
   // The concern currently being repaired, so only its button shows a spinner.
   const fixingId = fixMutation.isPending
     ? (fixMutation.variables ?? null)
     : null
 
-  // Apply a Fix-it result to component state. Kept at the call site (component
-  // state); the hook owns only the audit invalidation.
-  const applyRepairOutcome = (result: RepairResult, id: ConcernId) => {
+  // Reflect a Fix-it result in component state (pins, unresolved concerns,
+  // transient-notice). Pure UI, so it stays at the call site (skipped on
+  // unmount); the durable store write is persistRepairOutcome above.
+  const applyRepairOutcomeUi = (result: RepairResult, id: ConcernId) => {
     const outcome = classifyRepairOutcome(result)
     setTransientNotice(outcome.transientNotice)
     if (outcome.pinnedFields.length > 0) {
@@ -502,7 +520,6 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
         for (const f of outcome.pinnedFields) next.add(f)
         return next
       })
-      mergeUnresolved(org, { fields: outcome.pinnedFields })
     }
     if (outcome.unresolvedConcern !== null) {
       const message = outcome.unresolvedConcern
@@ -511,7 +528,6 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
         next.set(id, message)
         return next
       })
-      mergeUnresolved(org, { concerns: [id] })
     }
   }
 
@@ -596,7 +612,7 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
             if (!fixMutation.isPending)
               void runFix(() =>
                 fixMutation.mutateAsync(id, {
-                  onSuccess: (result) => applyRepairOutcome(result, id),
+                  onSuccess: (result) => applyRepairOutcomeUi(result, id),
                 }),
               )
           }}

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -588,6 +588,16 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
         </div>
       )}
 
+      {renameMutation.isError && (
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error">
+          <TriangleAlert
+            aria-hidden="true"
+            className="mt-0.5 size-4 shrink-0"
+          />
+          <span>{t("orgSettings.audit.renameError")}</span>
+        </div>
+      )}
+
       {transientNotice && (
         <div className="mt-4 flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
           <TriangleAlert
@@ -627,7 +637,7 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
         confirmLabel={t("orgSettings.audit.renameToMain")}
         dangerous
         needsConfirm={false}
-        onConfirm={() => renameMutation.mutateAsync().then(() => undefined)}
+        onConfirm={() => runFix(() => renameMutation.mutateAsync())}
         onClose={() => setConfirmRename(false)}
       />
     </SettingsSection>

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -10,9 +10,9 @@ import {
   XCircle,
 } from "lucide-react"
 
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { githubKeys } from "@/github-core/queries"
-import { renameConfigRepoToMain } from "@/github-core/mutations"
+import useRenameConfigRepoToMain from "@/hooks/mutations/useRenameConfigRepoToMain"
+import useRepairOrgPolicyConcern from "@/hooks/mutations/useRepairOrgPolicyConcern"
 import { Badge, Button, Spinner, type BadgeTone } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import PlanBadge from "@/components/PlanBadge"
@@ -26,7 +26,7 @@ import type {
   OrgAuditReport,
   OrgRecommendation,
 } from "@/orgPolicy/audit"
-import { REPAIRABLE_CONCERNS, repairConcern } from "@/orgPolicy/repair"
+import { REPAIRABLE_CONCERNS } from "@/orgPolicy/repair"
 import type { RepairResult } from "@/orgPolicy/repair"
 import { mergeUnresolved, readUnresolved } from "@/orgPolicy/unresolvedStore"
 import type { CheckState } from "@/github-core/orgChecks"
@@ -453,7 +453,6 @@ function AuditBody({
 
 const OrgPolicyAuditPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
   const queryClient = useQueryClient()
   const runFix = useSafeSubmit()
   const { data: planDetails } = useGetOrgPlanDetails(org)
@@ -486,51 +485,41 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
     isError,
   } = useGetOrgAudit(org, planDetails?.plan?.name)
 
-  const fixMutation = useMutation({
-    mutationFn: (id: ConcernId) =>
-      repairConcern(client, org, id, planDetails?.plan?.name),
-    onSuccess: (result, id) => {
-      const outcome = classifyRepairOutcome(result)
-      setTransientNotice(outcome.transientNotice)
-      if (outcome.pinnedFields.length > 0) {
-        setEnterprisePinned((prev) => {
-          const next = new Set(prev)
-          for (const f of outcome.pinnedFields) next.add(f)
-          return next
-        })
-        mergeUnresolved(org, { fields: outcome.pinnedFields })
-      }
-      if (outcome.unresolvedConcern !== null) {
-        const message = outcome.unresolvedConcern
-        setUnresolvedConcerns((prev) => {
-          const next = new Map(prev)
-          next.set(id, message)
-          return next
-        })
-        mergeUnresolved(org, { concerns: [id] })
-      }
-      void queryClient.invalidateQueries({
-        queryKey: githubKeys.orgAuditPrefix(org),
-      })
-    },
-  })
+  const fixMutation = useRepairOrgPolicyConcern(org, planDetails?.plan?.name)
   // The concern currently being repaired, so only its button shows a spinner.
   const fixingId = fixMutation.isPending
     ? (fixMutation.variables ?? null)
     : null
 
+  // Apply a Fix-it result to component state. Kept at the call site (component
+  // state); the hook owns only the audit invalidation.
+  const applyRepairOutcome = (result: RepairResult, id: ConcernId) => {
+    const outcome = classifyRepairOutcome(result)
+    setTransientNotice(outcome.transientNotice)
+    if (outcome.pinnedFields.length > 0) {
+      setEnterprisePinned((prev) => {
+        const next = new Set(prev)
+        for (const f of outcome.pinnedFields) next.add(f)
+        return next
+      })
+      mergeUnresolved(org, { fields: outcome.pinnedFields })
+    }
+    if (outcome.unresolvedConcern !== null) {
+      const message = outcome.unresolvedConcern
+      setUnresolvedConcerns((prev) => {
+        const next = new Map(prev)
+        next.set(id, message)
+        return next
+      })
+      mergeUnresolved(org, { concerns: [id] })
+    }
+  }
+
   // Renaming the config repo to `main` is a separate flow: it's a recommendation
   // (not a concern) and destructive to already-accepted student shims, so it's
   // gated behind a confirm modal rather than an inline Fix-it.
   const [confirmRename, setConfirmRename] = useState(false)
-  const renameMutation = useMutation({
-    mutationFn: () => renameConfigRepoToMain(client, org),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: githubKeys.orgAuditPrefix(org),
-      })
-    },
-  })
+  const renameMutation = useRenameConfigRepoToMain(org)
 
   return (
     <SettingsSection
@@ -605,7 +594,11 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
           unresolvedConcerns={unresolvedConcerns}
           onFix={(id) => {
             if (!fixMutation.isPending)
-              void runFix(() => fixMutation.mutateAsync(id))
+              void runFix(() =>
+                fixMutation.mutateAsync(id, {
+                  onSuccess: (result) => applyRepairOutcome(result, id),
+                }),
+              )
           }}
           onRenameConfigRepo={() => setConfirmRename(true)}
         />

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -1,5 +1,4 @@
 import { useState, type ReactNode } from "react"
-import { useQueryClient } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
@@ -55,7 +54,6 @@ const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
 // per-concern audit (U5/U6).
 const RerunOrgSetup = ({ org }: { org: string }) => {
   const { t } = useTranslation()
-  const queryClient = useQueryClient()
   const runRerun = useSafeSubmit()
 
   const { data: planDetails } = useGetOrgPlanDetails(org)
@@ -93,11 +91,22 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
       setSteps((prev) => applyStepUpdate(prev, update))
     },
     confirmSkeletonOverwrite,
+    // Unmount-safe: runs in the hook's onSuccess so a mid-run navigation can't
+    // drop the post-setup refetch. Only on a non-error outcome (init resolves
+    // with status "error" on a prerequisite failure).
+    invalidate: (queryClient, result) => {
+      if (result && result.status === "error") return
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgAuditPrefix(org),
+      })
+      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+    },
   })
 
   // Reset the board before the init call (must run before mutateAsync), then
-  // run setup. Invalidation + the status-"error" branch stay here via the
-  // per-call onSuccess.
+  // run setup. The step-machine setState (done/failed) stays here via the
+  // per-call onSuccess (correctly skipped on unmount); the cache invalidation
+  // lives in the hook so it survives an unmount.
   const runRerunFlow = () => {
     setStarted(true)
     setFailed(false)
@@ -108,15 +117,11 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
         if (!mountedRef.current) return
         setDone(true)
         // init resolves (not throws) with status "error" on a prerequisite
-        // failure; surface it instead of treating it as success.
+        // failure; surface it instead of treating it as success. (The cache
+        // invalidation is the hook's job — see `invalidate` above.)
         if (data && data.status === "error") {
           setFailed(true)
-          return
         }
-        void queryClient.invalidateQueries({
-          queryKey: githubKeys.orgAuditPrefix(org),
-        })
-        void queryClient.invalidateQueries({ queryKey: ["orgs"] })
       },
     })
   }

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -1,16 +1,12 @@
 import { useState, type ReactNode } from "react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { Button } from "@/components/ui"
-import {
-  initClassroom50,
-  type InitStepId,
-  type InitStepUpdate,
-} from "@/github-core/mutations"
+import { type InitStepId, type InitStepUpdate } from "@/github-core/mutations"
 import { githubKeys } from "@/github-core/queries"
+import useRunOrgSetup from "@/hooks/mutations/useRunOrgSetup"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import {
   INIT_STEP_ORDER,
@@ -59,7 +55,6 @@ const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
 // per-concern audit (U5/U6).
 const RerunOrgSetup = ({ org }: { org: string }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
   const queryClient = useQueryClient()
   const runRerun = useSafeSubmit()
 
@@ -87,41 +82,44 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
     ? INIT_STEP_ORDER.filter((id) => steps[id].status === "warning").length
     : 0
 
-  const mutation = useMutation({
-    mutationFn: async () => {
-      setStarted(true)
-      setFailed(false)
-      setDone(false)
-      setSteps(initialInitSteps)
-      return initClassroom50({
-        client,
-        org,
-        plan: planDetails?.plan?.name,
-        onStepUpdate: (update) => {
-          // init fires onStepUpdate across ~10 sequential steps; the user can
-          // navigate away mid-run. The work isn't cancelable (no AbortSignal),
-          // so the mounted guard just stops setState churn.
-          if (!mountedRef.current) return
-          setSteps((prev) => applyStepUpdate(prev, update))
-        },
-        confirmSkeletonOverwrite,
-      })
-    },
-    onSuccess: (data) => {
+  const mutation = useRunOrgSetup({
+    org,
+    plan: planDetails?.plan?.name,
+    onStepUpdate: (update) => {
+      // init fires onStepUpdate across ~10 sequential steps; the user can
+      // navigate away mid-run. The work isn't cancelable (no AbortSignal), so
+      // the mounted guard just stops setState churn.
       if (!mountedRef.current) return
-      setDone(true)
-      // init resolves (not throws) with status "error" on a prerequisite
-      // failure; surface it instead of treating it as success.
-      if (data && data.status === "error") {
-        setFailed(true)
-        return
-      }
-      void queryClient.invalidateQueries({
-        queryKey: githubKeys.orgAuditPrefix(org),
-      })
-      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      setSteps((prev) => applyStepUpdate(prev, update))
     },
+    confirmSkeletonOverwrite,
   })
+
+  // Reset the board before the init call (must run before mutateAsync), then
+  // run setup. Invalidation + the status-"error" branch stay here via the
+  // per-call onSuccess.
+  const runRerunFlow = () => {
+    setStarted(true)
+    setFailed(false)
+    setDone(false)
+    setSteps(initialInitSteps)
+    return mutation.mutateAsync(undefined, {
+      onSuccess: (data) => {
+        if (!mountedRef.current) return
+        setDone(true)
+        // init resolves (not throws) with status "error" on a prerequisite
+        // failure; surface it instead of treating it as success.
+        if (data && data.status === "error") {
+          setFailed(true)
+          return
+        }
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.orgAuditPrefix(org),
+        })
+        void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      },
+    })
+  }
 
   return (
     <SettingsSection
@@ -136,7 +134,7 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
           loadingLabel={t("orgSettings.rerun.running")}
           disabled={mutation.isPending}
           onClick={() => {
-            if (!mutation.isPending) void runRerun(() => mutation.mutateAsync())
+            if (!mutation.isPending) void runRerun(() => runRerunFlow())
           }}
         >
           {mutation.isPending


### PR DESCRIPTION
## Summary

**Tier-2 Phase F, U9 — batch 3 of 3** ([plan](docs/plans/2026-07-15-005-refactor-tier2-structural-debt-plan.md)), the final U9 batch. Converts the 8 inline `useMutation` sites across the org-setup/staff surfaces into 6 named `hooks/mutations/` hooks.

**Clean write ops** (invalidation in the hook, toasts at the call site):
- `useRenameConfigRepoToMain` (OrgPolicyAuditPane)
- `useRemoveStaffMember`, `useResendStaffInvite`, `useCancelStaffInvite` (ClassroomStaffSection)

**Orchestration wrappers** (rich component state stays at the call site; the hook owns only the always-run data-consistency):
- `useRepairOrgPolicyConcern` — owns the audit invalidation + a durable-store `onRepaired` callback; the pin/unresolved/notice setState stays inline.
- `useRunOrgSetup` — shared by `RerunOrgSetup` + `OrgSetupPage`; owns the `initClassroom50` call + a caller-supplied `invalidate` callback. The two sites invalidate different key sets and drive different step-machine state, so each keeps its own UI `onSuccess` + step-reset wrapper.

This completes U9: **zero inline `useMutation` outside `hooks/mutations/`** except the two infra hooks (`useGitHubOperation` / `useActionActivity` — generic dispatch/polling, not per-write ops) and the auth-flow sites in `useGithubAuth` (U11).

### Included ce-code-review fixes (2nd commit) — a real unmount-safety regression

A full multi-agent review (reliability reviewer verifying against the installed `@tanstack/query-core` v5 source) caught that **per-call `mutate(_, { onSuccess })` callbacks are gated on `hasListeners()` and dropped on unmount**, while **hook-level `onSuccess` always runs**. The initial batch-3 conversion had moved always-run data effects to the call site on the long-running, easily-abandoned `initClassroom50` + repair flows:

- **P1** — the post-setup cache invalidation (`orgAuditPrefix` / `["orgs"]`) would be silently skipped if the user navigated away mid-setup. Fixed: `useRunOrgSetup` runs the caller's `invalidate` in its own (unmount-safe) `onSuccess`; only step-machine setState stays at the call site.
- **P2** — the durable `mergeUnresolved` store write (recording a repair that didn't stick) had the same flaw. Fixed: `useRepairOrgPolicyConcern` runs an `onRepaired` data-callback in the hook (using a callback rather than importing the page's `classifyRepairOutcome`, to respect the layer boundary).

I verified the mechanism directly (`mutationObserver.ts:164`) before fixing. Correctness review found zero behavior issues in the conversions themselves. One residual is accepted by-design: a staff success toast can drop if the removal-refetch unmounts the row first (the vanished row already confirms the action).

### ce-code-review follow-ups (3rd + 4th commits) — reliability hardening + coverage

A second full multi-agent `ce-code-review` pass over the whole PR found **no P0/P1/P2 in the changed code** — the hook-vs-call-site split is verified behavior-preserving (invalidation parity checked against the merge base; `classifyRepairOutcome` is pure so its two call sites can't diverge). It surfaced one comment nit and two **pre-existing** reliability gaps that the extraction preserved rather than introduced; the hook extraction is the natural moment to close them:

- **`useCancelStaffInvite`** — dropped the "mirroring the resend hook" comment (the AGENTS.md "mirrors X" smell). *(3rd commit)*
- **`ClassroomStaffSection` / `PendingStaffRow`** — resend/cancel used raw `.mutate()` gated only by a render-lagged `busy` flag. Now routed through a per-row `useSafeSubmit` latch (via `mutateAsync`), so a same-tick double-click — or resend racing cancel on the same invite — can't start two overlapping writes before `isPending` flips.
- **`OrgPolicyAuditPane`** — the config-repo rename confirm was `mutateAsync().then()` with no `.catch`/`onError`: a failed rename was a silent unhandled rejection. Now routed through the pane's `runFix` latch with a `renameMutation.isError` banner (mirrors the existing `fixError` banner + a new `renameError` string), so a failed rename is re-entry-safe and visible.
- **Coverage** — added the missing `useResendStaffInvite` tests (multi-step delegation + the `t()`-free email-only throw), a repair-rejection case (`onRepaired`/invalidate must **not** run on error), the `useRunOrgSetup` org-absent branch, and the `RerunOrgSetup` status-error invalidate guard (both branches).

Not done, by design: extracting a shared `invalidateStaffTeam` helper across the three staff hooks — the blocks aren't identical (remove adds a roster sync + different key order), so direct duplication reads clearer than a partial helper.

## Test plan

- [x] Hook tests: 5 → **10** (added `useResendStaffInvite` delegation + email-only throw, repair-rejection, `useRunOrgSetup` org-absent, `RerunOrgSetup` status-error guard)
- [x] `tsc -b` clean; full `vitest` green (**147 files, 1563 tests**) — existing component tests confirm behavior preserved
- [x] Zero inline `useMutation` in the 4 converted files
- [x] `eslint .` + `arch:validate` + `prettier --check` clean (incl. the i18n key audit for the new `renameError` string)
- [x] Full `ce-code-review` (two passes) — the P1/P2 unmount-safety findings applied; follow-up reliability gaps + coverage closed; no remaining P0/P1/P2
