### PR TITLE
feat(web): show assignment description to students

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^17.0.8",
+        "react-markdown": "^10.1.0",
         "tailwindcss": "^4.3.2",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
@@ -3016,6 +3017,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3034,8 +3044,16 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/gensync": {
       "version": "1.0.5",
@@ -3043,6 +3061,15 @@
       "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
@@ -3056,6 +3083,21 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3082,7 +3124,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3097,6 +3138,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
@@ -3344,6 +3391,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.12.2",
@@ -4361,6 +4414,16 @@
         "@babel/types": "^7.26.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -4561,6 +4624,16 @@
         "url": "https://www.paypal.me/kirilvatev"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4604,6 +4677,46 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -4639,6 +4752,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "15.0.0",
@@ -4726,7 +4849,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/daisyui": {
@@ -4804,7 +4926,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4816,6 +4937,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -4927,7 +5061,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4940,6 +5073,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -5847,6 +5993,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -5873,6 +6029,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6393,6 +6555,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -6417,6 +6619,16 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/i18next": {
@@ -6505,6 +6717,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6528,6 +6746,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6682,6 +6924,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -6755,6 +7007,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-installed-globally": {
@@ -6832,6 +7094,18 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7458,6 +7732,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -7515,6 +7799,601 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7614,7 +8493,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7869,6 +8747,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -8043,6 +8946,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8107,6 +9020,33 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -8187,6 +9127,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -8561,6 +9534,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash-x": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -8674,6 +9657,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -8682,6 +9679,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -8790,6 +9805,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -9011,6 +10046,93 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unplugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
@@ -9112,6 +10234,34 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -9551,6 +10701,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-i18next": "^17.0.8",
+    "react-markdown": "^10.1.0",
     "tailwindcss": "^4.3.2",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -71,19 +71,20 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           </div>
         </div>
 
-        {assignment ? (
-          <div className="flex items-center gap-1.5 text-sm text-base-content/70">
-            <BookOpen
-              aria-hidden="true"
-              className="size-4 shrink-0 text-base-content/50"
-            />
+        {classroom && assignment ? (
+          <Link
+            to="/$org/$classroom/assignments/$assignment"
+            params={{ org, classroom, assignment }}
+            className="group inline-flex w-fit max-w-full items-center gap-1.5 text-sm text-base-content/70 transition-colors hover:text-primary"
+          >
+            <BookOpen aria-hidden="true" className="size-4 shrink-0" />
             <span className="truncate">
               {t("classes.repo.assignmentLabel")}{" "}
-              <span className="font-medium text-base-content/80">
+              <span className="font-medium text-base-content/80 group-hover:text-primary">
                 {assignment}
               </span>
             </span>
-          </div>
+          </Link>
         ) : null}
 
         <Card.Actions className="items-center justify-between gap-2 pt-1">

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import {
   BookOpen,
   ExternalLink,
+  FileText,
   GraduationCap,
   Pencil,
   UserRound,
@@ -135,15 +136,27 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
             )}
           </div>
 
-          <a
-            href={repo.html_url}
-            target="_blank"
-            rel="noreferrer"
-            className="btn btn-sm btn-primary"
-          >
-            {t("classes.repo.openRepo")}
-            <ExternalLink aria-hidden="true" className="size-4" />
-          </a>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {classroom && assignment && (
+              <Link
+                to="/$org/$classroom/assignments/$assignment"
+                params={{ org, classroom, assignment }}
+                className="btn btn-sm btn-outline"
+              >
+                <FileText aria-hidden="true" className="size-4" />
+                {t("classes.repo.viewDetails")}
+              </Link>
+            )}
+            <a
+              href={repo.html_url}
+              target="_blank"
+              rel="noreferrer"
+              className="btn btn-sm btn-primary"
+            >
+              {t("classes.repo.openRepo")}
+              <ExternalLink aria-hidden="true" className="size-4" />
+            </a>
+          </div>
         </Card.Actions>
       </Card.Body>
     </Card>

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -5,6 +5,8 @@ import {
   BookOpen,
   ExternalLink,
   FileText,
+  FolderGit2,
+  GraduationCap,
   Link2,
   Pencil,
   UserRound,
@@ -31,6 +33,9 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
   )
 
   const description = assignmentData?.description?.trim()
+  // Prefer the human assignment name; the repo name is the fallback identity
+  // (`<classroom>-<assignment>-<user>`) when assignment data hasn't resolved.
+  const title = assignmentData?.name || assignment || repo.name
 
   // Only group assignments have something a student can manage (collaborators);
   // for individual assignments the edit page is a dead-end, so no pencil.
@@ -70,7 +75,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
                 className="group inline-flex max-w-full items-center gap-1.5 transition-colors hover:text-primary"
               >
                 <h3 className="truncate text-base font-semibold leading-tight underline decoration-base-content/30 underline-offset-2 group-hover:decoration-primary">
-                  {repo.name}
+                  {title}
                 </h3>
                 <Link2
                   aria-hidden="true"
@@ -79,12 +84,32 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
               </Link>
             ) : (
               <h3 className="truncate text-base font-semibold leading-tight">
-                {repo.name}
+                {title}
               </h3>
             )}
-            <p className="truncate text-xs text-base-content/70">
-              {repo.owner?.login}
-            </p>
+            <div className="mt-1 flex flex-col gap-0.5 text-xs text-base-content/70">
+              {classroom ? (
+                <span className="inline-flex max-w-full items-center gap-1.5">
+                  <GraduationCap
+                    aria-hidden="true"
+                    className="size-3.5 shrink-0 text-base-content/50"
+                  />
+                  <span className="truncate">
+                    {t("classes.repo.classroomLabel")}{" "}
+                    <span className="font-medium text-base-content/80">
+                      {classroom}
+                    </span>
+                  </span>
+                </span>
+              ) : null}
+              <span className="inline-flex max-w-full items-center gap-1.5">
+                <FolderGit2
+                  aria-hidden="true"
+                  className="size-3.5 shrink-0 text-base-content/50"
+                />
+                <span className="truncate font-mono">{repo.name}</span>
+              </span>
+            </div>
           </div>
         </div>
 
@@ -112,7 +137,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
                 className="btn btn-sm btn-outline"
               >
                 <FileText aria-hidden="true" className="size-4" />
-                {t("classes.repo.viewDescription")}
+                {t("classes.repo.details")}
               </button>
             ) : null}
             <a

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -13,8 +13,9 @@ import {
   UsersRound,
 } from "lucide-react"
 
-import { Card, Markdown, Modal } from "@/components/ui"
+import { Button, Card, Markdown, Modal } from "@/components/ui"
 import type { GitHubRepo } from "@/github-core/types"
+import { assignmentDescription } from "@/types/classroom"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
 import useGetPublicAssignment from "@/hooks/useGetPublicAssignment"
@@ -32,7 +33,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
     secret,
   )
 
-  const description = assignmentData?.description?.trim()
+  const description = assignmentDescription(assignmentData)
   // Prefer the human assignment name; the repo name is the fallback identity
   // (`<classroom>-<assignment>-<user>`) when assignment data hasn't resolved.
   const title = assignmentData?.name || assignment || repo.name
@@ -131,49 +132,52 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
 
           <div className="flex flex-wrap items-center justify-end gap-2">
             {description ? (
-              <button
-                type="button"
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() => setDescriptionOpen(true)}
-                className="btn btn-sm btn-outline"
               >
                 <FileText aria-hidden="true" className="size-4" />
                 {t("classes.repo.details")}
-              </button>
+              </Button>
             ) : null}
-            <a
+            <Button
+              as="a"
+              variant="primary"
+              size="sm"
               href={repo.html_url}
               target="_blank"
               rel="noreferrer"
-              className="btn btn-sm btn-primary"
             >
               {t("classes.repo.openRepo")}
               <ExternalLink aria-hidden="true" className="size-4" />
-            </a>
+            </Button>
           </div>
         </Card.Actions>
       </Card.Body>
 
-      {description ? (
-        <Modal
-          open={descriptionOpen}
-          onClose={() => setDescriptionOpen(false)}
-          size="2xl"
-          aria-label={t("classes.repo.descriptionModalTitle")}
-        >
-          <div className="mb-4 pr-8">
-            <p className="text-xs font-medium uppercase tracking-wide text-base-content/50">
-              {t("classes.repo.descriptionModalTitle")}
-            </p>
-            <h3 className="text-lg font-bold">
-              {assignmentData?.name || assignment}
-            </h3>
-          </div>
+      {/* Always mount the Modal so its open/close effect can run; gating the
+          whole element on `description` would tear the open dialog out on a
+          background refetch without firing onClose, stranding descriptionOpen. */}
+      <Modal
+        open={descriptionOpen && Boolean(description)}
+        onClose={() => setDescriptionOpen(false)}
+        size="2xl"
+        aria-label={t("classes.repo.descriptionModalTitle")}
+      >
+        <div className="mb-4 pr-8">
+          <p className="text-xs font-medium uppercase tracking-wide text-base-content/50">
+            {t("classes.repo.descriptionModalTitle")}
+          </p>
+          <h3 className="text-lg font-bold">{title}</h3>
+        </div>
+        {description ? (
           <Markdown
             content={description}
             className="max-h-[70vh] overflow-y-auto pr-1"
           />
-        </Modal>
-      ) : null}
+        ) : null}
+      </Modal>
     </Card>
   )
 }

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   BookOpen,
@@ -10,7 +11,7 @@ import {
   UsersRound,
 } from "lucide-react"
 
-import { Card } from "@/components/ui"
+import { Card, Markdown, Modal } from "@/components/ui"
 import type { GitHubRepo } from "@/github-core/types"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
@@ -19,6 +20,7 @@ import { EnterDiv } from "@/lib/motionComponents"
 
 const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
   const { t } = useTranslation()
+  const [descriptionOpen, setDescriptionOpen] = useState(false)
   const cl50Yaml = useDotClassroom50(org, repo.name)
   const { classroom, assignment, secret } = cl50Yaml
   const { assignment: assignmentData } = useGetPublicAssignment(
@@ -27,6 +29,8 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
     assignment,
     secret,
   )
+
+  const description = assignmentData?.description?.trim()
 
   // Only group assignments have something a student can manage (collaborators);
   // for individual assignments the edit page is a dead-end, so no pencil.
@@ -73,9 +77,18 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           </div>
         </div>
 
-        <p className="line-clamp-2 min-h-10 text-sm text-base-content/70">
-          {repo.description || t("classes.repo.noDescription")}
-        </p>
+        <div className="min-h-10 text-sm">
+          {description ? (
+            <button
+              type="button"
+              onClick={() => setDescriptionOpen(true)}
+              className="link link-primary inline-flex items-center gap-1.5"
+            >
+              <FileText aria-hidden="true" className="size-4" />
+              {t("classes.repo.viewDescription")}
+            </button>
+          ) : null}
+        </div>
 
         {(classroom || assignment) && (
           <div className="alert alert-outline flex flex-col items-start">
@@ -152,6 +165,23 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           </div>
         </Card.Actions>
       </Card.Body>
+
+      {description ? (
+        <Modal
+          open={descriptionOpen}
+          onClose={() => setDescriptionOpen(false)}
+          size="2xl"
+          aria-label={t("classes.repo.descriptionModalTitle")}
+        >
+          <h3 className="mb-4 text-lg font-bold">
+            {assignmentData?.name || assignment}
+          </h3>
+          <Markdown
+            content={description}
+            className="max-h-[70vh] overflow-y-auto pr-1"
+          />
+        </Modal>
+      ) : null}
     </Card>
   )
 }

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -9,7 +9,7 @@ import {
   UsersRound,
 } from "lucide-react"
 
-import { Card } from "@/components/ui"
+import { Card, Markdown } from "@/components/ui"
 import type { GitHubRepo } from "@/github-core/types"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
@@ -72,9 +72,16 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           </div>
         </div>
 
-        <p className="line-clamp-2 min-h-10 text-sm text-base-content/70">
-          {repo.description || t("classes.repo.noDescription")}
-        </p>
+        {assignmentData?.description?.trim() ? (
+          <Markdown
+            content={assignmentData.description}
+            className="line-clamp-3 min-h-10 text-sm"
+          />
+        ) : (
+          <p className="line-clamp-2 min-h-10 text-sm text-base-content/70">
+            {repo.description || t("classes.repo.noDescription")}
+          </p>
+        )}
 
         {(classroom || assignment) && (
           <div className="alert alert-outline flex flex-col items-start">

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -10,7 +10,7 @@ import {
   UsersRound,
 } from "lucide-react"
 
-import { Card, Markdown } from "@/components/ui"
+import { Card } from "@/components/ui"
 import type { GitHubRepo } from "@/github-core/types"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
@@ -73,16 +73,9 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           </div>
         </div>
 
-        {assignmentData?.description?.trim() ? (
-          <Markdown
-            content={assignmentData.description}
-            className="line-clamp-3 min-h-10 text-sm"
-          />
-        ) : (
-          <p className="line-clamp-2 min-h-10 text-sm text-base-content/70">
-            {repo.description || t("classes.repo.noDescription")}
-          </p>
-        )}
+        <p className="line-clamp-2 min-h-10 text-sm text-base-content/70">
+          {repo.description || t("classes.repo.noDescription")}
+        </p>
 
         {(classroom || assignment) && (
           <div className="alert alert-outline flex flex-col items-start">

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -5,6 +5,7 @@ import {
   BookOpen,
   ExternalLink,
   FileText,
+  Link2,
   Pencil,
   UserRound,
   UsersRound,
@@ -80,10 +81,14 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
             <BookOpen aria-hidden="true" className="size-4 shrink-0" />
             <span className="truncate">
               {t("classes.repo.assignmentLabel")}{" "}
-              <span className="font-medium text-base-content/80 group-hover:text-primary">
+              <span className="font-medium text-base-content/80 underline decoration-base-content/30 underline-offset-2 group-hover:text-primary group-hover:decoration-primary">
                 {assignment}
               </span>
             </span>
+            <Link2
+              aria-hidden="true"
+              className="size-3.5 shrink-0 text-base-content/40 group-hover:text-primary"
+            />
           </Link>
         ) : null}
 

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -63,34 +63,30 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
             <BookOpen aria-hidden="true" className="size-5" />
           </div>
           <div className="min-w-0">
-            <h3 className="truncate text-base font-semibold leading-tight">
-              {repo.name}
-            </h3>
+            {classroom && assignment ? (
+              <Link
+                to="/$org/$classroom/assignments/$assignment"
+                params={{ org, classroom, assignment }}
+                className="group inline-flex max-w-full items-center gap-1.5 transition-colors hover:text-primary"
+              >
+                <h3 className="truncate text-base font-semibold leading-tight underline decoration-base-content/30 underline-offset-2 group-hover:decoration-primary">
+                  {repo.name}
+                </h3>
+                <Link2
+                  aria-hidden="true"
+                  className="size-3.5 shrink-0 text-base-content/40 group-hover:text-primary"
+                />
+              </Link>
+            ) : (
+              <h3 className="truncate text-base font-semibold leading-tight">
+                {repo.name}
+              </h3>
+            )}
             <p className="truncate text-xs text-base-content/70">
               {repo.owner?.login}
             </p>
           </div>
         </div>
-
-        {classroom && assignment ? (
-          <Link
-            to="/$org/$classroom/assignments/$assignment"
-            params={{ org, classroom, assignment }}
-            className="group inline-flex w-fit max-w-full items-center gap-1.5 text-sm text-base-content/70 transition-colors hover:text-primary"
-          >
-            <BookOpen aria-hidden="true" className="size-4 shrink-0" />
-            <span className="truncate">
-              {t("classes.repo.assignmentLabel")}{" "}
-              <span className="font-medium text-base-content/80 underline decoration-base-content/30 underline-offset-2 group-hover:text-primary group-hover:decoration-primary">
-                {assignment}
-              </span>
-            </span>
-            <Link2
-              aria-hidden="true"
-              className="size-3.5 shrink-0 text-base-content/40 group-hover:text-primary"
-            />
-          </Link>
-        ) : null}
 
         <Card.Actions className="items-center justify-between gap-2 pt-1">
           <div className="flex items-center gap-2">

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -5,7 +5,6 @@ import {
   BookOpen,
   ExternalLink,
   FileText,
-  GraduationCap,
   Pencil,
   UserRound,
   UsersRound,
@@ -58,76 +57,37 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
       )}
 
       <Card.Body className="gap-4">
-        <div className="flex items-start justify-between gap-4 pr-8">
+        <div className="flex items-center gap-3 pr-8">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <BookOpen aria-hidden="true" className="size-5" />
+          </div>
           <div className="min-w-0">
-            <div className="mb-2 flex items-center gap-2">
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                <BookOpen aria-hidden="true" className="size-5" />
-              </div>
-
-              <div className="min-w-0">
-                <h3 className="truncate text-base font-semibold leading-tight">
-                  {repo.name}
-                </h3>
-                <p className="truncate text-xs text-base-content/70">
-                  {repo.owner?.login}
-                </p>
-              </div>
-            </div>
+            <h3 className="truncate text-base font-semibold leading-tight">
+              {repo.name}
+            </h3>
+            <p className="truncate text-xs text-base-content/70">
+              {repo.owner?.login}
+            </p>
           </div>
         </div>
 
-        <div className="min-h-10 text-sm">
-          {description ? (
-            <button
-              type="button"
-              onClick={() => setDescriptionOpen(true)}
-              className="link link-primary inline-flex items-center gap-1.5"
-            >
-              <FileText aria-hidden="true" className="size-4" />
-              {t("classes.repo.viewDescription")}
-            </button>
-          ) : null}
-        </div>
-
-        {(classroom || assignment) && (
-          <div className="alert alert-outline flex flex-col items-start">
-            {classroom && (
-              <Link
-                to="/$org/$classroom"
-                params={{ org, classroom }}
-                className="max-w-full truncate group inline-flex w-fit gap-1.5 text-sm text-base-content/70 transition hover:text-primary"
-              >
-                <GraduationCap aria-hidden="true" className="size-4" />
-                <span className="truncate">
-                  {t("classes.repo.classroomLabel")}{" "}
-                  <span className="font-medium text-base-content/80 group-hover:text-primary">
-                    {classroom}
-                  </span>
-                </span>
-              </Link>
-            )}
-
-            {classroom && assignment && (
-              <Link
-                to="/$org/$classroom/assignments/$assignment"
-                params={{ org, classroom, assignment }}
-                className="max-w-full truncate group inline-flex w-fit gap-1.5 text-sm text-base-content/70 transition hover:text-primary"
-              >
-                <BookOpen aria-hidden="true" className="size-4" />
-                <span className="truncate">
-                  {t("classes.repo.assignmentLabel")}{" "}
-                  <span className="font-medium text-base-content/80 group-hover:text-primary">
-                    {assignment}
-                  </span>
-                </span>
-              </Link>
-            )}
+        {assignment ? (
+          <div className="flex items-center gap-1.5 text-sm text-base-content/70">
+            <BookOpen
+              aria-hidden="true"
+              className="size-4 shrink-0 text-base-content/50"
+            />
+            <span className="truncate">
+              {t("classes.repo.assignmentLabel")}{" "}
+              <span className="font-medium text-base-content/80">
+                {assignment}
+              </span>
+            </span>
           </div>
-        )}
+        ) : null}
 
-        <Card.Actions className="items-center justify-between pt-1">
-          <div className="flex flex-wrap items-end gap-2">
+        <Card.Actions className="items-center justify-between gap-2 pt-1">
+          <div className="flex items-center gap-2">
             {assignmentData?.mode === "individual" && (
               <div className="badge badge-ghost badge-sm py-3">
                 <UserRound aria-hidden="true" className="size-4" />{" "}
@@ -135,7 +95,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
               </div>
             )}
             {assignmentData?.mode === "group" && (
-              <div className="badge badge-ghost badge-sm">
+              <div className="badge badge-ghost badge-sm py-3">
                 <UsersRound aria-hidden="true" className="size-4" />{" "}
                 {t("classes.repo.group")}
               </div>
@@ -143,16 +103,16 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           </div>
 
           <div className="flex flex-wrap items-center justify-end gap-2">
-            {classroom && assignment && (
-              <Link
-                to="/$org/$classroom/assignments/$assignment"
-                params={{ org, classroom, assignment }}
+            {description ? (
+              <button
+                type="button"
+                onClick={() => setDescriptionOpen(true)}
                 className="btn btn-sm btn-outline"
               >
                 <FileText aria-hidden="true" className="size-4" />
-                {t("classes.repo.viewDetails")}
-              </Link>
-            )}
+                {t("classes.repo.viewDescription")}
+              </button>
+            ) : null}
             <a
               href={repo.html_url}
               target="_blank"
@@ -173,9 +133,14 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           size="2xl"
           aria-label={t("classes.repo.descriptionModalTitle")}
         >
-          <h3 className="mb-4 text-lg font-bold">
-            {assignmentData?.name || assignment}
-          </h3>
+          <div className="mb-4 pr-8">
+            <p className="text-xs font-medium uppercase tracking-wide text-base-content/50">
+              {t("classes.repo.descriptionModalTitle")}
+            </p>
+            <h3 className="text-lg font-bold">
+              {assignmentData?.name || assignment}
+            </h3>
+          </div>
           <Markdown
             content={description}
             className="max-h-[70vh] overflow-y-auto pr-1"

--- a/web/src/components/ui/Markdown.test.tsx
+++ b/web/src/components/ui/Markdown.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Markdown } from "./Markdown"
+
+afterEach(cleanup)
+
+describe("Markdown", () => {
+  it("drops embedded raw HTML instead of rendering it (no rehype-raw)", () => {
+    const { container } = render(
+      <Markdown
+        content={`<img src=x onerror="alert(1)"> <script>alert(1)</script> plain`}
+      />,
+    )
+    // Raw HTML is converted to inert text, never real elements: no <img>/<script>
+    // node exists and nothing carries the onerror handler as a live attribute.
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector("script")).toBeNull()
+    expect(container.querySelector("[onerror]")).toBeNull()
+    expect(container.textContent).toContain("plain")
+  })
+
+  it("renders an http(s) link in a new tab with rel=noreferrer", () => {
+    render(<Markdown content="[go](https://example.com)" />)
+    const link = screen.getByRole("link", { name: "go" })
+    expect(link.getAttribute("href")).toBe("https://example.com")
+    expect(link.getAttribute("target")).toBe("_blank")
+    expect(link.getAttribute("rel")).toBe("noreferrer")
+  })
+
+  it("degrades an unsafe link scheme to inert text, not an anchor", () => {
+    render(<Markdown content="[x](javascript:alert(1))" />)
+    expect(screen.queryByRole("link")).toBeNull()
+    expect(screen.getByText("x").tagName).toBe("SPAN")
+  })
+
+  it("does not leak react-markdown's node prop onto the anchor DOM element", () => {
+    const { container } = render(
+      <Markdown content="[go](https://example.com)" />,
+    )
+    const link = container.querySelector("a")
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute("node")).toBeNull()
+  })
+
+  it("maps markdown structure to the styled elements", () => {
+    const { container } = render(
+      <Markdown content={"# Title\n\n- one\n\n`code`"} />,
+    )
+    expect(container.querySelector("h1")?.className).toContain("text-xl")
+    expect(container.querySelector("ul")?.className).toContain("list-disc")
+    expect(container.querySelector("code")?.className).toContain("bg-base-200")
+  })
+})

--- a/web/src/components/ui/Markdown.tsx
+++ b/web/src/components/ui/Markdown.tsx
@@ -16,14 +16,15 @@ export type MarkdownProps = {
 }
 
 const components: Components = {
-  a: ({ href, children, ...props }) =>
+  // Only forward href/children; react-markdown also passes a `node` (hast
+  // Element) that must not spread onto the <a> as an invalid DOM attribute.
+  a: ({ href, children }) =>
     isSafeHttpUrl(href) ? (
       <a
         href={href}
         target="_blank"
         rel="noreferrer"
         className="link link-primary"
-        {...props}
       >
         {children}
       </a>

--- a/web/src/components/ui/Markdown.tsx
+++ b/web/src/components/ui/Markdown.tsx
@@ -1,0 +1,66 @@
+import ReactMarkdown, { type Components } from "react-markdown"
+
+import { isSafeHttpUrl } from "@/util/url"
+
+import { cx } from "./cx"
+
+// Renders teacher-authored assignment text. react-markdown never uses
+// dangerouslySetInnerHTML and (without rehype-raw, which we deliberately omit)
+// drops embedded HTML, so untrusted markdown can't inject script. Links are
+// further constrained to http(s) and open in a new tab. No @tailwindcss/typography
+// plugin is installed, so element styling is spelled out per tag.
+
+export type MarkdownProps = {
+  content: string
+  className?: string
+}
+
+const components: Components = {
+  a: ({ href, children, ...props }) =>
+    isSafeHttpUrl(href) ? (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className="link link-primary"
+        {...props}
+      >
+        {children}
+      </a>
+    ) : (
+      <span>{children}</span>
+    ),
+  h1: ({ children }) => <h1 className="text-xl font-bold">{children}</h1>,
+  h2: ({ children }) => <h2 className="text-lg font-bold">{children}</h2>,
+  h3: ({ children }) => <h3 className="text-base font-semibold">{children}</h3>,
+  ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
+  ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
+  code: ({ children }) => (
+    <code className="rounded bg-base-200 px-1 py-0.5 text-sm">{children}</code>
+  ),
+  pre: ({ children }) => (
+    <pre className="overflow-x-auto rounded-lg bg-base-200 p-3 text-sm">
+      {children}
+    </pre>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-base-300 pl-3 text-base-content/80">
+      {children}
+    </blockquote>
+  ),
+}
+
+export function Markdown({ content, className }: MarkdownProps) {
+  return (
+    <div
+      className={cx(
+        "flex flex-col gap-2 text-base-content/80 leading-relaxed break-words",
+        className,
+      )}
+    >
+      <ReactMarkdown components={components}>{content}</ReactMarkdown>
+    </div>
+  )
+}
+
+export default Markdown

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -50,6 +50,9 @@ export type { StatCardProps } from "./StatCard"
 export { LabeledControl } from "./LabeledControl"
 export type { LabeledControlProps } from "./LabeledControl"
 
+export { Markdown } from "./Markdown"
+export type { MarkdownProps } from "./Markdown"
+
 export { Toolbar } from "./Toolbar"
 export type {
   ToolbarProps,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1370,6 +1370,7 @@
       "individual": "Individual",
       "group": "Group",
       "openRepo": "Open repo",
+      "viewDetails": "View details",
       "emptyTitle": "No assignment repos yet",
       "emptyBody": "Repositories you can write to will appear here once assignments have been created for this organization."
     },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1439,6 +1439,7 @@
     "noDueDate": "No due date",
     "alreadyAcceptedHeading": "You've already accepted this assignment.",
     "acceptHeading": "Accept this assignment to get your own copy of the starter code repository.",
+    "descriptionLabel": "Assignment details",
     "repoAlreadyExists": "Repository already exists as:",
     "repoWillBeCreated": "Repository will be created as:",
     "errorTitle": "Could not accept assignment",
@@ -1675,6 +1676,7 @@
     },
     "student": {
       "submittedAt": "Submitted {{date}}",
+      "descriptionLabel": "Assignment details",
       "viewGrade": "View grade",
       "unavailable": "Unavailable",
       "modeGroup": "Group",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1364,7 +1364,6 @@
     "repo": {
       "manageGroupAria": "Manage group for {{assignment}}",
       "manageGroupTitle": "Manage group",
-      "assignmentLabel": "Assignment:",
       "individual": "Individual",
       "group": "Group",
       "openRepo": "Open repo",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1364,13 +1364,14 @@
     "repo": {
       "manageGroupAria": "Manage group for {{assignment}}",
       "manageGroupTitle": "Manage group",
-      "noDescription": "No description provided for this assignment repository.",
       "classroomLabel": "Classroom:",
       "assignmentLabel": "Assignment:",
       "individual": "Individual",
       "group": "Group",
       "openRepo": "Open repo",
       "viewDetails": "View details",
+      "viewDescription": "View assignment description",
+      "descriptionModalTitle": "Assignment description",
       "emptyTitle": "No assignment repos yet",
       "emptyBody": "Repositories you can write to will appear here once assignments have been created for this organization."
     },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1364,12 +1364,10 @@
     "repo": {
       "manageGroupAria": "Manage group for {{assignment}}",
       "manageGroupTitle": "Manage group",
-      "classroomLabel": "Classroom:",
       "assignmentLabel": "Assignment:",
       "individual": "Individual",
       "group": "Group",
       "openRepo": "Open repo",
-      "viewDetails": "View details",
       "viewDescription": "View assignment description",
       "descriptionModalTitle": "Assignment description",
       "emptyTitle": "No assignment repos yet",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1364,10 +1364,11 @@
     "repo": {
       "manageGroupAria": "Manage group for {{assignment}}",
       "manageGroupTitle": "Manage group",
+      "classroomLabel": "Classroom:",
       "individual": "Individual",
       "group": "Group",
       "openRepo": "Open repo",
-      "viewDescription": "View assignment description",
+      "details": "Details",
       "descriptionModalTitle": "Assignment description",
       "emptyTitle": "No assignment repos yet",
       "emptyBody": "Repositories you can write to will appear here once assignments have been created for this organization."

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -710,7 +710,10 @@ const AcceptAssignmentPage = () => {
                 {t("accept.descriptionLabel")}
               </summary>
               <div className="collapse-content">
-                <Markdown content={assignmentData.description} />
+                <Markdown
+                  content={assignmentData.description}
+                  className="max-h-80 overflow-y-auto"
+                />
               </div>
             </details>
           ) : null}

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -675,6 +675,8 @@ const AcceptAssignmentPage = () => {
     return <AssignmentNotFound user={user} assignment={assignment} />
   }
 
+  const description = assignmentDescription(assignmentData)
+
   return (
     <AcceptLayout>
       <AcceptCard>
@@ -705,13 +707,13 @@ const AcceptAssignmentPage = () => {
               : t("accept.acceptHeading")}
           </h2>
 
-          {assignmentDescription(assignmentData) ? (
+          {description ? (
             <details className="collapse collapse-arrow border border-base-300 bg-base-100">
               <summary className="collapse-title min-h-0 px-4 py-3 text-sm font-medium">
                 {t("accept.descriptionLabel")}
               </summary>
               <div className="collapse-content max-h-80 overflow-y-auto">
-                <Markdown content={assignmentDescription(assignmentData)} />
+                <Markdown content={description} />
               </div>
             </details>
           ) : null}

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -10,6 +10,7 @@ import {
 import GitHub from "@/assets/github.svg?react"
 import { Spinner } from "@/components/Spinner"
 import { Alert, Button, Card, Markdown } from "@/components/ui"
+import { assignmentDescription } from "@/types/classroom"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubUser } from "@/github-core/types"
 import { Link, useParams, useSearch } from "@tanstack/react-router"
@@ -704,16 +705,13 @@ const AcceptAssignmentPage = () => {
               : t("accept.acceptHeading")}
           </h2>
 
-          {assignmentData?.description?.trim() ? (
+          {assignmentDescription(assignmentData) ? (
             <details className="collapse collapse-arrow border border-base-300 bg-base-100">
               <summary className="collapse-title min-h-0 px-4 py-3 text-sm font-medium">
                 {t("accept.descriptionLabel")}
               </summary>
-              <div className="collapse-content">
-                <Markdown
-                  content={assignmentData.description}
-                  className="max-h-80 overflow-y-auto"
-                />
+              <div className="collapse-content max-h-80 overflow-y-auto">
+                <Markdown content={assignmentDescription(assignmentData)} />
               </div>
             </details>
           ) : null}

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -9,7 +9,7 @@ import {
 
 import GitHub from "@/assets/github.svg?react"
 import { Spinner } from "@/components/Spinner"
-import { Alert, Button, Card } from "@/components/ui"
+import { Alert, Button, Card, Markdown } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubUser } from "@/github-core/types"
 import { Link, useParams, useSearch } from "@tanstack/react-router"
@@ -703,6 +703,15 @@ const AcceptAssignmentPage = () => {
               ? t("accept.alreadyAcceptedHeading")
               : t("accept.acceptHeading")}
           </h2>
+
+          {assignmentData?.description?.trim() ? (
+            <div className="flex flex-col gap-1">
+              <label className="label text-sm">
+                {t("accept.descriptionLabel")}
+              </label>
+              <Markdown content={assignmentData.description} />
+            </div>
+          ) : null}
 
           <div className="divider my-0" />
 

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -705,12 +705,14 @@ const AcceptAssignmentPage = () => {
           </h2>
 
           {assignmentData?.description?.trim() ? (
-            <div className="flex flex-col gap-1">
-              <label className="label text-sm">
+            <details className="collapse collapse-arrow border border-base-300 bg-base-100">
+              <summary className="collapse-title min-h-0 px-4 py-3 text-sm font-medium">
                 {t("accept.descriptionLabel")}
-              </label>
-              <Markdown content={assignmentData.description} />
-            </div>
+              </summary>
+              <div className="collapse-content">
+                <Markdown content={assignmentData.description} />
+              </div>
+            </details>
           ) : null}
 
           <div className="divider my-0" />

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -25,7 +25,7 @@ import { safeHttpUrl } from "@/util/url"
 import type { GitHubRelease } from "@/github-core/types"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
-import { Alert, Badge, Button, Card } from "@/components/ui"
+import { Alert, Badge, Button, Card, Markdown } from "@/components/ui"
 
 // Strips the `submit/` tag prefix for a friendlier label, falling back to the
 // release name when present.
@@ -269,6 +269,14 @@ const StudentSubmissionPage = () => {
         }
       />
       <AssignmentMeta assignment={assignmentData} />
+      {assignmentData?.description?.trim() ? (
+        <div className="mt-3 flex flex-col gap-1">
+          <span className="text-sm font-medium text-base-content/70">
+            {t("submissions.student.descriptionLabel")}
+          </span>
+          <Markdown content={assignmentData.description} />
+        </div>
+      ) : null}
       {org && classroom && assignment ? (
         <SubmissionBody
           org={org}

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -259,6 +259,8 @@ const StudentSubmissionPage = () => {
     secret,
   )
 
+  const description = assignmentDescription(assignmentData)
+
   return (
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("nav.mySubmission")} />
@@ -270,12 +272,12 @@ const StudentSubmissionPage = () => {
         }
       />
       <AssignmentMeta assignment={assignmentData} />
-      {assignmentDescription(assignmentData) ? (
+      {description ? (
         <div className="mt-3 flex flex-col gap-1">
           <span className="text-sm font-medium text-base-content/70">
             {t("submissions.student.descriptionLabel")}
           </span>
-          <Markdown content={assignmentDescription(assignmentData)} />
+          <Markdown content={description} />
         </div>
       ) : null}
       {org && classroom && assignment ? (

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -24,6 +24,7 @@ import { formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { safeHttpUrl } from "@/util/url"
 import type { GitHubRelease } from "@/github-core/types"
 import type { Assignment } from "@/types/classroom"
+import { assignmentDescription } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 import { Alert, Badge, Button, Card, Markdown } from "@/components/ui"
 
@@ -269,12 +270,12 @@ const StudentSubmissionPage = () => {
         }
       />
       <AssignmentMeta assignment={assignmentData} />
-      {assignmentData?.description?.trim() ? (
+      {assignmentDescription(assignmentData) ? (
         <div className="mt-3 flex flex-col gap-1">
           <span className="text-sm font-medium text-base-content/70">
             {t("submissions.student.descriptionLabel")}
           </span>
-          <Markdown content={assignmentData.description} />
+          <Markdown content={assignmentDescription(assignmentData)} />
         </div>
       ) : null}
       {org && classroom && assignment ? (

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -121,6 +121,15 @@ export type Assignment = {
   migrated_from?: MigratedFrom
 }
 
+// Trimmed assignment description, or "" when absent. assignments.json is read
+// with an unchecked `as` cast, so a teacher-authored non-string `description:`
+// (a YAML block/list/number) would otherwise reach `.trim()` and throw during
+// render; coercing at this boundary keeps every student surface safe.
+export function assignmentDescription(assignment?: Assignment): string {
+  const value = assignment?.description
+  return typeof value === "string" ? value.trim() : ""
+}
+
 // classroom50/assignments/v1 `migrated_from`.
 export type MigratedFrom = {
   source: string


### PR DESCRIPTION
## Summary

Teachers can set an optional assignment **Description**, but it was stored and even fetched into the student web app yet never rendered on any student-facing surface (see [Discussion #292](https://github.com/foundation50/classroom50/discussions/292)). This wires it up across the student web surfaces, rendered as Markdown, and tidies the student assignments card along the way.

No data-layer changes were needed — `assignmentData.description` (and `name`) were already fetched into every affected page.

## What changed

**New `Markdown` UI primitive** (`web/src/components/ui/Markdown.tsx`): a thin `react-markdown` wrapper, exported from `components/ui`. Security-conscious for teacher-authored text — no `rehype-raw` (embedded HTML is dropped; `react-markdown` never uses `dangerouslySetInnerHTML`), links constrained to http(s) via the existing `isSafeHttpUrl` helper and opened in a new tab. Element styling is per-tag since there's no `@tailwindcss/typography` plugin.

**Accept page** (`AcceptAssignmentPage.tsx`): description shown in a collapsible `<details>` disclosure ("Assignment details"), collapsed by default. Expanded content is height-capped (`max-h-80` + `overflow-y-auto`) so a long description scrolls inside its own region and never pushes the Accept button off the vertically-centered card.

**Submission page** (`StudentSubmissionPage.tsx`): renders the full description (unconstrained — this is the canonical home) right after the mode/due meta.

**Student assignments card** (`OrgRepos.tsx` `RepoCard`) — reworked for clarity:
- Previously showed the empty *GitHub repo* description ("No description provided…"); that misleading line is gone.
- **Title** now uses the friendly assignment name (`assignmentData.name`), not the raw `<classroom>-<assignment>-<user>` repo slug. The title links to the student submission page, with a link affordance (underline + chain icon).
- Sub-lines show the **classroom** and the full **assignment repo** name.
- A **"Details"** button opens a modal previewing the full description (scrollable, `max-h-[70vh]`).
- Clean action row: mode badge · Details · Open repo.

**i18n**: added `accept.descriptionLabel`, `submissions.student.descriptionLabel`, `classes.repo.classroomLabel`, `classes.repo.details`, `classes.repo.descriptionModalTitle`; removed the now-unused `classes.repo.noDescription`, `assignmentLabel`, `viewDetails`, `viewDescription`. Description content itself is teacher data and isn't translated.

**Dependency**: `react-markdown@^10.1.0`.

## Long-description handling

Handled per-surface: the vertically-centered accept modal caps height and scrolls internally; the compact list card shows the description in a scrollable modal; the unconstrained submission page shows it in full.

## Verification

`cd web && npm run check` — `tsc -b` clean, eslint **0 errors** (pre-existing warnings only), vitest green, `arch:validate` passed, i18n audit `RESULT: PASS` (all new keys wired, 0 missing/dead), Prettier clean on all tracked files.

## Notes / follow-ups (out of scope)

- The student assignments list only shows repos the student already has push access to (i.e. accepted assignments). Not-yet-accepted assignments show the description on the accept page instead.
- Deferred: a dedicated student assignment-view page/dashboard and web-based submission (both feasible client-side, larger UX efforts).

## Review & hardening (post-review)

A structured multi-reviewer pass (correctness, security, testing, maintainability, project-standards, adversarial, api-contract, frontend-races) ran on the branch; all actionable findings are applied and verified:

- **Non-string description no longer crashes the render.** `assignments.json` is read with an unchecked cast, so a teacher-authored non-string `description:` reached `.trim()` and threw, dropping the route to the error boundary. Added `assignmentDescription()` in `types/classroom.ts` that coerces to a trimmed string at the type boundary; all three surfaces use it (also collapses the previously-triplicated `?.trim()` gate).
- **Card description modal no longer strands open.** The modal was conditionally mounted (`description ? <Modal/> : null`) with a bare `descriptionOpen` boolean, so a background React Query refetch that dropped the description tore out the open `<dialog>` without firing `onClose`. The `Modal` now always mounts, with `open` driven by `descriptionOpen && Boolean(description)`.
- **`Markdown` security primitive is now tested.** Added `Markdown.test.tsx` pinning the XSS posture: raw HTML dropped (no live `<img>`/`<script>`/`onerror`), http(s) links open in a new tab with `rel=noreferrer`, `javascript:` links degrade to inert `<span>`, and react-markdown's `node` prop no longer leaks onto the anchor.
- **Card actions use the `Button` primitive** (`Shared primitives first`): the Details button and the open-repo link now go through `Button` / `Button as="a"` instead of hand-written `btn` recipes.
- **Accept-page description scroll** now has a single height owner (`collapse-content` owns `max-h-80 overflow-y-auto`).
- **Simplification:** hoisted the duplicated `assignmentDescription(assignmentData)` gate+prop calls into a single `const` per render in both student pages.

**Re-verified:** `npm run check` — `tsc -b` clean, eslint **0 errors** (pre-existing warnings only), **1568 vitest pass** (incl. 5 new Markdown security tests), `arch:validate` + i18n audit `PASS`, Prettier clean.
