### PR TITLE
refactor(web): extract skeleton-drift fix into a mutation hook (Tier-2 U10)

### DIFF
--- a/web/src/components/SkeletonDriftBanner.test.ts
+++ b/web/src/components/SkeletonDriftBanner.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest"
 
 import {
-  isFixResolvedClean,
   resolveDriftBannerView,
   type DriftBannerInput,
 } from "./SkeletonDriftBanner"
+import { isFixResolvedClean } from "@/hooks/mutations/useFixSkeletonDrift"
 
 const base: DriftBannerInput = {
   hasOrg: true,

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -5,7 +5,10 @@ import { AnimatePresence } from "motion/react"
 import { useTranslation } from "react-i18next"
 
 import { AppBanner } from "@/components/AppBanner"
-import { useFixSkeletonDrift } from "@/hooks/mutations/useFixSkeletonDrift"
+import {
+  useFixSkeletonDrift,
+  isFixResolvedClean,
+} from "@/hooks/mutations/useFixSkeletonDrift"
 import { useSkeletonDrift } from "@/hooks/useSkeletonDrift"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import {
@@ -47,17 +50,6 @@ export function resolveDriftBannerView(
   if (fixResolvedClean && !isPending) return "success"
   if (hasDrift) return "warning"
   return "hidden"
-}
-
-// A fix leaves the org clean only when it completed and skipped nothing; a
-// declined overwrite leaves skippedOverwrite non-empty and must stay on the
-// warning view. Pure so the result-contract mapping is testable (mirrors
-// resolveSkeletonDrift), independent of the component's async wiring.
-export function isFixResolvedClean(result: {
-  status: string
-  skippedOverwrite: string[]
-}): boolean {
-  return result.status === "complete" && result.skippedOverwrite.length === 0
 }
 
 // Global warning banner for an org owner when the `classroom50` config repo's

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -169,12 +169,14 @@ export function SkeletonDriftBanner() {
                     if (org && pendingOrg !== org) {
                       const targetOrg = org
                       setPendingOrg(targetOrg)
+                      // Guard call-site UI state on mountedRef: these run
+                      // through useSafeSubmit, so treat the callbacks as
+                      // possibly firing after unmount and skip stale setState.
                       void runFix(() =>
                         mutation.mutateAsync(targetOrg, {
                           onSuccess: (result) => {
-                            // UI state (skipped on unmount); the drift-cache
-                            // reconcile is the hook's job. A declined overwrite
-                            // leaves files drifted -> no success view.
+                            // Success view only; the cache reconcile is the
+                            // hook's job (and runs even if we've unmounted).
                             if (
                               mountedRef.current &&
                               isFixResolvedClean(result)

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -1,15 +1,11 @@
 import { useEffect, useRef, useState } from "react"
 import { useParams } from "@tanstack/react-router"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { CheckCircle2, FileWarning } from "lucide-react"
 import { AnimatePresence } from "motion/react"
 import { useTranslation } from "react-i18next"
 
 import { AppBanner } from "@/components/AppBanner"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { ensureSkeletonFiles } from "@/github-core/mutations"
-import type { StaleSkeletonFile } from "@/github-core/mutations"
-import { githubKeys } from "@/github-core/queries"
+import { useFixSkeletonDrift } from "@/hooks/mutations/useFixSkeletonDrift"
 import { useSkeletonDrift } from "@/hooks/useSkeletonDrift"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import {
@@ -82,8 +78,6 @@ export function SkeletonDriftBanner() {
   const [dismissedOrg, setDismissedOrg] = useState<string>()
   const { t } = useTranslation()
 
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const runFix = useSafeSubmit()
 
   // The org whose fix just completed with nothing left drifted. Drives the green
@@ -113,30 +107,7 @@ export function SkeletonDriftBanner() {
     return () => resolveOverwriteRef.current(false)
   }, [org])
 
-  const mutation = useMutation({
-    // org is captured as a mutate variable so onSuccess attributes the result to
-    // the org the fix actually ran against, not the live param (which can change
-    // if the owner navigates while the run is in flight).
-    mutationFn: (targetOrg: string) =>
-      ensureSkeletonFiles(client, targetOrg, confirmSkeletonOverwrite),
-    onSuccess: (result, targetOrg) => {
-      if (!mountedRef.current) return
-      const key = githubKeys.skeletonDrift(targetOrg)
-      // A declined overwrite leaves files drifted -> stay on the warning view.
-      if (isFixResolvedClean(result)) {
-        setFixedCleanOrg(targetOrg)
-        // Seed the drift cache as clean directly. A post-commit tree read is
-        // eventually consistent and would refetch the old (drifted) SHAs, so
-        // invalidating here could re-flash the warning on the next mount.
-        queryClient.setQueryData<StaleSkeletonFile[]>(key, [])
-      } else {
-        void queryClient.invalidateQueries({ queryKey: key })
-      }
-    },
-    onSettled: () => {
-      if (mountedRef.current) setPendingOrg(undefined)
-    },
-  })
+  const mutation = useFixSkeletonDrift(confirmSkeletonOverwrite)
 
   const view = resolveDriftBannerView({
     hasOrg: Boolean(org),
@@ -204,8 +175,26 @@ export function SkeletonDriftBanner() {
                   disabled={pendingOrg === org}
                   onClick={() => {
                     if (org && pendingOrg !== org) {
-                      setPendingOrg(org)
-                      void runFix(() => mutation.mutateAsync(org))
+                      const targetOrg = org
+                      setPendingOrg(targetOrg)
+                      void runFix(() =>
+                        mutation.mutateAsync(targetOrg, {
+                          onSuccess: (result) => {
+                            // UI state (skipped on unmount); the drift-cache
+                            // reconcile is the hook's job. A declined overwrite
+                            // leaves files drifted -> no success view.
+                            if (
+                              mountedRef.current &&
+                              isFixResolvedClean(result)
+                            ) {
+                              setFixedCleanOrg(targetOrg)
+                            }
+                          },
+                          onSettled: () => {
+                            if (mountedRef.current) setPendingOrg(undefined)
+                          },
+                        }),
+                      )
                     }
                   }}
                 >

--- a/web/src/hooks/mutations/useFixSkeletonDrift.test.ts
+++ b/web/src/hooks/mutations/useFixSkeletonDrift.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+
+const ensureSkeletonFiles = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+
+vi.mock("@/github-core/mutations", () => ({
+  ensureSkeletonFiles: (client: unknown, org: unknown, confirm: unknown) =>
+    ensureSkeletonFiles(client, org, confirm),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useFixSkeletonDrift } from "./useFixSkeletonDrift"
+
+const ORG = "acme"
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useFixSkeletonDrift", () => {
+  it("seeds the drift cache empty when the fix resolved clean (avoids a stale refetch)", async () => {
+    ensureSkeletonFiles.mockResolvedValue({
+      status: "complete",
+      created: ["workflows/collect-scores.yaml"],
+      skippedOverwrite: [],
+    })
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const confirm = vi.fn(() => Promise.resolve(true))
+    const { result } = renderHook(() => useFixSkeletonDrift(confirm), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate(ORG)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(ensureSkeletonFiles).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG,
+      confirm,
+    )
+    expect(queryClient.getQueryData(githubKeys.skeletonDrift(ORG))).toEqual([])
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  it("invalidates instead of seeding when the fix skipped a declined overwrite", async () => {
+    ensureSkeletonFiles.mockResolvedValue({
+      status: "complete",
+      created: [],
+      skippedOverwrite: ["workflows/collect-scores.yaml"],
+    })
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(
+      () => useFixSkeletonDrift(() => Promise.resolve(false)),
+      { wrapper: wrapperWith(queryClient) },
+    )
+
+    result.current.mutate(ORG)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.skeletonDrift(ORG),
+    })
+    expect(
+      queryClient.getQueryData(githubKeys.skeletonDrift(ORG)),
+    ).toBeUndefined()
+  })
+
+  it("attributes the cache write to the mutate-variable org, not a shared param", async () => {
+    ensureSkeletonFiles.mockResolvedValue({
+      status: "complete",
+      created: [],
+      skippedOverwrite: [],
+    })
+    const queryClient = freshClient()
+    const { result } = renderHook(
+      () => useFixSkeletonDrift(() => Promise.resolve(true)),
+      { wrapper: wrapperWith(queryClient) },
+    )
+
+    result.current.mutate("other-org")
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(
+      queryClient.getQueryData(githubKeys.skeletonDrift("other-org")),
+    ).toEqual([])
+    expect(
+      queryClient.getQueryData(githubKeys.skeletonDrift(ORG)),
+    ).toBeUndefined()
+  })
+})

--- a/web/src/hooks/mutations/useFixSkeletonDrift.ts
+++ b/web/src/hooks/mutations/useFixSkeletonDrift.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { ensureSkeletonFiles } from "@/github-core/mutations"
+import type { StaleSkeletonFile } from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Refresh a config repo's drifted skeleton files (scaffolded workflows that fell
+// behind the bundled skeleton). `targetOrg` is the mutate variable — the banner
+// is a singleton across orgs, so the result must be attributed to the org the
+// fix ran against, not a live param that can change mid-run.
+//
+// The hook owns the drift-cache reconcile in its OWN onSuccess (unmount-safe):
+// a clean fix seeds the cache empty rather than invalidating, because a
+// post-commit tree read is eventually consistent and an invalidate could refetch
+// the old (drifted) SHAs and re-flash the warning; a declined/partial fix
+// (skippedOverwrite non-empty) leaves drift, so it invalidates instead. The
+// banner's per-org UI state (fixed-clean, pending) stays at the call site — see
+// ./README.md and the U9-batch-3 unmount-safety finding.
+export function useFixSkeletonDrift(
+  confirmOverwrite: (paths: string[]) => Promise<boolean>,
+) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (targetOrg: string) =>
+      ensureSkeletonFiles(client, targetOrg, confirmOverwrite),
+    onSuccess: (result, targetOrg) => {
+      const key = githubKeys.skeletonDrift(targetOrg)
+      const resolvedClean =
+        result.status === "complete" && result.skippedOverwrite.length === 0
+      if (resolvedClean) {
+        queryClient.setQueryData<StaleSkeletonFile[]>(key, [])
+      } else {
+        void queryClient.invalidateQueries({ queryKey: key })
+      }
+    },
+  })
+}
+
+export default useFixSkeletonDrift

--- a/web/src/hooks/mutations/useFixSkeletonDrift.ts
+++ b/web/src/hooks/mutations/useFixSkeletonDrift.ts
@@ -4,10 +4,8 @@ import type { StaleSkeletonFile } from "@/github-core/mutations"
 import { githubKeys } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
-// A fix resolved clean iff it completed with nothing skipped; a declined
-// overwrite (skippedOverwrite non-empty) leaves files drifted. Pure and shared:
-// the hook uses it to pick seed-vs-invalidate, the banner uses it to pick the
-// success-vs-warning view — one contract, one source.
+// The seed-vs-invalidate / success-vs-warning contract, shared by the hook and
+// the banner: a fix is clean iff it completed with nothing skipped.
 export function isFixResolvedClean(result: {
   status: string
   skippedOverwrite: string[]
@@ -15,18 +13,12 @@ export function isFixResolvedClean(result: {
   return result.status === "complete" && result.skippedOverwrite.length === 0
 }
 
-// Refresh a config repo's drifted skeleton files (scaffolded workflows that fell
-// behind the bundled skeleton). `targetOrg` is the mutate variable — the banner
-// is a singleton across orgs, so the result must be attributed to the org the
-// fix ran against, not a live param that can change mid-run.
-//
-// The hook owns the drift-cache reconcile in its OWN onSuccess (unmount-safe):
-// a clean fix seeds the cache empty rather than invalidating, because a
-// post-commit tree read is eventually consistent and an invalidate could refetch
-// the old (drifted) SHAs and re-flash the warning; a declined/partial fix
-// (skippedOverwrite non-empty) leaves drift, so it invalidates instead. The
-// banner's per-org UI state (fixed-clean, pending) stays at the call site — see
-// ./README.md and the U9-batch-3 unmount-safety finding.
+// Refresh a config repo's drifted skeleton files, reconciling the drift cache in
+// the hook's OWN onSuccess so it survives a mid-run unmount (per ./README.md).
+// The non-obvious part: a clean fix SEEDS the cache empty rather than
+// invalidating — a post-commit tree read is eventually consistent, so an
+// invalidate could refetch the old drifted SHAs and re-flash the warning; a
+// declined/partial fix still has drift, so it invalidates instead.
 export function useFixSkeletonDrift(
   confirmOverwrite: (paths: string[]) => Promise<boolean>,
 ) {

--- a/web/src/hooks/mutations/useFixSkeletonDrift.ts
+++ b/web/src/hooks/mutations/useFixSkeletonDrift.ts
@@ -4,6 +4,17 @@ import type { StaleSkeletonFile } from "@/github-core/mutations"
 import { githubKeys } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
+// A fix resolved clean iff it completed with nothing skipped; a declined
+// overwrite (skippedOverwrite non-empty) leaves files drifted. Pure and shared:
+// the hook uses it to pick seed-vs-invalidate, the banner uses it to pick the
+// success-vs-warning view — one contract, one source.
+export function isFixResolvedClean(result: {
+  status: string
+  skippedOverwrite: string[]
+}): boolean {
+  return result.status === "complete" && result.skippedOverwrite.length === 0
+}
+
 // Refresh a config repo's drifted skeleton files (scaffolded workflows that fell
 // behind the bundled skeleton). `targetOrg` is the mutate variable — the banner
 // is a singleton across orgs, so the result must be attributed to the org the
@@ -27,9 +38,7 @@ export function useFixSkeletonDrift(
       ensureSkeletonFiles(client, targetOrg, confirmOverwrite),
     onSuccess: (result, targetOrg) => {
       const key = githubKeys.skeletonDrift(targetOrg)
-      const resolvedClean =
-        result.status === "complete" && result.skippedOverwrite.length === 0
-      if (resolvedClean) {
+      if (isFixResolvedClean(result)) {
         queryClient.setQueryData<StaleSkeletonFile[]>(key, [])
       } else {
         void queryClient.invalidateQueries({ queryKey: key })


### PR DESCRIPTION
## What

Tier-2 Phase F unit **U10** — extract the last inline `useMutation` out of `SkeletonDriftBanner` into a dedicated `useFixSkeletonDrift` hook, matching the `hooks/mutations/*` pattern established across U9 (batches 1–3).

## Why

`SkeletonDriftBanner` was the last non-infra component holding an inline client + `useMutation`. Moving the write into a hook keeps the banner presentational (read via `useSkeletonDrift`, write via the hook) and puts the drift-cache reconcile where it survives unmount.

## How

- **New `web/src/hooks/mutations/useFixSkeletonDrift.ts`** owns the `ensureSkeletonFiles` mutation and the drift-cache reconcile in its **own** `onSuccess` (unmount-safe — a `mutateAsync` call-site `onSuccess` is dropped if the banner unmounts mid-run):
  - `targetOrg` is the **mutate variable**, so the result is attributed to the org the fix ran against even if the owner navigates away.
  - A **clean** fix *seeds* `skeletonDrift(org)` to `[]` rather than invalidating — a post-commit tree read is eventually consistent, so invalidating could refetch stale drifted SHAs and re-flash the warning. A declined/partial overwrite (`skippedOverwrite` non-empty) invalidates instead.
- **`SkeletonDriftBanner.tsx`** now holds only presentation + the `useSkeletonDrift` read + the hook call. Per-org UI state (`setFixedCleanOrg`, `setPendingOrg`) stays at the call site under `mountedRef` guards.
- **`isFixResolvedClean`** is single-sourced in the hook and imported by both the hook (seed-vs-invalidate) and the banner (success-vs-warning view) — one contract, one source (addresses the review's P3).

## Tests

- New `useFixSkeletonDrift.test.ts`: seed-clean vs invalidate branches + mutate-variable org attribution (red-verified before the hook logic).
- Existing `SkeletonDriftBanner.test.ts` (pure view/predicate functions) stays green; `isFixResolvedClean` cases now import from the hook.
- `npm run check` green (tsc + eslint + prettier + vitest).