### PR TITLE
docs(web): document auth-flow mutations as a deliberate hooks/mutations exception (Tier-2 U11)

### DIFF
--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -249,6 +249,13 @@ function useGithubAuthState() {
     },
   })
 
+  // Auth-flow mutations — a deliberate exception to the hooks/mutations/
+  // boundary (see that README). These drive the login state machine (screen /
+  // device / error), not GitHub data writes against the app's query cache:
+  // there is nothing to invalidate or reconcile, each has a single call site
+  // inside this provider, and their .isPending feeds this hook's returned flags
+  // (isRequestingDeviceCode / isValidatingPat). Lifting them into standalone
+  // hooks would fragment the state machine for no data-consistency gain.
   const exchangeCodeMutation = useMutation({
     mutationFn: exchangeWebCode,
   })

--- a/web/src/hooks/mutations/README.md
+++ b/web/src/hooks/mutations/README.md
@@ -33,3 +33,16 @@ no → call site.
 Hooks stay `t()`-free: a caller passes pre-translated strings via a `messages`
 bag. The boundary is a convention, not yet lint-enforced (P7 earmarks
 `eslint-plugin-boundaries`).
+
+## Deliberate exceptions
+
+The boundary is **GitHub data writes** against the app's query cache. Two
+`useMutation` clusters stay inline by design because they aren't that:
+
+- **`auth/useGithubAuth.tsx`** (`exchangeWebCode` / `requestDeviceCode` /
+  `fetchGithubUserWithScopes`) — login state-machine transitions, not cache
+  writes. No invalidation/reconcile, one call site each inside the provider, and
+  their `.isPending` feeds the provider's returned flags; extracting them would
+  fragment the state machine.
+- **`hooks/useGitHubOperation` / `hooks/useActionActivity`** — generic
+  write-infra wrappers, not a specific operation.


### PR DESCRIPTION
## What

Tier-2 Phase F unit **U11** — resolve the three `useMutation` sites in `auth/useGithubAuth.tsx` (`exchangeWebCode`, `requestDeviceCode`, `fetchGithubUserWithScopes`). The plan framed this as **decide + convert-or-document**; the decision is **document**.

## Why keep them inline

The `hooks/mutations/` boundary is for **GitHub data writes against the app's query cache**. These three are not that — they're **login state-machine transitions**:

- No cache invalidation/reconcile to centralize (the whole reason the hook layer exists). `completeSignIn` does a `prefetchQuery`, but that's a shared callback, not a per-mutation cache-reconcile.
- Each has a **single call site** inside the provider, tightly coupled to local state (`screen`, `device`, `abortRef`, `pendingReturnToRef`, `startDevicePolling`).
- Their `.isPending` feeds the provider's returned flags (`isRequestingDeviceCode`, `isValidatingPat`).

Lifting them into standalone hooks would fragment the auth state machine for zero data-consistency gain — exactly the "extraction hurts cohesion" case the unit's Execution note calls out ("prefer clarity over dogma").

## Change

- In-file comment above the three mutations explaining the deliberate exception.
- A **Deliberate exceptions** section in `hooks/mutations/README.md` covering both the auth flow and the two generic write-infra wrappers (`useGitHubOperation`, `useActionActivity`).

The "zero inline `useMutation`" DoD is thereby interpreted (per the plan) as "zero **GitHub-data-write** inline mutations," with the auth flow explicitly carved out.

## Tests

Documentation/comment-only — no behavior change. `Test expectation: none — documented exception` (per plan). Verified: `tsc -b` clean, eslint 0 errors, all 107 `src/auth` tests green.

## Follow-up discovered (not in this PR)

While re-grounding, I found four inline **data-write** `useMutation` sites the plan's inline-sweep re-grounding under-counted — `CreateClassroomPage`, `CreateAssignmentPage`, `EditAssignmentForm`, `EditClassroomPage`. These *are* the hook-shape (create/edit writes with cache invalidation), so they're a genuine "U9 batch 4", tracked separately.