### PR TITLE
refactor(web): extract create/edit classroom+assignment writes into mutation hooks (Tier-2 U9 batch 4)

### DIFF
--- a/web/src/hooks/mutations/createEditMutations.test.ts
+++ b/web/src/hooks/mutations/createEditMutations.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+const createClassroomFilesWithConflictRetry = vi.fn<
+  (...args: unknown[]) => Promise<unknown>
+>(() => Promise.resolve({ newCommitSha: "sha-c" }))
+const editClassroomWithConflictRetry = vi.fn<
+  (...args: unknown[]) => Promise<unknown>
+>(() => Promise.resolve({ newCommitSha: "sha-e" }))
+const createAssignment = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve({ newCommitSha: "sha-a" }),
+)
+const editAssignmentWithConflictRetry = vi.fn<
+  (...args: unknown[]) => Promise<unknown>
+>(() => Promise.resolve({ newCommitSha: "sha-ea" }))
+
+vi.mock("@/domain/classrooms", () => ({
+  createClassroomFilesWithConflictRetry: (client: unknown, input: unknown) =>
+    createClassroomFilesWithConflictRetry(client, input),
+  editClassroomWithConflictRetry: (client: unknown, input: unknown) =>
+    editClassroomWithConflictRetry(client, input),
+}))
+vi.mock("@/domain/assignments", () => ({
+  createAssignment: (client: unknown, input: unknown) =>
+    createAssignment(client, input),
+  editAssignmentWithConflictRetry: (client: unknown, input: unknown) =>
+    editAssignmentWithConflictRetry(client, input),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useCreateClassroom } from "./useCreateClassroom"
+import { useEditClassroom } from "./useEditClassroom"
+import { useCreateAssignment } from "./useCreateAssignment"
+import { useEditAssignment } from "./useEditAssignment"
+
+const ORG = "acme"
+const CLASSROOM = "cs101"
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useCreateClassroom", () => {
+  it("invalidates the config-repo listing and forwards onWrite", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const onWrite = vi.fn()
+    const { result } = renderHook(() => useCreateClassroom(ORG, onWrite), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ classroom: CLASSROOM } as never)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
+    })
+    expect(createClassroomFilesWithConflictRetry).toHaveBeenCalledWith(
+      expect.anything(),
+      { classroom: CLASSROOM },
+    )
+    expect(onWrite).toHaveBeenCalledWith(
+      { newCommitSha: "sha-c" },
+      { classroom: CLASSROOM },
+    )
+  })
+})
+
+describe("useEditClassroom", () => {
+  it("invalidates the exact classroom.json AND the listing, then forwards onWrite", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const onWrite = vi.fn()
+    const { result } = renderHook(
+      () => useEditClassroom(ORG, CLASSROOM, onWrite),
+      { wrapper: wrapperWith(queryClient) },
+    )
+
+    result.current.mutate({ slug: CLASSROOM, org: ORG } as never)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.jsonFile(
+        ORG,
+        CONFIG_REPO,
+        `${CLASSROOM}/classroom.json`,
+      ),
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
+    })
+    expect(editClassroomWithConflictRetry).toHaveBeenCalledWith(
+      expect.anything(),
+      { slug: CLASSROOM, org: ORG },
+    )
+    expect(onWrite).toHaveBeenCalledWith({ newCommitSha: "sha-e" })
+  })
+})
+
+describe("useCreateAssignment", () => {
+  it("invalidates the assignments.json listing and forwards onWrite", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const onWrite = vi.fn()
+    const { result } = renderHook(
+      () => useCreateAssignment(ORG, CLASSROOM, onWrite),
+      { wrapper: wrapperWith(queryClient) },
+    )
+
+    result.current.mutate({ slug: "hw1", name: "HW1" } as never)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.jsonFile(
+        ORG,
+        CONFIG_REPO,
+        `${CLASSROOM}/assignments.json`,
+      ),
+    })
+    expect(createAssignment).toHaveBeenCalledWith(expect.anything(), {
+      slug: "hw1",
+      name: "HW1",
+    })
+    expect(onWrite).toHaveBeenCalledWith(
+      { newCommitSha: "sha-a" },
+      { slug: "hw1", name: "HW1" },
+    )
+  })
+})
+
+describe("useEditAssignment", () => {
+  it("forwards onWrite and delegates to the domain write, but does NOT invalidate (edit path relies on its own refetch)", async () => {
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const onWrite = vi.fn()
+    const { result } = renderHook(() => useEditAssignment({ onWrite }), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ slug: "hw1", name: "HW1" } as never)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(editAssignmentWithConflictRetry).toHaveBeenCalledWith(
+      expect.anything(),
+      { slug: "hw1", name: "HW1" },
+    )
+    expect(onWrite).toHaveBeenCalledWith(
+      { newCommitSha: "sha-ea" },
+      { slug: "hw1", name: "HW1" },
+    )
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  it("runs the hook-level onMutate before the write settles", async () => {
+    const queryClient = freshClient()
+    const onMutate = vi.fn()
+    // A deferred write so we can observe state while it is still pending —
+    // proving onMutate is hook-level (fired pre-flight) rather than only that
+    // it eventually ran.
+    let resolveWrite!: (value: { newCommitSha: string }) => void
+    editAssignmentWithConflictRetry.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveWrite = resolve
+        }),
+    )
+    const { result } = renderHook(() => useEditAssignment({ onMutate }), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ slug: "hw1", name: "HW1" } as never)
+
+    // onMutate fired while the write is still unresolved.
+    await waitFor(() => expect(onMutate).toHaveBeenCalled())
+    expect(result.current.isPending).toBe(true)
+    expect(onMutate.mock.invocationCallOrder[0]).toBeLessThan(
+      editAssignmentWithConflictRetry.mock.invocationCallOrder[0],
+    )
+
+    resolveWrite({ newCommitSha: "sha-ea" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+})

--- a/web/src/hooks/mutations/useCreateAssignment.ts
+++ b/web/src/hooks/mutations/useCreateAssignment.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import {
+  createAssignment,
+  type CreateAssignmentInput,
+  type CreateAssignmentResult,
+} from "@/domain/assignments"
+import { githubKeys } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// Create an assignment. The hook owns the assignments.json listing invalidate
+// (unmount-safe — the new assignment must appear even if the creator navigates
+// away) and the unmount-safe deploy-tracking `onWrite` follow-up. UI (toasts,
+// navigate, inline error/warning banners) stays at the call site, including the
+// templateGrantWarning branch, which decides whether to navigate — see
+// ./README.md.
+export function useCreateAssignment(
+  org: string,
+  classroom: string,
+  onWrite?: (
+    result: CreateAssignmentResult,
+    input: CreateAssignmentInput,
+  ) => void,
+) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    CreateAssignmentResult,
+    GitHubAPIError,
+    CreateAssignmentInput
+  >({
+    mutationFn: (input) => createAssignment(client, input),
+    onSuccess: (result, input) => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(
+          org,
+          CONFIG_REPO,
+          `${classroom}/assignments.json`,
+        ),
+      })
+      onWrite?.(result, input)
+    },
+  })
+}
+
+export default useCreateAssignment

--- a/web/src/hooks/mutations/useCreateClassroom.ts
+++ b/web/src/hooks/mutations/useCreateClassroom.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import {
+  createClassroomFilesWithConflictRetry,
+  type CreateClassroomInput,
+  type CreateClassroomResult,
+} from "@/domain/classrooms"
+import { githubKeys } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// Create a classroom's config files. The hook owns the config-repo listing
+// invalidate (unmount-safe — the new classroom must appear regardless of the
+// creator navigating away) and, via `onWrite`, the deploy-tracking follow-up
+// that also must survive unmount. UI (toasts, navigate, error logging) stays at
+// the call site so it skips cleanly on unmount — see ./README.md. `onWrite`
+// carries the translated activity label from the call site, keeping the hook
+// t()-free.
+export function useCreateClassroom(
+  org: string,
+  onWrite?: (
+    result: CreateClassroomResult,
+    input: CreateClassroomInput,
+  ) => void,
+) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    CreateClassroomResult,
+    GitHubAPIError,
+    CreateClassroomInput
+  >({
+    mutationFn: (input) => createClassroomFilesWithConflictRetry(client, input),
+    onSuccess: (result, input) => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
+      })
+      onWrite?.(result, input)
+    },
+  })
+}
+
+export default useCreateClassroom

--- a/web/src/hooks/mutations/useEditAssignment.ts
+++ b/web/src/hooks/mutations/useEditAssignment.ts
@@ -1,0 +1,40 @@
+import { useMutation } from "@tanstack/react-query"
+import {
+  editAssignmentWithConflictRetry,
+  type CreateAssignmentInput,
+  type CreateAssignmentResult,
+} from "@/domain/assignments"
+import { GitHubAPIError } from "@/github-core/errors"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+// Save an assignment's settings. This edit path historically does NOT invalidate
+// the assignments cache (the page relies on its own refetch/staleTime), so the
+// hook preserves that and owns only the unmount-safe deploy-tracking `onWrite`
+// follow-up (its translated label comes from the call site, keeping the hook
+// t()-free). `onMutate` is hook-level (React Query forbids it as a call-site
+// option) so the caller's pre-flight banner reset runs before the write. UI
+// (success/warning banners, scroll) stays at the call site — see ./README.md.
+export function useEditAssignment(opts?: {
+  onWrite?: (
+    result: CreateAssignmentResult,
+    input: CreateAssignmentInput,
+  ) => void
+  onMutate?: () => void
+}) {
+  const { onWrite, onMutate } = opts ?? {}
+  const client = useGitHubClient()
+
+  return useMutation<
+    CreateAssignmentResult,
+    GitHubAPIError,
+    CreateAssignmentInput
+  >({
+    mutationFn: (input) => editAssignmentWithConflictRetry(client, input),
+    onMutate,
+    onSuccess: (result, input) => {
+      onWrite?.(result, input)
+    },
+  })
+}
+
+export default useEditAssignment

--- a/web/src/hooks/mutations/useEditClassroom.ts
+++ b/web/src/hooks/mutations/useEditClassroom.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { editClassroomWithConflictRetry } from "@/domain/classrooms"
+import {
+  type EditClassroomInput,
+  type EditClassroomResult,
+} from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// Save a classroom's settings. The hook owns both invalidates (the exact
+// classroom.json the detail read uses, plus the classes listing) so a rename
+// lands regardless of the editor navigating away; `onWrite` carries the
+// unmount-safe deploy-tracking follow-up with its translated label. Toasts stay
+// at the call site — see ./README.md.
+export function useEditClassroom(
+  org: string,
+  classroom: string,
+  onWrite?: (result: EditClassroomResult) => void,
+) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<EditClassroomResult, GitHubAPIError, EditClassroomInput>({
+    mutationFn: (input) => editClassroomWithConflictRetry(client, input),
+    onSuccess: (result) => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(
+          org,
+          CONFIG_REPO,
+          `${classroom}/classroom.json`,
+        ),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
+      })
+      onWrite?.(result)
+    },
+  })
+}
+
+export default useEditClassroom

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -1,4 +1,3 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 
 import Breadcrumb from "@/components/breadcrumb"
@@ -11,31 +10,22 @@ import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import CreateAssignmentForm from "@/pages/assignments/CreateAssignmentForm"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { GitHubAPIError } from "@/github-core/errors"
-import { createAssignment } from "@/domain/assignments"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useCreateAssignment } from "@/hooks/mutations/useCreateAssignment"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
-import { githubKeys } from "@/github-core/queries"
-import { CONFIG_REPO } from "@/util/configRepo"
 import { logger } from "@/lib/logger"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
-import type {
-  CreateAssignmentInput,
-  CreateAssignmentResult,
-} from "@/domain/assignments"
 
 const log = logger.scope("CreateAssignmentPage")
 
 const CreateAssignmentPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.newAssignment"))
-  const client = useGitHubClient()
   const navigate = useNavigate()
   const { org, classroom } = useParams({ strict: false })
-  const queryClient = useQueryClient()
   const { notify } = useToast()
   const { register } = useActionActivityRegistry()
   const [errorMessage, setErrorMessage] = useState("")
@@ -46,33 +36,10 @@ const CreateAssignmentPage = () => {
 
   const emptyRoster = useEmptyRosterWarning(org, classroom)
 
-  const createClassroomMutation = useMutation<
-    CreateAssignmentResult,
-    GitHubAPIError,
-    CreateAssignmentInput
-  >({
-    mutationFn: (input) => createAssignment(client, input),
-    onError: (err) => {
-      if (err instanceof GitHubAPIError) {
-        // Console-only trace (MutationCache already recorded this failure).
-        log.error("create assignment failed", {
-          status: err.status,
-          requestId: err.requestId,
-        })
-      } else {
-        log.error("non-GitHub API error", { err, record: true })
-      }
-      setErrorMessage(err.message)
-      window.scrollTo({ top: 0, behavior: "smooth" })
-    },
-    onSuccess: (result, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(
-          org ?? "",
-          CONFIG_REPO,
-          `${classroom ?? ""}/assignments.json`,
-        ),
-      })
+  const createAssignmentMutation = useCreateAssignment(
+    org ?? "",
+    classroom ?? "",
+    (result, variables) => {
       // Track the publish-pages deploy this commit triggers, anchored on SHA.
       if (org && result.newCommitSha) {
         register({
@@ -81,30 +48,8 @@ const CreateAssignmentPage = () => {
           anchor: { kind: "sha", sha: result.newCommitSha },
         })
       }
-      // If the template team grant failed, stay on the page to show the warning
-      // instead of navigating away.
-      if (result.templateGrantWarning) {
-        setWarningMessage(result.templateGrantWarning)
-        window.scrollTo({ top: 0, behavior: "smooth" })
-        return
-      }
-      // Toast before navigating: the provider is mounted above the router, so
-      // the confirmation survives the redirect.
-      notify({
-        tone: "success",
-        durationMs: 6000,
-        message: t("toasts.assignmentCreated"),
-      })
-      navigate({
-        to: "/$org/$classroom/assignments/$assignment",
-        params: {
-          org: org ?? "",
-          classroom: classroom ?? "",
-          assignment: variables.slug,
-        },
-      })
     },
-  })
+  )
 
   if (!org || !classroom) {
     return <MissingParams message={t("assignments.missingOrgOrClassroom")} />
@@ -143,40 +88,81 @@ const CreateAssignmentPage = () => {
           </Button>
         </AnimatedAlert>
         <CreateAssignmentForm
-          loading={createClassroomMutation.isPending}
+          loading={createAssignmentMutation.isPending}
           org={org}
           classroom={classroom}
           takenSlugs={takenSlugs}
           onSubmit={(values) => {
             setErrorMessage("")
             setWarningMessage("")
-            createClassroomMutation.mutateAsync({
-              name: values.name,
-              slug: values.slug,
-              mode: values.mode,
-              org,
-              template_repo: values.template_repo,
-              description: values.description,
-              due_date: values.due_date,
-              max_group_size: values.max_group_size,
-              feedback_pr: values.feedback_pr,
-              runs_on: values.runs_on,
-              container_image: values.container_image,
-              container_user: values.container_user,
-              runtime_python: values.runtime_python,
-              runtime_node: values.runtime_node,
-              runtime_java: values.runtime_java,
-              runtime_go: values.runtime_go,
-              runtime_rust: values.runtime_rust,
-              runtime_apt: values.runtime_apt,
-              setup_command: values.setup_command,
-              allowed_files: values.allowed_files,
-              pass_threshold: values.pass_threshold_enabled
-                ? values.pass_threshold
-                : undefined,
-              classroom,
-              tests: values.tests,
-            })
+            createAssignmentMutation.mutateAsync(
+              {
+                name: values.name,
+                slug: values.slug,
+                mode: values.mode,
+                org,
+                template_repo: values.template_repo,
+                description: values.description,
+                due_date: values.due_date,
+                max_group_size: values.max_group_size,
+                feedback_pr: values.feedback_pr,
+                runs_on: values.runs_on,
+                container_image: values.container_image,
+                container_user: values.container_user,
+                runtime_python: values.runtime_python,
+                runtime_node: values.runtime_node,
+                runtime_java: values.runtime_java,
+                runtime_go: values.runtime_go,
+                runtime_rust: values.runtime_rust,
+                runtime_apt: values.runtime_apt,
+                setup_command: values.setup_command,
+                allowed_files: values.allowed_files,
+                pass_threshold: values.pass_threshold_enabled
+                  ? values.pass_threshold
+                  : undefined,
+                classroom,
+                tests: values.tests,
+              },
+              {
+                onError: (err) => {
+                  if (err instanceof GitHubAPIError) {
+                    // Console-only trace (MutationCache already recorded this).
+                    log.error("create assignment failed", {
+                      status: err.status,
+                      requestId: err.requestId,
+                    })
+                  } else {
+                    log.error("non-GitHub API error", { err, record: true })
+                  }
+                  setErrorMessage(err.message)
+                  window.scrollTo({ top: 0, behavior: "smooth" })
+                },
+                onSuccess: (result, variables) => {
+                  // If the template team grant failed, stay on the page to show
+                  // the warning instead of navigating away.
+                  if (result.templateGrantWarning) {
+                    setWarningMessage(result.templateGrantWarning)
+                    window.scrollTo({ top: 0, behavior: "smooth" })
+                    return
+                  }
+                  // Toast before navigating: the provider is mounted above the
+                  // router, so the confirmation survives the redirect.
+                  notify({
+                    tone: "success",
+                    durationMs: 6000,
+                    message: t("toasts.assignmentCreated"),
+                  })
+                  navigate({
+                    to: "/$org/$classroom/assignments/$assignment",
+                    params: {
+                      org,
+                      classroom,
+                      assignment: variables.slug,
+                    },
+                  })
+                },
+              },
+            )
           }}
         />
       </RequireRole>

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -1,13 +1,11 @@
 import { useParams, useNavigate } from "@tanstack/react-router"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 
-import { createClassroomFilesWithConflictRetry } from "@/domain/classrooms"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
 import { GitHubAPIError } from "@/github-core/errors"
+import { useCreateClassroom } from "@/hooks/mutations/useCreateClassroom"
 import PageShell from "@/components/PageShell"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import Breadcrumb from "@/components/breadcrumb"
@@ -16,51 +14,21 @@ import MissingParams from "@/components/MissingParams"
 import { logger } from "@/lib/logger"
 import RequireRole from "@/components/RequireRole"
 import CreateClassroomForm from "./classes/CreateClassroomForm"
-import { githubKeys } from "@/github-core/queries"
-import { CONFIG_REPO } from "@/util/configRepo"
-import type {
-  CreateClassroomInput,
-  CreateClassroomResult,
-} from "@/domain/classrooms"
 
 const log = logger.scope("CreateClassroomPage")
 
 const CreateClassroomPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.newClassroom"))
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { notify } = useToast()
   const { register } = useActionActivityRegistry()
   const { user } = useGithubAuth()
   const { org } = useParams({ strict: false })
 
-  const createClassroomMutation = useMutation<
-    CreateClassroomResult,
-    GitHubAPIError,
-    CreateClassroomInput
-  >({
-    mutationFn: (input) => createClassroomFilesWithConflictRetry(client, input),
-    onError: (err) => {
-      if (err instanceof GitHubAPIError) {
-        // Console-only trace (MutationCache already recorded this failure).
-        log.error("create classroom failed", {
-          status: err.status,
-          requestId: err.requestId,
-        })
-      } else {
-        log.error("non-GitHub API error", { err, record: true })
-      }
-      notify({
-        tone: "error",
-        message: t("toasts.classroomCreateFailed", { message: err.message }),
-      })
-    },
-    onSuccess: (result, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(org ?? "", CONFIG_REPO),
-      })
+  const createClassroomMutation = useCreateClassroom(
+    org ?? "",
+    (result, variables) => {
       // Track the publish-pages deploy this commit triggers, anchored on SHA.
       if (org && result.newCommitSha) {
         register({
@@ -71,19 +39,8 @@ const CreateClassroomPage = () => {
           anchor: { kind: "sha", sha: result.newCommitSha },
         })
       }
-      // Toast before navigating: the provider is mounted above the router, so
-      // the confirmation survives the redirect.
-      notify({
-        tone: "success",
-        durationMs: 6000,
-        message: t("toasts.classroomCreated"),
-      })
-      navigate({
-        to: "/$org/$classroom",
-        params: { org: org ?? "", classroom: variables.classroom },
-      })
     },
-  })
+  )
 
   if (!org) {
     return <MissingParams message={t("classes.missingOrg")} />
@@ -96,14 +53,48 @@ const CreateClassroomPage = () => {
         <PageHeader title={t("classes.createTitle")} />
         <CreateClassroomForm
           onSubmit={(values) =>
-            createClassroomMutation.mutateAsync({
-              name: values.name,
-              classroom: values.slug,
-              org,
-              term: values.term,
-              secret: values.secret || undefined,
-              creator: user?.login,
-            })
+            createClassroomMutation.mutateAsync(
+              {
+                name: values.name,
+                classroom: values.slug,
+                org,
+                term: values.term,
+                secret: values.secret || undefined,
+                creator: user?.login,
+              },
+              {
+                onError: (err) => {
+                  if (err instanceof GitHubAPIError) {
+                    // Console-only trace (MutationCache already recorded this).
+                    log.error("create classroom failed", {
+                      status: err.status,
+                      requestId: err.requestId,
+                    })
+                  } else {
+                    log.error("non-GitHub API error", { err, record: true })
+                  }
+                  notify({
+                    tone: "error",
+                    message: t("toasts.classroomCreateFailed", {
+                      message: err.message,
+                    }),
+                  })
+                },
+                onSuccess: (_result, variables) => {
+                  // Toast before navigating: the provider is mounted above the
+                  // router, so the confirmation survives the redirect.
+                  notify({
+                    tone: "success",
+                    durationMs: 6000,
+                    message: t("toasts.classroomCreated"),
+                  })
+                  navigate({
+                    to: "/$org/$classroom",
+                    params: { org, classroom: variables.classroom },
+                  })
+                },
+              },
+            )
           }
         />
       </RequireRole>

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -7,19 +7,11 @@ import { Spinner } from "@/components/Spinner"
 import { useParams } from "@tanstack/react-router"
 import EditClassroomForm from "./classes/EditClassroomForm"
 import ClassroomStaffSection from "./classes/ClassroomStaffSection"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { GitHubAPIError } from "@/github-core/errors"
-import { githubKeys } from "@/github-core/queries"
-import { CONFIG_REPO } from "@/util/configRepo"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import { useTranslation } from "react-i18next"
-import {
-  type EditClassroomInput,
-  type EditClassroomResult,
-} from "@/github-core/mutations"
-import { editClassroomWithConflictRetry } from "@/domain/classrooms"
+import { useEditClassroom } from "@/hooks/mutations/useEditClassroom"
 import { isClassroomArchived } from "@/types/classroom"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
@@ -35,8 +27,6 @@ const EditClassroomContent = ({
   classroom: string
 }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const { notify } = useToast()
   const { register } = useActionActivityRegistry()
   const runSave = useSafeSubmit()
@@ -45,55 +35,18 @@ const EditClassroomContent = ({
     classroom,
   )
 
-  const editClassroomMutation = useMutation<
-    EditClassroomResult,
-    GitHubAPIError,
-    EditClassroomInput
-  >({
-    mutationFn: (input) => editClassroomWithConflictRetry(client, input),
-    onError: (err) => {
-      notify({
-        tone: "error",
-        message:
-          err instanceof GitHubAPIError && err.status === 409
-            ? t("toasts.classroomSaveConflict")
-            : t("toasts.classroomSaveFailed", { message: err.message }),
+  const editClassroomMutation = useEditClassroom(org, classroom, (result) => {
+    // A classroom.json write triggers a publish-pages deploy — surface it in
+    // the global activity banner, anchored on the commit SHA.
+    if (result?.newCommitSha) {
+      register({
+        org,
+        label: t("actionsBanner.workflow.publishClassroom", {
+          name: cl?.name ?? classroom,
+        }),
+        anchor: { kind: "sha", sha: result.newCommitSha },
       })
-    },
-    onSuccess: (result) => {
-      // Refresh the exact classroom.json query useGetClassroom reads (so a
-      // renamed name/term updates in place), plus the classes-list listing.
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(
-          org ?? "",
-          CONFIG_REPO,
-          `${classroom}/classroom.json`,
-        ),
-      })
-      queryClient.invalidateQueries({
-        queryKey: githubKeys.jsonFile(org ?? "", CONFIG_REPO),
-      })
-      // A classroom.json write triggers a publish-pages deploy — surface it in
-      // the global activity banner, anchored on the commit SHA.
-      if (org && result?.newCommitSha) {
-        register({
-          org,
-          label: t("actionsBanner.workflow.publishClassroom", {
-            name: cl?.name ?? classroom,
-          }),
-          anchor: { kind: "sha", sha: result.newCommitSha },
-        })
-      }
-      // Plain-text message only: NotificationProvider is mounted ABOVE the
-      // RouterProvider, so a TanStack <Link> here has no router context and
-      // throws on render, blanking the app. Settings update in place via the
-      // invalidations above, so no navigation link is needed.
-      notify({
-        tone: "success",
-        durationMs: 5000,
-        message: t("toasts.classroomSettingsSaved"),
-      })
-    },
+    }
   })
 
   return (
@@ -125,12 +78,39 @@ const EditClassroomContent = ({
             cl={cl}
             onSubmit={(values) =>
               runSave(() =>
-                editClassroomMutation.mutateAsync({
-                  name: values.name,
-                  slug: classroom,
-                  org,
-                  term: values.term,
-                }),
+                editClassroomMutation.mutateAsync(
+                  {
+                    name: values.name,
+                    slug: classroom,
+                    org,
+                    term: values.term,
+                  },
+                  {
+                    onError: (err) => {
+                      notify({
+                        tone: "error",
+                        message:
+                          err instanceof GitHubAPIError && err.status === 409
+                            ? t("toasts.classroomSaveConflict")
+                            : t("toasts.classroomSaveFailed", {
+                                message: err.message,
+                              }),
+                      })
+                    },
+                    onSuccess: () => {
+                      // Plain-text message only: NotificationProvider is mounted
+                      // ABOVE the RouterProvider, so a TanStack <Link> here has
+                      // no router context and throws on render, blanking the
+                      // app. Settings update in place via the hook's
+                      // invalidations, so no navigation link is needed.
+                      notify({
+                        tone: "success",
+                        durationMs: 5000,
+                        message: t("toasts.classroomSettingsSaved"),
+                      })
+                    },
+                  },
+                ),
               )
             }
           />

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -1,16 +1,11 @@
-import { useMutation } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import CreateAssignmentForm, {
   assignmentToFormValues,
 } from "./CreateAssignmentForm"
-import {
-  editAssignmentWithConflictRetry,
-  type CreateAssignmentInput,
-  type CreateAssignmentResult,
-} from "@/domain/assignments"
+import { type CreateAssignmentResult } from "@/domain/assignments"
 import { GitHubAPIError } from "@/github-core/errors"
-import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
+import { useEditAssignment } from "@/hooks/mutations/useEditAssignment"
 import { LoadingSwap } from "@/lib/LoadingSwap"
 import { Spinner } from "@/components/Spinner"
 
@@ -37,16 +32,9 @@ const EditAssignmentForm = ({
   readOnly?: boolean
 }) => {
   const { t } = useTranslation()
-  const client = useGitHubClient()
   const { register } = useActionActivityRegistry()
-  const editAssignmentMutation = useMutation<
-    CreateAssignmentResult,
-    GitHubAPIError,
-    CreateAssignmentInput
-  >({
-    mutationFn: (input) => editAssignmentWithConflictRetry(client, input),
-    onMutate,
-    onSuccess: (result, variables) => {
+  const editAssignmentMutation = useEditAssignment({
+    onWrite: (result, variables) => {
       // Track the publish-pages deploy this edit's commit triggers, anchored on
       // the commit SHA (head_sha on the runs API).
       if (result.newCommitSha) {
@@ -56,9 +44,8 @@ const EditAssignmentForm = ({
           anchor: { kind: "sha", sha: result.newCommitSha },
         })
       }
-      onSuccess(result)
     },
-    onError,
+    onMutate,
   })
 
   return (
@@ -80,33 +67,39 @@ const EditAssignmentForm = ({
           onCancel={onCancel}
           defaultValues={assignmentToFormValues(defaultData)}
           onSubmit={(values) => {
-            editAssignmentMutation.mutate({
-              name: values.name,
-              mode: values.mode,
-              org,
-              template_repo: values.template_repo,
-              description: values.description,
-              due_date: values.due_date,
-              max_group_size: values.max_group_size,
-              feedback_pr: values.feedback_pr,
-              runs_on: values.runs_on,
-              container_image: values.container_image,
-              container_user: values.container_user,
-              runtime_python: values.runtime_python,
-              runtime_node: values.runtime_node,
-              runtime_java: values.runtime_java,
-              runtime_go: values.runtime_go,
-              runtime_rust: values.runtime_rust,
-              runtime_apt: values.runtime_apt,
-              setup_command: values.setup_command,
-              allowed_files: values.allowed_files,
-              pass_threshold: values.pass_threshold_enabled
-                ? values.pass_threshold
-                : undefined,
-              classroom,
-              tests: values.tests,
-              slug: assignment,
-            })
+            editAssignmentMutation.mutate(
+              {
+                name: values.name,
+                mode: values.mode,
+                org,
+                template_repo: values.template_repo,
+                description: values.description,
+                due_date: values.due_date,
+                max_group_size: values.max_group_size,
+                feedback_pr: values.feedback_pr,
+                runs_on: values.runs_on,
+                container_image: values.container_image,
+                container_user: values.container_user,
+                runtime_python: values.runtime_python,
+                runtime_node: values.runtime_node,
+                runtime_java: values.runtime_java,
+                runtime_go: values.runtime_go,
+                runtime_rust: values.runtime_rust,
+                runtime_apt: values.runtime_apt,
+                setup_command: values.setup_command,
+                allowed_files: values.allowed_files,
+                pass_threshold: values.pass_threshold_enabled
+                  ? values.pass_threshold
+                  : undefined,
+                classroom,
+                tests: values.tests,
+                slug: assignment,
+              },
+              {
+                onSuccess: (result) => onSuccess(result),
+                onError,
+              },
+            )
           }}
         />
       ) : null}


### PR DESCRIPTION
## What

Tier-2 Phase F — a **U9 "batch 4"** that finishes the inline-mutation sweep. Extracts the four remaining inline **data-write** `useMutation` sites (found while re-grounding U11) into `hooks/mutations/` hooks, matching batches 1–3 and the `hooks/mutations/README.md` boundary.

| New hook | Converted call site |
| --- | --- |
| `useCreateClassroom` | `CreateClassroomPage` |
| `useEditClassroom` | `EditClassroomPage` |
| `useCreateAssignment` | `CreateAssignmentPage` |
| `useEditAssignment` | `assignments/EditAssignmentForm` |

## The split (per README)

- **Hook `onSuccess` (unmount-safe):** `queryClient.invalidateQueries(...)` — the exact keys the inline code used:
  - create-classroom → config-repo listing
  - edit-classroom → the exact `classroom.json` + the listing
  - create-assignment → `assignments.json` listing
  - **edit-assignment → intentionally none** (the edit path always relied on its own refetch/staleTime; preserved to avoid a behavior change, documented + asserted by test).
- **Hook `onWrite` data-callback (unmount-safe):** the publish-pages deploy-tracking `register(...)`, with its **`t()` label built at the call site** so hooks stay `t()`-free.
- **Call site (`mutate(vars, { onSuccess, onError })`):** toasts, `navigate`, error/warning `setState`, `window.scrollTo`, and the `templateGrantWarning` early-return-navigation branch — all UI, all skip cleanly on unmount.
- `useEditAssignment`'s `onMutate` (pre-flight banner reset) stays **hook-level** (React Query v5 forbids it as a call-site option). It and `onWrite` are passed as a single **options object** (`useEditAssignment({ onWrite, onMutate })`) — both are optional callbacks, so an options bag removes the positional-transposition footgun two adjacent function params would carry.

## Tests

New `createEditMutations.test.ts` (5 tests): for each hook, the correct invalidation keys, **delegation to the domain write** (`toHaveBeenCalledWith` on the mutation input, so a dropped/mangled payload or wrong-fn swap fails), and `onWrite` forwarding; the edit-assignment **no-invalidate** invariant; and the hook-level `onMutate` **ordering** — a deferred write proves it fires *while the write is still pending* (not merely that it eventually ran). The create-classroom invalidate assertion was red-verified before shipping.

`npm run check` green (tsc + eslint 0 errors + prettier + vitest). `ce-code-review` (full roster) surfaced three P2 quality findings — untested mutation-fn delegation, the `onMutate` test asserting "fired" rather than ordering, and the `useEditAssignment` two-positional-callback footgun — **all three are resolved in this PR** (delegation + ordering assertions added; signature switched to an options object). One flagged behavior-divergence candidate (edit-assignment banner dropped on mid-flight unmount) was investigated and **rejected** as unreachable: no path unmounts the form while its parent page survives mid-save.

## Sweep status

With this, every GitHub **data-write** inline `useMutation` is now in `hooks/mutations/`. The only remaining inline `useMutation`s are the deliberately-documented exceptions from U11 (auth-flow state machine + the generic `useGitHubOperation`/`useActionActivity` write-infra wrappers).
