### PR TITLE
refactor(web): dedupe write-callsite recipes and fix a redundant delete invalidate

### DIFF
--- a/web/src/hooks/useTrackPublishDeploy.test.ts
+++ b/web/src/hooks/useTrackPublishDeploy.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+const register = vi.fn<(...args: unknown[]) => string>(() => "id")
+
+vi.mock("@/context/actions/ActionActivityProvider", () => ({
+  useActionActivityRegistry: () => ({ register }),
+}))
+
+import { useTrackPublishDeploy } from "./useTrackPublishDeploy"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useTrackPublishDeploy", () => {
+  it("registers a SHA-anchored op with the pre-translated label", () => {
+    const { result } = renderHook(() => useTrackPublishDeploy())
+
+    result.current("acme", "sha-123", "Publishing cs101")
+
+    expect(register).toHaveBeenCalledWith({
+      org: "acme",
+      label: "Publishing cs101",
+      anchor: { kind: "sha", sha: "sha-123" },
+    })
+  })
+
+  it("no-ops when there is no commit SHA (no deploy was triggered)", () => {
+    const { result } = renderHook(() => useTrackPublishDeploy())
+
+    result.current("acme", undefined, "Publishing cs101")
+
+    expect(register).not.toHaveBeenCalled()
+  })
+
+  it("no-ops when org is empty", () => {
+    const { result } = renderHook(() => useTrackPublishDeploy())
+
+    result.current("", "sha-123", "Publishing cs101")
+
+    expect(register).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/hooks/useTrackPublishDeploy.ts
+++ b/web/src/hooks/useTrackPublishDeploy.ts
@@ -1,12 +1,8 @@
 import { useCallback } from "react"
 import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
 
-// Track the publish-pages deploy a config-repo write triggers, in the global
-// activity banner, anchored on the commit SHA. Single-sources the `{ kind:
-// "sha" }` anchor shape + the no-SHA guard that four create/edit write call
-// sites (classroom + assignment) otherwise hand-copy. `label` is pre-translated
-// by the caller (t() stays at the call site). No-ops when `sha` is falsy — a
-// write that produced no commit triggered no deploy.
+// Single-sources the `{ kind: "sha" }` publish-deploy anchor + no-SHA guard
+// that four create/edit write call sites otherwise hand-copy.
 export function useTrackPublishDeploy() {
   const { register } = useActionActivityRegistry()
 

--- a/web/src/hooks/useTrackPublishDeploy.ts
+++ b/web/src/hooks/useTrackPublishDeploy.ts
@@ -1,0 +1,22 @@
+import { useCallback } from "react"
+import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
+
+// Track the publish-pages deploy a config-repo write triggers, in the global
+// activity banner, anchored on the commit SHA. Single-sources the `{ kind:
+// "sha" }` anchor shape + the no-SHA guard that four create/edit write call
+// sites (classroom + assignment) otherwise hand-copy. `label` is pre-translated
+// by the caller (t() stays at the call site). No-ops when `sha` is falsy — a
+// write that produced no commit triggered no deploy.
+export function useTrackPublishDeploy() {
+  const { register } = useActionActivityRegistry()
+
+  return useCallback(
+    (org: string, sha: string | undefined, label: string) => {
+      if (!org || !sha) return
+      register({ org, label, anchor: { kind: "sha", sha } })
+    },
+    [register],
+  )
+}
+
+export default useTrackPublishDeploy

--- a/web/src/lib/logWriteFailure.test.ts
+++ b/web/src/lib/logWriteFailure.test.ts
@@ -35,8 +35,6 @@ describe("logWriteFailure", () => {
       status: 422,
       requestId: "req-9",
     })
-    // The MutationCache already records API failures, so this branch must NOT
-    // re-record (that would double-count).
     expect(error).toHaveBeenCalledWith(
       "create classroom failed",
       expect.not.objectContaining({ record: true }),

--- a/web/src/lib/logWriteFailure.test.ts
+++ b/web/src/lib/logWriteFailure.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { logWriteFailure } from "./logWriteFailure"
+import { GitHubAPIError } from "@/github-core/errors"
+import type { Logger } from "@/lib/logger"
+
+function fakeLogger() {
+  const error = vi.fn()
+  const log = { error } as unknown as Logger
+  return { log, error }
+}
+
+describe("logWriteFailure", () => {
+  it("logs a GitHubAPIError's status + requestId under the given message (no record)", () => {
+    const { log, error } = fakeLogger()
+    const err = new GitHubAPIError({
+      status: 422,
+      url: "https://api.github.com/x",
+      message: "boom",
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+      requestId: "req-9",
+    })
+
+    logWriteFailure(log, err, "create classroom failed")
+
+    expect(error).toHaveBeenCalledWith("create classroom failed", {
+      status: 422,
+      requestId: "req-9",
+    })
+    // The MutationCache already records API failures, so this branch must NOT
+    // re-record (that would double-count).
+    expect(error).toHaveBeenCalledWith(
+      "create classroom failed",
+      expect.not.objectContaining({ record: true }),
+    )
+  })
+
+  it("records a non-GitHub error under a generic message", () => {
+    const { log, error } = fakeLogger()
+    const err = new Error("network down")
+
+    logWriteFailure(log, err, "create assignment failed")
+
+    expect(error).toHaveBeenCalledWith("non-GitHub API error", {
+      err,
+      record: true,
+    })
+  })
+})

--- a/web/src/lib/logWriteFailure.ts
+++ b/web/src/lib/logWriteFailure.ts
@@ -1,0 +1,19 @@
+import type { Logger } from "@/lib/logger"
+import { GitHubAPIError } from "@/github-core/errors"
+
+// Console-only trace for a failed GitHub write. Single-sources the two-branch
+// shape the create/edit call sites hand-copy: a GitHubAPIError logs its
+// status/requestId under `message`; anything else is an unexpected non-API error
+// worth recording. The MutationCache already records the API failure, so the
+// GitHubAPIError branch does NOT set `record`.
+export function logWriteFailure(
+  log: Logger,
+  err: unknown,
+  message: string,
+): void {
+  if (err instanceof GitHubAPIError) {
+    log.error(message, { status: err.status, requestId: err.requestId })
+  } else {
+    log.error("non-GitHub API error", { err, record: true })
+  }
+}

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -9,13 +9,13 @@ import { AnimatedAlert, Button } from "@/components/ui"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import CreateAssignmentForm from "@/pages/assignments/CreateAssignmentForm"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
-import { GitHubAPIError } from "@/github-core/errors"
 import { useCreateAssignment } from "@/hooks/mutations/useCreateAssignment"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
+import { useTrackPublishDeploy } from "@/hooks/useTrackPublishDeploy"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { logger } from "@/lib/logger"
+import { logWriteFailure } from "@/lib/logWriteFailure"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -27,7 +27,7 @@ const CreateAssignmentPage = () => {
   const navigate = useNavigate()
   const { org, classroom } = useParams({ strict: false })
   const { notify } = useToast()
-  const { register } = useActionActivityRegistry()
+  const trackPublishDeploy = useTrackPublishDeploy()
   const [errorMessage, setErrorMessage] = useState("")
   const [warningMessage, setWarningMessage] = useState("")
 
@@ -40,14 +40,11 @@ const CreateAssignmentPage = () => {
     org ?? "",
     classroom ?? "",
     (result, variables) => {
-      // Track the publish-pages deploy this commit triggers, anchored on SHA.
-      if (org && result.newCommitSha) {
-        register({
-          org,
-          label: t("toasts.publishingAssignment", { name: variables.name }),
-          anchor: { kind: "sha", sha: result.newCommitSha },
-        })
-      }
+      trackPublishDeploy(
+        org ?? "",
+        result.newCommitSha,
+        t("toasts.publishingAssignment", { name: variables.name }),
+      )
     },
   )
 
@@ -125,15 +122,7 @@ const CreateAssignmentPage = () => {
               },
               {
                 onError: (err) => {
-                  if (err instanceof GitHubAPIError) {
-                    // Console-only trace (MutationCache already recorded this).
-                    log.error("create assignment failed", {
-                      status: err.status,
-                      requestId: err.requestId,
-                    })
-                  } else {
-                    log.error("non-GitHub API error", { err, record: true })
-                  }
+                  logWriteFailure(log, err, "create assignment failed")
                   setErrorMessage(err.message)
                   window.scrollTo({ top: 0, behavior: "smooth" })
                 },

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
-import { GitHubAPIError } from "@/github-core/errors"
+import { useTrackPublishDeploy } from "@/hooks/useTrackPublishDeploy"
 import { useCreateClassroom } from "@/hooks/mutations/useCreateClassroom"
 import PageShell from "@/components/PageShell"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -12,6 +11,7 @@ import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
 import { logger } from "@/lib/logger"
+import { logWriteFailure } from "@/lib/logWriteFailure"
 import RequireRole from "@/components/RequireRole"
 import CreateClassroomForm from "./classes/CreateClassroomForm"
 
@@ -22,23 +22,20 @@ const CreateClassroomPage = () => {
   useDocumentTitle(t("documentTitle.newClassroom"))
   const navigate = useNavigate()
   const { notify } = useToast()
-  const { register } = useActionActivityRegistry()
+  const trackPublishDeploy = useTrackPublishDeploy()
   const { user } = useGithubAuth()
   const { org } = useParams({ strict: false })
 
   const createClassroomMutation = useCreateClassroom(
     org ?? "",
     (result, variables) => {
-      // Track the publish-pages deploy this commit triggers, anchored on SHA.
-      if (org && result.newCommitSha) {
-        register({
-          org,
-          label: t("actionsBanner.workflow.publishClassroom", {
-            name: variables.classroom,
-          }),
-          anchor: { kind: "sha", sha: result.newCommitSha },
-        })
-      }
+      trackPublishDeploy(
+        org ?? "",
+        result.newCommitSha,
+        t("actionsBanner.workflow.publishClassroom", {
+          name: variables.classroom,
+        }),
+      )
     },
   )
 
@@ -64,15 +61,7 @@ const CreateClassroomPage = () => {
               },
               {
                 onError: (err) => {
-                  if (err instanceof GitHubAPIError) {
-                    // Console-only trace (MutationCache already recorded this).
-                    log.error("create classroom failed", {
-                      status: err.status,
-                      requestId: err.requestId,
-                    })
-                  } else {
-                    log.error("non-GitHub API error", { err, record: true })
-                  }
+                  logWriteFailure(log, err, "create classroom failed")
                   notify({
                     tone: "error",
                     message: t("toasts.classroomCreateFailed", {

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -36,8 +36,6 @@ const EditClassroomContent = ({
   )
 
   const editClassroomMutation = useEditClassroom(org, classroom, (result) => {
-    // A classroom.json write triggers a publish-pages deploy — surface it in
-    // the global activity banner, anchored on the commit SHA.
     trackPublishDeploy(
       org,
       result?.newCommitSha,

--- a/web/src/pages/EditClassroomPage.tsx
+++ b/web/src/pages/EditClassroomPage.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next"
 import { useEditClassroom } from "@/hooks/mutations/useEditClassroom"
 import { isClassroomArchived } from "@/types/classroom"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
+import { useTrackPublishDeploy } from "@/hooks/useTrackPublishDeploy"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import RequireRole from "@/components/RequireRole"
 import { LoadingSwap } from "@/lib/LoadingSwap"
@@ -28,7 +28,7 @@ const EditClassroomContent = ({
 }) => {
   const { t } = useTranslation()
   const { notify } = useToast()
-  const { register } = useActionActivityRegistry()
+  const trackPublishDeploy = useTrackPublishDeploy()
   const runSave = useSafeSubmit()
   const { data: cl, isLoading: loadingClassroom } = useGetClassroom(
     org,
@@ -38,15 +38,13 @@ const EditClassroomContent = ({
   const editClassroomMutation = useEditClassroom(org, classroom, (result) => {
     // A classroom.json write triggers a publish-pages deploy — surface it in
     // the global activity banner, anchored on the commit SHA.
-    if (result?.newCommitSha) {
-      register({
-        org,
-        label: t("actionsBanner.workflow.publishClassroom", {
-          name: cl?.name ?? classroom,
-        }),
-        anchor: { kind: "sha", sha: result.newCommitSha },
-      })
-    }
+    trackPublishDeploy(
+      org,
+      result?.newCommitSha,
+      t("actionsBanner.workflow.publishClassroom", {
+        name: cl?.name ?? classroom,
+      }),
+    )
   })
 
   return (

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -35,8 +35,7 @@ const EditAssignmentForm = ({
   const trackPublishDeploy = useTrackPublishDeploy()
   const editAssignmentMutation = useEditAssignment({
     onWrite: (result, variables) => {
-      // Track the publish-pages deploy this edit's commit triggers, anchored on
-      // the commit SHA (head_sha on the runs API).
+      // newCommitSha is the runs API's head_sha.
       trackPublishDeploy(
         org,
         result.newCommitSha,

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -4,7 +4,7 @@ import CreateAssignmentForm, {
 } from "./CreateAssignmentForm"
 import { type CreateAssignmentResult } from "@/domain/assignments"
 import { GitHubAPIError } from "@/github-core/errors"
-import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
+import { useTrackPublishDeploy } from "@/hooks/useTrackPublishDeploy"
 import { useEditAssignment } from "@/hooks/mutations/useEditAssignment"
 import { LoadingSwap } from "@/lib/LoadingSwap"
 import { Spinner } from "@/components/Spinner"
@@ -32,18 +32,16 @@ const EditAssignmentForm = ({
   readOnly?: boolean
 }) => {
   const { t } = useTranslation()
-  const { register } = useActionActivityRegistry()
+  const trackPublishDeploy = useTrackPublishDeploy()
   const editAssignmentMutation = useEditAssignment({
     onWrite: (result, variables) => {
       // Track the publish-pages deploy this edit's commit triggers, anchored on
       // the commit SHA (head_sha on the runs API).
-      if (result.newCommitSha) {
-        register({
-          org,
-          label: t("toasts.publishingAssignment", { name: variables.name }),
-          anchor: { kind: "sha", sha: result.newCommitSha },
-        })
-      }
+      trackPublishDeploy(
+        org,
+        result.newCommitSha,
+        t("toasts.publishingAssignment", { name: variables.name }),
+      )
     },
     onMutate,
   })

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -3,10 +3,7 @@ import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useArchiveClassroom } from "@/hooks/mutations/useArchiveClassroom"
 import { useDeleteClassroom } from "@/hooks/mutations/useDeleteClassroom"
-import { githubKeys } from "@/github-core/queries"
-import { CONFIG_REPO } from "@/util/configRepo"
 import { useForm } from "@tanstack/react-form"
-import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { Archive, ArchiveRestore, Trash2 } from "lucide-react"
 import { GitHubLink } from "@/components/GitHubLink"
@@ -214,7 +211,6 @@ const ArchiveClassroomButton = ({
 
 const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
   const { t } = useTranslation()
-  const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { org, classroom } = useParams({ strict: false })
   const [submitted, setSubmitted] = useState(false)
@@ -284,9 +280,8 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
               org={org}
               classroom={classroom}
               onDeleteClassroom={() => {
-                queryClient.invalidateQueries({
-                  queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
-                })
+                // Cache reconcile is owned by useDeleteClassroom; call site only
+                // navigates.
                 navigate({ to: "/$org", params: { org } })
               }}
             />


### PR DESCRIPTION
## What

A quality quick-wins PR bundling three findings from the post-sweep codebase debt audit — all touching the create/edit write call sites fresh from the mutation-hook work.

## 1. Fix a latent delete-classroom flicker (behavior fix)

`EditClassroomForm`'s delete callback fired `queryClient.invalidateQueries({ queryKey: jsonFile(org, CONFIG_REPO) })` — the **exact** dir-listing key `useDeleteClassroom` **deliberately avoids** invalidating. The hook optimistically drops the row and its own comment warns that an immediate invalidate re-reads the just-deleted dir (GitHub Contents API is read-after-write eventual) and **re-adds the deleted card**. So the call-site invalidate was actively defeating the hook's design.

Fix: remove the redundant invalidate (the hook owns the reconcile), keep only `navigate`, drop the now-dead `githubKeys`/`CONFIG_REPO`/`useQueryClient` imports + local.

## 2. `useTrackPublishDeploy` hook

Single-sources the "register a publish-pages deploy anchored on the commit SHA" recipe that **four** create/edit call sites hand-copied. Wraps `useActionActivityRegistry().register`, guards on `!org || !sha`, builds the `{ kind: "sha" }` anchor. The `t()` label stays at each call site (hooks stay `t()`-free). Adopted in `CreateClassroomPage`, `CreateAssignmentPage`, `EditClassroomPage`, `EditAssignmentForm`.

## 3. `logWriteFailure` helper

Single-sources the two-branch `onError` logging (GitHubAPIError → status/requestId; else → `record: true`) copied in the two create pages. The GitHubAPIError branch deliberately does **not** set `record` (the MutationCache already records it) — now asserted explicitly in the test.

## Tests

New `useTrackPublishDeploy.test.ts` (SHA-anchored register + no-op guards, red-verified) and `logWriteFailure.test.ts` (both branches + the no-double-record invariant). `npm run check` green. `ce-code-review` (full roster, 8 reviewers + validator) returned **Ready to merge** — its one P3 (comment restated the hook's rationale) is folded in.