### PR TITLE
refactor(web): drop self-referential comment in sidebarClasses

### DIFF
--- a/web/src/components/drawer/sidebarClasses.ts
+++ b/web/src/components/drawer/sidebarClasses.ts
@@ -1,5 +1,4 @@
-// Sidebar class-name recipes (dark rail). One source per AGENTS.md "one recipe,
-// one source" so a token rename lands once.
+// Sidebar class-name recipes (dark rail). Single source so a token rename lands once.
 
 export const navItemClass = (active: boolean, collapsed: boolean) =>
   `flex items-center gap-2 rounded-box border-l-2 px-2 py-2 transition-colors ${


### PR DESCRIPTION
Post-merge follow-up to #304. The `sidebarClasses.ts` header comment named the AGENTS.md rule itself ("One source per AGENTS.md 'one recipe, one source'"), which reads as a meta-comment. Drops the self-referential clause and keeps the rationale.

Before: `// Sidebar class-name recipes (dark rail). One source per AGENTS.md "one recipe, one source" so a token rename lands once.`
After: `// Sidebar class-name recipes (dark rail). Single source so a token rename lands once.`

Comment-only; no behavior change. tsc/eslint/prettier clean.