### PR TITLE
fix(web): recover classroom team read access to assignment templates (#305)

### DIFF
--- a/web/src/components/modals/TemplateAccessModal.test.tsx
+++ b/web/src/components/modals/TemplateAccessModal.test.tsx
@@ -123,6 +123,20 @@ describe("TemplateAccessModal", () => {
     ).toBeTruthy()
   })
 
+  it("shows the visibility caveat (not 'empty') for a non-owner with no visible teams", async () => {
+    orgRole = "member"
+    listRepoTeams.mockResolvedValue([])
+    renderModal()
+    expect(
+      await screen.findByText(
+        "assignments.template.accessModal.teamsUnavailable",
+      ),
+    ).toBeTruthy()
+    expect(
+      screen.queryByText("assignments.template.accessModal.teamsEmpty"),
+    ).toBeNull()
+  })
+
   it("shows the fix action to an org owner", () => {
     orgRole = "owner"
     renderModal()

--- a/web/src/components/modals/TemplateAccessModal.test.tsx
+++ b/web/src/components/modals/TemplateAccessModal.test.tsx
@@ -6,6 +6,7 @@ import {
   cleanup,
   fireEvent,
   waitFor,
+  act,
 } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { PropsWithChildren } from "react"
@@ -165,6 +166,58 @@ describe("TemplateAccessModal", () => {
       { org: ORG, classroom: "cs101", slug: "hw1", template },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     )
+  })
+
+  it("toasts success and disables fix after a clean grant (no re-flash)", async () => {
+    orgRole = "owner"
+    // Student team absent, so Fix starts enabled.
+    listRepoTeams.mockResolvedValue([])
+    renderModal()
+    await waitFor(() =>
+      expect(screen.getByText(FIX_ACTION).closest("button")?.disabled).toBe(
+        false,
+      ),
+    )
+
+    fireEvent.click(screen.getByText(FIX_ACTION))
+    const onSuccess = reconcileMutate.mock.calls[0][1].onSuccess
+    act(() => onSuccess({ warning: undefined }))
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: "success" }),
+    )
+    // Even though the eventually-consistent list is still empty, the button
+    // stays disabled and the empty state is suppressed — no post-success
+    // re-flash / re-enable.
+    await waitFor(() =>
+      expect(screen.getByText(FIX_ACTION).closest("button")?.disabled).toBe(
+        true,
+      ),
+    )
+    expect(
+      screen.queryByText("assignments.template.accessModal.teamsEmpty"),
+    ).toBeNull()
+  })
+
+  it("toasts the warning and keeps fix enabled when the grant fails", async () => {
+    orgRole = "owner"
+    listRepoTeams.mockResolvedValue([])
+    renderModal()
+    await waitFor(() =>
+      expect(screen.getByText(FIX_ACTION).closest("button")?.disabled).toBe(
+        false,
+      ),
+    )
+
+    fireEvent.click(screen.getByText(FIX_ACTION))
+    const onSuccess = reconcileMutate.mock.calls[0][1].onSuccess
+    act(() => onSuccess({ warning: "student grant failed" }))
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: "error" }),
+    )
+    // A failed grant must not latch "satisfied" — the owner can retry.
+    expect(screen.getByText(FIX_ACTION).closest("button")?.disabled).toBe(false)
   })
 
   it("enables fix when the classroom student team is missing", async () => {

--- a/web/src/components/modals/TemplateAccessModal.test.tsx
+++ b/web/src/components/modals/TemplateAccessModal.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import type { Assignment } from "@/types/classroom"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+let orgRole = "owner"
+vi.mock("@/context/githubOrgRole/GitHubOrgRoleProvider", () => ({
+  useGitHubOrgRole: () => ({ githubOrgRole: orgRole }),
+}))
+
+const notify = vi.fn()
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify, dismiss: vi.fn() }),
+}))
+
+const listRepoTeams = vi.fn()
+vi.mock("@/github-core/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/github-core/queries")>()
+  return {
+    ...actual,
+    repoTeamsQuery: (_client: unknown, owner: string, repo: string) => ({
+      queryKey: ["github", "repo-teams", owner, repo],
+      queryFn: () => listRepoTeams(owner, repo),
+      enabled: Boolean(owner && repo),
+    }),
+  }
+})
+
+const reconcileMutate = vi.fn()
+let reconcilePending = false
+vi.mock("@/hooks/mutations/useReconcileTemplateAccess", () => ({
+  useReconcileTemplateAccess: () => ({
+    mutate: reconcileMutate,
+    isPending: reconcilePending,
+  }),
+}))
+
+import { TemplateAccessModal } from "./TemplateAccessModal"
+
+const ORG = "acme"
+const template = { owner: ORG, repo: "tmpl", branch: "main" }
+const assignment = (over: Partial<Assignment> = {}): Assignment =>
+  ({
+    slug: "hw1",
+    name: "HW 1",
+    mode: "individual",
+    template,
+    ...over,
+  }) as Assignment
+
+function renderModal() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  const wrapper = ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client }, children)
+  return render(
+    createElement(TemplateAccessModal, {
+      org: ORG,
+      classroom: "cs101",
+      assignment: assignment(),
+      onClose: vi.fn(),
+    }),
+    { wrapper },
+  )
+}
+
+const FIX_ACTION = "assignments.template.accessModal.fixAction"
+const OWNER_NOTE = "assignments.template.accessModal.ownerOnlyNote"
+
+beforeEach(() => {
+  orgRole = "owner"
+  reconcilePending = false
+  listRepoTeams.mockReset()
+  listRepoTeams.mockResolvedValue([])
+  reconcileMutate.mockReset()
+  notify.mockReset()
+})
+
+afterEach(cleanup)
+
+describe("TemplateAccessModal", () => {
+  it("shows the template owner/repo and a GitHub link", async () => {
+    renderModal()
+    expect(screen.getByText("acme/tmpl")).toBeTruthy()
+    expect(
+      screen.getByText("assignments.template.accessModal.openOnGitHub"),
+    ).toBeTruthy()
+  })
+
+  it("lists the teams that have access", async () => {
+    listRepoTeams.mockResolvedValue([
+      {
+        id: 1,
+        name: "cs101 students",
+        slug: "classroom50-cs101",
+        html_url: "https://x",
+        permission: "pull",
+      },
+    ])
+    renderModal()
+    expect(await screen.findByText("cs101 students")).toBeTruthy()
+  })
+
+  it("shows the empty state when no team has access", async () => {
+    listRepoTeams.mockResolvedValue([])
+    renderModal()
+    expect(
+      await screen.findByText("assignments.template.accessModal.teamsEmpty"),
+    ).toBeTruthy()
+  })
+
+  it("shows the fix action to an org owner", () => {
+    orgRole = "owner"
+    renderModal()
+    expect(screen.queryByText(FIX_ACTION)).toBeTruthy()
+    expect(screen.queryByText(OWNER_NOTE)).toBeNull()
+  })
+
+  it("hides the fix action from a non-owner and shows the owner-only note", () => {
+    orgRole = "member"
+    renderModal()
+    expect(screen.queryByText(FIX_ACTION)).toBeNull()
+    expect(screen.queryByText(OWNER_NOTE)).toBeTruthy()
+  })
+
+  it("invokes the reconcile hook when the owner clicks fix", () => {
+    orgRole = "owner"
+    renderModal()
+    fireEvent.click(screen.getByText(FIX_ACTION))
+    expect(reconcileMutate).toHaveBeenCalledWith(
+      { org: ORG, classroom: "cs101", slug: "hw1", template },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    )
+  })
+
+  it("does not offer the fix action for an out-of-org template", () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    render(
+      createElement(TemplateAccessModal, {
+        org: ORG,
+        classroom: "cs101",
+        assignment: assignment({
+          template: { owner: "other", repo: "tmpl", branch: "main" },
+        }),
+        onClose: vi.fn(),
+      }),
+      {
+        wrapper: ({ children }: PropsWithChildren) =>
+          createElement(QueryClientProvider, { client }, children),
+      },
+    )
+    expect(screen.queryByText(FIX_ACTION)).toBeNull()
+    expect(screen.queryByText(OWNER_NOTE)).toBeNull()
+  })
+})

--- a/web/src/components/modals/TemplateAccessModal.test.tsx
+++ b/web/src/components/modals/TemplateAccessModal.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, cleanup, fireEvent } from "@testing-library/react"
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { PropsWithChildren } from "react"
 import { createElement } from "react"
@@ -158,6 +164,45 @@ describe("TemplateAccessModal", () => {
     expect(reconcileMutate).toHaveBeenCalledWith(
       { org: ORG, classroom: "cs101", slug: "hw1", template },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
+    )
+  })
+
+  it("enables fix when the classroom student team is missing", async () => {
+    orgRole = "owner"
+    // Only an unrelated team has access — the student team is absent.
+    listRepoTeams.mockResolvedValue([
+      {
+        id: 3,
+        name: "other",
+        slug: "some-other-team",
+        html_url: "https://x",
+        permission: "pull",
+      },
+    ])
+    renderModal()
+    await waitFor(() =>
+      expect(screen.getByText(FIX_ACTION).closest("button")?.disabled).toBe(
+        false,
+      ),
+    )
+  })
+
+  it("disables fix once the classroom student team already has access", async () => {
+    orgRole = "owner"
+    listRepoTeams.mockResolvedValue([
+      {
+        id: 1,
+        name: "cs101 students",
+        slug: "classroom50-cs101",
+        html_url: "https://x",
+        permission: "pull",
+      },
+    ])
+    renderModal()
+    await waitFor(() =>
+      expect(screen.getByText(FIX_ACTION).closest("button")?.disabled).toBe(
+        true,
+      ),
     )
   })
 

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -1,7 +1,7 @@
 import { useId } from "react"
 import { useTranslation } from "react-i18next"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { ExternalLink, KeyRound, ShieldCheck } from "lucide-react"
+import { ExternalLink, ShieldCheck } from "lucide-react"
 
 import { Badge, Button, Modal, Spinner } from "@/components/ui"
 import GitHub from "@/assets/github.svg?react"
@@ -13,7 +13,16 @@ import { can } from "@/authz"
 import { githubKeys, repoTeamsQuery } from "@/github-core/queries"
 import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
 import { useToast } from "@/context/notifications/NotificationProvider"
+import { classroomTeamSlug } from "@/util/teamSlug"
 import { githubTemplateRepoUrl } from "@/util/orgUrl"
+
+// The student classroom team read is what gates student acceptance and is
+// always expected; reconcile also grants the TA team best-effort, but a
+// classroom may have no TA team, so only the student team drives the
+// "already satisfied" decision (checking TA would dead-end a TA-less classroom).
+// Every repo permission includes read, so a team's presence in the repo-teams
+// list means it can read — reconcile only ever needs to ADD a missing team.
+const REQUIRED_ROLES = ["student"] as const
 
 // Review + fix a template's team access in one place: which template repo the
 // assignment uses, which GitHub teams can read it, and (org owners only) a
@@ -50,6 +59,25 @@ export const TemplateAccessModal = ({
   // The modal is only opened for templated assignments; narrow defensively
   // (after all hooks, to keep hook order stable).
   if (!template) return null
+
+  // Which classroom teams the template is missing. Every repo permission grants
+  // read, so a team present in the list already satisfies the requirement; only
+  // an absent required team needs the grant. We can only judge this when the
+  // team list is readable (owner + not errored) — otherwise treat it as unknown
+  // and leave the action enabled rather than falsely claiming "all set".
+  const teams = teamsQuery.data ?? []
+  const presentSlugs = new Set(teams.map((tm) => tm.slug.toLowerCase()))
+  const requiredSlugs = REQUIRED_ROLES.map((role) =>
+    classroomTeamSlug(classroom, role).toLowerCase(),
+  )
+  const accessKnown = isOwner && !teamsQuery.isPending && !teamsQuery.isError
+  const missingRequired = requiredSlugs.filter(
+    (slug) => !presentSlugs.has(slug),
+  )
+  // Enable only when we know access is missing; if unknown, stay enabled so the
+  // owner can still repair. Disable only when we can confirm all required teams
+  // are present.
+  const allRequiredPresent = accessKnown && missingRequired.length === 0
 
   const handleFix = () => {
     reconcile.mutate(
@@ -93,19 +121,10 @@ export const TemplateAccessModal = ({
       </div>
 
       <section className="mt-5">
-        <h4 className="text-sm font-semibold text-base-content/80">
-          {t("assignments.template.accessModal.templateHeading")}
-        </h4>
-        <div className="mt-2 flex items-center justify-between gap-3 rounded-box border border-base-content/10 bg-base-200/40 px-3 py-2">
-          <div className="min-w-0">
-            <div className="truncate font-mono text-sm">
-              {template.owner}/{template.repo}
-            </div>
-            <div className="text-xs text-base-content/60">
-              {t("assignments.template.accessModal.branchLabel")}:{" "}
-              <span className="font-mono">{template.branch}</span>
-            </div>
-          </div>
+        <div className="flex items-center justify-between gap-3">
+          <h4 className="text-sm font-semibold text-base-content/80">
+            {t("assignments.template.accessModal.templateHeading")}
+          </h4>
           <a
             href={githubTemplateRepoUrl(
               template.owner,
@@ -114,12 +133,21 @@ export const TemplateAccessModal = ({
             )}
             target="_blank"
             rel="noreferrer"
-            className="btn btn-sm btn-ghost shrink-0"
+            className="btn btn-xs btn-ghost shrink-0"
           >
             <GitHub aria-hidden="true" className="size-4" />
             {t("assignments.template.accessModal.openOnGitHub")}
             <ExternalLink aria-hidden="true" className="size-3.5" />
           </a>
+        </div>
+        <div className="mt-2 rounded-box border border-base-content/10 bg-base-200/40 px-3 py-2">
+          <div className="break-all font-mono text-sm">
+            {template.owner}/{template.repo}
+          </div>
+          <div className="text-xs text-base-content/60">
+            {t("assignments.template.accessModal.branchLabel")}:{" "}
+            <span className="font-mono">{template.branch}</span>
+          </div>
         </div>
       </section>
 
@@ -159,11 +187,14 @@ export const TemplateAccessModal = ({
             variant="primary"
             loading={reconcile.isPending}
             loadingLabel={t("assignments.template.reconcile.pending")}
-            disabled={reconcile.isPending}
-            title={t("assignments.template.accessModal.fixHint")}
+            disabled={reconcile.isPending || allRequiredPresent}
+            title={
+              allRequiredPresent
+                ? t("assignments.template.accessModal.fixSatisfied")
+                : t("assignments.template.accessModal.fixHint")
+            }
             onClick={handleFix}
           >
-            <KeyRound aria-hidden="true" className="size-4" />
             {t("assignments.template.accessModal.fixAction")}
           </Button>
         )}

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, KeyRound, ShieldCheck } from "lucide-react"
 import { Badge, Button, Modal, Spinner } from "@/components/ui"
 import GitHub from "@/assets/github.svg?react"
 import type { Assignment } from "@/types/classroom"
+import type { GitHubRepoTeam } from "@/github-core/types"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { can } from "@/authz"
@@ -130,6 +131,10 @@ export const TemplateAccessModal = ({
           loading={teamsQuery.isPending}
           errored={teamsQuery.isError}
           teams={teamsQuery.data ?? []}
+          // A non-owner sees only teams visible to their account, so an empty
+          // result may be a visibility gap rather than a genuinely unshared
+          // template — surface the caveat instead of "no teams".
+          partialVisibility={!isOwner}
           permissionLabel={(permission) =>
             t("assignments.template.accessModal.permissionLabel", {
               permission,
@@ -171,17 +176,18 @@ const TeamsList = ({
   loading,
   errored,
   teams,
+  partialVisibility,
   permissionLabel,
 }: {
   loading: boolean
   errored: boolean
-  teams: {
-    id: number
-    name: string
-    slug: string
-    html_url: string
-    permission: string
-  }[]
+  teams: Pick<
+    GitHubRepoTeam,
+    "id" | "name" | "slug" | "html_url" | "permission"
+  >[]
+  // The viewer only sees teams visible to their account (non-owner), so an
+  // empty list is inconclusive — show the visibility caveat, not "no teams".
+  partialVisibility: boolean
   permissionLabel: (permission: string) => string
 }) => {
   const { t } = useTranslation()
@@ -194,8 +200,9 @@ const TeamsList = ({
       </p>
     )
   }
-  // A repo-teams read that failed, or returned nothing the viewer can see.
-  if (errored) {
+  // A repo-teams read that failed, or (for a non-owner) returned nothing the
+  // viewer can see — either way, don't claim the template is unshared.
+  if (errored || (partialVisibility && teams.length === 0)) {
     return (
       <p className="mt-2 text-sm text-base-content/60">
         {t("assignments.template.accessModal.teamsUnavailable")}

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -1,6 +1,6 @@
-import { useId } from "react"
+import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { ExternalLink, ShieldCheck } from "lucide-react"
 
 import { Badge, Button, Modal, Spinner } from "@/components/ui"
@@ -10,7 +10,7 @@ import type { GitHubRepoTeam } from "@/github-core/types"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { can } from "@/authz"
-import { githubKeys, repoTeamsQuery } from "@/github-core/queries"
+import { repoTeamsQuery } from "@/github-core/queries"
 import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { classroomTeamSlug } from "@/util/teamSlug"
@@ -42,11 +42,16 @@ export const TemplateAccessModal = ({
   const { t } = useTranslation()
   const titleId = useId()
   const client = useGitHubClient()
-  const queryClient = useQueryClient()
   const { notify } = useToast()
   const { githubOrgRole } = useGitHubOrgRole()
   const isOwner = can("manageOrg", { githubOrgRole })
   const reconcile = useReconcileTemplateAccess()
+  // Latched once a grant from this modal succeeds. GitHub's repo-teams read is
+  // eventually consistent, so the post-grant refetch (owned by the reconcile
+  // hook) can briefly return the pre-grant list; without this the Fix button
+  // would re-enable and the list re-flash "no teams" right after the success
+  // toast. Cleared when the refetch settles with the granted team present.
+  const [granted, setGranted] = useState(false)
 
   const template = assignment.template
   const inOrg = !!template && template.owner.toLowerCase() === org.toLowerCase()
@@ -63,23 +68,29 @@ export const TemplateAccessModal = ({
   // Which classroom teams the template is missing. Every repo permission grants
   // read, so a team present in the list already satisfies the requirement; only
   // an absent required team needs the grant. We can only judge this when the
-  // team list is readable (owner + not errored) — otherwise treat it as unknown
-  // and leave the action enabled rather than falsely claiming "all set".
+  // team list is readable (owner + settled + not errored) — otherwise treat it
+  // as unknown and leave the action enabled rather than falsely claiming "all
+  // set". `isFetching` (not just `isPending`) so a background refetch after the
+  // grant doesn't expose a window where the button re-enables on stale data.
   const teams = teamsQuery.data ?? []
   const presentSlugs = new Set(teams.map((tm) => tm.slug.toLowerCase()))
   const requiredSlugs = REQUIRED_ROLES.map((role) =>
     classroomTeamSlug(classroom, role).toLowerCase(),
   )
-  const accessKnown = isOwner && !teamsQuery.isPending && !teamsQuery.isError
+  const accessKnown = isOwner && !teamsQuery.isFetching && !teamsQuery.isError
   const missingRequired = requiredSlugs.filter(
     (slug) => !presentSlugs.has(slug),
   )
-  // Enable only when we know access is missing; if unknown, stay enabled so the
-  // owner can still repair. Disable only when we can confirm all required teams
-  // are present.
+  // Confirmed present once the settled list contains every required team.
   const allRequiredPresent = accessKnown && missingRequired.length === 0
+  // Disable Fix when the team is confirmed present, OR when a grant already
+  // succeeded in this modal — the grant is idempotent and additive, so there's
+  // nothing left to fix, and this keeps the button from re-enabling while the
+  // eventually-consistent refetch settles.
+  const satisfied = allRequiredPresent || granted
 
   const handleFix = () => {
+    setGranted(false)
     reconcile.mutate(
       { org, classroom, slug: assignment.slug, template },
       {
@@ -90,13 +101,10 @@ export const TemplateAccessModal = ({
               message: `${t("assignments.template.reconcile.failed")} ${result.warning}`,
             })
           } else {
+            setGranted(true)
             notify({
               tone: "success",
               message: t("assignments.template.reconcile.success"),
-            })
-            // Refetch the team list so a newly granted team shows up.
-            void queryClient.invalidateQueries({
-              queryKey: githubKeys.repoTeams(template.owner, template.repo),
             })
           }
         },
@@ -161,8 +169,11 @@ export const TemplateAccessModal = ({
           teams={teamsQuery.data ?? []}
           // A non-owner sees only teams visible to their account, so an empty
           // result may be a visibility gap rather than a genuinely unshared
-          // template — surface the caveat instead of "no teams".
-          partialVisibility={!isOwner}
+          // template — surface the caveat instead of "no teams". After a
+          // successful grant here, the refetch is eventually consistent and may
+          // briefly still be empty — treat that like partial visibility rather
+          // than re-flashing "no teams".
+          partialVisibility={!isOwner || granted}
           permissionLabel={(permission) =>
             t("assignments.template.accessModal.permissionLabel", {
               permission,
@@ -187,9 +198,9 @@ export const TemplateAccessModal = ({
             variant="primary"
             loading={reconcile.isPending}
             loadingLabel={t("assignments.template.reconcile.pending")}
-            disabled={reconcile.isPending || allRequiredPresent}
+            disabled={reconcile.isPending || satisfied}
             title={
-              allRequiredPresent
+              satisfied
                 ? t("assignments.template.accessModal.fixSatisfied")
                 : t("assignments.template.accessModal.fixHint")
             }

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -1,0 +1,237 @@
+import { useId } from "react"
+import { useTranslation } from "react-i18next"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { ExternalLink, KeyRound, ShieldCheck } from "lucide-react"
+
+import { Badge, Button, Modal, Spinner } from "@/components/ui"
+import GitHub from "@/assets/github.svg?react"
+import type { Assignment } from "@/types/classroom"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
+import { can } from "@/authz"
+import { githubKeys, repoTeamsQuery } from "@/github-core/queries"
+import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import { githubTemplateRepoUrl } from "@/util/orgUrl"
+
+// Review + fix a template's team access in one place: which template repo the
+// assignment uses, which GitHub teams can read it, and (org owners only) a
+// one-click re-grant of the classroom student/TA teams. Merges the former
+// per-row "view source repo" link and "fix template access" button.
+export const TemplateAccessModal = ({
+  org,
+  classroom,
+  assignment,
+  onClose,
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+  onClose: () => void
+}) => {
+  const { t } = useTranslation()
+  const titleId = useId()
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+  const { notify } = useToast()
+  const { githubOrgRole } = useGitHubOrgRole()
+  const isOwner = can("manageOrg", { githubOrgRole })
+  const reconcile = useReconcileTemplateAccess()
+
+  const template = assignment.template
+  const inOrg = !!template && template.owner.toLowerCase() === org.toLowerCase()
+  // `enabled` is false when there's no template (empty owner/repo), so the
+  // hook order stays stable even for the defensive no-template case below.
+  const teamsQuery = useQuery(
+    repoTeamsQuery(client, template?.owner ?? "", template?.repo ?? ""),
+  )
+
+  // The modal is only opened for templated assignments; narrow defensively
+  // (after all hooks, to keep hook order stable).
+  if (!template) return null
+
+  const handleFix = () => {
+    reconcile.mutate(
+      { org, classroom, slug: assignment.slug, template },
+      {
+        onSuccess: (result) => {
+          if (result.warning) {
+            notify({
+              tone: "error",
+              message: `${t("assignments.template.reconcile.failed")} ${result.warning}`,
+            })
+          } else {
+            notify({
+              tone: "success",
+              message: t("assignments.template.reconcile.success"),
+            })
+            // Refetch the team list so a newly granted team shows up.
+            void queryClient.invalidateQueries({
+              queryKey: githubKeys.repoTeams(template.owner, template.repo),
+            })
+          }
+        },
+      },
+    )
+  }
+
+  return (
+    <Modal open onClose={onClose} size="lg" aria-labelledby={titleId}>
+      <div className="flex items-start gap-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <ShieldCheck className="size-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("assignments.template.accessModal.title")}
+          </h3>
+          <p className="mt-1 text-sm text-base-content/70">
+            {t("assignments.template.accessModal.description")}
+          </p>
+        </div>
+      </div>
+
+      <section className="mt-5">
+        <h4 className="text-sm font-semibold text-base-content/80">
+          {t("assignments.template.accessModal.templateHeading")}
+        </h4>
+        <div className="mt-2 flex items-center justify-between gap-3 rounded-box border border-base-content/10 bg-base-200/40 px-3 py-2">
+          <div className="min-w-0">
+            <div className="truncate font-mono text-sm">
+              {template.owner}/{template.repo}
+            </div>
+            <div className="text-xs text-base-content/60">
+              {t("assignments.template.accessModal.branchLabel")}:{" "}
+              <span className="font-mono">{template.branch}</span>
+            </div>
+          </div>
+          <a
+            href={githubTemplateRepoUrl(
+              template.owner,
+              template.repo,
+              template.branch,
+            )}
+            target="_blank"
+            rel="noreferrer"
+            className="btn btn-sm btn-ghost shrink-0"
+          >
+            <GitHub aria-hidden="true" className="size-4" />
+            {t("assignments.template.accessModal.openOnGitHub")}
+            <ExternalLink aria-hidden="true" className="size-3.5" />
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-5">
+        <h4 className="text-sm font-semibold text-base-content/80">
+          {t("assignments.template.accessModal.teamsHeading")}
+        </h4>
+        <TeamsList
+          loading={teamsQuery.isPending}
+          errored={teamsQuery.isError}
+          teams={teamsQuery.data ?? []}
+          permissionLabel={(permission) =>
+            t("assignments.template.accessModal.permissionLabel", {
+              permission,
+            })
+          }
+        />
+      </section>
+
+      <div className="modal-action mt-6 items-center">
+        {inOrg && !isOwner && (
+          <p className="mr-auto text-xs text-base-content/60">
+            {t("assignments.template.accessModal.ownerOnlyNote")}
+          </p>
+        )}
+        <form method="dialog">
+          <Button type="submit" variant="ghost" disabled={reconcile.isPending}>
+            {t("assignments.template.accessModal.close")}
+          </Button>
+        </form>
+        {inOrg && isOwner && (
+          <Button
+            variant="primary"
+            loading={reconcile.isPending}
+            loadingLabel={t("assignments.template.reconcile.pending")}
+            disabled={reconcile.isPending}
+            title={t("assignments.template.accessModal.fixHint")}
+            onClick={handleFix}
+          >
+            <KeyRound aria-hidden="true" className="size-4" />
+            {t("assignments.template.accessModal.fixAction")}
+          </Button>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+const TeamsList = ({
+  loading,
+  errored,
+  teams,
+  permissionLabel,
+}: {
+  loading: boolean
+  errored: boolean
+  teams: {
+    id: number
+    name: string
+    slug: string
+    html_url: string
+    permission: string
+  }[]
+  permissionLabel: (permission: string) => string
+}) => {
+  const { t } = useTranslation()
+
+  if (loading) {
+    return (
+      <p className="mt-2 flex items-center gap-2 text-sm text-base-content/60">
+        <Spinner size="xs" />
+        {t("assignments.template.accessModal.teamsLoading")}
+      </p>
+    )
+  }
+  // A repo-teams read that failed, or returned nothing the viewer can see.
+  if (errored) {
+    return (
+      <p className="mt-2 text-sm text-base-content/60">
+        {t("assignments.template.accessModal.teamsUnavailable")}
+      </p>
+    )
+  }
+  if (teams.length === 0) {
+    return (
+      <p className="mt-2 text-sm text-base-content/60">
+        {t("assignments.template.accessModal.teamsEmpty")}
+      </p>
+    )
+  }
+
+  return (
+    <ul className="mt-2 divide-y divide-base-content/5 rounded-box border border-base-content/10">
+      {teams.map((team) => (
+        <li
+          key={team.id}
+          className="flex items-center justify-between gap-3 px-3 py-2"
+        >
+          <a
+            href={team.html_url}
+            target="_blank"
+            rel="noreferrer"
+            className="min-w-0 truncate text-sm font-medium link link-hover"
+          >
+            {team.name}
+          </a>
+          <Badge tone="neutral" size="sm">
+            {permissionLabel(team.permission)}
+          </Badge>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default TemplateAccessModal

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -719,15 +719,25 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
   function makeGrantClient(opts: {
     classroomJson: Record<string, unknown>
     taGrantThrows?: boolean
+    // Visibility/kind of the template the edit resolves to. Defaults to a
+    // private in-org template repo (the grant path). Set private:false to model
+    // a public template (no grant), or isTemplate:false to model a non-template.
+    templatePrivate?: boolean
+    templateIsTemplate?: boolean
   }): { client: GitHubClient; grants: () => string[] } {
     const grants: string[] = []
-    const tmplRepo = {
-      name: "tmpl-v2",
-      full_name: `${ORG}/tmpl-v2`,
-      private: true,
-      is_template: true,
+    const templatePrivate = opts.templatePrivate ?? true
+    const templateIsTemplate = opts.templateIsTemplate ?? true
+    // Serve a repo read for BOTH the changed ref (tmpl-v2) and the stored ref
+    // (tmpl), so a test can drive either the changed-ref or the unchanged-ref
+    // branch of buildAssignmentEntry.
+    const makeRepo = (name: string) => ({
+      name,
+      full_name: `${ORG}/${name}`,
+      private: templatePrivate,
+      is_template: templateIsTemplate,
       default_branch: "main",
-    }
+    })
     const assignmentsFile = {
       schema: "classroom50/assignments/v1",
       assignments: [
@@ -777,7 +787,8 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
           content: b64(JSON.stringify(assignmentsFile)),
         }
       }
-      if (url.includes(`/repos/${ORG}/tmpl-v2`)) return tmplRepo
+      if (url.includes(`/repos/${ORG}/tmpl-v2`)) return makeRepo("tmpl-v2")
+      if (/\/repos\/[^/]+\/tmpl(\?|$)/.test(url)) return makeRepo("tmpl")
       if (url.endsWith("/git/trees")) return { sha: "newtree" }
       if (url.endsWith("/git/commits")) return { sha: "newcommit" }
       if (method === "PATCH" && url.includes("/git/refs/heads/main"))
@@ -795,14 +806,16 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     }
   }
 
-  function editInput() {
+  // `template_repo` defaults to a CHANGED ref (tmpl-v2 vs stored tmpl); pass
+  // "tmpl" to exercise the unchanged-ref re-affirm branch.
+  function editInput(templateRepo = "tmpl-v2") {
     return {
       org: ORG,
       classroom: CLASSROOM,
       slug: SLUG,
       name: "Homework 1",
       description: "",
-      template_repo: "tmpl-v2",
+      template_repo: templateRepo,
       due_date: "",
       mode: "individual",
       max_group_size: 0,
@@ -857,6 +870,41 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     // Student grant landed; TA failure did not surface as a save warning.
     expect(result.templateGrantWarning).toBeUndefined()
     expect(grants()).toEqual(["classroom50-cs50"])
+  })
+
+  it("re-affirms the grant on an UNCHANGED in-org private template ref", async () => {
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+      },
+    })
+
+    // Same owner/repo/branch as the stored template (tmpl) — the unchanged-ref
+    // branch. It must still re-affirm both teams so a dropped grant is repaired.
+    const result = await editAssignment(client, editInput("tmpl"))
+
+    expect(result.templateGrantWarning).toBeUndefined()
+    expect(grants()).toEqual(["classroom50-cs50", "classroom50-cs50-ta"])
+  })
+
+  it("does not grant on an unchanged PUBLIC template ref", async () => {
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+      },
+      templatePrivate: false,
+    })
+
+    const result = await editAssignment(client, editInput("tmpl"))
+
+    expect(result.templateGrantWarning).toBeUndefined()
+    expect(grants()).toEqual([])
   })
 })
 

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -18,6 +18,7 @@ export {
   createAssignment,
   editAssignmentWithConflictRetry,
   preserveUnmanagedAssignmentKeys,
+  tryGrantTeamTemplateRead,
   type CreateAssignmentResult,
 } from "./assignments/createEdit"
 export {

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -309,13 +309,15 @@ async function buildAssignmentEntry(
   if (input.template_repo.trim()) {
     const parsedTemplate = parseTemplateRef(input.template_repo, input.org)
     if (templateRefUnchanged(parsedTemplate, existingTemplate)) {
-      // Ref unchanged, so the team was already granted at create (needsTeamGrant
-      // stays false). But the stored ref may now be unreliable (e.g. a fork whose
-      // upstream went private, or a repo predating the fork guard), so still
-      // re-validate live via resolveTemplate — which runs the cross-org
-      // private-fork guard — and fail closed before any commit.
-      await resolveTemplate(client, input.org, parsedTemplate)
+      // Ref unchanged, but still re-validate live via resolveTemplate — it runs
+      // the cross-org private-fork guard and fails closed before any commit if
+      // the stored ref went unreliable (a fork whose upstream went private, a
+      // repo predating the guard). Reuse its needsTeamGrant so an unchanged-ref
+      // save re-affirms the (idempotent) team read: a grant GitHub or a prior
+      // failure dropped is repaired on the next edit, not left stranded.
+      const resolved = await resolveTemplate(client, input.org, parsedTemplate)
       template = existingTemplate!
+      needsTeamGrant = resolved.needsTeamGrant
     } else {
       const resolved = await resolveTemplate(client, input.org, parsedTemplate)
       template = resolved.template

--- a/web/src/github-core/queries.test.ts
+++ b/web/src/github-core/queries.test.ts
@@ -9,6 +9,7 @@ import {
   listAllOrgMembers,
   listOrgAdmins,
   listOrgTeams,
+  listRepoTeams,
   listTeamInvitations,
   releasesQuery,
   verifyClassroom50ConfigRepo,
@@ -179,6 +180,38 @@ describe("listOrgTeams (org teams fallback)", () => {
     } as unknown as GitHubClient
     const teams = await listOrgTeams(client, "acme")
     expect(teams.map((tm) => tm.slug)).toEqual(["classroom50-cs101"])
+  })
+})
+
+describe("listRepoTeams (repo teams, 404 -> [])", () => {
+  it("returns [] on 404 (repo gone/invisible — degrades to 'no teams listed')", async () => {
+    const client = {
+      request: vi.fn().mockRejectedValue(apiError(404)),
+    } as unknown as GitHubClient
+    await expect(listRepoTeams(client, "acme", "tmpl")).resolves.toEqual([])
+  })
+
+  it("rethrows a non-404 error rather than degrading silently", async () => {
+    const client = {
+      request: vi.fn().mockRejectedValue(apiError(500)),
+    } as unknown as GitHubClient
+    await expect(listRepoTeams(client, "acme", "tmpl")).rejects.toThrow(
+      GitHubAPIError,
+    )
+  })
+
+  it("returns the repo's teams with their permission on success", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue([
+        { id: 7, slug: "classroom50-cs101", permission: "pull" },
+        { id: 9, slug: "classroom50-cs101-ta", permission: "pull" },
+      ]),
+    } as unknown as GitHubClient
+    const teams = await listRepoTeams(client, "acme", "tmpl")
+    expect(teams.map((tm) => tm.slug)).toEqual([
+      "classroom50-cs101",
+      "classroom50-cs101-ta",
+    ])
   })
 })
 

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -60,6 +60,8 @@ export {
   teamMembersQuery,
   listOrgTeams,
   orgTeamsQuery,
+  listRepoTeams,
+  repoTeamsQuery,
   listMyTeams,
   myTeamsQuery,
 } from "./queries/teamReads"

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -45,6 +45,11 @@ export const githubKeys = {
 
   orgTeams: (org: string) => [...githubKeys.all, "org-teams", org] as const,
 
+  // Teams with access to a repo (GET /repos/{owner}/{repo}/teams) — repo-scoped,
+  // distinct from the org-scoped orgTeams.
+  repoTeams: (owner: string, repo: string) =>
+    [...githubKeys.all, "repo-teams", owner, repo] as const,
+
   myTeams: () => [...githubKeys.all, "my-teams"] as const,
 
   repo: (owner: string, repo: string) =>

--- a/web/src/github-core/queries/teamReads.ts
+++ b/web/src/github-core/queries/teamReads.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query"
 
 import type { GitHubClient } from "../client"
-import type { GitHubTeam, GitHubUser, MyTeam } from "../types"
+import type { GitHubTeam, GitHubRepoTeam, GitHubUser, MyTeam } from "../types"
 import { classroomTeamSlug } from "@/util/teamSlug"
 import {
   GitHubAPIError,
@@ -124,6 +124,41 @@ export function orgTeamsQuery(client: GitHubClient, org: string) {
     queryFn: () => listOrgTeams(client, org),
     enabled: Boolean(org),
     staleTime: 5 * 60 * 1000,
+  })
+}
+
+// Teams with access to a repo, across all pages (GET /repos/{owner}/{repo}/teams).
+// Needs only the token's repo scope (not repo-admin), but GitHub returns only
+// teams VISIBLE to the viewer — a non-owner may see a subset. 404 (repo gone /
+// invisible) -> [] so the caller degrades to "no teams listed".
+export async function listRepoTeams(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+): Promise<GitHubRepoTeam[]> {
+  return tolerateGitHubError(
+    () =>
+      paginateAll<GitHubRepoTeam>(
+        client,
+        (page) =>
+          `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+            repo,
+          )}/teams?per_page=100&page=${page}`,
+      ),
+    [],
+  )
+}
+
+export function repoTeamsQuery(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+) {
+  return queryOptions({
+    queryKey: githubKeys.repoTeams(owner, repo),
+    queryFn: () => listRepoTeams(client, owner, repo),
+    enabled: Boolean(owner && repo),
+    staleTime: 60 * 1000,
   })
 }
 

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -149,6 +149,16 @@ export type GitHubTeam = {
   description: string | null
 }
 
+// A team as returned by GET /repos/{owner}/{repo}/teams — GitHubTeam plus the
+// team's effective permission on that repo and its html_url (for linking).
+export type RepoAccessPermission =
+  "pull" | "triage" | "push" | "maintain" | "admin"
+
+export type GitHubRepoTeam = GitHubTeam & {
+  html_url: string
+  permission: RepoAccessPermission
+}
+
 // A team from GET /user/teams (the viewer's own memberships across orgs). Same
 // shape as GitHubTeam plus the required `organization` object, so a cross-org
 // listing can be filtered to a single org. Secret teams the viewer belongs to

--- a/web/src/hooks/mutations/useReconcileTemplateAccess.test.ts
+++ b/web/src/hooks/mutations/useReconcileTemplateAccess.test.ts
@@ -29,6 +29,7 @@ const KEY = [
   TEMPLATE.owner,
   TEMPLATE.repo,
 ]
+const REPO_TEAMS_KEY = ["github", "repo-teams", TEMPLATE.owner, TEMPLATE.repo]
 
 function wrapperWith(queryClient: QueryClient) {
   return ({ children }: PropsWithChildren) =>
@@ -44,7 +45,7 @@ beforeEach(() => {
 })
 
 describe("useReconcileTemplateAccess", () => {
-  it("seeds the team-access cache true on a clean grant (avoids a stale refetch)", async () => {
+  it("seeds the access cache true and refetches repo-teams on a clean grant", async () => {
     tryGrantTeamTemplateRead.mockResolvedValue(undefined)
     const queryClient = freshClient()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
@@ -61,11 +62,16 @@ describe("useReconcileTemplateAccess", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(result.current.data).toEqual({ warning: undefined })
+    // The boolean access key is seeded true (no refetch, so TemplateField's
+    // eventually-consistent read can't re-flash "no access").
     expect(queryClient.getQueryData(KEY)).toBe(true)
-    expect(invalidate).not.toHaveBeenCalled()
+    // The modal's repo-teams list can't be seeded (real team name/url/permission
+    // aren't known here), so it's refetched — and only it, never the access key.
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: REPO_TEAMS_KEY })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: KEY })
   })
 
-  it("invalidates (does not seed true) when the grant returns a warning", async () => {
+  it("invalidates only the access key (does not seed true or refetch repo-teams) on a warning", async () => {
     tryGrantTeamTemplateRead.mockResolvedValue("student grant failed")
     const queryClient = freshClient()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
@@ -83,6 +89,7 @@ describe("useReconcileTemplateAccess", () => {
 
     expect(result.current.data).toEqual({ warning: "student grant failed" })
     expect(invalidate).toHaveBeenCalledWith({ queryKey: KEY })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: REPO_TEAMS_KEY })
     expect(queryClient.getQueryData(KEY)).toBeUndefined()
   })
 

--- a/web/src/hooks/mutations/useReconcileTemplateAccess.test.ts
+++ b/web/src/hooks/mutations/useReconcileTemplateAccess.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+const tryGrantTeamTemplateRead =
+  vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
+
+vi.mock("@/domain/assignments", () => ({
+  tryGrantTeamTemplateRead: (...args: unknown[]) =>
+    tryGrantTeamTemplateRead(...args),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useReconcileTemplateAccess } from "./useReconcileTemplateAccess"
+
+const ORG = "cs50"
+const CLASSROOM = "cs50"
+const SLUG = "hw1"
+const TEMPLATE = { owner: ORG, repo: "tmpl", branch: "main" }
+const KEY = ["template-team-access", ORG, CLASSROOM, TEMPLATE.owner, TEMPLATE.repo]
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useReconcileTemplateAccess", () => {
+  it("seeds the team-access cache true on a clean grant (avoids a stale refetch)", async () => {
+    tryGrantTeamTemplateRead.mockResolvedValue(undefined)
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useReconcileTemplateAccess(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({
+      org: ORG,
+      classroom: CLASSROOM,
+      slug: SLUG,
+      template: TEMPLATE,
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual({ warning: undefined })
+    expect(queryClient.getQueryData(KEY)).toBe(true)
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  it("invalidates (does not seed true) when the grant returns a warning", async () => {
+    tryGrantTeamTemplateRead.mockResolvedValue("student grant failed")
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useReconcileTemplateAccess(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({
+      org: ORG,
+      classroom: CLASSROOM,
+      slug: SLUG,
+      template: TEMPLATE,
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual({ warning: "student grant failed" })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: KEY })
+    expect(queryClient.getQueryData(KEY)).toBeUndefined()
+  })
+
+  it("passes org/classroom/slug/template through to the domain grant", async () => {
+    tryGrantTeamTemplateRead.mockResolvedValue(undefined)
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useReconcileTemplateAccess(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({
+      org: ORG,
+      classroom: CLASSROOM,
+      slug: SLUG,
+      template: TEMPLATE,
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(tryGrantTeamTemplateRead).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG,
+      CLASSROOM,
+      SLUG,
+      TEMPLATE,
+    )
+  })
+})

--- a/web/src/hooks/mutations/useReconcileTemplateAccess.test.ts
+++ b/web/src/hooks/mutations/useReconcileTemplateAccess.test.ts
@@ -22,7 +22,13 @@ const ORG = "cs50"
 const CLASSROOM = "cs50"
 const SLUG = "hw1"
 const TEMPLATE = { owner: ORG, repo: "tmpl", branch: "main" }
-const KEY = ["template-team-access", ORG, CLASSROOM, TEMPLATE.owner, TEMPLATE.repo]
+const KEY = [
+  "template-team-access",
+  ORG,
+  CLASSROOM,
+  TEMPLATE.owner,
+  TEMPLATE.repo,
+]
 
 function wrapperWith(queryClient: QueryClient) {
   return ({ children }: PropsWithChildren) =>

--- a/web/src/hooks/mutations/useReconcileTemplateAccess.ts
+++ b/web/src/hooks/mutations/useReconcileTemplateAccess.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { tryGrantTeamTemplateRead } from "@/domain/assignments"
 import type { Assignment } from "@/types/classroom"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { githubKeys } from "@/github-core/queries"
 
 export type ReconcileTemplateAccessInput = {
   org: string
@@ -16,13 +17,19 @@ export type ReconcileTemplateAccessResult = { warning?: string }
 
 // Re-grant the classroom student team (and best-effort TA team) read on an
 // in-org private template, the recovery path for a grant that GitHub or a prior
-// failure dropped. The hook owns the team-access cache reconcile so it survives
-// unmount (per ./README.md): a clean grant SEEDS the ["template-team-access",…]
-// query true rather than invalidating — a post-grant read is eventually
-// consistent, so an invalidate could refetch stale "no access" and re-flash the
-// verdict; a warning leaves the query to refetch. Only TemplateField reads that
-// key, so this reconcile is a no-op for the assignments table (which feeds back
-// via a toast at the call site). Kept t()-free; call sites own toasts.
+// failure dropped. The hook is the single owner of the post-grant cache
+// reconcile (per ./README.md — it must survive unmount) for BOTH readers of
+// "team has template read": TemplateField's boolean ["template-team-access",…]
+// query and the template-access modal's repoTeams list. A clean grant SEEDS the
+// boolean true and invalidates repoTeams; a warning invalidates the boolean.
+//
+// Why seed the boolean but invalidate the list: GitHub's team reads are
+// eventually consistent after a grant, so an invalidate can refetch stale "no
+// access" and re-flash the verdict. TemplateField only needs a boolean, so we
+// seed it true (no refetch, no flash). The modal renders each granting team's
+// real name/url/permission from the list, which we can't fabricate, so it must
+// refetch — the modal suppresses the transient re-flash on its side while that
+// settles. Kept t()-free; call sites own toasts.
 export function useReconcileTemplateAccess() {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
@@ -43,7 +50,7 @@ export function useReconcileTemplateAccess() {
       return { warning }
     },
     onSuccess: (result, { org, classroom, template }) => {
-      const key = [
+      const accessKey = [
         "template-team-access",
         org,
         classroom,
@@ -51,10 +58,13 @@ export function useReconcileTemplateAccess() {
         template.repo,
       ]
       if (result.warning) {
-        void queryClient.invalidateQueries({ queryKey: key })
-      } else {
-        queryClient.setQueryData<boolean>(key, true)
+        void queryClient.invalidateQueries({ queryKey: accessKey })
+        return
       }
+      queryClient.setQueryData<boolean>(accessKey, true)
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.repoTeams(template.owner, template.repo),
+      })
     },
   })
 }

--- a/web/src/hooks/mutations/useReconcileTemplateAccess.ts
+++ b/web/src/hooks/mutations/useReconcileTemplateAccess.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { tryGrantTeamTemplateRead } from "@/domain/assignments"
+import type { Assignment } from "@/types/classroom"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+
+export type ReconcileTemplateAccessInput = {
+  org: string
+  classroom: string
+  slug: string
+  template: NonNullable<Assignment["template"]>
+}
+
+// A non-empty `warning` means the student grant failed (the domain layer never
+// throws here — see tryGrantTeamTemplateRead); the call site surfaces it.
+export type ReconcileTemplateAccessResult = { warning?: string }
+
+// Re-grant the classroom student team (and best-effort TA team) read on an
+// in-org private template, the recovery path for a grant that GitHub or a prior
+// failure dropped. The hook owns the team-access cache reconcile so it survives
+// unmount (per ./README.md): a clean grant SEEDS the ["template-team-access",…]
+// query true rather than invalidating — a post-grant read is eventually
+// consistent, so an invalidate could refetch stale "no access" and re-flash the
+// verdict; a warning leaves the query to refetch. Only TemplateField reads that
+// key, so this reconcile is a no-op for the assignments table (which feeds back
+// via a toast at the call site). Kept t()-free; call sites own toasts.
+export function useReconcileTemplateAccess() {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    ReconcileTemplateAccessResult,
+    Error,
+    ReconcileTemplateAccessInput
+  >({
+    mutationFn: async ({ org, classroom, slug, template }) => {
+      const warning = await tryGrantTeamTemplateRead(
+        client,
+        org,
+        classroom,
+        slug,
+        template,
+      )
+      return { warning }
+    },
+    onSuccess: (result, { org, classroom, template }) => {
+      const key = [
+        "template-team-access",
+        org,
+        classroom,
+        template.owner,
+        template.repo,
+      ]
+      if (result.warning) {
+        void queryClient.invalidateQueries({ queryKey: key })
+      } else {
+        queryClient.setQueryData<boolean>(key, true)
+      }
+    },
+  })
+}
+
+export default useReconcileTemplateAccess

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -857,8 +857,9 @@
         "teamsEmpty": "No teams have access to this template yet.",
         "teamsUnavailable": "Couldn't list this repository's teams — you may only see teams visible to your account.",
         "permissionLabel": "{{permission}} access",
-        "fixAction": "Grant classroom team read",
+        "fixAction": "Fix permissions",
         "fixHint": "Grants the classroom student and TA teams read access so students can accept.",
+        "fixSatisfied": "The classroom team already has read access — nothing to fix.",
         "ownerOnlyNote": "Only an organization owner can grant team access. Ask an owner to run this, or grant the teams read on the template in GitHub.",
         "close": "Close"
       }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -839,7 +839,15 @@
       "noBranch_1": "{{owner}}/{{repo}} has no default branch. Push a commit, or add",
       "noBranch_2": ".",
       "rateLimited": "GitHub rate limit hit. Try again shortly.",
-      "policyLink": "Check {{owner}}'s OAuth app policy"
+      "policyLink": "Check {{owner}}'s OAuth app policy",
+      "reconcile": {
+        "action": "Fix template access",
+        "aria": "Fix template access for this assignment",
+        "title": "Fix template access for this assignment",
+        "pending": "Granting…",
+        "success": "Granted the classroom team read on the template.",
+        "failed": "Couldn't grant template access:"
+      }
     }
   },
   "published": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -776,9 +776,7 @@
       "deleteConfirm": "Delete assignment",
       "deleteCancel": "Keep assignment",
       "reuseTitle": "Reuse in another classroom",
-      "reuseAria": "Reuse assignment in another classroom",
-      "sourceRepoTitle": "View source repository",
-      "sourceRepoAria": "View source repository for {{name}}"
+      "reuseAria": "Reuse assignment in another classroom"
     },
     "toolbar": {
       "searchPlaceholder": "Search assignments…",
@@ -842,11 +840,27 @@
       "policyLink": "Check {{owner}}'s OAuth app policy",
       "reconcile": {
         "action": "Fix template access",
-        "aria": "Fix template access for this assignment",
-        "title": "Fix template access for this assignment",
         "pending": "Granting…",
         "success": "Classroom team read on the template is confirmed.",
         "failed": "Couldn't grant template access:"
+      },
+      "accessModal": {
+        "triggerTitle": "Template access",
+        "triggerAria": "Review template access for {{name}}",
+        "title": "Template access",
+        "description": "Review which template repository this assignment uses and which GitHub teams can read it.",
+        "templateHeading": "Template repository",
+        "branchLabel": "branch",
+        "openOnGitHub": "Open on GitHub",
+        "teamsHeading": "Teams with access",
+        "teamsLoading": "Loading teams…",
+        "teamsEmpty": "No teams have access to this template yet.",
+        "teamsUnavailable": "Couldn't list this repository's teams — you may only see teams visible to your account.",
+        "permissionLabel": "{{permission}} access",
+        "fixAction": "Grant classroom team read",
+        "fixHint": "Grants the classroom student and TA teams read access so students can accept.",
+        "ownerOnlyNote": "Only an organization owner can grant team access. Ask an owner to run this, or grant the teams read on the template in GitHub.",
+        "close": "Close"
       }
     }
   },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -845,7 +845,7 @@
         "aria": "Fix template access for this assignment",
         "title": "Fix template access for this assignment",
         "pending": "Granting…",
-        "success": "Granted the classroom team read on the template.",
+        "success": "Classroom team read on the template is confirmed.",
         "failed": "Couldn't grant template access:"
       }
     }

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
 
@@ -24,6 +24,19 @@ vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({}),
 }))
 
+const reconcileMutate = vi.fn()
+vi.mock("@/hooks/mutations/useReconcileTemplateAccess", () => ({
+  useReconcileTemplateAccess: () => ({
+    mutate: reconcileMutate,
+    isPending: false,
+  }),
+}))
+
+const notify = vi.fn()
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify, dismiss: vi.fn() }),
+}))
+
 const scores = vi.fn()
 vi.mock("@/hooks/useGetScores", () => ({
   default: (...a: unknown[]) => scores(...a),
@@ -41,6 +54,9 @@ const wrap = (ui: ReactNode) => {
 const assignment = (over: Partial<Assignment> = {}): Assignment =>
   ({ slug: "hw1", name: "HW 1", mode: "individual", ...over }) as Assignment
 
+const inOrgTemplate = { owner: "acme", repo: "tmpl", branch: "main" }
+const RECONCILE_ARIA = "assignments.template.reconcile.aria"
+
 // The submission cell renders "<submitted> / <denominator>" as sibling text
 // nodes; read the row's textContent to assert the rendered ratio.
 const ratioText = () =>
@@ -49,6 +65,9 @@ const ratioText = () =>
 
 beforeEach(() => {
   scores.mockReset()
+  scores.mockReturnValue({ data: { submissions: {} } })
+  reconcileMutate.mockReset()
+  notify.mockReset()
 })
 
 afterEach(cleanup)
@@ -110,5 +129,102 @@ describe("AssignmentsTable submission denominator", () => {
     )
     expect(ratioText()).toContain("assignments.table.groupsSubmitted")
     expect(ratioText()).not.toContain("/ 11")
+  })
+})
+
+describe("AssignmentsTable — Fix template access button", () => {
+  it("renders the reconcile button for an in-org templated assignment", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment({ template: inOrgTemplate })]}
+        studentCount={0}
+      />,
+    )
+    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeTruthy()
+  })
+
+  it("does not render it for a template-less assignment", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment()]}
+        studentCount={0}
+      />,
+    )
+    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeNull()
+  })
+
+  it("does not render it for an out-of-org template", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[
+          assignment({ template: { ...inOrgTemplate, owner: "other" } }),
+        ]}
+        studentCount={0}
+      />,
+    )
+    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeNull()
+  })
+
+  it("does not render it when the classroom is archived", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment({ template: inOrgTemplate })]}
+        studentCount={0}
+        archived
+      />,
+    )
+    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeNull()
+  })
+
+  it("invokes the reconcile hook with the row's target on click", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment({ template: inOrgTemplate })]}
+        studentCount={0}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText(RECONCILE_ARIA))
+    expect(reconcileMutate).toHaveBeenCalledWith(
+      {
+        org: "acme",
+        classroom: "cs101",
+        slug: "hw1",
+        template: inOrgTemplate,
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    )
+  })
+
+  it("toasts success on a clean reconcile and error on a warning", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment({ template: inOrgTemplate })]}
+        studentCount={0}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText(RECONCILE_ARIA))
+    const { onSuccess } = reconcileMutate.mock.calls[0][1]
+
+    onSuccess({ warning: undefined })
+    expect(notify).toHaveBeenLastCalledWith(
+      expect.objectContaining({ tone: "success" }),
+    )
+
+    onSuccess({ warning: "student grant failed" })
+    expect(notify).toHaveBeenLastCalledWith(
+      expect.objectContaining({ tone: "error" }),
+    )
   })
 })

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -24,17 +24,12 @@ vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({}),
 }))
 
-const reconcileMutate = vi.fn()
-vi.mock("@/hooks/mutations/useReconcileTemplateAccess", () => ({
-  useReconcileTemplateAccess: () => ({
-    mutate: reconcileMutate,
-    isPending: false,
-  }),
-}))
-
-const notify = vi.fn()
-vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify, dismiss: vi.fn() }),
+// The modal is exercised in its own test; here we stub it to a marker so the
+// table test asserts only that the trigger renders and opens it.
+vi.mock("@/components/modals/TemplateAccessModal", () => ({
+  TemplateAccessModal: ({ assignment }: { assignment: { slug: string } }) => (
+    <div data-testid="template-access-modal">{assignment.slug}</div>
+  ),
 }))
 
 const scores = vi.fn()
@@ -55,7 +50,7 @@ const assignment = (over: Partial<Assignment> = {}): Assignment =>
   ({ slug: "hw1", name: "HW 1", mode: "individual", ...over }) as Assignment
 
 const inOrgTemplate = { owner: "acme", repo: "tmpl", branch: "main" }
-const RECONCILE_ARIA = "assignments.template.reconcile.aria"
+const ACCESS_ARIA = "assignments.template.accessModal.triggerAria"
 
 // The submission cell renders "<submitted> / <denominator>" as sibling text
 // nodes; read the row's textContent to assert the rendered ratio.
@@ -66,8 +61,6 @@ const ratioText = () =>
 beforeEach(() => {
   scores.mockReset()
   scores.mockReturnValue({ data: { submissions: {} } })
-  reconcileMutate.mockReset()
-  notify.mockReset()
 })
 
 afterEach(cleanup)
@@ -132,8 +125,8 @@ describe("AssignmentsTable submission denominator", () => {
   })
 })
 
-describe("AssignmentsTable — Fix template access button", () => {
-  it("renders the reconcile button for an in-org templated assignment", () => {
+describe("AssignmentsTable — Template access button", () => {
+  it("renders the trigger for an in-org templated assignment", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -142,7 +135,21 @@ describe("AssignmentsTable — Fix template access button", () => {
         studentCount={0}
       />,
     )
-    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeTruthy()
+    expect(screen.queryByLabelText(ACCESS_ARIA)).toBeTruthy()
+  })
+
+  it("renders the trigger for an out-of-org template too (review + link)", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[
+          assignment({ template: { ...inOrgTemplate, owner: "other" } }),
+        ]}
+        studentCount={0}
+      />,
+    )
+    expect(screen.queryByLabelText(ACCESS_ARIA)).toBeTruthy()
   })
 
   it("does not render it for a template-less assignment", () => {
@@ -154,24 +161,10 @@ describe("AssignmentsTable — Fix template access button", () => {
         studentCount={0}
       />,
     )
-    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeNull()
+    expect(screen.queryByLabelText(ACCESS_ARIA)).toBeNull()
   })
 
-  it("does not render it for an out-of-org template", () => {
-    wrap(
-      <AssignmentsTable
-        org="acme"
-        classroom="cs101"
-        assignments={[
-          assignment({ template: { ...inOrgTemplate, owner: "other" } }),
-        ]}
-        studentCount={0}
-      />,
-    )
-    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeNull()
-  })
-
-  it("does not render it when the classroom is archived", () => {
+  it("still renders it when archived (viewing stays available)", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -181,10 +174,10 @@ describe("AssignmentsTable — Fix template access button", () => {
         archived
       />,
     )
-    expect(screen.queryByLabelText(RECONCILE_ARIA)).toBeNull()
+    expect(screen.queryByLabelText(ACCESS_ARIA)).toBeTruthy()
   })
 
-  it("invokes the reconcile hook with the row's target on click", () => {
+  it("opens the template-access modal on click", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -193,38 +186,8 @@ describe("AssignmentsTable — Fix template access button", () => {
         studentCount={0}
       />,
     )
-    fireEvent.click(screen.getByLabelText(RECONCILE_ARIA))
-    expect(reconcileMutate).toHaveBeenCalledWith(
-      {
-        org: "acme",
-        classroom: "cs101",
-        slug: "hw1",
-        template: inOrgTemplate,
-      },
-      expect.objectContaining({ onSuccess: expect.any(Function) }),
-    )
-  })
-
-  it("toasts success on a clean reconcile and error on a warning", () => {
-    wrap(
-      <AssignmentsTable
-        org="acme"
-        classroom="cs101"
-        assignments={[assignment({ template: inOrgTemplate })]}
-        studentCount={0}
-      />,
-    )
-    fireEvent.click(screen.getByLabelText(RECONCILE_ARIA))
-    const { onSuccess } = reconcileMutate.mock.calls[0][1]
-
-    onSuccess({ warning: undefined })
-    expect(notify).toHaveBeenLastCalledWith(
-      expect.objectContaining({ tone: "success" }),
-    )
-
-    onSuccess({ warning: "student grant failed" })
-    expect(notify).toHaveBeenLastCalledWith(
-      expect.objectContaining({ tone: "error" }),
-    )
+    expect(screen.queryByTestId("template-access-modal")).toBeNull()
+    fireEvent.click(screen.getByLabelText(ACCESS_ARIA))
+    expect(screen.getByTestId("template-access-modal").textContent).toBe("hw1")
   })
 })

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -3,27 +3,24 @@ import { useTranslation } from "react-i18next"
 import {
   Copy,
   Eye,
-  KeyRound,
   Pencil,
+  ShieldCheck,
   Trash2,
   UserRound,
   UsersRound,
 } from "lucide-react"
 
-import GitHub from "@/assets/github.svg?react"
 import useGetScores from "@/hooks/useGetScores"
 import { formatDueDate } from "@/util/formatDate"
-import { githubTemplateRepoUrl } from "@/util/orgUrl"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 import { ConfirmModal } from "@/components/modals"
 import { ReuseAssignmentModal } from "@/components/modals/ReuseAssignmentModal"
+import { TemplateAccessModal } from "@/components/modals/TemplateAccessModal"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { useQueryClient } from "@tanstack/react-query"
 import { useDeleteAssignment } from "@/hooks/mutations/useDeleteAssignment"
-import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
-import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 import { Badge, Button } from "@/components/ui"
@@ -135,13 +132,11 @@ const ReuseAssignmentButton = ({
   )
 }
 
-// Per-row recovery: re-grant the classroom team read on this assignment's in-org
-// private template (the acceptance-blocking fix from issue #305). One-click, no
-// confirmation — the grant is idempotent and additive-only, so there's nothing
-// destructive to confirm. Shown for any org-owned template (the row lacks
-// visibility info); on a public/already-granted template the grant harmlessly
-// no-ops. Feedback is a toast (the table has no per-row access verdict to flip).
-const ReconcileTemplateAccessButton = ({
+// Per-row "Template access": opens a modal to review which template repo the
+// assignment uses and which GitHub teams can read it, and (org owners only)
+// re-grant the classroom student/TA teams read — the acceptance-blocking fix
+// from issue #305. Merges the former source-repo link and fix-access button.
+const TemplateAccessButton = ({
   org,
   classroom,
   assignment,
@@ -151,45 +146,35 @@ const ReconcileTemplateAccessButton = ({
   assignment: Assignment
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
-  const reconcile = useReconcileTemplateAccess()
-  const template = assignment.template
-  if (!template) return null
+  const [open, setOpen] = useState(false)
+  if (!assignment.template) return null
 
   return (
-    <Button
-      variant="ghost"
-      size="sm"
-      shape="circle"
-      loading={reconcile.isPending}
-      loadingLabel={t("assignments.template.reconcile.pending")}
-      disabled={reconcile.isPending}
-      title={t("assignments.template.reconcile.title")}
-      aria-label={t("assignments.template.reconcile.aria")}
-      onClick={(e) => {
-        e.stopPropagation()
-        reconcile.mutate(
-          { org, classroom, slug: assignment.slug, template },
-          {
-            onSuccess: (result) => {
-              if (result.warning) {
-                notify({
-                  tone: "error",
-                  message: `${t("assignments.template.reconcile.failed")} ${result.warning}`,
-                })
-              } else {
-                notify({
-                  tone: "success",
-                  message: t("assignments.template.reconcile.success"),
-                })
-              }
-            },
-          },
-        )
-      }}
-    >
-      <KeyRound aria-hidden="true" className="size-4" />
-    </Button>
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="circle"
+        title={t("assignments.template.accessModal.triggerTitle")}
+        aria-label={t("assignments.template.accessModal.triggerAria", {
+          name: assignment.name || assignment.slug,
+        })}
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen(true)
+        }}
+      >
+        <ShieldCheck aria-hidden="true" className="size-4" />
+      </Button>
+      {open ? (
+        <TemplateAccessModal
+          org={org}
+          classroom={classroom}
+          assignment={assignment}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </>
   )
 }
 
@@ -384,25 +369,11 @@ const AssignmentsTable = ({
                 </td>
                 <td>
                   {assignment.template && (
-                    <a
-                      href={githubTemplateRepoUrl(
-                        assignment.template.owner,
-                        assignment.template.repo,
-                        assignment.template.branch,
-                      )}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="btn btn-circle btn-sm btn-ghost"
-                      title={t("assignments.table.sourceRepoTitle")}
-                      aria-label={t("assignments.table.sourceRepoAria", {
-                        name: assignment.name || assignment.slug,
-                      })}
-                      onClick={(event) => {
-                        event.stopPropagation()
-                      }}
-                    >
-                      <GitHub aria-hidden="true" className="size-4" />
-                    </a>
+                    <TemplateAccessButton
+                      org={org}
+                      classroom={classroom}
+                      assignment={assignment}
+                    />
                   )}
                   <Link
                     className="btn btn-circle btn-sm btn-ghost"
@@ -429,15 +400,6 @@ const AssignmentsTable = ({
                   </Link>
                   {archived ? null : (
                     <>
-                      {assignment.template &&
-                      assignment.template.owner.toLowerCase() ===
-                        org.toLowerCase() ? (
-                        <ReconcileTemplateAccessButton
-                          org={org}
-                          classroom={classroom}
-                          assignment={assignment}
-                        />
-                      ) : null}
                       <ReuseAssignmentButton
                         org={org}
                         classroom={classroom}

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -1,6 +1,14 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
-import { Copy, Eye, Pencil, Trash2, UserRound, UsersRound } from "lucide-react"
+import {
+  Copy,
+  Eye,
+  KeyRound,
+  Pencil,
+  Trash2,
+  UserRound,
+  UsersRound,
+} from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
 import useGetScores from "@/hooks/useGetScores"
@@ -14,6 +22,8 @@ import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { useQueryClient } from "@tanstack/react-query"
 import { useDeleteAssignment } from "@/hooks/mutations/useDeleteAssignment"
+import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
+import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 import { Badge, Button } from "@/components/ui"
@@ -122,6 +132,64 @@ const ReuseAssignmentButton = ({
         />
       ) : null}
     </>
+  )
+}
+
+// Per-row recovery: re-grant the classroom team read on this assignment's in-org
+// private template (the acceptance-blocking fix from issue #305). One-click, no
+// confirmation — the grant is idempotent and additive-only, so there's nothing
+// destructive to confirm. Shown for any org-owned template (the row lacks
+// visibility info); on a public/already-granted template the grant harmlessly
+// no-ops. Feedback is a toast (the table has no per-row access verdict to flip).
+const ReconcileTemplateAccessButton = ({
+  org,
+  classroom,
+  assignment,
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+}) => {
+  const { t } = useTranslation()
+  const { notify } = useToast()
+  const reconcile = useReconcileTemplateAccess()
+  const template = assignment.template
+  if (!template) return null
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      shape="circle"
+      loading={reconcile.isPending}
+      loadingLabel={t("assignments.template.reconcile.pending")}
+      disabled={reconcile.isPending}
+      title={t("assignments.template.reconcile.title")}
+      aria-label={t("assignments.template.reconcile.aria")}
+      onClick={(e) => {
+        e.stopPropagation()
+        reconcile.mutate(
+          { org, classroom, slug: assignment.slug, template },
+          {
+            onSuccess: (result) => {
+              if (result.warning) {
+                notify({
+                  tone: "error",
+                  message: `${t("assignments.template.reconcile.failed")} ${result.warning}`,
+                })
+              } else {
+                notify({
+                  tone: "success",
+                  message: t("assignments.template.reconcile.success"),
+                })
+              }
+            },
+          },
+        )
+      }}
+    >
+      <KeyRound aria-hidden="true" className="size-4" />
+    </Button>
   )
 }
 
@@ -361,6 +429,15 @@ const AssignmentsTable = ({
                   </Link>
                   {archived ? null : (
                     <>
+                      {assignment.template &&
+                      assignment.template.owner.toLowerCase() ===
+                        org.toLowerCase() ? (
+                        <ReconcileTemplateAccessButton
+                          org={org}
+                          classroom={classroom}
+                          assignment={assignment}
+                        />
+                      ) : null}
                       <ReuseAssignmentButton
                         org={org}
                         classroom={classroom}

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -368,13 +368,6 @@ const AssignmentsTable = ({
                   })()}
                 </td>
                 <td>
-                  {assignment.template && (
-                    <TemplateAccessButton
-                      org={org}
-                      classroom={classroom}
-                      assignment={assignment}
-                    />
-                  )}
                   <Link
                     className="btn btn-circle btn-sm btn-ghost"
                     to="/$org/$classroom/assignments/$assignment/edit"
@@ -398,13 +391,30 @@ const AssignmentsTable = ({
                       <Pencil aria-hidden="true" className="size-4" />
                     )}
                   </Link>
-                  {archived ? null : (
+                  {archived ? (
+                    // Archived rows are view-only, but reviewing template access
+                    // (and reaching the source repo) stays available.
+                    assignment.template && (
+                      <TemplateAccessButton
+                        org={org}
+                        classroom={classroom}
+                        assignment={assignment}
+                      />
+                    )
+                  ) : (
                     <>
                       <ReuseAssignmentButton
                         org={org}
                         classroom={classroom}
                         assignment={assignment}
                       />
+                      {assignment.template && (
+                        <TemplateAccessButton
+                          org={org}
+                          classroom={classroom}
+                          assignment={assignment}
+                        />
+                      )}
                       <DeleteAssignmentButton
                         org={org}
                         classroom={classroom}

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -311,6 +311,9 @@ type CreateAssignmentFormProps = {
   // Classroom slug; template pre-flight uses it to check whether the classroom
   // team already has read on an in-org private template.
   classroom?: string
+  // Assignment slug (edit mode only); enables TemplateField's inline "Fix
+  // template access" recovery button. Absent on create.
+  slug?: string
   // Existing assignment slugs, for the create-mode uniqueness check.
   takenSlugs?: string[]
 }
@@ -391,6 +394,7 @@ const CreateAssignmentForm = ({
   readOnly = false,
   org,
   classroom,
+  slug,
   takenSlugs,
 }: CreateAssignmentFormProps) => {
   const { t } = useTranslation()
@@ -550,6 +554,7 @@ const CreateAssignmentForm = ({
                     field={field}
                     org={org}
                     classroom={classroom}
+                    slug={slug}
                   />
                 )}
               </form.Field>

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -61,6 +61,7 @@ const EditAssignmentForm = ({
           loading={editAssignmentMutation.isPending}
           org={org}
           classroom={classroom}
+          slug={assignment}
           onCancel={onCancel}
           defaultValues={assignmentToFormValues(defaultData)}
           onSubmit={(values) => {

--- a/web/src/pages/assignments/TemplateField.test.tsx
+++ b/web/src/pages/assignments/TemplateField.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+const verifyTemplateAccess = vi.fn()
+vi.mock("@/domain/assignments", () => ({
+  verifyTemplateAccess: (...a: unknown[]) => verifyTemplateAccess(...a),
+}))
+
+const teamHasRepoAccess = vi.fn()
+vi.mock("@/github-core/queries", () => ({
+  teamHasRepoAccess: (...a: unknown[]) => teamHasRepoAccess(...a),
+}))
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useOptionalGitHubClient: () => ({ request: vi.fn() }),
+}))
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({ user: { login: "teacher" }, isLoadingUser: false }),
+}))
+
+const reconcileMutate = vi.fn()
+let reconcilePending = false
+vi.mock("@/hooks/mutations/useReconcileTemplateAccess", () => ({
+  useReconcileTemplateAccess: () => ({
+    mutate: reconcileMutate,
+    isPending: reconcilePending,
+  }),
+}))
+
+import { TemplateField } from "./TemplateField"
+import type { StringField } from "./formFieldHelpers"
+
+const ORG = "cs50"
+const CLASSROOM = "cs50"
+const SLUG = "hw1"
+
+function fakeField(value: string): StringField {
+  return {
+    name: "template_repo",
+    state: { value },
+    handleChange: vi.fn(),
+    handleBlur: vi.fn(),
+  } as unknown as StringField
+}
+
+function renderField(props: Partial<Parameters<typeof TemplateField>[0]> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const wrapper = ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+  return render(
+    createElement(TemplateField, {
+      field: fakeField("tmpl"),
+      org: ORG,
+      classroom: CLASSROOM,
+      slug: SLUG,
+      ...props,
+    }),
+    { wrapper },
+  )
+}
+
+const ACTION_KEY = "assignments.template.reconcile.action"
+
+beforeEach(() => {
+  verifyTemplateAccess.mockReset()
+  teamHasRepoAccess.mockReset()
+  reconcileMutate.mockReset()
+  reconcilePending = false
+})
+
+afterEach(() => cleanup())
+
+describe("TemplateField — inline Fix template access", () => {
+  const okInOrgPrivate = {
+    kind: "ok",
+    owner: ORG,
+    repo: "tmpl",
+    branch: "main",
+    visibility: "private",
+    inOrg: true,
+  }
+
+  it("shows the Fix button for an in-org private template the team lacks", async () => {
+    verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
+    teamHasRepoAccess.mockResolvedValue(false)
+    renderField()
+    expect(await screen.findByText(ACTION_KEY)).toBeTruthy()
+  })
+
+  it("hides the Fix button when the team already has access", async () => {
+    verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
+    teamHasRepoAccess.mockResolvedValue(true)
+    renderField()
+    // The has-access verdict renders; the fix action must not.
+    await screen.findByText("assignments.template.privateHasAccess_2", {
+      exact: false,
+    })
+    expect(screen.queryByText(ACTION_KEY)).toBeNull()
+  })
+
+  it("hides the Fix button for a public template", async () => {
+    verifyTemplateAccess.mockResolvedValue({
+      kind: "ok",
+      owner: ORG,
+      repo: "tmpl",
+      branch: "main",
+      visibility: "public",
+      inOrg: true,
+    })
+    renderField()
+    await screen.findByText("assignments.template.okSuffix", { exact: false })
+    expect(screen.queryByText(ACTION_KEY)).toBeNull()
+  })
+
+  it("hides the Fix button on the create form (no slug)", async () => {
+    verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
+    teamHasRepoAccess.mockResolvedValue(false)
+    renderField({ slug: undefined })
+    await screen.findByText("assignments.template.privateWillGrant_2", {
+      exact: false,
+    })
+    expect(screen.queryByText(ACTION_KEY)).toBeNull()
+  })
+
+  it("invokes the reconcile hook with the resolved target on click", async () => {
+    verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
+    teamHasRepoAccess.mockResolvedValue(false)
+    renderField()
+    fireEvent.click(await screen.findByText(ACTION_KEY))
+    expect(reconcileMutate).toHaveBeenCalledWith(
+      {
+        org: ORG,
+        classroom: CLASSROOM,
+        slug: SLUG,
+        template: { owner: ORG, repo: "tmpl", branch: "main" },
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    )
+  })
+})

--- a/web/src/pages/assignments/TemplateField.test.tsx
+++ b/web/src/pages/assignments/TemplateField.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, cleanup, fireEvent } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { PropsWithChildren } from "react"
 import { createElement } from "react"
@@ -150,5 +150,33 @@ describe("TemplateField — inline Fix template access", () => {
       },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     )
+  })
+
+  it("renders the inline warning when the grant reports a failure", async () => {
+    verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
+    teamHasRepoAccess.mockResolvedValue(false)
+    renderField()
+    fireEvent.click(await screen.findByText(ACTION_KEY))
+    const onSuccess = reconcileMutate.mock.calls[0][1].onSuccess
+    act(() => onSuccess({ warning: "student grant failed" }))
+    expect(
+      screen.getByText("assignments.template.reconcile.failed", {
+        exact: false,
+      }).textContent,
+    ).toContain("student grant failed")
+  })
+
+  it("shows no inline warning on a clean grant", async () => {
+    verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
+    teamHasRepoAccess.mockResolvedValue(false)
+    renderField()
+    fireEvent.click(await screen.findByText(ACTION_KEY))
+    const onSuccess = reconcileMutate.mock.calls[0][1].onSuccess
+    act(() => onSuccess({ warning: undefined }))
+    expect(
+      screen.queryByText("assignments.template.reconcile.failed", {
+        exact: false,
+      }),
+    ).toBeNull()
   })
 })

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import type { ReactNode } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   AlertTriangle,
@@ -17,13 +18,14 @@ import {
   type TemplateAccessVerification,
 } from "@/domain/assignments"
 import { teamHasRepoAccess } from "@/github-core/queries"
+import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
 import {
   useDebouncedValue,
   normalizeOnBlur,
   type StringField,
 } from "./formFieldHelpers"
 import { InlineNote, InlineCode as Code } from "@/components/InlineNote"
-import { FormField, Input } from "@/components/ui"
+import { Button, FormField, Input } from "@/components/ui"
 import {
   templateForkNoteView,
   templateRestrictedNoteView,
@@ -36,10 +38,14 @@ export const TemplateField = ({
   field,
   org,
   classroom,
+  slug,
 }: {
   field: StringField
   org?: string
   classroom?: string
+  // Edit-only: enables the inline "Fix template access" recovery button. Absent
+  // on the create form (there's no assignment yet to reconcile).
+  slug?: string
 }) => {
   const { t } = useTranslation()
   const client = useOptionalGitHubClient()
@@ -147,8 +153,72 @@ export const TemplateField = ({
         pending={pending}
         org={org}
         teamHasAccess={teamHasAccess}
+        reconcile={
+          slug && org && classroom && inOrgPrivateTemplate ? (
+            <ReconcileTemplateAccessInline
+              org={org}
+              classroom={classroom}
+              slug={slug}
+              template={{
+                owner: inOrgPrivateTemplate.owner,
+                repo: inOrgPrivateTemplate.repo,
+                branch:
+                  verification?.kind === "ok"
+                    ? verification.branch
+                    : "main",
+              }}
+            />
+          ) : undefined
+        }
       />
     </>
+  )
+}
+
+// The inline "Fix template access" recovery button rendered inside the
+// "team doesn't have access yet" note. One-click, no confirmation (idempotent,
+// additive-only). On a clean grant the hook seeds the team-access query true, so
+// the surrounding verdict re-renders as "already has access"; a warning is shown
+// inline and the button returns to idle for a retry.
+const ReconcileTemplateAccessInline = ({
+  org,
+  classroom,
+  slug,
+  template,
+}: {
+  org: string
+  classroom: string
+  slug: string
+  template: { owner: string; repo: string; branch: string }
+}) => {
+  const { t } = useTranslation()
+  const reconcile = useReconcileTemplateAccess()
+  const [warning, setWarning] = useState<string | undefined>(undefined)
+
+  return (
+    <span className="mt-1.5 block">
+      <Button
+        variant="ghost"
+        size="sm"
+        loading={reconcile.isPending}
+        loadingLabel={t("assignments.template.reconcile.pending")}
+        disabled={reconcile.isPending}
+        onClick={() => {
+          setWarning(undefined)
+          reconcile.mutate(
+            { org, classroom, slug, template },
+            { onSuccess: (result) => setWarning(result.warning) },
+          )
+        }}
+      >
+        {t("assignments.template.reconcile.action")}
+      </Button>
+      {warning && (
+        <span className="mt-1 block text-xs text-error">
+          {t("assignments.template.reconcile.failed")} {warning}
+        </span>
+      )}
+    </span>
   )
 }
 
@@ -157,6 +227,7 @@ const TemplateVerificationNote = ({
   pending,
   org,
   teamHasAccess,
+  reconcile,
 }: {
   verification: TemplateAccessVerification | null
   pending: boolean
@@ -164,6 +235,9 @@ const TemplateVerificationNote = ({
   // For an in-org private template: true if the classroom team already has
   // read, false if granted on create, undefined if N/A or unresolved.
   teamHasAccess?: boolean
+  // Inline recovery button, rendered inside the "no access yet" verdict (edit
+  // form only). Undefined on create or when the verdict isn't in-org-private.
+  reconcile?: ReactNode
 }) => {
   const { t } = useTranslation()
   if (pending) {
@@ -198,6 +272,7 @@ const TemplateVerificationNote = ({
     t,
     fallbackOrg,
     teamHasAccess,
+    reconcile,
   })
 
   if (!nonMainNote) return verdict
@@ -214,11 +289,13 @@ function renderTemplateVerdict({
   t,
   fallbackOrg,
   teamHasAccess,
+  reconcile,
 }: {
   verification: Exclude<TemplateAccessVerification, { kind: "empty" }>
   t: ReturnType<typeof useTranslation>["t"]
   fallbackOrg: string
   teamHasAccess?: boolean
+  reconcile?: ReactNode
 }): ReactNode {
   switch (verification.kind) {
     case "ok": {
@@ -244,6 +321,7 @@ function renderTemplateVerdict({
             })}{" "}
             <Code>{verification.branch}</Code>
             {t("assignments.template.privateWillGrant_2")}
+            {reconcile}
           </Note>
         )
       }

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -84,7 +84,11 @@ export const TemplateField = ({
     verification?.kind === "ok" &&
     verification.inOrg &&
     verification.visibility === "private"
-      ? { owner: verification.owner, repo: verification.repo }
+      ? {
+          owner: verification.owner,
+          repo: verification.repo,
+          branch: verification.branch,
+        }
       : null
   const teamAccessEnabled = Boolean(
     client && org && classroom && inOrgPrivateTemplate,
@@ -162,10 +166,7 @@ export const TemplateField = ({
               template={{
                 owner: inOrgPrivateTemplate.owner,
                 repo: inOrgPrivateTemplate.repo,
-                branch:
-                  verification?.kind === "ok"
-                    ? verification.branch
-                    : "main",
+                branch: inOrgPrivateTemplate.branch,
               }}
             />
           ) : undefined


### PR DESCRIPTION
Fixes #305 — students could not accept assignments (`Couldn't copy the template`, a 404 from `POST /repos/{owner}/{repo}/generate`) because the classroom's student GitHub team had lost — or never received — `read` on the private in-org template, and the app offered no in-app way to restore it.

## What this does

- **Re-affirm on edit save (U1):** editing an assignment with an in-org private template now re-grants the student + TA team read even when the template ref is unchanged, so any edit opportunistically repairs a dropped grant. Non-fatal (a grant failure is a warning, never a failed save).
- **Reconcile hook (U2):** `useReconcileTemplateAccess` wraps the existing `tryGrantTeamTemplateRead` and owns the post-grant cache reconcile for **both** readers of "team has template read": on a clean grant it seeds `TemplateField`'s boolean `["template-team-access", …]` query `true` (no refetch → no flash) and refetches the modal's `repoTeams` list; a warning invalidates only the boolean key.
- **Inline recovery (U4):** the edit form's template note shows a "Fix template access" button when the team lacks read; the verdict flips to "already has access" on success.
- **Template access modal (table):** the per-row "view source repo" link and "fix access" button are merged into a single **Template access** action that opens a modal showing the template repo (full name + branch + Open on GitHub), the GitHub teams with access, and a **Fix permissions** action.

## Authorization

- Reviewing template access + the source link is available to any classroom staff viewer (even for archived assignments).
- **Fix permissions** is gated on `can("manageOrg", { githubOrgRole })` (org owner) — because granting team access requires repo-admin. Non-owners see a read-only review plus an owner-only note. The action is disabled once the classroom student team already has read, and enabled when it's missing.

## Cache coherence (post-review fixes)

GitHub's `GET /repos/{owner}/{repo}/teams` read is eventually consistent after a grant, so an immediate refetch can return the pre-grant list. Addressed so a successful "Fix permissions" never contradicts its own success toast:

- The reconcile hook is the single reconcile point (above), instead of the modal separately invalidating `repoTeams` — the two "team has access" caches no longer drift.
- The modal latches a local `granted` flag on success and gates the Fix button on `teamsQuery.isFetching` (not just `isPending`), so the eventually-consistent refetch can't re-enable the button or re-flash "no teams" between the toast and the settled list.

## Notes

- On the reported incident: the exact trigger isn't confirmed from the issue thread; this ships the recovery path everyone agreed was missing, which is correct regardless of the cause.
- No schema/`assignments.json` shape changes — no cross-tool (CLI/skeleton) mirror update needed.

## Verification

`cd web && npm run check` green (tsc + eslint + prettier + arch:validate + vitest) and the i18n audit passes. New tests cover both `onSuccess` branches (modal toasts + no post-grant re-flash; inline warning render) and the hook's dual-cache reconcile.
