### PR TITLE
feat(web): harden setup + auth flow against stuck GitHub reads (derive wizard stage, add recovery affordances, warn on outages)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import router from "./router"
 import { Spinner } from "@/components/Spinner"
 import { Button } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useGitHubHealth } from "@/lib/githubHealth"
 import { BASE_PATH, isAuthedPath } from "@/auth/authedPath"
 import { logger } from "@/lib/logger"
 
@@ -22,6 +23,10 @@ export function App() {
     signOut,
   } = useGithubAuth()
   const { t } = useTranslation()
+  const {
+    suspected: githubSuspected,
+    statusDescription: githubStatusDescription,
+  } = useGitHubHealth()
 
   useEffect(() => {
     if (status === "loading") return
@@ -65,6 +70,23 @@ export function App() {
             <p className="text-sm text-base-content/70">
               {t("auth.validationStuck")}
             </p>
+            {githubSuspected ? (
+              <p className="text-sm text-base-content/70">
+                {githubStatusDescription
+                  ? t("githubStatus.bodyConfirmed", {
+                      status: githubStatusDescription,
+                    })
+                  : t("githubStatus.bodyGeneric")}{" "}
+                <a
+                  href="https://www.githubstatus.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="link link-hover font-semibold text-base-content"
+                >
+                  {t("githubStatus.checkStatusLink")}
+                </a>
+              </p>
+            ) : null}
             <div className="flex flex-wrap items-center justify-center gap-3">
               <Button variant="primary" onClick={retryUserValidation}>
                 {t("submissions.errors.retry")}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "@/components/Spinner"
 import { Button } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useGitHubHealth } from "@/lib/githubHealth"
+import { GitHubStatusNote } from "@/components/GitHubStatusBanner"
 import { BASE_PATH, isAuthedPath } from "@/auth/authedPath"
 import { logger } from "@/lib/logger"
 
@@ -58,10 +59,9 @@ export function App() {
   }, [sessionEndedOnAuthedRoute])
 
   if (status === "loading" || sessionEndedOnAuthedRoute) {
-    // A settled, persistent validation failure (retries exhausted while online —
-    // a proxy/extension blocking api.github.com, or a wedged stored session)
-    // would otherwise spin forever. Offer an escape: retry the /user validation,
-    // or sign out to a clean re-login (the recovery path users hit today).
+    // A settled, persistent validation failure would otherwise spin forever
+    // (see isValidationStuck). Offer an escape: retry /user, or sign out to a
+    // clean re-login.
     if (isValidatingStuck) {
       return (
         <div className="min-h-screen grid place-items-center p-6">
@@ -72,19 +72,7 @@ export function App() {
             </p>
             {githubSuspected ? (
               <p className="text-sm text-base-content/70">
-                {githubStatusDescription
-                  ? t("githubStatus.bodyConfirmed", {
-                      status: githubStatusDescription,
-                    })
-                  : t("githubStatus.bodyGeneric")}{" "}
-                <a
-                  href="https://www.githubstatus.com"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="link link-hover font-semibold text-base-content"
-                >
-                  {t("githubStatus.checkStatusLink")}
-                </a>
+                <GitHubStatusNote statusDescription={githubStatusDescription} />
               </p>
             ) : null}
             <div className="flex flex-wrap items-center justify-center gap-3">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import router from "./router"
 import { Spinner } from "@/components/Spinner"
+import { Button } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { BASE_PATH, isAuthedPath } from "@/auth/authedPath"
 import { logger } from "@/lib/logger"
@@ -11,7 +12,15 @@ import { logger } from "@/lib/logger"
 const log = logger.scope("app")
 
 export function App() {
-  const { status, token, user, isOnline } = useGithubAuth()
+  const {
+    status,
+    token,
+    user,
+    isOnline,
+    isValidatingStuck,
+    retryUserValidation,
+    signOut,
+  } = useGithubAuth()
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -44,6 +53,31 @@ export function App() {
   }, [sessionEndedOnAuthedRoute])
 
   if (status === "loading" || sessionEndedOnAuthedRoute) {
+    // A settled, persistent validation failure (retries exhausted while online —
+    // a proxy/extension blocking api.github.com, or a wedged stored session)
+    // would otherwise spin forever. Offer an escape: retry the /user validation,
+    // or sign out to a clean re-login (the recovery path users hit today).
+    if (isValidatingStuck) {
+      return (
+        <div className="min-h-screen grid place-items-center p-6">
+          <div className="flex max-w-md flex-col items-center gap-4 text-center">
+            <Spinner size="lg" label={t("common.loadingApp")} />
+            <p className="text-sm text-base-content/70">
+              {t("auth.validationStuck")}
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Button variant="primary" onClick={retryUserValidation}>
+                {t("submissions.errors.retry")}
+              </Button>
+              <Button variant="ghost" onClick={signOut}>
+                {t("auth.validationStuckSignIn")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
     // Offline with a stored token that can't be validated yet: explain the hold
     // rather than showing a bare, indefinite "loading" spinner (the session is
     // preserved and resumes when connectivity returns).

--- a/web/src/auth/useGithubAuth.recovery.test.ts
+++ b/web/src/auth/useGithubAuth.recovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   classifyPatResult,
   isTransientUserError,
+  isValidationStuck,
   recoverStrandedExchange,
   resolveAuthStatus,
   shouldExpireOnUserError,
@@ -265,5 +266,52 @@ describe("isTransientUserError", () => {
   it("is false when there is no error", () => {
     expect(isTransientUserError(undefined)).toBe(false)
     expect(isTransientUserError(null)).toBe(false)
+  })
+})
+
+// The escape-hatch gate for the "loading" hold: when a token holder is online
+// with no cached user and /user validation has SETTLED into a transient error
+// (retries exhausted, not still fetching), the hold is a dead end and the App
+// shell shows a retry / sign-in-again surface instead of an endless spinner.
+// resolveAuthStatus still returns "loading" here on purpose (#187); this flag
+// only enriches that screen, so every hold-vs-bounce invariant is preserved.
+describe("isValidationStuck", () => {
+  const stuck = {
+    hasToken: true,
+    isOnline: true,
+    hasUser: false,
+    userQueryErrored: true,
+    userErrorIsTransient: true,
+    userQueryFetching: false,
+  }
+
+  it("is true when online, token present, no user, and settled on a transient error", () => {
+    expect(isValidationStuck(stuck)).toBe(true)
+  })
+
+  it("is false while a refetch is still in flight (not yet a dead end)", () => {
+    expect(isValidationStuck({ ...stuck, userQueryFetching: true })).toBe(false)
+  })
+
+  it("is false offline (that's the offlineHold case, not a stuck retry)", () => {
+    expect(isValidationStuck({ ...stuck, isOnline: false })).toBe(false)
+  })
+
+  it("is false once a user is cached (session already validated)", () => {
+    expect(isValidationStuck({ ...stuck, hasUser: true })).toBe(false)
+  })
+
+  it("is false with no token (nothing to validate)", () => {
+    expect(isValidationStuck({ ...stuck, hasToken: false })).toBe(false)
+  })
+
+  it("is false when the query has not errored", () => {
+    expect(isValidationStuck({ ...stuck, userQueryErrored: false })).toBe(false)
+  })
+
+  it("is false for a definitive (non-transient) error — resolveAuthStatus mounts the app instead", () => {
+    expect(isValidationStuck({ ...stuck, userErrorIsTransient: false })).toBe(
+      false,
+    )
   })
 })

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -122,6 +122,33 @@ export type AuthStatusInput = {
   hasUser: boolean
 }
 
+// Whether a token holder is stranded on the loading hold with no way forward:
+// online, no cached user, and the /user validation has SETTLED into a transient
+// error (retries exhausted, not still fetching). resolveAuthStatus keeps this
+// case at "loading" on purpose (#187 — don't eject a valid session on a blip),
+// but a *persistent* transient failure (a proxy/extension blocking
+// api.github.com, or a wedged stored session) would otherwise spin forever with
+// no escape. This drives the retry / sign-in-again affordance on the hold
+// screen. A 401 (dead token) and a definitive non-401 don't reach here — the
+// first signs out, the second resolves to "authenticated".
+export function isValidationStuck(input: {
+  hasToken: boolean
+  isOnline: boolean
+  hasUser: boolean
+  userQueryErrored: boolean
+  userErrorIsTransient: boolean
+  userQueryFetching: boolean
+}): boolean {
+  return (
+    input.hasToken &&
+    input.isOnline &&
+    !input.hasUser &&
+    input.userQueryErrored &&
+    input.userErrorIsTransient &&
+    !input.userQueryFetching
+  )
+}
+
 // Resolve the auth status for the router guard.
 //
 // Two offline cases, deliberately split:
@@ -797,6 +824,34 @@ function useGithubAuthState() {
     ],
   )
 
+  // True when the "loading" hold has become a dead end: online, token present,
+  // no cached user, and /user validation settled into a transient error with no
+  // refetch in flight. The App shell reads this to swap the bare spinner for a
+  // retry / sign-in-again surface instead of stranding the user.
+  const isValidatingStuck = useMemo(
+    () =>
+      isValidationStuck({
+        hasToken: Boolean(token),
+        isOnline,
+        hasUser: Boolean(githubUserQuery.data),
+        userQueryErrored: githubUserQuery.isError,
+        userErrorIsTransient: isTransientUserError(githubUserQuery.error),
+        userQueryFetching: githubUserQuery.isFetching,
+      }),
+    [
+      token,
+      isOnline,
+      githubUserQuery.data,
+      githubUserQuery.isError,
+      githubUserQuery.error,
+      githubUserQuery.isFetching,
+    ],
+  )
+
+  const retryUserValidation = useCallback(() => {
+    void githubUserQuery.refetch()
+  }, [githubUserQuery])
+
   // Navigate to the stashed deep link once status is "authenticated", so the
   // target _authed guard sees an authenticated context instead of bouncing
   // through /login (#71). history.push (not navigate({ to })) preserves the
@@ -841,6 +896,8 @@ function useGithubAuthState() {
     expireSession,
     sessionExpired,
     status,
+    isValidatingStuck,
+    retryUserValidation,
     isOnline,
   }
 }

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -824,10 +824,7 @@ function useGithubAuthState() {
     ],
   )
 
-  // True when the "loading" hold has become a dead end: online, token present,
-  // no cached user, and /user validation settled into a transient error with no
-  // refetch in flight. The App shell reads this to swap the bare spinner for a
-  // retry / sign-in-again surface instead of stranding the user.
+  // Live isValidationStuck against the current /user query state (see its doc).
   const isValidatingStuck = useMemo(
     () =>
       isValidationStuck({

--- a/web/src/components/GitHubStatusBanner.test.tsx
+++ b/web/src/components/GitHubStatusBanner.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react"
+
+const healthMock = vi.fn()
+vi.mock("@/lib/githubHealth", () => ({
+  useGitHubHealth: () => healthMock(),
+}))
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    // Echo the key (plus any interpolation) so assertions can target keys.
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.status ? `${key}:${String(opts.status)}` : key,
+  }),
+}))
+
+import { GitHubStatusBanner } from "./GitHubStatusBanner"
+
+const health = (over: Record<string, unknown> = {}) =>
+  healthMock.mockReturnValue({
+    suspected: false,
+    statusIndicator: null,
+    statusDescription: null,
+    ...over,
+  })
+
+afterEach(() => {
+  cleanup()
+  healthMock.mockReset()
+})
+
+describe("GitHubStatusBanner", () => {
+  it("renders nothing when GitHub is not suspected", () => {
+    health({ suspected: false })
+    render(<GitHubStatusBanner />)
+    expect(screen.queryByText("githubStatus.title")).toBeNull()
+  })
+
+  it("shows the generic body + status link when suspected with no confirmed status", () => {
+    health({ suspected: true })
+    render(<GitHubStatusBanner />)
+    expect(screen.queryByText("githubStatus.title")).not.toBeNull()
+    expect(screen.queryByText("githubStatus.bodyGeneric")).not.toBeNull()
+    const link = screen.getByText("githubStatus.checkStatusLink")
+    expect(link.getAttribute("href")).toBe("https://www.githubstatus.com")
+  })
+
+  it("shows the confirmed body with the githubstatus.com description when present", () => {
+    health({ suspected: true, statusDescription: "Partially Degraded Service" })
+    render(<GitHubStatusBanner />)
+    expect(
+      screen.queryByText(
+        "githubStatus.bodyConfirmed:Partially Degraded Service",
+      ),
+    ).not.toBeNull()
+    expect(screen.queryByText("githubStatus.bodyGeneric")).toBeNull()
+  })
+
+  it("hides after dismiss", async () => {
+    health({ suspected: true })
+    render(<GitHubStatusBanner />)
+    fireEvent.click(screen.getByLabelText("components.banner.dismiss"))
+    // AppBanner exit-animates via AnimatePresence, so removal isn't synchronous.
+    await waitFor(() =>
+      expect(screen.queryByText("githubStatus.title")).toBeNull(),
+    )
+  })
+})

--- a/web/src/components/GitHubStatusBanner.tsx
+++ b/web/src/components/GitHubStatusBanner.tsx
@@ -6,7 +6,33 @@ import { useTranslation } from "react-i18next"
 import { AppBanner } from "@/components/AppBanner"
 import { useGitHubHealth } from "@/lib/githubHealth"
 
-const GITHUB_STATUS_URL = "https://www.githubstatus.com"
+export const GITHUB_STATUS_URL = "https://www.githubstatus.com"
+
+// The outage body text (confirmed vs generic) plus the githubstatus.com link.
+// Shared by the authed banner and the unauthed stuck-bootstrap screen so the
+// copy and URL can't drift between them.
+export function GitHubStatusNote({
+  statusDescription,
+}: {
+  statusDescription: string | null
+}) {
+  const { t } = useTranslation()
+  return (
+    <>
+      {statusDescription
+        ? t("githubStatus.bodyConfirmed", { status: statusDescription })
+        : t("githubStatus.bodyGeneric")}{" "}
+      <a
+        href={GITHUB_STATUS_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="link link-hover font-semibold text-base-content"
+      >
+        {t("githubStatus.checkStatusLink")}
+      </a>
+    </>
+  )
+}
 
 // Global warning banner shown when the app suspects GitHub is having trouble
 // (repeated outage-shaped API failures), optionally enriched with the

--- a/web/src/components/GitHubStatusBanner.tsx
+++ b/web/src/components/GitHubStatusBanner.tsx
@@ -8,28 +8,45 @@ import { useGitHubHealth } from "@/lib/githubHealth"
 
 export const GITHUB_STATUS_URL = "https://www.githubstatus.com"
 
-// The outage body text (confirmed vs generic) plus the githubstatus.com link.
-// Shared by the authed banner and the unauthed stuck-bootstrap screen so the
-// copy and URL can't drift between them.
+// The outage body text (confirmed vs generic) plus the githubstatus.com link —
+// the single source of both, so the copy and URL can't drift between the authed
+// banner and the unauthed stuck-bootstrap screen. `block` renders the banner's
+// muted-paragraph + own-line link; the default is the inline fragment the
+// unauthed screen wraps in its own <p>.
 export function GitHubStatusNote({
   statusDescription,
+  block = false,
 }: {
   statusDescription: string | null
+  block?: boolean
 }) {
   const { t } = useTranslation()
+  const body = statusDescription
+    ? t("githubStatus.bodyConfirmed", { status: statusDescription })
+    : t("githubStatus.bodyGeneric")
+  const link = (
+    <a
+      href={GITHUB_STATUS_URL}
+      target="_blank"
+      rel="noreferrer"
+      className={`link link-hover font-semibold text-base-content${
+        block ? " self-start" : ""
+      }`}
+    >
+      {t("githubStatus.checkStatusLink")}
+    </a>
+  )
+  if (block) {
+    return (
+      <>
+        <p className="text-base-content/70">{body}</p>
+        {link}
+      </>
+    )
+  }
   return (
     <>
-      {statusDescription
-        ? t("githubStatus.bodyConfirmed", { status: statusDescription })
-        : t("githubStatus.bodyGeneric")}{" "}
-      <a
-        href={GITHUB_STATUS_URL}
-        target="_blank"
-        rel="noreferrer"
-        className="link link-hover font-semibold text-base-content"
-      >
-        {t("githubStatus.checkStatusLink")}
-      </a>
+      {body} {link}
     </>
   )
 }
@@ -61,19 +78,7 @@ export function GitHubStatusBanner() {
           title={t("githubStatus.title")}
           onDismiss={() => setDismissed(true)}
         >
-          <p className="text-base-content/70">
-            {statusDescription
-              ? t("githubStatus.bodyConfirmed", { status: statusDescription })
-              : t("githubStatus.bodyGeneric")}
-          </p>
-          <a
-            href={GITHUB_STATUS_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="link link-hover self-start font-semibold text-base-content"
-          >
-            {t("githubStatus.checkStatusLink")}
-          </a>
+          <GitHubStatusNote statusDescription={statusDescription} block />
         </AppBanner>
       ) : null}
     </AnimatePresence>

--- a/web/src/components/GitHubStatusBanner.tsx
+++ b/web/src/components/GitHubStatusBanner.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react"
+import { CloudOff } from "lucide-react"
+import { AnimatePresence } from "motion/react"
+import { useTranslation } from "react-i18next"
+
+import { AppBanner } from "@/components/AppBanner"
+import { useGitHubHealth } from "@/lib/githubHealth"
+
+const GITHUB_STATUS_URL = "https://www.githubstatus.com"
+
+// Global warning banner shown when the app suspects GitHub is having trouble
+// (repeated outage-shaped API failures), optionally enriched with the
+// authoritative githubstatus.com summary. Heuristic, so it's dismissible
+// (unlike OfflineBanner, which reflects a hard browser signal). Dismissal is
+// scoped to the current suspicion episode: once a success clears suspicion the
+// dismissed flag resets, so a later, distinct outage surfaces again.
+export function GitHubStatusBanner() {
+  const { suspected, statusDescription } = useGitHubHealth()
+  const [dismissed, setDismissed] = useState(false)
+  const { t } = useTranslation()
+
+  // Reset the per-episode dismissal the moment suspicion clears, without an
+  // effect (a render-time reset avoids the cascading-render lint).
+  if (!suspected && dismissed) setDismissed(false)
+
+  const show = suspected && !dismissed
+
+  return (
+    <AnimatePresence initial={false}>
+      {show ? (
+        <AppBanner
+          key="github-status"
+          tone="warning"
+          icon={<CloudOff className="size-5" aria-hidden="true" />}
+          title={t("githubStatus.title")}
+          onDismiss={() => setDismissed(true)}
+        >
+          <p className="text-base-content/70">
+            {statusDescription
+              ? t("githubStatus.bodyConfirmed", { status: statusDescription })
+              : t("githubStatus.bodyGeneric")}
+          </p>
+          <a
+            href={GITHUB_STATUS_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="link link-hover self-start font-semibold text-base-content"
+          >
+            {t("githubStatus.checkStatusLink")}
+          </a>
+        </AppBanner>
+      ) : null}
+    </AnimatePresence>
+  )
+}
+
+export default GitHubStatusBanner

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -90,5 +90,6 @@ export {
   getCollectScoresRunAfterId,
   getRegradeRunAfterId,
   getLastCollectScoresRun,
+  SERVICE_TOKEN_SECRET_NAME,
   type ServiceTokenStatus,
 } from "./queries/releaseRunReads"

--- a/web/src/github-core/queries/releaseRunReads.test.ts
+++ b/web/src/github-core/queries/releaseRunReads.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import { getServiceTokenStatus } from "./releaseRunReads"
+import type { GitHubClient } from "../client"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const apiError = (status: number) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: noRateLimit,
+  })
+
+const clientThrowing = (err: unknown): GitHubClient =>
+  ({ request: vi.fn().mockRejectedValue(err) }) as unknown as GitHubClient
+
+// getServiceTokenStatus resolves only DEFINITIVE verdicts (404 -> missing,
+// 403 -> unknown/permission_denied) and rethrows everything else. Resolving a
+// transient error to "unknown" would let an invalidation refetch overwrite the
+// optimistically-seeded "present" (useSaveServiceToken) and bounce the setup
+// wizard off its derived finish stage (#310).
+describe("getServiceTokenStatus", () => {
+  it("resolves 'missing' on a 404", async () => {
+    const status = await getServiceTokenStatus(
+      clientThrowing(apiError(404)),
+      "org",
+    )
+    expect(status.status).toBe("missing")
+  })
+
+  it("resolves 'unknown' (permission_denied) on a 403", async () => {
+    const status = await getServiceTokenStatus(
+      clientThrowing(apiError(403)),
+      "org",
+    )
+    expect(status.status).toBe("unknown")
+    expect(status.status === "unknown" && status.reason).toBe(
+      "permission_denied",
+    )
+  })
+
+  it("rethrows a transient 5xx instead of resolving 'unknown'", async () => {
+    await expect(
+      getServiceTokenStatus(clientThrowing(apiError(503)), "org"),
+    ).rejects.toThrow()
+  })
+
+  it("rethrows a network/timeout error instead of resolving 'unknown'", async () => {
+    await expect(
+      getServiceTokenStatus(
+        clientThrowing(new TypeError("Failed to fetch")),
+        "org",
+      ),
+    ).rejects.toThrow()
+  })
+})

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -56,7 +56,7 @@ type RepositorySecret = {
   created_at: string
   updated_at: string
 }
-const SERVICE_TOKEN_SECRET_NAME = "CLASSROOM50_SERVICE_TOKEN"
+export const SERVICE_TOKEN_SECRET_NAME = "CLASSROOM50_SERVICE_TOKEN"
 export type ServiceTokenStatus =
   | {
       status: "present"

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -5,7 +5,6 @@ import type { GitHubRelease, GitHubWorkflowRun } from "../types"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError, tolerateGitHubError } from "../errors"
 import { COLLECT_SCORES_WORKFLOW, REGRADE_WORKFLOW } from "../workflows"
-import { getErrorMessage } from "../errorMessage"
 import { githubKeys } from "./keys"
 
 // The submission-tag convention written by the autograde runner: each graded
@@ -115,14 +114,12 @@ export async function getServiceTokenStatus(
       }
     }
 
-    return {
-      status: "unknown",
-      secretName: SERVICE_TOKEN_SECRET_NAME,
-      reason: "unknown",
-      message: `Could not check the service token on the ${CONFIG_REPO} config repo: ${getErrorMessage(
-        err,
-      )}`,
-    }
+    // A transient failure (5xx/network) is not a verdict — resolving "unknown"
+    // here would let an invalidation refetch overwrite an optimistically-seeded
+    // "present" (useSaveServiceToken) and bounce the setup wizard off its
+    // derived stage. Rethrow so react-query retries/keeps the prior data, like
+    // the config-repo probe. Only definitive statuses above resolve a verdict.
+    throw err
   }
 }
 

--- a/web/src/hooks/mutations/useSaveServiceToken.test.ts
+++ b/web/src/hooks/mutations/useSaveServiceToken.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+import type { ServiceTokenStatus } from "@/github-core/queries"
+
+const validateServiceToken = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const putRepoSecret = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+
+vi.mock("@/github-core/mutations", () => ({
+  validateServiceToken: (...args: unknown[]) => validateServiceToken(...args),
+  putRepoSecret: (...args: unknown[]) => putRepoSecret(...args),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useSaveServiceToken } from "./useSaveServiceToken"
+
+const ORG = "cs50"
+const KEY = githubKeys.serviceToken(ORG)
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  validateServiceToken.mockResolvedValue(undefined)
+  putRepoSecret.mockResolvedValue(undefined)
+})
+
+describe("useSaveServiceToken", () => {
+  it("seeds status 'present' under the key the consumer reads (survives #307)", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useSaveServiceToken(ORG), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate("ghp_token")
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // The wizard derives its finish stage from exactly this key, so a drift in
+    // the key or shape would silently reopen #307.
+    const seeded = queryClient.getQueryData<ServiceTokenStatus>(KEY)
+    expect(seeded?.status).toBe("present")
+    expect(seeded?.secretName).toBe("CLASSROOM50_SERVICE_TOKEN")
+  })
+
+  it("uses the same key useGetServiceTokenStatus reads, defaulting a missing org to ''", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useSaveServiceToken(undefined), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate("ghp_token")
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Consumer reads githubKeys.serviceToken(org ?? ""); a drift here would seed
+    // under a key the wizard never reads and reopen #307.
+    expect(
+      queryClient.getQueryData<ServiceTokenStatus>(githubKeys.serviceToken(""))
+        ?.status,
+    ).toBe("present")
+  })
+})

--- a/web/src/hooks/mutations/useSaveServiceToken.ts
+++ b/web/src/hooks/mutations/useSaveServiceToken.ts
@@ -1,13 +1,17 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { putRepoSecret, validateServiceToken } from "@/github-core/mutations"
-import { githubKeys } from "@/github-core/queries"
+import {
+  githubKeys,
+  SERVICE_TOKEN_SECRET_NAME,
+  type ServiceTokenStatus,
+} from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Validate a service PAT and store it as the config repo's
-// CLASSROOM50_SERVICE_TOKEN secret. Hook invalidates the org list + this org's
-// service-token status; the field-clear/saved-kind/onSubmit UI effects (and the
-// useSafeSubmit composition) stay at the call site (see ./README.md).
+// CLASSROOM50_SERVICE_TOKEN secret. Hook seeds + invalidates the org list and
+// this org's service-token status; the field-clear/saved-kind UI effects (and
+// the useSafeSubmit composition) stay at the call site (see ./README.md).
 export function useSaveServiceToken(org: string | undefined) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
@@ -25,6 +29,20 @@ export function useSaveServiceToken(org: string | undefined) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      // Seed the status to "present" before the refetch so a UI deriving its
+      // state from token presence (the setup wizard) advances even if the
+      // invalidation refetch fails (offline / transient GitHub error) — the
+      // save itself already succeeded. The invalidate below reconciles the
+      // real created/updated timestamps once the network read lands.
+      const now = new Date().toISOString()
+      const seeded: ServiceTokenStatus = {
+        status: "present",
+        secretName: SERVICE_TOKEN_SECRET_NAME,
+        createdAt: now,
+        updatedAt: now,
+        message: "",
+      }
+      queryClient.setQueryData(githubKeys.serviceToken(org ?? ""), seeded)
       queryClient.invalidateQueries({
         queryKey: githubKeys.serviceToken(org ?? ""),
       })

--- a/web/src/hooks/mutations/useSaveServiceToken.ts
+++ b/web/src/hooks/mutations/useSaveServiceToken.ts
@@ -32,8 +32,11 @@ export function useSaveServiceToken(org: string | undefined) {
       // Seed the status to "present" before the refetch so a UI deriving its
       // state from token presence (the setup wizard) advances even if the
       // invalidation refetch fails (offline / transient GitHub error) — the
-      // save itself already succeeded. The invalidate below reconciles the
-      // real created/updated timestamps once the network read lands.
+      // save itself already succeeded. The seed survives such a failure because
+      // getServiceTokenStatus now rethrows transient errors, so react-query
+      // keeps this seeded data rather than overwriting it with a verdict. The
+      // invalidate below reconciles the real created/updated timestamps once a
+      // read lands.
       const now = new Date().toISOString()
       const seeded: ServiceTokenStatus = {
         status: "present",

--- a/web/src/hooks/useOrgClassroom50Status.ts
+++ b/web/src/hooks/useOrgClassroom50Status.ts
@@ -33,6 +33,12 @@ export async function probeOrgClassroom50Status(
   }
 }
 
+// Query key for the config-repo existence probe. Exported so callers that
+// invalidate/refetch the probe (e.g. the setup wizard after init) can't drift
+// from the key the hook registers.
+export const orgClassroom50StatusKey = (org: string | undefined) =>
+  ["github", "repos", org, CONFIG_REPO, "exists"] as const
+
 // Single-org probe for the `classroom50` config repo, to gate /$org/* routes.
 // Distinct from getClassroom50OrgSummary, which fans out across every org on the
 // landing page.
@@ -40,7 +46,7 @@ export function useOrgClassroom50Status(org: string | undefined) {
   const client = useGitHubClient()
 
   return useQuery<OrgClassroom50Status>({
-    queryKey: ["github", "repos", org, CONFIG_REPO, "exists"],
+    queryKey: orgClassroom50StatusKey(org),
     queryFn: () => probeOrgClassroom50Status(client, org ?? ""),
     staleTime: 10 * 60 * 1000,
     retry: retryTransientGitHubError,

--- a/web/src/lib/githubHealth/githubHealthStore.test.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.test.ts
@@ -164,12 +164,23 @@ describe("status probe enrichment", () => {
     expect(snap.statusDescription).toBeNull()
   })
 
-  it("stays suspected with no description when the probe fails", async () => {
-    fetchIndicatorMock.mockResolvedValue(null)
-    trip()
+  it("re-probes on a fresh episode after recovery (probe cache is re-armed on success)", async () => {
+    fetchIndicatorMock.mockResolvedValue({
+      indicator: "major",
+      description: "Major Service Outage",
+    })
+    trip(1000)
     await flush()
-    const snap = getGitHubHealthSnapshot()
-    expect(snap.suspected).toBe(true)
-    expect(snap.statusDescription).toBeNull()
+    expect(getGitHubHealthSnapshot().statusIndicator).toBe("major")
+    expect(fetchIndicatorMock).toHaveBeenCalledTimes(1)
+
+    recordGitHubSuccess()
+    expect(getGitHubHealthSnapshot().suspected).toBe(false)
+
+    // A distinct outage 5s later (well within PROBE_CACHE_MS) must still probe.
+    trip(6000)
+    await flush()
+    expect(getGitHubHealthSnapshot().statusIndicator).toBe("major")
+    expect(fetchIndicatorMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/web/src/lib/githubHealth/githubHealthStore.test.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.test.ts
@@ -183,4 +183,63 @@ describe("status probe enrichment", () => {
     expect(getGitHubHealthSnapshot().statusIndicator).toBe("major")
     expect(fetchIndicatorMock).toHaveBeenCalledTimes(2)
   })
+
+  it("a fresh episode still probes when a prior episode's probe is still in flight", async () => {
+    // Episode A's probe never resolves (slow network) — its in-flight flag must
+    // not starve episode B of its own guaranteed first probe after recovery.
+    let resolveA: (v: unknown) => void = () => {}
+    fetchIndicatorMock.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveA = res
+      }),
+    )
+    trip(1000)
+    await flush()
+    expect(fetchIndicatorMock).toHaveBeenCalledTimes(1)
+
+    recordGitHubSuccess()
+
+    fetchIndicatorMock.mockResolvedValueOnce({
+      indicator: "major",
+      description: "Major Service Outage",
+    })
+    trip(6000)
+    await flush()
+    // Episode B probed despite A still pending, and got its own result.
+    expect(fetchIndicatorMock).toHaveBeenCalledTimes(2)
+    expect(getGitHubHealthSnapshot().statusIndicator).toBe("major")
+
+    // A resolving late must not overwrite episode B.
+    resolveA({ indicator: "minor", description: "Stale Episode A" })
+    await flush()
+    expect(getGitHubHealthSnapshot().statusDescription).toBe(
+      "Major Service Outage",
+    )
+  })
+
+  it("a stale probe resolving into a new episode does not write its result onto it", async () => {
+    let resolveA: (v: unknown) => void = () => {}
+    fetchIndicatorMock.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveA = res
+      }),
+    )
+    trip(1000)
+    await flush()
+
+    recordGitHubSuccess()
+    // Episode B trips and its own probe reports healthy-but-generic (null).
+    fetchIndicatorMock.mockResolvedValueOnce(null)
+    trip(6000)
+    await flush()
+    expect(getGitHubHealthSnapshot().suspected).toBe(true)
+    expect(getGitHubHealthSnapshot().statusDescription).toBeNull()
+
+    // Episode A's stale probe resolves with an indicator; the epoch guard must
+    // discard it rather than enrich episode B with episode A's description.
+    resolveA({ indicator: "critical", description: "Stale Episode A" })
+    await flush()
+    expect(getGitHubHealthSnapshot().statusDescription).toBeNull()
+    expect(getGitHubHealthSnapshot().statusIndicator).toBeNull()
+  })
 })

--- a/web/src/lib/githubHealth/githubHealthStore.test.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const apiError = (status: number, over: Partial<GitHubRateLimit> = {}) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: { ...noRateLimit, ...over },
+  })
+
+// The status probe is mocked per-test so the threshold/recovery logic is tested
+// without a real fetch; probe-mapping is asserted via its resolved value.
+const fetchIndicatorMock = vi.fn()
+vi.mock("./githubStatusApi", () => ({
+  fetchGitHubStatusIndicator: () => fetchIndicatorMock(),
+}))
+
+import {
+  __resetGitHubHealthForTest,
+  getGitHubHealthSnapshot,
+  isOutageShapedError,
+  recordGitHubFailure,
+  recordGitHubSuccess,
+} from "./githubHealthStore"
+
+beforeEach(() => {
+  __resetGitHubHealthForTest()
+  fetchIndicatorMock.mockReset()
+  fetchIndicatorMock.mockResolvedValue(null)
+})
+
+afterEach(() => {
+  __resetGitHubHealthForTest()
+})
+
+describe("isOutageShapedError", () => {
+  it("treats a 5xx GitHubAPIError as outage-shaped", () => {
+    expect(isOutageShapedError(apiError(500))).toBe(true)
+    expect(isOutageShapedError(apiError(503))).toBe(true)
+  })
+
+  it("treats a bare network/timeout error as outage-shaped", () => {
+    expect(isOutageShapedError(new TypeError("Failed to fetch"))).toBe(true)
+  })
+
+  it("does NOT treat definitive 4xx (401/403/404) as outage-shaped", () => {
+    expect(isOutageShapedError(apiError(401))).toBe(false)
+    expect(isOutageShapedError(apiError(403))).toBe(false)
+    expect(isOutageShapedError(apiError(404))).toBe(false)
+  })
+
+  it("does NOT treat a rate limit as outage-shaped (429, or 403 with retry-after/remaining 0)", () => {
+    expect(isOutageShapedError(apiError(429))).toBe(false)
+    expect(isOutageShapedError(apiError(403, { retryAfter: 60 }))).toBe(false)
+    expect(isOutageShapedError(apiError(403, { remaining: 0 }))).toBe(false)
+  })
+
+  it("does NOT treat a caller/timeout abort as outage-shaped", () => {
+    expect(isOutageShapedError(new DOMException("aborted", "AbortError"))).toBe(
+      false,
+    )
+  })
+})
+
+describe("suspicion threshold", () => {
+  it("stays healthy below the 3-failure threshold", () => {
+    recordGitHubFailure(apiError(500), 1000)
+    recordGitHubFailure(apiError(500), 1100)
+    expect(getGitHubHealthSnapshot().suspected).toBe(false)
+  })
+
+  it("suspects an outage at 3 outage-shaped failures within the window", () => {
+    recordGitHubFailure(apiError(500), 1000)
+    recordGitHubFailure(new TypeError("Failed to fetch"), 1100)
+    recordGitHubFailure(apiError(503), 1200)
+    expect(getGitHubHealthSnapshot().suspected).toBe(true)
+  })
+
+  it("does not count failures that fell outside the 30s window", () => {
+    recordGitHubFailure(apiError(500), 1000)
+    recordGitHubFailure(apiError(500), 2000)
+    // 40s later: the first two are evicted, so this is only the 1st in-window.
+    recordGitHubFailure(apiError(500), 42000)
+    expect(getGitHubHealthSnapshot().suspected).toBe(false)
+  })
+
+  it("ignores non-outage errors entirely (a burst of 404s never suspects)", () => {
+    recordGitHubFailure(apiError(404), 1000)
+    recordGitHubFailure(apiError(404), 1100)
+    recordGitHubFailure(apiError(404), 1200)
+    recordGitHubFailure(apiError(429), 1300)
+    expect(getGitHubHealthSnapshot().suspected).toBe(false)
+  })
+})
+
+describe("recovery", () => {
+  it("clears suspicion on the next successful response", () => {
+    recordGitHubFailure(apiError(500), 1000)
+    recordGitHubFailure(apiError(500), 1100)
+    recordGitHubFailure(apiError(500), 1200)
+    expect(getGitHubHealthSnapshot().suspected).toBe(true)
+
+    recordGitHubSuccess()
+    expect(getGitHubHealthSnapshot().suspected).toBe(false)
+  })
+
+  it("resets the failure window on success so it takes a fresh 3 to re-suspect", () => {
+    recordGitHubFailure(apiError(500), 1000)
+    recordGitHubFailure(apiError(500), 1100)
+    recordGitHubSuccess()
+    // Two fresh failures — still below threshold because success cleared the prior two.
+    recordGitHubFailure(apiError(500), 1200)
+    recordGitHubFailure(apiError(500), 1300)
+    expect(getGitHubHealthSnapshot().suspected).toBe(false)
+  })
+})
+
+describe("status probe enrichment", () => {
+  // The probe fires as a floating promise inside recordGitHubFailure; flush the
+  // microtask queue so its setState lands before asserting.
+  const flush = async () => {
+    for (let i = 0; i < 5; i++) await Promise.resolve()
+  }
+  const trip = (base = 1000) => {
+    recordGitHubFailure(apiError(500), base)
+    recordGitHubFailure(apiError(500), base + 100)
+    recordGitHubFailure(apiError(500), base + 200)
+  }
+
+  it("enriches with the githubstatus.com description when the indicator is not 'none'", async () => {
+    fetchIndicatorMock.mockResolvedValue({
+      indicator: "major",
+      description: "Major Service Outage",
+    })
+    trip()
+    await flush()
+    const snap = getGitHubHealthSnapshot()
+    expect(snap.suspected).toBe(true)
+    expect(snap.statusIndicator).toBe("major")
+    expect(snap.statusDescription).toBe("Major Service Outage")
+  })
+
+  it("stays suspected with no description when the probe reports 'none' (local-only issue)", async () => {
+    fetchIndicatorMock.mockResolvedValue({
+      indicator: "none",
+      description: "All Systems Operational",
+    })
+    trip()
+    await flush()
+    const snap = getGitHubHealthSnapshot()
+    expect(snap.suspected).toBe(true)
+    expect(snap.statusDescription).toBeNull()
+  })
+
+  it("stays suspected with no description when the probe fails", async () => {
+    fetchIndicatorMock.mockResolvedValue(null)
+    trip()
+    await flush()
+    const snap = getGitHubHealthSnapshot()
+    expect(snap.suspected).toBe(true)
+    expect(snap.statusDescription).toBeNull()
+  })
+})

--- a/web/src/lib/githubHealth/githubHealthStore.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.ts
@@ -1,0 +1,156 @@
+import { GitHubAPIError } from "@/github-core/errors"
+import {
+  fetchGitHubStatusIndicator,
+  type GitHubStatusIndicator,
+} from "./githubStatusApi"
+
+// Heuristic GitHub-outage detector. GitHub itself has no push signal to the
+// browser, so we infer trouble from what the app actually experiences: repeated
+// outage-shaped API failures in a short window. That local signal *triggers*
+// suspicion; an authoritative githubstatus.com probe then confirms/enriches it.
+//
+// The detector is a module-level store (not React state) so both the authed
+// banner and the unauthed bootstrap screen read one source via useSyncExternalStore,
+// mirroring useOnlineStatus.
+
+// Cross more than this many outage-shaped failures within WINDOW_MS to suspect
+// an outage. A single blip must never trip it.
+const FAILURE_THRESHOLD = 3
+const WINDOW_MS = 30_000
+// Cache a status probe result this long so a burst of failures never hammers
+// githubstatus.com — one probe per suspicion episode is enough.
+const PROBE_CACHE_MS = 60_000
+
+export type GitHubHealth = {
+  // At least FAILURE_THRESHOLD outage-shaped failures landed within WINDOW_MS
+  // and no success has since cleared them.
+  suspected: boolean
+  // The authoritative githubstatus.com indicator, once a probe has resolved for
+  // the current suspicion episode. null until then (or if the probe failed).
+  statusIndicator: GitHubStatusIndicator | null
+  // The human-readable status summary from githubstatus.com (e.g. "Partially
+  // Degraded Service"), or null when unprobed / probe failed.
+  statusDescription: string | null
+}
+
+const HEALTHY: GitHubHealth = {
+  suspected: false,
+  statusIndicator: null,
+  statusDescription: null,
+}
+
+let state: GitHubHealth = HEALTHY
+let failureTimestamps: number[] = []
+let lastProbeAt: number | null = null
+let probeInFlight = false
+
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const listener of listeners) listener()
+}
+
+function setState(next: GitHubHealth) {
+  // Keep the reference stable when nothing changed so useSyncExternalStore
+  // subscribers bail out of a re-render (recordGitHubSuccess fires on every OK
+  // response — the steady state must not churn).
+  if (
+    state.suspected === next.suspected &&
+    state.statusIndicator === next.statusIndicator &&
+    state.statusDescription === next.statusDescription
+  ) {
+    return
+  }
+  state = next
+  emit()
+}
+
+// An error that plausibly signals GitHub being down, as opposed to a
+// client-side verdict. A GitHubAPIError with a 5xx status is a server fault; a
+// non-GitHubAPIError throw is a network failure or timeout (the client throws
+// these before onResponse — see client.ts). Definitive statuses (401/403/404)
+// and rate limits (429 / 403-with-retry) are the user's own state, never an
+// outage, so they must never trip the detector.
+export function isOutageShapedError(error: unknown): boolean {
+  if (error instanceof GitHubAPIError) {
+    if (error.isRateLimited) return false
+    return error.status >= 500
+  }
+  // A bare abort (caller cancel / navigation) is not a fault.
+  if (error instanceof DOMException && error.name === "AbortError") return false
+  // Anything else reaching a query/mutation error handler is a network/timeout
+  // failure (TypeError "Failed to fetch", timeout AbortError is handled above).
+  return true
+}
+
+async function probeStatus(now: number) {
+  if (probeInFlight) return
+  // Gate only against a *prior* probe — the first probe of an episode always
+  // runs (lastProbeAt === null).
+  if (lastProbeAt !== null && now - lastProbeAt < PROBE_CACHE_MS) return
+  probeInFlight = true
+  lastProbeAt = now
+  try {
+    const result = await fetchGitHubStatusIndicator()
+    // A probe that resolves after the suspicion already cleared must not
+    // resurrect the banner.
+    if (!state.suspected) return
+    if (!result || result.indicator === "none") {
+      // GitHub reports healthy (or the probe was inconclusive): keep the
+      // locally-suspected state with the generic message — the user is still
+      // hitting failures even if the global status is green (e.g. a proxy or
+      // GitHub edge issue that the status page doesn't reflect).
+      return
+    }
+    setState({
+      suspected: true,
+      statusIndicator: result.indicator,
+      statusDescription: result.description,
+    })
+  } finally {
+    probeInFlight = false
+  }
+}
+
+// Record an API failure. Only outage-shaped errors count toward suspicion; the
+// rest are ignored so a 404/403/rate-limit never reads as an outage.
+export function recordGitHubFailure(
+  error: unknown,
+  now: number = Date.now(),
+): void {
+  if (!isOutageShapedError(error)) return
+
+  failureTimestamps = failureTimestamps.filter((t) => now - t < WINDOW_MS)
+  failureTimestamps.push(now)
+
+  if (failureTimestamps.length >= FAILURE_THRESHOLD && !state.suspected) {
+    setState({ ...HEALTHY, suspected: true })
+  }
+  if (state.suspected) {
+    void probeStatus(now)
+  }
+}
+
+// Record a successful GitHub response. Any success is evidence GitHub is
+// reachable, so it clears the failure window and any suspicion.
+export function recordGitHubSuccess(): void {
+  if (failureTimestamps.length > 0) failureTimestamps = []
+  if (state.suspected) setState(HEALTHY)
+}
+
+export function subscribeGitHubHealth(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getGitHubHealthSnapshot(): GitHubHealth {
+  return state
+}
+
+// Test-only reset so the module-level store doesn't leak between cases.
+export function __resetGitHubHealthForTest(): void {
+  state = HEALTHY
+  failureTimestamps = []
+  lastProbeAt = null
+  probeInFlight = false
+}

--- a/web/src/lib/githubHealth/githubHealthStore.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.ts
@@ -22,14 +22,12 @@ const WINDOW_MS = 30_000
 const PROBE_CACHE_MS = 60_000
 
 export type GitHubHealth = {
-  // At least FAILURE_THRESHOLD outage-shaped failures landed within WINDOW_MS
-  // and no success has since cleared them.
+  // >= FAILURE_THRESHOLD outage-shaped failures within WINDOW_MS, uncleared.
   suspected: boolean
-  // The authoritative githubstatus.com indicator, once a probe has resolved for
-  // the current suspicion episode. null until then (or if the probe failed).
+  // Authoritative githubstatus.com indicator once probed; null until then.
   statusIndicator: GitHubStatusIndicator | null
-  // The human-readable status summary from githubstatus.com (e.g. "Partially
-  // Degraded Service"), or null when unprobed / probe failed.
+  // Human-readable githubstatus.com summary (e.g. "Partially Degraded
+  // Service"); null when unprobed / probe failed.
   statusDescription: string | null
 }
 
@@ -38,6 +36,8 @@ const HEALTHY: GitHubHealth = {
   statusIndicator: null,
   statusDescription: null,
 }
+
+export { HEALTHY as HEALTHY_GITHUB_HEALTH }
 
 let state: GitHubHealth = HEALTHY
 let failureTimestamps: number[] = []

--- a/web/src/lib/githubHealth/githubHealthStore.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.ts
@@ -13,7 +13,7 @@ import {
 // banner and the unauthed bootstrap screen read one source via useSyncExternalStore,
 // mirroring useOnlineStatus.
 
-// Cross more than this many outage-shaped failures within WINDOW_MS to suspect
+// Cross at least this many outage-shaped failures within WINDOW_MS to suspect
 // an outage. A single blip must never trip it.
 const FAILURE_THRESHOLD = 3
 const WINDOW_MS = 30_000
@@ -135,7 +135,14 @@ export function recordGitHubFailure(
 // reachable, so it clears the failure window and any suspicion.
 export function recordGitHubSuccess(): void {
   if (failureTimestamps.length > 0) failureTimestamps = []
-  if (state.suspected) setState(HEALTHY)
+  if (state.suspected) {
+    setState(HEALTHY)
+    // Re-arm the probe for the next episode: a distinct outage that trips
+    // within PROBE_CACHE_MS of this recovery must still get its guaranteed
+    // first probe (otherwise it shows the generic message while githubstatus
+    // may already report a real indicator). Mirrors the null-init gate.
+    lastProbeAt = null
+  }
 }
 
 export function subscribeGitHubHealth(listener: () => void): () => void {

--- a/web/src/lib/githubHealth/githubHealthStore.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.ts
@@ -43,6 +43,10 @@ let state: GitHubHealth = HEALTHY
 let failureTimestamps: number[] = []
 let lastProbeAt: number | null = null
 let probeInFlight = false
+// Bumped whenever suspicion is freshly entered or cleared, so a probe from a
+// prior outage episode can't apply its stale result to a later one (or block
+// the later one's own probe) during rapid outage/recovery flapping.
+let episodeId = 0
 
 const listeners = new Set<() => void>()
 
@@ -90,11 +94,13 @@ async function probeStatus(now: number) {
   if (lastProbeAt !== null && now - lastProbeAt < PROBE_CACHE_MS) return
   probeInFlight = true
   lastProbeAt = now
+  const probedEpisode = episodeId
   try {
     const result = await fetchGitHubStatusIndicator()
-    // A probe that resolves after the suspicion already cleared must not
-    // resurrect the banner.
-    if (!state.suspected) return
+    // A probe that resolves after its episode ended (suspicion cleared, or a
+    // fresh episode began during recovery flapping) must not resurrect the
+    // banner or write a stale indicator onto the new episode.
+    if (!state.suspected || episodeId !== probedEpisode) return
     if (!result || result.indicator === "none") {
       // GitHub reports healthy (or the probe was inconclusive): keep the
       // locally-suspected state with the generic message — the user is still
@@ -108,7 +114,10 @@ async function probeStatus(now: number) {
       statusDescription: result.description,
     })
   } finally {
-    probeInFlight = false
+    // Only the probe that still owns the current episode clears the in-flight
+    // flag; a superseded probe leaves the new episode's flag (set when it
+    // re-armed) untouched, so the new episode can still run its own probe.
+    if (episodeId === probedEpisode) probeInFlight = false
   }
 }
 
@@ -124,6 +133,12 @@ export function recordGitHubFailure(
   failureTimestamps.push(now)
 
   if (failureTimestamps.length >= FAILURE_THRESHOLD && !state.suspected) {
+    // Fresh episode: bump the epoch and re-arm the probe so this episode gets
+    // its own guaranteed first probe, independent of any probe still in flight
+    // from a just-ended episode (whose stale result the epoch guard discards).
+    episodeId++
+    lastProbeAt = null
+    probeInFlight = false
     setState({ ...HEALTHY, suspected: true })
   }
   if (state.suspected) {
@@ -137,11 +152,13 @@ export function recordGitHubSuccess(): void {
   if (failureTimestamps.length > 0) failureTimestamps = []
   if (state.suspected) {
     setState(HEALTHY)
-    // Re-arm the probe for the next episode: a distinct outage that trips
-    // within PROBE_CACHE_MS of this recovery must still get its guaranteed
-    // first probe (otherwise it shows the generic message while githubstatus
-    // may already report a real indicator). Mirrors the null-init gate.
+    // End the episode: bump the epoch so an in-flight probe from this episode
+    // discards its result instead of writing it onto a later suspicion, and
+    // re-arm so a distinct outage that trips within PROBE_CACHE_MS of this
+    // recovery still gets its guaranteed first probe.
+    episodeId++
     lastProbeAt = null
+    probeInFlight = false
   }
 }
 
@@ -160,4 +177,5 @@ export function __resetGitHubHealthForTest(): void {
   failureTimestamps = []
   lastProbeAt = null
   probeInFlight = false
+  episodeId = 0
 }

--- a/web/src/lib/githubHealth/githubStatusApi.test.ts
+++ b/web/src/lib/githubHealth/githubStatusApi.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { fetchGitHubStatusIndicator } from "./githubStatusApi"
+
+// The parser is otherwise only reached through a wholesale mock in the store
+// tests, so exercise its guard branches directly against a stubbed fetch.
+const okResponse = (body: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  }) as unknown as Response
+
+const notOkResponse = (status: number): Response =>
+  ({
+    ok: false,
+    status,
+    json: async () => ({}),
+  }) as unknown as Response
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("fetchGitHubStatusIndicator", () => {
+  it("maps a well-formed summary to {indicator, description}", async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({
+        status: { indicator: "major", description: "Major Service Outage" },
+      }),
+    )
+    expect(await fetchGitHubStatusIndicator()).toEqual({
+      indicator: "major",
+      description: "Major Service Outage",
+    })
+  })
+
+  it("returns null for an unknown indicator value", async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({ status: { indicator: "catastrophic", description: "x" } }),
+    )
+    expect(await fetchGitHubStatusIndicator()).toBeNull()
+  })
+
+  it("returns null when status is missing or not an object", async () => {
+    fetchMock.mockResolvedValue(okResponse({ nope: true }))
+    expect(await fetchGitHubStatusIndicator()).toBeNull()
+    fetchMock.mockResolvedValue(okResponse({ status: "degraded" }))
+    expect(await fetchGitHubStatusIndicator()).toBeNull()
+  })
+
+  it("returns null on a non-ok response", async () => {
+    fetchMock.mockResolvedValue(notOkResponse(503))
+    expect(await fetchGitHubStatusIndicator()).toBeNull()
+  })
+
+  it("defaults description to '' when it is absent or non-string", async () => {
+    fetchMock.mockResolvedValue(okResponse({ status: { indicator: "minor" } }))
+    expect(await fetchGitHubStatusIndicator()).toEqual({
+      indicator: "minor",
+      description: "",
+    })
+    fetchMock.mockResolvedValue(
+      okResponse({ status: { indicator: "none", description: 42 } }),
+    )
+    expect(await fetchGitHubStatusIndicator()).toEqual({
+      indicator: "none",
+      description: "",
+    })
+  })
+
+  it("returns null on a thrown/timeout fetch or malformed JSON", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"))
+    expect(await fetchGitHubStatusIndicator()).toBeNull()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("bad json")
+      },
+    } as unknown as Response)
+    expect(await fetchGitHubStatusIndicator()).toBeNull()
+  })
+})

--- a/web/src/lib/githubHealth/githubStatusApi.ts
+++ b/web/src/lib/githubHealth/githubStatusApi.ts
@@ -1,0 +1,63 @@
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("github:status")
+
+// githubstatus.com's public Statuspage summary. `indicator` escalates
+// none -> minor -> major -> critical; `description` is the human summary
+// (e.g. "Partially Degraded Service"). CORS-open (access-control-allow-origin: *).
+const STATUS_SUMMARY_URL = "https://www.githubstatus.com/api/v2/status.json"
+const PROBE_TIMEOUT_MS = 5_000
+
+export type GitHubStatusIndicator = "none" | "minor" | "major" | "critical"
+
+export type GitHubStatusResult = {
+  indicator: GitHubStatusIndicator
+  description: string
+}
+
+const INDICATORS: readonly GitHubStatusIndicator[] = [
+  "none",
+  "minor",
+  "major",
+  "critical",
+]
+
+function isIndicator(value: unknown): value is GitHubStatusIndicator {
+  return (
+    typeof value === "string" &&
+    (INDICATORS as readonly string[]).includes(value)
+  )
+}
+
+// Fetch githubstatus.com's current indicator. Best-effort and non-fatal: a
+// probe failure (network, timeout, unexpected shape) resolves to null so the
+// caller falls back to the generic "trouble reaching GitHub" message rather
+// than blocking on the status page's own availability.
+export async function fetchGitHubStatusIndicator(): Promise<GitHubStatusResult | null> {
+  try {
+    const res = await fetch(STATUS_SUMMARY_URL, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      cache: "no-store",
+    })
+    if (!res.ok) {
+      log.debug("status probe non-ok", { status: res.status })
+      return null
+    }
+    const body: unknown = await res.json()
+    const status =
+      typeof body === "object" && body !== null && "status" in body
+        ? (body as { status: unknown }).status
+        : null
+    if (typeof status !== "object" || status === null) return null
+    const indicator = (status as { indicator?: unknown }).indicator
+    const description = (status as { description?: unknown }).description
+    if (!isIndicator(indicator)) return null
+    return {
+      indicator,
+      description: typeof description === "string" ? description : "",
+    }
+  } catch {
+    log.debug("status probe failed")
+    return null
+  }
+}

--- a/web/src/lib/githubHealth/index.ts
+++ b/web/src/lib/githubHealth/index.ts
@@ -1,0 +1,12 @@
+export {
+  isOutageShapedError,
+  recordGitHubFailure,
+  recordGitHubSuccess,
+  type GitHubHealth,
+} from "./githubHealthStore"
+export { useGitHubHealth } from "./useGitHubHealth"
+export {
+  fetchGitHubStatusIndicator,
+  type GitHubStatusIndicator,
+  type GitHubStatusResult,
+} from "./githubStatusApi"

--- a/web/src/lib/githubHealth/useGitHubHealth.ts
+++ b/web/src/lib/githubHealth/useGitHubHealth.ts
@@ -3,6 +3,7 @@ import { useSyncExternalStore } from "react"
 import {
   getGitHubHealthSnapshot,
   subscribeGitHubHealth,
+  HEALTHY_GITHUB_HEALTH,
   type GitHubHealth,
 } from "./githubHealthStore"
 
@@ -12,12 +13,6 @@ export function useGitHubHealth(): GitHubHealth {
   return useSyncExternalStore(
     subscribeGitHubHealth,
     getGitHubHealthSnapshot,
-    () => HEALTHY_SERVER_SNAPSHOT,
+    () => HEALTHY_GITHUB_HEALTH,
   )
-}
-
-const HEALTHY_SERVER_SNAPSHOT: GitHubHealth = {
-  suspected: false,
-  statusIndicator: null,
-  statusDescription: null,
 }

--- a/web/src/lib/githubHealth/useGitHubHealth.ts
+++ b/web/src/lib/githubHealth/useGitHubHealth.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from "react"
+
+import {
+  getGitHubHealthSnapshot,
+  subscribeGitHubHealth,
+  type GitHubHealth,
+} from "./githubHealthStore"
+
+// Live GitHub-health signal for the UI. The server snapshot is always healthy
+// so nothing renders an outage state during SSR/tests-without-a-store.
+export function useGitHubHealth(): GitHubHealth {
+  return useSyncExternalStore(
+    subscribeGitHubHealth,
+    getGitHubHealthSnapshot,
+    () => HEALTHY_SERVER_SNAPSHOT,
+  )
+}
+
+const HEALTHY_SERVER_SNAPSHOT: GitHubHealth = {
+  suspected: false,
+  statusIndicator: null,
+  statusDescription: null,
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1260,6 +1260,12 @@
     "title": "You're offline",
     "body": "Classroom 50 works with live data from GitHub, so it needs a connection. This banner clears automatically when you're back online."
   },
+  "githubStatus": {
+    "title": "GitHub may be having problems",
+    "bodyConfirmed": "GitHub is reporting: {{status}}. Some actions may fail or be slow until it recovers.",
+    "bodyGeneric": "Classroom 50 is having trouble reaching GitHub. This is usually a temporary GitHub outage, but a VPN, proxy, or browser extension blocking api.github.com can cause it too.",
+    "checkStatusLink": "Check GitHub status"
+  },
   "skeletonDrift": {
     "title": "Classroom workflow files are out of date",
     "body": "The GitHub Actions workflows in this org's classroom50 config repo are out of date. Update them here to keep grading, score collection, and Pages publishing working.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -162,6 +162,8 @@
     "errorNetworkProxyTarget": "the Cloudflare Worker proxy",
     "errorOffline": "You appear to be offline. Check your connection and try again — signing in needs a network connection.",
     "offlineHold": "You're offline. Waiting for a connection to restore your session…",
+    "validationStuck": "Still trying to reach GitHub to verify your session. This is usually a temporary GitHub, network, or browser-extension issue. Retry, or sign in again to start fresh.",
+    "validationStuckSignIn": "Sign in again",
     "errorStateMismatch": "State mismatch -- possible CSRF. Please try signing in again.",
     "errorMissingPkce": "Missing PKCE verifier or client ID. Please try signing in again.",
     "errorClientIdMissing": "GitHub OAuth client ID is not configured (VITE_GITHUB_CLIENT_ID).",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -999,6 +999,8 @@
     "setupComplete": "Organization setup is complete. Review the steps below, then continue to set the service token.",
     "allSetTitle": "You're all set!",
     "allSetBody": "Your organization is ready to use Classroom 50. Head to your organization to create your first classroom and assignments.",
+    "manageServiceToken": "Manage service token",
+    "statusIndeterminate": "Couldn't determine your organization's setup status. This is usually a temporary GitHub or permissions issue, not a problem with your setup.",
     "goToOrg": "Go to {{org}}",
     "yourOrganization": "your organization",
     "notAdmin": "Classroom 50 setup requires org owner permissions. Ask an org owner to run setup.",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import {
   MutationCache,
+  QueryCache,
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query"
@@ -21,6 +22,7 @@ import { appVersion, formatAppVersion } from "./version"
 import { installDiagnosticsHandlers } from "./lib/diagnostics/globalHandlers"
 import { recordError } from "./lib/activity/activityStore"
 import { retryTransientGitHubError } from "./github-core/errors"
+import { recordGitHubFailure, recordGitHubSuccess } from "./lib/githubHealth"
 import { RateLimitOverlay } from "./components/dev/RateLimitOverlay"
 
 // Safe query defaults so a new `useQuery` can't silently inherit React Query's
@@ -41,6 +43,15 @@ const client = new QueryClient({
       staleTime: 30_000,
     },
   },
+  // Feed the GitHub-health detector from the read path: onError sees every
+  // rejected query — including the network/timeout failures that throw before
+  // the client's onResponse (see client.ts) — and onSuccess is proof GitHub is
+  // reachable, which clears any suspicion. The detector ignores non-outage
+  // errors (4xx/rate-limit), so this is safe to feed unfiltered.
+  queryCache: new QueryCache({
+    onError: (error) => recordGitHubFailure(error),
+    onSuccess: () => recordGitHubSuccess(),
+  }),
   // Record every failed mutation as session activity. Mutations are the app's
   // real write operations (create/delete/dispatch/enroll), so a rejection here is
   // a genuine, user-affecting failure — unlike the benign existence-check 404s on
@@ -49,7 +60,9 @@ const client = new QueryClient({
   mutationCache: new MutationCache({
     onError: (error, _variables, _context, mutation) => {
       recordError(error, { dedupKey: `mutation-${mutation.mutationId}` })
+      recordGitHubFailure(error)
     },
+    onSuccess: () => recordGitHubSuccess(),
   }),
 })
 

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -138,7 +138,7 @@ export function ServiceTokenInfo() {
   )
 }
 
-export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
+export const OrgSettingsPane = () => {
   const { t } = useTranslation()
   const runPat = useSafeSubmit()
   const { org } = useParams({ strict: false })
@@ -404,7 +404,6 @@ export const OrgSettingsPane = ({ onSubmit }: { onSubmit?: () => void }) => {
                     onSuccess: () => {
                       setServiceToken("")
                       setSavedKind(tokenAlreadySet ? "updated" : "saved")
-                      onSubmit?.()
                     },
                   }),
                 )

--- a/web/src/pages/OrgSetupPage.test.tsx
+++ b/web/src/pages/OrgSetupPage.test.tsx
@@ -97,6 +97,7 @@ const repoStatus = (over: Record<string, unknown> = {}) =>
   repoStatusMock.mockReturnValue({
     data: undefined,
     isLoading: false,
+    isError: false,
     refetch: vi.fn(),
     ...over,
   })
@@ -105,6 +106,7 @@ const tokenStatus = (over: Record<string, unknown> = {}) =>
   tokenStatusMock.mockReturnValue({
     data: undefined,
     isLoading: false,
+    isError: false,
     refetch: vi.fn(),
     ...over,
   })
@@ -192,18 +194,38 @@ describe("OrgSetupPage derived wizard stage", () => {
     expect(screen.queryByText("setup.nextServiceToken")).toBeNull()
   })
 
-  it("settled 'unknown' status => retry surface, not a silent stage 1", () => {
+  it("token 'unknown' status => retry surface, not a silent stage 1", () => {
     owner({ isOwner: true })
-    repoStatus({ data: "unknown" })
+    repoStatus({ data: "ready" })
     tokenStatus({ data: { status: "unknown" } })
     renderPage()
     expect(screen.queryByText("setup.statusIndeterminate")).not.toBeNull()
     expect(screen.queryByText("setup.runSetup")).toBeNull()
   })
 
-  it("status loading => spinner, not a stage-1 flash", () => {
+  it("config-probe error => retry surface, not a silent stage 1 (repo probe rethrows, no 'unknown' data)", () => {
+    owner({ isOwner: true })
+    // The config probe rethrows non-404s, so react-query surfaces isError with
+    // data still undefined — it never resolves the string "unknown".
+    repoStatus({ isError: true })
+    tokenStatus({ data: { status: "missing" } })
+    renderPage()
+    expect(screen.queryByText("setup.statusIndeterminate")).not.toBeNull()
+    expect(screen.queryByText("setup.runSetup")).toBeNull()
+  })
+
+  it("repo-probe loading => spinner, not a stage-1 flash", () => {
     owner({ isOwner: true })
     repoStatus({ isLoading: true })
+    tokenStatus({ data: { status: "missing" } })
+    renderPage()
+    expect(screen.queryByText("setup.loadingSetup")).not.toBeNull()
+    expect(screen.queryByText("setup.runSetup")).toBeNull()
+  })
+
+  it("token-probe loading => spinner, not a stage-1 flash", () => {
+    owner({ isOwner: true })
+    repoStatus({ data: "ready" })
     tokenStatus({ isLoading: true })
     renderPage()
     expect(screen.queryByText("setup.loadingSetup")).not.toBeNull()

--- a/web/src/pages/OrgSetupPage.test.tsx
+++ b/web/src/pages/OrgSetupPage.test.tsx
@@ -1,15 +1,32 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
 
-// Drive the owner verdict; assert the page's four render branches (pending /
-// settled-error / definitive non-owner / owner) without standing up the whole
-// PageShell + GitHub client + mutation graph the page pulls at load.
+// Drive the owner verdict and the two GitHub-derived status signals; assert the
+// page's render branches (owner gate + derived wizard stage) without standing
+// up the whole PageShell + GitHub client + mutation graph the page pulls at
+// load.
 const ownerMock = vi.fn()
 vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
   useIsOrgOwner: () => ownerMock(),
+}))
+
+const repoStatusMock = vi.fn()
+const tokenStatusMock = vi.fn()
+vi.mock("@/hooks/useOrgClassroom50Status", () => ({
+  useOrgClassroom50Status: () => repoStatusMock(),
+  orgClassroom50StatusKey: (org: string | undefined) => [
+    "github",
+    "repos",
+    org,
+    "classroom50",
+    "exists",
+  ],
+}))
+vi.mock("@/hooks/useGetServiceTokenStatus", () => ({
+  default: () => tokenStatusMock(),
 }))
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -24,15 +41,27 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   return {
     ...actual,
     useParams: () => ({ org: "acme" }),
-    Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+    Link: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   }
 })
 // Heavy boundaries the page mounts; stub to inert markers so the branch logic
-// is what we exercise.
+// is what we exercise. OrgSettingsPane stays null for the pure stage-routing
+// cases (stage 2 is asserted via the Back button the page owns).
 vi.mock("@/components/PageShell", () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }))
 vi.mock("@/components/PageHeader", () => ({ default: () => null }))
+// RouterButton renders a TanStack <Link>, which needs a RouterProvider we don't
+// mount here; stub it to a plain button so the stage-3 finish screen renders.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({ children }: { children: ReactNode }) => (
+      <button type="button">{children}</button>
+    ),
+  }
+})
 vi.mock("./OrgSettingsPage", () => ({ OrgSettingsPane: () => null }))
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({}),
@@ -64,6 +93,22 @@ const owner = (over: Record<string, unknown>) =>
     ...over,
   })
 
+const repoStatus = (over: Record<string, unknown> = {}) =>
+  repoStatusMock.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+    ...over,
+  })
+
+const tokenStatus = (over: Record<string, unknown> = {}) =>
+  tokenStatusMock.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+    ...over,
+  })
+
 const renderPage = () => {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
@@ -78,12 +123,16 @@ const renderPage = () => {
 afterEach(() => {
   cleanup()
   ownerMock.mockReset()
+  repoStatusMock.mockReset()
+  tokenStatusMock.mockReset()
   retry.mockReset()
 })
 
 describe("OrgSetupPage owner gate", () => {
   it("owner-pending => spinner, no not-admin alert (no denial flash mid-load)", () => {
     owner({ isPending: true })
+    repoStatus()
+    tokenStatus()
     renderPage()
     expect(screen.queryByText("setup.notAdmin")).toBeNull()
     expect(screen.queryByText("setup.loadingSetup")).not.toBeNull()
@@ -91,6 +140,8 @@ describe("OrgSetupPage owner gate", () => {
 
   it("settled owner-error => retry surface, not stranded, no not-admin alert", () => {
     owner({ isError: true })
+    repoStatus()
+    tokenStatus()
     renderPage()
     expect(screen.queryByText("setup.notAdmin")).toBeNull()
     expect(screen.queryByText("submissions.errors.retry")).not.toBeNull()
@@ -98,16 +149,106 @@ describe("OrgSetupPage owner gate", () => {
 
   it("definitive non-owner => not-admin alert, no spinner", () => {
     owner({})
+    repoStatus()
+    tokenStatus()
     renderPage()
     expect(screen.queryByText("setup.notAdmin")).not.toBeNull()
     expect(screen.queryByText("setup.loadingSetup")).toBeNull()
   })
+})
 
-  it("confirmed owner => setup steps, no not-admin alert", () => {
+describe("OrgSetupPage derived wizard stage", () => {
+  it("config missing => stage 1 (Run setup)", () => {
     owner({ isOwner: true })
+    repoStatus({ data: "missing" })
+    tokenStatus({ data: { status: "missing" } })
     renderPage()
-    expect(screen.queryByText("setup.notAdmin")).toBeNull()
-    // OrgSteps renders the step board / heading rather than the deny alert.
-    expect(screen.queryByText("submissions.errors.retry")).toBeNull()
+    expect(screen.queryByText("setup.runSetup")).not.toBeNull()
+    expect(screen.queryByText("setup.nextServiceToken")).toBeNull()
+    expect(screen.queryByText("setup.allSetTitle")).toBeNull()
+  })
+
+  it("config ready, token missing => stage 1 shows Next (advances to stage 2)", () => {
+    owner({ isOwner: true })
+    repoStatus({ data: "ready" })
+    tokenStatus({ data: { status: "missing" } })
+    renderPage()
+    // configReady surfaces the Next button instead of Run setup.
+    expect(screen.queryByText("setup.nextServiceToken")).not.toBeNull()
+    expect(screen.queryByText("setup.runSetup")).toBeNull()
+    // Advancing lands on stage 2 (Back button appears).
+    fireEvent.click(screen.getByText("setup.nextServiceToken"))
+    expect(screen.queryByText("setup.back")).not.toBeNull()
+  })
+
+  it("#307 regression: token present on fresh mount => stage 3, not stage 1", () => {
+    owner({ isOwner: true })
+    repoStatus({ data: "ready" })
+    tokenStatus({ data: { status: "present" } })
+    renderPage()
+    expect(screen.queryByText("setup.allSetTitle")).not.toBeNull()
+    // The stuck loop was landing here on step 1 "Run setup" after reload.
+    expect(screen.queryByText("setup.runSetup")).toBeNull()
+    expect(screen.queryByText("setup.nextServiceToken")).toBeNull()
+  })
+
+  it("settled 'unknown' status => retry surface, not a silent stage 1", () => {
+    owner({ isOwner: true })
+    repoStatus({ data: "unknown" })
+    tokenStatus({ data: { status: "unknown" } })
+    renderPage()
+    expect(screen.queryByText("setup.statusIndeterminate")).not.toBeNull()
+    expect(screen.queryByText("setup.runSetup")).toBeNull()
+  })
+
+  it("status loading => spinner, not a stage-1 flash", () => {
+    owner({ isOwner: true })
+    repoStatus({ isLoading: true })
+    tokenStatus({ isLoading: true })
+    renderPage()
+    expect(screen.queryByText("setup.loadingSetup")).not.toBeNull()
+    expect(screen.queryByText("setup.runSetup")).toBeNull()
+  })
+})
+
+describe("OrgSetupPage wizard navigation", () => {
+  it("stage 3 'Manage service token' returns to step 2 (back override beats derived floor)", () => {
+    owner({ isOwner: true })
+    repoStatus({ data: "ready" })
+    tokenStatus({ data: { status: "present" } })
+    renderPage()
+    expect(screen.queryByText("setup.allSetTitle")).not.toBeNull()
+    fireEvent.click(screen.getByText("setup.manageServiceToken"))
+    // Now on stage 2: the Back button is shown, finish screen gone.
+    expect(screen.queryByText("setup.back")).not.toBeNull()
+    expect(screen.queryByText("setup.allSetTitle")).toBeNull()
+  })
+
+  it("stage 2 'Back' returns to step 1 even when configReady", () => {
+    owner({ isOwner: true })
+    repoStatus({ data: "ready" })
+    tokenStatus({ data: { status: "missing" } })
+    renderPage()
+    fireEvent.click(screen.getByText("setup.nextServiceToken"))
+    expect(screen.queryByText("setup.back")).not.toBeNull()
+    fireEvent.click(screen.getByText("setup.back"))
+    // Back drops below the derived floor (stage 2) to stage 1's Next button.
+    expect(screen.queryByText("setup.nextServiceToken")).not.toBeNull()
+    expect(screen.queryByText("setup.back")).toBeNull()
+  })
+
+  it("token present: Manage then Back returns to the finish screen, not a trap", () => {
+    owner({ isOwner: true })
+    repoStatus({ data: "ready" })
+    tokenStatus({ data: { status: "present" } })
+    renderPage()
+    // Go to the token form from the finish screen…
+    fireEvent.click(screen.getByText("setup.manageServiceToken"))
+    expect(screen.queryByText("setup.back")).not.toBeNull()
+    expect(screen.queryByText("setup.allSetTitle")).toBeNull()
+    // …then Back returns to the derived floor (stage 3), not stage 1.
+    fireEvent.click(screen.getByText("setup.back"))
+    expect(screen.queryByText("setup.allSetTitle")).not.toBeNull()
+    expect(screen.queryByText("setup.runSetup")).toBeNull()
   })
 })

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -286,24 +286,17 @@ const OrgSetupPage = () => {
         />
       )}
       {!ownerPending && !isError && !isOwner && <NotAdminAlert />}
-      {!ownerPending && !isError && isOwner && statusLoading && (
-        <Spinner label={t("setup.loadingSetup")} />
-      )}
       {!ownerPending &&
         !isError &&
         isOwner &&
-        !statusLoading &&
-        statusIndeterminate && (
+        (statusLoading ? (
+          <Spinner label={t("setup.loadingSetup")} />
+        ) : statusIndeterminate ? (
           <QueryErrorAlert
             message={t("setup.statusIndeterminate")}
             onRetry={retryStatus}
           />
-        )}
-      {!ownerPending &&
-        !isError &&
-        isOwner &&
-        !statusLoading &&
-        !statusIndeterminate && (
+        ) : (
           <OrgSteps
             steps={steps}
             mutation={{
@@ -328,7 +321,7 @@ const OrgSetupPage = () => {
             }}
             onManageToken={() => setBackOverride(STAGE_SERVICE_TOKEN)}
           />
-        )}
+        ))}
 
       <SkeletonOverwriteModal
         paths={overwritePaths}

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -196,12 +196,14 @@ const OrgSetupPage = () => {
 
   const effectiveStage = backOverride ?? Math.max(derivedStage, forwardIntent)
 
-  // A settled (non-loading) "unknown" on either probe is indeterminate — a
-  // 403/permission or transient error, NOT a real "missing". Surfacing stage 1
-  // "Run setup" here would invite a needless skeleton-overwriting re-run, so
-  // show a retry surface instead. undefined data mid-flight is the loading case.
+  // A settled indeterminate probe is a 403/permission or transient error, NOT a
+  // real "missing". Surfacing stage 1 "Run setup" here would invite a needless
+  // skeleton-overwriting re-run, so show a retry surface instead. The two probes
+  // signal it differently: the config probe rethrows non-404s, so react-query
+  // surfaces isError (data stays undefined); the token probe resolves an
+  // explicit status:"unknown". undefined data mid-flight is the loading case.
   const statusIndeterminate =
-    (!repoStatusQuery.isLoading && repoStatusQuery.data === "unknown") ||
+    (!repoStatusQuery.isLoading && repoStatusQuery.isError) ||
     (!tokenStatusQuery.isLoading && tokenStatusQuery.data?.status === "unknown")
   const statusLoading = repoStatusQuery.isLoading || tokenStatusQuery.isLoading
 

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "@tanstack/react-router"
-import { ArrowLeft, ArrowRight, CheckCircle2 } from "lucide-react"
+import { ArrowLeft, ArrowRight, CheckCircle2, KeyRound } from "lucide-react"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useTranslation } from "react-i18next"
 
@@ -14,6 +14,11 @@ import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import { useState } from "react"
 import { type InitStepId, type InitStepUpdate } from "@/github-core/mutations"
 import useRunOrgSetup from "@/hooks/mutations/useRunOrgSetup"
+import useGetServiceTokenStatus from "@/hooks/useGetServiceTokenStatus"
+import {
+  useOrgClassroom50Status,
+  orgClassroom50StatusKey,
+} from "@/hooks/useOrgClassroom50Status"
 import { OrgSettingsPane } from "./OrgSettingsPage"
 import { EnterDiv } from "@/lib/motionComponents"
 import {
@@ -29,17 +34,21 @@ import {
 const OrgSteps = ({
   steps,
   mutation,
-  nextStep = false,
+  configReady = false,
   org = "",
   stage = 1,
-  setStage = () => {},
+  onGoToServiceToken = () => {},
+  onLeaveServiceToken = () => {},
+  onManageToken = () => {},
 }: {
   steps: Record<InitStepId, InitStepUpdate>
   mutation: { isPending: boolean; mutateAsync: () => Promise<unknown> }
-  nextStep?: boolean
+  configReady?: boolean
   org?: string
   stage?: number
-  setStage?: (num: number) => void
+  onGoToServiceToken?: () => void
+  onLeaveServiceToken?: () => void
+  onManageToken?: () => void
 }) => {
   const { t } = useTranslation()
   const runSetup = useSafeSubmit()
@@ -60,7 +69,7 @@ const OrgSteps = ({
           </ul>
           <Card.Actions className="col-start-3 justify-self-end">
             {stage === 1 &&
-              (!nextStep ? (
+              (!configReady ? (
                 <Button
                   variant="primary"
                   className="ml-auto"
@@ -75,14 +84,14 @@ const OrgSteps = ({
                 <Button
                   variant="primary"
                   className="ml-auto"
-                  onClick={() => setStage(2)}
+                  onClick={onGoToServiceToken}
                 >
                   {t("setup.nextServiceToken")}
                   <ArrowRight aria-hidden="true" className="size-4" />
                 </Button>
               ))}
             {stage === 2 && (
-              <Button variant="ghost" onClick={() => setStage(1)}>
+              <Button variant="ghost" onClick={onLeaveServiceToken}>
                 <ArrowLeft aria-hidden="true" className="size-4" />
                 {t("setup.back")}
               </Button>
@@ -92,7 +101,7 @@ const OrgSteps = ({
 
         {stage === 1 ? (
           <div className="grid gap-4">
-            {nextStep && (
+            {configReady && (
               <EnterDiv className="alert alert-success">
                 <CheckCircle2 aria-hidden="true" className="size-5 shrink-0" />
                 <div>{t("setup.setupComplete")}</div>
@@ -102,7 +111,7 @@ const OrgSteps = ({
           </div>
         ) : stage === 2 ? (
           <div className="px-20">
-            <OrgSettingsPane onSubmit={() => setStage(3)} />
+            <OrgSettingsPane />
           </div>
         ) : (
           <EnterDiv className="flex flex-col items-center gap-4 py-8 text-center">
@@ -115,14 +124,20 @@ const OrgSteps = ({
                 {t("setup.allSetBody")}
               </p>
             </div>
-            <RouterButton variant="primary" to="/$org" params={{ org }}>
-              <span className="truncate">
-                {t("setup.goToOrg", {
-                  org: org || t("setup.yourOrganization"),
-                })}
-              </span>
-              <ArrowRight aria-hidden="true" className="size-4 shrink-0" />
-            </RouterButton>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <RouterButton variant="primary" to="/$org" params={{ org }}>
+                <span className="truncate">
+                  {t("setup.goToOrg", {
+                    org: org || t("setup.yourOrganization"),
+                  })}
+                </span>
+                <ArrowRight aria-hidden="true" className="size-4 shrink-0" />
+              </RouterButton>
+              <Button variant="ghost" onClick={onManageToken}>
+                <KeyRound aria-hidden="true" className="size-4" />
+                {t("setup.manageServiceToken")}
+              </Button>
+            </div>
           </EnterDiv>
         )}
       </Card.Body>
@@ -140,6 +155,14 @@ const NotTeamOrEnterpriseNotice = () => {
   return <Alert tone="error">{t("setup.notTeamOrEnterprise")}</Alert>
 }
 
+// Derive the wizard stage from what exists on GitHub (config repo + service
+// token), matching the app's "behavior is derived from what exists" model. The
+// stage is NOT local state: it survives reload/remount because it's read from
+// GitHub. Backward navigation is the only local intent (see backOverride).
+const STAGE_SETUP = 1
+const STAGE_SERVICE_TOKEN = 2
+const STAGE_DONE = 3
+
 const OrgSetupPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.setup"))
@@ -149,10 +172,38 @@ const OrgSetupPage = () => {
     useState<Record<InitStepId, InitStepUpdate>>(initialInitSteps)
   const { data: orgPlanDetails, isLoading: isLoadingPlanDetails } =
     useGetOrgPlanDetails(org)
-  const [nextStep, setNextStep] = useState(false)
 
-  // Stage: 1 = init classroom50 repo, 2 = PAT, 3 = finished.
-  const [currentStage, setCurrentStage] = useState(1)
+  // Match OrgSettingsPane's `org ?? ""` so react-query dedupes on one key
+  // instead of forming a second cache entry.
+  const orgKey = org ?? ""
+  const repoStatusQuery = useOrgClassroom50Status(org)
+  const tokenStatusQuery = useGetServiceTokenStatus(orgKey)
+
+  const configReady = repoStatusQuery.data === "ready"
+  const tokenPresent = tokenStatusQuery.data?.status === "present"
+
+  // The derived FLOOR (survives reload/remount): a present token means the
+  // whole setup is done. A ready config alone does NOT force stage 2 — the
+  // teacher stays on step 1 to review the per-step board and advances with the
+  // explicit "Next" button (configReady just swaps "Run setup" for "Next").
+  const derivedStage = tokenPresent ? STAGE_DONE : STAGE_SETUP
+
+  // Forward intent only ever raises the stage (never traps the user below a
+  // derived advance). Backward intent (Back button, Manage-token) may drop
+  // below the derived floor; a fresh derived advance clears it.
+  const [forwardIntent, setForwardIntent] = useState(STAGE_SETUP)
+  const [backOverride, setBackOverride] = useState<number | null>(null)
+
+  const effectiveStage = backOverride ?? Math.max(derivedStage, forwardIntent)
+
+  // A settled (non-loading) "unknown" on either probe is indeterminate — a
+  // 403/permission or transient error, NOT a real "missing". Surfacing stage 1
+  // "Run setup" here would invite a needless skeleton-overwriting re-run, so
+  // show a retry surface instead. undefined data mid-flight is the loading case.
+  const statusIndeterminate =
+    (!repoStatusQuery.isLoading && repoStatusQuery.data === "unknown") ||
+    (!tokenStatusQuery.isLoading && tokenStatusQuery.data?.status === "unknown")
+  const statusLoading = repoStatusQuery.isLoading || tokenStatusQuery.isLoading
 
   // Skeleton-overwrite confirmation, mirroring RerunOrgSetup. /setup has no
   // re-entry guard, so a re-run on an already-set-up org can hit drifted,
@@ -171,14 +222,18 @@ const OrgSetupPage = () => {
     // Unmount-safe: the org-list refetch runs in the hook's onSuccess (init is
     // long-running and the user can navigate away). Always invalidate — even on
     // a status-"error" outcome — matching the prior unconditional invalidate.
+    // Also refetch the config-repo probe so the derived stage advances to 2.
     invalidate: (queryClient) => {
       void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      void queryClient.invalidateQueries({
+        queryKey: orgClassroom50StatusKey(org),
+      })
     },
   })
 
   // Reset the board before the init call (must run before mutateAsync), then
-  // run setup. Only the step-advance setState stays here (skipped on unmount);
-  // the cache invalidation lives in the hook so it survives an unmount.
+  // run setup. The board reset stays here (skipped on unmount); the cache
+  // invalidation lives in the hook so it survives an unmount.
   const runSetupFlow = () => {
     // Reset the board before a (re-)run so a prior run's per-step results —
     // including the orgDefaults unenforced-settings list — can't linger on an
@@ -192,8 +247,8 @@ const OrgSetupPage = () => {
           return
         }
         // Stay on step 1 after setup so the teacher can review per-step
-        // results; they advance with the explicit "Next" button.
-        setNextStep(true)
+        // results; the derived stage (configReady) surfaces the "Next" button.
+        void repoStatusQuery.refetch()
       },
     })
   }
@@ -206,6 +261,11 @@ const OrgSetupPage = () => {
   const isTeamOrEnterprise =
     orgPlanDetails?.plan?.name === "team" ||
     orgPlanDetails?.plan?.name === "enterprise"
+
+  const retryStatus = () => {
+    void repoStatusQuery.refetch()
+    void tokenStatusQuery.refetch()
+  }
 
   return (
     <PageShell page="classes" selected="assignments">
@@ -224,19 +284,49 @@ const OrgSetupPage = () => {
         />
       )}
       {!ownerPending && !isError && !isOwner && <NotAdminAlert />}
-      {!ownerPending && !isError && isOwner && (
-        <OrgSteps
-          steps={steps}
-          mutation={{
-            isPending: mutation.isPending,
-            mutateAsync: runSetupFlow,
-          }}
-          nextStep={nextStep}
-          org={org}
-          setStage={setCurrentStage}
-          stage={currentStage}
-        />
+      {!ownerPending && !isError && isOwner && statusLoading && (
+        <Spinner label={t("setup.loadingSetup")} />
       )}
+      {!ownerPending &&
+        !isError &&
+        isOwner &&
+        !statusLoading &&
+        statusIndeterminate && (
+          <QueryErrorAlert
+            message={t("setup.statusIndeterminate")}
+            onRetry={retryStatus}
+          />
+        )}
+      {!ownerPending &&
+        !isError &&
+        isOwner &&
+        !statusLoading &&
+        !statusIndeterminate && (
+          <OrgSteps
+            steps={steps}
+            mutation={{
+              isPending: mutation.isPending,
+              mutateAsync: runSetupFlow,
+            }}
+            configReady={configReady}
+            org={org}
+            stage={effectiveStage}
+            onGoToServiceToken={() => {
+              setBackOverride(null)
+              setForwardIntent(STAGE_SERVICE_TOKEN)
+            }}
+            // Leaving the token step returns to the derived floor: stage 1 when
+            // no token is set (the review board), or stage 3 when a token is
+            // present (the "Manage service token" round-trip from the finish
+            // screen). Reset both overrides so max(derivedStage, forwardIntent)
+            // governs — otherwise the stale forwardIntent would pin stage 2.
+            onLeaveServiceToken={() => {
+              setBackOverride(null)
+              setForwardIntent(STAGE_SETUP)
+            }}
+            onManageToken={() => setBackOverride(STAGE_SERVICE_TOKEN)}
+          />
+        )}
 
       <SkeletonOverwriteModal
         paths={overwritePaths}

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -197,13 +197,21 @@ const OrgSetupPage = () => {
   const effectiveStage = backOverride ?? Math.max(derivedStage, forwardIntent)
 
   // A settled indeterminate probe is a 403/permission or transient error, NOT a
-  // real "missing". Surfacing stage 1 "Run setup" here would invite a needless
-  // skeleton-overwriting re-run, so show a retry surface instead. The two probes
-  // signal it differently: the config probe rethrows non-404s, so react-query
-  // surfaces isError (data stays undefined); the token probe resolves an
-  // explicit status:"unknown". undefined data mid-flight is the loading case.
+  // real "missing" — surfacing stage 1 "Run setup" here would invite a needless
+  // skeleton-overwriting re-run, so show a retry surface instead. Both probes
+  // now rethrow non-definitive errors, so react-query surfaces isError; the
+  // token probe also resolves an explicit status:"unknown" for a 403. Gate the
+  // isError branches on data being absent: a *background* refetch that fails
+  // while prior data is still cached (a transient blip after a setup re-run, or
+  // an optimistically-seeded token) must keep the derived stage, not eject the
+  // user off a valid step. undefined data mid-flight is the loading case.
   const statusIndeterminate =
-    (!repoStatusQuery.isLoading && repoStatusQuery.isError) ||
+    (!repoStatusQuery.isLoading &&
+      repoStatusQuery.isError &&
+      repoStatusQuery.data === undefined) ||
+    (!tokenStatusQuery.isLoading &&
+      tokenStatusQuery.isError &&
+      tokenStatusQuery.data === undefined) ||
     (!tokenStatusQuery.isLoading && tokenStatusQuery.data?.status === "unknown")
   const statusLoading = repoStatusQuery.isLoading || tokenStatusQuery.isLoading
 

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
 import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
 import { OfflineBanner } from "@/components/OfflineBanner"
+import { GitHubStatusBanner } from "@/components/GitHubStatusBanner"
 import { UpdateAvailableBanner } from "@/components/UpdateAvailableBanner"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { Spinner } from "@/components/Spinner"
@@ -54,6 +55,7 @@ function AuthedLayout() {
   return (
     <>
       <OfflineBanner />
+      <GitHubStatusBanner />
       <ScopeWarningBanner />
       <SkeletonDriftBanner />
       <UpdateAvailableBanner />


### PR DESCRIPTION
Fixes #307.

Harden the org setup and auth-bootstrap flow so a stuck GitHub read never strands the user on an unrecoverable spinner or a wrong wizard step. This started as the #307 setup-wizard fix; while testing it against a live GitHub REST API degradation, two adjacent stranding paths surfaced (a wedged `/user` validation, and no signal during a GitHub outage), so this branch addresses all three under one theme: **derive state from what exists, and always give the user a way forward.**

## Changes in this PR

1. **Setup wizard stage derived from GitHub state** (`fix`, #307) — replace the wizard's local `useState` step with a stage derived from what exists on GitHub, so it survives reload/remount.
2. **Config-probe error is indeterminate, not stage 1** (`fix`) — a transient config-repo probe error now shows the retry surface instead of falling through to stage 1 "Run setup".
3. **Escape hatch for a stuck `/user` validation** (`fix`) — a retry / "Sign in again" affordance when a persistent `/user` failure would otherwise spin forever.
4. **Warn on likely GitHub outages** (`feat`) — a heuristic GitHub-health detector plus a warning (banner + bootstrap note) linking to githubstatus.com.

Titled `feat` because item 4 adds user-facing behavior; the rest are fixes on the same flow. Squash-merges as one release entry.

---

## 1. Setup wizard: derive stage from GitHub state (#307)

The setup wizard tracked its step in local React state (`useState`), so any reload or remount reset it to step 1. Once the service token was saved, step 2 collapsed to a Back-only view and step 3 became unreachable — the stuck loop the reporter described ("creating a new service token reloads the page, but it loads back to step 1 not step 3").

Derive the wizard stage from what exists on GitHub instead of local state, matching the app's derive-from-what-exists model:

- **Derived stage** — `tokenPresent ⇒ done`; `configReady ⇒ the "Next" affordance on step 1`. Both status queries are lifted into `OrgSetupPage` so they run on mount regardless of stage (previously the token query only ran inside `OrgSettingsPane` at step 2, so the derived stage could never reach 3 on a fresh load). State now survives reload/remount.
- **Navigation** — split forward/back intent (`effectiveStage = backOverride ?? max(derivedStage, forwardIntent)`) so Back is never forward-trapped. Added a "Manage service token" control on the finish screen (token rotation), with Back returning to the finish screen when a token is present.
- **Resilience** — seed the token-status cache to `present` on save success so the forward transition survives a failed/offline refetch. For the seed to actually survive, `getServiceTokenStatus` now rethrows transient errors instead of resolving `status:"unknown"` (see the review-fixes note below), so a failed reconciliation refetch keeps the seeded data rather than overwriting it.
- Removed the now-redundant `onSubmit={() => setStage(3)}` wiring.

## 2. Config-probe error is indeterminate, not stage 1

The two setup probes signal "indeterminate" differently: the token probe resolves an explicit `status: "unknown"`, but the config-repo probe *rethrows* non-404s, so react-query surfaces `isError` (data stays `undefined`) and never the string `"unknown"`. The original `statusIndeterminate` check only tested `data === "unknown"`, which is dead for the config probe — so a settled transient config-repo error fell through to stage 1 "Run setup", the same regression #307 fixed, but handled only for the token probe.

`statusIndeterminate` now keys off `isError` for the probes and shows the retry surface; the probe's throw-and-retry autoheal stays intact. Each `isError` branch is gated on `data === undefined` so that a *background* refetch failure (with prior data still cached) keeps the derived stage instead of ejecting the user off a valid step — see the review-fixes note. The indeterminate/loading tests are split **per probe** so the gap can't reopen silently.

## 3. Escape hatch for a stuck `/user` validation

A *persistent* transient `/user` validation failure — `api.github.com` blocked by a proxy/extension, or a stale stored token — holds auth at `"loading"` forever with no escape. The hold itself is intentional (#187 — don't eject a valid session on a blip), but there was no way out short of manually clearing site data and re-logging in.

Added `isValidationStuck` (online + token + no cached user + a *settled* transient error, no refetch in flight) and a retry / "Sign in again" affordance on the loading screen instead of a bare spinner. `resolveAuthStatus` is unchanged, so every hold-vs-bounce invariant is preserved; this only enriches the stuck screen. Covered by 7 `isValidationStuck` unit tests.

## 4. Warn on likely GitHub outages

Prompted by a real GitHub REST API degradation during testing (the app just spun). Added a heuristic GitHub-health detector and a user-facing warning with a githubstatus.com link, so an outage reads as an outage rather than a hang.

- **Detection** (`web/src/lib/githubHealth/`): >=3 outage-shaped API failures within 30s suspect an outage. "Outage-shaped" = 5xx or a network/timeout throw; rate limits (429 / 403-with-retry) and definitive 4xx (401/403/404) are explicitly excluded so a bad token or rate limit never reads as an outage. Then an authoritative githubstatus.com probe (`/api/v2/status.json`, best-effort, CORS-open) confirms and enriches the message. Any successful response clears the suspicion.
- **Wiring**: fed from React Query's `QueryCache`/`MutationCache` `onError`/`onSuccess` in `main.tsx` — `onError` sees the network/timeout failures that throw before the client's `onResponse`, so no per-query wiring is needed.
- **Surfaces**: a dismissible warning banner in the authed banner stack, and an outage note + githubstatus.com link on the unauthed loading/stuck bootstrap screen (where an outage during the `/user` bootstrap strands the user — pairs with #3). The confirmed/generic body + link is defined once (`GitHubStatusNote`) and reused by both surfaces.
- Covered by store + banner unit tests (classifier, threshold/window, recovery, probe mapping, multi-episode re-probe, dismiss).

## Review fixes

A full `ce-code-review` pass (8 reviewers + independent validation) on the whole branch surfaced a cluster around the same theme the PR targets — a transient GitHub blip during reconciliation could still eject the user from a correctly-derived stage. All addressed here:

1. **Seed clobbered by a transient refetch (P1).** `getServiceTokenStatus` caught *all* errors and resolved `status:"unknown"`, so the invalidation refetch queued right after the `setQueryData("present")` seed resolved as a react-query success on a transient blip and overwrote the seed — dropping the wizard off its just-shown finish screen. It now rethrows transient 5xx/network (keeping the definitive `404 → missing` / `403 → unknown` verdicts), so react-query keeps the seeded `present` on a failed refetch.
2. **Background-refetch eject (P2).** `statusIndeterminate` keyed off `isError` without checking for retained cached data, so a failed *background* refetch (with `"ready"`/`present` still cached) ejected the user to the retry alert. Both probe `isError` branches are now gated on `data === undefined`.
3. **Outage probe not episode-scoped (P2).** On recovery the probe re-armed `lastProbeAt` but not `probeInFlight`, so rapid outage→recovery→re-outage flapping could starve a fresh episode's first probe and let a prior episode's stale probe write its indicator onto the new suspicion. Fixed with an episode epoch: bumped on fresh suspicion and on recovery, captured at probe entry, and required to still match before the result is applied.
4. **One recipe, one source (P2).** `GitHubStatusBanner` re-inlined the body+link that `GitHubStatusNote` already owns; it now renders `GitHubStatusNote` (a `block` prop carries the banner's paragraph/own-line layout).
5. **Test coverage (P2).** Added direct tests for the `githubstatus.com` parser (`fetchGitHubStatusIndicator`), the `getServiceTokenStatus` transient-rethrow contract, the `useSaveServiceToken` seed key/shape, and the probe flapping guards.

## Verification

Full `npm run check` green: tsc + eslint + prettier clean (0 errors), 1661 tests passing (i18n coverage audit included).
