### PR TITLE
feat(web): hint at GitHub outages on transient template-verify and save failures

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,7 @@ import { Spinner } from "@/components/Spinner"
 import { Button } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useGitHubHealth } from "@/lib/githubHealth"
-import { GitHubStatusNote } from "@/components/GitHubStatusBanner"
+import { GitHubStatusNote } from "@/components/GitHubStatusNote"
 import { BASE_PATH, isAuthedPath } from "@/auth/authedPath"
 import { logger } from "@/lib/logger"
 

--- a/web/src/components/GitHubStatusBanner.tsx
+++ b/web/src/components/GitHubStatusBanner.tsx
@@ -4,52 +4,8 @@ import { AnimatePresence } from "motion/react"
 import { useTranslation } from "react-i18next"
 
 import { AppBanner } from "@/components/AppBanner"
+import { GitHubStatusNote } from "@/components/GitHubStatusNote"
 import { useGitHubHealth } from "@/lib/githubHealth"
-
-export const GITHUB_STATUS_URL = "https://www.githubstatus.com"
-
-// The outage body text (confirmed vs generic) plus the githubstatus.com link —
-// the single source of both, so the copy and URL can't drift between the authed
-// banner and the unauthed stuck-bootstrap screen. `block` renders the banner's
-// muted-paragraph + own-line link; the default is the inline fragment the
-// unauthed screen wraps in its own <p>.
-export function GitHubStatusNote({
-  statusDescription,
-  block = false,
-}: {
-  statusDescription: string | null
-  block?: boolean
-}) {
-  const { t } = useTranslation()
-  const body = statusDescription
-    ? t("githubStatus.bodyConfirmed", { status: statusDescription })
-    : t("githubStatus.bodyGeneric")
-  const link = (
-    <a
-      href={GITHUB_STATUS_URL}
-      target="_blank"
-      rel="noreferrer"
-      className={`link link-hover font-semibold text-base-content${
-        block ? " self-start" : ""
-      }`}
-    >
-      {t("githubStatus.checkStatusLink")}
-    </a>
-  )
-  if (block) {
-    return (
-      <>
-        <p className="text-base-content/70">{body}</p>
-        {link}
-      </>
-    )
-  }
-  return (
-    <>
-      {body} {link}
-    </>
-  )
-}
 
 // Global warning banner shown when the app suspects GitHub is having trouble
 // (repeated outage-shaped API failures), optionally enriched with the

--- a/web/src/components/GitHubStatusNote.tsx
+++ b/web/src/components/GitHubStatusNote.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from "react-i18next"
+
+export const GITHUB_STATUS_URL = "https://www.githubstatus.com"
+
+// The outage body text (confirmed vs generic) plus the githubstatus.com link —
+// the single source of both, so the copy and URL can't drift across the authed
+// banner, the unauthed stuck-bootstrap screen, and the inline field/write hints.
+// `block` renders the banner's muted-paragraph + own-line link; the default is
+// the inline fragment a caller wraps in its own element.
+export function GitHubStatusNote({
+  statusDescription,
+  block = false,
+}: {
+  statusDescription: string | null
+  block?: boolean
+}) {
+  const { t } = useTranslation()
+  const body = statusDescription
+    ? t("githubStatus.bodyConfirmed", { status: statusDescription })
+    : t("githubStatus.bodyGeneric")
+  const link = (
+    <a
+      href={GITHUB_STATUS_URL}
+      target="_blank"
+      rel="noreferrer"
+      className={`link link-hover font-semibold text-base-content${
+        block ? " self-start" : ""
+      }`}
+    >
+      {t("githubStatus.checkStatusLink")}
+    </a>
+  )
+  if (block) {
+    return (
+      <>
+        <p className="text-base-content/70">{body}</p>
+        {link}
+      </>
+    )
+  }
+  return (
+    <>
+      {body} {link}
+    </>
+  )
+}
+
+export default GitHubStatusNote

--- a/web/src/components/GitHubStatusNote.tsx
+++ b/web/src/components/GitHubStatusNote.tsx
@@ -44,5 +44,3 @@ export function GitHubStatusNote({
     </>
   )
 }
-
-export default GitHubStatusNote

--- a/web/src/components/MembershipError.test.tsx
+++ b/web/src/components/MembershipError.test.tsx
@@ -68,6 +68,8 @@ describe("classifyMembershipError", () => {
       org: "acme",
     })
     expect(info.cause).toBe("generic")
+    // A 403 is definitive, not an outage.
+    expect(info.isOutage).toBe(false)
   })
 
   it("routes a 500 to generic", () => {
@@ -75,6 +77,32 @@ describe("classifyMembershipError", () => {
       org: "acme",
     })
     expect(info.cause).toBe("generic")
+    // A 5xx is an outage — the card adds the githubstatus.com hint.
+    expect(info.isOutage).toBe(true)
+  })
+
+  it("flags a network error as an outage on the generic branch", () => {
+    const info = classifyMembershipError(new TypeError("Failed to fetch"), {
+      org: "acme",
+    })
+    expect(info.cause).toBe("generic")
+    expect(info.isOutage).toBe(true)
+  })
+
+  it("does not flag a definitive cause as an outage", () => {
+    expect(
+      classifyMembershipError(makeError({ status: 404 }), {}).isOutage,
+    ).toBe(false)
+    expect(
+      classifyMembershipError(
+        makeError({
+          status: 403,
+          ssoHeader:
+            "required; url=https://github.com/orgs/acme/sso?authorization_request=abc",
+        }),
+        {},
+      ).isOutage,
+    ).toBe(false)
   })
 
   it("routes a non-GitHub error (or null) to generic without diagnostics", () => {

--- a/web/src/components/MembershipError.tsx
+++ b/web/src/components/MembershipError.tsx
@@ -1,6 +1,8 @@
 import { AlertTriangle, UserPlus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { GitHubAPIError } from "@/github-core/errors"
+import { isDefiniteOutageError } from "@/lib/githubHealth"
+import { GitHubStatusNote } from "@/components/GitHubStatusNote"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { Card, CopyableDetails, Button, Badge } from "@/components/ui"
 import type { BadgeTone } from "@/components/ui"
@@ -20,6 +22,10 @@ export type MembershipErrorInfo = {
   cause: MembershipErrorCause
   // Present only for `ssoWithUrl`; a validated https://github.com SSO URL.
   ssoUrl: string | null
+  // True when a `generic` failure is a positively-identified GitHub outage (5xx
+  // / network), so the card can add the githubstatus.com hint instead of reading
+  // as a local problem. Never set for definitive causes (SSO / not-a-member).
+  isOutage: boolean
   // Data-minimized diagnostics for the copyable "for your instructor" block.
   // NOT the raw response body or raw X-GitHub-SSO header (which carries an
   // authorization_request token) — only an allow-listed, non-sensitive subset.
@@ -56,16 +62,26 @@ export function classifyMembershipError(
     if (error.isSsoRequired) {
       const ssoUrl = error.ssoAuthorizationUrl
       return ssoUrl
-        ? { cause: "ssoWithUrl", ssoUrl, details }
-        : { cause: "ssoUrlless", ssoUrl: null, details }
+        ? { cause: "ssoWithUrl", ssoUrl, isOutage: false, details }
+        : { cause: "ssoUrlless", ssoUrl: null, isOutage: false, details }
     }
     if (error.isNotFound) {
-      return { cause: "notAMember", ssoUrl: null, details }
+      return { cause: "notAMember", ssoUrl: null, isOutage: false, details }
     }
-    return { cause: "generic", ssoUrl: null, details }
+    return {
+      cause: "generic",
+      ssoUrl: null,
+      isOutage: isDefiniteOutageError(error),
+      details,
+    }
   }
 
-  return { cause: "generic", ssoUrl: null, details: base }
+  return {
+    cause: "generic",
+    ssoUrl: null,
+    isOutage: isDefiniteOutageError(error),
+    details: base,
+  }
 }
 
 const MembershipDetails = ({
@@ -203,6 +219,12 @@ export const MembershipError = ({
               <Button variant="primary" size="sm" onClick={onRetry}>
                 {t("membership.generic.retry")}
               </Button>
+            )}
+
+            {cause === "generic" && info.isOutage && (
+              <p className="text-sm leading-5 text-base-content/70">
+                <GitHubStatusNote statusDescription={null} />
+              </p>
             )}
           </div>
         </div>

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -3,6 +3,7 @@ import type { Assignment } from "@/types/classroom"
 import { getRepo } from "@/github-core/repoReads"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { GitHubAPIError } from "@/github-core/errors"
+import { isDefiniteOutageError } from "@/lib/githubHealth/githubHealthStore"
 import type { GitHubRepo } from "@/github-core/types"
 import { githubOrgOAuthPolicyUrl } from "@/auth/constants"
 import { TemplateAccessError } from "@/util/templateAccessError"
@@ -190,10 +191,14 @@ export type TemplateAccessVerification =
       httpStatus: number
       scopeGap: boolean
     }
-  // Rate limit hit; the check is inconclusive and should be retried.
-  | { kind: "rate-limited"; owner: string; repo: string }
-  // Verification couldn't complete (network or unexpected error).
-  | { kind: "unknown"; owner: string; repo: string }
+  // Rate limit hit; the check is inconclusive and should be retried. `outage` is
+  // true when the failure that produced this verdict is a positively-identified
+  // GitHub outage (5xx / network), so the note can add the githubstatus.com hint
+  // even if the global suspicion flag was cleared by this query resolving.
+  | { kind: "rate-limited"; owner: string; repo: string; outage: boolean }
+  // Verification couldn't complete (network or unexpected error). `outage` as
+  // above — set when the underlying failure was a positively-identified outage.
+  | { kind: "unknown"; owner: string; repo: string; outage: boolean }
   | {
       kind: "ok"
       owner: string
@@ -296,7 +301,13 @@ export async function verifyTemplateAccess(
     repo = await getRepo(client, parsed.owner, parsed.repo)
   } catch (err) {
     if (err instanceof GitHubAPIError && err.isRateLimited) {
-      return { kind: "rate-limited", owner: parsed.owner, repo: parsed.repo }
+      // A rate limit is the user's own state, never an outage.
+      return {
+        kind: "rate-limited",
+        owner: parsed.owner,
+        repo: parsed.repo,
+        outage: false,
+      }
     }
     if (err instanceof GitHubAPIError && err.isForbidden) {
       return {
@@ -313,7 +324,15 @@ export async function verifyTemplateAccess(
         scopeGap: err.isScopeGap,
       }
     }
-    return { kind: "unknown", owner: parsed.owner, repo: parsed.repo }
+    // The verify query resolves-successfully with this verdict, which clears the
+    // global outage suspicion — so carry the outage signal on the verdict itself
+    // (a 5xx / network failure here) rather than relying on the suspicion flag.
+    return {
+      kind: "unknown",
+      owner: parsed.owner,
+      repo: parsed.repo,
+      outage: isDefiniteOutageError(err),
+    }
   }
 
   if (!repo) {

--- a/web/src/github-core/client.test.ts
+++ b/web/src/github-core/client.test.ts
@@ -147,7 +147,7 @@ describe("createGitHubClient non-JSON response (GitHub-outage shape)", () => {
   }
 
   // A 5xx-with-HTML already flows through the non-OK branch as a GitHubAPIError
-  // carrying the real status, so isOutageShapedError classifies it (>= 500).
+  // carrying the real status, so isDefiniteOutageError classifies it (>= 500).
   it("throws a 5xx GitHubAPIError when a failed response carries an HTML body", async () => {
     stubTextFetch(503, "<html><body>Service Unavailable</body></html>")
     const client = createGitHubClient({ token: "t" })
@@ -191,5 +191,32 @@ describe("createGitHubClient non-JSON response (GitHub-outage shape)", () => {
     await expect(
       client.request<{ hello: string }>("/x", { method: "GET" }),
     ).resolves.toEqual({ hello: "world" })
+  })
+
+  // The synthetic 502 keeps X-GitHub-Request-Id (non-sensitive) so a real edge
+  // outage stays correlatable in support/audit, matching the non-OK branch.
+  it("preserves X-GitHub-Request-Id on the synthetic 502", async () => {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(
+        new Response("<html><body>proxy error</body></html>", {
+          status: 200,
+          headers: {
+            "content-type": "text/html",
+            "x-github-request-id": "ABCD:1234:EF",
+          },
+        }),
+      ),
+    )
+    const client = createGitHubClient({ token: "t" })
+
+    const err = await client.request("/rate_limit", { method: "GET" }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    expect((err as { status: number }).status).toBe(502)
+    expect((err as { requestId: string | null }).requestId).toBe("ABCD:1234:EF")
+    // The raw HTML body is still dropped.
+    expect((err as Error).message).not.toContain("proxy error")
   })
 })

--- a/web/src/github-core/client.test.ts
+++ b/web/src/github-core/client.test.ts
@@ -133,3 +133,63 @@ describe("createGitHubClient request logging", () => {
     debug.mockRestore()
   })
 })
+
+describe("createGitHubClient non-JSON response (GitHub-outage shape)", () => {
+  function stubTextFetch(status: number, body: string): void {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(
+        new Response(body, {
+          status,
+          headers: { "content-type": "text/html" },
+        }),
+      ),
+    )
+  }
+
+  // A 5xx-with-HTML already flows through the non-OK branch as a GitHubAPIError
+  // carrying the real status, so isOutageShapedError classifies it (>= 500).
+  it("throws a 5xx GitHubAPIError when a failed response carries an HTML body", async () => {
+    stubTextFetch(503, "<html><body>Service Unavailable</body></html>")
+    const client = createGitHubClient({ token: "t" })
+
+    await expect(
+      client.request("/rate_limit", { method: "GET" }),
+    ).rejects.toMatchObject({ name: "GitHubAPIError", status: 503 })
+  })
+
+  // The gap this closes: a 200 whose body is HTML (edge served a page without
+  // reaching GitHub's app layer) must not leak a raw JSON SyntaxError. It's
+  // remapped to a synthetic 502 GitHubAPIError so it reads as an outage.
+  it("remaps a 200 with an HTML body to a synthetic 5xx instead of a SyntaxError", async () => {
+    stubTextFetch(200, "<!DOCTYPE html><html><body>proxy error</body></html>")
+    const client = createGitHubClient({ token: "t" })
+
+    const err = await client.request("/rate_limit", { method: "GET" }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).name).toBe("GitHubAPIError")
+    expect((err as { status: number }).status).toBe(502)
+    // Never leak the parser's raw message or the HTML body.
+    expect((err as Error).message).not.toMatch(/Unexpected token/i)
+    expect((err as Error).message).not.toContain("proxy error")
+  })
+
+  it("still returns parsed JSON on a normal 200", async () => {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ hello: "world" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    )
+    const client = createGitHubClient({ token: "t" })
+
+    await expect(
+      client.request<{ hello: string }>("/x", { method: "GET" }),
+    ).resolves.toEqual({ hello: "world" })
+  })
+})

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -1,4 +1,8 @@
-import { GitHubAPIError, readGitHubRateLimitHeaders } from "./errors"
+import {
+  GitHubAPIError,
+  githubNonJsonResponseError,
+  readGitHubRateLimitHeaders,
+} from "./errors"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_GITHUB_CLIENT } from "@/lib/logScopes"
 import { countApiCall, publishRateLimit } from "@/lib/diagnostics/rateLimit"
@@ -178,7 +182,17 @@ export function createGitHubClient(args: {
         return undefined as T
       }
 
-      return JSON.parse(text) as T
+      try {
+        return JSON.parse(text) as T
+      } catch {
+        // A 2xx whose body isn't JSON means the response never reached GitHub's
+        // app layer — an edge/proxy served HTML (a known GitHub-outage shape:
+        // "requests not consistently reaching the application layer, returning
+        // HTML instead of the expected API format"). Surface it as a synthetic
+        // 5xx so it classifies as outage-shaped (feeds the health detector and
+        // the outage hint) instead of leaking a raw `SyntaxError` to the user.
+        throw githubNonJsonResponseError(res.url || path, res.status)
+      }
     },
 
     async requestRaw(path: string, options?: GitHubRequestOptions) {

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -191,7 +191,11 @@ export function createGitHubClient(args: {
         // HTML instead of the expected API format"). Surface it as a synthetic
         // 5xx so it classifies as outage-shaped (feeds the health detector and
         // the outage hint) instead of leaking a raw `SyntaxError` to the user.
-        throw githubNonJsonResponseError(res.url || path, res.status)
+        throw githubNonJsonResponseError(
+          res.url || path,
+          res.status,
+          res.headers.get("x-github-request-id"),
+        )
       }
     },
 

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -208,6 +208,31 @@ export function readGitHubRateLimitHeaders(res: Response): GitHubRateLimit {
   }
 }
 
+// A 2xx whose body isn't JSON: the response never reached GitHub's app layer
+// (an edge/proxy served HTML — a known REST-outage shape). Modeled as a
+// synthetic 5xx GitHubAPIError so it classifies as outage-shaped (isOutageShaped
+// Error, retryTransientGitHubError) and carries a short, non-HTML message rather
+// than leaking a raw JSON `SyntaxError`. The raw body is deliberately dropped.
+export function githubNonJsonResponseError(
+  url: string,
+  status: number,
+): GitHubAPIError {
+  return new GitHubAPIError({
+    status: 502,
+    url,
+    message: `GitHub returned a non-JSON response (HTTP ${status}) — this usually means GitHub is having trouble. Try again shortly.`,
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
 // Run a GitHub read/write, swallowing a tolerated error into `fallback` instead
 // of throwing — the "absent reads as empty/none" idiom, unified so call sites
 // stop re-spelling the `instanceof GitHubAPIError && status === 404` guard.

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -210,12 +210,15 @@ export function readGitHubRateLimitHeaders(res: Response): GitHubRateLimit {
 
 // A 2xx whose body isn't JSON: the response never reached GitHub's app layer
 // (an edge/proxy served HTML — a known REST-outage shape). Modeled as a
-// synthetic 5xx GitHubAPIError so it classifies as outage-shaped (isOutageShaped
+// synthetic 5xx GitHubAPIError so it classifies as an outage (isDefiniteOutage
 // Error, retryTransientGitHubError) and carries a short, non-HTML message rather
-// than leaking a raw JSON `SyntaxError`. The raw body is deliberately dropped.
+// than leaking a raw JSON `SyntaxError`. The raw body is deliberately dropped;
+// the X-GitHub-Request-Id is kept (non-sensitive) so a real edge outage stays
+// correlatable in support/audit just like a normal non-OK GitHubAPIError.
 export function githubNonJsonResponseError(
   url: string,
   status: number,
+  requestId: string | null = null,
 ): GitHubAPIError {
   return new GitHubAPIError({
     status: 502,
@@ -230,6 +233,7 @@ export function githubNonJsonResponseError(
       resource: null,
       retryAfter: null,
     },
+    requestId,
   })
 }
 

--- a/web/src/lib/githubHealth/githubHealthStore.test.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.test.ts
@@ -31,6 +31,7 @@ import {
   __resetGitHubHealthForTest,
   getGitHubHealthSnapshot,
   isOutageShapedError,
+  isDefiniteOutageError,
   recordGitHubFailure,
   recordGitHubSuccess,
 } from "./githubHealthStore"
@@ -71,6 +72,58 @@ describe("isOutageShapedError", () => {
     expect(isOutageShapedError(new DOMException("aborted", "AbortError"))).toBe(
       false,
     )
+  })
+
+  it("unwraps `.cause`: a wrapper around a 5xx is outage-shaped; around a 404 is not", () => {
+    class Wrapper extends Error {
+      constructor(cause: unknown) {
+        super("wrapped")
+        this.cause = cause
+      }
+    }
+    expect(isOutageShapedError(new Wrapper(apiError(502)))).toBe(true)
+    expect(isOutageShapedError(new Wrapper(apiError(404)))).toBe(false)
+    expect(isOutageShapedError(new Wrapper(apiError(429)))).toBe(false)
+  })
+})
+
+describe("isDefiniteOutageError (strict, for user-facing hints)", () => {
+  class Wrapper extends Error {
+    constructor(cause?: unknown) {
+      super("wrapped")
+      if (cause !== undefined) this.cause = cause
+    }
+  }
+
+  it("is true only for a 5xx or a network TypeError, unwrapping `.cause`", () => {
+    expect(isDefiniteOutageError(apiError(500))).toBe(true)
+    expect(isDefiniteOutageError(apiError(503))).toBe(true)
+    expect(isDefiniteOutageError(new TypeError("Failed to fetch"))).toBe(true)
+    expect(isDefiniteOutageError(new Wrapper(apiError(502)))).toBe(true)
+    expect(
+      isDefiniteOutageError(new Wrapper(new TypeError("Failed to fetch"))),
+    ).toBe(true)
+  })
+
+  it("is false for definitive 4xx, rate limit, abort — even wrapped", () => {
+    expect(isDefiniteOutageError(apiError(401))).toBe(false)
+    expect(isDefiniteOutageError(apiError(403))).toBe(false)
+    expect(isDefiniteOutageError(apiError(404))).toBe(false)
+    expect(isDefiniteOutageError(apiError(429))).toBe(false)
+    expect(isDefiniteOutageError(apiError(403, { retryAfter: 60 }))).toBe(false)
+    expect(
+      isDefiniteOutageError(new DOMException("aborted", "AbortError")),
+    ).toBe(false)
+    expect(isDefiniteOutageError(new Wrapper(apiError(404)))).toBe(false)
+  })
+
+  it("is false for a plain/unknown error with no outage cause (no false positive)", () => {
+    // A TemplateAccessError-like plain Error must never read as an outage.
+    expect(isDefiniteOutageError(new Error("ask your instructor"))).toBe(false)
+    expect(isDefiniteOutageError(new Wrapper())).toBe(false)
+    expect(isDefiniteOutageError("string")).toBe(false)
+    expect(isDefiniteOutageError(undefined)).toBe(false)
+    expect(isDefiniteOutageError(null)).toBe(false)
   })
 })
 

--- a/web/src/lib/githubHealth/githubHealthStore.test.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.test.ts
@@ -30,7 +30,6 @@ vi.mock("./githubStatusApi", () => ({
 import {
   __resetGitHubHealthForTest,
   getGitHubHealthSnapshot,
-  isOutageShapedError,
   isDefiniteOutageError,
   recordGitHubFailure,
   recordGitHubSuccess,
@@ -46,48 +45,7 @@ afterEach(() => {
   __resetGitHubHealthForTest()
 })
 
-describe("isOutageShapedError", () => {
-  it("treats a 5xx GitHubAPIError as outage-shaped", () => {
-    expect(isOutageShapedError(apiError(500))).toBe(true)
-    expect(isOutageShapedError(apiError(503))).toBe(true)
-  })
-
-  it("treats a bare network/timeout error as outage-shaped", () => {
-    expect(isOutageShapedError(new TypeError("Failed to fetch"))).toBe(true)
-  })
-
-  it("does NOT treat definitive 4xx (401/403/404) as outage-shaped", () => {
-    expect(isOutageShapedError(apiError(401))).toBe(false)
-    expect(isOutageShapedError(apiError(403))).toBe(false)
-    expect(isOutageShapedError(apiError(404))).toBe(false)
-  })
-
-  it("does NOT treat a rate limit as outage-shaped (429, or 403 with retry-after/remaining 0)", () => {
-    expect(isOutageShapedError(apiError(429))).toBe(false)
-    expect(isOutageShapedError(apiError(403, { retryAfter: 60 }))).toBe(false)
-    expect(isOutageShapedError(apiError(403, { remaining: 0 }))).toBe(false)
-  })
-
-  it("does NOT treat a caller/timeout abort as outage-shaped", () => {
-    expect(isOutageShapedError(new DOMException("aborted", "AbortError"))).toBe(
-      false,
-    )
-  })
-
-  it("unwraps `.cause`: a wrapper around a 5xx is outage-shaped; around a 404 is not", () => {
-    class Wrapper extends Error {
-      constructor(cause: unknown) {
-        super("wrapped")
-        this.cause = cause
-      }
-    }
-    expect(isOutageShapedError(new Wrapper(apiError(502)))).toBe(true)
-    expect(isOutageShapedError(new Wrapper(apiError(404)))).toBe(false)
-    expect(isOutageShapedError(new Wrapper(apiError(429)))).toBe(false)
-  })
-})
-
-describe("isDefiniteOutageError (strict, for user-facing hints)", () => {
+describe("isDefiniteOutageError", () => {
   class Wrapper extends Error {
     constructor(cause?: unknown) {
       super("wrapped")
@@ -95,14 +53,39 @@ describe("isDefiniteOutageError (strict, for user-facing hints)", () => {
     }
   }
 
-  it("is true only for a 5xx or a network TypeError, unwrapping `.cause`", () => {
+  it("is true for a 5xx GitHubAPIError, unwrapping `.cause`", () => {
     expect(isDefiniteOutageError(apiError(500))).toBe(true)
     expect(isDefiniteOutageError(apiError(503))).toBe(true)
-    expect(isDefiniteOutageError(new TypeError("Failed to fetch"))).toBe(true)
     expect(isDefiniteOutageError(new Wrapper(apiError(502)))).toBe(true)
+  })
+
+  it("is true for a network-failure TypeError across browser engines, unwrapping `.cause`", () => {
+    expect(isDefiniteOutageError(new TypeError("Failed to fetch"))).toBe(true)
+    expect(
+      isDefiniteOutageError(
+        new TypeError("NetworkError when attempting to fetch resource"),
+      ),
+    ).toBe(true)
+    expect(isDefiniteOutageError(new TypeError("Load failed"))).toBe(true)
     expect(
       isDefiniteOutageError(new Wrapper(new TypeError("Failed to fetch"))),
     ).toBe(true)
+  })
+
+  it("is true for a non-abort timeout DOMException", () => {
+    expect(
+      isDefiniteOutageError(new DOMException("timed out", "TimeoutError")),
+    ).toBe(true)
+  })
+
+  it("is false for a non-network TypeError (an ordinary local app bug)", () => {
+    // A property-access-on-undefined bug throws TypeError too; it must never
+    // read as a GitHub outage (that would mislabel the failure and hide it).
+    expect(
+      isDefiniteOutageError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
   })
 
   it("is false for definitive 4xx, rate limit, abort — even wrapped", () => {
@@ -111,10 +94,12 @@ describe("isDefiniteOutageError (strict, for user-facing hints)", () => {
     expect(isDefiniteOutageError(apiError(404))).toBe(false)
     expect(isDefiniteOutageError(apiError(429))).toBe(false)
     expect(isDefiniteOutageError(apiError(403, { retryAfter: 60 }))).toBe(false)
+    expect(isDefiniteOutageError(apiError(403, { remaining: 0 }))).toBe(false)
     expect(
       isDefiniteOutageError(new DOMException("aborted", "AbortError")),
     ).toBe(false)
     expect(isDefiniteOutageError(new Wrapper(apiError(404)))).toBe(false)
+    expect(isDefiniteOutageError(new Wrapper(apiError(429)))).toBe(false)
   })
 
   it("is false for a plain/unknown error with no outage cause (no false positive)", () => {
@@ -154,6 +139,20 @@ describe("suspicion threshold", () => {
     recordGitHubFailure(apiError(404), 1100)
     recordGitHubFailure(apiError(404), 1200)
     recordGitHubFailure(apiError(429), 1300)
+    expect(getGitHubHealthSnapshot().suspected).toBe(false)
+  })
+
+  it("ignores local app errors so unrelated non-GitHub throws never trip the banner", () => {
+    // These reach React Query's global onError (which feeds recordGitHubFailure
+    // unfiltered), but none is a positively-identified outage, so 3+ in-window
+    // must NOT suspect — a local bug is not "GitHub is down".
+    recordGitHubFailure(new Error("something local broke"), 1000)
+    recordGitHubFailure(
+      new TypeError("Cannot read properties of undefined"),
+      1100,
+    )
+    recordGitHubFailure("rejected with a string", 1200)
+    recordGitHubFailure(new Error("another local failure"), 1300)
     expect(getGitHubHealthSnapshot().suspected).toBe(false)
   })
 })

--- a/web/src/lib/githubHealth/githubHealthStore.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.ts
@@ -69,57 +69,62 @@ function setState(next: GitHubHealth) {
   emit()
 }
 
-// An error that plausibly signals GitHub being down, as opposed to a
-// client-side verdict. A GitHubAPIError with a 5xx status is a server fault; a
-// non-GitHubAPIError throw is a network failure or timeout (the client throws
-// these before onResponse — see client.ts). Definitive statuses (401/403/404)
-// and rate limits (429 / 403-with-retry) are the user's own state, never an
-// outage, so they must never trip the detector.
+// The single outage classifier, used both to feed the suspicion detector and to
+// gate user-facing hints. True ONLY when the error (after unwrapping `.cause`)
+// is a positively-identified outage — a 5xx GitHubAPIError, a network-failure
+// TypeError, or a non-abort timeout DOMException. Everything else is false:
+// a definitive 4xx, a rate limit, a caller/navigation abort, a friendly wrapper
+// with no outage cause (e.g. a TemplateAccessError — an instructor-action
+// problem), and any unrecognized local throw. Positive-identification only is
+// what keeps both the detector and the hint free of false positives — a bad
+// template / not-a-member / SSO gate / local app bug must never read as "GitHub
+// is down".
 //
 // Errors are unwrapped along `.cause` first: some flows rethrow a friendly
 // wrapper (e.g. AcceptStepError) that preserves the original GitHubAPIError as
 // its cause, and the classification must key off that original, not the wrapper.
-//
-// This is the PERMISSIVE detector classifier: an unrecognized throw counts as
-// outage-shaped, because over-counting toward suspicion is harmless (a single
-// success clears it) and we'd rather notice a real outage than miss it. For a
-// user-facing hint (where a false positive is misleading) use
-// `isDefiniteOutageError`, which only returns true on a positively-identified
-// outage shape.
-export function isOutageShapedError(error: unknown): boolean {
-  const unwrapped = outageRelevantError(error)
-  if (unwrapped instanceof GitHubAPIError) {
-    if (unwrapped.isRateLimited) return false
-    return unwrapped.status >= 500
-  }
-  // A bare abort (caller cancel / navigation) is not a fault.
-  if (unwrapped instanceof DOMException && unwrapped.name === "AbortError") {
-    return false
-  }
-  // Anything else reaching a query/mutation error handler is a network/timeout
-  // failure (TypeError "Failed to fetch", timeout AbortError is handled above).
-  return true
-}
-
-// The STRICT classifier for user-facing outage hints: true ONLY when the error
-// (after unwrapping `.cause`) is a positively-identified outage — a 5xx
-// GitHubAPIError or a network-failure TypeError. Everything else is false,
-// including a definitive 4xx, a rate limit, an abort, a friendly wrapper with
-// no outage cause (e.g. a TemplateAccessError — an instructor-action problem),
-// and any unrecognized throw. This is what keeps the hint free of false
-// positives (a bad template / not-a-member / SSO gate must never read as "GitHub
-// is down").
 export function isDefiniteOutageError(error: unknown): boolean {
   const unwrapped = outageRelevantError(error)
-  if (unwrapped instanceof GitHubAPIError) {
-    if (unwrapped.isRateLimited) return false
-    return unwrapped.status >= 500
-  }
-  // A genuine network failure — the fetch never got a response. `TypeError`
-  // ("Failed to fetch") is what the browser throws; a timeout is a (non-abort)
-  // DOMException. A caller/navigation abort is not a fault.
+  if (unwrapped instanceof GitHubAPIError)
+    return isServerFaultApiError(unwrapped)
+  // A genuine network failure — the fetch never got a response. A timeout is a
+  // (non-abort) DOMException; a caller/navigation abort is not a fault.
   if (unwrapped instanceof DOMException) return unwrapped.name !== "AbortError"
-  return unwrapped instanceof TypeError
+  // The browser's "fetch never reached the server" throw is a TypeError, but so
+  // is any `x.y`-on-undefined app bug — so require the network shape, else a
+  // local code bug would falsely read as "GitHub is down" (and hide its real
+  // message). `TypeError.cause` is not reliably set by the fetch path, so key
+  // off the message the platform uses ("Failed to fetch" / "NetworkError" /
+  // "Load failed" across engines).
+  return (
+    unwrapped instanceof TypeError && isNetworkFailureMessage(unwrapped.message)
+  )
+}
+
+// The one server-fault rule: a 5xx GitHubAPIError that isn't a rate limit.
+//
+// Deliberate trade-off (accepted, not a gap): a definitive 4xx is never an
+// outage even during a real incident. GitHub's edge can return 403/404 for
+// endpoints that would normally 200 while degraded, so those failures won't trip
+// the hint and the user may hit a "not-a-member"/"blocked" dead-end. We accept
+// that false-negative because 403/404 are overwhelmingly legitimate user state
+// (not-a-member, org restriction, SSO gate); counting them would reintroduce the
+// false-positive class this classifier exists to prevent. Corroborating a 4xx
+// burst with the githubstatus.com probe was considered and rejected as too risky
+// for the payoff.
+function isServerFaultApiError(error: GitHubAPIError): boolean {
+  if (error.isRateLimited) return false
+  return error.status >= 500
+}
+
+// Browsers throw a bare `TypeError` for a failed fetch, with an engine-specific
+// message: Chromium "Failed to fetch", Firefox "NetworkError when attempting to
+// fetch resource", Safari "Load failed". Match those so a non-network TypeError
+// (an ordinary app bug) is never mistaken for an outage.
+function isNetworkFailureMessage(message: string): boolean {
+  return /failed to fetch|networkerror|network request failed|load failed/i.test(
+    message,
+  )
 }
 
 // Follow the `.cause` chain to the error that actually carries the outage
@@ -178,13 +183,18 @@ async function probeStatus(now: number) {
   }
 }
 
-// Record an API failure. Only outage-shaped errors count toward suspicion; the
-// rest are ignored so a 404/403/rate-limit never reads as an outage.
+// Record an API failure. Only a positively-identified outage (5xx, network
+// failure, or timeout — see isDefiniteOutageError) counts toward suspicion, so a
+// definitive 4xx / rate limit, a caller abort, or an ordinary local app error
+// (a thrown plain Error/string that reaches React Query's global onError) never
+// trips the banner. Under-counting a genuinely ambiguous failure is the safe
+// direction here: suspicion drives user-visible surfaces, so a false "GitHub is
+// down" is worse than a missed one, and any success immediately clears it.
 export function recordGitHubFailure(
   error: unknown,
   now: number = Date.now(),
 ): void {
-  if (!isOutageShapedError(error)) return
+  if (!isDefiniteOutageError(error)) return
 
   failureTimestamps = failureTimestamps.filter((t) => now - t < WINDOW_MS)
   failureTimestamps.push(now)

--- a/web/src/lib/githubHealth/githubHealthStore.ts
+++ b/web/src/lib/githubHealth/githubHealthStore.ts
@@ -75,16 +75,73 @@ function setState(next: GitHubHealth) {
 // these before onResponse — see client.ts). Definitive statuses (401/403/404)
 // and rate limits (429 / 403-with-retry) are the user's own state, never an
 // outage, so they must never trip the detector.
+//
+// Errors are unwrapped along `.cause` first: some flows rethrow a friendly
+// wrapper (e.g. AcceptStepError) that preserves the original GitHubAPIError as
+// its cause, and the classification must key off that original, not the wrapper.
+//
+// This is the PERMISSIVE detector classifier: an unrecognized throw counts as
+// outage-shaped, because over-counting toward suspicion is harmless (a single
+// success clears it) and we'd rather notice a real outage than miss it. For a
+// user-facing hint (where a false positive is misleading) use
+// `isDefiniteOutageError`, which only returns true on a positively-identified
+// outage shape.
 export function isOutageShapedError(error: unknown): boolean {
-  if (error instanceof GitHubAPIError) {
-    if (error.isRateLimited) return false
-    return error.status >= 500
+  const unwrapped = outageRelevantError(error)
+  if (unwrapped instanceof GitHubAPIError) {
+    if (unwrapped.isRateLimited) return false
+    return unwrapped.status >= 500
   }
   // A bare abort (caller cancel / navigation) is not a fault.
-  if (error instanceof DOMException && error.name === "AbortError") return false
+  if (unwrapped instanceof DOMException && unwrapped.name === "AbortError") {
+    return false
+  }
   // Anything else reaching a query/mutation error handler is a network/timeout
   // failure (TypeError "Failed to fetch", timeout AbortError is handled above).
   return true
+}
+
+// The STRICT classifier for user-facing outage hints: true ONLY when the error
+// (after unwrapping `.cause`) is a positively-identified outage — a 5xx
+// GitHubAPIError or a network-failure TypeError. Everything else is false,
+// including a definitive 4xx, a rate limit, an abort, a friendly wrapper with
+// no outage cause (e.g. a TemplateAccessError — an instructor-action problem),
+// and any unrecognized throw. This is what keeps the hint free of false
+// positives (a bad template / not-a-member / SSO gate must never read as "GitHub
+// is down").
+export function isDefiniteOutageError(error: unknown): boolean {
+  const unwrapped = outageRelevantError(error)
+  if (unwrapped instanceof GitHubAPIError) {
+    if (unwrapped.isRateLimited) return false
+    return unwrapped.status >= 500
+  }
+  // A genuine network failure — the fetch never got a response. `TypeError`
+  // ("Failed to fetch") is what the browser throws; a timeout is a (non-abort)
+  // DOMException. A caller/navigation abort is not a fault.
+  if (unwrapped instanceof DOMException) return unwrapped.name !== "AbortError"
+  return unwrapped instanceof TypeError
+}
+
+// Follow the `.cause` chain to the error that actually carries the outage
+// signal. Bounded so a self-referential cause can't loop. Returns the deepest
+// GitHubAPIError/DOMException/TypeError if one exists in the chain, else the
+// original error.
+function outageRelevantError(error: unknown): unknown {
+  let current = error
+  for (let hops = 0; hops < 8; hops++) {
+    if (
+      current instanceof GitHubAPIError ||
+      current instanceof DOMException ||
+      current instanceof TypeError
+    ) {
+      return current
+    }
+    const cause: unknown =
+      current instanceof Error ? (current.cause as unknown) : undefined
+    if (cause === undefined || cause === null || cause === current) break
+    current = cause
+  }
+  return current
 }
 
 async function probeStatus(now: number) {

--- a/web/src/lib/githubHealth/index.ts
+++ b/web/src/lib/githubHealth/index.ts
@@ -5,6 +5,7 @@ export {
   type GitHubHealth,
 } from "./githubHealthStore"
 export { useGitHubHealth } from "./useGitHubHealth"
+export { useOutageHint } from "./useOutageHint"
 export {
   fetchGitHubStatusIndicator,
   type GitHubStatusIndicator,

--- a/web/src/lib/githubHealth/index.ts
+++ b/web/src/lib/githubHealth/index.ts
@@ -1,5 +1,6 @@
 export {
   isOutageShapedError,
+  isDefiniteOutageError,
   recordGitHubFailure,
   recordGitHubSuccess,
   type GitHubHealth,

--- a/web/src/lib/githubHealth/index.ts
+++ b/web/src/lib/githubHealth/index.ts
@@ -1,5 +1,4 @@
 export {
-  isOutageShapedError,
   isDefiniteOutageError,
   recordGitHubFailure,
   recordGitHubSuccess,

--- a/web/src/lib/githubHealth/useOutageHint.test.ts
+++ b/web/src/lib/githubHealth/useOutageHint.test.ts
@@ -13,7 +13,6 @@ vi.mock("./githubStatusApi", () => ({
 import {
   __resetGitHubHealthForTest,
   recordGitHubFailure,
-  recordGitHubSuccess,
 } from "./githubHealthStore"
 import { useOutageHint } from "./useOutageHint"
 
@@ -35,45 +34,86 @@ const apiError = (status: number, over: Partial<GitHubRateLimit> = {}) =>
     rateLimit: { ...noRateLimit, ...over },
   })
 
-// Trip suspicion the way the app does: >= 3 outage-shaped failures in the window.
-function suspectOutage() {
-  const base = Date.now()
-  recordGitHubFailure(apiError(500), base)
-  recordGitHubFailure(apiError(500), base + 100)
-  recordGitHubFailure(apiError(500), base + 200)
+// A friendly wrapper that preserves the original error as `.cause`, mirroring
+// AcceptStepError / any rethrown wrapper the app produces.
+class WrapperError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = "WrapperError"
+    if (cause !== undefined) this.cause = cause
+  }
 }
 
 beforeEach(() => __resetGitHubHealthForTest())
 afterEach(() => __resetGitHubHealthForTest())
 
-describe("useOutageHint", () => {
-  it("does not hint when no outage is suspected, even for an outage-shaped error", () => {
+describe("useOutageHint().isOutage — strict, false-positive-proof", () => {
+  it("is true for a 5xx and a network TypeError (regardless of suspicion)", () => {
     const { result } = renderHook(() => useOutageHint())
-    expect(result.current(apiError(500))).toBe(false)
-    expect(result.current(new TypeError("Failed to fetch"))).toBe(false)
+    expect(result.current.isOutage(apiError(500))).toBe(true)
+    expect(result.current.isOutage(apiError(503))).toBe(true)
+    expect(result.current.isOutage(new TypeError("Failed to fetch"))).toBe(true)
   })
 
-  it("hints for an outage-shaped error once an outage is suspected", () => {
+  it("is false for definitive 4xx, rate limits, and aborts", () => {
     const { result } = renderHook(() => useOutageHint())
-    act(() => suspectOutage())
-    expect(result.current(apiError(503))).toBe(true)
-    expect(result.current(new TypeError("Failed to fetch"))).toBe(true)
+    expect(result.current.isOutage(apiError(401))).toBe(false)
+    expect(result.current.isOutage(apiError(403))).toBe(false)
+    expect(result.current.isOutage(apiError(404))).toBe(false)
+    expect(result.current.isOutage(apiError(429))).toBe(false)
+    expect(result.current.isOutage(apiError(403, { retryAfter: 60 }))).toBe(
+      false,
+    )
+    expect(
+      result.current.isOutage(new DOMException("aborted", "AbortError")),
+    ).toBe(false)
   })
 
-  it("never hints for a definitive 4xx or rate limit, even when suspected", () => {
+  it("is false for a bare/unknown error (no false positive on a plain throw)", () => {
     const { result } = renderHook(() => useOutageHint())
-    act(() => suspectOutage())
-    expect(result.current(apiError(404))).toBe(false)
-    expect(result.current(apiError(403))).toBe(false)
-    expect(result.current(apiError(429))).toBe(false)
+    // A TemplateAccessError-like plain Error with no outage cause.
+    expect(result.current.isOutage(new Error("ask your instructor"))).toBe(
+      false,
+    )
+    expect(result.current.isOutage("some string")).toBe(false)
+    expect(result.current.isOutage(undefined)).toBe(false)
   })
 
-  it("stops hinting after a success clears suspicion (partial-outage flicker)", () => {
+  it("unwraps `.cause` — a wrapper around a 5xx hints, around a 404 does not", () => {
     const { result } = renderHook(() => useOutageHint())
-    act(() => suspectOutage())
-    expect(result.current(apiError(500))).toBe(true)
-    // A single success mid-outage clears the window and suspicion.
-    act(() => recordGitHubSuccess())
-    expect(result.current(apiError(500))).toBe(false)
+    expect(
+      result.current.isOutage(new WrapperError("failed", apiError(502))),
+    ).toBe(true)
+    expect(
+      result.current.isOutage(
+        new WrapperError("failed", new TypeError("Failed to fetch")),
+      ),
+    ).toBe(true)
+    // Definitive causes must never read as an outage through the wrapper.
+    expect(
+      result.current.isOutage(new WrapperError("not found", apiError(404))),
+    ).toBe(false)
+    expect(
+      result.current.isOutage(new WrapperError("rate limited", apiError(429))),
+    ).toBe(false)
+    // A wrapper with no cause is not an outage (e.g. TemplateAccessError).
+    expect(result.current.isOutage(new WrapperError("ask instructor"))).toBe(
+      false,
+    )
+  })
+})
+
+describe("useOutageHint().suspected — background signal", () => {
+  it("reflects the detector: false until tripped, true after 3 failures in the window", () => {
+    const { result, rerender } = renderHook(() => useOutageHint())
+    expect(result.current.suspected).toBe(false)
+    act(() => {
+      const base = Date.now()
+      recordGitHubFailure(apiError(500), base)
+      recordGitHubFailure(apiError(500), base + 100)
+      recordGitHubFailure(apiError(500), base + 200)
+    })
+    rerender()
+    expect(result.current.suspected).toBe(true)
   })
 })

--- a/web/src/lib/githubHealth/useOutageHint.test.ts
+++ b/web/src/lib/githubHealth/useOutageHint.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+
+// The store fires a best-effort githubstatus.com probe once suspicion trips;
+// stub it so the hook tests never hit the network.
+vi.mock("./githubStatusApi", () => ({
+  fetchGitHubStatusIndicator: () => Promise.resolve(null),
+}))
+
+import {
+  __resetGitHubHealthForTest,
+  recordGitHubFailure,
+  recordGitHubSuccess,
+} from "./githubHealthStore"
+import { useOutageHint } from "./useOutageHint"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const apiError = (status: number, over: Partial<GitHubRateLimit> = {}) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: { ...noRateLimit, ...over },
+  })
+
+// Trip suspicion the way the app does: >= 3 outage-shaped failures in the window.
+function suspectOutage() {
+  const base = Date.now()
+  recordGitHubFailure(apiError(500), base)
+  recordGitHubFailure(apiError(500), base + 100)
+  recordGitHubFailure(apiError(500), base + 200)
+}
+
+beforeEach(() => __resetGitHubHealthForTest())
+afterEach(() => __resetGitHubHealthForTest())
+
+describe("useOutageHint", () => {
+  it("does not hint when no outage is suspected, even for an outage-shaped error", () => {
+    const { result } = renderHook(() => useOutageHint())
+    expect(result.current(apiError(500))).toBe(false)
+    expect(result.current(new TypeError("Failed to fetch"))).toBe(false)
+  })
+
+  it("hints for an outage-shaped error once an outage is suspected", () => {
+    const { result } = renderHook(() => useOutageHint())
+    act(() => suspectOutage())
+    expect(result.current(apiError(503))).toBe(true)
+    expect(result.current(new TypeError("Failed to fetch"))).toBe(true)
+  })
+
+  it("never hints for a definitive 4xx or rate limit, even when suspected", () => {
+    const { result } = renderHook(() => useOutageHint())
+    act(() => suspectOutage())
+    expect(result.current(apiError(404))).toBe(false)
+    expect(result.current(apiError(403))).toBe(false)
+    expect(result.current(apiError(429))).toBe(false)
+  })
+
+  it("stops hinting after a success clears suspicion (partial-outage flicker)", () => {
+    const { result } = renderHook(() => useOutageHint())
+    act(() => suspectOutage())
+    expect(result.current(apiError(500))).toBe(true)
+    // A single success mid-outage clears the window and suspicion.
+    act(() => recordGitHubSuccess())
+    expect(result.current(apiError(500))).toBe(false)
+  })
+})

--- a/web/src/lib/githubHealth/useOutageHint.ts
+++ b/web/src/lib/githubHealth/useOutageHint.ts
@@ -1,0 +1,13 @@
+import { isOutageShapedError } from "./githubHealthStore"
+import { useGitHubHealth } from "./useGitHubHealth"
+
+// Whether an operation-level failure should be presented as a likely GitHub
+// outage: the error is outage-shaped (5xx / network / timeout — never a 4xx or
+// rate limit) AND the app already suspects an outage (>= 3 such failures in the
+// window). Gating on both means a single transient blip still reads as a local
+// failure; the outage hint only appears once GitHub degradation is genuinely
+// suspected. One source so every write call site opts in consistently.
+export function useOutageHint(): (error: unknown) => boolean {
+  const { suspected } = useGitHubHealth()
+  return (error: unknown) => suspected && isOutageShapedError(error)
+}

--- a/web/src/lib/githubHealth/useOutageHint.ts
+++ b/web/src/lib/githubHealth/useOutageHint.ts
@@ -1,13 +1,26 @@
-import { isOutageShapedError } from "./githubHealthStore"
+import { isDefiniteOutageError } from "./githubHealthStore"
 import { useGitHubHealth } from "./useGitHubHealth"
 
-// Whether an operation-level failure should be presented as a likely GitHub
-// outage: the error is outage-shaped (5xx / network / timeout — never a 4xx or
-// rate limit) AND the app already suspects an outage (>= 3 such failures in the
-// window). Gating on both means a single transient blip still reads as a local
-// failure; the outage hint only appears once GitHub degradation is genuinely
-// suspected. One source so every write call site opts in consistently.
-export function useOutageHint(): (error: unknown) => boolean {
-  const { suspected } = useGitHubHealth()
-  return (error: unknown) => suspected && isOutageShapedError(error)
+export type OutageHint = {
+  // True only when the error (unwrapped along `.cause`) is a positively-
+  // identified outage — a 5xx or a network failure. Never a definitive 4xx,
+  // rate limit, abort, or a friendly wrapper with no outage cause. Safe to show
+  // to a user without a false-positive risk, so it does NOT require `suspected`.
+  isOutage: (error: unknown) => boolean
+  // The app's background suspicion (>= 3 outage-shaped failures in the window).
+  // Use to gate passive/advisory hints where a single blip shouldn't fire; a
+  // definitive operation failure the user is staring at can rely on `isOutage`
+  // alone.
+  suspected: boolean
+  // Authoritative githubstatus.com summary when probed; null otherwise. Pass to
+  // GitHubStatusNote so a confirmed outage shows the specific status.
+  statusDescription: string | null
+}
+
+// Outage-hint inputs for a call site. One source so every surface classifies
+// consistently — a background advisory can gate on `suspected && isOutage(err)`,
+// while a foreground operation failure can hint on `isOutage(err)` alone.
+export function useOutageHint(): OutageHint {
+  const { suspected, statusDescription } = useGitHubHealth()
+  return { isOutage: isDefiniteOutageError, suspected, statusDescription }
 }

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -67,6 +67,12 @@ vi.mock("@/components/modals/GroupCollaboratorsModal", () => ({
 }))
 vi.mock("canvas-confetti", () => ({ default: vi.fn() }))
 
+// The health store fires a best-effort githubstatus.com probe once suspicion
+// trips; stub it so these tests never hit the network.
+vi.mock("@/lib/githubHealth/githubStatusApi", () => ({
+  fetchGitHubStatusIndicator: () => Promise.resolve(null),
+}))
+
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
   return {
@@ -90,6 +96,8 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 })
 
 import AcceptAssignmentPage from "./AcceptAssignmentPage"
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import { __resetGitHubHealthForTest } from "@/lib/githubHealth/githubHealthStore"
 
 const acceptedRepo: GitHubRepo = {
   id: 1,
@@ -118,9 +126,13 @@ const renderPage = (client: QueryClient) =>
 
 beforeEach(() => {
   acceptAssignment.mockReset()
+  __resetGitHubHealthForTest()
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  __resetGitHubHealthForTest()
+})
 
 describe("AcceptAssignmentPage repository cache", () => {
   it.each(["created", "already-accepted"] as const)(
@@ -175,4 +187,82 @@ describe("AcceptAssignmentPage repository cache", () => {
       )
     },
   )
+})
+
+describe("AcceptAssignmentPage outage hint", () => {
+  const noRateLimit: GitHubRateLimit = {
+    limit: null,
+    remaining: null,
+    used: null,
+    reset: null,
+    resource: null,
+    retryAfter: null,
+  }
+  const apiError = (status: number, over: Partial<GitHubRateLimit> = {}) =>
+    new GitHubAPIError({
+      status,
+      url: "https://api.github.com/x",
+      message: `HTTP ${status}`,
+      body: null,
+      rateLimit: { ...noRateLimit, ...over },
+    })
+
+  // Mirrors AcceptStepError: a friendly wrapper preserving the underlying
+  // GitHubAPIError as `.cause` (what the accept flow actually throws).
+  class AcceptStepLike extends Error {
+    constructor(message: string, cause?: unknown) {
+      super(message)
+      this.name = "AcceptStepError"
+      if (cause !== undefined) this.cause = cause
+    }
+  }
+
+  const STATUS_LINK = "githubStatus.checkStatusLink"
+
+  const renderAndAccept = async (rejection: unknown) => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    acceptAssignment.mockRejectedValue(rejection)
+    renderPage(client)
+    fireEvent.click(screen.getByRole("button", { name: "accept.acceptButton" }))
+    await waitFor(() =>
+      expect(screen.queryByText("accept.errorTitle")).not.toBeNull(),
+    )
+  }
+
+  it("shows the githubstatus.com hint when accept fails with a wrapped 5xx", async () => {
+    await renderAndAccept(
+      new AcceptStepLike("Provisioning failed (HTTP 502).", apiError(502)),
+    )
+    expect(screen.queryByText(STATUS_LINK)).not.toBeNull()
+  })
+
+  it("shows the hint when accept fails with a bare network error", async () => {
+    await renderAndAccept(new TypeError("Failed to fetch"))
+    expect(screen.queryByText(STATUS_LINK)).not.toBeNull()
+  })
+
+  it("does NOT show the hint for a wrapped 404 (not-found is a real, local problem)", async () => {
+    await renderAndAccept(
+      new AcceptStepLike("Repository not found (HTTP 404).", apiError(404)),
+    )
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+  })
+
+  it("does NOT show the hint for a rate limit", async () => {
+    await renderAndAccept(new AcceptStepLike("Rate limited.", apiError(429)))
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+  })
+
+  it("does NOT show the hint for a template-access error (instructor action, no cause)", async () => {
+    // A TemplateAccessError is a plain Error with no outage `.cause`.
+    await renderAndAccept(
+      new Error("Couldn't copy the template — ask your instructor."),
+    )
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+  })
 })

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -33,6 +33,8 @@ import useGetRepo from "@/hooks/useGetRepo"
 import useGetOwnOrgMembership from "@/hooks/useGetOwnOrgMembership"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { LanguageDialog } from "@/components/LanguageDialog"
+import { GitHubStatusNote } from "@/components/GitHubStatusNote"
+import { useOutageHint } from "@/lib/githubHealth"
 import { EnterDiv } from "@/lib/motionComponents"
 import { collapseVariants } from "@/lib/motion"
 import { AnimatePresence, motion } from "motion/react"
@@ -555,6 +557,7 @@ const AcceptAssignmentPage = () => {
   const [collaboratorsOpen, setCollaboratorsOpen] = useState(false)
   const [repairOpen, setRepairOpen] = useState(false)
   const runAccept = useSafeSubmit()
+  const outageHint = useOutageHint()
 
   // A pending invitee opened the accept link before becoming an active member.
   // Rather than bouncing to /onboard, accept + verify membership inline (shared
@@ -753,6 +756,13 @@ const AcceptAssignmentPage = () => {
                       ? acceptMutation.error.message
                       : t("accept.errorGeneric")}
                   </div>
+                  {outageHint.isOutage(acceptMutation.error) && (
+                    <div className="mt-2 text-sm">
+                      <GitHubStatusNote
+                        statusDescription={outageHint.statusDescription}
+                      />
+                    </div>
+                  )}
                   <div className="mt-2 text-xs opacity-80">
                     {t("accept.errorRetryHint")}
                   </div>

--- a/web/src/pages/CreateAssignmentPage.test.tsx
+++ b/web/src/pages/CreateAssignmentPage.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import { __resetGitHubHealthForTest } from "@/lib/githubHealth/githubHealthStore"
+
+// Capture the options (onError/onSuccess) the page passes to mutateAsync so a
+// test can drive each callback directly, without a real GitHub client/mutation.
+let lastMutateOptions: {
+  onError?: (err: unknown) => void
+  onSuccess?: (result: unknown, variables: unknown) => void
+} | null = null
+const mutateAsync = vi.fn(
+  (_input: unknown, options?: typeof lastMutateOptions) => {
+    lastMutateOptions = options ?? null
+    return Promise.resolve()
+  },
+)
+vi.mock("@/hooks/mutations/useCreateAssignment", () => ({
+  useCreateAssignment: () => ({ isPending: false, mutateAsync }),
+}))
+
+// The health store fires a best-effort githubstatus.com probe once suspicion
+// trips; stub it so these tests never hit the network.
+vi.mock("@/lib/githubHealth/githubStatusApi", () => ({
+  fetchGitHubStatusIndicator: () => Promise.resolve(null),
+}))
+
+// Stub the form to a single submit button that fires onSubmit with a minimal
+// payload — the page's onError/onSuccess wiring is what's under test.
+vi.mock("@/pages/assignments/CreateAssignmentForm", () => ({
+  default: ({ onSubmit }: { onSubmit: (values: { slug: string }) => void }) => (
+    <button type="button" onClick={() => onSubmit({ slug: "hw1" })}>
+      submit
+    </button>
+  ),
+}))
+
+// Heavy layout/role boundaries the page mounts; stub to pass-through so the
+// alert branch logic is what we exercise.
+vi.mock("@/components/PageShell", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+vi.mock("@/components/PageHeader", () => ({ default: () => null }))
+vi.mock("@/components/breadcrumb", () => ({ default: () => null }))
+vi.mock("@/components/RequireRole", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+vi.mock("@/components/EmptyRosterNotice", () => ({
+  EmptyRosterNotice: () => null,
+}))
+
+vi.mock("@/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: () => undefined,
+}))
+vi.mock("@/hooks/useGetClassAssignments", () => ({
+  default: () => ({ data: { assignments: [] } }),
+}))
+vi.mock("@/hooks/useEmptyRosterWarning", () => ({
+  default: () => ({ show: false, hasRosterRows: true }),
+}))
+vi.mock("@/hooks/useTrackPublishDeploy", () => ({
+  useTrackPublishDeploy: () => vi.fn(),
+}))
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify: vi.fn() }),
+}))
+
+const navigateMock = vi.fn()
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => ({ org: "acme", classroom: "cs101" }),
+  }
+})
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+import CreateAssignmentPage from "./CreateAssignmentPage"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+const apiError = (status: number, over: Partial<GitHubRateLimit> = {}) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: { ...noRateLimit, ...over },
+  })
+
+const STATUS_LINK = "githubStatus.checkStatusLink"
+
+const submit = () =>
+  fireEvent.click(screen.getByRole("button", { name: "submit" }))
+
+const failWith = (err: unknown) => act(() => lastMutateOptions?.onError?.(err))
+
+beforeEach(() => {
+  mutateAsync.mockClear()
+  lastMutateOptions = null
+  navigateMock.mockClear()
+  __resetGitHubHealthForTest()
+  vi.stubGlobal("scrollTo", vi.fn())
+})
+
+afterEach(() => {
+  cleanup()
+  __resetGitHubHealthForTest()
+  vi.unstubAllGlobals()
+})
+
+describe("CreateAssignmentPage outage save hint", () => {
+  it("shows the githubstatus.com hint (not the raw message) on an outage-shaped save failure", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    failWith(apiError(503))
+    expect(screen.queryByText(STATUS_LINK)).not.toBeNull()
+    // The raw error message is replaced by the outage note.
+    expect(screen.queryByText("HTTP 503")).toBeNull()
+  })
+
+  it("shows the hint for a wrapped network failure", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    failWith(new TypeError("Failed to fetch"))
+    expect(screen.queryByText(STATUS_LINK)).not.toBeNull()
+  })
+
+  it("shows the raw message and no hint on a definitive 4xx", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    failWith(apiError(404))
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+    expect(screen.queryByText("HTTP 404")).not.toBeNull()
+  })
+
+  it("shows the raw message and no hint on a rate limit", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    failWith(apiError(429))
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+    expect(screen.queryByText("HTTP 429")).not.toBeNull()
+  })
+
+  it("does not treat a non-network local error as an outage", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    failWith(new Error("something local broke"))
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+    expect(screen.queryByText("something local broke")).not.toBeNull()
+  })
+
+  it("clears the outage hint when a resubmit fails with a definitive error", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    failWith(apiError(503))
+    expect(screen.queryByText(STATUS_LINK)).not.toBeNull()
+
+    // Resubmit (onSubmit resets outageError) then fail definitively.
+    submit()
+    failWith(apiError(404))
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+    expect(screen.queryByText("HTTP 404")).not.toBeNull()
+  })
+})

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -16,7 +16,7 @@ import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { logger } from "@/lib/logger"
 import { logWriteFailure } from "@/lib/logWriteFailure"
-import { useGitHubHealth, useOutageHint } from "@/lib/githubHealth"
+import { useOutageHint } from "@/lib/githubHealth"
 import { GitHubStatusNote } from "@/components/GitHubStatusNote"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -34,8 +34,8 @@ const CreateAssignmentPage = () => {
   const [outageError, setOutageError] = useState(false)
   const [warningMessage, setWarningMessage] = useState("")
 
-  const { statusDescription: outageStatusDescription } = useGitHubHealth()
   const outageHint = useOutageHint()
+  const outageStatusDescription = outageHint.statusDescription
 
   const { data: assignmentsData } = useGetClassroomAssignments(org, classroom)
   const takenSlugs = (assignmentsData?.assignments ?? []).map((a) => a.slug)
@@ -136,9 +136,10 @@ const CreateAssignmentPage = () => {
                 onError: (err) => {
                   logWriteFailure(log, err, "create assignment failed")
                   // A transient outage-shaped failure during save reads as a
-                  // local "fetch failed" — swap in the outage hint when the app
-                  // suspects GitHub is degraded, so the teacher knows to retry.
-                  if (outageHint(err)) {
+                  // local "fetch failed" — swap in the outage hint (the strict
+                  // classifier keeps a definitive 4xx / rate limit reading as
+                  // the real message), so the teacher knows to retry.
+                  if (outageHint.isOutage(err)) {
                     setOutageError(true)
                     setErrorMessage(t("githubStatus.title"))
                   } else {

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -30,8 +30,15 @@ const CreateAssignmentPage = () => {
   const { org, classroom } = useParams({ strict: false })
   const { notify } = useToast()
   const trackPublishDeploy = useTrackPublishDeploy()
-  const [errorMessage, setErrorMessage] = useState("")
-  const [outageError, setOutageError] = useState(false)
+  // The error alert's content and its visibility are tracked separately so the
+  // AnimatePresence exit animation keeps rendering the last content while it
+  // collapses. Clearing the content on hide (a single `errorMessage` string)
+  // would blank the alert mid-collapse; instead we only flip `errorShown` off
+  // and leave `errorContent` frozen until the next failure replaces it.
+  const [errorContent, setErrorContent] = useState<
+    { kind: "message"; message: string } | { kind: "outage" }
+  >({ kind: "message", message: "" })
+  const [errorShown, setErrorShown] = useState(false)
   const [warningMessage, setWarningMessage] = useState("")
 
   const outageHint = useOutageHint()
@@ -69,11 +76,11 @@ const CreateAssignmentPage = () => {
             hasRosterRows={emptyRoster.hasRosterRows}
           />
         ) : null}
-        <AnimatedAlert tone="error" show={!!errorMessage}>
-          {outageError ? (
+        <AnimatedAlert tone="error" show={errorShown}>
+          {errorContent.kind === "outage" ? (
             <GitHubStatusNote statusDescription={outageStatusDescription} />
           ) : (
-            errorMessage
+            errorContent.message
           )}
         </AnimatedAlert>
         <AnimatedAlert
@@ -100,8 +107,9 @@ const CreateAssignmentPage = () => {
           classroom={classroom}
           takenSlugs={takenSlugs}
           onSubmit={(values) => {
-            setErrorMessage("")
-            setOutageError(false)
+            // Hide the alert but keep its content frozen for the exit collapse;
+            // the next failure (if any) replaces the content when it re-shows.
+            setErrorShown(false)
             setWarningMessage("")
             createAssignmentMutation.mutateAsync(
               {
@@ -139,13 +147,12 @@ const CreateAssignmentPage = () => {
                   // local "fetch failed" — swap in the outage hint (the strict
                   // classifier keeps a definitive 4xx / rate limit reading as
                   // the real message), so the teacher knows to retry.
-                  if (outageHint.isOutage(err)) {
-                    setOutageError(true)
-                    setErrorMessage(t("githubStatus.title"))
-                  } else {
-                    setOutageError(false)
-                    setErrorMessage(err.message)
-                  }
+                  setErrorContent(
+                    outageHint.isOutage(err)
+                      ? { kind: "outage" }
+                      : { kind: "message", message: err.message },
+                  )
+                  setErrorShown(true)
                   window.scrollTo({ top: 0, behavior: "smooth" })
                 },
                 onSuccess: (result, variables) => {

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -16,6 +16,8 @@ import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { logger } from "@/lib/logger"
 import { logWriteFailure } from "@/lib/logWriteFailure"
+import { useGitHubHealth, useOutageHint } from "@/lib/githubHealth"
+import { GitHubStatusNote } from "@/components/GitHubStatusNote"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -29,7 +31,11 @@ const CreateAssignmentPage = () => {
   const { notify } = useToast()
   const trackPublishDeploy = useTrackPublishDeploy()
   const [errorMessage, setErrorMessage] = useState("")
+  const [outageError, setOutageError] = useState(false)
   const [warningMessage, setWarningMessage] = useState("")
+
+  const { statusDescription: outageStatusDescription } = useGitHubHealth()
+  const outageHint = useOutageHint()
 
   const { data: assignmentsData } = useGetClassroomAssignments(org, classroom)
   const takenSlugs = (assignmentsData?.assignments ?? []).map((a) => a.slug)
@@ -64,7 +70,11 @@ const CreateAssignmentPage = () => {
           />
         ) : null}
         <AnimatedAlert tone="error" show={!!errorMessage}>
-          {errorMessage}
+          {outageError ? (
+            <GitHubStatusNote statusDescription={outageStatusDescription} />
+          ) : (
+            errorMessage
+          )}
         </AnimatedAlert>
         <AnimatedAlert
           tone="warning"
@@ -91,6 +101,7 @@ const CreateAssignmentPage = () => {
           takenSlugs={takenSlugs}
           onSubmit={(values) => {
             setErrorMessage("")
+            setOutageError(false)
             setWarningMessage("")
             createAssignmentMutation.mutateAsync(
               {
@@ -124,7 +135,16 @@ const CreateAssignmentPage = () => {
               {
                 onError: (err) => {
                   logWriteFailure(log, err, "create assignment failed")
-                  setErrorMessage(err.message)
+                  // A transient outage-shaped failure during save reads as a
+                  // local "fetch failed" — swap in the outage hint when the app
+                  // suspects GitHub is degraded, so the teacher knows to retry.
+                  if (outageHint(err)) {
+                    setOutageError(true)
+                    setErrorMessage(t("githubStatus.title"))
+                  } else {
+                    setOutageError(false)
+                    setErrorMessage(err.message)
+                  }
                   window.scrollTo({ top: 0, behavior: "smooth" })
                 },
                 onSuccess: (result, variables) => {

--- a/web/src/pages/assignments/TemplateField.test.tsx
+++ b/web/src/pages/assignments/TemplateField.test.tsx
@@ -228,6 +228,7 @@ describe("TemplateField — outage hint on inconclusive verdicts", () => {
       kind: "unknown",
       owner: ORG,
       repo: "tmpl",
+      outage: false,
     })
     act(() => suspectOutage())
     renderField()
@@ -236,11 +237,27 @@ describe("TemplateField — outage hint on inconclusive verdicts", () => {
     expect(screen.getByText("assignments.template.unknown")).toBeTruthy()
   })
 
-  it("does NOT show the hint on an 'unknown' verdict when no outage is suspected", async () => {
+  it("shows the hint on an 'unknown' verdict flagged as an outage, even with no global suspicion", async () => {
+    // The verify query resolves-successfully with this verdict, which clears the
+    // global suspicion — so a verify that itself failed with a 5xx/network error
+    // must still surface the hint via the verdict's own `outage` flag.
     verifyTemplateAccess.mockResolvedValue({
       kind: "unknown",
       owner: ORG,
       repo: "tmpl",
+      outage: true,
+    })
+    renderField()
+    expect(await screen.findByText(STATUS_LINK)).toBeTruthy()
+    expect(screen.getByText("assignments.template.unknown")).toBeTruthy()
+  })
+
+  it("does NOT show the hint on an 'unknown' verdict with no outage and no suspicion", async () => {
+    verifyTemplateAccess.mockResolvedValue({
+      kind: "unknown",
+      owner: ORG,
+      repo: "tmpl",
+      outage: false,
     })
     renderField()
     await screen.findByText("assignments.template.unknown")
@@ -252,6 +269,7 @@ describe("TemplateField — outage hint on inconclusive verdicts", () => {
       kind: "rate-limited",
       owner: ORG,
       repo: "tmpl",
+      outage: false,
     })
     act(() => suspectOutage())
     renderField()

--- a/web/src/pages/assignments/TemplateField.test.tsx
+++ b/web/src/pages/assignments/TemplateField.test.tsx
@@ -39,8 +39,19 @@ vi.mock("@/hooks/mutations/useReconcileTemplateAccess", () => ({
   }),
 }))
 
+// The health store fires a best-effort githubstatus.com probe once suspicion
+// trips; stub it so these tests never hit the network.
+vi.mock("@/lib/githubHealth/githubStatusApi", () => ({
+  fetchGitHubStatusIndicator: () => Promise.resolve(null),
+}))
+
 import { TemplateField } from "./TemplateField"
 import type { StringField } from "./formFieldHelpers"
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import {
+  __resetGitHubHealthForTest,
+  recordGitHubFailure,
+} from "@/lib/githubHealth/githubHealthStore"
 
 const ORG = "cs50"
 const CLASSROOM = "cs50"
@@ -80,9 +91,13 @@ beforeEach(() => {
   teamHasRepoAccess.mockReset()
   reconcileMutate.mockReset()
   reconcilePending = false
+  __resetGitHubHealthForTest()
 })
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  __resetGitHubHealthForTest()
+})
 
 describe("TemplateField — inline Fix template access", () => {
   const okInOrgPrivate = {
@@ -178,5 +193,82 @@ describe("TemplateField — inline Fix template access", () => {
         exact: false,
       }),
     ).toBeNull()
+  })
+})
+
+describe("TemplateField — outage hint on inconclusive verdicts", () => {
+  const noRateLimit: GitHubRateLimit = {
+    limit: null,
+    remaining: null,
+    used: null,
+    reset: null,
+    resource: null,
+    retryAfter: null,
+  }
+  const apiError = (status: number) =>
+    new GitHubAPIError({
+      status,
+      url: "https://api.github.com/x",
+      message: `HTTP ${status}`,
+      body: null,
+      rateLimit: noRateLimit,
+    })
+
+  function suspectOutage() {
+    const base = Date.now()
+    recordGitHubFailure(apiError(500), base)
+    recordGitHubFailure(apiError(500), base + 100)
+    recordGitHubFailure(apiError(500), base + 200)
+  }
+
+  const STATUS_LINK = "githubStatus.checkStatusLink"
+
+  it("shows the githubstatus.com hint on an 'unknown' verdict when an outage is suspected", async () => {
+    verifyTemplateAccess.mockResolvedValue({
+      kind: "unknown",
+      owner: ORG,
+      repo: "tmpl",
+    })
+    act(() => suspectOutage())
+    renderField()
+    expect(await screen.findByText(STATUS_LINK)).toBeTruthy()
+    // The local verdict copy still renders alongside the hint.
+    expect(screen.getByText("assignments.template.unknown")).toBeTruthy()
+  })
+
+  it("does NOT show the hint on an 'unknown' verdict when no outage is suspected", async () => {
+    verifyTemplateAccess.mockResolvedValue({
+      kind: "unknown",
+      owner: ORG,
+      repo: "tmpl",
+    })
+    renderField()
+    await screen.findByText("assignments.template.unknown")
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
+  })
+
+  it("shows the hint on a 'rate-limited' verdict when an outage is suspected", async () => {
+    verifyTemplateAccess.mockResolvedValue({
+      kind: "rate-limited",
+      owner: ORG,
+      repo: "tmpl",
+    })
+    act(() => suspectOutage())
+    renderField()
+    expect(await screen.findByText(STATUS_LINK)).toBeTruthy()
+  })
+
+  it("does NOT show the hint on a definitive verdict even when suspected", async () => {
+    verifyTemplateAccess.mockResolvedValue({
+      kind: "not-template",
+      owner: ORG,
+      repo: "tmpl",
+    })
+    act(() => suspectOutage())
+    renderField()
+    await screen.findByText("assignments.template.notTemplate", {
+      exact: false,
+    })
+    expect(screen.queryByText(STATUS_LINK)).toBeNull()
   })
 })

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -310,6 +310,16 @@ function renderTemplateVerdict({
   outageSuspected: boolean
   statusDescription: string | null
 }): ReactNode {
+  // The inconclusive verdicts hint at an outage when either the global suspicion
+  // is up OR this verify itself failed with an outage — the latter matters
+  // because the verify query resolves-successfully, clearing the global flag.
+  const outageHintNote = (verdictIsOutage: boolean) =>
+    verdictIsOutage || outageSuspected ? (
+      <span className="mt-1 block text-xs text-base-content/70">
+        <GitHubStatusNote statusDescription={statusDescription} />
+      </span>
+    ) : null
+
   switch (verification.kind) {
     case "ok": {
       // Students can't read an in-org private template directly; the classroom
@@ -443,11 +453,7 @@ function renderTemplateVerdict({
             owner: verification.owner,
             repo: verification.repo,
           })}
-          {outageSuspected && (
-            <span className="mt-1 block text-xs text-base-content/70">
-              <GitHubStatusNote statusDescription={statusDescription} />
-            </span>
-          )}
+          {outageHintNote(verification.outage)}
         </Note>
       )
 
@@ -478,11 +484,7 @@ function renderTemplateVerdict({
       return (
         <Note tone="neutral" icon={HelpCircle}>
           {t("assignments.template.rateLimited")}
-          {outageSuspected && (
-            <span className="mt-1 block text-xs text-base-content/70">
-              <GitHubStatusNote statusDescription={statusDescription} />
-            </span>
-          )}
+          {outageHintNote(verification.outage)}
         </Note>
       )
 

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -18,6 +18,8 @@ import {
   type TemplateAccessVerification,
 } from "@/domain/assignments"
 import { teamHasRepoAccess } from "@/github-core/queries"
+import { useGitHubHealth } from "@/lib/githubHealth"
+import { GitHubStatusNote } from "@/components/GitHubStatusNote"
 import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
 import {
   useDebouncedValue,
@@ -241,6 +243,7 @@ const TemplateVerificationNote = ({
   reconcile?: ReactNode
 }) => {
   const { t } = useTranslation()
+  const { suspected, statusDescription } = useGitHubHealth()
   if (pending) {
     return (
       <p className="mt-1.5 flex items-center gap-1.5 text-sm text-base-content/70">
@@ -274,6 +277,8 @@ const TemplateVerificationNote = ({
     fallbackOrg,
     teamHasAccess,
     reconcile,
+    outageSuspected: suspected,
+    statusDescription,
   })
 
   if (!nonMainNote) return verdict
@@ -291,12 +296,19 @@ function renderTemplateVerdict({
   fallbackOrg,
   teamHasAccess,
   reconcile,
+  outageSuspected,
+  statusDescription,
 }: {
   verification: Exclude<TemplateAccessVerification, { kind: "empty" }>
   t: ReturnType<typeof useTranslation>["t"]
   fallbackOrg: string
   teamHasAccess?: boolean
   reconcile?: ReactNode
+  // When the app suspects a GitHub outage, the inconclusive verdicts (unknown /
+  // rate-limited) get an outage hint so a transient degradation doesn't read as
+  // a broken template. No effect on definitive verdicts.
+  outageSuspected: boolean
+  statusDescription: string | null
 }): ReactNode {
   switch (verification.kind) {
     case "ok": {
@@ -431,6 +443,11 @@ function renderTemplateVerdict({
             owner: verification.owner,
             repo: verification.repo,
           })}
+          {outageSuspected && (
+            <span className="mt-1 block text-xs text-base-content/70">
+              <GitHubStatusNote statusDescription={statusDescription} />
+            </span>
+          )}
         </Note>
       )
 
@@ -461,6 +478,11 @@ function renderTemplateVerdict({
       return (
         <Note tone="neutral" icon={HelpCircle}>
           {t("assignments.template.rateLimited")}
+          {outageSuspected && (
+            <span className="mt-1 block text-xs text-base-content/70">
+              <GitHubStatusNote statusDescription={statusDescription} />
+            </span>
+          )}
         </Note>
       )
 


### PR DESCRIPTION
Closes #314.

## Problem

During a GitHub REST degradation, outage-prone operations fail transiently but report a **local-sounding** message that gives no clue GitHub is the cause — reading as "my template is broken" / "I did something wrong" rather than "GitHub is degraded, try again shortly."

Validated first-hand against the live [GitHub incident gxycch3076xk](https://www.githubstatus.com/incidents/gxycch3076xk) ("Degraded REST API Availability": ~35% of REST requests failing, *"requests not consistently reaching the application layer, resulting in failed requests returning HTML responses"*).

## What this does

Reuses the GitHub-health infra (from #310) so failing operations hint at the outage. One shared classifier, two gating models:

- **Foreground operation failures** (assignment save, student accept) hint when the error itself is a positively-identified outage — a real failure the user is staring at.
- **Passive/advisory hints** (template field's inconclusive verdicts) hint when either the verify itself failed with an outage **or** the app is broadly suspicious of an outage.

### Teacher surfaces
- **Template field** — augment the inconclusive `unknown` / `rate-limited` verdicts with the githubstatus.com hint. The verdict carries its own `outage` flag (set from the failure that produced it), so the hint survives the verify query resolving-successfully and clearing global suspicion; it also still shows when global suspicion is up.
- **Assignment save** — swap the raw "fetch failed" message for the outage note when the failure is outage-shaped.

### Student surfaces
- **Accept flow** — the highest-volume, least-technical audience. The accept flow wraps failures in a friendly `AcceptStepError` (preserving the underlying `GitHubAPIError` as `.cause`), so the accept page now shows the githubstatus.com hint on an outage-shaped accept failure.
- **Membership error (also onboarding)** — the shared error card's `generic` branch flags `isOutage` and shows the hint during an outage.

### Correctness — no false positives, no false negatives
- Single strict `isDefiniteOutageError`, used by **both** the suspicion detector and the user-facing hints, so the two can't diverge. Positive-identification only: a 5xx `GitHubAPIError`, a **network-shaped** `TypeError` (matched on the browser's "Failed to fetch" / "NetworkError" / "Load failed" messages — a plain `x.y`-on-undefined app bug does *not* count), or a non-abort timeout `DOMException`, **unwrapping `.cause`**. A definitive 4xx (not-a-member, SSO, restriction), a rate limit, an abort, a `TemplateAccessError`, and any unrecognized local throw **never** read as an outage.
- Because suspicion is fed unfiltered from React Query's global `onError`, gating it on the strict classifier is what keeps unrelated local errors from tripping the global "GitHub is having trouble" banner.
- Guarded `client.request`'s success-path `JSON.parse` so a **200-with-HTML** outage response throws a synthetic 502 `GitHubAPIError` (preserving `X-GitHub-Request-Id` for support correlation, dropping the raw HTML body) instead of leaking a raw `SyntaxError`.
- Accepted trade-off (documented in code): a definitive 4xx is never an outage even during a real incident — GitHub's edge can return 403/404 while degraded, but counting those would reintroduce the false-positive class the classifier exists to prevent.

### Refactor
- Extract `GitHubStatusNote` into its own component; add shared `useOutageHint()` returning `{ isOutage, suspected, statusDescription }`. One shared server-fault helper behind the classifier; the create-assignment error alert keeps its content stable through its exit animation.

Copy reuses the existing `githubStatus.*` keys (no new strings, no translation-coverage gap).

## Acceptance (#314)

- [x] Transient degradation during template verify, assignment save, or student accept names a likely GitHub/network outage + links githubstatus.com.
- [x] No behavior change when it's not an outage — a genuine bad template / not-a-member / real 4xx reads as before.
- [x] Rate limits and definitive 4xx are never mislabeled (guaranteed by the strict classifier + `.cause` unwrap).

## Testing

`npm run check` green (tsc, eslint 0 errors, prettier, dependency-cruiser, 1719 tests). Coverage includes the false-positive matrix (wrapped-5xx & network → hint; wrapped-404 / rate-limit / SSO / template-access / non-network `TypeError` / plain local throw → no hint), the `.cause` unwrap, the 200-with-HTML → synthetic-502 remap (incl. `X-GitHub-Request-Id` preservation), the timeout `DOMException` outage case, the partial-outage suspicion flicker, an unrelated-local-error burst *not* tripping suspicion, the template verdict's own `outage` flag surfacing the hint without global suspicion, and the create-assignment save two-state (outage note vs. raw message, and reset on resubmit).
