### PR TITLE
refactor(web): decompose UploadRoster into parse/import helpers + section components (Tier-2 U12)

### DIFF
--- a/web/src/pages/students/PreflightRecap.tsx
+++ b/web/src/pages/students/PreflightRecap.tsx
@@ -1,0 +1,157 @@
+import { useTranslation } from "react-i18next"
+import { Alert, Badge } from "@/components/ui"
+import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
+import type { PreflightResult } from "@/util/rosterUploadPreflight"
+
+// A small summary tile for a preflight bucket (count + label). Zero-count
+// buckets dim so the teacher's eye goes to what actually changes.
+const PreflightBucket = ({
+  tone,
+  title,
+  count,
+}: {
+  tone: "neutral" | "info" | "warning" | "error"
+  title: string
+  count: number
+}) => {
+  const toneClass =
+    count === 0
+      ? "border-base-300 opacity-50"
+      : tone === "error"
+        ? "border-error/40 bg-error/5"
+        : tone === "warning"
+          ? "border-warning/40 bg-warning/5"
+          : tone === "info"
+            ? "border-info/40 bg-info/5"
+            : "border-base-300"
+  return (
+    <div
+      className={`flex items-center justify-between gap-2 rounded-box border px-4 py-2.5 ${toneClass}`}
+    >
+      <span className="text-sm">{title}</span>
+      <Badge>{count}</Badge>
+    </div>
+  )
+}
+
+// The resolved-preflight recap: the all-members / invite banner, the four
+// action-bucket tiles, and the role-change/instructor-enroll confirmation box
+// that gates the primary button. Rendered only once the preflight resolves.
+export const PreflightRecap = ({
+  preflight,
+  roleChanges,
+  instructorEnrolls,
+  needsRoleConfirm,
+  confirmGrantsOwner,
+  roleChangesConfirmed,
+  onRoleChangesConfirmedChange,
+}: {
+  preflight: PreflightResult
+  roleChanges: PreflightResult["roleChanges"]
+  instructorEnrolls: PreflightResult["enroll"]
+  needsRoleConfirm: boolean
+  confirmGrantsOwner: boolean
+  roleChangesConfirmed: boolean
+  onRoleChangesConfirmedChange: (checked: boolean) => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <div className="mb-4 flex flex-col gap-2">
+      {preflight.allAlreadyMembers ? (
+        <Alert tone="info">
+          <span>{t("students.preflightAllMembersNote")}</span>
+        </Alert>
+      ) : preflight.needsInvite.length > 0 ? (
+        <Alert tone="warning">
+          <span>
+            {t("students.uploadInviteNotice", {
+              count: preflight.needsInvite.length,
+            })}
+          </span>
+        </Alert>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <PreflightBucket
+          tone="neutral"
+          title={t("students.preflightNoActionTitle")}
+          count={preflight.noAction.length}
+        />
+        <PreflightBucket
+          tone="warning"
+          title={t("students.preflightInviteTitle")}
+          count={preflight.needsInvite.length}
+        />
+        <PreflightBucket
+          tone="info"
+          title={t("students.preflightEnrollTitle")}
+          count={preflight.enroll.length}
+        />
+        <PreflightBucket
+          tone="error"
+          title={t("students.preflightRoleChangeTitle")}
+          count={preflight.roleChanges.length}
+        />
+      </div>
+
+      {/* Team moves and org-owner grants need explicit confirmation: a role
+          change is a destructive team move, and an instructor target (role
+          change OR enroll) grants org OWNER. List each and gate the primary
+          button on the checkbox. */}
+      {needsRoleConfirm ? (
+        <div className="mt-1 flex flex-col gap-2 rounded-box border border-error/30 bg-error/5 p-4">
+          <h4 className="text-sm font-semibold">
+            {t("students.preflightConfirmTitle")}
+          </h4>
+          <ul className="flex flex-col gap-1 text-sm">
+            {roleChanges.map((c) => (
+              <li
+                key={`change-${c.username}`}
+                className="flex items-center justify-between gap-2"
+              >
+                <code>{c.username}</code>
+                <span className="opacity-70">
+                  {t("students.preflightRoleChangeDetail", {
+                    from: t(ROLE_LABEL_KEY[c.currentRole]),
+                    to: t(ROLE_LABEL_KEY[c.role]),
+                  })}
+                </span>
+              </li>
+            ))}
+            {instructorEnrolls.map((e) => (
+              <li
+                key={`enroll-${e.username}`}
+                className="flex items-center justify-between gap-2"
+              >
+                <code>{e.username}</code>
+                <span className="opacity-70">
+                  {t("students.preflightEnrollOwnerDetail")}
+                </span>
+              </li>
+            ))}
+          </ul>
+          {confirmGrantsOwner ? (
+            <Alert tone="warning">
+              <span>{t("students.preflightRoleChangeOwnerNotice")}</span>
+            </Alert>
+          ) : null}
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              className="checkbox checkbox-sm mt-0.5"
+              checked={roleChangesConfirmed}
+              onChange={(e) =>
+                onRoleChangesConfirmedChange(e.currentTarget.checked)
+              }
+            />
+            <span>
+              {t("students.preflightConfirmRoleChanges", {
+                count: roleChanges.length + instructorEnrolls.length,
+              })}
+            </span>
+          </label>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/pages/students/RosterImportResult.tsx
+++ b/web/src/pages/students/RosterImportResult.tsx
@@ -1,0 +1,178 @@
+import { useTranslation } from "react-i18next"
+import { Alert, Button } from "@/components/ui"
+import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
+import type { BulkImportResult } from "@/domain/students"
+import type { InviteOutcome, RoleChangeOutcome } from "./runRosterImport"
+
+export type ImportResultSectionRow = {
+  key: string
+  label: string
+  detail?: string
+}
+
+// A titled, scrollable table of result rows (code + detail). Shared by the
+// roster-result view below and the email-invite result (via renderSection).
+export const ImportResultSection = ({
+  title,
+  rows,
+}: {
+  title: string
+  rows: ImportResultSectionRow[]
+}) => {
+  return (
+    <div>
+      <h4 className="font-bold mb-2">{title}</h4>
+
+      <div className="max-h-48 overflow-auto rounded-box border border-base-300">
+        <table className="table table-sm">
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.key}>
+                <td>
+                  <code>{row.key}</code>
+                </td>
+                <td className="opacity-70">{row.detail}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+// The completed roster-import view: the added-count banner, an optional invite-
+// pass error, and per-outcome result sections (added / skipped / team failures /
+// invited / deferred / failed / role changes / role-change failures).
+export const RosterImportResult = ({
+  result,
+  inviteError,
+  inviteOutcome,
+  roleChangeOutcome,
+  onDone,
+}: {
+  result: BulkImportResult
+  inviteError: string | null
+  inviteOutcome: InviteOutcome | null
+  roleChangeOutcome: RoleChangeOutcome | null
+  onDone: () => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <div className="mt-6 space-y-4">
+      <Alert tone="success">
+        <span>
+          {t("students.addedCount", { count: result.addedStudents.length })}
+        </span>
+      </Alert>
+
+      {inviteError && (
+        <Alert tone="error">
+          <span>
+            {t("students.invitePassFailed", { message: inviteError })}
+          </span>
+        </Alert>
+      )}
+
+      {result.addedStudents.length > 0 && (
+        <ImportResultSection
+          title={t("students.resultAdded")}
+          rows={result.addedStudents.map((student) => ({
+            key: student.username,
+            label: student.username,
+            detail: [student.first_name, student.last_name]
+              .filter(Boolean)
+              .join(" "),
+          }))}
+        />
+      )}
+
+      {result.skippedStudents.length > 0 && (
+        <ImportResultSection
+          title={t("students.resultSkipped")}
+          rows={result.skippedStudents.map((student) => ({
+            key: student.username,
+            label: student.username,
+            detail: student.message ?? student.reason,
+          }))}
+        />
+      )}
+
+      {result.teamResults?.some(
+        (teamResult) => teamResult.status === "failed",
+      ) && (
+        <ImportResultSection
+          title={t("students.resultTeamFailures")}
+          rows={result.teamResults
+            .filter((teamResult) => teamResult.status === "failed")
+            .map((teamResult) => ({
+              key: teamResult.username,
+              label: teamResult.username,
+              detail: teamResult.message ?? t("students.couldNotAddToTeam"),
+            }))}
+        />
+      )}
+
+      {inviteOutcome && inviteOutcome.invited.length > 0 && (
+        <ImportResultSection
+          title={t("students.resultInvited")}
+          rows={inviteOutcome.invited.map(({ username, role }) => ({
+            key: username,
+            label: username,
+            detail: t(ROLE_LABEL_KEY[role]),
+          }))}
+        />
+      )}
+
+      {inviteOutcome && inviteOutcome.deferred.length > 0 && (
+        <ImportResultSection
+          title={t("students.resultInvitesDeferred")}
+          rows={inviteOutcome.deferred.map((username) => ({
+            key: username,
+            label: username,
+            detail: t("students.inviteDeferredDetail"),
+          }))}
+        />
+      )}
+
+      {inviteOutcome && inviteOutcome.failed.length > 0 && (
+        <ImportResultSection
+          title={t("students.resultInvitesFailed")}
+          rows={inviteOutcome.failed.map((f) => ({
+            key: f.username,
+            label: f.username,
+            detail: f.message,
+          }))}
+        />
+      )}
+
+      {roleChangeOutcome && roleChangeOutcome.changed.length > 0 && (
+        <ImportResultSection
+          title={t("students.resultRoleChanged")}
+          rows={roleChangeOutcome.changed.map((c) => ({
+            key: c.username,
+            label: c.username,
+            detail: t(ROLE_LABEL_KEY[c.to]),
+          }))}
+        />
+      )}
+
+      {roleChangeOutcome && roleChangeOutcome.failed.length > 0 && (
+        <ImportResultSection
+          title={t("students.resultRoleChangeFailures")}
+          rows={roleChangeOutcome.failed.map((f, i) => ({
+            key: `${f.username}-${i}`,
+            label: f.username,
+            detail: f.message,
+          }))}
+        />
+      )}
+
+      <div className="modal-action">
+        <Button variant="primary" onClick={onDone}>
+          {t("students.done")}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from "react-i18next"
+import { Select } from "@/components/ui"
+import type { ImportRosterRow } from "@/domain/students"
+import type { ClassroomRole } from "@/util/teamRoster"
+import { coerceImportRole } from "./rosterImportParse"
+
+// The parsed-roster preview: one row per deduped username with its name/email/
+// section and an editable role Select (seeded from the CSV role column). Role
+// edits bubble up so the parent can re-run the preflight.
+export const RosterPreviewTable = ({
+  rows,
+  rolesByUser,
+  onRoleChange,
+}: {
+  rows: ImportRosterRow[]
+  rolesByUser: Record<string, ClassroomRole>
+  onRoleChange: (usernameKey: string, role: ClassroomRole) => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <div className="max-h-80 overflow-auto rounded-box border border-base-300">
+      <table className="table table-sm">
+        <thead>
+          <tr>
+            <th scope="col">#</th>
+            <th scope="col">{t("students.githubUsernameColumn")}</th>
+            <th scope="col">{t("students.nameColumn")}</th>
+            <th scope="col">{t("students.emailColumn")}</th>
+            <th scope="col">{t("students.sectionColumn")}</th>
+            <th scope="col">{t("students.roleColumn")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => {
+            const key = row.username.toLowerCase()
+            return (
+              <tr key={key}>
+                <td>{index + 1}</td>
+                <td>
+                  <code>{row.username}</code>
+                </td>
+                <td className="opacity-70">
+                  {[row.first_name, row.last_name].filter(Boolean).join(" ")}
+                </td>
+                <td className="opacity-70">{row.email}</td>
+                <td className="opacity-70">{row.section}</td>
+                <td>
+                  <Select
+                    selectSize="xs"
+                    className="w-32"
+                    aria-label={t("students.assignRoleLabel")}
+                    value={rolesByUser[key] ?? "student"}
+                    onChange={(e) => {
+                      // Read the value synchronously — React nulls the event's
+                      // currentTarget after the handler returns, so a deferred
+                      // setState updater must not touch `e`.
+                      const role = coerceImportRole(e.target.value) ?? "student"
+                      onRoleChange(key, role)
+                    }}
+                  >
+                    <option value="student">{t("students.roleStudent")}</option>
+                    <option value="ta">{t("students.roleTa")}</option>
+                    <option value="instructor">
+                      {t("students.roleInstructor")}
+                    </option>
+                  </Select>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -69,7 +69,6 @@ type UploadRosterProps = {
 }
 type ImportPhase = "idle" | "preview" | "importing" | "complete" | "error"
 
-// BODY
 const UploadRoster = ({
   org,
   classroom,
@@ -175,7 +174,6 @@ const UploadRoster = ({
     onOpenChange?.(false)
   }
 
-  // PREFLIGHT
   // Preflight the parsed rows against current GitHub membership whenever we're
   // in the preview and the rows or their assigned roles change. Read-only. A
   // stale-response guard (token) drops a slow classification superseded by a
@@ -347,7 +345,6 @@ const UploadRoster = ({
     if (file) await ingestFile(file)
   }
 
-  // STARTIMPORT
   const startImport = async () => {
     // Re-entry guard: a synchronous double-click would otherwise fire two
     // concurrent imports racing the same roster.csv read-modify-write.
@@ -432,7 +429,6 @@ const UploadRoster = ({
       ? 0
       : Math.round((progress.processed / progress.total) * 100)
 
-  // RENDER
   return (
     <>
       <input

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -2,30 +2,21 @@ import { useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Upload } from "lucide-react"
 
-import Papa from "papaparse"
-import { bulkEnrollStudentsInClassroom } from "@/domain/students"
-import type { GitHubClient } from "@/github-core/client"
-import { Alert, Badge, Button, Modal, Select, Spinner } from "@/components/ui"
 import {
-  applyClassroomRoleChange,
   bulkInviteByEmail,
-  inviteRosterStudents,
-  isLikelyGithubUsername,
-  NoNewStudentsError,
-  normalizeGithubUsername,
   resolveRosterUploadPreflight,
-  RosterCsvMalformedError,
-  splitName,
-  writeClassroomRoles,
-  type BulkImportResult,
-  type BulkInviteByEmailResult,
-  type ImportRosterRow,
 } from "@/domain/students"
+import type {
+  BulkImportResult,
+  BulkInviteByEmailResult,
+  ImportRosterRow,
+} from "@/domain/students"
+import type { GitHubClient } from "@/github-core/client"
+import { Alert, Button, Modal, Spinner } from "@/components/ui"
 import {
   hasInstructorPromotion,
   type PreflightResult,
 } from "@/util/rosterUploadPreflight"
-import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
 import { logger } from "@/lib/logger"
 import type { ClassroomRole } from "@/util/teamRoster"
 import {
@@ -39,179 +30,28 @@ import {
   EmailInviteResult,
 } from "@/pages/students/EmailInviteFlow"
 import {
-  OPTIONAL_IMPORT_HEADERS,
-  RECOGNIZED_IMPORT_HEADERS,
-  type OptionalImportHeader,
-} from "@/pages/students/rosterImportHeaders"
+  coerceImportRole,
+  detectImportHeaderIssue,
+  parseRosterImportFile,
+  type ImportHeaderIssue,
+} from "./rosterImportParse"
+import { runRosterImport, type ImportProgress } from "./runRosterImport"
+import type { InviteOutcome, RoleChangeOutcome } from "./runRosterImport"
+import { PreflightRecap } from "./PreflightRecap"
+import { RosterPreviewTable } from "./RosterPreviewTable"
+import { ImportResultSection, RosterImportResult } from "./RosterImportResult"
+
+// Preserve the module's original public surface: the pure parse helpers live in
+// ./rosterImportParse now, but UploadRoster.test.ts and any importer still pull
+// them from here.
+export {
+  coerceImportRole,
+  detectImportHeaderIssue,
+  parseRosterImportFile,
+  type ImportHeaderIssue,
+} from "./rosterImportParse"
 
 const log = logger.scope("students:UploadRoster")
-
-// Parse an uploaded roster into metadata rows. A CSV with a `username` header
-// column also honors first_name/last_name/name/email/section columns (case- and
-// order-insensitive); anything without a header falls back to one-username-per
-// -line. github_id in the file is ignored — it's re-derived from GitHub on
-// import so the stored id is authoritative. Rows are deduped by username.
-// Exported for unit testing.
-export const parseRosterImportFile = (text: string): ImportRosterRow[] => {
-  const trimmed = text.trim()
-  if (!trimmed) return []
-
-  const parsed = Papa.parse<Record<string, string>>(trimmed, {
-    header: true,
-    delimiter: "",
-    skipEmptyLines: "greedy",
-    transformHeader: (header) => header.trim().toLowerCase(),
-  })
-
-  const fields = parsed.meta.fields ?? []
-  const hasUsernameColumn =
-    parsed.errors.length === 0 && fields.includes("username")
-
-  const seen = new Set<string>()
-  const rows: ImportRosterRow[] = []
-
-  const push = (row: ImportRosterRow) => {
-    const username = normalizeGithubUsername(row.username)
-    if (!username || !isLikelyGithubUsername(username)) return
-    const key = username.toLowerCase()
-    if (seen.has(key)) return
-    seen.add(key)
-    rows.push({ ...row, username })
-  }
-
-  if (hasUsernameColumn) {
-    for (const raw of parsed.data) {
-      // Read the optional columns generically from the shared header list so
-      // the parser can't drift from what the diagnostic advertises. Two columns
-      // get special handling on top of the generic read: `name` is an alias
-      // that fills first/last when those split columns are ABSENT (not merely
-      // empty), and `role` is coerced through the known-role guard.
-      const cell = (header: OptionalImportHeader): string =>
-        (raw[header] ?? "").trim()
-      const fromName = splitName(raw.name ?? null)
-      push({
-        username: raw.username ?? "",
-        first_name: (raw.first_name ?? fromName.first_name).trim(),
-        last_name: (raw.last_name ?? fromName.last_name).trim(),
-        email: cell("email"),
-        section: cell("section"),
-        role: coerceImportRole(cell("role")),
-      })
-    }
-  } else {
-    for (const line of trimmed.split(/\r?\n/)) {
-      push({ username: line })
-    }
-  }
-
-  return rows
-}
-
-// Why an uploaded file yielded no importable rows, when the cause is the file's
-// SHAPE rather than just invalid handles. `null` means "no structural problem" —
-// either a valid header file or a bare one-username-per-line list, both of which
-// the parser handles; an empty result there is genuinely "no valid usernames".
-//   - missing-username-header: the file has a header row (a delimiter or a
-//     recognized column name) but no `username` column, so the required field
-//     can't be mapped. We surface the required + optional columns instead of
-//     silently falling back to treating each line as a username.
-//   - malformed: Papa reported a structural parse error (ragged rows, unclosed
-//     quote, ...), so the columns can't be trusted.
-export type ImportHeaderIssue =
-  | { kind: "missing-username-header"; present: string[]; optional: string[] }
-  | { kind: "malformed"; detail: string }
-
-// Inspect an uploaded file's structure to explain an empty/mis-parsed import.
-// Pure and side-effect-free so it's unit-testable and can run alongside
-// parseRosterImportFile without re-reading the file. Deliberately does NOT flag
-// a bare one-username-per-line list (the supported headerless format): that is
-// only "a header row missing username" when the first line looks like headers.
-export const detectImportHeaderIssue = (
-  text: string,
-): ImportHeaderIssue | null => {
-  const trimmed = text.trim()
-  if (!trimmed) return null
-
-  const parsed = Papa.parse<Record<string, string>>(trimmed, {
-    header: true,
-    delimiter: "",
-    skipEmptyLines: "greedy",
-    transformHeader: (header) => header.trim().toLowerCase(),
-  })
-
-  // Papa emits a benign "Delimiter" warning for single-column input (a bare
-  // username list) — that's not a structural defect, so ignore it. Only genuine
-  // structural errors (ragged rows, unclosed quotes) mean "malformed".
-  const structuralError = parsed.errors.find((e) => e.type !== "Delimiter")
-  if (structuralError) {
-    return { kind: "malformed", detail: structuralError.message }
-  }
-
-  const fields = (parsed.meta.fields ?? []).map((f) => f.trim()).filter(Boolean)
-  if (fields.includes("username")) return null
-
-  // A header row is one with >1 column (a delimiter was found) or a single
-  // recognized column name. A lone unrecognized token is a bare username list,
-  // not a mis-headered CSV — leave it to the one-per-line fallback.
-  const looksLikeHeaderRow =
-    fields.length > 1 ||
-    fields.some((f) =>
-      (RECOGNIZED_IMPORT_HEADERS as readonly string[]).includes(f),
-    )
-  if (!looksLikeHeaderRow) return null
-
-  return {
-    kind: "missing-username-header",
-    present: fields,
-    optional: [...OPTIONAL_IMPORT_HEADERS],
-  }
-}
-
-// Coerce a raw string to a ClassroomRole, or undefined when absent/unknown.
-// Case-insensitive; the upload defaults undefined to "student" and lets the
-// instructor override, so an unrecognized value degrades to student rather than
-// failing the whole import. Exported so both the CSV parse and the preview
-// Select coerce through one guard (no unchecked cast on raw input).
-export const coerceImportRole = (
-  raw: string | undefined,
-): ClassroomRole | undefined => {
-  const value = raw?.trim().toLowerCase()
-  if (value === "student" || value === "instructor" || value === "ta") {
-    return value
-  }
-  return undefined
-}
-
-// A small summary tile for a preflight bucket (count + label). Zero-count
-// buckets dim so the teacher's eye goes to what actually changes.
-const PreflightBucket = ({
-  tone,
-  title,
-  count,
-}: {
-  tone: "neutral" | "info" | "warning" | "error"
-  title: string
-  count: number
-}) => {
-  const toneClass =
-    count === 0
-      ? "border-base-300 opacity-50"
-      : tone === "error"
-        ? "border-error/40 bg-error/5"
-        : tone === "warning"
-          ? "border-warning/40 bg-warning/5"
-          : tone === "info"
-            ? "border-info/40 bg-info/5"
-            : "border-base-300"
-  return (
-    <div
-      className={`flex items-center justify-between gap-2 rounded-box border px-4 py-2.5 ${toneClass}`}
-    >
-      <span className="text-sm">{title}</span>
-      <Badge>{count}</Badge>
-    </div>
-  )
-}
 
 type UploadRosterProps = {
   org: string
@@ -228,45 +68,8 @@ type UploadRosterProps = {
   onOpenChange?: (open: boolean) => void
 }
 type ImportPhase = "idle" | "preview" | "importing" | "complete" | "error"
-type ImportProgress = {
-  processed: number
-  total: number
-  message: string
-}
 
-const ImportResultSection = ({
-  title,
-  rows,
-}: {
-  title: string
-  rows: {
-    key: string
-    label: string
-    detail?: string
-  }[]
-}) => {
-  return (
-    <div>
-      <h4 className="font-bold mb-2">{title}</h4>
-
-      <div className="max-h-48 overflow-auto rounded-box border border-base-300">
-        <table className="table table-sm">
-          <tbody>
-            {rows.map((row) => (
-              <tr key={row.key}>
-                <td>
-                  <code>{row.key}</code>
-                </td>
-                <td className="opacity-70">{row.detail}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  )
-}
-
+// BODY
 const UploadRoster = ({
   org,
   classroom,
@@ -299,18 +102,14 @@ const UploadRoster = ({
     useState<BulkInviteByEmailResult | null>(null)
   // Why an empty parse produced no rows, when the cause is the file's shape (no
   // `username` header, or malformed CSV) rather than merely invalid handles.
-  // Lets the preview explain the required columns instead of a generic "no
-  // valid usernames". Null when the file shape is fine.
   const [headerIssue, setHeaderIssue] = useState<ImportHeaderIssue | null>(null)
   // Per-row role the instructor is about to invite as, keyed by lowercased
-  // username. Seeded from the CSV `role` column (else "student") and editable in
-  // the preview. Instructor -> org owner invite (called out in the confirm).
+  // username. Seeded from the CSV `role` column (else "student") and editable.
   const [rolesByUser, setRolesByUser] = useState<Record<string, ClassroomRole>>(
     {},
   )
   // Preflight against current GitHub membership (read-only). Null until the
-  // preview's classification resolves; drives the no-action / invite / enroll /
-  // role-change buckets and gates the confirm checkbox.
+  // preview's classification resolves.
   const [preflight, setPreflight] = useState<PreflightResult | null>(null)
   const [preflighting, setPreflighting] = useState(false)
   const [preflightError, setPreflightError] = useState<string | null>(null)
@@ -322,40 +121,18 @@ const UploadRoster = ({
     message: "",
   })
   const [result, setResult] = useState<BulkImportResult | null>(null)
-  // Outcome of the follow-up org-invite pass for uploaded non-members
-  // (deferred = rate-limited, failed = couldn't invite). Surfaced in the result
-  // dialog so an un-invited upload isn't silently lost (it won't appear on the
-  // team-driven roster until re-invited or accepted).
-  const [inviteOutcome, setInviteOutcome] = useState<{
-    invited: { username: string; role: ClassroomRole }[]
-    deferred: string[]
-    failed: { username: string; message: string }[]
-  } | null>(null)
-  // A hard failure of the invite pass AFTER the roster.csv write already
-  // succeeded. Surfaced inside the (still-shown) result view rather than
-  // collapsing to the bare error screen, which would hide the rows that landed.
+  const [inviteOutcome, setInviteOutcome] = useState<InviteOutcome | null>(null)
   const [inviteError, setInviteError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  // Outcome of the confirmed role-change (team-move) pass, surfaced in the
-  // result dialog alongside the invite outcomes.
-  const [roleChangeOutcome, setRoleChangeOutcome] = useState<{
-    changed: { username: string; to: ClassroomRole }[]
-    failed: { username: string; message: string }[]
-  } | null>(null)
+  const [roleChangeOutcome, setRoleChangeOutcome] =
+    useState<RoleChangeOutcome | null>(null)
 
-  // Visibility is owned by the controlling parent via `open` (the roster page
-  // always passes it). Fall back to phase-driven only if used uncontrolled.
+  // Visibility is owned by the controlling parent via `open`.
   const isOpen = open ?? phase !== "idle"
 
-  // A stale-response token for the async file ingest (see ingestFile). Bumped
-  // here so a reset/close cancels an in-flight file.text() read before its
-  // writes can land on a cleared modal.
+  // A stale-response token for the async file ingest (see ingestFile).
   const ingestToken = useRef(0)
 
-  // Clear the file/preview state and return to the drop-zone (idle) screen —
-  // WITHOUT closing the modal. Used when the user cancels/dismisses the preview:
-  // they land back on the drop zone to pick a different file, and there's no
-  // close-then-reopen flash.
   const resetToDropZone = () => {
     ingestToken.current += 1
     setPhase("idle")
@@ -394,18 +171,14 @@ const UploadRoster = ({
     wasOpenRef.current = Boolean(open)
   }, [open])
 
-  // The X / backdrop / Esc always dismiss the whole modal, from any screen —
-  // that's what a close affordance means. Stepping back to the drop zone is a
-  // distinct, explicit action (the preview's "Cancel" button), not what the X
-  // does. State is cleared by the open->false effect, so there's no flash.
   const handleClose = () => {
     onOpenChange?.(false)
   }
 
+  // PREFLIGHT
   // Preflight the parsed rows against current GitHub membership whenever we're
-  // in the preview and the rows or their assigned roles change (a role edit can
-  // move a row between the no-action / enroll / role-change buckets). Read-only.
-  // A stale-response guard (token) drops a slow classification superseded by a
+  // in the preview and the rows or their assigned roles change. Read-only. A
+  // stale-response guard (token) drops a slow classification superseded by a
   // newer role edit. Clearing the confirm checkbox on every re-run forces the
   // teacher to re-confirm after they change a role.
   const preflightToken = useRef(0)
@@ -418,9 +191,6 @@ const UploadRoster = ({
   useEffect(() => {
     if (phase !== "preview" || rows.length === 0) return
     const token = ++preflightToken.current
-    // Reset to the loading state, then fetch the fresh classification (an
-    // external-system sync: the async read supersedes any prior result). The
-    // synchronous resets here are the intended "clear then load" transition.
     /* eslint-disable react-hooks/set-state-in-effect */
     setPreflighting(true)
     setPreflightError(null)
@@ -462,37 +232,21 @@ const UploadRoster = ({
     () => (preflight?.enroll ?? []).filter((e) => e.role === "instructor"),
     [preflight],
   )
-  // Confirmation is required for any team move (role change) or any org-owner
-  // grant via an instructor enroll — both are actions the teacher must approve.
   const needsRoleConfirm =
     roleChanges.length > 0 || instructorEnrolls.length > 0
-  // The listed confirmation items (role changes + instructor enrolls) grant org
-  // OWNER only when one of THOSE targets instructor — not merely because some
-  // other row in the file is an instructor. Keeps the in-box owner warning
-  // matched to the change it sits next to (a Student -> TA move must not claim
-  // it grants owner).
   const confirmGrantsOwner = useMemo(
     () => hasInstructorPromotion(roleChanges) || instructorEnrolls.length > 0,
     [roleChanges, instructorEnrolls],
   )
-  // The broad "any row is assigned instructor" signal — used only for the
-  // general pre-preflight notice above the table (a fresh instructor invite also
-  // grants owner, and that row isn't in the confirm box).
   const anyInstructorAssigned = useMemo(
     () =>
       confirmGrantsOwner ||
       Object.values(rolesByUser).some((r) => r === "instructor"),
     [confirmGrantsOwner, rolesByUser],
   )
-  // The primary action is blocked while the preflight is resolving/failed, or
-  // while role changes / instructor enrolls await explicit confirmation.
   const emailHasInstructor = emails.some(
     (e) => (emailRoles[e.toLowerCase()] ?? "student") === "instructor",
   )
-  // Once the preflight resolves, "process" is only meaningful when it will do
-  // something (send an invite, enroll onto a team, or change a role). An upload
-  // where every row is already correctly enrolled is all no-action, so the
-  // primary button is disabled — there's nothing to confirm.
   const hasActionableWork =
     (preflight?.needsInvite.length ?? 0) +
       (preflight?.enroll.length ?? 0) +
@@ -507,12 +261,7 @@ const UploadRoster = ({
         (!preflight || hasActionableWork) &&
         (!needsRoleConfirm || roleChangesConfirmed)
 
-  // The roster primary-button label reflects what processing will actually do:
-  //   - some rows need an org invite -> "Import & invite N members"
-  //   - everyone's already a member (no invites) -> a generic "Confirm changes",
-  //     since the recap already spells out the team moves being confirmed
-  //   - preflight not resolved yet -> a neutral "Import N members"
-  // "members" (not "students") because a batch can assign TA/instructor too.
+  // The roster primary-button label reflects what processing will actually do.
   const willSendInvites = (preflight?.needsInvite.length ?? 0) > 0
   const rosterPrimaryLabel = willSendInvites
     ? t("students.importAndInviteMembers", { count: rows.length })
@@ -523,8 +272,7 @@ const UploadRoster = ({
       : t("students.importMembers", { count: rows.length })
 
   // Seed the preview state for a given kind from the raw text. Used both on
-  // initial ingest (with the auto-detected kind) and when the teacher overrides
-  // the detected kind in the preview — re-parsing the same text, no re-read.
+  // initial ingest and when the teacher overrides the detected kind.
   const applyKind = (text: string, kind: UploadKind) => {
     setUploadKind(kind)
     if (kind === "email-list") {
@@ -536,18 +284,14 @@ const UploadRoster = ({
         ),
       )
       setEmailOwnerConfirmed(false)
-      // Clear roster-side state so a switch back and forth can't leave stale rows.
       setRows([])
       setHeaderIssue(null)
     } else {
       const parsedRows = parseRosterImportFile(text)
       setRows(parsedRows)
-      // Only diagnose the file shape when nothing parsed — a non-empty result
-      // means the header path worked, so the (rare) header issue is moot.
       setHeaderIssue(
         parsedRows.length === 0 ? detectImportHeaderIssue(text) : null,
       )
-      // Seed the per-row role from the CSV role column (else student).
       setRolesByUser(
         Object.fromEntries(
           parsedRows.map((r) => [
@@ -560,12 +304,6 @@ const UploadRoster = ({
     }
   }
 
-  // Read + classify a chosen/dropped file, seed the auto-detected kind, and show
-  // the preview (where the teacher can override the kind before processing).
-  // A stale-response token guards the post-await writes (mirroring
-  // preflightToken): a close (resetToDropZone via the open->false effect) or a
-  // second file dropped while file.text() is in flight bumps the token, so the
-  // superseded read bails instead of re-populating a closed/replaced modal.
   const ingestFile = async (file: File) => {
     const token = ++ingestToken.current
     try {
@@ -596,9 +334,7 @@ const UploadRoster = ({
   ) => {
     const input = event.currentTarget
     const file = input.files?.[0]
-    if (!file) {
-      return
-    }
+    if (!file) return
     await ingestFile(file)
     input.value = ""
   }
@@ -611,15 +347,14 @@ const UploadRoster = ({
     if (file) await ingestFile(file)
   }
 
+  // STARTIMPORT
   const startImport = async () => {
-    // Re-entry guard: a synchronous double-click (before React re-renders the
-    // button out of the preview phase) would otherwise fire two concurrent
-    // imports racing the same roster.csv read-modify-write.
+    // Re-entry guard: a synchronous double-click would otherwise fire two
+    // concurrent imports racing the same roster.csv read-modify-write.
     if (phase === "importing") return
 
     // Email-list branch: send org invitations by email (no roster.csv write),
-    // then land on the same result screen. Kept before the roster pass so the
-    // two flows never both run.
+    // then land on the same result screen.
     if (uploadKind === "email-list") {
       setPhase("importing")
       setError(null)
@@ -658,217 +393,38 @@ const UploadRoster = ({
     setInviteOutcome(null)
     setInviteError(null)
     setRoleChangeOutcome(null)
-    setProgress({
-      processed: 0,
-      total: rows.length,
-      message: t("students.startingImport"),
+
+    const outcome = await runRosterImport(client, {
+      org,
+      classroom,
+      rows,
+      rolesByUser,
+      // Snapshot the classification computed in the preview so the process pass
+      // matches exactly what the teacher confirmed.
+      plan: preflight,
+      onProgress: setProgress,
+      messages: {
+        startingImport: t("students.startingImport"),
+        invitingUploaded: t("students.invitingUploaded"),
+        processRoleChanges: t("students.processRoleChanges"),
+        importFailed: t("students.importFailed"),
+        roleWritebackMalformed: t("students.roleWritebackMalformed"),
+        roleWritebackFailed: t("students.roleWritebackFailed"),
+      },
     })
 
-    // 1) Write the roster.csv rows (identity + name/email/section) and team-add
-    //    anyone already an active org member. A re-run where every uploaded row
-    //    already exists throws NoNewStudentsError (nothing to commit) — that is
-    //    benign here: we still run the invite pass below so a student whose
-    //    first invite was rate-limited/failed gets re-invited. Any other enroll
-    //    error is a genuine failure (nothing written) -> error screen.
-    let importResult: BulkImportResult
-    try {
-      importResult = await bulkEnrollStudentsInClassroom(client, {
-        org,
-        classroom,
-        rows,
-        onProgress: setProgress,
-      })
-    } catch (err) {
-      if (err instanceof NoNewStudentsError) {
-        // All rows already in roster.csv — synthesize an empty result so the
-        // completed view still renders, then fall through to the invite pass.
-        importResult = { addedStudents: [], skippedStudents: [] }
-      } else {
-        log.error("roster import failed", { err, record: true })
-        setError(
-          err instanceof Error ? err.message : t("students.importFailed"),
-        )
-        setPhase("error")
-        return
-      }
-    }
-    setResult(importResult)
-
-    // Snapshot the classification computed in the preview so the process pass
-    // matches exactly what the teacher confirmed. (Recomputing here could drift
-    // if membership changed between preview and process.)
-    const plan = preflight
-
-    // 2) The team is the source of truth for who shows on the roster, so send
-    //    org invites for uploaded students who aren't already members — they
-    //    then appear as a `pending` row. Invite the FULL uploaded set (not just
-    //    the newly-added rows): inviteRosterStudents no-ops anyone already
-    //    active/pending, so a re-run after a rate limit still re-invites a
-    //    student whose first invite was deferred (their CSV row already exists,
-    //    so they'd otherwise be skipped as a duplicate and, since CSV-only rows
-    //    don't render, silently lost). Thread the github_id the enroll pass
-    //    just resolved (from addedStudents, keyed by login) so the invite
-    //    targets the immutable account rather than re-resolving a possibly
-    //    recycled/renamed login. Their roster.csv row enriches the pending row;
-    //    deferred/failed invites are surfaced in the result dialog.
-    //
-    //    SKIP the invite pass entirely when the preflight found every uploaded
-    //    username is already an active org member — there's nothing to invite,
-    //    so don't hammer the invite endpoint (requirement: skip invites when all
-    //    are members).
-    const idByLogin = new Map(
-      importResult.addedStudents.map((s) => [
-        s.username.toLowerCase(),
-        s.github_id,
-      ]),
-    )
-    if (!plan?.allAlreadyMembers) {
-      setProgress({
-        processed: 0,
-        total: rows.length,
-        message: t("students.invitingUploaded"),
-      })
-      try {
-        const inviteRes = await inviteRosterStudents(client, {
-          org,
-          classroom,
-          students: rows.map((r) => ({
-            username: r.username,
-            github_id: idByLogin.get(r.username.toLowerCase()) ?? "",
-            role: rolesByUser[r.username.toLowerCase()] ?? "student",
-          })),
-          onProgress: setProgress,
-        })
-        setInviteOutcome({
-          invited: inviteRes.invited,
-          deferred: inviteRes.deferred,
-          failed: inviteRes.failed.map((f) => ({
-            username: f.username,
-            message: f.message,
-          })),
-        })
-      } catch (err) {
-        // The roster.csv write already landed; a hard invite failure must not
-        // hide it behind the bare error screen. Keep the completed view and show
-        // the invite error there — the teacher can re-run to retry the invites.
-        log.error("roster invite pass failed", { err, record: true })
-        setInviteError(
-          err instanceof Error ? err.message : t("students.importFailed"),
-        )
-      }
+    if (!outcome.ok) {
+      setError(outcome.error)
+      setPhase("error")
+      return
     }
 
-    // 3) Persist the assigned role back to roster.csv for EVERY uploaded row,
-    //    not just the freshly-invited ones. A row that was deferred (rate
-    //    limit), skipped (already a member/pending), or failed still has a
-    //    teacher-assigned role and a roster row from step 1 — omitting them
-    //    would leave their role blank until a later sync. writeClassroomRoles
-    //    only touches existing rows whose role actually changed, so covering
-    //    the full set is safe and idempotent. Best-effort: a writeback failure
-    //    doesn't undo the invites (role converges on the next sync). A
-    //    malformed roster.csv is surfaced distinctly so the teacher fixes it.
-    const roleWriteback = rows
-      .map((r) => ({
-        username: r.username,
-        role: rolesByUser[r.username.toLowerCase()] ?? "student",
-      }))
-      .filter((r) => r.username.trim())
-    if (roleWriteback.length > 0) {
-      try {
-        await writeClassroomRoles(client, {
-          org,
-          classroom,
-          roles: roleWriteback,
-        })
-      } catch (err) {
-        if (err instanceof RosterCsvMalformedError) {
-          setInviteError(t("students.roleWritebackMalformed"))
-        } else {
-          // A transient/other writeback failure isn't fatal (the role converges
-          // on the next sync), but the completed dialog would otherwise show a
-          // bare success — surface a soft warning so the teacher knows the role
-          // column didn't persist this run.
-          setInviteError(t("students.roleWritebackFailed"))
-        }
-        log.warn("roster role writeback failed", { err, record: true })
-      }
-    }
-
-    // 4) Apply the CONFIRMED team assignments the preflight identified:
-    //    - role_change: an active member on a DIFFERENT classroom team -> move
-    //      them (drop every non-target team; instructor target grants org owner,
-    //      a demotion off instructor revokes it). Gated behind the confirmation
-    //      checkbox in the preview.
-    //    - enroll: an active member on NO classroom team -> an additive team-add
-    //      onto the CSV role's team (empty fromRoles, so nothing is dropped).
-    //    Both route through applyClassroomRoleChange (re-verifies active membership,
-    //    never team-adds a non-member). Best-effort per row: a failure is
-    //    surfaced in the result dialog, not fatal (the roster write already
-    //    landed).
-    const moves: {
-      username: string
-      fromRoles: ClassroomRole[]
-      toRole: ClassroomRole
-    }[] = [
-      ...(plan?.roleChanges ?? []).map((c) => ({
-        username: c.username,
-        fromRoles: c.currentRoles,
-        toRole: c.role,
-      })),
-      ...(plan?.enroll ?? []).map((e) => ({
-        username: e.username,
-        fromRoles: [] as ClassroomRole[],
-        toRole: e.role,
-      })),
-    ]
-    if (moves.length > 0) {
-      setProgress({
-        processed: 0,
-        total: moves.length,
-        message: t("students.processRoleChanges"),
-      })
-      const changed: {
-        username: string
-        to: ClassroomRole
-      }[] = []
-      const failed: { username: string; message: string }[] = []
-      let done = 0
-      for (const move of moves) {
-        try {
-          const res = await applyClassroomRoleChange(client, {
-            org,
-            classroom,
-            username: move.username,
-            github_id: idByLogin.get(move.username.toLowerCase()),
-            fromRoles: move.fromRoles,
-            toRole: move.toRole,
-          })
-          changed.push({ username: res.username, to: res.toRole })
-          // A best-effort old-team removal failure is a warning, not a hard
-          // failure — surface it alongside so the teacher can retry.
-          for (const w of res.warnings) {
-            failed.push({ username: move.username, message: w })
-          }
-        } catch (err) {
-          log.error("roster role change failed", { err, record: true })
-          failed.push({
-            username: move.username,
-            message: err instanceof Error ? err.message : String(err),
-          })
-        } finally {
-          done += 1
-          setProgress({
-            processed: done,
-            total: moves.length,
-            message: t("students.processRoleChanges"),
-          })
-        }
-      }
-      setRoleChangeOutcome({ changed, failed })
-    }
-
+    setResult(outcome.importResult)
+    setInviteOutcome(outcome.inviteOutcome)
+    setInviteError(outcome.inviteError)
+    setRoleChangeOutcome(outcome.roleChangeOutcome)
     setPhase("complete")
-    onSuccess?.(importResult)
+    onSuccess?.(outcome.importResult)
   }
 
   const progressPercent =
@@ -876,6 +432,7 @@ const UploadRoster = ({
       ? 0
       : Math.round((progress.processed / progress.total) * 100)
 
+  // RENDER
   return (
     <>
       <input
@@ -950,10 +507,7 @@ const UploadRoster = ({
 
         {phase === "preview" && (
           <div className="mt-6">
-            {/* Detected format + override, rendered once above the branch
-                split: the file was auto-classified; the teacher can switch if
-                the guess is wrong before processing. The roster-CSV / username
-                body renders in the block below (it carries the preflight). */}
+            {/* Detected format + override, above the branch split. */}
             <DetectedFormatSelect
               value={uploadKind}
               onChange={(kind) => applyKind(fileText, kind)}
@@ -1000,105 +554,15 @@ const UploadRoster = ({
                 </span>
               </Alert>
             ) : preflight ? (
-              <div className="mb-4 flex flex-col gap-2">
-                {preflight.allAlreadyMembers ? (
-                  <Alert tone="info">
-                    <span>{t("students.preflightAllMembersNote")}</span>
-                  </Alert>
-                ) : preflight.needsInvite.length > 0 ? (
-                  <Alert tone="warning">
-                    <span>
-                      {t("students.uploadInviteNotice", {
-                        count: preflight.needsInvite.length,
-                      })}
-                    </span>
-                  </Alert>
-                ) : null}
-
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  <PreflightBucket
-                    tone="neutral"
-                    title={t("students.preflightNoActionTitle")}
-                    count={preflight.noAction.length}
-                  />
-                  <PreflightBucket
-                    tone="warning"
-                    title={t("students.preflightInviteTitle")}
-                    count={preflight.needsInvite.length}
-                  />
-                  <PreflightBucket
-                    tone="info"
-                    title={t("students.preflightEnrollTitle")}
-                    count={preflight.enroll.length}
-                  />
-                  <PreflightBucket
-                    tone="error"
-                    title={t("students.preflightRoleChangeTitle")}
-                    count={preflight.roleChanges.length}
-                  />
-                </div>
-
-                {/* Team moves and org-owner grants need explicit confirmation:
-                    a role change is a destructive team move, and an instructor
-                    target (role change OR enroll) grants org OWNER. List each
-                    and gate the primary button on the checkbox. */}
-                {needsRoleConfirm ? (
-                  <div className="mt-1 flex flex-col gap-2 rounded-box border border-error/30 bg-error/5 p-4">
-                    <h4 className="text-sm font-semibold">
-                      {t("students.preflightConfirmTitle")}
-                    </h4>
-                    <ul className="flex flex-col gap-1 text-sm">
-                      {roleChanges.map((c) => (
-                        <li
-                          key={`change-${c.username}`}
-                          className="flex items-center justify-between gap-2"
-                        >
-                          <code>{c.username}</code>
-                          <span className="opacity-70">
-                            {t("students.preflightRoleChangeDetail", {
-                              from: t(ROLE_LABEL_KEY[c.currentRole]),
-                              to: t(ROLE_LABEL_KEY[c.role]),
-                            })}
-                          </span>
-                        </li>
-                      ))}
-                      {instructorEnrolls.map((e) => (
-                        <li
-                          key={`enroll-${e.username}`}
-                          className="flex items-center justify-between gap-2"
-                        >
-                          <code>{e.username}</code>
-                          <span className="opacity-70">
-                            {t("students.preflightEnrollOwnerDetail")}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                    {confirmGrantsOwner ? (
-                      <Alert tone="warning">
-                        <span>
-                          {t("students.preflightRoleChangeOwnerNotice")}
-                        </span>
-                      </Alert>
-                    ) : null}
-                    <label className="flex items-start gap-2 text-sm">
-                      <input
-                        type="checkbox"
-                        className="checkbox checkbox-sm mt-0.5"
-                        checked={roleChangesConfirmed}
-                        onChange={(e) =>
-                          setRoleChangesConfirmed(e.currentTarget.checked)
-                        }
-                      />
-                      <span>
-                        {t("students.preflightConfirmRoleChanges", {
-                          count: roleChanges.length + instructorEnrolls.length,
-                        })}
-                      </span>
-                    </label>
-                  </div>
-                ) : null}
-              </div>
+              <PreflightRecap
+                preflight={preflight}
+                roleChanges={roleChanges}
+                instructorEnrolls={instructorEnrolls}
+                needsRoleConfirm={needsRoleConfirm}
+                confirmGrantsOwner={confirmGrantsOwner}
+                roleChangesConfirmed={roleChangesConfirmed}
+                onRoleChangesConfirmedChange={setRoleChangesConfirmed}
+              />
             ) : null}
 
             {/* Instructor-owner notice even before preflight resolves, whenever
@@ -1110,68 +574,13 @@ const UploadRoster = ({
             ) : null}
 
             {rows.length > 0 ? (
-              <div className="max-h-80 overflow-auto rounded-box border border-base-300">
-                <table className="table table-sm">
-                  <thead>
-                    <tr>
-                      <th scope="col">#</th>
-                      <th scope="col">{t("students.githubUsernameColumn")}</th>
-                      <th scope="col">{t("students.nameColumn")}</th>
-                      <th scope="col">{t("students.emailColumn")}</th>
-                      <th scope="col">{t("students.sectionColumn")}</th>
-                      <th scope="col">{t("students.roleColumn")}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {rows.map((row, index) => {
-                      const key = row.username.toLowerCase()
-                      return (
-                        <tr key={key}>
-                          <td>{index + 1}</td>
-                          <td>
-                            <code>{row.username}</code>
-                          </td>
-                          <td className="opacity-70">
-                            {[row.first_name, row.last_name]
-                              .filter(Boolean)
-                              .join(" ")}
-                          </td>
-                          <td className="opacity-70">{row.email}</td>
-                          <td className="opacity-70">{row.section}</td>
-                          <td>
-                            <Select
-                              selectSize="xs"
-                              className="w-32"
-                              aria-label={t("students.assignRoleLabel")}
-                              value={rolesByUser[key] ?? "student"}
-                              onChange={(e) => {
-                                // Read the value synchronously — React nulls the
-                                // event's currentTarget after the handler
-                                // returns, so a deferred setState updater must
-                                // not touch `e`.
-                                const role =
-                                  coerceImportRole(e.target.value) ?? "student"
-                                setRolesByUser((prev) => ({
-                                  ...prev,
-                                  [key]: role,
-                                }))
-                              }}
-                            >
-                              <option value="student">
-                                {t("students.roleStudent")}
-                              </option>
-                              <option value="ta">{t("students.roleTa")}</option>
-                              <option value="instructor">
-                                {t("students.roleInstructor")}
-                              </option>
-                            </Select>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
+              <RosterPreviewTable
+                rows={rows}
+                rolesByUser={rolesByUser}
+                onRoleChange={(key, role) =>
+                  setRolesByUser((prev) => ({ ...prev, [key]: role }))
+                }
+              />
             ) : (
               <Alert tone="warning">
                 {headerIssue?.kind === "missing-username-header" ? (
@@ -1251,124 +660,13 @@ const UploadRoster = ({
         )}
 
         {phase === "complete" && result && (
-          <div className="mt-6 space-y-4">
-            <Alert tone="success">
-              <span>
-                {t("students.addedCount", {
-                  count: result.addedStudents.length,
-                })}
-              </span>
-            </Alert>
-
-            {inviteError && (
-              <Alert tone="error">
-                <span>
-                  {t("students.invitePassFailed", { message: inviteError })}
-                </span>
-              </Alert>
-            )}
-
-            {result.addedStudents.length > 0 && (
-              <ImportResultSection
-                title={t("students.resultAdded")}
-                rows={result.addedStudents.map((student) => ({
-                  key: student.username,
-                  label: student.username,
-                  detail: [student.first_name, student.last_name]
-                    .filter(Boolean)
-                    .join(" "),
-                }))}
-              />
-            )}
-
-            {result.skippedStudents.length > 0 && (
-              <ImportResultSection
-                title={t("students.resultSkipped")}
-                rows={result.skippedStudents.map((student) => ({
-                  key: student.username,
-                  label: student.username,
-                  detail: student.message ?? student.reason,
-                }))}
-              />
-            )}
-
-            {result.teamResults?.some(
-              (teamResult) => teamResult.status === "failed",
-            ) && (
-              <ImportResultSection
-                title={t("students.resultTeamFailures")}
-                rows={result.teamResults
-                  .filter((teamResult) => teamResult.status === "failed")
-                  .map((teamResult) => ({
-                    key: teamResult.username,
-                    label: teamResult.username,
-                    detail:
-                      teamResult.message ?? t("students.couldNotAddToTeam"),
-                  }))}
-              />
-            )}
-
-            {inviteOutcome && inviteOutcome.invited.length > 0 && (
-              <ImportResultSection
-                title={t("students.resultInvited")}
-                rows={inviteOutcome.invited.map(({ username, role }) => ({
-                  key: username,
-                  label: username,
-                  detail: t(ROLE_LABEL_KEY[role]),
-                }))}
-              />
-            )}
-
-            {inviteOutcome && inviteOutcome.deferred.length > 0 && (
-              <ImportResultSection
-                title={t("students.resultInvitesDeferred")}
-                rows={inviteOutcome.deferred.map((username) => ({
-                  key: username,
-                  label: username,
-                  detail: t("students.inviteDeferredDetail"),
-                }))}
-              />
-            )}
-
-            {inviteOutcome && inviteOutcome.failed.length > 0 && (
-              <ImportResultSection
-                title={t("students.resultInvitesFailed")}
-                rows={inviteOutcome.failed.map((f) => ({
-                  key: f.username,
-                  label: f.username,
-                  detail: f.message,
-                }))}
-              />
-            )}
-
-            {roleChangeOutcome && roleChangeOutcome.changed.length > 0 && (
-              <ImportResultSection
-                title={t("students.resultRoleChanged")}
-                rows={roleChangeOutcome.changed.map((c) => ({
-                  key: c.username,
-                  label: c.username,
-                  detail: t(ROLE_LABEL_KEY[c.to]),
-                }))}
-              />
-            )}
-
-            {roleChangeOutcome && roleChangeOutcome.failed.length > 0 && (
-              <ImportResultSection
-                title={t("students.resultRoleChangeFailures")}
-                rows={roleChangeOutcome.failed.map((f, i) => ({
-                  key: `${f.username}-${i}`,
-                  label: f.username,
-                  detail: f.message,
-                }))}
-              />
-            )}
-
-            <div className="modal-action">
-              <Button variant="primary" onClick={handleClose}>
-                {t("students.done")}
-              </Button>
-            </div>
-          </div>
+          <RosterImportResult
+            result={result}
+            inviteError={inviteError}
+            inviteOutcome={inviteOutcome}
+            roleChangeOutcome={roleChangeOutcome}
+            onDone={handleClose}
+          />
         )}
 
         {phase === "error" && (

--- a/web/src/pages/students/rosterImportParse.ts
+++ b/web/src/pages/students/rosterImportParse.ts
@@ -1,0 +1,149 @@
+import Papa from "papaparse"
+import {
+  isLikelyGithubUsername,
+  normalizeGithubUsername,
+  splitName,
+  type ImportRosterRow,
+} from "@/domain/students"
+import type { ClassroomRole } from "@/util/teamRoster"
+import {
+  OPTIONAL_IMPORT_HEADERS,
+  RECOGNIZED_IMPORT_HEADERS,
+  type OptionalImportHeader,
+} from "@/pages/students/rosterImportHeaders"
+
+// Coerce a raw string to a ClassroomRole, or undefined when absent/unknown.
+// Case-insensitive; the upload defaults undefined to "student" and lets the
+// instructor override, so an unrecognized value degrades to student rather than
+// failing the whole import. Exported so both the CSV parse and the preview
+// Select coerce through one guard (no unchecked cast on raw input).
+export const coerceImportRole = (
+  raw: string | undefined,
+): ClassroomRole | undefined => {
+  const value = raw?.trim().toLowerCase()
+  if (value === "student" || value === "instructor" || value === "ta") {
+    return value
+  }
+  return undefined
+}
+
+// Parse an uploaded roster into metadata rows. A CSV with a `username` header
+// column also honors first_name/last_name/name/email/section columns (case- and
+// order-insensitive); anything without a header falls back to one-username-per
+// -line. github_id in the file is ignored — it's re-derived from GitHub on
+// import so the stored id is authoritative. Rows are deduped by username.
+// Exported for unit testing.
+export const parseRosterImportFile = (text: string): ImportRosterRow[] => {
+  const trimmed = text.trim()
+  if (!trimmed) return []
+
+  const parsed = Papa.parse<Record<string, string>>(trimmed, {
+    header: true,
+    delimiter: "",
+    skipEmptyLines: "greedy",
+    transformHeader: (header) => header.trim().toLowerCase(),
+  })
+
+  const fields = parsed.meta.fields ?? []
+  const hasUsernameColumn =
+    parsed.errors.length === 0 && fields.includes("username")
+
+  const seen = new Set<string>()
+  const rows: ImportRosterRow[] = []
+
+  const push = (row: ImportRosterRow) => {
+    const username = normalizeGithubUsername(row.username)
+    if (!username || !isLikelyGithubUsername(username)) return
+    const key = username.toLowerCase()
+    if (seen.has(key)) return
+    seen.add(key)
+    rows.push({ ...row, username })
+  }
+
+  if (hasUsernameColumn) {
+    for (const raw of parsed.data) {
+      // Read the optional columns generically from the shared header list so
+      // the parser can't drift from what the diagnostic advertises. Two columns
+      // get special handling on top of the generic read: `name` is an alias
+      // that fills first/last when those split columns are ABSENT (not merely
+      // empty), and `role` is coerced through the known-role guard.
+      const cell = (header: OptionalImportHeader): string =>
+        (raw[header] ?? "").trim()
+      const fromName = splitName(raw.name ?? null)
+      push({
+        username: raw.username ?? "",
+        first_name: (raw.first_name ?? fromName.first_name).trim(),
+        last_name: (raw.last_name ?? fromName.last_name).trim(),
+        email: cell("email"),
+        section: cell("section"),
+        role: coerceImportRole(cell("role")),
+      })
+    }
+  } else {
+    for (const line of trimmed.split(/\r?\n/)) {
+      push({ username: line })
+    }
+  }
+
+  return rows
+}
+
+// Why an uploaded file yielded no importable rows, when the cause is the file's
+// SHAPE rather than just invalid handles. `null` means "no structural problem" —
+// either a valid header file or a bare one-username-per-line list, both of which
+// the parser handles; an empty result there is genuinely "no valid usernames".
+//   - missing-username-header: the file has a header row (a delimiter or a
+//     recognized column name) but no `username` column, so the required field
+//     can't be mapped. We surface the required + optional columns instead of
+//     silently falling back to treating each line as a username.
+//   - malformed: Papa reported a structural parse error (ragged rows, unclosed
+//     quote, ...), so the columns can't be trusted.
+export type ImportHeaderIssue =
+  | { kind: "missing-username-header"; present: string[]; optional: string[] }
+  | { kind: "malformed"; detail: string }
+
+// Inspect an uploaded file's structure to explain an empty/mis-parsed import.
+// Pure and side-effect-free so it's unit-testable and can run alongside
+// parseRosterImportFile without re-reading the file. Deliberately does NOT flag
+// a bare one-username-per-line list (the supported headerless format): that is
+// only "a header row missing username" when the first line looks like headers.
+export const detectImportHeaderIssue = (
+  text: string,
+): ImportHeaderIssue | null => {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+
+  const parsed = Papa.parse<Record<string, string>>(trimmed, {
+    header: true,
+    delimiter: "",
+    skipEmptyLines: "greedy",
+    transformHeader: (header) => header.trim().toLowerCase(),
+  })
+
+  // Papa emits a benign "Delimiter" warning for single-column input (a bare
+  // username list) — that's not a structural defect, so ignore it. Only genuine
+  // structural errors (ragged rows, unclosed quotes) mean "malformed".
+  const structuralError = parsed.errors.find((e) => e.type !== "Delimiter")
+  if (structuralError) {
+    return { kind: "malformed", detail: structuralError.message }
+  }
+
+  const fields = (parsed.meta.fields ?? []).map((f) => f.trim()).filter(Boolean)
+  if (fields.includes("username")) return null
+
+  // A header row is one with >1 column (a delimiter was found) or a single
+  // recognized column name. A lone unrecognized token is a bare username list,
+  // not a mis-headered CSV — leave it to the one-per-line fallback.
+  const looksLikeHeaderRow =
+    fields.length > 1 ||
+    fields.some((f) =>
+      (RECOGNIZED_IMPORT_HEADERS as readonly string[]).includes(f),
+    )
+  if (!looksLikeHeaderRow) return null
+
+  return {
+    kind: "missing-username-header",
+    present: fields,
+    optional: [...OPTIONAL_IMPORT_HEADERS],
+  }
+}

--- a/web/src/pages/students/runRosterImport.test.ts
+++ b/web/src/pages/students/runRosterImport.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const bulkEnrollStudentsInClassroom =
+  vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const inviteRosterStudents = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const writeClassroomRoles = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const applyClassroomRoleChange =
+  vi.fn<(...args: unknown[]) => Promise<unknown>>()
+
+vi.mock("@/domain/students", () => {
+  // Declared inside the (hoisted) factory so they exist when the mock evaluates.
+  class NoNewStudentsError extends Error {}
+  class RosterCsvMalformedError extends Error {}
+  return {
+    bulkEnrollStudentsInClassroom: (...a: unknown[]) =>
+      bulkEnrollStudentsInClassroom(...a),
+    inviteRosterStudents: (...a: unknown[]) => inviteRosterStudents(...a),
+    writeClassroomRoles: (...a: unknown[]) => writeClassroomRoles(...a),
+    applyClassroomRoleChange: (...a: unknown[]) =>
+      applyClassroomRoleChange(...a),
+    NoNewStudentsError,
+    RosterCsvMalformedError,
+  }
+})
+
+// Pull the error classes back from the mocked module so tests throw the exact
+// constructors runRosterImport's instanceof checks compare against.
+const { NoNewStudentsError, RosterCsvMalformedError } =
+  (await import("@/domain/students")) as unknown as {
+    NoNewStudentsError: new (msg?: string) => Error
+    RosterCsvMalformedError: new (msg?: string) => Error
+  }
+
+import { runRosterImport } from "./runRosterImport"
+import type { GitHubClient } from "@/github-core/client"
+import type { ImportRosterRow } from "@/domain/students"
+
+const client = {} as unknown as GitHubClient
+const messages = {
+  startingImport: "starting",
+  invitingUploaded: "inviting",
+  processRoleChanges: "moving",
+  importFailed: "import-failed",
+  roleWritebackMalformed: "roleback-malformed",
+  roleWritebackFailed: "roleback-failed",
+}
+
+const rows: ImportRosterRow[] = [{ username: "alice" }, { username: "bob" }]
+
+const call = (over: Record<string, unknown> = {}) =>
+  runRosterImport(client, {
+    org: "acme",
+    classroom: "cs101",
+    rows,
+    rolesByUser: { alice: "student", bob: "ta" },
+    plan: null,
+    onProgress: vi.fn(),
+    messages,
+    ...over,
+  })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  bulkEnrollStudentsInClassroom.mockResolvedValue({
+    addedStudents: [{ username: "alice", github_id: "1" }],
+    skippedStudents: [],
+  })
+  inviteRosterStudents.mockResolvedValue({
+    invited: [{ username: "alice", role: "student" }],
+    deferred: [],
+    failed: [],
+  })
+  writeClassroomRoles.mockResolvedValue(undefined)
+  applyClassroomRoleChange.mockImplementation((...args: unknown[]) => {
+    const input = args[1] as { username: string; toRole: string }
+    return Promise.resolve({
+      username: input.username,
+      toRole: input.toRole,
+      warnings: [],
+    })
+  })
+})
+
+describe("runRosterImport — happy path", () => {
+  it("enrolls, invites, writes back roles, and reports the outcome", async () => {
+    const out = await call()
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(bulkEnrollStudentsInClassroom).toHaveBeenCalledOnce()
+    expect(inviteRosterStudents).toHaveBeenCalledOnce()
+    expect(writeClassroomRoles).toHaveBeenCalledOnce()
+    expect(out.inviteOutcome?.invited).toEqual([
+      { username: "alice", role: "student" },
+    ])
+    expect(out.inviteError).toBeNull()
+  })
+})
+
+describe("runRosterImport — enroll failures", () => {
+  it("falls through NoNewStudentsError to the invite pass with an empty result", async () => {
+    bulkEnrollStudentsInClassroom.mockRejectedValueOnce(
+      new NoNewStudentsError("none"),
+    )
+    const out = await call()
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.importResult.addedStudents).toEqual([])
+    // The invite pass still runs so a previously-deferred student is re-invited.
+    expect(inviteRosterStudents).toHaveBeenCalledOnce()
+  })
+
+  it("returns ok:false on a hard enroll failure (nothing written)", async () => {
+    bulkEnrollStudentsInClassroom.mockRejectedValueOnce(new Error("boom"))
+    const out = await call()
+    expect(out.ok).toBe(false)
+    if (out.ok) return
+    expect(out.error).toBe("boom")
+    expect(inviteRosterStudents).not.toHaveBeenCalled()
+  })
+})
+
+describe("runRosterImport — invite + writeback soft failures", () => {
+  it("keeps ok:true and surfaces inviteError when the invite pass throws", async () => {
+    inviteRosterStudents.mockRejectedValueOnce(new Error("invite-boom"))
+    const out = await call()
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.inviteError).toBe("invite-boom")
+  })
+
+  it("maps a malformed roster.csv writeback to the malformed message", async () => {
+    writeClassroomRoles.mockRejectedValueOnce(
+      new RosterCsvMalformedError("bad"),
+    )
+    const out = await call()
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.inviteError).toBe("roleback-malformed")
+  })
+
+  it("maps a generic writeback failure to the soft-warning message", async () => {
+    writeClassroomRoles.mockRejectedValueOnce(new Error("transient"))
+    const out = await call()
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.inviteError).toBe("roleback-failed")
+  })
+})
+
+describe("runRosterImport — allAlreadyMembers skips invites", () => {
+  it("does not call the invite endpoint when every row is already a member", async () => {
+    const out = await call({
+      plan: {
+        allAlreadyMembers: true,
+        needsInvite: [],
+        enroll: [],
+        roleChanges: [],
+        noAction: rows.map((r) => ({ username: r.username })),
+      },
+    })
+    expect(out.ok).toBe(true)
+    expect(inviteRosterStudents).not.toHaveBeenCalled()
+  })
+})
+
+describe("runRosterImport — confirmed team moves", () => {
+  it("applies role changes + enrolls from the plan and reports them", async () => {
+    const out = await call({
+      plan: {
+        allAlreadyMembers: false,
+        needsInvite: [],
+        noAction: [],
+        roleChanges: [
+          { username: "carol", currentRoles: ["student"], role: "ta" },
+        ],
+        enroll: [{ username: "dave", role: "student" }],
+      },
+    })
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(applyClassroomRoleChange).toHaveBeenCalledTimes(2)
+    expect(out.roleChangeOutcome?.changed).toEqual([
+      { username: "carol", to: "ta" },
+      { username: "dave", to: "student" },
+    ])
+  })
+
+  it("reports a per-move failure without aborting the batch", async () => {
+    applyClassroomRoleChange
+      .mockRejectedValueOnce(new Error("move-boom"))
+      .mockResolvedValueOnce({
+        username: "dave",
+        toRole: "student",
+        warnings: [],
+      })
+    const out = await call({
+      plan: {
+        allAlreadyMembers: false,
+        needsInvite: [],
+        noAction: [],
+        roleChanges: [
+          { username: "carol", currentRoles: ["student"], role: "ta" },
+        ],
+        enroll: [{ username: "dave", role: "student" }],
+      },
+    })
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.roleChangeOutcome?.failed).toEqual([
+      { username: "carol", message: "move-boom" },
+    ])
+    expect(out.roleChangeOutcome?.changed).toEqual([
+      { username: "dave", to: "student" },
+    ])
+  })
+})

--- a/web/src/pages/students/runRosterImport.ts
+++ b/web/src/pages/students/runRosterImport.ts
@@ -1,0 +1,289 @@
+import {
+  applyClassroomRoleChange,
+  bulkEnrollStudentsInClassroom,
+  inviteRosterStudents,
+  NoNewStudentsError,
+  RosterCsvMalformedError,
+  writeClassroomRoles,
+  type BulkImportResult,
+  type ImportRosterRow,
+} from "@/domain/students"
+import type { GitHubClient } from "@/github-core/client"
+import type { PreflightResult } from "@/util/rosterUploadPreflight"
+import type { ClassroomRole } from "@/util/teamRoster"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("students:runRosterImport")
+
+export type ImportProgress = {
+  processed: number
+  total: number
+  message: string
+}
+
+export type InviteOutcome = {
+  invited: { username: string; role: ClassroomRole }[]
+  deferred: string[]
+  failed: { username: string; message: string }[]
+}
+
+export type RoleChangeOutcome = {
+  changed: { username: string; to: ClassroomRole }[]
+  failed: { username: string; message: string }[]
+}
+
+// Translated status/warning strings, passed in so this orchestrator stays
+// t()-free (mirrors the hooks/mutations messages-bag convention).
+export type RosterImportMessages = {
+  startingImport: string
+  invitingUploaded: string
+  processRoleChanges: string
+  importFailed: string
+  roleWritebackMalformed: string
+  roleWritebackFailed: string
+}
+
+// The full roster-import outcome. On a hard enroll failure (nothing written) the
+// caller shows the error screen; otherwise the roster.csv write landed and the
+// caller shows the completed view even if a later pass reported a soft warning.
+export type RosterImportOutcome =
+  | { ok: false; error: string }
+  | {
+      ok: true
+      importResult: BulkImportResult
+      inviteOutcome: InviteOutcome | null
+      inviteError: string | null
+      roleChangeOutcome: RoleChangeOutcome | null
+    }
+
+// The roster-CSV import flow (username/CSV upload branch): write roster.csv +
+// team-add existing members, invite non-members, write back assigned roles, and
+// apply the confirmed team moves the preflight identified. Extracted from
+// UploadRoster so the multi-step sequencing is reasoned about (and tested) apart
+// from the modal's phase/setState wiring. The caller owns all React state; this
+// returns the outcomes to map onto it. `onProgress` streams the same progress
+// shape the component renders.
+export async function runRosterImport(
+  client: GitHubClient,
+  params: {
+    org: string
+    classroom: string
+    rows: ImportRosterRow[]
+    rolesByUser: Record<string, ClassroomRole>
+    // The classification computed in the preview, snapshotted so the process
+    // pass matches exactly what the teacher confirmed.
+    plan: PreflightResult | null
+    onProgress: (progress: ImportProgress) => void
+    messages: RosterImportMessages
+  },
+): Promise<RosterImportOutcome> {
+  const { org, classroom, rows, rolesByUser, plan, onProgress, messages } =
+    params
+
+  onProgress({
+    processed: 0,
+    total: rows.length,
+    message: messages.startingImport,
+  })
+
+  // 1) Write the roster.csv rows (identity + name/email/section) and team-add
+  //    anyone already an active org member. A re-run where every uploaded row
+  //    already exists throws NoNewStudentsError (nothing to commit) — that is
+  //    benign here: we still run the invite pass below so a student whose first
+  //    invite was rate-limited/failed gets re-invited. Any other enroll error is
+  //    a genuine failure (nothing written) -> error screen.
+  let importResult: BulkImportResult
+  try {
+    importResult = await bulkEnrollStudentsInClassroom(client, {
+      org,
+      classroom,
+      rows,
+      onProgress,
+    })
+  } catch (err) {
+    if (err instanceof NoNewStudentsError) {
+      // All rows already in roster.csv — synthesize an empty result so the
+      // completed view still renders, then fall through to the invite pass.
+      importResult = { addedStudents: [], skippedStudents: [] }
+    } else {
+      log.error("roster import failed", { err, record: true })
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : messages.importFailed,
+      }
+    }
+  }
+
+  let inviteOutcome: InviteOutcome | null = null
+  let inviteError: string | null = null
+  let roleChangeOutcome: RoleChangeOutcome | null = null
+
+  // 2) The team is the source of truth for who shows on the roster, so send org
+  //    invites for uploaded students who aren't already members — they then
+  //    appear as a `pending` row. Invite the FULL uploaded set (not just the
+  //    newly-added rows): inviteRosterStudents no-ops anyone already
+  //    active/pending, so a re-run after a rate limit still re-invites a student
+  //    whose first invite was deferred (their CSV row already exists, so they'd
+  //    otherwise be skipped as a duplicate and, since CSV-only rows don't
+  //    render, silently lost). Thread the github_id the enroll pass just
+  //    resolved (from addedStudents, keyed by login) so the invite targets the
+  //    immutable account rather than re-resolving a possibly recycled/renamed
+  //    login. Their roster.csv row enriches the pending row; deferred/failed
+  //    invites are surfaced in the result dialog.
+  //
+  //    SKIP the invite pass entirely when the preflight found every uploaded
+  //    username is already an active org member — there's nothing to invite, so
+  //    don't hammer the invite endpoint.
+  const idByLogin = new Map(
+    importResult.addedStudents.map((s) => [
+      s.username.toLowerCase(),
+      s.github_id,
+    ]),
+  )
+  if (!plan?.allAlreadyMembers) {
+    onProgress({
+      processed: 0,
+      total: rows.length,
+      message: messages.invitingUploaded,
+    })
+    try {
+      const inviteRes = await inviteRosterStudents(client, {
+        org,
+        classroom,
+        students: rows.map((r) => ({
+          username: r.username,
+          github_id: idByLogin.get(r.username.toLowerCase()) ?? "",
+          role: rolesByUser[r.username.toLowerCase()] ?? "student",
+        })),
+        onProgress,
+      })
+      inviteOutcome = {
+        invited: inviteRes.invited,
+        deferred: inviteRes.deferred,
+        failed: inviteRes.failed.map((f) => ({
+          username: f.username,
+          message: f.message,
+        })),
+      }
+    } catch (err) {
+      // The roster.csv write already landed; a hard invite failure must not hide
+      // it behind the bare error screen. Keep the completed view and show the
+      // invite error there — the teacher can re-run to retry the invites.
+      log.error("roster invite pass failed", { err, record: true })
+      inviteError = err instanceof Error ? err.message : messages.importFailed
+    }
+  }
+
+  // 3) Persist the assigned role back to roster.csv for EVERY uploaded row, not
+  //    just the freshly-invited ones. A row that was deferred (rate limit),
+  //    skipped (already a member/pending), or failed still has a teacher-
+  //    assigned role and a roster row from step 1 — omitting them would leave
+  //    their role blank until a later sync. writeClassroomRoles only touches
+  //    existing rows whose role actually changed, so covering the full set is
+  //    safe and idempotent. Best-effort: a writeback failure doesn't undo the
+  //    invites (role converges on the next sync). A malformed roster.csv is
+  //    surfaced distinctly so the teacher fixes it.
+  const roleWriteback = rows
+    .map((r) => ({
+      username: r.username,
+      role: rolesByUser[r.username.toLowerCase()] ?? "student",
+    }))
+    .filter((r) => r.username.trim())
+  if (roleWriteback.length > 0) {
+    try {
+      await writeClassroomRoles(client, {
+        org,
+        classroom,
+        roles: roleWriteback,
+      })
+    } catch (err) {
+      if (err instanceof RosterCsvMalformedError) {
+        inviteError = messages.roleWritebackMalformed
+      } else {
+        // A transient/other writeback failure isn't fatal (the role converges on
+        // the next sync), but the completed dialog would otherwise show a bare
+        // success — surface a soft warning so the teacher knows the role column
+        // didn't persist this run.
+        inviteError = messages.roleWritebackFailed
+      }
+      log.warn("roster role writeback failed", { err, record: true })
+    }
+  }
+
+  // 4) Apply the CONFIRMED team assignments the preflight identified:
+  //    - role_change: an active member on a DIFFERENT classroom team -> move
+  //      them (drop every non-target team; instructor target grants org owner, a
+  //      demotion off instructor revokes it). Gated behind the confirmation
+  //      checkbox in the preview.
+  //    - enroll: an active member on NO classroom team -> an additive team-add
+  //      onto the CSV role's team (empty fromRoles, so nothing is dropped).
+  //    Both route through applyClassroomRoleChange (re-verifies active
+  //    membership, never team-adds a non-member). Best-effort per row: a failure
+  //    is surfaced in the result dialog, not fatal (the roster write landed).
+  const moves: {
+    username: string
+    fromRoles: ClassroomRole[]
+    toRole: ClassroomRole
+  }[] = [
+    ...(plan?.roleChanges ?? []).map((c) => ({
+      username: c.username,
+      fromRoles: c.currentRoles,
+      toRole: c.role,
+    })),
+    ...(plan?.enroll ?? []).map((e) => ({
+      username: e.username,
+      fromRoles: [] as ClassroomRole[],
+      toRole: e.role,
+    })),
+  ]
+  if (moves.length > 0) {
+    onProgress({
+      processed: 0,
+      total: moves.length,
+      message: messages.processRoleChanges,
+    })
+    const changed: { username: string; to: ClassroomRole }[] = []
+    const failed: { username: string; message: string }[] = []
+    let done = 0
+    for (const move of moves) {
+      try {
+        const res = await applyClassroomRoleChange(client, {
+          org,
+          classroom,
+          username: move.username,
+          github_id: idByLogin.get(move.username.toLowerCase()),
+          fromRoles: move.fromRoles,
+          toRole: move.toRole,
+        })
+        changed.push({ username: res.username, to: res.toRole })
+        // A best-effort old-team removal failure is a warning, not a hard
+        // failure — surface it alongside so the teacher can retry.
+        for (const w of res.warnings) {
+          failed.push({ username: move.username, message: w })
+        }
+      } catch (err) {
+        log.error("roster role change failed", { err, record: true })
+        failed.push({
+          username: move.username,
+          message: err instanceof Error ? err.message : String(err),
+        })
+      } finally {
+        done += 1
+        onProgress({
+          processed: done,
+          total: moves.length,
+          message: messages.processRoleChanges,
+        })
+      }
+    }
+    roleChangeOutcome = { changed, failed }
+  }
+
+  return {
+    ok: true,
+    importResult,
+    inviteOutcome,
+    inviteError,
+    roleChangeOutcome,
+  }
+}


### PR DESCRIPTION
## What

Tier-2 unit **U12** — decompose `pages/students/UploadRoster.tsx` (**1399 → 697 lines**), the largest UI giant, into an orchestrator + extracted helpers + section components. Behavior-preserving; the multi-step import flow and parse helpers gained unit tests.

## The split (all in `pages/students/`)

| File | Contents | Lines |
| --- | --- | --- |
| `rosterImportParse.ts` | pure `parseRosterImportFile` / `detectImportHeaderIssue` / `coerceImportRole` + `ImportHeaderIssue` (moved verbatim) | 149 |
| `runRosterImport.ts` | the roster-branch import orchestration (old `startImport` steps 1–4: enroll → invite → role writeback → team moves) as a `t()`-free async fn returning a discriminated `{ok:false,error} \| {ok:true,…outcomes}` | 289 |
| `PreflightRecap.tsx` | resolved-preflight recap (buckets + confirm box + `PreflightBucket`) | 157 |
| `RosterPreviewTable.tsx` | preview table + role Select | 75 |
| `RosterImportResult.tsx` | completed roster-result view + shared `ImportResultSection` | 178 |
| `UploadRoster.tsx` | **orchestrator**: owns state + preflight effect + email branch + wiring; roster branch delegates to `runRosterImport` and maps its outcome onto setState. Re-exports the 3 parse helpers | 697 |

## Why this shape

- The ~260-line `startImport` roster flow (a 4-step read-modify-write sequence with NoNewStudents fall-through, invite-skip, best-effort writeback + team moves) was buried in the component and **untestable**. Extracting it as a pure-ish async fn that returns outcomes (caller owns React state) makes the sequencing directly testable.
- `runRosterImport` stays `t()`-free via a `messages` bag (mirrors the `hooks/mutations` convention).
- `UploadRoster.tsx` re-exports `parseRosterImportFile`/`detectImportHeaderIssue`/`coerceImportRole`/`ImportHeaderIssue`, so `UploadRoster.test.ts`, `StudentListPage`, and the rendered test are **unchanged**.

## Tests

- New `runRosterImport.test.ts` (**9 tests**): happy path; NoNewStudentsError fall-through; hard enroll fail → `ok:false` + no invite (red-verified); invite-pass soft fail; malformed **and** generic writeback message split; `allAlreadyMembers` skips invites; confirmed role-change + enroll moves; per-move failure reported without aborting.
- Existing `UploadRoster.test.ts` (pure helpers) + `UploadRoster.test.tsx` (rendered modal: ingest, kind override, reset, canProcess) stay green (22 tests) — confirms behavior preserved.
- `npm run check` green (164 files / 1726+ tests); `arch:validate` no violations (624 modules, cycle-free; new files are downward-only leaves).

## Review

`ce-code-review` (`depth:full`) did a line-by-line comparison against the original and verified every high-risk invariant (NoNewStudents fall-through, invite-skip, full-set invite, idByLogin threading, full-row writeback, malformed-vs-generic split, moves array, per-move warnings, last-writer-wins on inviteError, unchanged email branch, re-export surface). Verdict **Ready to merge**, zero actionable findings. Its two highest-value testing-gap notes (generic writeback failure, per-move failure) are **folded in** above.

A second `ce-code-review` pass (correctness + reliability + frontend-races + testing + project-standards) re-confirmed all 15 equivalence invariants hold and applied one P3 fix: dropped four section-marker comments (`// BODY` / `// PREFLIGHT` / `// STARTIMPORT` / `// RENDER`) that narrated self-explanatory code (AGENTS.md style rule). `tsc`, the touched suites (31 tests), prettier, and eslint stay green.

Last of the four Tier-2 Phase F UI giants except **U14** (`EnrolledStudents`, 1054).
