### PR TITLE
feat(cli): add latest-submission link to Feedback PR body

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/scripts/ensure_feedback_pr.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/ensure_feedback_pr.py
@@ -187,12 +187,20 @@ def label_for_mode(mode: str) -> tuple[str, str]:
     return _LABELS.get((mode or "").strip().lower(), _LABELS["individual"])
 
 
-def pr_body(head: str) -> str:
-    """The Feedback PR body (GitHub Classroom-style)."""
+def pr_body(head: str, release_url: str) -> str:
+    """The Feedback PR body (GitHub Classroom-style).
+
+    release_url is the static `.../releases/latest` link (not a pinned tag), so
+    it self-updates as new submissions publish even though this body is written
+    once at PR creation and only refreshed to backfill a missing link.
+    """
     return "\n".join([
         ":wave:! Classroom 50 opened this pull request as a place for your "
         "teacher to leave feedback on your work. It updates automatically. "
         "**Don't close or merge this pull request** unless your teacher tells you to.",
+        "",
+        f"Each commit is automatically graded — the latest autograding result "
+        f"is [here]({release_url}).",
         "",
         "Your teacher can leave comments and feedback on your code here. Click "
         "the **Subscribe** button to be notified when that happens.",
@@ -211,6 +219,8 @@ def pr_body(head: str) -> str:
         "- **Commits** lists each pushed commit; open one to see its changes.",
         "- Autograde results appear as the `classroom50/autograde` commit "
         "status / check on each submission.",
+        f"- The [latest autograding result]({release_url}) has the per-test "
+        f"detail behind that status.",
         "- This page is an overview — commits, line comments, and a general "
         "comment box below.",
         "",
@@ -222,7 +232,7 @@ def pr_body(head: str) -> str:
     ])
 
 
-def create_pr(repo: str, head: str, mode: str) -> str:
+def create_pr(repo: str, head: str, mode: str, release_url: str) -> str:
     """Create the Feedback PR, returning its URL. Best-effort labels it first.
     Raises GhError on a create failure (caller handles the race)."""
     label, color = label_for_mode(mode)
@@ -231,7 +241,8 @@ def create_pr(repo: str, head: str, mode: str) -> str:
        "--description", "Classroom 50 teacher-managed feedback PR", check=False)
     return gh("pr", "create", "--repo", repo,
               "--base", BASE_BRANCH, "--head", head,
-              "--title", "Feedback", "--body", pr_body(head), "--label", label)
+              "--title", "Feedback", "--body", pr_body(head, release_url),
+              "--label", label)
 
 
 def existing_pr_url(repo: str, head: str) -> str:
@@ -240,6 +251,30 @@ def existing_pr_url(repo: str, head: str) -> str:
     return gh("pr", "list", "--repo", repo, "--base", BASE_BRANCH,
               "--head", head, "--state", "all", "--json", "url",
               "--jq", "(.[0] // {}).url // \"\"", check=False)
+
+
+def backfill_release_link(repo: str, number: str, head: str,
+                          release_url: str) -> None:
+    """Add the latest-submission link to an OPEN PR whose body lacks it.
+
+    Best-effort and idempotent (mirrors the label/reopen tolerance): if the body
+    already contains the link it's left alone; an empty/transient body read skips
+    the edit rather than risk clobbering; a failed edit logs a warning and never
+    flips the run's outcome (the PR is still in place). Caller gates on OPEN
+    state so merged/closed PRs are never edited.
+    """
+    body = gh("pr", "view", number, "--repo", repo,
+              "--json", "body", "--jq", ".body", check=False)
+    if not body or release_url in body:
+        return
+    try:
+        gh("pr", "edit", number, "--repo", repo,
+           "--body", pr_body(head, release_url))
+    except GhError as exc:
+        print(f"::warning::could not backfill latest-submission link on "
+              f"Feedback PR #{number}: {exc.output}")
+        return
+    print(f"Backfilled latest-submission link on Feedback PR #{number}")
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +289,10 @@ def ensure_feedback_pr(repo: str, base_sha: str, mode: str, server_url: str,
     the EXIT-trap status emission is replaced by main()'s finally block.
     """
     run_url = f"{server_url}/{repo}/actions/runs/{run_id}"
+    # Static "latest" pointer (set-latest job keeps it current), not a pinned
+    # submit-tag URL — the body is written once at creation, so a tag would go
+    # stale but /releases/latest self-updates. See #262.
+    release_url = f"{server_url}/{repo}/releases/latest"
 
     head = head_branch(repo)  # GhError here -> main() reports error (no false success)
 
@@ -277,7 +316,7 @@ def ensure_feedback_pr(repo: str, base_sha: str, mode: str, server_url: str,
     pr = find_pr(repo, head)
     if pr is None:
         try:
-            url = create_pr(repo, head, mode)
+            url = create_pr(repo, head, mode, release_url)
         except GhError as exc:
             # A concurrent run (submit/* tag vs main push use different
             # concurrency groups) can win the create race; re-query before
@@ -317,6 +356,12 @@ def ensure_feedback_pr(repo: str, base_sha: str, mode: str, server_url: str,
             return ("failure", "could not reopen the closed Feedback PR", url)
         print(f"Reopened Feedback PR #{pr['number']} (was closed unmerged)")
         return ("success", "Feedback PR reopened", url)
+
+    # Backfill the latest-submission link onto an already-open PR whose body
+    # predates it (#262). Only OPEN, unmerged PRs are edited — a merged/closed
+    # PR is the teacher's "grading done" signal and must stay untouched.
+    if pr["state"] == "OPEN":
+        backfill_release_link(repo, pr["number"], head, release_url)
 
     print(f"Feedback PR #{pr['number']} already present "
           f"(state={pr['state']} merged={pr['mergedAt'] or 'none'}); nothing to do")

--- a/cli/gh-teacher/skeleton_tests/test_ensure_feedback_pr.py
+++ b/cli/gh-teacher/skeleton_tests/test_ensure_feedback_pr.py
@@ -63,6 +63,10 @@ class FakeGh:
                 # existing_pr_url (--json url) so the race-recovery query can
                 # be driven through the stub, not monkeypatched out.
                 return "pr_list_url" if "url" in args else "pr_list"
+            if args[1] == "view":
+                # Disambiguate the reopen state read (--json state) from the
+                # backfill body read (--json body).
+                return "pr_view_body" if "body" in args else "pr_view"
             return f"pr_{args[1]}"
         if args[0] == "label":
             return "label"
@@ -154,16 +158,19 @@ def test_base_check_transient_error_does_not_open_pr(monkeypatch):
 
 
 def test_existing_open_pr_left_in_place(monkeypatch):
+    linked = f"body with {SERVER}/{REPO}/releases/latest"
     fake, state, desc, url = _run(monkeypatch, {
         "head_branch": "main",
         "base_sha": BASE_SHA,                 # base already correct
         "pr_list": _pr_list_json("7", "OPEN", ""),
+        "pr_view_body": linked,               # already has the link -> no edit
     })
     assert state == "success"
     assert desc == "Feedback PR in place"
     assert url.endswith("/pull/7")
     assert not fake.made("pr create")
     assert not fake.made("pr reopen")
+    assert not fake.made("pr edit")
 
 
 def test_closed_unmerged_pr_reopened(monkeypatch):
@@ -177,6 +184,8 @@ def test_closed_unmerged_pr_reopened(monkeypatch):
     assert state == "success"
     assert desc == "Feedback PR reopened"
     assert fake.made("pr reopen 7")
+    # Reopen path returns before backfill — a just-reopened PR is not edited.
+    assert not fake.made("pr edit")
 
 
 def test_failed_reopen_reports_failure(monkeypatch):
@@ -215,6 +224,66 @@ def test_merged_pr_left_alone(monkeypatch):
     assert state == "success"
     assert desc == "Feedback PR in place"
     assert not fake.made("pr reopen")
+    # AE4: a merged PR is never body-edited (grading-done signal stays put).
+    assert not fake.made("pr view")
+    assert not fake.made("pr edit")
+
+
+def test_open_pr_missing_link_is_backfilled(monkeypatch):
+    # AE2: OPEN PR whose body lacks the link -> edited with a link-bearing body.
+    fake, state, desc, url = _run(monkeypatch, {
+        "head_branch": "main",
+        "base_sha": BASE_SHA,
+        "pr_list": _pr_list_json("7", "OPEN", ""),
+        "pr_view_body": "old body without the link",
+        "pr_edit": "",
+    })
+    assert state == "success"
+    assert desc == "Feedback PR in place"
+    assert fake.made("pr edit 7")
+    edit = [c for c in fake.calls if c[0] == "pr" and c[1] == "edit"]
+    assert any("/releases/latest" in arg for arg in edit[0])
+
+
+def test_open_pr_already_linked_not_edited(monkeypatch):
+    # AE3: body already contains the link -> no edit.
+    linked = f"body with {SERVER}/{REPO}/releases/latest already"
+    fake, state, desc, url = _run(monkeypatch, {
+        "head_branch": "main",
+        "base_sha": BASE_SHA,
+        "pr_list": _pr_list_json("7", "OPEN", ""),
+        "pr_view_body": linked,
+    })
+    assert state == "success"
+    assert desc == "Feedback PR in place"
+    assert not fake.made("pr edit")
+
+
+def test_open_pr_empty_body_read_skips_edit(monkeypatch):
+    # Skip-on-empty: a transient/empty body read must not trigger a clobbering
+    # edit; the run still succeeds.
+    fake, state, desc, url = _run(monkeypatch, {
+        "head_branch": "main",
+        "base_sha": BASE_SHA,
+        "pr_list": _pr_list_json("7", "OPEN", ""),
+        "pr_view_body": "",
+    })
+    assert state == "success"
+    assert desc == "Feedback PR in place"
+    assert not fake.made("pr edit")
+
+
+def test_open_pr_backfill_edit_failure_still_success(monkeypatch):
+    # AE5: a failed backfill edit is best-effort -> run still succeeds.
+    fake, state, desc, url = _run(monkeypatch, {
+        "head_branch": "main",
+        "base_sha": BASE_SHA,
+        "pr_list": _pr_list_json("7", "OPEN", ""),
+        "pr_view_body": "old body without the link",
+        "pr_edit": efp.GhError(["pr", "edit"], 1, "not allowed"),
+    })
+    assert state == "success"
+    assert desc == "Feedback PR in place"
 
 
 def test_create_race_lost_recovers_to_success(monkeypatch):
@@ -303,10 +372,31 @@ def test_label_for_mode(mode, want_label):
 
 
 def test_pr_body_mentions_head_and_base(monkeypatch):
-    body = efp.pr_body("main")
+    body = efp.pr_body("main", "https://github.com/cs50/x/releases/latest")
     assert "`main`" in body
     assert f"`{efp.BASE_BRANCH}`" in body
     assert "Classroom 50" in body
+
+
+def test_pr_body_links_latest_submission():
+    release_url = "https://github.com/cs50/x/releases/latest"
+    body = efp.pr_body("main", release_url)
+    # The link is present, and appears in both the student intro and the
+    # teacher-notes <details> block so both audiences can reach it (#262/#260).
+    assert release_url in body
+    intro, _, teacher_notes = body.partition("<details>")
+    assert release_url in intro
+    assert release_url in teacher_notes
+
+
+def test_create_pr_threads_latest_release_url(monkeypatch):
+    fake = FakeGh({"pr_create": "https://github.com/cs50/x/pull/1", "label": ""})
+    monkeypatch.setattr(efp, "gh", fake)
+    efp.create_pr(REPO, "main", "individual",
+                  f"{SERVER}/{REPO}/releases/latest")
+    create = [c for c in fake.calls if c[0] == "pr" and c[1] == "create"]
+    assert create, "expected a pr create call"
+    assert any("/releases/latest" in arg for arg in create[0])
 
 
 @pytest.mark.parametrize("out, want", [


### PR DESCRIPTION
## Summary

Adds a link to the latest autograding release into the Feedback PR body so students and teachers can jump straight from the Feedback PR to a submission's per-test grading detail. This closes the gap where the Feedback PR surfaced only the `classroom50/autograde` commit status but gave no path to the actual failure detail behind it.

Resolves #262. Directly helps with the visibility gap noted in #260.

## What changed

`cli/gh-teacher/skeleton/dotgithub/scripts/ensure_feedback_pr.py`:
- `pr_body(head, release_url)` now renders a link to `<server>/<owner>/<repo>/releases/latest` in both the student-facing intro and the teacher-notes block.
- New PRs get the link at creation (`create_pr` threads the URL through).
- Already-open Feedback PRs are backfilled via `gh pr edit` — a new `backfill_release_link` helper, gated on `OPEN` state and link-absence.

## Key decisions

- **Static `/releases/latest`, not a pinned submit-tag URL.** The body is written once at creation, so a tag URL would freeze at the first submission. GitHub's `set-latest` job keeps `releases/latest` pointing at the newest submission, so the static path self-updates server-side.
- **Backfill is OPEN-gated, idempotent, and best-effort.** Merged/closed PRs are never edited (a teacher merge is the "grading done" signal). A body that already has the link is left alone; an empty/transient body read skips the edit; a failed `gh pr edit` logs a warning and never flips the run's success/failure/error status — mirroring the existing label/reopen tolerance in this script.

## Testing

`python3 -m pytest cli/gh-teacher/skeleton_tests -q` -> **475 passed** (feedback-PR suite went 28 -> 34 tests).

New/updated coverage:
- Link present in both the intro and teacher-notes regions; `create_pr` threads the URL end-to-end.
- Backfill matrix: OPEN missing-link -> edited; already-linked -> no edit; MERGED -> no view/no edit; CLOSED-unmerged -> reopen path only (no edit); empty body read -> skip; `gh pr edit` failure -> run still succeeds.

Ruff clean on both files.

## Post-Deploy Monitoring & Validation

This is a client-side/CI script fetched from Pages and run by the autograde-runner workflow on student repos; there is no server component.

- **What to watch:** the next autograde run on any assignment repo — confirm the opened/updated Feedback PR body contains a working "latest autograding result" link, and that the `classroom50/feedback-pr` commit status stays `success`.
- **Healthy signal:** Feedback PR body shows the link; existing open Feedback PRs gain it on their next submission; Actions log shows `Backfilled latest-submission link on Feedback PR #N` (or no line when already present).
- **Failure signal / mitigation:** a `::warning::could not backfill latest-submission link` in the runner log is non-fatal by design (the PR is still in place); if backfill edits misbehave, the OPEN-gate + idempotency contain blast radius, and the change is revert-safe (single script + tests).
- **Validation window/owner:** first few autograde runs after the config repo re-publishes the script.
