### PR TITLE
refactor(web): decompose EnrolledStudents into helpers + auto-effect hooks + row/invite components (Tier-2 U14)

### DIFF
--- a/web/src/pages/students/EnrolledStudents.section.test.ts
+++ b/web/src/pages/students/EnrolledStudents.section.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   groupStudentsBySection,
   nextSelectedKeyAfterSave,
-} from "./EnrolledStudents"
+} from "./enrolledStudentsHelpers"
 import type { Student } from "@/types/classroom"
 
 const student = (username: string, section?: string): Student =>

--- a/web/src/pages/students/EnrolledStudents.smoke.test.tsx
+++ b/web/src/pages/students/EnrolledStudents.smoke.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import type { ReactElement } from "react"
+
+// A rendered smoke test locking the component's phase views (loading / empty /
+// populated + failed-invites) before the U14 decomposition, so the extraction
+// can't silently regress what the page shows. useTeamRoster is the single data
+// source driving every branch, so mocking it (plus the mutation hooks + the
+// context/cache hooks the module loads) is enough to render provider-free.
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) =>
+        opts && "count" in opts ? `${key}:${opts.count}` : key,
+    }),
+  }
+})
+
+const useTeamRoster = vi.fn()
+vi.mock("@/hooks/useTeamRoster", () => ({
+  useTeamRoster: (...args: unknown[]) => useTeamRoster(...args),
+  useInvalidateTeamRoster: () => () => {},
+}))
+
+// Mutation hooks -> inert objects (no network); the smoke test never fires them.
+const inertMutation = { mutate: vi.fn(), isPending: false }
+vi.mock("@/hooks/mutations/useDismissFailedInvite", () => ({
+  useDismissFailedInvite: () => inertMutation,
+}))
+vi.mock("@/hooks/mutations/useSyncRoster", () => ({
+  useSyncRoster: () => inertMutation,
+}))
+vi.mock("@/hooks/mutations/useMigrateRoster", () => ({
+  useMigrateRoster: () => inertMutation,
+}))
+vi.mock("@/hooks/mutations/useReinviteFailedInvite", () => ({
+  useReinviteFailedInvite: () => inertMutation,
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify: vi.fn() }),
+}))
+vi.mock("@/hooks/useGitHubResources", () => ({
+  useGitHubViewer: () => ({ data: null }),
+}))
+vi.mock("@/hooks/useGetStudents", () => ({
+  useUpdateRosterCache: () => () => {},
+}))
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>()
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) }
+})
+// Child surfaces with their own tests + provider needs; stub so the smoke test
+// renders EnrolledStudents' own markup provider-free.
+vi.mock("@/pages/students/RosterMemberModal", () => ({ default: () => null }))
+vi.mock("@/pages/students/RosterBulkActionsBar", () => ({
+  default: () => null,
+}))
+
+import EnrolledStudents from "./EnrolledStudents"
+import type { SuppressedLogins } from "@/hooks/useSuppressedLogins"
+
+const suppressedLogins: SuppressedLogins = {
+  remember: vi.fn(),
+  forget: vi.fn(),
+  has: () => false,
+  clear: vi.fn(),
+}
+
+const emptyRoster = {
+  rows: [],
+  counts: { enrolled: 0, pending: 0 },
+  isLoading: false,
+  isError: false,
+  isEmpty: true,
+  pendingHidden: false,
+  failedInvitations: [],
+  teamSlugByRole: {},
+  csvMissingCount: 0,
+  csvMissingLogins: [],
+  backfillNeededLogins: [],
+  orgMembersKnown: true,
+  refetch: vi.fn(),
+}
+
+const renderView = (): ReactElement => (
+  <EnrolledStudents
+    students={[]}
+    org="acme"
+    classroom="cs101"
+    suppressedLogins={suppressedLogins}
+  />
+)
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("EnrolledStudents — rendered phase views", () => {
+  it("shows the loading spinner while the roster loads", () => {
+    useTeamRoster.mockReturnValue({
+      ...emptyRoster,
+      isLoading: true,
+      isEmpty: false,
+    })
+    render(renderView())
+    expect(screen.getByText("students.loadingRoster")).not.toBeNull()
+  })
+
+  it("shows the empty state when the roster has no rows", () => {
+    useTeamRoster.mockReturnValue(emptyRoster)
+    render(renderView())
+    expect(screen.getByText("students.emptyTitle")).not.toBeNull()
+  })
+
+  it("shows the load-error state with a retry", () => {
+    useTeamRoster.mockReturnValue({
+      ...emptyRoster,
+      isError: true,
+      isEmpty: false,
+    })
+    render(renderView())
+    expect(screen.getByText("students.rosterLoadError")).not.toBeNull()
+    expect(
+      screen.getByRole("button", { name: "students.rosterRetry" }),
+    ).not.toBeNull()
+  })
+
+  it("renders a populated roster row with its handle", () => {
+    useTeamRoster.mockReturnValue({
+      ...emptyRoster,
+      isEmpty: false,
+      counts: { enrolled: 1, pending: 0 },
+      rows: [
+        {
+          key: "alice",
+          username: "alice",
+          email: "",
+          section: "",
+          github_id: "1",
+          roles: ["student"],
+          state: "enrolled",
+        },
+      ],
+    })
+    render(renderView())
+    expect(screen.getByText("alice")).not.toBeNull()
+  })
+
+  it("surfaces failed invitations with a dismiss affordance", () => {
+    useTeamRoster.mockReturnValue({
+      ...emptyRoster,
+      isEmpty: false,
+      failedInvitations: [
+        { id: 7, login: "ghost", email: null, failed_reason: "bounced" },
+      ],
+    })
+    render(renderView())
+    expect(screen.getByText("students.failedInvitesTitle:1")).not.toBeNull()
+    expect(screen.getByText("ghost")).not.toBeNull()
+  })
+})

--- a/web/src/pages/students/EnrolledStudents.smoke.test.tsx
+++ b/web/src/pages/students/EnrolledStudents.smoke.test.tsx
@@ -26,16 +26,20 @@ vi.mock("@/hooks/useTeamRoster", () => ({
   useInvalidateTeamRoster: () => () => {},
 }))
 
-// Mutation hooks -> inert objects (no network); the smoke test never fires them.
+// Mutation hooks -> inert objects (no network); most phase tests never fire
+// them. Migrate + sync get dedicated, per-test-controllable spies so the
+// composed wiring test can open the migrate gate and observe the auto-sync.
 const inertMutation = { mutate: vi.fn(), isPending: false }
+const migrateMutate = vi.fn()
+const syncMutate = vi.fn()
 vi.mock("@/hooks/mutations/useDismissFailedInvite", () => ({
   useDismissFailedInvite: () => inertMutation,
 }))
 vi.mock("@/hooks/mutations/useSyncRoster", () => ({
-  useSyncRoster: () => inertMutation,
+  useSyncRoster: () => ({ mutate: syncMutate, isPending: false }),
 }))
 vi.mock("@/hooks/mutations/useMigrateRoster", () => ({
-  useMigrateRoster: () => inertMutation,
+  useMigrateRoster: () => ({ mutate: migrateMutate, isPending: false }),
 }))
 vi.mock("@/hooks/mutations/useReinviteFailedInvite", () => ({
   useReinviteFailedInvite: () => inertMutation,
@@ -101,6 +105,9 @@ const renderView = (): ReactElement => (
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  // clearAllMocks resets call records but not implementations; reset the
+  // migrate spy so one test's onSettled stub can't leak the gate into the next.
+  migrateMutate.mockReset()
 })
 
 describe("EnrolledStudents — rendered phase views", () => {
@@ -165,5 +172,32 @@ describe("EnrolledStudents — rendered phase views", () => {
     render(renderView())
     expect(screen.getByText("students.failedInvitesTitle:1")).not.toBeNull()
     expect(screen.getByText("ghost")).not.toBeNull()
+  })
+
+  // Composed wiring: exercises the useRosterAutoMigrate -> migrateSettledFor ->
+  // useRosterAutoSync seam through EnrolledStudents (the isolated-hook tests in
+  // rosterAutoEffects.test.ts can't, since the gate is opened via the migrate
+  // mutation's onSettled here). Migrate settles the gate, drift is present, so
+  // auto-sync must fire exactly once.
+  it("auto-syncs once when migrate settles and the roster has drift", () => {
+    migrateMutate.mockImplementation((_vars, opts) => opts?.onSettled?.())
+    useTeamRoster.mockReturnValue({
+      ...emptyRoster,
+      isEmpty: false,
+      csvMissingLogins: ["ghost"],
+    })
+    render(renderView())
+    expect(syncMutate).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not auto-sync while the migrate gate is still closed", () => {
+    // Default migrate mock never calls onSettled -> gate stays shut.
+    useTeamRoster.mockReturnValue({
+      ...emptyRoster,
+      isEmpty: false,
+      csvMissingLogins: ["ghost"],
+    })
+    render(renderView())
+    expect(syncMutate).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -63,14 +63,6 @@ import { FailedInvitationsList } from "./FailedInvitationsList"
 import { RosterParseProblems } from "./RosterParseProblems"
 import { RosterWarnings } from "./RosterWarnings"
 
-// Preserve the module's original public surface: the pure helpers moved to
-// ./enrolledStudentsHelpers but EnrolledStudents.section.test.ts imports them
-// from here.
-export {
-  groupStudentsBySection,
-  nextSelectedKeyAfterSave,
-} from "./enrolledStudentsHelpers"
-
 const EnrolledStudents = ({
   students = [],
   parseProblems = [],
@@ -447,11 +439,6 @@ const EnrolledStudents = ({
 
   return (
     <div className="flex w-full flex-col gap-6">
-      {/* Malformed roster.csv: name every bad line so the teacher can fix
-          the file on GitHub. Distinct from a network load error — this is a bad
-          file, and reads/writes silently misbehave until it's corrected. */}
-      {/* Malformed roster.csv: name every bad line so the teacher can fix the
-          file on GitHub. */}
       {parseProblems.length > 0 ? (
         <RosterParseProblems
           parseProblems={parseProblems}

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -19,7 +19,6 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useGitHubViewer } from "@/hooks/useGitHubResources"
 import type { GitHubOrgInvitation } from "@/github-core/types"
 import { invalidateInviteQueries as invalidateInviteQueriesForOrg } from "@/github-core/queries"
-import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { useUpdateRosterCache } from "@/hooks/useGetStudents"
 import { useTeamRoster, useInvalidateTeamRoster } from "@/hooks/useTeamRoster"
 import { useSyncRoster } from "@/hooks/mutations/useSyncRoster"
@@ -35,7 +34,6 @@ import {
   type StatusFilter,
 } from "@/pages/students/rosterFilter"
 import { studentKey, toStudent } from "@/util/roster"
-import { rosterPath } from "@/util/rosterPath"
 import { isSameGitHubUser } from "@/util/students"
 import {
   resolveSelectedRows,
@@ -50,8 +48,8 @@ import RosterBulkActionsBar, {
   type AddStudentActions,
 } from "@/pages/students/RosterBulkActionsBar"
 import type { StudentCsvRow } from "@/domain/students"
-import { AnimatePresence, motion } from "motion/react"
-import { collapseVariants, enterExit } from "@/lib/motion"
+import { motion } from "motion/react"
+import { enterExit } from "@/lib/motion"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -62,6 +60,8 @@ import { useRosterAutoMigrate } from "./useRosterAutoMigrate"
 import { useRosterAutoSync } from "./useRosterAutoSync"
 import { RosterRow } from "./RosterRow"
 import { FailedInvitationsList } from "./FailedInvitationsList"
+import { RosterParseProblems } from "./RosterParseProblems"
+import { RosterWarnings } from "./RosterWarnings"
 
 // Preserve the module's original public surface: the pure helpers moved to
 // ./enrolledStudentsHelpers but EnrolledStudents.section.test.ts imports them
@@ -450,80 +450,21 @@ const EnrolledStudents = ({
       {/* Malformed roster.csv: name every bad line so the teacher can fix
           the file on GitHub. Distinct from a network load error — this is a bad
           file, and reads/writes silently misbehave until it's corrected. */}
+      {/* Malformed roster.csv: name every bad line so the teacher can fix the
+          file on GitHub. */}
       {parseProblems.length > 0 ? (
-        <Alert tone="error">
-          <div className="flex flex-col gap-2">
-            <span className="font-medium">
-              {t("students.rosterParseError")}
-            </span>
-            <ul className="list-disc pl-5 text-sm">
-              {parseProblems.map((p, i) => (
-                <li key={`${p.line}-${i}`}>
-                  {t("students.rosterParseErrorLine", {
-                    line: p.line,
-                    message: p.message,
-                  })}
-                </li>
-              ))}
-            </ul>
-            <a
-              href={`https://github.com/${encodeURIComponent(org)}/${CONFIG_REPO}/edit/${DEFAULT_BRANCH}/${rosterPath(
-                classroom,
-              )
-                .split("/")
-                .map(encodeURIComponent)
-                .join("/")}`}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
-            >
-              {t("students.rosterEditOnGitHub")}
-            </a>
-            {onRecheckRoster ? (
-              <div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  loading={rechecking}
-                  loadingLabel={t("students.rosterRechecking")}
-                  disabled={rechecking}
-                  onClick={onRecheckRoster}
-                >
-                  {t("students.rosterRecheck")}
-                </Button>
-              </div>
-            ) : null}
-          </div>
-        </Alert>
+        <RosterParseProblems
+          parseProblems={parseProblems}
+          org={org}
+          classroom={classroom}
+          onRecheckRoster={onRecheckRoster}
+          rechecking={rechecking}
+        />
       ) : null}
 
-      {/* Warnings / action results. */}
+      {/* Per-row action warnings/results. */}
       {Object.keys(warnings).length > 0 ? (
-        <div className="flex w-full flex-col gap-2">
-          <AnimatePresence initial={false}>
-            {Object.entries(warnings).map(([key, warning]) => (
-              <motion.div
-                key={key}
-                layout
-                variants={collapseVariants}
-                initial="initial"
-                animate="animate"
-                exit="exit"
-                role="alert"
-                className="alert alert-warning alert-soft overflow-hidden"
-              >
-                <span className="text-sm">{warning}</span>
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => dismissWarning(key)}
-                >
-                  {t("students.dismiss")}
-                </Button>
-              </motion.div>
-            ))}
-          </AnimatePresence>
-        </div>
+        <RosterWarnings warnings={warnings} onDismiss={dismissWarning} />
       ) : null}
 
       {/* Pending-invites banner: clicking "Review" filters to pending so the

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -1,12 +1,4 @@
-import {
-  AlertTriangle,
-  ChevronRight,
-  Plus,
-  RefreshCw,
-  Send,
-  Upload,
-  X,
-} from "lucide-react"
+import { AlertTriangle, Plus, RefreshCw, Send, Upload, X } from "lucide-react"
 
 import {
   Alert,
@@ -17,8 +9,6 @@ import {
   Spinner,
   Toolbar,
 } from "@/components/ui"
-import Avatar from "@/components/avatar"
-import { RoleBadges } from "./RoleBadges"
 import type { Student } from "@/types/classroom"
 import { useQueryClient } from "@tanstack/react-query"
 import type { RosterCsvProblem } from "@/domain/students"
@@ -33,20 +23,11 @@ import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { useUpdateRosterCache } from "@/hooks/useGetStudents"
 import { useTeamRoster, useInvalidateTeamRoster } from "@/hooks/useTeamRoster"
 import { useSyncRoster } from "@/hooks/mutations/useSyncRoster"
-import { useMigrateRoster } from "@/hooks/mutations/useMigrateRoster"
 import { useReinviteFailedInvite } from "@/hooks/mutations/useReinviteFailedInvite"
-import {
-  dropSuppressed,
-  type SuppressedLogins,
-} from "@/hooks/useSuppressedLogins"
+import type { SuppressedLogins } from "@/hooks/useSuppressedLogins"
 import type { TeamRosterRow, ClassroomRole } from "@/util/teamRoster"
 import { STAFF_ROLES } from "@/types/classroom"
-import {
-  ROLE_LABEL_KEY,
-  STATE_BADGE_TONE,
-  STATE_LABEL_KEY,
-  hasStudentEnrollment,
-} from "@/util/classroomRoleUI"
+import { ROLE_LABEL_KEY, hasStudentEnrollment } from "@/util/classroomRoleUI"
 import {
   filterRosterRows,
   NO_SECTION,
@@ -56,7 +37,6 @@ import {
 import { studentKey, toStudent } from "@/util/roster"
 import { rosterPath } from "@/util/rosterPath"
 import { isSameGitHubUser } from "@/util/students"
-import { GitHubIdentity } from "@/pages/orgMembers/memberPresentation"
 import {
   resolveSelectedRows,
   selectableRows,
@@ -65,7 +45,6 @@ import {
   toggleSelectAll,
 } from "@/pages/orgMembers/selection"
 import { useRangeSelection } from "@/pages/orgMembers/useRangeSelection"
-import { rosterRowToMemberRow, rosterRowInitials } from "@/util/memberRow"
 import RosterMemberModal from "@/pages/students/RosterMemberModal"
 import RosterBulkActionsBar, {
   type AddStudentActions,
@@ -73,45 +52,24 @@ import RosterBulkActionsBar, {
 import type { StudentCsvRow } from "@/domain/students"
 import { AnimatePresence, motion } from "motion/react"
 import { collapseVariants, enterExit } from "@/lib/motion"
-import { ClickableRow } from "@/lib/motionComponents"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
+import {
+  groupStudentsBySection,
+  nextSelectedKeyAfterSave,
+} from "./enrolledStudentsHelpers"
+import { useRosterAutoMigrate } from "./useRosterAutoMigrate"
+import { useRosterAutoSync } from "./useRosterAutoSync"
+import { RosterRow } from "./RosterRow"
+import { FailedInvitationsList } from "./FailedInvitationsList"
 
-// Group rows by `section`, sorted by name with the unlabeled ("No section")
-// bucket last. Generic over any row with a `section` field.
-export function groupStudentsBySection<T extends { section?: string }>(
-  students: T[],
-): Array<{ section: string; students: T[] }> {
-  const bySection = new Map<string, T[]>()
-  for (const student of students) {
-    const label = student.section?.trim() || NO_SECTION
-    const bucket = bySection.get(label)
-    if (bucket) bucket.push(student)
-    else bySection.set(label, [student])
-  }
-  return Array.from(bySection.entries())
-    .sort(([a], [b]) => {
-      if (a === NO_SECTION) return 1
-      if (b === NO_SECTION) return -1
-      return a.localeCompare(b, undefined, { numeric: true })
-    })
-    .map(([section, group]) => ({ section, students: group }))
-}
-
-// After a metadata save, where should the open detail modal's selection point?
-// An edit can't change an editable row's identity (rows key on
-// github_id/username; the form edits only name/email/section), so this is
-// normally a no-op — but if the key ever moves, follow it so the modal stays on
-// the same person instead of snapping shut. Only re-points the row that was
-// saved; any other selection is left alone.
-export function nextSelectedKeyAfterSave(
-  prev: string | null,
-  savedRowKey: string,
-  nextRowKey: string,
-): string | null {
-  if (!nextRowKey || nextRowKey === savedRowKey) return prev
-  return prev === savedRowKey ? nextRowKey : prev
-}
+// Preserve the module's original public surface: the pure helpers moved to
+// ./enrolledStudentsHelpers but EnrolledStudents.section.test.ts imports them
+// from here.
+export {
+  groupStudentsBySection,
+  nextSelectedKeyAfterSave,
+} from "./enrolledStudentsHelpers"
 
 const EnrolledStudents = ({
   students = [],
@@ -376,33 +334,14 @@ const EnrolledStudents = ({
       : []),
   ]
 
-  // Auto-migrate on open: converge a classroom bootstrapped before the roster
-  // rename so roster.csv always physically exists. Idempotent and cheap (a
-  // no-op once roster.csv is present). It runs BEFORE auto-sync (which gates on
-  // migrateSettledFor) so the two roster writers don't race on the ref. The
-  // rename changes only the file's path, not its content, and reads already
-  // fall back to the legacy name, so there's no cache to invalidate — a plain
-  // invalidate here would refetch eventually-consistent bytes and needlessly
-  // re-arm auto-sync.
-  const [migrateSettledFor, setMigrateSettledFor] = useState<string | null>(
-    null,
+  // Auto-migrate on open (see useRosterAutoMigrate): converge a pre-rename
+  // classroom so roster.csv physically exists, and gate auto-sync on its
+  // settling so the two roster writers don't race.
+  const { migrateSettledFor } = useRosterAutoMigrate(
+    org,
+    classroom,
+    !isLoading && !isError,
   )
-  const migrateMutation = useMigrateRoster(org, classroom)
-  // Fire once per classroom (the component instance is reused across a
-  // $classroom param switch, so a boolean would skip later classrooms).
-  const migratedForRef = useRef<string | null>(null)
-  useEffect(() => {
-    if (isLoading || isError) return
-    if (migratedForRef.current === classroom) return
-    migratedForRef.current = classroom
-    setMigrateSettledFor(null)
-    // onSettled unblocks auto-sync (mount-fired UI coordination) so it lives at
-    // the call site; even a migrate hiccup must still release the gate.
-    migrateMutation.mutate(undefined, {
-      onSettled: () => setMigrateSettledFor(classroom),
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [classroom, isLoading, isError])
 
   // Explicit teacher-triggered CSV backfill (also auto-run on open). The hook
   // owns the roster-file invalidation that must always run; the toasts live
@@ -427,54 +366,19 @@ const EnrolledStudents = ({
       },
     })
 
-  // Auto-sync on open: append team members lacking a CSV row (fire once per
-  // drift episode, per classroom; re-arm when the drift clears). Gated on
-  // migrate having settled for this classroom so the two roster writers run in
-  // sequence, not a race. dropSuppressed skips any csv-missing member the
-  // teacher just unenrolled whose best-effort team-drop failed — otherwise
-  // auto-sync would re-append the student it just removed. (suppressedLogins is
-  // read in the effect, not during render; syncRosterFromTeam re-derives the
-  // authoritative set server-side.)
-  //
-  // Keyed by classroom (not a boolean): the component instance is reused across
-  // a $classroom param switch, so a boolean set true for a drifting classroom A
-  // would wrongly skip a drifting classroom B navigated to directly (no
-  // intervening zero-drift render to reset it).
-  const autoSyncedForRef = useRef<string | null>(null)
-  const csvMissingKey = csvMissingLogins.join(",")
-  const backfillNeededKey = backfillNeededLogins.join(",")
-  useEffect(() => {
-    if (isLoading || isError) return
-    // Wait for the migrate pass to settle first (converges the legacy roster
-    // name onto roster.csv) so sync's write can't race migrate's on the ref.
-    if (migrateSettledFor !== classroom) return
-    // Sync when there's drift to fix: a team member with no CSV row (missing),
-    // OR an existing CSV row that's stale against the team (blank github_id or a
-    // wrong role — the login-only row case). Without the backfill term a
-    // login-only row would never converge, since it isn't "missing". BOTH terms
-    // drop suppressed (just-unenrolled) logins so a stale row lingering during
-    // the eventual-consistency window can't re-fire a resurrecting sync.
-    const hasMissing =
-      dropSuppressed(csvMissingLogins, suppressedLogins).length > 0
-    const hasBackfill =
-      dropSuppressed(backfillNeededLogins, suppressedLogins).length > 0
-    if (!hasMissing && !hasBackfill) {
-      if (autoSyncedForRef.current === classroom)
-        autoSyncedForRef.current = null
-      return
-    }
-    if (autoSyncedForRef.current === classroom || syncMutation.isPending) return
-    autoSyncedForRef.current = classroom
-    runSync()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    csvMissingKey,
-    backfillNeededKey,
-    isLoading,
-    isError,
-    migrateSettledFor,
+  // Auto-sync on open (see useRosterAutoSync): append team members lacking a
+  // CSV row when there's drift, gated on migrate settling; the caller owns
+  // runSync (and its toasts, which skip on unmount).
+  useRosterAutoSync({
     classroom,
-  ])
+    ready: !isLoading && !isError,
+    migrateSettledFor,
+    csvMissingLogins,
+    backfillNeededLogins,
+    suppressedLogins,
+    syncPending: syncMutation.isPending,
+    runSync,
+  })
 
   const onRowMetadataSaved = (rowKey: string, updated: StudentCsvRow) => {
     updateRosterCache((current) => {
@@ -529,87 +433,17 @@ const EnrolledStudents = ({
       suppressedLogins.remember(removed.map((r) => r.username))
   }
 
-  const renderRow = (row: TeamRosterRow) => {
-    const member = rosterRowToMemberRow(row)
-    const displayName = member.name
-    const displayHandle = row.username || row.email
-    const displayInitials = rosterRowInitials(row)
-    const selfRow = isSelf(row)
-
-    return (
-      <ClickableRow
-        key={row.key}
-        className="group/row flex cursor-pointer items-center justify-between gap-4 px-6 py-4 hover:bg-base-200"
-        role="button"
-        tabIndex={0}
-        onClick={() => setSelectedKey(row.key)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault()
-            setSelectedKey(row.key)
-          }
-        }}
-      >
-        <input
-          type="checkbox"
-          className="checkbox checkbox-sm shrink-0"
-          aria-label={
-            selfRow
-              ? t("students.bulk.selfNotSelectable")
-              : t("students.bulk.selectRow", { label: displayHandle })
-          }
-          disabled={selfRow}
-          title={selfRow ? t("students.bulk.selfNotSelectable") : undefined}
-          checked={selectedKeys.has(row.key)}
-          onClick={(e) => {
-            e.stopPropagation()
-            handleRowCheckboxClick(e, row.key)
-          }}
-          onChange={() => handleToggleRow(row.key)}
-        />
-        <div className="min-w-0 flex-1">
-          <Avatar
-            name={displayName}
-            github={displayHandle}
-            initials={displayInitials}
-            subtitle={<GitHubIdentity row={member} />}
-          />
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {(() => {
-            // Enrolled/pending rows assert role(s) (the team is the authority),
-            // shown as one badge per role via RoleBadges. Needs-attention rows
-            // have no team role yet, so they render no role badge.
-            if (
-              row.state === "needs_attention_in_org" ||
-              row.state === "needs_attention_not_in_org"
-            ) {
-              return null
-            }
-            return <RoleBadges roles={row.roles} />
-          })()}
-          {row.section.trim() ? (
-            <Badge tone="info" className="shrink-0">
-              {row.section.trim()}
-            </Badge>
-          ) : null}
-          {row.state !== "enrolled" ? (
-            <Badge
-              size="sm"
-              tone={STATE_BADGE_TONE[row.state]}
-              className="shrink-0"
-            >
-              {t(STATE_LABEL_KEY[row.state])}
-            </Badge>
-          ) : null}
-          <ChevronRight
-            aria-hidden="true"
-            className="size-4 text-base-content/30 transition-transform duration-150 group-hover/row:translate-x-0.5 group-hover/row:text-base-content/70"
-          />
-        </div>
-      </ClickableRow>
-    )
-  }
+  const renderRow = (row: TeamRosterRow) => (
+    <RosterRow
+      key={row.key}
+      row={row}
+      selfRow={isSelf(row)}
+      checked={selectedKeys.has(row.key)}
+      onOpen={setSelectedKey}
+      onCheckboxClick={handleRowCheckboxClick}
+      onToggle={handleToggleRow}
+    />
+  )
 
   return (
     <div className="flex w-full flex-col gap-6">
@@ -738,74 +572,26 @@ const EnrolledStudents = ({
         </Alert>
       ) : null}
 
-      {/* Failed/expired invitations (owner-only). GitHub couldn't deliver these,
-          so they need a re-invite or dismissal — surfaced here since they never
-          appear as roster rows. */}
+      {/* Failed/expired invitations (owner-only). */}
       {!isLoading && !isError && failedInvitations.length > 0 ? (
-        <Alert tone="warning" className="flex-col items-stretch gap-2">
-          <span className="text-sm font-medium">
-            {t("students.failedInvitesTitle", {
-              count: failedInvitations.length,
-            })}
-          </span>
-          <ul className="flex flex-col divide-y divide-warning/20">
-            {failedInvitations.map((inv) => {
-              const who = inv.login || inv.email || String(inv.id)
-              return (
-                <li
-                  key={inv.id}
-                  className="flex items-center justify-between gap-3 py-1.5"
-                >
-                  <span className="min-w-0 text-sm">
-                    <span className="font-mono">{who}</span>
-                    {inv.failed_reason ? (
-                      <span className="text-base-content/60">
-                        {" "}
-                        — {inv.failed_reason}
-                      </span>
-                    ) : null}
-                  </span>
-                  <div className="flex shrink-0 items-center gap-1">
-                    {inv.login || inv.email ? (
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        disabled={
-                          reinviteFailedInvite.isPending ||
-                          dismissFailedInvite.isPending
-                        }
-                        onClick={() => reinvite(inv)}
-                      >
-                        {t("students.reinvite")}
-                      </Button>
-                    ) : null}
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      disabled={
-                        reinviteFailedInvite.isPending ||
-                        dismissFailedInvite.isPending
-                      }
-                      onClick={() =>
-                        dismissFailedInvite.mutate(inv.id, {
-                          onError: (err) =>
-                            notify({
-                              tone: "error",
-                              message: t("students.failedInviteDismissError", {
-                                error: getErrorMessage(err),
-                              }),
-                            }),
-                        })
-                      }
-                    >
-                      {t("students.dismiss")}
-                    </Button>
-                  </div>
-                </li>
-              )
-            })}
-          </ul>
-        </Alert>
+        <FailedInvitationsList
+          failedInvitations={failedInvitations}
+          actionsDisabled={
+            reinviteFailedInvite.isPending || dismissFailedInvite.isPending
+          }
+          onReinvite={reinvite}
+          onDismiss={(inv) =>
+            dismissFailedInvite.mutate(inv.id, {
+              onError: (err) =>
+                notify({
+                  tone: "error",
+                  message: t("students.failedInviteDismissError", {
+                    error: getErrorMessage(err),
+                  }),
+                }),
+            })
+          }
+        />
       ) : null}
 
       {/* Toolbar: search + status filter (group-by-section lives in the table

--- a/web/src/pages/students/FailedInvitationsList.tsx
+++ b/web/src/pages/students/FailedInvitationsList.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from "react-i18next"
+import { Alert, Button } from "@/components/ui"
+import type { GitHubOrgInvitation } from "@/github-core/types"
+
+// Failed/expired invitations (owner-only). GitHub couldn't deliver these, so
+// they need a re-invite or dismissal — surfaced here since they never appear as
+// roster rows. A login-less, email-less invite can't be re-issued (dismiss-only).
+export const FailedInvitationsList = ({
+  failedInvitations,
+  actionsDisabled,
+  onReinvite,
+  onDismiss,
+}: {
+  failedInvitations: GitHubOrgInvitation[]
+  actionsDisabled: boolean
+  onReinvite: (inv: GitHubOrgInvitation) => void
+  onDismiss: (inv: GitHubOrgInvitation) => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <Alert tone="warning" className="flex-col items-stretch gap-2">
+      <span className="text-sm font-medium">
+        {t("students.failedInvitesTitle", { count: failedInvitations.length })}
+      </span>
+      <ul className="flex flex-col divide-y divide-warning/20">
+        {failedInvitations.map((inv) => {
+          const who = inv.login || inv.email || String(inv.id)
+          return (
+            <li
+              key={inv.id}
+              className="flex items-center justify-between gap-3 py-1.5"
+            >
+              <span className="min-w-0 text-sm">
+                <span className="font-mono">{who}</span>
+                {inv.failed_reason ? (
+                  <span className="text-base-content/60">
+                    {" "}
+                    — {inv.failed_reason}
+                  </span>
+                ) : null}
+              </span>
+              <div className="flex shrink-0 items-center gap-1">
+                {inv.login || inv.email ? (
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    disabled={actionsDisabled}
+                    onClick={() => onReinvite(inv)}
+                  >
+                    {t("students.reinvite")}
+                  </Button>
+                ) : null}
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={actionsDisabled}
+                  onClick={() => onDismiss(inv)}
+                >
+                  {t("students.dismiss")}
+                </Button>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </Alert>
+  )
+}

--- a/web/src/pages/students/RosterParseProblems.tsx
+++ b/web/src/pages/students/RosterParseProblems.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from "react-i18next"
+import { Alert, Button } from "@/components/ui"
+import type { RosterCsvProblem } from "@/domain/students"
+import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
+import { rosterPath } from "@/util/rosterPath"
+
+// Malformed roster.csv: name every bad line so the teacher can fix the file on
+// GitHub. Distinct from a network load error — this is a bad file, and
+// reads/writes silently misbehave until it's corrected.
+export const RosterParseProblems = ({
+  parseProblems,
+  org,
+  classroom,
+  onRecheckRoster,
+  rechecking,
+}: {
+  parseProblems: RosterCsvProblem[]
+  org: string
+  classroom: string
+  onRecheckRoster?: () => void
+  rechecking?: boolean
+}) => {
+  const { t } = useTranslation()
+  return (
+    <Alert tone="error">
+      <div className="flex flex-col gap-2">
+        <span className="font-medium">{t("students.rosterParseError")}</span>
+        <ul className="list-disc pl-5 text-sm">
+          {parseProblems.map((p, i) => (
+            <li key={`${p.line}-${i}`}>
+              {t("students.rosterParseErrorLine", {
+                line: p.line,
+                message: p.message,
+              })}
+            </li>
+          ))}
+        </ul>
+        <a
+          href={`https://github.com/${encodeURIComponent(org)}/${CONFIG_REPO}/edit/${DEFAULT_BRANCH}/${rosterPath(
+            classroom,
+          )
+            .split("/")
+            .map(encodeURIComponent)
+            .join("/")}`}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          {t("students.rosterEditOnGitHub")}
+        </a>
+        {onRecheckRoster ? (
+          <div>
+            <Button
+              variant="ghost"
+              size="sm"
+              loading={rechecking}
+              loadingLabel={t("students.rosterRechecking")}
+              disabled={rechecking}
+              onClick={onRecheckRoster}
+            >
+              {t("students.rosterRecheck")}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </Alert>
+  )
+}

--- a/web/src/pages/students/RosterRow.tsx
+++ b/web/src/pages/students/RosterRow.tsx
@@ -1,0 +1,106 @@
+import { ChevronRight } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import Avatar from "@/components/avatar"
+import { Badge } from "@/components/ui"
+import { RoleBadges } from "./RoleBadges"
+import { GitHubIdentity } from "@/pages/orgMembers/memberPresentation"
+import { STATE_BADGE_TONE, STATE_LABEL_KEY } from "@/util/classroomRoleUI"
+import { rosterRowToMemberRow, rosterRowInitials } from "@/util/memberRow"
+import { ClickableRow } from "@/lib/motionComponents"
+import type { TeamRosterRow } from "@/util/teamRoster"
+
+// One roster row: avatar + identity, role/section/state badges, and the
+// selection checkbox (disabled for the signed-in teacher's own row). Clicking
+// the row opens the detail modal; the checkbox is selection-only.
+export const RosterRow = ({
+  row,
+  selfRow,
+  checked,
+  onOpen,
+  onCheckboxClick,
+  onToggle,
+}: {
+  row: TeamRosterRow
+  selfRow: boolean
+  checked: boolean
+  onOpen: (key: string) => void
+  onCheckboxClick: (
+    event: React.MouseEvent<HTMLInputElement>,
+    key: string,
+  ) => void
+  onToggle: (key: string) => void
+}) => {
+  const { t } = useTranslation()
+  const member = rosterRowToMemberRow(row)
+  const displayName = member.name
+  const displayHandle = row.username || row.email
+  const displayInitials = rosterRowInitials(row)
+
+  return (
+    <ClickableRow
+      className="group/row flex cursor-pointer items-center justify-between gap-4 px-6 py-4 hover:bg-base-200"
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(row.key)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onOpen(row.key)
+        }
+      }}
+    >
+      <input
+        type="checkbox"
+        className="checkbox checkbox-sm shrink-0"
+        aria-label={
+          selfRow
+            ? t("students.bulk.selfNotSelectable")
+            : t("students.bulk.selectRow", { label: displayHandle })
+        }
+        disabled={selfRow}
+        title={selfRow ? t("students.bulk.selfNotSelectable") : undefined}
+        checked={checked}
+        onClick={(e) => {
+          e.stopPropagation()
+          onCheckboxClick(e, row.key)
+        }}
+        onChange={() => onToggle(row.key)}
+      />
+      <div className="min-w-0 flex-1">
+        <Avatar
+          name={displayName}
+          github={displayHandle}
+          initials={displayInitials}
+          subtitle={<GitHubIdentity row={member} />}
+        />
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {/* Enrolled/pending rows assert role(s) (the team is the authority),
+            shown as one badge per role via RoleBadges. Needs-attention rows have
+            no team role yet, so they render no role badge. */}
+        {row.state === "needs_attention_in_org" ||
+        row.state === "needs_attention_not_in_org" ? null : (
+          <RoleBadges roles={row.roles} />
+        )}
+        {row.section.trim() ? (
+          <Badge tone="info" className="shrink-0">
+            {row.section.trim()}
+          </Badge>
+        ) : null}
+        {row.state !== "enrolled" ? (
+          <Badge
+            size="sm"
+            tone={STATE_BADGE_TONE[row.state]}
+            className="shrink-0"
+          >
+            {t(STATE_LABEL_KEY[row.state])}
+          </Badge>
+        ) : null}
+        <ChevronRight
+          aria-hidden="true"
+          className="size-4 text-base-content/30 transition-transform duration-150 group-hover/row:translate-x-0.5 group-hover/row:text-base-content/70"
+        />
+      </div>
+    </ClickableRow>
+  )
+}

--- a/web/src/pages/students/RosterWarnings.tsx
+++ b/web/src/pages/students/RosterWarnings.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from "react-i18next"
+import { AnimatePresence, motion } from "motion/react"
+import { Button } from "@/components/ui"
+import { collapseVariants } from "@/lib/motion"
+
+// Per-row action warnings (keyed by row.key so one action's warning can't
+// clobber another's), each dismissable. Animated in/out so a resolved warning
+// collapses rather than snapping away.
+export const RosterWarnings = ({
+  warnings,
+  onDismiss,
+}: {
+  warnings: Record<string, string>
+  onDismiss: (key: string) => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <AnimatePresence initial={false}>
+        {Object.entries(warnings).map(([key, warning]) => (
+          <motion.div
+            key={key}
+            layout
+            variants={collapseVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            role="alert"
+            className="alert alert-warning alert-soft overflow-hidden"
+          >
+            <span className="text-sm">{warning}</span>
+            <Button variant="ghost" size="xs" onClick={() => onDismiss(key)}>
+              {t("students.dismiss")}
+            </Button>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/web/src/pages/students/enrolledStudentsHelpers.ts
+++ b/web/src/pages/students/enrolledStudentsHelpers.ts
@@ -1,0 +1,37 @@
+import { NO_SECTION } from "@/pages/students/rosterFilter"
+
+// Group rows by `section`, sorted by name with the unlabeled ("No section")
+// bucket last. Generic over any row with a `section` field.
+export function groupStudentsBySection<T extends { section?: string }>(
+  students: T[],
+): Array<{ section: string; students: T[] }> {
+  const bySection = new Map<string, T[]>()
+  for (const student of students) {
+    const label = student.section?.trim() || NO_SECTION
+    const bucket = bySection.get(label)
+    if (bucket) bucket.push(student)
+    else bySection.set(label, [student])
+  }
+  return Array.from(bySection.entries())
+    .sort(([a], [b]) => {
+      if (a === NO_SECTION) return 1
+      if (b === NO_SECTION) return -1
+      return a.localeCompare(b, undefined, { numeric: true })
+    })
+    .map(([section, group]) => ({ section, students: group }))
+}
+
+// After a metadata save, where should the open detail modal's selection point?
+// An edit can't change an editable row's identity (rows key on
+// github_id/username; the form edits only name/email/section), so this is
+// normally a no-op — but if the key ever moves, follow it so the modal stays on
+// the same person instead of snapping shut. Only re-points the row that was
+// saved; any other selection is left alone.
+export function nextSelectedKeyAfterSave(
+  prev: string | null,
+  savedRowKey: string,
+  nextRowKey: string,
+): string | null {
+  if (!nextRowKey || nextRowKey === savedRowKey) return prev
+  return prev === savedRowKey ? nextRowKey : prev
+}

--- a/web/src/pages/students/rosterAutoEffects.test.ts
+++ b/web/src/pages/students/rosterAutoEffects.test.ts
@@ -73,6 +73,19 @@ describe("useRosterAutoSync", () => {
     expect(runSync).toHaveBeenCalledTimes(1)
   })
 
+  it("fires on backfill-only drift (login-only row, no csv-missing)", () => {
+    const runSync = vi.fn()
+    renderHook(() =>
+      useRosterAutoSync({
+        ...base,
+        csvMissingLogins: [],
+        backfillNeededLogins: ["legacyRow"],
+        runSync,
+      }),
+    )
+    expect(runSync).toHaveBeenCalledTimes(1)
+  })
+
   it("stays gated until migrate settles for this classroom", () => {
     const runSync = vi.fn()
     const { rerender } = renderHook((props) => useRosterAutoSync(props), {

--- a/web/src/pages/students/rosterAutoEffects.test.ts
+++ b/web/src/pages/students/rosterAutoEffects.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+// Drive the two extracted roster auto-effect hooks directly, since the rendered
+// smoke test can't exercise them (its migrate mock never settles the gate and it
+// supplies no drift). These pin the highest-risk part of the U14 split: the
+// once-per-classroom guard refs, the migrate-before-sync gate, and re-arm.
+
+const migrateMutate = vi.fn()
+vi.mock("@/hooks/mutations/useMigrateRoster", () => ({
+  useMigrateRoster: () => ({ mutate: migrateMutate, isPending: false }),
+}))
+
+import { useRosterAutoMigrate } from "./useRosterAutoMigrate"
+import { useRosterAutoSync } from "./useRosterAutoSync"
+import type { SuppressedLogins } from "@/hooks/useSuppressedLogins"
+
+const noSuppression: SuppressedLogins = {
+  remember: vi.fn(),
+  forget: vi.fn(),
+  has: () => false,
+  clear: vi.fn(),
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("useRosterAutoMigrate", () => {
+  it("fires once per classroom and opens the gate via onSettled", () => {
+    const { result, rerender } = renderHook(
+      ({ classroom, ready }) => useRosterAutoMigrate("acme", classroom, ready),
+      { initialProps: { classroom: "cs101", ready: true } },
+    )
+    expect(migrateMutate).toHaveBeenCalledTimes(1)
+    // The gate stays null until onSettled runs...
+    expect(result.current.migrateSettledFor).toBeNull()
+    // ...even on the error path (onSettled, not onSuccess).
+    migrateMutate.mock.calls[0][1].onSettled()
+    rerender({ classroom: "cs101", ready: true })
+    expect(result.current.migrateSettledFor).toBe("cs101")
+    // A same-classroom rerender must not re-fire.
+    expect(migrateMutate).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire until ready, then re-fires for a new classroom", () => {
+    const { rerender } = renderHook(
+      ({ classroom, ready }) => useRosterAutoMigrate("acme", classroom, ready),
+      { initialProps: { classroom: "cs101", ready: false } },
+    )
+    expect(migrateMutate).not.toHaveBeenCalled()
+    rerender({ classroom: "cs101", ready: true })
+    expect(migrateMutate).toHaveBeenCalledTimes(1)
+    // A $classroom route switch on the reused instance must migrate the new one.
+    rerender({ classroom: "cs202", ready: true })
+    expect(migrateMutate).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("useRosterAutoSync", () => {
+  const base = {
+    classroom: "cs101",
+    ready: true,
+    migrateSettledFor: "cs101",
+    csvMissingLogins: ["ghost"],
+    backfillNeededLogins: [] as string[],
+    suppressedLogins: noSuppression,
+    syncPending: false,
+  }
+
+  it("fires runSync once when drift exists and migrate has settled", () => {
+    const runSync = vi.fn()
+    renderHook(() => useRosterAutoSync({ ...base, runSync }))
+    expect(runSync).toHaveBeenCalledTimes(1)
+  })
+
+  it("stays gated until migrate settles for this classroom", () => {
+    const runSync = vi.fn()
+    const { rerender } = renderHook((props) => useRosterAutoSync(props), {
+      initialProps: {
+        ...base,
+        migrateSettledFor: null as string | null,
+        runSync,
+      },
+    })
+    expect(runSync).not.toHaveBeenCalled()
+    rerender({ ...base, migrateSettledFor: "cs101", runSync })
+    expect(runSync).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire when there is no drift", () => {
+    const runSync = vi.fn()
+    renderHook(() =>
+      useRosterAutoSync({
+        ...base,
+        csvMissingLogins: [],
+        backfillNeededLogins: [],
+        runSync,
+      }),
+    )
+    expect(runSync).not.toHaveBeenCalled()
+  })
+
+  it("skips drift logins the teacher just unenrolled (dropSuppressed)", () => {
+    const runSync = vi.fn()
+    renderHook(() =>
+      useRosterAutoSync({
+        ...base,
+        suppressedLogins: { ...noSuppression, has: () => true },
+        runSync,
+      }),
+    )
+    expect(runSync).not.toHaveBeenCalled()
+  })
+
+  it("does not stack a fire while a sync is already pending", () => {
+    const runSync = vi.fn()
+    renderHook(() => useRosterAutoSync({ ...base, syncPending: true, runSync }))
+    expect(runSync).not.toHaveBeenCalled()
+  })
+
+  it("re-arms after drift clears then re-appears", () => {
+    const runSync = vi.fn()
+    const { rerender } = renderHook((props) => useRosterAutoSync(props), {
+      initialProps: { ...base, runSync },
+    })
+    expect(runSync).toHaveBeenCalledTimes(1)
+    // Drift clears -> the per-classroom guard resets.
+    rerender({ ...base, csvMissingLogins: [], runSync })
+    // Drift re-appears -> it fires again for the same classroom.
+    rerender({ ...base, csvMissingLogins: ["ghost2"], runSync })
+    expect(runSync).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web/src/pages/students/useRosterAutoMigrate.ts
+++ b/web/src/pages/students/useRosterAutoMigrate.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from "react"
+import { useMigrateRoster } from "@/hooks/mutations/useMigrateRoster"
+
+// Auto-migrate on open: converge a classroom bootstrapped before the roster
+// rename so roster.csv always physically exists. Idempotent and cheap (a no-op
+// once roster.csv is present). It runs BEFORE auto-sync (which gates on the
+// returned `migrateSettledFor`) so the two roster writers don't race on the
+// ref. The rename changes only the file's path, not its content, and reads
+// already fall back to the legacy name, so there's no cache to invalidate — a
+// plain invalidate here would refetch eventually-consistent bytes and needlessly
+// re-arm auto-sync. Returns the classroom the migrate has settled for, which
+// gates useRosterAutoSync.
+export function useRosterAutoMigrate(
+  org: string,
+  classroom: string,
+  ready: boolean,
+): { migrateSettledFor: string | null } {
+  const [migrateSettledFor, setMigrateSettledFor] = useState<string | null>(
+    null,
+  )
+  const migrateMutation = useMigrateRoster(org, classroom)
+  // Fire once per classroom (the component instance is reused across a
+  // $classroom param switch, so a boolean would skip later classrooms).
+  const migratedForRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!ready) return
+    if (migratedForRef.current === classroom) return
+    migratedForRef.current = classroom
+    setMigrateSettledFor(null)
+    // onSettled unblocks auto-sync (mount-fired UI coordination) so it lives at
+    // the call site; even a migrate hiccup must still release the gate.
+    migrateMutation.mutate(undefined, {
+      onSettled: () => setMigrateSettledFor(classroom),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classroom, ready])
+
+  return { migrateSettledFor }
+}

--- a/web/src/pages/students/useRosterAutoSync.ts
+++ b/web/src/pages/students/useRosterAutoSync.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react"
+import {
+  dropSuppressed,
+  type SuppressedLogins,
+} from "@/hooks/useSuppressedLogins"
+
+// Auto-sync on open: append team members lacking a CSV row (fire once per drift
+// episode, per classroom; re-arm when the drift clears). Gated on migrate having
+// settled for this classroom so the two roster writers run in sequence, not a
+// race. dropSuppressed skips any csv-missing member the teacher just unenrolled
+// whose best-effort team-drop failed — otherwise auto-sync would re-append the
+// student it just removed. (suppressedLogins is read in the effect, not during
+// render; the sync re-derives the authoritative set server-side.)
+//
+// Keyed by classroom (not a boolean): the component instance is reused across a
+// $classroom param switch, so a boolean set true for a drifting classroom A
+// would wrongly skip a drifting classroom B navigated to directly (no
+// intervening zero-drift render to reset it).
+//
+// The caller owns `runSync` (and its toasts, which skip on unmount); this hook
+// only decides WHEN to fire it. `syncPending` is threaded so a fire can't stack
+// on an in-flight sync.
+export function useRosterAutoSync(params: {
+  classroom: string
+  ready: boolean
+  migrateSettledFor: string | null
+  csvMissingLogins: string[]
+  backfillNeededLogins: string[]
+  suppressedLogins: SuppressedLogins
+  syncPending: boolean
+  runSync: () => void
+}): void {
+  const {
+    classroom,
+    ready,
+    migrateSettledFor,
+    csvMissingLogins,
+    backfillNeededLogins,
+    suppressedLogins,
+    syncPending,
+    runSync,
+  } = params
+
+  const autoSyncedForRef = useRef<string | null>(null)
+  const csvMissingKey = csvMissingLogins.join(",")
+  const backfillNeededKey = backfillNeededLogins.join(",")
+  useEffect(() => {
+    if (!ready) return
+    // Wait for the migrate pass to settle first (converges the legacy roster
+    // name onto roster.csv) so sync's write can't race migrate's on the ref.
+    if (migrateSettledFor !== classroom) return
+    // Sync when there's drift to fix: a team member with no CSV row (missing),
+    // OR an existing CSV row that's stale against the team (blank github_id or a
+    // wrong role — the login-only row case). Without the backfill term a
+    // login-only row would never converge, since it isn't "missing". BOTH terms
+    // drop suppressed (just-unenrolled) logins so a stale row lingering during
+    // the eventual-consistency window can't re-fire a resurrecting sync.
+    const hasMissing =
+      dropSuppressed(csvMissingLogins, suppressedLogins).length > 0
+    const hasBackfill =
+      dropSuppressed(backfillNeededLogins, suppressedLogins).length > 0
+    if (!hasMissing && !hasBackfill) {
+      if (autoSyncedForRef.current === classroom)
+        autoSyncedForRef.current = null
+      return
+    }
+    if (autoSyncedForRef.current === classroom || syncPending) return
+    autoSyncedForRef.current = classroom
+    runSync()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [csvMissingKey, backfillNeededKey, ready, migrateSettledFor, classroom])
+}


### PR DESCRIPTION
## What

Tier-2 unit **U14** — decompose `pages/students/EnrolledStudents.tsx` (**1052 → 779 lines**), the last and highest-risk UI giant (tangled roster state + auto-migrate/auto-sync effects, and it had **no rendered test** before this).

## Safety-net-first approach

Because there was no test coverage, I added a **rendered smoke test against the original component first** (loading / empty / error / populated row / failed-invites), then did the extraction — the smoke test staying green proves the view's phase behavior is preserved. Per code-review feedback, I **also** added direct `renderHook` tests for the two extracted effect hooks (the smoke test can't drive them).

## The split (all in `pages/students/`)

| File | Contents | Lines |
| --- | --- | --- |
| `enrolledStudentsHelpers.ts` | pure `groupStudentsBySection` + `nextSelectedKeyAfterSave` (moved) | 37 |
| `useRosterAutoMigrate.ts` | migrate-on-open effect + `migrateSettledFor` gate | 39 |
| `useRosterAutoSync.ts` | drift-gated auto-sync-on-open effect (caller owns `runSync` + toasts) | 72 |
| `RosterRow.tsx` | one roster row (avatar + badges + selection checkbox) | 106 |
| `FailedInvitationsList.tsx` | the failed/expired-invitations alert | 68 |
| `RosterParseProblems.tsx` | the malformed-roster.csv error block | 71 |
| `RosterWarnings.tsx` | the per-row action-warnings stack | 41 |
| `EnrolledStudents.tsx` | orchestrator (state + derived memos + wiring) | 766 |

## Why this shape

- The two **auto-effect hooks** were the trickiest logic (two roster writers coordinated via classroom-keyed guard refs, a migrate-before-sync gate, re-arm-on-zero-drift). Extracting them makes that coordination directly unit-testable — which surfaced that the smoke test alone didn't cover them.
- `runSync` (with its success/error toasts) and the reinvite/dismiss handlers stay in the orchestrator; the hooks/components take callbacks.
- The moved helpers keep their own home in `enrolledStudentsHelpers.ts`; `EnrolledStudents.section.test.ts` imports them directly and `StudentListPage` only ever used the default export.

## Tests

- **`rosterAutoEffects.test.ts` (9 renderHook tests):** migrate fires once-per-classroom + opens the gate via `onSettled` (incl. the error path) + re-fires for a new classroom; auto-sync fires once on csv-missing **and** on backfill-only drift, stays gated until migrate settles, no-drift no-op, `dropSuppressed` skip, no stacking while pending, **re-arm after drift clears then re-appears**. The migrate-before-sync gate was **red-verified** (inverting it fails 3 tests — exactly the regression the smoke test would have missed).
- **`EnrolledStudents.smoke.test.tsx` (7 rendered tests):** the 5 phase views, plus two composed tests driving the `useRosterAutoMigrate → migrateSettledFor → useRosterAutoSync` seam through the real component (gate opens + drift → sync fires once; gate closed → no sync).
- Existing `EnrolledStudents.section.test.ts` stays green.
- `npm run check` green; `arch:validate` no violations (cycle-free).

## Review

`ce-code-review` (`depth:full`) verified the risky dep-collapse (`[isLoading,isError]→[ready]`), migrate-before-sync ordering, guard refs, and re-arm all reproduce the original — correctness / frontend-races / adversarial all returned zero findings. Verdict **Ready with fixes**; all four actionable findings are now folded in:

- Removed a doubled `Malformed roster.csv` comment block (rationale lives once, on `RosterParseProblems`).
- Dropped the test-only helper re-export shim from `EnrolledStudents.tsx`; its sole caller now imports from `enrolledStudentsHelpers` directly.
- Added the missing backfill-only auto-sync drift test.
- Added the composed migrate→sync render test covering the seam the isolated-hook tests can't reach.

This completes the four Tier-2 Phase F UI giants (U12/U13/U15 already merged).
