### PR TITLE
refactor(web): enforce leaf-layer boundaries + dedupe workflow-label map (Tier-3 PR A)

### DIFF
--- a/web/.dependency-cruiser.cjs
+++ b/web/.dependency-cruiser.cjs
@@ -44,6 +44,19 @@ module.exports = {
         path: "^src/(domain|pages|components|hooks|context|routes)/",
       },
     },
+    {
+      name: "leaf-not-up",
+      severity: "error",
+      comment:
+        "util/lib/types/eslint are leaf layers: no import of view or orchestration code (pages/components/hooks/context/routes/domain/orgPolicy/skeleton). Move any shared type into types/. Value edges only here (tsPreCompilationDeps off); the eslint boundaries rule also blocks type edges.",
+      from: {
+        path: "^src/(util|lib|types|eslint)/",
+        pathNot: "\\.test\\.(ts|tsx)$",
+      },
+      to: {
+        path: "^src/(pages|components|hooks|context|routes|domain|orgPolicy|skeleton)/",
+      },
+    },
   ],
   options: {
     doNotFollow: { path: "node_modules" },

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -202,11 +202,14 @@ export default defineConfig([
     },
   },
   // Enforce the layered architecture (features -> components -> domain ->
-  // github-core -> util/types, strictly downward) by disallowing the three
+  // github-core -> util/types, strictly downward) by disallowing the
   // load-bearing inversions. `default: allow` + explicit disallows (not
   // deny-by-default) keeps benign lateral edges quiet; dependency-cruiser adds
-  // the CI-side holistic pass. Rationale for the policy shape and the deferred
-  // util/types leaf rule lives in the Tier-2E PR (#290).
+  // the CI-side holistic pass. The leaf layers (util/lib/types) are guarded by
+  // the leaf policy below — they may not import ANY higher layer, at value OR
+  // type kind (a leaf that needs a view/data type means the type is misfiled;
+  // lift it into types/). Rationale for the policy shape lives in the Tier-2E
+  // PR (#290); the leaf rule landed in Tier-3.
   //
   // Adding a new src/<layer>/ dir needs THREE coordinated edits or it is
   // silently unenforced: (1) a boundaries/elements entry below, (2) a disallow
@@ -262,6 +265,11 @@ export default defineConfig([
         { type: "types", pattern: "src/types/**", partialMatch: false },
         { type: "i18n", pattern: "src/i18n/**", partialMatch: false },
         { type: "locales", pattern: "src/locales/**", partialMatch: false },
+        {
+          type: "eslintTooling",
+          pattern: "src/eslint/**",
+          partialMatch: false,
+        },
       ],
     },
     rules: {
@@ -317,6 +325,38 @@ export default defineConfig([
               },
               message:
                 "github-core/ is the lowest data layer: it must not import domain or view code at runtime. Keep dependencies downward (util/types).",
+            },
+            {
+              // Leaf layers: pure helpers (util), app infra (lib), shared types
+              // (types), and lint tooling (eslintTooling) must not import the
+              // view or orchestration layers, at value OR type kind. A leaf that
+              // "needs" a page/component/hook/context/domain type means the type
+              // is misfiled — lift it into types/ (see the BadgeTone -> types/
+              // move in Tier-3). They may still depend downward/laterally on
+              // github-core, authz, auth, and each other, which is why those are
+              // NOT in the disallow set. eslintTooling (src/eslint/**) is a lint
+              // rule impl that must never import app code at all.
+              from: {
+                element: { type: ["util", "lib", "types", "eslintTooling"] },
+              },
+              disallow: {
+                to: {
+                  element: {
+                    type: [
+                      "pages",
+                      "components",
+                      "hooks",
+                      "context",
+                      "routes",
+                      "domain",
+                      "orgPolicy",
+                      "skeleton",
+                    ],
+                  },
+                },
+              },
+              message:
+                "util/lib/types/eslint are leaf layers: they must not import view or orchestration code (pages/components/hooks/context/routes/domain/orgPolicy/skeleton). Move any shared type into types/.",
             },
           ],
         },

--- a/web/src/components/ui/Badge.tsx
+++ b/web/src/components/ui/Badge.tsx
@@ -1,14 +1,16 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react"
 
 import { cx } from "./cx"
+import type { BadgeTone } from "@/types/badgeTone"
 
 // The canonical status chip. Wraps daisyUI `badge` so the ~45 inline sites
 // share one mapping. `soft` (default true) is the house style for semantic
 // status; `ghost` covers neutral count/tag chips. Semantic tones inherit the
 // per-theme `.badge-soft` contrast nudge from index.css.
 
-export type BadgeTone =
-  "neutral" | "primary" | "secondary" | "info" | "success" | "warning" | "error"
+// Re-exported so existing `@/components/ui` importers of BadgeTone are unchanged;
+// the canonical definition now lives in types/ (a leaf) so pure util can use it.
+export type { BadgeTone }
 
 export type BadgeSize = "xs" | "sm" | "md"
 

--- a/web/src/context/actions/ActionActivityProvider.tsx
+++ b/web/src/context/actions/ActionActivityProvider.tsx
@@ -8,29 +8,11 @@ import {
 } from "react"
 
 import { logger } from "@/lib/logger"
+import type { ActionAnchor, ActionOperation } from "@/util/actionActivity"
 
 const log = logger.scope("context:actions")
 
-// A teacher action this session that triggered a workflow; the banner turns each
-// into a tracker bound to its run. Attribution anchors:
-//  - "sha":        a push run (publish-pages), matched by head_sha.
-//  - "sinceRunId": a workflow_dispatch run (collect-scores / regrade), matched
-//                  by workflow + the oldest run past the pre-POST baseline.
-export type ActionAnchor =
-  | { kind: "sha"; sha: string }
-  | { kind: "sinceRunId"; workflow: string; sinceRunId: number | null }
-
-export type ActionOperation = {
-  // Stable id for dedup, storage, and dismissal.
-  id: string
-  org: string
-  // Human label, already translated by the caller.
-  label: string
-  anchor: ActionAnchor
-  // Dispatch time; anchors GC and same-workflow registration order. Survives a
-  // remount via sessionStorage.
-  startedAt: number
-}
+export type { ActionAnchor, ActionOperation }
 
 type ActionActivityContextValue = {
   // Record a session op for later run attribution. Returns its id.

--- a/web/src/eslintBoundaries.test.ts
+++ b/web/src/eslintBoundaries.test.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from "node:url"
 const COMPONENTS_DIR = fileURLToPath(new URL("./components", import.meta.url))
 const GITHUB_CORE_DIR = fileURLToPath(new URL("./github-core", import.meta.url))
 const DOMAIN_DIR = fileURLToPath(new URL("./domain", import.meta.url))
+const UTIL_DIR = fileURLToPath(new URL("./util", import.meta.url))
 const WEB_ROOT = fileURLToPath(new URL("../", import.meta.url))
 const ESLINT_BIN = fileURLToPath(
   new URL("../node_modules/.bin/eslint", import.meta.url),
@@ -65,6 +66,7 @@ describe("layered-architecture boundary guard is live", () => {
       const compDir = mkdtempSync(`${COMPONENTS_DIR}/__boundaries_probe_`)
       const coreDir = mkdtempSync(`${GITHUB_CORE_DIR}/__boundaries_probe_`)
       const domainDir = mkdtempSync(`${DOMAIN_DIR}/__boundaries_probe_`)
+      const utilDir = mkdtempSync(`${UTIL_DIR}/__boundaries_probe_`)
       try {
         // components -> pages: an upward reach-up. Must be flagged.
         writeFileSync(
@@ -100,6 +102,26 @@ describe("layered-architecture boundary guard is live", () => {
           `${compDir}/compDynamic.ts`,
           `export const load = () => import("@/pages/ClassesPage")\n`,
         )
+        // util -> components (value): a leaf reaching into the view layer. Must
+        // fire — this is the Tier-3 leaf-layer policy.
+        writeFileSync(
+          `${utilDir}/leafUpwardValue.ts`,
+          `import { Badge } from "@/components/ui"\nexport const e = Badge\n`,
+        )
+        // util -> components (TYPE-only): the leaf policy omits dependency.kind,
+        // so it must block even a type edge (unlike the value-scoped policies).
+        // This is what caught the BadgeTone reach-up the Tier-3 move fixed.
+        writeFileSync(
+          `${utilDir}/leafUpwardType.ts`,
+          `import type { BadgeTone } from "@/components/ui"\nexport type F = BadgeTone\n`,
+        )
+        // util -> github-core (value): a legal downward leaf import (util
+        // already depends on github-core). Must NOT fire — proves the leaf
+        // policy deliberately allows the github-core edge.
+        writeFileSync(
+          `${utilDir}/leafDownward.ts`,
+          `import { GitHubAPIError } from "@/github-core/errors"\nexport const g = GitHubAPIError\n`,
+        )
 
         const byFile = ruleIdsByFile([
           `${compDir}/compUpward.ts`,
@@ -108,6 +130,9 @@ describe("layered-architecture boundary guard is live", () => {
           `${domainDir}/domainUpward.ts`,
           `${compDir}/compReexport.ts`,
           `${compDir}/compDynamic.ts`,
+          `${utilDir}/leafUpwardValue.ts`,
+          `${utilDir}/leafUpwardType.ts`,
+          `${utilDir}/leafDownward.ts`,
         ])
 
         expect(
@@ -140,10 +165,27 @@ describe("layered-architecture boundary guard is live", () => {
           byFile["compDynamic.ts"],
           "boundaries/dependencies did not fire on a components->pages dynamic import() — `dynamic-import` is missing from boundaries/dependency-nodes, so lazy-loaded reach-ups are invisible.",
         ).toContain("boundaries/dependencies")
+        expect(
+          byFile["leafUpwardValue.ts"],
+          "boundaries/dependencies did not fire on a util->components value import — the Tier-3 leaf-layer policy has gone inert (check the util/lib/types policy + the eslintTooling/leaf elements in eslint.config.js).",
+        ).toContain("boundaries/dependencies")
+        expect(
+          byFile["leafUpwardType.ts"],
+          "boundaries/dependencies did not fire on a util->components TYPE-only import — the leaf policy must omit dependency.kind so it blocks type edges too (this is the BadgeTone reach-up class).",
+        ).toContain("boundaries/dependencies")
+        expect(
+          byFile["leafDownward.ts"],
+          "leafDownward.ts was not linted at all — the leaf negative control is meaningless.",
+        ).toBeDefined()
+        expect(
+          byFile["leafDownward.ts"],
+          "boundaries/dependencies fired on a legal util->util downward import — the leaf policy is too strict.",
+        ).not.toContain("boundaries/dependencies")
       } finally {
         rmSync(compDir, { recursive: true, force: true })
         rmSync(coreDir, { recursive: true, force: true })
         rmSync(domainDir, { recursive: true, force: true })
+        rmSync(utilDir, { recursive: true, force: true })
       }
     },
   )

--- a/web/src/eslintBoundaries.test.ts
+++ b/web/src/eslintBoundaries.test.ts
@@ -24,6 +24,7 @@ const COMPONENTS_DIR = fileURLToPath(new URL("./components", import.meta.url))
 const GITHUB_CORE_DIR = fileURLToPath(new URL("./github-core", import.meta.url))
 const DOMAIN_DIR = fileURLToPath(new URL("./domain", import.meta.url))
 const UTIL_DIR = fileURLToPath(new URL("./util", import.meta.url))
+const ESLINT_TOOLING_DIR = fileURLToPath(new URL("./eslint", import.meta.url))
 const WEB_ROOT = fileURLToPath(new URL("../", import.meta.url))
 const ESLINT_BIN = fileURLToPath(
   new URL("../node_modules/.bin/eslint", import.meta.url),
@@ -67,6 +68,9 @@ describe("layered-architecture boundary guard is live", () => {
       const coreDir = mkdtempSync(`${GITHUB_CORE_DIR}/__boundaries_probe_`)
       const domainDir = mkdtempSync(`${DOMAIN_DIR}/__boundaries_probe_`)
       const utilDir = mkdtempSync(`${UTIL_DIR}/__boundaries_probe_`)
+      const eslintToolingDir = mkdtempSync(
+        `${ESLINT_TOOLING_DIR}/__boundaries_probe_`,
+      )
       try {
         // components -> pages: an upward reach-up. Must be flagged.
         writeFileSync(
@@ -122,6 +126,15 @@ describe("layered-architecture boundary guard is live", () => {
           `${utilDir}/leafDownward.ts`,
           `import { GitHubAPIError } from "@/github-core/errors"\nexport const g = GitHubAPIError\n`,
         )
+        // eslintTooling -> components: the eslintTooling element shares the leaf
+        // policy's `from`-set, but src/eslint/** imports no app code today, so
+        // only this probe proves it's actually classified and enforced — without
+        // it, dropping eslintTooling (or lib/types) from the `from`-set would
+        // pass green since util alone still trips the rule.
+        writeFileSync(
+          `${eslintToolingDir}/toolingUpward.ts`,
+          `import { Badge } from "@/components/ui"\nexport const h = Badge\n`,
+        )
 
         const byFile = ruleIdsByFile([
           `${compDir}/compUpward.ts`,
@@ -133,6 +146,7 @@ describe("layered-architecture boundary guard is live", () => {
           `${utilDir}/leafUpwardValue.ts`,
           `${utilDir}/leafUpwardType.ts`,
           `${utilDir}/leafDownward.ts`,
+          `${eslintToolingDir}/toolingUpward.ts`,
         ])
 
         expect(
@@ -181,11 +195,16 @@ describe("layered-architecture boundary guard is live", () => {
           byFile["leafDownward.ts"],
           "boundaries/dependencies fired on a legal util->util downward import — the leaf policy is too strict.",
         ).not.toContain("boundaries/dependencies")
+        expect(
+          byFile["toolingUpward.ts"],
+          "boundaries/dependencies did not fire on a src/eslint (eslintTooling) -> components import — eslintTooling was dropped from the leaf policy `from`-set or its boundaries/elements entry is missing (eslint.config.js).",
+        ).toContain("boundaries/dependencies")
       } finally {
         rmSync(compDir, { recursive: true, force: true })
         rmSync(coreDir, { recursive: true, force: true })
         rmSync(domainDir, { recursive: true, force: true })
         rmSync(utilDir, { recursive: true, force: true })
+        rmSync(eslintToolingDir, { recursive: true, force: true })
       }
     },
   )

--- a/web/src/hooks/useActionActivity.ts
+++ b/web/src/hooks/useActionActivity.ts
@@ -21,6 +21,7 @@ import {
   runUrl,
   trackerPhase,
   workflowFile,
+  WORKFLOW_LABEL_KEY,
   type TrackerPhase,
 } from "@/util/actionActivity"
 
@@ -48,13 +49,6 @@ const RETRY_OPTIMISTIC_MS = 20_000
 // failure present anywhere cancels this — failures stay until dismissed so the
 // teacher (and the Retry affordance) aren't hidden.
 const ALL_SUCCESS_DISMISS_MS = 8000
-
-// Generic label for a discovered run (cron, another teacher) matching no op.
-const WORKFLOW_LABEL_KEY: Record<string, string> = {
-  "publish-pages.yaml": "actionsBanner.workflow.publishPages",
-  "collect-scores.yaml": "actionsBanner.workflow.collectScores",
-  "regrade.yaml": "actionsBanner.workflow.regrade",
-}
 
 // One row in the banner: an action and its live state.
 export type Tracker = {

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -33,14 +33,7 @@ import {
   type ActivityFilterState,
 } from "./orgActivity/ActivityToolbar"
 import { TimelineRow } from "./orgActivity/TimelineRow"
-
-// Workflow file -> i18n label key, reused from the actions banner. Module-level
-// so the map isn't reallocated per render / per run item.
-const WORKFLOW_LABEL_KEY: Record<string, string> = {
-  "publish-pages.yaml": "actionsBanner.workflow.publishPages",
-  "collect-scores.yaml": "actionsBanner.workflow.collectScores",
-  "regrade.yaml": "actionsBanner.workflow.regrade",
-}
+import { WORKFLOW_LABEL_KEY } from "@/util/actionActivity"
 
 // Unified, owner-only org Activity view. Merges three sources into one filterable,
 // newest-first timeline:

--- a/web/src/types/badgeTone.ts
+++ b/web/src/types/badgeTone.ts
@@ -1,0 +1,5 @@
+// The semantic tone shared by the Badge primitive and role/state presentation
+// maps. Lives in types/ (a leaf) so pure helpers like util/classroomRoleUI can
+// reference it without importing up into the components layer.
+export type BadgeTone =
+  "neutral" | "primary" | "secondary" | "info" | "success" | "warning" | "error"

--- a/web/src/util/actionActivity.test.ts
+++ b/web/src/util/actionActivity.test.ts
@@ -11,9 +11,9 @@ import {
   runUrl,
   trackerPhase,
   workflowFile,
+  type ActionOperation,
 } from "./actionActivity"
 import type { GitHubWorkflowRun } from "@/github-core/types"
-import type { ActionOperation } from "@/context/actions/ActionActivityProvider"
 import en from "@/locales/en.json"
 import { flattenBundle } from "@/i18n/customLocale"
 

--- a/web/src/util/actionActivity.ts
+++ b/web/src/util/actionActivity.ts
@@ -1,9 +1,31 @@
 import type { GitHubWorkflowRun } from "@/github-core/types"
-import type { ActionOperation } from "@/context/actions/ActionActivityProvider"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Pure helpers behind the activity banner, split out so run-attribution and
 // org-parsing are testable without React / the router.
+
+// A teacher action this session that triggered a workflow; the banner turns each
+// into a tracker bound to its run. Attribution anchors:
+//  - "sha":        a push run (publish-pages), matched by head_sha.
+//  - "sinceRunId": a workflow_dispatch run (collect-scores / regrade), matched
+//                  by workflow + the oldest run past the pre-POST baseline.
+// Lives here (the pure module) rather than the provider so run-attribution
+// helpers stay dependency-free; the provider imports these down.
+export type ActionAnchor =
+  | { kind: "sha"; sha: string }
+  | { kind: "sinceRunId"; workflow: string; sinceRunId: number | null }
+
+export type ActionOperation = {
+  // Stable id for dedup, storage, and dismissal.
+  id: string
+  org: string
+  // Human label, already translated by the caller.
+  label: string
+  anchor: ActionAnchor
+  // Dispatch time; anchors GC and same-workflow registration order. Survives a
+  // remount via sessionStorage.
+  startedAt: number
+}
 
 // Reserved top-level URL segments that aren't an org slug.
 const RESERVED_FIRST_SEGMENTS = new Set(["login"])
@@ -151,4 +173,12 @@ export const PHASE_LABEL_KEY: Record<TrackerPhase, string> = {
   running: "actionsBanner.state.running",
   success: "actionsBanner.state.success",
   failed: "actionsBanner.state.failed",
+}
+
+// The i18n key for a workflow file's human label. Shared by the activity banner
+// (useActionActivity) and the org activity page so the mapping has one source.
+export const WORKFLOW_LABEL_KEY: Record<string, string> = {
+  "publish-pages.yaml": "actionsBanner.workflow.publishPages",
+  "collect-scores.yaml": "actionsBanner.workflow.collectScores",
+  "regrade.yaml": "actionsBanner.workflow.regrade",
 }

--- a/web/src/util/classroomRoleUI.ts
+++ b/web/src/util/classroomRoleUI.ts
@@ -1,4 +1,4 @@
-import type { BadgeTone } from "@/components/ui"
+import type { BadgeTone } from "@/types/badgeTone"
 import { ROLE_RANK, sortRolesByRank, type ClassroomRole } from "@/authz"
 import type { TeamRosterRow, TeamRosterRowState } from "@/util/teamRoster"
 


### PR DESCRIPTION
## What

Tier-3 "PR A" — the quick-wins bundle from the Tier-3 polish/hardening plan: units **U1 + U2 + U3**. All behavior-preserving (no test's expected values change).

## U2 — reverse two upward `util/` type-edges

The leaf layer had two upward `import type` edges (invisible to the value-scoped boundary rules, but real layer inversions):

- **`util/actionActivity.ts → @/context`**: the `ActionAnchor`/`ActionOperation` types now live in `util/actionActivity.ts` (the pure module that uses them); the provider imports them **down** and re-exports them (`export type { … }`) so provider-path consumers (e.g. `useTrackPublishDeploy`) are unchanged.
- **`util/classroomRoleUI.ts → @/components/ui`**: `BadgeTone` moved to a new leaf `types/badgeTone.ts`; `Badge.tsx` imports + re-exports it (so the 7 `@/components/ui` `BadgeTone` importers are untouched); `classroomRoleUI.ts` imports from `@/types/badgeTone`.

All three moved symbols are byte-identical to the originals.

## U3 — de-dupe `WORKFLOW_LABEL_KEY`

The workflow→label map was byte-identical in `useActionActivity.ts` and `OrgActivityPage.tsx`. Both removed; one shared `export const WORKFLOW_LABEL_KEY` added to `util/actionActivity.ts` beside `PHASE_LABEL_KEY`; both consumers import it (AGENTS.md "one recipe, one source").

## U1 — enforce the leaf-layer boundary rule

The deferred `util`/`lib`/`types` leaf rule is now enforced (the `eslint.config.js:208` comment's TODO):

- New `boundaries/dependencies` policy: `from util/lib/types/eslintTooling` disallow `to pages/components/hooks/context/routes/domain/orgPolicy/skeleton`. It **deliberately omits `dependency.kind`**, so it blocks **both value AND type** edges (unlike the 3 existing value-scoped policies) — that's what catches the BadgeTone-class type reach-up. `github-core`/`authz`/`auth` are **excluded** (leaves legitimately import those today).
- New `eslintTooling` element (`src/eslint/**`) — folded into the leaf `from`-set so it's actually enforced (all 3 coordinated edits, per the config's own mandate).
- `.dependency-cruiser.cjs` `leaf-not-up` mirror (value-edge only — `tsPreCompilationDeps` off).
- `eslintBoundaries.test.ts` extended: util→components **value** probe fires, util→components **type-only** probe fires (proves the no-kind-scope), util→github-core downward stays clean, and an **eslintTooling→components** probe fires (the shared leaf `from`-set is `{util,lib,types,eslintTooling}`; since `src/eslint/**` imports no app code today, this is the only thing that catches a regression dropping `eslintTooling` from the set).

## Verification

`npm run check` green (170 files / 1778 tests); `arch:validate` no violations (640 modules); extended boundaries liveness test passes.

## Review

`ce-code-review` (full roster) verified byte-identity of all moved types, the leaf-policy correctness (no false-positive on the legit `util→github-core/authz/auth` edges, type-edge blocking confirmed empirically), and no new cycle. Verdict **Ready with fixes**; all three findings **folded in**: the `eslintTooling` element now has its enforcing policy + dependency-cruiser mirror (was 1-of-3 edits), the orphaned dedupe comment is removed, and the negative-control probe now exercises a real `util→github-core` edge.

A second `ce-code-review` pass (correctness + testing + maintainability + project-standards + adversarial + agent-native + learnings) found the leaf policy sound and the moves byte-identical, with one actionable gap that **testing and adversarial independently agreed on**: the liveness test only probed `util`-origin leaves, so a config regression dropping `eslintTooling`/`lib`/`types` from the shared `from`-set would pass green. **Folded in** — an `eslintTooling→components` probe now brackets the set (commit `1e1742ed`). Two remaining P3 advisories left as-is by intent: the now-consumer-less `export type { ActionAnchor, ActionOperation }` shim on the provider (the down-import path is canonical; the re-export is a stable-surface convenience), and the `refactor(web):` title yielding no web changelog entry (correct — this is behavior-preserving hardening).

## Known residual (pre-existing, out of scope)

`src/auth/` is a mixed element (view components + leaf-safe helpers), so a leaf could import auth *view* code undetected. Correctly **not** fixable here without breaking the real `util/lib → @/auth/{scopes,storage}` edges; closing it is a separate `auth/` split. First unit of the Tier-3 plan (docs/plans/2026-07-17-001).
