### PR TITLE
fix(web): update daisyUI to fix non-expanding details

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -43,7 +43,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
         "babel-plugin-react-compiler": "^1.0.0",
-        "daisyui": "^5.6.10",
+        "daisyui": "^5.6.14",
         "dependency-cruiser": "^18.1.0",
         "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.1.8",
@@ -4852,9 +4852,9 @@
       "license": "MIT"
     },
     "node_modules/daisyui": {
-      "version": "5.6.10",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.10.tgz",
-      "integrity": "sha512-vk2E+iIETWGd/jUAC0Bu6OLU4HJSSj7Q2vvsZGiJN/+vt1RK3/UEiLYC9GTldQdD3yQkjNzWb8AYYpmTenQzJg==",
+      "version": "5.6.18",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.18.tgz",
+      "integrity": "sha512-6y9rboRQl8fosnusy/5pg11yp+H0LtK3YdtfS4Vf2QVnaYOKasNdYm6hDxeiT6bwZPdl4WRPzVIlIApdo2ssBg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/web/package.json
+++ b/web/package.json
@@ -54,7 +54,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "babel-plugin-react-compiler": "^1.0.0",
-    "daisyui": "^5.6.10",
+    "daisyui": "^5.6.14",
     "dependency-cruiser": "^18.1.0",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Summary

Fixes non-opening details on login page by updating daisyUI to the version that includes https://github.com/saadeghi/daisyui/pull/4613

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] ~~If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.~~
- [x] ~~If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).~~
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(web): ...`, `fix(gh-teacher): ...`).
