### PR TITLE
fix: enable notifications on staff teams (teacher/ta)

### DIFF
--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -348,9 +348,13 @@ func adoptSecretTeamByName(client githubapi.Client, org, name, description, noti
 		return TeamRef{}, fmt.Errorf("GET %s (adopting existing team): %w", getPath, err)
 	}
 	// Batch every drifted field into one PATCH (description only drifts for the
-	// student team, which carries the bootstrap record).
+	// student team, which carries the bootstrap record). GitHub returns
+	// notification_setting only to org members, so an empty value is "unknown,
+	// not read" — skip it rather than force a PATCH every reconcile. A concrete
+	// value that differs is reconciled on purpose (e.g. a student team left
+	// enabled gets disabled — #335).
 	needPrivacy := existing.Privacy != "secret"
-	needNotification := existing.NotificationSetting != notificationSetting
+	needNotification := existing.NotificationSetting != "" && existing.NotificationSetting != notificationSetting
 	needDescription := description != "" && existing.Description != description
 	if needPrivacy || needNotification || needDescription {
 		patch := map[string]any{}

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -57,6 +57,14 @@ const (
 // ResolveClassroomStaffTeam.
 var StaffRoles = []StaffRole{RoleTeacher, RoleTA}
 
+// GitHub team-level notification toggle, set at create and reconciled on adopt.
+// Students stay disabled (assignment-repo churn would spam the class); staff
+// enable it so @mentions reach the TAs/teachers (#335).
+const (
+	notificationsEnabled  = "notifications_enabled"
+	notificationsDisabled = "notifications_disabled"
+)
+
 // StaffTeamRepoPermissions maps a staff role to the repo permission a staff
 // team gets on each student assignment repo and on private in-org templates.
 // The TA-team template read is applied at TWO points: eagerly at assignment
@@ -170,7 +178,7 @@ func EnsureClassroomTeam(client githubapi.Client, org, shortName, description st
 	if !CanonicalTeamSlugShortName(shortName) {
 		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking membership and template grants)", shortName)
 	}
-	return ensureSecretTeamByName(client, org, classroomTeamName(shortName), description)
+	return ensureSecretTeamByName(client, org, classroomTeamName(shortName), description, notificationsDisabled)
 }
 
 // EnsureClassroomStaffTeam creates (or adopts) the per-classroom STAFF team for
@@ -182,7 +190,7 @@ func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, ro
 	}
 	// Staff teams carry no bootstrap description: staff read the authoritative
 	// classroom.json directly, and the secret belongs only on the student team.
-	return ensureSecretTeamByName(client, org, staffTeamName(shortName, role), "")
+	return ensureSecretTeamByName(client, org, staffTeamName(shortName, role), "", notificationsEnabled)
 }
 
 // EnsureStaffTeams creates (or adopts) both staff teams (teacher, ta) and
@@ -288,10 +296,11 @@ func ReconcileClassroomTeamDescription(client githubapi.Client, org, shortName, 
 //
 // `members_can_create_teams: false` (init's lockdown) doesn't block this — the
 // teacher authenticates as an org owner.
-func ensureSecretTeamByName(client githubapi.Client, org, name, description string) (TeamRef, error) {
+func ensureSecretTeamByName(client githubapi.Client, org, name, description, notificationSetting string) (TeamRef, error) {
 	teamBody := map[string]any{
-		"name":    name,
-		"privacy": "secret",
+		"name":                 name,
+		"privacy":              "secret",
+		"notification_setting": notificationSetting,
 	}
 	if description != "" {
 		teamBody["description"] = description
@@ -303,12 +312,11 @@ func ensureSecretTeamByName(client githubapi.Client, org, name, description stri
 	createPath := fmt.Sprintf("orgs/%s/teams", url.PathEscape(org))
 	var created TeamRef
 	if err := client.Post(createPath, bytes.NewReader(body), &created); err != nil {
-		// 422 = a team with this name already exists. Adopt it in place
-		// (read id/slug, ensure privacy `secret`, reconcile description) so a
+		// 422 = a team with this name already exists; adopt it in place so a
 		// re-run reconciles. If the adopt read 404s, the 422 wasn't a name
 		// collision — surface the original create error.
 		if cliutil.IsHTTPStatus(err, http.StatusUnprocessableEntity) {
-			adopted, adoptErr := adoptSecretTeamByName(client, org, name, description)
+			adopted, adoptErr := adoptSecretTeamByName(client, org, name, description, notificationSetting)
 			if adoptErr != nil {
 				if cliutil.IsHTTPStatus(adoptErr, http.StatusNotFound) {
 					return TeamRef{}, fmt.Errorf("POST %s: %w", createPath, err)
@@ -323,29 +331,34 @@ func ensureSecretTeamByName(client githubapi.Client, org, name, description stri
 }
 
 // adoptSecretTeamByName reads an existing team by slug (== name, given the
-// canonical short-name guard) and reconciles its privacy to `secret` (an older
-// or hand-created team might be `closed`) and, when `description` is non-empty
-// and differs, its description. Used on the 422 already-exists path.
-func adoptSecretTeamByName(client githubapi.Client, org, name, description string) (TeamRef, error) {
+// canonical short-name guard) and reconciles drift toward the desired state:
+// privacy `secret`, the notification setting, and (when non-empty and differing)
+// the description. Used on the 422 already-exists path.
+func adoptSecretTeamByName(client githubapi.Client, org, name, description, notificationSetting string) (TeamRef, error) {
 	slug := name
 	getPath := fmt.Sprintf("orgs/%s/teams/%s", url.PathEscape(org), url.PathEscape(slug))
 	var existing struct {
-		ID          int64  `json:"id"`
-		Slug        string `json:"slug"`
-		Privacy     string `json:"privacy"`
-		Description string `json:"description"`
+		ID                  int64  `json:"id"`
+		Slug                string `json:"slug"`
+		Privacy             string `json:"privacy"`
+		NotificationSetting string `json:"notification_setting"`
+		Description         string `json:"description"`
 	}
 	if err := client.Get(getPath, &existing); err != nil {
 		return TeamRef{}, fmt.Errorf("GET %s (adopting existing team): %w", getPath, err)
 	}
-	// Reconcile privacy and (for the student team) the bootstrap description in
-	// one PATCH when either drifts from the desired state.
+	// Batch every drifted field into one PATCH (description only drifts for the
+	// student team, which carries the bootstrap record).
 	needPrivacy := existing.Privacy != "secret"
+	needNotification := existing.NotificationSetting != notificationSetting
 	needDescription := description != "" && existing.Description != description
-	if needPrivacy || needDescription {
+	if needPrivacy || needNotification || needDescription {
 		patch := map[string]any{}
 		if needPrivacy {
 			patch["privacy"] = "secret"
+		}
+		if needNotification {
+			patch["notification_setting"] = notificationSetting
 		}
 		if needDescription {
 			patch["description"] = description

--- a/cli/gh-teacher/internal/configrepo/team_http_test.go
+++ b/cli/gh-teacher/internal/configrepo/team_http_test.go
@@ -140,6 +140,74 @@ func TestEnsureClassroomTeam_AdoptSkipsPatchWhenDescriptionMatches(t *testing.T)
 	}
 }
 
+// TestEnsureClassroomStaffTeam_AdoptSkipsPatchWhenNotificationOmitted: GitHub
+// returns notification_setting only to org members, so it can be absent from
+// the adopt GET. An absent value must read as "unknown, not read" — not as
+// drift — so an already-secret team issues no PATCH (#335 guard).
+func TestEnsureClassroomStaffTeam_AdoptSkipsPatchWhenNotificationOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/orgs/o/teams" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"name already taken"}`))
+		case r.URL.Path == "/orgs/o/teams/classroom50-cs101-teacher" && r.Method == http.MethodGet:
+			// notification_setting omitted (not visible to this token).
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": 7, "slug": "classroom50-cs101-teacher", "privacy": "secret",
+			})
+		case r.Method == http.MethodPatch:
+			t.Errorf("must not PATCH when notification_setting is absent from the GET (unknown, not drifted)")
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	if _, err := EnsureClassroomStaffTeam(client, "o", "cs101", RoleTeacher); err != nil {
+		t.Fatalf("EnsureClassroomStaffTeam adopt: %v", err)
+	}
+}
+
+// TestEnsureClassroomStaffTeam_AdoptReconcilesNotification: when the adopt GET
+// returns a concrete notification_setting that differs from the desired one,
+// the reconcile PATCHes it (a staff team left disabled gets enabled — #335).
+func TestEnsureClassroomStaffTeam_AdoptReconcilesNotification(t *testing.T) {
+	var patched map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/orgs/o/teams" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"name already taken"}`))
+		case r.URL.Path == "/orgs/o/teams/classroom50-cs101-teacher" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": 7, "slug": "classroom50-cs101-teacher", "privacy": "secret",
+				"notification_setting": "notifications_disabled",
+			})
+		case r.URL.Path == "/orgs/o/teams/classroom50-cs101-teacher" && r.Method == http.MethodPatch:
+			_ = json.NewDecoder(r.Body).Decode(&patched)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	if _, err := EnsureClassroomStaffTeam(client, "o", "cs101", RoleTeacher); err != nil {
+		t.Fatalf("EnsureClassroomStaffTeam adopt: %v", err)
+	}
+	if patched == nil {
+		t.Fatal("expected a PATCH reconciling the drifted notification_setting")
+	}
+	if patched["notification_setting"] != "notifications_enabled" {
+		t.Errorf("PATCH notification_setting = %v, want notifications_enabled", patched["notification_setting"])
+	}
+}
+
 func TestStaffTeamName(t *testing.T) {
 	cases := []struct {
 		short string

--- a/cli/gh-teacher/internal/configrepo/team_http_test.go
+++ b/cli/gh-teacher/internal/configrepo/team_http_test.go
@@ -121,10 +121,11 @@ func TestEnsureClassroomTeam_AdoptSkipsPatchWhenDescriptionMatches(t *testing.T)
 			_, _ = w.Write([]byte(`{"message":"name already taken"}`))
 		case r.URL.Path == "/orgs/o/teams/classroom50-cs101" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"id": 7, "slug": "classroom50-cs101", "privacy": "secret", "description": desc,
+				"id": 7, "slug": "classroom50-cs101", "privacy": "secret",
+				"notification_setting": "notifications_disabled", "description": desc,
 			})
 		case r.Method == http.MethodPatch:
-			t.Errorf("must not PATCH when privacy and description already match")
+			t.Errorf("must not PATCH when privacy, notification setting, and description already match")
 			w.WriteHeader(http.StatusOK)
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -190,12 +191,16 @@ func TestEnsureStaffTeams(t *testing.T) {
 		switch {
 		case r.URL.Path == "/orgs/o/teams" && r.Method == http.MethodPost:
 			var body struct {
-				Name    string `json:"name"`
-				Privacy string `json:"privacy"`
+				Name                string `json:"name"`
+				Privacy             string `json:"privacy"`
+				NotificationSetting string `json:"notification_setting"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			if body.Privacy != "secret" {
 				t.Errorf("team %q created with privacy %q, want secret", body.Name, body.Privacy)
+			}
+			if body.NotificationSetting != "notifications_enabled" {
+				t.Errorf("staff team %q created with notification_setting %q, want notifications_enabled (#335)", body.Name, body.NotificationSetting)
 			}
 			createdNames = append(createdNames, body.Name)
 			// slug == name (canonical short-name).

--- a/web/src/github-core/mutations.teamNotifications.test.ts
+++ b/web/src/github-core/mutations.teamNotifications.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ensureClassroomTeam, ensureClassroomRoleTeam } from "./mutations"
+import { GitHubAPIError } from "./errors"
+import type { GitHubClient } from "./client"
+import type { GitHubRequestOptions } from "./client"
+
+// Pins the team-level notification policy (#335): student teams create with
+// notifications_disabled (assignment-repo churn would spam the class), staff
+// teams with notifications_enabled (so @mentions reach TAs/teachers). tsc keeps
+// the arg well-typed but cannot catch a wrong literal — these do.
+
+type Call = { path: string; options?: GitHubRequestOptions }
+
+function apiError(status: number): GitHubAPIError {
+  return new GitHubAPIError({
+    status,
+    url: "x",
+    message: "err",
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
+// A fake client recording every request. `adoptGet` (when set) is returned for
+// the adopt GET and forces the POST to 422 so the adopt path runs.
+function makeClient(adoptGet?: Record<string, unknown>) {
+  const calls: Call[] = []
+  const request = vi.fn(
+    async (path: string, options?: GitHubRequestOptions): Promise<unknown> => {
+      calls.push({ path, options })
+      const method = options?.method ?? "GET"
+      if (path.endsWith("/teams") && method === "POST") {
+        if (adoptGet) throw apiError(422)
+        return { id: 1, slug: "created" }
+      }
+      if (method === "GET") return adoptGet
+      if (method === "PATCH") return undefined
+      return undefined
+    },
+  )
+  const client = { request } as unknown as GitHubClient
+  const posts = () => calls.filter((c) => c.path.endsWith("/teams"))
+  const patches = () => calls.filter((c) => c.options?.method === "PATCH")
+  return { client, calls, posts, patches }
+}
+
+describe("ensureClassroomTeam / ensureClassroomRoleTeam create notification_setting", () => {
+  it("creates the student team with notifications_disabled", async () => {
+    const { client, posts } = makeClient()
+    await ensureClassroomTeam(client, "o", "cs101")
+    const body = posts()[0]?.options?.body as {
+      notification_setting?: string
+    }
+    expect(body.notification_setting).toBe("notifications_disabled")
+  })
+
+  it("creates staff teams with notifications_enabled (teacher and ta)", async () => {
+    for (const role of ["teacher", "ta"] as const) {
+      const { client, posts } = makeClient()
+      await ensureClassroomRoleTeam(client, "o", "cs101", role)
+      const body = posts()[0]?.options?.body as {
+        notification_setting?: string
+      }
+      expect(body.notification_setting).toBe("notifications_enabled")
+    }
+  })
+})
+
+describe("adoptSecretTeamByName notification_setting reconcile", () => {
+  it("PATCHes notification_setting when the existing value drifts", async () => {
+    const { client, patches } = makeClient({
+      id: 7,
+      slug: "classroom50-cs101-teacher",
+      privacy: "secret",
+      notification_setting: "notifications_disabled",
+    })
+    await ensureClassroomRoleTeam(client, "o", "cs101", "teacher")
+    const body = patches()[0]?.options?.body as {
+      notification_setting?: string
+    }
+    expect(patches()).toHaveLength(1)
+    expect(body.notification_setting).toBe("notifications_enabled")
+  })
+
+  it("does not PATCH when notification_setting already matches", async () => {
+    const { client, patches } = makeClient({
+      id: 7,
+      slug: "classroom50-cs101",
+      privacy: "secret",
+      notification_setting: "notifications_disabled",
+    })
+    await ensureClassroomTeam(client, "o", "cs101")
+    expect(patches()).toHaveLength(0)
+  })
+
+  it("does not PATCH when GitHub omits notification_setting from the GET (unknown, not drifted)", async () => {
+    // GitHub returns notification_setting only to org members; an absent value
+    // must read as unknown, not as drift — otherwise every reconcile PATCHes.
+    const { client, patches } = makeClient({
+      id: 7,
+      slug: "classroom50-cs101-teacher",
+      privacy: "secret",
+    })
+    await ensureClassroomRoleTeam(client, "o", "cs101", "teacher")
+    expect(patches()).toHaveLength(0)
+  })
+})

--- a/web/src/github-core/mutations/teams.ts
+++ b/web/src/github-core/mutations/teams.ts
@@ -3,7 +3,7 @@ import { type GitHubTeam } from "../types"
 import { GitHubAPIError, tolerateGitHubError } from "../errors"
 import type { StaffRole } from "@/types/classroom"
 import { STAFF_ROLES } from "@/types/classroom"
-import { createTeam } from "../teamWrites"
+import { createTeam, type TeamNotificationSetting } from "../teamWrites"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { classroomTeamSlug } from "@/util/teamSlug"
 
@@ -39,41 +39,55 @@ function isCanonicalTeamShortName(shortName: string): boolean {
 }
 
 // Create (or adopt) a `secret` team by exact name. Idempotent: adopts a
-// same-named team on 422 and reconciles privacy to `secret`. `created: false`
-// means it pre-existed and must NOT be deleted on a create-failure rollback.
-// The shared core the students team and staff teams build on.
+// same-named team on 422, reconciling privacy and notification setting.
+// `created: false` means it pre-existed and must NOT be deleted on a
+// create-failure rollback. The shared core the student and staff teams build on.
 async function ensureSecretTeamByName(
   client: GitHubClient,
   org: string,
   name: string,
+  notify: TeamNotificationSetting,
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   try {
-    const created = await createTeam(client, { org, name, privacy: "secret" })
+    const created = await createTeam(client, {
+      org,
+      name,
+      privacy: "secret",
+      notification_setting: notify,
+    })
     return { id: created.id, slug: created.slug, created: true }
   } catch (err) {
     if (err instanceof GitHubAPIError && err.status === 422) {
-      const adopted = await adoptSecretTeamByName(client, org, name)
+      const adopted = await adoptSecretTeamByName(client, org, name, notify)
       return { ...adopted, created: false }
     }
     throw err
   }
 }
 
-// Adopt an existing same-named team: read its { id, slug } and reconcile privacy
-// to `secret`. Our names are already slug-safe (guarded upstream), so the name
-// doubles as the lookup slug.
+// Adopt an existing same-named team: read its { id, slug } and reconcile drift
+// (privacy, notification setting). Names are slug-safe (guarded upstream), so
+// the name doubles as the lookup slug.
 async function adoptSecretTeamByName(
   client: GitHubClient,
   org: string,
   name: string,
+  notify: TeamNotificationSetting,
 ): Promise<ClassroomTeamRef> {
   const existing = await client.request<GitHubTeam>(
     `/orgs/${org}/teams/${name}`,
   )
-  if (existing.privacy !== "secret") {
+  const patch: {
+    privacy?: "secret"
+    notification_setting?: TeamNotificationSetting
+  } = {}
+  if (existing.privacy !== "secret") patch.privacy = "secret"
+  if (existing.notification_setting !== notify)
+    patch.notification_setting = notify
+  if (Object.keys(patch).length > 0) {
     await client.request(`/orgs/${org}/teams/${existing.slug}`, {
       method: "PATCH",
-      body: { privacy: "secret" },
+      body: patch,
     })
   }
   return { id: existing.id, slug: existing.slug }
@@ -98,7 +112,12 @@ export async function ensureClassroomTeam(
   classroom: string,
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   assertCanonicalTeamShortName(classroom)
-  return ensureSecretTeamByName(client, org, classroomTeamSlug(classroom))
+  return ensureSecretTeamByName(
+    client,
+    org,
+    classroomTeamSlug(classroom),
+    "notifications_disabled",
+  )
 }
 
 // The per-classroom staff team refs persisted under classroom.json `teams`.
@@ -120,7 +139,14 @@ export async function ensureClassroomRoleTeam(
   role: StaffRole,
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   assertCanonicalTeamShortName(classroom)
-  return ensureSecretTeamByName(client, org, classroomTeamSlug(classroom, role))
+  // Staff teams enable notifications so @mentions in issues/discussions reach
+  // the teachers/TAs (#335) — unlike the student team, which stays disabled.
+  return ensureSecretTeamByName(
+    client,
+    org,
+    classroomTeamSlug(classroom, role),
+    "notifications_enabled",
+  )
 }
 
 // Grant a team `push` (write) on the org's `classroom50` config repo, so its

--- a/web/src/github-core/mutations/teams.ts
+++ b/web/src/github-core/mutations/teams.ts
@@ -82,7 +82,14 @@ async function adoptSecretTeamByName(
     notification_setting?: TeamNotificationSetting
   } = {}
   if (existing.privacy !== "secret") patch.privacy = "secret"
-  if (existing.notification_setting !== notify)
+  // GitHub returns notification_setting only to org members, so an absent value
+  // is "unknown, not read" — skip it rather than PATCH every reconcile. A
+  // concrete value that differs is reconciled on purpose (a student team left
+  // enabled gets disabled — #335).
+  if (
+    existing.notification_setting !== undefined &&
+    existing.notification_setting !== notify
+  )
     patch.notification_setting = notify
   if (Object.keys(patch).length > 0) {
     await client.request(`/orgs/${org}/teams/${existing.slug}`, {
@@ -139,8 +146,8 @@ export async function ensureClassroomRoleTeam(
   role: StaffRole,
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   assertCanonicalTeamShortName(classroom)
-  // Staff teams enable notifications so @mentions in issues/discussions reach
-  // the teachers/TAs (#335) — unlike the student team, which stays disabled.
+  // Staff enable notifications (student team stays disabled); see
+  // TeamNotificationSetting.
   return ensureSecretTeamByName(
     client,
     org,

--- a/web/src/github-core/teamWrites.ts
+++ b/web/src/github-core/teamWrites.ts
@@ -1,11 +1,15 @@
 import type { GitHubClient } from "./client"
-import type { GitHubTeam } from "./types"
+import type { GitHubTeam, TeamNotificationSetting } from "./types"
+
+// Re-exported for callers; the type lives in types.ts to avoid an import cycle.
+export type { TeamNotificationSetting }
 
 export type CreateTeamInput = {
   org: string
   name: string
   description?: string
   privacy?: "secret" | "closed"
+  notification_setting?: TeamNotificationSetting
   maintainers?: string[]
   repo_names?: string[]
 }

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -141,11 +141,20 @@ export type GitHubFileListing = {
   path: string
 }
 
+// GitHub's team-level notification toggle. Student teams stay
+// `notifications_disabled` (assignment-repo churn would spam the class); staff
+// teams want `notifications_enabled` so @mentions reach the TAs/teachers (#335).
+// Lives here (a leaf module) so GitHubTeam and teamWrites share it without a cycle.
+export type TeamNotificationSetting =
+  "notifications_enabled" | "notifications_disabled"
+
 export type GitHubTeam = {
   id: number
   name: string
   slug: string
   privacy: "secret" | "closed"
+  // Only returned by GET/POST/PATCH .../teams to org members; read defensively.
+  notification_setting?: TeamNotificationSetting
   description: string | null
 }
 


### PR DESCRIPTION
## Summary

Fixes #335. Staff teams (`teacher`, `ta`) were created with team notifications **disabled**, so `@`-mentioning them in issues/Discussions never pinged the TAs/teachers.

- **Enable** `notification_setting: notifications_enabled` for staff teams.
- **Keep** student teams `notifications_disabled` — every push/PR to an assignment repo would otherwise spam the whole class.
- **Reconcile on adopt (422):** existing classrooms self-heal on the next touch, not only newly-created ones.
- **Skip the reconcile when GitHub omits the field:** `notification_setting` is only returned to org members, so an absent value on the adopt GET reads as *unknown* (Go `""`, web `undefined`), not as drift — otherwise a correctly-configured team gets a redundant PATCH on every reconcile.
- **Align web and CLI**, which had drifted: the web disabled notifications on *every* team (the direct cause of #335), while the CLI set nothing and inherited GitHub's `notifications_enabled` default.

## Changes

**Web** (`web/`)
- `github-core/types.ts` — `TeamNotificationSetting` union (single source of truth, leaf module to avoid an import cycle); `GitHubTeam.notification_setting` read defensively.
- `github-core/teamWrites.ts` — `notification_setting` on `CreateTeamInput`.
- `github-core/mutations/teams.ts` — thread the setting through `ensureSecretTeamByName`/`adoptSecretTeamByName`; student = disabled, staff = enabled; adopt reconciles it in a single combined PATCH, guarding on a known (defined) existing value.
- `github-core/mutations.teamNotifications.test.ts` — new: assert student creates `notifications_disabled` / staff `notifications_enabled`, adopt PATCHes on drift, skips when matching, and skips when GitHub omits the field.

**CLI** (`cli/gh-teacher/`)
- `internal/configrepo/team.go` — same threading; `notificationsEnabled`/`notificationsDisabled` consts; adopt reconciles the setting, treating an empty (unread) value as unknown rather than drifted.
- `internal/configrepo/team_http_test.go` — assert staff teams create with `notifications_enabled`; adopt-skip test covers the matching case; new tests cover the omitted-field skip and the concrete-drift reconcile.

## Testing

- Web: `tsc -b`, `eslint`, `prettier`, `vitest run src/github-core` (218 passed), `depcruise` (no cycle).
- CLI: `go build ./...`, `go vet`, `go test ./...` (all packages pass), `gofmt` clean.

Both tracks are affected on purpose (release-please is path-scoped): the fix touches `web/**` and `cli/**`, so it lands in both release tracks.
