### PR TITLE
feat(web): surface web upload as the primary submission action

### DIFF
--- a/web/src/components/SubmitGuidance.tsx
+++ b/web/src/components/SubmitGuidance.tsx
@@ -3,11 +3,9 @@ import { useTranslation } from "react-i18next"
 import { CopyableCode } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 
-// How-to-submit guidance shown when a student has accepted but has no graded
-// release yet. The web app can't submit (that's `gh student submit`, which
-// snapshots the branch and pushes; the autograder then tags submit/* and
-// publishes the release the submission page reads), so this gives the student
-// the two concrete steps: clone the repo, then submit from the CLI.
+// The command-line alternative to the web Upload button: clone the repo, then
+// `gh student submit` (which snapshots the branch and pushes; the autograder
+// then tags submit/* and publishes the release the submission page reads).
 export function SubmitGuidance({ repoHtmlUrl }: { repoHtmlUrl: string }) {
   const { t } = useTranslation()
   const cloneUrl = `${repoHtmlUrl}.git`
@@ -23,11 +21,15 @@ export function SubmitGuidance({ repoHtmlUrl }: { repoHtmlUrl: string }) {
   )
 
   return (
-    <div className="mt-4 space-y-3 rounded-box border border-base-200 p-4">
-      <h3 className="text-sm font-semibold">
+    <details className="group mt-4 rounded-box border border-base-200 p-4">
+      <summary className="flex cursor-pointer items-center gap-2 text-sm font-semibold marker:content-none">
+        <span className="transition-transform group-open:rotate-90">▶</span>
         {t("submissions.student.submitGuide.title")}
-      </h3>
-      <ol className="space-y-3">
+      </summary>
+      <p className="mt-2 text-sm text-base-content/70">
+        {t("submissions.student.submitGuide.intro")}
+      </p>
+      <ol className="mt-3 space-y-3">
         <li className="space-y-1.5">
           <p className="text-sm text-base-content/70">
             {t("submissions.student.submitGuide.step1")}
@@ -51,7 +53,7 @@ export function SubmitGuidance({ repoHtmlUrl }: { repoHtmlUrl: string }) {
           />
         </li>
       </ol>
-    </div>
+    </details>
   )
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1796,10 +1796,11 @@
       "notAccepted_prefix": "You haven't accepted this assignment yet.",
       "notAccepted_link": "Accept it",
       "notAccepted_suffix": "to get your repository, then push your work to be graded.",
-      "noGradedYet": "No graded submission yet. Push a commit to your assignment repository and the autograder will publish your result here.",
+      "noGradedYet": "No graded submission yet. Upload your files above, or push to your assignment repository from the command line — the autograder will publish your result here.",
       "openMyRepo": "Open my repository",
       "submitGuide": {
-        "title": "How to submit",
+        "title": "Prefer the command line?",
+        "intro": "You can also submit from a terminal instead of uploading above.",
         "step1": "Clone your assignment repository (once):",
         "step2": "From inside the repository, submit your work for grading:",
         "copyClone": "Copy clone command",

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -187,22 +187,24 @@ const SubmissionBody = ({
         <Alert tone="info">
           <div>{t("submissions.student.noGradedYet")}</div>
         </Alert>
-        <Button
-          as="a"
-          variant="outline"
-          size="sm"
-          href={studentRepo.html_url}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <ExternalLink aria-hidden="true" className="size-4" />
-          {t("submissions.student.openMyRepo")}
-        </Button>
-        <SubmitUpload
-          org={org}
-          repo={studentRepo.name}
-          assignment={assignment}
-        />
+        <div className="flex flex-wrap items-center gap-2">
+          <SubmitUpload
+            org={org}
+            repo={studentRepo.name}
+            assignment={assignment}
+          />
+          <Button
+            as="a"
+            variant="outline"
+            size="sm"
+            href={studentRepo.html_url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <ExternalLink aria-hidden="true" className="size-4" />
+            {t("submissions.student.openMyRepo")}
+          </Button>
+        </div>
         <SubmitGuidance repoHtmlUrl={studentRepo.html_url} />
       </EnterDiv>
     )
@@ -214,17 +216,24 @@ const SubmissionBody = ({
         <p className="text-sm text-base-content/70">
           {t("submissions.student.releasesIntro")}
         </p>
-        <Button
-          as="a"
-          variant="outline"
-          size="sm"
-          href={studentRepo.html_url}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <ExternalLink aria-hidden="true" className="size-4" />
-          {t("submissions.student.openMyRepo")}
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <SubmitUpload
+            org={org}
+            repo={studentRepo.name}
+            assignment={assignment}
+          />
+          <Button
+            as="a"
+            variant="outline"
+            size="sm"
+            href={studentRepo.html_url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <ExternalLink aria-hidden="true" className="size-4" />
+            {t("submissions.student.openMyRepo")}
+          </Button>
+        </div>
       </div>
 
       <Card as={EnterDiv} bordered={false} className="border border-base-200">
@@ -234,8 +243,6 @@ const SubmissionBody = ({
           ))}
         </ul>
       </Card>
-
-      <SubmitUpload org={org} repo={studentRepo.name} assignment={assignment} />
     </div>
   )
 }


### PR DESCRIPTION
## What

Reworks the student submission page so the browser **Upload submission** action reads as the primary way to submit, now that web uploads exist.

- **Reorder + layout:** Upload submission now comes before *Open my repository*, and the two buttons sit on a single flex-wrap row (previously stacked one per line) in both the not-yet-graded and graded-releases states.
- **CLI guidance behind a toggle:** the clone/submit steps are collapsed into a `<details>` **"Prefer the command line?"** disclosure (same pattern as the assignment form's Advanced section), keeping the CLI available without competing with the upload button.
- **Copy:** `noGradedYet` now points at the upload button first ("Upload your files above, or push … from the command line"); `submitGuide.title` becomes "Prefer the command line?" with a new `intro` line.

## Why

The page still framed `git clone` + `gh student submit` as the only ("How to submit") path, which no longer matches the UI now that students can upload from the browser.

## Testing

- `npx tsc -b` — clean
- `npx eslint` + `npx prettier --check` on touched files — clean
- `npx vitest run src/components/SubmitGuidance.test.tsx` — pass