### PR TITLE
fix(web): let CLDR fixed-count plural forms drop the count placeholder in verify_locale

### DIFF
--- a/web/src/locales/test_verify_locale.py
+++ b/web/src/locales/test_verify_locale.py
@@ -231,6 +231,51 @@ class TestExistingGate:
         )
         assert code == 1
 
+    def test_plural_form_may_drop_base_placeholder(self, monkeypatch, tmp_path):
+        # CLDR one/two/zero categories apply to a fixed count, so a fluent
+        # translation legitimately omits {{count}} (Arabic "one student").
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            base={"n_one": "{{count}} student", "n_other": "{{count}} students"},
+            trans={"n_one": "طالب واحد", "n_other": "{{count}} طلاب"},
+        )
+        assert code == 0
+
+    def test_plural_form_adding_a_placeholder_still_fails(self, monkeypatch, tmp_path):
+        # Subset only: a plural form may drop, never introduce, a placeholder.
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            base={"n_one": "{{count}} student", "n_other": "{{count}} students"},
+            trans={"n_one": "{{count}} {{extra}}", "n_other": "{{count}} طلاب"},
+        )
+        assert code == 1
+
+    def test_other_plural_form_must_keep_placeholder(self, monkeypatch, tmp_path):
+        # _other is the open-ended fallback (2+, fractions) and must keep the
+        # count; only fixed-count categories (_zero/_one/_two) may drop it.
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            base={"n_one": "{{count}} student", "n_other": "{{count}} students"},
+            trans={"n_one": "طالب واحد", "n_other": "طلاب"},
+        )
+        assert code == 1
+
+    def test_non_plural_key_still_requires_exact_placeholders(
+        self, monkeypatch, tmp_path
+    ):
+        # The subset relaxation is plural-only; a normal key dropping a
+        # placeholder is still a bug (renders a blank where a value belongs).
+        code = _run(
+            monkeypatch,
+            tmp_path,
+            base={"greeting": "Hello {{name}}"},
+            trans={"greeting": "Hallo"},
+        )
+        assert code == 1
+
     def test_extra_plural_variant_allowed(self, monkeypatch, tmp_path):
         code = _run(
             monkeypatch,

--- a/web/src/locales/verify_locale.py
+++ b/web/src/locales/verify_locale.py
@@ -39,6 +39,25 @@ def placeholders(value):
     return sorted(re.findall(r"\{\{.*?\}\}", value))
 
 
+def placeholders_ok(key, base_val, trans_val):
+    """Whether a translated string's placeholders are acceptable vs the base.
+
+    Non-plural keys require an exact match. A fixed-count plural category
+    (_zero/_one/_two) may OMIT placeholders the base carries: those categories
+    apply to a specific count, so a fluent translation drops "{{count}}"
+    (Arabic "طالب واحد" = "one student", not "{{count}} students"). The
+    open-ended categories (_few/_many/_other) cover arbitrary counts and must
+    keep the base's placeholders exactly. Adding a placeholder the base never
+    had is always a mismatch (a stray/typo interpolation that renders raw).
+    """
+    base_ph, trans_ph = placeholders(base_val), placeholders(trans_val)
+    if base_ph == trans_ph:
+        return True
+    if any(key.endswith(suffix) for suffix in ("_zero", "_one", "_two")):
+        return set(trans_ph).issubset(set(base_ph))
+    return False
+
+
 def markup_markers(value):
     """Sorted list of <tag>/</tag>/<tag/> markers in a string (empty for non-strings).
 
@@ -157,7 +176,7 @@ def main():
     mk_mismatch = []
     attr_markers = []
     for key in sorted(base_keys & trans_keys):
-        if placeholders(base[key]) != placeholders(trans[key]):
+        if not placeholders_ok(key, base[key], trans[key]):
             ph_mismatch.append((key, placeholders(base[key]), placeholders(trans[key])))
         if markup_markers(base[key]) != markup_markers(trans[key]):
             mk_mismatch.append((key, markup_markers(base[key]), markup_markers(trans[key])))


### PR DESCRIPTION
## Summary

The post-merge **Translate locales** workflow failed the `translate (ar)` and `translate (he)` gates ([run 29777611327](https://github.com/foundation50/classroom50/actions/runs/29777611327/job/88470739108)) with 49 and 38 `PLACEHOLDER mismatches` respectively — all of the form `base=['{{count}}'] translated=[]` on `_one` keys.

**Root cause:** CLDR fixed-count plural categories legitimately omit the count. In Arabic the `one` category applies only to the literal count 1, so a fluent translation is "طالب واحد" ("one student"), not "{{count}} students". Hebrew's `one`/`two` behave the same. `verify_locale.py`'s placeholder-parity check demanded exact placeholder equality on every shared key, so it rejected these correct translations. `ar`/`he` are the first rich-plural, count-heavy languages to hit this; `fa`/`ur` use `(one, other)` like English and passed.

**Fix:** allow `_zero`/`_one`/`_two` forms to *drop* (never *add*) a base placeholder. The open-ended `_few`/`_many`/`_other` categories cover arbitrary counts and still require the base's placeholders exactly; non-plural keys stay strict. A stray/extra placeholder is still a failure.

## Testing

- `python3 -m pytest web/src/locales -q` → 92 pass (4 new: fixed-count drop allowed, added-placeholder rejected, `_other` must keep, non-plural stays strict).
- Reproduced the exact CI signature against the patched gate: `RESULT: PASS`, `PLACEHOLDER mismatches (0)`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Built, tested, and linted the module(s) I touched (`web/src/locales` pytest).
- [x] No cross-binary contract changed (web-internal locale tooling).
- [x] Conventional Commits.