### PR TITLE
feat(web): capability-gate RBAC so TAs/Head TAs can't invoke owner-only or write ops

### DIFF
--- a/cli/gh-teacher/init_skeleton_test.go
+++ b/cli/gh-teacher/init_skeleton_test.go
@@ -414,11 +414,12 @@ func TestCollectScoresCommitPrefix(t *testing.T) {
 // student-assignment-repo / private-template axis) is the source of truth;
 // collect_scores.py hand-mirrors it as STAFF_TEAM_PERMISSIONS with no
 // compile-time link, so a role added on only one side would otherwise pass CI
-// while the collector silently grants the wrong set. The head-TA (hta) role
-// gets config-repo write (a separate axis, configrepo.ConfigRepoPermission,
-// which the collector does not manage), so it is intentionally absent from this
-// template-repo map. Assert every Go entry appears verbatim as a Python dict
-// literal in the embedded script.
+// while the collector silently grants the wrong set. The non-owner staff roles
+// (head-TA and TA) map to `pull` here; the teacher/instructor roles are absent
+// (owners get repo access via ownership). Note this template-repo axis is
+// SEPARATE from configrepo.ConfigRepoPermission (config-repo write), which the
+// collector does not manage. Assert every Go entry appears verbatim as a Python
+// dict literal in the embedded script.
 func TestStaffPermsParity_GoVsInlinePython(t *testing.T) {
 	files, err := skeletonFiles("main")
 	if err != nil {

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -348,7 +348,7 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 // template, so their team needs an explicit read grant; the teacher team is
 // omitted (its members are org owners with repo access via ownership).
 func grantStaffTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, tmplOwner, tmplRepo string) {
-	for _, role := range []configrepo.StaffRole{configrepo.RoleHeadTA, configrepo.RoleTA} {
+	for _, role := range configrepo.TemplateReadStaffRoles {
 		// StaffTeamRepoPermissions is a presence gate: grant read only for a role
 		// mapped to a student-repo/template permission.
 		if _, ok := configrepo.StaffTeamRepoPermissions[role]; !ok {

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -318,7 +318,8 @@ type grantContext struct {
 //
 // The student-team grant is org-owner-only. A non-owner author (head-TA) gets a
 // 403; since the commit already landed, that is NOT fatal — it warns with
-// owner-required guidance and returns nil. Only a non-403 grant error is fatal.
+// owner-required guidance and returns nil. A rate-limit/abuse 403 stays fatal
+// (transient, not a permission denial); any other error is fatal too.
 //
 // After the student grant it best-effort grants the classroom's non-owner staff
 // teams (head-TA, TA) the same read, so a base-permission-`none` head-TA/TA can
@@ -336,9 +337,12 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 	}
 	granted, err := configrepo.GrantTeamRepoRead(client, org, team.Slug, tmplOwner, tmplRepo)
 	if err != nil {
-		// A 403 is the expected non-owner-author case (see the doc comment):
-		// warn with owner-required guidance and return nil. Only non-403 is fatal.
-		if cliutil.IsHTTPStatus(err, http.StatusForbidden) {
+		// A 403 is the expected non-owner-author case (see the doc comment): warn
+		// with owner-required guidance and return nil. But a rate-limit/abuse 403
+		// (Retry-After / x-ratelimit-remaining) is transient, not a permission
+		// denial — keep it fatal so a throttle stays a loud, non-zero-exit failure
+		// rather than misleading owner guidance. Only a non-rate-limited 403 is benign.
+		if cliutil.IsHTTPStatus(err, http.StatusForbidden) && !cliutil.IsRateLimited(err) {
 			_, _ = fmt.Fprintf(errOut, "Warning: assignment %s, but granting the %s team read on the private template %s/%s needs an organization owner (a non-owner can't grant repo access at GitHub). Students can't `gh student accept` until an owner grants it — re-run this command as an owner%s, open the classroom in the web app (which grants it automatically), or grant the %s team read on %s/%s directly in GitHub (Settings -> Collaborators and teams).\n",
 				ctx.verb, ctx.classroomNoun, tmplOwner, tmplRepo, ctx.rerunHint, team.Slug, tmplOwner, tmplRepo)
 			return nil

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -318,14 +318,13 @@ type grantContext struct {
 //
 // The student-team grant is org-owner-only. A non-owner author (head-TA) gets a
 // 403; since the commit already landed, that is NOT fatal — it warns with
-// owner-required guidance and returns nil (an owner re-affirms it; collect-scores
-// also re-affirms). Only an unexpected (non-403) grant error is fatal.
+// owner-required guidance and returns nil. Only a non-403 grant error is fatal.
 //
 // After the student grant it best-effort grants the classroom's non-owner staff
-// teams (head-TA, TA) the same read, so a base-permission-`none` head-TA/TA (an
-// org member on that team) can read the private template without waiting for a
-// collect-scores run. That grant is non-blocking: its failure warns to errOut
-// but never fails an operation that already succeeded for students.
+// teams (head-TA, TA) the same read, so a base-permission-`none` head-TA/TA can
+// read the private template without waiting for collect-scores. That grant is
+// non-blocking: its failure warns to errOut but never fails an operation that
+// already succeeded for students.
 func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, slug, tmplOwner, tmplRepo string, ctx grantContext) error {
 	team, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
@@ -337,14 +336,8 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 	}
 	granted, err := configrepo.GrantTeamRepoRead(client, org, team.Slug, tmplOwner, tmplRepo)
 	if err != nil {
-		// The grant (PUT team/repo) is org-owner-only. A non-owner author (e.g. a
-		// head-TA, who has config-repo write and can author) can't perform it and
-		// gets a 403 — but the commit already landed, so don't fail the whole
-		// operation. Surface actionable owner-required guidance and return nil,
-		// mirroring the web's templateGrantOwnerRequiredWarning; an owner re-affirms
-		// it (re-run the command, open the classroom in the web app, or grant the
-		// team read directly), and collect-scores re-affirms it too. Reserve the
-		// fatal return for genuinely unexpected errors.
+		// A 403 is the expected non-owner-author case (see the doc comment):
+		// warn with owner-required guidance and return nil. Only non-403 is fatal.
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) {
 			_, _ = fmt.Fprintf(errOut, "Warning: assignment %s, but granting the %s team read on the private template %s/%s needs an organization owner (a non-owner can't grant repo access at GitHub). Students can't `gh student accept` until an owner grants it — re-run this command as an owner%s, open the classroom in the web app (which grants it automatically), or grant the %s team read on %s/%s directly in GitHub (Settings -> Collaborators and teams).\n",
 				ctx.verb, ctx.classroomNoun, tmplOwner, tmplRepo, ctx.rerunHint, team.Slug, tmplOwner, tmplRepo)
@@ -360,11 +353,9 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 }
 
 // grantStaffTeamTemplateRead best-effort grants the classroom's non-owner staff
-// teams (head-TA and TA) read on a private, org-owned template (see
-// grantClassroomTeamTemplateRead for the non-blocking rationale). A head-TA/TA
-// is a plain org member with base permission `none` on a private in-org
-// template, so their team needs an explicit read grant; the teacher team is
-// omitted (its members are org owners with repo access via ownership).
+// teams (TemplateReadStaffRoles: head-TA, TA) read on a private, org-owned
+// template — see grantClassroomTeamTemplateRead for the non-blocking rationale
+// and TemplateReadStaffRoles for why the teacher team is omitted.
 func grantStaffTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, tmplOwner, tmplRepo string) {
 	for _, role := range configrepo.TemplateReadStaffRoles {
 		// StaffTeamRepoPermissions is a presence gate: grant read only for a role

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -341,29 +341,35 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 	return nil
 }
 
-// grantStaffTeamTemplateRead best-effort grants the classroom's TA staff team
-// read on a private, org-owned template (see grantClassroomTeamTemplateRead for
-// the non-blocking rationale). StaffTeamRepoPermissions is a presence gate here:
-// grant the TA team read only when the role is mapped.
+// grantStaffTeamTemplateRead best-effort grants the classroom's non-owner staff
+// teams (head-TA and TA) read on a private, org-owned template (see
+// grantClassroomTeamTemplateRead for the non-blocking rationale). A head-TA/TA
+// is a plain org member with base permission `none` on a private in-org
+// template, so their team needs an explicit read grant; the teacher team is
+// omitted (its members are org owners with repo access via ownership).
 func grantStaffTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, tmplOwner, tmplRepo string) {
-	if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; !ok {
-		return
-	}
-	taTeam, ok, err := configrepo.ResolveClassroomStaffTeam(client, org, classroom, branch, configrepo.RoleTA)
-	if err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: could not read the TA staff team to grant read on private template %s/%s (%v); TAs get read at the next collect-scores run.\n", tmplOwner, tmplRepo, err)
-		return
-	}
-	if !ok {
-		return // no TA team recorded (older classroom) — clean skip
-	}
-	granted, err := configrepo.GrantTeamRepoRead(client, org, taTeam.Slug, tmplOwner, tmplRepo)
-	if err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: could not grant TA staff team %s read on private template %s/%s (%v); TAs get read at the next collect-scores run.\n", taTeam.Slug, tmplOwner, tmplRepo, err)
-		return
-	}
-	if granted {
-		_, _ = fmt.Fprintf(out, "%s: granted TA staff team %s read on private template %s/%s\n", org, taTeam.Slug, tmplOwner, tmplRepo)
+	for _, role := range []configrepo.StaffRole{configrepo.RoleHeadTA, configrepo.RoleTA} {
+		// StaffTeamRepoPermissions is a presence gate: grant read only for a role
+		// mapped to a student-repo/template permission.
+		if _, ok := configrepo.StaffTeamRepoPermissions[role]; !ok {
+			continue
+		}
+		team, ok, err := configrepo.ResolveClassroomStaffTeam(client, org, classroom, branch, role)
+		if err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: could not read the %s staff team to grant read on private template %s/%s (%v); staff get read at the next collect-scores run.\n", role, tmplOwner, tmplRepo, err)
+			continue
+		}
+		if !ok {
+			continue // no team recorded (older classroom) — clean skip
+		}
+		granted, err := configrepo.GrantTeamRepoRead(client, org, team.Slug, tmplOwner, tmplRepo)
+		if err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: could not grant %s staff team %s read on private template %s/%s (%v); staff get read at the next collect-scores run.\n", role, team.Slug, tmplOwner, tmplRepo, err)
+			continue
+		}
+		if granted {
+			_, _ = fmt.Fprintf(out, "%s: granted %s staff team %s read on private template %s/%s\n", org, role, team.Slug, tmplOwner, tmplRepo)
+		}
 	}
 }
 

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -316,11 +316,16 @@ type grantContext struct {
 // and reuse; the caller decides WHEN and supplies the wording. A classroom with
 // no team yields an actionable error, not a 404 on a guessed slug.
 //
-// After the student grant it best-effort grants the classroom's TA staff team
-// the same read, so a base-permission-`none` TA (an org member on the TA team)
-// can read the private template without waiting for a collect-scores run. That
-// grant is non-blocking: its failure warns to errOut but never fails an
-// operation that already succeeded for students (collect-scores re-affirms it).
+// The student-team grant is org-owner-only. A non-owner author (head-TA) gets a
+// 403; since the commit already landed, that is NOT fatal — it warns with
+// owner-required guidance and returns nil (an owner re-affirms it; collect-scores
+// also re-affirms). Only an unexpected (non-403) grant error is fatal.
+//
+// After the student grant it best-effort grants the classroom's non-owner staff
+// teams (head-TA, TA) the same read, so a base-permission-`none` head-TA/TA (an
+// org member on that team) can read the private template without waiting for a
+// collect-scores run. That grant is non-blocking: its failure warns to errOut
+// but never fails an operation that already succeeded for students.
 func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writer, org, classroom, branch, slug, tmplOwner, tmplRepo string, ctx grantContext) error {
 	team, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
@@ -332,6 +337,19 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 	}
 	granted, err := configrepo.GrantTeamRepoRead(client, org, team.Slug, tmplOwner, tmplRepo)
 	if err != nil {
+		// The grant (PUT team/repo) is org-owner-only. A non-owner author (e.g. a
+		// head-TA, who has config-repo write and can author) can't perform it and
+		// gets a 403 — but the commit already landed, so don't fail the whole
+		// operation. Surface actionable owner-required guidance and return nil,
+		// mirroring the web's templateGrantOwnerRequiredWarning; an owner re-affirms
+		// it (re-run the command, open the classroom in the web app, or grant the
+		// team read directly), and collect-scores re-affirms it too. Reserve the
+		// fatal return for genuinely unexpected errors.
+		if cliutil.IsHTTPStatus(err, http.StatusForbidden) {
+			_, _ = fmt.Fprintf(errOut, "Warning: assignment %s, but granting the %s team read on the private template %s/%s needs an organization owner (a non-owner can't grant repo access at GitHub). Students can't `gh student accept` until an owner grants it — re-run this command as an owner%s, open the classroom in the web app (which grants it automatically), or grant the %s team read on %s/%s directly in GitHub (Settings -> Collaborators and teams).\n",
+				ctx.verb, ctx.classroomNoun, tmplOwner, tmplRepo, ctx.rerunHint, team.Slug, tmplOwner, tmplRepo)
+			return nil
+		}
 		return fmt.Errorf("assignment %s, but granting the %s team read on the private template %s/%s failed: %w", ctx.verb, ctx.classroomNoun, tmplOwner, tmplRepo, err)
 	}
 	if granted {

--- a/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
@@ -756,7 +756,7 @@ func TestRunAssignmentReuse_TAGrantFailureIsNonFatal(t *testing.T) {
 	if student != "o/hello-template" {
 		t.Errorf("student team grant = %q, want o/hello-template", student)
 	}
-	if !strings.Contains(errOut.String(), "TA staff team") {
+	if !strings.Contains(errOut.String(), "could not grant ta staff team") {
 		t.Errorf("expected a TA-grant warning on stderr, got %q", errOut.String())
 	}
 }

--- a/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
@@ -26,6 +26,8 @@ type reuseFixture struct {
 	grantedRepo string
 	// grantedTATeam records a PUT TA-staff-team repo grant target, if any.
 	grantedTATeam string
+	// grantedHTATeam records a PUT head-TA-staff-team repo grant target, if any.
+	grantedHTATeam string
 }
 
 // reuseServerConfig parameterizes the mock: the source/target classroom
@@ -132,6 +134,20 @@ func newReuseServer(t *testing.T, cfg reuseServerConfig) (*httptest.Server, *reu
 		}
 	})
 
+	// Head-TA-staff-team grant: GET probe + PUT grant. Fires only when the target
+	// classroom.json records a `teams.hta` block (older classrooms skip it).
+	mux.HandleFunc("/orgs/o/teams/classroom50-dst-hta/repos/o/hello-template", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPut:
+			fix.mu.Lock()
+			fix.grantedHTATeam = "o/hello-template"
+			fix.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
 	// Commit-tree write loop.
 	mux.HandleFunc("/repos/o/classroom50/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
@@ -224,9 +240,9 @@ func targetClassroomBody(active *bool) string {
 	return string(b)
 }
 
-// targetClassroomBodyWithTA is targetClassroomBody plus a recorded TA staff
-// team, so the reuse grant path also grants the TA team read on a private
-// in-org template.
+// targetClassroomBodyWithTA is targetClassroomBody plus recorded head-TA and TA
+// staff teams, so the reuse grant path also grants those non-owner staff teams
+// read on a private in-org template.
 func targetClassroomBodyWithTA() string {
 	doc := map[string]any{
 		"schema":     "classroom50/classroom/v1",
@@ -236,7 +252,8 @@ func targetClassroomBodyWithTA() string {
 		"org":        "o",
 		"team":       map[string]any{"id": 7, "slug": "classroom50-dst"},
 		"teams": map[string]any{
-			"ta": map[string]any{"id": 9, "slug": "classroom50-dst-ta"},
+			"hta": map[string]any{"id": 8, "slug": "classroom50-dst-hta"},
+			"ta":  map[string]any{"id": 9, "slug": "classroom50-dst-ta"},
 		},
 	}
 	b, _ := json.Marshal(doc)
@@ -696,10 +713,13 @@ func TestRunAssignmentReuse_GrantsTATeam(t *testing.T) {
 		t.Fatalf("runAssignmentReuse: %v", err)
 	}
 	fix.mu.Lock()
-	student, ta := fix.grantedRepo, fix.grantedTATeam
+	student, ta, hta := fix.grantedRepo, fix.grantedTATeam, fix.grantedHTATeam
 	fix.mu.Unlock()
 	if student != "o/hello-template" {
 		t.Errorf("student team grant = %q, want o/hello-template", student)
+	}
+	if hta != "o/hello-template" {
+		t.Errorf("head-TA team grant = %q, want o/hello-template", hta)
 	}
 	if ta != "o/hello-template" {
 		t.Errorf("TA team grant = %q, want o/hello-template", ta)
@@ -723,13 +743,16 @@ func TestRunAssignmentReuse_NoTATeamSkips(t *testing.T) {
 		t.Fatalf("runAssignmentReuse: %v", err)
 	}
 	fix.mu.Lock()
-	student, ta := fix.grantedRepo, fix.grantedTATeam
+	student, ta, hta := fix.grantedRepo, fix.grantedTATeam, fix.grantedHTATeam
 	fix.mu.Unlock()
 	if student != "o/hello-template" {
 		t.Errorf("student team grant = %q, want o/hello-template", student)
 	}
 	if ta != "" {
 		t.Errorf("no TA grant expected, got %q", ta)
+	}
+	if hta != "" {
+		t.Errorf("no head-TA grant expected, got %q", hta)
 	}
 }
 

--- a/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
@@ -44,6 +44,10 @@ type reuseServerConfig struct {
 	// the default 204 (success). Set to e.g. 500 to exercise the
 	// grant-fails-after-the-copy-landed path.
 	grantStatus int
+	// grantRateLimited, when set, makes the classroom-team grant PUT return a
+	// 403 WITH a Retry-After header — GitHub's secondary-rate-limit shape, which
+	// must stay fatal (distinct from a plain permission 403, which is benign).
+	grantRateLimited bool
 	// templateOwner overrides the template repo owner (default "o", the
 	// org). Set to a different owner to exercise the out-of-org private
 	// template branch (warn, no grant). The source assignments body must
@@ -105,6 +109,11 @@ func newReuseServer(t *testing.T, cfg reuseServerConfig) (*httptest.Server, *reu
 			// 404 => not yet granted, so GrantTeamRepoRead will PUT.
 			w.WriteHeader(http.StatusNotFound)
 		case http.MethodPut:
+			if cfg.grantRateLimited {
+				w.Header().Set("Retry-After", "60")
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
 			if cfg.grantStatus != 0 {
 				w.WriteHeader(cfg.grantStatus)
 				return
@@ -646,6 +655,33 @@ func TestRunAssignmentReuse_GrantForbiddenIsNonFatal(t *testing.T) {
 	fix.mu.Unlock()
 	if committed == nil {
 		t.Errorf("copy should have been committed even when the grant 403s")
+	}
+}
+
+// TestRunAssignmentReuse_GrantRateLimitedStaysFatal: a 403 carrying a Retry-After
+// header is GitHub's secondary-rate-limit shape, not a permission denial — it must
+// stay FATAL (a transient throttle reported as "needs an organization owner" +
+// exit 0 would hide the real cause). Distinct from GrantForbiddenIsNonFatal.
+func TestRunAssignmentReuse_GrantRateLimitedStaysFatal(t *testing.T) {
+	server, _ := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceAssignmentsBody(),
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBody(nil),
+		templatePrivate:   true,
+		grantRateLimited:  true,
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentReuse(client, &out, &errOut, baseReuseParams())
+	if err == nil {
+		t.Fatalf("a rate-limited (Retry-After) 403 must fail the reuse, got nil error")
+	}
+	if !strings.Contains(err.Error(), "failed") {
+		t.Errorf("expected the fatal grant-failure error, got %v", err)
+	}
+	if strings.Contains(errOut.String(), "organization owner") {
+		t.Errorf("a rate-limit 403 must NOT surface owner-required guidance, got %q", errOut.String())
 	}
 }
 

--- a/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
@@ -617,6 +617,38 @@ func TestRunAssignmentReuse_GrantFailureAfterCommit(t *testing.T) {
 	}
 }
 
+// TestRunAssignmentReuse_GrantForbiddenIsNonFatal: the classroom-team grant PUT
+// is org-owner-only, so a non-owner author (head-TA) gets a 403. Since the copy
+// already committed, the reuse must NOT fail — it warns with owner-required
+// guidance on stderr and returns nil (an owner re-affirms it; collect-scores
+// also does). Distinct from GrantFailureAfterCommit, where a non-403 error stays
+// fatal.
+func TestRunAssignmentReuse_GrantForbiddenIsNonFatal(t *testing.T) {
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceAssignmentsBody(),
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBody(nil),
+		templatePrivate:   true,
+		grantStatus:       http.StatusForbidden,
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	if err := runAssignmentReuse(client, &out, &errOut, baseReuseParams()); err != nil {
+		t.Fatalf("a 403 on the owner-only grant must not fail the reuse, got %v", err)
+	}
+	if !strings.Contains(errOut.String(), "organization owner") {
+		t.Errorf("expected an owner-required warning on stderr, got %q", errOut.String())
+	}
+	// The copy still landed.
+	fix.mu.Lock()
+	committed := fix.committed
+	fix.mu.Unlock()
+	if committed == nil {
+		t.Errorf("copy should have been committed even when the grant 403s")
+	}
+}
+
 // TestRunAssignmentReuse_JSONOutput: --json emits the resolved copy with the
 // FINAL (auto-suffixed) slug on stdout, the machine-readable contract an
 // agent reads instead of scraping the human summary.

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -294,12 +294,12 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 		slug string
 	}
 	var staffTargets []staffTarget
-	if staffTeams != nil {
-		if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleHeadTA]; ok && staffTeams.HeadTA != nil {
-			staffTargets = append(staffTargets, staffTarget{configrepo.RoleHeadTA, staffTeams.HeadTA.Slug})
+	for _, role := range configrepo.TemplateReadStaffRoles {
+		if _, ok := configrepo.StaffTeamRepoPermissions[role]; !ok {
+			continue
 		}
-		if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; ok && staffTeams.TA != nil {
-			staffTargets = append(staffTargets, staffTarget{configrepo.RoleTA, staffTeams.TA.Slug})
+		if ref := staffTeams.RefForRole(role); ref != nil {
+			staffTargets = append(staffTargets, staffTarget{role, ref.Slug})
 		}
 	}
 	var grantFailures int

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -281,14 +281,12 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// repo's visibility, use the team's authoritative slug, and track failures
 	// so the exit code reflects a template students can't yet accept.
 	//
-	// The non-owner staff teams (head-TA, TA) get the same read (best-effort) so a
-	// base-permission-`none` head-TA/TA can read the template without waiting for
-	// collect-scores. The slugs come from the just-created staffTeams
-	// (classroom.json isn't committed until CommitTree above, so it can't be
-	// re-resolved here). StaffTeamRepoPermissions is a presence gate: grant a
-	// staff team read only when its role is mapped. A staff-grant failure only
-	// warns — it's not a student blocker, so it never adds to grantFailures or
-	// changes the exit code.
+	// The non-owner staff teams (TemplateReadStaffRoles: head-TA, TA) get the same
+	// read, best-effort — but their slugs come from the just-created staffTeams
+	// here, since classroom.json isn't committed until CommitTree above and can't
+	// be re-resolved. Presence-gated on StaffTeamRepoPermissions; a staff-grant
+	// failure only warns (not a student blocker) so it never touches grantFailures
+	// or the exit code.
 	type staffTarget struct {
 		role configrepo.StaffRole
 		slug string

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -281,17 +281,26 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// repo's visibility, use the team's authoritative slug, and track failures
 	// so the exit code reflects a template students can't yet accept.
 	//
-	// The TA staff team gets the same read (best-effort) so a base-permission-
-	// `none` TA can read the template without waiting for collect-scores. The
-	// TA slug comes from the just-created staffTeams (classroom.json isn't
-	// committed until CommitTree above, so it can't be re-resolved here).
-	// StaffTeamRepoPermissions is a presence gate: grant the TA team read only
-	// when the role is mapped. A TA-grant failure only warns — it's not a
-	// student blocker, so it never adds to grantFailures or changes the exit
-	// code.
-	taSlug := ""
-	if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; ok && staffTeams != nil && staffTeams.TA != nil {
-		taSlug = staffTeams.TA.Slug
+	// The non-owner staff teams (head-TA, TA) get the same read (best-effort) so a
+	// base-permission-`none` head-TA/TA can read the template without waiting for
+	// collect-scores. The slugs come from the just-created staffTeams
+	// (classroom.json isn't committed until CommitTree above, so it can't be
+	// re-resolved here). StaffTeamRepoPermissions is a presence gate: grant a
+	// staff team read only when its role is mapped. A staff-grant failure only
+	// warns — it's not a student blocker, so it never adds to grantFailures or
+	// changes the exit code.
+	type staffTarget struct {
+		role configrepo.StaffRole
+		slug string
+	}
+	var staffTargets []staffTarget
+	if staffTeams != nil {
+		if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleHeadTA]; ok && staffTeams.HeadTA != nil {
+			staffTargets = append(staffTargets, staffTarget{configrepo.RoleHeadTA, staffTeams.HeadTA.Slug})
+		}
+		if _, ok := configrepo.StaffTeamRepoPermissions[configrepo.RoleTA]; ok && staffTeams.TA != nil {
+			staffTargets = append(staffTargets, staffTarget{configrepo.RoleTA, staffTeams.TA.Slug})
+		}
 	}
 	var grantFailures int
 	for i := range resolved {
@@ -310,18 +319,20 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 			_, _ = fmt.Fprintf(out, "%s: granted classroom team %s read on private template %s/%s\n",
 				plan.TargetOrg, team.Slug, rt.Template.Owner, rt.Template.Repo)
 		}
-		if taSlug == "" {
-			continue
-		}
-		taGranted, taErr := configrepo.GrantTeamRepoRead(client, plan.TargetOrg, taSlug, rt.Template.Owner, rt.Template.Repo)
-		if taErr != nil {
-			_, _ = fmt.Fprintf(errOut, "Warning: %s: could not grant TA staff team %s read on private template %s/%s (%v); TAs get read at the next collect-scores run.\n",
-				plan.TargetOrg, taSlug, rt.Template.Owner, rt.Template.Repo, taErr)
-			continue
-		}
-		if taGranted {
-			_, _ = fmt.Fprintf(out, "%s: granted TA staff team %s read on private template %s/%s\n",
-				plan.TargetOrg, taSlug, rt.Template.Owner, rt.Template.Repo)
+		for _, st := range staffTargets {
+			if st.slug == "" {
+				continue
+			}
+			staffGranted, staffErr := configrepo.GrantTeamRepoRead(client, plan.TargetOrg, st.slug, rt.Template.Owner, rt.Template.Repo)
+			if staffErr != nil {
+				_, _ = fmt.Fprintf(errOut, "Warning: %s: could not grant %s staff team %s read on private template %s/%s (%v); staff get read at the next collect-scores run.\n",
+					plan.TargetOrg, st.role, st.slug, rt.Template.Owner, rt.Template.Repo, staffErr)
+				continue
+			}
+			if staffGranted {
+				_, _ = fmt.Fprintf(out, "%s: granted %s staff team %s read on private template %s/%s\n",
+					plan.TargetOrg, st.role, st.slug, rt.Template.Owner, rt.Template.Repo)
+			}
 		}
 	}
 

--- a/cli/gh-teacher/internal/classroom/migrate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_test.go
@@ -312,7 +312,7 @@ func TestRunMigrate_NonDryRun_TAGrantFailureIsNonFatal(t *testing.T) {
 	if state.commitsCreated != 1 {
 		t.Errorf("commits created = %d, want 1 (migration still completes)", state.commitsCreated)
 	}
-	if !strings.Contains(stderr.String(), "could not grant TA staff team") {
+	if !strings.Contains(stderr.String(), "could not grant ta staff team") {
 		t.Errorf("expected a TA-grant warning on stderr, got:\n%s", stderr.String())
 	}
 }

--- a/cli/gh-teacher/internal/classroom/migrate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_test.go
@@ -253,17 +253,20 @@ func TestRunMigrate_NonDryRun_HappyPath(t *testing.T) {
 		}
 	}
 
-	// The private migrated template grants read to BOTH the student classroom
-	// team and the TA staff team (eager grant at migrate, not only at
-	// collect-scores).
+	// The private migrated template grants read to the student classroom team
+	// plus the non-owner staff teams (HTA + TA) — the eager grant at migrate, not
+	// only at collect-scores.
 	if got := state.templateGrants["classroom50-classroom50test"]; got != "cs50-fall-2026/readability" {
 		t.Errorf("student team template grant = %q, want cs50-fall-2026/readability", got)
+	}
+	if got := state.templateGrants["classroom50-classroom50test-hta"]; got != "cs50-fall-2026/readability" {
+		t.Errorf("HTA team template grant = %q, want cs50-fall-2026/readability", got)
 	}
 	if got := state.templateGrants["classroom50-classroom50test-ta"]; got != "cs50-fall-2026/readability" {
 		t.Errorf("TA team template grant = %q, want cs50-fall-2026/readability", got)
 	}
-	// Only the TA staff team is eagerly granted (StaffTeamRepoPermissions gate);
-	// the teacher team must NOT get template read.
+	// Only the non-owner staff teams are eagerly granted (StaffTeamRepoPermissions
+	// gate); the teacher team must NOT get template read (owners have it already).
 	if got, ok := state.templateGrants["classroom50-classroom50test-teacher"]; ok {
 		t.Errorf("teacher team must not be granted template read, got %q", got)
 	}

--- a/cli/gh-teacher/internal/cliutil/httpstatus.go
+++ b/cli/gh-teacher/internal/cliutil/httpstatus.go
@@ -8,3 +8,10 @@ import "github.com/foundation50/classroom50-cli-shared/ghutil"
 func IsHTTPStatus(err error, code int) bool {
 	return ghutil.IsHTTPStatus(err, code)
 }
+
+// IsRateLimited reports whether err is a GitHub rate-limit / secondary-limit
+// (abuse) response rather than a genuine authz denial. Thin wrapper over the
+// shared ghutil helper.
+func IsRateLimited(err error) bool {
+	return ghutil.IsRateLimited(err)
+}

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -68,20 +68,23 @@ const (
 
 // StaffTeamRepoPermissions maps a staff role to the repo permission a staff
 // team gets on each student assignment repo and on private in-org templates.
-// The TA-team template read is applied at TWO points: eagerly at assignment
-// add/reuse and classroom migrate (see grantStaffTeamTemplateRead / migrate.go),
-// and again as an idempotent re-affirm at collect-scores. The eager sites use
-// this map only as a presence gate and hardcode read (GrantTeamRepoRead);
-// collect-scores reads the value. Source of truth for the collector's
-// hand-mirrored STAFF_TEAM_PERMISSIONS (collect_scores.py) — keep in lockstep.
+// The head-TA/TA-team template read is applied at TWO points: eagerly at
+// assignment add/reuse and classroom migrate (see grantStaffTeamTemplateRead /
+// migrate.go), and again as an idempotent re-affirm at collect-scores. The eager
+// sites use this map only as a presence gate and hardcode read
+// (GrantTeamRepoRead); collect-scores reads the value. Source of truth for the
+// collector's hand-mirrored STAFF_TEAM_PERMISSIONS (collect_scores.py) — keep in
+// lockstep.
 //
-// A role absent from this map is granted nothing (the teacher team already
-// gets its access at classroom setup, so only the TA team needs a grant today).
+// A role absent from this map is granted nothing here. The teacher team is
+// omitted (its members are org owners with repo access via ownership); head-TA
+// and TA are plain members that need an explicit read grant.
 // Adding a future non-read staff permission is a one-line addition here and in
 // the mirror, but would also need the eager sites to consume the value instead
 // of hardcoding read.
 var StaffTeamRepoPermissions = map[StaffRole]string{
-	RoleTA: "pull",
+	RoleHeadTA: "pull",
+	RoleTA:     "pull",
 }
 
 // ConfigRepoPermission is the permission a staff role's team gets on the org's

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -87,6 +87,15 @@ var StaffTeamRepoPermissions = map[StaffRole]string{
 	RoleTA:     "pull",
 }
 
+// TemplateReadStaffRoles is the ordered set of NON-OWNER staff roles that get an
+// eager read grant on a private in-org template (head-TA, then TA). The teacher
+// team is omitted — its members are org owners with repo access via ownership.
+// Single-sources the loop in grantStaffTeamTemplateRead (reuse.go) and the
+// per-role grant in migrate.go so adding a future non-owner staff role is one
+// line here. Each role is still presence-gated against StaffTeamRepoPermissions
+// at the call site.
+var TemplateReadStaffRoles = []StaffRole{RoleHeadTA, RoleTA}
+
 // ConfigRepoPermission is the permission a staff role's team gets on the org's
 // `classroom50` config repo. Teacher (and its legacy instructor alias) and the
 // head-TA can author assignments → `push`; a plain TA is read-only → `pull`.
@@ -116,6 +125,25 @@ type StaffTeamsRef struct {
 	Instructor *TeamRef `json:"instructor,omitempty"`
 	HeadTA     *TeamRef `json:"hta,omitempty"`
 	TA         *TeamRef `json:"ta,omitempty"`
+}
+
+// RefForRole returns the persisted staff-team ref for a canonical staff role
+// (teacher/hta/ta), or nil when absent. Lets callers iterate a role set (e.g.
+// TemplateReadStaffRoles) instead of hand-matching each struct field. The
+// legacy instructor alias resolves to the teacher ref.
+func (r *StaffTeamsRef) RefForRole(role StaffRole) *TeamRef {
+	if r == nil {
+		return nil
+	}
+	switch role {
+	case RoleTeacher, RoleInstructor:
+		return r.Teacher
+	case RoleHeadTA:
+		return r.HeadTA
+	case RoleTA:
+		return r.TA
+	}
+	return nil
 }
 
 // ResolveClassroomTeam reads the persisted team ref from the classroom's

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -87,13 +87,12 @@ var StaffTeamRepoPermissions = map[StaffRole]string{
 	RoleTA:     "pull",
 }
 
-// TemplateReadStaffRoles is the ordered set of NON-OWNER staff roles that get an
-// eager read grant on a private in-org template (head-TA, then TA). The teacher
-// team is omitted — its members are org owners with repo access via ownership.
-// Single-sources the loop in grantStaffTeamTemplateRead (reuse.go) and the
-// per-role grant in migrate.go so adding a future non-owner staff role is one
-// line here. Each role is still presence-gated against StaffTeamRepoPermissions
-// at the call site.
+// TemplateReadStaffRoles is the ordered set of non-owner staff roles that get an
+// eager read grant on a private in-org template (head-TA, then TA; teacher
+// omitted per StaffTeamRepoPermissions above). Single-sources the loops in
+// grantStaffTeamTemplateRead (reuse.go) and migrate.go so a future non-owner
+// staff role is one line here. Still presence-gated against
+// StaffTeamRepoPermissions at each call site.
 var TemplateReadStaffRoles = []StaffRole{RoleHeadTA, RoleTA}
 
 // ConfigRepoPermission is the permission a staff role's team gets on the org's

--- a/cli/gh-teacher/internal/configrepo/team_http_test.go
+++ b/cli/gh-teacher/internal/configrepo/team_http_test.go
@@ -226,16 +226,20 @@ func TestStaffTeamName(t *testing.T) {
 	}
 }
 
-// TestStaffTeamRepoPermissions pins the collect-time grant map: the TA team
-// gets read (pull), and the teacher role is intentionally absent (its access
-// is granted at classroom setup, not by the collector). This map is the source
-// of truth the collector's STAFF_TEAM_PERMISSIONS mirror must match in lockstep.
+// TestStaffTeamRepoPermissions pins the collect-time grant map: the non-owner
+// staff teams (head-TA and TA) get read (pull), and the teacher/instructor
+// roles are intentionally absent (owners get repo access via ownership, not the
+// collector). This map is the source of truth the collector's
+// STAFF_TEAM_PERMISSIONS mirror must match in lockstep.
 func TestStaffTeamRepoPermissions(t *testing.T) {
+	if got := StaffTeamRepoPermissions[RoleHeadTA]; got != "pull" {
+		t.Errorf("StaffTeamRepoPermissions[hta] = %q, want %q", got, "pull")
+	}
 	if got := StaffTeamRepoPermissions[RoleTA]; got != "pull" {
 		t.Errorf("StaffTeamRepoPermissions[ta] = %q, want %q", got, "pull")
 	}
 	if _, ok := StaffTeamRepoPermissions[RoleTeacher]; ok {
-		t.Error("teacher must NOT be in StaffTeamRepoPermissions — the collector grants it nothing")
+		t.Error("teacher must NOT be in StaffTeamRepoPermissions — owners get repo access via ownership")
 	}
 	if _, ok := StaffTeamRepoPermissions[RoleInstructor]; ok {
 		t.Error("instructor must NOT be in StaffTeamRepoPermissions — the collector grants it nothing")

--- a/cli/gh-teacher/internal/configrepo/team_test.go
+++ b/cli/gh-teacher/internal/configrepo/team_test.go
@@ -41,3 +41,34 @@ func TestCanonicalTeamSlugShortName(t *testing.T) {
 		}
 	}
 }
+
+// TestRefForRole covers the role->ref mapping the eager grant loops rely on:
+// the legacy instructor alias resolves to the teacher ref, each canonical role
+// returns its own ref, an unknown role returns nil, and a nil receiver is safe.
+func TestRefForRole(t *testing.T) {
+	teacher := &TeamRef{ID: 1, Slug: "classroom50-cs50-teacher"}
+	hta := &TeamRef{ID: 2, Slug: "classroom50-cs50-hta"}
+	ta := &TeamRef{ID: 3, Slug: "classroom50-cs50-ta"}
+	refs := &StaffTeamsRef{Teacher: teacher, HeadTA: hta, TA: ta}
+
+	cases := []struct {
+		name string
+		refs *StaffTeamsRef
+		role StaffRole
+		want *TeamRef
+	}{
+		{"teacher", refs, RoleTeacher, teacher},
+		{"instructor alias -> teacher", refs, RoleInstructor, teacher},
+		{"hta", refs, RoleHeadTA, hta},
+		{"ta", refs, RoleTA, ta},
+		{"unknown role -> nil", refs, StaffRole("bogus"), nil},
+		{"nil receiver -> nil", nil, RoleTeacher, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.refs.RefForRole(tc.role); got != tc.want {
+				t.Errorf("RefForRole(%q) = %v, want %v", tc.role, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -73,12 +73,12 @@ SUBMIT_TAG_PREFIX = "submit/"
 
 # Repo permission the grant gives each staff role's team. Hand-mirrored from Go
 # StaffTeamRepoPermissions (source of truth; parity-tested) — keep in lockstep.
-# The TA-team template read is granted eagerly at assignment add/reuse and
-# classroom migrate (Go side, which hardcodes read there); this collect-time
+# The head-TA/TA-team template read is granted eagerly at assignment add/reuse
+# and classroom migrate (Go side, which hardcodes read there); this collect-time
 # grant reads the value below and is the idempotent re-affirm. A role absent
-# here gets nothing (the teacher team is granted at classroom setup, so only
-# TA needs a grant today).
-STAFF_TEAM_PERMISSIONS = {"ta": "pull"}
+# here gets nothing (the teacher team is an org owner with access via ownership,
+# so only the non-owner staff teams — head-TA and TA — need a grant).
+STAFF_TEAM_PERMISSIONS = {"hta": "pull", "ta": "pull"}
 
 RFC3339_RE = re.compile(
     r"^\d{4}-\d{2}-\d{2}T([01]\d|2[0-3]):[0-5]\d:[0-5]\d"

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -2296,6 +2296,11 @@ class TestStaffTeamPermissions:
     def test_ta_maps_to_pull(self):
         assert cs.STAFF_TEAM_PERMISSIONS["ta"] == "pull"
 
+    def test_hta_maps_to_pull(self):
+        # The head-TA team, like the TA team, is a non-owner staff team that needs
+        # explicit read on private in-org templates/student repos.
+        assert cs.STAFF_TEAM_PERMISSIONS["hta"] == "pull"
+
     def test_instructor_not_granted_at_collect_time(self):
         # The instructor team gets its access at classroom setup; the collector
         # must not grant it (parity with Go StaffTeamRepoPermissions).

--- a/cli/shared/ghutil/ghutil.go
+++ b/cli/shared/ghutil/ghutil.go
@@ -96,8 +96,15 @@ func IsRateLimited(err error) bool {
 		httpErr.StatusCode != http.StatusTooManyRequests {
 		return false
 	}
-	return httpErr.Headers.Get("Retry-After") != "" ||
-		httpErr.Headers.Get("X-RateLimit-Remaining") == "0"
+	if httpErr.Headers.Get("Retry-After") != "" ||
+		httpErr.Headers.Get("X-RateLimit-Remaining") == "0" {
+		return true
+	}
+	// Secondary limits may omit both headers while keeping remaining non-zero;
+	// the only signal is then the body message (go-gh maps it to Message).
+	msg := strings.ToLower(httpErr.Message)
+	return strings.Contains(msg, "secondary rate limit") ||
+		strings.Contains(msg, "abuse")
 }
 
 // BackoffDelay is the exponential backoff for optimistic-retry loops:

--- a/cli/shared/ghutil/ghutil.go
+++ b/cli/shared/ghutil/ghutil.go
@@ -80,6 +80,26 @@ func IsHTTPNotFound(err error) bool {
 	return IsHTTPStatus(err, http.StatusNotFound)
 }
 
+// IsRateLimited reports whether err is a GitHub rate-limit / secondary-limit
+// (abuse) response rather than a genuine permission denial. GitHub signals these
+// with a `Retry-After` header (secondary limit / 429) or `x-ratelimit-remaining:
+// 0` (primary limit), and they surface as 403 or 429 — indistinguishable from a
+// real authz 403 by status code alone. Callers that treat a plain 403 as benign
+// (e.g. "an owner must grant this") must exclude this case so a transient
+// throttle stays a loud, non-zero-exit failure instead of silent guidance.
+func IsRateLimited(err error) bool {
+	httpErr, ok := errors.AsType[*api.HTTPError](err)
+	if !ok {
+		return false
+	}
+	if httpErr.StatusCode != http.StatusForbidden &&
+		httpErr.StatusCode != http.StatusTooManyRequests {
+		return false
+	}
+	return httpErr.Headers.Get("Retry-After") != "" ||
+		httpErr.Headers.Get("X-RateLimit-Remaining") == "0"
+}
+
 // BackoffDelay is the exponential backoff for optimistic-retry loops:
 // 200ms * 2^attempt (attempt is 0-based), i.e. 200ms, 400ms, 800ms, ...
 // Callers gate it (skip the sleep after the final attempt).

--- a/cli/shared/ghutil/ghutil_test.go
+++ b/cli/shared/ghutil/ghutil_test.go
@@ -271,3 +271,38 @@ func TestResolveSettledDefaultBranch(t *testing.T) {
 		}
 	})
 }
+
+// TestIsRateLimited pins the fatal-vs-benign 403 split callers rely on: a plain
+// authz 403 is benign (false), but every rate-limit shape stays fatal (true),
+// including the header-less secondary limit whose only signal is the body
+// message. A miss here silently drops an owner-only grant (see reuse.go).
+func TestIsRateLimited(t *testing.T) {
+	httpErr := func(code int, headers map[string]string, msg string) error {
+		h := http.Header{}
+		for k, v := range headers {
+			h.Set(k, v)
+		}
+		return &api.HTTPError{StatusCode: code, Headers: h, Message: msg}
+	}
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"plain authz 403", httpErr(http.StatusForbidden, nil, "Must have admin rights"), false},
+		{"403 + Retry-After", httpErr(http.StatusForbidden, map[string]string{"Retry-After": "60"}, ""), true},
+		{"403 + x-ratelimit-remaining 0", httpErr(http.StatusForbidden, map[string]string{"X-RateLimit-Remaining": "0"}, ""), true},
+		{"429 + Retry-After", httpErr(http.StatusTooManyRequests, map[string]string{"Retry-After": "60"}, ""), true},
+		{"header-less secondary limit (message only)", httpErr(http.StatusForbidden, nil, "You have exceeded a secondary rate limit"), true},
+		{"legacy abuse-detection message", httpErr(http.StatusForbidden, nil, "You have triggered an abuse detection mechanism"), true},
+		{"404", httpErr(http.StatusNotFound, nil, ""), false},
+		{"non-HTTPError", io.EOF, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsRateLimited(tc.err); got != tc.want {
+				t.Errorf("IsRateLimited(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/web/src/authz/capabilities.test.ts
+++ b/web/src/authz/capabilities.test.ts
@@ -15,6 +15,7 @@ const orgRoles: GitHubOrgRole[] = [
 const classroomRoles: ResolvedRole[] = [
   "teacher",
   "instructor",
+  "hta",
   "ta",
   "student",
   "unresolved",
@@ -65,6 +66,23 @@ describe("can — classroom capabilities (fail-closed on unresolved)", () => {
     )
     // Off a classroom (no classroomRole) — denied.
     expect(can("viewClassroomStaffContent", {})).toBe(false)
+  })
+
+  it("authorAssignments: teacher|hta only (TA read-only, student/unresolved denied)", () => {
+    // Config-repo write tier: teacher (+ legacy instructor alias) and head-TA
+    // can author assignments.
+    expect(can("authorAssignments", { classroomRole: "teacher" })).toBe(true)
+    expect(can("authorAssignments", { classroomRole: "instructor" })).toBe(true)
+    expect(can("authorAssignments", { classroomRole: "hta" })).toBe(true)
+    // A plain TA is read-only on the config repo — denied.
+    expect(can("authorAssignments", { classroomRole: "ta" })).toBe(false)
+    expect(can("authorAssignments", { classroomRole: "student" })).toBe(false)
+    // Fail-closed on the in-flight sentinel.
+    expect(can("authorAssignments", { classroomRole: "unresolved" })).toBe(
+      false,
+    )
+    // Off a classroom (no classroomRole) — denied.
+    expect(can("authorAssignments", {})).toBe(false)
   })
 
   it("editClassroomSettings: teacher only (TA, student, unresolved all denied)", () => {
@@ -157,6 +175,7 @@ describe("deny-by-default coverage across the whole matrix", () => {
     "manageOrg",
     "viewOrgStaffContent",
     "viewClassroomStaffContent",
+    "authorAssignments",
     "editClassroomSettings",
     "previewAsRole",
     "claimTeacher",

--- a/web/src/authz/capabilities.test.ts
+++ b/web/src/authz/capabilities.test.ts
@@ -69,12 +69,9 @@ describe("can — classroom capabilities (fail-closed on unresolved)", () => {
   })
 
   it("authorAssignments: teacher|hta only (TA read-only, student/unresolved denied)", () => {
-    // Config-repo write tier: teacher (+ legacy instructor alias) and head-TA
-    // can author assignments.
     expect(can("authorAssignments", { classroomRole: "teacher" })).toBe(true)
     expect(can("authorAssignments", { classroomRole: "instructor" })).toBe(true)
     expect(can("authorAssignments", { classroomRole: "hta" })).toBe(true)
-    // A plain TA is read-only on the config repo — denied.
     expect(can("authorAssignments", { classroomRole: "ta" })).toBe(false)
     expect(can("authorAssignments", { classroomRole: "student" })).toBe(false)
     // Fail-closed on the in-flight sentinel.

--- a/web/src/authz/capabilities.ts
+++ b/web/src/authz/capabilities.ts
@@ -13,6 +13,7 @@ export type Capability =
   | "viewOrgStaffContent"
   // Classroom-scoped.
   | "viewClassroomStaffContent" // roster / authoring / submissions (teacher|hta|ta)
+  | "authorAssignments" // config-repo assignment writes (teacher|hta); needs no owner call
   | "editClassroomSettings" // teacher only
   | "previewAsRole" // the "view as" offer — teacher only
   | "claimTeacher" // org owner who currently resolves to student here
@@ -47,6 +48,12 @@ export function can(cap: Capability, input: CapabilityInput): boolean {
         classroomRole === "hta" ||
         classroomRole === "ta"
       )
+    case "authorAssignments":
+      // Config-repo write tier: teacher (+ legacy instructor) and head-TA can
+      // author assignments; a plain TA is read-only (config-repo `pull`), so a
+      // TA save would 403 at GitHub. The template read-grant is owner-only and
+      // gated separately on `manageOrg` (see the module doc / plan KTD-4).
+      return isTeacherRole(classroomRole) || classroomRole === "hta"
     case "editClassroomSettings":
       return isTeacherRole(classroomRole)
     case "previewAsRole":

--- a/web/src/components/RequireRole.test.tsx
+++ b/web/src/components/RequireRole.test.tsx
@@ -161,6 +161,54 @@ describe("RequireRole — teacher gate on a classroom", () => {
   })
 })
 
+describe("RequireRole — author gate on a classroom", () => {
+  it("a teacher can author", () => {
+    paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
+    classroomCtxMock.mockReturnValue(ctx({ role: "teacher" }))
+    render(<RequireRole allow="author">{child}</RequireRole>)
+    expect(shown()).toBe("child")
+  })
+
+  it("a head TA can author", () => {
+    paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
+    classroomCtxMock.mockReturnValue(ctx({ role: "hta" }))
+    render(<RequireRole allow="author">{child}</RequireRole>)
+    expect(shown()).toBe("child")
+  })
+
+  it("a plain TA is 404'd from authoring (read-only tier)", () => {
+    paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
+    classroomCtxMock.mockReturnValue(ctx({ role: "ta" }))
+    render(<RequireRole allow="author">{child}</RequireRole>)
+    expect(shown()).toBe("notfound")
+  })
+
+  it("a student is 404'd from authoring", () => {
+    paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
+    classroomCtxMock.mockReturnValue(ctx({ role: "student" }))
+    render(<RequireRole allow="author">{child}</RequireRole>)
+    expect(shown()).toBe("notfound")
+  })
+
+  it("holds the spinner while the classroom role is unresolved", () => {
+    paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
+    classroomCtxMock.mockReturnValue(
+      ctx({ role: "unresolved", roleResolved: false }),
+    )
+    render(<RequireRole allow="author">{child}</RequireRole>)
+    expect(shown()).toBe("spinner")
+  })
+
+  it("shows a retryable error when the role read settles in error", () => {
+    paramsMock.mockReturnValue({ org: "acme", classroom: "cs101" })
+    classroomCtxMock.mockReturnValue(
+      ctx({ role: "unresolved", roleResolved: false, isError: true }),
+    )
+    render(<RequireRole allow="author">{child}</RequireRole>)
+    expect(shown()).toBe("error")
+  })
+})
+
 describe("RequireRole — owner gate on org-level routes", () => {
   it("an org owner reaches org-wide settings", () => {
     paramsMock.mockReturnValue({ org: "acme" })

--- a/web/src/components/RequireRole.tsx
+++ b/web/src/components/RequireRole.tsx
@@ -10,7 +10,7 @@ import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 import { QueryErrorAlert } from "@/components/QueryErrorAlert"
 
 // What a guarded surface requires:
-// - "staff": any classroom staff (teacher/ta) — for classroom CONTENT
+// - "staff": any classroom staff (teacher/hta/ta) — for classroom CONTENT
 //   (roster, authoring, submissions). On an org-level surface (no $classroom,
 //   e.g. Published) this is the org-scoped team-based "staff of any classroom"
 //   signal (useOrgStaff); on a classroom surface it reads the shared context.

--- a/web/src/components/RequireRole.tsx
+++ b/web/src/components/RequireRole.tsx
@@ -14,11 +14,14 @@ import { QueryErrorAlert } from "@/components/QueryErrorAlert"
 //   (roster, authoring, submissions). On an org-level surface (no $classroom,
 //   e.g. Published) this is the org-scoped team-based "staff of any classroom"
 //   signal (useOrgStaff); on a classroom surface it reads the shared context.
+// - "author": can author assignments in THIS classroom (teacher|hta) — the
+//   config-repo write tier. A plain TA sees staff content but can't mutate, so
+//   this excludes ta (and student). Reads the classroom context.
 // - "teacher": teacher of THIS classroom (excludes TAs) — for classroom
 //   SETTINGS. Reads the classroom context. Needs a $classroom route.
 // - "owner": org admin only — for ORG-wide settings/setup. Reads the org-role
 //   context. Independent of any classroom team (KTD-4).
-export type RoleRequirement = "staff" | "teacher" | "owner"
+export type RoleRequirement = "staff" | "author" | "teacher" | "owner"
 
 // Gate page content by role. While the role resolves we show a spinner (never
 // flash a 404 at a real staffer), then children or NotFound. Access is
@@ -33,6 +36,7 @@ const RequireRole = ({
 }) => {
   if (allow === "owner") return <RequireOwner>{children}</RequireOwner>
   if (allow === "teacher") return <RequireTeacher>{children}</RequireTeacher>
+  if (allow === "author") return <RequireAuthor>{children}</RequireAuthor>
   return <RequireStaff>{children}</RequireStaff>
 }
 
@@ -107,6 +111,26 @@ const RequireOrgStaff = ({ children }: { children: ReactNode }) => {
       })}
       errored={isError}
       onRetry={refetch}
+    >
+      {children}
+    </RoleGate>
+  )
+}
+
+// Author gate: can author assignments in this classroom (teacher|hta). A TA
+// sees staff content but can't mutate the config repo, so this is a tier above
+// `staff` and below `teacher` (which is settings-only). Gate on `roleResolved`
+// (the fine role short-circuits on the first confirmed elevation read).
+const RequireAuthor = ({ children }: { children: ReactNode }) => {
+  const { role, roleResolved, isError, retry } = useClassroomRoleContext()
+  return (
+    <RoleGate
+      resolved={roleResolved}
+      permitted={can("authorAssignments", {
+        classroomRole: role,
+      })}
+      errored={isError}
+      onRetry={retry}
     >
       {children}
     </RoleGate>

--- a/web/src/context/githubOrgRole/useIsOrgOwner.test.ts
+++ b/web/src/context/githubOrgRole/useIsOrgOwner.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/context/githubOrgRole/GitHubOrgRoleProvider", () => ({
   useGitHubOrgRole: () => orgRoleMock(),
 }))
 
-import { useIsOrgOwner } from "./useIsOrgOwner"
+import { useIsOrgOwner, useCanAttemptTemplateGrant } from "./useIsOrgOwner"
 
 const retry = vi.fn()
 
@@ -63,5 +63,44 @@ describe("useIsOrgOwner", () => {
     expect(r.isPending).toBe(false)
     expect(r.isError).toBe(true)
     expect(r.retry).toBe(retry)
+  })
+})
+
+const attemptWithOrgRole = (
+  value: Partial<{ githubOrgRole: string; isError: boolean }>,
+) => {
+  orgRoleMock.mockReturnValue({
+    githubOrgRole: "unresolved",
+    isError: false,
+    retry,
+    ...value,
+  })
+  return renderHook(() => useCanAttemptTemplateGrant()).result.current
+}
+
+describe("useCanAttemptTemplateGrant", () => {
+  it("owner => attempt the grant", () => {
+    expect(attemptWithOrgRole({ githubOrgRole: "owner" })).toBe(true)
+  })
+
+  // The fix for the org-role-pending race: a not-yet-confirmed role must NOT be
+  // treated as a confirmed non-owner, or a real owner mid-load skips the
+  // student-team grant and sees the misleading owner-required warning.
+  it("unresolved (in flight) => attempt (real owner mustn't be demoted)", () => {
+    expect(attemptWithOrgRole({ githubOrgRole: "unresolved" })).toBe(true)
+  })
+
+  it("unresolved + settled error => attempt (grant path fails soft, never throws)", () => {
+    expect(
+      attemptWithOrgRole({ githubOrgRole: "unresolved", isError: true }),
+    ).toBe(true)
+  })
+
+  it("confirmed member => do not attempt (owner-required warning is accurate)", () => {
+    expect(attemptWithOrgRole({ githubOrgRole: "member" })).toBe(false)
+  })
+
+  it("confirmed non-member => do not attempt", () => {
+    expect(attemptWithOrgRole({ githubOrgRole: "non-member" })).toBe(false)
   })
 })

--- a/web/src/context/githubOrgRole/useIsOrgOwner.ts
+++ b/web/src/context/githubOrgRole/useIsOrgOwner.ts
@@ -19,3 +19,20 @@ export function useIsOrgOwner(): {
     retry,
   }
 }
+
+// Whether an assignment write should ATTEMPT the owner-only template read-grant.
+// Distinct from `isOwner`: a not-yet-confirmed org role (in flight, or settled in
+// a transient error) must NOT be treated as a confirmed non-owner, or a real
+// owner deep-linking into the form before the org read settles skips the
+// student-team grant and gets the misleading owner-required warning — students
+// then 404 on accept. Attempt the grant unless the role is a CONFIRMED non-owner
+// (member/non-member): the grant path never throws, so a non-owner's optimistic
+// attempt fails soft into the same actionable warning, while a real owner's
+// succeeds. The owner-required warning is reserved for the confirmed-non-owner
+// case, where it is accurate.
+export function useCanAttemptTemplateGrant(): boolean {
+  const { githubOrgRole } = useGitHubOrgRole()
+  const confirmedNonOwner =
+    githubOrgRole === "member" || githubOrgRole === "non-member"
+  return !confirmedNonOwner
+}

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -990,10 +990,12 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     ])
   })
 
-  it("skips the owner-only grant for a non-owner author (canGrantTemplateAccess absent)", async () => {
+  it("warns (not silently) when a non-owner author skips the owner-only grant", async () => {
     // A head-TA edit carries a stored in-org private template but no owner
     // rights; the write path must not attempt addRepositoryToTeam (it would
-    // 403). The edit still succeeds with no warning.
+    // 403). The edit succeeds, no grant fires — but it must NOT silently return
+    // undefined, or students 404 on accept with no signal. Surface an
+    // owner-required warning instead so a teacher/owner can grant it.
     const { client, grants } = makeGrantClient({
       classroomJson: {
         schema: "classroom50/classroom/v1",
@@ -1012,8 +1014,10 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
       nonOwner as unknown as Parameters<typeof editAssignment>[1],
     )
 
-    expect(result.templateGrantWarning).toBeUndefined()
+    // No owner-only grant fired, but the author is told an owner must act.
     expect(grants()).toEqual([])
+    expect(result.templateGrantWarning).toBeDefined()
+    expect(result.templateGrantWarning).toContain("organization owner")
   })
 
   it("grants only the student team when no staff teams are recorded", async () => {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -961,6 +961,9 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
       mode: "individual",
       max_group_size: 0,
       tests: [],
+      // These tests exercise the owner-only template read-grant, which the
+      // write path now performs only when the caller holds manageOrg.
+      canGrantTemplateAccess: true,
     } as unknown as Parameters<typeof editAssignment>[1]
   }
 
@@ -978,6 +981,30 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
 
     expect(result.templateGrantWarning).toBeUndefined()
     expect(grants()).toEqual(["classroom50-cs50", "classroom50-cs50-ta"])
+  })
+
+  it("skips the owner-only grant for a non-owner author (canGrantTemplateAccess absent)", async () => {
+    // A head-TA edit carries a stored in-org private template but no owner
+    // rights; the write path must not attempt addRepositoryToTeam (it would
+    // 403). The edit still succeeds with no warning.
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+      },
+    })
+
+    const { canGrantTemplateAccess: _omit, ...nonOwner } =
+      editInput() as Record<string, unknown>
+    const result = await editAssignment(
+      client,
+      nonOwner as unknown as Parameters<typeof editAssignment>[1],
+    )
+
+    expect(result.templateGrantWarning).toBeUndefined()
+    expect(grants()).toEqual([])
   })
 
   it("grants only the student team when no TA team is recorded", async () => {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -967,20 +967,27 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     } as unknown as Parameters<typeof editAssignment>[1]
   }
 
-  it("grants both the student team and the TA staff team on a private in-org template", async () => {
+  it("grants the student team plus the HTA and TA staff teams on a private in-org template", async () => {
     const { client, grants } = makeGrantClient({
       classroomJson: {
         schema: "classroom50/classroom/v1",
         short_name: CLASSROOM,
         team: { id: 7, slug: "classroom50-cs50" },
-        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+        teams: {
+          hta: { id: 8, slug: "classroom50-cs50-hta" },
+          ta: { id: 9, slug: "classroom50-cs50-ta" },
+        },
       },
     })
 
     const result = await editAssignment(client, editInput())
 
     expect(result.templateGrantWarning).toBeUndefined()
-    expect(grants()).toEqual(["classroom50-cs50", "classroom50-cs50-ta"])
+    expect(grants()).toEqual([
+      "classroom50-cs50",
+      "classroom50-cs50-hta",
+      "classroom50-cs50-ta",
+    ])
   })
 
   it("skips the owner-only grant for a non-owner author (canGrantTemplateAccess absent)", async () => {
@@ -1009,7 +1016,7 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     expect(grants()).toEqual([])
   })
 
-  it("grants only the student team when no TA team is recorded", async () => {
+  it("grants only the student team when no staff teams are recorded", async () => {
     const { client, grants } = makeGrantClient({
       classroomJson: {
         schema: "classroom50/classroom/v1",
@@ -1024,22 +1031,26 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     expect(grants()).toEqual(["classroom50-cs50"])
   })
 
-  it("keeps the edit successful when the TA grant fails (non-blocking)", async () => {
+  it("keeps the edit successful when a staff grant fails (non-blocking)", async () => {
     const { client, grants } = makeGrantClient({
       classroomJson: {
         schema: "classroom50/classroom/v1",
         short_name: CLASSROOM,
         team: { id: 7, slug: "classroom50-cs50" },
-        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+        teams: {
+          hta: { id: 8, slug: "classroom50-cs50-hta" },
+          ta: { id: 9, slug: "classroom50-cs50-ta" },
+        },
       },
       taGrantThrows: true,
     })
 
     const result = await editAssignment(client, editInput())
 
-    // Student grant landed; TA failure did not surface as a save warning.
+    // Student + HTA grants landed; the TA failure did not surface as a save
+    // warning and did not abort the loop.
     expect(result.templateGrantWarning).toBeUndefined()
-    expect(grants()).toEqual(["classroom50-cs50"])
+    expect(grants()).toEqual(["classroom50-cs50", "classroom50-cs50-hta"])
   })
 
   it("re-affirms the grant on an UNCHANGED in-org private template ref", async () => {
@@ -1048,16 +1059,23 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
         schema: "classroom50/classroom/v1",
         short_name: CLASSROOM,
         team: { id: 7, slug: "classroom50-cs50" },
-        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+        teams: {
+          hta: { id: 8, slug: "classroom50-cs50-hta" },
+          ta: { id: 9, slug: "classroom50-cs50-ta" },
+        },
       },
     })
 
     // Same owner/repo/branch as the stored template (tmpl) — the unchanged-ref
-    // branch. It must still re-affirm both teams so a dropped grant is repaired.
+    // branch. It must still re-affirm every team so a dropped grant is repaired.
     const result = await editAssignment(client, editInput("tmpl"))
 
     expect(result.templateGrantWarning).toBeUndefined()
-    expect(grants()).toEqual(["classroom50-cs50", "classroom50-cs50-ta"])
+    expect(grants()).toEqual([
+      "classroom50-cs50",
+      "classroom50-cs50-hta",
+      "classroom50-cs50-ta",
+    ])
   })
 
   it("does not grant on an unchanged PUBLIC template ref", async () => {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1098,6 +1098,73 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     expect(result.templateGrantWarning).toBeUndefined()
     expect(grants()).toEqual([])
   })
+
+  // Reuse path (copyAssignmentToClassroom) shares the same canGrantTemplateAccess
+  // guard as create/edit; exercise both the owner (grants fire) and non-owner
+  // (grants skipped, owner-required warning) branches through the grant client.
+  function reuseSource(): Assignment {
+    return {
+      slug: "hw1",
+      name: "Homework 1",
+      mode: "individual",
+      autograder: "default",
+      feedback_pr: true,
+      // In-org private template (served by makeGrantClient's `tmpl` route).
+      template: { owner: ORG, repo: "tmpl", branch: "main" },
+    }
+  }
+
+  it("reuse: owner grants student + HTA + TA teams on a private in-org template", async () => {
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+        teams: {
+          hta: { id: 8, slug: "classroom50-cs50-hta" },
+          ta: { id: 9, slug: "classroom50-cs50-ta" },
+        },
+      },
+    })
+
+    const result = await copyAssignmentToClassroom(client, {
+      org: ORG,
+      source: reuseSource(),
+      targetClassroom: CLASSROOM,
+      targetSlug: "hw1-copy",
+      canGrantTemplateAccess: true,
+    })
+
+    expect(result.templateGrantWarning).toBeUndefined()
+    expect(grants()).toEqual([
+      "classroom50-cs50",
+      "classroom50-cs50-hta",
+      "classroom50-cs50-ta",
+    ])
+  })
+
+  it("reuse: non-owner author warns (no grant) instead of silently skipping", async () => {
+    const { client, grants } = makeGrantClient({
+      classroomJson: {
+        schema: "classroom50/classroom/v1",
+        short_name: CLASSROOM,
+        team: { id: 7, slug: "classroom50-cs50" },
+        teams: { ta: { id: 9, slug: "classroom50-cs50-ta" } },
+      },
+    })
+
+    const result = await copyAssignmentToClassroom(client, {
+      org: ORG,
+      source: reuseSource(),
+      targetClassroom: CLASSROOM,
+      targetSlug: "hw1-copy",
+      // canGrantTemplateAccess omitted => non-owner (fail-closed).
+    })
+
+    expect(grants()).toEqual([])
+    expect(result.templateGrantWarning).toBeDefined()
+    expect(result.templateGrantWarning).toContain("organization owner")
+  })
 })
 
 describe("copyAssignmentToClassroom (reuse fork guard)", () => {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
+import { readFileSync } from "node:fs"
+import path from "node:path"
 
 import {
   addFounderCollaborator,
@@ -13,6 +15,8 @@ import {
   preserveUnmanagedAssignmentKeys,
   resolveAutograderWorkflow,
   resolveTemplate,
+  resolveTemplateGrant,
+  TEMPLATE_READ_STAFF_ROLES,
   verifyTemplateAccess,
 } from "./assignments"
 import type { GitHubClient } from "@/github-core/client"
@@ -848,7 +852,7 @@ describe("editAssignment (preserved-entry integration)", () => {
   })
 })
 
-describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
+describe("grantTeamTemplateRead (student + HTA/TA staff team eager grant)", () => {
   const ORG = "cs50"
   const CLASSROOM = "cs50"
   const SLUG = "hw1"
@@ -1164,6 +1168,142 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
     expect(grants()).toEqual([])
     expect(result.templateGrantWarning).toBeDefined()
     expect(result.templateGrantWarning).toContain("organization owner")
+  })
+
+  // resolveTemplateGrant is the single grant-decision recipe shared verbatim by
+  // createAssignment, editAssignment, and copyAssignmentToClassroom. Testing it
+  // directly covers the create entry point's owner/non-owner branch (create
+  // builds a full form input the grant-suite mock above doesn't model) without
+  // duplicating the whole create write path. Nested here to reuse makeGrantClient
+  // and the ORG/CLASSROOM fixtures the mock hardcodes.
+  describe("resolveTemplateGrant (shared create/edit/reuse grant decision)", () => {
+    const template = { owner: ORG, repo: "tmpl", branch: "main" }
+
+    it("owner (canGrant true) attempts the grant: student + HTA + TA", async () => {
+      const { client, grants } = makeGrantClient({
+        classroomJson: {
+          schema: "classroom50/classroom/v1",
+          short_name: CLASSROOM,
+          team: { id: 7, slug: "classroom50-cs50" },
+          teams: {
+            hta: { id: 8, slug: "classroom50-cs50-hta" },
+            ta: { id: 9, slug: "classroom50-cs50-ta" },
+          },
+        },
+      })
+
+      const warning = await resolveTemplateGrant(
+        client,
+        ORG,
+        CLASSROOM,
+        "hw1",
+        template,
+        true,
+      )
+
+      expect(warning).toBeUndefined()
+      expect(grants()).toEqual([
+        "classroom50-cs50",
+        "classroom50-cs50-hta",
+        "classroom50-cs50-ta",
+      ])
+    })
+
+    it("confirmed non-owner (canGrant false) warns and fires no grant", async () => {
+      const { client, grants } = makeGrantClient({
+        classroomJson: {
+          schema: "classroom50/classroom/v1",
+          short_name: CLASSROOM,
+          team: { id: 7, slug: "classroom50-cs50" },
+        },
+      })
+
+      const warning = await resolveTemplateGrant(
+        client,
+        ORG,
+        CLASSROOM,
+        "hw1",
+        template,
+        false,
+      )
+
+      expect(grants()).toEqual([])
+      expect(warning).toBeDefined()
+      expect(warning).toContain("organization owner")
+    })
+
+    it("undefined flag is treated as non-owner (fail-closed): warns, no grant", async () => {
+      const { client, grants } = makeGrantClient({
+        classroomJson: {
+          schema: "classroom50/classroom/v1",
+          short_name: CLASSROOM,
+          team: { id: 7, slug: "classroom50-cs50" },
+        },
+      })
+
+      const warning = await resolveTemplateGrant(
+        client,
+        ORG,
+        CLASSROOM,
+        "hw1",
+        template,
+        undefined,
+      )
+
+      expect(grants()).toEqual([])
+      expect(warning).toContain("organization owner")
+    })
+  })
+})
+
+// The TS non-owner staff-team read set is a hand-mirror of the Go source of
+// truth (configrepo.TemplateReadStaffRoles). Parse the Go literal and assert the
+// two agree, so adding a role on the Go side without updating the TS grant fails
+// here — a visible, required edit rather than a silent drop from the web grant.
+describe("TEMPLATE_READ_STAFF_ROLES parity with Go TemplateReadStaffRoles", () => {
+  // Go role-constant -> wire string (configrepo team.go: RoleHeadTA="hta", etc.).
+  const GO_ROLE_VALUES: Record<string, string> = {
+    RoleTeacher: "teacher",
+    RoleInstructor: "instructor",
+    RoleHeadTA: "hta",
+    RoleTA: "ta",
+  }
+
+  it("matches the Go non-owner staff role set", () => {
+    // web/ is process.cwd() in vitest; the Go source is a sibling under cli/.
+    const teamGo = readFileSync(
+      path.join(
+        process.cwd(),
+        "..",
+        "cli",
+        "gh-teacher",
+        "internal",
+        "configrepo",
+        "team.go",
+      ),
+      "utf8",
+    )
+    const match = teamGo.match(
+      /var TemplateReadStaffRoles = \[\]StaffRole\{([^}]*)\}/,
+    )
+    expect(
+      match,
+      "TemplateReadStaffRoles literal not found in team.go",
+    ).toBeTruthy()
+    const goRoles = match![1]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((constName) => {
+        const value = GO_ROLE_VALUES[constName]
+        expect(
+          value,
+          `unknown Go StaffRole constant ${constName}; add it to GO_ROLE_VALUES`,
+        ).toBeTruthy()
+        return value
+      })
+
+    expect([...TEMPLATE_READ_STAFF_ROLES]).toEqual(goRoles)
   })
 })
 

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -996,8 +996,10 @@ describe("grantTeamTemplateRead (TA staff team eager grant)", () => {
       },
     })
 
-    const { canGrantTemplateAccess: _omit, ...nonOwner } =
-      editInput() as Record<string, unknown>
+    // A non-owner input simply omits canGrantTemplateAccess (the mutation hook
+    // sets it from can("manageOrg")); build one without the flag.
+    const nonOwner = editInput("tmpl-v2") as Record<string, unknown>
+    delete nonOwner.canGrantTemplateAccess
     const result = await editAssignment(
       client,
       nonOwner as unknown as Parameters<typeof editAssignment>[1],

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -19,6 +19,8 @@ export {
   editAssignmentWithConflictRetry,
   preserveUnmanagedAssignmentKeys,
   tryGrantTeamTemplateRead,
+  resolveTemplateGrant,
+  TEMPLATE_READ_STAFF_ROLES,
   type CreateAssignmentResult,
 } from "./assignments/createEdit"
 export {

--- a/web/src/domain/assignments/copyReuse.ts
+++ b/web/src/domain/assignments/copyReuse.ts
@@ -38,6 +38,10 @@ export type CopyAssignmentInput = {
   // Default to the source slug/name; the slug must be unique in the target.
   targetSlug?: string
   targetName?: string
+  // Whether the acting user may perform the owner-only template read-grant
+  // (addRepositoryToTeam). Set from can("manageOrg") at the call site;
+  // fail-closed when absent so a non-owner reuse skips the owner-only grant.
+  canGrantTemplateAccess?: boolean
 }
 
 // First slug not in `taken`, suffixing `-2`, `-3`, … A base ending in `-<n>`
@@ -238,7 +242,7 @@ export async function copyAssignmentToClassroom(
   const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
 
   let templateGrantWarning: string | undefined
-  if (needsTeamGrant && entry.template) {
+  if (input.canGrantTemplateAccess && needsTeamGrant && entry.template) {
     templateGrantWarning = await tryGrantTeamTemplateRead(
       client,
       org,

--- a/web/src/domain/assignments/copyReuse.ts
+++ b/web/src/domain/assignments/copyReuse.ts
@@ -24,6 +24,7 @@ import {
 } from "./accessPrimitives"
 import {
   tryGrantTeamTemplateRead,
+  templateGrantOwnerRequiredWarning,
   type CreateAssignmentResult,
 } from "./createEdit"
 
@@ -242,14 +243,20 @@ export async function copyAssignmentToClassroom(
   const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
 
   let templateGrantWarning: string | undefined
-  if (input.canGrantTemplateAccess && needsTeamGrant && entry.template) {
-    templateGrantWarning = await tryGrantTeamTemplateRead(
-      client,
-      org,
-      targetClassroom,
-      entry.slug,
-      entry.template,
-    )
+  if (needsTeamGrant && entry.template) {
+    templateGrantWarning = input.canGrantTemplateAccess
+      ? await tryGrantTeamTemplateRead(
+          client,
+          org,
+          targetClassroom,
+          entry.slug,
+          entry.template,
+        )
+      : templateGrantOwnerRequiredWarning(
+          targetClassroom,
+          entry.slug,
+          entry.template,
+        )
   }
 
   return {

--- a/web/src/domain/assignments/copyReuse.ts
+++ b/web/src/domain/assignments/copyReuse.ts
@@ -22,11 +22,7 @@ import {
   classifyPrivateFork,
   crossOrgPrivateForkError,
 } from "./accessPrimitives"
-import {
-  tryGrantTeamTemplateRead,
-  templateGrantOwnerRequiredWarning,
-  type CreateAssignmentResult,
-} from "./createEdit"
+import { resolveTemplateGrant, type CreateAssignmentResult } from "./createEdit"
 
 export type CopyAssignmentInput = {
   org: string
@@ -244,19 +240,14 @@ export async function copyAssignmentToClassroom(
 
   let templateGrantWarning: string | undefined
   if (needsTeamGrant && entry.template) {
-    templateGrantWarning = input.canGrantTemplateAccess
-      ? await tryGrantTeamTemplateRead(
-          client,
-          org,
-          targetClassroom,
-          entry.slug,
-          entry.template,
-        )
-      : templateGrantOwnerRequiredWarning(
-          targetClassroom,
-          entry.slug,
-          entry.template,
-        )
+    templateGrantWarning = await resolveTemplateGrant(
+      client,
+      org,
+      targetClassroom,
+      entry.slug,
+      entry.template,
+      input.canGrantTemplateAccess,
+    )
   }
 
   return {

--- a/web/src/domain/assignments/copyReuse.ts
+++ b/web/src/domain/assignments/copyReuse.ts
@@ -35,9 +35,7 @@ export type CopyAssignmentInput = {
   // Default to the source slug/name; the slug must be unique in the target.
   targetSlug?: string
   targetName?: string
-  // Whether the acting user may perform the owner-only template read-grant
-  // (addRepositoryToTeam). Set from can("manageOrg") at the call site;
-  // fail-closed when absent so a non-owner reuse skips the owner-only grant.
+  // See CreateAssignmentInput.canGrantTemplateAccess — same owner-only grant gate.
   canGrantTemplateAccess?: boolean
 }
 

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -242,19 +242,14 @@ export async function editAssignment(
   // rather than silently skipping (which would 404 students on accept).
   let templateGrantWarning: string | undefined
   if (needsTeamGrant && preservedEntry.template) {
-    templateGrantWarning = input.canGrantTemplateAccess
-      ? await tryGrantTeamTemplateRead(
-          client,
-          input.org,
-          input.classroom,
-          input.slug,
-          preservedEntry.template,
-        )
-      : templateGrantOwnerRequiredWarning(
-          input.classroom,
-          input.slug,
-          preservedEntry.template,
-        )
+    templateGrantWarning = await resolveTemplateGrant(
+      client,
+      input.org,
+      input.classroom,
+      input.slug,
+      preservedEntry.template,
+      input.canGrantTemplateAccess,
+    )
   }
 
   return {
@@ -552,6 +547,15 @@ async function buildAssignmentEntry(
   return { entry, needsTeamGrant }
 }
 
+// The NON-OWNER staff roles that get an eager read grant on a private in-org
+// template (head-TA, then TA). Single-sources the slug set below so the web
+// grant can't silently omit a role. Mirror of the Go source of truth
+// configrepo.TemplateReadStaffRoles ([RoleHeadTA, RoleTA]) — the two are
+// hand-synced; a parity test pins this list so a Go-side addition forces a
+// visible TS edit here rather than silently dropping from the web grant. The
+// teacher team is omitted (owners have repo access via ownership).
+export const TEMPLATE_READ_STAFF_ROLES = ["hta", "ta"] as const
+
 // Grant the classroom team read on an in-org private template so rostered
 // students can generate from it (mirrors the CLI's assignment add). The slug
 // comes from classroom.json (authoritative). A genuinely teamless classroom
@@ -575,10 +579,9 @@ async function grantTeamTemplateRead(
     // template repo without their team being granted, so grant both here. The
     // teacher team is intentionally omitted — its members are org owners with
     // repo access via ownership, so a team grant is redundant.
-    staffTeamSlugs = [
-      classroomJson.teams?.hta?.slug,
-      classroomJson.teams?.ta?.slug,
-    ].filter((s): s is string => Boolean(s))
+    staffTeamSlugs = TEMPLATE_READ_STAFF_ROLES.map(
+      (role) => classroomJson.teams?.[role]?.slug,
+    ).filter((s): s is string => Boolean(s))
   } catch (err) {
     // 404 = no classroom.json (pre-feature) is a genuine "no team"; fall
     // through. Anything else is transient and must not be misread as "no team".
@@ -682,6 +685,26 @@ export function templateGrantOwnerRequiredWarning(
   )
 }
 
+// The one grant-decision recipe shared by create / edit / reuse: attempt the
+// owner-only team read-grant when the caller may (canGrantTemplateAccess), else
+// return the owner-required warning instead of silently skipping — a silent skip
+// would 404 students on accept with no signal. Single-sourced so the three write
+// paths can't drift. `canGrantTemplateAccess` is set true unless the caller has
+// CONFIRMED the actor is a non-owner (see useCanAttemptTemplateGrant), so a real
+// owner mid-load still attempts (tryGrantTeamTemplateRead never throws).
+export async function resolveTemplateGrant(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  slug: string,
+  template: NonNullable<Assignment["template"]>,
+  canGrantTemplateAccess: boolean | undefined,
+): Promise<string | undefined> {
+  return canGrantTemplateAccess
+    ? tryGrantTeamTemplateRead(client, org, classroom, slug, template)
+    : templateGrantOwnerRequiredWarning(classroom, slug, template)
+}
+
 // Refuse a write into an archived classroom (active: false). The UI hides the
 // affordances, but the write path is the authoritative guard — a stale tab, a
 // direct API call, or a CLI/agent must not mutate an archived classroom. Reads
@@ -758,19 +781,14 @@ export async function createAssignment(
 
   let templateGrantWarning: string | undefined
   if (needsTeamGrant && assignmentBody.template) {
-    templateGrantWarning = input.canGrantTemplateAccess
-      ? await tryGrantTeamTemplateRead(
-          client,
-          input.org,
-          input.classroom,
-          input.slug,
-          assignmentBody.template,
-        )
-      : templateGrantOwnerRequiredWarning(
-          input.classroom,
-          input.slug,
-          assignmentBody.template,
-        )
+    templateGrantWarning = await resolveTemplateGrant(
+      client,
+      input.org,
+      input.classroom,
+      input.slug,
+      assignmentBody.template,
+      input.canGrantTemplateAccess,
+    )
   }
 
   return {

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -236,23 +236,25 @@ export async function editAssignment(
 
   // Grant the (possibly changed) in-org private template a team read — a
   // non-fatal warning, never thrown (the edit already committed). needsTeamGrant
-  // implies a resolved template, so the guard just narrows the type. Skip the
-  // grant for a non-owner (canGrantTemplateAccess false): addRepositoryToTeam is
-  // owner-only, so a head-TA edit that carries a stored template would otherwise
-  // 403 here even though it never touched the template field.
+  // implies a resolved template, so the guard just narrows the type.
+  // addRepositoryToTeam is org-owner-only, so a non-owner author (head-TA) can't
+  // perform it: attempt it for an owner, else surface an owner-required warning
+  // rather than silently skipping (which would 404 students on accept).
   let templateGrantWarning: string | undefined
-  if (
-    input.canGrantTemplateAccess &&
-    needsTeamGrant &&
-    preservedEntry.template
-  ) {
-    templateGrantWarning = await tryGrantTeamTemplateRead(
-      client,
-      input.org,
-      input.classroom,
-      input.slug,
-      preservedEntry.template,
-    )
+  if (needsTeamGrant && preservedEntry.template) {
+    templateGrantWarning = input.canGrantTemplateAccess
+      ? await tryGrantTeamTemplateRead(
+          client,
+          input.org,
+          input.classroom,
+          input.slug,
+          preservedEntry.template,
+        )
+      : templateGrantOwnerRequiredWarning(
+          input.classroom,
+          input.slug,
+          preservedEntry.template,
+        )
   }
 
   return {
@@ -659,6 +661,27 @@ export async function tryGrantTeamTemplateRead(
   }
 }
 
+// The warning shown when a NON-owner author (e.g. a head-TA) saves an
+// assignment whose private in-org template needs a classroom-team read grant.
+// The grant (addRepositoryToTeam) is org-owner-only at GitHub, so the author
+// can't perform it — but we must NOT return `undefined` (a silent "clean"
+// result) or students would hit a 404 on `gh student accept` with nothing
+// pointing at the cause. Surface an actionable warning instead: an org owner
+// grants the team read (or re-saves), then students can accept. Mirrors the
+// failure-path wording of tryGrantTeamTemplateRead.
+export function templateGrantOwnerRequiredWarning(
+  classroom: string,
+  slug: string,
+  template: NonNullable<Assignment["template"]>,
+): string {
+  return (
+    `Assignment "${slug}" was saved, but its private template ${template.owner}/${template.repo} ` +
+    `needs the ${classroomTeamSlug(classroom)} team granted read — a step only an organization owner can do. ` +
+    `Students can't accept it until an owner opens this classroom (which grants it automatically) or grants ` +
+    `the team read on ${template.owner}/${template.repo} directly in GitHub (Settings -> Collaborators and teams).`
+  )
+}
+
 // Refuse a write into an archived classroom (active: false). The UI hides the
 // affordances, but the write path is the authoritative guard — a stale tab, a
 // direct API call, or a CLI/agent must not mutate an archived classroom. Reads
@@ -734,18 +757,20 @@ export async function createAssignment(
   )
 
   let templateGrantWarning: string | undefined
-  if (
-    input.canGrantTemplateAccess &&
-    needsTeamGrant &&
-    assignmentBody.template
-  ) {
-    templateGrantWarning = await tryGrantTeamTemplateRead(
-      client,
-      input.org,
-      input.classroom,
-      input.slug,
-      assignmentBody.template,
-    )
+  if (needsTeamGrant && assignmentBody.template) {
+    templateGrantWarning = input.canGrantTemplateAccess
+      ? await tryGrantTeamTemplateRead(
+          client,
+          input.org,
+          input.classroom,
+          input.slug,
+          assignmentBody.template,
+        )
+      : templateGrantOwnerRequiredWarning(
+          input.classroom,
+          input.slug,
+          assignmentBody.template,
+        )
   }
 
   return {

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -236,9 +236,16 @@ export async function editAssignment(
 
   // Grant the (possibly changed) in-org private template a team read — a
   // non-fatal warning, never thrown (the edit already committed). needsTeamGrant
-  // implies a resolved template, so the guard just narrows the type.
+  // implies a resolved template, so the guard just narrows the type. Skip the
+  // grant for a non-owner (canGrantTemplateAccess false): addRepositoryToTeam is
+  // owner-only, so a head-TA edit that carries a stored template would otherwise
+  // 403 here even though it never touched the template field.
   let templateGrantWarning: string | undefined
-  if (needsTeamGrant && preservedEntry.template) {
+  if (
+    input.canGrantTemplateAccess &&
+    needsTeamGrant &&
+    preservedEntry.template
+  ) {
     templateGrantWarning = await tryGrantTeamTemplateRead(
       client,
       input.org,
@@ -718,7 +725,11 @@ export async function createAssignment(
   )
 
   let templateGrantWarning: string | undefined
-  if (needsTeamGrant && assignmentBody.template) {
+  if (
+    input.canGrantTemplateAccess &&
+    needsTeamGrant &&
+    assignmentBody.template
+  ) {
     templateGrantWarning = await tryGrantTeamTemplateRead(
       client,
       input.org,

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -564,11 +564,19 @@ async function grantTeamTemplateRead(
   template: NonNullable<Assignment["template"]>,
 ) {
   let teamSlug: string | undefined
-  let taTeamSlug: string | undefined
+  let staffTeamSlugs: string[] = []
   try {
     const classroomJson = await getClassroomJson(client, { org, classroom })
     teamSlug = classroomJson.team?.slug
-    taTeamSlug = classroomJson.teams?.ta?.slug
+    // Non-owner staff teams that need explicit read on a private template: HTA
+    // and TA. A base-permission-`none` head-TA/TA can't read a private in-org
+    // template repo without their team being granted, so grant both here. The
+    // teacher team is intentionally omitted — its members are org owners with
+    // repo access via ownership, so a team grant is redundant.
+    staffTeamSlugs = [
+      classroomJson.teams?.hta?.slug,
+      classroomJson.teams?.ta?.slug,
+    ].filter((s): s is string => Boolean(s))
   } catch (err) {
     // 404 = no classroom.json (pre-feature) is a genuine "no team"; fall
     // through. Anything else is transient and must not be misread as "no team".
@@ -595,25 +603,26 @@ async function grantTeamTemplateRead(
     permission: "pull",
   })
 
-  // Best-effort: grant the TA staff team the same read so a base-permission-
-  // `none` TA can read the private template without waiting for collect-scores
-  // (mirrors the CLI). Non-blocking — the student grant above is what gates
-  // `student accept`; a TA-grant failure only warns and collect-scores
-  // re-affirms it. A classroom with no recorded TA team is a clean skip.
-  if (taTeamSlug) {
+  // Best-effort: grant the non-owner staff teams (HTA, TA) the same read so a
+  // base-permission-`none` head-TA/TA can read the private template without
+  // waiting for collect-scores (mirrors the CLI). Non-blocking — the student
+  // grant above is what gates `student accept`; a staff-grant failure only warns
+  // and collect-scores re-affirms it. A classroom with no recorded staff team is
+  // a clean skip (the list is already filtered to present slugs).
+  for (const staffTeamSlug of staffTeamSlugs) {
     try {
       await addRepositoryToTeam(client, {
         org,
-        teamSlug: taTeamSlug,
+        teamSlug: staffTeamSlug,
         owner: template.owner,
         repo: template.repo,
         permission: "pull",
       })
     } catch (err) {
-      log.warn("granting TA staff team template read failed (non-fatal)", {
+      log.warn("granting staff team template read failed (non-fatal)", {
         org,
         classroom,
-        taTeamSlug,
+        staffTeamSlug,
         template: `${template.owner}/${template.repo}`,
         err,
       })

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -237,9 +237,6 @@ export async function editAssignment(
   // Grant the (possibly changed) in-org private template a team read — a
   // non-fatal warning, never thrown (the edit already committed). needsTeamGrant
   // implies a resolved template, so the guard just narrows the type.
-  // addRepositoryToTeam is org-owner-only, so a non-owner author (head-TA) can't
-  // perform it: attempt it for an owner, else surface an owner-required warning
-  // rather than silently skipping (which would 404 students on accept).
   let templateGrantWarning: string | undefined
   if (needsTeamGrant && preservedEntry.template) {
     templateGrantWarning = await resolveTemplateGrant(
@@ -574,11 +571,9 @@ async function grantTeamTemplateRead(
   try {
     const classroomJson = await getClassroomJson(client, { org, classroom })
     teamSlug = classroomJson.team?.slug
-    // Non-owner staff teams that need explicit read on a private template: HTA
-    // and TA. A base-permission-`none` head-TA/TA can't read a private in-org
-    // template repo without their team being granted, so grant both here. The
-    // teacher team is intentionally omitted — its members are org owners with
-    // repo access via ownership, so a team grant is redundant.
+    // Non-owner staff teams (TEMPLATE_READ_STAFF_ROLES) need an explicit read on
+    // a private template; the teacher team is omitted (owners have it via
+    // ownership).
     staffTeamSlugs = TEMPLATE_READ_STAFF_ROLES.map(
       (role) => classroomJson.teams?.[role]?.slug,
     ).filter((s): s is string => Boolean(s))
@@ -608,12 +603,9 @@ async function grantTeamTemplateRead(
     permission: "pull",
   })
 
-  // Best-effort: grant the non-owner staff teams (HTA, TA) the same read so a
-  // base-permission-`none` head-TA/TA can read the private template without
-  // waiting for collect-scores (mirrors the CLI). Non-blocking — the student
-  // grant above is what gates `student accept`; a staff-grant failure only warns
-  // and collect-scores re-affirms it. A classroom with no recorded staff team is
-  // a clean skip (the list is already filtered to present slugs).
+  // Best-effort staff-team grants (mirrors the CLI): non-blocking, since the
+  // student grant above is what gates `student accept` and collect-scores
+  // re-affirms these. The list is already filtered to present slugs.
   for (const staffTeamSlug of staffTeamSlugs) {
     try {
       await addRepositoryToTeam(client, {
@@ -664,14 +656,10 @@ export async function tryGrantTeamTemplateRead(
   }
 }
 
-// The warning shown when a NON-owner author (e.g. a head-TA) saves an
-// assignment whose private in-org template needs a classroom-team read grant.
-// The grant (addRepositoryToTeam) is org-owner-only at GitHub, so the author
-// can't perform it — but we must NOT return `undefined` (a silent "clean"
-// result) or students would hit a 404 on `gh student accept` with nothing
-// pointing at the cause. Surface an actionable warning instead: an org owner
-// grants the team read (or re-saves), then students can accept. Mirrors the
-// failure-path wording of tryGrantTeamTemplateRead.
+// The warning returned (not undefined) when a non-owner author saves an
+// assignment whose private in-org template needs the owner-only team read-grant.
+// Returning undefined would read as "clean" and 404 students on accept with no
+// signal; this points them at an owner instead.
 export function templateGrantOwnerRequiredWarning(
   classroom: string,
   slug: string,
@@ -686,12 +674,10 @@ export function templateGrantOwnerRequiredWarning(
 }
 
 // The one grant-decision recipe shared by create / edit / reuse: attempt the
-// owner-only team read-grant when the caller may (canGrantTemplateAccess), else
-// return the owner-required warning instead of silently skipping — a silent skip
-// would 404 students on accept with no signal. Single-sourced so the three write
-// paths can't drift. `canGrantTemplateAccess` is set true unless the caller has
-// CONFIRMED the actor is a non-owner (see useCanAttemptTemplateGrant), so a real
-// owner mid-load still attempts (tryGrantTeamTemplateRead never throws).
+// owner-only team read-grant when canGrantTemplateAccess is set, else return the
+// owner-required warning rather than silently skipping (a silent skip would 404
+// students on accept). Single-sourced so the three write paths can't drift; the
+// flag's tri-state derivation lives in useCanAttemptTemplateGrant.
 export async function resolveTemplateGrant(
   client: GitHubClient,
   org: string,

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -227,6 +227,13 @@ export type CreateAssignmentInput = {
   allowed_files?: string
   pass_threshold?: number
   tests: AssignmentTestDraft[]
+  // Whether the acting user may perform the owner-only template read-grant
+  // (addRepositoryToTeam). Set from can("manageOrg") at the call site. When
+  // false/absent, the save skips the grant (fail-closed) so a non-owner author
+  // — e.g. a head-TA — never fires the owner-only call and never 403s; the
+  // grant was always best-effort, and an owner re-affirms it later. GitHub is
+  // the real enforcer regardless.
+  canGrantTemplateAccess?: boolean
 }
 export async function createAssignmentWithConflictRetry(
   client: GitHubClient,

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -227,12 +227,12 @@ export type CreateAssignmentInput = {
   allowed_files?: string
   pass_threshold?: number
   tests: AssignmentTestDraft[]
-  // Whether the acting user may perform the owner-only template read-grant
-  // (addRepositoryToTeam). Set from can("manageOrg") at the call site. When
-  // false/absent, the save skips the grant (fail-closed) so a non-owner author
-  // — e.g. a head-TA — never fires the owner-only call and never 403s; the
-  // grant was always best-effort, and an owner re-affirms it later. GitHub is
-  // the real enforcer regardless.
+  // Whether the write path may attempt the owner-only template read-grant
+  // (addRepositoryToTeam). Set from useCanAttemptTemplateGrant at the call site
+  // (true unless the org role is a confirmed non-owner). When false the save
+  // skips the grant and returns an owner-required warning instead of firing the
+  // owner-only call — the grant is best-effort and an owner re-affirms it later.
+  // GitHub is the real enforcer regardless.
   canGrantTemplateAccess?: boolean
 }
 export async function createAssignmentWithConflictRetry(

--- a/web/src/hooks/mutations/createEditMutations.test.ts
+++ b/web/src/hooks/mutations/createEditMutations.test.ts
@@ -36,6 +36,17 @@ vi.mock("@/domain/assignments", () => ({
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({ request: vi.fn() }),
 }))
+// The assignment mutation hooks inject canGrantTemplateAccess from the org-owner
+// verdict; mock it deterministically (owner) so the forwarded-input assertions
+// are stable.
+vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
+  useIsOrgOwner: () => ({
+    isOwner: true,
+    isPending: false,
+    isError: false,
+    retry: vi.fn(),
+  }),
+}))
 
 import { useCreateClassroom } from "./useCreateClassroom"
 import { useEditClassroom } from "./useEditClassroom"
@@ -138,6 +149,7 @@ describe("useCreateAssignment", () => {
     expect(createAssignment).toHaveBeenCalledWith(expect.anything(), {
       slug: "hw1",
       name: "HW1",
+      canGrantTemplateAccess: true,
     })
     expect(onWrite).toHaveBeenCalledWith(
       { newCommitSha: "sha-a" },
@@ -160,7 +172,7 @@ describe("useEditAssignment", () => {
 
     expect(editAssignmentWithConflictRetry).toHaveBeenCalledWith(
       expect.anything(),
-      { slug: "hw1", name: "HW1" },
+      { slug: "hw1", name: "HW1", canGrantTemplateAccess: true },
     )
     expect(onWrite).toHaveBeenCalledWith(
       { newCommitSha: "sha-ea" },

--- a/web/src/hooks/mutations/createEditMutations.test.ts
+++ b/web/src/hooks/mutations/createEditMutations.test.ts
@@ -36,9 +36,9 @@ vi.mock("@/domain/assignments", () => ({
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({ request: vi.fn() }),
 }))
-// The assignment mutation hooks inject canGrantTemplateAccess from the org-owner
-// verdict; mock it deterministically (owner) so the forwarded-input assertions
-// are stable.
+// The assignment mutation hooks inject canGrantTemplateAccess from the org-role
+// verdict; mock it deterministically (attemptable) so the forwarded-input
+// assertions are stable.
 vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
   useIsOrgOwner: () => ({
     isOwner: true,
@@ -46,6 +46,7 @@ vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
     isError: false,
     retry: vi.fn(),
   }),
+  useCanAttemptTemplateGrant: () => true,
 }))
 
 import { useCreateClassroom } from "./useCreateClassroom"

--- a/web/src/hooks/mutations/useCreateAssignment.ts
+++ b/web/src/hooks/mutations/useCreateAssignment.ts
@@ -7,6 +7,7 @@ import {
 import { githubKeys } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Create an assignment. The hook owns the assignments.json listing invalidate
@@ -25,13 +26,18 @@ export function useCreateAssignment(
 ) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
+  // The owner-only template read-grant is gated in the write path on this flag
+  // (see CreateAssignmentInput.canGrantTemplateAccess); a non-owner author skips
+  // it rather than 403'ing.
+  const { isOwner } = useIsOrgOwner()
 
   return useMutation<
     CreateAssignmentResult,
     GitHubAPIError,
     CreateAssignmentInput
   >({
-    mutationFn: (input) => createAssignment(client, input),
+    mutationFn: (input) =>
+      createAssignment(client, { ...input, canGrantTemplateAccess: isOwner }),
     onSuccess: (result, input) => {
       void queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(

--- a/web/src/hooks/mutations/useCreateAssignment.ts
+++ b/web/src/hooks/mutations/useCreateAssignment.ts
@@ -26,10 +26,8 @@ export function useCreateAssignment(
 ) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
-  // The owner-only template read-grant is attempted in the write path when this
-  // flag is set. Attempt unless the org role is a CONFIRMED non-owner, so a real
-  // owner whose org read hasn't settled still grants (a non-owner's attempt
-  // fails soft into the owner-required warning). See useCanAttemptTemplateGrant.
+  // Attempt the owner-only template read-grant unless the org role is a
+  // confirmed non-owner (see useCanAttemptTemplateGrant).
   const canGrantTemplateAccess = useCanAttemptTemplateGrant()
 
   return useMutation<

--- a/web/src/hooks/mutations/useCreateAssignment.ts
+++ b/web/src/hooks/mutations/useCreateAssignment.ts
@@ -7,7 +7,7 @@ import {
 import { githubKeys } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
+import { useCanAttemptTemplateGrant } from "@/context/githubOrgRole/useIsOrgOwner"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Create an assignment. The hook owns the assignments.json listing invalidate
@@ -26,10 +26,11 @@ export function useCreateAssignment(
 ) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
-  // The owner-only template read-grant is gated in the write path on this flag
-  // (see CreateAssignmentInput.canGrantTemplateAccess); a non-owner author skips
-  // it rather than 403'ing.
-  const { isOwner } = useIsOrgOwner()
+  // The owner-only template read-grant is attempted in the write path when this
+  // flag is set. Attempt unless the org role is a CONFIRMED non-owner, so a real
+  // owner whose org read hasn't settled still grants (a non-owner's attempt
+  // fails soft into the owner-required warning). See useCanAttemptTemplateGrant.
+  const canGrantTemplateAccess = useCanAttemptTemplateGrant()
 
   return useMutation<
     CreateAssignmentResult,
@@ -37,7 +38,7 @@ export function useCreateAssignment(
     CreateAssignmentInput
   >({
     mutationFn: (input) =>
-      createAssignment(client, { ...input, canGrantTemplateAccess: isOwner }),
+      createAssignment(client, { ...input, canGrantTemplateAccess }),
     onSuccess: (result, input) => {
       void queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(

--- a/web/src/hooks/mutations/useEditAssignment.ts
+++ b/web/src/hooks/mutations/useEditAssignment.ts
@@ -25,8 +25,7 @@ export function useEditAssignment(opts?: {
   const { onWrite, onMutate } = opts ?? {}
   const client = useGitHubClient()
   // Attempt the owner-only template read-grant unless the org role is a
-  // CONFIRMED non-owner (a real owner mid-load still grants; a non-owner's
-  // attempt fails soft into the owner-required warning).
+  // confirmed non-owner (see useCanAttemptTemplateGrant).
   const canGrantTemplateAccess = useCanAttemptTemplateGrant()
 
   return useMutation<

--- a/web/src/hooks/mutations/useEditAssignment.ts
+++ b/web/src/hooks/mutations/useEditAssignment.ts
@@ -6,7 +6,7 @@ import {
 } from "@/domain/assignments"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
+import { useCanAttemptTemplateGrant } from "@/context/githubOrgRole/useIsOrgOwner"
 
 // Save an assignment's settings. This edit path historically does NOT invalidate
 // the assignments cache (the page relies on its own refetch/staleTime), so the
@@ -24,9 +24,10 @@ export function useEditAssignment(opts?: {
 }) {
   const { onWrite, onMutate } = opts ?? {}
   const client = useGitHubClient()
-  // Skip the owner-only template read-grant for a non-owner author (head-TA):
-  // the grant fires from the stored template on any edit, so gate it here.
-  const { isOwner } = useIsOrgOwner()
+  // Attempt the owner-only template read-grant unless the org role is a
+  // CONFIRMED non-owner (a real owner mid-load still grants; a non-owner's
+  // attempt fails soft into the owner-required warning).
+  const canGrantTemplateAccess = useCanAttemptTemplateGrant()
 
   return useMutation<
     CreateAssignmentResult,
@@ -36,7 +37,7 @@ export function useEditAssignment(opts?: {
     mutationFn: (input) =>
       editAssignmentWithConflictRetry(client, {
         ...input,
-        canGrantTemplateAccess: isOwner,
+        canGrantTemplateAccess,
       }),
     onMutate,
     onSuccess: (result, input) => {

--- a/web/src/hooks/mutations/useEditAssignment.ts
+++ b/web/src/hooks/mutations/useEditAssignment.ts
@@ -6,6 +6,7 @@ import {
 } from "@/domain/assignments"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 
 // Save an assignment's settings. This edit path historically does NOT invalidate
 // the assignments cache (the page relies on its own refetch/staleTime), so the
@@ -23,13 +24,20 @@ export function useEditAssignment(opts?: {
 }) {
   const { onWrite, onMutate } = opts ?? {}
   const client = useGitHubClient()
+  // Skip the owner-only template read-grant for a non-owner author (head-TA):
+  // the grant fires from the stored template on any edit, so gate it here.
+  const { isOwner } = useIsOrgOwner()
 
   return useMutation<
     CreateAssignmentResult,
     GitHubAPIError,
     CreateAssignmentInput
   >({
-    mutationFn: (input) => editAssignmentWithConflictRetry(client, input),
+    mutationFn: (input) =>
+      editAssignmentWithConflictRetry(client, {
+        ...input,
+        canGrantTemplateAccess: isOwner,
+      }),
     onMutate,
     onSuccess: (result, input) => {
       onWrite?.(result, input)

--- a/web/src/hooks/mutations/useReuseAssignment.ts
+++ b/web/src/hooks/mutations/useReuseAssignment.ts
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
+import { useCanAttemptTemplateGrant } from "@/context/githubOrgRole/useIsOrgOwner"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import {
@@ -44,8 +44,9 @@ export function useReuseAssignment({
 }: UseReuseAssignmentParams) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
-  // Skip the owner-only template read-grant for a non-owner author (head-TA).
-  const { isOwner } = useIsOrgOwner()
+  // Attempt the owner-only template read-grant unless the org role is a
+  // CONFIRMED non-owner (see useCanAttemptTemplateGrant).
+  const canGrantTemplateAccess = useCanAttemptTemplateGrant()
 
   const [slugInput, setSlugInput] = useState("")
   const [slugTouched, setSlugTouched] = useState(false)
@@ -122,7 +123,7 @@ export function useReuseAssignment({
       source,
       targetClassroom,
       targetSlug: normalizedSlug,
-      canGrantTemplateAccess: isOwner,
+      canGrantTemplateAccess,
     })
   }
 

--- a/web/src/hooks/mutations/useReuseAssignment.ts
+++ b/web/src/hooks/mutations/useReuseAssignment.ts
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import {
@@ -43,6 +44,8 @@ export function useReuseAssignment({
 }: UseReuseAssignmentParams) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
+  // Skip the owner-only template read-grant for a non-owner author (head-TA).
+  const { isOwner } = useIsOrgOwner()
 
   const [slugInput, setSlugInput] = useState("")
   const [slugTouched, setSlugTouched] = useState(false)
@@ -119,6 +122,7 @@ export function useReuseAssignment({
       source,
       targetClassroom,
       targetSlug: normalizedSlug,
+      canGrantTemplateAccess: isOwner,
     })
   }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -246,6 +246,14 @@
     "statusNeedsAttentionInOrg": "Assign a role",
     "statusNeedsAttentionNotInOrg": "Not in org",
     "viewCsvOnGitHub": "View roster.csv",
+    "approx": {
+      "notice": "Approximate roster from roster.csv (teacher-maintained). The authoritative live enrollment and invite management are available to teachers.",
+      "caption": "Roster from roster.csv",
+      "colName": "Name",
+      "colSection": "Section",
+      "colRole": "Role",
+      "empty": "No one is listed in roster.csv yet."
+    },
     "classroomTeamLabel": "Classroom team",
     "teamNotYet": "Not on the team yet",
     "statusLabel": "Status",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -246,9 +246,9 @@
     "statusNeedsAttentionInOrg": "Assign a role",
     "statusNeedsAttentionNotInOrg": "Not in org",
     "viewCsvOnGitHub": "View roster.csv",
-    "approx": {
-      "notice": "Approximate roster from roster.csv (teacher-maintained). The authoritative live enrollment and invite management are available to teachers.",
-      "caption": "Roster from roster.csv",
+    "csvRoster": {
+      "notice": "CSV roster from roster.csv (teacher-maintained). The authoritative team-driven roster and invite management are available to teachers.",
+      "caption": "CSV roster from roster.csv",
       "colName": "Name",
       "colSection": "Section",
       "colRole": "Role",

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -122,6 +122,9 @@ export const TeacherAssignmentsView = ({
   const myRoleLabelKey = roleLabelKey(myRole)
   const myRoleLabel = myRoleLabelKey ? t(myRoleLabelKey) : null
   const archived = isClassroomArchived(classroomData ?? {})
+  // Author tier (teacher|hta) gates the mutating affordances; a TA sees the
+  // list read-only. GitHub is the real enforcer (config-repo write), this is UX.
+  const canAuthor = can("authorAssignments", { classroomRole: myRole })
   const emptyRoster = useEmptyRosterWarning(org, classroom)
 
   const [query, setQuery] = useState("")
@@ -170,9 +173,9 @@ export const TeacherAssignmentsView = ({
             <Badge tone="neutral" size="md">
               {t("assignments.archived")}
             </Badge>
-          ) : (
+          ) : canAuthor ? (
             <NewAssignmentButton org={org} classroom={classroom} />
-          )
+          ) : null
         }
       />
       {archived ? (
@@ -225,6 +228,7 @@ export const TeacherAssignmentsView = ({
           studentCount={studentCount}
           loading={assignmentsLoading}
           archived={archived}
+          canAuthor={canAuthor}
         />
       )}
     </div>

--- a/web/src/pages/CreateAssignmentPage.test.tsx
+++ b/web/src/pages/CreateAssignmentPage.test.tsx
@@ -111,6 +111,8 @@ const submit = () =>
   fireEvent.click(screen.getByRole("button", { name: "submit" }))
 
 const failWith = (err: unknown) => act(() => lastMutateOptions?.onError?.(err))
+const succeedWith = (result: unknown) =>
+  act(() => lastMutateOptions?.onSuccess?.(result, { slug: "hw1" }))
 
 beforeEach(() => {
   mutateAsync.mockClear()
@@ -178,5 +180,26 @@ describe("CreateAssignmentPage outage save hint", () => {
     failWith(apiError(404))
     expect(screen.queryByText(STATUS_LINK)).toBeNull()
     expect(screen.queryByText("HTTP 404")).not.toBeNull()
+  })
+})
+
+describe("CreateAssignmentPage templateGrantWarning surfacing", () => {
+  const WARNING =
+    "needs the classroom50-cs101 team granted read — an organization owner"
+
+  it("renders the warning and stays on the page (no navigate) when the grant is skipped", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    succeedWith({ newCommitSha: "sha", templateGrantWarning: WARNING })
+    expect(screen.queryByText(WARNING)).not.toBeNull()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it("navigates and shows no warning on a clean save", () => {
+    render(<CreateAssignmentPage />)
+    submit()
+    succeedWith({ newCommitSha: "sha" })
+    expect(screen.queryByText(WARNING)).toBeNull()
+    expect(navigateMock).toHaveBeenCalled()
   })
 })

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -67,7 +67,7 @@ const CreateAssignmentPage = () => {
   return (
     <PageShell selected="assignments">
       <Breadcrumb endpoint={t("assignments.createBreadcrumb")} />
-      <RequireRole>
+      <RequireRole allow="author">
         <PageHeader title={t("assignments.createHeading")} />
         {emptyRoster.show ? (
           <EmptyRosterNotice

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -174,6 +174,7 @@ const EditAssignmentPage = () => {
   const router = useRouter()
   const { role } = useClassroomRoleContext()
   const isStaff = can("viewClassroomStaffContent", { classroomRole: role })
+  const canAuthor = can("authorAssignments", { classroomRole: role })
   const isStudent = role === "student"
   const { data: assignments } = useGetClassroomAssignments(org, classroom)
   const { data: classroomData } = useGetClassroom(org, classroom)
@@ -221,7 +222,7 @@ const EditAssignmentPage = () => {
           classroom={classroom}
           assignment={assignment}
           defaultData={assignmentData}
-          readOnly={archived}
+          readOnly={archived || !canAuthor}
           onCancel={() => {
             router.history.back()
           }}

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -209,10 +209,8 @@ const TeamRosterContent = ({
   )
 }
 
-// The CSV roster: a read-only view for a non-owner staffer (TA / head TA),
-// sourced from roster.csv (which they can read via config-repo access) because
-// the student team is secret and its member list is unreadable to anyone not on
-// it or an org owner. Fires no team-membership or invite reads, so nothing 403s.
+// The CSV roster wrapper for a non-owner staffer — fires no team-membership or
+// invite reads (so nothing 403s). See CsvRosterView for the roster.csv rationale.
 const CsvRosterContent = ({
   org,
   classroom,

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -6,6 +6,7 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import EnrolledStudents from "@/pages/students/EnrolledStudents"
+import RosterApproxView from "@/pages/students/RosterApproxView"
 import UploadRoster from "@/pages/students/UploadRoster"
 import InviteLinksModal from "@/pages/students/InviteLinksModal"
 import { GitHubLink } from "@/components/GitHubLink"
@@ -17,6 +18,7 @@ import { useSuppressedLogins } from "@/hooks/useSuppressedLogins"
 import { invalidateInviteQueries } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import RequireRole from "@/components/RequireRole"
+import RoleResolvingFallback from "@/components/RoleResolvingFallback"
 import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { toStudent } from "@/util/roster"
@@ -25,7 +27,10 @@ import { Badge } from "@/components/ui"
 import { ROLE_BADGE_TONE } from "@/util/classroomRoleUI"
 import { useTranslation } from "react-i18next"
 
-const StudentListContent = ({
+// The full team-driven roster: live GitHub membership, pending/failed invites,
+// and every management action. Owner-only — it calls useTeamRoster (whose
+// student-team read 403s for a non-owner) and the owner-only invite reads.
+const OwnerRosterContent = ({
   org,
   classroom,
 }: {
@@ -201,6 +206,59 @@ const StudentListContent = ({
         </>
       ) : null}
     </>
+  )
+}
+
+// The read-only roster for a non-owner staffer (TA / head TA). Sourced from
+// roster.csv (which they can read via config-repo access) because the student
+// team is secret and its member list is unreadable to anyone not on it or an
+// org owner. Fires no team-membership or invite reads, so nothing 403s.
+const StaffRosterContent = ({
+  org,
+  classroom,
+}: {
+  org: string
+  classroom: string
+}) => {
+  const { t } = useTranslation()
+  const { students } = useGetStudents(org, classroom)
+
+  return (
+    <>
+      <PageHeader
+        title={t("nav.roster")}
+        subtitle={
+          <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <GitHubLink
+              href={`https://github.com/${org}/${CONFIG_REPO}/blob/${DEFAULT_BRANCH}/${rosterPath(classroom)}`}
+              label={t("students.viewCsvOnGitHub")}
+              title={t("students.viewCsvOnGitHub")}
+            />
+          </span>
+        }
+      />
+      <RosterApproxView students={students} />
+    </>
+  )
+}
+
+// Branch the roster experience on org ownership: a teacher (org owner) gets the
+// live team-driven view with management; a TA/head TA gets the read-only
+// roster.csv approximation. Split so the owner-only useTeamRoster reads only run
+// for an owner (a non-owner can't render OwnerRosterContent without 403s).
+const StudentListContent = ({
+  org,
+  classroom,
+}: {
+  org: string
+  classroom: string
+}) => {
+  const { isOwner, isPending } = useIsOrgOwner()
+  if (isPending) return <RoleResolvingFallback />
+  return isOwner ? (
+    <OwnerRosterContent org={org} classroom={classroom} />
+  ) : (
+    <StaffRosterContent org={org} classroom={classroom} />
   )
 }
 

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -6,7 +6,7 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import EnrolledStudents from "@/pages/students/EnrolledStudents"
-import RosterApproxView from "@/pages/students/RosterApproxView"
+import CsvRosterView from "@/pages/students/CsvRosterView"
 import UploadRoster from "@/pages/students/UploadRoster"
 import InviteLinksModal from "@/pages/students/InviteLinksModal"
 import { GitHubLink } from "@/components/GitHubLink"
@@ -27,10 +27,10 @@ import { Badge } from "@/components/ui"
 import { ROLE_BADGE_TONE } from "@/util/classroomRoleUI"
 import { useTranslation } from "react-i18next"
 
-// The full team-driven roster: live GitHub membership, pending/failed invites,
-// and every management action. Owner-only — it calls useTeamRoster (whose
+// The team-driven roster: live GitHub membership, pending/failed invites, and
+// every management action. Owner-only — it calls useTeamRoster (whose
 // student-team read 403s for a non-owner) and the owner-only invite reads.
-const OwnerRosterContent = ({
+const TeamRosterContent = ({
   org,
   classroom,
 }: {
@@ -209,11 +209,11 @@ const OwnerRosterContent = ({
   )
 }
 
-// The read-only roster for a non-owner staffer (TA / head TA). Sourced from
-// roster.csv (which they can read via config-repo access) because the student
-// team is secret and its member list is unreadable to anyone not on it or an
-// org owner. Fires no team-membership or invite reads, so nothing 403s.
-const StaffRosterContent = ({
+// The CSV roster: a read-only view for a non-owner staffer (TA / head TA),
+// sourced from roster.csv (which they can read via config-repo access) because
+// the student team is secret and its member list is unreadable to anyone not on
+// it or an org owner. Fires no team-membership or invite reads, so nothing 403s.
+const CsvRosterContent = ({
   org,
   classroom,
 }: {
@@ -237,15 +237,15 @@ const StaffRosterContent = ({
           </span>
         }
       />
-      <RosterApproxView students={students} />
+      <CsvRosterView students={students} />
     </>
   )
 }
 
 // Branch the roster experience on org ownership: a teacher (org owner) gets the
-// live team-driven view with management; a TA/head TA gets the read-only
-// roster.csv approximation. Split so the owner-only useTeamRoster reads only run
-// for an owner (a non-owner can't render OwnerRosterContent without 403s).
+// team-driven roster with management; a TA/head TA gets the read-only CSV
+// roster. Split so the owner-only useTeamRoster reads only run for an owner (a
+// non-owner can't render TeamRosterContent without 403s).
 const StudentListContent = ({
   org,
   classroom,
@@ -256,9 +256,9 @@ const StudentListContent = ({
   const { isOwner, isPending } = useIsOrgOwner()
   if (isPending) return <RoleResolvingFallback />
   return isOwner ? (
-    <OwnerRosterContent org={org} classroom={classroom} />
+    <TeamRosterContent org={org} classroom={classroom} />
   ) : (
-    <StaffRosterContent org={org} classroom={classroom} />
+    <CsvRosterContent org={org} classroom={classroom} />
   )
 }
 

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -109,6 +109,11 @@ const useLiveNow = (referenceMs: number | null) => {
 const SubmissionsPageContent = () => {
   const { t } = useTranslation()
   const { org, classroom, assignment } = useParams({ strict: false })
+  // Regrade-all is a config-repo-write tier action (teacher|hta); Collect and
+  // per-row regrade stay all-staff (the page already gates entry on
+  // viewClassroomStaffContent). GitHub is the real enforcer; this is the UX gate.
+  const { role: classroomRole } = useClassroomRoleContext()
+  const canRegradeAll = can("authorAssignments", { classroomRole })
   const {
     data: scoresData,
     refetch: refetchScores,
@@ -761,6 +766,7 @@ const SubmissionsPageContent = () => {
               collecting={collecting}
               regrading={regrading}
               regradeAllActive={regradeAllActive}
+              canRegradeAll={canRegradeAll}
               emptyRoster={emptyRoster.show}
               emptyRepo={isEmptyRepoAssignment}
               onCollect={() => collectScores.collect()}

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -209,6 +209,7 @@ const AssignmentsTable = ({
   studentCount,
   loading = false,
   archived = false,
+  canAuthor = false,
 }: {
   org: string
   classroom: string
@@ -220,11 +221,18 @@ const AssignmentsTable = ({
   // When archived, hide per-row mutating actions (edit/reuse/delete); viewing
   // stays available.
   archived?: boolean
+  // Whether the viewer can author assignments (teacher|hta). A TA sees the list
+  // read-only: the pencil becomes a view icon and reuse/delete are hidden, same
+  // shape as the archived case. GitHub also 403s a TA's config-repo write, so
+  // this is the UX guard, not the enforcer.
+  canAuthor?: boolean
 }) => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { data: scoresData } = useGetScores(org, classroom)
   const navigate = useNavigate()
+  // Mutating row actions require both an unarchived classroom and author rights.
+  const canMutate = !archived && canAuthor
 
   return (
     <EnterDiv
@@ -377,23 +385,24 @@ const AssignmentsTable = ({
                       assignment: assignment.slug,
                     }}
                     title={
-                      archived
-                        ? t("assignments.table.viewAssignment")
-                        : t("assignments.table.editAssignment")
+                      canMutate
+                        ? t("assignments.table.editAssignment")
+                        : t("assignments.table.viewAssignment")
                     }
                     onClick={(event) => {
                       event.stopPropagation()
                     }}
                   >
-                    {archived ? (
-                      <Eye aria-hidden="true" className="size-4" />
-                    ) : (
+                    {canMutate ? (
                       <Pencil aria-hidden="true" className="size-4" />
+                    ) : (
+                      <Eye aria-hidden="true" className="size-4" />
                     )}
                   </Link>
-                  {archived ? (
-                    // Archived rows are view-only, but reviewing template access
-                    // (and reaching the source repo) stays available.
+                  {!canMutate ? (
+                    // Read-only rows (archived, or viewer can't author): reviewing
+                    // template access (and reaching the source repo) stays
+                    // available; the modal itself owner-gates the re-grant.
                     assignment.template && (
                       <TemplateAccessButton
                         org={org}

--- a/web/src/pages/assignments/TemplateField.test.tsx
+++ b/web/src/pages/assignments/TemplateField.test.tsx
@@ -29,6 +29,18 @@ vi.mock("@/github-core/queries", () => ({
 vi.mock("@/context/github/GitHubProvider", () => ({
   useOptionalGitHubClient: () => ({ request: vi.fn() }),
 }))
+// The "Fix template access" recovery is owner-only (addRepositoryToTeam). Default
+// the viewer to an org owner so the inline-Fix tests exercise the offered path;
+// a non-owner case is covered by the dedicated test below.
+let mockIsOwner = true
+vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
+  useIsOrgOwner: () => ({
+    isOwner: mockIsOwner,
+    isPending: false,
+    isError: false,
+    retry: vi.fn(),
+  }),
+}))
 vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => ({ user: { login: "teacher" }, isLoadingUser: false }),
 }))
@@ -94,6 +106,7 @@ beforeEach(() => {
   teamHasRepoAccess.mockReset()
   reconcileMutate.mockReset()
   reconcilePending = false
+  mockIsOwner = true
   __resetGitHubHealthForTest()
 })
 
@@ -150,6 +163,20 @@ describe("TemplateField — inline Fix template access", () => {
     verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
     teamHasRepoAccess.mockResolvedValue(false)
     renderField({ slug: undefined })
+    await screen.findByText("assignments.template.privateWillGrant", {
+      exact: false,
+    })
+    expect(screen.queryByText(ACTION_KEY)).toBeNull()
+  })
+
+  it("hides the Fix button for a non-owner (the grant is owner-only)", async () => {
+    // A head-TA authoring can set a template but can't grant team read
+    // (addRepositoryToTeam is org-owner-only), so the recovery must not show.
+    mockIsOwner = false
+    verifyTemplateAccess.mockResolvedValue(okInOrgPrivate)
+    teamHasRepoAccess.mockResolvedValue(false)
+    renderField()
+    // Wait for verification to settle, then assert the fix action is absent.
     await screen.findByText("assignments.template.privateWillGrant", {
       exact: false,
     })

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react"
 import GitHub from "@/assets/github.svg?react"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import {
   verifyTemplateAccess,
@@ -51,6 +52,11 @@ export const TemplateField = ({
 }) => {
   const { t } = useTranslation()
   const client = useOptionalGitHubClient()
+  // The "Fix template access" recovery grants a team read on the template repo
+  // (addRepositoryToTeam) — an org-owner-only GitHub call. Only offer it to an
+  // owner; a non-owner (e.g. a head-TA authoring) would 403. Org owner and
+  // classroom teacher are independent axes (KTD-4), so gate on manageOrg.
+  const { isOwner } = useIsOrgOwner()
   const { user, isLoadingUser } = useGithubAuth()
   const viewerLogin = user?.login
   const rawValue = field.state.value
@@ -160,7 +166,7 @@ export const TemplateField = ({
         org={org}
         teamHasAccess={teamHasAccess}
         reconcile={
-          slug && org && classroom && inOrgPrivateTemplate ? (
+          isOwner && slug && org && classroom && inOrgPrivateTemplate ? (
             <ReconcileTemplateAccessInline
               org={org}
               classroom={classroom}

--- a/web/src/pages/classes/ClassroomStaffSection.test.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+// Drive the defense-in-depth gate directly off the classroom role: a non-teacher
+// must force the staff actions read-only even when the archived `disabled` prop
+// is false. Real `can()` is used; only the role signal + leaf data hooks are mocked.
+const roleMock = vi.fn()
+vi.mock("@/context/classroomRole/ClassroomRoleProvider", () => ({
+  useClassroomRoleContext: () => roleMock(),
+}))
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify: vi.fn() }),
+}))
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>()
+  return { ...actual, useQuery: () => ({ data: [], isLoading: false }) }
+})
+const noopMutation = { mutate: vi.fn(), isPending: false }
+vi.mock("@/hooks/mutations/useAddStaffMember", () => ({
+  useAddStaffMember: () => noopMutation,
+}))
+vi.mock("@/hooks/mutations/useRemoveStaffMember", () => ({
+  default: () => noopMutation,
+}))
+vi.mock("@/hooks/mutations/useResendStaffInvite", () => ({
+  default: () => noopMutation,
+}))
+vi.mock("@/hooks/mutations/useCancelStaffInvite", () => ({
+  default: () => noopMutation,
+}))
+
+import ClassroomStaffSection from "./ClassroomStaffSection"
+
+const usernameInput = () =>
+  screen.getByPlaceholderText(
+    "classes.staff.usernamePlaceholder",
+  ) as HTMLInputElement
+
+afterEach(() => {
+  cleanup()
+  roleMock.mockReset()
+})
+
+describe("ClassroomStaffSection — canManageStaff gate", () => {
+  it("a teacher can manage staff (actions enabled)", () => {
+    roleMock.mockReturnValue({ role: "teacher" })
+    render(<ClassroomStaffSection org="acme" classroom="cs101" />)
+    expect(usernameInput().disabled).toBe(false)
+  })
+
+  it("a TA cannot manage staff even when not archived (actions disabled)", () => {
+    roleMock.mockReturnValue({ role: "ta" })
+    render(<ClassroomStaffSection org="acme" classroom="cs101" />)
+    expect(usernameInput().disabled).toBe(true)
+  })
+
+  it("an archived classroom disables actions even for a teacher", () => {
+    roleMock.mockReturnValue({ role: "teacher" })
+    render(<ClassroomStaffSection org="acme" classroom="cs101" disabled />)
+    expect(usernameInput().disabled).toBe(true)
+  })
+})

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -5,6 +5,8 @@ import { Loader2, Send, ShieldCheck, UserPlus, X, XCircle } from "lucide-react"
 import { GitHubLink } from "@/components/GitHubLink"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
+import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
+import { can } from "@/authz"
 import { ConfirmModal } from "@/components/modals"
 import { teamMembersQuery, teamInvitationsQuery } from "@/github-core/queries"
 import { classroomTeamSlug } from "@/util/teamSlug"
@@ -39,8 +41,10 @@ const ROLE_PLURAL_KEY: Record<StaffRole, string> = {
 }
 
 // Manage a classroom's staff (teacher / head TA / TA), backed by the
-// per-classroom GitHub teams `classroom50-<classroom>-<role>`. The route
-// already gates; the actions assume teacher/owner.
+// per-classroom GitHub teams `classroom50-<classroom>-<role>`. The route gates
+// to teachers, but this section also asserts can("editClassroomSettings")
+// in-component so it fails closed if ever mounted outside RequireRole (the
+// underlying team/invite ops are owner-only at GitHub — the true enforcer).
 const ClassroomStaffSection = ({
   org,
   classroom,
@@ -52,6 +56,12 @@ const ClassroomStaffSection = ({
   disabled?: boolean
 }) => {
   const { t } = useTranslation()
+  const { role } = useClassroomRoleContext()
+  // Defense-in-depth: only a classroom teacher may mutate staff. Fold into the
+  // read-only `disabled` state so every action (add/remove/role/resend/cancel)
+  // fails closed rather than relying solely on the route guard.
+  const canManageStaff = can("editClassroomSettings", { classroomRole: role })
+  const actionsDisabled = disabled || !canManageStaff
   return (
     <Card bordered={false} className="w-full mt-8">
       <Card.Body>
@@ -74,7 +84,7 @@ const ClassroomStaffSection = ({
           {t("classes.staff.description")}
         </p>
 
-        <AddStaff org={org} classroom={classroom} disabled={disabled} />
+        <AddStaff org={org} classroom={classroom} disabled={actionsDisabled} />
 
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 mt-2">
           {STAFF_ROLES.map((role) => (
@@ -83,7 +93,7 @@ const ClassroomStaffSection = ({
               org={org}
               classroom={classroom}
               role={role}
-              disabled={disabled}
+              disabled={actionsDisabled}
             />
           ))}
         </div>

--- a/web/src/pages/students/CsvRosterView.test.tsx
+++ b/web/src/pages/students/CsvRosterView.test.tsx
@@ -10,7 +10,7 @@ vi.mock("react-i18next", async (importOriginal) => {
   }
 })
 
-import RosterApproxView from "./RosterApproxView"
+import CsvRosterView from "./CsvRosterView"
 import type { Student } from "@/types/classroom"
 
 const student = (overrides: Partial<Student> = {}): Student => ({
@@ -28,15 +28,15 @@ afterEach(() => {
   cleanup()
 })
 
-describe("RosterApproxView", () => {
-  it("shows the approximate-source notice", () => {
-    render(<RosterApproxView students={[student()]} />)
-    expect(screen.getByText("students.approx.notice")).toBeTruthy()
+describe("CsvRosterView", () => {
+  it("shows the CSV-source notice", () => {
+    render(<CsvRosterView students={[student()]} />)
+    expect(screen.getByText("students.csvRoster.notice")).toBeTruthy()
   })
 
   it("renders a row per roster.csv entry with name, section, and role", () => {
     render(
-      <RosterApproxView
+      <CsvRosterView
         students={[
           student({ username: "alice", first_name: "Alice", last_name: "Ng" }),
           student({
@@ -56,13 +56,13 @@ describe("RosterApproxView", () => {
   })
 
   it("maps a blank/unknown role cell to the student badge", () => {
-    render(<RosterApproxView students={[student({ role: "" })]} />)
+    render(<CsvRosterView students={[student({ role: "" })]} />)
     expect(screen.getByText("students.roleStudent")).toBeTruthy()
   })
 
   it("falls back to the username when no name is recorded", () => {
     render(
-      <RosterApproxView
+      <CsvRosterView
         students={[
           student({ username: "carol", first_name: "", last_name: "" }),
         ]}
@@ -73,12 +73,12 @@ describe("RosterApproxView", () => {
   })
 
   it("renders an empty-state row when roster.csv has no entries", () => {
-    render(<RosterApproxView students={[]} />)
-    expect(screen.getByText("students.approx.empty")).toBeTruthy()
+    render(<CsvRosterView students={[]} />)
+    expect(screen.getByText("students.csvRoster.empty")).toBeTruthy()
   })
 
   it("renders no mutating controls (read-only)", () => {
-    const { container } = render(<RosterApproxView students={[student()]} />)
+    const { container } = render(<CsvRosterView students={[student()]} />)
     expect(container.querySelectorAll("button")).toHaveLength(0)
   })
 })

--- a/web/src/pages/students/CsvRosterView.test.tsx
+++ b/web/src/pages/students/CsvRosterView.test.tsx
@@ -60,6 +60,26 @@ describe("CsvRosterView", () => {
     expect(screen.getByText("students.roleStudent")).toBeTruthy()
   })
 
+  it("maps each known role cell to its badge (teacher/instructor/ta)", () => {
+    render(
+      <CsvRosterView
+        students={[
+          student({ username: "t", role: "teacher" }),
+          student({ username: "i", role: "instructor" }),
+          student({ username: "a", role: "ta" }),
+        ]}
+      />,
+    )
+    // teacher + its legacy instructor alias share the teacher label.
+    expect(screen.getAllByText("students.roleTeacher")).toHaveLength(2)
+    expect(screen.getByText("students.roleTa")).toBeTruthy()
+  })
+
+  it("maps the role cell case-insensitively", () => {
+    render(<CsvRosterView students={[student({ role: "HTA" })]} />)
+    expect(screen.getByText("students.roleHeadTa")).toBeTruthy()
+  })
+
   it("falls back to the username when no name is recorded", () => {
     render(
       <CsvRosterView

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -30,15 +30,16 @@ function displayName(student: Student): string {
   return full || student.username
 }
 
-// Read-only roster for a non-owner staffer (TA / head TA), sourced from the
-// config repo's roster.csv rather than GitHub team membership. A TA/HTA is a
-// plain org member who is NOT on the classroom's secret student team, so the
-// team-members API (GET /orgs/{org}/teams/{slug}/members) 403s for them — they
-// genuinely can't read the authoritative enrollment. roster.csv (which they can
-// read via config-repo access) is a good-enough approximation: teacher-
-// maintained, not live, and carrying no pending invites or management actions
-// (all owner-only). Owners get the live team-driven EnrolledStudents view.
-const RosterApproxView = ({ students }: { students: Student[] }) => {
+// The read-only "CSV roster" — a non-owner staffer's (TA / head TA) view of the
+// class, sourced from the config repo's roster.csv rather than GitHub team
+// membership (the "team-driven roster" the owner sees via EnrolledStudents). A
+// TA/HTA is a plain org member who is NOT on the classroom's secret student
+// team, so the team-members API (GET /orgs/{org}/teams/{slug}/members) 403s for
+// them — they genuinely can't read the authoritative enrollment. roster.csv
+// (which they can read via config-repo access) is a good-enough stand-in:
+// teacher-maintained, not live, and carrying no pending invites or management
+// actions (all owner-only).
+const CsvRosterView = ({ students }: { students: Student[] }) => {
   const { t } = useTranslation()
 
   const rows = useMemo(
@@ -53,24 +54,26 @@ const RosterApproxView = ({ students }: { students: Student[] }) => {
     <div className="flex flex-col gap-4">
       <Alert tone="info">
         <Info aria-hidden="true" className="size-5" />
-        <span>{t("students.approx.notice")}</span>
+        <span>{t("students.csvRoster.notice")}</span>
       </Alert>
 
       <div className="overflow-x-auto rounded-box border border-base-content/5 bg-base-100">
         <table className="table">
-          <caption className="sr-only">{t("students.approx.caption")}</caption>
+          <caption className="sr-only">
+            {t("students.csvRoster.caption")}
+          </caption>
           <thead>
             <tr>
-              <th scope="col">{t("students.approx.colName")}</th>
-              <th scope="col">{t("students.approx.colSection")}</th>
-              <th scope="col">{t("students.approx.colRole")}</th>
+              <th scope="col">{t("students.csvRoster.colName")}</th>
+              <th scope="col">{t("students.csvRoster.colSection")}</th>
+              <th scope="col">{t("students.csvRoster.colRole")}</th>
             </tr>
           </thead>
           <tbody>
             {rows.length === 0 ? (
               <tr>
                 <td colSpan={3} className="text-center">
-                  {t("students.approx.empty")}
+                  {t("students.csvRoster.empty")}
                 </td>
               </tr>
             ) : (
@@ -98,4 +101,4 @@ const RosterApproxView = ({ students }: { students: Student[] }) => {
   )
 }
 
-export default RosterApproxView
+export default CsvRosterView

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -4,26 +4,8 @@ import { Info } from "lucide-react"
 
 import { Alert } from "@/components/ui"
 import { RoleBadges } from "./RoleBadges"
+import { coerceImportRole } from "./rosterImportParse"
 import type { Student } from "@/types/classroom"
-import type { ClassroomRole } from "@/util/teamRoster"
-
-// Map a roster.csv `role` cell to a ClassroomRole for the badge. The column is
-// best-effort metadata (teacher/hta/ta/student, the legacy "instructor", or
-// blank), so an unknown/blank value renders as a plain student.
-function roleFromCsv(role: string): ClassroomRole {
-  switch (role.trim().toLowerCase()) {
-    case "teacher":
-      return "teacher"
-    case "instructor":
-      return "instructor"
-    case "hta":
-      return "hta"
-    case "ta":
-      return "ta"
-    default:
-      return "student"
-  }
-}
 
 function displayName(student: Student): string {
   const full = `${student.first_name} ${student.last_name}`.trim()
@@ -89,7 +71,9 @@ const CsvRosterView = ({ students }: { students: Student[] }) => {
                   </td>
                   <td>{student.section || "—"}</td>
                   <td>
-                    <RoleBadges roles={[roleFromCsv(student.role)]} />
+                    <RoleBadges
+                      roles={[coerceImportRole(student.role) ?? "student"]}
+                    />
                   </td>
                 </tr>
               ))

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -12,15 +12,11 @@ function displayName(student: Student): string {
   return full || student.username
 }
 
-// The read-only "CSV roster" — a non-owner staffer's (TA / head TA) view of the
-// class, sourced from the config repo's roster.csv rather than GitHub team
-// membership (the "team-driven roster" the owner sees via EnrolledStudents). A
-// TA/HTA is a plain org member who is NOT on the classroom's secret student
-// team, so the team-members API (GET /orgs/{org}/teams/{slug}/members) 403s for
-// them — they genuinely can't read the authoritative enrollment. roster.csv
-// (which they can read via config-repo access) is a good-enough stand-in:
-// teacher-maintained, not live, and carrying no pending invites or management
-// actions (all owner-only).
+// The read-only "CSV roster" for a non-owner staffer (TA / head TA), sourced
+// from the config repo's roster.csv rather than GitHub team membership. A TA/HTA
+// isn't on the classroom's secret student team, so the team-members API 403s for
+// them — roster.csv (readable via config-repo access) is the stand-in:
+// teacher-maintained, not live, no invites or management actions.
 const CsvRosterView = ({ students }: { students: Student[] }) => {
   const { t } = useTranslation()
 

--- a/web/src/pages/students/EnrolledStudents.smoke.test.tsx
+++ b/web/src/pages/students/EnrolledStudents.smoke.test.tsx
@@ -61,10 +61,29 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
   return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) }
 })
 // Child surfaces with their own tests + provider needs; stub so the smoke test
-// renders EnrolledStudents' own markup provider-free.
-vi.mock("@/pages/students/RosterMemberModal", () => ({ default: () => null }))
+// renders EnrolledStudents' own markup provider-free. RosterMemberModal's stub
+// captures its canManage prop so the owner-gate wiring test can assert it.
+let capturedCanManage: boolean | undefined
+vi.mock("@/pages/students/RosterMemberModal", () => ({
+  default: (props: { canManage?: boolean }) => {
+    capturedCanManage = props.canManage
+    return null
+  },
+}))
 vi.mock("@/pages/students/RosterBulkActionsBar", () => ({
   default: () => null,
+}))
+
+// Owner-gate: EnrolledStudents forwards canManage={isOwner} to RosterMemberModal
+// (was !pendingHidden). Mock the org-owner verdict so the wiring test can flip it.
+let mockIsOwner = true
+vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
+  useIsOrgOwner: () => ({
+    isOwner: mockIsOwner,
+    isPending: false,
+    isError: false,
+    retry: vi.fn(),
+  }),
 }))
 
 import EnrolledStudents from "./EnrolledStudents"
@@ -108,6 +127,8 @@ afterEach(() => {
   // clearAllMocks resets call records but not implementations; reset the
   // migrate spy so one test's onSettled stub can't leak the gate into the next.
   migrateMutate.mockReset()
+  mockIsOwner = true
+  capturedCanManage = undefined
 })
 
 describe("EnrolledStudents — rendered phase views", () => {
@@ -199,5 +220,41 @@ describe("EnrolledStudents — rendered phase views", () => {
     })
     render(renderView())
     expect(syncMutate).not.toHaveBeenCalled()
+  })
+
+  // Owner-gate wiring: the per-member modal's management actions hit owner-only
+  // org APIs, so canManage must forward the org-owner verdict (isOwner), not the
+  // old !pendingHidden proxy. A non-owner staffer (TA/HTA) never reaches this
+  // component (StudentListPage routes them to CsvRosterContent), but the write
+  // path is the real guard, so pin the wiring both ways.
+  const populatedRoster = {
+    ...emptyRoster,
+    isEmpty: false,
+    counts: { enrolled: 1, pending: 0 },
+    rows: [
+      {
+        key: "alice",
+        username: "alice",
+        email: "",
+        section: "",
+        github_id: "1",
+        roles: ["student"],
+        state: "enrolled",
+      },
+    ],
+  }
+
+  it("forwards canManage=true to the member modal for an org owner", () => {
+    mockIsOwner = true
+    useTeamRoster.mockReturnValue(populatedRoster)
+    render(renderView())
+    expect(capturedCanManage).toBe(true)
+  })
+
+  it("forwards canManage=false to the member modal for a non-owner", () => {
+    mockIsOwner = false
+    useTeamRoster.mockReturnValue(populatedRoster)
+    render(renderView())
+    expect(capturedCanManage).toBe(false)
   })
 })

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -16,6 +16,7 @@ import { useDismissFailedInvite } from "@/hooks/mutations/useDismissFailedInvite
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import { useGitHubViewer } from "@/hooks/useGitHubResources"
 import type { GitHubOrgInvitation } from "@/github-core/types"
 import { invalidateInviteQueries as invalidateInviteQueriesForOrg } from "@/github-core/queries"
@@ -94,6 +95,12 @@ const EnrolledStudents = ({
   const { t } = useTranslation()
   const { notify } = useToast()
   const { data: viewer } = useGitHubViewer()
+  // Roster invite / unenroll / role-change all hit owner-only org APIs
+  // (createOrgInvitation, removeOrgMembership, setOrgMembershipRole). Gate the
+  // per-member modal's management actions on an explicit org-owner check rather
+  // than the old `!pendingHidden` proxy — GitHub is the true enforcer, this is
+  // the UX gate.
+  const { isOwner } = useIsOrgOwner()
   const updateRosterCache = useUpdateRosterCache(org, classroom)
   const invalidateTeamRoster = useInvalidateTeamRoster(org, classroom)
 
@@ -732,7 +739,7 @@ const EnrolledStudents = ({
         classroom={classroom}
         teamSlugByRole={teamSlugByRole}
         row={selected}
-        canManage={!pendingHidden}
+        canManage={isOwner}
         isSelf={selected ? isSelf(selected) : false}
         onClose={() => setSelectedKey(null)}
         onSaved={(rowKey, updated) => onRowMetadataSaved(rowKey, updated)}

--- a/web/src/pages/students/RosterApproxView.test.tsx
+++ b/web/src/pages/students/RosterApproxView.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+import RosterApproxView from "./RosterApproxView"
+import type { Student } from "@/types/classroom"
+
+const student = (overrides: Partial<Student> = {}): Student => ({
+  username: "alice",
+  first_name: "Alice",
+  last_name: "Ng",
+  email: "",
+  section: "S1",
+  github_id: "1",
+  role: "student",
+  ...overrides,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("RosterApproxView", () => {
+  it("shows the approximate-source notice", () => {
+    render(<RosterApproxView students={[student()]} />)
+    expect(screen.getByText("students.approx.notice")).toBeTruthy()
+  })
+
+  it("renders a row per roster.csv entry with name, section, and role", () => {
+    render(
+      <RosterApproxView
+        students={[
+          student({ username: "alice", first_name: "Alice", last_name: "Ng" }),
+          student({
+            username: "bob",
+            first_name: "Bob",
+            last_name: "Lee",
+            section: "S2",
+            role: "hta",
+          }),
+        ]}
+      />,
+    )
+    expect(screen.getByText("Alice Ng")).toBeTruthy()
+    expect(screen.getByText("Bob Lee")).toBeTruthy()
+    // The head-TA row's role maps to the head-TA badge label.
+    expect(screen.getByText("students.roleHeadTa")).toBeTruthy()
+  })
+
+  it("maps a blank/unknown role cell to the student badge", () => {
+    render(<RosterApproxView students={[student({ role: "" })]} />)
+    expect(screen.getByText("students.roleStudent")).toBeTruthy()
+  })
+
+  it("falls back to the username when no name is recorded", () => {
+    render(
+      <RosterApproxView
+        students={[
+          student({ username: "carol", first_name: "", last_name: "" }),
+        ]}
+      />,
+    )
+    // Both the display-name cell and the username line show the login.
+    expect(screen.getAllByText("carol").length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("renders an empty-state row when roster.csv has no entries", () => {
+    render(<RosterApproxView students={[]} />)
+    expect(screen.getByText("students.approx.empty")).toBeTruthy()
+  })
+
+  it("renders no mutating controls (read-only)", () => {
+    const { container } = render(<RosterApproxView students={[student()]} />)
+    expect(container.querySelectorAll("button")).toHaveLength(0)
+  })
+})

--- a/web/src/pages/students/RosterApproxView.tsx
+++ b/web/src/pages/students/RosterApproxView.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { Info } from "lucide-react"
+
+import { Alert } from "@/components/ui"
+import { RoleBadges } from "./RoleBadges"
+import type { Student } from "@/types/classroom"
+import type { ClassroomRole } from "@/util/teamRoster"
+
+// Map a roster.csv `role` cell to a ClassroomRole for the badge. The column is
+// best-effort metadata (teacher/hta/ta/student, the legacy "instructor", or
+// blank), so an unknown/blank value renders as a plain student.
+function roleFromCsv(role: string): ClassroomRole {
+  switch (role.trim().toLowerCase()) {
+    case "teacher":
+      return "teacher"
+    case "instructor":
+      return "instructor"
+    case "hta":
+      return "hta"
+    case "ta":
+      return "ta"
+    default:
+      return "student"
+  }
+}
+
+function displayName(student: Student): string {
+  const full = `${student.first_name} ${student.last_name}`.trim()
+  return full || student.username
+}
+
+// Read-only roster for a non-owner staffer (TA / head TA), sourced from the
+// config repo's roster.csv rather than GitHub team membership. A TA/HTA is a
+// plain org member who is NOT on the classroom's secret student team, so the
+// team-members API (GET /orgs/{org}/teams/{slug}/members) 403s for them — they
+// genuinely can't read the authoritative enrollment. roster.csv (which they can
+// read via config-repo access) is a good-enough approximation: teacher-
+// maintained, not live, and carrying no pending invites or management actions
+// (all owner-only). Owners get the live team-driven EnrolledStudents view.
+const RosterApproxView = ({ students }: { students: Student[] }) => {
+  const { t } = useTranslation()
+
+  const rows = useMemo(
+    () =>
+      [...students].sort((a, b) =>
+        displayName(a).localeCompare(displayName(b)),
+      ),
+    [students],
+  )
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Alert tone="info">
+        <Info aria-hidden="true" className="size-5" />
+        <span>{t("students.approx.notice")}</span>
+      </Alert>
+
+      <div className="overflow-x-auto rounded-box border border-base-content/5 bg-base-100">
+        <table className="table">
+          <caption className="sr-only">{t("students.approx.caption")}</caption>
+          <thead>
+            <tr>
+              <th scope="col">{t("students.approx.colName")}</th>
+              <th scope="col">{t("students.approx.colSection")}</th>
+              <th scope="col">{t("students.approx.colRole")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="text-center">
+                  {t("students.approx.empty")}
+                </td>
+              </tr>
+            ) : (
+              rows.map((student) => (
+                <tr key={student.username || student.github_id}>
+                  <td>
+                    <div className="font-bold">{displayName(student)}</div>
+                    {student.username ? (
+                      <div className="font-mono text-xs text-base-content/70">
+                        {student.username}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td>{student.section || "—"}</td>
+                  <td>
+                    <RoleBadges roles={[roleFromCsv(student.role)]} />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default RosterApproxView

--- a/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+import { SubmissionsActionsMenu } from "./SubmissionsActionsMenu"
+
+const baseProps = {
+  collecting: false,
+  regrading: false,
+  regradeAllActive: false,
+  emptyRoster: false,
+  onCollect: () => {},
+  onRegradeAll: () => {},
+  viewHref: "https://example.test/run",
+  viewLabel: "submissions.menu.viewWorkflow",
+  onDownloadCsv: () => {},
+  downloadDisabled: false,
+}
+
+afterEach(() => cleanup())
+
+describe("SubmissionsActionsMenu — canRegradeAll gate", () => {
+  it("shows Regrade all when the viewer may batch-regrade", () => {
+    render(<SubmissionsActionsMenu {...baseProps} canRegradeAll={true} />)
+    expect(screen.queryByText("submissions.regradeAll.label")).not.toBeNull()
+    // Collect stays available regardless (all-staff action).
+    expect(screen.queryByText("submissions.collect.label")).not.toBeNull()
+  })
+
+  it("hides Regrade all for a viewer who can't (TA), keeping Collect", () => {
+    render(<SubmissionsActionsMenu {...baseProps} canRegradeAll={false} />)
+    expect(screen.queryByText("submissions.regradeAll.label")).toBeNull()
+    expect(screen.queryByText("submissions.collect.label")).not.toBeNull()
+  })
+
+  it("defaults to showing Regrade all when the prop is omitted", () => {
+    render(<SubmissionsActionsMenu {...baseProps} />)
+    expect(screen.queryByText("submissions.regradeAll.label")).not.toBeNull()
+  })
+})

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -17,6 +17,7 @@ export function SubmissionsActionsMenu({
   collecting,
   regrading,
   regradeAllActive,
+  canRegradeAll = true,
   emptyRoster,
   emptyRepo = false,
   onCollect,
@@ -29,6 +30,11 @@ export function SubmissionsActionsMenu({
   collecting: boolean
   regrading: boolean
   regradeAllActive: boolean
+  // Whether the viewer may trigger "Regrade all" (teacher|hta). A plain TA can
+  // Collect and regrade individual rows but not batch-regrade; GitHub 403s a
+  // pull-only TA regardless, so this is the UX gate. Defaults true for callers
+  // that don't gate (the item stays visible).
+  canRegradeAll?: boolean
   emptyRoster: boolean
   // empty_repo assignment: never autogrades, so the grading actions (Collect
   // now / Regrade all / View workflow) are hidden — only the CSV export stays.
@@ -104,26 +110,28 @@ export function SubmissionsActionsMenu({
         </li>
         {!emptyRepo && (
           <>
-            <li>
-              <button
-                type="button"
-                disabled={disabledActions}
-                title={regradeTitle}
-                onClick={() => {
-                  closeMenu()
-                  if (disabledActions) return
-                  onRegradeAll()
-                }}
-              >
-                <RefreshCw
-                  aria-hidden="true"
-                  className={`size-4 ${regradeAllActive ? "animate-spin" : ""}`}
-                />
-                {regradeAllActive
-                  ? t("submissions.regradeAll.active")
-                  : t("submissions.regradeAll.label")}
-              </button>
-            </li>
+            {canRegradeAll && (
+              <li>
+                <button
+                  type="button"
+                  disabled={disabledActions}
+                  title={regradeTitle}
+                  onClick={() => {
+                    closeMenu()
+                    if (disabledActions) return
+                    onRegradeAll()
+                  }}
+                >
+                  <RefreshCw
+                    aria-hidden="true"
+                    className={`size-4 ${regradeAllActive ? "animate-spin" : ""}`}
+                  />
+                  {regradeAllActive
+                    ? t("submissions.regradeAll.active")
+                    : t("submissions.regradeAll.label")}
+                </button>
+              </li>
+            )}
             <li>
               <a href={viewHref} target="_blank" rel="noreferrer">
                 <ExternalLink aria-hidden="true" className="size-4" />


### PR DESCRIPTION
## Summary

Hardens role-based access control in the web app so a user only sees and can invoke actions their GitHub org role + classroom team actually permit, and extends the private-template read-grant to the Head TA team across all three tools.

GitHub only enforces **Owner vs Member**; teachers are org owners, while TAs/Head TAs/students are members on per-classroom `secret` teams. These UI gates are UX/expectation alignment — **GitHub's 403 remains the true enforcer** — so the goal is to not surface actions that would fail, and to express the real permission tiers.

### RBAC (web)
- New `authorAssignments` capability (`teacher|hta`): gates create/edit/delete/reuse assignment and Regrade-all. TAs get a **read-only** assignment view. Collect + per-row regrade stay all-staff.
- Added a `RequireRole allow="author"` arm (the old `staff|teacher|owner` couldn't express teacher|hta).
- Template-repo field + "Fix template access" gated on `manageOrg` (org owner), **not** the teacher role — org-owner and classroom-teacher are independent axes (KTD-4). A save-path guard makes the owner-only `addRepositoryToTeam` a no-op for a non-owner author, and now surfaces an **owner-required warning** instead of silently skipping (so students never hit an unexplained accept 404).
- Defense-in-depth `can()` assertions on `ClassroomStaffSection` and roster management (`can("manageOrg")` instead of the `!pendingHidden` proxy).

### CSV roster for TA/HTA
- TAs/Head TAs can't list the `secret` student team via the GitHub API, so `StudentListPage` branches on org-ownership: owners get the live **team-driven roster** (full management); TA/HTA get a **read-only CSV roster** from `roster.csv` (config-repo readable), clearly labeled as an approximation.

### Private-template read-grant (web + Go CLI + Python collector)
- The eager grant on a private in-org template now covers **student + Head TA + TA** teams (was student + TA — the HTA team was missed). Updated in lockstep: the Go `StaffTeamRepoPermissions` contract, the Python `STAFF_TEAM_PERMISSIONS` mirror, and the eager grant sites (`assignment add`/`reuse`/`migrate`), single-sourced as `TemplateReadStaffRoles`.

## Testing
- web: `tsc -b`, eslint, prettier, i18n audit all clean; **2011 vitest tests** pass.
- cli: `go build ./...` + full `go test ./...` pass; **476 Python** skeleton tests pass.
- Reviewed with an 8-persona `ce-code-review`; the one regression it surfaced (non-owner author silently dropping the student-team grant) is fixed in this branch, and the Go reuse/migrate tests now assert the Head TA grant.

## Notes
- No server/state model changes; no schema change (roles/team model unchanged — only client-side capability mapping refined, plus the additive `hta` entry in the existing staff-permission contract).

## Review follow-ups (2nd round)
A 9-persona `ce-code-review` pass surfaced two behavioral gaps and some test-coverage gaps, all addressed on this branch:

- **fix(web): attempt the template grant unless the org role is a _confirmed_ non-owner.** `canGrantTemplateAccess` was derived from `isOwner`, which is `false` while the org-membership read is in flight/errored — so a real owner deep-linking into the form before that read settled skipped the student-team grant and saw the owner-required warning (students then 404 until re-save). Now gated on a confirmed non-owner (the grant path never throws, so a non-owner's optimistic attempt fails soft into the same warning). Shared decision single-sourced as `resolveTemplateGrant`.
- **fix(cli): non-owner author gets owner-required guidance, not a fatal 403.** `grantClassroomTeamTemplateRead` returned the raw 403 fatally after the commit landed, so a head-TA driving `assignment add`/`reuse` got an opaque error + non-zero exit despite a successful commit (diverging from the web). A 403 on the owner-only student-team grant is now non-fatal (warn to stderr, exit 0); non-403 errors stay fatal.
- **Test hardening:** `useCanAttemptTemplateGrant` unit tests for the pending/errored states (previously green-while-red); `resolveTemplateGrant` owner/non-owner/undefined branch tests (closes the untested `createAssignment` grant branch); a `TEMPLATE_READ_STAFF_ROLES` parity test binding the TS non-owner staff set to Go's `TemplateReadStaffRoles`; a Go `RoleHeadTA` pin in `TestStaffTeamRepoPermissions`; a `RefForRole` table test; and a Go 403-non-fatal reuse test. Refreshed a stale parity-test comment.

- **refactor(web): reuse `coerceImportRole` in `CsvRosterView`.** A `ce-simplify-code` pass found the view's hand-rolled `roleFromCsv` duplicated the exported `coerceImportRole`; consolidated onto the shared coercer (render-identical — `instructor` and `teacher` share the badge label/tone). No other simplifications met the behavior-preserving bar.
