### PR TITLE
feat(web): show live submission presence in teacher gradebook

### DIFF
--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -14,6 +14,8 @@ export {
   isFreshRepoLagError,
   withFreshRepoRetry,
   REPO_READ_CONCURRENCY,
+  withGithubReadSlot,
+  retryOnRateLimit,
   type FreshRepoRetryOptions,
 } from "./queries/shared"
 export {

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -90,6 +90,7 @@ export {
 } from "./queries/pagesReads"
 export {
   releasesQuery,
+  latestSubmitReleaseWithAssets,
   getServiceTokenStatus,
   getCollectScoresRunAfterId,
   getRegradeRunAfterId,

--- a/web/src/github-core/queries/releaseRunReads.test.ts
+++ b/web/src/github-core/queries/releaseRunReads.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
-import { getServiceTokenStatus } from "./releaseRunReads"
+import {
+  getServiceTokenStatus,
+  latestSubmitReleaseWithAssets,
+} from "./releaseRunReads"
 import type { GitHubClient } from "../client"
+import type { GitHubRelease } from "../types"
 
 const noRateLimit: GitHubRateLimit = {
   limit: null,
@@ -63,5 +67,77 @@ describe("getServiceTokenStatus", () => {
         "org",
       ),
     ).rejects.toThrow()
+  })
+})
+
+const clientReturning = (releases: GitHubRelease[]): GitHubClient =>
+  ({ request: vi.fn().mockResolvedValue(releases) }) as unknown as GitHubClient
+
+const release = (
+  tag: string,
+  when: string,
+  extra: Partial<GitHubRelease> = {},
+): GitHubRelease => ({
+  id: 1,
+  tag_name: tag,
+  name: tag,
+  html_url: `https://github.com/o/r/releases/tag/${tag}`,
+  draft: false,
+  prerelease: false,
+  created_at: when,
+  published_at: when,
+  ...extra,
+})
+
+describe("latestSubmitReleaseWithAssets", () => {
+  it("returns the newest submit/* release among several", async () => {
+    const client = clientReturning([
+      release("submit/2026-01-01T00:00:00Z-aaaa", "2026-01-01T00:00:00Z"),
+      release("submit/2026-03-01T00:00:00Z-cccc", "2026-03-01T00:00:00Z"),
+      release("submit/2026-02-01T00:00:00Z-bbbb", "2026-02-01T00:00:00Z"),
+    ])
+    const latest = await latestSubmitReleaseWithAssets(client, "o", "r")
+    expect(latest?.tag_name).toBe("submit/2026-03-01T00:00:00Z-cccc")
+  })
+
+  it("ignores non-submit/* tags", async () => {
+    const client = clientReturning([
+      release("v1.0.0", "2026-05-01T00:00:00Z"),
+      release("submit/2026-01-01T00:00:00Z-aaaa", "2026-01-01T00:00:00Z"),
+    ])
+    const latest = await latestSubmitReleaseWithAssets(client, "o", "r")
+    expect(latest?.tag_name).toBe("submit/2026-01-01T00:00:00Z-aaaa")
+  })
+
+  it("returns null when there are no submit/* releases", async () => {
+    const client = clientReturning([release("v1.0.0", "2026-05-01T00:00:00Z")])
+    expect(await latestSubmitReleaseWithAssets(client, "o", "r")).toBeNull()
+  })
+
+  it("returns null on a 404 (repo not accepted)", async () => {
+    const client = clientThrowing(apiError(404))
+    expect(await latestSubmitReleaseWithAssets(client, "o", "r")).toBeNull()
+  })
+
+  it("rethrows a non-404 error (e.g. 403) rather than hiding it as no-submission", async () => {
+    await expect(
+      latestSubmitReleaseWithAssets(clientThrowing(apiError(403)), "o", "r"),
+    ).rejects.toThrow()
+  })
+
+  it("carries the release's assets through for the caller", async () => {
+    const client = clientReturning([
+      release("submit/2026-01-01T00:00:00Z-aaaa", "2026-01-01T00:00:00Z", {
+        assets: [
+          {
+            id: 9,
+            name: "result.json",
+            browser_download_url: "https://github.com/o/r/releases/download/x",
+          },
+        ],
+      }),
+    ])
+    const latest = await latestSubmitReleaseWithAssets(client, "o", "r")
+    expect(latest?.assets?.[0]?.name).toBe("result.json")
   })
 })

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -18,6 +18,14 @@ export function releaseTime(release: GitHubRelease): number {
   return new Date(release.published_at ?? release.created_at).getTime()
 }
 
+// The `submit/*` releases from a repo's release list, newest first — the shared
+// filter+sort both the full-list query and the latest-only read derive from.
+function submitReleasesNewestFirst(releases: GitHubRelease[]): GitHubRelease[] {
+  return releases
+    .filter((r) => r.tag_name.startsWith(SUBMISSION_TAG_PREFIX))
+    .sort((a, b) => releaseTime(b) - releaseTime(a))
+}
+
 // All graded-submission releases for a student's repo, newest first. A repo
 // with no releases yet (or a first push still grading) returns []. The release
 // page shows the rendered grade, so we only need the metadata.
@@ -40,9 +48,7 @@ export function releasesQuery(
           { method: "GET", signal },
         )
 
-        return releases
-          .filter((r) => r.tag_name.startsWith(SUBMISSION_TAG_PREFIX))
-          .sort((a, b) => releaseTime(b) - releaseTime(a))
+        return submitReleasesNewestFirst(releases)
       }, []),
     enabled: Boolean(owner && repo),
     staleTime: 5 * 60 * 1000,
@@ -51,14 +57,12 @@ export function releasesQuery(
 }
 
 // The newest `submit/*` release for a repo (with its assets), or null when the
+// The newest `submit/*` release for a repo (with its assets), or null when the
 // repo has no submission release or doesn't exist (404). Used by the live
-// teacher fan-out: one call per assignment repo yields whether the student has
-// submitted and — once the asset-download path is resolved — the handle to
-// `result.json`. A single `per_page=100` page is sufficient for "newest": the
-// list sorts newest-first and we only want the latest, so unlike the CLI's
-// all_submit_releases full walk we don't paginate. A missing repo (not
-// accepted) 404s and resolves to null rather than throwing, so one absent repo
-// never voids a batch.
+// teacher fan-out. A missing repo (not accepted) 404s and resolves to null
+// rather than throwing, so one absent repo never voids a batch. Reads a single
+// page — GitHub returns releases newest-first, so the top submit release is the
+// latest (unlike the CLI's full-history walk).
 export async function latestSubmitReleaseWithAssets(
   client: GitHubClient,
   owner: string,
@@ -73,11 +77,7 @@ export async function latestSubmitReleaseWithAssets(
       { method: "GET", signal },
     )
 
-    const submits = releases
-      .filter((r) => r.tag_name.startsWith(SUBMISSION_TAG_PREFIX))
-      .sort((a, b) => releaseTime(b) - releaseTime(a))
-
-    return submits[0] ?? null
+    return submitReleasesNewestFirst(releases)[0] ?? null
   }, null)
 }
 

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -11,10 +11,10 @@ import { githubKeys } from "./keys"
 // push publishes a `submit/<timestamp>-<sha>` release whose body GitHub renders
 // as the score + per-test table. We list these and link students straight to
 // the release page rather than reading result.json.
-const SUBMISSION_TAG_PREFIX = "submit/"
+export const SUBMISSION_TAG_PREFIX = "submit/"
 
 // published_at is null for a draft; fall back to created_at so ordering holds.
-function releaseTime(release: GitHubRelease): number {
+export function releaseTime(release: GitHubRelease): number {
   return new Date(release.published_at ?? release.created_at).getTime()
 }
 
@@ -48,6 +48,37 @@ export function releasesQuery(
     staleTime: 5 * 60 * 1000,
     retry: false,
   })
+}
+
+// The newest `submit/*` release for a repo (with its assets), or null when the
+// repo has no submission release or doesn't exist (404). Used by the live
+// teacher fan-out: one call per assignment repo yields whether the student has
+// submitted and — once the asset-download path is resolved — the handle to
+// `result.json`. A single `per_page=100` page is sufficient for "newest": the
+// list sorts newest-first and we only want the latest, so unlike the CLI's
+// all_submit_releases full walk we don't paginate. A missing repo (not
+// accepted) 404s and resolves to null rather than throwing, so one absent repo
+// never voids a batch.
+export async function latestSubmitReleaseWithAssets(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  signal?: AbortSignal,
+): Promise<GitHubRelease | null> {
+  return tolerateGitHubError(async () => {
+    const releases = await client.request<GitHubRelease[]>(
+      `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+        repo,
+      )}/releases?per_page=100`,
+      { method: "GET", signal },
+    )
+
+    const submits = releases
+      .filter((r) => r.tag_name.startsWith(SUBMISSION_TAG_PREFIX))
+      .sort((a, b) => releaseTime(b) - releaseTime(a))
+
+    return submits[0] ?? null
+  }, null)
 }
 
 type RepositorySecret = {

--- a/web/src/github-core/queries/shared.test.ts
+++ b/web/src/github-core/queries/shared.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import { retryOnRateLimit, withGithubReadSlot } from "./shared"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const rateLimitedError = (retryAfter: number | null = 0) =>
+  new GitHubAPIError({
+    status: 429,
+    url: "https://api.github.com/x",
+    message: "rate limited",
+    body: null,
+    rateLimit: { ...noRateLimit, retryAfter },
+  })
+
+const plainError = (status: number) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: noRateLimit,
+  })
+
+describe("retryOnRateLimit", () => {
+  it("returns the result when the call succeeds first try", async () => {
+    const fn = vi.fn().mockResolvedValue("ok")
+    await expect(retryOnRateLimit(fn)).resolves.toBe("ok")
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries once on a rate-limit error, then succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitedError(0))
+      .mockResolvedValueOnce("ok")
+    await expect(retryOnRateLimit(fn)).resolves.toBe("ok")
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it("throws if the rate-limit persists past the single retry", async () => {
+    const fn = vi.fn().mockRejectedValue(rateLimitedError(0))
+    await expect(retryOnRateLimit(fn)).rejects.toBeInstanceOf(GitHubAPIError)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not retry a non-rate-limit error (e.g. 403 scope gap, 500)", async () => {
+    const fn = vi.fn().mockRejectedValue(plainError(500))
+    await expect(retryOnRateLimit(fn)).rejects.toBeInstanceOf(GitHubAPIError)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not retry a plain rejection that is not a GitHubAPIError", async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await expect(retryOnRateLimit(fn)).rejects.toBeInstanceOf(TypeError)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("withGithubReadSlot", () => {
+  it("bounds concurrent reads to the shared cap across interleaved callers", async () => {
+    let inFlight = 0
+    let peak = 0
+    const release: Array<() => void> = []
+
+    // 20 tasks that each block until we release them, so we can observe the
+    // peak simultaneous count the semaphore permits.
+    const tasks = Array.from({ length: 20 }, () =>
+      withGithubReadSlot(async () => {
+        inFlight++
+        peak = Math.max(peak, inFlight)
+        await new Promise<void>((resolve) => release.push(resolve))
+        inFlight--
+      }),
+    )
+
+    // Let the scheduler admit the first wave, then drain everything.
+    await Promise.resolve()
+    await Promise.resolve()
+    while (release.length > 0) {
+      release.shift()!()
+      await Promise.resolve()
+      await Promise.resolve()
+    }
+    await Promise.all(tasks)
+
+    // REPO_READ_CONCURRENCY is 8; the shared semaphore must never exceed it
+    // even though 20 tasks were queued at once.
+    expect(peak).toBeLessThanOrEqual(8)
+    expect(peak).toBeGreaterThan(0)
+  })
+})

--- a/web/src/github-core/queries/shared.ts
+++ b/web/src/github-core/queries/shared.ts
@@ -13,6 +13,83 @@ export const log = logger.scope(LOG_SCOPE_QUERIES)
 // while still beating a strictly-sequential loop.
 export const REPO_READ_CONCURRENCY = 8
 
+// A small FIFO counting semaphore. Independent per-repo fan-outs (the live
+// submissions hook and the group-member hook) can run on the same page load;
+// each capping *itself* at REPO_READ_CONCURRENCY still lets their union burst to
+// 2x, which is exactly the secondary-rate-limit shape we're avoiding. Sharing
+// one semaphore across every per-repo read makes the cap apply to the aggregate
+// in-flight requests, not per-pool. FIFO so no waiter starves.
+class Semaphore {
+  private available: number
+  private readonly waiters: Array<() => void> = []
+
+  constructor(permits: number) {
+    this.available = Math.max(1, permits)
+  }
+
+  private acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--
+      return Promise.resolve()
+    }
+    return new Promise((resolve) => this.waiters.push(resolve))
+  }
+
+  private release(): void {
+    const next = this.waiters.shift()
+    if (next) {
+      next()
+    } else {
+      this.available++
+    }
+  }
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire()
+    try {
+      return await fn()
+    } finally {
+      this.release()
+    }
+  }
+}
+
+// The single gate every per-repo GitHub read passes through, so concurrent
+// fan-outs share one budget. mapWithConcurrency still shapes each caller's task
+// list; this bounds the aggregate wire concurrency underneath it.
+const githubReadSemaphore = new Semaphore(REPO_READ_CONCURRENCY)
+
+export function withGithubReadSlot<T>(fn: () => Promise<T>): Promise<T> {
+  return githubReadSemaphore.run(fn)
+}
+
+// Retry-After ceiling: a real secondary-limit backoff is usually ~60s, but a
+// client fan-out shouldn't hang a page that long. Cap the wait so one throttled
+// repo can't stall the batch; beyond this the read surfaces as an error the UI
+// reports rather than an indefinite spinner.
+const MAX_RATE_LIMIT_WAIT_MS = 8000
+
+// Run a GitHub read, retrying ONCE if it fails with a rate-limit (429, or a 403
+// carrying Retry-After / remaining:0). Waits the server's Retry-After (bounded),
+// falling back to a short delay when the header is absent. Non-rate-limit errors
+// propagate immediately. One retry only — a persistent throttle should surface,
+// not loop.
+export async function retryOnRateLimit<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn()
+  } catch (err) {
+    if (err instanceof GitHubAPIError && err.isRateLimited) {
+      const retryAfterMs =
+        err.rateLimit.retryAfter !== null
+          ? err.rateLimit.retryAfter * 1000
+          : 1000
+      await sleep(Math.min(retryAfterMs, MAX_RATE_LIMIT_WAIT_MS))
+      return await fn()
+    }
+    throw err
+  }
+}
+
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -108,6 +108,16 @@ export type GitHubRepo = {
   html_url: string
 }
 
+// A release asset (GET /repos/{o}/{r}/releases returns these inline). The live
+// teacher view reads `result.json` from here; `browser_download_url` is the
+// download entry point (the authed API asset route 302-redirects to signed S3).
+export type GitHubReleaseAsset = {
+  id: number
+  name: string
+  browser_download_url: string
+  size?: number
+}
+
 export type GitHubRelease = {
   id: number
   tag_name: string
@@ -117,6 +127,9 @@ export type GitHubRelease = {
   prerelease: boolean
   created_at: string
   published_at: string | null
+  // Present on the list endpoint; absent-tolerant so existing release readers
+  // (student submissions list) that ignore assets keep working.
+  assets?: GitHubReleaseAsset[]
 }
 
 export type GitHubUser = {

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -70,6 +70,10 @@ export type SubmissionRow = {
   late?: boolean
   // Last (re-)graded instant of the latest submission (mirrors submissions[0]).
   gradedAt?: string
+  // A live-only row: the student has a submit/* release the collector hasn't
+  // ingested yet, so it carries presence (datetime/release) but no grade.
+  // Rendered as "submitted, not yet collected" rather than a 0/0 score.
+  pending?: boolean
   // Per-attempt history, newest first; the summary fields above mirror submissions[0].
   submissions: SubmissionAttempt[]
 }

--- a/web/src/hooks/useGroupRepoMembers.test.tsx
+++ b/web/src/hooks/useGroupRepoMembers.test.tsx
@@ -46,7 +46,11 @@ describe("useGroupRepoMemberLogins", () => {
       { wrapper: wrapper(makeClient()) },
     )
     await waitFor(() =>
-      expect([...result.current].sort()).toEqual(["alice", "bob", "carol"]),
+      expect([...result.current.logins].sort()).toEqual([
+        "alice",
+        "bob",
+        "carol",
+      ]),
     )
   })
 
@@ -85,7 +89,9 @@ describe("useGroupRepoMemberLogins", () => {
         ]),
       { wrapper: wrapper(makeClient()) },
     )
-    await waitFor(() => expect([...result.current].sort()).toEqual(["carol"]))
+    await waitFor(() =>
+      expect([...result.current.logins].sort()).toEqual(["carol"]),
+    )
   })
 
   it("does not fetch when there are no group repos", () => {
@@ -93,6 +99,22 @@ describe("useGroupRepoMemberLogins", () => {
       wrapper: wrapper(makeClient()),
     })
     expect(request).not.toHaveBeenCalled()
-    expect(result.current.size).toBe(0)
+    expect(result.current.logins.size).toBe(0)
+    // Nothing to reconcile, so never pending — the "no group" list can settle.
+    expect(result.current.isPending).toBe(false)
+  })
+
+  it("reports isPending until the collaborator fetch resolves", async () => {
+    request.mockResolvedValue([user("alice")])
+    const { result } = renderHook(
+      () =>
+        useGroupRepoMemberLogins("acme", [
+          { owner: "alice", repoName: "cs101-hw1-alice" },
+        ]),
+      { wrapper: wrapper(makeClient()) },
+    )
+    expect(result.current.isPending).toBe(true)
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.logins.has("alice")).toBe(true)
   })
 })

--- a/web/src/hooks/useGroupRepoMembers.ts
+++ b/web/src/hooks/useGroupRepoMembers.ts
@@ -27,7 +27,7 @@ type GroupRepoRef = { owner: string; repoName: string }
 export function useGroupRepoMemberLogins(
   org: string,
   repos: GroupRepoRef[],
-): Set<string> {
+): { logins: Set<string>; isPending: boolean } {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
 
@@ -36,7 +36,9 @@ export function useGroupRepoMemberLogins(
   // of group repos changes, not on every render.
   const repoKey = [...repoNames].sort().join(",")
 
-  const { data } = useQuery({
+  const enabled = Boolean(org) && repoNames.length > 0
+
+  const { data, isLoading } = useQuery({
     queryKey: [...githubKeys.all, "group-collaborators", org, repoKey] as const,
     queryFn: async () => {
       const logins = new Set<string>()
@@ -76,9 +78,15 @@ export function useGroupRepoMemberLogins(
       return logins
     },
     staleTime: 60 * 1000,
-    enabled: Boolean(org) && repoNames.length > 0,
+    enabled,
   })
 
   const empty = useMemo(() => new Set<string>(), [])
-  return data ?? empty
+  return {
+    logins: data ?? empty,
+    // Pending only while an enabled fetch hasn't resolved yet. A disabled hook
+    // (no group repos) is never pending — there's nothing to reconcile — so the
+    // "no group" list can settle immediately.
+    isPending: enabled && isLoading,
+  }
 }

--- a/web/src/hooks/useGroupRepoMembers.ts
+++ b/web/src/hooks/useGroupRepoMembers.ts
@@ -2,7 +2,12 @@ import { useMemo } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { githubKeys, REPO_READ_CONCURRENCY } from "@/github-core/queries"
+import {
+  githubKeys,
+  REPO_READ_CONCURRENCY,
+  retryOnRateLimit,
+  withGithubReadSlot,
+} from "@/github-core/queries"
 import type { GitHubUser } from "@/github-core/types"
 import { mapWithConcurrency } from "@/util/concurrency"
 
@@ -47,8 +52,15 @@ export function useGroupRepoMemberLogins(
           try {
             // affiliation=direct excludes org-inherited access (owners/admins),
             // matching useGetRepoCollaborators so both share one cache entry.
-            const collaborators = await client.request<GitHubUser[]>(
-              `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators?affiliation=direct`,
+            // Through the shared read slot (+ rate-limit retry) so this fan-out
+            // and the live-submissions fan-out share one concurrency budget on
+            // the same page load rather than each bursting to REPO_READ_CONCURRENCY.
+            const collaborators = await withGithubReadSlot(() =>
+              retryOnRateLimit(() =>
+                client.request<GitHubUser[]>(
+                  `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators?affiliation=direct`,
+                ),
+              ),
             )
             // Prime the per-repo cache the rows and Members modal read from.
             queryClient.setQueryData(

--- a/web/src/hooks/useLiveSubmissions.test.tsx
+++ b/web/src/hooks/useLiveSubmissions.test.tsx
@@ -149,6 +149,34 @@ describe("useLiveSubmissions", () => {
     expect(result.current.hasNextPage).toBe(false)
   })
 
+  it("retries a rate-limited repo read and counts it as submitted, not an error", async () => {
+    // First call for the repo is a 429 (retry-after 0 = immediate), second (the
+    // retry) succeeds — the shared retryOnRateLimit wrapper should absorb it so
+    // it lands as a submission, not an errorCount.
+    const rateLimited = new GitHubAPIError({
+      status: 429,
+      url: "https://api.github.com/x",
+      message: "rate limited",
+      body: null,
+      rateLimit: { ...noRateLimit, retryAfter: 0 },
+    })
+    let calls = 0
+    request.mockImplementation(() => {
+      calls++
+      if (calls === 1) return Promise.reject(rateLimited)
+      return Promise.resolve([
+        submitRelease("submit/x", "2026-01-01T00:00:00Z"),
+      ])
+    })
+    const { result } = renderHook(
+      () => useLiveSubmissions({ ...base, repoOwners: ["a"] }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+    expect(result.current.submissions.map((s) => s.owner)).toEqual(["a"])
+    expect(result.current.errorCount).toBe(0)
+  })
+
   it("refetch() re-reads the current page's repos", async () => {
     request.mockResolvedValue([
       submitRelease("submit/x", "2026-01-01T00:00:00Z"),

--- a/web/src/hooks/useLiveSubmissions.test.tsx
+++ b/web/src/hooks/useLiveSubmissions.test.tsx
@@ -138,6 +138,21 @@ describe("useLiveSubmissions", () => {
     )
     expect(request).not.toHaveBeenCalled()
     expect(result.current.submissions).toEqual([])
+    // A disabled fan-out has nothing to wait for, so it must not report pending
+    // (else the page would hold the "not submitted" list forever).
+    expect(result.current.isPending).toBe(false)
+  })
+
+  it("reports isPending until the first fan-out resolves", async () => {
+    request.mockResolvedValue([
+      submitRelease("submit/x", "2026-01-01T00:00:00Z"),
+    ])
+    const { result } = renderHook(
+      () => useLiveSubmissions({ ...base, repoOwners: ["a"] }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    expect(result.current.isPending).toBe(true)
+    await waitFor(() => expect(result.current.isPending).toBe(false))
   })
 
   it("does not fetch when there are no repo owners", () => {

--- a/web/src/hooks/useLiveSubmissions.test.tsx
+++ b/web/src/hooks/useLiveSubmissions.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+const request = vi.fn()
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request }),
+}))
+
+import { useLiveSubmissions } from "./useLiveSubmissions"
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const apiError = (status: number) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: noRateLimit,
+  })
+
+const submitRelease = (tag: string, when: string) => ({
+  id: 1,
+  tag_name: tag,
+  name: tag,
+  html_url: `https://github.com/o/r/releases/tag/${tag}`,
+  draft: false,
+  prerelease: false,
+  created_at: when,
+  published_at: when,
+})
+
+const makeClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const wrapper =
+  (client: QueryClient) =>
+  ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+
+const base = {
+  org: "acme",
+  classroom: "cs101",
+  assignment: "hw1",
+  enabled: true,
+}
+
+beforeEach(() => {
+  request.mockReset()
+})
+
+describe("useLiveSubmissions", () => {
+  it("fetches only the first pageSize owners and flags hasNextPage", async () => {
+    request.mockResolvedValue([
+      submitRelease("submit/x", "2026-01-01T00:00:00Z"),
+    ])
+    const owners = Array.from({ length: 5 }, (_, i) => `s${i}`)
+
+    const { result } = renderHook(
+      () =>
+        useLiveSubmissions({
+          ...base,
+          repoOwners: owners,
+          page: 0,
+          pageSize: 2,
+        }),
+      { wrapper: wrapper(makeClient()) },
+    )
+
+    await waitFor(() => expect(result.current.submissions.length).toBe(2))
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(result.current.hasNextPage).toBe(true)
+  })
+
+  it("hasNextPage is false on the last page", async () => {
+    request.mockResolvedValue([
+      submitRelease("submit/x", "2026-01-01T00:00:00Z"),
+    ])
+    const owners = ["a", "b", "c"]
+
+    const { result } = renderHook(
+      () =>
+        useLiveSubmissions({
+          ...base,
+          repoOwners: owners,
+          page: 1,
+          pageSize: 2,
+        }),
+      { wrapper: wrapper(makeClient()) },
+    )
+
+    await waitFor(() => expect(result.current.submissions.length).toBe(1))
+    expect(result.current.hasNextPage).toBe(false)
+  })
+
+  it("treats a repo with no submit release as not-submitted, not an error", async () => {
+    request.mockResolvedValue([]) // repo exists but no submissions
+    const { result } = renderHook(
+      () => useLiveSubmissions({ ...base, repoOwners: ["a"] }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+    expect(result.current.submissions).toEqual([])
+    expect(result.current.errorCount).toBe(0)
+  })
+
+  it("counts a repo's non-404 failure without dropping the others", async () => {
+    request.mockImplementation((url: string) =>
+      url.includes("cs101-hw1-bad")
+        ? Promise.reject(apiError(500))
+        : Promise.resolve([submitRelease("submit/x", "2026-01-01T00:00:00Z")]),
+    )
+    const { result } = renderHook(
+      () => useLiveSubmissions({ ...base, repoOwners: ["good", "bad"] }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+    expect(result.current.submissions.map((s) => s.owner)).toEqual(["good"])
+    expect(result.current.errorCount).toBe(1)
+  })
+
+  it("does not fetch when disabled (e.g. empty_repo assignment)", () => {
+    const { result } = renderHook(
+      () => useLiveSubmissions({ ...base, repoOwners: ["a"], enabled: false }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    expect(request).not.toHaveBeenCalled()
+    expect(result.current.submissions).toEqual([])
+  })
+
+  it("does not fetch when there are no repo owners", () => {
+    const { result } = renderHook(
+      () => useLiveSubmissions({ ...base, repoOwners: [] }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    expect(request).not.toHaveBeenCalled()
+    expect(result.current.hasNextPage).toBe(false)
+  })
+})

--- a/web/src/hooks/useLiveSubmissions.test.tsx
+++ b/web/src/hooks/useLiveSubmissions.test.tsx
@@ -148,4 +148,19 @@ describe("useLiveSubmissions", () => {
     expect(request).not.toHaveBeenCalled()
     expect(result.current.hasNextPage).toBe(false)
   })
+
+  it("refetch() re-reads the current page's repos", async () => {
+    request.mockResolvedValue([
+      submitRelease("submit/x", "2026-01-01T00:00:00Z"),
+    ])
+    const { result } = renderHook(
+      () => useLiveSubmissions({ ...base, repoOwners: ["a", "b"] }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+    expect(request).toHaveBeenCalledTimes(2)
+
+    result.current.refetch()
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(4))
+  })
 })

--- a/web/src/hooks/useLiveSubmissions.ts
+++ b/web/src/hooks/useLiveSubmissions.ts
@@ -6,6 +6,8 @@ import {
   REPO_READ_CONCURRENCY,
   githubKeys,
   latestSubmitReleaseWithAssets,
+  retryOnRateLimit,
+  withGithubReadSlot,
 } from "@/github-core/queries"
 import type { GitHubRelease } from "@/github-core/types"
 import { studentRepoName } from "@/util/studentRepo"
@@ -126,11 +128,14 @@ export function useLiveSubmissions({
         async (owner) => {
           const repo = studentRepoName(classroom!, assignment!, owner)
           try {
-            const release = await latestSubmitReleaseWithAssets(
-              client,
-              org!,
-              repo,
-              signal,
+            // Route through the shared read slot so this fan-out and any other
+            // per-repo fan-out on the page (e.g. group-member reads) share one
+            // concurrency budget, and retry once on a rate-limit before giving
+            // up on a repo.
+            const release = await withGithubReadSlot(() =>
+              retryOnRateLimit(() =>
+                latestSubmitReleaseWithAssets(client, org!, repo, signal),
+              ),
             )
             // 404 (repo not accepted) resolves to null inside the query — that
             // is "not submitted", not an error.
@@ -143,8 +148,9 @@ export function useLiveSubmissions({
               })
             }
           } catch {
-            // A non-404 failure (403/5xx/network) for one repo
-            // must not void the whole page — count it and move on.
+            // A non-404 failure (403/5xx/network, or a rate-limit that persisted
+            // past one retry) for one repo must not void the whole page — count
+            // it and move on.
             errorCount++
           }
         },

--- a/web/src/hooks/useLiveSubmissions.ts
+++ b/web/src/hooks/useLiveSubmissions.ts
@@ -11,6 +11,11 @@ import type { GitHubRelease } from "@/github-core/types"
 import { studentRepoName } from "@/util/studentRepo"
 import { mapWithConcurrency } from "@/util/concurrency"
 
+// How many of an assignment's repos the live fan-out reads per page ("Show
+// next N"). One source of truth: the hook defaults `pageSize` to this and the
+// page's control label derives its N from it, so the two can't drift.
+export const LIVE_PAGE_SIZE = 50
+
 // One student/group repo's live submission state, read directly from its
 // `submit/*` releases — independent of the collected scores.json snapshot.
 // `owner` is the repo-name component (the individual student login, or the
@@ -26,8 +31,9 @@ export type LiveSubmission = {
 }
 
 export type UseLiveSubmissionsResult = {
-  // Live submissions found on the current page window, keyed insertion-free by
-  // owner (lowercased) so the merge in the dashboard can union by owner.
+  // Live submissions found on the current page window, in completion order and
+  // original-case owner; the dashboard merge unions these over the snapshot by
+  // owner (case-insensitive).
   submissions: LiveSubmission[]
   // Repo owners on the current page that could not be read (404 is treated as
   // "not submitted", so these are the 403/5xx/network failures). Surfaced so
@@ -72,7 +78,7 @@ export function useLiveSubmissions({
   assignment,
   repoOwners,
   page = 0,
-  pageSize = 50,
+  pageSize = LIVE_PAGE_SIZE,
   enabled = true,
 }: UseLiveSubmissionsArgs): UseLiveSubmissionsResult {
   const client = useGitHubClient()
@@ -137,7 +143,7 @@ export function useLiveSubmissions({
               })
             }
           } catch {
-            // A non-404 failure (403/5xx/network after retries) for one repo
+            // A non-404 failure (403/5xx/network) for one repo
             // must not void the whole page — count it and move on.
             errorCount++
           }

--- a/web/src/hooks/useLiveSubmissions.ts
+++ b/web/src/hooks/useLiveSubmissions.ts
@@ -178,8 +178,7 @@ export function useLiveSubmissions({
     // it is never pending; otherwise it's pending until the first result lands.
     isPending: active && isLoading,
     hasNextPage,
-    // react-query's refetch returns a promise; the caller fires-and-forgets, so
-    // narrow it to void to keep the result type simple.
+    // Fire-and-forget; narrow react-query's promise to void.
     refetch: () => {
       void refetch()
     },

--- a/web/src/hooks/useLiveSubmissions.ts
+++ b/web/src/hooks/useLiveSubmissions.ts
@@ -1,0 +1,160 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import {
+  REPO_READ_CONCURRENCY,
+  githubKeys,
+  latestSubmitReleaseWithAssets,
+} from "@/github-core/queries"
+import type { GitHubRelease } from "@/github-core/types"
+import { studentRepoName } from "@/util/studentRepo"
+import { mapWithConcurrency } from "@/util/concurrency"
+
+// One student/group repo's live submission state, read directly from its
+// `submit/*` releases — independent of the collected scores.json snapshot.
+// `owner` is the repo-name component (the individual student login, or the
+// group founder). This is the *presence* shape: whether a submission exists,
+// when, and the release link. The graded fields (score/tests) are added once
+// the result.json asset-download path is resolved (see the plan's U2 spike);
+// keeping presence separate lets that drop in without reshaping callers.
+export type LiveSubmission = {
+  owner: string
+  submittedAt: string
+  releaseUrl: string
+  tag: string
+}
+
+export type UseLiveSubmissionsResult = {
+  // Live submissions found on the current page window, keyed insertion-free by
+  // owner (lowercased) so the merge in the dashboard can union by owner.
+  submissions: LiveSubmission[]
+  // Repo owners on the current page that could not be read (404 is treated as
+  // "not submitted", so these are the 403/5xx/network failures). Surfaced so
+  // the UI can say "k repos couldn't be read" rather than silently undercount.
+  errorCount: number
+  isFetching: boolean
+  // True when more owners remain beyond the current page window.
+  hasNextPage: boolean
+}
+
+const submitReleaseTime = (release: GitHubRelease): string =>
+  release.published_at ?? release.created_at
+
+export type UseLiveSubmissionsArgs = {
+  org: string | undefined
+  classroom: string | undefined
+  assignment: string | undefined
+  // Repo-name owner segments: roster/team logins for individual assignments,
+  // group-founder logins (from existingGroupRepos) for group assignments.
+  repoOwners: string[]
+  // 0-based page index; each page reads `pageSize` owners.
+  page?: number
+  pageSize?: number
+  // Off switch: empty_repo assignments never autograde, so the page disables
+  // the fan-out rather than reading releases that can't exist.
+  enabled?: boolean
+}
+
+// Reads live submissions for the current page of an assignment's repos, one
+// bounded-concurrency fan-out of `latestSubmitReleaseWithAssets` per owner.
+// Assignment-scoped (never the whole org) and paginated so a 500-student class
+// costs one release call per owner in a 50-owner window, not 500 at once. A
+// single repo's non-404 failure is caught per-repo (like useGroupRepoMemberLogins)
+// so it can't void the whole batch.
+export function useLiveSubmissions({
+  org,
+  classroom,
+  assignment,
+  repoOwners,
+  page = 0,
+  pageSize = 50,
+  enabled = true,
+}: UseLiveSubmissionsArgs): UseLiveSubmissionsResult {
+  const client = useGitHubClient()
+
+  const start = page * pageSize
+  const windowOwners = useMemo(
+    () => repoOwners.slice(start, start + pageSize),
+    [repoOwners, start, pageSize],
+  )
+  const hasNextPage = start + pageSize < repoOwners.length
+
+  // Stable key over the exact window (sorted) so the batch only refires when
+  // the owner set or page changes, not on every render.
+  const windowKey = useMemo(
+    () =>
+      [...windowOwners]
+        .map((o) => o.toLowerCase())
+        .sort()
+        .join(","),
+    [windowOwners],
+  )
+
+  const active =
+    enabled &&
+    Boolean(org && classroom && assignment) &&
+    windowOwners.length > 0
+
+  const { data, isFetching } = useQuery({
+    queryKey: [
+      ...githubKeys.all,
+      "live-submissions",
+      org ?? "",
+      classroom ?? "",
+      assignment ?? "",
+      page,
+      windowKey,
+    ] as const,
+    queryFn: async ({ signal }) => {
+      const submissions: LiveSubmission[] = []
+      let errorCount = 0
+
+      await mapWithConcurrency(
+        windowOwners,
+        REPO_READ_CONCURRENCY,
+        async (owner) => {
+          const repo = studentRepoName(classroom!, assignment!, owner)
+          try {
+            const release = await latestSubmitReleaseWithAssets(
+              client,
+              org!,
+              repo,
+              signal,
+            )
+            // 404 (repo not accepted) resolves to null inside the query — that
+            // is "not submitted", not an error.
+            if (release) {
+              submissions.push({
+                owner,
+                submittedAt: submitReleaseTime(release),
+                releaseUrl: release.html_url,
+                tag: release.tag_name,
+              })
+            }
+          } catch {
+            // A non-404 failure (403/5xx/network after retries) for one repo
+            // must not void the whole page — count it and move on.
+            errorCount++
+          }
+        },
+      )
+
+      return { submissions, errorCount }
+    },
+    enabled: active,
+    staleTime: 60 * 1000,
+    retry: false,
+  })
+
+  const empty = useMemo(() => [] as LiveSubmission[], [])
+
+  return {
+    submissions: data?.submissions ?? empty,
+    errorCount: data?.errorCount ?? 0,
+    isFetching,
+    hasNextPage,
+  }
+}
+
+export default useLiveSubmissions

--- a/web/src/hooks/useLiveSubmissions.ts
+++ b/web/src/hooks/useLiveSubmissions.ts
@@ -42,6 +42,11 @@ export type UseLiveSubmissionsResult = {
   // the UI can say "k repos couldn't be read" rather than silently undercount.
   errorCount: number
   isFetching: boolean
+  // True only while the FIRST fetch for the current inputs is in flight (not a
+  // background refetch). Callers gate flash-prone derived state (e.g. the
+  // "not submitted" list) on this so a row doesn't first render not-submitted
+  // and then jump to Pending once live presence lands.
+  isPending: boolean
   // True when more owners remain beyond the current page window.
   hasNextPage: boolean
   // Force a re-read of the current page's live submissions, bypassing the
@@ -108,7 +113,7 @@ export function useLiveSubmissions({
     Boolean(org && classroom && assignment) &&
     windowOwners.length > 0
 
-  const { data, isFetching, refetch } = useQuery({
+  const { data, isFetching, isLoading, refetch } = useQuery({
     queryKey: [
       ...githubKeys.all,
       "live-submissions",
@@ -169,6 +174,9 @@ export function useLiveSubmissions({
     submissions: data?.submissions ?? empty,
     errorCount: data?.errorCount ?? 0,
     isFetching,
+    // A disabled fan-out (empty_repo, or no owners) has nothing to wait for, so
+    // it is never pending; otherwise it's pending until the first result lands.
+    isPending: active && isLoading,
     hasNextPage,
     // react-query's refetch returns a promise; the caller fires-and-forgets, so
     // narrow it to void to keep the result type simple.

--- a/web/src/hooks/useLiveSubmissions.ts
+++ b/web/src/hooks/useLiveSubmissions.ts
@@ -36,6 +36,10 @@ export type UseLiveSubmissionsResult = {
   isFetching: boolean
   // True when more owners remain beyond the current page window.
   hasNextPage: boolean
+  // Force a re-read of the current page's live submissions, bypassing the
+  // staleTime — wired to the page's Refresh control so it refreshes live
+  // presence alongside the collected snapshot.
+  refetch: () => void
 }
 
 const submitReleaseTime = (release: GitHubRelease): string =>
@@ -96,7 +100,7 @@ export function useLiveSubmissions({
     Boolean(org && classroom && assignment) &&
     windowOwners.length > 0
 
-  const { data, isFetching } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: [
       ...githubKeys.all,
       "live-submissions",
@@ -154,6 +158,11 @@ export function useLiveSubmissions({
     errorCount: data?.errorCount ?? 0,
     isFetching,
     hasNextPage,
+    // react-query's refetch returns a promise; the caller fires-and-forgets, so
+    // narrow it to void to keep the result type simple.
+    refetch: () => {
+      void refetch()
+    },
   }
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1554,8 +1554,8 @@
       "checking": "Checking submissions live…",
       "pending_one": "{{count}} submitted, not yet collected",
       "pending_other": "{{count}} submitted, not yet collected",
-      "errors_one": "{{count}} repo couldn't be read",
-      "errors_other": "{{count}} repos couldn't be read",
+      "incomplete_one": "{{count}} repo couldn't be read, so submission counts and the \"not submitted\" list may be incomplete. Retry with Refresh, or run \"Collect now\".",
+      "incomplete_other": "{{count}} repos couldn't be read, so submission counts and the \"not submitted\" list may be incomplete. Retry with Refresh, or run \"Collect now\".",
       "showNext": "Show next {{count}}"
     },
     "menu": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1550,6 +1550,14 @@
     "updated": "Updated {{when}}",
     "justNow": "just now",
     "refresh": "Refresh submissions",
+    "live": {
+      "checking": "Checking submissions live…",
+      "pending_one": "{{count}} submitted, not yet collected",
+      "pending_other": "{{count}} submitted, not yet collected",
+      "errors_one": "{{count}} repo couldn't be read",
+      "errors_other": "{{count}} repos couldn't be read",
+      "showNext": "Show next {{count}}"
+    },
     "menu": {
       "actions": "Actions",
       "metrics": "Metrics",
@@ -1696,6 +1704,8 @@
       "noDetailsLabel": "No autograder details yet",
       "noDetails": "No details yet",
       "noGradingTitle": "Autograding is disabled for this assignment",
+      "pendingGrade": "Pending",
+      "pendingGradeTitle": "Submitted — grade not yet collected. Run \"Collect now\" or wait for the nightly collection.",
       "notSubmitted": "Not submitted",
       "acceptedAwaiting": "Accepted · awaiting submission",
       "notAccepted": "Not accepted",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1705,6 +1705,7 @@
       "noDetails": "No details yet",
       "noGradingTitle": "Autograding is disabled for this assignment",
       "resolvingNonSubmitters": "Checking who hasn't submitted yet…",
+      "loading": "Loading submissions…",
       "pendingGrade": "Pending",
       "pendingGradeTitle": "Submitted — grade not yet collected. Run \"Collect now\" or wait for the nightly collection.",
       "notSubmitted": "Not submitted",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1704,6 +1704,7 @@
       "noDetailsLabel": "No autograder details yet",
       "noDetails": "No details yet",
       "noGradingTitle": "Autograding is disabled for this assignment",
+      "resolvingNonSubmitters": "Checking who hasn't submitted yet…",
       "pendingGrade": "Pending",
       "pendingGradeTitle": "Submitted — grade not yet collected. Run \"Collect now\" or wait for the nightly collection.",
       "notSubmitted": "Not submitted",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -259,6 +259,16 @@ const SubmissionsPageContent = () => {
         : students.map((s) => s.username).filter(Boolean),
     [isGroupAssignment, groupRepoList, students],
   )
+  // Clamp the requested page to the last valid page for the CURRENT owner set.
+  // The page component isn't remounted across assignment navigation, so a
+  // leftover offset from a longer assignment would otherwise slice past a
+  // shorter one's owners and show an empty window (#347 review). Clamping in the
+  // derived value (rather than a setState-in-effect) keeps the reset render-pure.
+  const lastLivePage =
+    liveRepoOwners.length > 0
+      ? Math.ceil(liveRepoOwners.length / LIVE_PAGE_SIZE) - 1
+      : 0
+  const effectiveLivePage = Math.min(livePage, lastLivePage)
   const {
     submissions: liveSubmissions,
     errorCount: liveErrorCount,
@@ -269,7 +279,7 @@ const SubmissionsPageContent = () => {
     classroom,
     assignment,
     repoOwners: liveRepoOwners,
-    page: livePage,
+    page: effectiveLivePage,
     pageSize: LIVE_PAGE_SIZE,
     enabled: !isEmptyRepoAssignment,
   })
@@ -739,7 +749,7 @@ const SubmissionsPageContent = () => {
               variant="ghost"
               size="xs"
               disabled={liveFetching}
-              onClick={() => setLivePage((p) => p + 1)}
+              onClick={() => setLivePage(effectiveLivePage + 1)}
             >
               {t("submissions.live.showNext", { count: LIVE_PAGE_SIZE })}
             </Button>

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -746,11 +746,6 @@ const SubmissionsPageContent = () => {
               {t("submissions.live.pending", { count: livePendingCount })}
             </Badge>
           )}
-          {liveErrorCount > 0 && (
-            <span className="text-warning">
-              {t("submissions.live.errors", { count: liveErrorCount })}
-            </span>
-          )}
           {liveHasNextPage && (
             <Button
               variant="ghost"
@@ -762,6 +757,17 @@ const SubmissionsPageContent = () => {
             </Button>
           )}
         </div>
+      )}
+
+      {/* When some repos couldn't be read, the live presence view is
+          known-incomplete: a student who submitted to an unreadable repo won't
+          get a Pending row and would read as not-submitted. Mark the derived
+          counts/lists provisional so a transient failure can't be mistaken for
+          an authoritative "not submitted". */}
+      {!isEmptyRepoAssignment && liveErrorCount > 0 && (
+        <Alert tone="warning" role="status">
+          {t("submissions.live.incomplete", { count: liveErrorCount })}
+        </Alert>
       )}
 
       {/* Live status strip. Full phase mapping: dispatching stays a quiet

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -331,19 +331,13 @@ const SubmissionsPageContent = () => {
   // group's row (#245), so listing them as "no group" too would double-count
   // them. Gated on scores having loaded — until then scoresInfo is empty and
   // would flag the whole roster.
-  // The "not submitted" list is derived last, from every source that can still
-  // reclassify a student: the collected snapshot, the live submit/* fan-out, and
-  // (for groups) the collaborator reconciliation. Gate it on all three settling
-  // so a student never renders as "not submitted" and then jumps to "Pending" /
-  // a group row as a later source resolves (the flash). Until ready, hold the
-  // prior list rather than recomputing an intermediate one.
+  // Hold the "not submitted" list until every source that can still reclassify
+  // a student settles (snapshot, live fan-out, group-member reconciliation) —
+  // else a submitter flashes "not submitted" before resolving to Pending.
   const scoresLoaded = scoresData !== undefined
-  // Core data still arriving on first paint: until the snapshot has loaded (and
-  // the roster resolved), an empty rows/non-submitters set means "not loaded
-  // yet", not "nothing here" — so the table shows a loading state rather than
-  // flashing the "No submissions collected yet" empty message (which then
-  // vanishes once data lands). A background refetch doesn't count (scoresLoaded
-  // stays true), so Refresh never blanks a populated table.
+  // Empty rows before the snapshot+roster land mean "loading", not "empty" —
+  // gate the empty state on this so it doesn't flash on first paint. A
+  // background refetch keeps scoresLoaded true, so Refresh never blanks the table.
   const initialLoading = !scoresLoaded || rosterLoading
   const nonSubmittersReady =
     scoresLoaded && !livePending && !groupMembersPending
@@ -684,11 +678,8 @@ const SubmissionsPageContent = () => {
                 shape="circle"
                 disabled={scoresFetching || liveFetching}
                 onClick={() => {
-                  // Refresh both data sources the page shows: the collected
-                  // snapshot (scores.json) AND the live submission fan-out.
-                  // Refreshing only the snapshot would leave the "Pending" live
-                  // rows — the part that reflects a just-pushed submission —
-                  // stale, which is the opposite of what Refresh implies.
+                  // Refresh both sources the page shows — snapshot alone would
+                  // leave the live "Pending" rows stale.
                   refetchScores()
                   refetchLive()
                 }}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -338,6 +338,13 @@ const SubmissionsPageContent = () => {
   // a group row as a later source resolves (the flash). Until ready, hold the
   // prior list rather than recomputing an intermediate one.
   const scoresLoaded = scoresData !== undefined
+  // Core data still arriving on first paint: until the snapshot has loaded (and
+  // the roster resolved), an empty rows/non-submitters set means "not loaded
+  // yet", not "nothing here" — so the table shows a loading state rather than
+  // flashing the "No submissions collected yet" empty message (which then
+  // vanishes once data lands). A background refetch doesn't count (scoresLoaded
+  // stays true), so Refresh never blanks a populated table.
+  const initialLoading = !scoresLoaded || rosterLoading
   const nonSubmittersReady =
     scoresLoaded && !livePending && !groupMembersPending
   const nonSubmitters = useMemo(() => {
@@ -921,6 +928,7 @@ const SubmissionsPageContent = () => {
         filtered={hasActiveFilter}
         onClearFilters={clearFilters}
         emptyRepo={isEmptyRepoAssignment}
+        initialLoading={initialLoading}
         nonSubmittersLoading={
           !nonSubmittersReady &&
           students.length > 0 &&

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -274,6 +274,7 @@ const SubmissionsPageContent = () => {
     errorCount: liveErrorCount,
     isFetching: liveFetching,
     hasNextPage: liveHasNextPage,
+    refetch: refetchLive,
   } = useLiveSubmissions({
     org,
     classroom,
@@ -668,15 +669,25 @@ const SubmissionsPageContent = () => {
                 variant="ghost"
                 size="xs"
                 shape="circle"
-                disabled={scoresFetching}
-                onClick={() => refetchScores()}
+                disabled={scoresFetching || liveFetching}
+                onClick={() => {
+                  // Refresh both data sources the page shows: the collected
+                  // snapshot (scores.json) AND the live submission fan-out.
+                  // Refreshing only the snapshot would leave the "Pending" live
+                  // rows — the part that reflects a just-pushed submission —
+                  // stale, which is the opposite of what Refresh implies.
+                  refetchScores()
+                  refetchLive()
+                }}
                 aria-label={t("submissions.refresh")}
                 title={t("submissions.refresh")}
               >
                 <RefreshCw
                   aria-hidden="true"
                   size={12}
-                  className={scoresFetching ? "animate-spin" : ""}
+                  className={
+                    scoresFetching || liveFetching ? "animate-spin" : ""
+                  }
                 />
               </Button>
             </span>

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -42,7 +42,7 @@ import {
   type SubmissionSort,
 } from "@/pages/submissions/dashboard"
 import useGetScores from "@/hooks/useGetScores"
-import useLiveSubmissions from "@/hooks/useLiveSubmissions"
+import useLiveSubmissions, { LIVE_PAGE_SIZE } from "@/hooks/useLiveSubmissions"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetStudents from "@/hooks/useGetStudents"
@@ -76,10 +76,6 @@ import {
 import { githubTemplateRepoUrl } from "@/util/orgUrl"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubLink } from "@/components/GitHubLink"
-
-// Live-submission fan-out page size: how many of the assignment's repos we read
-// per "Show next" click. One source so the control label and the hook agree.
-export const LIVE_PAGE_SIZE = 50
 
 // Re-renders so a relative "updated X ago" label stays live, at a cadence that
 // matches the elapsed magnitude: every second under a minute, every minute

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -269,6 +269,7 @@ const SubmissionsPageContent = () => {
     submissions: liveSubmissions,
     errorCount: liveErrorCount,
     isFetching: liveFetching,
+    isPending: livePending,
     hasNextPage: liveHasNextPage,
     refetch: refetchLive,
   } = useLiveSubmissions({
@@ -309,7 +310,8 @@ const SubmissionsPageContent = () => {
   // the repo name) plus each repo's collaborators means a teammate on a
   // formed-but-unsubmitted group isn't also listed as "no group" (#245). The
   // fetch is throttled and shares the collaborators cache with the rows/modal.
-  const groupRepoMembers = useGroupRepoMemberLogins(org ?? "", groupRepoList)
+  const { logins: groupRepoMembers, isPending: groupMembersPending } =
+    useGroupRepoMemberLogins(org ?? "", groupRepoList)
   const groupRepoFounders = useMemo(
     () =>
       new Set([
@@ -329,11 +331,19 @@ const SubmissionsPageContent = () => {
   // group's row (#245), so listing them as "no group" too would double-count
   // them. Gated on scores having loaded — until then scoresInfo is empty and
   // would flag the whole roster.
+  // The "not submitted" list is derived last, from every source that can still
+  // reclassify a student: the collected snapshot, the live submit/* fan-out, and
+  // (for groups) the collaborator reconciliation. Gate it on all three settling
+  // so a student never renders as "not submitted" and then jumps to "Pending" /
+  // a group row as a later source resolves (the flash). Until ready, hold the
+  // prior list rather than recomputing an intermediate one.
   const scoresLoaded = scoresData !== undefined
+  const nonSubmittersReady =
+    scoresLoaded && !livePending && !groupMembersPending
   const nonSubmitters = useMemo(() => {
-    if (!scoresLoaded) return []
+    if (!nonSubmittersReady) return []
     return reconcileNonSubmitters(students, scoresInfo, groupRepoFounders)
-  }, [scoresLoaded, scoresInfo, students, groupRepoFounders])
+  }, [nonSubmittersReady, scoresInfo, students, groupRepoFounders])
 
   // Dashboard controls — all client-side over already-loaded data.
   const [query, setQuery] = useState("")
@@ -911,6 +921,11 @@ const SubmissionsPageContent = () => {
         filtered={hasActiveFilter}
         onClearFilters={clearFilters}
         emptyRepo={isEmptyRepoAssignment}
+        nonSubmittersLoading={
+          !nonSubmittersReady &&
+          students.length > 0 &&
+          showsNonSubmitters(effectiveFilters)
+        }
       />
       <ConfirmModal
         open={regradeConfirmOpen}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -31,6 +31,7 @@ import {
   filterAndSortRows,
   filterNonSubmitters,
   hasAccepted,
+  mergeLiveRows,
   reconcileNonSubmitters,
   rosterScopedRows,
   rowInSection,
@@ -41,6 +42,7 @@ import {
   type SubmissionSort,
 } from "@/pages/submissions/dashboard"
 import useGetScores from "@/hooks/useGetScores"
+import useLiveSubmissions from "@/hooks/useLiveSubmissions"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetStudents from "@/hooks/useGetStudents"
@@ -74,6 +76,10 @@ import {
 import { githubTemplateRepoUrl } from "@/util/orgUrl"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubLink } from "@/components/GitHubLink"
+
+// Live-submission fan-out page size: how many of the assignment's repos we read
+// per "Show next" click. One source so the control label and the hook agree.
+export const LIVE_PAGE_SIZE = 50
 
 // Re-renders so a relative "updated X ago" label stays live, at a cadence that
 // matches the elapsed magnitude: every second under a minute, every minute
@@ -199,18 +205,13 @@ const SubmissionsPageContent = () => {
   // Gate on a resolved roster so a transient load/permission failure falls back
   // to unscoped rows rather than blanking a populated gradebook.
   const rosterReady = !rosterLoading && !rosterError
-  const scoresInfo = useMemo(() => {
-    const rows = scoresData?.submissions?.[assignment ?? ""] || []
-    return rosterReady ? rosterScopedRows(rows, students) : rows
-  }, [scoresData, assignment, rosterReady, students])
+  const snapshotRows = useMemo(() => {
+    return scoresData?.submissions?.[assignment ?? ""] || []
+  }, [scoresData, assignment])
 
   // Org repo list drives repo-existence signals (individual acceptance below and
   // group-repo enumeration here).
   const { data: orgRepos } = useGetOrgRepos(org ?? "")
-
-  // Repos whose latest submission landed after the deadline. `late` is computed
-  // upstream (collect_scores.py) from push time, not grade time.
-  const lateCount = scoresInfo.filter((row) => row.late).length
 
   // Due-date presentation: absolute date + a relative countdown ("in 3 days" /
   // "2 hours ago"). Past due flips the badge to error and the label to overdue.
@@ -243,6 +244,59 @@ const SubmissionsPageContent = () => {
         : [],
     [isGroupAssignment, orgRepos, classroom, assignment, siblingSlugs],
   )
+
+  // Live submission presence for THIS assignment, read directly from student
+  // repos' submit/* releases — so a student who pushed but hasn't been collected
+  // yet still shows as submitted (issue #347). Owners: roster logins for
+  // individual assignments, group-founder logins for group assignments. Paginated
+  // (50/page) so a large class doesn't fan out every repo at once; empty_repo
+  // assignments never autograde, so the fan-out is disabled there.
+  const [livePage, setLivePage] = useState(0)
+  const liveRepoOwners = useMemo(
+    () =>
+      isGroupAssignment
+        ? groupRepoList.map((repo) => repo.owner)
+        : students.map((s) => s.username).filter(Boolean),
+    [isGroupAssignment, groupRepoList, students],
+  )
+  const {
+    submissions: liveSubmissions,
+    errorCount: liveErrorCount,
+    isFetching: liveFetching,
+    hasNextPage: liveHasNextPage,
+  } = useLiveSubmissions({
+    org,
+    classroom,
+    assignment,
+    repoOwners: liveRepoOwners,
+    page: livePage,
+    pageSize: LIVE_PAGE_SIZE,
+    enabled: !isEmptyRepoAssignment,
+  })
+
+  // Merge live presence over the snapshot (snapshot wins per owner; live adds a
+  // pending row for an as-yet-uncollected submitter), then roster-scope as
+  // before. Gate roster-scoping on a resolved roster so a transient failure
+  // falls back to unscoped rows rather than blanking a populated gradebook.
+  const scoresInfo = useMemo(() => {
+    const merged = mergeLiveRows(
+      snapshotRows,
+      liveSubmissions.map((s) => ({
+        owner: s.owner,
+        datetime: s.submittedAt,
+        release: s.releaseUrl,
+      })),
+    )
+    return rosterReady ? rosterScopedRows(merged, students) : merged
+  }, [snapshotRows, liveSubmissions, rosterReady, students])
+
+  // Repos whose latest submission landed after the deadline. `late` is computed
+  // upstream (collect_scores.py) from push time, not grade time.
+  const lateCount = scoresInfo.filter((row) => row.late).length
+
+  // Live-only rows: submitted (submit/* release exists) but not yet in the
+  // collected snapshot — the #347 lag the live view closes.
+  const livePendingCount = scoresInfo.filter((row) => row.pending).length
   // Members of every existing group repo, fetched (bounded) and reconciled so
   // the "no group" list is accurate on load: the union of founders (known from
   // the repo name) plus each repo's collaborators means a teammate on a
@@ -653,6 +707,45 @@ const SubmissionsPageContent = () => {
           )}
         </p>
       </div>
+
+      {/* Live-submission strip: presence read directly from student repos'
+          submit/* releases, so a just-pushed student shows before the next
+          collect (issue #347). Hidden for empty_repo assignments (never
+          autograded). "Show next" pages the fan-out in LIVE_PAGE_SIZE windows so
+          a large class isn't read all at once. */}
+      {!isEmptyRepoAssignment && (
+        <div
+          className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-base-content/70"
+          role="status"
+        >
+          {liveFetching && (
+            <span className="inline-flex items-center gap-1.5">
+              <Spinner size="xs" />
+              {t("submissions.live.checking")}
+            </span>
+          )}
+          {livePendingCount > 0 && (
+            <Badge tone="info" size="sm">
+              {t("submissions.live.pending", { count: livePendingCount })}
+            </Badge>
+          )}
+          {liveErrorCount > 0 && (
+            <span className="text-warning">
+              {t("submissions.live.errors", { count: liveErrorCount })}
+            </span>
+          )}
+          {liveHasNextPage && (
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={liveFetching}
+              onClick={() => setLivePage((p) => p + 1)}
+            >
+              {t("submissions.live.showNext", { count: LIVE_PAGE_SIZE })}
+            </Button>
+          )}
+        </div>
+      )}
 
       {/* Live status strip. Full phase mapping: dispatching stays a quiet
           neutral line (transient); running/completed/failed/timeout become an

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -139,6 +139,20 @@ describe("SubmissionsTable non-submitter repo links", () => {
   })
 })
 
+describe("SubmissionsTable initial loading", () => {
+  it("shows the loading state and not the empty state while core data loads", () => {
+    render(<SubmissionsTable {...baseProps} initialLoading />)
+    expect(screen.getByText("submissions.table.loading")).toBeTruthy()
+    expect(screen.queryByText("submissions.table.emptyNoDataTitle")).toBeNull()
+  })
+
+  it("shows the empty state (not loading) once loaded with no data", () => {
+    render(<SubmissionsTable {...baseProps} initialLoading={false} />)
+    expect(screen.getByText("submissions.table.emptyNoDataTitle")).toBeTruthy()
+    expect(screen.queryByText("submissions.table.loading")).toBeNull()
+  })
+})
+
 describe("SubmissionsTable empty_repo score cell", () => {
   it("renders a no-grading em-dash instead of a score for an empty_repo assignment", () => {
     render(

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -622,6 +622,13 @@ const SubmissionsTable = ({
                           >
                             —
                           </span>
+                        ) : rest.pending ? (
+                          <Badge
+                            ghost
+                            title={t("submissions.table.pendingGradeTitle")}
+                          >
+                            {t("submissions.table.pendingGrade")}
+                          </Badge>
                         ) : (
                           <ScoreBadge
                             score={score}

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -26,6 +26,7 @@ import {
   EmphasisLtr,
   Modal,
   MonoLtr,
+  Spinner,
   rtlFlip,
 } from "@/components/ui"
 import { scoreTone } from "@/pages/submissions/dashboard"
@@ -411,6 +412,7 @@ const SubmissionsTable = ({
   filtered = false,
   onClearFilters,
   emptyRepo = false,
+  nonSubmittersLoading = false,
 }: {
   scores: SubmissionRow[]
   students: Student[]
@@ -441,6 +443,10 @@ const SubmissionsTable = ({
   // empty_repo assignment: never autogrades, so score badges and the
   // Feedback-PR/regrade actions are hidden (repos + accept state stay useful).
   emptyRepo?: boolean
+  // The "not submitted" list is still resolving from the live/group fan-outs;
+  // render a resolving affordance instead of prematurely listing students who
+  // may reclassify to submitted/pending.
+  nonSubmittersLoading?: boolean
 }) => {
   const { t } = useTranslation()
   const passBar = thresholdFraction ?? null
@@ -495,7 +501,8 @@ const SubmissionsTable = ({
           <tbody>
             {!scores?.length &&
               !nonSubmitters.length &&
-              !unsubmittedGroupRepos.length && (
+              !unsubmittedGroupRepos.length &&
+              !nonSubmittersLoading && (
                 <tr>
                   <td colSpan={5} className="py-10 text-center">
                     <div className="mx-auto flex max-w-sm flex-col items-center gap-2">
@@ -766,6 +773,19 @@ const SubmissionsTable = ({
                 onManage={() => setManageOwner(owner)}
               />
             ))}
+            {nonSubmittersLoading && (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="py-4 text-center text-sm text-base-content/60"
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <Spinner size="xs" />
+                    {t("submissions.table.resolvingNonSubmitters")}
+                  </span>
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </EnterDiv>

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -412,6 +412,7 @@ const SubmissionsTable = ({
   filtered = false,
   onClearFilters,
   emptyRepo = false,
+  initialLoading = false,
   nonSubmittersLoading = false,
 }: {
   scores: SubmissionRow[]
@@ -443,6 +444,10 @@ const SubmissionsTable = ({
   // empty_repo assignment: never autogrades, so score badges and the
   // Feedback-PR/regrade actions are hidden (repos + accept state stay useful).
   emptyRepo?: boolean
+  // Core data (snapshot + roster) is still loading on first paint; render a
+  // loading state rather than the "no submissions" empty state, which would
+  // otherwise flash before data arrives.
+  initialLoading?: boolean
   // The "not submitted" list is still resolving from the live/group fan-outs;
   // render a resolving affordance instead of prematurely listing students who
   // may reclassify to submitted/pending.
@@ -499,7 +504,20 @@ const SubmissionsTable = ({
             </tr>
           </thead>
           <tbody>
-            {!scores?.length &&
+            {initialLoading && (
+              <tr>
+                <td colSpan={5} className="py-10 text-center">
+                  <div className="mx-auto flex max-w-sm flex-col items-center gap-2">
+                    <Spinner size="md" />
+                    <p className="text-sm text-base-content/70">
+                      {t("submissions.table.loading")}
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            )}
+            {!initialLoading &&
+              !scores?.length &&
               !nonSubmitters.length &&
               !unsubmittedGroupRepos.length &&
               !nonSubmittersLoading && (

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -10,6 +10,7 @@ import {
   applyStatusSelection,
   buildScoresCsvRows,
   buildSectionLookup,
+  classAverage,
   computeStats,
   distinctSections,
   existingGroupRepos,
@@ -861,5 +862,30 @@ describe("mergeLiveRows", () => {
       ],
     )
     expect(merged.map((r) => r.owner)).toEqual(["new", "old"])
+  })
+
+  it("pending rows are excluded from the class average", () => {
+    const rows = [
+      row({ owner: "alice", score: 10, "max-score": 10 }),
+      row({ owner: "bob", score: 0, "max-score": 0, pending: true }),
+    ]
+    // Only alice's 10 counts; bob's placeholder 0 must not drag it to 5.
+    expect(classAverage(rows)).toBe(10)
+  })
+
+  it("pending rows export a blank score/max, not a graded zero", () => {
+    const rows = [
+      row({
+        owner: "bob",
+        usernames: ["bob"],
+        score: 0,
+        "max-score": 0,
+        pending: true,
+      }),
+    ]
+    const [csv] = buildScoresCsvRows(rows, [])
+    expect(csv.score).toBe("")
+    expect(csv.max_score).toBe("")
+    expect(csv.usernames).toBe("bob")
   })
 })

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -16,6 +16,7 @@ import {
   filterAndSortRows,
   filterNonSubmitters,
   hasAccepted,
+  mergeLiveRows,
   nonSubmitterStatus,
   reconcileNonSubmitters,
   rosterScopedRows,
@@ -803,5 +804,62 @@ describe("statusSelectValue / applyStatusSelection", () => {
     )
     expect(out.section).toBe("P3")
     expect(out.passing).toBe("failing")
+  })
+})
+
+describe("mergeLiveRows", () => {
+  const live = (owner: string, datetime: string) => ({
+    owner,
+    datetime,
+    release: `https://github.com/o/${owner}/releases/tag/submit`,
+  })
+
+  it("keeps snapshot rows unchanged", () => {
+    const snapshot = [row({ owner: "alice", score: 8 })]
+    const merged = mergeLiveRows(snapshot, [])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].score).toBe(8)
+    expect(merged[0].pending).toBeUndefined()
+  })
+
+  it("adds a pending row for a live-only owner absent from the snapshot", () => {
+    const snapshot = [row({ owner: "alice" })]
+    const merged = mergeLiveRows(snapshot, [
+      live("bob", "2026-06-21T10:00:00Z"),
+    ])
+    const bob = merged.find((r) => r.owner === "bob")
+    expect(bob).toBeDefined()
+    expect(bob?.pending).toBe(true)
+    expect(bob?.["max-score"]).toBe(0)
+    expect(bob?.usernames).toEqual(["bob"])
+  })
+
+  it("does not duplicate an owner already in the snapshot (snapshot wins)", () => {
+    const snapshot = [row({ owner: "alice", score: 9 })]
+    const merged = mergeLiveRows(snapshot, [
+      live("Alice", "2026-06-25T10:00:00Z"),
+    ])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].score).toBe(9)
+    expect(merged[0].pending).toBeUndefined()
+  })
+
+  it("matches owners case-insensitively", () => {
+    const snapshot = [row({ owner: "Alice" })]
+    const merged = mergeLiveRows(snapshot, [
+      live("alice", "2026-06-25T10:00:00Z"),
+    ])
+    expect(merged).toHaveLength(1)
+  })
+
+  it("orders live-only rows newest-first", () => {
+    const merged = mergeLiveRows(
+      [],
+      [
+        live("old", "2026-01-01T00:00:00Z"),
+        live("new", "2026-09-01T00:00:00Z"),
+      ],
+    )
+    expect(merged.map((r) => r.owner)).toEqual(["new", "old"])
   })
 })

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -38,7 +38,51 @@ export function rosterScopedRows(
   return rows.filter((row) => rowOnRoster(row, rosterLogins))
 }
 
-// `thresholdFraction` is the passing bar as a fraction of max, or `null` when
+// Fold live submission presence (submit/* releases read directly from student
+// repos) into the collected snapshot rows. `scores.json` stays the source of
+// record: a snapshot row always wins for an owner it already covers (it carries
+// the graded score; live presence carries none yet — see the plan's U2 spike).
+// Live adds a row ONLY for an owner absent from the snapshot — a student who
+// pushed but hasn't been collected yet (the #347 lag). Such a row is marked
+// `pending` (no grade) so the table shows "submitted, not yet collected" rather
+// than a fake 0/0. Owner match is case-insensitive; the union preserves snapshot
+// order, then appends live-only rows newest-first.
+export type LiveSubmissionPresence = {
+  owner: string
+  datetime: string
+  release: string
+}
+
+export function mergeLiveRows(
+  snapshotRows: SubmissionRow[],
+  liveRows: LiveSubmissionPresence[],
+): SubmissionRow[] {
+  const snapshotOwners = new Set(
+    snapshotRows.map((row) => row.owner.trim().toLowerCase()),
+  )
+
+  const liveOnly = liveRows
+    .filter((live) => !snapshotOwners.has(live.owner.trim().toLowerCase()))
+    .sort(
+      (a, b) => new Date(b.datetime).getTime() - new Date(a.datetime).getTime(),
+    )
+    .map<SubmissionRow>((live) => ({
+      usernames: [live.owner],
+      owner: live.owner,
+      datetime: live.datetime,
+      commit: "",
+      release: live.release,
+      review: "",
+      score: 0,
+      "max-score": 0,
+      submissionCount: 1,
+      pending: true,
+      submissions: [],
+    }))
+
+  return [...snapshotRows, ...liveOnly]
+}
+
 // the assignment sets no threshold — then every row is "ungraded" (as is an
 // ungraded/zero-max row).
 export type PassState = "passing" | "failing" | "ungraded"

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -165,9 +165,13 @@ export function computeStats(
 
 // Mean of the numeric scores, rounded to 2 decimals, or null when none is finite
 // (rendered "N/A"). Avoids the old `sum/length || 1` bug where an empty/NaN
-// result showed "1" (`/` binds before `||`).
+// result showed "1" (`/` binds before `||`). Pending live rows (a submit/*
+// release the collector hasn't ingested yet) carry a placeholder 0/0 and no
+// real grade, so they're excluded — otherwise every uncollected submitter would
+// drag the average toward 0, the opposite of the intended presence signal.
 export function classAverage(rows: SubmissionRow[]): number | null {
   const numericScores = rows
+    .filter((row) => !row.pending)
     .map((row) => Number(row["score"]))
     .filter((n) => Number.isFinite(n))
   if (numericScores.length === 0) return null
@@ -572,7 +576,7 @@ export function filterNonSubmitters(
 // contract downstream sheets rely on — keep them stable.
 export type ScoresCsvRow = {
   usernames: string
-  score: number
+  score: number | string
   max_score: number | string
   submissions: number
   submitted_at: string
@@ -592,8 +596,11 @@ export function buildScoresCsvRows(
     )
     .map(({ usernames, score, datetime, submissionCount, late, ...rest }) => ({
       usernames: usernames.join(", "),
-      score,
-      max_score: rest["max-score"],
+      // A pending live row (submitted, not yet collected) has no real grade —
+      // export a blank score, not a 0, so importing the CSV can't record a
+      // graded zero for a student who actually submitted.
+      score: rest.pending ? "" : score,
+      max_score: rest.pending ? "" : rest["max-score"],
       submissions: submissionCount,
       submitted_at: new Date(datetime).toISOString(),
       late: late ? "yes" : "no",


### PR DESCRIPTION
## Summary

Adds a **live, per-assignment submission-presence** view to the teacher gradebook, addressing the "teacher sees zero submissions" half of #347.

Today the teacher page reads only the batch snapshot `<classroom>/scores.json`, which refreshes only on the nightly cron or a manual "Collect now" — so a student who pushed (and whose autograder published a `submit/*` release) shows nothing until a collect runs, even though the student's own view reads releases live. This change fans out `GET /repos/{org}/{repo}/releases` across the open assignment's repos and surfaces submitters immediately.

- **U1** — `latestSubmitReleaseWithAssets` query + `assets` on `GitHubRelease`.
- **U3** — `useLiveSubmissions`: paginated fan-out (`LIVE_PAGE_SIZE`, 50/page) with per-repo error tolerance — a 404 is "not submitted"; a non-404 is retried once on a rate limit, then counted as an error instead of voiding the batch.
- **U4/U5** — `mergeLiveRows` folds live presence over the snapshot (**snapshot always wins per owner**; live-only owners appear as a `pending` row), merged *before* `rosterScopedRows` so off-roster students are never resurrected. UI: live-check spinner, "N submitted, not yet collected" badge, "Show next 50", a "Pending" badge in the table, and a provisional-incompleteness warning (below).

### Scope / non-goals

- **Presence only.** Live **grades** are intentionally deferred: fetching+validating `result.json` in the browser is gated on an unresolved spike (can the OAuth token be kept off the S3 asset redirect? does CORS expose the asset body?). See the plan's Open Questions. `scores.json` stays the source of record; nothing is written back from the browser.
- **Known gap (documented, not silently shipped):** off-team / off-roster / service-token-gap students still show as not-submitted, because live rows stay inside the existing `rosterScopedRows` choke point. A bypass/annotate path is deferred.
- Does **not** change the collector, the autograde trigger, or the `scores.json` schema.
- The autograder **cost** half of #347 (Actions minutes per push, tag-only grade mode) is out of scope for this PR.

### Robustness (folded in from two review passes)

- **Pending rows never pollute aggregates:** `classAverage` excludes them (no drag toward 0), the CSV export emits a blank score/max (no phantom graded 0 in an LMS import), and the live page offset is clamped to the current owner set (switching assignments can't strand the view on an out-of-range page).
- **Refresh covers both sources:** the gradebook Refresh button re-reads the live fan-out *and* the collected `scores.json` snapshot (and its spinner reflects both), so it reflects a just-pushed submission rather than only the stale snapshot.
- **Shared read budget + rate-limit backoff:** a single FIFO semaphore caps the *aggregate* per-repo reads across the live fan-out and the group-member fan-out (they no longer each burst to the concurrency limit on a group-assignment load); a bounded `Retry-After` retry absorbs a transient 429/secondary-limit before a repo is counted as failed.
- **Partial failure is surfaced, not hidden:** when some repos can't be read, a warning alert marks the submission counts and the "not submitted" list as possibly incomplete (retry with Refresh, or Collect now) — a transient error can't be mistaken for an authoritative "not submitted".
- `LIVE_PAGE_SIZE` is single-sourced so the control label and the fan-out page size can't drift.

### Loading & first-paint UX (no flashing)

The gradebook aggregates state from several independently-resolving sources (snapshot, live `submit/*` fan-out, roster, group-member reconciliation). Naively that flashes as each lands, so:

- **Loading state instead of an empty flash:** while the core data (snapshot + roster) is still loading, the table shows a "Loading submissions…" state rather than briefly flashing "No submissions collected yet". A background refetch (Refresh) keeps the populated table — only the true first paint shows loading.
- **No not-submitted -> Pending flash:** the "not submitted" list is held until the live fan-out (first load) and group-member reconciliation settle, so a submitter resolves straight to their Pending/submitted row instead of first appearing as not-submitted. A subtle "Checking who hasn't submitted yet…" row marks the section as still resolving.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx vitest run` — 2103 tests pass (192 files), incl. new coverage for `latestSubmitReleaseWithAssets`, `useLiveSubmissions` (paging, per-repo tolerance, rate-limit retry, refetch, first-load `isPending`), `mergeLiveRows`/pending-row handling, the shared semaphore + `retryOnRateLimit`, group-member `isPending`, and the table loading/empty states
- [x] `npx eslint` clean on touched files
- [x] `npx prettier --check` clean
- [x] i18n audit (`test_audit_i18n.py`) passes
- [ ] Manual: open an assignment where an on-roster student pushed but no collect ran → they appear as "Pending" (no not-submitted flash); Refresh reflects it
- [ ] Manual: first load shows "Loading submissions…", not the empty message; "Show next 50" pages a >50 class; a repo the token can't read surfaces the provisional-incompleteness warning; disabling/failing live leaves today's behavior intact