### PR TITLE
fix(web): guide teachers past missing and Free-plan orgs in setup modal

### DIFF
--- a/web/src/components/MissingOrgNotice.tsx
+++ b/web/src/components/MissingOrgNotice.tsx
@@ -1,0 +1,68 @@
+import { ChevronDown, ExternalLink, Info, RefreshCw } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui"
+
+// Collapsible notice explaining that GitHub only surfaces orgs the OAuth grant
+// covers, with a link to manage that access and a refresh. Shared by the orgs
+// page and the new-org modal so the "grant access" fix is always one click away
+// when an org is missing.
+function MissingOrgNotice({
+  refreshing,
+  onRefresh,
+}: {
+  refreshing: boolean
+  onRefresh: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <details className="group rounded-xl border border-info/20 bg-info/5">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-sm">
+        <Info aria-hidden="true" className="size-4 shrink-0 text-info" />
+        <span className="min-w-0 flex-1 truncate font-medium text-base-content">
+          {t("orgs.missingNotice.title")}
+        </span>
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={refreshing}
+          onClick={(e) => {
+            // The button lives inside <summary>; stop the click from toggling
+            // the disclosure so refreshing doesn't also expand/collapse it.
+            e.preventDefault()
+            onRefresh()
+          }}
+        >
+          <RefreshCw
+            aria-hidden="true"
+            className={["size-3.5", refreshing ? "animate-spin" : ""].join(" ")}
+          />
+          {refreshing
+            ? t("orgs.missingNotice.refreshing")
+            : t("orgs.missingNotice.refresh")}
+        </Button>
+        <ChevronDown
+          aria-hidden="true"
+          className="size-4 shrink-0 text-base-content/50 transition-transform group-open:rotate-180"
+        />
+      </summary>
+
+      <div className="border-t border-info/20 px-4 py-3">
+        <p className="text-sm leading-6 text-base-content/70">
+          {t("orgs.missingNotice.body")}
+        </p>
+        <a
+          href="https://github.com/settings/connections/applications"
+          target="_blank"
+          rel="noreferrer"
+          className="btn btn-info btn-sm mt-3"
+        >
+          {t("orgs.missingNotice.manageOauth")}
+          <ExternalLink aria-hidden="true" className="size-4" />
+        </a>
+      </div>
+    </details>
+  )
+}
+
+export default MissingOrgNotice

--- a/web/src/components/MissingOrgNotice.tsx
+++ b/web/src/components/MissingOrgNotice.tsx
@@ -51,15 +51,18 @@ function MissingOrgNotice({
         <p className="text-sm leading-6 text-base-content/70">
           {t("orgs.missingNotice.body")}
         </p>
-        <a
+        <Button
+          as="a"
           href="https://github.com/settings/connections/applications"
           target="_blank"
           rel="noreferrer"
-          className="btn btn-info btn-sm mt-3"
+          variant="info"
+          size="sm"
+          className="mt-3"
         >
           {t("orgs.missingNotice.manageOauth")}
           <ExternalLink aria-hidden="true" className="size-4" />
-        </a>
+        </Button>
       </div>
     </details>
   )

--- a/web/src/components/modals/FreePlanInfoModal.test.tsx
+++ b/web/src/components/modals/FreePlanInfoModal.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+
+import FreePlanInfoModal from "./FreePlanInfoModal"
+
+afterEach(cleanup)
+
+describe("FreePlanInfoModal", () => {
+  it("renders the org login and the GitHub Education link", () => {
+    render(<FreePlanInfoModal open orgLogin="acme" onClose={vi.fn()} />)
+    expect(screen.getByText("acme")).toBeTruthy()
+    const link = screen
+      .getByText("orgs.newOrg.freePlanInfo.educationCta")
+      .closest("a")
+    expect(link?.getAttribute("href")).toBe("https://github.com/education")
+    expect(link?.getAttribute("target")).toBe("_blank")
+  })
+
+  it("omits the org-name line when orgLogin is null", () => {
+    render(<FreePlanInfoModal open orgLogin={null} onClose={vi.fn()} />)
+    // The plan-requirement body still renders; only the mono org name is gone.
+    expect(screen.getByText("orgs.newOrg.freePlanInfo.body")).toBeTruthy()
+    expect(screen.queryByText("acme")).toBeNull()
+  })
+
+  it("calls onClose when the dismiss button is clicked", () => {
+    const onClose = vi.fn()
+    render(<FreePlanInfoModal open orgLogin="acme" onClose={onClose} />)
+    fireEvent.click(screen.getByText("orgs.newOrg.freePlanInfo.dismiss"))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/modals/FreePlanInfoModal.tsx
+++ b/web/src/components/modals/FreePlanInfoModal.tsx
@@ -42,15 +42,18 @@ function FreePlanInfoModal({
         <p className="mt-1 text-sm leading-6 text-base-content/70">
           {t("orgs.newOrg.freePlanInfo.educationBody")}
         </p>
-        <a
+        <Button
+          as="a"
           href="https://github.com/education"
           target="_blank"
           rel="noreferrer"
-          className="btn btn-info btn-sm mt-3"
+          variant="info"
+          size="sm"
+          className="mt-3"
         >
           {t("orgs.newOrg.freePlanInfo.educationCta")}
           <ExternalLink aria-hidden="true" className="size-4" />
-        </a>
+        </Button>
       </div>
 
       <div className="modal-action">

--- a/web/src/components/modals/FreePlanInfoModal.tsx
+++ b/web/src/components/modals/FreePlanInfoModal.tsx
@@ -1,0 +1,65 @@
+import { ExternalLink } from "lucide-react"
+import { useId } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Button, Modal } from "@/components/ui"
+
+// Explains why a Free-plan org can't be set up and points the teacher at the
+// GitHub Education benefit that upgrades an org to Team for free. Opened from a
+// Free-plan row in NewOrgModal. Facts per GitHub Education docs: verified
+// teachers can upgrade any org they own to GitHub Team at no cost.
+function FreePlanInfoModal({
+  open,
+  orgLogin,
+  onClose,
+}: {
+  open: boolean
+  orgLogin: string | null
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const titleId = useId()
+
+  return (
+    <Modal open={open} onClose={onClose} size="md" aria-labelledby={titleId}>
+      <h3 id={titleId} className="text-lg font-bold">
+        {t("orgs.newOrg.freePlanInfo.title")}
+      </h3>
+      {orgLogin && (
+        <p className="mt-1 font-mono text-sm text-base-content/60">
+          {orgLogin}
+        </p>
+      )}
+
+      <p className="mt-4 text-sm leading-6 text-base-content/80">
+        {t("orgs.newOrg.freePlanInfo.body")}
+      </p>
+
+      <div className="mt-4 rounded-box border border-info/20 bg-info/5 p-4">
+        <p className="text-sm font-semibold">
+          {t("orgs.newOrg.freePlanInfo.educationTitle")}
+        </p>
+        <p className="mt-1 text-sm leading-6 text-base-content/70">
+          {t("orgs.newOrg.freePlanInfo.educationBody")}
+        </p>
+        <a
+          href="https://github.com/education"
+          target="_blank"
+          rel="noreferrer"
+          className="btn btn-info btn-sm mt-3"
+        >
+          {t("orgs.newOrg.freePlanInfo.educationCta")}
+          <ExternalLink aria-hidden="true" className="size-4" />
+        </a>
+      </div>
+
+      <div className="modal-action">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          {t("orgs.newOrg.freePlanInfo.dismiss")}
+        </Button>
+      </div>
+    </Modal>
+  )
+}
+
+export default FreePlanInfoModal

--- a/web/src/components/modals/NewOrgModal.test.tsx
+++ b/web/src/components/modals/NewOrgModal.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+
+import type { Classroom50OrgSummary } from "@/github-core/queries"
+import type { NeedsSetupPlans } from "@/hooks/useNeedsSetupPlans"
+
+// Count-aware t() so the pluralized pickPrompt (_one/_other + {{count}}) is
+// actually exercised rather than collapsed to the raw key.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: { count?: number }) => {
+        if (key === "orgs.newOrg.pickPrompt" && opts?.count !== undefined) {
+          const suffix = opts.count === 1 ? "_one" : "_other"
+          return `${key}${suffix}:${opts.count}`
+        }
+        return key
+      },
+    }),
+  }
+})
+
+const navigate = vi.fn()
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return { ...actual, useNavigate: () => navigate }
+})
+
+let plansResult: NeedsSetupPlans = { byLogin: {}, pending: new Set() }
+vi.mock("@/hooks/useNeedsSetupPlans", () => ({
+  default: () => plansResult,
+}))
+
+import NewOrgModal from "./NewOrgModal"
+
+const summary = (
+  login: string,
+  over: Partial<Classroom50OrgSummary["org"]> = {},
+): Classroom50OrgSummary =>
+  ({
+    org: {
+      login,
+      id: login.length + login.charCodeAt(0),
+      avatar_url: "https://x/avatar.png",
+      description: null,
+      html_url: `https://github.com/${login}`,
+      ...over,
+    },
+    membership: { state: "active", role: "admin" },
+    classroom50: {
+      status: "needs_setup",
+      canAccessRepo: false,
+      canInitialize: true,
+      pagesUrl: "",
+    },
+  }) as Classroom50OrgSummary
+
+function renderModal(orgs: Classroom50OrgSummary[]) {
+  return render(
+    <NewOrgModal
+      open
+      needsSetupOrgs={orgs}
+      refreshing={false}
+      onRefresh={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  )
+}
+
+beforeEach(() => {
+  navigate.mockReset()
+  plansResult = { byLogin: {}, pending: new Set() }
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  )
+  vi.stubGlobal(
+    "MutationObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("NewOrgModal", () => {
+  it("routes a supported (paid) org into the setup wizard", () => {
+    plansResult = { byLogin: { acme: "team" }, pending: new Set() }
+    renderModal([summary("acme")])
+
+    expect(screen.getByText("orgs.newOrg.setUp")).toBeTruthy()
+    fireEvent.click(screen.getByText("acme"))
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/$org/setup",
+      params: { org: "acme" },
+    })
+  })
+
+  it("opens the Free-plan explainer instead of routing for a free org", () => {
+    plansResult = { byLogin: { acme: "free" }, pending: new Set() }
+    renderModal([summary("acme")])
+
+    expect(screen.getByText("orgs.newOrg.notSupportedBadge")).toBeTruthy()
+    expect(screen.getByText("orgs.newOrg.details")).toBeTruthy()
+
+    fireEvent.click(screen.getByText("acme"))
+    expect(navigate).not.toHaveBeenCalled()
+    // The explainer content is now shown.
+    expect(screen.getByText("orgs.newOrg.freePlanInfo.title")).toBeTruthy()
+  })
+
+  it("disables a row and shows a spinner while its plan is still loading", () => {
+    plansResult = { byLogin: {}, pending: new Set(["acme"]) }
+    renderModal([summary("acme")])
+
+    const row = screen.getByText("acme").closest("button")
+    expect(row?.disabled).toBe(true)
+    // Neither the Set up affordance nor the Not-supported badge shows yet.
+    expect(screen.queryByText("orgs.newOrg.setUp")).toBeNull()
+    expect(screen.queryByText("orgs.newOrg.notSupportedBadge")).toBeNull()
+
+    fireEvent.click(screen.getByText("acme"))
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it("shows a pluralized count in the heading", () => {
+    plansResult = {
+      byLogin: { a: "team", b: "team" },
+      pending: new Set(),
+    }
+    const { rerender } = renderModal([summary("a"), summary("b")])
+    expect(screen.getByText("orgs.newOrg.pickPrompt_other:2")).toBeTruthy()
+
+    plansResult = { byLogin: { a: "team" }, pending: new Set() }
+    rerender(
+      <NewOrgModal
+        open
+        needsSetupOrgs={[summary("a")]}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("orgs.newOrg.pickPrompt_one:1")).toBeTruthy()
+  })
+
+  it("renders the missing-org notice inside the modal", () => {
+    plansResult = { byLogin: { acme: "team" }, pending: new Set() }
+    renderModal([summary("acme")])
+    expect(screen.getByText("orgs.missingNotice.title")).toBeTruthy()
+  })
+
+  it("shows the all-set-up copy and the notice when there are no orgs", () => {
+    renderModal([])
+    expect(screen.getByText("orgs.newOrg.allSetUp")).toBeTruthy()
+    expect(screen.getByText("orgs.missingNotice.title")).toBeTruthy()
+  })
+})

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -151,7 +151,7 @@ function NewOrgModal({
       </Modal>
 
       <FreePlanInfoModal
-        open={freePlanOrg !== null}
+        open={open && freePlanOrg !== null}
         orgLogin={freePlanOrg}
         onClose={() => setFreePlanOrg(null)}
       />

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -1,32 +1,41 @@
 import { useNavigate } from "@tanstack/react-router"
 import { ExternalLink } from "lucide-react"
-import { useId } from "react"
+import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import PlanBadge from "@/components/PlanBadge"
-import { Button, Modal } from "@/components/ui"
+import MissingOrgNotice from "@/components/MissingOrgNotice"
+import FreePlanInfoModal from "@/components/modals/FreePlanInfoModal"
+import { Badge, Button, Modal } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
+import useScrollFade from "@/hooks/useScrollFade"
 import { classifyPlan } from "@/lib/orgPlan"
 
 // Modal that lets a teacher start Classroom 50 setup on an existing GitHub org.
 // GitHub orgs can't be created client-side, so this lists the orgs the user
 // already owns that lack a classroom50 config repo (needs_setup) and routes the
-// chosen one into the existing /$org/setup wizard. Free-plan orgs are shown but
-// disabled — they can't complete setup, so routing them to the wizard would be a
-// dead end.
+// chosen one into the existing /$org/setup wizard. Free-plan orgs can't complete
+// setup, so their row opens an explainer (upgrade via GitHub Education) instead
+// of routing into a dead-end wizard.
 function NewOrgModal({
   open,
   needsSetupOrgs,
+  refreshing,
+  onRefresh,
   onClose,
 }: {
   open: boolean
   needsSetupOrgs: Classroom50OrgSummary[]
+  refreshing: boolean
+  onRefresh: () => void
   onClose: () => void
 }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const titleId = useId()
+  const listRef = useScrollFade<HTMLUListElement>()
+  const [freePlanOrg, setFreePlanOrg] = useState<string | null>(null)
 
   const logins = needsSetupOrgs.map((summary) => summary.org.login)
   const plans = useNeedsSetupPlans(open ? logins : [])
@@ -37,96 +46,116 @@ function NewOrgModal({
   }
 
   return (
-    <Modal open={open} onClose={onClose} size="lg" aria-labelledby={titleId}>
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h3 id={titleId} className="text-lg font-bold">
-            {t("orgs.newOrg.title")}
-          </h3>
-          <p className="mt-1 text-sm text-base-content/70">
-            {t("orgs.newOrg.description")}
-          </p>
+    <>
+      <Modal open={open} onClose={onClose} size="2xl" aria-labelledby={titleId}>
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h3 id={titleId} className="text-lg font-bold">
+              {t("orgs.newOrg.title")}
+            </h3>
+            <p className="mt-1 text-sm text-base-content/70">
+              {t("orgs.newOrg.description")}
+            </p>
+          </div>
         </div>
-      </div>
 
-      {needsSetupOrgs.length === 0 ? (
-        <p className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
-          {t("orgs.newOrg.allSetUp")}
-        </p>
-      ) : (
-        <>
-          <p className="mt-6 text-xs font-semibold uppercase tracking-wide text-base-content/60">
-            {t("orgs.newOrg.pickPrompt")}
+        <div className="mt-6">
+          <MissingOrgNotice refreshing={refreshing} onRefresh={onRefresh} />
+        </div>
+
+        {needsSetupOrgs.length === 0 ? (
+          <p className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+            {t("orgs.newOrg.allSetUp")}
           </p>
-          <ul className="mt-2 flex max-h-80 flex-col gap-2 overflow-y-auto">
-            {needsSetupOrgs.map((summary) => {
-              const { org } = summary
-              const planName = plans[org.login]
-              const isFree = classifyPlan(planName) === "free"
-              return (
-                <li key={org.id}>
-                  <button
-                    type="button"
-                    disabled={isFree}
-                    title={
-                      isFree ? t("orgs.newOrg.freePlanDisabled") : undefined
-                    }
-                    onClick={() => handleSelect(org.login)}
-                    className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
-                  >
-                    <img
-                      src={org.avatar_url}
-                      alt=""
-                      className="size-9 shrink-0 rounded-lg border border-base-300"
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-semibold">
-                        {org.login}
+        ) : (
+          <>
+            <p className="mt-6 text-xs font-semibold uppercase tracking-wide text-base-content/60">
+              {t("orgs.newOrg.pickPrompt", { count: needsSetupOrgs.length })}
+            </p>
+            <ul
+              ref={listRef}
+              className="scroll-fade-y mt-2 flex max-h-80 flex-col gap-2"
+            >
+              {needsSetupOrgs.map((summary) => {
+                const { org } = summary
+                const planName = plans[org.login]
+                const isFree = classifyPlan(planName) === "free"
+                return (
+                  <li key={org.id}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        isFree
+                          ? setFreePlanOrg(org.login)
+                          : handleSelect(org.login)
+                      }
+                      className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200"
+                    >
+                      <img
+                        src={org.avatar_url}
+                        alt=""
+                        className="size-9 shrink-0 rounded-lg border border-base-300"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-semibold">
+                          {org.login}
+                        </span>
+                        {org.description && (
+                          <span className="block truncate text-sm text-base-content/60">
+                            {org.description}
+                          </span>
+                        )}
                       </span>
-                      {org.description && (
-                        <span className="block truncate text-sm text-base-content/60">
-                          {org.description}
+                      {planName && !isFree && (
+                        <PlanBadge
+                          name={planName}
+                          title={t("orgs.card.planTitlePaid")}
+                          className="shrink-0"
+                        />
+                      )}
+                      {isFree ? (
+                        <>
+                          <Badge tone="warning" size="sm" className="shrink-0">
+                            {t("orgs.newOrg.notSupportedBadge")}
+                          </Badge>
+                          <span className="btn btn-outline btn-xs shrink-0">
+                            {t("orgs.newOrg.details")}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="btn btn-primary btn-xs shrink-0">
+                          {t("orgs.newOrg.setUp")}
                         </span>
                       )}
-                    </span>
-                    {planName && (
-                      <PlanBadge
-                        name={planName}
-                        title={
-                          isFree
-                            ? t("orgs.card.planTitleFree")
-                            : t("orgs.card.planTitlePaid")
-                        }
-                        className="shrink-0"
-                      />
-                    )}
-                    {!isFree && (
-                      <span className="btn btn-primary btn-xs shrink-0">
-                        {t("orgs.newOrg.setUp")}
-                      </span>
-                    )}
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        </>
-      )}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </>
+        )}
 
-      <div className="modal-action">
-        <Button
-          as="a"
-          href="https://github.com/organizations/new"
-          target="_blank"
-          rel="noreferrer"
-          variant="ghost"
-          size="sm"
-        >
-          {t("orgs.newOrg.createOnGitHub")}
-          <ExternalLink aria-hidden="true" className="size-4" />
-        </Button>
-      </div>
-    </Modal>
+        <div className="modal-action">
+          <Button
+            as="a"
+            href="https://github.com/organizations/new"
+            target="_blank"
+            rel="noreferrer"
+            variant="ghost"
+            size="sm"
+          >
+            {t("orgs.newOrg.createOnGitHub")}
+            <ExternalLink aria-hidden="true" className="size-4" />
+          </Button>
+        </div>
+      </Modal>
+
+      <FreePlanInfoModal
+        open={freePlanOrg !== null}
+        orgLogin={freePlanOrg}
+        onClose={() => setFreePlanOrg(null)}
+      />
+    </>
   )
 }
 

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import PlanBadge from "@/components/PlanBadge"
 import MissingOrgNotice from "@/components/MissingOrgNotice"
 import FreePlanInfoModal from "@/components/modals/FreePlanInfoModal"
-import { Badge, Button, Modal } from "@/components/ui"
+import { Badge, Button, Modal, Spinner } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import useScrollFade from "@/hooks/useScrollFade"
@@ -38,7 +38,9 @@ function NewOrgModal({
   const [freePlanOrg, setFreePlanOrg] = useState<string | null>(null)
 
   const logins = needsSetupOrgs.map((summary) => summary.org.login)
-  const plans = useNeedsSetupPlans(open ? logins : [])
+  const { byLogin: plans, pending: pendingPlans } = useNeedsSetupPlans(
+    open ? logins : [],
+  )
 
   const handleSelect = (login: string) => {
     onClose()
@@ -79,17 +81,19 @@ function NewOrgModal({
               {needsSetupOrgs.map((summary) => {
                 const { org } = summary
                 const planName = plans[org.login]
+                const planLoading = pendingPlans.has(org.login)
                 const isFree = classifyPlan(planName) === "free"
                 return (
                   <li key={org.id}>
                     <button
                       type="button"
+                      disabled={planLoading}
                       onClick={() =>
                         isFree
                           ? setFreePlanOrg(org.login)
                           : handleSelect(org.login)
                       }
-                      className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200"
+                      className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200 disabled:cursor-wait disabled:opacity-60 disabled:hover:bg-transparent"
                     >
                       <img
                         src={org.avatar_url}
@@ -113,7 +117,9 @@ function NewOrgModal({
                           className="shrink-0"
                         />
                       )}
-                      {isFree ? (
+                      {planLoading ? (
+                        <Spinner size="sm" className="shrink-0" />
+                      ) : isFree ? (
                         <>
                           <Badge tone="warning" size="sm" className="shrink-0">
                             {t("orgs.newOrg.notSupportedBadge")}

--- a/web/src/hooks/useNeedsSetupPlans.ts
+++ b/web/src/hooks/useNeedsSetupPlans.ts
@@ -3,15 +3,22 @@ import { useQueries } from "@tanstack/react-query"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import type { GitHubOrgDetails } from "@/github-core/types"
 
+export type NeedsSetupPlans = {
+  // login -> plan name, or undefined when the plan isn't visible (non-owner) or
+  // hasn't loaded yet.
+  byLogin: Record<string, string | undefined>
+  // logins whose plan query is still in flight. Every needs-setup org is
+  // admin-owned (plan is visible), so a login is `pending` only while loading —
+  // callers use this to avoid classifying a loading org as supported.
+  pending: Set<string>
+}
+
 // Batch plan-name fetches for a set of org logins. Only the "needs setup" subset
 // of the home view is passed in — every such org is admin-owned, so `plan` is
 // visible — which keeps this fan-out off the general org list the home path
 // avoids paying for. Keyed identically to useGetOrgPlanDetails so the setup page
-// reuses the same cache. Maps login -> plan name, or undefined when the plan
-// isn't visible (non-owner) or hasn't loaded.
-const useNeedsSetupPlans = (
-  logins: string[],
-): Record<string, string | undefined> => {
+// reuses the same cache.
+const useNeedsSetupPlans = (logins: string[]): NeedsSetupPlans => {
   const client = useGitHubClient()
 
   const results = useQueries({
@@ -23,11 +30,13 @@ const useNeedsSetupPlans = (
   })
 
   const byLogin: Record<string, string | undefined> = {}
+  const pending = new Set<string>()
   logins.forEach((login, i) => {
     byLogin[login] = results[i]?.data?.plan?.name
+    if (results[i]?.isPending) pending.add(login)
   })
 
-  return byLogin
+  return { byLogin, pending }
 }
 
 export default useNeedsSetupPlans

--- a/web/src/hooks/useScrollFade.test.tsx
+++ b/web/src/hooks/useScrollFade.test.tsx
@@ -4,9 +4,9 @@ import { act, cleanup, render } from "@testing-library/react"
 
 import { useScrollFade } from "./useScrollFade"
 
-// happy-dom has no layout engine, so scroll metrics are stubbed per element and
-// ResizeObserver is mocked to a no-op we can ignore (the scroll path covers the
-// same update()).
+// happy-dom has no layout engine, so scroll metrics are stubbed per element.
+// ResizeObserver / MutationObserver are mocked so tests can drive their
+// callbacks and assert teardown.
 function stubMetrics(
   el: HTMLElement,
   metrics: { scrollTop: number; scrollHeight: number; clientHeight: number },
@@ -18,13 +18,22 @@ function stubMetrics(
   })
   Object.defineProperty(el, "scrollHeight", {
     configurable: true,
+    writable: true,
     value: metrics.scrollHeight,
   })
   Object.defineProperty(el, "clientHeight", {
     configurable: true,
+    writable: true,
     value: metrics.clientHeight,
   })
 }
+
+// Capture observer instances so tests can fire callbacks and assert disconnect.
+const resizeInstances: {
+  cb: ResizeObserverCallback
+  observe: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+}[] = []
 
 function Harness({
   metrics,
@@ -45,8 +54,25 @@ function Harness({
 
 describe("useScrollFade", () => {
   beforeEach(() => {
+    resizeInstances.length = 0
     vi.stubGlobal(
       "ResizeObserver",
+      class {
+        cb: ResizeObserverCallback
+        observe = vi.fn()
+        disconnect = vi.fn()
+        constructor(cb: ResizeObserverCallback) {
+          this.cb = cb
+          resizeInstances.push({
+            cb,
+            observe: this.observe,
+            disconnect: this.disconnect,
+          })
+        }
+      },
+    )
+    vi.stubGlobal(
+      "MutationObserver",
       class {
         observe() {}
         disconnect() {}
@@ -118,5 +144,38 @@ describe("useScrollFade", () => {
     })
     expect(el.dataset.fadeTop).toBe("true")
     expect(el.dataset.fadeBottom).toBe("false")
+  })
+
+  it("recomputes when the ResizeObserver fires (content grows after mount)", () => {
+    const { getByTestId } = render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 200, clientHeight: 200 }}
+      />,
+    )
+    const el = getByTestId("list")
+    expect(el.dataset.fadeBottom).toBe("false")
+
+    act(() => {
+      // Content grew past the capped box after async data arrived.
+      ;(el as unknown as { scrollHeight: number }).scrollHeight = 400
+      resizeInstances[0].cb([], resizeInstances[0] as unknown as ResizeObserver)
+    })
+    expect(el.dataset.fadeBottom).toBe("true")
+  })
+
+  it("disconnects observers and removes the scroll listener on unmount", () => {
+    const { getByTestId, unmount } = render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 400, clientHeight: 200 }}
+      />,
+    )
+    const el = getByTestId("list")
+    const removeSpy = vi.spyOn(el, "removeEventListener")
+    const { disconnect } = resizeInstances[0]
+
+    unmount()
+
+    expect(disconnect).toHaveBeenCalled()
+    expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function))
   })
 })

--- a/web/src/hooks/useScrollFade.test.tsx
+++ b/web/src/hooks/useScrollFade.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, render } from "@testing-library/react"
+
+import { useScrollFade } from "./useScrollFade"
+
+// happy-dom has no layout engine, so scroll metrics are stubbed per element and
+// ResizeObserver is mocked to a no-op we can ignore (the scroll path covers the
+// same update()).
+function stubMetrics(
+  el: HTMLElement,
+  metrics: { scrollTop: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: metrics.scrollTop,
+  })
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  })
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  })
+}
+
+function Harness({
+  metrics,
+}: {
+  metrics: { scrollTop: number; scrollHeight: number; clientHeight: number }
+}) {
+  const ref = useScrollFade<HTMLDivElement>()
+  return (
+    <div
+      data-testid="list"
+      ref={(el) => {
+        if (el) stubMetrics(el, metrics)
+        ref(el)
+      }}
+    />
+  )
+}
+
+describe("useScrollFade", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it("fades only the bottom when scrolled to the top of an overflowing list", () => {
+    const { getByTestId } = render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 400, clientHeight: 200 }}
+      />,
+    )
+    const el = getByTestId("list")
+    expect(el.dataset.fadeTop).toBe("false")
+    expect(el.dataset.fadeBottom).toBe("true")
+  })
+
+  it("fades only the top when scrolled to the bottom", () => {
+    const { getByTestId } = render(
+      <Harness
+        metrics={{ scrollTop: 200, scrollHeight: 400, clientHeight: 200 }}
+      />,
+    )
+    const el = getByTestId("list")
+    expect(el.dataset.fadeTop).toBe("true")
+    expect(el.dataset.fadeBottom).toBe("false")
+  })
+
+  it("fades both edges when scrolled to the middle", () => {
+    const { getByTestId } = render(
+      <Harness
+        metrics={{ scrollTop: 100, scrollHeight: 400, clientHeight: 200 }}
+      />,
+    )
+    const el = getByTestId("list")
+    expect(el.dataset.fadeTop).toBe("true")
+    expect(el.dataset.fadeBottom).toBe("true")
+  })
+
+  it("fades neither edge when content fits without scrolling", () => {
+    const { getByTestId } = render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 200, clientHeight: 200 }}
+      />,
+    )
+    const el = getByTestId("list")
+    expect(el.dataset.fadeTop).toBe("false")
+    expect(el.dataset.fadeBottom).toBe("false")
+  })
+
+  it("recomputes edges on scroll", () => {
+    const { getByTestId } = render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 400, clientHeight: 200 }}
+      />,
+    )
+    const el = getByTestId("list")
+    expect(el.dataset.fadeTop).toBe("false")
+
+    act(() => {
+      ;(el as unknown as { scrollTop: number }).scrollTop = 200
+      el.dispatchEvent(new Event("scroll"))
+    })
+    expect(el.dataset.fadeTop).toBe("true")
+    expect(el.dataset.fadeBottom).toBe("false")
+  })
+})

--- a/web/src/hooks/useScrollFade.ts
+++ b/web/src/hooks/useScrollFade.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef } from "react"
+
+// Drives the `scroll-fade-y` mask: sets data-fade-top / data-fade-bottom on the
+// element to whichever edge still has hidden content, so the fade only appears
+// where there's more to scroll to. Attributes are written straight to the DOM
+// (no state) to avoid a re-render on every scroll frame.
+export function useScrollFade<T extends HTMLElement>() {
+  const elementRef = useRef<T | null>(null)
+
+  const update = useCallback((el: T) => {
+    const { scrollTop, scrollHeight, clientHeight } = el
+    // 1px slack absorbs sub-pixel rounding at the extremes.
+    const atTop = scrollTop <= 1
+    const atBottom = scrollTop + clientHeight >= scrollHeight - 1
+    el.dataset.fadeTop = String(!atTop)
+    el.dataset.fadeBottom = String(!atBottom && scrollHeight > clientHeight)
+  }, [])
+
+  const ref = useCallback(
+    (el: T | null) => {
+      elementRef.current = el
+      if (el) update(el)
+    },
+    [update],
+  )
+
+  useEffect(() => {
+    const el = elementRef.current
+    if (!el) return
+    const onScroll = () => update(el)
+    el.addEventListener("scroll", onScroll, { passive: true })
+    const observer = new ResizeObserver(() => update(el))
+    observer.observe(el)
+    return () => {
+      el.removeEventListener("scroll", onScroll)
+      observer.disconnect()
+    }
+  }, [update])
+
+  return ref
+}
+
+export default useScrollFade

--- a/web/src/hooks/useScrollFade.ts
+++ b/web/src/hooks/useScrollFade.ts
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 // Drives the `scroll-fade-y` mask: sets data-fade-top / data-fade-bottom on the
 // element to whichever edge still has hidden content, so the fade only appears
 // where there's more to scroll to. Attributes are written straight to the DOM
 // (no state) to avoid a re-render on every scroll frame.
 export function useScrollFade<T extends HTMLElement>() {
-  const elementRef = useRef<T | null>(null)
+  // Track the node in state (not a ref) so the effect re-subscribes when the
+  // element remounts — e.g. a conditionally-rendered list that appears after a
+  // loading/empty phase. A ref wouldn't retrigger the effect, leaking listeners
+  // on the old node and leaving the new one unbound.
+  const [element, setElement] = useState<T | null>(null)
 
   const update = useCallback((el: T) => {
     const { scrollTop, scrollHeight, clientHeight } = el
@@ -16,28 +20,30 @@ export function useScrollFade<T extends HTMLElement>() {
     el.dataset.fadeBottom = String(!atBottom && scrollHeight > clientHeight)
   }, [])
 
-  const ref = useCallback(
-    (el: T | null) => {
-      elementRef.current = el
-      if (el) update(el)
-    },
-    [update],
-  )
-
   useEffect(() => {
-    const el = elementRef.current
-    if (!el) return
-    const onScroll = () => update(el)
-    el.addEventListener("scroll", onScroll, { passive: true })
-    const observer = new ResizeObserver(() => update(el))
-    observer.observe(el)
+    if (!element) return
+    const recompute = () => update(element)
+    recompute()
+    element.addEventListener("scroll", recompute, { passive: true })
+    // Observe the container and its children: the container catches viewport
+    // resizes, the children catch content growing after mount (e.g. async row
+    // badges) that changes scrollHeight without resizing the capped box.
+    const observer = new ResizeObserver(recompute)
+    observer.observe(element)
+    for (const child of element.children) observer.observe(child)
+    const mutations = new MutationObserver(() => {
+      for (const child of element.children) observer.observe(child)
+      recompute()
+    })
+    mutations.observe(element, { childList: true })
     return () => {
-      el.removeEventListener("scroll", onScroll)
+      element.removeEventListener("scroll", recompute)
       observer.disconnect()
+      mutations.disconnect()
     }
-  }, [update])
+  }, [element, update])
 
-  return ref
+  return setElement
 }
 
 export default useScrollFade

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -188,6 +188,30 @@ body {
   }
 }
 
+/* Scroll affordance for capped-height lists. `scroll-fade-y` marks the
+   container; a small hook (useScrollFade) sets data-fade-top / data-fade-bottom
+   to the edge(s) that have more content, and the mask softens only that edge.
+   No hook / no support => no attributes => no fade, list still scrolls. */
+@utility scroll-fade-y {
+  overflow-y: auto;
+  --scroll-fade-size: 1.75rem;
+  --scroll-fade-top: 0px;
+  --scroll-fade-bottom: 0px;
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 var(--scroll-fade-top),
+    #000 calc(100% - var(--scroll-fade-bottom)),
+    transparent 100%
+  );
+  &[data-fade-top="true"] {
+    --scroll-fade-top: var(--scroll-fade-size);
+  }
+  &[data-fade-bottom="true"] {
+    --scroll-fade-bottom: var(--scroll-fade-size);
+  }
+}
+
 /* Micro-interaction feedback for every daisyUI button (there is no shared
    Button component; this covers all `.btn` sites at once). A slight press-in on
    :active makes clicks feel tactile. daisyUI already handles hover colors. */

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -598,7 +598,6 @@
     },
     "card": {
       "noAccessBadge": "No <code>classroom50</code> access",
-      "planTitleFree": "Free plan — Classroom 50 needs a Team or Enterprise organization",
       "planTitlePaid": "GitHub plan — Classroom 50 can be set up on Team and Enterprise plans",
       "viewOnGitHub": "View on GitHub",
       "openOnGitHub": "Open {{org}} on GitHub",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -573,11 +573,21 @@
       "button": "Set up new organization",
       "title": "Set up a new Classroom 50 organization",
       "description": "Pick one of your GitHub organizations to configure Classroom 50 in. Don't see the one you want? Create it on GitHub first.",
-      "pickPrompt": "Organizations ready to set up",
+      "pickPrompt_one": "Organization ready to set up ({{count}})",
+      "pickPrompt_other": "Organizations ready to set up ({{count}})",
       "createOnGitHub": "Create an organization on GitHub",
-      "allSetUp": "All of your organizations are already set up.",
+      "allSetUp": "All organizations we can see are already set up.",
       "setUp": "Set up",
-      "freePlanDisabled": "Free plan — Classroom 50 needs a Team or Enterprise organization"
+      "notSupportedBadge": "Not supported",
+      "details": "Details",
+      "freePlanInfo": {
+        "title": "This organization is on the Free plan",
+        "body": "Classroom 50 only works with organizations on the GitHub Team or Enterprise plan.",
+        "educationTitle": "Get GitHub Team for free",
+        "educationBody": "As a verified teacher, you can upgrade any organization you own to GitHub Team at no cost through GitHub Education.",
+        "educationCta": "Learn more at GitHub Education",
+        "dismiss": "Got it"
+      }
     },
     "missingNotice": {
       "title": "Not seeing your organization?",

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -12,12 +12,9 @@ import { useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
   ChevronDown,
-  ExternalLink,
-  Info,
   Lock,
   MailOpen,
   Plus,
-  RefreshCw,
   ShieldCheck,
   User,
 } from "lucide-react"
@@ -34,64 +31,6 @@ import { EnterDiv } from "@/lib/motionComponents"
 import { orgListPrefs, type OrgSortKey } from "@/lib/orgListPrefs"
 import { useListPrefsState } from "@/lib/listPrefs"
 import { formatRelativeToNow } from "@/util/formatDate"
-
-function MissingOrgNotice({
-  refreshing,
-  onRefresh,
-}: {
-  refreshing: boolean
-  onRefresh: () => void
-}) {
-  const { t } = useTranslation()
-  return (
-    <details className="group rounded-xl border border-info/20 bg-info/5">
-      <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-sm">
-        <Info aria-hidden="true" className="size-4 shrink-0 text-info" />
-        <span className="min-w-0 flex-1 truncate font-medium text-base-content">
-          {t("orgs.missingNotice.title")}
-        </span>
-        <Button
-          variant="ghost"
-          size="xs"
-          disabled={refreshing}
-          onClick={(e) => {
-            // The button lives inside <summary>; stop the click from toggling
-            // the disclosure so refreshing doesn't also expand/collapse it.
-            e.preventDefault()
-            onRefresh()
-          }}
-        >
-          <RefreshCw
-            aria-hidden="true"
-            className={["size-3.5", refreshing ? "animate-spin" : ""].join(" ")}
-          />
-          {refreshing
-            ? t("orgs.missingNotice.refreshing")
-            : t("orgs.missingNotice.refresh")}
-        </Button>
-        <ChevronDown
-          aria-hidden="true"
-          className="size-4 shrink-0 text-base-content/50 transition-transform group-open:rotate-180"
-        />
-      </summary>
-
-      <div className="border-t border-info/20 px-4 py-3">
-        <p className="text-sm leading-6 text-base-content/70">
-          {t("orgs.missingNotice.body")}
-        </p>
-        <a
-          href="https://github.com/settings/connections/applications"
-          target="_blank"
-          rel="noreferrer"
-          className="btn btn-info btn-sm mt-3"
-        >
-          {t("orgs.missingNotice.manageOauth")}
-          <ExternalLink aria-hidden="true" className="size-4" />
-        </a>
-      </div>
-    </details>
-  )
-}
 
 // A single pending org invitation: org identity from the membership record
 // (avatar/name/description) plus an inline accept-and-verify. Pending members
@@ -502,11 +441,6 @@ const OrgsPage = () => {
           <>
             <PageHeader title={t("orgs.headingCl50")} />
 
-            <MissingOrgNotice
-              refreshing={isFetching}
-              onRefresh={handleRefresh}
-            />
-
             {hasInvites && <PendingInvites invites={pendingInvites} />}
 
             {hasContent && (
@@ -613,6 +547,8 @@ const OrgsPage = () => {
       <NewOrgModal
         open={modalOpen}
         needsSetupOrgs={needsSetupOrgs}
+        refreshing={isFetching}
+        onRefresh={handleRefresh}
         onClose={() => setModalOpen(false)}
       />
     </>

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -538,6 +538,16 @@ const OrgsPage = () => {
               <EmptyState
                 title={t("orgs.emptyTitle")}
                 body={t("orgs.emptyBody")}
+                action={
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => setModalOpen(true)}
+                  >
+                    <Plus aria-hidden="true" className="size-4" />
+                    {t("orgs.setUpFirst.cta")}
+                  </Button>
+                }
               />
             )}
           </>


### PR DESCRIPTION
## Summary

Improves the "Set up new organization" flow so teachers aren't stuck when an org is missing or on the Free plan.

Motivated by two support threads:
- [discussion #352](https://github.com/foundation50/classroom50/discussions/352) — a teacher couldn't add a second org (GitHub only returns orgs the OAuth grant covers) and the modal said everything was "already set up".
- [discussion #330](https://github.com/foundation50/classroom50/discussions/330) — a teacher's orgs appeared but weren't clickable (disabled Free-plan rows) and they spent an hour on OAuth re-auth fixes before a maintainer explained the real cause: Classroom 50 needs a Team/Enterprise plan, upgradable for free via GitHub Education. This PR surfaces that guidance in-product.

- **Missing orgs:** moved the "Not seeing your organization?" grant-access notice off the page and into the modal (above the list), so the fix is where teachers look. The misleading `allSetUp` copy no longer asserts completeness.
- **Free-plan orgs:** instead of a disabled dead-end row, Free-plan orgs show a "Not supported" badge + a "Details" button. Clicking opens a concise, fact-checked explainer that points to the free GitHub Team upgrade via [GitHub Education](https://github.com/education) (verified teachers can upgrade any org they own to Team at no cost) — the same answer the maintainer gave manually in #330.
- **List clarity:** added a `useScrollFade` hook + `scroll-fade-y` utility that softly fades only the edge of the capped org list that has more content, so it's clear the list scrolls. Also shows a pluralized count in the "Organizations ready to set up (N)" heading and widened the modal to `2xl` for long org names.

## Test plan

- [x] `npm run typecheck`, `eslint`, `prettier --check` clean on touched files
- [x] `vitest run` — 2108 pass (incl. i18n key audit + locale coverage); 5 new `useScrollFade` tests
- [ ] Manual: open the modal with 0 / 1 / many needs-setup orgs — notice shows above the list, count/pluralization correct, long names legible, scroll fade appears only where there's more content
- [ ] Manual: click a Free-plan org's row/Details — explainer opens with the org name and the GitHub Education link