### PR TITLE
fix(web): patch brace-expansion DoS (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4448,9 +4448,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5659,9 +5659,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#17](https://github.com/foundation50/classroom50/security/dependabot/17) — **brace-expansion DoS** (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149, high). `expand_` recurses into `post` unconditionally before its early returns, giving `O(2ⁿ)` blow-up on consecutive non-expanding `{}` groups; it reaches us transitively via `minimatch` brace patterns.

Refreshed `web/package-lock.json` to patched versions (dev-scoped transitive deps only):

| Copy | Before | After | Consumer |
| --- | --- | --- | --- |
| top-level `brace-expansion` | 5.0.6 | **5.0.7** | `minimatch@10.2.5` (`^5.0.5`) |
| nested under `eslint-plugin-jsx-a11y` | 1.1.15 | **1.1.16** | `minimatch@3.1.5` (`^1.1.7`) |

Existing semver ranges already accepted the patches, so `package.json` is unchanged and the diff is 6 lines.

## Test plan

- [x] `tsc -b` passes
- [x] `vitest run` — 198 files / 2143 tests passed
- [x] `eslint .` — 0 errors
- [x] `npm audit` confirms the brace-expansion advisory is gone

_Note: a separate, unrelated `js-yaml` advisory (GHSA-52cp-r559-cp3m) remains on the default branch — not addressed here._