### PR TITLE
fix(web): harden GitHub Actions usage panel and pause verification

### DIFF
--- a/web/src/github-core/mutations.orgActionsMode.test.ts
+++ b/web/src/github-core/mutations.orgActionsMode.test.ts
@@ -172,6 +172,20 @@ describe("setOrgActionsMode", () => {
     expect(result).toMatchObject({ status: "warning", reason: "failed" })
   })
 
+  it("pause warns (readback_failed) when the verify read itself throws", async () => {
+    // Writes succeed but the confirmation read fails — fail closed rather than
+    // report a clean pause we couldn't verify.
+    const { client } = makeClient({
+      repo: { id: 42 },
+      repositories: apiError(500),
+    })
+    const result = await setOrgActionsMode(client, org, "paused")
+    expect(result).toMatchObject({
+      status: "warning",
+      reason: "readback_failed",
+    })
+  })
+
   it("pause maps a non-404 getRepo failure to a structured warning", async () => {
     const { client } = makeClient({ repo: apiError(403) })
     const result = await setOrgActionsMode(client, org, "paused")

--- a/web/src/github-core/mutations/provisioning.ts
+++ b/web/src/github-core/mutations/provisioning.ts
@@ -1184,7 +1184,12 @@ export async function getOrgActionsMode(
       : // "selected" but not our config repo: a teacher-set policy we didn't
         // author. Treat as active so we never claim a pause we can't honor.
         "active"
-  } catch {
+  } catch (err) {
+    // Swallow to "unknown" — the UI's fail-safe (shows unknownNotice, disables
+    // the toggle) and setOrgActionsMode re-reads and fail-closes on write. Log
+    // the underlying error so a transient 5xx is diagnosable and not silently
+    // conflated with a genuine permission/enterprise-policy lockout.
+    logSetup.warn("couldn't read org Actions mode", { org, err })
     return "unknown"
   }
 }
@@ -1358,13 +1363,22 @@ export async function setOrgActionsMode(
     // Read back the effective selection: both PUTs returning 2xx doesn't prove
     // the config repo actually landed in the allow-list (eventual consistency,
     // id drift). If it isn't there, its own workflows are blocked — surface it
-    // instead of reporting a false success.
+    // instead of reporting a false success. Fail closed to match
+    // ensureOrgActionsEnabled: if the verify read itself throws, warn rather
+    // than claim a clean pause we couldn't confirm.
     let confirmed: boolean
     try {
       confirmed = await orgActionsSelectionIncludesConfigRepo(client, org)
     } catch {
-      // Couldn't verify — don't claim a clean pause, but the writes succeeded.
-      confirmed = true
+      return {
+        status: "warning",
+        org,
+        reason: "readback_failed",
+        settingsUrl,
+        message:
+          `${org}: autograding paused, but we couldn't confirm the ${CONFIG_REPO} config repo is allow-listed (the verification read failed). ` +
+          `If its workflows stop, check ${settingsUrl}.`,
+      }
     }
     if (!confirmed) {
       return {

--- a/web/src/github-core/queries/billingReads.test.ts
+++ b/web/src/github-core/queries/billingReads.test.ts
@@ -91,9 +91,40 @@ describe("getOrgActionsUsage", () => {
     })
   })
 
-  it("returns null when billing isn't readable (403)", async () => {
+  it("matches a display-name product value ('GitHub Actions'), not just 'actions'", async () => {
+    const request = async () => ({
+      usageItems: [
+        {
+          product: "GitHub Actions",
+          sku: "actions_linux",
+          unitType: "minutes",
+          grossQuantity: 300,
+          netAmount: 0,
+        },
+      ],
+    })
+    const client = { request } as unknown as GitHubClient
+    expect(await getOrgActionsUsage(client, org)).toEqual({
+      minutes: 300,
+      netAmountUsd: 0,
+    })
+  })
+
+  it("returns null when a non-empty report sums to all-zero (likely preview drift)", async () => {
+    // Renamed preview fields read as absent -> every item contributes 0. Don't
+    // confidently show "0 min / $0" — treat as unavailable.
+    const request = async () => ({
+      usageItems: [
+        { product: "Actions", sku: "actions_linux", unitType: "minutes" },
+      ],
+    })
+    const client = { request } as unknown as GitHubClient
+    expect(await getOrgActionsUsage(client, org)).toBeNull()
+  })
+
+  it("returns null (and doesn't throw) on a non-API error", async () => {
     const request = async () => {
-      throw apiError(403)
+      throw new TypeError("boom")
     }
     const client = { request } as unknown as GitHubClient
     expect(await getOrgActionsUsage(client, org)).toBeNull()

--- a/web/src/github-core/queries/billingReads.ts
+++ b/web/src/github-core/queries/billingReads.ts
@@ -1,11 +1,15 @@
 import type { GitHubClient } from "../client"
 import { GitHubAPIError } from "../errors"
+import { logger } from "@/lib/logger"
+import { LOG_SCOPE_GITHUB_SETUP } from "@/lib/logScopes"
 import {
   classifyBudget,
   orgBudgetsApiPath,
   type BudgetVerdict,
   type BudgetsListResponse,
 } from "@/orgPolicy/budget"
+
+const log = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
 // GitHub Actions usage for the current billing month, read from the enhanced
 // billing platform's usage-summary endpoint. The legacy
@@ -20,16 +24,19 @@ import {
 const USAGE_PRODUCT_ACTIONS = "actions"
 const USAGE_UNIT_MINUTES = "minutes"
 
+// Fields typed optional because the usage-summary endpoint is in public preview
+// and its shape may change; a renamed field then reads as absent (handled
+// below) rather than a confident-but-wrong 0.
 type BillingUsageItem = {
-  product: string
-  sku: string
-  unitType: string
+  product?: string
+  sku?: string
+  unitType?: string
   // grossQuantity is total usage (e.g. all Actions minutes run); netQuantity is
   // only the BILLABLE remainder after the plan's included quota, so it reads 0
   // while you're still within quota. We want total usage, so sum grossQuantity.
-  grossQuantity: number
+  grossQuantity?: number
   // netAmount is post-quota, post-discount USD actually billed (0 within quota).
-  netAmount: number
+  netAmount?: number
 }
 
 type BillingUsageSummary = {
@@ -50,6 +57,17 @@ function orgUsageSummaryApiPath(org: string): string {
   return `/organizations/${org}/settings/billing/usage/summary?product=${USAGE_PRODUCT_ACTIONS}`
 }
 
+// Advisory billing reads never block the kill switch: an expected 403 (no
+// billing visibility) / 404 / 410 (endpoint moved) degrades silently to null,
+// but an unexpected failure (5xx, network, or a non-API error such as a shape
+// change throwing a TypeError) is logged so real breakage is observable rather
+// than indistinguishable from "no billing".
+function billingReadFailed(what: string, org: string, err: unknown): null {
+  const unexpected = !(err instanceof GitHubAPIError) || err.status >= 500
+  if (unexpected) log.warn(`${what} read failed unexpectedly`, { org, err })
+  return null
+}
+
 // Current-month Actions usage, or null when billing isn't readable/available.
 export async function getOrgActionsUsage(
   client: GitHubClient,
@@ -59,27 +77,37 @@ export async function getOrgActionsUsage(
     const resp = await client.request<BillingUsageSummary>(
       orgUsageSummaryApiPath(org),
     )
-    const items = (resp.usageItems ?? []).filter(
-      (i) => i.product?.toLowerCase() === USAGE_PRODUCT_ACTIONS,
+    // The request is already scoped server-side via ?product=actions; match
+    // loosely (substring) so a display-name value like "GitHub Actions" from
+    // the preview endpoint doesn't silently drop every item.
+    const items = (resp.usageItems ?? []).filter((i) =>
+      i.product?.toLowerCase().includes(USAGE_PRODUCT_ACTIONS),
     )
     const minutes = items
       .filter((i) => i.unitType?.toLowerCase() === USAGE_UNIT_MINUTES)
       .reduce((sum, i) => sum + (i.grossQuantity ?? 0), 0)
     const netAmountUsd = items.reduce((sum, i) => sum + (i.netAmount ?? 0), 0)
+    // Non-empty report that sums to nothing usually means the preview contract
+    // drifted (renamed quantity/amount fields), not genuinely zero usage —
+    // treat as unavailable rather than confidently showing "0 min / $0.00".
+    if (items.length > 0 && minutes === 0 && netAmountUsd === 0) {
+      log.warn("actions usage summary returned only zero quantities", { org })
+      return null
+    }
     return { minutes: Math.round(minutes), netAmountUsd }
   } catch (err) {
-    // A 403 (no billing visibility) / 404 / 410 (endpoint moved) / transient
-    // failure is advisory — never block the kill switch on missing billing.
-    if (err instanceof GitHubAPIError) return null
-    return null
+    return billingReadFailed("actions usage", org, err)
   }
 }
 
 // Included Actions minutes per month by GitHub plan. GitHub doesn't expose the
 // quota via the API — it's a fixed per-plan allowance — so we map it from the
-// org's plan.name (GET /orgs/{org}, owner-only). Source: GitHub Actions billing
-// docs. null when the plan is unknown/unrecognized (hide the quota bar rather
-// than guess).
+// org's plan.name (GET /orgs/{org}, owner-only). null when the plan is
+// unknown/unrecognized (hide the quota bar rather than guess).
+//
+// Source: GitHub Actions billing docs; verified 2026-07-22. If GitHub changes
+// plan quotas this map drifts silently — re-verify against the docs when
+// touching it.
 const PLAN_INCLUDED_ACTIONS_MINUTES: Record<string, number> = {
   free: 2000,
   // "Free for organizations" also reports as "free"; both are 2000.
@@ -109,7 +137,6 @@ export async function getOrgActionsBudget(
     )
     return classifyBudget(resp.budgets ?? [])
   } catch (err) {
-    if (err instanceof GitHubAPIError) return null
-    return null
+    return billingReadFailed("actions budget", org, err)
   }
 }

--- a/web/src/hooks/mutations/useSetOrgActionsMode.ts
+++ b/web/src/hooks/mutations/useSetOrgActionsMode.ts
@@ -7,10 +7,11 @@ import {
   type SetOrgActionsModeResult,
 } from "@/github-core/mutations"
 
-// Pause/resume autograding org-wide. Invalidates the derived actions-mode read
-// AND the org audit (the audit's orgActions concern reads the same policy), so
-// both reflect the flip. The invalidation lives in the hook's onSuccess so a
-// mid-flight unmount can't drop it.
+// Pause/resume autograding org-wide. Invalidates the derived actions-mode read,
+// the org audit (its orgActions concern reads the same policy), and the usage +
+// budget panels (a flip can change what's shown), so the whole section reflects
+// the change. The invalidation lives in the hook's onSuccess so a mid-flight
+// unmount can't drop it.
 export function useSetOrgActionsMode(org: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
@@ -23,6 +24,12 @@ export function useSetOrgActionsMode(org: string) {
       })
       void queryClient.invalidateQueries({
         queryKey: githubKeys.orgAuditPrefix(org),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgActionsUsage(org),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgActionsBudget(org),
       })
     },
   })

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -96,7 +96,7 @@ const ActionsUsagePanel = ({ org }: { org: string }) => {
               : budget.amount === 0
                 ? t("orgSettings.actions.budgetHardStop")
                 : t("orgSettings.actions.budgetAmount", {
-                    amount: budget.amount,
+                    amount: budget.amount.toFixed(2),
                   })}
           </span>
           <a


### PR DESCRIPTION
## Summary

Follow-up hardening from the post-merge code review of #365 (the GitHub Actions kill switch + usage panel). No behavior-breaking changes — refreshes, resilience, and observability improvements plus a fail-closed correctness fix.

## Changes

**Correctness / reliability (P2)**
- **Usage panel refreshes on toggle** — `useSetOrgActionsMode` now invalidates `orgActionsUsage` and `orgActionsBudget` (in addition to mode + audit), so the minutes/`$`/budget lines update immediately after a pause/resume instead of lingering stale for up to the 5-min `staleTime`.
- **Resilient Actions product filter** — the usage read matches `product` by substring (`includes("actions")`) so a preview display-name value like `"GitHub Actions"` doesn't silently zero out usage.
- **Fail-closed pause verification** — if the post-pause allow-list read-back itself throws, `setOrgActionsMode` now returns a `readback_failed` warning ("paused, but couldn't confirm the config repo is allow-listed") instead of reporting clean success, matching `ensureOrgActionsEnabled`'s posture.

**Robustness / observability (P3)**
- Billing reads (`getOrgActionsUsage` / `getOrgActionsBudget`) share one helper that logs unexpected failures (non-API or `>=500`) while still degrading expected `403/404/410` silently to null — a real breakage is no longer indistinguishable from "no billing".
- Usage-summary preview fields typed optional; a non-empty report that sums to all-zero (likely a renamed preview field) returns null rather than confidently showing `0 min / $0.00`.
- Per-plan included-minutes constant carries a dated "verified 2026-07-22, re-verify against docs" note.
- Budget amount formats with `.toFixed(2)`, consistent with the usage cost line.
- `getOrgActionsMode` logs the underlying error before returning `unknown`, so a transient 5xx is diagnosable and not conflated with a permission lockout.

## Tests

Added coverage for the `"GitHub Actions"` display-name filter, the all-zero-preview -> null guard, a non-API error path, and the pause read-back-throws -> `readback_failed` branch.

## Verification

`tsc -b` clean, eslint/prettier clean, full web suite green (2218 tests).

Addresses the review follow-ups on the merged #365; web-only.