### PR TITLE
fix(web): bump js-yaml to 4.3.0 for GHSA-52cp-r559-cp3m

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7285,9 +7285,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves Dependabot alert [#18](https://github.com/foundation50/classroom50/security/dependabot/18) (GHSA-52cp-r559-cp3m / CVE-2026-59869, high).

## What

Bumps the transitive dev dependency `js-yaml` from `4.2.0` to `4.3.0` in `web/package-lock.json`.

## Why

`js-yaml` < 4.3.0 can spend quadratic CPU time parsing YAML merge-key chains (CWE-400 / CWE-407 uncontrolled resource consumption). 4.3.0 caps the total merged keys per parse.

It's dev-only and transitive (`vite-plugin-svgr → @svgr/core → cosmiconfig → js-yaml`), so no runtime impact, but the alert is cleared and the supply chain stays clean.

## Verification

- `npm audit` reports 0 vulnerabilities.
- `npx vite build` succeeds (svgr, the consumer of js-yaml, runs during build).