### PR TITLE
docs: rewrite wiki for clarity and add glossary

### DIFF
--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -1,43 +1,83 @@
 # Assignment Templates
 
-An assignment's starter code in classroom50 is a normal GitHub repo with the "Template repository" flag turned on. `gh student accept` creates a fresh private copy of the template for each student; `gh student submit` fetches a couple of files back from it on every submit. This page describes the expected layout.
+An assignment's starter code is a normal GitHub repository with the **Template
+repository** flag turned on. `gh student accept` creates a fresh private copy
+for each student; `gh student submit` re-fetches a couple of files from it on
+every submission. This page describes the expected layout.
 
-> **Templates are optional.** A teacher can register an assignment without a template (`gh teacher assignment add` with no `--template`). Students then get an *empty* private repo containing only the autograder workflow shim — useful for write-from-scratch or short-answer work. For repos with *nothing at all* in them — no shim, no metadata, no autograding — pass `--empty-repo` instead (see the [teacher CLI guide](gh-teacher)). The rest of this page applies only to assignments that *do* ship a template.
+> [!NOTE]
+> **Templates are optional.** Register an assignment without `--template` and
+> students get an *empty* repo containing only the autograder shim — good for
+> write-from-scratch or short-answer work. For repos with *nothing at all* (no
+> shim, no autograding), use `--empty-repo` instead. The rest of this page
+> applies only to assignments that ship a template.
 
-A worked example lives at [`templates/example-assignment/`](https://github.com/foundation50/classroom50/tree/main/templates/example-assignment).
+A worked example lives at
+[`templates/example-assignment/`](https://github.com/foundation50/classroom50/tree/main/templates/example-assignment).
 
-## Required structure
+## Structure
 
 ```
 .
-├── README.md              # student-facing description of the assignment
+├── README.md              # student-facing assignment description
 ├── .gitignore             # optional, re-fetched on every gh student submit
 ├── .github/               # optional, re-fetched on every gh student submit
 │   └── workflows/         # CI for student copies (NOT autograde — see below)
 └── <starter code>         # whatever files the assignment needs
 ```
 
-Notes on each piece:
+- **`README.md`** — what the student sees on their copy. Describe the assignment,
+  expected output, and evaluation criteria.
+- **`.gitignore`** (optional) — re-fetched from the template on every submit, so
+  updating it once propagates to every student's next submission.
+- **`.github/`** (optional) — same re-fetch behavior. Put non-autograde
+  workflows here (linters, formatters, dependabot).
+- **Starter code** — any files the student starts from, from a single file to a
+  full project.
 
-- **`README.md`** — what the student sees when they land on their copy of the repo. Describe the assignment, expected output, evaluation criteria, etc.
-- **`.gitignore`** (optional) — if present, `gh student submit` re-fetches this from the template at submit time. Update it once on the template and every student's next submission picks it up.
-- **`.github/`** (optional) — same re-fetch behavior. **The autograde workflow does not live in the template.** `gh student accept` writes a universal shim at `.github/workflows/autograde.yaml` (embedded in `gh-student`, with the org substituted in); the shim never changes after accept. The shim's only job is to `uses:` the reusable autograde-runner workflow in your `classroom50` config repo. That workflow fetches `runner.py` (the runner-side bootstrap) which resolves and execs the per-assignment or classroom-default `autograder.py` entrypoint. Put non-autograde workflows in this template directory (linters, formatters, dependabot, etc.); leave autograding to your config repo (`<classroom>/autograder.py` for the classroom default — set via `gh teacher autograder set-default`, optional per-assignment `autograder.py` overrides under `<classroom>/autograders/<slug>/`, and the `runtime:` block on each `assignments.json` entry). **Never include `.github/workflows/autograde.yaml` in the template** — submit's `.github/` re-fetch would clobber the accept-time shim and double-grade or break grading entirely.
-- **Starter code** — any files the student should start from. The template can be a single file or a full project skeleton.
+> [!WARNING]
+> **Never put `.github/workflows/autograde.yaml` in the template.** The autograde
+> shim is written by `gh student accept` (it's embedded in `gh-student`) and
+> never changes after accept. A copy in the template would be clobbered by
+> submit's `.github/` re-fetch and double-grade or break grading. Autograding
+> logic lives in your config repo, not the template — see [Autograders](Autograders).
 
-## Setting it up
+## Set it up
 
-1. Create a normal repo in your classroom org with the structure above. Register it with `gh teacher assignment add ... --template <owner>/<repo>` — the **assignment slug** you choose there (e.g. `hello`, `dna`) is what students pass as `<assignment>` to `gh student accept`, and it does not have to match the template repo's name.
-2. **Set the template's visibility.** A **public** template always works. A **private** template works if it lives **in your teaching org** — `gh teacher assignment add` grants the classroom's team read access to it, so students can create from it under the "No permission" org baseline. A private template **outside** your org is rejected by `gh teacher assignment add` (students can't be granted access, so `gh student accept` would 404). The GitHub Enterprise Cloud "internal" visibility also works, on plans that have it.
-3. **Mark it as a template** in `Settings → General → Template repository`.
+1. **Create a repository** with the structure above, then register it:
 
-That's it. Students can now run:
+   ```sh
+   gh teacher assignment add <org> <classroom> <slug> --name "…" --template <owner>/<repo>
+   ```
+
+   The assignment **slug** (e.g. `hello`) is what students pass to
+   `gh student accept`; it needn't match the repository name.
+
+2. **Set visibility** (see below).
+3. **Mark it as a template** in **Settings → General → Template repository**.
+
+Students can then run:
 
 ```sh
-gh student accept <org> <classroom> <assignment-slug>
+gh student accept <org> <classroom> <slug>
 ```
 
-…which will create `<org>/<classroom>-<assignment-slug>-<username>` from your template, lowercased.
+…which creates `<org>/<classroom>-<slug>-<username>` (lowercased) from your
+template.
 
-## Why these specific files re-sync
+> [!NOTE]
+> **Template visibility.** A **public** template always works. A **private**
+> template works only if it's **inside your organization** — `gh teacher
+> assignment add` grants the classroom team read access to it. A private
+> template **outside** your organization is rejected (students can't be granted
+> access, so accept would 404). Enterprise Cloud's "internal" visibility also
+> works.
 
-`gh student submit` re-fetches `.gitignore` and `.github/` from the template (recorded in `.classroom50.yaml`) on every submission. Starter code and the README are **not** re-fetched — they belong to the student once accepted. The autograde workflow shim is set once at accept time and never refreshed; runtime, dependency, and grading-logic changes propagate via the runner workflow and `assignments.json` on the teacher's side, both fetched fresh by the runner on every submission.
+## Why `.gitignore` and `.github/` re-sync
+
+On every submission, `gh student submit` re-fetches `.gitignore` and `.github/`
+from the template (recorded in `.classroom50.yaml`). Starter code and the README
+are **not** re-fetched — they belong to the student once accepted. Runtime,
+dependency, and grading-logic changes propagate separately, through the runner
+workflow and `assignments.json`, which the runner fetches fresh on every
+submission.

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -1,31 +1,55 @@
 # Autograders
 
-How Classroom 50 grades student submissions, and how teachers customize.
+How Classroom 50 grades submissions, and how to customize grading.
 
-## Architecture in one paragraph
+## How grading works
 
-Every push to a student's `main` branch triggers the small shim at `.github/workflows/autograde.yaml`, which calls the reusable **autograde-runner** in `<org>/classroom50`. The `setup` job detects acceptance commits, creates or reuses the submit tag, validates assignment/runtime configuration, and passes configured release-file paths to `grade`. The `grade` job checks out the graded commit, runs the Pages-fetched `runner.py` and configured autograder, and then copies accepted extra files into a fresh directory under runner temp. The same job posts the commit status, publishes the core Release output before the extras, and maintains the Feedback PR. Extra collection or upload failures warn without changing the grade or suppressing core publication. The serialized `set-latest` job advances the latest pointer only after core Release publication. Grading and publishing share a job and runner, so the workflow does not provide a credential or hostile-workflow isolation boundary between them. `collect-scores.yaml` later aggregates each Release's `result.json` into `<classroom>/scores.json`.
+Every push to a student's default branch triggers a small shim at
+`.github/workflows/autograde.yaml`, which calls the reusable **autograde-runner**
+workflow in `<org>/classroom50`. On each submission the runner:
 
-Everything substantive (runner workflow, `runner.py`, classroom-default and per-assignment `autograder.py`, runtime configuration, per-assignment bundle) lives in the config repo and is fetched at workflow runtime, so teacher edits propagate to every existing student repo on the next submission with zero per-student-repo maintenance.
+1. Creates (or reuses) the `submit/<UTC-timestamp>-<short-sha>` tag.
+2. Fetches `runner.py` and the assignment's autograder from Pages.
+3. Runs the autograder against the graded commit.
+4. Publishes a GitHub Release with the score, and maintains the Feedback PR.
 
-## Submission triggers
+Later, `collect-scores.yaml` aggregates each Release's `result.json` into
+`<classroom>/scores.json`.
 
-The shim listens on two events:
+Everything substantive — the runner workflow, `runner.py`, autograders, runtime
+config — lives in the config repo and is fetched at run time, so teacher edits
+reach every existing student repo on the next submission with no per-repo
+maintenance.
 
-- **`push` to `main`** — every commit grades, **except the acceptance commit**. The runner creates the `submit/<UTC-timestamp>-<short-sha>` tag at the pushed SHA. This is what `gh student submit` and a plain `git push origin main` both end up using.
-- **`push` of a `submit/*` tag** — manual or web-UI tag pushes work too. The runner detects the tag-trigger and reuses `github.ref_name` instead of creating a new tag.
+> [!NOTE]
+> Grading and publishing share one job and runner, so the workflow is **not** a
+> credential or hostile-workflow isolation boundary between them.
 
-Tags pushed by the runner with the workflow's `GITHUB_TOKEN` don't fire workflows (GitHub's anti-recursion rule), so the auto-tag step never causes a second run.
+## Which commits grade
 
-### The acceptance commit is not graded
+The shim triggers on two events:
 
-Accepting an assignment lands `.classroom50.yaml` + the autograde shim in one student-authored commit, which fires this workflow — but that commit is the student *accepting*, not *submitting*, so there's nothing to grade. The `setup` job detects it (the pushed commit is the commit that introduced `.classroom50.yaml`, with nothing stacked on top) and **skips tagging, grading, and the release** — no `submit/*` tag, no `0/0` "acceptance" release. The run still appears in the Actions tab with a `notice` explaining there's nothing to grade yet.
+- **Push to the default branch** — every commit grades, **except the acceptance
+  commit** (the one that introduced `.classroom50.yaml`, with nothing on top).
+- **Push of a `submit/*` tag** — manual tag pushes work too.
 
-Detection reuses the same accept-commit contract as the Feedback PR baseline (the structural `.classroom50.yaml` marker, not a commit subject — see ["How the baseline is identified"](#feedback-pull-requests)), and is **fail-open**: any uncertainty (shallow clone that can't deepen, unreadable git history, a Pages fetch failure) grades rather than risk dropping a real submission. The first `gh student submit` always stacks a fresh commit on top (it commits with `--allow-empty`), so it is never mistaken for the acceptance and always grades. Templates whose default branch isn't `main` don't fire the workflow at accept time at all; their first graded run is the first `gh student submit` to `main`, which is correctly a submission.
+<details>
+<summary>Why the acceptance commit is skipped</summary>
+
+Accepting lands `.classroom50.yaml` + the shim in one commit, which fires the
+workflow — but that's *accepting*, not *submitting*. The runner detects it and
+skips tagging, grading, and the Release (the run still appears in the Actions
+tab with a `notice`). Detection is **fail-open**: any uncertainty grades rather
+than risk dropping a real submission. Your first `gh student submit` always
+stacks a fresh commit, so it's never mistaken for the acceptance.
+
+</details>
 
 ## The `result.json` contract
 
-This is the **only** contract every autograder must satisfy. Whatever produces it — pytest, check50, JUnit, a shell script, a Rust binary — is up to the teacher. The runner reads `result.json` from the workflow workspace after the autograder exits.
+This is the **only** contract every autograder must satisfy — whatever produces
+it (pytest, check50, a shell script, a Rust binary) is up to you. The runner
+reads `result.json` from the workspace after the autograder exits.
 
 ```json
 {
@@ -42,44 +66,68 @@ This is the **only** contract every autograder must satisfy. Whatever produces i
   "score":           4,
   "max-score":       5,
   "tests": [
-    { "test-name": "compiles",       "passed": true,  "score": 4, "max-score": 4 },
-    { "test-name": "outputs_correct","passed": false, "score": 0, "max-score": 1 }
+    { "test-name": "compiles",        "passed": true,  "score": 4, "max-score": 4 },
+    { "test-name": "outputs_correct", "passed": false, "score": 0, "max-score": 1 }
   ]
 }
 ```
 
 | Field | Type | Notes |
 |---|---|---|
-| `schema` | string | Must be `classroom50/result/v1` exactly |
-| `classroom` | string | Must match `<classroom>` in the repo name |
-| `assignment` | string | Must match `<assignment>` in the repo name |
-| `assignment_type` | string | `"individual"` or `"group"`, stamped by the runner from the assignment mode. `collect-scores` cross-checks it against `assignments.json` `mode` and warns-and-skips a mismatched submission |
-| `owner` | string | The repo owner login (the `<username>` from `<classroom>-<assignment>-<username>`). The **identity anchor** the validators check; for an individual assignment it is the sole credited student, for a group it is the founder whose repo was graded. There is no `usernames` field — who pushed is `submitted_by`, who is credited (group) is resolved by collection |
-| `submission` | string | The submit-tag name |
-| `commit` | string | URL to the submission commit |
-| `release` | string | URL to the release |
-| `review` | string | URL teachers click to review — the full diff from the starter code to the graded commit (compare view); falls back to the commit view when repo history is unavailable or there is nothing to compare (baseline == graded commit) |
-| `datetime` | string | UTC ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`) |
-| `score` | int | Sum of test scores (0 ≤ score ≤ max-score) |
-| `max-score` | int | Sum of test max-scores |
-| `tests` | `[object]` | Per-test breakdown (optional content — `[]` is valid for the "vacuous pass / no tests configured" case) |
-| `submitted_by` | object | Optional. The GitHub actor who pushed this submission: `{"username": <login>, "id": <numeric id\|null>}`, stamped by the runner from `GITHUB_ACTOR`/`GITHUB_ACTOR_ID`. For a **group** submission the score is credited to every member (collection resolves the member list), but `submitted_by` records *who actually pushed* this submission — so teachers can see who did the work even though the grade is shared. Absent on results produced before this field existed |
+| `schema` | string | Exactly `classroom50/result/v1`. |
+| `classroom` / `assignment` | string | Must match the repo name. |
+| `assignment_type` | string | `individual` or `group`, stamped by the runner. |
+| `owner` | string | The repo owner login — the identity anchor. |
+| `submission` | string | The submit-tag name. |
+| `commit` / `release` / `review` | string | URLs. `review` is the full diff from starter code to the graded commit. |
+| `datetime` | string | UTC ISO 8601. |
+| `score` / `max-score` | int | Sum of test scores / max-scores. |
+| `tests` | array | Per-test breakdown (`[]` is valid for a vacuous pass). |
+| `submitted_by` | object | Optional. Who pushed: `{"username", "id"}`. |
 
-`collect-scores.yaml` validates this payload before merging into `scores.json`. Mismatches against the source repo's identity (classroom/assignment/`owner` triple) are rejected with a warning, and a submission whose `assignment_type` disagrees with the assignment's configured `mode` is warned-and-skipped. The `owner` must equal the repo-name-derived owner in both modes.
+`collect-scores` validates this before merging into `scores.json`. A payload
+whose identity (classroom/assignment/`owner`) doesn't match the source repo is
+rejected, and a mismatched `assignment_type` is warned-and-skipped — so a hostile
+payload can't land in another student's gradebook.
 
-**scores.json shape.** The gradebook is keyed by assignment slug under a root `assignments` object; each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is one repo's record: `owner` (the stable key), `submissions` (the full history, newest first — each a stored result/v1 payload), and — for a **group** entry — `member_usernames` (the credited members). An individual entry has no member list; its `owner` is the sole credited student.
+<details>
+<summary>scores.json shape</summary>
 
-**Group attribution model.** For a group assignment, `collect-scores` credits the shared score to every collaborator on the repo who is **on the classroom team** (the repo owner is always included), recorded as the entry's `member_usernames`. Crediting is gated on **team membership, not on collaborator permission level** — a teammate is credited whether they hold `push` or `admin`. A few consequences worth knowing:
+The gradebook is keyed by assignment slug under a root `assignments` object;
+each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is
+one repo's record: `owner` (the stable key), `submissions` (full history, newest
+first), and — for a group — `member_usernames` (credited members).
 
-- **Classmates on the team are mutually trusted.** GitHub does not record *how* a collaborator was added, so collection cannot distinguish a teammate the founder added via `gh student invite` from one a student added directly through the GitHub UI. A student could therefore add a teammate who is on the classroom team as a collaborator and credit them this assignment's score. The team intersection bounds this to classmates on the team — an account off the team can never be credited — and this "students in a classroom are mutually trusted" model is intentional. If you need stricter control, review the collaborator list on each group repo.
-- **Permission level does not gate crediting.** Crediting is decided by classroom-team membership, not by whether a collaborator is `push` or `admin`. This matters because a teammate who is *also an org owner* is `admin` on every repo, and the founder is kept `admin` so they can invite teammates — an earlier version excluded all admins and silently credited only the repo owner. Teachers/TAs are excluded automatically because they are **not on the student team**, so dropping the admin filter loses no protection. (Permission level is still used by `gh student invite` when *counting* members against `max_group_size` — but that is an advisory limit, separate from crediting.)
-- **If only the owner is credited, collection warns.** When a group submission resolves to the owner alone (no other teammate on the team found), `collect-scores` emits a `::warning::` pointing you to check that each teammate is both on the classroom team and a collaborator on the repo — so the silent "team submission scored as solo" case is visible.
-- **`submitted_by` records the pusher.** Each submission carries who pushed it (see the `submitted_by` field above), so even though the grade is shared across the team you can see who submitted each push.
-- **Rows are keyed by the repo owner.** In `scores.json` each row carries an `owner` field (the repo owner login) and the bucket is keyed on it, so re-collecting a group repo whose member set changed (e.g. a teammate joined, or a transient read degraded attribution to owner-only) **updates the same row in place** rather than leaving a stale duplicate.
+</details>
 
-## Declarative tests (no `autograder.py`)
+### Group attribution model
 
-The lowest-friction way to grade: describe input/output, run-command, and pytest checks directly on the assignment's entry in `assignments.json`, and the runner grades them with a built-in interpreter — no grading code to write. The three test types map one-to-one onto GitHub Classroom's legacy autograder presets, so migrating classrooms can keep their existing tests.
+A group assignment is graded once, in the founder's repo. `collect-scores`
+credits the shared score to every collaborator **on the classroom team** (the
+owner is always included), recorded as the entry's `member_usernames`.
+
+- **Crediting is by team membership, not permission level.** A teammate is
+  credited whether they hold `push` or `admin`. Teachers and TAs are excluded
+  automatically because they aren't on the student team.
+- **Classmates on the team are mutually trusted.** Collection can't tell how a
+  collaborator was added, so a student could credit a teammate who's on the team.
+  The team intersection bounds this to classmates — an account off the team is
+  never credited. Review each group repo's collaborators if you need stricter
+  control.
+- **Owner-only submissions warn.** If a group submission resolves to just the
+  owner, collection emits a `::warning::` so the "team submission scored as solo"
+  case is visible.
+- **`submitted_by` records the pusher**, so you can see who did the work even
+  though the grade is shared.
+- **Rows are keyed by the repo owner**, so re-collecting a group repo whose
+  members changed updates the same row in place.
+
+## Declarative tests
+
+The lowest-friction way to grade: describe io/run/pytest checks directly on the
+assignment, and the runner grades them with a built-in interpreter — no grading
+code to write. The three types map onto GitHub Classroom's legacy autograder
+presets.
 
 Author tests one at a time:
 
@@ -93,7 +141,9 @@ gh teacher assignment test list cs50-fall-2026 cs-principles hello
 gh teacher assignment test remove cs50-fall-2026 cs-principles hello compiles
 ```
 
-Or set the whole array at once with `gh teacher assignment add ... --tests <file.json>` (`--tests -` reads stdin). The file is a bare JSON array of test specs — the same shape `assignment test list --json` emits:
+Or set the whole array at once with `gh teacher assignment add ... --tests
+<file.json>` (`--tests -` reads stdin). The file is a bare JSON array — the same
+shape `assignment test list --json` emits:
 
 ```json
 [
@@ -103,120 +153,124 @@ Or set the whole array at once with `gh teacher assignment add ... --tests <file
   { "name": "greets by name", "type": "io", "setup": "gcc -o hello hello.c",
     "run": "./hello", "input": "Alice\n", "expected": "^hello,\\s+Alice\\b",
     "comparison": "regex", "points": 2 },
-  { "name": "pytest suite", "type": "python",
-    "run": "python -m pytest -q", "timeout": 120, "points": 10 }
+  { "name": "pytest suite", "type": "python", "run": "python -m pytest -q", "timeout": 120, "points": 10 }
 ]
 ```
 
-> The runner auto-installs `pytest` and `pytest-json-report` for `python` tests, so no `setup` install line is needed. Add one (e.g. `"setup": "pip install --quiet pytest==8.* pytest-json-report"`) only to pin a version — the runner leaves an already-importable version untouched.
-
-### How it flows
-
-The tests live inline on the assignment's entry in `assignments.json`. On the next config-repo push, the publish-pages workflow **materializes** them into `<classroom>/autograders/<slug>/tests.json` and tars that into the per-assignment Pages bundle, alongside any fixture files in the same directory. At grade time, `runner.py` runs each spec in the student checkout: one row per test in `result.json`, plus a pass/fail breakdown in the release body with failure details for each failing test — a unified diff of expected vs. actual stdout for `exact` io tests, verbatim expected/actual blocks for `included`/`regex`, and captured stderr. Captured output is truncated at 2000 characters.
-
-The same breakdown surfaces in three places per run: the **release body** (Markdown, as above), the **grade job's log** under the "Grade details" step (one ANSI-colored PASS/FAIL line per test, plus a collapsible log group per failing test with its details), and the **run's Summary page** (the release-body Markdown, mirrored via `$GITHUB_STEP_SUMMARY` — custom autograders get this too). Students and teachers debugging from the Actions tab see failures without opening the release.
-
-Test commands are teacher-authored shell, executed at the same privilege as a hand-written `autograder.py` — inside the sandboxed grade job, fetched as data from Pages, never interpolated into workflow YAML. Students can't edit `assignments.json`; it lives in your config repo.
-
 ### Test types
 
-| Type | Pass criterion | Type-specific fields |
+| Type | Passes when | Type-specific fields |
 |---|---|---|
 | `io` | stdout of `run` matches `expected` per `comparison` | `input` / `input-file`, `expected` / `expected-file`, `comparison` |
 | `run` | exit code of `run` equals `exit-code` (default 0) | `exit-code` |
-| `python` | pytest passes; points split across cases as `points × passed/total`. The runner auto-installs `pytest` + `pytest-json-report`; if a report still can't be produced (e.g. an offline runner), it falls back to all-or-nothing on the exit code | — |
+| `python` | pytest passes; points split across cases | — |
+
+> [!NOTE]
+> The runner auto-installs `pytest` and `pytest-json-report` for `python` tests.
+> Add a `setup` install line only to pin a version.
 
 ### Fields
 
-| Field | Type | Notes |
-|---|---|---|
-| `name` | string | Required. Unique within the assignment (it's the test's identity in `result.json`), ≤ 100 bytes (UTF-8), no control characters. |
-| `type` | string | Required. `io`, `run`, or `python`. |
-| `run` | string | Required. Shell command, executed in the student checkout. |
-| `setup` | string | Optional pre-command (e.g. compile). Non-zero exit fails the test with captured stderr. |
-| `input` / `input-file` | string | `io` only, mutually exclusive. Inline stdin, or a fixture file bundled from `<classroom>/autograders/<slug>/`. |
-| `expected` / `expected-file` | string | `io` only, mutually exclusive. Inline expected stdout, or a bundled fixture. Must be non-empty for `included`/`regex` — an empty expected would match everything. |
-| `comparison` | string | `io` only. `included` (substring), `exact` (equal after trimming surrounding whitespace), or `regex` (Python `re.search` with `re.MULTILINE`, so `^`/`$` anchor at line boundaries and lookaround/backreferences work; a malformed pattern surfaces as a failing test, not a write error). |
-| `timeout` | int | Seconds, 1–600. Omit (or 0) for the default of 10s. Applies to `setup` and `run` separately. |
-| `exit-code` | int | `run` only, 0–255. Omit to require 0. |
-| `points` | int | Required, 0–1000. 0-point tests are informational. |
+| Field | Notes |
+|---|---|
+| `name` | Required. Unique within the assignment; ≤ 100 UTF-8 bytes; no control characters. |
+| `type` | Required. `io`, `run`, or `python`. |
+| `run` | Required. Shell command, run in the student checkout. |
+| `setup` | Optional pre-command (e.g. compile). Non-zero exit fails the test. |
+| `input` / `input-file` | `io` only, mutually exclusive. Inline stdin or a bundled fixture. |
+| `expected` / `expected-file` | `io` only, mutually exclusive. Must be non-empty for `included`/`regex`. |
+| `comparison` | `io` only. `included` (substring), `exact` (trimmed equality), or `regex` (Python `re.search`, multiline). |
+| `timeout` | Seconds, 1–600. Omit or 0 for the default of 10s. Applies to `setup` and `run` separately. |
+| `exit-code` | `run` only, 0–255. Omit to require 0. |
+| `points` | Required, 0–1000. 0-point tests are informational. |
 
-At most 100 tests per assignment. Large fixtures belong in files (`input-file` / `expected-file`) committed under `<classroom>/autograders/<slug>/` rather than inline, so `assignments.json` stays well under the contents-API size ceiling.
+At most 100 tests per assignment. Put large fixtures in files
+(`input-file` / `expected-file`) under `<classroom>/autograders/<slug>/`, not
+inline.
 
-### Precedence and the conflict rule
+<details>
+<summary>How tests flow, and where failures surface</summary>
 
-Entrypoint resolution order in `runner.py`:
+Tests live inline in `assignments.json`. On the next config-repo push,
+publish-pages **materializes** them into the assignment's Pages bundle as
+`tests.json`. At grade time, `runner.py` runs each spec in the student checkout:
+one row per test in `result.json`, plus a failure breakdown in three places — the
+**Release body**, the **grade job log** ("Grade details"), and the **run Summary
+page**. Captured output is truncated at 2000 characters.
 
-1. Bundled per-assignment `autograder.py` — a hand-written override always wins (the escape hatch).
-2. Bundled per-assignment `tests.json` — the declarative grader.
+Specs are validated three times: by the CLI at write time, by the runner
+workflow at submission setup, and by `runner.py` before executing.
+
+</details>
+
+### Precedence
+
+`runner.py` resolves the grading entrypoint in this order:
+
+1. Per-assignment `<classroom>/autograders/<slug>/autograder.py` (an override
+   always wins).
+2. Per-assignment `tests.json` (declarative tests).
 3. Classroom default `<classroom>/autograder.py`.
-4. None of the above — vacuous pass.
+4. None of the above → vacuous pass.
 
-Tests beat the classroom default (more specific intent); a per-assignment `autograder.py` beats tests. So that precedence never silently swallows anyone's tests, the CLI refuses `assignment test add` and `assignment add --tests` while `<classroom>/autograders/<slug>/autograder.py` exists. When declarative tests can't express what you need, remove them and graduate to an `autograder.py`.
+To keep precedence from silently swallowing tests, the CLI refuses `assignment
+test add` / `--tests` while a per-assignment `autograder.py` exists.
 
-### Validation
+<details>
+<summary>Writing a valid assignments.json from another client (e.g. a GUI)</summary>
 
-Specs are validated three times, mirroring the `runtime:` block's discipline. The CLI checks at write time (enums, bounds, name uniqueness, field applicability). The inline validator in `autograde-runner.yaml` re-checks at submission setup, so a hand-edited `assignments.json` fails with a clear `::error::` instead of mid-grade. And `runner.py` re-checks the materialized `tests.json` before executing, turning a malformed file into a `status=error` release rather than a crash.
+Anything that writes a valid `assignments.json` gets the whole pipeline for
+free. A non-CLI client should:
 
-### For other clients (GUI)
+1. Validate against
+   [`schemas/assignments-v1.schema.json`](https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json)
+   (two rules it can't express: unique test names, and name length ≤ 100 UTF-8
+   *bytes*).
+2. Probe before writing tests: `<classroom>/autograders/<slug>/autograder.py`
+   must NOT exist, and `.github/scripts/materialize_tests.py` MUST exist.
+3. Write via the git-data API and retry on a non-fast-forward rejection.
 
-Anything that writes a valid `assignments.json` gets the whole pipeline for free — materialization and grading don't care who authored the file. A non-CLI client (e.g. the web UI) should:
+The CLI parses strictly (unknown fields rejected), so persist only schema fields.
 
-1. Validate against [`schemas/assignments-v1.schema.json`](https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json) before writing (a JSON Schema mirroring the CLI's validators; usable directly with `ajv`). Two rules it can't express: test names must be unique within an assignment, and name length is capped at 100 UTF-8 *bytes*.
-2. Probe before writing tests, exactly like the CLI: `<classroom>/autograders/<slug>/autograder.py` must NOT exist (mutual exclusion), and `.github/scripts/materialize_tests.py` MUST exist (skeleton supports materialization).
-3. Write via the git-data API against the current branch tip and retry on a non-fast-forward rejection — the read-modify-write loop in `cli/gh-teacher/tree_commit.go` is the reference implementation.
-
-The CLI must stay interoperable with the file afterwards, and it parses strictly (unknown fields are rejected) — so only schema fields may be persisted. `examples/declarative-tests/tests.json` is a canonical fixture covering every test feature.
+</details>
 
 ## Writing an `autograder.py`
 
-The autograder is a Python script the runner invokes once per submission. There are two scopes:
+The autograder is a Python script the runner invokes once per submission. There
+are two scopes:
 
-| Path | Scope | Resolution |
+| Path | Scope | Used when |
 |---|---|---|
-| `<classroom>/autograders/<slug>/autograder.py` | One assignment | Used if present in the bundle |
-| `<classroom>/autograders/<slug>/tests.json` | One assignment | [Declarative tests](#declarative-tests-no-autograderpy), materialized from `assignments.json`; used when no per-assignment `autograder.py` exists |
-| `<classroom>/autograder.py` | One classroom | Falls back to this when the assignment has neither of the above |
+| `<classroom>/autograders/<slug>/autograder.py` | One assignment | Present in the bundle. |
+| `<classroom>/autograders/<slug>/tests.json` | One assignment | [Declarative tests](#declarative-tests); no per-assignment `autograder.py`. |
+| `<classroom>/autograder.py` | One classroom | Neither of the above exists. |
 
-If none exist, the runner synthesizes a vacuous-pass result (status=`success`, score 0/0, summary "submitted — no autograder configured for `<slug>`") and the submission still lands as a tagged release. "No autograder configured" is a valid mid-setup state — classrooms work end-to-end before any grading code is written.
-
-Replace the classroom default to grade every assignment in the classroom with one script (e.g., a slug-driven dispatcher that calls a third-party grader like `check50`); add per-assignment overrides only where individual assignments diverge from the classroom default.
+If none exist, the runner emits a vacuous pass (score 0/0) and the submission
+still lands as a tagged Release — a valid mid-setup state.
 
 ### Contract
 
 The runner provides:
 
-- **Environment variables**:
-  - `CLASSROOM`, `ASSIGNMENT`, `SUBMISSION_TAG`, `PAGES_BASE_URL`
-  - `USERNAME` / `OWNER` (the repo owner, derived from the repo name; identical value)
-  - `ASSIGNMENT_TYPE` (`individual` or `group`)
-  - `COMMIT_URL`, `RELEASE_URL`, `REVIEW_URL` (full diff from the starter code to the graded commit; equals `COMMIT_URL` when history is unavailable or there is nothing to compare)
-  - All standard `GITHUB_*` (REPOSITORY, SHA, ACTOR, OUTPUT, etc.)
-- **Working directory**: the student's repo checkout (relative paths resolve to student code).
-- **Sibling files**: anything else under `<classroom>/autograders/<slug>/` is bundled with the autograder and lives at `Path(__file__).parent` after extraction. Use `Path(__file__).parent` to find fixtures, helpers, framework configs, etc.
+- **Environment variables:** `CLASSROOM`, `ASSIGNMENT`, `SUBMISSION_TAG`,
+  `PAGES_BASE_URL`, `USERNAME`/`OWNER`, `ASSIGNMENT_TYPE`, `COMMIT_URL`,
+  `RELEASE_URL`, `REVIEW_URL`, and all standard `GITHUB_*`.
+- **Working directory:** the student's checkout (relative paths resolve to
+  student code).
+- **Sibling files:** anything else under `<classroom>/autograders/<slug>/` is
+  bundled and lives at `Path(__file__).parent`.
 
-The autograder must produce:
+The autograder must produce **`./result.json`** (required). Optionally
+`./release-body.md` and `status=`/`summary=` in `$GITHUB_OUTPUT`; the runner
+synthesizes them from `result.json` if absent. Exit **0** if it ran end-to-end
+(pass/fail is in `result.json`); a **non-zero** exit is an infrastructure error
+and the runner synthesizes a `status=error` result.
 
-- **`./result.json`** — `classroom50/result/v1` payload (REQUIRED).
-- **`./release-body.md`** — Markdown body for the GitHub Release (optional; the runner synthesizes one from `result.json` if absent).
-- **`status=` and `summary=` lines in `$GITHUB_OUTPUT`** (optional; the runner derives them from `result.json` if absent — `success` when all tests pass or `tests` is empty, `failure` when any test failed).
+<details>
+<summary>Template: pytest</summary>
 
-Exit code:
-
-- **0** — autograder ran end-to-end (test pass/fail captured in `result.json`).
-- **non-zero** — infrastructure failure. The runner synthesizes a `status=error` result.
-
-### Classroom default (diagnostic stub)
-
-`gh teacher autograder set-default <org> <classroom>` (with no `--from`) drops a diagnostic stub at `<classroom>/autograder.py`. The stub echoes every env var to stdout, writes a vacuous-pass `result.json` (empty `tests` array → "submitted, no autograder configured"), and exits 0. This lets you verify the runner wires up correctly before writing real grading logic. Replace it via `set-default --from <path>` once you're ready to grade.
-
-If you skip `set-default` entirely, the runner produces the same vacuous-pass result on its own — submissions still tag and publish releases, just with status=`success` 0/0. The stub is only useful if you want diagnostic stdout in the workflow log.
-
-Inspect the current default with `gh teacher autograder show <org> <classroom>` (`--json` for metadata: whether it's the stub, its size, and git blob `sha`). To revert a classroom to "no autograder configured" outright, `gh teacher autograder remove <org> <classroom>` deletes the file (distinct from `set-default` with no `--from`, which overwrites it with the stub). Named shims and per-assignment overrides under `autograders/` are listed by `gh teacher autograder list` but authored via ordinary git operations.
-
-### Template: pytest
-
-Drop this at `<classroom>/autograders/<slug>/autograder.py` alongside your `test_*.py` files:
+Drop at `<classroom>/autograders/<slug>/autograder.py` alongside your `test_*.py`
+files:
 
 ```python
 """Pytest-based autograder. Runs sibling test_*.py files against
@@ -228,8 +282,7 @@ from pathlib import Path
 HERE = Path(__file__).parent
 REPORT = HERE / "pytest-report.json"
 
-# Per-test weights. Anything not listed here gets DEFAULT_WEIGHT.
-WEIGHTS = {}
+WEIGHTS = {}          # per-test overrides; anything else gets DEFAULT_WEIGHT
 DEFAULT_WEIGHT = 1
 
 subprocess.run(
@@ -265,8 +318,7 @@ result = {
     "schema":     "classroom50/result/v1",
     "classroom":  os.environ["CLASSROOM"],
     "assignment": os.environ["ASSIGNMENT"],
-    # owner + assignment_type are stamped authoritatively by the runner —
-    # you may omit them (or set them from OWNER / ASSIGNMENT_TYPE env).
+    # owner + assignment_type are stamped authoritatively by the runner.
     "submission": os.environ["SUBMISSION_TAG"],
     "commit":     os.environ["COMMIT_URL"],
     "release":    os.environ["RELEASE_URL"],
@@ -278,22 +330,20 @@ result = {
     "tests":      tests,
 }
 Path("result.json").write_text(json.dumps(result, indent=2))
-
-# Let the runner synthesize release-body.md and status/summary
-# from result.json (which it does whenever they're absent).
 ```
 
-Test files are still ordinary pytest — `test_*.py` next to `autograder.py`, optional `conftest.py` for fixtures.
+</details>
 
-### Template: minimal custom
+<details>
+<summary>Template: minimal custom</summary>
 
-Anything that produces `result.json` works. Compile-and-diff, image-similarity scoring, web-scraping the student's deployed app — write it however you like:
+Anything that produces `result.json` works — compile-and-diff, image scoring,
+scraping a deployed app:
 
 ```python
 import datetime, json, os, subprocess
 from pathlib import Path
 
-# Compile, run, compare output.
 subprocess.run(["gcc", "-o", "hello", "hello.c"], check=True)
 proc = subprocess.run(["./hello"], capture_output=True, text=True, check=False)
 passed = proc.stdout.strip() == "Hello, world!"
@@ -302,8 +352,6 @@ result = {
     "schema":     "classroom50/result/v1",
     "classroom":  os.environ["CLASSROOM"],
     "assignment": os.environ["ASSIGNMENT"],
-    # owner + assignment_type are stamped authoritatively by the runner —
-    # you may omit them (or set them from OWNER / ASSIGNMENT_TYPE env).
     "submission": os.environ["SUBMISSION_TAG"],
     "commit":     os.environ["COMMIT_URL"],
     "release":    os.environ["RELEASE_URL"],
@@ -320,11 +368,22 @@ result = {
 Path("result.json").write_text(json.dumps(result, indent=2))
 ```
 
-## The `runtime` block in `assignments.json`
+</details>
 
-Per-assignment runtime customization (runner OS, language toolchains, system packages, container image) lives in `assignments.json` as an optional `runtime:` field on each entry. The autograde-runner workflow's setup job reads it on every submission, so changes propagate without any student-repo edit and without changing the workflow file.
+### Classroom default
 
-Pass a JSON file to `gh teacher assignment add --runtime`:
+`gh teacher autograder set-default <org> <classroom> --from <path>` installs a
+default that grades every assignment without its own autograder or tests. With no
+`--from`, it installs a diagnostic stub (echoes the environment, emits a vacuous
+pass) — useful for verifying the pipeline. Inspect it with `autograder show`, and
+delete it outright with `autograder remove`.
+
+## The `runtime` block
+
+Per-assignment environment (runner OS, language toolchains, packages, container
+image) lives as an optional `runtime` field on each `assignments.json` entry. The
+runner reads it on every submission, so changes propagate with no student-repo
+edit. Pass a JSON file to `gh teacher assignment add --runtime`:
 
 ```json
 {
@@ -337,129 +396,92 @@ Pass a JSON file to `gh teacher assignment add --runtime`:
 }
 ```
 
-```sh
-gh teacher assignment add cs50-fall-2026 cs-principles greet \
-    --name "Greet" --template cs50/greet-template \
-    --runtime ./runtime-greet.json
-```
+When omitted, the default is `ubuntu-latest` + Python 3.12. Inside a `container`,
+the image owns the toolchain unless you set `python` explicitly.
 
-When `runtime` is omitted, the workflow defaults to `ubuntu-latest` with Python 3.12 set up via `actions/setup-python` so most autograders work without any per-assignment runtime config. No other toolchains are set up and no apt install runs. Inside a custom `container`, the image owns the toolchain — `python` is left alone unless explicitly set. On a **self-hosted** runner the workflow skips *all* managed toolchain/apt setup and uses the runner's own prebuilt environment — see [Custom / self-hosted runners](#custom--self-hosted-runners).
+| Field | Notes |
+|---|---|
+| `runs-on` | A single runner label (`"ubuntu-latest"`) or an array (`["self-hosted", "gpu"]`). No allow-list — you own the label; each is anti-injection-checked (1–10 labels). |
+| `python` / `node` / `java` / `go` | Version passed to the matching `setup-*` action. Skipped when unset (`python` defaults to 3.12 on the host path). |
+| `rust` | Rustup toolchain (`stable`, `1.79`, …) via `dtolnay/rust-toolchain`. |
+| `apt` | Debian/Ubuntu package names. Linux runners only. Mutually exclusive with `container`. |
+| `container` | Escape hatch — see below. |
 
-### Fields
+<details>
+<summary>Custom and self-hosted runners</summary>
 
-| Field | Type | Notes |
-|---|---|---|
-| `runs-on` | string \| `[string]` | Runner selection, exactly like GitHub Actions' own `runs-on`: a single label (`"ubuntu-latest"`) or an array of labels (`["self-hosted", "gpu"]`) for a custom / self-hosted runner. No value allow-list — you own getting the label right; each label is only anti-injection-checked (1–10 labels). Omit for `ubuntu-latest`. |
-| `python` / `node` / `java` / `go` | string | Version strings passed to `actions/setup-python` / `setup-node` / `setup-java` (with `distribution: temurin`) / `setup-go`. `node`, `java`, `go` steps are skipped when their field is unset. `python` defaults to `3.12` on the host path; inside a `container` the image owns Python unless `python` is set explicitly. On a **self-hosted** runner these steps are skipped entirely (the runner supplies its own toolchains and dependencies). |
-| `rust` | string | Rustup toolchain specifier (`stable`, `nightly`, `1.79`, `nightly-2025-01-01`) passed to `dtolnay/rust-toolchain` (no first-party setup action exists). Skipped when unset. |
-| `apt` | `[string]` | Each package name must match `^[a-z0-9][a-z0-9.+-]{0,63}$` (Debian/Ubuntu source-package grammar, length-capped). Linux runners only. |
-| `container` | object | Escape hatch — see below. Mutually exclusive with `apt`. |
+`runs-on` works exactly as in any Actions workflow. Multiple labels are AND-ed; a
+misspelled label just won't match a runner. A `container` needs a Linux
+`runs-on`.
 
-### Custom / self-hosted runners
+**Self-hosted runners keep their own toolchains.** On a self-hosted runner the
+grade job skips *all* managed toolchain/apt setup (even the default Python), so
+the autograder runs against the interpreter and packages your image ships. Bake
+those into the runner image; `runner.py` still installs `pytest` /
+`pytest-json-report` on demand. Detection uses `runner.environment`, so keep the
+runner agent (v2.294.0+) up to date.
 
-`runs-on` works exactly as it does in any GitHub Actions workflow. For a GitHub-hosted runner, give a single label; for CPU/memory-heavy assignments on your own infrastructure, give your self-hosted label(s):
+</details>
 
-```json
-{ "runs-on": ["self-hosted", "gpu"] }
-```
-
-Multiple labels are AND-ed by Actions (a runner must carry all of them). There is no allow-list of valid labels — a misspelled label simply won't match a runner (the job queues until one does), the same behavior as a hand-written workflow, so double-check custom labels. Each label is validated against `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$` purely so it can't inject into the workflow YAML. A `container` can be combined with a self-hosted Linux `runs-on`; matching the runner OS to the image is your responsibility (a recognized `macos-*`/`windows-*` label with a container is rejected, since Actions only runs containers on Linux).
-
-**Self-hosted runners keep their own toolchains.** On a self-hosted runner the grade job skips *all* managed toolchain/apt setup (`setup-python`, `setup-node`, `setup-java`, `setup-go`, `rust-toolchain`, and the `apt install` step) — even the default Python 3.12. The autograder runs against the interpreter and dependencies your runner image already ships. This is deliberate: layering a fresh `setup-python` on top would prepend an interpreter that lacks your preinstalled packages (e.g. `numpy`, `torch`), so imports would fail. Detection uses GitHub's `runner.environment` context (`self-hosted` vs `github-hosted`), resolved on the actual runner at step time — so it applies to any self-hosted runner regardless of how you target it (labels, `--no-default-labels`, or a runner group). Bake the toolchains and dependencies your assignments need into the runner image; `runner.py` still installs `pytest` / `pytest-json-report` into that interpreter on demand if they're missing. `runtime.python` (etc.) and `runtime.apt` are therefore ignored on a self-hosted runner — provision those in the image instead.
-
-> **Keep the runner agent up to date.** `runner.environment` is only reported by the GitHub Actions runner agent from **v2.294.0** onward. Runners auto-update by default, so this is a non-issue in practice — but a runner pinned to an older version (or air-gapped with auto-update disabled) reports no environment, and the skip won't engage (managed setup runs, re-exposing the original clobber). Keep auto-update on, or run a recent agent.
-
-> **Security note.** The autograde runner re-validates `assignments.json` on every student submission, but the `runs-on` value comes from your config repo (teacher-authored), never from student input — so a permissive `runs-on` doesn't widen what an untrusted student repo can request.
-
-### Custom container
-
-Anything beyond apt + setup-X actions reaches for `runtime.container`. The image runs on Linux hosts; `runs-on` may be omitted or set to an `ubuntu-*` label.
+<details>
+<summary>Custom container</summary>
 
 ```json
-{
-  "container": {
-    "image": "cs50/cli:latest",
-    "user": "root"
-  }
-}
+{ "container": { "image": "cs50/cli:latest", "user": "root" } }
 ```
 
-`user` is recommended for any image that doesn't run as root by default (cs50/cli, most maintained Docker Hub images). Without it, `actions/checkout` fails with `EACCES: permission denied` when writing to GitHub Actions' temp directory at `/__w/_temp/`. Accepts `docker run --user` syntax: a name (`root`, `appuser`), a numeric uid (`0`, `1000`), or `uid:gid` (`1000:1000`). Internally translated to `container.options: --user <value>` because GitHub Actions doesn't accept `container.user` directly.
+The image must be **publicly pullable** (private-registry pull secrets can't be
+delivered safely in a student repo). Set `user` for any image that doesn't run
+as root by default, or `actions/checkout` fails with a permission error. `image`
+is required and injection-checked; `user` accepts `docker run --user` syntax.
 
-The image must be **publicly pullable**. The grade job runs inside the student repo, where GitHub Actions provides no way to deliver a private-registry pull secret safely, so private images are not supported — publish your grading image publicly (e.g. a public `ghcr.io/<org>/<name>`).
+</details>
 
-| Field | Type | Notes |
-|---|---|---|
-| `image` | string | Required. Must be publicly pullable. Validated against an injection-safe character set. |
-| `user` | string | Optional but recommended for non-root images. `^[A-Za-z0-9_][A-Za-z0-9_.-]{0,31}(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,31})?$`. |
+> [!NOTE]
+> `runtime` values are teacher-authored (from your config repo), never student
+> input, so a permissive `runs-on` doesn't widen what a student repo can request.
 
-## Attaching generated files to submission Releases
+## Feedback pull requests
 
-An assignment may attach generated PDFs, plots, logs, or other files to each submission Release. Configure exact paths in the web form's **Submission release files** textarea, one per line, or write the equivalent optional assignment field:
+The Feedback PR is **on by default** for assignments created with `gh teacher
+assignment add` (`--feedback-pr=false` to disable). When on, the runner maintains
+**one long-lived "Feedback" pull request per student repo** so you review
+cumulative work with inline comments alongside the scored Release.
 
-```json
-"release_assets": [
-  "report.pdf",
-  "plots/chart.png"
-]
-```
+- **Base = a frozen branch.** On the first submission with a diff, the runner
+  creates a `feedback` branch at the student's baseline commit (the accept
+  commit) and never advances it. The PR is `base = feedback`, `head = default
+  branch`, so it always shows the full starter→latest diff.
+- **One PR, reused** across submissions, labeled **Individual Assignment** or
+  **Group Assignment**. A student closing it reopens it; a teacher merge is left
+  alone.
+- **Opens on first work, not at accept** — unlike GitHub Classroom, so the diff
+  never includes the setup files.
 
-The runner resolves paths in the submission workspace **after grading**, so an autograder may generate them. Each entry names an exact path, not a glob; `*`, `?`, `[` and `]` remain literal in a parent directory. An absent or empty list disables the feature.
+<details>
+<summary>Baseline resolution and prerequisites</summary>
 
-During setup, the workflow validates the ordered paths and passes them to the existing grade job. After grading, `runner.py` copies accepted files into a fresh directory under runner temp and reports only their Release-safe basenames. The existing Release step publishes the core result first, then uploads accepted extras.
+The runner resolves the baseline as **the commit that introduced
+`.classroom50.yaml`** (a structural marker, not a commit subject). If no such
+commit is found, it opens the PR against the root commit and **warns** that the
+baseline is untrusted; if no baseline resolves at all, it **skips** with a
+warning.
 
-GitHub Release uploads flatten each path to its basename. Configure at most 50 path strings totaling at most 8 KiB (8,192 raw UTF-8 bytes), and give every path a unique basename. A basename must contain 1 to 255 ASCII characters using only letters, digits, `.`, `_`, and `-`; it may not begin or end with `.`, contain consecutive periods, or be `result.json` or `release-body.md` (case-insensitive). Paths must be relative, use `/`, contain no empty, `.` or `..` segment, and may not select the root `.git` tree. `.github/report.pdf` is allowed.
+**Prerequisites (handled by `gh teacher init`):** the org setting "Allow GitHub
+Actions to create and approve pull requests" must be on, and two org rulesets
+protect submission history and the frozen `feedback` branch. If you enable
+feedback on an org set up before this feature, **re-run `gh teacher init`**.
 
-The 8 KiB limit applies only to the configured path strings. At runtime, the runner accepts only observed regular files inside the workspace, rejects any symlink in the path, and applies a separate 100 MiB total file-content budget in configuration order. If the next file does not fit, it skips that file and still considers later smaller files. Missing, unsafe, oversized, or failed extra uploads produce warnings but do not change a passing/failing grade, block `result.json`, or stop the latest pointer after core publication.
+**Student repos accepted before this feature** use an older shim and must be
+re-created (delete + re-accept) to pick up the new one.
 
-Classroom 50 submission publishing does not support GitHub Immutable Releases. The first publication creates and publishes the Release with `result.json` before uploading extras, so immutable mode rejects those later uploads. With Immutable Releases disabled, workflow reruns edit the Release and replace `result.json`; each extra is replaced only when its `--clobber` upload succeeds, so reruns also depend on mutable Releases. Removing a configured path, or skipping it before upload because it is missing, unsafe, or over budget, does **not** delete a same-named asset already present on the Release; Classroom 50 cannot safely infer ownership of unknown Release assets.
+</details>
 
-To roll this out to an existing organization, install or upgrade to the new `gh-teacher` CLI, run `gh teacher init <org>`, approve the skeleton refresh, and wait for the config repo's `Publish Pages` workflow to finish before the next submission or regrade. Student repos need no changes because their existing shims use the refreshed shared workflow and Pages resources.
+## Restricting submission files (`allowed_files`)
 
-## Customization layers
-
-| What you want to change | Where to edit it | Propagation |
-|---|---|---|
-| **Simple checks for one assignment, no grading code** | `tests:` block in the matching `assignments.json` entry (via `gh teacher assignment test add` / `--tests`) | Next config-repo Pages publish, then next submission |
-| **Grading logic for one assignment** | `<classroom>/autograders/<slug>/autograder.py` (mutually exclusive with the `tests:` block) | Next submission |
-| **Grading logic shared across one classroom** | `<classroom>/autograder.py` (set via `gh teacher autograder set-default`; can branch on `ASSIGNMENT` to handle slug differences) | Next submission |
-| **Runtime environment for one assignment** | `runtime:` block in the matching `assignments.json` entry | Next submission |
-| **Runtime environment shared across many assignments** | Repeat the `runtime:` block on each entry, or pick a container image that covers everyone | Next submission |
-| **Generated files attached to submission Releases** | `release_assets:` in `assignments.json`, normally edited through the web form | Next submission or regrade |
-
-All customization layers live in the config repo. None require a change in a student repo.
-
-Edit `autograde-runner.yaml` only when you need to add a language toolchain GitHub does not provide a setup action for or replace the runner bootstrap. Use `autograder.py`, declarative tests, assignment settings, and `runtime:` for ordinary customization.
-
-## Feedback Pull Requests
-
-The **Feedback PR is on by default** for assignments created with `gh teacher assignment add` (persisted as `feedback_pr: true` in `assignments.json`); pass `--feedback-pr=false` to turn it off for a given assignment. When on, the autograde runner maintains **one long-lived "Feedback" pull request per student repo** so you review the student's cumulative work with inline GitHub review comments instead of (or alongside) the scored Release.
-
-> **Difference from GitHub Classroom:** GitHub Classroom opens the feedback PR at *accept* time; Classroom 50 opens it on the student's **first submission that adds work**. GitHub can't open a zero-change PR, and — when the repo was created by an accept flow — we freeze the PR base at the accept commit so the diff you review contains only the student's own work, never the setup files (`.classroom50.yaml`, the autograde workflow). If the accept commit can't be identified, we fall back to the root commit and warn (see "Open by default, warn when untrusted" below). Bonus: if a student edits those setup files, it shows up as a change in the Feedback PR diff.
-
-**How it works:**
-
-- **Base = a frozen branch.** On the first submission that has a diff, the runner creates a `feedback` branch pointing at the student's **baseline commit** (the accept commit when it can be identified, otherwise the repo's root commit — see below), then never advances it. The PR is `base = feedback`, `head = the default branch`, so it always shows the full starter→latest-submission diff and auto-updates on every submission.
-- **One PR, reused.** The runner opens the PR once and reuses it across submissions. It's titled **Feedback** and labeled **Individual Assignment** or **Group Assignment** (by the assignment's `mode`) so you can filter/spot them. If a student closes it without merging, the runner reopens it; a teacher **merge** is treated as the "grading done" signal and left alone.
-- **Open by default, warn when untrusted.** The runner prefers the **trusted baseline** — the commit that introduced `.classroom50.yaml` — and opens the PR silently when it finds it. If no commit is detected as *adding* that marker (a repo not created by an accept flow, or rewritten history that dropped the add), the runner **still opens the PR** against the repo's **root commit** and emits a workflow **warning** that the baseline is *untrusted* (the diff may include starter/plumbing files). Only when **no baseline resolves at all** — git can't read history (e.g. a container's "dubious ownership" guard) or the workspace isn't a git repo — does it **skip**, with a warning naming the cause. It also warns if the `feedback` branch already exists at a commit other than the expected baseline (a sign someone pre-created it). *Rationale: a reviewable diff against the root beats no review surface; the warning tells you to verify.*
-
-> **How the baseline is identified (the accept-commit contract).** The runner resolves the baseline as **the commit that introduced `.classroom50.yaml`** — a structural marker, not the commit's subject line. Every accept client (`gh student accept`, the web GUI, any future client) creates `.classroom50.yaml` in its accept commit, so the baseline resolves regardless of how that commit is worded, localized, or squashed, and a student can't move it by reusing a subject. The single source of the path is `classroomcfg.MetadataPath` (Go side) / `runner.ACCEPT_MARKER_PATH` (Python side).
-- **Observable.** The runner posts a `classroom50/feedback-pr` commit status (`success` / `failure` / `error`) with the PR URL as the target, alongside the `classroom50/autograde` status — so a script or agent can poll whether the Feedback PR is in place without scraping the job log.
-
-**Prerequisites (handled by `gh teacher init`):**
-
-- The org setting **"Allow GitHub Actions to create and approve pull requests"** must be on — the workflow's `GITHUB_TOKEN` can't open the PR otherwise. `init` enables it. (GitHub couples "create" and "approve" in this single org setting; there is no create-only toggle. This is safe in the default Classroom 50 model because no branch requires PR review — but if you later add a required-review rule to a repo in this org, be aware a workflow token could self-approve.)
-- Two org **rulesets** `init` installs: one blocks force-push/deletion on the default branch (so submission history can't be rewritten), one locks the `feedback` branch against updates/deletes by anyone but an org admin (so students can't move or merge the frozen base). Org admins (you) bypass both, so you can merge the Feedback PR.
-
-If you enable `--feedback-pr` on an org that was set up before this feature, **re-run `gh teacher init`** to apply the org setting and rulesets. Re-running init **reconciles** the rulesets: an existing Classroom 50 ruleset is updated in place to the current definition, so a stale ruleset from an older CLI (e.g. one targeting the wrong branch pattern) is repaired rather than left behind.
-
-**Student repos accepted before this feature shipped.** The autograde shim in each student repo is written at `gh student accept` time and is **not** updated by re-accepting (re-accept is a no-op on an existing repo). Older shims grant only `contents`/`statuses` to the reusable runner; the Feedback PR runner additionally needs `pull-requests: write`, and a reusable workflow whose caller grants less than it requires **fails to load** — GitHub reports a `startup_failure` ("This run likely failed because of a workflow file issue") with no job logs. Repos created with the current `gh student accept` grant the right scope and are unaffected; pre-existing repos must be re-created (delete + re-accept) to pick up the new shim. (Pre-launch, this affects only test repos.)
-
-**Limitations:** the per-repo limit relies on the org rulesets being in place; on a plan or policy that rejects org rulesets, `init` warns and continues, and the protections silently don't apply. The Feedback PR opens only when there's a diff to show (a submission identical to the baseline produces no PR).
-
-## Restricting which files a submission may contain (`allowed_files`)
-
-An assignment can declare an **`allowed_files`** list in `assignments.json` — an ordered list of **`.gitignore`-style patterns** that defines which files belong to the submission. It is an *allowlist expressed in gitignore syntax*: write `*` to ignore everything, then `!hello.py` to re-include exactly the files you want.
+An assignment can declare `allowed_files` — an ordered list of `.gitignore`-style
+patterns defining which files belong to the submission. It's an allowlist in
+gitignore syntax: `*` ignores everything, then `!hello.py` re-includes it.
 
 ```sh
 gh teacher assignment add cs50-fall-2026 cs-principles hello \
@@ -467,75 +489,100 @@ gh teacher assignment add cs50-fall-2026 cs-principles hello \
     --allowed-files '*' --allowed-files '!hello.py'
 ```
 
-persists:
+- **Git's own syntax:** order matters, last match wins, `!` re-includes. Pass
+  `--allowed-files` once per pattern (don't comma-join). Omit it (or pass empty)
+  to allow every file.
+- **Re-running `add` rewrites the whole entry**, so re-pass `--allowed-files` to
+  keep it (the CLI warns when it's dropped).
+
+> [!WARNING]
+> **`allowed_files` gates what the autograder *reads*.** Files are removed
+> *before* grading, so any file the grader needs — starter scaffolding, helpers,
+> fixtures — must be allowlisted too, or grading fails with a confusing "file not
+> found". Control files (`.classroom50.yaml`, `.github/`) are always kept.
+>
+> **It fails open** and is a grading-scope/hygiene tool, **not** a security
+> boundary: a student who forces a git failure (or just `git push`es) gets the
+> unfiltered tree graded. Never use it to hide an answer key. Removals are logged
+> in the release body ("Removed N file(s)").
+
+## Attaching files to submission Releases
+
+Attach generated PDFs, plots, or logs to each submission's Release via the web
+form's **Submission release files**, or the `release_assets` field:
 
 ```json
-"allowed_files": ["*", "!hello.py"]
+"release_assets": ["report.pdf", "plots/chart.png"]
 ```
 
-- **Syntax is git's own.** Ordering matters, last match wins, and `!` re-includes — exactly like a `.gitignore`. So `["*", "!hello.py"]` allows only `hello.py`, while `["node_modules/", "*.lock"]` just drops that noise and allows everything else.
-- **Repeatable, order-preserving flag.** Pass `--allowed-files` once per pattern (do **not** comma-join them); order is preserved into the manifest because gitignore matching is order-dependent.
-- **Optional and backward-compatible.** Omit it (or pass an empty list) and every file is allowed, exactly as before.
-- **Re-running `add` rewrites the whole entry.** Like `--tests` and `--template`, omitting `--allowed-files` on a re-add drops a previously set allowlist (and warns loudly). Pass `--allowed-files` again to keep it; pass it with no value as a deliberate, silent clear.
+The runner resolves these paths **after grading** (so an autograder can generate
+them) and uploads them under their basenames.
 
-### How it is enforced
+**Limits:** at most 50 paths totaling ≤ 8 KiB; each basename must be unique,
+Release-safe (ASCII letters/digits/`.`/`_`/`-`, no leading/trailing dot, no `..`,
+not `result.json` or `release-body.md`), and relative. A separate 100 MiB
+file-content budget applies at runtime. Missing, unsafe, oversized, or failed
+uploads warn without changing the grade.
 
-Enforcement is **two-sided**. The autograde runner is the real enforcement point (a plain `git push` bypasses the submit-side filter, but never the runner) — though it deliberately **fails open**, so it is the *enforcement point*, not a guaranteed security boundary:
+> [!NOTE]
+> Submission publishing doesn't support GitHub Immutable Releases (reruns edit
+> the Release in place). To roll this out to an existing org, run `gh teacher
+> init`, approve the skeleton refresh, and wait for `publish-pages` to finish.
 
-1. **`gh student submit`** filters the snapshot it pushes, leaving disallowed files out of the submission. This is best-effort convenience — a plain `git commit && git push` bypasses it.
-2. **The autograde runner** (`runner.py`) is where enforcement actually happens. Immediately after checkout and **before** it runs the autograder, the runner removes every working-tree file the patterns disallow, so — **when git is available** — the autograder only ever sees allowed files, no matter how the student pushed. (On git/resource failure it fails open; see below.)
+## Where to customize
 
-**Control files are always kept.** `.classroom50.yaml`, the `.github/` workflow shim, and the runner's own outputs are never removed, even under a bare `*` pattern — so enforcement can't break grading.
+| To change… | Edit… | Propagates on… |
+|---|---|---|
+| Simple checks, no code | `tests` block (`assignment test add` / `--tests`) | Next Pages publish, then next submission |
+| Grading logic for one assignment | `<classroom>/autograders/<slug>/autograder.py` | Next submission |
+| Grading logic for a classroom | `<classroom>/autograder.py` (`autograder set-default`) | Next submission |
+| Runtime for one assignment | `runtime` block on the entry | Next submission |
+| Files attached to Releases | `release_assets` (usually via the web form) | Next submission or regrade |
 
-> **`allowed_files` gates what the autograder *reads*, not just what the student authors.** Removal happens *before* the autograder runs, so any file the grader needs — starter scaffolding, `helpers.py`, data fixtures, `requirements.txt` — must be inside the allowlist too, or it is deleted and grading fails with a confusing "file not found"/import error that looks like the student's bug. When in doubt, allowlist every file the grader touches (e.g. `--allowed-files '*' --allowed-files '!hello.py' --allowed-files '!helpers.py'`), or keep grader-only fixtures in the autograder bundle rather than the student repo. The release-body "Removed N file(s)" note lists exactly what was stripped, so a surprise removal is diagnosable there.
-
-> **`.github/` is force-kept and cannot be constrained by `allowed_files`.** The whole `.github/` subtree (and `.classroom50.yaml`) survives the allowlist so the autograde shim keeps working. A student can therefore commit arbitrary files under `.github/` that the allowlist won't strip. This is inert today — the runner only executes the Pages-fetched entrypoint and `.classroom50.yaml` is re-validated before use — but do not point a custom autograder at student-controlled `.github/` content.
-
-**It fails open.** Enforcement is a grading-scope/hygiene tool, not a secret-hiding security control, so if the runner cannot enforce a non-empty allowlist — git is unavailable or hangs, the matcher errors, the working tree can't be enumerated — it logs the failure, **skips enforcement, and grades the unfiltered submission** rather than blocking the grade. (Both sides are lenient: `gh student submit`'s pre-push filter is best-effort by design too.) An empty/absent allowlist has nothing to enforce and always grades normally. **Never use `allowed_files` to hide a solution or answer-key file from the autograder** — a student who forces a git failure (or just `git push`es) gets the unfiltered tree graded. If you later need the allowlist to be an authoritative boundary, `enforce_allowed_files` in `runner.py` documents how to flip it to fail-closed (publish an `error` result instead of grading).
-
-**It does not rewrite history.** Removal happens in the working tree only, so the baseline commit, the review compare link, and the Feedback PR diff are unaffected; only the files the autograder *reads* change.
-
-**Removals are reported.** When the runner strips files, it logs them and appends a "Removed N file(s) outside the assignment's allowed files" section to the submission's `release-body.md`, so a student whose required file is misnamed or missing can see why the autograder didn't find it.
-
-## Custom runner workflow (rare)
-
-The `--autograder <name>` flag on `gh teacher assignment add` exists for the rare case where you want an assignment to call a fundamentally different *reusable workflow* — not just a different `autograder.py`, but a different runner entirely. To opt in:
-
-1. Drop a sibling shim at `<classroom>/autograders/<name>.yaml` in the config repo. Its `uses:` line points at your custom reusable workflow.
-2. `gh teacher assignment add ... --autograder <name>`. The CLI verifies the file exists at write time.
-
-`gh student accept` fetches the named shim from Pages instead of using the embedded default, so the student repo gets your custom shim. Most teachers never need this.
+All layers live in the config repo; none require a student-repo change. Edit
+`autograde-runner.yaml` only to add a toolchain GitHub has no setup action for,
+or to replace the runner bootstrap.
 
 ## Failure paths
 
-Classroom 50 distinguishes an ordinary passing or failing grade from a grading or publication infrastructure error. Passing and failing grades publish the core submission Release; an infrastructure `error` posts an error status and does not update the Release.
+Classroom 50 separates an ordinary pass/fail grade from an infrastructure error.
+Passing and failing grades publish the Release; an `error` posts an error status
+and leaves the Release unchanged.
 
 | What failed | What surfaces |
 |---|---|
-| Invalid hand-edited `release_assets` configuration | Setup exits with a field-specific `::error::` before grading; no Release update |
-| Grading/autograder infrastructure produces `status=error` | Grade posts `status=error`; no Release update |
-| Configured extra is missing, unsafe, a directory/symlink, or over budget | Warning; valid core and other extras continue |
-| Core Release creation or `result.json` upload | Grade job fails; latest does not move; an already-posted grade status is not rewritten |
-| One extra Release upload | Warning; later extras continue; core Release stays published |
-| Tests run and some fail | `status=failure`; core Release and valid extras publish. Failure details also appear on the run's Summary page and — for declarative tests — as a per-test report in the grade job's log ("Grade details" step), so there's no need to open the release. |
-| All tests pass | `status=success`; core Release and valid extras publish |
+| Invalid hand-edited `release_assets` config | Setup exits with a field-specific `::error::`; no Release update |
+| Autograder produces `status=error` | Grade posts `error`; no Release update |
+| A configured extra is missing/unsafe/over budget | Warning; core and other extras continue |
+| Core Release or `result.json` upload fails | Grade job fails; latest pointer doesn't move |
+| Some tests fail | `status=failure`; Release publishes; details in the log and Summary |
+| All tests pass | `status=success`; Release publishes |
 
-Failures that prevent the reusable workflow from loading do not appear in `scores.json`; collect-scores counts the student as not yet submitted. GitHub shows failures from a called reusable workflow as nested jobs in the student's Actions tab.
+A failure that stops the reusable workflow from loading doesn't appear in
+`scores.json`; collect counts the student as not-yet-submitted.
 
 ## No credentials required
 
-Students never configure any tokens, secrets, or env vars. The full grading flow runs entirely on:
-
-1. **Job-scoped `GITHUB_TOKEN` credentials.** `setup` uses its token to write the submit tag and acceptance status. `grade` checks out with `persist-credentials: false` and runs the autograder; later steps in that same job receive `GH_TOKEN` to post status, publish the Release, and maintain the Feedback PR. Because grading and publishing share one runner, this arrangement is not a credential or hostile-workflow isolation boundary. `set-latest` uses its job token to update the latest pointer.
-2. **Unauthenticated GitHub Pages fetches** — the publish-pages allow-list keeps `assignments.json`, `autograder.py`, `autograders/*.yaml`, and the per-assignment bundles public even when the config repo is private.
-3. **Reusable-workflow access** between the student repo and the `classroom50` config repo — both live in the teacher's org. `gh teacher init` configures this access automatically; teachers in orgs with restrictive Actions policies may need to enable it manually at Settings → Actions → General → Access on the `classroom50` repo.
-
-The only personal access token in the entire system is `CLASSROOM50_SERVICE_TOKEN`, which is teacher-side, stored as an Actions secret on the config repo, used only by `collect-scores.yaml`. Students never see it.
+Students never configure tokens or secrets. Grading runs on the job-scoped
+`GITHUB_TOKEN`, unauthenticated Pages fetches, and reusable-workflow access
+between the student repo and the config repo (both in the teacher's org,
+configured by `init`). The only PAT in the system is the teacher-side
+`CLASSROOM50_SERVICE_TOKEN`, used only by `collect-scores.yaml`.
 
 ## Operational notes
 
-- **Every push grades, every push gets its own release.** Pushing 5 commits in 10 minutes produces 5 graded runs and 5 releases — `cancel-in-progress: false` on purpose. (See [Submission triggers](#submission-triggers) for the trigger contract.)
-- **"Latest" pointer follows commit time.** The serialized `set-latest` job compares the committer timestamps of the new submission commit and the commit tagged by the current `submit/*` latest Release. It moves the pointer only when the new commit is newer. If either timestamp is unavailable, it leaves the pointer unchanged. When no current `submit/*` latest Release exists or GitHub cannot resolve its tag ref, the job marks the new Release latest.
-- **CDN propagation:** GitHub Pages can take up to ~10 minutes to serve updated content after a push. If a student submits during that window, their workflow may fetch the previous version of `runner.py`, the default autograder, or the bundle.
-- **Re-runs:** A workflow rerun grades the commit again. `gh release upload --clobber` replaces `result.json` and each successfully uploaded extra, but the workflow does not delete assets that are no longer configured or are skipped before upload.
-- **Tag immutability:** Submit tags shouldn't be force-pushed or deleted -- in `scores.json` rows are bucketed by assignment slug and keyed within a bucket by the repo `owner`, so `collect-scores.yaml` would re-ingest the same key with new data on the next collect.
+- **Every push grades, every push gets a Release.** Five pushes in ten minutes
+  produce five graded runs and five Releases.
+- **"Latest" follows commit time** — the pointer moves only when the new
+  submission's commit is newer than the current latest.
+- **Pages CDN lag:** updated content can take ~10 minutes to serve, so a
+  submission in that window may fetch the previous `runner.py` or bundle.
+- **Don't force-push or delete submit tags** — collection keys on them.
+
+## Custom runner workflow (rare)
+
+The `--autograder <name>` flag calls a fundamentally different *reusable
+workflow*, not just a different `autograder.py`. Drop a shim at
+`<classroom>/autograders/<name>.yaml` (its `uses:` points at your workflow) and
+register it with `gh teacher assignment add ... --autograder <name>`. Most
+teachers never need this.

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -16,8 +16,8 @@ workflow in `<org>/classroom50`. On each submission the runner:
 Later, `collect-scores.yaml` aggregates each Release's `result.json` into
 `<classroom>/scores.json`.
 
-Everything substantive — the runner workflow, `runner.py`, autograders, runtime
-config — lives in the config repo and is fetched at run time, so teacher edits
+Everything substantive (the runner workflow, `runner.py`, autograders, runtime
+config) lives in the config repo and is fetched at run time, so teacher edits
 reach every existing student repo on the next submission with no per-repo
 maintenance.
 
@@ -75,7 +75,7 @@ reads `result.json` from the workspace after the autograder exits.
 | Field | Type | Notes |
 |---|---|---|
 | `schema` | string | Exactly `classroom50/result/v1`. |
-| `classroom` / `assignment` | string | Must match the repo name. |
+| `classroom` / `assignment` | string | Must match the source repo's identity (checked in code alongside `owner`). |
 | `assignment_type` | string | `individual` or `group`, stamped by the runner. |
 | `owner` | string | The repo owner login — the identity anchor. |
 | `submission` | string | The submit-tag name. |
@@ -83,11 +83,11 @@ reads `result.json` from the workspace after the autograder exits.
 | `datetime` | string | UTC ISO 8601. |
 | `score` / `max-score` | int | Sum of test scores / max-scores. |
 | `tests` | array | Per-test breakdown (`[]` is valid for a vacuous pass). |
-| `submitted_by` | object | Optional. Who pushed: `{"username", "id"}`. |
+| `submitted_by` | object | Optional. Who pushed: `username`, and `id` (which may be null or absent). |
 
 `collect-scores` validates this before merging into `scores.json`. A payload
 whose identity (classroom/assignment/`owner`) doesn't match the source repo is
-rejected, and a mismatched `assignment_type` is warned-and-skipped — so a hostile
+rejected, and a mismatched `assignment_type` is warned-and-skipped, so a hostile
 payload can't land in another student's gradebook.
 
 <details>
@@ -581,7 +581,7 @@ configured by `init`). The only PAT in the system is the teacher-side
 
 ## Custom runner workflow (rare)
 
-The `--autograder <name>` flag calls a fundamentally different *reusable
+The `--autograder <name>` flag calls a different *reusable
 workflow*, not just a different `autograder.py`. Drop a shim at
 `<classroom>/autograders/<name>.yaml` (its `uses:` points at your workflow) and
 register it with `gh teacher assignment add ... --autograder <name>`. Most

--- a/wiki/CLI-Student-Guide.md
+++ b/wiki/CLI-Student-Guide.md
@@ -53,8 +53,8 @@ an empty repo if it's template-less), then prints a `git clone` command.
 2. Looks up the assignment in the classroom's published manifest.
 3. Resolves the autograder workflow.
 4. Creates your private repository (a template copy, or an empty repo).
-5. Keeps you as an `admin` collaborator (so a group founder can invite
-   teammates).
+5. Sets your repo role: `push` for an individual assignment, or `admin` for a
+   group assignment (so a group founder can invite teammates).
 6. Commits the setup files (`.classroom50.yaml` and the autograde workflow).
 7. Prints the `git clone` command.
 
@@ -99,8 +99,10 @@ If your teacher registered the assignment with `--mode group`, teammates share
    ```
 
 Each teammate is added with `push` permission and gets a GitHub invitation. Only
-the founder can add collaborators. Keep the group within the size your teacher
-set — the CLI doesn't enforce the cap, so coordinate within your group.
+the founder can add collaborators. When run from inside the group repo,
+`gh student invite` refuses to add past the size your teacher set, but this cap
+is advisory: it can be bypassed (for example, via the GitHub UI), and the
+authoritative crediting happens at grading time.
 
 The whole group works in the one repository and submits from it. At grading
 time, everyone on the roster who is a collaborator gets the same score.

--- a/wiki/CLI-Student-Guide.md
+++ b/wiki/CLI-Student-Guide.md
@@ -1,16 +1,23 @@
-# Classroom 50 CLI - Student Guide
+# CLI Student Guide
 
-End-to-end walkthrough for students. Install the CLI first — see [Installation](Installation).
+An end-to-end walkthrough of the `gh student` CLI. [Install the CLI](Installation)
+first.
+
+For every command and flag, see the [`gh student` reference](gh-student).
+
+**The path:** [log in](#1-log-in) → [accept an assignment](#2-accept-an-assignment)
+→ [clone and work](#3-clone-and-work) → [submit](#4-submit).
 
 ## Before you start
 
 Your teacher must have already:
 
 1. Set up a GitHub organization for the classroom.
-2. Registered the assignment (optionally with a template repo).
-3. Invited you to the org (you'll get an email invitation).
+2. Registered the assignment.
+3. Invited you to the organization (you'll get an email).
 
-You don't need to accept the org invitation in the GitHub UI — `gh student accept` does it for you on first use.
+You don't need to accept the organization invite in the GitHub UI —
+`gh student accept` does it for you.
 
 ## 1. Log in
 
@@ -18,11 +25,10 @@ You don't need to accept the org invitation in the GitHub UI — `gh student acc
 gh student login
 ```
 
-![Demo: gh student login](images/gh_student_auth.gif)
+![gh student login](images/gh_student_auth.gif)
 
-This runs `gh auth login` with the unified Classroom 50 scope set — `admin:org`, `read:org`, `repo`, and `workflow` — the same scopes `gh teacher login` requests, so a single sign-in works across both CLIs. (A student only exercises `read:org`, `repo`, and `workflow`; `admin:org` is included for parity and is harmless on a student account.) If you skip this step, the next command you run will trigger the login flow automatically.
-
-`gh student logout` mirrors `gh auth logout`.
+This runs `gh auth login` with the scopes you need. If you skip it, the next
+command logs you in automatically. `gh student logout` mirrors `gh auth logout`.
 
 ## 2. Accept an assignment
 
@@ -30,38 +36,48 @@ This runs `gh auth login` with the unified Classroom 50 scope set — `admin:org
 gh student accept <org> <classroom> <assignment>
 ```
 
-![Demo: gh student accept](images/gh_student_accept.gif)
+![gh student accept](images/gh_student_accept.gif)
 
-- `<org>` — the GitHub org your classroom uses.
-- `<classroom>` — the classroom your teacher set up (e.g. `cs-principles`). Has to match a real classroom directory in your org's `classroom50` config repo.
-- `<assignment>` — the slug your teacher registered with `gh teacher assignment add` (e.g. `hello`).
+- `<org>` — your classroom's GitHub organization.
+- `<classroom>` — the classroom your teacher set up (e.g. `cs-principles`).
+- `<assignment>` — the assignment slug (e.g. `hello`).
 
-What this command does:
+This creates a **private** repository at
+`<org>/<classroom>-<assignment>-<username>` from the assignment's template (or
+an empty repo if it's template-less), then prints a `git clone` command.
 
-1. Auto-accepts any pending org invitation for your account.
-2. Looks up the assignment in the classroom's published manifest (`https://<org>.github.io/classroom50/<classroom>/assignments.json`). If the assignment has a template repo, that's used as the starter; the template may live in another org — your teacher's `gh teacher assignment add --template <owner>/<repo>` chose it. Some assignments are **template-less** (your teacher omitted `--template`) — those start from an empty repo.
-3. Resolves the autograder workflow shim. For the default autograder (the common case), the universal shim embedded in `gh-student` is used directly. For a non-default `--autograder <name>` your teacher registered, the shim is fetched from Pages (`https://<org>.github.io/classroom50/<classroom>/autograders/<name>.yaml`) — if that fetch fails, no half-baked repo is left behind.
-4. Creates a **private** repo at `<org>/<classroom>-<assignment>-<username>` (lowercased), with issues, projects, and wiki disabled. With a template it's a copy of that template; for a template-less assignment it's an empty repo (just the autograder shim — write your solution from scratch).
-5. Keeps you as an `admin` collaborator on the new repo (so a group founder can add teammates with `gh student invite`).
-6. Writes `.classroom50.yaml` and `.github/workflows/autograde.yaml` (the resolved shim) in a single commit. The metadata records the classroom and assignment (plus the template-repo identity when there is one); the runner derives everything else at workflow time.
-7. Prints the `git clone` command for your new repo.
+<details>
+<summary>What accept does, step by step</summary>
 
-If you've already accepted this assignment, the command short-circuits with `Assignment already accepted: <org>/<repo>` and leaves your existing repo (and any work in it) alone — re-running is safe.
+1. Auto-accepts any pending organization invitation.
+2. Looks up the assignment in the classroom's published manifest.
+3. Resolves the autograder workflow.
+4. Creates your private repository (a template copy, or an empty repo).
+5. Keeps you as an `admin` collaborator (so a group founder can invite
+   teammates).
+6. Commits the setup files (`.classroom50.yaml` and the autograde workflow).
+7. Prints the `git clone` command.
 
-**Errors you might see:**
+</details>
 
-- _"the classroom may not exist yet, or `publish-pages.yaml` may not have run"_ — your teacher hasn't completed the classroom setup yet, or the Pages site hasn't deployed. Wait a few minutes and try again, or ask your teacher to confirm.
-- _"assignment X is not registered in ..."_ — typo, or your teacher hasn't run `gh teacher assignment add` yet for this assignment.
-- _"autograder `<name>` not published yet"_ — the assignment references an autograder workflow whose YAML isn't on the Pages site. Ask your teacher to confirm `<classroom>/autograders/<name>.yaml` exists in the config repo and that `publish-pages.yaml` has run.
-- _"autograder `<name>` is malformed YAML"_ — the teacher's autograder workflow has a YAML syntax error. Ask them to fix the file in the config repo before retrying.
-- _"template `<owner>/<repo>` is not accessible to you"_ — the template repo is private and not shared with you; ask your teacher to make it public or grant your account access.
-- _"assignment `<X>` has unsupported mode `<mode>`"_ — the assignment's `mode` in the manifest is neither `individual` nor `group` (likely a hand-edited `assignments.json`). Ask your teacher to fix it. (Both `individual` and `group` assignments accept normally — see the group-assignment note below.)
+Already accepted? The command reports `Assignment already accepted` and leaves
+your existing repo (and your work) alone.
+
+**Common errors:**
+
+| Message | What it means |
+| --- | --- |
+| "the classroom may not exist yet, or `publish-pages.yaml` may not have run" | Setup isn't finished or Pages hasn't deployed. Wait a few minutes, or ask your teacher. |
+| "assignment X is not registered" | A typo, or your teacher hasn't added the assignment yet. |
+| "autograder `<name>` not published yet" | The autograder's YAML isn't on the Pages site. Ask your teacher to confirm it exists and that Pages has deployed. |
+| "template `<owner>/<repo>` is not accessible to you" | The template is private and not shared with you. Ask your teacher to make it public or grant access. |
 
 ## 3. Clone and work
 
-Run the `git clone` command that `gh student accept` printed. Edit the code in your usual editor, commit and push to your repo's `main` branch as you normally would.
+Run the `git clone` command that `gh student accept` printed. Edit, commit, and
+push to your repository's default branch as usual.
 
-If you'd like to collaborate with a classmate or invite a TA to your repo:
+To collaborate with a classmate or invite a TA:
 
 ```sh
 gh student invite <org>/<repo> <username>
@@ -71,48 +87,63 @@ That adds them with `push` permission.
 
 ### Group assignments
 
-If your teacher registered the assignment with `--mode group`, teammates share **one** repo instead of each getting their own:
+If your teacher registered the assignment with `--mode group`, teammates share
+**one** repository:
 
-1. **One teammate accepts first.** Whoever runs `gh student accept <org> <classroom> <assignment>` first creates the shared repo, named after them (`<classroom>-<assignment>-<their-username>`). They become the repo's **admin**.
-2. **That same teammate adds the others** — the founder (not the joiners) runs, once per teammate:
+1. **One teammate accepts first.** They create the shared repository (named after
+   them) and become its **admin** (the "founder").
+2. **The founder adds each teammate:**
 
-```sh
-gh student invite <org>/<repo> <teammate-username>
-```
+   ```sh
+   gh student invite <org>/<classroom>-<assignment>-<founder-username> <teammate-username>
+   ```
 
-`<repo>` is the shared repo (`<classroom>-<assignment>-<founder-username>`). Each teammate is added with `push` permission and receives a GitHub invitation to accept. Only the repo's admin (the founder) can add collaborators, which is why joins are founder-driven — a plain org member can't see or modify a teammate's private repo. Keep the group within the size your teacher set (the CLI doesn't hard-enforce the cap on `invite`, so coordinate within your group).
+Each teammate is added with `push` permission and gets a GitHub invitation. Only
+the founder can add collaborators. Keep the group within the size your teacher
+set — the CLI doesn't enforce the cap, so coordinate within your group.
 
-The whole group works in the one repo and submits from it like any other assignment (below). At grading time everyone on the roster who is a collaborator on the repo is credited with the same score.
+The whole group works in the one repository and submits from it. At grading
+time, everyone on the roster who is a collaborator gets the same score.
 
 ## 4. Submit
 
-From inside the cloned repo:
+From inside the cloned repository:
 
 ```sh
 gh student submit
 ```
 
-![Demo: gh student submit](images/gh_student_submit.gif)
+![gh student submit](images/gh_student_submit.gif)
 
-`gh student submit` snapshots your current branch and pushes it as a new commit on top of `main`. The autograde workflow runs automatically on the push: it tags the commit with `submit/<UTC-timestamp>-<short-sha>`, runs the autograder, and publishes a GitHub Release with your score a minute or two later.
+This snapshots your current branch and pushes it as a new commit. The autograde
+workflow runs automatically: it tags the commit `submit/<UTC-timestamp>-<short-sha>`,
+grades it, and publishes a GitHub Release with your score a minute or two later.
 
-You can also `git push` directly — the result is identical. `gh student submit` exists mainly to refresh the teacher's `.gitignore` and `.github/` from the assignment template before pushing, so any teacher-side updates flow through. (For a template-less assignment there's no template to refresh from, so submit just commits and pushes.)
+> [!NOTE]
+> You can also `git push` directly — the result is the same. `gh student submit`
+> exists mainly to pull any teacher-side updates to `.gitignore` and `.github/`
+> from the template before pushing. (For a template-less assignment there's
+> nothing to refresh, so it just commits and pushes.)
 
-When submit finishes, two URLs are printed:
+When submit finishes, it prints two URLs:
 
-- **Autograde** — the repo's Actions tab. The autograde run for this submission shows up there within a few seconds and creates the submit tag.
-- **Releases** — the releases page. The scored release lands once the workflow finishes; per-test results appear in the release body.
+- **Autograde** — the Actions tab, where the run appears in a few seconds.
+- **Releases** — where the scored Release lands once grading finishes.
 
-A few useful properties:
+**Good to know:**
 
-- **Every push grades.** Whether through `gh student submit` or `git push`, every commit on `main` triggers a graded run with its own tag and release — except the very first commit from accepting the assignment, which has nothing to grade and is skipped automatically. The latest release on the page is always the most recent submission.
-- **History is preserved.** Submissions overlay as commits on top of the existing `main`; prior commits stay reachable for review.
-- **No git config required.** The commit is authored with your GitHub login and noreply email, passed via `git -c user.name=... -c user.email=...`, so a fresh shell with no global git identity still submits cleanly. `GIT_AUTHOR_*` / `GIT_COMMITTER_*` environment variables override these defaults if you want a custom identity.
-- **Build artifacts are excluded.** Only tracked files plus untracked-not-ignored files are submitted, so build outputs and unrelated local files don't end up in the snapshot.
-
-Submit tags follow the shape `submit/2026-06-01T14-32-05Z-a1b2c3d` (UTC timestamp, hyphens between time components, then a short SHA suffix). Tags are immutable, so each submission's snapshot stays linkable forever.
+- **Every push grades.** Each commit on the default branch triggers a graded run
+  with its own tag and Release — except the first commit from accepting, which
+  has nothing to grade and is skipped. The latest Release is always your most
+  recent submission.
+- **History is preserved.** Submissions stack as commits; prior commits stay
+  reachable for review.
+- **No git config required.** Commits are authored with your GitHub login and
+  noreply email, so a fresh shell submits cleanly.
+- **Build artifacts are excluded.** Only tracked and untracked-not-ignored files
+  are submitted.
 
 ## See also
 
-- [`gh student` command reference](gh-student) — every command and flag.
-- [Troubleshooting](Troubleshooting) — debug flags, common errors.
+- [`gh student` reference](gh-student) — every command and flag.
+- [Troubleshooting](Troubleshooting) — debug flags and common errors.

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -150,7 +150,7 @@ returns 401/403):
 gh workflow run probe-token.yaml --repo <org>/classroom50
 ```
 
-A green run confirms every scope; a red run's log names the missing one. It's
+A green run confirms every scope; a red run's log names the missing scope(s). It's
 side-effect free.
 
 </details>
@@ -310,9 +310,10 @@ address.
 gh teacher roster import <org> <classroom> <path-to-csv>
 ```
 
-Accepts a header of `username,first_name,last_name,email,section` (or the same
-plus `github_id`). Every username is resolved up front — one typo aborts the
-whole import before any commit. New students are invited.
+Accepts a header of `username,first_name,last_name,email,section` (a trailing
+`github_id` column is accepted but ignored, since the CLI re-resolves each ID
+from GitHub). Every username is resolved up front; one typo aborts the whole
+import before any commit. New students are invited.
 
 **View the roster:**
 
@@ -359,7 +360,7 @@ shim). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | `--description <text>` | Short description. |
 | `--due <ISO-8601>` | Due date, e.g. `2026-09-15T23:59:00-04:00`. Stored as UTC; local timezone assumed if you omit the offset. A bare date with no time is rejected. |
 | `--mode individual\|group` | `individual` (default) or `group`. Group requires `--max-group-size`. |
-| `--max-group-size <N>` | Max collaborators on a group repo (`>= 2`). Advisory, not hard-enforced. |
+| `--max-group-size <N>` | Max collaborators on a group repo (2–100). Advisory, not hard-enforced. |
 | `--runtime <path>` | JSON describing the autograde environment (`runs-on`, language versions, `apt`, or a `container`). Omit for ubuntu-latest + Python 3.12. See [Autograders](Autograders). |
 | `--autograder <name>` | Reserved for swapping the whole reusable workflow (rare). Use `--runtime` for language toolchains. |
 
@@ -471,8 +472,9 @@ for each one probes for the expected repo, clones it (or reports `Missing:
 <username>`), and refreshes `result.json` (latest submission) and `results.json`
 (all submissions) from the repo's releases.
 
-It then writes a `scores.csv` at the destination root — **one line per
-submission** — with a blank-score line for non-submitters, so you can sort by
+It then writes a `scores.csv` at the destination root, **one line per
+submission** (a student with several pushes contributes several lines), plus a
+blank-score line for each non-submitter, so you can sort by
 score to see who hasn't submitted.
 
 Each run creates a fresh timestamped folder. Override the destination with `-d`:

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -1,232 +1,326 @@
-# Classroom 50 CLI - Teacher Guide
+# CLI Teacher Guide
 
-This is an end-to-end walkthrough of the Classroom 50 CLI for teachers. Each step assumes the previous ones are done. Install the CLI first — see [Installation](Installation).
+An end-to-end walkthrough of the `gh teacher` CLI. Each step builds on the last.
+[Install the CLI](Installation) first.
 
-## 1. Set up the organization (one-time, on github.com)
+For every command and flag, see the [`gh teacher` reference](gh-teacher).
 
-The CLI doesn't create the org for you. Do these once via the GitHub web UI:
+**The path:**
+
+1. [Create a GitHub organization](#1-create-a-github-organization) (on github.com).
+2. [Log in](#2-log-in).
+3. [Set up the organization](#3-set-up-the-organization) (`gh teacher init`).
+4. [Add a classroom](#4-add-a-classroom).
+5. [Invite students](#5-invite-students).
+6. [Track students in the roster](#6-track-students-in-the-roster).
+7. [Add assignments](#7-add-assignments).
+8. [Remove people when needed](#8-remove-people-when-needed).
+9. [Collect scores](#9-collect-scores).
+10. [Download submissions](#10-download-submissions).
+
+## 1. Create a GitHub organization
+
+The CLI doesn't create the organization for you. Do this once on github.com:
 
 1. **Create the organization** at <https://github.com/account/organizations/new>.
-2. **(Optional) Create a template assignment repo.** Assignments can be template-less (students get an empty starter repo with just the autograder shim), so this step is only needed for assignments that ship starter code. Any repo flagged as a template (Settings → "Template repository") works. **A public template always works.** A **private** template works too — but only if it lives **inside your teaching org**: each classroom gets a GitHub team (created by `gh teacher classroom add`), and `gh teacher assignment add` grants that team read access to an in-org private template, so rostered students can create their repo from it under the "No permission" org baseline. A private template **outside** your org is rejected by `gh teacher assignment add` (students can't be granted access to another org's private repo, so `gh student accept` would 404). (GitHub Enterprise Cloud also has an "internal" visibility that all enterprise members can read without per-repo collaboration — see [GitHub's docs on internal repositories](https://docs.github.com/en/enterprise-cloud@latest/repositories/creating-and-managing-repositories/about-repositories#about-internal-repositories).) See [Assignment Templates](Assignment-Templates) for the expected file structure; copy that layout into your own template repo.
+2. **(Optional) Create a template repository** for assignments that ship starter
+   code. Flag it as a template in **Settings → Template repository**. See
+   [Assignment Templates](Assignment-Templates) for the expected layout.
 
-The org member-privilege lockdown (base permission "No permission", and disabling every member capability except private-repo creation) is applied by `gh teacher init` (step 3 below) — no manual web-UI tweak required for those. Four settings that have no API are listed as a one-time manual checklist under step 3.
+> [!NOTE]
+> **Template visibility.** A **public** template always works. A **private**
+> template works only if it's **inside your organization** — `gh teacher
+> assignment add` grants the classroom's team read access to it. A private
+> template **outside** your organization is rejected. (Enterprise Cloud's
+> "internal" visibility also works.)
 
-## 2. Log in with the right scopes
+`gh teacher init` (step 3) locks down organization member privileges for you.
+Four settings have no API and are listed as a manual checklist in that step.
 
-`gh teacher login` grants the OAuth scopes the teacher commands need (`admin:org` for org invitations, `workflow` so `gh teacher init` can commit the config repo's workflow files), which a plain `gh auth login` doesn't. Run once:
+## 2. Log in
 
 ```sh
 gh teacher login
 ```
 
-![Demo: gh teacher login](images/gh_teacher_auth.gif)
+![gh teacher login](images/gh_teacher_auth.gif)
 
-This shells out to `gh auth login -s admin:org -s read:org -s repo -s workflow` and opens a browser to authorize. This is the unified Classroom 50 scope set — `gh student login` requests the same scopes, so one sign-in covers both CLIs. If you haven't logged in to `gh` before, it performs the initial login and grants the scopes in one shot; if you have, it re-authenticates with them appended.
+This runs `gh auth login` with the scopes the teacher commands need
+(`admin:org`, `read:org`, `repo`, `workflow`) and opens a browser to authorize.
+It's the same scope set `gh student login` requests, so one sign-in covers both
+CLIs.
 
-If you skip this step and have no token at all, the CLI detects the missing token and runs `gh teacher login` automatically. If a token exists but lacks one of the required scopes (e.g. `admin:org` for `gh teacher invite` or `workflow` for `gh teacher init`), the affected command fails with an error instructing you to run `gh teacher login` to grant the missing scope.
+> [!NOTE]
+> If you skip this, the CLI logs you in automatically on first use. If your
+> existing token lacks a required scope, the affected command fails with a
+> message telling you to run `gh teacher login`.
 
-## 3. Bootstrap the classroom50 config repo
+## 3. Set up the organization
 
-Run once per teaching org to create `<org>/classroom50` — the private config repo that will hold classroom metadata, published assignment manifests, and collected scores:
+Run once per organization to create `<org>/classroom50`, the private config repo
+that holds classroom metadata, published assignment manifests, and collected
+scores:
 
 ```sh
 CLASSROOM50_SERVICE_TOKEN=github_pat_... gh teacher init <org>
 ```
 
-Or omit the env var and the command prompts for the token interactively:
+Or omit the variable and `init` prompts for the token:
 
 ```sh
 gh teacher init <org>
 ```
 
-`init` is idempotent: re-running picks up where a prior run left off. It also offers to refresh skeleton files that differ from the CLI's embedded version (how an existing org gains new features like declarative tests) — since that resets any teacher edits to those files, it asks for confirmation first and skips them if you decline (`--yes` skips the prompt for scripted runs).
+`init` is **idempotent** — re-running picks up where a prior run left off. It
+also offers to refresh skeleton files when the CLI ships newer versions (this is
+how an existing organization gains new features); it asks before overwriting, so
+your edits are safe. Use `--yes` to skip the prompt in scripts.
 
-**Preview first with `--dry-run`.** `gh teacher init <org> --dry-run` runs the read-only preflight checks (OAuth scopes, org access and ownership, plan, and service-token availability) and lists the steps init would perform, without changing anything. If a hard check fails — a missing `admin:org`/`workflow` scope, an org you can't see or don't own, or no token and no interactive terminal — init stops **before** mutating the org, so you never end up half-configured. Run it once before the real run to catch setup problems early.
+**Useful flags:**
 
-**Machine-readable output with `--json`.** `gh teacher init <org> --json` emits a single JSON object on stdout (and suppresses the human progress output) summarizing the run: the config repo and Pages URLs, `lockdown_complete`, `lockdown_manual_steps` (member-privilege settings init couldn't apply via the API — plan-gated or enterprise-pinned — each with the exact GitHub-UI instruction to set by hand), `feedback_pr_ready`, `service_token` (how the token was configured this run), the preflight results, every warning, and `manual_hardening_required` — the four settings that have no REST API — as structured `[{setting, url}]` arrays. This lets an orchestrating script or agent branch on "are there manual steps pending?" and "is the org ready?" without scraping prose. `--dry-run --json` emits the same shape with `"dry_run": true`. Add `--quiet`/`-q` to drop the per-step progress chatter while keeping warnings and the final summary.
+| Flag | Purpose |
+| --- | --- |
+| `--dry-run` | Run read-only preflight checks and list planned steps without changing anything. Run this once first to catch problems early. |
+| `--json` | Emit a machine-readable summary (implies `--quiet`). Lets a script check "any manual steps pending?" and "is the org ready?". |
+| `--quiet` / `-q` | Drop per-step progress; keep warnings and the final summary. |
+| `--yes` | Skip the skeleton-refresh confirmation. |
 
-### Creating the service token
+<details>
+<summary>What <code>init</code> configures</summary>
 
-`gh teacher init` provisions a repo-level Actions secret named `CLASSROOM50_SERVICE_TOKEN` (used by `collect-scores.yaml` to read student submissions). You supply the token value; **create it from your own GitHub account** — GitHub's Terms of Service generally permit only one account per person, so there's no separate "service account" to create. Just scope the token tightly to the org you're provisioning.
+`init` applies a least-privilege lockdown of organization member privileges (the
+only member capabilities left on are private-repo creation, so `gh student
+accept` works, and public Pages creation, so the config repo can publish),
+enables GitHub Actions, creates the private `classroom50` repo, commits the
+skeleton workflows and scripts, enables GitHub Pages (public, so students and
+the autograder can fetch published files), protects the default branch, raises
+workflow token permissions, allows reusable-workflow access, and uploads the
+service token secret.
 
-Create a **fine-grained personal access token** at **Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token**:
+This lockdown is what makes it safe for `gh student accept` to leave each
+student as **admin** of their own repository: they need admin to manage
+collaborators, and the organization-level locks remove the dangerous repo-admin
+powers (delete, transfer, visibility change) org-wide.
+
+</details>
+
+### Create the service token
+
+`init` provisions a repo secret named `CLASSROOM50_SERVICE_TOKEN`, used by the
+score-collection and regrade workflows. Create it from **your own** GitHub
+account (there's no separate service account) and scope it tightly to this
+organization.
+
+Create a **fine-grained personal access token** at **Settings → Developer
+settings → Personal access tokens → Fine-grained tokens → Generate new token**:
 
 1. **Token name** — e.g. `classroom50-<org>`.
-2. **Resource owner** — select **the organization** (`<org>`). This is the critical step: the token can only reach repos owned by the resource owner you pick here. If the org isn't listed, the org has blocked fine-grained PATs (an org owner must allow them).
-3. **Expiration** — your choice (fine-grained PATs allow up to 1 year). Set a calendar reminder to rotate before it expires.
-4. **Repository access** — **All repositories**. Student repos are created on demand by `gh student accept`, so they don't exist yet — a "Only select repositories" token silently misses them (see the note below).
-5. **Repository permissions** — set **Contents: Read and write**, **Actions: Read and write**, and **Administration: Read and write**. (`Metadata: Read-only` is added automatically; that's all group-assignment collaborator reads need too.) Contents read collects scores; Contents write lets regrade push `submit/*` tags; Actions write lets regrade re-run each student repo's autograde workflow; Administration write lets collect grant staff teams (e.g. TAs) read access to student repos and private templates.
-6. **Organization permissions** — set **Members: Read-only**. This is a **separate section** from Repository permissions and only appears once the org is the Resource owner; it lets `collect-scores` list the classroom team's members (collection is team-driven). It is **not** implied by any repository scope.
+2. **Resource owner** — select **the organization**. This is critical: the token
+   can only reach repos owned by the resource owner you pick.
+3. **Expiration** — up to 1 year. Set a reminder to rotate it.
+4. **Repository access** — **All repositories**. Student repos are created on
+   demand, so "Only select repositories" silently misses them.
+5. **Repository permissions** — **Contents: Read and write**, **Actions: Read
+   and write**, **Administration: Read and write**. (Metadata: Read is added
+   automatically.)
+6. **Organization permissions** — **Members: Read**. This is a separate section
+   that appears only after you pick the org as resource owner. It lets score
+   collection list the classroom team.
 7. **Generate** and copy the `github_pat_…` value.
 
-**Approval:** if your org requires approval for fine-grained PATs (the GitHub default), a token created by a regular member stays *pending* until an org owner approves it. Because `gh teacher init` requires you to be an **org owner**, a token you create is **auto-approved** — so it just works. (A classic PAT also works; it's broader than necessary, but init won't stop you.)
+> [!NOTE]
+> Because `gh teacher init` requires you to be an **organization owner**, a
+> token you create is auto-approved even if your org requires approval for
+> fine-grained PATs.
 
-**How init uses it:** supply the value via the `CLASSROOM50_SERVICE_TOKEN` environment variable, or let init prompt for it (hidden input) on first setup — there is no `--token` flag (command-line PATs leak via shell history and process listings). init **validates the token against your org before storing it** (it must be able to read *and write* repo contents, and read the org's members), so a mis-scoped or unapproved token is caught immediately instead of surfacing weeks later as a failed `collect-scores` run. On a **re-run**, if the secret is already configured, init leaves it untouched and tells you so — to replace it, set `CLASSROOM50_SERVICE_TOKEN` and re-run, or use `gh teacher rotate-service-token <org>`.
+**Supply the token** via the `CLASSROOM50_SERVICE_TOKEN` environment variable or
+the interactive prompt — there is no `--token` flag (command-line tokens leak
+via shell history). `init` validates the token against your organization before
+storing it. On a re-run, an existing secret is left untouched; to replace it, set
+the variable and re-run, or use `gh teacher rotate-service-token <org>`.
 
-**Verify the full scope set after provisioning.** init's validation is a cheap pre-store check — it proves Contents:write and probes org-member access, but it can't verify the repo-level `Actions` permission (regrade needs it) or the exact per-classroom team read before the team exists. For an exhaustive, read-only signal, run the probe workflow once after `init`/`rotate` (or any time collect/regrade 401/403s):
+<details>
+<summary>Verify the full token scope after provisioning</summary>
+
+`init`'s validation is a cheap pre-store check. For an exhaustive, read-only
+check, run the probe workflow after `init`/`rotate` (or any time collect/regrade
+returns 401/403):
 
 ```sh
 gh workflow run probe-token.yaml --repo <org>/classroom50
 ```
 
-A green run confirms Contents Read+Write, Actions Read+Write, Administration Read+Write, org Members: Read (including each classroom's team read), and Metadata; a red run's log names the missing scope. It's side-effect free — no tags pushed, no runs re-run.
+A green run confirms every scope; a red run's log names the missing one. It's
+side-effect free.
 
-> **Group assignments need no extra scope.** A group assignment grades once in
-> the first-accepter's repo; `collect-scores` then reads that repo's collaborators
-> to give every group member the same score row. Listing collaborators
-> (`GET /repos/{owner}/{repo}/collaborators`) requires only `Metadata: read`,
-> which is auto-included on every fine-grained PAT (and already implied by the
-> `Contents: read` you grant above), so the same token works for
-> individual and group assignments alike — no scope change needed.
+</details>
 
-> **Why all repositories, not just `<classroom>-*`?** Student repos are created on
-> demand when students run `gh student accept`, so they don't exist when you mint the
-> token — a PAT scoped to "Only select repositories" can't include them, and
-> `collect-scores` silently counts those students as not submitted, logging
-> `0/<N> submitted` for the assignment, since an unreadable repo and one with no
-> release yet both surface as a 404 from the `/releases` listing. Org-wide
-> `Contents: read` is broader than strictly necessary, but it avoids that trap;
-> tighten it later if your org policy requires.
-
-Rotate before expiry with:
+Rotate before expiry:
 
 ```sh
 gh teacher rotate-service-token <org>
-
 ```
 
-**What `init` sets up:** a least-privilege lockdown of org member privileges (the only enabled member capabilities are private repo creation — `members_can_create_private_repositories: true` so `gh student accept` works — and public Pages creation, which init **enforces** so the config repo's public Pages site keeps publishing; everything else is denied: `default_repository_permission: none`, no private Pages, no repo delete/transfer, no repo visibility change, no issue deletion, no team creation, no dependency-insights viewing, and no member-invited outside collaborators — applied via a combined `PATCH /orgs/{org}` that falls back to one PATCH per policy if a plan-gated or enterprise-locked field is rejected, warning only for the fields it can't set; **public/internal repo creation is locked off only on GitHub Enterprise Cloud** — on Team/Free, GitHub couples public and private repo creation into a single "all or none" choice and the student flow needs private creation, so members can also create public repos there and init skips that field), GitHub Actions enabled for the org and re-enabled on the `classroom50` repo so the workflows can run, private `classroom50` repo with `auto_init`, embedded workflows (`publish-pages.yaml`, `collect-scores.yaml`, reusable `autograde-runner.yaml`), GitHub Pages (workflow build, visibility set to **public** so students can fetch published `assignments.json` unauthenticated; non-default `--autograder` YAML shims, when registered, are also fetched from Pages), branch protection on the default branch, workflow `GITHUB_TOKEN` permissions (409 tolerated when the org enforces a stricter policy — skeleton workflows declare their own workflow-level `permissions:` blocks), reusable-workflow access for other repos in the org (so student shims can `uses:` the runner), and the repo-level `CLASSROOM50_SERVICE_TOKEN` Actions secret.
+### Manual organization hardening (one-time)
 
-This member-privilege lockdown is what makes it safe for `gh student accept` to leave each student as **admin** of their own assignment repo: students need admin to manage collaborators (so a group founder can add teammates with `gh student invite`), and the org-level locks defang the dangerous repo-admin powers (delete, transfer, visibility change) org-wide.
+Four member-privilege settings have **no API**, so `init` can't set them (it
+prints this same reminder). Apply them once at
+**Org → Settings → Member privileges**
+(`https://github.com/organizations/<org>/settings/member_privileges`):
 
-### Manual org hardening (one-time)
+- [ ] **App access requests** → "Members only" (or disable).
+- [ ] **Uncheck** "Allow repository admins to install GitHub Apps for their
+      repositories".
+- [ ] **Projects base permissions** → "No access".
+- [ ] **Uncheck** "Allow repository administrators to rename branches protected
+      by organization rules". (Defense-in-depth; the config repo's rulesets
+      already protect submission history.)
 
-Four member-privilege settings have **no REST API**, so `gh teacher init` can't set them (it prints this same reminder). Apply them once at **Org → Settings → Member privileges** (`https://github.com/organizations/<org>/settings/member_privileges`):
+> [!NOTE]
+> **Plan check.** `init` warns if the organization isn't on Team or Enterprise
+> Cloud (needed for Pages from a private repo). The warning is advisory.
 
-- [ ] **Set "App access requests"** to "Members only" (or "Disable app access requests")
-- [ ] **Uncheck "Allow repository admins to install GitHub Apps for their repositories"** (under "GitHub Apps")
-- [ ] **Set "Projects base permissions"** to "No access"
-- [ ] **Uncheck "Allow repository administrators to rename branches protected by organization rules"** (under "Branch renames"; enabled by default on new orgs; **defense-in-depth** — the `classroom50-protect-submission-history` org ruleset already protects each repo's default branch with org-admin-only bypass, so a student-admin cannot rename out of that protection. Disable it as a tidy-up.)
+### Audit the lockdown
 
-**Plan check.** `init` warns when the org is not on Team or Enterprise Cloud (required for Pages from a private repo). The warning is advisory; you can still proceed.
+Any time, confirm the organization is still locked down:
 
-**Auditing the lockdown (`gh teacher audit <org>`).** After applying the manual settings — or any time you want to confirm the org is still locked down — run `gh teacher audit <org>`. It's **read-only** (makes no changes) and re-reads the org to report, per setting, whether the least-privilege value is actually in effect. It groups results into:
+```sh
+gh teacher audit <org>
+```
 
-- **Verified (read from the API)** — the settings `init` sets via `PATCH /orgs/{org}`; verify reads each live value and flags any that drifted (e.g. you re-checked "Allow members to delete or transfer repositories").
-- **Confirm by hand** — the four web-UI-only settings above; GitHub exposes no REST API to read them, so verify lists them for you to eyeball rather than implying they're fine.
+It's **read-only** and reports, per setting, whether the least-privilege value is
+in effect: **Verified** (read from the API), **Action required** (drifted), and
+**Confirm by hand** (the four API-less settings above). It exits non-zero when a
+critical field is unenforced, so it's scriptable; add `--json` for a
+machine-readable report.
 
-It exits non-zero when a **critical** API-readable lockdown field is unenforced, so it's scriptable (`gh teacher audit <org> && …`). `--json` emits a machine-readable report (with `lockdown_complete`, `enforced`, `unenforced`, and `manual_unreadable`) for agents. This is the answer to "I unchecked everything from init's Action-required list — did it take?": audit confirms the API-readable ones and reminds you which four you must confirm visually.
-
-After `init` completes, the CLI prints the future Pages URL (`https://<org>.github.io/classroom50/`) and suggests `gh teacher classroom add` as the next step.
+When `init` finishes, it prints the future Pages URL
+(`https://<org>.github.io/classroom50/`) and suggests adding a classroom next.
 
 ## 4. Add a classroom
 
-> **Migrating from GitHub Classroom?** If you already run a course on the legacy product, replace steps 4 and 7 with `gh teacher classroom migrate --source <id-or-org> --target <org>` — it discovers the source classroom, copies each starter repo into your target org as a fresh template, and commits a populated `<short-name>/` directory in one Tree commit. The roster and scores are not migrated; onboard students for the new term via step 6 below. See [`gh teacher classroom migrate`](gh-teacher#gh-teacher-classroom-migrate) for the full reference; pass `--dry-run` first to preview without writing.
+> [!TIP]
+> **Migrating from GitHub Classroom?** Replace steps 4 and 7 with
+> `gh teacher classroom migrate --source <id-or-org> --target <org>`. It copies
+> each starter repo into your organization as a fresh template and commits the
+> classroom in one go. Roster and scores aren't migrated. Pass `--dry-run`
+> first. See [`gh teacher classroom migrate`](gh-teacher#classroom-migrate).
 
-Each classroom is a directory at the root of `<org>/classroom50` holding four files:
+Each classroom is a directory in `<org>/classroom50` holding four files:
 
-- `classroom.json` — public name / term / org metadata.
-- `assignments.json` — assignment manifest (published via Pages, fetched by `gh student accept` and by the autograde-runner workflow on every submission).
-- `roster.csv` — private roster.
-- `scores.json` — private collected scores.
+| File | Purpose |
+| --- | --- |
+| `classroom.json` | Name, term, and organization metadata. |
+| `assignments.json` | The assignment manifest (published via Pages; read by `gh student accept` and the autograde runner). |
+| `roster.csv` | The roster (private). |
+| `scores.json` | Collected scores (private). |
 
-Plus, optionally:
+Optionally, add grading logic later:
 
-- `autograder.py` at the classroom root — the **classroom default autograder**, used by every assignment that doesn't have its own override. Drop it via `gh teacher autograder set-default` (no scaffold by default — classrooms work without one, the runner just publishes a vacuous-pass result).
-- `autograders/<slug>/` subdirectories — **per-assignment overrides**. One folder per assignment slug containing `autograder.py` (the entrypoint) and any sibling fixtures or helpers.
+- `<classroom>/autograder.py` — the **classroom default autograder**, used by
+  every assignment without its own. Install it with `gh teacher autograder
+  set-default`.
+- `<classroom>/autograders/<slug>/` — **per-assignment overrides**.
 
-Foundation50-managed pieces (the runner-side bootstrap `.github/scripts/runner.py`, the runner workflow, the publish-pages allow-list) live at the org level, not per-classroom; the autograder shim that lands in each student repo is embedded in `gh-student` and never has to be edited by a teacher.
-
-Scaffold one with:
+Create a classroom:
 
 ```sh
 gh teacher classroom add <org> <short-name> --name "<full name>" --term <term>
-```
-
-For example:
-
-```sh
 gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Spring-2026
 ```
 
-The `<short-name>` must match `^[a-z0-9][a-z0-9-]{1,38}$` (2-39 chars, lowercase letters/digits/hyphens, starting with a letter or digit) because it flows into student repo names like `<short-name>-<assignment>-<username>`. `--name` and `--term` are optional but recommended — they're written into `classroom.json` and surface in the published Pages site (forthcoming) and in `gh teacher download` summaries.
+The `<short-name>` must match `^[a-z0-9][a-z0-9-]{1,38}$` (2–39 characters,
+lowercase letters/digits/hyphens, starting with a letter or digit), because it
+becomes part of student repo names like `<short-name>-<assignment>-<username>`.
+`--name` and `--term` are optional but recommended.
 
-The command commits all four paths in a single Tree commit on the default branch. It also creates a **GitHub team** named `classroom50-<short-name>` (privacy `secret`) for the classroom — rostered students are added to it, and it's what grants them read access to in-org private assignment templates (see step 7). If a team by that name already exists, it's adopted in place. If `<org>/classroom50` doesn't exist yet, it prints `run gh teacher init <org> first` and exits non-zero. If the `<short-name>` directory already exists, it refuses to overwrite rather than clobbering an in-progress classroom — modify it via `gh teacher roster add` (step 6) and `gh teacher assignment add` (step 7) instead.
+This commits the four files and creates a **GitHub team** named
+`classroom50-<short-name>` that grants rostered students read access to in-org
+private templates. Run it once per classroom; you can have several side by side.
 
-Run this command once per classroom you teach in the org. You can have several classrooms side by side in the same `classroom50` repo.
+**Manage classrooms later:**
 
-**Managing classrooms later.** List what's registered with `gh teacher classroom list <org>` (add `--json` for the display name and term). Change a classroom's display name or term with `gh teacher classroom edit <org> <short-name> --name "…" --term …` (the short-name itself is immutable). Delete one with `gh teacher classroom remove <org> <short-name>` — it removes the `<short-name>/` config directory and deletes the classroom's `classroom50-<short-name>` team (not student repos), and asks you to type the short-name to confirm (`--yes` skips the prompt). See the [`gh teacher` reference](gh-teacher#gh-teacher-classroom-list) for details.
+- List: `gh teacher classroom list <org>` (add `--json` for name and term).
+- Rename/retag: `gh teacher classroom edit <org> <short-name> --name "…" --term …`
+  (the short-name itself is immutable).
+- Delete: `gh teacher classroom remove <org> <short-name>` — removes the config
+  directory and the team, but **not** student repos.
 
-## 5. Invite students to the org
+## 5. Invite students
 
-The fastest way to add students is `gh teacher roster add` (next step) — it registers them in the classroom roster *and* sends an org invite in one shot. Use the bare `gh teacher invite` only for ad-hoc cases (e.g., inviting a TA who shouldn't be in the student roster, or bringing in someone before the roster is set up):
+The fastest way to add students is `gh teacher roster add` (next step) — it
+rosters them *and* sends an organization invite. Use bare `gh teacher invite`
+only for ad-hoc cases, like inviting a TA who isn't a student:
 
 ```sh
 gh teacher invite <org> <username>
 ```
 
-![Demo: gh teacher invite](images/gh_teacher_invite.gif)
+![gh teacher invite](images/gh_teacher_invite.gif)
 
-The student gets an email invitation. They can accept it by visiting `https://github.com/<org>`, or skip ahead and let `gh student accept` auto-accept the pending invite when they accept their first assignment.
+The student gets an email invitation, or `gh student accept` auto-accepts the
+pending invite when they accept their first assignment.
 
-Common API failures (missing scope, not an admin, org not found, already a member, pending invite) surface as actionable messages instead of raw HTTP errors.
-
-To invite a teaching assistant as an org admin instead:
-
-```sh
-gh teacher invite --admin <org> <username>
-```
-
-To invite someone to a single repo rather than the whole org (e.g. a TA on a specific assignment):
+**Other targets:**
 
 ```sh
-gh teacher invite <org>/<repo> <username>                 # default: push
-gh teacher invite -p maintain <org>/<repo> <username>     # other permissions
+gh teacher invite --admin <org> <username>              # invite as org admin (e.g. a TA)
+gh teacher invite <org>/<repo> <username>               # invite to one repo (default: push)
+gh teacher invite -p maintain <org>/<repo> <username>   # other permissions
 ```
 
-Permission options for `-p`: `pull`, `triage`, `push`, `maintain`, `admin`. Re-running with a different `-p` updates the existing collaborator's permission in place.
+`-p` accepts `pull`, `triage`, `push`, `maintain`, `admin`. Re-running updates
+the collaborator's permission in place.
 
 ## 6. Track students in the roster
 
-Each classroom keeps a `roster.csv` file inside `<org>/classroom50/<classroom>/`. The CLI manages it for you with three subcommands; you should rarely hand-edit the file.
+Each classroom keeps a `roster.csv`. The CLI manages it — you rarely hand-edit
+it.
 
-> **Renamed from `students.csv`.** This file used to be `students.csv`. Classrooms created before the rename are still read automatically (readers fall back to the legacy name), so nothing breaks — but new writes always target `roster.csv`. To convert an existing classroom in a single commit, run `gh teacher roster migrate <org> <classroom>`.
+> [!NOTE]
+> **Renamed from `students.csv`.** Older classrooms are still read
+> automatically, but new writes target `roster.csv`. Convert one with
+> `gh teacher roster migrate <org> <classroom>`.
 
 **Add or update one student:**
 
 ```sh
-gh teacher roster add <org> <classroom> <username> [--first-name <name>] [--last-name <name>] [--email <addr>] [--section <id>]
-gh teacher roster add cs50-fall-2026 cs-principles alice --first-name Alice --last-name Andersson --email alice@example.edu --section section-1
+gh teacher roster add <org> <classroom> <username> [--first-name <n>] [--last-name <n>] [--email <addr>] [--section <id>]
+gh teacher roster add cs50-fall-2026 cs-principles alice --first-name Alice --email alice@example.edu --section section-1
 ```
 
-This resolves the student's immutable `github_id` (GitHub's numeric account ID), upserts the row in `roster.csv` (case-insensitive match on username), and sends an org invitation if they aren't already a member. It also adds the student to the classroom's `classroom50-<classroom>` team, so they inherit read access to the classroom's in-org private assignment templates (the membership goes active immediately for an existing org member, or pending until they accept the org invite). All four data flags are optional; values left unset become empty cells in the CSV. Re-running with the same arguments is safe — the row is replaced, the org invite is skipped if already pending or active, and the team add is idempotent. `gh teacher roster remove` symmetrically removes the student from the team (org membership is left untouched).
+Resolves the student's numeric `github_id`, upserts the row (case-insensitive by
+username), sends an organization invite if needed, and adds the student to the
+classroom team (so they can read in-org private templates). Re-running is safe.
 
 **Correct an existing student's details:**
 
 ```sh
-gh teacher roster update <org> <classroom> <username> [--first-name <name>] [--last-name <name>] [--email <addr>] [--section <id>]
-gh teacher roster update cs50-fall-2026 cs-principles alice --email alice@example.edu
+gh teacher roster update <org> <classroom> <username> [--email <addr>] ...
 ```
 
-Reach for `update` when you just need to fix a field on someone already on the roster — a misspelled name, a new email, a section move. Only the flags you pass change; every other column (including `github_id`) is preserved, so `update` won't blank fields the way re-running `add` does. Unlike `add`, it's **roster-only**: no org invite, no `github_id` re-resolution. Pass `--email ""` to clear an address. At least one data flag is required, a patch that already matches the row is a no-op, and an unknown username is an error (it points you at `roster add`).
+Use `update` to fix a field on someone already on the roster. Only the flags you
+pass change; everything else (including `github_id`) is preserved. Unlike `add`,
+it's roster-only: no invite, no `github_id` lookup. Pass `--email ""` to clear an
+address.
 
-**Bulk import from a local CSV:**
+**Bulk import from a CSV:**
 
 ```sh
 gh teacher roster import <org> <classroom> <path-to-csv>
 ```
 
-Accepts either the canonical 6-column header (`username,first_name,last_name,email,section,github_id` — the same shape `roster.csv` uses on disk) or a 5-column header without `github_id` (recommended for hand-authored CSVs since `github_id` is CLI-managed). The `email` column values may be empty per row. All usernames are resolved up-front; a single typo aborts the whole import before any commit. The entire file is then written in one Tree commit, and every new student is invited to the org. Re-running is safe — already-imported rows just refresh.
+Accepts a header of `username,first_name,last_name,email,section` (or the same
+plus `github_id`). Every username is resolved up front — one typo aborts the
+whole import before any commit. New students are invited.
 
-**View the current roster:**
+**View the roster:**
 
 ```sh
-gh teacher roster list <org> <classroom>
-gh teacher roster list cs50-fall-2026 cs-principles --json
-gh teacher roster list cs50-fall-2026 cs-principles --quiet
+gh teacher roster list <org> <classroom>            # aligned table
+gh teacher roster list <org> <classroom> --json     # for scripting
+gh teacher roster list <org> <classroom> --quiet    # one username per line
 ```
-
-Prints `roster.csv` without opening it on GitHub. Default output is an aligned table (username, name, email, section, github_id; empty cells show as `-`) with a `N student(s)` summary on stderr. Use `--json` for scripting (the full row objects) or `--quiet` for one username per line (handy for piping into `xargs` or an agent loop). An empty roster exits 0 with a clear note; a missing `roster.csv` points you back at `gh teacher classroom add`. Read-only — no commit lands.
 
 **Remove a student from the roster:**
 
@@ -234,181 +328,166 @@ Prints `roster.csv` without opening it on GitHub. Default output is an aligned t
 gh teacher roster remove <org> <classroom> <username>
 ```
 
-Drops the row from `roster.csv`. **Does NOT remove org membership** — use `gh teacher remove <org> <username>` (step 8) for that. Splitting roster removal from org removal is deliberate: an off-by-one roster edit shouldn't be able to revoke a student's access to every repo in the org.
+> [!NOTE]
+> This does **not** remove organization membership — use `gh teacher remove`
+> (step 8) for that. Splitting the two is deliberate: a roster edit shouldn't be
+> able to revoke a student's access to every repo in the organization.
 
-**Migrate a legacy classroom's roster file:**
-
-```sh
-gh teacher roster migrate <org> <classroom>
-```
-
-Renames a classroom's legacy `students.csv` to `roster.csv` in a single commit. Idempotent — a classroom already on `roster.csv` (or with no roster file yet) is a no-op. You rarely need this: readers already fall back to the legacy name, so migrating is only about making the on-disk name match the current convention.
-
-`roster list` is read-only; the write subcommands (`add`, `update`, `import`, `remove`, `migrate`) go through an optimistic-update-with-rebase loop (a small number of retries with exponential backoff) so two teachers editing the roster concurrently can't silently lose each other's work. If you see a `lost the rebase race` message, just retry the command.
+> [!NOTE]
+> Roster writes use an optimistic-rebase loop, so two teachers editing at once
+> can't lose each other's work. If you see `lost the rebase race`, retry.
 
 ## 7. Add assignments
 
-Each classroom keeps an `assignments.json` file inside `<org>/classroom50/<classroom>/`. Each entry pairs a slug (used in student repo names like `<classroom>-<slug>-<username>`) with an optional template repo, an optional due date, an optional runtime block, and the workflow-shim name (the `autograder` field; defaults to `default` = the universal shim embedded in `gh-student`). Register one with:
+Each classroom keeps an `assignments.json`. Register an assignment:
 
 ```sh
-gh teacher assignment add <org> <classroom> <slug> --name "<name>" [--template <owner>/<repo>[@branch]] [--description <text>] [--due <ISO-8601>] [--runtime <path>] [--autograder <name>]
+gh teacher assignment add <org> <classroom> <slug> --name "<name>" [flags]
 gh teacher assignment add cs50-fall-2026 cs-principles hello --name "Hello" --template cs50/hello-template --due 2026-09-15T23:59:00-04:00
-gh teacher assignment add cs50-fall-2026 cs-principles greet --name "Greet" --template cs50/greet-template --runtime ./runtime-c.json
 gh teacher assignment add cs50-fall-2026 cs-principles reflection --name "Reflection"   # no template → empty starter repo
 ```
 
-**`--name` is required; `--template` is optional.** Omit `--template` for a template-less assignment — students then get an **empty** private repo containing only the autograder workflow shim (no starter files), which is useful for write-from-scratch or short-answer work. The slug must match `^[a-z0-9][a-z0-9-]{1,38}$` (the same shape as classroom short-names). When you do pass `--template`, the template repo must be flagged `is_template: true` (Settings → "Template repository") and visible to your token. **Private templates:** if the template is private and lives **in your org**, `assignment add` grants the classroom's team read access to it so students can generate from it (idempotent — re-running won't duplicate the grant). A private template **outside** your org is rejected, since students can't be granted access to it. A public template anywhere works with no grant. When you omit `@branch`, the CLI reads the template's default branch from `GET /repos/{owner}/{repo}` and writes that into `assignments.json`. **Note:** re-running `assignment add` on an existing assignment *without* `--template` drops its template (the entry becomes template-less); the CLI warns when this happens.
-
-**Per-assignment grading is NOT registered here.** Drop an `autograder.py` at `<classroom>/autograders/<slug>/autograder.py` in the config repo — that single file is the entrypoint the runner invokes per submission. Or run `gh teacher autograder set-default <org> <classroom> --from <path>` to install a classroom default at `<classroom>/autograder.py` that grades every assignment in the classroom. See the [Autograders](Autograders) wiki page for the entrypoint contract and templates (pytest, check50, custom).
+**`--name` is required; `--template` is optional.** Omit `--template` for a
+template-less assignment (students get an empty repo with just the autograder
+shim). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 
 **Optional flags:**
 
-- `--description <text>` — short description written into the entry.
-- `--due <ISO-8601>` — a due date, e.g. `2026-09-15T23:59:00-04:00`. Normalized to a UTC instant before storage (so that example lands as `2026-09-16T03:59:00Z`). If you omit the offset (`2026-09-15T23:59:00`), your machine's local timezone is auto-detected and applied. The original value and detected zone are preserved in a `due_meta` block for auditing. A bare date with no time is rejected as ambiguous.
-- `--mode individual|group` — `individual` (default) gives each student their own repo. `group` lets teammates share one repo: the first student to `gh student accept` creates it (and becomes its admin), then adds teammates with `gh student invite <org>/<repo> <teammate>`. Requires `--max-group-size`.
-- `--max-group-size <N>` — maximum collaborators on a group repo (`>= 2`; required with `--mode group`, rejected otherwise). **The limit is advisory** — the CLI does not hard-enforce it; the founder coordinates group size when adding teammates, and collaborators can also be added directly through GitHub's web UI. At collection time a group submission's score is fanned out to every rostered member (the runner emits the owner; `collect-scores` reads the repo's collaborators and credits each — see step 9).
-- `--runtime <path>` — JSON file describing the runtime environment for this assignment's autograde job (`runs-on`, `python` / `node` / `java` / `go` / `rust`, `apt`, or a custom `container` image). Omit for the defaults (ubuntu-latest + Python 3.12). The runner reads this on every submission, so changes propagate without any student-repo edit. See the [Autograders](Autograders) wiki page for the schema and worked examples.
-- `--autograder <name>` — reserved for swapping the entire reusable workflow (rare). For different language toolchains or apt packages, use `--runtime` instead. Default `default` resolves to the universal shim embedded in `gh-student`; non-default values reference a sibling `<classroom>/autograders/<name>.yaml` you've authored, and the CLI verifies that file exists before the assignment lands.
+| Flag | Purpose |
+| --- | --- |
+| `--template <owner>/<repo>[@branch]` | Starter-code repository (must be flagged as a template). Branch defaults to the template's default. |
+| `--description <text>` | Short description. |
+| `--due <ISO-8601>` | Due date, e.g. `2026-09-15T23:59:00-04:00`. Stored as UTC; local timezone assumed if you omit the offset. A bare date with no time is rejected. |
+| `--mode individual\|group` | `individual` (default) or `group`. Group requires `--max-group-size`. |
+| `--max-group-size <N>` | Max collaborators on a group repo (`>= 2`). Advisory, not hard-enforced. |
+| `--runtime <path>` | JSON describing the autograde environment (`runs-on`, language versions, `apt`, or a `container`). Omit for ubuntu-latest + Python 3.12. See [Autograders](Autograders). |
+| `--autograder <name>` | Reserved for swapping the whole reusable workflow (rare). Use `--runtime` for language toolchains. |
 
-Re-running with the same slug replaces the entry in place (idempotent). New slugs append.
+> [!NOTE]
+> **Custom grading isn't registered here.** Drop an `autograder.py` at
+> `<classroom>/autograders/<slug>/` in the config repo, or set a classroom
+> default with `gh teacher autograder set-default`. See [Autograders](Autograders).
 
-Remove an entry with:
+Re-running with the same slug replaces the entry in place; new slugs append.
+
+**Remove an assignment:**
 
 ```sh
 gh teacher assignment remove <org> <classroom> <slug>
 ```
 
-This does NOT touch existing student repos — the starter code and submission history stay intact; only new `gh student accept` invocations stop finding the slug. Idempotent: an already-absent slug exits 0 with a note.
+This does **not** touch existing student repos — only new `gh student accept`
+calls stop finding the slug.
 
-**List what's registered** at any time:
+**List assignments:**
 
 ```sh
-gh teacher assignment list <org> <classroom>            # one slug per line on stdout
-gh teacher assignment list <org> <classroom> --json     # full JSON array of entries
+gh teacher assignment list <org> <classroom>            # one slug per line
+gh teacher assignment list <org> <classroom> --json     # full entries
 ```
 
-The default form is pipeable directly into `xargs gh teacher download` or any other command that takes a slug from stdin; the `--json` form preserves every field (template ref, due, autograder) for scripting against the manifest. Pass `-q` to suppress the stderr summary when capturing stdout in a script.
-
-## 8. Remove students or TAs when needed
+## 8. Remove people when needed
 
 ```sh
-gh teacher remove <org> <username>           # remove from organization
+gh teacher remove <org> <username>           # remove from the organization
 gh teacher remove <org>/<repo> <username>    # remove from one repo
 ```
 
-The org form revokes access to every repository in the org, removes the user from all teams, and cancels any pending invitation in one call. Both forms are idempotent — a 404 (user is not a member or collaborator) prints a clear message and exits 0 so re-runs are safe.
+The org form revokes access to every repo, removes the user from all teams, and
+cancels any pending invitation. Both forms are idempotent.
 
-**Check who's actually a member:**
+**Check who's actually a member** (the roster is the *intended* list; this is
+*actual* GitHub membership):
 
 ```sh
-gh teacher member list <org>         # org members + pending invitations, with role
-gh teacher member list <org>/<repo>  # repo collaborators, with permission level
+gh teacher member list <org>         # org members + pending invitations
+gh teacher member list <org>/<repo>  # repo collaborators
 ```
-
-The roster (`roster.csv`) is the *intended* class list; this is *actual* GitHub membership, so the two can drift — e.g. a student who was added to the roster but never accepted their org invite still shows as a pending `invitation`, not a `member`. Default output is a table (`LOGIN`, `KIND`, `ROLE`, `GITHUB_ID`); add `--json` for scripting or `--quiet` for one login per line (pipe into `xargs`/`grep` or diff against the roster to spot who hasn't joined yet). Reading an org's pending invitations needs the `admin:org` scope (the same scope `invite` uses). Read-only.
 
 ## 9. Collect scores
 
-Every student submission publishes a GitHub Release on their own repo carrying a `result.json` asset. The `collect-scores` workflow in `<org>/classroom50` walks every `(student, assignment)` pair in `<classroom>/roster.csv` × `<classroom>/assignments.json`, collects **every** `submit/*` release for each expected repo, and aggregates the results into `<classroom>/scores.json` — the authoritative score record for the class.
+Every submission publishes a GitHub Release carrying a `result.json`. The
+`collect-scores` workflow walks every `(student, assignment)` pair, collects each
+repo's submissions, and aggregates them into `<classroom>/scores.json` — the
+class's authoritative gradebook.
 
-Run it from the Actions tab on `<org>/classroom50`, or trigger it from your shell:
+Run it from the Actions tab on `<org>/classroom50`, or from your shell:
 
 ```sh
 gh workflow run collect-scores.yaml --repo <org>/classroom50
-gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=cs-principles    # one classroom only
+gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=cs-principles   # one classroom
 ```
 
-The skeleton committed by `gh teacher init` ships the workflow with a nightly cron (`17 4 * * *` UTC), so even if you never trigger it manually, scores land in `scores.json` once a day. If you want manual-only triggering, comment out the `schedule:` block in `.github/workflows/collect-scores.yaml`.
+The workflow also runs nightly (`17 4 * * *` UTC), so scores land daily even if
+you never trigger it. To disable that, comment out the `schedule:` block in
+`.github/workflows/collect-scores.yaml`.
 
-What it does on each run:
+<details>
+<summary>What each collection run does</summary>
 
-1. Iterates every classroom under `<org>/classroom50/<classroom>/` (or just the one you passed via `-f classroom=`).
-2. For each `(student, assignment)` pair in `roster.csv` × `assignments.json`, computes the canonical repo name `<classroom>-<assignment>-<username>` (the same formula `gh student accept` uses) and walks that repo's `submit/*` releases. No releases (or a `404`) means the student hasn't accepted or hasn't submitted yet — the collector counts the gap and moves on.
-3. For every `submit/*` release found, downloads `result.json`, schema-validates it, and checks the payload's identity against the source repo: `classroom` / `assignment` must match, the payload's `owner` must equal the repo-name-derived owner, and the payload's `assignment_type` must match the assignment's configured `mode` (a mismatch is warned-and-skipped). This defends against a hostile autograder payload trying to land in the wrong scores.json. For a group assignment, the collector then reads the repo's collaborators and records the rostered member list on the entry's `member_usernames`.
-4. Upserts the validated payloads into `<classroom>/scores.json` under that assignment's bucket as one entry per repo (keyed by `owner`), with every collected submission retained newest-first in the entry's `submissions` list (each a stored `result.json` minus the redundant `assignment` bucket key). If the assignment has `due`, each submission record gets `"late": true|false` by comparing its `datetime` against the due timestamp. **Existing entries with `"override": true` are preserved verbatim** -- if you hand-edited an entry to grant partial credit, the next collect run leaves it alone.
-5. Logs a per-assignment `cs-principles/hello: 23/30 submitted` line so you see roster coverage at a glance.
-6. Commits the updated `*/scores.json` files back to `<org>/classroom50` on a single `[Classroom 50] collect: refresh scores.json` commit. A no-op run (no submissions changed) does not produce a commit.
+1. Iterates each classroom (or just the one you passed).
+2. For each `(student, assignment)` pair, computes the repo name
+   `<classroom>-<assignment>-<username>` and walks its `submit/*` releases. No
+   releases means the student hasn't accepted or submitted yet.
+3. Downloads and schema-validates each `result.json`, checking its identity
+   against the source repo (a hostile payload can't land in another student's
+   scores). For a group assignment, it reads the repo's collaborators and
+   records the credited members.
+4. Upserts the results into `scores.json`, newest first. If the assignment has a
+   `due`, each submission is marked `late` or not. Entries flagged
+   `"override": true` are preserved verbatim.
+5. Logs a per-assignment `cs-principles/hello: 23/30 submitted` line.
+6. Commits the updated `scores.json`. A no-op run produces no commit.
 
-**Token requirements.** The workflow reads the `CLASSROOM50_SERVICE_TOKEN` secret provisioned by `gh teacher init` (a fine-grained PAT with `Contents: Read and write`, `Actions: Read and write`, `Administration: Read and write`, and `Members: Read` on the org; see the service-token note in the setup section above). If that token expires mid-semester, the workflow run fails loudly with a 401/403 — rotate with `gh teacher rotate-service-token <org>`.
+</details>
 
-**Override workflow.** To grant partial credit for a flaky test or correct a misgrade, hand-edit `<classroom>/scores.json` in the config repo, change the entry's submission `score`, and add `"override": true` to the entry. Commit and push. The next collect run will leave that entry alone. A `gh teacher score override` CLI helper is planned for a later release; until then, the JSON edit is the canonical path.
+> [!NOTE]
+> **Override a score.** To grant partial credit or fix a misgrade, edit
+> `<classroom>/scores.json`, change the submission's `score`, add
+> `"override": true` to the entry, and commit. Later collection runs leave it
+> alone.
 
-**`scores.json` shape:** the root `assignments` object is keyed by assignment slug; each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is one repo's gradebook record, keyed by `owner` (the repo owner). For an **individual** assignment, `owner` is the sole credited student. For a **group** assignment, the entry also carries `member_usernames` — every credited member (collect-scores reads the group repo's collaborators and intersects them with the roster; see the group note below). Each entry's `submissions` list holds every collected submission (newest first); each is the validated `result.json` payload with the redundant `assignment` field dropped (it's the bucket key) — carrying `owner`, `assignment_type`, and optionally `submitted_by` (who pushed) and `late`.
+> [!WARNING]
+> If the service token expires mid-semester, collection fails with a 401/403.
+> Rotate it with `gh teacher rotate-service-token <org>`.
 
-```json
-{
-  "schema": "classroom50/scores/v1",
-  "assignments": {
-    "hello": {
-      "type": "individual",
-      "entries": [
-        {
-          "owner": "alice",
-          "submissions": [
-            {
-              "schema": "classroom50/result/v1",
-              "classroom": "cs-principles",
-              "assignment_type": "individual",
-              "owner": "alice",
-              "submission": "submit/2026-06-01T14-32-05Z-a1b2c3d",
-              "commit": "https://github.com/cs50-fall-2026/cs-principles-hello-alice/commit/...",
-              "release": "https://github.com/cs50-fall-2026/cs-principles-hello-alice/releases/tag/submit%2F2026-06-01T14-32-05Z-a1b2c3d",
-              "review": "https://github.com/cs50-fall-2026/cs-principles-hello-alice/compare/...",
-              "datetime": "2026-06-01T14:33:11Z",
-              "score": 18,
-              "max-score": 30,
-              "tests": [
-                { "test-name": "compiles", "passed": true, "score": 10, "max-score": 10 }
-              ],
-              "submitted_by": { "username": "alice", "id": 12345 }
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
-```
-
-One entry per repo within each assignment bucket: per student for individual assignments, per group (`member_usernames` carries all members) for group assignments. Re-running collect appends new submissions to each entry's `submissions` history and refreshes the entry unless `override: true` is set. (Pre-canonical scores.json shapes are **not** migrated — a non-canonical file fails the run loudly.)
-
-**Group assignments.** A group assignment is graded once, in the first-accepter's repo. `collect-scores` reads that repo's collaborators, **keeps only those on the classroom team** (the owner is always credited), and records that member list as the entry's `member_usernames`, so every teammate on the team gets the same score — `scores.csv` then has a line per member per submission with the shared score. Crediting is gated on team membership, **not** on collaborator permission (a teammate who is also an org owner / admin is still credited). A collaborator not on the classroom team added out-of-band (e.g. via the GitHub UI) is **not** credited. Reading collaborators needs only `Metadata: read` (auto-included on every fine-grained PAT and already implied by `Contents: read`), so the existing service token works as-is. If the collaborator read fails, or only the owner is found, the score is credited to the repo owner only and the run logs a warning. Teammates who joined a repo own no repo of their own, so they are not reported as "missing" in `gh teacher download`.
+**Group assignments** are graded once, in the founder's repo. Collection reads
+that repo's collaborators, keeps those on the classroom team, and credits each
+with the same score. See [Autograders](Autograders#group-attribution-model) for
+the full attribution model.
 
 ## 10. Download submissions
 
-After students have run `gh student submit` and the autograde workflow has published its release, pull every student's latest submission for an assignment with:
+Pull every student's latest submission for an assignment:
 
 ```sh
 gh teacher download <org> <classroom> <assignment>
 ```
 
-![Demo: gh teacher download](images/gh_teacher_download.gif)
+![gh teacher download](images/gh_teacher_download.gif)
 
-By default the command is **team-driven**: it lists the classroom GitHub team's members (the source of truth for enrollment) and reads `<classroom>/assignments.json` from your config repo, then for each team member:
+By default this is **team-driven**: it lists the classroom team's members, and
+for each one probes for the expected repo, clones it (or reports `Missing:
+<username>`), and refreshes `result.json` (latest submission) and `results.json`
+(all submissions) from the repo's releases.
 
-1. Probes whether the expected `<classroom>-<assignment>-<username>` repo exists in the org.
-2. Clones it if it does, or reports `Missing: <username> (not accepted yet?)` if it doesn't.
-3. After each clone, refreshes `<repo>/result.json` (the latest submit-tag submission) **and** `<repo>/results.json` (every submission, newest first) from that repo's submit-tag releases — so the autograded payloads land alongside the code.
+It then writes a `scores.csv` at the destination root — **one line per
+submission** — with a blank-score line for non-submitters, so you can sort by
+score to see who hasn't submitted.
 
-After all clones, the command writes a `scores.csv` summary at the destination root: **one line per submission**, grouped by team member in team-member order (`username,score,max_score,datetime,submission_tag,submitted_by,review_url,late,override`). `roster.csv` (if present) supplies each row's optional name/section/email metadata. A student who pushed N times contributes N lines (newest first); for a group assignment each credited member gets the team's submission lines. Non-submitters get a single blank-score line so you can sort the spreadsheet by score and immediately see who hasn't submitted yet.
-
-Each run produces a fresh timestamped folder named `<classroom>-<assignment>_submissions_YYYY_MM_DD_T_HH_MM_SS/` (24-hour local time), so re-running picks up newer submissions without overwriting earlier downloads. Override the destination with `-d`:
-
-```sh
-gh teacher download -d <dir> <org> <classroom> <assignment>     # literal, no timestamp
-```
-
-Existing target dirs are skipped on the clone step, but `result.json` is still refreshed on the existing clones — so re-running after the latest `collect-scores.yaml` cycle picks up the newest score without re-cloning. Pass `--quiet` / `-q` to suppress the per-repo summary; pass `--verbose` / `-v` to stream raw git output instead of the concise `Cloning <name>... Done` summary.
-
-**Fallback for unconfigured classrooms.** If the config repo isn't bootstrapped yet (no `roster.csv`, no `assignments.json`), or you want to clone every matching repo regardless of who's currently rostered, pass `--by-pattern`:
+Each run creates a fresh timestamped folder. Override the destination with `-d`:
 
 ```sh
-gh teacher download --by-pattern <org> <classroom> <assignment>
+gh teacher download -d <dir> <org> <classroom> <assignment>
 ```
 
-That skips the roster lookup and instead pages through the org's repos, cloning every one whose name starts with `<classroom>-<assignment>-`. The `result.json` refresh and the `scores.csv` summary are also skipped in this mode.
+> [!NOTE]
+> **Unconfigured classrooms.** If the config repo isn't bootstrapped, or you
+> want every matching repo regardless of the roster, pass `--by-pattern`. It
+> clones every repo whose name starts with `<classroom>-<assignment>-` and skips
+> the `result.json` refresh and `scores.csv` summary.
 
 ## See also
 
-- [`gh teacher` command reference](gh-teacher) — every command and flag.
-- [Troubleshooting](Troubleshooting) — debug flags, common errors.
+- [`gh teacher` reference](gh-teacher) — every command and flag.
+- [Troubleshooting](Troubleshooting) — debug flags and common errors.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -26,7 +26,7 @@ model, or the [Glossary](Glossary) for the core concepts.
 
 ### Is there a web app, or is it CLI-only?
 
-Both, and they're **alternatives** — not a supplement. Teachers can do
+Both, and they're **alternatives**, not supplements. Teachers can do
 everything from [classroom50.org](https://classroom50.org) or from the
 `gh teacher` CLI; students can accept and submit from either. Use whichever you
 prefer. See the [Web Teacher Guide](Web-Teacher-Guide) or
@@ -34,7 +34,7 @@ prefer. See the [Web Teacher Guide](Web-Teacher-Guide) or
 
 ### Can I self-host Classroom 50?
 
-There's no server to host — Classroom 50 runs entirely on GitHub's
+There's no server to host. Classroom 50 runs entirely on GitHub's
 infrastructure and public APIs. The web app is a static, open-source site, so
 you're welcome to host your own copy. It only integrates with GitHub, not with
 self-hosted Git platforms.
@@ -44,7 +44,7 @@ self-hosted Git platforms.
 ### Can one organization hold multiple classrooms?
 
 Yes. A **classroom** is a directory in your organization's `classroom50` config
-repo, and an organization can hold as many as you like — for example, one per
+repo, and an organization can hold as many as you like, for example one per
 course, section, or term. Add each with **Create classroom** in the web app or
 `gh teacher classroom add`.
 
@@ -149,7 +149,7 @@ they open their repository. See [Assignment Templates](Assignment-Templates).
 
 ### Can I grade without writing test code?
 
-Yes — use **declarative tests** (input/output, run-command, or pytest checks)
+Yes. Use **declarative tests** (input/output, run-command, or pytest checks)
 defined right on the assignment. No grading script needed. For more control,
 write an `autograder.py`. See [Autograders](Autograders).
 
@@ -208,16 +208,19 @@ Collection leaves overridden entries untouched on future runs. See
 
 ### How do I export grades?
 
-Download all submissions as a CSV from the submissions page
-(**Download Scores (CSV)**), or with `gh teacher download`. The raw score data
-also lives in `scores.json` in your config repo, so you can build your own
-automations against it.
+Download scores as a CSV from the submissions page
+(**Download scores (CSV)**). The `gh teacher download` command clones every
+submission repo and also writes a `scores.csv` summary at the destination root.
+The raw score data also lives in `scores.json` in your config repo, so you can
+build your own automations against it.
 
 ### As a teacher, can I test an assignment as a student?
 
-Organization owners can't accept their own assignments (GitHub treats owners
-differently from members). To test the full student flow, use a separate GitHub
-account that you add to the classroom as a student.
+You can accept your own assignment, but as an organization owner you'll keep
+`admin` on the repository (GitHub won't let an owner reduce their own access to
+`write`), so it won't match a real student's setup. To test the exact student
+experience, use a separate GitHub account that you add to the classroom as a
+student.
 
 ## Migrating from GitHub Classroom
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,260 @@
+# FAQ
+
+Common questions about Classroom 50, grouped by topic. For error messages and
+fixes, see [Troubleshooting](Troubleshooting); for terms, see the
+[Glossary](Glossary).
+
+## Getting started
+
+### Do I need a paid GitHub plan?
+
+You need a GitHub organization on the **Team** or **Enterprise** plan.
+Verified educators get GitHub Team **free** through
+[GitHub Education](https://github.com/education/teachers), which unlocks
+everything Classroom 50 relies on (notably GitHub Pages from a private repo).
+Free/personal organizations can't host a classroom.
+
+### How is Classroom 50 different from GitHub Classroom?
+
+The teaching model is familiar — you create assignments (optionally with
+starter code), students accept to get their own repository, and submissions are
+auto-graded — but Classroom 50 has **no servers of its own**. Everything lives
+in your GitHub organization: classroom settings, roster, assignments, and scores
+sit in a private `classroom50` config repo, and grading runs in GitHub Actions.
+See [How Classroom 50 Works](How-Classroom-50-Works) for the full model, or the
+[Glossary](Glossary) for the core concepts.
+
+### Is there a web app, or is it CLI-only?
+
+Both, and they're **alternatives** — not a supplement. Teachers can do
+everything from [classroom50.org](https://classroom50.org) or from the
+`gh teacher` CLI; students can accept and submit from either. Use whichever you
+prefer. See the [Web Teacher Guide](Web-Teacher-Guide) or
+[CLI Teacher Guide](CLI-Teacher-Guide).
+
+### Can I self-host Classroom 50?
+
+There's no server to host — Classroom 50 runs entirely on GitHub's
+infrastructure and public APIs. The web app is a static, open-source site, so
+you're welcome to host your own copy. It only integrates with GitHub, not with
+self-hosted Git platforms.
+
+## Organizations and classrooms
+
+### Can one organization hold multiple classrooms?
+
+Yes. A **classroom** is a directory in your organization's `classroom50` config
+repo, and an organization can hold as many as you like — for example, one per
+course, section, or term. Add each with **Create classroom** in the web app or
+`gh teacher classroom add`.
+
+### Should I create one organization per course, like GitHub Classroom?
+
+You don't have to. Because one organization holds many classrooms, most teachers
+use a single organization and add a classroom per course or term. You can still
+use separate organizations if you prefer — each just needs its own one-time
+setup.
+
+### Can a classroom have multiple teachers or TAs?
+
+Yes. Classroom 50 has four roles: **teacher** (organization owner, full
+control), **head TA** (config-repo write, not an owner), **TA** (config-repo
+read-only), and **student**. Manage staff in the web app under a classroom's
+**Settings → Staff and roles**, or with `gh teacher staff add`. See the
+[Glossary](Glossary#roles) for what each role can do.
+
+### Can students join a classroom themselves with a link?
+
+Not on their own — GitHub requires an organization owner to invite members. Add
+students to the roster (by username, by email, or by bulk CSV upload), which
+sends the organization invitation. **Once they've joined the organization**, the
+assignment accept links work without any further action from you.
+
+## Rosters and students
+
+### Can I add students in bulk, or by email?
+
+Yes. Upload a CSV or a text file of GitHub usernames (web app: **Upload**; CLI:
+`gh teacher roster import`). You can also invite students by **email address**
+when you don't know their GitHub username — they complete a short onboarding
+step to link their account.
+
+### Can I see the whole roster, including students who haven't accepted?
+
+Yes. The submissions view lists every rostered student, not just those who
+accepted, with their status — so you can see at a glance who hasn't started.
+
+### What happens when I unenroll or remove a student?
+
+They're separate actions, on purpose:
+
+- **Unenroll** removes the student from the classroom roster and team. It does
+  **not** remove them from the organization and does **not** delete their
+  assignment repositories.
+- **Remove from the organization** revokes their access to every repo (including
+  their assignment repos) but still doesn't delete anything.
+- **Deleting a repository** is always a separate, manual step.
+
+See [How Classroom 50 Works](How-Classroom-50-Works#lifecycle-enroll-unenroll-and-remove-are-separate).
+
+## Assignments
+
+### Can I use a private repository as an assignment template?
+
+Yes, if the template lives **inside your organization**. When you register the
+assignment, Classroom 50 automatically grants the classroom's team read access
+so students can copy it. A **public** template works from anywhere. A private
+template **outside** your organization can't be shared with students — copy it
+into your organization or make it public. See
+[Assignment Templates](Assignment-Templates).
+
+> [!NOTE]
+> Grant the template when you **create** the assignment. If you create the
+> assignment first and add a private template later by editing it, the team
+> read grant isn't re-applied and students may get a 404 on accept.
+
+### Can I set a deadline with a specific time, not just a date?
+
+Yes. Deadlines support a date **and** time (down to the second, in your
+timezone). Submissions after the deadline are **marked late**; nothing is
+blocked automatically.
+
+### What's the difference between "template-less" and "empty repository"?
+
+- **Template-less** (no template chosen): students get a repo containing only
+  the autograder setup — good for write-from-scratch or short-answer work.
+- **Empty repository**: a completely bare repo — no starter files **and** no
+  autograding or feedback pull request. Use it when students build everything
+  themselves, including their own GitHub Actions.
+
+**Empty repository is permanent** for an assignment — you can't switch it on or
+off after creating the assignment.
+
+### How do group assignments work?
+
+Choose **Group** when creating the assignment and set a maximum group size. The
+first teammate to accept creates the shared repository and becomes its owner
+(the "founder"); they then invite the other teammates as collaborators. Everyone
+on the roster who is a collaborator gets the same score. Group repositories are
+named after the founder's username; custom group names aren't supported, and
+renaming a group repository isn't recommended.
+
+### Does the assignment description show to students?
+
+The description is stored with the assignment, but student-facing instructions
+are best placed in the template's `README.md` — that's what students see when
+they open their repository. See [Assignment Templates](Assignment-Templates).
+
+## Autograding and Actions
+
+### Can I grade without writing test code?
+
+Yes — use **declarative tests** (input/output, run-command, or pytest checks)
+defined right on the assignment. No grading script needed. For more control,
+write an `autograder.py`. See [Autograders](Autograders).
+
+### Can I turn autograding off, or reduce Actions usage?
+
+Yes. Create an assignment with **no autograding tests**, and no grading runs
+(Classroom 50 still uses a lightweight workflow to tag submissions and support
+written feedback, which uses far fewer Actions minutes). You can also **pause
+autograding org-wide** from the organization's Actions settings in the web app,
+and setup applies a **$0 Actions spending cap** by default so a runaway workflow
+can't run up a bill.
+
+### Can I use my own (self-hosted) runners?
+
+Yes. Set `runs-on` in the assignment's runtime to your self-hosted labels (for
+example `["self-hosted", "gpu"]`). Self-hosted runners keep their own
+toolchains, so Classroom 50 skips managed toolchain setup on them — provision
+what your assignments need in the runner image. See
+[Autograders](Autograders#the-runtime-block).
+
+### Can the autograder show students *why* a test failed?
+
+Yes. Each submission's Release and the Actions run summary include a per-test
+breakdown (expected vs. actual output for I/O tests, captured stderr). A custom
+`autograder.py` can add its own diagnostic messages to `result.json`.
+
+### Can students use GitHub Codespaces?
+
+If Codespaces is enabled for your organization, students can open their
+assignment repository in Codespaces like any other repo. Classroom 50 doesn't
+manage Codespaces itself — any education Codespaces benefit is handled on
+GitHub's side.
+
+## Grades and submissions
+
+### A student submitted, but I don't see a grade. Why?
+
+A few common reasons:
+
+- **Scores haven't been collected yet.** Collection runs nightly; click
+  **Collect now** on the submissions page to pull the latest immediately.
+- **GitHub Pages is still deploying.** Right after a config change, published
+  files can take a few minutes to go live.
+- **The student's repo predates a workflow update.** If you updated Classroom 50
+  after they accepted, have them re-accept (or re-create the repo) to pick up the
+  current setup.
+
+See [Troubleshooting](Troubleshooting) for specific error messages.
+
+### Can I manually override or adjust a grade?
+
+Yes. Edit the classroom's `scores.json` in the config repo: change the
+submission's `score` and add `"override": true` to that entry, then commit.
+Collection leaves overridden entries untouched on future runs. See
+[Collect scores](CLI-Teacher-Guide#9-collect-scores).
+
+### How do I export grades?
+
+Download all submissions as a CSV from the submissions page
+(**Download Scores (CSV)**), or with `gh teacher download`. The raw score data
+also lives in `scores.json` in your config repo, so you can build your own
+automations against it.
+
+### As a teacher, can I test an assignment as a student?
+
+Organization owners can't accept their own assignments (GitHub treats owners
+differently from members). To test the full student flow, use a separate GitHub
+account that you add to the classroom as a student.
+
+## Migrating from GitHub Classroom
+
+### Can I import my existing GitHub Classroom?
+
+Yes. `gh teacher classroom migrate` imports a GitHub Classroom into your
+`classroom50` config repo — it copies each starter repo into your organization
+as a fresh template and recreates the assignments. Rosters, scores, and past
+student repositories are **not** migrated; you re-onboard students for the new
+term. See [`gh teacher classroom migrate`](gh-teacher#classroom-migrate).
+
+### Will my existing scripts that manipulate student repos still work?
+
+Likely yes. As with GitHub Classroom, each student gets a normal GitHub
+repository named `<classroom>-<assignment>-<username>`, so scripts that automate
+git operations against those repos generally carry over.
+
+## Access and permissions
+
+### Why does signing in ask for access to all my repositories?
+
+Classroom 50 authenticates the same way the GitHub CLI does, using GitHub's
+`repo` scope. That scope is all-or-nothing — GitHub provides no way to limit it
+to a single organization's repositories — so the grant covers your repos even
+though Classroom 50 only acts on classroom ones. This matches the CLI's behavior.
+
+### What is the service token, and is it the same one the web app set up?
+
+The **service token** is a fine-grained personal access token stored as a secret
+in your config repo; the score-collection and regrade workflows use it. It's the
+**same** token whether you set it up through the web app or the CLI — you only
+need one per organization. See
+[the service-token setup](CLI-Teacher-Guide#create-the-service-token).
+
+## Roadmap
+
+Some capabilities from GitHub Classroom aren't available today, including
+**LTI / LMS grade passback** and a built-in **manual-grading UI**. Classroom 50
+is open source and actively developed — share ideas or track direction in
+[Discussions](https://github.com/foundation50/classroom50/discussions).

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -18,11 +18,11 @@ Free/personal organizations can't host a classroom.
 
 The teaching model is familiar — you create assignments (optionally with
 starter code), students accept to get their own repository, and submissions are
-auto-graded — but Classroom 50 has **no servers of its own**. Everything lives
-in your GitHub organization: classroom settings, roster, assignments, and scores
-sit in a private `classroom50` config repo, and grading runs in GitHub Actions.
-See [How Classroom 50 Works](How-Classroom-50-Works) for the full model, or the
-[Glossary](Glossary) for the core concepts.
+auto-graded — but Classroom 50 has no server or database of its own. Your
+classroom settings, roster, assignments, and scores are stored in a private
+`classroom50` config repo in your organization, and grading runs in GitHub
+Actions. See [How Classroom 50 Works](How-Classroom-50-Works) for the full
+model, or the [Glossary](Glossary) for the core concepts.
 
 ### Is there a web app, or is it CLI-only?
 

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -1,6 +1,6 @@
 # GitHub Integration
 
-Every place Classroom 50 touches GitHub — what you do manually, what the CLI
+Every place Classroom 50 touches GitHub: what you do manually, what the CLI
 handles, and the complete list of REST API calls the tooling makes.
 
 ## Manual steps
@@ -159,7 +159,7 @@ read-only probe:
 gh workflow run probe-token.yaml --repo <org>/classroom50
 ```
 
-A green run confirms every scope; a red run's log names the missing one.
+A green run confirms every scope; a red run's log names the missing scope(s).
 Side-effect free.
 
 ---

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -205,7 +205,7 @@ The CLIs call GitHub through [`go-gh`](https://github.com/cli/go-gh);
 | POST | `/repos/{template_owner}/{template_repo}/generate` | Generate the repo from a template. |
 | POST | `/orgs/{org}/repos` | Create an empty repo (template-less). |
 | GET / PATCH | `/repos/{owner}/{repo}` | Recover from "already exists"; disable issues/projects/wiki. |
-| PUT | `/repos/{owner}/{repo}/collaborators/{username}` | Keep the student as admin; `gh student invite`. |
+| PUT | `/repos/{owner}/{repo}/collaborators/{username}` | Set the founder role: `push` (individual) or `admin` (group); also backs `gh student invite`. |
 | GET / POST / PATCH | `/repos/{owner}/{repo}/git/{refs,commits,blobs,trees}` + `/branches/{branch}` | Commit the setup files. |
 | GET | `/repos/{owner}/{repo}/contents/{path}` | Fetch `.gitignore`/`.github/` from the template (`submit`). |
 

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -1,295 +1,265 @@
 # GitHub Integration
 
-This page documents every place where Classroom 50 touches GitHub's API or authentication infrastructure — what you have to do manually in a browser, what the CLI handles for you, and the complete list of REST API calls the tooling makes.
+Every place Classroom 50 touches GitHub — what you do manually, what the CLI
+handles, and the complete list of REST API calls the tooling makes.
 
 ## Manual steps
 
-### 1. Org setup (one-time, github.com web UI)
+### 1. Create the organization (one-time, on github.com)
 
-The CLI never creates the org for you. Do the following once before running any CLI commands:
+The CLI never creates the organization. Before running any CLI command:
 
-1. **Create the organization** at <https://github.com/account/organizations/new>. Free orgs work for public template repos; Team or Enterprise Cloud is required for GitHub Pages from a private repo (the `classroom50` config repo is private).
+1. **Create the organization** at <https://github.com/account/organizations/new>.
+   Free orgs work for public templates; Team or Enterprise Cloud is required for
+   Pages from the private `classroom50` config repo.
+2. **Flag your template repositories** under **Settings → General → Template
+   repository**.
 
-2. **Flag your template repos as templates** under each repo's `Settings → General → Template repository`. A **public** template works on any plan. A **private** template works if it lives **inside your org**: `gh teacher assignment add` grants the classroom's GitHub team read on it, so rostered students can create from it under the "No permission" baseline. A private template **outside** your org is rejected by `gh teacher assignment add` (students can't be granted access). GitHub Enterprise Cloud's "internal" visibility also works — see [GitHub's docs on internal repositories](https://docs.github.com/en/enterprise-cloud@latest/repositories/creating-and-managing-repositories/about-repositories#about-internal-repositories).
+> [!NOTE]
+> **Template visibility.** Public works on any plan. A private template works
+> only if it's **inside your org** (`gh teacher assignment add` grants the
+> classroom team read). A private template **outside** your org is rejected.
+> Enterprise Cloud's "internal" visibility also works.
 
-Org-level member privileges are locked to least-privilege automatically — `gh teacher init` applies them via `PATCH /orgs/{org}` (see the REST table below), retrying each policy individually if the combined PATCH hits a plan-gated or enterprise-locked field. After init, the only things an org member can do are create a **private** repository (needed so `gh student accept` works) and publish a **public** Pages site (enforced so the `classroom50` config repo's site — the unauthenticated `assignments.json` source — keeps working); private Pages, repo delete/transfer, visibility changes, issue deletion, team creation, dependency insights, and member-invited outside collaborators are all denied. **Public-repo creation is the one exception by plan:** restricting members to *private repositories only* is a GitHub Enterprise Cloud capability, so init only locks public-repo creation off on Enterprise Cloud. On **Team/Free**, GitHub couples public and private into a single "all or none" choice (the legacy creation-type field has no Team-valid "private-only" value, and the UI auto-checks Public when you check Private) — and since the student flow needs private creation enabled, members can also create public repos there. init therefore skips that field on non-Enterprise plans rather than attempting an impossible lockdown that would also disable private creation. init *enforces* (not just allows) the Pages policy, so re-running `gh teacher init` resets a teacher who tightened it back to the working state. This is what makes it safe for `gh student accept` to leave the student as **admin** of their own repo (so a group founder can add teammates with `gh student invite`) — the dangerous repo-admin powers are defanged org-wide. The fields GitHub rejects on your plan are the one case where you'd still flip them yourself at `https://github.com/organizations/<org>/settings/member_privileges`; init warns per rejected field with that link.
+`gh teacher init` locks organization member privileges to least-privilege
+automatically. After it runs, a member can only create a **private** repository
+(so `gh student accept` works) and publish a **public** Pages site (so the config
+repo's `assignments.json` stays reachable).
 
-**Four member-privilege settings have no REST API** and `gh teacher init` cannot set or even read them — apply them manually once at `https://github.com/organizations/<org>/settings/member_privileges` (init prints this reminder too):
+<details>
+<summary>Why student repos can safely leave the student as admin</summary>
 
-- **Set "App access requests"** to "Members only" (or "Disable app access requests")
-- **Uncheck "Allow repository admins to install GitHub Apps for their repositories"** (under "GitHub Apps")
-- **Set "Projects base permissions"** to "No access"
-- **Uncheck "Allow repository administrators to rename branches protected by organization rules"** (under "Branch renames"; enabled by default on new orgs; defense-in-depth — the `classroom50-protect-submission-history` org ruleset already protects each repo's default branch with org-admin-only bypass, so a student-admin can't rename out of that protection. Disable it as a tidy-up.)
+The lockdown denies the dangerous org-wide powers (private Pages, repo
+delete/transfer, visibility change, issue deletion, team creation, dependency
+insights, member-invited outside collaborators). Public-repo creation is the one
+exception by plan: it's locked off only on Enterprise Cloud, because Team/Free
+couples public and private creation and the student flow needs private creation.
+So it's safe for `gh student accept` to leave a student as **admin** of their own
+repo — a group founder needs admin to add teammates, and the org locks defang the
+rest.
 
-### 2. Teacher authentication (`gh teacher login`)
+</details>
 
-Run once per machine or after a token rotation:
+**Four member-privilege settings have no API** — apply them once at
+`https://github.com/organizations/<org>/settings/member_privileges` (`init`
+prints this reminder):
+
+- [ ] **App access requests** → "Members only" (or disable).
+- [ ] **Uncheck** "Allow repository admins to install GitHub Apps for their
+      repositories".
+- [ ] **Projects base permissions** → "No access".
+- [ ] **Uncheck** "Allow repository administrators to rename branches protected
+      by organization rules".
+
+### 2. Teacher authentication
+
+Run once per machine, or after a token rotation:
 
 ```sh
 gh teacher login
 ```
 
-This shells out to `gh auth login -s admin:org -s read:org -s repo -s workflow` and opens a browser to complete GitHub's OAuth device flow (a one-time code you enter at <https://github.com/login/device>). This is the **unified Classroom 50 scope set** — `gh teacher login` and `gh student login` request the same scopes, so authenticating for one CLI covers the other. None of these are granted by a plain `gh auth login`: `admin:org` is required for org-level invitations (and implies `read:org`), `repo` for repo creation/contents/collaborator management, and `workflow` lets `gh teacher init` commit the config repo's `.github/workflows/` files via the Git Data API (GitHub returns a misleading `404` on that write without it). If you skip this step and have no token at all, the CLI detects the missing token and runs the login flow automatically. If a token exists but lacks one of these scopes, the affected command fails with an error telling you to run `gh teacher login` to grant the missing scope. (`delete_repo` is **not** in this set — opt in with `gh teacher login -s delete_repo` for `gh teacher teardown`.)
-
-OAuth scopes requested by the teacher CLI (identical to the student CLI):
+This runs `gh auth login -s admin:org -s read:org -s repo -s workflow` and opens
+a browser. It's the unified Classroom 50 scope set — `gh teacher login` and
+`gh student login` request the same scopes, so authenticating one CLI covers the
+other. (`delete_repo` is not included — opt in with `gh teacher login -s
+delete_repo` for teardown.)
 
 | Scope | Required for |
-|-------|--------------|
-| `admin:org` | Sending org invitations, reading and removing org memberships (implies `read:org`) |
-| `read:org` | Checking org membership (requested explicitly for parity with the student CLI and web GUI) |
-| `repo` | Assignment-repo creation, contents writes, disabling repo features, adding collaborators |
-| `workflow` | Committing the config repo's `.github/workflows/` files during `gh teacher init` (GitHub 404s the Git Data API write without it) |
+|---|---|
+| `admin:org` | Org invitations, reading and removing memberships (implies `read:org`). |
+| `read:org` | Checking org membership. |
+| `repo` | Repo creation, contents writes, collaborators. |
+| `workflow` | Committing the config repo's workflow files during `init` (GitHub 404s the write without it). |
 
-### 3. Student authentication (`gh student login`)
-
-Run once per student machine:
+### 3. Student authentication
 
 ```sh
 gh student login
 ```
 
-Same device flow as above, and — as of the scope unification — the **same scope set** (`admin:org`, `read:org`, `repo`, `workflow`), so a student who has already authenticated a teacher CLI (or vice versa) needs no re-auth. The scopes a student actually exercises:
-
-| Scope | Required for |
-|-------|--------------|
-| `read:org` | Checking and accepting org membership |
-| `repo` | Generating private assignment repos from templates, disabling repo features, adding collaborators |
-| `workflow` | Committing `.github/workflows/autograde.yaml` into the assignment repo at accept time |
+Same device flow and the **same scope set**, so a student who authenticated a
+teacher CLI (or vice versa) needs no re-auth. A student exercises `read:org`
+(accept org membership), `repo` (generate repos, collaborators), and `workflow`
+(commit the autograde shim at accept).
 
 ### 4. Fine-grained PAT for score collection
 
-`gh teacher init` uploads a PAT into the `CLASSROOM50_SERVICE_TOKEN` Actions secret of your `classroom50` config repo. That PAT is what the `collect-scores.yaml` workflow uses to read releases from student repos across the org.
+`gh teacher init` uploads a PAT into the `CLASSROOM50_SERVICE_TOKEN` secret; the
+`collect-scores.yaml` workflow uses it to read student repos across the org.
 
-**Create the PAT at <https://github.com/settings/personal-access-tokens/new>** (from your own GitHub account — GitHub's Terms of Service generally permit only one account per person, so there's no separate "service account" to create; scope the token tightly to the org you're provisioning instead):
+Create it at <https://github.com/settings/personal-access-tokens/new> from your
+own account (scope it tightly to the org):
 
 | Setting | Value |
-|---------|-------|
-| Resource owner | your teaching org |
-| Repository access | **All repositories** ("Only select repositories" misses student repos, which `gh student accept` creates on demand after the token is minted) |
-| Repository → Contents | **Read and write** (Read: collect student repo releases; Write: regrade pushes `submit/*` tags — one shared token) |
-| Repository → Actions | **Read and write** (regrade re-runs each student repo's autograde workflow run via the Actions rerun API) |
-| Repository → **Administration** | **Read and write** (collect grants staff teams — e.g. TAs — read access to student repos and private templates via `PUT /orgs/{org}/teams/{slug}/repos/...`; **not** implied by Contents) |
-| Repository → Metadata | **Read** (mandatory — GitHub auto-includes it on every fine-grained PAT; this is what lets `collect-scores` read group-repo collaborators, so group assignments need no extra scope) |
-| Organization → **Members** | **Read** (collection is team-driven: it lists the classroom GitHub team's members to derive who is enrolled. This is a **separate section** from Repository permissions and only appears once the org is selected as Resource owner — it is **not** implied by any repository scope) |
-| Expiry | 1–366 days (fine-grained PATs support up to 1 year); set a calendar reminder to rotate before it expires |
+|---|---|
+| Resource owner | Your teaching org. |
+| Repository access | **All repositories** ("Only select repositories" misses on-demand student repos). |
+| Contents | **Read and write** (read: collect; write: regrade pushes `submit/*` tags). |
+| Actions | **Read and write** (regrade re-runs autograde). |
+| Administration | **Read and write** (grant staff teams read on student repos/templates). |
+| Metadata | **Read** (auto-included; lets collection read group-repo collaborators). |
+| Organization → **Members** | **Read** (list the classroom team; separate section, shown only once the org is the resource owner). |
+| Expiry | Up to 1 year; set a rotation reminder. |
 
-> **Where is "Members"?** It lives under **Organization permissions**, a
-> collapsible section shown **only after you pick the org as Resource owner** —
-> distinct from the **Repository permissions** section where Contents/Metadata
-> live. It is not granted by, or implied by, any repository permission, so a
-> Contents-only token passes `gh teacher rotate-service-token`'s Contents check
-> yet fails the first API call `collect-scores` makes (listing the classroom
-> team). `rotate-service-token` now probes `GET /orgs/{org}/members` too, so a
-> Members-less token is rejected at rotation time rather than in a cron run.
+> [!IMPORTANT]
+> **Members: Read** is under **Organization permissions**, not Repository
+> permissions, and isn't implied by any repository scope. A Contents-only token
+> passes a Contents check but fails the first call collection makes.
 
-> **Group assignments need no extra scope.** For a group assignment the
-> autograder runs once in the first-accepter's repo and emits a single score;
-> `collect_scores.py` then reads that repo's **collaborators** to fan the score
-> out to every group member **on the classroom team** (the owner is always
-> credited; a collaborator not on the team, added out-of-band, is excluded). Listing collaborators
-> (`GET /repos/{owner}/{repo}/collaborators`) requires only `Metadata: read`,
-> which is auto-included on every fine-grained PAT and already implied by the
-> `Contents: read` grant above — so the same service token serves individual and
-> group assignments. If the collaborator read fails for any reason, the group
-> submission still scores for the repo owner and `collect-scores` logs a
-> `::warning::` naming the repo.
+> [!NOTE]
+> **Group assignments need no extra scope.** Collection reads a group repo's
+> collaborators via `Metadata: read` (auto-included) and credits members on the
+> classroom team. If the read fails, the owner is still scored and a warning is
+> logged.
 
-Supply the PAT to `gh teacher init` via the environment variable (never a flag — command-line PATs leak via shell history):
+Supply the token via the environment variable (never a flag — command-line PATs
+leak via shell history):
 
 ```sh
 CLASSROOM50_SERVICE_TOKEN=github_pat_... gh teacher init <org>
 ```
 
-Or omit it and the CLI prompts for it with hidden TTY input. The token is encrypted with libsodium sealbox before being uploaded to GitHub and is never written to disk.
+It's encrypted with libsodium before upload and never written to disk. Rotate
+with `gh teacher rotate-service-token <org>`.
 
-To rotate an expiring token, create a new one with the same settings and run:
+### 5. GitHub Pages
 
-```sh
-CLASSROOM50_SERVICE_TOKEN=github_pat_... gh teacher rotate-service-token <org>
-```
+`init` enables Pages and sets visibility to public. **The first deployment needs
+the `publish-pages.yaml` workflow to run once** — push to the default branch or
+trigger it from the Actions tab. The CLI prints the Pages URL
+(`https://<org>.github.io/classroom50/`) after `init`.
 
-### 5. GitHub Pages (automatic, but requires Actions to run)
-
-`gh teacher init` enables Pages programmatically via [`POST https://api.github.com/repos/{owner}/{repo}/pages`](https://docs.github.com/en/rest/pages/pages#create-a-github-pages-site) and sets visibility to public via [`PUT https://api.github.com/repos/{owner}/{repo}/pages`](https://docs.github.com/en/rest/pages/pages#update-information-about-a-github-pages-site). The Pages site is built by the `publish-pages.yaml` workflow that `init` commits into the config repo. **The first Pages deployment requires the workflow to run at least once** — either push a commit to the default branch or trigger it manually from the Actions tab. The CLI prints the expected Pages URL (`https://<org>.github.io/classroom50/`) after `init` finishes; it may take a minute to go live.
-
-If `init` warns that the org-level workflow token policy is too restrictive (the endpoint is org-scoped and requires an org owner to change it), you can apply it yourself:
+If `init` warns that the org workflow-token policy or reusable-workflow access is
+too restrictive, apply them yourself:
 
 ```sh
 gh api -X PUT /orgs/<org>/actions/permissions/workflow \
-  -f default_workflow_permissions=write \
-  -f can_approve_pull_request_reviews=false
-```
-
-Similarly, if the reusable workflow access warning fires:
-
-```sh
+  -f default_workflow_permissions=write -f can_approve_pull_request_reviews=false
 gh api -X PUT /repos/<org>/classroom50/actions/permissions/access \
   -f access_level=organization
 ```
 
 ### 6. Score collection
 
-Scores are collected by the `collect-scores.yaml` Actions workflow in your `classroom50` config repo. It runs on a nightly cron (`17 4 * * *` UTC) automatically once `init` is done. To trigger it manually:
+The `collect-scores.yaml` workflow runs nightly (`17 4 * * *` UTC). Trigger it
+manually:
 
 ```sh
 gh workflow run collect-scores.yaml --repo <org>/classroom50
-gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=<short-name>   # single classroom
+gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=<short-name>
 ```
 
-Or use the **Actions** tab on `<org>/classroom50` → `collect-scores.yaml` → **Run workflow**.
+### 7. Verify the service token
 
-### 7. Verify the service token (`probe-token.yaml`)
-
-After `gh teacher init` / `gh teacher rotate-service-token`, or whenever a collect/regrade run fails with a `401`/`403`, run the probe workflow to confirm the `CLASSROOM50_SERVICE_TOKEN` holds every scope the pipeline needs. It's read-only (no tags pushed, no runs re-run):
+After `init`/`rotate`, or when collect/regrade returns 401/403, run the
+read-only probe:
 
 ```sh
 gh workflow run probe-token.yaml --repo <org>/classroom50
 ```
 
-Or **Actions** tab → `probe-token.yaml` → **Run workflow**. A green run means the token has Contents Read+Write, Actions Read+Write, Administration Read+Write, org Members: Read (including the per-classroom team read), and Metadata. A red run's log lists exactly which scope is missing and how to fix it — re-scope and `gh teacher rotate-service-token <org>`.
+A green run confirms every scope; a red run's log names the missing one.
+Side-effect free.
 
 ---
 
-## GitHub REST API reference
+## REST API reference
 
-The CLIs call the GitHub REST API through [`go-gh`](https://github.com/cli/go-gh) (`RESTClient`), which resolves paths relative to `https://api.github.com` on github.com or `https://<host>/api/v3` on GitHub Enterprise Server. The `collect_scores.py` script uses Python's `urllib` with a `Bearer` token. No Octokit, no axios, no raw `fetch()`.
+The CLIs call GitHub through [`go-gh`](https://github.com/cli/go-gh);
+`collect_scores.py` uses `urllib` with a bearer token.
 
 ### `gh teacher` CLI
 
-| Method | URL | Purpose |
-|--------|-----|---------|
-| GET | [`https://api.github.com/user`](https://docs.github.com/en/rest/users/users#get-the-authenticated-user) | Verify authenticated identity (whoami) |
-| GET | [`https://api.github.com/orgs/{org}`](https://docs.github.com/en/rest/orgs/orgs#get-an-organization) | Check org plan (warn if Pages from a private repo requires Team or Enterprise Cloud) |
-| PATCH | [`https://api.github.com/orgs/{org}`](https://docs.github.com/en/rest/orgs/orgs#update-an-organization) | Lock down org member privileges to least-privilege at `init` time. The only enabled member capabilities are private repo creation (`members_can_create_private_repositories: true`) and public Pages creation (`members_can_create_pages: true` + `members_can_create_public_pages: true`, **enforced** so the config repo's public Pages site can publish — re-running init resets it). Everything else is denied: `default_repository_permission: "none"`, and `false` for private Pages, repo delete/transfer, repo visibility change, issue deletion, team creation, dependency-insights viewing, member-invited outside collaborators, and read-access discussion creation. **Public/internal repo creation** is only locked off on GitHub Enterprise Cloud (where "private repos only" exists); on Team/Free that field is skipped because public+private are coupled and the student flow needs private creation. Combined PATCH with a per-field retry on 403/422 so a plan-gated field only warns. |
-| GET | [`https://api.github.com/orgs/{org}/actions/permissions`](https://docs.github.com/en/rest/actions/permissions#get-github-actions-permissions-for-an-organization) | Read whether GitHub Actions is enabled for the org |
-| PUT | [`https://api.github.com/orgs/{org}/actions/permissions`](https://docs.github.com/en/rest/actions/permissions#set-github-actions-permissions-for-an-organization) | Enable GitHub Actions for the org when it's disabled org-wide |
-| POST | [`https://api.github.com/orgs/{org}/repos`](https://docs.github.com/en/rest/repos/repos#create-an-organization-repository) | Create the `classroom50` config repo |
-| GET | [`https://api.github.com/repos/{owner}/{repo}`](https://docs.github.com/en/rest/repos/repos#get-a-repository) | Check whether the config repo already exists |
-| POST | [`https://api.github.com/repos/{owner}/{repo}/pages`](https://docs.github.com/en/rest/pages/pages#create-a-github-pages-site) | Enable GitHub Pages (workflow build source) |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/pages`](https://docs.github.com/en/rest/pages/pages#update-information-about-a-github-pages-site) | Set Pages visibility to public |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/branches/{branch}/protection`](https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection) | Branch protection on the config repo (no force-push, no delete) |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/actions/permissions`](https://docs.github.com/en/rest/actions/permissions#get-github-actions-permissions-for-a-repository) | Read whether Actions is enabled for the config repo |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/actions/permissions`](https://docs.github.com/en/rest/actions/permissions#set-github-actions-permissions-for-a-repository) | Re-enable Actions on the config repo when it's off |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/actions/permissions/workflow`](https://docs.github.com/en/rest/actions/permissions#get-default-workflow-permissions-for-a-repository) | Read current workflow token policy (detect org-enforced override) |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/actions/permissions/workflow`](https://docs.github.com/en/rest/actions/permissions#set-default-workflow-permissions-for-a-repository) | Set default `GITHUB_TOKEN` to write permissions |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/actions/permissions/access`](https://docs.github.com/en/rest/actions/permissions#set-the-level-of-access-for-workflows-outside-of-the-repository) | Allow reusable workflows from the same org |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/actions/secrets/public-key`](https://docs.github.com/en/rest/actions/secrets#get-a-repository-public-key) | Retrieve sealbox public key for encrypting the collect PAT |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/actions/secrets/CLASSROOM50_SERVICE_TOKEN`](https://docs.github.com/en/rest/actions/secrets#create-or-update-a-repository-secret) | Upload the encrypted service PAT as an Actions secret |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/contents/{path}`](https://docs.github.com/en/rest/repos/contents#get-repository-content) | Read existing files in the config repo (idempotency checks, skeleton probing) |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/git/refs/heads/{branch}`](https://docs.github.com/en/rest/git/refs#get-a-reference) | Resolve branch tip SHA before a tree commit |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/git/commits/{commit_sha}`](https://docs.github.com/en/rest/git/commits#get-a-commit-object) | Read parent commit metadata |
-| POST | [`https://api.github.com/repos/{owner}/{repo}/git/blobs`](https://docs.github.com/en/rest/git/blobs#create-a-blob) | Upload file content as a blob (for tree commits) |
-| POST | [`https://api.github.com/repos/{owner}/{repo}/git/trees`](https://docs.github.com/en/rest/git/trees#create-a-tree) | Create a new git tree |
-| POST | [`https://api.github.com/repos/{owner}/{repo}/git/commits`](https://docs.github.com/en/rest/git/commits#create-a-commit) | Create a commit object |
-| PATCH | [`https://api.github.com/repos/{owner}/{repo}/git/refs/heads/{branch}`](https://docs.github.com/en/rest/git/refs#update-a-reference) | Fast-forward the branch to the new commit (with rebase retry on conflict) |
-| GET | [`https://api.github.com/repos/{owner}/{repo}`](https://docs.github.com/en/rest/repos/repos#get-a-repository) | Validate a template repo and read its default branch |
-| GET | [`https://api.github.com/users/{username}`](https://docs.github.com/en/rest/users/users#get-a-user) | Resolve a GitHub login to its numeric account ID |
-| POST | [`https://api.github.com/orgs/{org}/invitations`](https://docs.github.com/en/rest/orgs/members#create-an-organization-invitation) | Send an org membership invitation |
-| GET | [`https://api.github.com/orgs/{org}/memberships/{username}`](https://docs.github.com/en/rest/orgs/members#get-an-organization-membership-for-a-user) | Check a user's org membership state |
-| DELETE | [`https://api.github.com/orgs/{org}/memberships/{username}`](https://docs.github.com/en/rest/orgs/members#remove-an-organization-membership-for-a-user) | Remove a user from the org |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/collaborators/{username}`](https://docs.github.com/en/rest/collaborators/collaborators#add-a-repository-collaborator) | Add a repo collaborator (direct invite) |
-| DELETE | [`https://api.github.com/repos/{owner}/{repo}/collaborators/{username}`](https://docs.github.com/en/rest/collaborators/collaborators#remove-a-repository-collaborator) | Remove a repo collaborator |
-| DELETE | [`https://api.github.com/repos/{owner}/{repo}`](https://docs.github.com/en/rest/repos/repos#delete-a-repository) | Delete a repository (`gh teacher teardown`; requires the `delete_repo` OAuth scope, not granted by default — opt in with `gh teacher login -s delete_repo`) |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/releases`](https://docs.github.com/en/rest/releases/releases#list-releases) | Page through all releases to collect every `submit/*` submission (score collection / download) |
-| GET | [`https://api.github.com/orgs/{org}/repos`](https://docs.github.com/en/rest/repos/repos#list-organization-repositories) | Page through org repos for `--by-pattern` download mode |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/releases/assets/{asset_id}`](https://docs.github.com/en/rest/releases/assets#get-a-release-asset) | Download a `result.json` release asset (`Accept: application/octet-stream`) |
-| GET | [`https://api.github.com/classrooms`](https://docs.github.com/en/rest/classroom/classroom#list-classrooms) | List GitHub Classroom classrooms the user administers (org-name `--source` resolution for `migrate`) |
-| GET | [`https://api.github.com/classrooms/{classroom_id}`](https://docs.github.com/en/rest/classroom/classroom#get-a-classroom) | Get a single GitHub Classroom by ID (numeric `--source` for `migrate`) |
-| GET | [`https://api.github.com/classrooms/{classroom_id}/assignments`](https://docs.github.com/en/rest/classroom/classroom#list-assignments-for-a-classroom) | List a source classroom's assignments (`migrate` discovery) |
-| GET | [`https://api.github.com/assignments/{assignment_id}`](https://docs.github.com/en/rest/classroom/classroom#get-an-assignment) | Fetch a source assignment's `starter_code_repository` + deadline (`migrate` discovery) |
-| POST | [`https://api.github.com/repos/{template_owner}/{template_repo}/generate`](https://docs.github.com/en/rest/repos/repos#create-a-repository-using-a-template) | Copy each source starter repo into the target org as a fresh template (`migrate` template copy) |
-| PATCH | [`https://api.github.com/repos/{owner}/{repo}`](https://docs.github.com/en/rest/repos/repos#update-a-repository) | Set `is_template: true` on the newly-generated target repo (`migrate` template copy) |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/branches/{branch}`](https://docs.github.com/en/rest/branches/branches#get-a-branch) | Wait for the freshly-generated target repo's branch ref to stabilize (`migrate` template copy) |
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/user` | Whoami. |
+| GET | `/orgs/{org}` | Check org plan. |
+| PATCH | `/orgs/{org}` | Lock down member privileges at `init`. |
+| GET / PUT | `/orgs/{org}/actions/permissions` | Read/enable org Actions. |
+| POST | `/orgs/{org}/repos` | Create the `classroom50` config repo. |
+| GET | `/repos/{owner}/{repo}` | Check the config repo / validate a template. |
+| POST / PUT | `/repos/{owner}/{repo}/pages` | Enable Pages and set it public. |
+| PUT | `/repos/{owner}/{repo}/branches/{branch}/protection` | Protect the config repo branch. |
+| GET / PUT | `/repos/{owner}/{repo}/actions/permissions` | Read/re-enable Actions on the config repo. |
+| GET / PUT | `/repos/{owner}/{repo}/actions/permissions/workflow` | Read/set `GITHUB_TOKEN` permissions. |
+| PUT | `/repos/{owner}/{repo}/actions/permissions/access` | Allow same-org reusable workflows. |
+| GET / PUT | `/repos/{owner}/{repo}/actions/secrets/...` | Upload the encrypted service PAT. |
+| GET / POST / PATCH | `/repos/{owner}/{repo}/git/{refs,commits,blobs,trees}` | Tree-commit config files (with rebase retry). |
+| GET | `/users/{username}` | Resolve a login to its numeric ID. |
+| POST | `/orgs/{org}/invitations` | Send an org invitation. |
+| GET / DELETE | `/orgs/{org}/memberships/{username}` | Check / remove org membership. |
+| PUT / DELETE | `/repos/{owner}/{repo}/collaborators/{username}` | Add / remove a repo collaborator. |
+| DELETE | `/repos/{owner}/{repo}` | Delete a repo (`teardown`; needs `delete_repo`). |
+| GET | `/repos/{owner}/{repo}/releases` + `/releases/assets/{id}` | Collect `submit/*` releases and `result.json`. |
+| GET | `/orgs/{org}/repos` | Page org repos for `--by-pattern` download. |
+| GET | `/classrooms`, `/classrooms/{id}`, `/classrooms/{id}/assignments`, `/assignments/{id}` | GitHub Classroom discovery (`migrate`). |
+| POST / PATCH | `/repos/{owner}/{repo}/generate`, `/repos/{owner}/{repo}` | Copy source starter repos as templates (`migrate`). |
 
 ### `gh student` CLI
 
-| Method | URL | Purpose |
-|--------|-----|---------|
-| GET | [`https://api.github.com/user`](https://docs.github.com/en/rest/users/users#get-the-authenticated-user) | Verify authenticated identity (whoami, git identity) |
-| GET | [`https://api.github.com/user/memberships/orgs/{org}`](https://docs.github.com/en/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user) | Check whether the student is already an org member |
-| PATCH | [`https://api.github.com/user/memberships/orgs/{org}`](https://docs.github.com/en/rest/orgs/members#update-an-organization-membership-for-the-authenticated-user) | Accept a pending org invitation |
-| POST | [`https://api.github.com/repos/{template_owner}/{template_repo}/generate`](https://docs.github.com/en/rest/repos/repos#create-a-repository-using-a-template) | Generate the student's assignment repo from the template (templated assignments) |
-| POST | [`https://api.github.com/orgs/{org}/repos`](https://docs.github.com/en/rest/repos/repos#create-an-organization-repository) | Create an empty `auto_init` assignment repo (template-less assignments) |
-| GET | [`https://api.github.com/repos/{owner}/{repo}`](https://docs.github.com/en/rest/repos/repos#get-a-repository) | Recover from a 422 "repository already exists" during generate |
-| PATCH | [`https://api.github.com/repos/{owner}/{repo}`](https://docs.github.com/en/rest/repos/repos#update-a-repository) | Disable issues, projects, and wiki on the new repo (visibility is set to private at generation time) |
-| PUT | [`https://api.github.com/repos/{owner}/{repo}/collaborators/{username}`](https://docs.github.com/en/rest/collaborators/collaborators#add-a-repository-collaborator) | Keep the student as an `admin` collaborator on their assignment repo (org-level member-privilege lockdown defangs the org-wide danger of repo-admin) |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/branches/{branch}`](https://docs.github.com/en/rest/branches/branches#get-a-branch) | Wait for the template's default branch to stabilize after generate |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/git/refs/heads/{branch}`](https://docs.github.com/en/rest/git/refs#get-a-reference) | Resolve branch tip SHA before a tree commit |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/git/commits/{commit_sha}`](https://docs.github.com/en/rest/git/commits#get-a-commit-object) | Read parent commit metadata |
-| POST | [`https://api.github.com/repos/{owner}/{repo}/git/blobs`](https://docs.github.com/en/rest/git/blobs#create-a-blob) | Upload file content as blobs (used by both `accept` and `submit`) |
-| POST | [`https://api.github.com/repos/{owner}/{repo}/git/trees`](https://docs.github.com/en/rest/git/trees#create-a-tree) | Create a new git tree |
-| POST | [`https://api.github.com/repos/{owner}/{repo}/git/commits`](https://docs.github.com/en/rest/git/commits#create-a-commit) | Create a commit object |
-| PATCH | [`https://api.github.com/repos/{owner}/{repo}/git/refs/heads/{branch}`](https://docs.github.com/en/rest/git/refs#update-a-reference) | Fast-forward the branch to the new commit |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/contents/{path}`](https://docs.github.com/en/rest/repos/contents#get-repository-content) | Fetch `.gitignore` and `.github/` from the template repo (`gh student submit` only) |
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/user` | Whoami / git identity. |
+| GET / PATCH | `/user/memberships/orgs/{org}` | Check / accept a pending org invite. |
+| POST | `/repos/{template_owner}/{template_repo}/generate` | Generate the repo from a template. |
+| POST | `/orgs/{org}/repos` | Create an empty repo (template-less). |
+| GET / PATCH | `/repos/{owner}/{repo}` | Recover from "already exists"; disable issues/projects/wiki. |
+| PUT | `/repos/{owner}/{repo}/collaborators/{username}` | Keep the student as admin; `gh student invite`. |
+| GET / POST / PATCH | `/repos/{owner}/{repo}/git/{refs,commits,blobs,trees}` + `/branches/{branch}` | Commit the setup files. |
+| GET | `/repos/{owner}/{repo}/contents/{path}` | Fetch `.gitignore`/`.github/` from the template (`submit`). |
 
-### `collect_scores.py` (runs inside GitHub Actions, uses `CLASSROOM50_SERVICE_TOKEN`)
+### `collect_scores.py` (Actions, uses `CLASSROOM50_SERVICE_TOKEN`)
 
-| Method | URL | Purpose | Required FG-PAT permission |
-|--------|-----|---------|----------------------------|
-| GET | [`https://api.github.com/orgs/{org}/teams/{team_slug}/members`](https://docs.github.com/en/rest/teams/members#list-team-members) | List the classroom team's members (team-driven enrollment; the source of the (student, assignment) pairs) | **Organization → Members: Read** |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/releases`](https://docs.github.com/en/rest/releases/releases#list-releases) | Page through a student's assignment-repo releases to collect every `submit/*` submission | **Repository → Contents: Read** |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/releases/assets/{asset_id}`](https://docs.github.com/en/rest/releases/assets#get-a-release-asset) | Download the `result.json` asset from a release | **Repository → Contents: Read** |
-| GET | [`https://api.github.com/repos/{owner}/{repo}/collaborators`](https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators) | List a group repo's collaborators to fan the score out to teammates on the classroom team | **Repository → Metadata: Read** (auto-included) |
-| GET / PUT | [`https://api.github.com/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}`](https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions) | Grant a classroom staff team (e.g. TAs) its mapped permission on each existing student repo and private in-org template (idempotent GET pre-check, then PUT when missing) | **Repository → Administration: Read and write** |
+| Method | Endpoint | Purpose | FG-PAT permission |
+|--------|----------|---------|-------------------|
+| GET | `/orgs/{org}/teams/{slug}/members` | List the classroom team (team-driven enrollment). | **Members: Read** |
+| GET | `/repos/{owner}/{repo}/releases` + `/releases/assets/{id}` | Collect submissions and `result.json`. | **Contents: Read** |
+| GET | `/repos/{owner}/{repo}/collaborators` | Fan a group score to teammates. | **Metadata: Read** |
+| GET / PUT | `/orgs/{org}/teams/{slug}/repos/{owner}/{repo}` | Grant staff teams read on student repos/templates. | **Administration: R/W** |
 
-### `probe_token.py` (runs inside GitHub Actions, uses `CLASSROOM50_SERVICE_TOKEN`)
+### `probe_token.py` (Actions, read-only)
 
-Read-only. Exercises every scope the token needs so a teacher gets one green/red signal after provisioning or rotating. No writes — write scopes are proven with read-only proxies GitHub gates behind the write permission.
+Exercises every scope with read-only proxies GitHub gates behind the write
+permission: `/orgs/{org}/members`, `/orgs/{org}/teams/{slug}/members`,
+`/repos/{org}/classroom50` (its `permissions.push`/`admin`),
+`/repos/{org}/classroom50/actions/permissions`, and
+`/repos/{org}/classroom50/collaborators`.
 
-| Method | URL | Purpose | Scope proven |
-|--------|-----|---------|--------------|
-| GET | [`https://api.github.com/orgs/{org}/members`](https://docs.github.com/en/rest/orgs/members#list-organization-members) | Org-members proxy for the team read | **Organization → Members: Read** |
-| GET | [`https://api.github.com/orgs/{org}/teams/{team_slug}/members`](https://docs.github.com/en/rest/teams/members#list-team-members) | The exact per-classroom team read collect makes (also tests team visibility) | **Organization → Members: Read** |
-| GET | [`https://api.github.com/repos/{org}/classroom50`](https://docs.github.com/en/rest/repos/repos#get-a-repository) | Config repo readable + `permissions.push` + `permissions.admin` | **Contents: Read**, **Contents: Write** (via `permissions.push`), and **Administration: Write** (via `permissions.admin`) |
-| GET | [`https://api.github.com/repos/{org}/classroom50/actions/permissions`](https://docs.github.com/en/rest/actions/permissions#get-github-actions-permissions-for-a-repository) | Reachable only with the Actions permission | **Actions: Read and write** (regrade rerun) |
-| GET | [`https://api.github.com/repos/{org}/classroom50/collaborators`](https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators) | Metadata endpoint (group attribution) | **Metadata: Read** (auto-included) |
+### `autograde-runner.yaml` (reusable, runs in student repos)
 
-### `autograde-runner.yaml` (reusable workflow, runs in student repos)
+Jobs: `setup` (create the submit tag, validate config), `grade` (run
+`runner.py` + the autograder, post status, publish the Release, maintain the
+Feedback PR), and `set-latest` (serialized latest-pointer update). It posts
+`/repos/{owner}/{repo}/statuses/{sha}`, uses `git tag`/`git push` and `gh
+release` for tags and Releases, and fetches unauthenticated from Pages:
 
-The workflow has `setup`, `grade`, and `set-latest` jobs. `setup` creates the submit tag without executing submission code, validates assignment configuration, and passes the ordered release-file paths to `grade`. `grade` uses `persist-credentials: false`, runs `runner.py` and the autograder, then posts status, publishes the Release, and maintains the Feedback PR on the same runner. `set-latest` serializes updates to the latest pointer. Grading and publishing in the same job is not a credential or hostile-workflow isolation boundary.
-
-| Method | URL | Purpose |
-|--------|-----|---------|
-| POST | [`https://api.github.com/repos/{owner}/{repo}/statuses/{sha}`](https://docs.github.com/en/rest/commits/statuses#create-a-commit-status) | Post `classroom50/autograde`: `setup` posts acceptance `success`; `grade` posts final `success`, `failure`, or `error` |
-
-The workflow also uses `git tag` + `git push` against the student's repo to create the `submit/<UTC-timestamp>-<short-sha>` tag for branch-triggered runs, and `gh release` subcommands (`view`, `edit`, `upload`, `create`) to publish `result.json` and configured extras on the submission tag release. The latest-pointer flip lives in a separate `set-latest` job with a per-repo concurrency group so concurrent submissions can't race on the read-modify-write.
-
-The runner setup also fetches from GitHub Pages without authentication (public by design):
-
-| Method | URL | Purpose |
-|--------|-----|---------|
-| GET | `https://{org}.github.io/classroom50/{classroom}/assignments.json` | Load the classroom's assignment manifest (and the per-assignment runtime block for the grade job) |
-| GET | `https://{org}.github.io/classroom50/runner.py` | Fetch the runner-side bootstrap (org-level; one per config repo, shared across all classrooms) |
-| GET | `https://{org}.github.io/classroom50/{classroom}/autograder.py` | Fetch the classroom default autograder (only when set via `gh teacher autograder set-default` and the assignment has no per-assignment override). 404 → runner publishes a vacuous-pass result. |
-| GET | `https://{org}.github.io/classroom50/{classroom}/autograders/{slug}.tar.gz` | Download the per-assignment bundle (entrypoint `autograder.py` plus any sibling fixtures; fetched by `runner.py` at runtime) |
-
-After grading, `runner.py` copies accepted extras into a fresh directory under runner temp and emits only their Release-safe basenames. The existing Release step uploads core output first, then the staged extras. Collection and extra-upload failures warn and continue without changing the grade or suppressing core publication. GitHub Releases remain the durable teacher and student surface.
+| Endpoint | Purpose |
+|----------|---------|
+| `https://{org}.github.io/classroom50/{classroom}/assignments.json` | The assignment manifest + runtime block. |
+| `https://{org}.github.io/classroom50/runner.py` | The runner bootstrap (org-level). |
+| `https://{org}.github.io/classroom50/{classroom}/autograder.py` | The classroom default (404 → vacuous pass). |
+| `https://{org}.github.io/classroom50/{classroom}/autograders/{slug}.tar.gz` | The per-assignment bundle. |
 
 ---
 
-## GitHub Actions workflows
-
-### Scaffolded by `gh teacher init` into each `<org>/classroom50` config repo
+## Workflows scaffolded into `classroom50`
 
 | File | Triggers | Purpose |
 |------|----------|---------|
-| `publish-pages.yaml` | Push to default branch, `workflow_dispatch` | Deploy `assignments.json`, classroom-default `autograder.py` files, autograder workflow shims, the runner-side bootstrap, and per-assignment bundles to GitHub Pages |
-| `collect-scores.yaml` | `workflow_dispatch`, cron `17 4 * * *` UTC | Run `collect_scores.py`, aggregate `result.json` assets into `*/scores.json` |
-| `probe-token.yaml` | `workflow_dispatch` | Run `probe_token.py` — a read-only check that `CLASSROOM50_SERVICE_TOKEN` holds every scope collect and regrade need. Run it after provisioning/rotating, or when a collect/regrade run 401/403s. |
-| `autograde-runner.yaml` (reusable) | Called from each student's `autograde.yaml` | Validated setup, grading and Release publication, then a serialized latest-pointer update |
+| `publish-pages.yaml` | Push to default branch, `workflow_dispatch` | Deploy `assignments.json`, autograders, shims, `runner.py`, and bundles to Pages. |
+| `collect-scores.yaml` | `workflow_dispatch`, nightly cron | Aggregate `result.json` into `*/scores.json`. |
+| `probe-token.yaml` | `workflow_dispatch` | Read-only service-token scope check. |
+| `autograde-runner.yaml` (reusable) | Called by each student's `autograde.yaml` | Grade, publish, update the latest pointer. |
 
----
+## Environment variables and secrets
 
-## Environment variables and secrets summary
+| Variable / Secret | Set by | Used by | Purpose |
+|-------------------|--------|---------|---------|
+| `CLASSROOM50_SERVICE_TOKEN` | `gh teacher init` | `collect-scores.yaml` | Read student repo releases; regrade. |
+| `GITHUB_TOKEN` | Actions | Runner jobs | Tags, status, Release, Feedback PR. |
+| `GH_DEBUG=api` | Developer | `go-gh` | Log REST traffic. |
+| `GITHUB_REPOSITORY_OWNER` / `GITHUB_API_URL` | Actions | `collect_scores.py` | Org name and API base (supports Enterprise Server). |
 
-| Variable / Secret | Where set | Used by | Purpose |
-|-------------------|-----------|---------|---------|
-| `CLASSROOM50_SERVICE_TOKEN` | `gh teacher init` (Actions secret on `classroom50`) | `collect-scores.yaml`, `collect_scores.py` | Fine-grained PAT for reading student repo releases |
-| `GITHUB_TOKEN` / `github.token` | Automatically injected by Actions | `setup`, `grade`, and `set-latest` jobs | Student-repo token used for tag, status, Release, Feedback PR, and latest-pointer operations |
-| `GH_TOKEN` | Set from `github.token` only on GitHub-calling shell steps | Tag/status, Release, Feedback PR, and latest-pointer commands | `gh` CLI authentication; not set on the autograder step, though grading and publishing remain in the same job |
-| `GH_DEBUG=api` | Developer shell | `go-gh` (teacher & student CLIs) | Log all REST request/response traffic |
-| `GITHUB_REPOSITORY_OWNER` | Actions context | `collect_scores.py` | Org name inside the collect workflow |
-| `GITHUB_API_URL` | Actions context | `collect_scores.py` | API base URL (supports GitHub Enterprise Server) |
-| `GH_API_URL` | Test override | `collect_scores.py` tests | Override API base in unit tests |
-
-The teacher and student CLIs do not use `GITHUB_TOKEN` or `GH_TOKEN`. They read credentials from the `gh` auth store (typically `~/.config/gh/hosts.yml`), populated by `gh teacher login` / `gh student login`.
+The teacher and student CLIs read credentials from the `gh` auth store (populated
+by `gh teacher login` / `gh student login`), not from `GITHUB_TOKEN`.

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -46,7 +46,8 @@ the shared repository and invite the other teammates as collaborators.
 
 **Template repository** — A GitHub repository, flagged as a template, that
 supplies an assignment's **starter code**. Each student who accepts gets a copy.
-Assignments can also be template-less (an empty starter repo).
+Assignments can also be template-less, in which case a student's repository
+contains only the autograder setup.
 
 **Deadline (due date)** — An optional date and time for an assignment.
 Submissions after it are marked *late*; nothing is blocked.
@@ -82,7 +83,7 @@ the template.
 
 **Unlisted classroom** — A classroom whose published files live at an
 unguessable URL instead of a predictable one. This is obscurity, not access
-control — anyone with the link can read the files.
+control: anyone with the link can read the files.
 
 ## Repository naming
 

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -1,0 +1,93 @@
+# Glossary
+
+Terms used throughout Classroom 50, in the web app, the CLI, and this wiki.
+
+## Core concepts
+
+**Classroom** — The basic unit of Classroom 50: one course's students,
+assignments, roster, and scores. A classroom belongs to a GitHub organization,
+and an organization can hold several classrooms (for example, one per term or
+section).
+
+**Assignment** — A piece of coursework in a classroom. May be individual or
+group, may include starter code, and may have a deadline and autograding.
+
+**Individual assignment** — Each student gets their own repository.
+
+**Group assignment** — Teammates share one repository. The first student to
+accept creates it and invites the others.
+
+**Roster** — The list of students in a classroom. Backed by a `roster.csv`
+file, but the classroom's GitHub team is the source of truth for who is
+enrolled.
+
+**Organization (org)** — The GitHub organization that hosts a Classroom 50
+setup. Requires the Team or Enterprise plan.
+
+**Config repo** — The private `classroom50` repository in your organization.
+It holds every classroom's settings, roster, assignments, autograders, and
+scores. Classroom 50 has no other backend.
+
+## Roles
+
+**Teacher** — Full control of a classroom. Granted organization owner and write
+access to the config repo.
+
+**Head TA** — Write access to the config repo, but not organization owner.
+
+**TA** — Read-only access to the config repo.
+
+**Student** — A member of the classroom who accepts and submits assignments.
+
+## Assignments and grading
+
+**Template repository** — A GitHub repository, flagged as a template, that
+supplies an assignment's **starter code**. Each student who accepts gets a copy.
+Assignments can also be template-less (an empty starter repo).
+
+**Deadline (due date)** — An optional date and time for an assignment.
+Submissions after it are marked *late*; nothing is blocked.
+
+**Autograder** — The grading logic that runs on each submission. Can be
+declarative tests (defined in the assignment) or a Python script you write.
+
+**Declarative tests** — Input/output, run-command, and pytest checks defined
+directly on an assignment, graded with no code to write.
+
+**Runner** — The shared grading engine that runs in GitHub Actions on every
+submission.
+
+**Submission** — A push to a student's assignment repository. Each submission
+is tagged, graded, and published as a GitHub Release.
+
+**Feedback pull request** — An optional, long-lived pull request per student
+repository for inline review of a student's work.
+
+**Score / gradebook** — Collected results. The gradebook (`scores.json`) is
+built by the score-collection workflow; teachers can download it as CSV.
+
+## Access and setup
+
+**Service token** — A fine-grained personal access token (PAT) stored as a
+secret in the config repo. The score-collection and regrade workflows use it to
+read and update student repositories.
+
+**Accept** — The student action that creates their assignment repository from
+the template.
+
+**Submit** — The student action that pushes work for grading.
+
+**Unlisted classroom** — A classroom whose published files live at an
+unguessable URL instead of a predictable one. This is obscurity, not access
+control — anyone with the link can read the files.
+
+## Repository naming
+
+Assignment repositories are named:
+
+```
+<classroom>-<assignment>-<username>
+```
+
+For a group assignment, `<username>` is the founder who created the shared
+repository.

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -39,6 +39,9 @@ access to the config repo.
 
 **Student** — A member of the classroom who accepts and submits assignments.
 
+**Founder** — For a group assignment, the student who accepts first: they create
+the shared repository and invite the other teammates as collaborators.
+
 ## Assignments and grading
 
 **Template repository** — A GitHub repository, flagged as a template, that

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,24 +7,24 @@ supported by the [Fifty Foundation](https://fifty.foundation).
 Use it as a web app at [classroom50.org](https://classroom50.org/) or as the
 `gh teacher` and `gh student` command-line tools.
 
-## The one idea to start with
+## How it works, in brief
 
-Classroom 50 has **no server and no database of its own.** The web app is a
-static site hosted on GitHub Pages, and the CLI runs on your machine — neither
-stores anything. **GitHub *is* the backend.** Your classrooms, roster,
-assignments, and grades aren't kept in a Classroom 50 account; they're stored
-*as* GitHub itself — organization membership, team membership, repositories,
-commit history, permissions, and a few config files in your organization.
+Classroom 50 has no server or database of its own. The web app is a static site
+hosted on GitHub Pages and the CLI runs on your machine; the app keeps only a
+small amount of local state in your browser (your GitHub access token and
+interface preferences). Your classrooms, roster, assignments, and grades are not
+kept in a Classroom 50 account — they are stored in GitHub, as organization and
+team membership, repositories, commit history, permissions, and a few config
+files in your organization.
 
-One consequence matters from day one: because there's no always-on server,
-**some things only happen when a teacher (an organization owner) is signed in
-and acting.** Signing in and doing things — creating a classroom, adding a
-student, saving an assignment — is what triggers the automation and records the
-state. So teachers stay more hands-on than with a hosted service: you're not
-just using the tool, you're the part of it that runs.
+One consequence is worth noting early: because there is no always-on server,
+some operations happen only when a teacher (an organization owner) is signed in
+and acting. Actions such as creating a classroom, adding a student, or saving an
+assignment run at the time you perform them and record the resulting state.
+Teachers therefore stay more involved in administration than they would with a
+hosted service.
 
-If you read nothing else first, read [How Classroom 50 Works](How-Classroom-50-Works)
-— it makes this mental model concrete before you start clicking.
+For the full model, see [How Classroom 50 Works](How-Classroom-50-Works).
 
 ## What you can do
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -37,7 +37,9 @@ repositories, and all grading runs in GitHub Actions.
 2. Teachers: [CLI Teacher Guide](CLI-Teacher-Guide).
 3. Students: [CLI Student Guide](CLI-Student-Guide).
 
-New to the terminology? See the [Glossary](Glossary).
+New to the terminology? See the [Glossary](Glossary). Curious how it all fits
+together? Read [How Classroom 50 Works](How-Classroom-50-Works). Have a question?
+Check the [FAQ](FAQ).
 
 ## Training sessions
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,6 +7,25 @@ supported by the [Fifty Foundation](https://fifty.foundation).
 Use it as a web app at [classroom50.org](https://classroom50.org/) or as the
 `gh teacher` and `gh student` command-line tools.
 
+## The one idea to start with
+
+Classroom 50 has **no server and no database of its own.** The web app is a
+static site hosted on GitHub Pages, and the CLI runs on your machine — neither
+stores anything. **GitHub *is* the backend.** Your classrooms, roster,
+assignments, and grades aren't kept in a Classroom 50 account; they're stored
+*as* GitHub itself — organization membership, team membership, repositories,
+commit history, permissions, and a few config files in your organization.
+
+One consequence matters from day one: because there's no always-on server,
+**some things only happen when a teacher (an organization owner) is signed in
+and acting.** Signing in and doing things — creating a classroom, adding a
+student, saving an assignment — is what triggers the automation and records the
+state. So teachers stay more hands-on than with a hosted service: you're not
+just using the tool, you're the part of it that runs.
+
+If you read nothing else first, read [How Classroom 50 Works](How-Classroom-50-Works)
+— it makes this mental model concrete before you start clicking.
+
 ## What you can do
 
 - Create individual and group assignments, with or without starter code.
@@ -14,8 +33,8 @@ Use it as a web app at [classroom50.org](https://classroom50.org/) or as the
 - Leave inline feedback on student work.
 - Manage rosters, track submissions, and collect scores.
 
-Classroom 50 has **no servers of its own**: all data lives in your GitHub
-repositories, and all grading runs in GitHub Actions.
+Auto-grading and background tasks run in **GitHub Actions**; published data is
+served from **GitHub Pages** — all inside your own organization.
 
 ## What you need
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -13,7 +13,7 @@ Classroom 50 has no server or database of its own. The web app is a static site
 hosted on GitHub Pages and the CLI runs on your machine; the app keeps only a
 small amount of local state in your browser (your GitHub access token and
 interface preferences). Your classrooms, roster, assignments, and grades are not
-kept in a Classroom 50 account — they are stored in GitHub, as organization and
+kept in a Classroom 50 account; they are stored in GitHub, as organization and
 team membership, repositories, commit history, permissions, and a few config
 files in your organization.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,57 +1,62 @@
 # Classroom 50
 
-Classroom 50 is a free and open-source tool for managing and grading programming assignments via GitHub. Supported by the [Fifty Foundation](https://fifty.foundation) as an open-source alternative to GitHub Classroom, Classroom 50 supports creating assignments, defining auto-graded correctness tests, and managing submissions.
+Classroom 50 is a free, open-source tool for distributing and auto-grading
+programming assignments on GitHub. It's an alternative to GitHub Classroom,
+supported by the [Fifty Foundation](https://fifty.foundation).
 
-Classroom 50 exists both as a web application (available at [https://classroom50.org](https://classroom50.org/)) and as a command-line tool.
+Use it as a web app at [classroom50.org](https://classroom50.org/) or as the
+`gh teacher` and `gh student` command-line tools.
 
-## Training Sessions
+## What you can do
 
-The Fifty Foundation will host two online training sessions to teach you how to use Classroom 50 and to answer your questions live. The sessions will take place at the following times:
+- Create individual and group assignments, with or without starter code.
+- Auto-grade submissions with declarative tests or your own grading scripts.
+- Leave inline feedback on student work.
+- Manage rosters, track submissions, and collect scores.
 
-- [Friday, July 24, 1pm-2pm EDT](https://time.cs50.io/20260724T1300-0400/PT1H?title=Classroom+50+Training+Session)
-- [Friday, August 14, 1pm-2pm EDT](https://time.cs50.io/20260814T1300-0400/PT1H?title=Classroom+50+Training+Session)
+Classroom 50 has **no servers of its own**: all data lives in your GitHub
+repositories, and all grading runs in GitHub Actions.
 
-To sign up to attend one of the training sessions, [complete the registration form here](https://docs.google.com/forms/d/e/1FAIpQLSdSZzOUOtSExmldFOsdlePWGZkJELHnZBpH3NPhXAJMDG9eXA/viewform?usp=dialog).
+## What you need
 
-A recorded training session will also be made available for those who cannot attend live.
+- A GitHub account.
+- A GitHub organization on the **Team** or **Enterprise** plan (free for
+  verified teachers through [GitHub Education](https://docs.github.com/en/education/about-github-education/github-education-for-teachers/apply-to-github-education-as-a-teacher)).
 
-## Features
+## Get started
 
-Classroom 50 supports:
+**Web app** — no installation required:
 
-- Creating assignments with starter code
-- Defining correctness tests
-- Distributing individual and group assignments
-- Collecting and auto-grading submissions
-- Providing inline qualitative feedback on submissions
-- Managing classroom rosters and scores
+1. Teachers: [Web Teacher Guide](Web-Teacher-Guide).
+2. Students: [Web Student Guide](Web-Student-Guide).
 
-Classroom 50 is entirely GitHub-based and does not have any servers of its own: all data lives in GitHub repositories and all auto-grading runs in GitHub Actions.
+**Command line** — needs the [GitHub CLI (`gh`)](https://cli.github.com/) and
+[Go](https://go.dev/):
 
-Teachers and students can use Classroom 50 through the web interface at https://classroom50.org or via the command-line interface (CLI), which is available as `gh teacher` and `gh student` GitHub CLI extensions.
+1. [Install the CLI](Installation).
+2. Teachers: [CLI Teacher Guide](CLI-Teacher-Guide).
+3. Students: [CLI Student Guide](CLI-Student-Guide).
 
-To use Classroom 50, you'll need:
+New to the terminology? See the [Glossary](Glossary).
 
-- A GitHub account
-- A GitHub organization with at least the Team plan (free via GitHub Education for verified teachers).
+## Training sessions
 
-## Try Classroom 50
+The Fifty Foundation hosts live online training sessions:
 
-> Note: If you used the pre-release version of Classroom 50 before July 1, 2026, you will likely need to reset your Classroom 50 organization before using the current version. To reset your organization, delete the `classroom50` repository in your GitHub organization. Note that this will remove all existing classrooms and student data.
+- [Friday, July 24, 1–2pm EDT](https://time.cs50.io/20260724T1300-0400/PT1H?title=Classroom+50+Training+Session)
+- [Friday, August 14, 1–2pm EDT](https://time.cs50.io/20260814T1300-0400/PT1H?title=Classroom+50+Training+Session)
 
-### Web Interface
+[Register here](https://docs.google.com/forms/d/e/1FAIpQLSdSZzOUOtSExmldFOsdlePWGZkJELHnZBpH3NPhXAJMDG9eXA/viewform?usp=dialog).
+A recording will be made available afterward.
 
-1. Follow the [Web Teacher Guide](Web-Teacher-Guide) to set up your classroom with Classroom 50.
-2. Students can follow the steps in the [Web Student Guide](Web-Student-Guide) to accept and submit assignments.
+> [!NOTE]
+> If you used the pre-release version of Classroom 50 before July 1, 2026,
+> reset your organization before using the current version: delete the
+> `classroom50` repository in your GitHub organization. This removes all
+> existing classrooms and student data.
 
-### CLI
+## Get help
 
-1. Follow the [Installation](Installation) guide. Go and the [GitHub CLI (`gh`)](https://cli.github.com/) are the only prerequisites.
-2. Walk through the [CLI Teacher Guide](CLI-Teacher-Guide) to set up your classroom with Classroom 50.
-3. Students can follow the steps in the [CLI Student Guide](CLI-Student-Guide) to accept and submit assignments.
-
-## Get Help
-
-- **Questions, ideas, feature requests:** open a thread on our [Discussions page](https://github.com/foundation50/classroom50/discussions).
-- **Bug reports:** file an [issue](https://github.com/foundation50/classroom50/issues).
+- **Questions and ideas:** [Discussions](https://github.com/foundation50/classroom50/discussions).
+- **Bug reports:** [Issues](https://github.com/foundation50/classroom50/issues).
 - **Email updates:** subscribe at [fifty.foundation](https://fifty.foundation).

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -1,0 +1,177 @@
+# How Classroom 50 Works
+
+This page explains the model behind Classroom 50 — how it uses GitHub, why
+permissions and workflows behave the way they do, and how it differs from GitHub
+Classroom. If you've wondered "why is my student an admin?" or "why didn't
+unenrolling delete their repo?", the answers are here.
+
+## No backend: everything lives on GitHub
+
+Classroom 50 has **no servers of its own**. There is no database and no hosted
+state. Everything lives in your GitHub organization:
+
+- **Classroom settings, roster, assignments, and scores** live as files
+  (`classroom.json`, `roster.csv`, `assignments.json`, `scores.json`) in a
+  private **config repo** named `classroom50` in your organization.
+- **Student work** lives in per-assignment repositories.
+- **Grading** runs in **GitHub Actions**, inside each student's repository.
+- **Published data** students need (like the assignment list) is served from
+  **GitHub Pages**.
+
+Because state is derived from what exists on GitHub, most behavior is a
+consequence of GitHub's own rules — which is why the sections below matter.
+
+## Two ways things happen: your token vs. Actions
+
+Classroom 50 does work in two distinct ways, and knowing which is which explains
+most "why did this happen?" questions:
+
+1. **Interactive actions** (creating a classroom, adding students, accepting an
+   assignment) run **as you**, using your signed-in GitHub token. They happen
+   immediately and are limited by *your* GitHub permissions.
+2. **Asynchronous actions** (publishing to Pages, collecting scores, regrading)
+   run in **GitHub Actions workflows** in your config repo. They happen in the
+   background and can take a minute or more — and they depend on the
+   [service token](#the-service-token), not on you being online.
+
+So when a change "hasn't shown up yet," it's usually an async workflow still
+running (or GitHub Pages still deploying), not a lost action.
+
+## The web app and CLI are the same thing
+
+The web app and the `gh teacher` / `gh student` CLIs are **two front ends over
+the same GitHub operations** — not a primary system and a secondary one. A
+classroom created in the web app is fully manageable from the CLI and vice
+versa, because both read and write the same files and teams in your
+organization. Use whichever you prefer, or mix them.
+
+## Roles are GitHub organization roles and teams
+
+Classroom 50 has four roles, and each maps directly onto a GitHub construct:
+
+| Role | On GitHub | Can |
+| --- | --- | --- |
+| **Teacher** | Organization **owner**, on the `-teacher` team | Everything, including org + classroom settings |
+| **Head TA** | Org **member**, on the `-hta` team | Write the config repo; manage the classroom; not an owner |
+| **TA** | Org **member**, on the `-ta` team | Read the config repo; view submissions |
+| **Student** | Org **member**, on the classroom team | Accept and submit assignments |
+
+Every classroom has a set of `secret` GitHub teams
+(`classroom50-<classroom>-{teacher,hta,ta}` plus the student team
+`classroom50-<classroom>`). Membership in these teams *is* the role — there's no
+separate role database. That's why staff you invite show up as GitHub team
+invitations, and why the classroom's **team is the source of truth for who's
+enrolled** (not the `roster.csv`, which only carries display details like name
+and section).
+
+## The permission model: why students are admins
+
+The organization is locked down to **least privilege**. During setup, Classroom
+50 sets the org's base permission to **"No permission"** and disables risky
+member capabilities (repo deletion, transfer, visibility changes, and more).
+This org-wide lockdown is the safety boundary.
+
+Against that backdrop, each student's access to *their own* assignment
+repository is deliberately generous:
+
+- **Individual assignments:** the student is created as an admin of their repo,
+  then downgraded to **write** — enough to push work, not enough to do damage.
+- **Group assignments:** the first student to accept (the **founder**) keeps
+  **admin** on the shared repo, because they need it to invite teammates as
+  collaborators. Classroom 50 has no separate "create a team" step — students
+  form their own groups.
+
+This is safe **because of** the org lockdown: even an admin on their own repo
+can't delete it, change its visibility, transfer it, or reach another student's
+private repo (the "No permission" base blocks cross-repo access). The generous
+per-repo access and the strict org policy work together.
+
+> [!NOTE]
+> TAs and head TAs get read access to student repositories through the
+> score-collection workflow, not at accept time — so a newly accepted repo has
+> no staff team attached to it, which is expected.
+
+## Why org policies sometimes "drift"
+
+If you run both Classroom 50 and GitHub Classroom in the same organization, they
+can disagree on a setting and flip it back and forth — most notably private-repo
+forking. That tug-of-war shows up as "policy drift" in the setup/audit check.
+Classroom 50 no longer enforces the forking setting for this reason; private
+templates work either way. If you see a setting you fixed revert later, another
+tool (or an org/enterprise policy) is changing it back.
+
+## How grading flows
+
+1. A student pushes to their repository (via `gh student submit` or a plain
+   `git push`).
+2. A small workflow in their repo calls the shared **autograde runner** in your
+   config repo, which fetches the grading logic from Pages and runs it.
+3. The result is published as a **GitHub Release** on the student's repo.
+4. The **score-collection** workflow gathers those results into `scores.json`.
+
+Autograding is optional — an assignment with no tests still tags submissions and
+supports feedback. See [Autograders](Autograders) for the full pipeline.
+
+### The Feedback PR opens on the first submission, not at accept
+
+If you enable the Feedback pull request, it appears on the student's **first
+submission that adds work**, not when they accept. This is by design: GitHub
+can't open a pull request with no changes, and opening it later keeps the setup
+files (the accept marker and autograde workflow) out of the diff you review. See
+[Autograders](Autograders#feedback-pull-requests).
+
+## Lifecycle: enroll, unenroll, and remove are separate
+
+Classroom 50 keeps three actions deliberately distinct, so a small mistake can't
+cascade into deleting a student's work:
+
+- **Unenrolling** a student removes them from the classroom's roster and team.
+  It does **not** remove them from the organization, and it does **not** delete
+  their assignment repositories.
+- **Removing** a student from the organization revokes their access to every
+  repo in it (and, as a side effect, to their assignment repos) — but still
+  doesn't delete the repositories.
+- **Deleting** a repository is always a separate, manual action.
+
+## Assignment repositories
+
+Each accepted assignment produces a repository named:
+
+```
+<classroom>-<assignment>-<username>
+```
+
+For a group assignment, `<username>` is the founder who created the shared repo.
+These are normal GitHub repositories — scripts that automate git operations
+against them generally work the same as they did with GitHub Classroom.
+
+> [!NOTE]
+> **Adding a template after the fact is a gotcha.** Classroom 50 grants the
+> classroom team read access to a private in-org template when you *create* the
+> assignment with that template. If you create an assignment first and add the
+> template later by editing it, that grant isn't re-applied — students may then
+> 404 on accept. Set the template when creating the assignment, or re-grant team
+> access to it.
+
+## The service token
+
+The **service token** is a fine-grained personal access token stored as a secret
+in your config repo. The background workflows (score collection, regrade) use it
+to read and update student repositories across the org — work that can't run as
+"you" because it happens on a schedule when you're not online. It's the same
+token whether you set it up in the web app or the CLI, and you need only one per
+organization. See [the service-token setup](CLI-Teacher-Guide#create-the-service-token).
+
+## How this differs from GitHub Classroom
+
+| | GitHub Classroom | Classroom 50 |
+| --- | --- | --- |
+| Backend | Hosted service | None — GitHub repos + Actions |
+| Classroom ↔ org | One classroom per org | Many classrooms per org |
+| Grading | Hosted autograder | GitHub Actions in each repo |
+| Feedback PR | Opened at accept | Opened on first submission |
+| Group naming | Team names | Founder's username |
+| Data | In the service | In your `classroom50` config repo (yours to keep) |
+
+For a term-by-term reference, see the [Glossary](Glossary); for common questions,
+see the [FAQ](FAQ).

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -1,41 +1,76 @@
 # How Classroom 50 Works
 
-This page explains the model behind Classroom 50 — how it uses GitHub, why
-permissions and workflows behave the way they do, and how it differs from GitHub
-Classroom. If you've wondered "why is my student an admin?" or "why didn't
-unenrolling delete their repo?", the answers are here.
+Start here if you're new. This page builds the mental model behind Classroom 50
+— what it is, where your data actually lives, and why teachers stay hands-on —
+before you touch any buttons. It also answers the "why did that happen?"
+questions (why is my student an admin? why didn't unenrolling delete their
+repo?) that only make sense once the model clicks.
 
-## No backend: everything lives on GitHub
+## The mental model: GitHub is the backend
 
-Classroom 50 has **no servers of its own**. There is no database and no hosted
-state. Everything lives in your GitHub organization:
+Most tools you've used have a server and a database: you log in to *their*
+account, and *their* computers remember your data. **Classroom 50 has neither.**
 
-- **Classroom settings, roster, assignments, and scores** live as files
-  (`classroom.json`, `roster.csv`, `assignments.json`, `scores.json`) in a
-  private **config repo** named `classroom50` in your organization.
-- **Student work** lives in per-assignment repositories.
-- **Grading** runs in **GitHub Actions**, inside each student's repository.
-- **Published data** students need (like the assignment list) is served from
-  **GitHub Pages**.
+- The **web app** ([classroom50.org](https://classroom50.org)) is a static site
+  hosted on GitHub Pages. It runs entirely in your browser.
+- The **CLI** (`gh teacher` / `gh student`) runs on your own machine.
 
-Because state is derived from what exists on GitHub, most behavior is a
-consequence of GitHub's own rules — which is why the sections below matter.
+Neither stores anything. There is no "Classroom 50 database." Instead, **GitHub
+itself is the backend**, and your classroom's state is stored *as* ordinary
+GitHub things:
 
-## Two ways things happen: your token vs. Actions
+| What you think of as… | Is actually stored as… |
+| --- | --- |
+| Your classrooms, assignments, scores | Config files in a private `classroom50` repo in your org |
+| Who's enrolled | GitHub **organization + team membership** |
+| Who's staff (teacher/TA) | Membership in `secret` GitHub **teams** |
+| A student's submissions | **Commit history** and Releases in their repo |
+| Who can do what | GitHub **permissions** |
 
-Classroom 50 does work in two distinct ways, and knowing which is which explains
-most "why did this happen?" questions:
+So Classroom 50 doesn't *have* your data — it **reads and writes GitHub on your
+behalf**, and then reads GitHub back to show you the current picture. Almost
+every behavior in the rest of this page follows from that one fact.
 
-1. **Interactive actions** (creating a classroom, adding students, accepting an
-   assignment) run **as you**, using your signed-in GitHub token. They happen
-   immediately and are limited by *your* GitHub permissions.
-2. **Asynchronous actions** (publishing to Pages, collecting scores, regrading)
-   run in **GitHub Actions workflows** in your config repo. They happen in the
-   background and can take a minute or more — and they depend on the
-   [service token](#the-service-token), not on you being online.
+## Why teachers stay hands-on
 
-So when a change "hasn't shown up yet," it's usually an async workflow still
-running (or GitHub Pages still deploying), not a lost action.
+Because there is no always-on server, **nothing happens on its own while you're
+logged out.** The app can't quietly reconcile state in the background the way a
+hosted service would. Instead:
+
+- **You are the engine for interactive work.** Creating a classroom, adding a
+  student, saving an assignment, inviting a TA — these run *as you*, in the
+  moment you do them, using your signed-in GitHub token. If you don't do them,
+  they don't happen.
+- **Signing in can itself trigger work.** Opening a classroom lets the app
+  reconcile things that drifted (for example, migrating an old team name or
+  re-checking org settings). Some upkeep only occurs *because* an owner signed
+  in and loaded the page.
+- **Background jobs still need to be set up by you.** Score collection and
+  regrading run as GitHub Actions on a schedule, but only after you've
+  provisioned the [service token](#the-service-token) that lets them act when
+  you're offline.
+
+**What this means for you:** plan to stay more actively involved than with a
+hosted product. Treat Classroom 50 as *administering your own GitHub org* with
+help, not as a service that runs itself. When something looks out of date,
+signing in and revisiting the page is often what brings it up to date.
+
+## Interactive vs. background: your token vs. Actions
+
+Zooming in on the split above — work happens in exactly two ways, and knowing
+which is which explains most "why did/didn't this happen?" questions:
+
+1. **Interactive actions** run **as you**, with your signed-in GitHub token, the
+   instant you take them (create a classroom, add a student, accept an
+   assignment). They're limited by *your* GitHub permissions and require you to
+   be present.
+2. **Asynchronous actions** run in **GitHub Actions workflows** in your config
+   repo (publishing to Pages, collecting scores, regrading). They run in the
+   background, can take a minute or more, and depend on the
+   [service token](#the-service-token) rather than on you being online.
+
+So when a change "hasn't shown up yet," it's usually a background workflow still
+running (or GitHub Pages still deploying) — not a lost action.
 
 ## The web app and CLI are the same thing
 

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -1,69 +1,66 @@
 # How Classroom 50 Works
 
-Start here if you're new. This page builds the mental model behind Classroom 50
-— what it is, where your data actually lives, and why teachers stay hands-on —
-before you touch any buttons. It also answers the "why did that happen?"
-questions (why is my student an admin? why didn't unenrolling delete their
-repo?) that only make sense once the model clicks.
+This page describes the model behind Classroom 50 — what it is, where its data
+is stored, and why teachers remain involved in administration. It also explains
+behavior that is otherwise surprising, such as why a student is an admin of
+their repository, or why unenrolling a student does not delete their repository.
 
 ## The mental model: GitHub is the backend
 
-Most tools you've used have a server and a database: you log in to *their*
-account, and *their* computers remember your data. **Classroom 50 has neither.**
+Many web tools have a server and a database: you sign in to their account, and
+their systems store your data. Classroom 50 does not work this way.
 
 - The **web app** ([classroom50.org](https://classroom50.org)) is a static site
-  hosted on GitHub Pages. It runs entirely in your browser.
+  hosted on GitHub Pages. It runs in your browser.
 - The **CLI** (`gh teacher` / `gh student`) runs on your own machine.
 
-Neither stores anything. There is no "Classroom 50 database." Instead, **GitHub
-itself is the backend**, and your classroom's state is stored *as* ordinary
-GitHub things:
+Neither keeps a database of classroom data. The web app stores only a small
+amount of local state in your browser — your GitHub access token and interface
+preferences such as theme and language — and the CLI reuses the GitHub CLI's
+stored credentials. Everything else is stored in GitHub, and your classroom's
+state is represented by ordinary GitHub data:
 
-| What you think of as… | Is actually stored as… |
+| What you think of as… | Is stored as… |
 | --- | --- |
 | Your classrooms, assignments, scores | Config files in a private `classroom50` repo in your org |
-| Who's enrolled | GitHub **organization + team membership** |
-| Who's staff (teacher/TA) | Membership in `secret` GitHub **teams** |
-| A student's submissions | **Commit history** and Releases in their repo |
-| Who can do what | GitHub **permissions** |
+| Who's enrolled | GitHub organization and team membership |
+| Who's staff (teacher/TA) | Membership in `secret` GitHub teams |
+| A student's submissions | Commit history and Releases in their repo |
+| Who can do what | GitHub permissions |
 
-So Classroom 50 doesn't *have* your data — it **reads and writes GitHub on your
-behalf**, and then reads GitHub back to show you the current picture. Almost
-every behavior in the rest of this page follows from that one fact.
+Classroom 50 reads and writes this GitHub data on your behalf, then reads it
+back to show the current state. Most of the behavior described below follows
+from this.
 
-## Why teachers stay hands-on
+## Why teachers stay involved
 
-Because there is no always-on server, **nothing happens on its own while you're
-logged out.** The app can't quietly reconcile state in the background the way a
-hosted service would. Instead:
+Because there is no always-on server, the app does not change state on its own
+while you are signed out. It cannot reconcile state in the background the way a
+hosted service can. As a result:
 
-- **You are the engine for interactive work.** Creating a classroom, adding a
-  student, saving an assignment, inviting a TA — these run *as you*, in the
-  moment you do them, using your signed-in GitHub token. If you don't do them,
-  they don't happen.
-- **Signing in can itself trigger work.** Opening a classroom lets the app
-  reconcile things that drifted (for example, migrating an old team name or
-  re-checking org settings). Some upkeep only occurs *because* an owner signed
-  in and loaded the page.
-- **Background jobs still need to be set up by you.** Score collection and
-  regrading run as GitHub Actions on a schedule, but only after you've
-  provisioned the [service token](#the-service-token) that lets them act when
-  you're offline.
+- **Interactive work runs as you.** Creating a classroom, adding a student,
+  saving an assignment, or inviting a TA runs at the moment you do it, using
+  your signed-in GitHub token. These changes happen only when you make them.
+- **Signing in can trigger reconciliation.** Opening a classroom lets the app
+  correct things that have drifted — for example, migrating an old team name or
+  re-checking organization settings. Some upkeep occurs only after an owner
+  signs in and loads the page.
+- **Background jobs require setup.** Score collection and regrading run as
+  GitHub Actions on a schedule, but only after you provision the
+  [service token](#the-service-token) that lets them act while you are offline.
 
-**What this means for you:** plan to stay more actively involved than with a
-hosted product. Treat Classroom 50 as *administering your own GitHub org* with
-help, not as a service that runs itself. When something looks out of date,
-signing in and revisiting the page is often what brings it up to date.
+For teachers, this means administering Classroom 50 is closer to administering
+your own GitHub organization than to using a hosted service. If a view looks out
+of date, signing in and reopening the page often updates it.
 
-## Interactive vs. background: your token vs. Actions
+## Interactive vs. background work
 
-Zooming in on the split above — work happens in exactly two ways, and knowing
-which is which explains most "why did/didn't this happen?" questions:
+Work happens in one of two ways. Knowing which applies explains most questions
+about why a change did or did not take effect:
 
-1. **Interactive actions** run **as you**, with your signed-in GitHub token, the
-   instant you take them (create a classroom, add a student, accept an
-   assignment). They're limited by *your* GitHub permissions and require you to
-   be present.
+1. **Interactive actions** run as you, with your signed-in GitHub token, at the
+   time you take them (create a classroom, add a student, accept an assignment).
+   They are limited by your GitHub permissions and require you to be present.
 2. **Asynchronous actions** run in **GitHub Actions workflows** in your config
    repo (publishing to Pages, collecting scores, regrading). They run in the
    background, can take a minute or more, and depend on the
@@ -72,13 +69,13 @@ which is which explains most "why did/didn't this happen?" questions:
 So when a change "hasn't shown up yet," it's usually a background workflow still
 running (or GitHub Pages still deploying) — not a lost action.
 
-## The web app and CLI are the same thing
+## The web app and CLI are equivalent
 
-The web app and the `gh teacher` / `gh student` CLIs are **two front ends over
-the same GitHub operations** — not a primary system and a secondary one. A
-classroom created in the web app is fully manageable from the CLI and vice
-versa, because both read and write the same files and teams in your
-organization. Use whichever you prefer, or mix them.
+The web app and the `gh teacher` / `gh student` CLIs are two front ends over the
+same GitHub operations; neither is primary. A classroom created in the web app
+is fully manageable from the CLI and vice versa, because both read and write the
+same files and teams in your organization. Use whichever you prefer, or mix
+them.
 
 ## Roles are GitHub organization roles and teams
 

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -67,7 +67,7 @@ about why a change did or did not take effect:
    [service token](#the-service-token) rather than on you being online.
 
 So when a change "hasn't shown up yet," it's usually a background workflow still
-running (or GitHub Pages still deploying) — not a lost action.
+running (or GitHub Pages still deploying), not a lost action.
 
 ## The web app and CLI are equivalent
 
@@ -104,10 +104,10 @@ member capabilities (repo deletion, transfer, visibility changes, and more).
 This org-wide lockdown is the safety boundary.
 
 Against that backdrop, each student's access to *their own* assignment
-repository is deliberately generous:
+repository is deliberately broad:
 
 - **Individual assignments:** the student is created as an admin of their repo,
-  then downgraded to **write** — enough to push work, not enough to do damage.
+  then downgraded to **write**, enough to push work but not enough to do damage.
 - **Group assignments:** the first student to accept (the **founder**) keeps
   **admin** on the shared repo, because they need it to invite teammates as
   collaborators. Classroom 50 has no separate "create a team" step — students
@@ -120,13 +120,13 @@ per-repo access and the strict org policy work together.
 
 > [!NOTE]
 > TAs and head TAs get read access to student repositories through the
-> score-collection workflow, not at accept time — so a newly accepted repo has
-> no staff team attached to it, which is expected.
+> score-collection workflow, not at accept time. A newly accepted repo
+> therefore has no staff team attached to it, which is expected.
 
 ## Why org policies sometimes "drift"
 
 If you run both Classroom 50 and GitHub Classroom in the same organization, they
-can disagree on a setting and flip it back and forth — most notably private-repo
+can disagree on a setting and flip it back and forth, most notably private-repo
 forking. That tug-of-war shows up as "policy drift" in the setup/audit check.
 Classroom 50 no longer enforces the forking setting for this reason; private
 templates work either way. If you see a setting you fixed revert later, another
@@ -198,7 +198,7 @@ organization. See [the service-token setup](CLI-Teacher-Guide#create-the-service
 
 | | GitHub Classroom | Classroom 50 |
 | --- | --- | --- |
-| Backend | Hosted service | None — GitHub repos + Actions |
+| Backend | Hosted service | None (GitHub repos + Actions) |
 | Classroom ↔ org | One classroom per org | Many classrooms per org |
 | Grading | Hosted autograder | GitHub Actions in each repo |
 | Feedback PR | Opened at accept | Opened on first submission |

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,112 +1,102 @@
 # Installation
 
-`gh teacher` and `gh student` are `gh` CLI extensions written in Go. The
-quickest way to install them is from their published releases; if you're
-hacking on the extensions themselves, build from a local checkout instead.
+`gh teacher` and `gh student` are extensions for the [GitHub CLI (`gh`)](https://cli.github.com/),
+written in Go. Install them from their published releases, or build from source
+if you're developing the extensions themselves.
 
 ## Prerequisites
 
 - [GitHub CLI (`gh`)](https://cli.github.com/)
-- [Go](https://go.dev/doc/install) (any recent version) — only needed for the build-from-source path below.
+- [Go](https://go.dev/doc/install) — only for the build-from-source path.
 
-You do **not** need to run `gh auth login` first — the `gh teacher login` / `gh student login` commands below handle GitHub authentication with the right scopes.
+You don't need to run `gh auth login` first. The `login` commands below handle
+GitHub authentication with the right scopes.
 
-## Install both extensions (recommended)
-
-Installs precompiled binaries for your platform from each extension's releases:
+## Install (recommended)
 
 ```sh
 gh extension install foundation50/gh-teacher
 gh extension install foundation50/gh-student
 ```
 
-`gh teacher` and `gh student` are now available in your shell. Verify with:
+Verify:
 
 ```sh
 gh teacher --help
 gh student --help
 ```
 
-Update to the latest release at any time with:
+## Update
 
 ```sh
 gh extension upgrade gh-teacher
 gh extension upgrade gh-student
 ```
 
-Or update every installed extension in one go:
+Or update everything at once with `gh extension upgrade --all`. `gh` also checks
+for new releases in the background and tells you when an extension is out of
+date.
 
-```sh
-gh extension upgrade --all
-```
-
-`gh` also checks for new releases in the background and prints a hint when either extension is out of date, so you'll usually be told when an upgrade is available.
-
-To pin a specific version, pass `--pin` (the version is the release tag, e.g. `v1.0.0`):
+To pin a version, pass `--pin <tag>`:
 
 ```sh
 gh extension install foundation50/gh-teacher --pin v1.0.0
 ```
 
-### Verifying a download (optional)
+## Log in
 
-Each release ships a `checksums.txt` and build provenance attestations. To
-confirm a binary was produced by the official release pipeline:
+Each CLI has a `login` command that runs `gh auth login` with the extra OAuth
+scopes Classroom 50 needs:
 
 ```sh
-# Build provenance (gh 2.49+). The binaries are published on the extension
-# repos, but the provenance attestations are recorded against the source
-# monorepo, so point --repo at where the attestation lives:
-gh attestation verify <path-to-binary> --repo foundation50/classroom50
-
-# Or check the SHA-256 against the release's checksums.txt:
-sha256sum <path-to-binary>
+gh teacher login
+gh student login
 ```
 
-> If `gh attestation verify` reports "no attestations found", confirm your `gh`
-> is 2.49+ and that you passed `--repo foundation50/classroom50` (the source
-> repo that produced the build), not the extension repo the binary was
-> downloaded from.
+If you skip this and run another command first, the CLI runs the login flow for
+you automatically. `gh teacher logout` / `gh student logout` mirror
+`gh auth logout`.
+
+## Next steps
+
+- Teachers: [CLI Teacher Guide](CLI-Teacher-Guide).
+- Students: [CLI Student Guide](CLI-Student-Guide).
+
+---
 
 ## Build from source (for development)
 
-If you're working on the extensions, install them from a local checkout so your
-changes take effect:
+Install from a local checkout so your changes take effect:
 
 ```sh
 git clone https://github.com/foundation50/classroom50
 cd classroom50
 
-# teacher extension
 (cd cli/gh-teacher && go build . && gh extension install .)
-
-# student extension
 (cd cli/gh-student && go build . && gh extension install .)
 ```
 
-### Updating after a `git pull`
-
-`gh extension install .` only needs to run once per extension. After pulling new commits, just rebuild:
+After pulling new commits, just rebuild — you don't need to reinstall:
 
 ```sh
 (cd cli/gh-teacher && go build .)
 (cd cli/gh-student && go build .)
 ```
 
-## Logging in
+## Verify a download (optional)
 
-Each CLI has a `login` command that runs `gh auth login` with the extra OAuth scopes the classroom workflows require.
+Each release ships a `checksums.txt` and build provenance attestations. To
+confirm a binary came from the official release pipeline:
 
 ```sh
-gh teacher login   # requests admin:org (org invites) + workflow (init commits the config repo's workflows)
-gh student login   # requests read:org, repo, and workflow (needed to accept assignments)
+# Build provenance (gh 2.49+). Point --repo at the source monorepo, where the
+# attestations are recorded (not the extension repo the binary came from):
+gh attestation verify <path-to-binary> --repo foundation50/classroom50
+
+# Or check the SHA-256 against the release's checksums.txt:
+sha256sum <path-to-binary>
 ```
 
-If you skip this step and run another command first, the CLI detects the missing token and runs the login flow for you. The explicit step is just for predictability on a fresh setup.
-
-`gh teacher logout` / `gh student logout` mirror `gh auth logout`.
-
-## What's next
-
-- Teachers: continue to the [CLI Teacher Guide](CLI-Teacher-Guide).
-- Students: continue to the [CLI Student Guide](CLI-Student-Guide).
+> [!NOTE]
+> If `gh attestation verify` reports "no attestations found", confirm your `gh`
+> is 2.49+ and that you passed `--repo foundation50/classroom50`.

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -76,7 +76,7 @@ cd classroom50
 (cd cli/gh-student && go build . && gh extension install .)
 ```
 
-After pulling new commits, just rebuild — you don't need to reinstall:
+After pulling new commits, rebuild — you don't need to reinstall:
 
 ```sh
 (cd cli/gh-teacher && go build .)

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,122 +1,156 @@
 # Troubleshooting
 
-## Make the CLI tell you what it's doing
+## See what the CLI is doing
 
-Both CLIs accept `--verbose` / `-v` on any command. It surfaces per-step operational details — each REST call, the response status, raw `git` output during clone, metadata writes, collaborator updates — and is the first thing to try when something doesn't behave as expected.
+Both CLIs accept `--verbose` / `-v` on any command. It shows each REST call,
+response status, raw `git` output, and metadata writes — try it first when
+something misbehaves.
 
 ```sh
 gh student submit -v
 gh teacher download -v <org> <classroom> <assignment>
 ```
 
-For raw REST request/response logging (headers + bodies), set `GH_DEBUG=api` in the environment. This is honored by the underlying [`go-gh`](https://github.com/cli/go-gh) library and is the most detailed view of what's hitting the GitHub API.
+For raw REST request/response logging (headers + bodies), set `GH_DEBUG=api`:
 
 ```sh
 GH_DEBUG=api gh teacher invite <org> <username>
 ```
 
-Commands that emit informational summaries also accept `--quiet` / `-q` to suppress them (and to forward `--quiet` to `git` where applicable) — useful for scripting.
+Commands with informational output also accept `--quiet` / `-q`.
 
-## "Missing scope" / 403 errors on `gh teacher invite`
+## "Missing scope" / 403 on `gh teacher invite`
 
-Org-level invitations require the `admin:org` OAuth scope, which `gh auth login` doesn't grant by default. Run:
+Org invitations need the `admin:org` scope, which a plain `gh auth login`
+doesn't grant. Run:
 
 ```sh
 gh teacher login
 ```
 
-This re-authenticates with `admin:org` appended. The CLI also detects this missing scope and runs the login flow for you automatically if you skip it.
+The CLI also detects this and logs you in automatically if you skip it.
 
 ## `git/trees: HTTP 404` on `gh teacher init`
 
-`gh teacher init` commits the config repo's `.github/workflows/` files via the Git Data API, which GitHub gates behind the `workflow` OAuth scope. A token without it is rejected with a misleading `404 Not Found` (`POST .../git/trees: HTTP 404`), leaving the `classroom50` repo with only a README. Re-authenticate so the token carries `workflow`:
+`init` commits workflow files via the Git Data API, which GitHub gates behind
+the `workflow` scope. A token without it is rejected with a misleading 404,
+leaving `classroom50` with only a README. Re-authenticate:
 
 ```sh
 gh teacher login
-```
-
-`gh teacher login` requests `workflow` automatically. To add it to your existing token in place instead:
-
-```sh
+# or add the scope in place:
 gh auth refresh -s admin:org,workflow
 ```
 
-Whether a plain `gh auth login` already granted `workflow` depends on unrelated choices in its prompts (gh adds it only when you set it up as your HTTPS git credential helper), which is why this surfaces on some machines and not others. `init` now detects the missing scope and fails fast with this remediation instead of the bare 404.
+Whether a plain `gh auth login` already granted `workflow` depends on unrelated
+prompt choices, which is why this appears on some machines and not others.
 
 ## "Not an admin" on `gh teacher invite`
 
-Your authenticated user has to be an org owner (or have a role that includes member-invitation permission) for `POST /orgs/{org}/invitations` to succeed. Verify your role under `https://github.com/orgs/<org>/people` — your name should show `Owner`. If you're an admin via a team, GitHub's invitation API still requires owner-level permission.
+You must be an organization owner for `POST /orgs/{org}/invitations` to succeed.
+Check under `https://github.com/orgs/<org>/people` — you should show **Owner**.
+(Team-based admin isn't enough for the invitation API.)
 
-## "Already a member" / "Pending invite" on `gh teacher invite`
+## "Already a member" / "Pending invite"
 
-These aren't errors — they mean the desired state already exists. The CLI translates them into clear messages and exits 0 so you can re-run invite commands as part of a script without manual case-handling.
+Not errors — the desired state already exists. The CLI reports them clearly and
+exits 0, so invite commands are safe to re-run in scripts.
 
 ## "Assignment already accepted" on `gh student accept`
 
-You've already accepted this assignment; the repo exists at `<org>/<classroom>-<assignment>-<username>`. The CLI short-circuits to avoid touching your existing repo (and your work in it). Clone it with the URL from `gh repo view <org>/<repo>` if you don't have it locally.
+You've already accepted; the repo is at
+`<org>/<classroom>-<assignment>-<username>`. The CLI short-circuits to protect
+your work. Clone it with the URL from `gh repo view <org>/<repo>` if you don't
+have it locally.
 
 ## "Template not found" / 404 on `gh student accept`
 
-(This only applies to assignments that have a template — template-less assignments create an empty repo and never hit a template lookup.) Three things to check, in order:
+Only applies to assignments with a template. Check, in order:
 
-1. **The template repo must be readable by the student.** A **public** template always works. A **private** template works if it lives **inside your org**: `gh teacher assignment add` grants the classroom's GitHub team (`classroom50-<classroom>`) read on it, and rostered students inherit that read. A private template **outside** your org can't be granted to the team, so `gh teacher assignment add` rejects it — if you registered one before this check existed, re-add the assignment with an in-org copy or a public template. (GitHub Enterprise Cloud's "internal" visibility also works.) If a student still 404s, confirm they're on the roster (so they're in the classroom team) — `gh teacher roster add` adds them.
-2. **The repo must be flagged as a template** in `Settings → General → Template repository`.
-3. **The `<assignment>` argument must match the slug your teacher registered** with `gh teacher assignment add` in `assignments.json` — case is normalized, but spelling has to be exact. It does not have to match the template repo's name.
+1. **The template is readable by the student.** Public always works. A private
+   template works only if it's inside your org (the classroom team is granted
+   read). A private template outside your org can't be shared — re-add the
+   assignment with an in-org copy or a public template. If a student still 404s,
+   confirm they're on the roster (so they're in the team).
+2. **The repo is flagged as a template** in Settings → Template repository.
+3. **The `<assignment>` argument matches the registered slug** (case is
+   normalized; spelling must be exact).
 
 ## "Could not find `.classroom50.yaml`" on `gh student submit`
 
-`gh student submit` reads template metadata from `.classroom50.yaml` at the repo root. If it's missing, you're likely running submit from outside the cloned assignment repo, or from a clone that wasn't created by `gh student accept` (which is what writes that file). `cd` into the directory the `git clone` command created and try again.
+`submit` reads that file at the repo root. If it's missing, you're likely running
+submit from outside the cloned assignment repo, or from a clone not created by
+`gh student accept`. `cd` into the directory the `git clone` command created.
 
 ## "autograder `<name>` not published yet" on `gh student accept`
 
-The assignment's `assignments.json` references an autograder workflow whose YAML isn't on the Pages site. Two common causes:
+The assignment references an autograder workflow whose YAML isn't on Pages. Two
+causes:
 
-1. **The file doesn't exist.** This error only fires for non-default `--autograder <name>` values. The `default` autograder is embedded in `gh-student` itself and never needs a config-repo file. For other names (e.g. `--autograder c-makefile`), the corresponding `<classroom>/autograders/<name>.yaml` must be hand-created in the config repo before the assignment is registered. Ask your teacher to confirm the file is there.
-2. **`publish-pages.yaml` hasn't run yet.** Even when the file exists in the config repo, the Pages site needs the publish workflow to deploy. A fresh classroom dir requires one Pages deployment to surface the autograders; ask your teacher to wait a minute and try again.
+1. **The file doesn't exist.** This fires only for non-default `--autograder
+   <name>` values; `<classroom>/autograders/<name>.yaml` must exist in the config
+   repo. Ask your teacher to confirm.
+2. **`publish-pages.yaml` hasn't run.** A fresh classroom needs one Pages
+   deployment. Wait a minute and retry.
 
-## "autograder `<name>` is malformed YAML" on `gh student accept`
+("autograder `<name>` is malformed YAML" means the workflow has a syntax error —
+`gh student` validates before writing, so a broken file never lands. Ask the
+teacher to fix it.)
 
-The teacher's autograder workflow has a YAML syntax error. `gh student` validates the fetched YAML before writing it into your repo, so a broken file never lands. Ask the teacher to check `<classroom>/autograders/<name>.yaml` in the config repo and re-run after they fix it.
+## Submit pushed a commit but the teacher sees no new work
 
-## Submit pushed a commit but the teacher doesn't see new work
-
-`gh student submit` pushes to the assignment repo's actual default branch (resolved from the repo — `master`, `develop`, or `main`), and the autograde workflow triggers on that same branch, so grading fires regardless of the branch name. If a submission still isn't graded, confirm the push landed on the repo's default branch on GitHub and that the autograde workflow ran under the repo's Actions tab.
+`submit` pushes to the repo's actual default branch (`main`, `master`, or
+`develop`), and autograding triggers on that branch. If a submission still isn't
+graded, confirm the push landed on the default branch and that the autograde
+workflow ran under the repo's Actions tab.
 
 ## `gh teacher download` clones nothing
 
-By default, `gh teacher download` is **team-driven**: it lists the classroom GitHub team's members (the source of truth for enrollment) and reads `<classroom>/assignments.json` from your config repo, then probes `GET /repos/<org>/<classroom>-<assignment>-<username>` for each team member. If you get zero clones:
+By default `download` is team-driven. If you get zero clones:
 
-- Confirm `<org>/classroom50` exists and the classroom team has members (`gh teacher roster add` / `gh teacher roster import`, which add students to the org and the team).
-- Confirm `<assignment>` is registered in `<classroom>/assignments.json` (`gh teacher assignment list <org> <classroom>`).
-- Verify a few student repos exist under `https://github.com/orgs/<org>/repositories?q=<classroom>-<assignment>`.
-- Re-run with `-v` to see which team members were probed and which repos were missing.
+- Confirm `<org>/classroom50` exists and the classroom team has members (add them
+  with `gh teacher roster add` / `import`).
+- Confirm `<assignment>` is registered (`gh teacher assignment list`).
+- Verify a few student repos exist under
+  `https://github.com/orgs/<org>/repositories?q=<classroom>-<assignment>`.
+- Re-run with `-v` to see which members were probed.
 
-If the config repo isn't bootstrapped yet, or you want every matching repo regardless of the roster, pass `--by-pattern` — that mode pages through `GET /orgs/{org}/repos` and clones every repo whose name starts with `<classroom>-<assignment>-`.
+If the config repo isn't bootstrapped, or you want every matching repo regardless
+of the roster, pass `--by-pattern`.
 
-## `collect-scores` warns "collected 0 submissions" for a whole classroom
+## `collect-scores` warns "collected 0 submissions"
 
-The nightly `collect-scores` workflow logs a `::warning::` when a non-empty roster x assignment set yields zero readable submissions. Because a fine-grained PAT returns `404` for repos outside its scope -- indistinguishable from "no release yet" -- this almost always means the `CLASSROOM50_SERVICE_TOKEN` can't read the student repos, not that the whole class submitted nothing. (An early-term run before anyone has submitted will also trip it; the warning is hedged with "if you expected submissions.")
+Almost always means the `CLASSROOM50_SERVICE_TOKEN` can't read the student repos
+— not that the class submitted nothing. (A fine-grained PAT returns 404 for
+out-of-scope repos, indistinguishable from "no release yet".)
 
-- Confirm the service token has **`Contents: Read and write` on all org repos** (not "Only select repositories" -- student repos are created on demand by `gh student accept`, so a pre-chosen list misses them) **and Organization `Members: Read`** (collection lists the classroom team; a missing `Members` scope 403s the run — see below). See the [service-token note](GitHub-Integration#4-fine-grained-pat-for-score-collection).
-- Re-scope and rotate it with `gh teacher rotate-service-token <org>`.
-- A `401`/`403` instead fails the run loudly (bad/expired token, or a missing `Members: Read` scope); the `0 submissions` warning is specifically the silent-404 case.
+- Confirm the token has **Contents: Read and write on all org repos** (not "Only
+  select repositories" — student repos are created on demand) **and Organization
+  Members: Read**.
+- Re-scope and rotate with `gh teacher rotate-service-token <org>`.
+- A `401`/`403` (rather than the `0 submissions` warning) means a bad/expired
+  token or a missing `Members: Read` scope.
+
+See the [service-token setup](GitHub-Integration#4-fine-grained-pat-for-score-collection).
 
 ## Build fails after a `git pull`
 
-`gh extension install .` only registers the binary the **first** time. After pulling new commits in this repo, re-run `go build .` inside the extension folder:
+`gh extension install .` registers the binary only the first time. After pulling
+new commits, rebuild:
 
 ```sh
 (cd cli/gh-teacher && go build .)
 (cd cli/gh-student && go build .)
 ```
 
-If `go build` itself fails, run `go mod tidy` first to catch any new dependencies.
+If `go build` itself fails, run `go mod tidy` first.
 
 ## Filing an issue
 
-If none of the above explain what you're seeing, open an issue at <https://github.com/foundation50/classroom50/issues>. Useful to include:
+If none of the above helps, open an issue at
+<https://github.com/foundation50/classroom50/issues>. Include:
 
-- The exact command you ran (with arguments).
-- The full output, ideally with `-v` and/or `GH_DEBUG=api` set.
-- Your `gh --version` and Go version (`go version`).
-- OS and shell.
+- The exact command you ran.
+- The full output, ideally with `-v` and/or `GH_DEBUG=api`.
+- Your `gh --version` and `go version`.
+- Your OS and shell.

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -31,7 +31,7 @@ At [classroom50.org](https://classroom50.org), sign in with GitHub using
 [OAuth 2](https://oauth.net/2/). Two options:
 
 - **Sign in with GitHub** — the standard browser flow.
-- **Use a device code** — a manual fallback: paste a code into a GitHub page,
+- **Use a device code** — a manual fallback. Paste a code into a GitHub page,
   and Classroom 50 detects when you've authorized it.
 
 ![Classroom 50 login flow](images/web_login_flow_student.png)

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -1,93 +1,102 @@
-# Classroom 50 Web - Student Guide
+# Web Student Guide
 
-Visit [classroom50.org](https://www.classroom50.org) to access the web interface.
+This guide walks you through using Classroom 50's web app at
+[classroom50.org](https://www.classroom50.org) as a student. Prefer the
+terminal? See the [CLI Student Guide](CLI-Student-Guide).
 
-# Introduction
+**The path:** join your classroom's organization → sign in → accept an
+assignment → do the work and submit → view your grade.
 
-This guide describes how to use Classroom 50 via its web interface at [classroom50.org](https://www.classroom50.org). Classroom 50 is also available as a [command-line tool](/CLI-Student-Guide.md).
+> [!TIP]
+> Have feedback, a bug, or an idea? Reach out in our
+> [discussions](https://github.com/foundation50/classroom50/discussions).
 
-This guide will cover the following topics, roughly in the order a student is likely to encounter them when joining a classroom in Classroom 50:
+## Before you start
 
-- [GitHub Setup](#github-setup)
-- [Joining Your Classroom](#joining-your-classroom)
-- [Logging Into Classroom 50](#logging-into-classroom-50)
-- [Viewing Organizations](#viewing-organizations)
-- [Accepting Assignments](#accepting-assignments)
-- [Submitting Assignments](#submitting-assignments)
-- [Group Assignments](#group-assignments)
-- [Viewing Submissions](#viewing-submissions)
+You need a [GitHub account](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github).
+Classroom 50 runs entirely on GitHub.
 
-> As you use Classroom 50, if you have feature requests, discover bugs, or would like to suggest ideas for improvements, please reach out to us in our [discussion forums](https://github.com/foundation50/classroom50/discussions); we look forward to hearing from you!
+## Join your classroom
 
-# GitHub Setup
+Your classroom belongs to a [GitHub organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/about-organizations).
+When your teacher invites you, GitHub emails you a link to join.
 
-Classroom 50 is built entirely atop GitHub's existing infrastructure; as a result, in order to use Classroom 50 for your classrooms and assignments, [you will need a GitHub account first](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github).
+**Accept that invitation before signing in to Classroom 50.**
 
-# Joining Your Classroom
+## Sign in
 
-Before you can view and accept assignments for your classroom, you will need to be invited to the [GitHub organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/about-organizations) to which your classroom belongs.
+![Classroom 50 login screen](images/web_login_screen.png)
 
-When your teacher invites you to the organization, you'll receive an email from GitHub with a link to accept the invitation. Accept the invitation before logging into Classroom 50.
+At [classroom50.org](https://classroom50.org), sign in with GitHub using
+[OAuth 2](https://oauth.net/2/). Two options:
 
-# Logging into Classroom 50
+- **Sign in with GitHub** — the standard browser flow.
+- **Use a device code** — a manual fallback: paste a code into a GitHub page,
+  and Classroom 50 detects when you've authorized it.
 
-![Classroom 50 Login Screen](images/web_login_screen.png)
+![Classroom 50 login flow](images/web_login_flow_student.png)
 
-When visiting [https://classroom50.org](https://classroom50.org), you'll be prompted with a login screen.
+## View your organizations
 
-Classroom 50 uses your GitHub credentials to establish a connection to GitHub using [OAuth 2](https://oauth.net/2/). You have two options for how to sign in:
+![Organizations view](images/web_organizations_student.png)
 
-- **Sign in with GitHub**: This is a standard OAuth flow that will use your web browser to ask GitHub for permission to perform tasks on your behalf and then redirect back to the Classroom 50 app.
-- **Use a device code instead**: This is a more manual process that can act as a fallback; it requires you to copy and paste an authentication code into a page on GitHub's website that then triggers a similar OAuth permissions authorization. Once complete, Classroom 50 will poll to verify that it's been completed.
+After signing in, find the organization for your classroom — it has a
+**Student** label. Open it to see the assignments you have access to.
 
-![Picture of Classroom 50 login flow](images/web_login_flow_student.png)
+![No assignments yet](images/web_assignments_none_student.png)
 
-# Viewing Organizations
+## Accept an assignment
 
-![Organizations view of Classroom 50](images/web_organizations_student.png)
+When your teacher shares an assignment link, open it and accept on a page like
+this:
 
-After logging in, you'll see a list of GitHub organizations. Look for the organization that corresponds to the classroom you're joining and that has a "Student" label beneath it.
+![Accepting an assignment](images/web_accept_assignment_student.png)
 
-Clicking on any organization will then show you your list of assignments across the organization's classrooms to which you have access and have accepted.
+Accepting creates a GitHub repository for you, named after the classroom, the
+assignment, and your username — for example,
+`introduction-to-computer-science-hello-assignment-username`.
 
-![View of student assignment page with no assignments](images/web_assignments_none_student.png)
+Afterward, your organization page lists the assignment repository you now own:
 
-# Accepting Assignments
+![One assignment](images/web_assignments_student.png)
 
-When your teacher gives you a new assignment, you'll be sent a link to accept the assignment. When you visit the link, you can then accept the assignment on a page like the one below.
+## Submit your work
 
-![View of accepting an assignment as a student](images/web_accept_assignment_student.png)
+You submit by [committing](https://github.com/git-guides/git-commit) and
+[pushing](https://github.com/git-guides/git-push) to the repository you got when
+you accepted. Using the CLI instead? See
+[Submit in the CLI Student Guide](https://github.com/foundation50/classroom50/wiki/CLI-Student-Guide#4-submit).
 
-Once you've accepted the assignment, a GitHub repository will be created for you within the organization that's named after your classroom, the assignment, and your username, e.g., `introduction-to-computer-science-hello-assignment-username`.
+## Group assignments
 
-After accepting an assignment, visiting your organization page again will show you at least one assignment/repository you now have created and have access to:
+Some assignments are done in a group. When accepting, you'll see the assignment
+tagged **Individual** or **Group**.
 
-![View of student assignment page with one assignment](images/web_assignments_student.png)
+For a group assignment:
 
-# Submitting Assignments
+1. **One teammate accepts** and creates the shared repository.
+2. **That teammate adds the others** as collaborators.
 
-Because Classroom 50 is built atop GitHub, the process for assignment submission uses GitHub as well. Submitting involves [committing](https://github.com/git-guides/git-commit) and [pushing](https://github.com/git-guides/git-push) changes to the repository you created when accepting your assignment. If you're using the Classroom 50 CLI, [see the instructions here](https://github.com/foundation50/classroom50/wiki/CLI-Student-Guide#4-submit) for further details on how to submit your assignments.
+To add collaborators, click the edit pencil at the top-right of a group
+assignment:
 
-# Group Assignments
+![Group assignment page](images/web_assignment_edit_student.png)
 
-On some assignments, you may be allowed to work in a group rather than individually. When accepting an assignment, you will see it tagged as either "Individual" or "Group" when doing so.
+Then click **Manage collaborators**:
 
-In the group assignment case, one student in your group should accept the assignment and the other students can be added as collaborators by the student who created the repository.
+![Manage collaborators](images/web_assignment_manage_collaborators_student.png)
 
-To access the interface for adding collaborators, first click the edit pencil at the top-right of a group assignment, which will take you to the following page:
+> [!NOTE]
+> Collaborators must be members of the organization and enrolled in the
+> classroom.
 
-![View of group assignment page for student](images/web_assignment_edit_student.png)
+## View your submissions
 
-Then, click the "Manage collaborators" button for the assignment to be taken to the following interface, where you can then add collaborators to your project (note that they must be members of the organization and enrolled in the classroom for this to work):
+Open the assignment and click **My submission** in the left menu:
 
-![View of managing collaborators for student](images/web_assignment_manage_collaborators_student.png)
+![Assignment submission](images/web_assignment_submission_student.png)
 
-# Viewing Submissions
+If your teacher configured autograding, click **View grade** to see your results
+on GitHub:
 
-On the assignment page, it's also possible to view your submissions thus far. Click the "My Submission" link in the left menu to see them. Assuming you've submitted at least once, you should see something like this:
-
-![View of assignment submission for student](images/web_assignment_submission_student.png)
-
-Classroom 50 is set up to run autograding for assignments by default. If your teacher has autograding configured for your assignment, clicking on "View grade" will take you to a page on GitHub where you can view the results for your submission.
-
-![View of assignment submission on GitHub](images/web_assignment_github_release_student.png)
+![Submission on GitHub](images/web_assignment_github_release_student.png)

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -14,7 +14,7 @@ collect submissions.
 
 ## Before you start: GitHub setup
 
-Classroom 50 stores everything in GitHub — there are no Classroom 50 servers.
+Classroom 50 stores its state in GitHub; there are no Classroom 50 servers.
 Your classroom data lives in a [GitHub organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/about-organizations),
 and rosters and submissions live in a repository inside it.
 
@@ -36,7 +36,7 @@ At [classroom50.org](https://classroom50.org), sign in with GitHub using
 [OAuth 2](https://oauth.net/2/). Two options:
 
 - **Sign in with GitHub** — the standard browser flow.
-- **Use a device code** — a manual fallback: paste a code into a GitHub page,
+- **Use a device code** — a manual fallback. Paste a code into a GitHub page,
   and Classroom 50 detects when you've authorized it.
 
 When authorizing, grant access to any organization you'll use with Classroom 50.
@@ -53,9 +53,9 @@ After signing in, you'll see the organizations you can use. Each shows a status:
 
 | Status | Meaning |
 | --- | --- |
-| **Ready** | Set up and ready — click **Open**. |
-| **Needs service token** | Set up, but needs a service token before score collection works — click **Complete Setup**. |
-| **Uninitialized** | Not set up yet — appears under "Set up new organization". |
+| **Ready** | Set up and ready. Use **Open**. |
+| **Needs service token** | Set up, but a service token is still required before score collection works. |
+| **Uninitialized** | Not set up yet. Appears under "Set up new organization". |
 
 Don't see your organization? Grant it access in Classroom 50's
 [OAuth settings](https://github.com/settings/connections/applications).
@@ -64,7 +64,7 @@ Don't see your organization? Grant it access in Classroom 50's
 
 ![Setup steps](images/web_setup.png)
 
-Click **Setup** on an uninitialized organization, then **Run setup**. This
+Click **Set up** on an uninitialized organization, then **Run setup**. This
 configures your organization's settings and creates a `classroom50` config
 repository to hold Classroom 50's state.
 
@@ -105,8 +105,9 @@ On **My classrooms**, click **Create classroom**:
 
 ![Unlisted links toggle](images/web_create_classroom_hash.png)
 
-**Unlisted links** (optional) publish this classroom's assignment data at an
-unguessable URL instead of a predictable one based on the slug.
+**Use an unlisted link for this classroom** (optional) publishes this
+classroom's assignment data at an unguessable URL instead of a predictable one
+based on the slug.
 
 > [!WARNING]
 > Unlisted links are obscurity, not access control. The files are still public;
@@ -133,8 +134,8 @@ On the classroom page, click **+ Assignment**. Fill in:
   used as each student's starting point. Enter `<owner>/<repo>`, or just
   `<repo>` if it's in this organization. Leave blank for an empty starter repo.
 - **Due date** (optional) — a date and time in your local timezone.
-- **Assignment type** — **Individual** (one repository per student) or **Group**
-  (students share a repository and submit together).
+- **Assignment type** — **Individual** (one repository per student) or **Group
+  project** (students share a repository and submit together).
 - **Feedback pull request** — automatically opens a pull request per student so
   you can review changes and leave inline feedback.
 - **Empty repository** — creates each student's repository completely empty: no
@@ -171,7 +172,7 @@ Optional settings for customizing the autograding environment:
 
 ### Autograding tests
 
-Autograding tests run every time a student pushes. Click **+ Add Test** to add
+Autograding tests run every time a student pushes. Click **Add test** to add
 one.
 
 ![Autograding tests](images/web_create_assignment_tests.png)
@@ -207,7 +208,7 @@ fields.
 
 ![Python pytest test](images/web_create_assignment_tests_python_pytest.png)
 
-When you're done, click **Create Assignment**.
+When you're done, click **Create assignment**.
 
 ![Classroom with one assignment](images/web_classroom_with_assignment.png)
 
@@ -225,7 +226,7 @@ GitHub organization.
 > Students must accept the organization invitation before they can work on
 > assignments.
 
-**Add a student** — add one student by GitHub username (name and email
+**Add member** — add one student by GitHub username (name and email
 optional). You can enter an email instead of a username; that student then
 completes a separate onboarding process (see below).
 
@@ -284,7 +285,7 @@ CSV for a spreadsheet or external tool.
 
 ## Edit assignments and classrooms
 
-- **Edit an assignment** — open the assignment, then **Assignment Settings**.
+- **Edit an assignment** — open the assignment, then **Assignment settings**.
   Same form as creating one, pre-filled.
 - **Edit a classroom** — open the classroom, then **Settings**. Same form as
   creating one, pre-filled.

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -1,238 +1,290 @@
-# Classroom 50 Web - Teacher Guide
+# Web Teacher Guide
 
-Visit [classroom50.org](https://www.classroom50.org) to access the web interface.
+This guide walks you through Classroom 50's web app at
+[classroom50.org](https://www.classroom50.org), in the order you'll use it to
+run a course. Prefer the terminal? See the [CLI Teacher Guide](CLI-Teacher-Guide).
 
-# Introduction
+**The path:** set up a GitHub organization → sign in → run one-time setup →
+create a classroom → create assignments → add students → share accept links →
+collect submissions.
 
-This guide describes how to use Classroom 50 via its web interface at [classroom50.org](https://www.classroom50.org). Classroom 50 is also available as a [command-line tool](/CLI-Teacher-Guide.md).
+> [!TIP]
+> Have feedback, a bug, or an idea? Reach out in our
+> [discussions](https://github.com/foundation50/classroom50/discussions).
 
-This guide will cover the following topics, roughly in the order a teacher is likely to encounter them when managing a class with Classroom 50:
+## Before you start: GitHub setup
 
-- [GitHub Setup](#github-setup)
-- [Logging Into Classroom 50](#logging-into-classroom-50)
-- [Viewing Organizations](#viewing-organizations)
-- [Setting Up Classroom 50](#setting-up-classroom-50)
-- [Viewing and Creating Classrooms](#viewing-and-creating-classrooms)
-- [Creating an Assignment](#creating-an-assignment)
-- [Viewing and Adding Students](#viewing-and-adding-students)
-- [Viewing and Collecting Submissions](#viewing-and-collecting-submissions)
-- [Editing Assignments and Classrooms](#editing-assignments-and-classrooms)
+Classroom 50 stores everything in GitHub — there are no Classroom 50 servers.
+Your classroom data lives in a [GitHub organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/about-organizations),
+and rosters and submissions live in a repository inside it.
 
-> As you use Classroom 50, if you have feature requests, discover bugs, or would like to suggest ideas for improvements, please reach out to us in our [discussion forums](https://github.com/foundation50/classroom50/discussions); we look forward to hearing from you!
+You need:
 
-# GitHub Setup
+1. A [GitHub account](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github).
+2. A GitHub organization on the **Team** or **Enterprise** plan. Classroom 50
+   relies on Team-plan features like GitHub Pages and branch protection.
 
-Classroom 50 is built entirely atop GitHub's existing infrastructure, with no Classroom 50-owned servers storing your data. As a result, teachers can access all of their classroom data via GitHub: classrooms store data in GitHub organizations, and student rosters and submission data are stored in a specially-marked repository within your organization.
+> [!NOTE]
+> Verified educators can get Team-tier organizations **free** through
+> [GitHub Education](https://docs.github.com/en/education/about-github-education/github-education-for-teachers/apply-to-github-education-as-a-teacher).
 
-## Organizations
+## Sign in
 
-At the core of Classroom 50 is a [GitHub organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/about-organizations) that acts as a container for everything Classroom 50 needs to function. Once you have a [GitHub account](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github), you will also need to create an organization that is on a Team or Enterprise plan.
+![Classroom 50 login screen](images/web_login_screen.png)
 
-### Team/Enterprise
+At [classroom50.org](https://classroom50.org), sign in with GitHub using
+[OAuth 2](https://oauth.net/2/). Two options:
 
-For Classroom 50 to work properly, a [Team](https://docs.github.com/en/get-started/learning-about-github/githubs-plans#github-team) or [Enterprise](https://docs.github.com/en/get-started/learning-about-github/githubs-plans#github-enterprise) tier of organization is required. Classroom 50 uses Team plan features like GitHub Pages and branch protection to ensure that students' accounts have access to the data they need while also securing Classroom 50 against potential accidents or misuse.
+- **Sign in with GitHub** — the standard browser flow.
+- **Use a device code** — a manual fallback: paste a code into a GitHub page,
+  and Classroom 50 detects when you've authorized it.
 
-> **Note that verified educators can apply to receive Team-tier organizations for free through GitHub Education**; see the information and steps [here](https://docs.github.com/en/education/about-github-education/github-education-for-teachers/apply-to-github-education-as-a-teacher) to get started if this applies to you!
+When authorizing, grant access to any organization you'll use with Classroom 50.
+If you don't own the organization, you may need to request access and have an
+owner approve it in the organization's OAuth settings.
 
-Once you've created a GitHub organization on the Team plan, you're all set to begin using Classroom 50!
+![Classroom 50 login flow](images/web_login_flow.png)
 
-## Logging into Classroom 50
+## View your organizations
 
-![Classroom 50 Login Screen](images/web_login_screen.png)
+![Organizations view](images/web_organizations.png)
 
-When visiting [https://classroom50.org](https://classroom50.org), you'll be prompted with a login screen.
+After signing in, you'll see the organizations you can use. Each shows a status:
 
-Classroom 50 uses your GitHub credentials to establish a connection to GitHub using [OAuth 2](https://oauth.net/2/). You have two options for how to sign in:
+| Status | Meaning |
+| --- | --- |
+| **Ready** | Set up and ready — click **Open**. |
+| **Needs service token** | Set up, but needs a service token before score collection works — click **Complete Setup**. |
+| **Uninitialized** | Not set up yet — appears under "Set up new organization". |
 
-- **Sign in with GitHub**: This is a standard OAuth flow that will use your web browser to ask GitHub for permission to perform tasks on your behalf and then redirect back to the Classroom 50 app.
-- **Use a device code instead**: This is a more manual process that can act as a fallback; it requires you to copy and paste an authentication code into a page on GitHub's website that then triggers a similar OAuth permissions authorization. Once complete, Classroom 50 will poll to verify that it's been completed.
+Don't see your organization? Grant it access in Classroom 50's
+[OAuth settings](https://github.com/settings/connections/applications).
 
-When authorizing with GitHub, ensure that any organizations you would like to use with Classroom 50 are given permission here. If you are the organization owner, you can allow access to the organization as part of the confirmation on GitHub's OAuth login screen; if you are not the organization owner, you may need to "Request" access and then have an owner grant access through the organization's OAuth settings.
+## Set up an organization (one-time)
 
-![Picture of Classroom 50 login flow](images/web_login_flow.png)
+![Setup steps](images/web_setup.png)
 
-# Viewing Organizations
+Click **Setup** on an uninitialized organization, then **Run setup**. This
+configures your organization's settings and creates a `classroom50` config
+repository to hold Classroom 50's state.
 
-![Organizations view of Classroom 50](images/web_organizations.png)
+When step 1 is complete, continue to step 2 to add your service token.
 
-After logging in, you'll see a list of organizations you can use with Classroom 50. An organization can be in one of the following states:
+### Add a service token
 
-- **Ready**: The organization is configured to use with Classroom 50. An "Open" button is available to access the classroom.
-- **Needs service token**: The organization needs a service token to be configured by clicking "Complete Setup" for score collection to work correctly.
-- **Uninitialized**: The organization shows up in the "Set Up New Classroom 50 Organization" section and can be used to begin Classroom 50 setup.
+The **service token** is a fine-grained personal access token (PAT) with read
+access to your organization's repositories. Classroom 50 stores it as the
+`CLASSROOM50_SERVICE_TOKEN` secret in your config repo, where the daily
+score-collection workflow uses it.
 
-If your GitHub organization is not shown on this page, edit Classroom 50's [OAuth access privileges](https://github.com/settings/connections/applications) to grant access to the organization.
+![Service token setup](images/web_pat.png)
 
-# Setting Up Classroom 50
+Classroom 50 sends you to GitHub to create the token, then you paste it back
+into the form to finish setup.
 
-![Overview of steps for Classroom 50 setup process](images/web_setup.png)
+## Create a classroom
 
-On the [organization listing](#viewing-organizations) page, click "Setup" on an uninitialized organization to see the setup process for that organization. Clicking "Run setup" will begin the automated setup process, which involves configuring organization settings and setting up a configuration repository for storing Classroom 50 state.
+![Classrooms in an organization](images/web_classes.png)
 
-Once the Step 1 checklist is complete, move on to Step 2, where you can set up your `classroom50` service token.
+Open a set-up organization from its card, or visit
+`https://classroom50.org/<ORG>`, to see its classrooms.
 
-## Personal Access Token
+> [!NOTE]
+> A **classroom** holds a group of students and their assignments. An
+> organization can have many classrooms — for example, one per class period or
+> term.
 
-Classroom 50 needs a service token, a fine-grained Personal Access Token (PAT) with read access to the repositories in your classroom’s GitHub organization. It is stored as the `CLASSROOM50_SERVICE_TOKEN` secret on your `classroom50` config repo. The service token is used once daily as part of the score-collection workflow.
+On **My classrooms**, click **Create classroom**:
 
-![Step 2 of the setup process, for setting a Personal Access Token](images/web_pat.png)
+![Create classroom form](images/web_create_classroom.png)
 
-Classroom 50's interface will direct you to GitHub to obtain a PAT, at which point you can paste it into the Classroom 50 input field and submit the form to complete Classroom 50 setup.
+- **Name** — the classroom's display name.
+- **Slug** — a unique identifier used in URLs and repository names.
+- **Term** (optional) — shown in various places to distinguish course
+  offerings.
 
-# Viewing and Creating Classrooms
+![Unlisted links toggle](images/web_create_classroom_hash.png)
 
-![View of classes within a setup organization](images/web_classes.png)
+**Unlisted links** (optional) publish this classroom's assignment data at an
+unguessable URL instead of a predictable one based on the slug.
 
-To view a configured Classroom 50 organization, click "Open" on its card on the homepage or visit a URL of the form `https://classroom50.org/<ORG>`. Once there, you will be able to view any of the classrooms you have set up within that organization.
+> [!WARNING]
+> Unlisted links are obscurity, not access control. The files are still public;
+> anyone with the link can read them.
 
-> In Classroom 50's model, a "classroom" encapsulates a collection of students and a set of assignments for those students. Organizations may contain multiple classrooms. For example, you might create a classroom for each class period you teach for each semester.
+After creating, you'll get a URL of the form
+`https://classroom50.org/<ORG>/<CLASSROOM>` to view your new classroom.
 
-## Creating a Classroom
+![Create classroom success](images/web_create_classroom_success.png)
 
-![View of the "+ Create classroom" form](images/web_create_classroom.png)
+> [!NOTE]
+> Behind the scenes, this adds a subdirectory to your `classroom50` repository
+> holding the classroom's roster and assignment list.
 
-Click "Create classroom" on the "My classrooms" page to create a new classroom. Each classroom needs a **name** and a **slug** (a unique identifier for the classroom). The **term** is optional but is displayed in various places and can help differentiate between different offerings of the same course.
+## Create an assignment
 
-![View of "unlisted links" toggle form in "+ Create classroom form"](images/web_create_classroom_hash.png)
+![Assignment form](images/web_create_assignment.png)
 
-The **unlisted links** feature adds a layer of obscurity to publicly published assignment data. Classroom 50 uses GitHub Pages to make certain files, such as assignment metadata, public so that students can access them without being organization owners. By default, the classroom slug is used in the URL, which might therefore be guessable. When this feature is enabled, links will still be published publicly but after a generated hash that is harder to guess.
+On the classroom page, click **+ Assignment**. Fill in:
 
-Once created, you'll see a message that provides you with a URL (of the form `https://classroom50.org/<ORG>/<CLASSROOM>`) that you can visit to view your newly created classroom.
+- **Name** — the assignment's name.
+- **Description** (optional) — details for students.
+- **Template repository** (optional) — a [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)
+  used as each student's starting point. Enter `<owner>/<repo>`, or just
+  `<repo>` if it's in this organization. Leave blank for an empty starter repo.
+- **Due date** (optional) — a date and time in your local timezone.
+- **Assignment type** — **Individual** (one repository per student) or **Group**
+  (students share a repository and submit together).
+- **Feedback pull request** — automatically opens a pull request per student so
+  you can review changes and leave inline feedback.
+- **Empty repository** — creates each student's repository completely empty: no
+  starter files, no autograding, no feedback pull request. Use it when students
+  build everything from scratch, including their own GitHub Actions.
 
-> Behind the scenes, the classroom creation process creates a new subdirectory in your `classroom50` repository that holds all classroom metadata, including the student roster and assignment list.
+> [!WARNING]
+> **Empty repository is permanent** — you can't change it after creating the
+> assignment, because repositories students already accepted can't be
+> retrofitted. Enabling it hides the template and grading fields.
 
-![Success alert after creating classroom](images/web_create_classroom_success.png)
+### Advanced settings
 
-## Viewing Classrooms
+Optional settings for customizing the autograding environment:
 
-![View of specific org classroom](images/web_classroom.png)
+- **GitHub runner** — the [runner](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners)
+  autograding runs on. `ubuntu-latest` is a good default.
+- **Docker image** — grade inside a custom Docker image. The runner must be an
+  Ubuntu variant, or Actions errors.
+- **Setup command** — a shell command run before grading (for example, to
+  compile C code with `gcc`).
+- **Allowed files** — a `.gitignore`-style list controlling which files are
+  considered during grading.
+- **Submission release files** — exact workspace-relative file paths (one per
+  line) to attach to each submission's Release after grading. Paths are not
+  globs; basenames must be unique and Release-safe. Missing or unsafe files are
+  skipped with a warning.
 
-Most of a teacher's time in Classroom 50 will be spent on the classroom pages, creating and configuring assignments as well as managing students and their submissions.
+> [!NOTE]
+> Existing organizations must refresh the shared skeleton before using
+> submission release files. Submission publishing doesn't support GitHub
+> Immutable Releases. See [Autograders](Autograders#attaching-files-to-submission-releases)
+> for path rules and limits.
 
-## Creating an Assignment
+### Autograding tests
 
-![View of "+ Assignment" form](images/web_create_assignment.png)
+Autograding tests run every time a student pushes. Click **+ Add Test** to add
+one.
 
-Click the "+ Assignment" button on the classroom page to create a new assignment. You'll be prompted to provide information about the assignment, including:
+![Autograding tests](images/web_create_assignment_tests.png)
 
-- **Name**: An identifier for your assignment.
-- **Description**: Optional additional text describing the assignment.
-- **Template Repository**: Assignments don't need a template, but you can optionally provide [a template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository) that will be used as the starting point for students' assignment repositories. If you want your assignment to use a template, specify it here either via `<owner>/<repo>` or just `<repo>` if the template repository is located in the classroom's GitHub organization.
-- **Due Date**: A specific date and time at which the assignment is due in your local timezone.
-- **Assignment Type**: Students may submit either **Individual** or **Group** assignments. In individual assignments, each repository belongs to only one student; in group assignments, students can collaborate on the same repository and submit their work together.
-- - **Feedback pull request**: This feature creates a pull request (PR) automatically for students when they submit, in order to provide a clean and flexible way for teachers to view a student's changes and provide feedback on their work.
-- **Empty repository**: Creates each student's repository completely empty — no starter files, no autograding setup, no feedback pull request. Use this for assignments where students build everything from scratch, including their own GitHub Actions workflows (which would otherwise conflict with the autograding setup). Because the repositories carry no grading machinery, autograding, scores, and the feedback PR are disabled for the assignment, and the submissions page shows who accepted rather than grades. **This choice is permanent**: it can't be toggled after the assignment is created, since repositories students have already accepted can't be retrofitted. Enabling it hides the template, autograding-test, and grading-related fields.
+Each test has:
 
-### Creating an Assignment - Advanced Settings
+- **Test name** — shown to students to indicate what passed or failed.
+- **Test type** — Input/Output, Run command, or Python (pytest).
+- **Setup command** — an optional command run before the test.
+- **Run command** — the command the runner executes.
+- **Timeout (seconds)** — how long to wait before terminating the test.
+- **Points** — the test's weight.
 
-For teachers seeking more technical customization of their autograding workflows, the assignment creation form has a section dedicated to advanced settings. These advanced settings include:
+The three test types add their own fields:
 
-- **GitHub Runner**: [GitHub Actions](https://github.com/features/actions) autograding workflows run with [GitHub Runners](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners), essentially virtual machines that act as the environment within which the workflows execute. For most use cases, `ubuntu-latest` is a reasonable default, but you can customize the runner used for your assignment here.
-- **Docker Image**: This field allows specifying a custom Docker image in which autograding checks are run. Note that when using this override, the Runner **must** be an Ubuntu variant, otherwise Actions will trigger an error.
-- **Setup Command**: In cases where an assignment needs some setup work before autograding can actually be processed (e.g., to compile some C code using `gcc`), specify a shell command here that runs before autograding begins.
-- **Allowed files**: To prevent certain files from being included for consideration during the autograding process, this serves as a `.gitignore`-style list of files or patterns that teachers can use to include only certain files.
-- **Submission release files**: Enter one exact workspace-relative file path per line. The workflow collects these files after grading and uploads them to the submission Release under their basenames. Paths are not globs, and basenames must be unique and Release-safe. Missing or unsafe files produce warnings without changing the grade or suppressing `result.json`.
+**Input/Output** — provide input and check the output.
 
-Existing organizations must refresh the shared skeleton before using this field. Submission publishing does not support GitHub Immutable Releases. See [Attaching generated files to submission Releases](Autograders#attaching-generated-files-to-submission-releases) for path rules, limits, rollout, and rerun behavior.
+![Input/Output test](images/web_create_assignment_tests.png)
 
-### Creating an Assignment - Autograding Tests
+- **Input (stdin)** — text sent to standard input.
+- **Expected output** — text to check for in standard output.
+- **Comparison** — **Included** (expected appears somewhere in the output),
+  **Exact** (output equals expected), or **Regex** (output matches a pattern).
 
-Each assignment can have autograding tests associated with it. These tests run every time a student pushes to their repository. Click "+ Add Test" to configure a new test for the assignment.
+**Run command** — pass when a command returns a given exit code.
 
-![View of Autograding Tests view for "+ Assignment" form](images/web_create_assignment_tests.png)
+![Run command test](images/web_create_assignment_tests_run_command.png)
 
-When adding a new test, you'll be prompted to specify:
+- **Required exit code** — the exit code needed to pass.
 
-- **Test Name**: A name or description for the test, used to indicate to students what passed or failed.
-- **Test Type**: One of three variant types of tests with their own expected input and output shapes.
-- **Setup Command**: An initial command to run within the autograder prior to the test itself executing.
-- **Run Command**: The actual command the runner should invoke in order to run the test.
-- **Timeout (seconds)**: How long the test should wait before terminating early in the event an expected response is not detected when running the test.
-- **Points**: The number of points the test is worth, used to weight some tests as more important than others.
+**Python (pytest)** — runs `pytest` against test files in the template. No extra
+fields.
 
-Additionally, each of the variants within the "Test Type" field ("Input/Output", "Run command", and "Python (pytest)") each have their own set of conditionally available fields.
+![Python pytest test](images/web_create_assignment_tests_python_pytest.png)
 
-#### Autograding Tests - Input/Output
+When you're done, click **Create Assignment**.
 
-![View of Autograding Tests view for "+ Assignment" form, Input/Output variant](images/web_create_assignment_tests.png)
+![Classroom with one assignment](images/web_classroom_with_assignment.png)
 
-This test variant is for providing input to a student's program and expecting output of a particular form.
+## Add students
 
-- **Input (stdin)**: Value sent to standard input during the test execution.
-- **Expected Output**: Value to check for in standard output during the test execution.
-- **Comparison**: The type of comparison that should be performed to determine correctness; options are "Included" (meaning the expected result is _somewhere_ within the output), "Exact" (meaning output and the expected result are identical), and "Regex" (meaning a regular expression can be specified if seeking output that matches a particular pattern).
+Students must be on the classroom roster before they can accept assignments.
 
-#### Autograding Tests - Run command
+![Students page, empty](images/web_students_none.png)
 
-This test variant is for cases where running a command (e.g. running student's code with particular arguments) is expected to return a particular exit code.
+On a classroom's **Students** page, add students and see who has joined and who
+has a pending invitation. Adding a student sends them an invitation to join your
+GitHub organization.
 
-![View of Autograding Tests view for "+ Assignment" form, Run command variant](images/web_create_assignment_tests_run_command.png)
+> [!IMPORTANT]
+> Students must accept the organization invitation before they can work on
+> assignments.
 
-- **Required Exit Code**: The exit code that should be returned for the student to receive credit for the test.
+**Add a student** — add one student by GitHub username (name and email
+optional). You can enter an email instead of a username; that student then
+completes a separate onboarding process (see below).
 
-#### Autograding Tests - Python (pytest)
+**Upload roster** — bulk-add students from a CSV or text file of GitHub
+usernames.
 
-This test variant does not provide any customizable fields but instead assumes a Python-based testing environment with `pytest` (a Python testing library) installed and running a set of test files with it.
+**Enrolled students** — the students already in this classroom. Classroom 50
+gives you two shareable links: one to accept the organization invite, and one to
+onboard students added by email. Below the links, each student's status shows
+whether they've joined the organization.
 
-![View of Autograding Tests view for "+ Assignment" form, Python (pytest) variant](images/web_create_assignment_tests_python_pytest.png)
+## Collect submissions
 
-Once you are ready with your assignment definition, including any advanced settings and tests, click "Create Assignment" at the bottom of the screen to confirm creation of the assignment.
+![Assignment with no submissions](images/web_viewing_assignment.png)
 
-![View of classroom page with one assignment](images/web_classroom_with_assignment.png)
+Once an assignment exists, share its accept link with students: expand the
+**How students accept** panel and copy the URL. When a student opens it, they're
+taken to the accept page:
 
-# Viewing and Adding Students
+![Accepting an assignment](images/web_accept_assignment.png)
 
-In order for students to accept an assignment, they need to be added to the classroom's roster first.
+Accepting creates a repository named `<CLASSROOM>-<ASSIGNMENT>-<USERNAME>`.
+Pushing to it triggers autograding, which builds a Release containing a
+`result.json` file. The score-collection workflow (which runs daily, or on
+demand) aggregates those results into the classroom's gradebook.
 
-![View of Students page with no students](images/web_students_none.png)
+![Accept success](images/web_accept_assignment_success.png)
 
-On the "Students" page within each classroom, you can add students to your classroom roster for that classroom, as well as see which students have already been added and which students still have pending invitations. When students are added to the roster, they will be sent an invitation to join your GitHub organization. Students **must accept the invitation in order to start work on assignments in the classroom**.
+### View submissions
 
-### Add Student
+![Assignment with submissions](images/web_viewing_assignment_submissions.png)
 
-The **Add Student** panel in the top left allows for adding a student via their GitHub username; their name and email may also be optionally provided. An email can be provided in place of a GitHub username, in which case that user will have to complete a separate onboarding process (see [below](#enrolled-students) for further information).
+Collect scores by letting the nightly workflow run, or click **Collect now** at
+the top of the submissions page. Click **View workflow** to see the Actions run.
 
-### Upload Roster
+The top of the page shows:
 
-If you already have a CSV or text file prepared with all of the GitHub usernames of your students, this provides you with a bulk option for adding many students at once.
+- **Submitted** — submissions vs. students enrolled.
+- **Classroom average** — average grade among students who submitted.
+- **Passing** — how many students are passing vs. failing.
+- **Accepted** — how many students accepted (one per student).
 
-### Enrolled Students
+> [!TIP]
+> For larger classes, use the search box, filters ("Submitted", "On time",
+> passing/failing, "Accepted"), and sorting (by name or submission date).
 
-This is a list of all of your students already added to this classroom. As a convenience, Classroom 50 adds shareable links for teachers to provide their students: one to easily accept their organization invite, the other to onboard students in the event they've been added by email rather than by username. Below these links you can see all students in the classroom, along with their status of whether they've successfully joined the classroom's GitHub organization.
+Each row shows a student's (or group's) latest submission plus its full history
+(newest first). For each submission you can view the score, the submission date,
+and links to the repository, the commit, the feedback pull request
+(**Review**), and the Release (**Details**).
 
-# Viewing and Collecting Submissions
+### Download scores
 
-![View of existing assignment with no submissions](images/web_viewing_assignment.png)
+Click **Download Scores (CSV)** at the top right to export all submissions as a
+CSV for a spreadsheet or external tool.
 
-In the screenshot above, we can see that as a teacher, once you've created an assignment, you'll be able to send students a link via which they can accept the submission, at which point they will be able to then submit to it and trigger a workflow that will build a release and thereafter include any such scores as part of the score collection workflow for teachers. You need simply uncollapse the "How students accept" panel and copy the URL via its right-hand copy button, after which you can then paste to students. Should a student visit said URL, they will be taken to the following page to trigger the assignment acceptance process:
+## Edit assignments and classrooms
 
-![View of accepting an assignment as a student](images/web_accept_assignment.png)
-
-Once your student has accepted the assignment, they will be given a repo named `<CLASSROOM>-<ASSIGNMENT>-<USERNAME>` to which they can then submit their assignment through either the CLI or by committing directly. Submitting an assignment in this way will trigger an autograding workflow that ultimately produces a relase for this repository with a `result.json` file, which the score collection workflow that teachers can choose to run manually (the default for which is an automatic run daily) will aggregate into a `scores.json` file within the `classroom50/<CLASSROOM>` classroom folder.
-
-![View of assignment acceptance success](images/web_accept_assignment_success.png)
-
-## Viewing Submissions
-
-Assuming you have students who have accepted the assignment, the next important puzzle piece is aggregating the submissions themselves. Scores are aggregated together rather than being done per individual student submission; teachers can choose to just allow the default nightly collection workflow to trigger, or they can trigger a manual workflow run for submission collection at any time by clicking "Collect now" at the top of the [submissions page](#viewing-and-collecting-submissions); additionally, teachers can click "View workflow" if they're interested in seeing the Actions run of the workflow in more detail. The following shows an example of what actual submissions for the assignment might look like:
-
-![View of existing assignment page with some submissions](images/web_viewing_assignment_submissions.png)
-
-As you can see, we have a few important pieces of data we can now view:
-
-- **Submitted**: The number of submissions / the number of students enrolled in the classroom.
-- **Classroom Average**: The average grade of the students who have submitted thus far.
-- **Passing**: The number of students who are passing the assignment, as well as the number who are failing.
-- **Accepted**: The number of submissions that have been accepted (one per student).
-
-> For larger classes, Classroom 50 offers some useful sorting and filtering options just below, including a search box; a series of semantic filters such as "Submitted", "On Time", and more; a filter for passing or failing grades, and a filter for "Accepted" versus "Not accepted". In addition, there are options available for sorting, such as by alphabetical order or submission date.
-
-Each submission row itself contains not only the most recent submission for the student (or group) submitting, but also an itemized list of all submissions in total in case viewing said history is useful (by default sorted by most recent, reverse chronological order). The score is of course shown, as well as the date submitted, and buttons to view the repository itself, commit for the submission, Pull Request (or "Review"), and the release created for the submission (or "Details").
-
-### Downloading Scores
-
-For teachers interested in downloading all submissions as once, the top-right **Download Scores (CSV)** button allows for an easy one-click option to gather all submissions into a comma-separated list for processing in external programs or importing into Excel or Google Sheets.
-
-# Editing Assignments and Classrooms
-
-As shown on the lefthand drawer menu in the screenshot above, there's an option when viewing an assignment to visit "Assignment Settings"; clicking this will open the same form used when [creating an assignment](#creating-an-assignment), though with all fields pre-populated with the pre-existing data for the assignment. Similarly, one can edit classrooms themselves by clicking the "Settings" button in the lefthand drawer when viewing a classroom, which will take them to the [form for creating a classroom](#creating-a-classroom), with the data similarly pre-filled.
+- **Edit an assignment** — open the assignment, then **Assignment Settings**.
+  Same form as creating one, pre-filled.
+- **Edit a classroom** — open the classroom, then **Settings**. Same form as
+  creating one, pre-filled.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,5 +1,7 @@
 - [Home](Home)
+- [How Classroom 50 Works](How-Classroom-50-Works)
 - [Glossary](Glossary)
+- [FAQ](FAQ)
 - **Web app**
   - [Web Teacher Guide](Web-Teacher-Guide)
   - [Web Student Guide](Web-Student-Guide)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,8 +1,9 @@
 - [Home](Home)
-- **Web Interface**
+- [Glossary](Glossary)
+- **Web app**
   - [Web Teacher Guide](Web-Teacher-Guide)
   - [Web Student Guide](Web-Student-Guide)
-- **Command-Line Interface**
+- **Command line**
   - [Installation](Installation)
   - [CLI Teacher Guide](CLI-Teacher-Guide)
   - [CLI Student Guide](CLI-Student-Guide)

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -11,7 +11,7 @@ with a non-zero exit code. Pass `--verbose` / `-v` for per-step detail.
 | Command | Description |
 | --- | --- |
 | `whoami` | Print the authenticated GitHub user. |
-| `login` | Log in with the scopes needed to accept assignments (`read:org`, `repo`, `workflow`). |
+| `login` | Log in with the unified Classroom 50 scopes (`admin:org`, `read:org`, `repo`, `workflow`) — the same set `gh teacher login` requests, so one sign-in covers both. A student only exercises `read:org`, `repo`, and `workflow`. |
 | `logout` | Log out via `gh auth logout`. |
 | `accept <org> <classroom> <assignment>` | Accept an assignment: auto-accept the org invite, create your private repo, and set up autograding. |
 | `invite <org>/<repo> <username>` | Invite a classmate or TA to your repo with `push` permission. |
@@ -115,8 +115,8 @@ override the default identity.
 ## `whoami` / `login` / `logout`
 
 - `whoami` — prints the authenticated GitHub user.
-- `login` — runs `gh auth login -s read:org -s repo -s workflow`; add scopes with
-  `-s`.
+- `login` — runs `gh auth login -s admin:org -s read:org -s repo -s workflow`
+  (the unified scope set, shared with `gh teacher login`); add scopes with `-s`.
 - `logout` — runs `gh auth logout`.
 
 ## Contributing

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -40,12 +40,12 @@ a `git clone` command.
 4. Creates the repo — from the template, an empty `auto_init` repo, or (for an
    `empty_repo` assignment) a truly bare repo with steps 3 and 7 skipped.
 5. Disables issues, projects, and wiki.
-6. Keeps you as an `admin` collaborator (so a group founder can invite
-   teammates; the org lockdown removes the org-wide danger of repo-admin).
+6. Sets your repo role: `push` for an individual assignment, or `admin` for a
+   group assignment (so a group founder can invite teammates).
 7. Commits `.classroom50.yaml` and `.github/workflows/autograde.yaml` in one
    commit. The metadata records the classroom, assignment, and (when present)
-   the template repo, which `gh student submit` re-fetches `.gitignore` and
-   `.github/` from.
+   the template repo. `gh student submit` re-fetches `.gitignore` and `.github/`
+   from that template.
 8. Prints the `git clone` command.
 
 </details>
@@ -80,7 +80,8 @@ Run from inside a cloned assignment repo:
 gh student submit
 ```
 
-Snapshots your current working tree and pushes it as a new commit on the repo's
+Snapshots your submittable files (tracked, plus untracked files that aren't
+ignored) and pushes them as a new commit on the repo's
 default branch. The autograde workflow then tags the commit
 `submit/<UTC-timestamp>-<short-sha>`, grades it, and publishes a scored Release a
 minute or two later.
@@ -108,7 +109,7 @@ override the default identity.
 
 > [!NOTE]
 > **Feedback PR timing.** If your teacher enabled feedback, one long-lived
-> Feedback pull request appears on your **first submission that adds work** — not
+> Feedback pull request appears on your **first submission that adds work**, not
 > at accept time (GitHub can't open a PR with no changes). The one PR is reused
 > for every later submission.
 

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -1,99 +1,125 @@
 # `gh student` reference
 
-Complete reference for the student CLI. For a step-by-step walkthrough, see the [CLI Student Guide](CLI-Student-Guide).
+Every command and flag for the student CLI. For a walkthrough, see the
+[CLI Student Guide](CLI-Student-Guide).
 
-Run `gh student <command> --help` for the live flag list. Errors always go to stderr with a non-zero exit code. Pass `--verbose` / `-v` to any command to see per-step operational details (repo creation, collaborator updates, metadata writes, `git` activity).
+Run `gh student <command> --help` for the live flag list. Errors go to stderr
+with a non-zero exit code. Pass `--verbose` / `-v` for per-step detail.
 
 ## Commands at a glance
 
 | Command | Description |
 | --- | --- |
-| `gh student whoami` | Print the authenticated GitHub user. |
-| `gh student login` | Log in to GitHub via `gh auth login`, requesting `read:org`, `repo`, and `workflow` (required for accepting assignments — `workflow` covers committing `.github/workflows/autograde.yaml` into the assignment repo). Pass `-s` to add other scopes. Other commands trigger this same login flow automatically when no token is configured for `github.com`. |
-| `gh student logout` | Log out of GitHub via `gh auth logout`. |
-| `gh student accept <org> <classroom> <assignment>` | Accept an assignment: auto-accept any pending org invite, create a private repo (a copy of the assignment's template, or an empty repo if the assignment is template-less), keep the student as `admin` (so a group founder can `gh student invite` teammates), write `.classroom50.yaml`, and print clone instructions. |
-| `gh student invite <org>/<repo> <user>` | Invite a classmate or TA to the repo with `push` permission. For group assignments, the founder uses this to add each teammate. |
-| `gh student submit` | Snapshot the current branch and push it as a new commit on top of the assignment repo's default branch (refreshing the teacher's `.gitignore` and `.github/` from the template first, when the assignment has one). The autograde workflow tags and grades automatically. |
+| `whoami` | Print the authenticated GitHub user. |
+| `login` | Log in with the scopes needed to accept assignments (`read:org`, `repo`, `workflow`). |
+| `logout` | Log out via `gh auth logout`. |
+| `accept <org> <classroom> <assignment>` | Accept an assignment: auto-accept the org invite, create your private repo, and set up autograding. |
+| `invite <org>/<repo> <username>` | Invite a classmate or TA to your repo with `push` permission. |
+| `submit` | Snapshot the current branch and push it for grading. |
 
-## `gh student accept`
+## `accept`
 
 ```sh
 gh student accept <org> <classroom> <assignment>
 ```
 
-Creates a private assignment repo for the student under `<org>/<classroom>-<assignment>-<username>` (lowercased) — a copy of the assignment's template repo, or an empty repo if the assignment is template-less — then prints a `git clone` command.
+Creates a private repo at `<org>/<classroom>-<assignment>-<username>` (a copy of
+the assignment's template, or an empty repo if it's template-less), then prints
+a `git clone` command.
 
-Under the hood:
+<details>
+<summary>What accept does, step by step</summary>
 
-1. If the student has a pending org invitation, auto-accept it via `PATCH /user/memberships/orgs/{org}` with `{"state": "active"}` ([docs](https://docs.github.com/en/rest/orgs/members?apiVersion=2026-03-10#update-an-organization-membership-for-the-authenticated-user)).
-2. **Look up the assignment on the classroom's Pages site.** Fetch `https://<org>.github.io/classroom50/<classroom>/assignments.json` (the published `assignments.json`; no token required) and find the entry whose `slug` matches `<assignment>`. If the entry has a `template.{owner,repo,branch}` block it's used to resolve the source template; if the `template` block is absent, the assignment is **template-less** and an empty repo is created instead (step 4). Errors are surfaced loudly:
-   - **Pages 404** → "the classroom may not exist yet, or `publish-pages.yaml` may not have run; ask your teacher to confirm the Pages site has deployed".
-   - **Schema mismatch** (e.g. `assignments.json` advertises a v2 shape but this `gh-student` only handles v1) → tells the student to update `gh-student`.
-   - **Missing slug** → "ask your teacher to run `gh teacher assignment add <org> <classroom> <assignment>`".
-   - **`mode: group`** → accepted. The first teammate to `gh student accept` creates the shared repo (named after them) and becomes its admin; they then add the others with `gh student invite <org>/<repo> <teammate>`. Only an unrecognized mode errors.
-3. **Resolve the autograder workflow shim.** When the assignment's `autograder` field is `default` (the common case), the universal shim embedded in `gh-student` is used directly — no Pages fetch. When it's a non-default name (a teacher who's wired up a custom reusable workflow), the shim is fetched from `https://<org>.github.io/classroom50/<classroom>/autograders/<entry.autograder>.yaml`. Errors are surfaced loudly:
-   - **404** → "autograder `<name>` not published yet — ask your teacher to confirm `<classroom>/autograders/<name>.yaml` exists in the config repo and that `publish-pages.yaml` has run".
-   - **Malformed YAML** → "autograder `<name>` is malformed YAML — ask your teacher to check the file in the config repo".
-   - **Empty body** → "Pages deployment may still be in flight; retry in a minute" (the Pages cache occasionally serves a stub right after a fresh deploy).
+1. Auto-accepts any pending org invitation.
+2. Looks up the assignment in the classroom's published `assignments.json` on
+   Pages. A `template` block resolves the starter; its absence means a
+   template-less empty repo.
+3. Resolves the autograder workflow shim. The `default` autograder uses the shim
+   embedded in `gh-student`; a non-default one is fetched from Pages (resolved
+   *before* creating the repo, so a fetch failure leaves no half-baked repo).
+4. Creates the repo — from the template, an empty `auto_init` repo, or (for an
+   `empty_repo` assignment) a truly bare repo with steps 3 and 7 skipped.
+5. Disables issues, projects, and wiki.
+6. Keeps you as an `admin` collaborator (so a group founder can invite
+   teammates; the org lockdown removes the org-wide danger of repo-admin).
+7. Commits `.classroom50.yaml` and `.github/workflows/autograde.yaml` in one
+   commit. The metadata records the classroom, assignment, and (when present)
+   the template repo, which `gh student submit` re-fetches `.gitignore` and
+   `.github/` from.
+8. Prints the `git clone` command.
 
-   Resolution happens *before* creating the assignment repo so a non-default-shim fetch failure surfaces without leaving a half-baked repo on the teacher's org.
-4. **Create the assignment repo.**
-   - **Templated assignment:** `POST /repos/{template.owner}/{template.repo}/generate` ([docs](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-a-repository-using-a-template)) creates `<classroom>-<assignment>-<username>` (lowercased) under `<org>` from the template. The template may live in another org — a **404 on this call** surfaces "template `<owner>/<repo>` is not accessible to you — ask your teacher to make it public or grant your account access".
-   - **Template-less assignment:** `POST /orgs/{org}/repos` with `{"private": true, "auto_init": true}` creates an empty repo (the `auto_init` gives it an initial commit + default branch). The shim is committed onto the repo's `default_branch` (falling back to `main` if the response omits it).
-   - **Empty-repo assignment** (`empty_repo: true` in the entry): `POST /orgs/{org}/repos` with `{"private": true, "auto_init": false}` creates a **truly bare** repo — no initial commit, no branches. Steps 3 and 7 are skipped entirely (no shim is resolved, no `.classroom50.yaml` or autograde workflow is committed): the assignment never autogrades, and accept reports that the repo is empty and autograding is disabled. The student clones, then creates and pushes their own work.
+</details>
 
-   Either way, a 422 with the GitHub "already exists" message short-circuits to `Assignment already accepted: <org>/<repo>` and leaves the existing repo untouched.
-5. **Disable issues, projects, and wiki** on the new repo via `PATCH /repos/{owner}/{repo}` so the assignment surface is just code + history.
-6. **Keep `<username>` as an `admin` collaborator** via `PUT /repos/{owner}/{repo}/collaborators/{username}` ([docs](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#add-a-repository-collaborator)). The PUT is an upsert and re-affirms the creator-default `admin` (no downgrade). Admin is required so a group founder can manage collaborators — they add teammates with `gh student invite <org>/<repo> <teammate>`. The org-level member-privilege lockdown from `gh teacher init` removes the org-wide danger of repo-admin (no delete/transfer/visibility change).
-7. **Drop `.classroom50.yaml` and `.github/workflows/autograde.yaml` in a single Tree commit** on the repo's branch (the template branch, or the empty repo's default branch). The metadata records:
-   - `classroom` / `assignment` — identity.
-   - `source.{owner,repo,branch}` — the template repo (resolved from the assignments.json entry). `gh student submit` reads this on every submit to refresh the teacher's `.gitignore` and `.github/`. **Omitted for a template-less assignment** — there's no source to refresh from, so submit skips that step.
+Already accepted? The command reports `Assignment already accepted: <org>/<repo>`
+and leaves your repo alone.
 
-   The runner derives the config-repo coordinates at workflow time from the calling repo's org (`${{ github.repository_owner }}`) and the classroom slug, so no extra block is needed on disk.
-8. Print the `git clone` command, with a warning if the student is currently inside a git repo (to avoid an accidental nested clone).
+**Common errors:**
 
-Re-running on an already-accepted assignment short-circuits with `Assignment already accepted: <org>/<repo>` and leaves the existing repo (and any work in it) alone.
+| Message | What it means |
+| --- | --- |
+| "the classroom may not exist yet, or `publish-pages.yaml` may not have run" | Setup isn't finished or Pages hasn't deployed. Wait, or ask your teacher. |
+| "assignment X is not registered" | A typo, or your teacher hasn't added the assignment. |
+| "autograder `<name>` not published yet" / "is malformed YAML" | The autograder's YAML is missing or broken. Ask your teacher. |
+| "template `<owner>/<repo>` is not accessible to you" | The template is private and not shared with you. Ask your teacher to make it public or grant access. |
+| "assignment `<X>` has unsupported mode `<mode>`" | The manifest's `mode` is neither `individual` nor `group` (likely hand-edited). Ask your teacher. |
 
-## `gh student invite`
+## `invite`
 
 ```sh
 gh student invite <org>/<repo> <username>
 ```
 
-Invites a classmate or TA to a repo with `push` permission. Calls `PUT /repos/{owner}/{repo}/collaborators/{username}` ([docs](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#add-a-repository-collaborator)).
+Adds a classmate or TA to your repo with `push` permission. For a group
+assignment, the founder uses this to add each teammate.
 
-## `gh student submit`
+## `submit`
+
+Run from inside a cloned assignment repo:
 
 ```sh
 gh student submit
 ```
 
-Run from inside a cloned assignment repo. Snapshots the current working tree and pushes it as a new commit on top of the repo's default branch (which may be `master` if the template used it). The autograde workflow in the student repo listens for the push, creates its own `submit/<UTC-timestamp>-<short-sha>` tag, and publishes a scored Release at that tag a minute or two later.
+Snapshots your current working tree and pushes it as a new commit on the repo's
+default branch. The autograde workflow then tags the commit
+`submit/<UTC-timestamp>-<short-sha>`, grades it, and publishes a scored Release a
+minute or two later.
 
-Functionally equivalent to `git commit -am "Submit" && git push`, with the template `.gitignore`/`.github/` refresh as the only delta (skipped for a template-less assignment) — submit doesn't manage tags, manifests, or the autograde workflow shim itself.
+Functionally equivalent to `git commit -am "Submit" && git push`, with one extra
+step: it refreshes the teacher's `.gitignore` and `.github/` from the template
+(skipped for a template-less assignment).
 
-Under the hood:
+<details>
+<summary>What submit does, step by step</summary>
 
-1. **Read `.classroom50.yaml`** from the local clone for `source.owner`, `source.repo`, `source.branch`, `classroom`, and `assignment`.
-2. **Copy submittable files** (tracked + untracked-not-ignored) into a temp worktree so the submission isn't polluted by build artifacts or unrelated state.
-3. **Fetch teacher `.gitignore` and `.github/`** (both optional) from `source.owner/source.repo@source.branch` via `GET /repos/{owner}/{repo}/contents/{path}` ([docs](https://docs.github.com/en/rest/repos/contents?apiVersion=2026-03-10#get-repository-content)) so any teacher-side updates flow through on the next submit.
-4. **Push the submission to `main`.** `git clone --bare` the remote, stage the temp worktree, commit (with the user's GitHub login + noreply email, scoped via `git -c user.name=... -c user.email=...`), push as a fast-forward. Submissions overlay as commits — no force-push, prior commits stay reachable for review.
-5. **Print URLs** for the Actions tab (where the autograde run will appear) and the releases page (where the scored release will land).
+1. Reads `.classroom50.yaml` for the template coordinates and identity.
+2. Copies submittable files (tracked + untracked-not-ignored) into a temp
+   worktree, so build artifacts don't pollute the submission.
+3. Fetches the teacher's `.gitignore` and `.github/` from the template.
+4. Commits (with your GitHub login + noreply email) and pushes to the default
+   branch as a fast-forward — no force-push; prior commits stay reachable.
+5. Prints the Actions and Releases URLs.
 
-The commit is authored with the user's GitHub login and noreply email (`<id>+<login>@users.noreply.github.com`) via `git -c user.name=... -c user.email=...`, so a fresh shell with no global git identity still submits cleanly. `GIT_AUTHOR_*` / `GIT_COMMITTER_*` environment variables override these defaults.
+Tagging is the runner's job. The **acceptance commit** is skipped (nothing to
+grade); your first real submit always grades. `GIT_AUTHOR_*` / `GIT_COMMITTER_*`
+override the default identity.
 
-Tagging is the runner's job — the autograde workflow's first step creates `submit/<UTC-timestamp>-<short-sha>` at the just-pushed SHA. That gives each submission an immutable history entry plus its own Release without `gh student submit` having to know anything about tags. The one exception is the **acceptance commit** (the commit `gh student accept` lands to set the repo up): it fires the workflow but has no work to grade, so the runner detects it and skips tagging, grading, and the release. Your first real `gh student submit` is always graded.
+</details>
 
-`gh student submit` pushes to the assignment repo's **actual default branch** (resolved from the repo, not hardcoded), so a template whose default branch is `master`/`develop` grades correctly without a stray `main` branch appearing. The autograde workflow's push trigger targets that same branch.
+> [!NOTE]
+> **Feedback PR timing.** If your teacher enabled feedback, one long-lived
+> Feedback pull request appears on your **first submission that adds work** — not
+> at accept time (GitHub can't open a PR with no changes). The one PR is reused
+> for every later submission.
 
-**Feedback PR timing.** If your teacher enabled feedback, a single long-lived **Feedback** pull request appears on your **first submission that adds work** — not at accept time. (GitHub can't open a pull request with no changes to show, and right after accepting there's nothing yet.) Unlike GitHub Classroom — which opens the feedback PR the moment you accept — Classroom 50 waits for real work, so the diff your teacher reviews never includes the setup files (`.classroom50.yaml`, the autograde workflow). A side benefit: if you ever change those setup files, it stands out in the diff. The one PR is reused for every later submission.
+## `whoami` / `login` / `logout`
 
-## `gh student whoami` / `login` / `logout`
-
-- `gh student whoami` — prints the authenticated GitHub user.
-- `gh student login` — runs `gh auth login -s read:org -s repo -s workflow`, optionally with additional scopes via `-s/--scopes`.
-- `gh student logout` — runs `gh auth logout`.
+- `whoami` — prints the authenticated GitHub user.
+- `login` — runs `gh auth login -s read:org -s repo -s workflow`; add scopes with
+  `-s`.
+- `logout` — runs `gh auth logout`.
 
 ## Contributing
 
-Building, testing, and linting the extension is documented in the [`cli/gh-student/` README](https://github.com/foundation50/classroom50/blob/main/cli/gh-student/README.md) in the repo (where contributors expect to find it).
+Building, testing, and linting the extension are documented in the
+[`cli/gh-student/` README](https://github.com/foundation50/classroom50/blob/main/cli/gh-student/README.md).

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -1,767 +1,572 @@
 # `gh teacher` reference
 
-Complete reference for the teacher CLI. For a step-by-step walkthrough, see the [CLI Teacher Guide](CLI-Teacher-Guide).
+Every command and flag for the teacher CLI. For a walkthrough, see the
+[CLI Teacher Guide](CLI-Teacher-Guide).
 
-Run `gh teacher <command> --help` for the live flag list. Errors always go to stderr with a non-zero exit code. Commands that emit informational output accept `--quiet` / `-q` to suppress it; pass `--verbose` / `-v` to see per-step operational details (e.g. raw `git` output during `download`).
+Run `gh teacher <command> --help` for the live flag list. Errors go to stderr
+with a non-zero exit code. Pass `--quiet` / `-q` to suppress informational
+output, or `--verbose` / `-v` for per-step detail.
 
 ## Commands at a glance
 
 | Command | Description |
 | --- | --- |
-| `gh teacher whoami` | Print the authenticated GitHub user. |
-| `gh teacher login` | Log in to GitHub via `gh auth login`, requesting the unified Classroom 50 scope set — `admin:org`, `read:org`, `repo`, `workflow` — the same set `gh student login` requests, so one sign-in covers both CLIs. Pass `-s` to add other scopes (e.g. `delete_repo` for teardown). Other commands trigger this same login flow automatically when no token is configured for `github.com`. |
-| `gh teacher logout` | Log out of GitHub via `gh auth logout`. |
-| `gh teacher invite <org> <user>` | Invite user to an org (use `--admin` for org admin). |
-| `gh teacher invite <org>/<repo> <user>` | Invite user to a specific repo. Default permission `push`; override with `-p {pull,triage,push,maintain,admin}`. Re-running updates the collaborator in place. |
-| `gh teacher remove <org> <user>` | Remove user from an org. Revokes access to every repo in the org, removes them from all teams, and cancels any pending invitation. Idempotent. |
-| `gh teacher remove <org>/<repo> <user>` | Remove user from a single repo. Idempotent. |
-| `gh teacher member list <org>` | List actual org members + pending invitations, with role. Optional: `--json`, `--quiet` (login-only). Read-only. |
-| `gh teacher member list <org>/<repo>` | List actual repo collaborators, with permission level. Optional: `--json`, `--quiet` (login-only). Read-only. |
-| `gh teacher download <org> <classroom> <assignment>` | Team-driven by default: clone one repo per classroom-team member (the source of truth for enrollment), refresh each repo's `result.json` (latest submission) and `results.json` (every submission) from its submit-tag releases, and write a per-submission `scores.csv` summary at the destination root. `roster.csv` supplies optional name/section/email metadata for that summary but never decides who is cloned. Pass `--by-pattern` to skip the team lookup and clone by name prefix instead. Default destination is `<classroom>-<assignment>_submissions_<YYYY_MM_DD_T_HH_MM_SS>/`; override with `-d`. |
-| `gh teacher teardown <org>` | Delete every repo in a Classroom 50 org (development reset). Requires `<org>/classroom50` to exist (the marker repo guards against accidental teardown of non-Classroom orgs); prompts for typed org-name confirmation unless `--yes`; deletes `classroom50` last so an interrupted run stays safe to re-run. Requires the `delete_repo` OAuth scope (opt in once via `gh teacher login -s delete_repo`). |
-| `gh teacher init <org>` | Bootstrap `<org>/classroom50` (org member defaults, config repo, Pages, branch protection, service-token secret). Idempotent; re-runs also refresh stale skeleton files after a confirmation prompt (`--yes` to skip). |
-| `gh teacher audit <org>` | Read-only audit of the org member-privilege lockdown. Re-reads the org and reports which API-readable settings are enforced vs. drifted, plus the four web-UI-only settings it can't read (confirm by hand). Exits non-zero if **any** API-readable lockdown field is unenforced (matching the web GUI's verdict); `--json` for a machine-readable report. |
-| `gh teacher rotate-service-token <org>` | Replace the `CLASSROOM50_SERVICE_TOKEN` repo secret on an existing config repo. |
-| `gh teacher classroom add <org> <short-name>` | Add a new classroom directory to `<org>/classroom50`. Optional flags: `--name "<display name>"`, `--term <e.g. Spring-2026>`. Refuses to overwrite an existing classroom. |
-| `gh teacher classroom list <org>` | List the classrooms registered in `<org>/classroom50`, one short-name per line. Archived classrooms (`active: false`) are hidden by default — pass `--all` to include them (tagged ` (archived)`). Optional: `--json` (full `{short_name, name, term, active}` objects), `--quiet` (suppress the stderr summary). Read-only. |
-| `gh teacher classroom edit <org> <short-name>` | Update a classroom's display name and/or term in `classroom.json`. Requires at least one of `--name "<display name>"`, `--term <term>`. The short-name itself is immutable. No-op when values are unchanged. |
-| `gh teacher classroom archive <org> <short-name>` | Mark a classroom as archived (`active: false`). Archived classrooms drop out of the default `classroom list`, and `assignment add`/`reuse` refuse to write into them. Existing student repos are untouched. No-op if already archived. Reverse with `unarchive`. |
-| `gh teacher classroom unarchive <org> <short-name>` | Restore an archived classroom to active by dropping the `active` flag from `classroom.json` (absent = active). No-op if already active. |
-| `gh teacher classroom remove <org> <short-name>` | Delete a classroom's `<short-name>/` directory from `<org>/classroom50` in one commit. Prompts for the typed short-name to confirm; `--yes` skips the prompt. Does NOT delete student repos. |
-| `gh teacher classroom migrate --source <id-or-org> --target <org>` | Import an existing GitHub Classroom into `<target>/classroom50`. Discovers the source classroom (numeric ID or org login), copies each starter repo into the target org as a fresh template, and commits a populated `<short-name>/` directory in one Tree commit. Optional: `--short-name`, `--term`, `--template-suffix`, `--include-archived`, `--dry-run`. Roster and scores are NOT migrated. |
-| `gh teacher roster list <org> <classroom>` | List the students in `roster.csv` as an aligned table (username, name, email, section, github_id). Optional: `--json` (full `{username, first_name, last_name, email, section, github_id}` objects), `--quiet` (one username per line, no table or stderr summary). Read-only. |
-| `gh teacher roster add <org> <classroom> <username>` | Append or upsert a student in `roster.csv`; resolves `github_id`, sends an org invite if needed. Optional flags: `--first-name`, `--last-name`, `--email`, `--section`. |
-| `gh teacher roster update <org> <classroom> <username>` | Correct fields on an existing row (matched by username); only the flags you pass change, `github_id` and unset columns are preserved. Roster-only: no invite, no `github_id` re-resolution. Errors if the student isn't on the roster. Same four optional flags as `add`. |
-| `gh teacher roster remove <org> <classroom> <username>` | Remove a row from `roster.csv`. Does NOT touch org membership (use `gh teacher remove <org> <username>` for that). Idempotent. |
-| `gh teacher roster import <org> <classroom> <path-to-csv>` | Bulk upsert from a local CSV (`username,first_name,last_name,email,section` header; trailing `github_id` accepted but ignored). One Tree commit; auto-invites new students. |
-| `gh teacher roster migrate <org> <classroom>` | Rename a classroom's legacy `students.csv` to `roster.csv` in one commit. Idempotent; a classroom already on `roster.csv` is a no-op. |
-| `gh teacher staff add <org> <classroom> <username>` | Add a user to a classroom's staff team. `--role teacher` (default) or `--role ta`. Membership only — no `roster.csv` change. |
-| `gh teacher staff remove <org> <classroom> <username>` | Remove a user from a classroom's staff team (`--role teacher`/`ta`). Does not touch org membership. Idempotent. |
-| `gh teacher assignment add <org> <classroom> <slug>` | Register or upsert an assignment in `assignments.json`. Required flag: `--name`. Optional: `--template <owner>/<repo>[@branch]` (starter-code repo; omit for a template-less assignment, where students get an empty repo with just the autograder shim), `--description`, `--due` (ISO-8601; stored as UTC, local timezone assumed when the offset is omitted), `--mode` (`individual` default, or `group`), `--max-group-size <N>` (required with `--mode group`, `>= 2`), `--runtime <path-to-json>` (per-assignment runtime: `runs-on`, language toolchains, apt packages, container image), `--tests <path-to-json>` (declarative io/run/python tests, graded with no `autograder.py`), `--autograder <name>` (default `default`; non-default values reference a sibling shim at `<classroom>/autograders/<name>.yaml`), `--feedback-pr` (open one long-lived teacher-review PR per student repo — **on by default**; `--feedback-pr=false` to disable), `--empty-repo` (truly bare student repos: no README/marker/autograde shim, autograding and feedback PR disabled; immutable after creation; mutually exclusive with template/tests/feedback-pr/allowed-files/pass-threshold), `--pass-threshold <0–100>` (opt-in advisory passing bar shown by gradebook clients; off when omitted, distinct from `0`). Custom grading code is NOT registered here — drop an `autograder.py` (and any sibling fixtures) under `<classroom>/autograders/<slug>/` in the config repo, or set a classroom default with `gh teacher autograder set-default`. |
-| `gh teacher assignment test add <org> <classroom> <slug>` | Add or update one declarative test on an existing assignment's `tests` block. Required flags: `--name`, `--type {io,run,python}`, `--run`. Optional: `--setup`, `--input`/`--input-file`, `--expected`/`--expected-file`, `--comparison {included,exact,regex}`, `--timeout`, `--exit-code`, `--points`. Mutually exclusive with a per-assignment `autograder.py`. |
-| `gh teacher assignment test list <org> <classroom> <slug>` | Print the declarative test names on an assignment, one per line. `--json` for the full spec array, `-q` to suppress the stderr summary. Read-only. |
-| `gh teacher assignment test remove <org> <classroom> <slug> <test-name>` | Drop one declarative test by name. Idempotent. |
-| `gh teacher autograder set-default <org> <classroom>` | Drop a default `autograder.py` at `<classroom>/autograder.py` in the config repo. With `--from <path>` (or `--from -` for stdin), uploads the given Python source. Without `--from`, installs a diagnostic stub that echoes runner metadata and emits a vacuous-pass `result.json` — useful for verifying the runner pipeline before authoring real grading logic. |
-| `gh teacher autograder show <org> <classroom>` | Print the classroom default `autograder.py` to stdout, or report none. Optional: `--json` (metadata `{path, exists, is_stub, size, sha}` instead of the body), `--quiet` (suppress the stderr summary). Read-only. |
-| `gh teacher autograder list <org> <classroom>` | List named shims (`<name>.yaml`) and per-assignment override bundles (`<slug>/`) under `<classroom>/autograders/`, one per line. Optional: `--json` (full `{name, kind, path}` objects), `--quiet`. The classroom default is not listed (use `show`). Read-only. |
-| `gh teacher autograder remove <org> <classroom>` | Delete the classroom default `<classroom>/autograder.py` in one commit (distinct from overwriting it with the stub). Prompts `[y/N]` to confirm; `--yes` skips. Idempotent. Does NOT touch per-assignment overrides or named shims. |
-| `gh teacher assignment reuse <org> <source-slug> --from <src> --to <dst>` | Copy an assignment record from one classroom's `assignments.json` into another in the **same org**, changing only slug/name. Every field is copied verbatim (template, due, mode, autograder, tests, …), including unknown/future fields. Refuses an archived target. Optional: `--slug`/`--name` to override (a colliding slug auto-suffixes `-2`/`-3`… case-insensitively unless `--slug` is given), `--json` (emit the resolved copy incl. the final slug). Re-grants the private in-org template's team read for the target. In-org only (v1). |
-| `gh teacher assignment list <org> <classroom>` | Print every assignment slug registered in `assignments.json`, one per line on stdout. Pass `--json` for the full entries array, `-q` to suppress the stderr summary. Read-only. |
+| `whoami` | Print the authenticated GitHub user. |
+| `login` | Log in with the Classroom 50 scopes (`admin:org`, `read:org`, `repo`, `workflow`). Add scopes with `-s` (e.g. `delete_repo`). |
+| `logout` | Log out via `gh auth logout`. |
+| `init <org>` | Set up `<org>/classroom50` (org lockdown, config repo, Pages, branch protection, service token). Idempotent. |
+| `audit <org>` | Read-only audit of the org member-privilege lockdown. |
+| `rotate-service-token <org>` | Replace the `CLASSROOM50_SERVICE_TOKEN` secret. |
+| `classroom add <org> <short-name>` | Add a classroom. Flags: `--name`, `--term`, `--unlisted`, `--key`. |
+| `classroom list <org>` | List classrooms. Flags: `--all`, `--json`, `--quiet`. |
+| `classroom edit <org> <short-name>` | Update a classroom's name/term. |
+| `classroom archive` / `unarchive <org> <short-name>` | Archive or restore a classroom. |
+| `classroom remove <org> <short-name>` | Delete a classroom's config directory (not student repos). |
+| `classroom migrate --source <id-or-org> --target <org>` | Import a GitHub Classroom. |
+| `roster list <org> <classroom>` | List roster rows. Flags: `--json`, `--quiet`. |
+| `roster add <org> <classroom> <username>` | Add/upsert a student; invites them. |
+| `roster update <org> <classroom> <username>` | Correct fields on an existing row (roster-only). |
+| `roster remove <org> <classroom> <username>` | Remove a roster row (not org membership). |
+| `roster import <org> <classroom> <csv>` | Bulk upsert from a CSV. |
+| `roster migrate <org> <classroom>` | Rename legacy `students.csv` to `roster.csv`. |
+| `staff add` / `remove <org> <classroom> <username>` | Manage staff teams (`--role teacher\|ta`). |
+| `assignment add <org> <classroom> <slug>` | Register/upsert an assignment. |
+| `assignment reuse <org> <slug> --from <src> --to <dst>` | Copy an assignment into another classroom. |
+| `assignment remove <org> <classroom> <slug>` | Remove an assignment entry. |
+| `assignment list <org> <classroom>` | List assignment slugs. Flags: `--json`, `-q`. |
+| `assignment test add/list/remove` | Manage an assignment's declarative tests. |
+| `autograder set-default <org> <classroom>` | Install/replace the classroom default `autograder.py`. |
+| `autograder show/list/remove <org> <classroom>` | Inspect or delete autograders. |
+| `invite <org>[/<repo>] <username>` | Invite to an org or repo. |
+| `remove <org>[/<repo>] <username>` | Remove from an org or repo. |
+| `member list <org>[/<repo>]` | List actual members/collaborators. |
+| `download <org> <classroom> <assignment>` | Clone submissions and write `scores.csv`. |
+| `teardown <org>` | Delete every repo in a Classroom 50 org (dev reset). |
 
-## `gh teacher init`
+## `init`
 
-One-shot bootstrap for the per-org `classroom50` config repo. See the [CLI Teacher Guide](CLI-Teacher-Guide) for when to run it in your workflow.
+One-time bootstrap for the per-org `classroom50` config repo. See the
+[CLI Teacher Guide](CLI-Teacher-Guide#3-set-up-the-organization) for when to run
+it.
 
 ```sh
 CLASSROOM50_SERVICE_TOKEN=github_pat_... gh teacher init <org>
-gh teacher init <org>                  # interactive token prompt (first setup)
-gh teacher init <org> --dry-run        # preview preflight + planned steps, no changes
-gh teacher init <org> --json           # machine-readable summary on stdout
-gh teacher init <org> --yes            # skip the skeleton-refresh confirmation (scripted runs)
+gh teacher init <org>              # interactive token prompt
+gh teacher init <org> --dry-run    # preview, no changes
+gh teacher init <org> --json       # machine-readable summary
+gh teacher init <org> --yes        # skip the skeleton-refresh prompt
 ```
 
-Performs these steps in order:
+Idempotent — re-running resumes where a prior run stopped and offers to refresh
+stale skeleton files (after a confirmation prompt).
 
-1. **Org plan check** — `GET /orgs/{org}`; warns when the org is not on Team or Enterprise Cloud (Pages from a private repo). Advisory only.
-2. **Tighten org member defaults** — a combined `PATCH /orgs/{org}` setting `default_repository_permission: "none"` (new members don't get implicit read access to other repos in the org -- existing members and their established access are unaffected) and `members_can_create_repositories: true` + `members_can_create_private_repositories: true` (so `gh student accept` can create each student's private repo). Restricting members to *private repos only* (`members_can_create_public_repositories: false`) is a GitHub Enterprise Cloud capability and is applied only there; on Team/Free GitHub couples public+private into one "all or none" choice and the student flow needs private creation, so members can also create public repos on those plans (init skips that field rather than attempting an impossible lockdown that would also disable private creation). Idempotent -- re-runs on an already-tightened org are no-ops. On 403/422 (a plan-gated or enterprise-locked field), init retries each policy in its own PATCH, applies the ones GitHub accepts, and warns per rejected field with a manual fix at `https://github.com/organizations/{org}/settings/member_privileges`; init still completes. Re-audit any time with `gh teacher audit <org>`.
-3. **Enable org Actions** — `GET`/`PUT /orgs/{org}/actions/permissions` turns Actions on for the org when it's disabled org-wide (Classroom50's workflows run as Actions and won't run otherwise); if Actions is limited to selected repositories, init warns to include the config and `<classroom>-*` repos. Read failures and enterprise-locked rejections warn-and-continue.
-4. **Create or fetch repo** — `POST /orgs/{org}/repos` with `auto_init: true` for `classroom50`. On 422 (name taken), falls back to `GET /repos/{org}/classroom50`. The default branch from the response flows through to later steps (org policy can rename `main`). Init then re-enables Actions on the new repo via `GET`/`PUT /repos/{owner}/{repo}/actions/permissions` so the skeleton push and first workflow run aren't blocked.
-5. **Skeleton drop / refresh** — fresh repos get a single Tree commit of the embedded files (`.github/workflows/`, `.github/scripts/`, `README.md`); `publish-pages.yaml` is templated with the org's actual default branch at commit time. On re-runs, init diffs the repo's skeleton against this CLI's embedded version: identical files report "skeleton up to date", and stale or missing files (e.g. an org bootstrapped before declarative tests gaining `materialize_tests.py`) are listed and committed **after a confirmation prompt** — teacher-customized skeleton files would be reset, so declining is allowed and init continues. `--yes` skips the prompt.
-6. **Enable Pages** — `POST .../pages` with `build_type: workflow`; 409 = already enabled. Followed by `PUT .../pages` with `{"public": true}` so the published content is reachable unauthenticated: the student CLIs fetch `assignments.json` (and a non-default `--autograder` shim, when registered); the runner workflow fetches `assignments.json`, `runner.py`, the per-classroom `<classroom>/autograder.py` (when set), and per-assignment bundles. The visibility step is warn-and-continue if the API rejects it (rare org policy), with a manual `Settings → Pages → Visibility` toggle as the recovery path.
-7. **Branch protection** — no force pushes or branch deletion on the default branch.
-8. **Workflow permissions** — raises default `GITHUB_TOKEN` to `write`. HTTP 409 (org-enforced policy) is tolerated; skeleton workflows declare workflow-level `permissions:` blocks.
-9. **Reusable-workflow access** — `PUT .../actions/permissions/access` with `access_level: organization` so student-repo shims can `uses:` the autograde-runner workflow. 403/409 is warn-and-continue with manual recovery instructions.
-10. **Service token** — reads `CLASSROOM50_SERVICE_TOKEN` from env (trimmed), piped stdin, or hidden TTY prompt; validates it can read org repo contents; libsodium sealbox-encrypts and uploads as a repo-level Actions secret. A re-run with the secret already present leaves it untouched.
+<details>
+<summary>Steps <code>init</code> performs, in order</summary>
 
-**Service token requirements:** fine-grained PAT with `Contents: Read and write`, `Actions: Read and write`, and Organization `Members: Read` on the org (student repos are created on demand by `gh student accept`, so an "Only select repositories" scope silently misses them). `Contents: write` pushes `submit/*` tags and `Actions: write` re-runs autograde workflows during regrade; `Members: Read` lets `collect-scores` list the classroom team (collection is team-driven); it is a separate Organization-permissions section, not implied by any repository scope. This also covers **group assignments** — `collect-scores` reads a group repo's collaborators via the always-present `Metadata: read` permission (auto-included on every fine-grained PAT), so no extra scope beyond the above is needed.
+1. **Org plan check** — warns if not on Team/Enterprise Cloud (Pages from a
+   private repo). Advisory.
+2. **Tighten member defaults** — `default_repository_permission: none`, plus
+   private-repo creation enabled so `gh student accept` works. On a plan-gated
+   rejection it retries per policy and warns per field.
+3. **Enable org Actions** — turns Actions on if it's off org-wide.
+4. **Create or fetch the config repo** — `classroom50`, with `auto_init`.
+5. **Skeleton drop / refresh** — commits the embedded workflows and scripts; on
+   re-runs, refreshes stale files after confirmation (`--yes` skips).
+6. **Enable Pages** — public, so students and the runner can fetch published
+   files unauthenticated.
+7. **Branch protection** — no force-push or deletion on the default branch.
+8. **Workflow permissions** — raises `GITHUB_TOKEN` to write.
+9. **Reusable-workflow access** — lets student shims call the runner workflow.
+10. **Service token** — validates and uploads `CLASSROOM50_SERVICE_TOKEN`.
 
-**Skeleton shipped:**
+</details>
 
-| Path | Status |
+**Service token requirements:** a fine-grained PAT with **Contents: Read and
+write**, **Actions: Read and write**, **Administration: Read and write** (repo),
+and **Members: Read** (organization). Scope it to **All repositories** — student
+repos are created on demand, so "Only select repositories" misses them. See the
+[CLI Teacher Guide](CLI-Teacher-Guide#create-the-service-token) for the full
+walkthrough.
+
+<details>
+<summary>Skeleton files shipped into the config repo</summary>
+
+| Path | Purpose |
 | --- | --- |
-| `.github/workflows/publish-pages.yaml` | Working allow-list Pages publisher |
-| `.github/workflows/collect-scores.yaml` | Working `workflow_dispatch` + nightly cron |
-| `.github/workflows/probe-token.yaml` | `workflow_dispatch` service-token health check. Runs `probe_token.py` to exercise every scope the token needs (Contents R/W, Actions R/W, Members: Read, Metadata) with read-only calls; green means the token will work for collect and regrade. Side-effect free. |
-| `.github/workflows/autograde-runner.yaml` | Reusable workflow called by every student-repo autograde shim |
-| `.github/scripts/runner.py` | Runner-side bootstrap fetched from Pages on every submission. Downloads the per-assignment bundle, resolves the entrypoint (per-assignment `autograder.py` if present, otherwise the classroom default at `<classroom>/autograder.py`, otherwise a vacuous-pass synthesis), execs it, and validates the v1 `result.json` it produces. Teachers don't normally edit this file — grading logic lives in `autograder.py`. |
-| `.github/scripts/collect_scores.py` | Working team-driven score collector. Walks `(student, assignment)` pairs from the classroom GitHub team x `assignments.json`, collects **every** submit-tag release per `<classroom>-<assignment>-<username>` repo, downloads + schema-validates each `result.json`, and upserts into `<classroom>/scores.json`. The root `assignments` map is keyed by slug → `{type, entries[]}`; each entry is one repo's record (`owner` key, `submissions[]` history, `member_usernames` for groups). `override:true` entries respected; atomic per-classroom write; a malformed per-classroom file is isolated (skip + continue, run exits non-zero). Per-assignment "X of Y submitted" summary on stdout. |
-| `.github/scripts/probe_token.py` | Service-token scope probe (run by `probe-token.yaml`). Read-only checks that the `CLASSROOM50_SERVICE_TOKEN` holds every scope collect and regrade need — org Members: Read (plus the exact per-classroom team read), Contents Read+Write (via the config repo's `permissions.push`), Actions Read+Write (via `actions/permissions` reachability), and Metadata. Exits non-zero listing any missing scope; "no student repos / no team yet" is a pass with a note. |
-| `README.md` | Describes the config repo layout |
+| `.github/workflows/publish-pages.yaml` | Publishes allow-listed files to Pages. |
+| `.github/workflows/collect-scores.yaml` | `workflow_dispatch` + nightly cron score collection. |
+| `.github/workflows/probe-token.yaml` | Read-only service-token health check. |
+| `.github/workflows/autograde-runner.yaml` | Reusable workflow called by every student repo. |
+| `.github/scripts/runner.py` | Grading bootstrap fetched from Pages each submission. |
+| `.github/scripts/collect_scores.py` | Team-driven score collector. |
+| `.github/scripts/probe_token.py` | Service-token scope probe. |
+| `README.md` | Describes the config repo layout. |
 
-Score collection and regrade are both **team-driven**: the classroom GitHub team is the source of truth for enrollment, so the workflows list its members and compute the canonical `<classroom>-<assignment>-<username>` repo for each pair (against `assignments.json`), then act on those repos — collect gathers every submit-tag release; regrade re-runs each repo's latest autograde run (or first-grades a never-graded repo). A repo with no releases means the student hasn't accepted or submitted yet (no error — just a gap in the "X of Y submitted" report). A student with a submission repo but off the classroom team is not enumerated. No org-repo enumeration, no longest-slug-wins disambiguation, no cross-repo write PAT or `repository_dispatch` from student repos.
+Both collection and regrade are **team-driven**: the classroom GitHub team is
+the source of truth for enrollment.
 
-## `gh teacher audit`
+</details>
 
-Read-only audit of the org member-privilege lockdown — the standalone counterpart to the read-back `init` does at the end of its run. Makes **no changes**; safe to run any time.
+## `audit`
+
+Read-only audit of the org member-privilege lockdown. Makes no changes.
 
 ```sh
 gh teacher audit <org>
-gh teacher audit <org> --json    # machine-readable report on stdout
+gh teacher audit <org> --json
 ```
 
-Re-reads `GET /orgs/{org}` and classifies each in-scope member-default setting (filtered by the org's plan) into:
+Classifies each in-scope setting as **Verified** (API value matches the
+lockdown), **Action required** (drifted, with the fix), or **Confirm by hand**
+(the four settings GitHub exposes no API to read). Exits non-zero when any
+API-readable field is unenforced, so `gh teacher audit <org> && …` is safe in
+scripts. `--json` emits `{org, plan, read_ok, lockdown_complete, enforced,
+unenforced, manual_unreadable, settings_url}`.
 
-- **Verified (read from the API)** — settings whose live value matches the locked-down value `init` applies via `PATCH /orgs/{org}`. Drift is flagged here (e.g. you re-checked "Allow members to delete or transfer repositories").
-- **Action required** — API-readable settings that are NOT locked down, each with the exact GitHub-UI fix. Critical fields (the ones that defang the founder repo-admin grant org-wide) failing is what makes the command exit non-zero.
-- **Confirm by hand** — the four web-UI-only settings (App access requests, repo-admin GitHub App installs, Projects base permissions, branch renames). GitHub exposes **no REST API to read** these, so audit can neither confirm nor deny them; it lists them for a visual check rather than implying they're fine.
+## `rotate-service-token`
 
-**Exit status** is non-zero when **any** API-readable field is unenforced — critical or not (so `gh teacher audit <org> && …` is safe in scripts) or when the org couldn't be read back (inconclusive — treated as a conservative failure, never a false all-clear). This matches the web GUI, which flags **any** drift as "Needs attention"; the two tools agree on the same org state. The unreadable manual items never fail the command. `--json` emits `{org, plan, read_ok, lockdown_complete, enforced[], unenforced[], manual_unreadable[], settings_url}` for an orchestrating agent to branch on.
-
-This answers "I unchecked everything from init's Action-required list — did it take?": audit confirms the API-readable settings landed and reminds you which four you must confirm visually.
-
-## `gh teacher rotate-service-token`
-
-Re-runs only the service-token step of `init` — replaces the `CLASSROOM50_SERVICE_TOKEN` secret in place. Use when the PAT nears expiry or after a suspected compromise. The supplied token is **validated against the org before it's stored** (it must be able to read repository contents), so a misconfigured PAT is caught here rather than via a failed `collect-scores` run.
+Replaces the `CLASSROOM50_SERVICE_TOKEN` secret in place. Use when the PAT nears
+expiry or after a suspected compromise.
 
 ```sh
 CLASSROOM50_SERVICE_TOKEN=github_pat_... gh teacher rotate-service-token <org>
 gh teacher rotate-service-token <org>
 ```
 
-Fails with a clear message if `<org>/classroom50` does not exist (`run gh teacher init <org> first`). Accepts the same token input paths as `init`.
+The token is validated against the organization before it's stored. Fails
+clearly if `<org>/classroom50` doesn't exist.
 
-## `gh teacher classroom add`
+## `classroom`
 
-Create a new classroom directory at the root of `<org>/classroom50` and scaffold its four canonical files in a single commit:
+Classrooms are root-level directories in `<org>/classroom50`, each with a
+`classroom.json`.
+
+### `classroom add`
 
 ```sh
-gh teacher classroom add <org> <short-name> --name "<full name>" --term <term>
+gh teacher classroom add <org> <short-name> [--name "<full name>"] [--term <term>]
 gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Spring-2026
-gh teacher classroom add cs50-fall-2026 intro-java
 ```
 
-**Short-name rules** (must match `^[a-z0-9][a-z0-9-]{1,38}$`):
+**Short-name rules:** `^[a-z0-9][a-z0-9-]{1,38}$` — 2–39 characters, lowercase
+letters/digits/hyphens, starting with a letter or digit. It becomes part of
+student repo names (`<short-name>-<assignment>-<username>`).
 
-- 2-39 characters total
-- lowercase letters, digits, or hyphens
-- must start with a letter or digit (not a hyphen)
+Scaffolds four files in one commit — `classroom.json`, `assignments.json`,
+`roster.csv`, `scores.json` — and creates the `classroom50-<short-name>` GitHub
+team (plus `-teacher` and `-ta` staff teams). Refuses to overwrite an existing
+classroom.
 
-The short-name flows into student repo names like `<short-name>-<assignment>-<username>` (the convention `gh student accept` and `gh teacher download` rely on), so it has to stay within GitHub's repo-name constraints.
+<details>
+<summary>What the scaffold does and doesn't include</summary>
 
-**Flags:**
+The `roster.csv` header is
+`username,first_name,last_name,email,section,github_id`; `github_id` is
+CLI-managed — don't hand-edit it.
 
-- `--name <full name>` — display name written into `classroom.json` (e.g. `"CS Principles"`). Optional but recommended.
-- `--term <term>` — term identifier written into `classroom.json` (e.g. `Spring-2026`). Optional.
+Not included: the shared runner bootstrap (landed once by `init`), any
+autograder (classrooms grade as a vacuous pass until you add one), and the
+autograde shim (embedded in `gh-student`, dropped into each student repo at
+accept).
 
-**What it scaffolds**, all in one Tree commit on the default branch:
+**Legacy alias:** `instructor` is the former name for `teacher`; a pre-rename
+team is migrated to `-teacher` automatically on touch.
 
-| Path | Schema sentinel | Contents |
-| --- | --- | --- |
-| `<short-name>/classroom.json` | `classroom50/classroom/v1` | `name`, `short_name`, `term`, `org`, and a `team` block (`{id, slug}`) recording the classroom's GitHub team |
-| `<short-name>/assignments.json` | `classroom50/assignments/v1` | Empty `assignments: []` array — populated by `gh teacher assignment add`. |
-| `<short-name>/roster.csv` | n/a | Header row begins with `username,first_name,last_name,email,section,github_id`. The `email` column is optional per row (values may be empty). The trailing `github_id` is a hidden column populated by `gh teacher roster add/import` — do not hand-edit it. Any extra trailing columns after `github_id` (e.g. left over from an older file) are read past and preserved on edit. |
-| `<short-name>/scores.json` | `classroom50/scores/v1` | Scaffolds with an empty `assignments: {}` object -- entries are written by the `collect-scores.yaml` workflow, keyed by assignment slug → `{type, entries[]}`. |
+</details>
 
-Three things this scaffold does **not** include:
+**Errors:** missing config repo → `run gh teacher init <org> first`; existing
+classroom directory → refuses to overwrite; bad short-name → prints the rule.
 
-- **The runner-side bootstrap** (`.github/scripts/runner.py`) is landed once by `gh teacher init` and shared across every classroom in the org. The runner stays untouched in normal use.
-- **No autograder by default.** Classrooms work end-to-end without one — the runner publishes a vacuous-pass `result.json` (status=`success`, score 0/0) so submissions still tag and release. Add a classroom default later with `gh teacher autograder set-default`, or per-assignment overrides at `<classroom>/autograders/<slug>/autograder.py`.
-- **The autograder workflow shim** is embedded in `gh-student` and dropped into each student repo at accept time. Teachers don't write or maintain it.
-
-Per-assignment autograders (an `autograder.py` entrypoint + any sibling fixtures) go under `<short-name>/autograders/<slug>/` once the classroom is in place; the runner picks them over the classroom default at `<short-name>/autograder.py`. Per-assignment runtime customization (Python version, language toolchains, apt packages, container image) lives in the `runtime:` block on each `assignments.json` entry; see [Autograders](Autograders) for the schema.
-
-**Classroom team.** Besides the config files, `classroom add` creates a GitHub team `classroom50-<short-name>` (privacy `secret`, via `POST /orgs/{org}/teams`), reconciling-and-adopting an existing team of that name rather than failing. The team's members are the classroom's rostered students (added by `gh teacher roster add`); it exists to grant those students read access to **in-org private** assignment templates (`gh teacher assignment add` grants `pull` on the template to this team). `gh teacher classroom remove` deletes the team; `gh teacher roster remove` drops a student from it. `members_can_create_teams: false` (set by `init`'s lockdown) doesn't block this — the teacher authenticates as an org owner.
-
-**Staff teams.** `classroom add` (and `classroom migrate`) also create two `secret` staff teams — `classroom50-<short-name>-teacher` and `classroom50-<short-name>-ta` — each granted `push` (write) on the `classroom50` config repo so staff can author assignments. The creating teacher is added to the teacher team as a maintainer. Their `{id, slug}` are recorded under `classroom.json` `teams.{teacher,ta}`, mirroring the web GUI so a classroom managed from either surface has the same staff teams. Manage membership with `gh teacher staff add/remove` (below). `classroom remove` and `teardown` sweep the staff teams alongside the students team.
-
-> **Legacy alias.** `instructor` is the former name for `teacher` and is still accepted for backward compatibility — the two co-exist. Classrooms created before the rename record a `classroom50-<short-name>-instructor` team under `teams.instructor`; the app migrates that team to `classroom50-<short-name>-teacher` automatically on the next touch (readers accept either, writers prefer `teacher`).
-
-**Errors:**
-
-- `<org>/classroom50` does not exist → prints `run gh teacher init <org> first` and exits non-zero.
-- `<short-name>` directory already exists in the config repo → refuses to overwrite. Use `gh teacher roster add` or `gh teacher assignment add` to modify an existing classroom.
-- Short-name fails the slug regex → prints the exact rule with the offending input.
-
-The command commits all four paths in a single Tree commit on the default branch.
-
-## `gh teacher classroom list`
-
-List every classroom registered in `<org>/classroom50`. A classroom is a root-level directory containing a `classroom.json`; directories without one (e.g. `.github`) are skipped.
+### `classroom list`
 
 ```sh
-gh teacher classroom list <org>
-gh teacher classroom list cs50-fall-2026
-gh teacher classroom list cs50-fall-2026 --all
-gh teacher classroom list cs50-fall-2026 --json
+gh teacher classroom list <org> [--all] [--json] [--quiet]
 ```
 
-Default output is one short-name per line on stdout — pipeable into `xargs`, `grep`, or an agent loop. A one-line `<org>/classroom50: N classroom(s)` summary prints to stderr.
+One short-name per line on stdout. Archived classrooms (`active: false`) are
+hidden unless you pass `--all` (tagged ` (archived)`). `--json` emits
+`{short_name, name, term, active}` objects; `--quiet` suppresses the stderr
+summary. Read-only.
 
-**Archived classrooms are hidden by default.** A classroom archived with `gh teacher classroom archive` (`active: false` in its `classroom.json`) drops out of the default listing, mirroring the web's default classes view. Pass `--all` to include them: in the default output an archived classroom is tagged ` (archived)` after its short-name; in `--json` it carries `"active": false`. An active classroom omits the `active` key entirely (absent = active), so legacy classrooms and re-activated ones read identically.
-
-**Flags:**
-
-- `--json` — emit the full JSON array of `{short_name, name, term, active}` objects instead of bare short-names, preserving the display name, term, and archival state without a second call. `active` is present only on archived classrooms (`false`); absent means active. Scripts/agents that need archived classrooms too must pass `--all` — the filter runs before both the text and JSON render paths.
-- `--all` — include archived classrooms (`active: false`), which are hidden by default.
-- `-q`, `--quiet` — suppress the stderr summary so stdout is the only output stream a capturing script has to parse.
-
-This is a read-only command; no commit lands on the repo. Missing `<org>/classroom50` points at `gh teacher init`. Exits 0 with empty stdout when no classrooms are registered yet.
-
-## `gh teacher classroom edit`
-
-Update the display name and/or term in `<org>/classroom50/<short-name>/classroom.json`:
+### `classroom edit`
 
 ```sh
-gh teacher classroom edit <org> <short-name> --name "<full name>" --term <term>
-gh teacher classroom edit cs50-fall-2026 cs-principles --name "Computer Science Principles"
-gh teacher classroom edit cs50-fall-2026 cs-principles --term Fall-2026
+gh teacher classroom edit <org> <short-name> [--name "<full name>"] [--term <term>]
 ```
 
-At least one of `--name` / `--term` must be provided. Only the flags you pass are changed; the rest of `classroom.json` (including `short_name`, `org`, and any `migrated_from` provenance) is preserved.
+Updates the display name and/or term. At least one flag is required; the
+short-name is immutable (it flows into repo names). No-op when values are
+unchanged.
 
-**The short-name is immutable.** It flows into student repo names (`<short-name>-<assignment>-<username>`), so renaming it would orphan existing repos — to rename, add a new classroom instead.
-
-Lands as a single Tree commit on the default branch. Re-running with values that already match the file is a no-op (no commit). Missing config repo points at `gh teacher init`; a missing classroom points at `gh teacher classroom add`.
-
-## `gh teacher classroom archive` / `unarchive`
-
-Toggle a classroom's lifecycle state via the `active` flag in `<org>/classroom50/<short-name>/classroom.json`:
+### `classroom archive` / `unarchive`
 
 ```sh
 gh teacher classroom archive <org> <short-name>
-gh teacher classroom archive cs50-fall-2026 cs-principles
-gh teacher classroom unarchive cs50-fall-2026 cs-principles
+gh teacher classroom unarchive <org> <short-name>
 ```
 
-**Archival semantics** (schema `classroom50/classroom/v1`, mirroring the web): `active: false` = archived; `active: true` **or absent** = active. Legacy classrooms that never wrote the key read as active. `archive` stamps `active: false`; `unarchive` **drops the key entirely** (rather than writing `active: true`) so a re-activated classroom is byte-identical to one that was never archived.
+`archive` sets `active: false`; `unarchive` drops the key (absent = active).
+Archived classrooms leave the default `list`, and `assignment add`/`reuse`
+refuse to write into them. Existing student repos are untouched. Both are
+idempotent.
 
-**What archiving does:**
+> [!NOTE]
+> Student `accept` is blocked only after the next `publish-pages` run updates the
+> published index — a documented v1 limitation, matching the web app.
 
-- The classroom is **hidden from the default `gh teacher classroom list`** (pass `--all` to see it, tagged ` (archived)`).
-- `gh teacher assignment add` and `gh teacher assignment reuse` **refuse to write** into an archived target classroom, with an error pointing at `unarchive`.
-- **Existing student repos are untouched** — archiving is a config-repo state change only.
-
-**Student `accept` is blocked only after the next publish.** The student-facing accept guard reads `active` from the published `classrooms-index.json`, which only gains the flag on the next `publish-pages` run (and only once the classroom has re-run `gh teacher init` to pick up the updated `publish-pages.yaml`). Until then, archive is teacher-side only — a documented v1 limitation, matching the web. `archive` prints a stderr note to this effect.
-
-Both verbs land a single Tree commit and are **idempotent**: re-archiving an already-archived classroom (or unarchiving an active one) is a no-op with a `no changes` note and no commit. Missing config repo points at `gh teacher init`; a missing classroom points at `gh teacher classroom add`.
-
-## `gh teacher classroom remove`
-
-Delete a classroom's `<short-name>/` directory — `classroom.json`, `assignments.json`, `roster.csv`, `scores.json`, and any `autograders/` — from `<org>/classroom50` in a single commit:
+### `classroom remove`
 
 ```sh
-gh teacher classroom remove <org> <short-name>
-gh teacher classroom remove cs50-fall-2026 cs-principles
-gh teacher classroom remove --yes cs50-fall-2026 cs-principles
+gh teacher classroom remove <org> <short-name> [--yes]
 ```
 
-This removes the classroom's **configuration only**. It does NOT delete student assignment repositories already created in the org — remove those via the GitHub web UI (or `gh teacher teardown` for a full development reset) if intended.
+Deletes the `<short-name>/` directory and the classroom's teams in one commit.
+Prompts for the typed short-name unless `--yes`. Does **not** delete student
+repos.
 
-**Confirmation.** You'll be asked to type the short-name to confirm before anything is deleted. Pass `--yes` to skip the prompt (scripted runs only).
+### `classroom migrate`
 
-**Flags:**
-
-- `--yes` — skip the typed-confirmation prompt.
-
-Missing config repo points at `gh teacher init`; a non-existent classroom exits non-zero with `nothing to remove`. The deletion is one Tree commit that sets every blob under `<short-name>/` to `null`; git prunes the now-empty directory automatically.
-
-## `gh teacher classroom migrate`
-
-Import an existing GitHub Classroom into your `<target>/classroom50` config repo. For each assignment, the command copies the source starter repo into the target org as a fresh template (with `is_template: true`), then commits the matching `<short-name>/` directory — `classroom.json` / `assignments.json` / `roster.csv` / `scores.json` — in a single Tree commit.
+Import an existing GitHub Classroom into `<target>/classroom50`.
 
 ```sh
-gh teacher classroom migrate --source <id-or-org> --target <org>
-gh teacher classroom migrate --source 95884 --target cs50-fall-2026 --dry-run
-gh teacher classroom migrate --source classroom50test --target cs50-fall-2026
-gh teacher classroom migrate --source 95884 --target cs50-fall-2026 \
-    --short-name cs-principles --term Spring-2026
+gh teacher classroom migrate --source <id-or-org> --target <org> [--dry-run]
+gh teacher classroom migrate --source 95884 --target cs50-fall-2026 --short-name cs-principles --term Spring-2026
 ```
 
-**Why this exists.** GitHub Classroom is 1:1 with orgs — the org IS the classroom container. Classroom 50 hosts multiple classrooms per org under one `classroom50` config repo. To migrate N legacy classrooms into one target org, run this command N times, once per source classroom.
+For each assignment, it copies the source starter repo into the target
+organization as a fresh template, then commits the classroom's four-file
+scaffold. GitHub Classroom is 1:1 with organizations, so migrate several legacy
+classrooms into one target organization by running this once per source.
 
-**What it does** (in order):
+**Flags:** `--source <id-or-org>` (required), `--target <org>` (required),
+`--short-name`, `--term`, `--template-suffix` (escape target name collisions),
+`--include-archived`, `--dry-run`.
 
-1. **Discovery** — resolves `--source`, derives a short-name from the classroom name, fetches every assignment detail (including `starter_code_repository`) from the GitHub Classroom REST API.
-2. **Pre-flight** — refuses if the target `<short-name>/` directory already exists in `<target>/classroom50` before any template repos are created.
-3. **Template copy** — for each assignment: verify the source repo is a template → probe the target name for collision → `POST /repos/.../generate` → `PATCH .../is_template:true` → wait for the new branch ref to stabilize.
-4. **Config commit** — single Tree commit on `<target>/classroom50` writing the four-file scaffold with the migrated entries.
+**Not migrated:** roster, scores, accepted student repos, and GitHub Classroom's
+autograding config. Re-onboard students with `gh teacher roster add`/`import`
+and author grading under `<classroom>/autograders/<slug>/`.
 
-**Flags:**
+<details>
+<summary>Source resolution, provenance, and failure model</summary>
 
-- `--source <id-or-org>` (required) — numeric GitHub Classroom ID (e.g. `95884`) or the source org's login (e.g. `classroom50test`).
-- `--target <org>` (required) — destination org where the `classroom50` config repo lives. Run `gh teacher init <target>` first if it doesn't exist yet. `--target` is *unrelated to the source classroom's org* — Classroom 50 lets you migrate several legacy classrooms into one target org as siblings under the same `classroom50` repo.
-- `--short-name <name>` — override the auto-derived classroom directory name. By default the source classroom's name is slugified (lowercase, non-alnum → `-`, collapsed, trimmed, truncated to 39 chars) and validated against `^[a-z0-9][a-z0-9-]{1,38}$`. Pass `--short-name` explicitly if the derived value fails validation.
-- `--term <text>` — set `classroom.json.term` (e.g. `Spring-2026`).
-- `--template-suffix <suffix>` — appended to every target template repo name. Use to escape collisions: `--template-suffix migrated` renames the target template from `<slug>` to `<slug>-migrated`.
-- `--include-archived` — include archived classrooms when resolving `--source` by org name (ignored when `--source` is a numeric ID — archived classrooms always resolve by ID, with a stderr warning).
-- `--dry-run` — run discovery and print the plan without any API writes against source or target. Useful for previewing what would migrate before committing to anything.
+- **Numeric source** resolves the classroom directly; **org-login source** lists
+  the classrooms you administer and matches by organization. Multiple matches in
+  one org enumerate candidates and ask for `--source <id>`.
+- Each migrated entry carries a `migrated_from` provenance block.
+- `mode: group` assignments migrate with their `max_group_size`.
+- Per-assignment failures skip that entry with a reason; the commit still lands
+  with the successes and exits non-zero. Re-running reuses templates that
+  already exist.
 
-**Source resolution:**
+</details>
 
-- **Numeric** (`--source 95884`) → `GET /classrooms/95884` directly. Archived classrooms resolve with a stderr warning (`archived in GitHub Classroom — proceeding`). The `--include-archived` flag is irrelevant here.
-- **Org login** (`--source classroom50test`) → list every classroom your token can administer, fetch each one's detail to recover `organization.login`, filter case-insensitively. The Classroom listing endpoint doesn't carry `organization` so the per-row detail fetch is unavoidable. Errors when zero matches (with a hint about `--include-archived`) or when multiple classrooms in the same org match (enumerates candidates with IDs and asks for `--source <id>`).
+## `roster`
 
-**Target template repo naming.** Each migrated assignment becomes `<target>/<slug>` in the target org. Use `--template-suffix <s>` to rename to `<slug>-<s>` when a name collides with an existing repo. If the colliding repo is *already* a template (e.g. you re-ran migrate), the existing template is reused without re-generating; if it's a regular repo, migrate skips that assignment with an actionable error pointing at `--template-suffix`.
+Manage student rows in `<org>/classroom50/<classroom>/roster.csv`. All write
+subcommands use an optimistic-rebase loop (up to 5 retries), so concurrent
+teacher edits don't lose each other's work. Every row carries an immutable
+numeric `github_id` (CLI-managed — don't hand-edit it) so a username change
+doesn't desynchronize records.
 
-**`migrated_from` provenance.** Every migrated `classroom.json` and `assignments.json` entry carries an optional `migrated_from` block recording the legacy classroom/assignment IDs, source starter-repo path, GitHub Classroom invite link, and migration timestamp. Hand-authored classrooms (from `gh teacher classroom add` / `gh teacher assignment add`) never carry this block — it's exclusively a provenance marker for migrated content.
-
-**`mode: "group"` preserved.** Group assignments from the source are recorded in `assignments.json` with their `max_group_size` (mapped from the source's `max_teams`, falling back to the cap when the source doesn't report a usable value). Migrated group assignments work end-to-end like CLI-created ones — no re-migration needed.
-
-**What's NOT migrated** (covered by separate workflows):
-
-- **Roster** — `roster.csv` is left empty. Re-onboard students for the new term with `gh teacher roster add` / `gh teacher roster import`. (This is a deliberate "fresh start" — most teachers want a clean roster for the new term anyway.)
-- **Scores / grades** — `scores.json` is left empty.
-- **Accepted-assignment student repos** — student work isn't cloned. The new term starts fresh; old submissions stay on the legacy org if you need them.
-- **Autograding test config** — GitHub Classroom's `.github/classroom/autograding.json` schema doesn't translate to our `autograder.py` model. Author grading code separately under `<classroom>/autograders/<slug>/` or set a classroom default with `gh teacher autograder set-default`.
-
-**Failure model.** Per-assignment failures are best-effort: a source repo that isn't a template, a target collision with a non-template repo, or a failed generate/PATCH call skips that single entry with a stderr reason. The commit still lands with the entries that succeeded; exit code is non-zero so partial completion is visible. Re-running reuses any templates that already exist (collision = template path).
-
-**Errors:**
-
-- `<target>/classroom50` missing → `run gh teacher init <target> first`.
-- Target classroom dir already exists → `pick a different --short-name or delete the dir`. The pre-flight probe fires *before* any template repos get created, so no orphan repos are left behind in the target org.
-- `--source <id>` 404 → `classroom is not accessible — confirm you are a GitHub Classroom admin`.
-- `--source <org>` resolves to zero classrooms → `no classrooms found in org "<source>"`. If `--include-archived` wasn't passed, the error includes a hint about it.
-- `--source <org>` resolves to multiple classrooms (rare — Classroom is 1:1 with orgs) → lists candidates with IDs and asks for `--source <id>`.
-- Derived short-name fails the slug regex → asks for `--short-name <name>` explicitly with the offending input.
-
-## `gh teacher roster`
-
-Manage student rows in `<org>/classroom50/<classroom>/roster.csv`. All three subcommands write through a shared optimistic-update-with-rebase loop: each attempt reads the current branch tip, re-applies the upsert/remove against the latest file, and PATCHes the ref with a fast-forward check. Up to 5 attempts with exponential backoff before giving up — concurrent edits from multiple teachers can't silently lose each other's work.
-
-Every row carries an immutable numeric `github_id` (resolved at write time via `GET /users/{username}`) so a mid-class username change doesn't desynchronize records. The `github_id` column is CLI-managed; teachers should not hand-edit it. The column is named `github_id` (not the API-side `id`) to keep the source unambiguous when classroom50 grows additional ID columns from non-GitHub sources.
-
-### `gh teacher roster list`
+### `roster list`
 
 ```sh
-gh teacher roster list <org> <classroom>
-gh teacher roster list cs50-fall-2026 cs-principles --json
-gh teacher roster list cs50-fall-2026 cs-principles --quiet
+gh teacher roster list <org> <classroom> [--json] [--quiet]
 ```
 
-Reads `<classroom>/roster.csv` and prints it. Three output modes:
+Default is an aligned table (empty cells show as `-`). `--json` emits full row
+objects (`github_id` is `0` when unresolved); `--quiet` prints one username per
+line. Read-only.
 
-- **Default** — an aligned table on stdout (`USERNAME`, `NAME`, `EMAIL`, `SECTION`, `GITHUB_ID`; empty cells render as `-`), plus a one-line `<org>/<repo>/<classroom>/roster.csv: N student(s)` summary on stderr.
-- `--json` — emit the full JSON array of `{username, first_name, last_name, email, section, github_id}` objects (`github_id` is `0` for an unresolved row, not omitted; gate on `github_id == 0`). Takes precedence over `--quiet`.
-- **`--quiet`** — one username per line on stdout, no table and no stderr summary — pipeable into `xargs`, `grep`, or an agent loop.
-
-An empty roster is a clean exit-0: the table shows just the header (or stdout is empty under `--json`/`--quiet`), and stderr notes there are no students. A missing `roster.csv` errors and points at `gh teacher classroom add`. Read-only; no commit lands.
-
-### `gh teacher roster add`
+### `roster add`
 
 ```sh
 gh teacher roster add <org> <classroom> <username> [--first-name <n>] [--last-name <n>] [--email <addr>] [--section <s>]
-gh teacher roster add cs50-fall-2026 cs-principles alice --first-name Alice --last-name Andersson --email alice@example.edu --section section-1
-gh teacher roster add cs50-fall-2026 cs-principles bob
 ```
 
-Appends or upserts one row by `username` (case-insensitive match). All four data flags are optional; an absent flag writes an empty value into its column. After the roster write lands, sends an org invitation if the student isn't already a member and doesn't have a pending invite — same path `gh teacher invite` uses, but quiet about already-member/already-pending cases.
+Upserts one row by username (case-insensitive), then invites the student to the
+organization if needed and adds them to the classroom team. Safe to re-run.
 
-Safe to re-run: the row is replaced in place — every run produces a commit, but a no-change re-run yields a same-tree commit (never duplicates or removes data). The org-invite step is skipped when the student is already an active or pending member.
-
-### `gh teacher roster update`
+### `roster update`
 
 ```sh
 gh teacher roster update <org> <classroom> <username> [--first-name <n>] [--last-name <n>] [--email <addr>] [--section <s>]
-gh teacher roster update cs50-fall-2026 cs-principles alice --email alice@example.edu
-gh teacher roster update cs50-fall-2026 cs-principles alice --first-name Alice --section section-2
 ```
 
-Corrects fields on an **existing** row, matched by `<username>` (case-insensitive). Only the flags you pass are changed — every other column, including the immutable `github_id`, is left untouched. This is the difference from `roster add`, which rewrites the whole row and blanks any field you don't re-supply. Pass `--email ""` to clear an address.
+Corrects fields on an **existing** row. Only the flags you pass change;
+`github_id` and other columns are preserved. Roster-only: no invite, no
+`github_id` lookup. Pass `--email ""` to clear an address. At least one flag is
+required; an unknown username is an error.
 
-**Roster-only:** unlike `roster add`, it never sends an org invite and never re-resolves `github_id` — use it for typo fixes, not onboarding. At least one data flag is required. A patch that already matches the row is a no-op (no commit). Unlike `roster remove`, an unknown `<username>` is an **error** (you're correcting a specific person), pointing you at `gh teacher roster add`.
-
-### `gh teacher roster remove`
+### `roster remove`
 
 ```sh
 gh teacher roster remove <org> <classroom> <username>
 ```
 
-Drops the row matching `<username>` (case-insensitive). Idempotent: a no-op + zero exit when the row is already absent. **Does NOT remove org membership** — that's a separate `gh teacher remove <org> <username>` so an off-by-one roster edit can't accidentally revoke a student's repo access.
+Drops the row (idempotent). Does **not** remove organization membership — use
+`gh teacher remove <org> <username>` for that.
 
-### `gh teacher roster import`
+### `roster import`
 
 ```sh
 gh teacher roster import <org> <classroom> <path-to-csv>
-gh teacher roster import cs50-fall-2026 cs-principles ./section-1.csv
 ```
 
-Bulk upsert from a local CSV. Accepts either header shape:
+Bulk upsert. Accepts a 5-column header
+(`username,first_name,last_name,email,section`) or 6-column with a trailing
+`github_id` (which is ignored and re-resolved). Every username is resolved up
+front — one typo aborts before any commit. New students are invited.
 
-- **5-column** (recommended for hand-authored CSVs): `username,first_name,last_name,email,section`
-- **6-column** (exported from a previous `roster.csv`): same as above plus `github_id`, which is ignored — the CLI re-resolves `github_id` at import time so the on-disk roster always carries the GitHub-authoritative ID.
+### `roster migrate`
 
-The `email` column values may be empty per row.
-
-> **Import takes only the canonical shape.** If your `roster.csv` carries extra columns appended after `github_id` (e.g. left over from an older file), trim everything after `github_id` before importing — `roster import` accepts only the 5- or 6-column canonical header and rejects a wider file with a message naming the cause. `roster add`/`roster update`/`roster remove` *do* preserve those extra columns; import re-resolves `github_id` and carries no extra state, so it stays canonical-only by design.
-
-Resolves every username up-front (one `GET /users/{username}` per row); a non-existent username aborts the import with the row number, before any commit. Once all usernames resolve, the entire file is written in a single Tree commit — there's no partial-import state visible on the repo. After the commit, each non-member is invited; the command prints a summary `N invited, M already members, K already pending`.
-
-Duplicate usernames within the input (case-insensitive) collapse with last-wins semantics.
-
-### Errors common to all three subcommands
-
-- `<org>/classroom50` missing → `run gh teacher init <org> first`, non-zero exit.
-- `<classroom>/roster.csv` missing → `run gh teacher classroom add <org> <classroom> first, or restore the file if it was deleted`.
-- `roster.csv` header doesn't begin with `username,first_name,last_name,email,section,github_id` → exits non-zero with the offending header. (Optional extra columns appended after `github_id` are accepted and preserved.)
-- GitHub user not found (404 from `GET /users/{username}`) → exits with the offending username.
-- Repeated rebase failures (the CLI retries a small fixed number of times with exponential backoff) → exits with a `lost the rebase race` message and a hint to retry or investigate concurrent writers.
-
-## `gh teacher staff`
-
-Manage a classroom's **staff teams** — the per-classroom GitHub teams that back the web GUI's in-app roles: `classroom50-<classroom>-teacher` and `classroom50-<classroom>-ta`, each granted write on the `classroom50` config repo. Membership lives entirely in these GitHub teams (there is **no** `role` column in `roster.csv`), so a classroom's staff is the same whether managed from the CLI or the web. (`instructor` is a legacy alias of `teacher`; a pre-rename `classroom50-<classroom>-instructor` team is migrated to `-teacher` automatically on touch.)
-
-The staff teams are created by `gh teacher classroom add` / `classroom migrate`. If a classroom predates the staff-teams feature (no `teams` block in `classroom.json`), re-run `gh teacher classroom add <org> <classroom>` to create them, then add staff.
-
-### `gh teacher staff add`
-
+```sh
+gh teacher roster migrate <org> <classroom>
 ```
+
+Renames a classroom's legacy `students.csv` to `roster.csv` in one commit.
+Idempotent.
+
+**Errors common to roster commands:** missing config repo → `run gh teacher init
+<org> first`; missing `roster.csv` → points at `classroom add`; bad header →
+prints the offending header; unknown GitHub user → prints the username; repeated
+rebase failures → `lost the rebase race`, retry.
+
+## `staff`
+
+Manage a classroom's **staff teams** — `classroom50-<classroom>-teacher` and
+`-ta`, each granted write on the config repo. Membership lives entirely in these
+teams (there's no `role` column in `roster.csv`), so a classroom's staff is the
+same from the CLI or the web app. (`instructor` is a legacy alias of `teacher`.)
+
+```sh
 gh teacher staff add <org> <classroom> <username> [--role teacher|ta]
-gh teacher staff add cs50-fall-2026 cs-principles alice
-gh teacher staff add cs50-fall-2026 cs-principles bob --role ta
-```
-
-Adds `<username>` to the classroom's teacher (default) or ta staff team. `--role` accepts `teacher` or `ta` (case-insensitive; defaults to `teacher`). The legacy value `instructor` is still accepted as an alias of `teacher`. The user gains write on the config repo through the team; if they aren't yet an org member the team membership goes pending until they accept the org invitation. The team slug is read from `classroom.json` (authoritative — never re-derived). If the classroom predates the staff-teams feature (or its `teams` block is partial), `staff add` self-heals: it creates/adopts the missing team, grants it config-repo write, and records the ref in `classroom.json` before adding the user.
-
-### `gh teacher staff remove`
-
-```
 gh teacher staff remove <org> <classroom> <username> [--role teacher|ta]
-gh teacher staff remove cs50-fall-2026 cs-principles alice --role ta
 ```
 
-Removes `<username>` from the named staff team. **Does NOT** touch the user's org membership. Idempotent — a user who isn't on the team (or an already-gone team) is a clean no-op.
+`--role` defaults to `teacher`. `add` self-heals a classroom that predates staff
+teams (creating and recording the missing team). `remove` doesn't touch org
+membership and is idempotent.
 
-**Errors:** missing config repo → `run gh teacher init <org> first`; classroom not found → points at `gh teacher classroom add`; GitHub user not found → exits with the offending username.
+## `assignment`
 
-## `gh teacher assignment`
+Manage entries in `<org>/classroom50/<classroom>/assignments.json` — the manifest
+the autograde workflow and `gh student accept` both read. Writes use the same
+optimistic-rebase loop as roster commands.
 
-Manage entries in `<org>/classroom50/<classroom>/assignments.json` — the authoritative manifest the autograde workflow and `gh student accept` both read. Each entry pairs a `slug` (used in student repo names like `<classroom>-<slug>-<username>`) with an optional template repo, an optional due date, a `mode` (`individual` or `group`), and an optional `autograder` name (defaults to `default`).
-
-Writes flow through the same optimistic-update-with-rebase loop the roster commands use (up to 5 attempts with exponential backoff), so concurrent edits from multiple teachers don't silently lose each other's work.
-
-### `gh teacher assignment add`
+### `assignment add`
 
 ```sh
-gh teacher assignment add <org> <classroom> <slug> --name "<name>" [--template <owner>/<repo>[@branch]] [--description <text>] [--due <ISO-8601>] [--mode individual|group] [--max-group-size <N>] [--runtime <path-to-json>] [--tests <path-to-json>] [--autograder <name>] [--feedback-pr] [--empty-repo] [--pass-threshold <0–100>]
+gh teacher assignment add <org> <classroom> <slug> --name "<name>" [flags]
 gh teacher assignment add cs50-fall-2026 cs-principles hello --name "Hello" --template cs50/hello-template --due 2026-09-15T23:59:00-04:00
-gh teacher assignment add cs50-fall-2026 cs-principles project --name "Project" --template cs50/project-template --mode group --max-group-size 3
-gh teacher assignment add cs50-fall-2026 cs-principles intro --name "Intro" --template cs50/intro-template@main --runtime ./runtime-c.json
-gh teacher assignment add cs50-fall-2026 cs-principles reflection --name "Reflection"   # template-less: empty starter repo
-gh teacher assignment add cs50-fall-2026 cs-principles actions-lab --name "Actions Lab" --empty-repo   # truly bare repo, no autograding
+gh teacher assignment add cs50-fall-2026 cs-principles reflection --name "Reflection"   # template-less
+gh teacher assignment add cs50-fall-2026 cs-principles actions-lab --name "Actions Lab" --empty-repo
 ```
 
-Register or upsert one assignment. Idempotent on re-run: the same `slug` replaces the existing entry in place (position-preserving), a new `slug` appends. Replacement is wholesale — re-running without `--tests` drops any tests previously added via `gh teacher assignment test add`, and re-running without `--template` drops a previously-set template (making the assignment template-less). The CLI prints a warning in both cases.
+Registers or upserts one assignment. Re-running with the same slug replaces the
+entry wholesale (dropping tests or a template you don't re-pass — the CLI warns).
+The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 
-**Slug rules** (same as classroom short-names): `^[a-z0-9][a-z0-9-]{1,38}$`, 2-39 chars, lowercase letters/digits/hyphens, starting with a letter or digit. The slug becomes part of the student repo name `<classroom>-<slug>-<username>`, so the constraint mirrors GitHub's repo-name rules.
+**Required:** `--name`.
 
-**Required flags:**
+**Optional:**
 
-- `--name <display name>` — written into `assignments.json`'s `name` field. Used in release titles and the published Pages site (forthcoming).
+| Flag | Purpose |
+| --- | --- |
+| `--template <owner>/<repo>[@branch]` | Starter-code repo (must be flagged as a template). Omit for a template-less empty repo. Branch defaults to the template's default. |
+| `--description <text>` | Short description. |
+| `--due <ISO-8601>` | Due date; timezone required. Stored verbatim. |
+| `--mode individual\|group` | `individual` (default) or `group` (requires `--max-group-size`). |
+| `--max-group-size <N>` | Max group collaborators (`>= 2`). Advisory. |
+| `--runtime <path>` | JSON runtime (`runs-on`, toolchains, `apt`, `container`). See [Autograders](Autograders). |
+| `--tests <path>` | JSON array of declarative tests. Mutually exclusive with a per-assignment `autograder.py`. |
+| `--autograder <name>` | Swap the reusable workflow (rare). Default `default`. |
+| `--feedback-pr` | One review PR per student repo. **On by default**; `--feedback-pr=false` disables. |
+| `--empty-repo` | Truly bare repos (no README/marker/shim); autograding and feedback PR disabled; immutable; mutually exclusive with template/tests/feedback-pr/allowed-files/pass-threshold. |
+| `--pass-threshold <0–100>` | Advisory passing bar shown by gradebook clients. Off when omitted (distinct from `0`). |
 
-**Optional flags:**
+**Where grading logic lives** (increasing effort): declarative `--tests` → a
+per-assignment `<classroom>/autograders/<slug>/autograder.py` → a classroom
+default via `gh teacher autograder set-default`. See [Autograders](Autograders).
 
-- `--template <owner>/<repo>[@branch]` — the starter-code repo. **Optional**: omit it for a template-less assignment, where `gh student accept` creates an *empty* private repo containing only the autograder workflow shim (no starter files). When supplied, the CLI calls `GET /repos/{owner}/{repo}` to verify it exists, is visible to your token, and has `is_template: true`. When you omit `@branch`, the template's `default_branch` from the response is used; pass `@main` (or `@master`, etc.) to pin explicitly.
+<details>
+<summary>Errors</summary>
 
-- `--description <text>` — short description written into the entry (omitted from the file when empty).
-- `--due <ISO-8601>` — due date in RFC 3339 form, e.g. `2026-09-15T23:59:00-04:00`. The timezone is required. Stored verbatim, so a teacher's choice of offset round-trips through the file.
-- `--mode individual|group` — `individual` (default) gives each student their own repo. `group` lets teammates share one repo: the first student to `gh student accept` creates it (and becomes its admin), then adds others with `gh student invite` (see the [gh student](gh-student) reference). Requires `--max-group-size`.
-- `--max-group-size <N>` — maximum collaborators on a group repo (`>= 2`; required with `--mode group`, rejected otherwise). **The limit is advisory** — not hard-enforced by the CLI; the founder coordinates group size when adding teammates, and collaborators can also be added through GitHub's web UI. Grading attribution fans a group submission's score to every rostered member at collection time (the runner emits the owner; `collect-scores` reads the repo's collaborators and credits each — see the [Autograders](Autograders) wiki page).
-- `--runtime <path>` — JSON file (or `-` for stdin) describing the runtime environment for this assignment's autograde job: `runs-on` (a single runner label or an array of labels, including self-hosted), `python` / `node` / `java` / `go` / `rust` toolchain versions, `apt` packages, and an escape-hatch `container` image. Omit for the defaults (ubuntu-latest + Python 3.12). See the [Autograders](Autograders) wiki page for the full schema and worked examples.
-- `--tests <path>` — JSON file with a bare array of declarative test specs (`io` / `run` / `python`), or `-` for stdin. Replaces the entry's whole `tests` block — the bulk counterpart to `gh teacher assignment test add`, in the same shape `assignment test list --json` emits. Mutually exclusive with a per-assignment `autograder.py`. See the [Autograders](Autograders) wiki page for the field reference.
-- `--autograder <name>` — reserved for the rare case where you want to call a different *reusable workflow* entirely (not just different language toolchains — for that, use `--runtime`). The default `default` resolves to the universal shim embedded in `gh-student`. Non-default values reference a sibling shim at `<classroom>/autograders/<name>.yaml` in the config repo; the referenced file must exist at write time.
-- `--feedback-pr` — control the **Feedback Pull Request**: each student repo gets one long-lived PR (base = a frozen `feedback` branch at the student's baseline commit, head = the default branch) so you review the full starter→submission diff with inline GitHub review comments. The autograde runner opens/updates it on submissions that have a diff; the PR auto-updates as the student submits. The PR is labeled **Individual Assignment** or **Group Assignment** by the assignment's mode. **Default on** — pass `--feedback-pr=false` to disable it for an assignment (e.g. an autograded-only problem set where you won't review diffs). Requires `gh teacher init` to have enabled the org "Allow GitHub Actions to create and approve pull requests" setting and installed the feedback rulesets (init does this automatically; re-run init if your org was set up before this feature). See the [Autograders](Autograders) wiki page for the full flow and limitations.
-- `--empty-repo` — create **truly bare** student repos: `gh student accept` makes the repo with no initial commit and lands **no control files** — no README, no `.classroom50.yaml` accept marker, no `.github/workflows/autograde.yaml` shim. For assignments where students build the entire repo from scratch, including their own GitHub Actions workflows (which would otherwise conflict with or break the autograde shim). Consequences: **autograding and the Feedback PR are disabled** for the assignment (regrade and score collection skip it; the gradebook shows accept state but no scores), and the flag is **immutable after creation** — re-running `assignment add` with a different `empty_repo` value is rejected, because repos students already accepted are never retrofitted with (or stripped of) control files. Removing the assignment and re-adding the **same** slug is not a way around this: `assignment remove` leaves the student repos in place, so the re-added slug would strand them on the old behavior — to change `empty_repo`, add the assignment under a **new** slug. Mutually exclusive with `--template`, `--tests`, `--feedback-pr`, `--allowed-files`, and `--pass-threshold`.
-- `--pass-threshold <0–100>` — opt-in passing bar as a percentage of max score: at or above it a gradebook client (e.g. the web GUI) shows a submission as passing. **Advisory/display-only** — like `--max-group-size`, the CLI does not enforce it and it never changes a student's score. **Omit to leave it off** (no passing concept at all, which is distinct from a 0% bar); pass `--pass-threshold 0` for an explicit 0%. Note `assignment add` rewrites the whole entry, so re-running it **without** `--pass-threshold` clears a previously-set value (often set in the gradebook GUI) — the command warns when this happens; pass the flag again to keep it.
+- Missing config repo / `assignments.json` → points at `init` / `classroom add`.
+- Template 404 → make it public or copy it into the org.
+- Template private and outside `<org>` → rejected (students can't be granted
+  access).
+- Template not flagged as a template → names the Settings toggle.
+- `--autograder <name>` references a missing file → tells you to create it.
+- `--runtime` / `--tests` fail validation → names the offending field.
+- Repeated rebase failures → `lost the rebase race`.
 
-**Where grading logic lives.** Three options, in increasing order of effort:
+**Same-slug concurrent writes** are last-writer-wins; both commits stay in git
+history, so an unexpected overwrite is recoverable with `git revert`.
 
-1. **Declarative tests** — pass `--tests` here (or use `gh teacher assignment test add`) to describe io/run/python checks the runner grades with no grading code.
-2. **Per-assignment `autograder.py`** — a Python script that produces `result.json`, dropped at `<classroom>/autograders/<slug>/autograder.py` in the config repo. Sibling fixtures and helpers ride along in the bundle. Mutually exclusive with declarative tests.
-3. **Classroom default** — `gh teacher autograder set-default <org> <classroom>` installs `<classroom>/autograder.py`, used by every assignment that has neither of the above.
+</details>
 
-See the [Autograders](Autograders) wiki page for the entrypoint contract and copy-pasteable templates (pytest, check50, custom).
-
-**Errors:**
-
-- `<org>/classroom50` missing → `run gh teacher init <org> first`, non-zero.
-- `<classroom>/assignments.json` missing → `run gh teacher classroom add <org> <classroom> first, or restore the file if it was deleted`.
-- Template repo 404 (private, in another org, or doesn't exist) → `template <owner>/<repo> is not visible to your account — either make it public, or copy it into your org and reference the copy`.
-- Template repo exists but is **private and outside `<org>`** → rejected: `template <owner>/<repo> is private and outside the org <org> — students can't be granted access to it … Copy it into <org> and reference the copy, or make the template public`. (A private template **inside** `<org>` is accepted, and the classroom team is granted `pull` on it so students can generate from it.)
-- Template repo exists but `is_template: false` → message naming the Settings toggle to flip.
-- `--autograder <name>` (non-default) references a file that doesn't exist in the config repo at write time → `autograder "<name>" does not exist at <org>/classroom50/<classroom>/autograders/<name>.yaml — create it (or pass --autograder default) before registering this assignment`. The default name resolves to the embedded gh-student shim and skips the file-existence probe.
-- `--runtime <path>` JSON fails validation (e.g. a `runs-on` label with whitespace or shell metacharacters, more than 10 labels, an empty `runs-on` string/array, a malformed apt name, or an unsupported container key) → an error naming the offending field, with the path to the JSON file.
-- `--tests <path>` JSON fails validation (unknown field, bad `type`/`comparison`, out-of-bounds timeout/points, duplicate names) → an error naming the offending test and field, with the path to the JSON file.
-- `--tests` passed while `<classroom>/autograders/<slug>/autograder.py` exists → `declarative tests and a hand-written autograder.py are mutually exclusive`, with the conflicting path.
-- `--tests` passed but the config repo is missing `.github/scripts/materialize_tests.py` (skeleton predates declarative tests, so they would never run) → an error pointing at `gh teacher init` to update the skeleton. Applies to `gh teacher assignment test add` too.
-- Repeated rebase failures (5 attempts with exponential backoff) → `lost the rebase race` with a retry hint.
-
-**Same-slug concurrent writes.** The rebase loop handles concurrent edits to *different* slugs cleanly — each teacher's retry sees the other's commit and re-applies their own upsert. For concurrent edits to the *same* slug (two teachers running `gh teacher assignment add hello ...` within the rebase window), the contract is last-writer-wins: the loser's retry observes the winner's entry and replaces it with theirs, without an on-CLI signal. Both commits remain in the config repo's git history, so a teacher who notices an unexpected overwrite can recover with `git revert` on the config repo.
-
-### `gh teacher assignment reuse`
+### `assignment reuse`
 
 ```sh
-gh teacher assignment reuse <org> <source-slug> --from <source-classroom> --to <target-classroom> [--slug <new-slug>] [--name "<new name>"] [--json]
-gh teacher assignment reuse cs50-fall-2026 hello --from cs-principles-2025 --to cs-principles-2026
-gh teacher assignment reuse cs50-fall-2026 hello --from old --to new --slug hello-redux --name "Hello (Redux)"
-gh teacher assignment reuse cs50-fall-2026 hello --from old --to new --json
+gh teacher assignment reuse <org> <source-slug> --from <src-classroom> --to <dst-classroom> [--slug <new>] [--name "<new>"] [--json]
 ```
 
-Copy an existing assignment record from one classroom's `assignments.json` into another's, **within the same org** — the scriptable counterpart to the web's "reuse assignment", ideal for rebuilding last term's assignments in a new classroom. The source record is copied **verbatim** through the typed entry (template, due/due_meta, mode, autograder, max_group_size, feedback_pr, runtime, allowed_files, pass_threshold, tests, description); only the slug and name can change. Unknown/future top-level entry fields (added by a newer binary or the web GUI) are preserved too, so reuse never drops a field this CLI doesn't yet model.
+Copies an assignment record into another classroom in the **same org** — the
+scriptable version of the web app's "reuse assignment". Every field is copied
+verbatim (including unknown/future ones); only slug and name can change. Student
+repos and scores are not copied.
 
-**Required flags:**
+- A colliding slug auto-suffixes `-2`, `-3`, … unless you pass `--slug`
+  explicitly (which refuses a collision). Read the final slug from `--json`, not
+  the prose.
+- Re-grants the target classroom's team read on a private in-org template.
+  In-org only (v1). Refuses an archived target.
 
-- `--from <source-classroom>` — the classroom to copy from.
-- `--to <target-classroom>` — the classroom to copy into (same org).
-
-**Optional flags:**
-
-- `--slug <new-slug>` — slug for the copy in the target classroom. By default the source slug is reused; on a **case-insensitive** collision it auto-suffixes `-2`, `-3`, … (slugs become GitHub repo path segments, which are case-insensitive). Passing `--slug` explicitly **refuses** a colliding name instead of auto-suffixing. An auto-suffix that would exceed the 39-char slug cap errors with a hint to pass a shorter `--slug`.
-- `--name "<new name>"` — display name for the copy (default: the source name).
-- `--json` — emit the resolved copy as JSON on stdout — `{org, classroom, slug, source_slug, auto_suffixed, template}` — instead of the human summary. **Read the final slug from here**, not by parsing the prose: an auto-suffixed slug isn't known until the write resolves the collision, so scripts/agents should rely on the `slug` field. Advisory notes still go to stderr, keeping stdout a single parseable JSON value.
-
-**Template team grant.** When the copied assignment references a **private, in-org** template, reuse re-applies the target classroom's team read grant on it (the same grant `assignment add` performs) so rostered students in the target classroom can generate from it. A public template (or no template) needs no grant. A **private out-of-org** template can't be granted (reuse is in-org only for private templates in v1) — reuse warns and lands the copy anyway rather than failing; copy the template into the org and re-add to fix it. A template that 404s (deleted or invisible) warns similarly.
-
-**In-org only (v1).** Cross-org reuse of a private template is out of scope, since the target classroom's students can only be team-granted read on a template inside their own org.
-
-**Archived target refused.** Like `assignment add`, reuse refuses to write into an archived (`active: false`) target classroom, pointing at `gh teacher classroom unarchive`.
-
-**Errors:**
-
-- `<org>/classroom50` missing → `run gh teacher init <org> first`.
-- Source slug not found in the source classroom → lists the `gh teacher assignment list` command to see available slugs.
-- An explicit `--slug` that collides (case-insensitively) in the target → `choose a different --slug`.
-- `--from` and `--to` are the same classroom with no `--slug` → refused (an in-place reuse must rename to a distinct slug).
-- The post-commit template grant fails (missing team, transport error) **after the copy already landed** → the error makes the partial state clear; the copy is committed and re-running is safe (the grant is idempotent).
-
-### `gh teacher assignment remove`
+### `assignment remove`
 
 ```sh
 gh teacher assignment remove <org> <classroom> <slug>
 ```
 
-Drops the matching entry. Idempotent: if the slug is already absent, exits 0 with a note. **Does NOT touch existing student repos** — the starter code and submission history stay intact; only new `gh student accept` invocations stop finding the slug.
+Drops the entry (idempotent). Does **not** touch existing student repos — only
+new `gh student accept` calls stop finding the slug.
 
-### `gh teacher assignment list`
+### `assignment list`
 
 ```sh
-gh teacher assignment list <org> <classroom>
-gh teacher assignment list <org> <classroom> --json
-gh teacher assignment list <org> <classroom> -q | xargs -I{} gh teacher download <org> <classroom> {}
+gh teacher assignment list <org> <classroom> [--json] [-q]
 ```
 
-Read-only enumeration of every slug registered in `<org>/classroom50/<classroom>/assignments.json`. Default output is one slug per line on stdout — pipeable directly into `xargs gh teacher download`, `grep`, an agent loop, or anything else expecting a newline-separated list.
+One slug per line (pipeable into `xargs`). `--json` emits the full entries array.
+Read-only.
 
-**Flags:**
-
-- `--json` — emit the full JSON array of assignment entries instead of one slug per line. Preserves every field (template ref, due, mode, autograder, runtime, tests) so an agent can introspect the manifest without a second API call. Output matches the on-disk indent so `jq` pipes work without reformatting.
-- `--quiet` / `-q` — suppress the one-line stderr summary (`<repo-path>: N assignments`). Use this when capturing stdout from a script that should not have to filter mixed streams.
-
-**Errors:** same shape as `add` and `remove` — missing config repo points at `gh teacher init`, missing `assignments.json` points at `gh teacher classroom add`. Exits 0 with empty stdout when the classroom has no assignments yet (the stderr summary, when not suppressed, hints at `gh teacher assignment add` for the next step).
-
-### `gh teacher assignment test`
+### `assignment test`
 
 ```sh
-gh teacher assignment test add <org> <classroom> <slug> --name "<name>" --type {io,run,python} --run "<command>" [--setup <cmd>] [--input <text> | --input-file <name>] [--expected <text> | --expected-file <name>] [--comparison {included,exact,regex}] [--timeout <seconds>] [--exit-code <n>] [--points <n>]
+gh teacher assignment test add <org> <classroom> <slug> --name "<n>" --type {io,run,python} --run "<cmd>" [options]
 gh teacher assignment test list <org> <classroom> <slug> [--json] [-q]
 gh teacher assignment test remove <org> <classroom> <slug> <test-name>
-
-gh teacher assignment test add cs50-fall-2026 cs-principles hello \
-    --name compiles --type run --run "gcc -o hello hello.c" --points 1
-gh teacher assignment test add cs50-fall-2026 cs-principles hello \
-    --name "prints hello" --type io --setup "gcc -o hello hello.c" \
-    --run ./hello --expected "Hello, world!" --comparison included --points 2
 ```
 
-Manage the **declarative `tests` block** on an existing assignment — GitHub Classroom-style io / run / python checks the runner grades with a built-in interpreter, no `autograder.py` needed. On the next config-repo push, publish-pages materializes the block into the assignment's Pages bundle as `tests.json`; grading picks it up on the submission after that. See the [Autograders](Autograders) wiki page for the field reference, comparison semantics, and precedence rules.
+Manage the declarative `tests` block — GitHub Classroom-style io/run/python
+checks graded with no `autograder.py`. `add` upserts by `--name`; it's refused
+while a per-assignment `autograder.py` exists. See
+[Autograders](Autograders#declarative-tests) for fields and semantics. For bulk
+edits, use `assignment add --tests <file.json>`.
 
-- **`add`** upserts one test by `--name`: the same name replaces in place, a new name appends. The slug must already be registered (`gh teacher assignment add` first). Refused while a hand-written `<classroom>/autograders/<slug>/autograder.py` exists — the runner prefers `autograder.py`, so the tests would silently never run.
-- **`list`** prints test names one per line on stdout (pipeable into `remove`); `--json` emits the full spec array (`[]` when empty), `-q` suppresses the stderr summary. Read-only.
-- **`remove`** drops one test by name. Idempotent: an already-absent name exits 0 with a note and lands no commit. Errors only if the slug itself isn't registered.
+## `autograder`
 
-For bulk edits (or a GUI/agent export), `gh teacher assignment add ... --tests <file.json>` replaces the whole array in one write.
-
-Writes flow through the same optimistic-rebase loop as every other `assignments.json` edit; the conflict probe and slug lookup re-run against each attempt's parent commit, so concurrent edits rebase cleanly.
-
-## `gh teacher autograder`
-
-Manage the **classroom default autograder** at `<classroom>/autograder.py` — `set-default` to install or replace it, `show` to read it, `remove` to delete it, and `list` to enumerate the named shims and per-assignment overrides under `<classroom>/autograders/`. The runner uses the default for every assignment in the classroom that has neither a per-assignment override under `<classroom>/autograders/<slug>/` nor a declarative `tests` block on its entry.
-
-### `gh teacher autograder set-default`
+Manage the **classroom default autograder** at `<classroom>/autograder.py` and
+inspect the autograders under `<classroom>/autograders/`.
 
 ```sh
-gh teacher autograder set-default <org> <classroom> --from <path>
-gh teacher autograder set-default <org> <classroom> --from -
-gh teacher autograder set-default <org> <classroom>
-gh teacher autograder set-default cs50-fall-2026 cs-principles \
-    --from examples/autograders/cs50/autograder.py
+gh teacher autograder set-default <org> <classroom> [--from <path|->]
+gh teacher autograder show <org> <classroom> [--json] [-q]
+gh teacher autograder list <org> <classroom> [--json] [-q]
+gh teacher autograder remove <org> <classroom> [--yes]
 ```
 
-Replaces `<classroom>/autograder.py` in the config repo with the contents of `--from <path>`. `--from -` reads from stdin (one-shot agent flows). When `--from` is omitted, installs the diagnostic stub shipped with this CLI — the stub echoes every env var the runner exposed and emits a vacuous-pass `result.json`, so teachers can verify the pipeline before authoring real grading logic.
+- **`set-default`** replaces `<classroom>/autograder.py` with `--from` (a file or
+  `-` for stdin). With no `--from`, it installs a diagnostic stub that echoes the
+  runner's environment and emits a vacuous pass — useful for verifying the
+  pipeline. The classroom must already exist.
+- **`show`** prints the default to stdout; `--json` emits metadata
+  `{path, exists, is_stub, size, sha}`. Read-only.
+- **`list`** enumerates named shims (`<name>.yaml`) and per-assignment override
+  bundles (`<slug>/`); `--json` emits `{name, kind, path}`. The default isn't
+  listed (use `show`). Read-only.
+- **`remove`** deletes the default (distinct from overwriting it with the stub).
+  Prompts unless `--yes`. Idempotent.
 
-Lands as a single Tree commit on the config repo's default branch and is picked up by every subsequent submission once the next `publish-pages.yaml` run deploys (~30s). Re-running with the same content is a no-op.
+Named shims and per-assignment `autograder.py` overrides are **read-only from the
+CLI** — author them with ordinary git operations. See [Autograders](Autograders).
 
-**Validation.** The classroom must already exist (`<classroom>/classroom.json` present in the repo). If it doesn't, the command refuses to write — preventing typos from creating phantom-classroom directories that contain only `autograder.py`. Run `gh teacher classroom add` first.
-
-### `gh teacher autograder show`
-
-```sh
-gh teacher autograder show <org> <classroom>
-gh teacher autograder show cs50-fall-2026 cs-principles
-gh teacher autograder show cs50-fall-2026 cs-principles --json
-gh teacher autograder show cs50-fall-2026 cs-principles > autograder.py
-```
-
-Print the classroom default at `<classroom>/autograder.py`. Default output writes the file body to stdout (pipe it to a file or pager); a one-line stderr summary says whether it's the shipped diagnostic stub or a custom autograder, with its size.
-
-**Flags:**
-
-- `--json` — emit metadata only — `{path, exists, is_stub, size, sha}` — without the body, so a script can branch on whether a real autograder is installed. `sha` is the git blob object id (matches what the contents/trees API reports).
-- `-q`, `--quiet` — suppress the stderr summary so stdout is the only output stream.
-
-Read-only; no commit lands. When the classroom has no default autograder, stdout stays empty and stderr says so — the command still exits 0, because an unset default is a valid mid-setup state (graded as a vacuous pass). A missing classroom points at `gh teacher classroom add`.
-
-### `gh teacher autograder list`
+## `invite`
 
 ```sh
-gh teacher autograder list <org> <classroom>
-gh teacher autograder list cs50-fall-2026 cs-principles
-gh teacher autograder list cs50-fall-2026 cs-principles --json
-```
-
-List everything under `<classroom>/autograders/`: named workflow shims (`<name>.yaml`, opted into with `gh teacher assignment add --autograder <name>`) and per-assignment override bundles (`<slug>/`, holding a hand-written `autograder.py` for that one assignment). Default output is one entry per line on stdout — named shims as `<name>.yaml`, override bundles as `<slug>/` (trailing slash). A one-line `<path>: N autograder(s)` summary goes to stderr.
-
-**Flags:**
-
-- `--json` — emit the full array of `{name, kind, path}` objects (`kind` is `named-shim` or `per-assignment`).
-- `-q`, `--quiet` — suppress the stderr summary.
-
-The classroom **default** (`<classroom>/autograder.py`) is not listed here — inspect it with `gh teacher autograder show`. Read-only; no commit lands. Stray non-`.yaml` files at the top of `autograders/` are skipped.
-
-### `gh teacher autograder remove`
-
-```sh
-gh teacher autograder remove <org> <classroom>
-gh teacher autograder remove --yes cs50-fall-2026 cs-principles
-```
-
-Delete `<classroom>/autograder.py` in a single commit. This is distinct from `set-default` with no `--from`, which **overwrites** the file with the diagnostic stub — `remove` deletes it outright.
-
-**Grading impact.** Once removed, any assignment in the classroom that has neither a per-assignment override (`<classroom>/autograders/<slug>/autograder.py`) nor a declarative `tests` block falls back to a vacuous pass (0/0) on its next submission, until you set a new default. Per-assignment overrides and named shims are **not** touched.
-
-**Confirmation.** You'll be asked to confirm (`[y/N]`) before anything is deleted; pass `--yes` to skip the prompt (scripted runs only). Idempotent: removing a classroom that has no default autograder is a clean no-op.
-
-### Named and per-assignment autograders
-
-Named shims (`<classroom>/autograders/<name>.yaml`) and per-assignment overrides (`<classroom>/autograders/<slug>/autograder.py`) are **read-only from the CLI** — `autograder list` shows what's present, but authoring, editing, and deleting them is done with ordinary git operations against the config repo (the files ride into each submission's Pages bundle). See [Autograders](Autograders) for the file layout and precedence rules.
-
-## `gh teacher invite`
-
-Uses the API to invite a student or teaching assistant to an org or a specific repo.
-
-```sh
-gh teacher invite <org> <username>             # direct_member to org
-gh teacher invite --admin <org> <username>     # admin to org
-gh teacher invite <org>/<repo> <username>      # collaborator on repo (default push)
+gh teacher invite <org> <username>             # org member
+gh teacher invite --admin <org> <username>     # org admin
+gh teacher invite <org>/<repo> <username>      # repo collaborator (default push)
 gh teacher invite -p maintain <org>/<repo> <username>
 ```
 
-Under the hood:
+Invites by resolved user ID. `-p` accepts `pull`, `triage`, `push`, `maintain`,
+`admin`; re-running updates the collaborator in place. Org invites need
+`admin:org` (run `gh teacher login` once). Common API states (already a member,
+pending invite, not an admin) become actionable messages.
 
-1. Resolve the username to a user ID via `GET /users/{username}` ([docs](https://docs.github.com/en/rest/users/users?apiVersion=2026-03-10#get-a-user)).
-2. For org targets, invite by user ID via `POST /orgs/{org}/invitations` ([docs](https://docs.github.com/en/rest/orgs/members?apiVersion=2026-03-10#create-an-organization-invitation)).
-3. For repo targets, add via `PUT /repos/{owner}/{repo}/collaborators/{username}` ([docs](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#add-a-repository-collaborator)).
-4. Advise the user to sign in to `https://github.com` as the invited GitHub user, then visit `https://github.com/<org>` to accept.
-
-The org-invitation endpoint requires the `admin:org` OAuth scope. Run `gh teacher login` once before the first org invite to grant it.
-
-Common API failures (missing scope, not an admin, org not found, already a member, pending invite) are translated into actionable messages instead of raw HTTP errors.
-
-## `gh teacher remove`
+## `remove`
 
 ```sh
-gh teacher remove <org> <username>           # remove from organization
-gh teacher remove <org>/<repo> <username>    # remove from one repository
+gh teacher remove <org> <username>           # from the organization
+gh teacher remove <org>/<repo> <username>    # from one repo
 ```
 
-- Org targets call `DELETE /orgs/{org}/memberships/{username}` ([docs](https://docs.github.com/en/rest/orgs/members?apiVersion=2026-03-10#remove-organization-membership-for-a-user)). Revokes access to every repository in the org, removes the user from all teams, and cancels any pending invitation in one call.
-- Repo targets call `DELETE /repos/{owner}/{repo}/collaborators/{username}` ([docs](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#remove-a-repository-collaborator)).
-- Both forms are idempotent: a `204` prints `removed <username>`; a `404` (user is not a member or collaborator) prints a clear message and exits 0 so re-runs are safe.
+The org form revokes access to every repo, removes the user from all teams, and
+cancels any pending invitation. Both forms are idempotent (a 404 exits 0).
 
-## `gh teacher member list`
+## `member list`
 
 ```sh
-gh teacher member list <org>         # org members + pending invitations, with role
-gh teacher member list <org>/<repo>  # repo collaborators, with permission level
+gh teacher member list <org>         # members + pending invitations, with role
+gh teacher member list <org>/<repo>  # collaborators, with permission
 gh teacher member list <org> --json
 gh teacher member list <org> --quiet
 ```
 
-The Read counterpart to `invite` / `remove`. The roster (`roster.csv`) is the *intended* membership; this command shows *actual* GitHub membership, so the two can be reconciled when they drift (a student who never accepted their invite, or a collaborator added out of band).
+Shows *actual* GitHub membership (the roster is the *intended* list), so you can
+reconcile drift — e.g. a student who never accepted their invite. Default is an
+aligned table; `--json` emits `{login, kind, role, github_id}`; `--quiet` prints
+one login per line. Reading org invitations needs `admin:org`. Read-only.
 
-- **Org target** lists active members and pending invitations. Active members come from `GET /orgs/{org}/members` ([docs](https://docs.github.com/en/rest/orgs/members?apiVersion=2026-03-10#list-organization-members)) — walked once with `?role=admin` to label admins and once unfiltered — and pending invitations from `GET /orgs/{org}/invitations` ([docs](https://docs.github.com/en/rest/orgs/members?apiVersion=2026-03-10#list-pending-organization-invitations)). Reading pending invitations needs the `admin:org` scope; a `403` surfaces as a clear "scope required" error rather than silently dropping them. Each row's `kind` is `member` or `invitation`; `role` is `admin` or `member`.
-- **Repo target** lists collaborators from `GET /repos/{owner}/{repo}/collaborators` ([docs](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#list-repository-collaborators)); `kind` is `collaborator` and `role` is the permission level (`read`/`triage`/`write`/`maintain`/`admin`).
-- **Output:** default is an aligned table (`LOGIN`, `KIND`, `ROLE`, `GITHUB_ID`; a missing id or unreported permission renders as `-`) with a one-line `<target>: N member(s)` (or `N collaborator(s)`) summary on stderr. `--json` emits the full array of `{login, kind, role, github_id}` objects (empty target → `[]`, not `null`); `--quiet` prints one login per line with no table or stderr summary. `--json` takes precedence over `--quiet`. In `--json`, `github_id` is always present and is `0` when the source endpoint doesn't report a numeric id (e.g. pending invitations); `role` is `admin`/`member` (or `billing_manager`) for an org and the permission level for a repo, and may be an empty string when GitHub doesn't report it.
-- Both surfaces are paginated (100 per page) so large orgs/repos enumerate fully. Read-only; no write lands.
-
-## `gh teacher download`
+## `download`
 
 ```sh
 gh teacher download <org> <classroom> <assignment>              # team-driven (default)
-gh teacher download --by-pattern <org> <classroom> <assignment> # skip team, clone by name prefix
-gh teacher download -d <dir> <org> <classroom> <assignment>     # literal dir, no timestamp
-gh teacher download -v <org> <classroom> <assignment>           # stream raw git output per repo
-gh teacher download -q <org> <classroom> <assignment>           # suppress per-repo summary, forward --quiet to git
+gh teacher download --by-pattern <org> <classroom> <assignment> # clone by name prefix
+gh teacher download -d <dir> <org> <classroom> <assignment>     # literal dir
 ```
 
-### Team-driven mode (default)
+**Team-driven (default):** lists the classroom team's members and, for each,
+probes the expected `<classroom>-<assignment>-<username>` repo, clones it (or
+reports `Missing: <username>`), and refreshes `result.json` (latest) and
+`results.json` (all submissions) from its releases. Then writes a `scores.csv`
+at the destination root — one line per submission, with a blank-score line for
+non-submitters.
 
-The command lists the classroom GitHub team's members (the source of truth for enrollment) and reads `<classroom>/assignments.json`, then for each team member:
+Each run creates a fresh timestamped folder unless you pass `-d`. Existing target
+dirs are skipped on clone but still get `result.json` refreshed.
 
-1. Computes the canonical `<classroom>-<assignment>-<username>` repo name (lowercased — matches `gh student accept`'s naming).
-2. Probes `GET /repos/<org>/<name>` ([docs](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#get-a-repository)). A 404 prints `Missing: <username> (not accepted yet?)` and contributes to the per-run summary; a non-404 error surfaces as a per-repo failure.
-3. For repos that exist, shells out to `gh repo clone <org>/<name> <dir>/<name>` so authentication flows through the current `gh` session.
-4. For each cloned repo (and for repos already on disk), refreshes `<repo>/result.json` (the latest submission) **and** `<repo>/results.json` (every submit-tag submission, newest first) from that repo's submit-tag releases. Each asset is fetched via the release's asset API URL with `Accept: application/octet-stream`, and `Authorization` is stripped on the redirect to the signed storage URL so the GitHub token never reaches the storage origin. A repo with no submit-tag releases, or releases with no `result.json` asset, is a silent no-op.
-5. After all clones, writes a `scores.csv` summary at the destination root with **one line per submission**, grouped by team member in team-member order (columns `username,score,max_score,datetime,submission_tag,submitted_by,review_url,late,override`). `roster.csv` (if present) supplies each row's optional name/section/email metadata. A student who pushed N times contributes N lines (newest first); for a group assignment each credited member (the entry's `member_usernames`) gets the team's submission lines. Non-submitters get a single blank-score line so a teacher can sort by score and immediately see who hasn't submitted yet. Student-controlled string cells are guarded against spreadsheet formula injection.
+**`--by-pattern`** pages through the org's repos and clones every one whose name
+starts with `<classroom>-<assignment>-`, skipping the team lookup, the
+`result.json` refresh, and the `scores.csv` summary. Use it when the config repo
+isn't bootstrapped, or to grab every matching repo regardless of the roster.
 
-The command refuses to run when:
-
-- `<org>/classroom50` doesn't exist → `run gh teacher init <org> first`.
-- The classroom directory / `assignments.json` is missing → `run gh teacher classroom add` first.
-- `<assignment>` isn't registered in `assignments.json` → `run gh teacher assignment add <org> <classroom> <assignment>` first, or pass `--by-pattern` to skip the team lookup.
-
-### `--by-pattern`
-
-Pages through `GET /orgs/{org}/repos` ([docs](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-organization-repositories)) and clones every repo whose name starts with `<classroom>-<assignment>-`. Skips the team lookup, the `result.json` refresh, and the `scores.csv` summary — useful when the config repo isn't bootstrapped yet, or when you want every matching repo regardless of who's currently enrolled.
-
-### Destination
-
-Default is `<classroom>-<assignment>_submissions_YYYY_MM_DD_T_HH_MM_SS/` (24-hour local time) so each run produces a fresh folder and prior downloads are preserved without manual cleanup. Pass `-d` to override (the value is taken literally, no timestamp appended).
-
-Existing target dirs are skipped on the clone step, so re-runs with the same `-d` pick up new submissions without aborting on the ones already cloned. `result.json` is still refreshed on the existing clones — so a re-run after the latest collect-scores cycle picks up the newest score without re-cloning. Clone failures carry git's actionable diagnostic (e.g. `fatal: ...`) rather than just an exit code; a non-zero exit code surfaces after the rest of the run still completes.
-
-## `gh teacher teardown`
+## `teardown`
 
 ```sh
-gh teacher teardown <org>              # interactive (typed org-name prompt)
-gh teacher teardown --yes <org>        # skip the prompt (scripted runs)
+gh teacher teardown <org>          # typed org-name prompt
+gh teacher teardown --yes <org>    # skip the prompt (scripts only)
 ```
 
-Delete every repository in `<org>` after confirming the org is a Classroom 50 setup. Intended for **development scenarios** — resetting a test org between runs of `gh teacher init` / `migrate` / etc. Production teachers should use the GitHub web UI for selective deletion; this is a sledgehammer.
+Deletes **every** repository in `<org>` — a development reset. It confirms the
+`classroom50` marker repo exists (refusing otherwise), lists all repos, prompts
+for the typed org name, then deletes each (the config repo last, so an
+interrupted run stays safe to re-run).
 
-**What it does:**
+> [!WARNING]
+> Requires the `delete_repo` scope, which is **not** in the default set. Opt in
+> once with `gh teacher login -s delete_repo`.
 
-1. Confirms the marker repo exists: `GET /repos/<org>/classroom50`. A 404 refuses teardown with `not found — refusing teardown on an org without the Classroom 50 marker repo`. This is the safety net that prevents accidental nukes of orgs that aren't dedicated to a single classroom.
-2. Lists every repo in the org via `GET /orgs/<org>/repos` (paginated). Prints the full set on stdout — teachers see exactly what's about to disappear.
-3. Prompts for **typed org-name confirmation** (e.g. `Type the org name (cs50-fall-2026) to confirm:`). Anything other than the org name aborts with `confirmation did not match org name — aborted without deleting anything`. Pass `--yes` to skip the prompt; CI / scripts only.
-4. Issues `DELETE /repos/<org>/<repo>` for each repo. `<org>/classroom50` is deleted **last** so a mid-run failure leaves the marker repo behind — re-running teardown still passes the precondition check and tries again on the survivors.
-5. Per-repo failures are tolerated: each prints to stderr with the failure reason and the run continues. Exits non-zero when any repo failed so scripts see the partial-completion signal.
+## `whoami` / `login` / `logout`
 
-**Required scope (opt-in).** `delete_repo` is NOT part of the default `gh teacher login` scope set. Opt in once with `gh teacher login -s delete_repo` before running teardown. This is intentional: teachers who haven't explicitly opted in can't accidentally wipe their org. If your token lacks the scope, the first `DELETE` returns 403 and teardown surfaces an actionable hint pointing back at `gh teacher login -s delete_repo`.
-
-**Errors:**
-
-- `<org>/classroom50` not found → refuses with the "Classroom 50 marker repo" message. Re-create with `gh teacher init <org>` if this is intended, or delete repos manually via the web UI.
-- Confirmation mismatch → aborts cleanly, no `DELETE` calls are made.
-- 403 on a `DELETE` → token lacks `delete_repo`. Run `gh teacher login -s delete_repo` and retry.
-- Other per-repo failures → continue the run, print to stderr, exit non-zero at the end.
-
-## `gh teacher whoami` / `login` / `logout`
-
-- `gh teacher whoami` — prints the authenticated GitHub user (a thin wrapper around `gh api user`).
-- `gh teacher login` — runs `gh auth login -s admin:org -s read:org -s repo -s workflow` (the unified scope set shared with `gh student login`), optionally with additional scopes via `-s/--scopes`.
-- `gh teacher logout` — runs `gh auth logout`.
+- `whoami` — prints the authenticated GitHub user.
+- `login` — runs `gh auth login -s admin:org -s read:org -s repo -s workflow`;
+  add scopes with `-s`.
+- `logout` — runs `gh auth logout`.
 
 ## Contributing
 
-Building, testing, and linting the extension is documented in the [`cli/gh-teacher/` README](https://github.com/foundation50/classroom50/blob/main/cli/gh-teacher/README.md) in the repo (where contributors expect to find it).
+Building, testing, and linting the extension are documented in the
+[`cli/gh-teacher/` README](https://github.com/foundation50/classroom50/blob/main/cli/gh-teacher/README.md).

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -57,7 +57,7 @@ gh teacher init <org> --json       # machine-readable summary
 gh teacher init <org> --yes        # skip the skeleton-refresh prompt
 ```
 
-Idempotent — re-running resumes where a prior run stopped and offers to refresh
+Idempotent: re-running resumes where a prior run stopped and offers to refresh
 stale skeleton files (after a confirmation prompt).
 
 <details>
@@ -154,15 +154,17 @@ student repo names (`<short-name>-<assignment>-<username>`).
 
 Scaffolds four files in one commit — `classroom.json`, `assignments.json`,
 `roster.csv`, `scores.json` — and creates the `classroom50-<short-name>` GitHub
-team (plus `-teacher`, `-hta`, and `-ta` staff teams). Refuses to overwrite an existing
+team (plus the `classroom50-<short-name>-{teacher,hta,ta}` staff teams). Refuses to overwrite an existing
 classroom.
 
 <details>
 <summary>What the scaffold does and doesn't include</summary>
 
 The `roster.csv` header is
-`username,first_name,last_name,email,section,github_id`; `github_id` is
-CLI-managed — don't hand-edit it.
+`username,first_name,last_name,email,section,github_id,role`. `github_id` is
+CLI-managed (don't hand-edit it), and `role` is best-effort metadata refreshed
+from the classroom's GitHub teams (the teams, not this column, remain the role
+authority).
 
 Not included: the shared runner bootstrap (landed once by `init`), any
 autograder (classrooms grade as a vacuous pass until you add one), and the
@@ -378,7 +380,7 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | `--description <text>` | Short description. |
 | `--due <ISO-8601>` | Due date; timezone required. Stored verbatim. |
 | `--mode individual\|group` | `individual` (default) or `group` (requires `--max-group-size`). |
-| `--max-group-size <N>` | Max group collaborators (`>= 2`). Advisory. |
+| `--max-group-size <N>` | Max group collaborators (2–100). Advisory. |
 | `--runtime <path>` | JSON runtime (`runs-on`, toolchains, `apt`, `container`). See [Autograders](Autograders). |
 | `--tests <path>` | JSON array of declarative tests. Mutually exclusive with a per-assignment `autograder.py`. |
 | `--autograder <name>` | Swap the reusable workflow (rare). Default `default`. |
@@ -533,8 +535,8 @@ gh teacher download -d <dir> <org> <classroom> <assignment>     # literal dir
 probes the expected `<classroom>-<assignment>-<username>` repo, clones it (or
 reports `Missing: <username>`), and refreshes `result.json` (latest) and
 `results.json` (all submissions) from its releases. Then writes a `scores.csv`
-at the destination root — one line per submission, with a blank-score line for
-non-submitters.
+at the destination root, one line per submission (a student with several pushes
+contributes several lines), plus a blank-score line for each non-submitter.
 
 Each run creates a fresh timestamped folder unless you pass `-d`. Existing target
 dirs are skipped on clone but still get `result.json` refreshed.

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -29,7 +29,7 @@ output, or `--verbose` / `-v` for per-step detail.
 | `roster remove <org> <classroom> <username>` | Remove a roster row (not org membership). |
 | `roster import <org> <classroom> <csv>` | Bulk upsert from a CSV. |
 | `roster migrate <org> <classroom>` | Rename legacy `students.csv` to `roster.csv`. |
-| `staff add` / `remove <org> <classroom> <username>` | Manage staff teams (`--role teacher\|ta`). |
+| `staff add` / `remove <org> <classroom> <username>` | Manage staff teams (`--role teacher\|hta\|ta`). |
 | `assignment add <org> <classroom> <slug>` | Register/upsert an assignment. |
 | `assignment reuse <org> <slug> --from <src> --to <dst>` | Copy an assignment into another classroom. |
 | `assignment remove <org> <classroom> <slug>` | Remove an assignment entry. |
@@ -154,7 +154,7 @@ student repo names (`<short-name>-<assignment>-<username>`).
 
 Scaffolds four files in one commit — `classroom.json`, `assignments.json`,
 `roster.csv`, `scores.json` — and creates the `classroom50-<short-name>` GitHub
-team (plus `-teacher` and `-ta` staff teams). Refuses to overwrite an existing
+team (plus `-teacher`, `-hta`, and `-ta` staff teams). Refuses to overwrite an existing
 classroom.
 
 <details>
@@ -334,14 +334,15 @@ rebase failures → `lost the rebase race`, retry.
 
 ## `staff`
 
-Manage a classroom's **staff teams** — `classroom50-<classroom>-teacher` and
-`-ta`, each granted write on the config repo. Membership lives entirely in these
-teams (there's no `role` column in `roster.csv`), so a classroom's staff is the
-same from the CLI or the web app. (`instructor` is a legacy alias of `teacher`.)
+Manage a classroom's **staff teams** — `classroom50-<classroom>-{teacher,hta,ta}`.
+The `teacher` and `hta` (head TA) teams get write on the config repo; `ta` gets
+read-only. Membership lives entirely in these teams (there's no `role` column in
+`roster.csv`), so a classroom's staff is the same from the CLI or the web app.
+(`instructor` is a legacy alias of `teacher`.)
 
 ```sh
-gh teacher staff add <org> <classroom> <username> [--role teacher|ta]
-gh teacher staff remove <org> <classroom> <username> [--role teacher|ta]
+gh teacher staff add <org> <classroom> <username> [--role teacher|hta|ta]
+gh teacher staff remove <org> <classroom> <username> [--role teacher|hta|ta]
 ```
 
 `--role` defaults to `teacher`. `add` self-heals a classroom that predates staff

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -338,9 +338,9 @@ rebase failures → `lost the rebase race`, retry.
 
 Manage a classroom's **staff teams** — `classroom50-<classroom>-{teacher,hta,ta}`.
 The `teacher` and `hta` (head TA) teams get write on the config repo; `ta` gets
-read-only. Membership lives entirely in these teams (there's no `role` column in
-`roster.csv`), so a classroom's staff is the same from the CLI or the web app.
-(`instructor` is a legacy alias of `teacher`.)
+read-only. The classroom's GitHub teams — not the `role` column in `roster.csv` —
+are the role authority, so a classroom's staff is the same from the CLI or the
+web app. (`instructor` is a legacy alias of `teacher`.)
 
 ```sh
 gh teacher staff add <org> <classroom> <username> [--role teacher|hta|ta]


### PR DESCRIPTION
## What

Rewrites all wiki pages to be easier to read and follow, and adds a new **Glossary** page. Structure is preserved (same page set, headings, screenshots); content is condensed and clarified.

## Why

The wiki had grown verbose — dense run-on paragraphs, deep security/rationale asides buried in the happy path, and exhaustive reference prose. This pass makes pages scannable while keeping every fact.

## Approach

Grounded in **GitHub Classroom's own docs conventions** and current task-based technical-writing practices:

- **Answer-first** intros; short happy-path summaries atop each guide.
- **Verb-first / question-shaped headings.**
- **Bullets and tables** over prose for options, fields, and errors.
- **`<details>` and `> [!NOTE/WARNING]` callouts** for deep rationale and edge cases, out of the main flow.
- **Standardized terminology** across pages (classroom, assignment, roster, template repository, config repo, service token, …), matching GitHub Classroom and the app UI.

## Changes

- **Added:** `Glossary.md` (+ linked from `Home` and `_Sidebar`).
- **Rewrote:** all 12 existing pages. Reference pages condensed aggressively (e.g. `gh-teacher` per-command prose → tight bullets + collapsibles).
- **Deleted:** none. `images/` untouched.

## Deploy

`publish-wiki.yaml` syncs `wiki/` → the GitHub wiki on merge to `main`. Verified against the live wiki: no direct (non-bot) edits, so the reconcile guard will pass. `docs:` type — no release/changelog impact.