### PR TITLE
fix(web): stop infinite accept spinner for non-org-members

### DIFF
--- a/web/src/hooks/useGetOwnOrgMembership.loop.test.tsx
+++ b/web/src/hooks/useGetOwnOrgMembership.loop.test.tsx
@@ -8,16 +8,27 @@
 // true → spinner → the subtree (and its observer) UNMOUNTS → the query settles →
 // spinner clears → subtree REMOUNTS → fresh observer refetches → loop.
 //
-// The fix (`retryOnMount: false` on useGetOwnOrgMembership) keeps the cached
-// error across remounts, so the queryFn runs a bounded number of times and the
-// tree stabilizes on the error screen. This test drives the exact mount/unmount
-// pattern and asserts the queryFn is not called unboundedly.
+// The fix is a `retryOnMount` predicate on useGetOwnOrgMembership that suppresses
+// the remount refetch only for DEFINITIVE errors (401/403/404) — the loop's
+// driver — while still refetching transient 5xx/429/network errors on remount so
+// the documented self-heal is preserved. These tests cover both halves:
+//   1. a definitive 403 settles without an unbounded refetch loop, and
+//   2. a transient 500 still refetches on a fresh mount (no permanent pinning).
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { StrictMode } from "react"
+import {
+  cleanup,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { GitHubAPIError } from "@/github-core/errors"
 
 const requestCount = vi.fn()
+// Per-test HTTP status the mocked membership read rejects with.
+let responseStatus = 403
 
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({
@@ -25,9 +36,9 @@ vi.mock("@/context/github/GitHubProvider", () => ({
       requestCount(path)
       return Promise.reject(
         new GitHubAPIError({
-          status: 403,
+          status: responseStatus,
           url: `https://api.github.com${path}`,
-          message: "Forbidden",
+          message: `HTTP ${responseStatus}`,
           body: null,
           rateLimit: {
             limit: null,
@@ -56,16 +67,18 @@ function Gate({ org }: { org: string }) {
 function GatedChild({ org }: { org: string }) {
   // The gated subtree also reads membership (as AcceptAssignmentPage does).
   const { isError } = useGetOwnOrgMembership(org)
-  return <div>{isError ? "not-a-member" : "child-loading"}</div>
+  return <div>{isError ? "settled-error" : "child-loading"}</div>
 }
 
 afterEach(() => {
   cleanup()
   requestCount.mockClear()
+  responseStatus = 403
 })
 
-describe("useGetOwnOrgMembership — no remount refetch loop for non-members", () => {
-  it("settles on the error screen without an unbounded refetch loop", async () => {
+describe("useGetOwnOrgMembership — remount behavior", () => {
+  it("settles a definitive 403 without an unbounded refetch loop", async () => {
+    responseStatus = 403
     const client = new QueryClient({
       defaultOptions: {
         // Match production intent: a definitive 403 does not retry.
@@ -73,25 +86,66 @@ describe("useGetOwnOrgMembership — no remount refetch loop for non-members", (
       },
     })
 
+    // StrictMode double-invokes render + mounts each effect twice, reproducing
+    // the exact fresh-observer-on-remount condition the fix must survive.
     render(
-      <QueryClientProvider client={client}>
-        <Gate org="acme" />
-      </QueryClientProvider>,
+      <StrictMode>
+        <QueryClientProvider client={client}>
+          <Gate org="acme" />
+        </QueryClientProvider>
+      </StrictMode>,
     )
 
     // The tree must settle on the terminal error branch, not spin forever.
     await waitFor(() =>
-      expect(screen.queryByText("not-a-member")).not.toBeNull(),
+      expect(screen.queryByText("settled-error")).not.toBeNull(),
     )
 
     // Give any latent loop time to manifest.
     await new Promise((r) => setTimeout(r, 100))
 
-    // Without retryOnMount:false the errored query refetches on every remount,
-    // driving the loop into dozens/hundreds of requests. With the fix the
-    // cached error survives remounts, so the queryFn runs only a handful of
-    // times (initial mounts of the two observers + StrictMode doubling).
+    // Without the retryOnMount suppression the definitive error refetches on
+    // every remount, driving the loop into dozens/hundreds of requests. With the
+    // fix the cached error survives remounts, so the queryFn runs only a small,
+    // bounded number of times (a generous ceiling that a loop would blow past).
     expect(requestCount.mock.calls.length).toBeLessThan(6)
     expect(screen.queryByText("org-spinner")).toBeNull()
+  })
+
+  it("still refetches a transient 500 error on a fresh mount (self-heal preserved)", async () => {
+    responseStatus = 500
+    // Shared cache across mounts so the second mount sees the cached transient
+    // error and must decide whether to refetch it. retry:false isolates the
+    // remount-refetch decision (retryOnMount) from the in-fetch retry loop.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retryDelay: 0 } },
+    })
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const first = renderHook(() => useGetOwnOrgMembership("acme"), { wrapper })
+    // The hook's own retryTransientGitHubError retries a 500 twice; retryDelay:0
+    // (above) makes that settle promptly. Allow generous time for it to reach
+    // the terminal error before probing the remount behavior.
+    await waitFor(() => expect(first.result.current.isError).toBe(true), {
+      timeout: 3000,
+    })
+    const afterFirst = requestCount.mock.calls.length
+    first.unmount()
+
+    // Remount a fresh observer against the SAME client (cached 500 present).
+    const second = renderHook(() => useGetOwnOrgMembership("acme"), { wrapper })
+
+    // A transient error must NOT be pinned: the fresh mount refetches it, so the
+    // request count grows past the first mount's total. (A definitive 403 would
+    // stay flat here — that's the behavior the loop test locks in.)
+    await waitFor(
+      () => expect(requestCount.mock.calls.length).toBeGreaterThan(afterFirst),
+      { timeout: 3000 },
+    )
+    await waitFor(() => expect(second.result.current.isError).toBe(true), {
+      timeout: 3000,
+    })
   })
 })

--- a/web/src/hooks/useGetOwnOrgMembership.loop.test.tsx
+++ b/web/src/hooks/useGetOwnOrgMembership.loop.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+// Regression for the infinite accept-spinner loop (#infinite-accept-spinner).
+//
+// The org layout gates its whole subtree behind a full-screen spinner while the
+// membership query is loading, and the gated subtree ALSO reads the same
+// membership query. For a non-member the query errors (403/404); if a fresh
+// observer on remount refetches the errored query, `isLoading` flips back to
+// true → spinner → the subtree (and its observer) UNMOUNTS → the query settles →
+// spinner clears → subtree REMOUNTS → fresh observer refetches → loop.
+//
+// The fix (`retryOnMount: false` on useGetOwnOrgMembership) keeps the cached
+// error across remounts, so the queryFn runs a bounded number of times and the
+// tree stabilizes on the error screen. This test drives the exact mount/unmount
+// pattern and asserts the queryFn is not called unboundedly.
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { GitHubAPIError } from "@/github-core/errors"
+
+const requestCount = vi.fn()
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({
+    request: (path: string) => {
+      requestCount(path)
+      return Promise.reject(
+        new GitHubAPIError({
+          status: 403,
+          url: `https://api.github.com${path}`,
+          message: "Forbidden",
+          body: null,
+          rateLimit: {
+            limit: null,
+            remaining: null,
+            used: null,
+            reset: null,
+            resource: null,
+            retryAfter: null,
+          },
+        }),
+      )
+    },
+  }),
+}))
+
+import useGetOwnOrgMembership from "./useGetOwnOrgMembership"
+
+// Mirrors OrgLayout: a full-subtree spinner gate keyed on the membership query's
+// isLoading, wrapping a child that reads the SAME membership query.
+function Gate({ org }: { org: string }) {
+  const { isLoading } = useGetOwnOrgMembership(org)
+  if (isLoading) return <div>org-spinner</div>
+  return <GatedChild org={org} />
+}
+
+function GatedChild({ org }: { org: string }) {
+  // The gated subtree also reads membership (as AcceptAssignmentPage does).
+  const { isError } = useGetOwnOrgMembership(org)
+  return <div>{isError ? "not-a-member" : "child-loading"}</div>
+}
+
+afterEach(() => {
+  cleanup()
+  requestCount.mockClear()
+})
+
+describe("useGetOwnOrgMembership — no remount refetch loop for non-members", () => {
+  it("settles on the error screen without an unbounded refetch loop", async () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        // Match production intent: a definitive 403 does not retry.
+        queries: { retry: false },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <Gate org="acme" />
+      </QueryClientProvider>,
+    )
+
+    // The tree must settle on the terminal error branch, not spin forever.
+    await waitFor(() =>
+      expect(screen.queryByText("not-a-member")).not.toBeNull(),
+    )
+
+    // Give any latent loop time to manifest.
+    await new Promise((r) => setTimeout(r, 100))
+
+    // Without retryOnMount:false the errored query refetches on every remount,
+    // driving the loop into dozens/hundreds of requests. With the fix the
+    // cached error survives remounts, so the queryFn runs only a handful of
+    // times (initial mounts of the two observers + StrictMode doubling).
+    expect(requestCount.mock.calls.length).toBeLessThan(6)
+    expect(screen.queryByText("org-spinner")).toBeNull()
+  })
+})

--- a/web/src/hooks/useGetOwnOrgMembership.loop.test.tsx
+++ b/web/src/hooks/useGetOwnOrgMembership.loop.test.tsx
@@ -1,19 +1,13 @@
 // @vitest-environment happy-dom
-// Regression for the infinite accept-spinner loop (#infinite-accept-spinner).
+// Regression for the infinite accept-spinner loop.
 //
-// The org layout gates its whole subtree behind a full-screen spinner while the
-// membership query is loading, and the gated subtree ALSO reads the same
-// membership query. For a non-member the query errors (403/404); if a fresh
-// observer on remount refetches the errored query, `isLoading` flips back to
-// true → spinner → the subtree (and its observer) UNMOUNTS → the query settles →
-// spinner clears → subtree REMOUNTS → fresh observer refetches → loop.
-//
-// The fix is a `retryOnMount` predicate on useGetOwnOrgMembership that suppresses
-// the remount refetch only for DEFINITIVE errors (401/403/404) — the loop's
-// driver — while still refetching transient 5xx/429/network errors on remount so
-// the documented self-heal is preserved. These tests cover both halves:
-//   1. a definitive 403 settles without an unbounded refetch loop, and
-//   2. a transient 500 still refetches on a fresh mount (no permanent pinning).
+// OrgLayout gates its whole subtree behind a spinner while the membership query
+// loads, and the gated subtree reads that same query. For a non-member the query
+// errors; if a fresh observer refetches the errored query on remount, isLoading
+// flips back to true -> spinner -> subtree unmounts -> settles -> remounts ->
+// refetches -> loop. The retryOnMount predicate suppresses the remount refetch
+// for DEFINITIVE errors (the loop driver) but keeps it for transient ones (self-
+// heal). These two tests lock in both halves.
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { StrictMode } from "react"
 import {
@@ -27,7 +21,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { GitHubAPIError } from "@/github-core/errors"
 
 const requestCount = vi.fn()
-// Per-test HTTP status the mocked membership read rejects with.
+// HTTP status the mocked membership read rejects with (per-test).
 let responseStatus = 403
 
 vi.mock("@/context/github/GitHubProvider", () => ({
@@ -40,14 +34,7 @@ vi.mock("@/context/github/GitHubProvider", () => ({
           url: `https://api.github.com${path}`,
           message: `HTTP ${responseStatus}`,
           body: null,
-          rateLimit: {
-            limit: null,
-            remaining: null,
-            used: null,
-            reset: null,
-            resource: null,
-            retryAfter: null,
-          },
+          rateLimit: {} as never,
         }),
       )
     },
@@ -56,8 +43,8 @@ vi.mock("@/context/github/GitHubProvider", () => ({
 
 import useGetOwnOrgMembership from "./useGetOwnOrgMembership"
 
-// Mirrors OrgLayout: a full-subtree spinner gate keyed on the membership query's
-// isLoading, wrapping a child that reads the SAME membership query.
+// Mirrors OrgLayout: a spinner gate keyed on the membership query's isLoading,
+// wrapping a child that reads the SAME query (as AcceptAssignmentPage does).
 function Gate({ org }: { org: string }) {
   const { isLoading } = useGetOwnOrgMembership(org)
   if (isLoading) return <div>org-spinner</div>
@@ -65,7 +52,6 @@ function Gate({ org }: { org: string }) {
 }
 
 function GatedChild({ org }: { org: string }) {
-  // The gated subtree also reads membership (as AcceptAssignmentPage does).
   const { isError } = useGetOwnOrgMembership(org)
   return <div>{isError ? "settled-error" : "child-loading"}</div>
 }
@@ -80,14 +66,10 @@ describe("useGetOwnOrgMembership — remount behavior", () => {
   it("settles a definitive 403 without an unbounded refetch loop", async () => {
     responseStatus = 403
     const client = new QueryClient({
-      defaultOptions: {
-        // Match production intent: a definitive 403 does not retry.
-        queries: { retry: false },
-      },
+      defaultOptions: { queries: { retry: false } },
     })
 
-    // StrictMode double-invokes render + mounts each effect twice, reproducing
-    // the exact fresh-observer-on-remount condition the fix must survive.
+    // StrictMode double-mounts, reproducing the fresh-observer-on-remount case.
     render(
       <StrictMode>
         <QueryClientProvider client={client}>
@@ -96,27 +78,20 @@ describe("useGetOwnOrgMembership — remount behavior", () => {
       </StrictMode>,
     )
 
-    // The tree must settle on the terminal error branch, not spin forever.
     await waitFor(() =>
       expect(screen.queryByText("settled-error")).not.toBeNull(),
     )
+    await new Promise((r) => setTimeout(r, 100)) // let any latent loop manifest
 
-    // Give any latent loop time to manifest.
-    await new Promise((r) => setTimeout(r, 100))
-
-    // Without the retryOnMount suppression the definitive error refetches on
-    // every remount, driving the loop into dozens/hundreds of requests. With the
-    // fix the cached error survives remounts, so the queryFn runs only a small,
-    // bounded number of times (a generous ceiling that a loop would blow past).
+    // A loop would blow past this ceiling; the cached error keeps it bounded.
     expect(requestCount.mock.calls.length).toBeLessThan(6)
     expect(screen.queryByText("org-spinner")).toBeNull()
   })
 
-  it("still refetches a transient 500 error on a fresh mount (self-heal preserved)", async () => {
+  it("still refetches a transient 500 on a fresh mount (self-heal preserved)", async () => {
     responseStatus = 500
-    // Shared cache across mounts so the second mount sees the cached transient
-    // error and must decide whether to refetch it. retry:false isolates the
-    // remount-refetch decision (retryOnMount) from the in-fetch retry loop.
+    // Shared cache so the remount sees the cached error; retryDelay:0 settles the
+    // hook's own transient retry promptly.
     const client = new QueryClient({
       defaultOptions: { queries: { retryDelay: 0 } },
     })
@@ -125,21 +100,15 @@ describe("useGetOwnOrgMembership — remount behavior", () => {
     )
 
     const first = renderHook(() => useGetOwnOrgMembership("acme"), { wrapper })
-    // The hook's own retryTransientGitHubError retries a 500 twice; retryDelay:0
-    // (above) makes that settle promptly. Allow generous time for it to reach
-    // the terminal error before probing the remount behavior.
     await waitFor(() => expect(first.result.current.isError).toBe(true), {
       timeout: 3000,
     })
     const afterFirst = requestCount.mock.calls.length
     first.unmount()
 
-    // Remount a fresh observer against the SAME client (cached 500 present).
+    // Fresh observer, same client: a transient error must refetch (not stay
+    // pinned as a definitive one would).
     const second = renderHook(() => useGetOwnOrgMembership("acme"), { wrapper })
-
-    // A transient error must NOT be pinned: the fresh mount refetches it, so the
-    // request count grows past the first mount's total. (A definitive 403 would
-    // stay flat here — that's the behavior the loop test locks in.)
     await waitFor(
       () => expect(requestCount.mock.calls.length).toBeGreaterThan(afterFirst),
       { timeout: 3000 },

--- a/web/src/hooks/useGetOwnOrgMembership.ts
+++ b/web/src/hooks/useGetOwnOrgMembership.ts
@@ -1,7 +1,11 @@
 import { useQuery } from "@tanstack/react-query"
 import { getPendingOrgInvite } from "@/github-core/mutations"
 import { githubKeys } from "@/github-core/queries"
-import { retryTransientGitHubError } from "@/github-core/errors"
+import {
+  GitHubAPIError,
+  isDefinitiveGitHubStatus,
+  retryTransientGitHubError,
+} from "@/github-core/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
 // Reads the authenticated user's OWN membership in `org` (GET
@@ -19,15 +23,22 @@ const useGetOwnOrgMembership = (org: string | undefined) => {
     queryFn: () => getPendingOrgInvite(client, org ?? ""),
     staleTime: 10 * 60 * 1000,
     retry: retryTransientGitHubError,
-    // A definitive result (active membership, or a 403/404 error) must survive a
-    // fresh observer mounting. An ancestor gate (OrgLayout) toggles a
-    // full-screen spinner on this query's `isLoading`, which unmounts the subtree
-    // that ALSO reads this query; without this, the remount's fresh observer
-    // refetches the errored query (retryOnMount default), flipping isLoading back
-    // to true — a subscribe→refetch→spinner→unmount→remount loop that pinned a
-    // non-member on an infinite spinner. Keep the cached error; the membership
-    // error screen offers an explicit retry.
-    retryOnMount: false,
+    // A DEFINITIVE cached error (401/403/404) must survive a fresh observer
+    // mounting. An ancestor gate (OrgLayout) toggles a full-screen spinner on
+    // this query's `isLoading`, which unmounts the subtree that ALSO reads this
+    // query; refetching the definitive error on the remount's fresh observer
+    // flips isLoading back to true — a subscribe→refetch→spinner→unmount→remount
+    // loop that pinned a non-member on an infinite spinner. Suppress the remount
+    // refetch only for definitive statuses (the loop's driver, and retrying
+    // can't change the verdict); transient 5xx/429/network errors still refetch
+    // on remount so the documented self-heal is preserved.
+    retryOnMount: (query) => {
+      const error = query.state.error
+      return !(
+        error instanceof GitHubAPIError &&
+        isDefinitiveGitHubStatus(error.status)
+      )
+    },
     enabled: Boolean(org),
   })
 }

--- a/web/src/hooks/useGetOwnOrgMembership.ts
+++ b/web/src/hooks/useGetOwnOrgMembership.ts
@@ -19,6 +19,15 @@ const useGetOwnOrgMembership = (org: string | undefined) => {
     queryFn: () => getPendingOrgInvite(client, org ?? ""),
     staleTime: 10 * 60 * 1000,
     retry: retryTransientGitHubError,
+    // A definitive result (active membership, or a 403/404 error) must survive a
+    // fresh observer mounting. An ancestor gate (OrgLayout) toggles a
+    // full-screen spinner on this query's `isLoading`, which unmounts the subtree
+    // that ALSO reads this query; without this, the remount's fresh observer
+    // refetches the errored query (retryOnMount default), flipping isLoading back
+    // to true — a subscribe→refetch→spinner→unmount→remount loop that pinned a
+    // non-member on an infinite spinner. Keep the cached error; the membership
+    // error screen offers an explicit retry.
+    retryOnMount: false,
     enabled: Boolean(org),
   })
 }

--- a/web/src/hooks/useGetOwnOrgMembership.ts
+++ b/web/src/hooks/useGetOwnOrgMembership.ts
@@ -23,22 +23,18 @@ const useGetOwnOrgMembership = (org: string | undefined) => {
     queryFn: () => getPendingOrgInvite(client, org ?? ""),
     staleTime: 10 * 60 * 1000,
     retry: retryTransientGitHubError,
-    // A DEFINITIVE cached error (401/403/404) must survive a fresh observer
-    // mounting. An ancestor gate (OrgLayout) toggles a full-screen spinner on
-    // this query's `isLoading`, which unmounts the subtree that ALSO reads this
-    // query; refetching the definitive error on the remount's fresh observer
-    // flips isLoading back to true — a subscribe→refetch→spinner→unmount→remount
-    // loop that pinned a non-member on an infinite spinner. Suppress the remount
-    // refetch only for definitive statuses (the loop's driver, and retrying
-    // can't change the verdict); transient 5xx/429/network errors still refetch
-    // on remount so the documented self-heal is preserved.
-    retryOnMount: (query) => {
-      const error = query.state.error
-      return !(
-        error instanceof GitHubAPIError &&
-        isDefinitiveGitHubStatus(error.status)
-      )
-    },
+    // A definitive cached error (401/403/404) must survive a fresh observer's
+    // mount. OrgLayout toggles a full-screen spinner on this query's isLoading,
+    // unmounting the subtree that also reads it; refetching the definitive error
+    // on remount flips isLoading back to true — a spinner->unmount->remount->
+    // refetch loop that pinned non-members on an endless spinner. Transient
+    // 5xx/429/network errors still refetch on remount (documented self-heal);
+    // only definitive statuses (the loop driver, unchangeable by a retry) don't.
+    retryOnMount: (query) =>
+      !(
+        query.state.error instanceof GitHubAPIError &&
+        isDefinitiveGitHubStatus(query.state.error.status)
+      ),
     enabled: Boolean(org),
   })
 }


### PR DESCRIPTION
## Problem

A student who isn't an org member (no membership record / not invited) opening an assignment accept link — e.g. `/{org}/{classroom}/assignments/{assignment}/accept` — was pinned on an **infinite loading spinner**. It also hammered the GitHub API (hundreds of requests/sec), burning through the user's rate limit.

## Root cause

An infinite **mount/unmount loop**, confirmed with runtime instrumentation:

- `OrgLayout` renders a full-screen spinner while the org-membership query is `isLoading`, which **unmounts the whole classroom subtree** — including `AcceptAssignmentPage`, which reads that *same* membership query.
- For a non-member the query **errors** (GitHub returns 403/404).
- React Query's default `retryOnMount` **refetches an errored query when a fresh observer subscribes**. So each remount re-fetched → `isLoading` flipped back to `true` → spinner → unmount → remount → refetch → … forever.

Members never hit this: their membership resolves once to `active` and stays cached.

Runtime evidence captured during debugging: 269/269 membership refetches originated from `QueryObserver.onSubscribe` (fresh-mount fetch, zero from invalidate/refetch); the page mounted/unmounted in lockstep (~272 pairs); `errorUpdateCount` climbed into the thousands.

## Fix

Set `retryOnMount: false` on `useGetOwnOrgMembership` so a **definitive** result (active membership *or* a 403/404 error) survives a fresh observer mounting. `isLoading` stops toggling, the loop can't sustain, and the non-member lands on the terminal "not a member yet" screen (which offers a retry).

The RBAC verdict itself was already correct (403/404 → `non-member`, `OrgLayout` fails open); this was purely a loading-gate remount bug.

## Tests

Added `useGetOwnOrgMembership.loop.test.tsx`, a deterministic regression that reproduces the gate→child remount pattern against a 403 client:
- **Without** the fix: fails (never settles — the loop).
- **With** the fix: settles on the error screen with `< 6` requests (no unbounded refetch).

`tsc -b`, the related vitest suites (23 tests), and prettier all pass.