### PR TITLE
fix(web): recover accept secret from team description for bare links

### DIFF
--- a/web/src/components/org/StudentAssignmentList.test.tsx
+++ b/web/src/components/org/StudentAssignmentList.test.tsx
@@ -51,6 +51,10 @@ vi.mock("@/hooks/useGetMyOrgRepos", () => ({
 }))
 vi.mock("@/hooks/useStudentClassrooms", () => ({
   useStudentClassrooms: () => studentClassrooms(),
+  useClassroomSecret: (_org?: string, classroom?: string) =>
+    studentClassrooms().classrooms.find(
+      (c: { classroom: string; secret?: string }) => c.classroom === classroom,
+    )?.secret,
 }))
 vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => ({ user: { login: "student1" } }),

--- a/web/src/components/org/StudentAssignmentList.tsx
+++ b/web/src/components/org/StudentAssignmentList.tsx
@@ -15,7 +15,7 @@ import { EnterDiv } from "@/lib/motionComponents"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
-import { useStudentClassrooms } from "@/hooks/useStudentClassrooms"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { useListPrefsState } from "@/lib/listPrefs"
 import { studentAssignmentListPrefs } from "@/lib/studentAssignmentListPrefs"
 import {
@@ -32,19 +32,6 @@ import {
   isPastDue,
 } from "@/util/formatDate"
 import type { Assignment } from "@/types/classroom"
-
-// Resolve the classroom's capability secret for a student, config-free: the
-// team-description bootstrap record (useStudentClassrooms) is the primary
-// source; for a pre-schema team it falls back to any of the student's accepted
-// repos' membership in this classroom (the caller passes that secret in). Empty
-// when the classroom is listed (no secret needed).
-function useClassroomSecret(
-  org: string,
-  classroom: string,
-): string | undefined {
-  const { classrooms } = useStudentClassrooms(org)
-  return classrooms.find((c) => c.classroom === classroom)?.secret
-}
 
 function ModeBadge({ mode }: { mode: Assignment["mode"] }) {
   const { t } = useTranslation()

--- a/web/src/hooks/useStudentClassrooms.ts
+++ b/web/src/hooks/useStudentClassrooms.ts
@@ -117,3 +117,17 @@ export function useStudentClassrooms(
 }
 
 export default useStudentClassrooms
+
+// Resolve a student's capability secret for a classroom, config-free: the
+// team-description bootstrap record is the source. `enabled: false` skips the
+// GET /user/teams read for callers that already hold the secret (e.g. an accept
+// link's ?k=), returning undefined without a network round-trip.
+export function useClassroomSecret(
+  org: string | undefined,
+  classroom: string | undefined,
+  enabled = true,
+): string | undefined {
+  const { classrooms } = useStudentClassrooms(enabled ? org : undefined)
+  if (!classroom) return undefined
+  return classrooms.find((c) => c.classroom === classroom)?.secret
+}

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -13,20 +13,37 @@ import type { GitHubRepo } from "@/github-core/types"
 
 const acceptAssignment = vi.fn()
 
+const pagesAssignmentsSpy =
+  vi.fn<(org?: string, classroom?: string, secret?: string) => void>()
+const searchParams: { k?: string } = { k: "test-secret" }
+let studentClassroomsData: Array<{ classroom: string; secret?: string }> = []
+
 vi.mock("@/domain/assignments", () => ({
   acceptAssignment: (...args: unknown[]) => acceptAssignment(...args),
 }))
 vi.mock("@/hooks/usePagesAssignments", () => ({
+  default: (org?: string, classroom?: string, secret?: string) => {
+    pagesAssignmentsSpy(org, classroom, secret)
+    return {
+      data: [
+        {
+          slug: "hello-python",
+          name: "Hello Python",
+          mode: "individual",
+          autograder: "default",
+        },
+      ],
+      isLoading: false,
+    }
+  },
+}))
+vi.mock("@/hooks/useStudentClassrooms", () => ({
   default: () => ({
-    data: [
-      {
-        slug: "hello-python",
-        name: "Hello Python",
-        mode: "individual",
-        autograder: "default",
-      },
-    ],
+    classrooms: studentClassroomsData,
     isLoading: false,
+    isError: false,
+    roleResolved: true,
+    refetch: vi.fn(),
   }),
 }))
 vi.mock("@/hooks/useGetRepo", () => ({
@@ -90,7 +107,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
       classroom: "cs101",
       assignment: "hello-python",
     }),
-    useSearch: () => ({ k: "test-secret" }),
+    useSearch: () => searchParams,
     Link: ({ children }: { children: ReactNode }) => <a href="/">{children}</a>,
   }
 })
@@ -126,6 +143,9 @@ const renderPage = (client: QueryClient) =>
 
 beforeEach(() => {
   acceptAssignment.mockReset()
+  pagesAssignmentsSpy.mockReset()
+  searchParams.k = "test-secret"
+  studentClassroomsData = []
   __resetGitHubHealthForTest()
 })
 
@@ -187,6 +207,51 @@ describe("AcceptAssignmentPage repository cache", () => {
       )
     },
   )
+})
+
+describe("AcceptAssignmentPage secret selection", () => {
+  const renderWith = () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    renderPage(client)
+  }
+
+  it("uses the ?k= link secret when present", () => {
+    searchParams.k = "test-secret"
+    studentClassroomsData = [{ classroom: "cs101", secret: "team-secret" }]
+    renderWith()
+    expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "cs101",
+      "test-secret",
+    )
+  })
+
+  it("falls back to the team-description secret for a bare accept link", () => {
+    searchParams.k = undefined
+    studentClassroomsData = [{ classroom: "cs101", secret: "team-secret" }]
+    renderWith()
+    expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "cs101",
+      "team-secret",
+    )
+  })
+
+  it("passes no secret for a bare link when the student has no matching team", () => {
+    searchParams.k = undefined
+    studentClassroomsData = [{ classroom: "other", secret: "team-secret" }]
+    renderWith()
+    expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "cs101",
+      undefined,
+    )
+  })
 })
 
 describe("AcceptAssignmentPage outage hint", () => {

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -38,13 +38,14 @@ vi.mock("@/hooks/usePagesAssignments", () => ({
   },
 }))
 vi.mock("@/hooks/useStudentClassrooms", () => ({
-  default: () => ({
-    classrooms: studentClassroomsData,
-    isLoading: false,
-    isError: false,
-    roleResolved: true,
-    refetch: vi.fn(),
-  }),
+  useClassroomSecret: (
+    _org?: string,
+    classroom?: string,
+    enabled = true,
+  ): string | undefined => {
+    if (!enabled || !classroom) return undefined
+    return studentClassroomsData.find((c) => c.classroom === classroom)?.secret
+  },
 }))
 vi.mock("@/hooks/useGetRepo", () => ({
   default: () => ({ data: null, isLoading: false }),

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -26,6 +26,7 @@ import {
   MembershipError,
 } from "@/components/MembershipError"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
+import useStudentClassrooms from "@/hooks/useStudentClassrooms"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { studentRepoName } from "@/util/studentRepo"
@@ -526,7 +527,16 @@ const AcceptAssignmentPage = () => {
   // selects the <classroom>/<secret>/ Pages path; absent otherwise. Read
   // loosely so the page works if mounted without the typed route in tests.
   const search = useSearch({ strict: false }) as { k?: string }
-  const secret = typeof search.k === "string" ? search.k : undefined
+  const linkSecret = typeof search.k === "string" ? search.k : undefined
+
+  // Fallback for a bare accept link (no ?k=): an already-enrolled student's own
+  // team description carries the classroom's capability secret, so recover it
+  // from GET /user/teams. The link secret still wins when present.
+  const { classrooms: studentClassrooms } = useStudentClassrooms(org)
+  const teamSecret = classroom
+    ? studentClassrooms.find((c) => c.classroom === classroom)?.secret
+    : undefined
+  const secret = linkSecret ?? teamSecret
 
   const { user } = useGithubAuth()
   const username = user?.login

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -26,7 +26,7 @@ import {
   MembershipError,
 } from "@/components/MembershipError"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
-import useStudentClassrooms from "@/hooks/useStudentClassrooms"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { studentRepoName } from "@/util/studentRepo"
@@ -530,12 +530,9 @@ const AcceptAssignmentPage = () => {
   const linkSecret = typeof search.k === "string" ? search.k : undefined
 
   // Fallback for a bare accept link (no ?k=): an already-enrolled student's own
-  // team description carries the classroom's capability secret, so recover it
-  // from GET /user/teams. The link secret still wins when present.
-  const { classrooms: studentClassrooms } = useStudentClassrooms(org)
-  const teamSecret = classroom
-    ? studentClassrooms.find((c) => c.classroom === classroom)?.secret
-    : undefined
+  // team description carries the classroom's capability secret. Skipped when the
+  // link already supplies one, so the common path avoids a GET /user/teams read.
+  const teamSecret = useClassroomSecret(org, classroom, !linkSecret)
   const secret = linkSecret ?? teamSecret
 
   const { user } = useGithubAuth()


### PR DESCRIPTION
## Problem

Visiting a **bare** accept link for a protected classroom (no `?k=`), e.g. `/<org>/protected-classroom/assignments/test/accept`, failed: the page read the secret only from the `?k=` query param, so with no secret it fetched the **unprotected** Pages path (`.../protected-classroom/assignments.json`) which 404s. For a protected classroom, `assignments.json` is only published under the secret-prefixed path.

## Fix

`AcceptAssignmentPage` now falls back to the capability secret stored in the enrolled student's own team description (recovered via `GET /user/teams`) when `?k=` is absent. The link secret still wins when present.

- Already-enrolled student on a bare link → secret recovered → protected path fetched → accept works.
- Non-member (no team, no secret) → still falls back to the unprotected path and 404s, which is correct (they must use the full `?k=` invite link).

The secret lookup is the shared `useClassroomSecret` hook (also used by `StudentAssignmentList`), and its `GET /user/teams` read is skipped when `?k=` already supplies the secret, so the common path avoids the extra request.

## Tests

Added 3 cases covering secret precedence: `?k=` wins, team-description fallback, and no-matching-team → no secret. `tsc -b`, eslint, prettier, and vitest all green (28 tests across the affected suites).