### PR TITLE
fix(ci): deploy release-please web tag by gating on tag_name

### DIFF
--- a/.github/workflows/web-release-please.yaml
+++ b/.github/workflows/web-release-please.yaml
@@ -36,8 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      # `web--*` keys because component is "web" (see release-please-config).
-      release_created: ${{ steps.release.outputs['web--release_created'] }}
+      # Path-prefixed outputs use the package PATH (the key under `packages` in
+      # release-please-config.json), which is "web" — not the `component`. Gate
+      # on tag_name (empty ⇒ no release) rather than release_created: it's a
+      # single string that's robust to the boolean/string coercion that made the
+      # deploy job silently skip on the v1.12/v1.13 releases.
       tag_name: ${{ steps.release.outputs['web--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v5
@@ -48,12 +51,20 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # Dump every output release-please emitted so a future "tag created but
+      # deploy skipped" regression is root-causeable from this log alone.
+      - name: Debug release-please outputs
+        env:
+          RP_OUTPUTS: ${{ toJSON(steps.release.outputs) }}
+        run: echo "$RP_OUTPUTS"
+
   # Build + deploy the freshly tagged release to production. Gated on a real
-  # release (Release PR merged) so a plain push to main never deploys. Mirrors
-  # web-deploy.yaml's build so the tagged commit ships stamped with its version.
+  # release (non-empty tag_name ⇒ Release PR was merged) so a plain push to main
+  # never deploys. Mirrors web-deploy.yaml's build so the tagged commit ships
+  # stamped with its version.
   deploy:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.tag_name != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Problem

`web-v1.13.0` (and `v1.12.0`) were tagged and released, but production
(classroom50.org) was never rebuilt — it stayed on a manual July-21 deploy
(commit \`9e8f017e\`, pre-1.12).

The release-please \`deploy\` job was gated on \`release_created == 'true'\`, but
that output resolved empty on both release runs, so \`deploy\` skipped instantly
(the \`chore: release main\` run finished in 14s with \`deploy\` skipped) while the
tag + GitHub Release were still created.

## Fix

- Gate \`deploy\` on non-empty \`web--tag_name\` instead of \`release_created\` — a
  single string is robust to the boolean/string coercion that made the gate
  falsy.
- Add a "Debug release-please outputs" step that dumps every output, so a future
  "tag created but deploy skipped" is root-causeable from the run log alone.

Path-prefixed outputs key on the package **path** (\`web\`), not the \`component\`;
the debug dump will confirm the exact output shape on the next release.

## Verification

v1.13.0 is already live: I dispatched the manual \`web-deploy.yaml\` escape hatch
against \`web-v1.13.0\`, it deployed successfully, and \`classroom50.org\` now
serves \`1.13.0\`. This PR fixes the *automatic* path for the next release.

Infra-only (\`.github/**\`), so it does not itself cut a web release.