### PR TITLE
fix(web): recover accept secret from team description for bare links

### DIFF
--- a/web/src/components/org/StudentAssignmentList.test.tsx
+++ b/web/src/components/org/StudentAssignmentList.test.tsx
@@ -51,6 +51,10 @@ vi.mock("@/hooks/useGetMyOrgRepos", () => ({
 }))
 vi.mock("@/hooks/useStudentClassrooms", () => ({
   useStudentClassrooms: () => studentClassrooms(),
+  useClassroomSecret: (_org?: string, classroom?: string) =>
+    studentClassrooms().classrooms.find(
+      (c: { classroom: string; secret?: string }) => c.classroom === classroom,
+    )?.secret,
 }))
 vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => ({ user: { login: "student1" } }),

--- a/web/src/components/org/StudentAssignmentList.test.tsx
+++ b/web/src/components/org/StudentAssignmentList.test.tsx
@@ -51,10 +51,12 @@ vi.mock("@/hooks/useGetMyOrgRepos", () => ({
 }))
 vi.mock("@/hooks/useStudentClassrooms", () => ({
   useStudentClassrooms: () => studentClassrooms(),
-  useClassroomSecret: (_org?: string, classroom?: string) =>
-    studentClassrooms().classrooms.find(
+  useClassroomSecret: (_org?: string, classroom?: string) => ({
+    secret: studentClassrooms().classrooms.find(
       (c: { classroom: string; secret?: string }) => c.classroom === classroom,
     )?.secret,
+    isLoading: false,
+  }),
 }))
 vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => ({ user: { login: "student1" } }),

--- a/web/src/components/org/StudentAssignmentList.tsx
+++ b/web/src/components/org/StudentAssignmentList.tsx
@@ -371,7 +371,10 @@ export function StudentAssignmentList({
 }) {
   const { t } = useTranslation()
   const { user } = useGithubAuth()
-  const secret = useClassroomSecret(org, classroom)
+  const { secret, isLoading: loadingSecret } = useClassroomSecret(
+    org,
+    classroom,
+  )
   const { viewMode, sortKey, changeView, changeSort } = useListPrefsState(
     studentAssignmentListPrefs,
   )
@@ -382,9 +385,10 @@ export function StudentAssignmentList({
 
   const {
     data: assignments,
-    isLoading,
+    isLoading: loadingAssignmentsData,
     isError,
-  } = usePagesAssignments(org, classroom, secret)
+  } = usePagesAssignments(org, classroom, secret, !loadingSecret)
+  const isLoading = loadingSecret || loadingAssignmentsData
   const { data: repos } = useGetOrgRepos(org)
 
   const acceptedSlugs = useMemo(() => {

--- a/web/src/components/org/StudentAssignmentList.tsx
+++ b/web/src/components/org/StudentAssignmentList.tsx
@@ -15,7 +15,7 @@ import { EnterDiv } from "@/lib/motionComponents"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
-import { useStudentClassrooms } from "@/hooks/useStudentClassrooms"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { useListPrefsState } from "@/lib/listPrefs"
 import { studentAssignmentListPrefs } from "@/lib/studentAssignmentListPrefs"
 import {
@@ -32,19 +32,6 @@ import {
   isPastDue,
 } from "@/util/formatDate"
 import type { Assignment } from "@/types/classroom"
-
-// Resolve the classroom's capability secret for a student, config-free: the
-// team-description bootstrap record (useStudentClassrooms) is the primary
-// source; for a pre-schema team it falls back to any of the student's accepted
-// repos' membership in this classroom (the caller passes that secret in). Empty
-// when the classroom is listed (no secret needed).
-function useClassroomSecret(
-  org: string,
-  classroom: string,
-): string | undefined {
-  const { classrooms } = useStudentClassrooms(org)
-  return classrooms.find((c) => c.classroom === classroom)?.secret
-}
 
 function ModeBadge({ mode }: { mode: Assignment["mode"] }) {
   const { t } = useTranslation()

--- a/web/src/hooks/usePagesAssignments.ts
+++ b/web/src/hooks/usePagesAssignments.ts
@@ -10,11 +10,15 @@ const usePagesAssignments = (
   // (post-accept), or classroom.json (teachers). Empty/undefined fetches the
   // plain path (unprotected classroom).
   secret?: string,
+  // Gate the read while the secret is still being resolved: fetching under a
+  // not-yet-known secret would hit the unprotected path and 404 a protected
+  // classroom. Defaults true for callers whose secret is available synchronously.
+  enabled = true,
 ) => {
   return useQuery({
     queryKey: ["pages", "assignments", org, classroom, secret ?? ""],
     queryFn: () => fetchPagesAssignments(org ?? "", classroom ?? "", secret),
-    enabled: Boolean(org && classroom),
+    enabled: enabled && Boolean(org && classroom),
   })
 }
 

--- a/web/src/hooks/useStudentClassrooms.test.tsx
+++ b/web/src/hooks/useStudentClassrooms.test.tsx
@@ -17,7 +17,10 @@ vi.mock("@/github-core/queries", () => ({
   myTeamsQuery: () => ({ queryKey: ["my-teams"] }),
 }))
 
-import { useStudentClassrooms } from "./useStudentClassrooms"
+import {
+  useStudentClassrooms,
+  useClassroomSecret,
+} from "./useStudentClassrooms"
 import type { MyTeam } from "@/github-core/types"
 
 const team = (
@@ -224,5 +227,68 @@ describe("useStudentClassrooms", () => {
       "zeta",
       "alpha",
     ])
+  })
+})
+
+describe("useClassroomSecret", () => {
+  it("returns the matching classroom's secret when enabled", () => {
+    useQueryMock.mockReturnValue(
+      teams({
+        data: [
+          team("classroom50-ml", {
+            description: desc({ name: "ML", secret: "a1b2c3d4" }),
+          }),
+        ],
+        isSuccess: true,
+      }),
+    )
+    const { result } = renderHook(() => useClassroomSecret("acme", "ml"))
+    expect(result.current).toEqual({ secret: "a1b2c3d4", isLoading: false })
+  })
+
+  it("returns undefined for a classroom with no matching team", () => {
+    useQueryMock.mockReturnValue(
+      teams({ data: [team("classroom50-cs101")], isSuccess: true }),
+    )
+    const { result } = renderHook(() => useClassroomSecret("acme", "ml"))
+    expect(result.current.secret).toBeUndefined()
+  })
+
+  it("skips the GET /user/teams read when disabled", () => {
+    useQueryMock.mockReturnValue(teams())
+    const { result } = renderHook(() => useClassroomSecret("acme", "ml", false))
+    // The read is gated off: org is passed as undefined, so useStudentClassrooms
+    // disables the query rather than issuing a network round-trip.
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    )
+    expect(result.current).toEqual({ secret: undefined, isLoading: false })
+  })
+
+  it("reports isLoading while the enabled read is in flight", () => {
+    useQueryMock.mockReturnValue(teams({ fetchStatus: "fetching" }))
+    const { result } = renderHook(() => useClassroomSecret("acme", "ml"))
+    expect(result.current).toEqual({ secret: undefined, isLoading: true })
+  })
+
+  it("never reports isLoading when disabled, even mid-flight", () => {
+    useQueryMock.mockReturnValue(teams({ fetchStatus: "fetching" }))
+    const { result } = renderHook(() => useClassroomSecret("acme", "ml", false))
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("returns undefined without a match when classroom is absent", () => {
+    useQueryMock.mockReturnValue(
+      teams({
+        data: [
+          team("classroom50-ml", {
+            description: desc({ secret: "a1b2c3d4" }),
+          }),
+        ],
+        isSuccess: true,
+      }),
+    )
+    const { result } = renderHook(() => useClassroomSecret("acme", undefined))
+    expect(result.current.secret).toBeUndefined()
   })
 })

--- a/web/src/hooks/useStudentClassrooms.ts
+++ b/web/src/hooks/useStudentClassrooms.ts
@@ -122,12 +122,20 @@ export default useStudentClassrooms
 // team-description bootstrap record is the source. `enabled: false` skips the
 // GET /user/teams read for callers that already hold the secret (e.g. an accept
 // link's ?k=), returning undefined without a network round-trip.
+//
+// `isLoading` is the in-flight state of that read, so a caller can wait before
+// fetching under a still-undefined secret (a protected classroom would 404 the
+// unprotected path). It is false when the read is disabled — nothing to wait on.
 export function useClassroomSecret(
   org: string | undefined,
   classroom: string | undefined,
   enabled = true,
-): string | undefined {
-  const { classrooms } = useStudentClassrooms(enabled ? org : undefined)
-  if (!classroom) return undefined
-  return classrooms.find((c) => c.classroom === classroom)?.secret
+): { secret: string | undefined; isLoading: boolean } {
+  const { classrooms, isLoading } = useStudentClassrooms(
+    enabled ? org : undefined,
+  )
+  const secret = classroom
+    ? classrooms.find((c) => c.classroom === classroom)?.secret
+    : undefined
+  return { secret, isLoading: enabled ? isLoading : false }
 }

--- a/web/src/hooks/useStudentClassrooms.ts
+++ b/web/src/hooks/useStudentClassrooms.ts
@@ -118,14 +118,10 @@ export function useStudentClassrooms(
 
 export default useStudentClassrooms
 
-// Resolve a student's capability secret for a classroom, config-free: the
-// team-description bootstrap record is the source. `enabled: false` skips the
-// GET /user/teams read for callers that already hold the secret (e.g. an accept
-// link's ?k=), returning undefined without a network round-trip.
-//
-// `isLoading` is the in-flight state of that read, so a caller can wait before
-// fetching under a still-undefined secret (a protected classroom would 404 the
-// unprotected path). It is false when the read is disabled — nothing to wait on.
+// A student's capability secret for a classroom, from the team-description
+// bootstrap record (config-free). `enabled: false` skips the GET /user/teams
+// read for callers that already hold the secret (e.g. an accept link's ?k=).
+// `isLoading` tracks that read; false when disabled (nothing to wait on).
 export function useClassroomSecret(
   org: string | undefined,
   classroom: string | undefined,

--- a/web/src/hooks/useStudentClassrooms.ts
+++ b/web/src/hooks/useStudentClassrooms.ts
@@ -117,3 +117,17 @@ export function useStudentClassrooms(
 }
 
 export default useStudentClassrooms
+
+// Resolve a student's capability secret for a classroom, config-free: the
+// team-description bootstrap record is the source. `enabled: false` skips the
+// GET /user/teams read for callers that already hold the secret (e.g. an accept
+// link's ?k=), returning undefined without a network round-trip.
+export function useClassroomSecret(
+  org: string | undefined,
+  classroom: string | undefined,
+  enabled = true,
+): string | undefined {
+  const { classrooms } = useStudentClassrooms(enabled ? org : undefined)
+  if (!classroom) return undefined
+  return classrooms.find((c) => c.classroom === classroom)?.secret
+}

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -13,20 +13,37 @@ import type { GitHubRepo } from "@/github-core/types"
 
 const acceptAssignment = vi.fn()
 
+const pagesAssignmentsSpy =
+  vi.fn<(org?: string, classroom?: string, secret?: string) => void>()
+const searchParams: { k?: string } = { k: "test-secret" }
+let studentClassroomsData: Array<{ classroom: string; secret?: string }> = []
+
 vi.mock("@/domain/assignments", () => ({
   acceptAssignment: (...args: unknown[]) => acceptAssignment(...args),
 }))
 vi.mock("@/hooks/usePagesAssignments", () => ({
+  default: (org?: string, classroom?: string, secret?: string) => {
+    pagesAssignmentsSpy(org, classroom, secret)
+    return {
+      data: [
+        {
+          slug: "hello-python",
+          name: "Hello Python",
+          mode: "individual",
+          autograder: "default",
+        },
+      ],
+      isLoading: false,
+    }
+  },
+}))
+vi.mock("@/hooks/useStudentClassrooms", () => ({
   default: () => ({
-    data: [
-      {
-        slug: "hello-python",
-        name: "Hello Python",
-        mode: "individual",
-        autograder: "default",
-      },
-    ],
+    classrooms: studentClassroomsData,
     isLoading: false,
+    isError: false,
+    roleResolved: true,
+    refetch: vi.fn(),
   }),
 }))
 vi.mock("@/hooks/useGetRepo", () => ({
@@ -90,7 +107,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
       classroom: "cs101",
       assignment: "hello-python",
     }),
-    useSearch: () => ({ k: "test-secret" }),
+    useSearch: () => searchParams,
     Link: ({ children }: { children: ReactNode }) => <a href="/">{children}</a>,
   }
 })
@@ -126,6 +143,9 @@ const renderPage = (client: QueryClient) =>
 
 beforeEach(() => {
   acceptAssignment.mockReset()
+  pagesAssignmentsSpy.mockReset()
+  searchParams.k = "test-secret"
+  studentClassroomsData = []
   __resetGitHubHealthForTest()
 })
 
@@ -187,6 +207,51 @@ describe("AcceptAssignmentPage repository cache", () => {
       )
     },
   )
+})
+
+describe("AcceptAssignmentPage secret selection", () => {
+  const renderWith = () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    renderPage(client)
+  }
+
+  it("uses the ?k= link secret when present", () => {
+    searchParams.k = "test-secret"
+    studentClassroomsData = [{ classroom: "cs101", secret: "team-secret" }]
+    renderWith()
+    expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "cs101",
+      "test-secret",
+    )
+  })
+
+  it("falls back to the team-description secret for a bare accept link", () => {
+    searchParams.k = undefined
+    studentClassroomsData = [{ classroom: "cs101", secret: "team-secret" }]
+    renderWith()
+    expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "cs101",
+      "team-secret",
+    )
+  })
+
+  it("passes no secret for a bare link when the student has no matching team", () => {
+    searchParams.k = undefined
+    studentClassroomsData = [{ classroom: "other", secret: "team-secret" }]
+    renderWith()
+    expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "cs101",
+      undefined,
+    )
+  })
 })
 
 describe("AcceptAssignmentPage outage hint", () => {

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -42,9 +42,13 @@ vi.mock("@/hooks/useStudentClassrooms", () => ({
     _org?: string,
     classroom?: string,
     enabled = true,
-  ): string | undefined => {
-    if (!enabled || !classroom) return undefined
-    return studentClassroomsData.find((c) => c.classroom === classroom)?.secret
+  ): { secret: string | undefined; isLoading: boolean } => {
+    if (!enabled || !classroom) return { secret: undefined, isLoading: false }
+    return {
+      secret: studentClassroomsData.find((c) => c.classroom === classroom)
+        ?.secret,
+      isLoading: false,
+    }
   },
 }))
 vi.mock("@/hooks/useGetRepo", () => ({
@@ -234,6 +238,20 @@ describe("AcceptAssignmentPage secret selection", () => {
 
   it("falls back to the team-description secret for a bare accept link", () => {
     searchParams.k = undefined
+    studentClassroomsData = [{ classroom: "cs101", secret: "team-secret" }]
+    renderWith()
+    expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "cs101",
+      "team-secret",
+    )
+  })
+
+  it("treats an empty ?k= as absent and uses the team-description secret", () => {
+    // A bare `?k=` (empty value) must not shadow the recovered team secret: the
+    // enabled gate already treats "" as absent, so precedence must agree, or a
+    // protected classroom fetches the unprotected path and 404s.
+    searchParams.k = ""
     studentClassroomsData = [{ classroom: "cs101", secret: "team-secret" }]
     renderWith()
     expect(pagesAssignmentsSpy).toHaveBeenLastCalledWith(

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -38,13 +38,14 @@ vi.mock("@/hooks/usePagesAssignments", () => ({
   },
 }))
 vi.mock("@/hooks/useStudentClassrooms", () => ({
-  default: () => ({
-    classrooms: studentClassroomsData,
-    isLoading: false,
-    isError: false,
-    roleResolved: true,
-    refetch: vi.fn(),
-  }),
+  useClassroomSecret: (
+    _org?: string,
+    classroom?: string,
+    enabled = true,
+  ): string | undefined => {
+    if (!enabled || !classroom) return undefined
+    return studentClassroomsData.find((c) => c.classroom === classroom)?.secret
+  },
 }))
 vi.mock("@/hooks/useGetRepo", () => ({
   default: () => ({ data: null, isLoading: false }),

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -542,9 +542,6 @@ const AcceptAssignmentPage = () => {
   const { user } = useGithubAuth()
   const username = user?.login
 
-  // Wait for the team-description read before fetching assignments: under a
-  // still-undefined secret the read would hit the unprotected path and 404 a
-  // protected classroom.
   const { data: assignmentsData, isLoading: loadingAssignmentsData } =
     usePagesAssignments(org, classroom, secret, !loadingSecret)
   const loadingAssignments = loadingSecret || loadingAssignmentsData

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -26,6 +26,7 @@ import {
   MembershipError,
 } from "@/components/MembershipError"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
+import useStudentClassrooms from "@/hooks/useStudentClassrooms"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { studentRepoName } from "@/util/studentRepo"
@@ -526,7 +527,16 @@ const AcceptAssignmentPage = () => {
   // selects the <classroom>/<secret>/ Pages path; absent otherwise. Read
   // loosely so the page works if mounted without the typed route in tests.
   const search = useSearch({ strict: false }) as { k?: string }
-  const secret = typeof search.k === "string" ? search.k : undefined
+  const linkSecret = typeof search.k === "string" ? search.k : undefined
+
+  // Fallback for a bare accept link (no ?k=): an already-enrolled student's own
+  // team description carries the classroom's capability secret, so recover it
+  // from GET /user/teams. The link secret still wins when present.
+  const { classrooms: studentClassrooms } = useStudentClassrooms(org)
+  const teamSecret = classroom
+    ? studentClassrooms.find((c) => c.classroom === classroom)?.secret
+    : undefined
+  const secret = linkSecret ?? teamSecret
 
   const { user } = useGithubAuth()
   const username = user?.login

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -26,7 +26,7 @@ import {
   MembershipError,
 } from "@/components/MembershipError"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
-import useStudentClassrooms from "@/hooks/useStudentClassrooms"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { studentRepoName } from "@/util/studentRepo"
@@ -530,12 +530,9 @@ const AcceptAssignmentPage = () => {
   const linkSecret = typeof search.k === "string" ? search.k : undefined
 
   // Fallback for a bare accept link (no ?k=): an already-enrolled student's own
-  // team description carries the classroom's capability secret, so recover it
-  // from GET /user/teams. The link secret still wins when present.
-  const { classrooms: studentClassrooms } = useStudentClassrooms(org)
-  const teamSecret = classroom
-    ? studentClassrooms.find((c) => c.classroom === classroom)?.secret
-    : undefined
+  // team description carries the classroom's capability secret. Skipped when the
+  // link already supplies one, so the common path avoids a GET /user/teams read.
+  const teamSecret = useClassroomSecret(org, classroom, !linkSecret)
   const secret = linkSecret ?? teamSecret
 
   const { user } = useGithubAuth()

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -527,19 +527,27 @@ const AcceptAssignmentPage = () => {
   // selects the <classroom>/<secret>/ Pages path; absent otherwise. Read
   // loosely so the page works if mounted without the typed route in tests.
   const search = useSearch({ strict: false }) as { k?: string }
-  const linkSecret = typeof search.k === "string" ? search.k : undefined
+  const linkSecret =
+    typeof search.k === "string" && search.k !== "" ? search.k : undefined
 
   // Fallback for a bare accept link (no ?k=): an already-enrolled student's own
-  // team description carries the classroom's capability secret. Skipped when the
-  // link already supplies one, so the common path avoids a GET /user/teams read.
-  const teamSecret = useClassroomSecret(org, classroom, !linkSecret)
+  // team description carries the classroom's capability secret.
+  const { secret: teamSecret, isLoading: loadingSecret } = useClassroomSecret(
+    org,
+    classroom,
+    !linkSecret,
+  )
   const secret = linkSecret ?? teamSecret
 
   const { user } = useGithubAuth()
   const username = user?.login
 
-  const { data: assignmentsData, isLoading: loadingAssignments } =
-    usePagesAssignments(org, classroom, secret)
+  // Wait for the team-description read before fetching assignments: under a
+  // still-undefined secret the read would hit the unprotected path and 404 a
+  // protected classroom.
+  const { data: assignmentsData, isLoading: loadingAssignmentsData } =
+    usePagesAssignments(org, classroom, secret, !loadingSecret)
+  const loadingAssignments = loadingSecret || loadingAssignmentsData
   const {
     data: orgInvite,
     isLoading: loadingOrgMembership,


### PR DESCRIPTION
## Problem

Visiting a **bare** accept link for a protected classroom (no `?k=`), e.g. `/<org>/protected-classroom/assignments/test/accept`, failed: the page read the secret only from the `?k=` query param, so with no secret it fetched the **unprotected** Pages path (`.../protected-classroom/assignments.json`) which 404s. For a protected classroom, `assignments.json` is only published under the secret-prefixed path.

## Fix

`AcceptAssignmentPage` now falls back to the capability secret stored in the enrolled student's own team description (recovered via `GET /user/teams`) when `?k=` is absent. The link secret still wins when present.

- Already-enrolled student on a bare link → secret recovered → protected path fetched → accept works.
- Non-member (no team, no secret) → still falls back to the unprotected path and 404s, which is correct (they must use the full `?k=` invite link).

The secret lookup is the shared `useClassroomSecret` hook (also used by `StudentAssignmentList`), and its `GET /user/teams` read is skipped when `?k=` already supplies the secret, so the common path avoids the extra request.

## Robustness (code-review follow-ups)

Three findings from review were fixed in the latest commit:

- **Empty `?k=` no longer discards the recovered secret.** A bare `?k=` (empty value) previously kept `secret = ""` — the `enabled` gate treated it as absent (firing the team read) while precedence treated it as present, so a protected classroom still 404'd. `linkSecret` now normalizes `""` to `undefined`, so both paths agree.
- **No transient undefined-secret fetch.** `useClassroomSecret` now exposes the `GET /user/teams` in-flight state, and both `AcceptAssignmentPage` and `StudentAssignmentList` gate `usePagesAssignments` on it. Previously the assignments read fired immediately with `secret === undefined` (hitting the unprotected path / a wasted 404 and a possible "not found" flash) before the team read resolved.

## Tests

- Secret precedence at the page level: `?k=` wins, team-description fallback, empty `?k=` → team fallback, and no-matching-team → no secret.
- `useClassroomSecret` is now exercised against the **real** hook in `useStudentClassrooms.test.tsx`: the `enabled: false` skip (asserted via the query gate), the loading passthrough, and matching/no-match/absent-classroom.

`tsc -b`, eslint, prettier, and the full vitest suite (2295 tests) are green.
