### PR TITLE
fix(web): don't fail org preflight when the Actions budget is unreadable

### DIFF
--- a/web/src/github-core/mutations/provisioning.ts
+++ b/web/src/github-core/mutations/provisioning.ts
@@ -583,11 +583,17 @@ export async function ensurePages(
   }
 
   // Not enforced, or the read-back was unreadable: surface why, preferring the
-  // write-time warning when we have one.
+  // write-time warning when we have one. verdict.detail is an i18n descriptor
+  // (see CheckVerdict); this module builds English messages, so surface its
+  // status param when present rather than the whole descriptor.
+  const readFailReason =
+    verdict.detail?.params?.status ??
+    verdict.detail?.params?.reason ??
+    "read failed"
   const message =
     visibilityResult.warning ??
     (verdict.state === "unreadable"
-      ? `${org}/${repo}: couldn't verify GitHub Pages (${verdict.detail ?? "read failed"}). Check it at ${settingsUrl} → Pages.`
+      ? `${org}/${repo}: couldn't verify GitHub Pages (${readFailReason}). Check it at ${settingsUrl} → Pages.`
       : `${org}/${repo}: GitHub Pages isn't fully configured (needs a workflow build and a public site). Set it at ${settingsUrl} → Pages.`)
 
   return {

--- a/web/src/github-core/orgChecks.test.ts
+++ b/web/src/github-core/orgChecks.test.ts
@@ -271,7 +271,9 @@ describe("checkWorkflowPermissions", () => {
     })
     const verdict = await checkWorkflowPermissions(client, "acme")
     expect(verdict.state).toBe("enforced")
-    expect(verdict.detail).toMatch(/org policy/i)
+    expect(verdict.detail?.key).toBe(
+      "orgSettings.audit.detail.workflowOrgManaged",
+    )
   })
 
   it("unenforced when repo is read but the org allows write (fixable)", async () => {

--- a/web/src/github-core/orgChecks.ts
+++ b/web/src/github-core/orgChecks.ts
@@ -172,12 +172,14 @@ export async function checkOrgBudget(
         }
     }
   } catch (err) {
-    // Any read failure (403 no billing visibility, 404 plan without budgets,
-    // transient) is advisory/inconclusive — mirror the CLI, which never treats
-    // an unreadable budgets list as critical drift. (Unlike other checks, a 404
-    // here is "can't read", not "not configured": an org with no budget returns
-    // 200 with an empty list.)
-    return { state: "unreadable", detail: readFailedDetail(err) }
+    // A read failure yields "unreadable", which deriveVerdict treats as
+    // advisory (never gates) for orgBudget specifically. (A 404 here is "can't
+    // read", not "not configured": an org with no budget returns 200 with an
+    // empty list, so we don't reuse unreadableFrom.)
+    return {
+      state: "unreadable",
+      detail: `couldn't verify the Actions spending cap (${readFailedDetail(err)}) — likely enterprise-managed billing or a plan without org budgets. Confirm a $0 hard-stop cap manually.`,
+    }
   }
 }
 

--- a/web/src/github-core/orgChecks.ts
+++ b/web/src/github-core/orgChecks.ts
@@ -34,23 +34,38 @@ export const RECOMMENDED_ORG_DEFAULT_BRANCH = DEFAULT_BRANCH
 // inconclusive.
 export type CheckState = "enforced" | "unenforced" | "warn" | "unreadable"
 
-export type CheckVerdict = {
-  state: CheckState
-  detail?: string
+// An i18n descriptor for a concern's `detail`: a translation key plus its
+// interpolation params. The data layer stays language-free — it names the
+// message; the render site (OrgPolicyAuditPane, provisioning) calls t(). Keys
+// live under `orgSettings.audit.detail.*` in the locale packs.
+export type CheckDetail = {
+  key: string
+  params?: Record<string, string | number>
 }
 
-// The `detail` string for a failed read, distinguishing an HTTP status from a
-// non-API error. Shared so every "unreadable" verdict phrases it identically.
-export function readFailedDetail(err: unknown): string {
+export type CheckVerdict = {
+  state: CheckState
+  detail?: CheckDetail
+}
+
+// The `detail` descriptor for a failed read, distinguishing an HTTP status from
+// a non-API error. Shared so every "unreadable" verdict phrases it identically.
+export function readFailedDetail(err: unknown): CheckDetail {
   if (err instanceof GitHubAPIError) {
-    return `read failed (${err.status})`
+    return {
+      key: "orgSettings.audit.detail.readFailedStatus",
+      params: { status: err.status },
+    }
   }
-  return "read failed"
+  return { key: "orgSettings.audit.detail.readFailed" }
 }
 
 function unreadableFrom(err: unknown): CheckVerdict {
   if (err instanceof GitHubAPIError && err.status === 404) {
-    return { state: "unenforced", detail: "not configured" }
+    return {
+      state: "unenforced",
+      detail: { key: "orgSettings.audit.detail.notConfigured" },
+    }
   }
   return { state: "unreadable", detail: readFailedDetail(err) }
 }
@@ -131,7 +146,13 @@ export async function checkOrgActions(
       state: enforced ? "enforced" : "unenforced",
       detail: enforced
         ? undefined
-        : `enabled_repositories="${perms.enabled_repositories}", allowed_actions="${perms.allowed_actions ?? "unset"}"`,
+        : {
+            key: "orgSettings.audit.detail.orgActions",
+            params: {
+              enabledRepositories: perms.enabled_repositories,
+              allowedActions: perms.allowed_actions ?? "unset",
+            },
+          },
     }
   } catch (err) {
     return unreadableFrom(err)
@@ -163,12 +184,15 @@ export async function checkOrgBudget(
       case "warn":
         return {
           state: "warn",
-          detail: `Actions budget is $${v.amount} (over $${BUDGET_WARN_THRESHOLD}); recommend a $0 hard-stop cap`,
+          detail: {
+            key: "orgSettings.audit.detail.budgetOverThreshold",
+            params: { amount: v.amount, threshold: BUDGET_WARN_THRESHOLD },
+          },
         }
       case "missing":
         return {
           state: "unenforced",
-          detail: "no $0 hard-stop Actions budget",
+          detail: { key: "orgSettings.audit.detail.budgetMissing" },
         }
     }
   } catch (err) {
@@ -178,7 +202,13 @@ export async function checkOrgBudget(
     // empty list, so we don't reuse unreadableFrom.)
     return {
       state: "unreadable",
-      detail: `couldn't verify the Actions spending cap (${readFailedDetail(err)}) — likely enterprise-managed billing or a plan without org budgets. Confirm a $0 hard-stop cap manually.`,
+      detail: {
+        key: "orgSettings.audit.detail.budgetUnreadable",
+        params: {
+          reason:
+            err instanceof GitHubAPIError ? String(err.status) : "read failed",
+        },
+      },
     }
   }
 }
@@ -326,8 +356,7 @@ export async function checkWorkflowPermissions(
       if (orgPerms.default_workflow_permissions !== "write") {
         return {
           state: "enforced",
-          detail:
-            "org policy defaults workflows to read; the skeleton workflows declare their own permissions",
+          detail: { key: "orgSettings.audit.detail.workflowOrgManaged" },
         }
       }
     } catch {

--- a/web/src/github-core/rulesets.test.ts
+++ b/web/src/github-core/rulesets.test.ts
@@ -146,6 +146,9 @@ describe("checkRulesets", () => {
     ])
     const verdict = await checkRulesets(client, "acme")
     expect(verdict.state).toBe("unenforced")
-    expect(verdict.detail).toContain(RULESET_NAME_FEEDBACK_BASE)
+    expect(verdict.detail?.key).toBe("orgSettings.audit.detail.rulesetsMissing")
+    expect(String(verdict.detail?.params?.names)).toContain(
+      RULESET_NAME_FEEDBACK_BASE,
+    )
   })
 })

--- a/web/src/github-core/rulesets.ts
+++ b/web/src/github-core/rulesets.ts
@@ -116,7 +116,12 @@ export async function checkRulesets(
     return {
       state: missing.length === 0 ? "enforced" : "unenforced",
       detail:
-        missing.length === 0 ? undefined : `missing: ${missing.join(", ")}`,
+        missing.length === 0
+          ? undefined
+          : {
+              key: "orgSettings.audit.detail.rulesetsMissing",
+              params: { names: missing.join(", ") },
+            },
     }
   } catch (err) {
     return { state: "unreadable", detail: readFailedDetail(err) }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1132,6 +1132,17 @@
       "saveButton": "Save service token"
     },
     "audit": {
+      "detail": {
+        "readFailed": "read failed",
+        "readFailedStatus": "read failed ({{status}})",
+        "notConfigured": "not configured",
+        "orgActions": "enabled_repositories=\"{{enabledRepositories}}\", allowed_actions=\"{{allowedActions}}\"",
+        "budgetOverThreshold": "Actions budget is ${{amount}} (over ${{threshold}}); recommend a $0 hard-stop cap",
+        "budgetMissing": "no $0 hard-stop Actions budget",
+        "budgetUnreadable": "couldn't verify the Actions spending cap (read failed ({{reason}})) — likely enterprise-managed billing or a plan without org budgets. Confirm a $0 hard-stop cap manually.",
+        "workflowOrgManaged": "org policy defaults workflows to read; the skeleton workflows declare their own permissions",
+        "rulesetsMissing": "missing: {{names}}"
+      },
       "title": "Organization policy",
       "planBadgeTitle": "GitHub plan — determines which policies are in scope (Enterprise unlocks additional member-privilege fields)",
       "description": "What Classroom 50 configures on your behalf, and whether anything has drifted from the expected lockdown.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1246,7 +1246,10 @@
       "title": "Organization preflight check failed",
       "body_one": "An issue was found with this organization's {{categories}}.",
       "body_other": "Issues were found with this organization's {{categories}}.",
-      "reviewFix": "Review and fix on the <settingsLink>organization settings page</settingsLink>."
+      "reviewFix": "Review and fix on the <settingsLink>organization settings page</settingsLink>.",
+      "unverifiedTitle": "Couldn't verify the Actions spending cap",
+      "unverifiedBody": "This organization's billing couldn't be read, so we can't confirm a spending cap is set. Keep an eye on Actions costs, and check your billing settings or with your billing admin if usage isn't capped.",
+      "unverifiedReview": "See details on the <settingsLink>organization settings page</settingsLink>."
     },
     "overwrite": {
       "title": "Update workflow files to keep grading working?",

--- a/web/src/orgPolicy/audit.test.ts
+++ b/web/src/orgPolicy/audit.test.ts
@@ -164,16 +164,76 @@ describe("buildOrgAuditReport", () => {
     expect(budget?.verdict.state).toBe("warn")
   })
 
-  it("treats an unreadable budgets list as advisory, failing the verdict but distinct from missing", async () => {
+  it("treats an unreadable budget as advisory (never gates), distinct from a missing cap", async () => {
+    // Enterprise-managed billing returns 400 on the org budgets endpoint; a
+    // plan without budgets can 403/404. None of these is fixable by the teacher,
+    // so — mirroring the CLI's "Recommended (not required)" — an unreadable cap
+    // must NOT fail the verdict. Only a missing cap (unenforced) is critical.
+    for (const status of [400, 403, 404]) {
+      const report = await buildOrgAuditReport(
+        makeClient({ budgets: httpError(status) }),
+        "acme",
+        "team",
+      )
+      const budget = report.concerns.find((c) => c.id === "orgBudget")
+      expect(budget?.verdict.state).toBe("unreadable")
+      // The verdict stays ok: an unreadable budget is the one unreadable concern
+      // that doesn't gate (see deriveVerdict).
+      expect(report.verdict).toBe("ok")
+    }
+  })
+
+  it("exempts only orgBudget: an unreadable budget alongside another unreadable concern still fails", async () => {
+    // Guards the narrowness of the exception — it must stay orgBudget-scoped.
+    // Pages unreadable (500) must still gate even though the budget (400) does
+    // not, in the same report.
     const report = await buildOrgAuditReport(
-      makeClient({ budgets: httpError(403) }),
+      {
+        request: <T>(path: string) => {
+          const ok = (v: unknown) => Promise.resolve(v as T)
+          if (path === "/orgs/acme") {
+            const live: Record<string, unknown> = {}
+            for (const s of memberDefaultSettings("team"))
+              live[s.field] = s.value
+            return ok(live)
+          }
+          if (path.endsWith("/actions/permissions"))
+            return ok({ enabled_repositories: "all", allowed_actions: "all" })
+          if (path.endsWith("/actions/permissions/workflow"))
+            return ok({
+              default_workflow_permissions: "write",
+              can_approve_pull_request_reviews: true,
+            })
+          if (path.includes("/protection"))
+            return ok({
+              allow_force_pushes: { enabled: false },
+              allow_deletions: { enabled: false },
+            })
+          if (path.includes("/permissions/access"))
+            return ok({ access_level: "organization" })
+          if (path.includes("/settings/billing/budgets"))
+            return Promise.reject(httpError(400)) as Promise<T>
+          if (path.includes("/pages"))
+            return Promise.reject(httpError(500)) as Promise<T>
+          if (path.includes("/rulesets"))
+            return ok([
+              { id: 1, name: RULESET_NAME_SUBMISSION_HISTORY },
+              { id: 2, name: RULESET_NAME_FEEDBACK_BASE },
+            ])
+          return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
+        },
+        requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      },
       "acme",
       "team",
     )
-    const budget = report.concerns.find((c) => c.id === "orgBudget")
-    // Unreadable (not "unenforced"): the CLI treats this as advisory, and the
-    // GUI's deriveVerdict fails on unreadable like any other read outage.
-    expect(budget?.verdict.state).toBe("unreadable")
+    expect(report.verdict).toBe("fail")
+    expect(
+      report.concerns.find((c) => c.id === "orgBudget")?.verdict.state,
+    ).toBe("unreadable")
+    expect(report.concerns.find((c) => c.id === "pages")?.verdict.state).toBe(
+      "unreadable",
+    )
   })
 
   it("recommends switching a non-main org default branch without failing", async () => {

--- a/web/src/orgPolicy/audit.ts
+++ b/web/src/orgPolicy/audit.ts
@@ -135,6 +135,13 @@ function concernSettingsUrl(id: ConcernId, org: string): string {
 // Any drift fails the audit — stricter than the CLI, which warns on
 // non-critical drift (see header). An unreadable concern also fails: a partial
 // read outage is "needs attention", not a clean bill.
+//
+// The one exception is orgBudget: its endpoint is legitimately, permanently
+// unreadable for enterprise-managed billing (org budget URLs 400/404) and plans
+// that don't expose budgets, so an unreadable cap is an expected steady state,
+// not an outage. Mirroring the CLI (which lists it under "Recommended"), an
+// unreadable budget is advisory and never gates — but a missing cap
+// (unenforced) is still critical drift that fails.
 function deriveVerdict(
   readOk: boolean,
   lockdownComplete: boolean,
@@ -142,9 +149,10 @@ function deriveVerdict(
 ): AuditVerdict {
   if (!readOk) return "fail"
   if (!lockdownComplete) return "fail"
-  const anyUnresolved = concerns.some(
-    (c) => c.verdict.state === "unenforced" || c.verdict.state === "unreadable",
-  )
+  const anyUnresolved = concerns.some((c) => {
+    if (c.id === "orgBudget" && c.verdict.state === "unreadable") return false
+    return c.verdict.state === "unenforced" || c.verdict.state === "unreadable"
+  })
   return anyUnresolved ? "fail" : "ok"
 }
 

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.test.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.test.tsx
@@ -14,7 +14,10 @@ vi.mock("react-i18next", async (importOriginal) => {
 })
 
 import { ConcernRow } from "./OrgPolicyAuditPane"
-import { classifyRepairOutcome } from "./OrgPolicyAuditPane"
+import {
+  classifyRepairOutcome,
+  CONCERN_STATE_BADGE,
+} from "./OrgPolicyAuditPane"
 import type { ConcernCheck } from "@/orgPolicy/audit"
 
 afterEach(cleanup)
@@ -56,6 +59,38 @@ describe("ConcernRow", () => {
     // The manual settings link is still available.
     const link = screen.getByText("orgSettings.audit.viewOnGitHub").closest("a")
     expect(link?.getAttribute("href")).toBe(drifted.settingsUrl)
+  })
+
+  it("renders a translated detail descriptor via its i18n key", () => {
+    const unreadable: ConcernCheck = {
+      id: "orgBudget",
+      title: "Actions spending cap",
+      verdict: {
+        state: "unreadable",
+        detail: {
+          key: "orgSettings.audit.detail.budgetUnreadable",
+          params: { reason: "400" },
+        },
+      },
+      settingsUrl:
+        "https://github.com/organizations/acme/settings/billing/budgets",
+    }
+    render(
+      <ConcernRow concern={unreadable} canFix fixing={false} onFix={noop} />,
+    )
+    // The raw descriptor is never rendered; the key is (t() passes it through
+    // in this test's mock), proving detail goes through translation.
+    expect(
+      screen.getByText("orgSettings.audit.detail.budgetUnreadable"),
+    ).not.toBeNull()
+  })
+})
+
+describe("CONCERN_STATE_BADGE", () => {
+  it("renders an unreadable concern with a warning, non-ghost badge", () => {
+    // A ghost badge would ignore the tone and render neutral-grey (Badge.tsx),
+    // silently swallowing the warning intent — guard against that regression.
+    expect(CONCERN_STATE_BADGE.unreadable).toEqual({ tone: "warning" })
   })
 })
 

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -80,7 +80,7 @@ const CONCERN_STATE_LABEL: Record<CheckState, string> = {
   unreadable: "orgSettings.audit.stateUnreadable",
 }
 
-const CONCERN_STATE_BADGE: Record<
+export const CONCERN_STATE_BADGE: Record<
   CheckState,
   { tone: BadgeTone; ghost?: boolean }
 > = {
@@ -153,7 +153,7 @@ export function ConcernRow({
           <div className="text-sm font-semibold">{concern.title}</div>
           {concern.verdict.detail && (
             <p className="mt-0.5 text-xs text-base-content/70">
-              {concern.verdict.detail}
+              {t(concern.verdict.detail.key, concern.verdict.detail.params)}
             </p>
           )}
           {unresolvedMessage !== undefined && (

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -87,7 +87,9 @@ const CONCERN_STATE_BADGE: Record<
   enforced: { tone: "success" },
   unenforced: { tone: "error" },
   warn: { tone: "warning" },
-  unreadable: { tone: "neutral", ghost: true },
+  // Warning, not ghost: "couldn't verify — confirm manually" is attention-worthy,
+  // and a ghost badge would ignore the tone and render neutral-grey (Badge.tsx).
+  unreadable: { tone: "warning" },
 }
 
 // What a Fix-it result means for the pane, derived purely from the RepairResult

--- a/web/src/pages/orgSettings/OrgPreflightNotice.test.tsx
+++ b/web/src/pages/orgSettings/OrgPreflightNotice.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+// Match assertions on stable i18n keys, not English copy; keep the rest of
+// react-i18next real so <Trans> and the transitive setup still load.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+// The router <Link> renders as an anchor in isolation; stub it so we don't need
+// a RouterProvider just to assert which notice shows.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}))
+
+import type { OrgAuditReport } from "@/orgPolicy/audit"
+
+const tokenStatus = vi.fn()
+const planDetails = vi.fn()
+const audit = vi.fn()
+
+vi.mock("@/hooks/useGetServiceTokenStatus", () => ({
+  default: () => tokenStatus(),
+}))
+vi.mock("@/hooks/useGetOrgPlanDetails", () => ({
+  default: () => planDetails(),
+}))
+vi.mock("@/hooks/useGetOrgAudit", () => ({ default: () => audit() }))
+
+import OrgPreflightNotice from "./OrgPreflightNotice"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+// Minimal report; only the fields OrgPreflightNotice reads matter.
+const report = (over: Partial<OrgAuditReport>): { data: OrgAuditReport } => ({
+  data: {
+    org: "acme",
+    plan: "team",
+    verdict: "ok",
+    readOk: true,
+    lockdownComplete: true,
+    unenforcedDefaults: [],
+    defaultVerdicts: [],
+    concerns: [],
+    manualUnreadable: [],
+    recommendations: [],
+    ...over,
+  } as OrgAuditReport,
+})
+
+const settled = () => {
+  tokenStatus.mockReturnValue({ data: { status: "present" }, isPending: false })
+  planDetails.mockReturnValue({
+    data: { plan: { name: "team" } },
+    isPending: false,
+  })
+}
+
+const unreadableBudget = {
+  id: "orgBudget" as const,
+  title: "Actions spending cap",
+  verdict: { state: "unreadable" as const },
+  settingsUrl: "https://github.com/organizations/acme/settings/billing/budgets",
+}
+
+describe("OrgPreflightNotice", () => {
+  it("stays invisible while any input is still loading", () => {
+    tokenStatus.mockReturnValue({ data: undefined, isPending: true })
+    planDetails.mockReturnValue({ data: undefined, isPending: false })
+    audit.mockReturnValue({ data: undefined, isLoading: true })
+    const { container } = render(<OrgPreflightNotice org="acme" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("shows the hard error banner when the policy audit fails", () => {
+    settled()
+    audit.mockReturnValue(report({ verdict: "fail" }))
+    render(<OrgPreflightNotice org="acme" />)
+    expect(screen.getByText("orgSettings.preflight.title")).not.toBeNull()
+    // The neutral cap-unverified notice must NOT also show.
+    expect(
+      screen.queryByText("orgSettings.preflight.unverifiedTitle"),
+    ).toBeNull()
+  })
+
+  it("shows a neutral warning (not the failure banner) when the budget is unreadable but the verdict is ok", () => {
+    settled()
+    audit.mockReturnValue(
+      report({ verdict: "ok", concerns: [unreadableBudget] }),
+    )
+    const { container } = render(<OrgPreflightNotice org="acme" />)
+    expect(
+      screen.getByText("orgSettings.preflight.unverifiedTitle"),
+    ).not.toBeNull()
+    // Never gates: the hard-failure banner stays hidden, and the callout is
+    // warning-toned, not error.
+    expect(screen.queryByText("orgSettings.preflight.title")).toBeNull()
+    expect(container.querySelector(".alert-warning")).not.toBeNull()
+    expect(container.querySelector(".alert-error")).toBeNull()
+  })
+
+  it("shows the failure banner (not the warning) when the audit fails AND the budget is unreadable", () => {
+    settled()
+    audit.mockReturnValue(
+      report({ verdict: "fail", concerns: [unreadableBudget] }),
+    )
+    render(<OrgPreflightNotice org="acme" />)
+    expect(screen.getByText("orgSettings.preflight.title")).not.toBeNull()
+    expect(
+      screen.queryByText("orgSettings.preflight.unverifiedTitle"),
+    ).toBeNull()
+  })
+
+  it("stays fully invisible when everything is clean and readable", () => {
+    settled()
+    audit.mockReturnValue(report({ verdict: "ok", concerns: [] }))
+    const { container } = render(<OrgPreflightNotice org="acme" />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/web/src/pages/orgSettings/OrgPreflightNotice.tsx
+++ b/web/src/pages/orgSettings/OrgPreflightNotice.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router"
 import { Trans, useTranslation } from "react-i18next"
-import { XCircle } from "lucide-react"
+import { AlertTriangle, XCircle } from "lucide-react"
 
 import useGetServiceTokenStatus from "@/hooks/useGetServiceTokenStatus"
 import useGetOrgAudit from "@/hooks/useGetOrgAudit"
@@ -38,32 +38,65 @@ const OrgPreflightNotice = ({ org }: { org: string }) => {
     failing.push(t("orgSettings.preflight.categoryServiceToken"))
   if (policyFail) failing.push(t("orgSettings.preflight.categoryOrgPolicy"))
 
-  if (failing.length === 0) return null
+  if (failing.length > 0) {
+    const categories = failing.join(", ")
+    return (
+      <CalloutDiv role="alert" className="alert alert-error alert-soft mb-6">
+        <XCircle aria-hidden="true" className="size-5" />
+        <div className="text-sm">
+          <p className="font-semibold">{t("orgSettings.preflight.title")}</p>
+          <p className="mt-0.5 text-base-content/70">
+            {t("orgSettings.preflight.body", {
+              count: failing.length,
+              categories,
+            })}{" "}
+            <Trans
+              i18nKey="orgSettings.preflight.reviewFix"
+              components={{
+                settingsLink: (
+                  <Link to="/$org/settings" params={{ org }} className="link" />
+                ),
+              }}
+            />
+          </p>
+        </div>
+      </CalloutDiv>
+    )
+  }
 
-  const categories = failing.join(", ")
-
-  return (
-    <CalloutDiv role="alert" className="alert alert-error alert-soft mb-6">
-      <XCircle aria-hidden="true" className="size-5" />
-      <div className="text-sm">
-        <p className="font-semibold">{t("orgSettings.preflight.title")}</p>
-        <p className="mt-0.5 text-base-content/70">
-          {t("orgSettings.preflight.body", {
-            count: failing.length,
-            categories,
-          })}{" "}
-          <Trans
-            i18nKey="orgSettings.preflight.reviewFix"
-            components={{
-              settingsLink: (
-                <Link to="/$org/settings" params={{ org }} className="link" />
-              ),
-            }}
-          />
-        </p>
-      </div>
-    </CalloutDiv>
+  // No hard failure, but the spending-cap read is inconclusive (enterprise-
+  // managed billing returns 400/403/404 permanently). Don't gate — that's the
+  // whole point of treating an unreadable budget as advisory — but don't go
+  // silently green either: nudge the teacher to confirm a cap with their admin.
+  // Derived live from the audit each render; nothing is persisted.
+  const budgetUnverified = audit?.concerns.some(
+    (c) => c.id === "orgBudget" && c.verdict.state === "unreadable",
   )
+  if (budgetUnverified) {
+    return (
+      <CalloutDiv role="status" className="alert alert-warning alert-soft mb-6">
+        <AlertTriangle aria-hidden="true" className="size-5" />
+        <div className="text-sm">
+          <p className="font-semibold">
+            {t("orgSettings.preflight.unverifiedTitle")}
+          </p>
+          <p className="mt-0.5 text-base-content/70">
+            {t("orgSettings.preflight.unverifiedBody")}{" "}
+            <Trans
+              i18nKey="orgSettings.preflight.unverifiedReview"
+              components={{
+                settingsLink: (
+                  <Link to="/$org/settings" params={{ org }} className="link" />
+                ),
+              }}
+            />
+          </p>
+        </div>
+      </CalloutDiv>
+    )
+  }
+
+  return null
 }
 
 export default OrgPreflightNotice


### PR DESCRIPTION
Fixes #383.

## Problem

Teachers whose org billing is managed at the **enterprise** level get HTTP **400** from the org billing-budgets endpoint (org-level billing URLs 404/400 for enterprise-managed orgs). The org policy audit's `deriveVerdict` failed on *any* concern in the `unreadable` state — including the budget concern — so these orgs saw a **persistent, unfixable** red banner:

> Organization preflight check failed — An issue was found with this organization's organization policy. (Actions spending cap read failed (400).)

## Root cause: a CLI↔web parity bug

The budget-cap policy is meant to behave identically in the CLI and the web app, but they diverged on an **unreadable** budget:

- **CLI** (`cli/gh-teacher/internal/audit/audit.go`): a budget read failure is advisory (`ReadOK=false`), listed under "Recommended (not required)" — never gates.
- **Web** (`web/src/orgPolicy/audit.ts`): `deriveVerdict` failed the whole audit on any `unreadable` concern, budget included.

The `checkOrgBudget` comment already *claimed* CLI parity ("advisory/inconclusive… never treats an unreadable budgets list as critical drift"), but the verdict logic broke that promise.

## Fix

`deriveVerdict` now treats an **unreadable `orgBudget`** concern as advisory (non-gating), matching the CLI. Crucially:

- A **missing** cap (state `unenforced`, from a readable 200 + empty list) **still fails** — real, fixable drift.
- **Every other** concern still fails on `unreadable` — a partial read outage there is genuinely actionable. Budget is the one concern that's legitimately, permanently unreadable for a class of orgs (enterprise-managed billing, plans without budgets).

Also improves the concern's `detail` copy to explain the likely cause (enterprise-managed billing / plan without budgets) and prompt manual confirmation of a \$0 cap.

## Tests

- Unreadable budget → verdict `ok` across **400 / 403 / 404** (issue's 400 included).
- Missing cap → still `fail` (`unenforced`).
- Scoping guard: an unreadable budget **alongside** an unreadable pages read still fails — proves the exception stays `orgBudget`-scoped.
- Existing "pages 500 → unreadable → fail" guard unchanged.

`tsc -b`, vitest (19/19 in the audit suite), eslint, and prettier all clean. No CLI change (it was already correct); no `budget.ts`/`budget.go` classifier drift.

## Follow-up: surface the unreadable cap in the preflight (don't go silently green)

Making an unreadable budget non-gating fixed the false-red, but it introduced a loss-of-signal: `OrgPreflightNotice` derives its banner solely from `verdict === "fail"`, so an org whose spending cap can't be verified now shows a **fully clean** preflight, with the "couldn't verify" detail living only on the settings pane. The teacher opening the org sees nothing.

Added a **separate, neutral, non-gating warning notice** (warning tone, not error; `role="status"`) that appears when the audit isn't failing but the `orgBudget` concern is `unreadable`. It stays out of the way of real failures (the hard error banner still wins) and is derived live from the audit each render — nothing is persisted.

The copy is deliberately **cause-neutral** — it doesn't assert enterprise-managed billing (the warning fires on any unreadable budget, and the only enterprise signal, `plan.name`, is owner-only and ≠ enterprise-managed billing) and doesn't push our own $0-cap recommendation. It states what happened and where to look:

> Couldn't verify the Actions spending cap — This organization's billing couldn't be read, so we can't confirm a spending cap is set. Keep an eye on Actions costs, and check your billing settings or with your billing admin if usage isn't capped.

New tests (`OrgPreflightNotice.test.tsx`) lock the states: loading → hidden; `fail` → error banner (warning suppressed); `ok` + unreadable budget → warning (not error, non-gating); `fail` + unreadable budget → error wins; all-clean → hidden.
