### PR TITLE
docs: fix e.g. comma and lower-case spelling in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,8 @@ the type right is functional, not cosmetic.
   - `docs:` `chore:` `ci:` `test:` `refactor:` `perf:` `style:` -> no release on their own
 - **Scope** (optional): the affected area — `web`, `gh-teacher`, `gh-student`,
   `cli`, `locales`. Omit for repo-wide changes.
-- **Summary:** imperative mood, lower-case, no trailing period, aim for <= 72
-  characters (e.g. `fix(web): stop double-firing the accept request`).
+- **Summary:** imperative mood, lowercase, no trailing period, aim for <= 72
+  characters (e.g., `fix(web): stop double-firing the accept request`).
 - **Body:** optional and usually unnecessary. Add one only when the "why" isn't
   obvious from the summary; keep it short and explain intent or trade-offs, not
   what the diff already shows. Wrap at ~72 columns.


### PR DESCRIPTION
## Description
This PR fixes minor punctuation and spelling in `CONTRIBUTING.md`.

## Details
1. Added missing comma after `e.g.` (`e.g., fix(web)... `).
2. Fixed `lower-case` -> `lowercase` under summary conventions.