### PR TITLE
fix(web): only create an autograding test when the editor is confirmed

### DIFF
--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -46,6 +46,9 @@ export type ModalProps = {
   closeDisabled?: boolean
   "aria-labelledby"?: string
   "aria-label"?: string
+  // Forwarded to the dialog element. Lets a caller repurpose keys (e.g. Enter)
+  // without hand-rolling a wrapper the a11y lint would flag.
+  onKeyDown?: React.KeyboardEventHandler<HTMLDialogElement>
   // Extra classes for the modal-box.
   boxClassName?: string
   dialogRef?: RefObject<HTMLDialogElement | null>
@@ -62,6 +65,7 @@ export function Modal({
   boxClassName,
   dialogRef,
   ref,
+  onKeyDown,
   children,
   ...aria
 }: ModalProps) {
@@ -92,6 +96,7 @@ export function Modal({
       ref={setRefs}
       className="modal"
       onClose={() => onClose?.()}
+      onKeyDown={onKeyDown}
       onCancel={(event) => {
         // Esc triggers `cancel` before `close`. When dismissal is blocked
         // (e.g., a submit is in flight), veto it so the dialog stays open —

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -865,7 +865,6 @@
       "timeout": "Timeout (seconds)",
       "timeoutHint": "0 = default (10s)",
       "points": "Points",
-      "done": "Done",
       "type": {
         "io": {
           "label": "Input/Output",

--- a/web/src/pages/assignments/AutogradingTestsPane.test.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+// Match on stable i18n keys rather than English copy; keep the rest of
+// react-i18next real so transitive setup still loads.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+    Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+  }
+})
+
+import AutogradingTestsPane, { draftsEqual } from "./AutogradingTestsPane"
+import { useAssignmentForm } from "./assignmentFormModel"
+import { emptyTestDraft } from "@/util/assignmentTests"
+
+afterEach(cleanup)
+
+// happy-dom lacks the native <dialog> showModal/close; stub them so the pane's
+// imperative open/close doesn't throw.
+beforeAll(() => {
+  const proto = globalThis.HTMLDialogElement?.prototype
+  if (!proto) return
+  proto.showModal = function (this: HTMLDialogElement) {
+    this.open = true
+  }
+  proto.close = function (this: HTMLDialogElement) {
+    this.open = false
+    this.dispatchEvent(new Event("close"))
+  }
+})
+
+// A live form is required for the pane (it reads/writes form.tests). Build one
+// with the real useAssignmentForm so commit routing exercises the actual
+// TanStack array API, then expose the form instance for assertions.
+const Harness = ({
+  onForm,
+}: {
+  onForm: (form: ReturnType<typeof useAssignmentForm>) => void
+}) => {
+  const form = useAssignmentForm(
+    undefined,
+    () => {},
+    ((k: string) => k) as never,
+  )
+  onForm(form)
+  return <AutogradingTestsPane form={form} />
+}
+
+const renderPane = () => {
+  let form!: ReturnType<typeof useAssignmentForm>
+  render(<Harness onForm={(f) => (form = f)} />)
+  return () => form.state.values.tests
+}
+
+describe("draftsEqual", () => {
+  it("is true for two fresh empty drafts", () => {
+    expect(draftsEqual(emptyTestDraft(), emptyTestDraft())).toBe(true)
+  })
+
+  it("is false when any single field differs", () => {
+    expect(
+      draftsEqual(emptyTestDraft(), { ...emptyTestDraft(), name: "x" }),
+    ).toBe(false)
+    expect(
+      draftsEqual(emptyTestDraft(), { ...emptyTestDraft(), points: 5 }),
+    ).toBe(false)
+    expect(
+      draftsEqual(emptyTestDraft(), { ...emptyTestDraft(), type: "run" }),
+    ).toBe(false)
+  })
+
+  it("is true for equal-but-distinct objects", () => {
+    const a = emptyTestDraft()
+    const b = { ...a }
+    expect(draftsEqual(a, b)).toBe(true)
+  })
+})
+
+describe("AutogradingTestsPane editor commit gating", () => {
+  const openEditor = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByText("assignments.autograder.addTest"))
+  }
+
+  // The commit button lives in the modal's `.modal-action` footer; the pane's
+  // own "Add test" button shares its label, so scope the lookup to the footer.
+  const commitButton = () => {
+    const action = document.querySelector(".modal-action")
+    if (!action) throw new Error("modal not open")
+    const buttons = Array.from(action.querySelectorAll("button"))
+    const commit = buttons.find(
+      (b) =>
+        b.textContent === "assignments.autograder.addTest" ||
+        b.textContent === "common.save",
+    )
+    if (!commit) throw new Error("commit button not found")
+    return commit as HTMLButtonElement
+  }
+
+  it("clicking Add test does not create an entry until commit", async () => {
+    const user = userEvent.setup()
+    const tests = renderPane()
+
+    expect(screen.getByText("assignments.autograder.empty")).toBeTruthy()
+    await openEditor(user)
+
+    // Editor is open, but nothing committed yet.
+    expect(tests()).toHaveLength(0)
+    expect(screen.getByText("assignments.autograder.empty")).toBeTruthy()
+  })
+
+  it("Cancel discards the draft, leaving the list empty", async () => {
+    const user = userEvent.setup()
+    const tests = renderPane()
+
+    await openEditor(user)
+    await user.type(
+      screen.getByLabelText("assignments.autograder.testName"),
+      "Prints hello",
+    )
+    await user.click(screen.getByText("common.cancel"))
+
+    expect(tests()).toHaveLength(0)
+  })
+
+  it("the commit button is disabled until the draft is dirty", async () => {
+    const user = userEvent.setup()
+    renderPane()
+    await openEditor(user)
+
+    const commit = commitButton()
+    expect(commit.disabled).toBe(true)
+
+    await user.type(
+      screen.getByLabelText("assignments.autograder.testName"),
+      "Prints hello",
+    )
+    expect(commit.disabled).toBe(false)
+  })
+
+  it("committing a valid new test appends exactly one entry", async () => {
+    const user = userEvent.setup()
+    const tests = renderPane()
+
+    await openEditor(user)
+    await user.type(
+      screen.getByLabelText("assignments.autograder.testName"),
+      "Prints hello",
+    )
+    await user.type(
+      screen.getByLabelText("assignments.autograder.runCommand"),
+      "./hello",
+    )
+    // Default io + "included" comparison requires expected output; fill it so
+    // the draft passes validateTestDraft on commit.
+    await user.type(
+      screen.getByLabelText("assignments.autograder.expectedOutput"),
+      "hello",
+    )
+    await user.click(commitButton())
+
+    await waitFor(() => expect(tests()).toHaveLength(1))
+    expect(tests()[0]).toMatchObject({ name: "Prints hello", run: "./hello" })
+  })
+
+  it("an invalid draft (blank run) surfaces an error and does not commit", async () => {
+    const user = userEvent.setup()
+    const tests = renderPane()
+
+    await openEditor(user)
+    await user.type(
+      screen.getByLabelText("assignments.autograder.testName"),
+      "Prints hello",
+    )
+    await user.click(commitButton())
+
+    expect((await screen.findAllByRole("alert")).length).toBeGreaterThan(0)
+    expect(tests()).toHaveLength(0)
+  })
+})

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -53,12 +53,16 @@ type AutogradingTestModalProps = {
   dialogRef: React.RefObject<HTMLDialogElement | null>
   index: number | null
   onClose: () => void
+  onCancel: () => void
+  onDone: () => void
 }
 const AutogradingTestModal = ({
   form,
   dialogRef,
   index,
   onClose,
+  onCancel,
+  onDone,
 }: AutogradingTestModalProps) => {
   const { t } = useTranslation()
   const titleId = useId()
@@ -91,7 +95,7 @@ const AutogradingTestModal = ({
   }
 
   const handleDone = () => {
-    if (validateAndShowErrors()) onClose()
+    if (validateAndShowErrors()) onDone()
   }
 
   return (
@@ -470,7 +474,7 @@ const AutogradingTestModal = ({
         </div>
       </div>
       <div className="modal-backdrop">
-        <button type="button" onClick={onClose}>
+        <button type="button" onClick={onCancel}>
           {t("common.close")}
         </button>
       </div>
@@ -487,6 +491,12 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
   const { t } = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  // The editor is for a just-added draft not yet committed: closing it without
+  // "Done" discards the draft so an empty test never lands in the list.
+  const isNewRef = useRef(false)
+  // Set by "Done" so the dialog's close handler keeps (rather than discards) a
+  // pending new draft. Escape/backdrop leave it false → discard.
+  const committedRef = useRef(false)
 
   useEffect(() => {
     if (editingIndex === null) return
@@ -498,13 +508,40 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
   }, [editingIndex])
 
   const openEditor = (index: number) => {
+    isNewRef.current = false
+    committedRef.current = false
     setEditingIndex(index)
   }
 
-  const closeEditor = () => {
+  const openNewEditor = () => {
+    const newIndex = form.getFieldValue("tests").length
+    form.pushFieldValue("tests", emptyTestDraft())
+    isNewRef.current = true
+    committedRef.current = false
+    setEditingIndex(newIndex)
+  }
+
+  // Single close handler for every path (Done, Escape, backdrop): a pending new
+  // draft is discarded unless "Done" committed it; existing tests keep edits.
+  const handleClose = () => {
+    if (isNewRef.current && !committedRef.current && editingIndex !== null) {
+      form.removeFieldValue("tests", editingIndex)
+    }
+    isNewRef.current = false
+    committedRef.current = false
+    setEditingIndex(null)
+  }
+
+  const closeDialog = () => {
     const dialog = dialogRef.current
     if (dialog?.open) dialog.close()
-    setEditingIndex(null)
+    else handleClose()
+  }
+
+  // "Done" marks the draft committed, then closes (fires handleClose).
+  const commitEditor = () => {
+    committedRef.current = true
+    closeDialog()
   }
 
   return (
@@ -535,14 +572,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                 </h3>
               </div>
               <div>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    const newIndex = field.state.value.length
-                    field.pushValue(emptyTestDraft())
-                    openEditor(newIndex)
-                  }}
-                >
+                <Button variant="outline" onClick={openNewEditor}>
                   {t("assignments.autograder.addTest")}
                 </Button>
               </div>
@@ -640,7 +670,9 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
               form={form}
               dialogRef={dialogRef}
               index={editingIndex}
-              onClose={closeEditor}
+              onClose={handleClose}
+              onCancel={closeDialog}
+              onDone={commitEditor}
             />
           </Card.Body>
         )}

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -4,7 +4,15 @@ import type { TFunction } from "i18next"
 import { Pencil, Trash } from "lucide-react"
 import type { AssignmentForm } from "./assignmentFormModel"
 
-import { Badge, Button, Card, Input, Select, Textarea } from "@/components/ui"
+import {
+  Badge,
+  Button,
+  Card,
+  Input,
+  Modal,
+  Select,
+  Textarea,
+} from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import { emptyTestDraft, validateTestDraft } from "@/util/assignmentTests"
 import type { AssignmentTestComparison } from "@/types/classroom"
@@ -36,10 +44,9 @@ const FieldError = ({ error, id }: { error?: string; id?: string }) =>
     </p>
   ) : null
 
-// The editor works on a local copy so nothing lands in the form's `tests` array
-// until the user commits: `mode` decides whether commit pushes a new entry or
-// overwrites the one at `index`; `baseline` is the state the copy opened with,
-// used for the dirty check that gates the commit button.
+// Editor works on a local copy; nothing reaches the form's `tests` until commit.
+// `mode` routes commit (append vs overwrite at `index`); `baseline` is the
+// opening state the dirty check compares against.
 type EditorState = {
   mode: "new" | "edit"
   index: number
@@ -83,14 +90,15 @@ const AutogradingTestModal = ({
   const field = (name: keyof AssignmentTestDraft) => `${fieldId}-${name}`
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
+    <Modal
+      dialogRef={dialogRef}
+      size="3xl"
+      boxClassName="max-h-[90vh]"
       aria-labelledby={titleId}
       onClose={onCancel}
       onKeyDown={(e) => {
         // Enter inside a modal input would implicitly submit the surrounding
-        // create-assignment form (this dialog renders inside it). Repurpose as
+        // create-assignment form (this modal renders inside it). Repurpose as
         // commit; textareas keep Enter for newlines.
         if (
           e.key === "Enter" &&
@@ -103,295 +111,279 @@ const AutogradingTestModal = ({
         }
       }}
     >
-      <div className="modal-box max-w-3xl max-h-[90vh]">
-        <div className="mb-6">
-          <h3 id={titleId} className="text-lg font-bold">
-            {t("assignments.autograder.editTest", { number: editor.index + 1 })}
-          </h3>
-          <p className="text-sm opacity-70">
-            {t("assignments.autograder.editTestHint")}
+      <div className="mb-6">
+        <h3 id={titleId} className="text-lg font-bold">
+          {t("assignments.autograder.editTest", { number: editor.index + 1 })}
+        </h3>
+        <p className="text-sm opacity-70">
+          {t("assignments.autograder.editTestHint")}
+        </p>
+      </div>
+
+      <div className="space-y-5">
+        <div>
+          <label htmlFor={field("name")} className="label font-bold">
+            {t("assignments.autograder.testName")}
+          </label>
+          <Input
+            id={field("name")}
+            value={draft.name}
+            onChange={(e) => set("name", e.target.value)}
+            placeholder={t("assignments.autograder.testNamePlaceholder")}
+            invalid={!!errors.name}
+            aria-describedby={
+              errors.name ? `${field("name")}-error` : undefined
+            }
+          />
+          <FieldError error={errors.name} id={`${field("name")}-error`} />
+        </div>
+
+        <fieldset>
+          <legend className="label font-bold">
+            {t("assignments.autograder.testType")}
+          </legend>
+          <div className="join w-full">
+            {TYPE_OPTIONS.map((option) => (
+              <input
+                key={option.value}
+                type="radio"
+                className="join-item btn btn-sm"
+                name={`${fieldId}-type`}
+                aria-label={t(option.labelKey)}
+                checked={draft.type === option.value}
+                onChange={() => set("type", option.value)}
+              />
+            ))}
+          </div>
+          <p className="label text-sm pt-1">
+            {(() => {
+              const hintKey = TYPE_OPTIONS.find(
+                (o) => o.value === draft.type,
+              )?.hintKey
+              return hintKey ? t(hintKey) : null
+            })()}
           </p>
+        </fieldset>
+
+        <div>
+          <label htmlFor={field("setup")} className="label font-bold">
+            {t("assignments.autograder.setupCommand")}
+          </label>
+          <Input
+            id={field("setup")}
+            className="font-mono"
+            value={draft.setup}
+            onChange={(e) => set("setup", e.target.value)}
+            placeholder={t("assignments.autograder.setupCommandPlaceholder")}
+          />
         </div>
 
-        <div className="space-y-5">
-          <div>
-            <label htmlFor={field("name")} className="label font-bold">
-              {t("assignments.autograder.testName")}
+        <div>
+          <label htmlFor={field("run")} className="label font-bold">
+            {t("assignments.autograder.runCommand")}
+          </label>
+          <Input
+            id={field("run")}
+            className="font-mono"
+            value={draft.run}
+            onChange={(e) => set("run", e.target.value)}
+            placeholder={t("assignments.autograder.runCommandPlaceholder")}
+            invalid={!!errors.run}
+            aria-describedby={errors.run ? `${field("run")}-error` : undefined}
+          />
+          <FieldError error={errors.run} id={`${field("run")}-error`} />
+        </div>
+
+        {draft.type === "io" && (
+          <>
+            <div>
+              <label htmlFor={field("input")} className="label font-bold">
+                {t("assignments.autograder.input")}
+              </label>
+              <Textarea
+                id={field("input")}
+                className="font-mono"
+                value={draft.input}
+                onChange={(e) => set("input", e.target.value)}
+                placeholder={t("assignments.autograder.inputPlaceholder")}
+                rows={3}
+              />
+            </div>
+
+            <div>
+              <label htmlFor={field("expected")} className="label font-bold">
+                {t("assignments.autograder.expectedOutput")}
+              </label>
+              <Textarea
+                id={field("expected")}
+                className="font-mono"
+                value={draft.expected}
+                onChange={(e) => set("expected", e.target.value)}
+                placeholder={t(
+                  "assignments.autograder.expectedOutputPlaceholder",
+                )}
+                rows={5}
+                invalid={!!errors.expected}
+                aria-describedby={
+                  errors.expected ? `${field("expected")}-error` : undefined
+                }
+              />
+              <FieldError
+                error={errors.expected}
+                id={`${field("expected")}-error`}
+              />
+            </div>
+
+            <div>
+              <label htmlFor={field("comparison")} className="label font-bold">
+                {t("assignments.autograder.comparison")}
+              </label>
+              <Select
+                id={field("comparison")}
+                value={draft.comparison}
+                onChange={(e) =>
+                  set("comparison", e.target.value as AssignmentTestComparison)
+                }
+              >
+                <option value="included">
+                  {t("assignments.autograder.comparisonIncluded")}
+                </option>
+                <option value="exact">
+                  {t("assignments.autograder.comparisonExact")}
+                </option>
+                <option value="regex">
+                  {t("assignments.autograder.comparisonRegex")}
+                </option>
+              </Select>
+            </div>
+          </>
+        )}
+
+        {draft.type === "run" && (
+          <div className="flex flex-col">
+            <label htmlFor={field("exitCode")} className="label font-bold">
+              {t("assignments.autograder.exitCode")}
             </label>
             <Input
-              id={field("name")}
-              value={draft.name}
-              onChange={(e) => set("name", e.target.value)}
-              placeholder={t("assignments.autograder.testNamePlaceholder")}
-              invalid={!!errors.name}
+              id={field("exitCode")}
+              className="w-32"
+              type="number"
+              min={0}
+              max={255}
+              step={1}
+              value={draft.exitCode}
+              onChange={(e) =>
+                set(
+                  "exitCode",
+                  e.target.value === "" ? "" : e.target.valueAsNumber,
+                )
+              }
+              placeholder="0"
+              invalid={!!errors.exitCode}
               aria-describedby={
-                errors.name ? `${field("name")}-error` : undefined
+                errors.exitCode ? `${field("exitCode")}-error` : undefined
               }
             />
-            <FieldError error={errors.name} id={`${field("name")}-error`} />
-          </div>
-
-          <fieldset>
-            <legend className="label font-bold">
-              {t("assignments.autograder.testType")}
-            </legend>
-            <div className="join w-full">
-              {TYPE_OPTIONS.map((option) => (
-                <input
-                  key={option.value}
-                  type="radio"
-                  className="join-item btn btn-sm"
-                  name={`${fieldId}-type`}
-                  aria-label={t(option.labelKey)}
-                  checked={draft.type === option.value}
-                  onChange={() => set("type", option.value)}
-                />
-              ))}
-            </div>
             <p className="label text-sm pt-1">
-              {(() => {
-                const hintKey = TYPE_OPTIONS.find(
-                  (o) => o.value === draft.type,
-                )?.hintKey
-                return hintKey ? t(hintKey) : null
-              })()}
+              {t("assignments.autograder.exitCodeHint")}
             </p>
-          </fieldset>
-
-          <div>
-            <label htmlFor={field("setup")} className="label font-bold">
-              {t("assignments.autograder.setupCommand")}
-            </label>
-            <Input
-              id={field("setup")}
-              className="font-mono"
-              value={draft.setup}
-              onChange={(e) => set("setup", e.target.value)}
-              placeholder={t("assignments.autograder.setupCommandPlaceholder")}
+            <FieldError
+              error={errors.exitCode}
+              id={`${field("exitCode")}-error`}
             />
           </div>
+        )}
 
-          <div>
-            <label htmlFor={field("run")} className="label font-bold">
-              {t("assignments.autograder.runCommand")}
+        {draft.type === "python" && (
+          <p className="rounded-box border border-dashed p-3 text-sm opacity-70">
+            <Trans
+              i18nKey="assignments.autograder.pythonNote"
+              components={{ code: <code dir="ltr" /> }}
+            />
+          </p>
+        )}
+
+        <div className="flex gap-8">
+          <div className="flex flex-col">
+            <label htmlFor={field("timeout")} className="label font-bold">
+              {t("assignments.autograder.timeout")}
             </label>
             <Input
-              id={field("run")}
-              className="font-mono"
-              value={draft.run}
-              onChange={(e) => set("run", e.target.value)}
-              placeholder={t("assignments.autograder.runCommandPlaceholder")}
-              invalid={!!errors.run}
+              id={field("timeout")}
+              className="w-32"
+              type="number"
+              min={0}
+              max={600}
+              step={1}
+              value={draft.timeout}
+              onChange={(e) =>
+                set(
+                  "timeout",
+                  e.target.value === "" ? 0 : e.target.valueAsNumber,
+                )
+              }
+              invalid={!!errors.timeout}
               aria-describedby={
-                errors.run ? `${field("run")}-error` : undefined
+                errors.timeout ? `${field("timeout")}-error` : undefined
               }
             />
-            <FieldError error={errors.run} id={`${field("run")}-error`} />
-          </div>
-
-          {draft.type === "io" && (
-            <>
-              <div>
-                <label htmlFor={field("input")} className="label font-bold">
-                  {t("assignments.autograder.input")}
-                </label>
-                <Textarea
-                  id={field("input")}
-                  className="font-mono"
-                  value={draft.input}
-                  onChange={(e) => set("input", e.target.value)}
-                  placeholder={t("assignments.autograder.inputPlaceholder")}
-                  rows={3}
-                />
-              </div>
-
-              <div>
-                <label htmlFor={field("expected")} className="label font-bold">
-                  {t("assignments.autograder.expectedOutput")}
-                </label>
-                <Textarea
-                  id={field("expected")}
-                  className="font-mono"
-                  value={draft.expected}
-                  onChange={(e) => set("expected", e.target.value)}
-                  placeholder={t(
-                    "assignments.autograder.expectedOutputPlaceholder",
-                  )}
-                  rows={5}
-                  invalid={!!errors.expected}
-                  aria-describedby={
-                    errors.expected ? `${field("expected")}-error` : undefined
-                  }
-                />
-                <FieldError
-                  error={errors.expected}
-                  id={`${field("expected")}-error`}
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor={field("comparison")}
-                  className="label font-bold"
-                >
-                  {t("assignments.autograder.comparison")}
-                </label>
-                <Select
-                  id={field("comparison")}
-                  value={draft.comparison}
-                  onChange={(e) =>
-                    set(
-                      "comparison",
-                      e.target.value as AssignmentTestComparison,
-                    )
-                  }
-                >
-                  <option value="included">
-                    {t("assignments.autograder.comparisonIncluded")}
-                  </option>
-                  <option value="exact">
-                    {t("assignments.autograder.comparisonExact")}
-                  </option>
-                  <option value="regex">
-                    {t("assignments.autograder.comparisonRegex")}
-                  </option>
-                </Select>
-              </div>
-            </>
-          )}
-
-          {draft.type === "run" && (
-            <div className="flex flex-col">
-              <label htmlFor={field("exitCode")} className="label font-bold">
-                {t("assignments.autograder.exitCode")}
-              </label>
-              <Input
-                id={field("exitCode")}
-                className="w-32"
-                type="number"
-                min={0}
-                max={255}
-                step={1}
-                value={draft.exitCode}
-                onChange={(e) =>
-                  set(
-                    "exitCode",
-                    e.target.value === "" ? "" : e.target.valueAsNumber,
-                  )
-                }
-                placeholder="0"
-                invalid={!!errors.exitCode}
-                aria-describedby={
-                  errors.exitCode ? `${field("exitCode")}-error` : undefined
-                }
-              />
-              <p className="label text-sm pt-1">
-                {t("assignments.autograder.exitCodeHint")}
-              </p>
-              <FieldError
-                error={errors.exitCode}
-                id={`${field("exitCode")}-error`}
-              />
-            </div>
-          )}
-
-          {draft.type === "python" && (
-            <p className="rounded-box border border-dashed p-3 text-sm opacity-70">
-              <Trans
-                i18nKey="assignments.autograder.pythonNote"
-                components={{ code: <code dir="ltr" /> }}
-              />
+            <p className="label text-sm pt-1">
+              {t("assignments.autograder.timeoutHint")}
             </p>
-          )}
+            <FieldError
+              error={errors.timeout}
+              id={`${field("timeout")}-error`}
+            />
+          </div>
 
-          <div className="flex gap-8">
-            <div className="flex flex-col">
-              <label htmlFor={field("timeout")} className="label font-bold">
-                {t("assignments.autograder.timeout")}
-              </label>
-              <Input
-                id={field("timeout")}
-                className="w-32"
-                type="number"
-                min={0}
-                max={600}
-                step={1}
-                value={draft.timeout}
-                onChange={(e) =>
-                  set(
-                    "timeout",
-                    e.target.value === "" ? 0 : e.target.valueAsNumber,
-                  )
-                }
-                invalid={!!errors.timeout}
-                aria-describedby={
-                  errors.timeout ? `${field("timeout")}-error` : undefined
-                }
-              />
-              <p className="label text-sm pt-1">
-                {t("assignments.autograder.timeoutHint")}
-              </p>
-              <FieldError
-                error={errors.timeout}
-                id={`${field("timeout")}-error`}
-              />
-            </div>
-
-            <div className="flex flex-col">
-              <label htmlFor={field("points")} className="label font-bold">
-                {t("assignments.autograder.points")}
-              </label>
-              <Input
-                id={field("points")}
-                className="w-32"
-                type="number"
-                min={0}
-                max={1000}
-                step={1}
-                value={draft.points}
-                onChange={(e) =>
-                  set(
-                    "points",
-                    e.target.value === "" ? 0 : e.target.valueAsNumber,
-                  )
-                }
-                invalid={!!errors.points}
-                aria-describedby={
-                  errors.points ? `${field("points")}-error` : undefined
-                }
-              />
-              <FieldError
-                error={errors.points}
-                id={`${field("points")}-error`}
-              />
-            </div>
+          <div className="flex flex-col">
+            <label htmlFor={field("points")} className="label font-bold">
+              {t("assignments.autograder.points")}
+            </label>
+            <Input
+              id={field("points")}
+              className="w-32"
+              type="number"
+              min={0}
+              max={1000}
+              step={1}
+              value={draft.points}
+              onChange={(e) =>
+                set(
+                  "points",
+                  e.target.value === "" ? 0 : e.target.valueAsNumber,
+                )
+              }
+              invalid={!!errors.points}
+              aria-describedby={
+                errors.points ? `${field("points")}-error` : undefined
+              }
+            />
+            <FieldError error={errors.points} id={`${field("points")}-error`} />
           </div>
         </div>
+      </div>
 
-        <div className="modal-action">
-          <Button variant="ghost" onClick={onCancel}>
-            {t("common.cancel")}
-          </Button>
-          <Button variant="primary" onClick={handleCommit} disabled={!dirty}>
-            {editor.mode === "new"
-              ? t("assignments.autograder.addTest")
-              : t("common.save")}
-          </Button>
-        </div>
+      <div className="modal-action">
+        <Button variant="ghost" onClick={onCancel}>
+          {t("common.cancel")}
+        </Button>
+        <Button variant="primary" onClick={handleCommit} disabled={!dirty}>
+          {editor.mode === "new"
+            ? t("assignments.autograder.addTest")
+            : t("common.save")}
+        </Button>
       </div>
-      <div className="modal-backdrop">
-        <button type="button" onClick={onCancel}>
-          {t("common.close")}
-        </button>
-      </div>
-    </dialog>
+    </Modal>
   )
 }
 
-// Structural equality over the flat draft; drives the editor's dirty check so an
-// untouched test (a fresh `emptyTestDraft`, or an existing test reopened) can't
-// be committed. All fields are primitives, so key-by-key comparison suffices.
-const draftsEqual = (a: AssignmentTestDraft, b: AssignmentTestDraft): boolean =>
+// Drives the editor's dirty check so an untouched draft can't be committed.
+// Safe as a key-by-key `===` because every draft field is a primitive.
+export const draftsEqual = (
+  a: AssignmentTestDraft,
+  b: AssignmentTestDraft,
+): boolean =>
   (Object.keys(a) as (keyof AssignmentTestDraft)[]).every(
     (key) => a[key] === b[key],
   )
@@ -435,9 +427,8 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
     setEditor(null)
   }
 
-  // Only here does the local draft reach the form: append a new test or
-  // overwrite the edited one. Cancel/Escape/backdrop never call this, so an
-  // untouched or abandoned draft leaves the list unchanged.
+  // The only path from a local draft into the form. Cancel/Escape/backdrop
+  // never reach it, so an abandoned draft leaves the list unchanged.
   const commitEditor = (draft: AssignmentTestDraft) => {
     if (!editor) return
     if (editor.mode === "new") {
@@ -448,11 +439,10 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
     closeEditor()
   }
 
-  const otherNames = (tests: AssignmentTestDraft[]) =>
+  const otherNames = (tests: AssignmentTestDraft[], active: EditorState) =>
     tests
-      .filter((_, i) => !editor || editor.mode === "new" || i !== editor.index)
+      .filter((_, i) => active.mode === "new" || i !== active.index)
       .map((d) => d.name.trim())
-
   return (
     <Card bordered={false}>
       <form.Field name="tests" mode="array">
@@ -582,7 +572,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                 key={`${editor.mode}-${editor.index}`}
                 editor={editor}
                 dialogRef={dialogRef}
-                otherNames={otherNames(field.state.value)}
+                otherNames={otherNames(field.state.value, editor)}
                 onCancel={closeEditor}
                 onCommit={commitEditor}
               />

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -27,6 +27,8 @@ const TYPE_OPTIONS = [
   },
 ] as const
 
+type TestErrors = Partial<Record<keyof AssignmentTestDraft, string>>
+
 const FieldError = ({ error, id }: { error?: string; id?: string }) =>
   error ? (
     <p id={id} className="text-error text-sm mt-1" role="alert">
@@ -34,80 +36,62 @@ const FieldError = ({ error, id }: { error?: string; id?: string }) =>
     </p>
   ) : null
 
-// Draft fields that can carry a validation error; stale errors are cleared on
-// each re-validation.
-const VALIDATED_FIELDS = [
-  "name",
-  "run",
-  "points",
-  "timeout",
-  "input",
-  "inputFile",
-  "expected",
-  "expectedFile",
-  "exitCode",
-] as const
+// The editor works on a local copy so nothing lands in the form's `tests` array
+// until the user commits: `mode` decides whether commit pushes a new entry or
+// overwrites the one at `index`; `baseline` is the state the copy opened with,
+// used for the dirty check that gates the commit button.
+type EditorState = {
+  mode: "new" | "edit"
+  index: number
+  baseline: AssignmentTestDraft
+}
 
 type AutogradingTestModalProps = {
-  form: AssignmentForm
+  editor: EditorState
   dialogRef: React.RefObject<HTMLDialogElement | null>
-  index: number | null
-  onClose: () => void
+  otherNames: string[]
   onCancel: () => void
-  onDone: () => void
+  onCommit: (draft: AssignmentTestDraft) => void
 }
+
 const AutogradingTestModal = ({
-  form,
+  editor,
   dialogRef,
-  index,
-  onClose,
+  otherNames,
   onCancel,
-  onDone,
+  onCommit,
 }: AutogradingTestModalProps) => {
   const { t } = useTranslation()
   const titleId = useId()
-  if (index === null) return null
+  const fieldId = useId()
+  const [draft, setDraft] = useState<AssignmentTestDraft>(editor.baseline)
+  const [errors, setErrors] = useState<TestErrors>({})
 
-  // Validate this test now (form-level validator only runs on page submit) and
-  // surface per-field errors. Returns valid?; "Done" waits until valid.
-  const validateAndShowErrors = () => {
-    const drafts: AssignmentTestDraft[] = form.state.values.tests
-    const otherNames = drafts
-      .filter((_, i) => i !== index)
-      .map((d) => d.name.trim())
-    const errors = validateTestDraft(drafts[index], otherNames)
+  const set = <K extends keyof AssignmentTestDraft>(
+    key: K,
+    value: AssignmentTestDraft[K],
+  ) => setDraft((prev) => ({ ...prev, [key]: value }))
 
-    for (const fieldName of VALIDATED_FIELDS) {
-      const message = errors[fieldName]
-      const key = `tests[${index}].${fieldName}` as Parameters<
-        typeof form.getFieldMeta
-      >[0]
-      // Fields that never mounted (e.g., exit code on an io test, or unbuilt
-      // fixture-file inputs) have no meta and nowhere to show an error.
-      if (!form.getFieldMeta(key)) continue
-      form.setFieldMeta(key, (meta) => ({
-        ...meta,
-        errorMap: { ...meta.errorMap, onSubmit: message },
-      }))
-    }
+  const dirty = !draftsEqual(draft, editor.baseline)
 
-    return Object.keys(errors).length === 0
+  const handleCommit = () => {
+    const found = validateTestDraft(draft, otherNames)
+    setErrors(found)
+    if (Object.keys(found).length === 0) onCommit(draft)
   }
 
-  const handleDone = () => {
-    if (validateAndShowErrors()) onDone()
-  }
+  const field = (name: keyof AssignmentTestDraft) => `${fieldId}-${name}`
 
   return (
     <dialog
       ref={dialogRef}
       className="modal"
       aria-labelledby={titleId}
-      onClose={onClose}
+      onClose={onCancel}
       onKeyDown={(e) => {
         // Enter inside a modal input would implicitly submit the surrounding
         // create-assignment form (this dialog renders inside it). Repurpose as
-        // "Done"; textareas keep Enter for newlines.
+        // commit; textareas keep Enter for newlines.
         if (
           e.key === "Enter" &&
           e.target instanceof HTMLElement &&
@@ -115,14 +99,14 @@ const AutogradingTestModal = ({
           e.target.tagName !== "BUTTON"
         ) {
           e.preventDefault()
-          handleDone()
+          if (dirty) handleCommit()
         }
       }}
     >
       <div className="modal-box max-w-3xl max-h-[90vh]">
         <div className="mb-6">
           <h3 id={titleId} className="text-lg font-bold">
-            {t("assignments.autograder.editTest", { number: index + 1 })}
+            {t("assignments.autograder.editTest", { number: editor.index + 1 })}
           </h3>
           <p className="text-sm opacity-70">
             {t("assignments.autograder.editTestHint")}
@@ -130,346 +114,268 @@ const AutogradingTestModal = ({
         </div>
 
         <div className="space-y-5">
-          <form.Field name={`tests[${index}].name`}>
-            {(field) => (
+          <div>
+            <label htmlFor={field("name")} className="label font-bold">
+              {t("assignments.autograder.testName")}
+            </label>
+            <Input
+              id={field("name")}
+              value={draft.name}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder={t("assignments.autograder.testNamePlaceholder")}
+              invalid={!!errors.name}
+              aria-describedby={
+                errors.name ? `${field("name")}-error` : undefined
+              }
+            />
+            <FieldError error={errors.name} id={`${field("name")}-error`} />
+          </div>
+
+          <fieldset>
+            <legend className="label font-bold">
+              {t("assignments.autograder.testType")}
+            </legend>
+            <div className="join w-full">
+              {TYPE_OPTIONS.map((option) => (
+                <input
+                  key={option.value}
+                  type="radio"
+                  className="join-item btn btn-sm"
+                  name={`${fieldId}-type`}
+                  aria-label={t(option.labelKey)}
+                  checked={draft.type === option.value}
+                  onChange={() => set("type", option.value)}
+                />
+              ))}
+            </div>
+            <p className="label text-sm pt-1">
+              {(() => {
+                const hintKey = TYPE_OPTIONS.find(
+                  (o) => o.value === draft.type,
+                )?.hintKey
+                return hintKey ? t(hintKey) : null
+              })()}
+            </p>
+          </fieldset>
+
+          <div>
+            <label htmlFor={field("setup")} className="label font-bold">
+              {t("assignments.autograder.setupCommand")}
+            </label>
+            <Input
+              id={field("setup")}
+              className="font-mono"
+              value={draft.setup}
+              onChange={(e) => set("setup", e.target.value)}
+              placeholder={t("assignments.autograder.setupCommandPlaceholder")}
+            />
+          </div>
+
+          <div>
+            <label htmlFor={field("run")} className="label font-bold">
+              {t("assignments.autograder.runCommand")}
+            </label>
+            <Input
+              id={field("run")}
+              className="font-mono"
+              value={draft.run}
+              onChange={(e) => set("run", e.target.value)}
+              placeholder={t("assignments.autograder.runCommandPlaceholder")}
+              invalid={!!errors.run}
+              aria-describedby={
+                errors.run ? `${field("run")}-error` : undefined
+              }
+            />
+            <FieldError error={errors.run} id={`${field("run")}-error`} />
+          </div>
+
+          {draft.type === "io" && (
+            <>
               <div>
-                <label htmlFor={field.name} className="label font-bold">
-                  {t("assignments.autograder.testName")}
+                <label htmlFor={field("input")} className="label font-bold">
+                  {t("assignments.autograder.input")}
                 </label>
-                <Input
-                  id={field.name}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder={t("assignments.autograder.testNamePlaceholder")}
-                  invalid={field.state.meta.errors.length > 0}
+                <Textarea
+                  id={field("input")}
+                  className="font-mono"
+                  value={draft.input}
+                  onChange={(e) => set("input", e.target.value)}
+                  placeholder={t("assignments.autograder.inputPlaceholder")}
+                  rows={3}
+                />
+              </div>
+
+              <div>
+                <label htmlFor={field("expected")} className="label font-bold">
+                  {t("assignments.autograder.expectedOutput")}
+                </label>
+                <Textarea
+                  id={field("expected")}
+                  className="font-mono"
+                  value={draft.expected}
+                  onChange={(e) => set("expected", e.target.value)}
+                  placeholder={t(
+                    "assignments.autograder.expectedOutputPlaceholder",
+                  )}
+                  rows={5}
+                  invalid={!!errors.expected}
                   aria-describedby={
-                    field.state.meta.errors.length > 0
-                      ? `${field.name}-error`
-                      : undefined
+                    errors.expected ? `${field("expected")}-error` : undefined
                   }
                 />
                 <FieldError
-                  error={field.state.meta.errors[0]}
-                  id={`${field.name}-error`}
+                  error={errors.expected}
+                  id={`${field("expected")}-error`}
                 />
               </div>
-            )}
-          </form.Field>
 
-          <form.Field name={`tests[${index}].type`}>
-            {(field) => (
-              <fieldset>
-                <legend className="label font-bold">
-                  {t("assignments.autograder.testType")}
-                </legend>
-                <div className="join w-full">
-                  {TYPE_OPTIONS.map((option) => (
-                    <input
-                      key={option.value}
-                      type="radio"
-                      className="join-item btn btn-sm"
-                      name={`tests-${index}-type`}
-                      aria-label={t(option.labelKey)}
-                      checked={field.state.value === option.value}
-                      onChange={() => field.handleChange(option.value)}
-                    />
-                  ))}
-                </div>
-                <p className="label text-sm pt-1">
-                  {(() => {
-                    const hintKey = TYPE_OPTIONS.find(
-                      (o) => o.value === field.state.value,
-                    )?.hintKey
-                    return hintKey ? t(hintKey) : null
-                  })()}
-                </p>
-              </fieldset>
-            )}
-          </form.Field>
-
-          <form.Field name={`tests[${index}].setup`}>
-            {(field) => (
               <div>
-                <label htmlFor={field.name} className="label font-bold">
-                  {t("assignments.autograder.setupCommand")}
+                <label
+                  htmlFor={field("comparison")}
+                  className="label font-bold"
+                >
+                  {t("assignments.autograder.comparison")}
                 </label>
-                <Input
-                  id={field.name}
-                  className="font-mono"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder={t(
-                    "assignments.autograder.setupCommandPlaceholder",
-                  )}
-                />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name={`tests[${index}].run`}>
-            {(field) => (
-              <div>
-                <label htmlFor={field.name} className="label font-bold">
-                  {t("assignments.autograder.runCommand")}
-                </label>
-                <Input
-                  id={field.name}
-                  className="font-mono"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder={t(
-                    "assignments.autograder.runCommandPlaceholder",
-                  )}
-                  invalid={field.state.meta.errors.length > 0}
-                  aria-describedby={
-                    field.state.meta.errors.length > 0
-                      ? `${field.name}-error`
-                      : undefined
+                <Select
+                  id={field("comparison")}
+                  value={draft.comparison}
+                  onChange={(e) =>
+                    set(
+                      "comparison",
+                      e.target.value as AssignmentTestComparison,
+                    )
                   }
-                />
-                <FieldError
-                  error={field.state.meta.errors[0]}
-                  id={`${field.name}-error`}
-                />
+                >
+                  <option value="included">
+                    {t("assignments.autograder.comparisonIncluded")}
+                  </option>
+                  <option value="exact">
+                    {t("assignments.autograder.comparisonExact")}
+                  </option>
+                  <option value="regex">
+                    {t("assignments.autograder.comparisonRegex")}
+                  </option>
+                </Select>
               </div>
-            )}
-          </form.Field>
+            </>
+          )}
 
-          <form.Subscribe selector={(state) => state.values.tests[index]?.type}>
-            {(typeValue) => (
-              <>
-                {typeValue === "io" && (
-                  <>
-                    <form.Field name={`tests[${index}].input`}>
-                      {(field) => (
-                        <div>
-                          <label
-                            htmlFor={field.name}
-                            className="label font-bold"
-                          >
-                            {t("assignments.autograder.input")}
-                          </label>
-                          <Textarea
-                            id={field.name}
-                            className="font-mono"
-                            value={field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) => field.handleChange(e.target.value)}
-                            placeholder={t(
-                              "assignments.autograder.inputPlaceholder",
-                            )}
-                            rows={3}
-                          />
-                        </div>
-                      )}
-                    </form.Field>
+          {draft.type === "run" && (
+            <div className="flex flex-col">
+              <label htmlFor={field("exitCode")} className="label font-bold">
+                {t("assignments.autograder.exitCode")}
+              </label>
+              <Input
+                id={field("exitCode")}
+                className="w-32"
+                type="number"
+                min={0}
+                max={255}
+                step={1}
+                value={draft.exitCode}
+                onChange={(e) =>
+                  set(
+                    "exitCode",
+                    e.target.value === "" ? "" : e.target.valueAsNumber,
+                  )
+                }
+                placeholder="0"
+                invalid={!!errors.exitCode}
+                aria-describedby={
+                  errors.exitCode ? `${field("exitCode")}-error` : undefined
+                }
+              />
+              <p className="label text-sm pt-1">
+                {t("assignments.autograder.exitCodeHint")}
+              </p>
+              <FieldError
+                error={errors.exitCode}
+                id={`${field("exitCode")}-error`}
+              />
+            </div>
+          )}
 
-                    <form.Field name={`tests[${index}].expected`}>
-                      {(field) => (
-                        <div>
-                          <label
-                            htmlFor={field.name}
-                            className="label font-bold"
-                          >
-                            {t("assignments.autograder.expectedOutput")}
-                          </label>
-                          <Textarea
-                            id={field.name}
-                            className="font-mono"
-                            value={field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) => field.handleChange(e.target.value)}
-                            placeholder={t(
-                              "assignments.autograder.expectedOutputPlaceholder",
-                            )}
-                            rows={5}
-                            invalid={field.state.meta.errors.length > 0}
-                            aria-describedby={
-                              field.state.meta.errors.length > 0
-                                ? `${field.name}-error`
-                                : undefined
-                            }
-                          />
-                          <FieldError
-                            error={field.state.meta.errors[0]}
-                            id={`${field.name}-error`}
-                          />
-                        </div>
-                      )}
-                    </form.Field>
-
-                    <form.Field name={`tests[${index}].comparison`}>
-                      {(field) => (
-                        <div>
-                          <label
-                            htmlFor={field.name}
-                            className="label font-bold"
-                          >
-                            {t("assignments.autograder.comparison")}
-                          </label>
-                          <Select
-                            id={field.name}
-                            value={field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) =>
-                              field.handleChange(
-                                e.target.value as AssignmentTestComparison,
-                              )
-                            }
-                          >
-                            <option value="included">
-                              {t("assignments.autograder.comparisonIncluded")}
-                            </option>
-                            <option value="exact">
-                              {t("assignments.autograder.comparisonExact")}
-                            </option>
-                            <option value="regex">
-                              {t("assignments.autograder.comparisonRegex")}
-                            </option>
-                          </Select>
-                        </div>
-                      )}
-                    </form.Field>
-                  </>
-                )}
-
-                {typeValue === "run" && (
-                  <form.Field name={`tests[${index}].exitCode`}>
-                    {(field) => (
-                      <div className="flex flex-col">
-                        <label htmlFor={field.name} className="label font-bold">
-                          {t("assignments.autograder.exitCode")}
-                        </label>
-                        <Input
-                          id={field.name}
-                          className="w-32"
-                          type="number"
-                          min={0}
-                          max={255}
-                          step={1}
-                          value={field.state.value}
-                          onBlur={field.handleBlur}
-                          onChange={(e) =>
-                            field.handleChange(
-                              e.target.value === ""
-                                ? ""
-                                : e.target.valueAsNumber,
-                            )
-                          }
-                          placeholder="0"
-                          invalid={field.state.meta.errors.length > 0}
-                          aria-describedby={
-                            field.state.meta.errors.length > 0
-                              ? `${field.name}-error`
-                              : undefined
-                          }
-                        />
-                        <p className="label text-sm pt-1">
-                          {t("assignments.autograder.exitCodeHint")}
-                        </p>
-                        <FieldError
-                          error={field.state.meta.errors[0]}
-                          id={`${field.name}-error`}
-                        />
-                      </div>
-                    )}
-                  </form.Field>
-                )}
-
-                {typeValue === "python" && (
-                  <p className="rounded-box border border-dashed p-3 text-sm opacity-70">
-                    <Trans
-                      i18nKey="assignments.autograder.pythonNote"
-                      components={{ code: <code dir="ltr" /> }}
-                    />
-                  </p>
-                )}
-              </>
-            )}
-          </form.Subscribe>
+          {draft.type === "python" && (
+            <p className="rounded-box border border-dashed p-3 text-sm opacity-70">
+              <Trans
+                i18nKey="assignments.autograder.pythonNote"
+                components={{ code: <code dir="ltr" /> }}
+              />
+            </p>
+          )}
 
           <div className="flex gap-8">
-            <form.Field name={`tests[${index}].timeout`}>
-              {(field) => (
-                <div className="flex flex-col">
-                  <label htmlFor={field.name} className="label font-bold">
-                    {t("assignments.autograder.timeout")}
-                  </label>
-                  <Input
-                    id={field.name}
-                    className="w-32"
-                    type="number"
-                    min={0}
-                    max={600}
-                    step={1}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) =>
-                      field.handleChange(
-                        e.target.value === "" ? 0 : e.target.valueAsNumber,
-                      )
-                    }
-                    invalid={field.state.meta.errors.length > 0}
-                    aria-describedby={
-                      field.state.meta.errors.length > 0
-                        ? `${field.name}-error`
-                        : undefined
-                    }
-                  />
-                  <p className="label text-sm pt-1">
-                    {t("assignments.autograder.timeoutHint")}
-                  </p>
-                  <FieldError
-                    error={field.state.meta.errors[0]}
-                    id={`${field.name}-error`}
-                  />
-                </div>
-              )}
-            </form.Field>
+            <div className="flex flex-col">
+              <label htmlFor={field("timeout")} className="label font-bold">
+                {t("assignments.autograder.timeout")}
+              </label>
+              <Input
+                id={field("timeout")}
+                className="w-32"
+                type="number"
+                min={0}
+                max={600}
+                step={1}
+                value={draft.timeout}
+                onChange={(e) =>
+                  set(
+                    "timeout",
+                    e.target.value === "" ? 0 : e.target.valueAsNumber,
+                  )
+                }
+                invalid={!!errors.timeout}
+                aria-describedby={
+                  errors.timeout ? `${field("timeout")}-error` : undefined
+                }
+              />
+              <p className="label text-sm pt-1">
+                {t("assignments.autograder.timeoutHint")}
+              </p>
+              <FieldError
+                error={errors.timeout}
+                id={`${field("timeout")}-error`}
+              />
+            </div>
 
-            <form.Field name={`tests[${index}].points`}>
-              {(field) => (
-                <div className="flex flex-col">
-                  <label htmlFor={field.name} className="label font-bold">
-                    {t("assignments.autograder.points")}
-                  </label>
-                  <Input
-                    id={field.name}
-                    className="w-32"
-                    type="number"
-                    min={0}
-                    max={1000}
-                    step={1}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) =>
-                      field.handleChange(
-                        e.target.value === "" ? 0 : e.target.valueAsNumber,
-                      )
-                    }
-                    invalid={field.state.meta.errors.length > 0}
-                    aria-describedby={
-                      field.state.meta.errors.length > 0
-                        ? `${field.name}-error`
-                        : undefined
-                    }
-                  />
-                  <FieldError
-                    error={field.state.meta.errors[0]}
-                    id={`${field.name}-error`}
-                  />
-                </div>
-              )}
-            </form.Field>
+            <div className="flex flex-col">
+              <label htmlFor={field("points")} className="label font-bold">
+                {t("assignments.autograder.points")}
+              </label>
+              <Input
+                id={field("points")}
+                className="w-32"
+                type="number"
+                min={0}
+                max={1000}
+                step={1}
+                value={draft.points}
+                onChange={(e) =>
+                  set(
+                    "points",
+                    e.target.value === "" ? 0 : e.target.valueAsNumber,
+                  )
+                }
+                invalid={!!errors.points}
+                aria-describedby={
+                  errors.points ? `${field("points")}-error` : undefined
+                }
+              />
+              <FieldError
+                error={errors.points}
+                id={`${field("points")}-error`}
+              />
+            </div>
           </div>
         </div>
 
         <div className="modal-action">
-          <Button variant="primary" onClick={handleDone}>
-            {t("assignments.autograder.done")}
+          <Button variant="ghost" onClick={onCancel}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="primary" onClick={handleCommit} disabled={!dirty}>
+            {editor.mode === "new"
+              ? t("assignments.autograder.addTest")
+              : t("common.save")}
           </Button>
         </div>
       </div>
@@ -482,6 +388,14 @@ const AutogradingTestModal = ({
   )
 }
 
+// Structural equality over the flat draft; drives the editor's dirty check so an
+// untouched test (a fresh `emptyTestDraft`, or an existing test reopened) can't
+// be committed. All fields are primitives, so key-by-key comparison suffices.
+const draftsEqual = (a: AssignmentTestDraft, b: AssignmentTestDraft): boolean =>
+  (Object.keys(a) as (keyof AssignmentTestDraft)[]).every(
+    (key) => a[key] === b[key],
+  )
+
 const typeBadge = (type: AssignmentTestDraft["type"], t: TFunction) => {
   const labelKey = TYPE_OPTIONS.find((o) => o.value === type)?.labelKey
   return labelKey ? t(labelKey) : type
@@ -490,59 +404,54 @@ const typeBadge = (type: AssignmentTestDraft["type"], t: TFunction) => {
 const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
   const { t } = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const [editingIndex, setEditingIndex] = useState<number | null>(null)
-  // The editor is for a just-added draft not yet committed: closing it without
-  // "Done" discards the draft so an empty test never lands in the list.
-  const isNewRef = useRef(false)
-  // Set by "Done" so the dialog's close handler keeps (rather than discards) a
-  // pending new draft. Escape/backdrop leave it false → discard.
-  const committedRef = useRef(false)
+  const [editor, setEditor] = useState<EditorState | null>(null)
 
   useEffect(() => {
-    if (editingIndex === null) return
-
+    if (!editor) return
     const dialog = dialogRef.current
     if (!dialog || dialog.open) return
-
     dialog.showModal()
-  }, [editingIndex])
-
-  const openEditor = (index: number) => {
-    isNewRef.current = false
-    committedRef.current = false
-    setEditingIndex(index)
-  }
+  }, [editor])
 
   const openNewEditor = () => {
-    const newIndex = form.getFieldValue("tests").length
-    form.pushFieldValue("tests", emptyTestDraft())
-    isNewRef.current = true
-    committedRef.current = false
-    setEditingIndex(newIndex)
+    setEditor({
+      mode: "new",
+      index: form.getFieldValue("tests").length,
+      baseline: emptyTestDraft(),
+    })
   }
 
-  // Single close handler for every path (Done, Escape, backdrop): a pending new
-  // draft is discarded unless "Done" committed it; existing tests keep edits.
-  const handleClose = () => {
-    if (isNewRef.current && !committedRef.current && editingIndex !== null) {
-      form.removeFieldValue("tests", editingIndex)
-    }
-    isNewRef.current = false
-    committedRef.current = false
-    setEditingIndex(null)
+  const openEditEditor = (index: number) => {
+    setEditor({
+      mode: "edit",
+      index,
+      baseline: form.getFieldValue("tests")[index],
+    })
   }
 
-  const closeDialog = () => {
+  const closeEditor = () => {
     const dialog = dialogRef.current
     if (dialog?.open) dialog.close()
-    else handleClose()
+    setEditor(null)
   }
 
-  // "Done" marks the draft committed, then closes (fires handleClose).
-  const commitEditor = () => {
-    committedRef.current = true
-    closeDialog()
+  // Only here does the local draft reach the form: append a new test or
+  // overwrite the edited one. Cancel/Escape/backdrop never call this, so an
+  // untouched or abandoned draft leaves the list unchanged.
+  const commitEditor = (draft: AssignmentTestDraft) => {
+    if (!editor) return
+    if (editor.mode === "new") {
+      form.pushFieldValue("tests", draft)
+    } else {
+      form.setFieldValue(`tests[${editor.index}]`, draft)
+    }
+    closeEditor()
   }
+
+  const otherNames = (tests: AssignmentTestDraft[]) =>
+    tests
+      .filter((_, i) => !editor || editor.mode === "new" || i !== editor.index)
+      .map((d) => d.name.trim())
 
   return (
     <Card bordered={false}>
@@ -637,7 +546,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => openEditor(index)}
+                              onClick={() => openEditEditor(index)}
                               aria-label={t("assignments.autograder.editTest", {
                                 number: index + 1,
                               })}
@@ -666,14 +575,18 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
               </tbody>
             </table>
 
-            <AutogradingTestModal
-              form={form}
-              dialogRef={dialogRef}
-              index={editingIndex}
-              onClose={handleClose}
-              onCancel={closeDialog}
-              onDone={commitEditor}
-            />
+            {editor && (
+              <AutogradingTestModal
+                // Remount per open so the local draft re-initializes from the
+                // freshly opened baseline.
+                key={`${editor.mode}-${editor.index}`}
+                editor={editor}
+                dialogRef={dialogRef}
+                otherNames={otherNames(field.state.value)}
+                onCancel={closeEditor}
+                onCommit={commitEditor}
+              />
+            )}
           </Card.Body>
         )}
       </form.Field>


### PR DESCRIPTION
## Problem

Clicking **Add test** in the autograder immediately committed an empty draft into the `tests` array. The modal edited the live array by index, so the entry existed before anything was filled in — and it stayed there (and would be saved) if you closed the modal without finishing, e.g. an empty "Test 1 · 10 pts" row the moment you clicked **Add test**.

## Change

The editor now works on a **local draft copy** and only mutates the form's `tests` array on commit:

- **Add test / edit** opens the modal on a local copy; nothing touches `tests` yet.
- The primary button is **disabled until the draft differs from its opening state** (dirty check), and validates on click (surfacing field errors) before committing.
- The button is labelled **Add test** for a new test and **Save** when editing, next to an explicit **Cancel**.
- **Cancel / Escape / backdrop** discard the local draft — the list is unchanged.
- Commit appends (new) or overwrites at the edited index (existing). Page-submit validation is unchanged and re-checks committed tests.

## Review follow-ups (in this PR)

A multi-lens code review (correctness, frontend-races, maintainability, project-standards, testing, adversarial) confirmed the fix closes the bug with no defects, and surfaced a few improvements now applied:

- **Use the shared `Modal` primitive** instead of a hand-rolled `<dialog>` (per repo UI conventions); added an `onKeyDown` passthrough to `Modal` so the Enter-to-commit handler needs no wrapper element.
- Removed a dead branch in the name-uniqueness filter.
- Added tests: the confirm-to-create behavior (Add test doesn't append until a valid commit; Cancel discards; dirty-gate enable/disable; invalid draft blocked), plus a `draftsEqual` unit.
- Trimmed narrating comments to the terse WHY the repo style calls for.

## Verification

- `tsc -b` clean
- `eslint` — 0 errors (one pre-existing a11y warning, untouched)
- `prettier --check` clean
- `vitest run` — 2352/2352 pass (8 new)