### PR TITLE
fix(web): clear Sync-now stale state after a completed collect

### DIFF
--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import Papa from "papaparse"
 
+import { useQueryClient } from "@tanstack/react-query"
 import { useParams, Navigate } from "@tanstack/react-router"
 
 import Breadcrumb from "@/components/breadcrumb"
@@ -33,6 +34,7 @@ import {
   filterNonSubmitters,
   hasAccepted,
   latestAssignmentPush,
+  latestCollectedAt,
   mergeLiveRows,
   reconcileNonSubmitters,
   rosterScopedRows,
@@ -73,6 +75,7 @@ import {
   COLLECT_SCORES_WORKFLOW,
   REGRADE_WORKFLOW,
 } from "@/github-core/workflows"
+import { githubKeys } from "@/github-core/queries"
 import {
   formatDueDateTime,
   formatRelativeToNow,
@@ -91,6 +94,7 @@ const EMPTY_SET: Set<string> = new Set()
 const SubmissionsPageContent = () => {
   const { t } = useTranslation()
   const { org, classroom, assignment } = useParams({ strict: false })
+  const queryClient = useQueryClient()
   // Regrade-all is a config-repo-write tier action (teacher|hta); Collect and
   // per-row regrade stay all-staff (the page already gates entry on
   // viewClassroomStaffContent). GitHub is the real enforcer; this is the UX gate.
@@ -639,11 +643,6 @@ const SubmissionsPageContent = () => {
       ? t("submissions.actions.viewRun")
       : t("submissions.actions.viewWorkflow")
 
-  const lastCollectedLabel =
-    lastRun?.status === "completed" && lastRun.created_at
-      ? formatRelativeToNow(new Date(lastRun.created_at))
-      : null
-
   // Staleness heuristic (no extra API call): the most recent push across this
   // assignment's repos, read from the already-loaded org repo list's pushed_at.
   // If it's newer than the last completed collect run, scores.json probably
@@ -658,23 +657,56 @@ const SubmissionsPageContent = () => {
       ),
     [orgRepos, classroom, assignment, siblingSlugs],
   )
+
+  // Effective "last collected" prefers the run we just dispatched and know
+  // finished over the status=completed query, which can still report the prior
+  // run while GitHub's Actions list catches up. Gating on phase "completed"
+  // means conclusion === "success" (see useGitHubOperation), so a failed/timed
+  // -out run never relaxes the button. Both the freshness label and the
+  // staleness color read this one value so they can't disagree.
+  const lastRunCompletedAt =
+    lastRun?.status === "completed" ? lastRun.created_at : null
+  const trackedCompletedAt =
+    collectScores.phase === "completed"
+      ? (collectScores.run?.created_at ?? null)
+      : null
+  const effectiveLastCollectedAt = latestCollectedAt(
+    lastRunCompletedAt,
+    trackedCompletedAt,
+  )
+
+  const lastCollectedLabel = effectiveLastCollectedAt
+    ? formatRelativeToNow(new Date(effectiveLastCollectedAt))
+    : null
   const snapshotStale =
     !isEmptyRepoAssignment &&
-    snapshotIsStale(
-      latestPush,
-      lastRun?.status === "completed" ? lastRun.created_at : null,
-    )
+    snapshotIsStale(latestPush, effectiveLastCollectedAt)
 
   // Refresh scores + last-run timestamp + org repo list once a manual collection
   // finishes, so the freshness line re-derives (the collect just consumed the
-  // pushes latestPush was flagging).
+  // pushes latestPush was flagging). Invalidate (not just refetch) the last-run
+  // query: its 60s staleTime would otherwise let a cached entry from before the
+  // run short-circuit the update, leaving the "Last collected" line lagging even
+  // though the button color is already correct from the tracked run.
   useEffect(() => {
     if (collectScores.phase === "completed") {
       refetchScores()
+      if (org) {
+        queryClient.invalidateQueries({
+          queryKey: githubKeys.lastCollectScoresRun(org),
+        })
+      }
       refetchLastRun()
       refetchOrgRepos()
     }
-  }, [collectScores.phase, refetchScores, refetchLastRun, refetchOrgRepos])
+  }, [
+    collectScores.phase,
+    org,
+    queryClient,
+    refetchScores,
+    refetchLastRun,
+    refetchOrgRepos,
+  ])
 
   const downloadScoresCsv = () => {
     // Group grades are per-repo (keyed by the founder/owner), so a per-teammate

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -614,8 +614,7 @@ const SubmissionsPageContent = () => {
   // spinner/label (distinct from the page-wide `regrading` gate).
   const regradeAllActive =
     regradeAll.phase === "dispatching" || regradeAll.phase === "running"
-  const { data: lastRun, refetch: refetchLastRun } =
-    useGetLastCollectScoresRun(org)
+  const { data: lastRun } = useGetLastCollectScoresRun(org)
   const collectWorkflowUrl = `https://github.com/${org}/${CONFIG_REPO}/actions/workflows/${COLLECT_SCORES_WORKFLOW}`
   const regradeWorkflowUrl = `https://github.com/${org}/${CONFIG_REPO}/actions/workflows/${REGRADE_WORKFLOW}`
   const collecting =
@@ -684,10 +683,10 @@ const SubmissionsPageContent = () => {
 
   // Refresh scores + last-run timestamp + org repo list once a manual collection
   // finishes, so the freshness line re-derives (the collect just consumed the
-  // pushes latestPush was flagging). Invalidate (not just refetch) the last-run
-  // query: its 60s staleTime would otherwise let a cached entry from before the
-  // run short-circuit the update, leaving the "Last collected" line lagging even
-  // though the button color is already correct from the tracked run.
+  // pushes latestPush was flagging). Invalidate the last-run query rather than
+  // refetching it: its 60s staleTime would otherwise let a cached entry from
+  // before the run short-circuit the update, leaving the "Last collected" line
+  // lagging even though the button color is already correct from the tracked run.
   useEffect(() => {
     if (collectScores.phase === "completed") {
       refetchScores()
@@ -696,17 +695,9 @@ const SubmissionsPageContent = () => {
           queryKey: githubKeys.lastCollectScoresRun(org),
         })
       }
-      refetchLastRun()
       refetchOrgRepos()
     }
-  }, [
-    collectScores.phase,
-    org,
-    queryClient,
-    refetchScores,
-    refetchLastRun,
-    refetchOrgRepos,
-  ])
+  }, [collectScores.phase, org, queryClient, refetchScores, refetchOrgRepos])
 
   const downloadScoresCsv = () => {
     // Group grades are per-repo (keyed by the founder/owner), so a per-teammate

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -25,6 +25,7 @@ import {
   filterNonSubmitters,
   hasAccepted,
   latestAssignmentPush,
+  latestCollectedAt,
   mergeLiveRows,
   nonSubmitterStatus,
   pageBounds,
@@ -1005,6 +1006,72 @@ describe("latestAssignmentPush / snapshotIsStale", () => {
   it("is never stale when there is no push", () => {
     expect(snapshotIsStale(null, null)).toBe(false)
     expect(snapshotIsStale(null, "2026-06-20T10:00:00Z")).toBe(false)
+  })
+})
+
+describe("latestCollectedAt", () => {
+  it("returns the newer ISO regardless of argument order", () => {
+    expect(
+      latestCollectedAt("2026-06-20T10:00:00Z", "2026-06-25T10:00:00Z"),
+    ).toBe("2026-06-25T10:00:00Z")
+    expect(
+      latestCollectedAt("2026-06-25T10:00:00Z", "2026-06-20T10:00:00Z"),
+    ).toBe("2026-06-25T10:00:00Z")
+  })
+
+  it("returns the non-null value when the other is null/undefined", () => {
+    expect(latestCollectedAt("2026-06-20T10:00:00Z", null)).toBe(
+      "2026-06-20T10:00:00Z",
+    )
+    expect(latestCollectedAt(null, "2026-06-20T10:00:00Z")).toBe(
+      "2026-06-20T10:00:00Z",
+    )
+    expect(latestCollectedAt("2026-06-20T10:00:00Z", undefined)).toBe(
+      "2026-06-20T10:00:00Z",
+    )
+  })
+
+  it("returns null when both are null/undefined", () => {
+    expect(latestCollectedAt(null, null)).toBeNull()
+    expect(latestCollectedAt(undefined, undefined)).toBeNull()
+  })
+
+  it("discards an unparseable value rather than letting it win", () => {
+    expect(latestCollectedAt("not-a-date", "2026-06-20T10:00:00Z")).toBe(
+      "2026-06-20T10:00:00Z",
+    )
+    expect(latestCollectedAt("2026-06-20T10:00:00Z", "not-a-date")).toBe(
+      "2026-06-20T10:00:00Z",
+    )
+    expect(latestCollectedAt("not-a-date", null)).toBeNull()
+  })
+})
+
+// The freshness button's color is snapshotIsStale(latestPush, effective) where
+// effective = latestCollectedAt(lastRun, trackedRun). These cases prove the two
+// helpers compose to clear the button after a completed sync (R1) without going
+// falsely quiet when a newer push exists (R2), even while the status=completed
+// query still reports an older run.
+describe("freshness: effective last-collected clears stale after a sync", () => {
+  const lagging = "2026-06-20T10:00:00Z" // stale getLastCollectScoresRun result
+  const trackedRun = "2026-06-25T12:00:00Z" // the just-finished run we hold
+
+  it("clears stale when the tracked run is newer than the push (R1)", () => {
+    const push = "2026-06-25T11:00:00Z"
+    const effective = latestCollectedAt(lagging, trackedRun)
+    expect(snapshotIsStale(push, effective)).toBe(false)
+  })
+
+  it("stays stale when a push is newer than the tracked run (R2)", () => {
+    const push = "2026-06-25T13:00:00Z"
+    const effective = latestCollectedAt(lagging, trackedRun)
+    expect(snapshotIsStale(push, effective)).toBe(true)
+  })
+
+  it("stays stale on the lagging run alone before the tracked run lands", () => {
+    const push = "2026-06-25T11:00:00Z"
+    const effective = latestCollectedAt(lagging, null)
+    expect(snapshotIsStale(push, effective)).toBe(true)
   })
 })
 

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -221,6 +221,24 @@ export function snapshotIsStale(
   return pushMs > collectMs
 }
 
+// Newer of two ISO "last collected" timestamps. Lets the freshness view prefer a
+// just-finished tracked run over the lagging status=completed query, which can
+// still report the prior run while GitHub's Actions list catches up. Null-safe;
+// unparseable inputs are discarded rather than winning the comparison.
+export function latestCollectedAt(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): string | null {
+  const aMs = a ? new Date(a).getTime() : NaN
+  const bMs = b ? new Date(b).getTime() : NaN
+  const aOk = Number.isFinite(aMs)
+  const bOk = Number.isFinite(bMs)
+  if (!aOk && !bOk) return null
+  if (!aOk) return b ?? null
+  if (!bOk) return a ?? null
+  return aMs >= bMs ? (a ?? null) : (b ?? null)
+}
+
 // the assignment sets no threshold — then every row is "ungraded" (as is an
 // ungraded/zero-max row).
 export type PassState = "passing" | "failing" | "ungraded"


### PR DESCRIPTION
## Summary
- The submissions-page freshness button derived its red **"Sync now"** state from `getLastCollectScoresRun` (filtered `status=completed`), which lags GitHub Actions' eventual consistency. After a successful sync the button often stayed red until a full page reload, because the one-shot post-completion refetch raced that lag and never re-fired.
- Derive an effective "last collected" timestamp from the finished run the page **already holds** (`collectScores.run`, gated on `phase === "completed"` → success-only) via a new pure `latestCollectedAt(a, b)` helper. Both the button color (`snapshotStale`) and the "Last collected" label now read this one value, so a successful sync clears the stale state deterministically — no reload needed.
- Comparing against the run's `created_at` (rather than force-clearing) preserves the genuine-stale case: a push newer than the run still reads red.
- Hardened the post-completion effect to **invalidate** the `lastCollectScoresRun` query (not just refetch), so its 60s cache can't short-circuit the "Last collected" line converging.

## Test plan
- [x] `latestCollectedAt` unit cases (newer-of-two, null-safe, discards unparseable) in `dashboard.test.ts`
- [x] Composed freshness cases: clears after sync (R1), stays red on a newer push (R2), stays red on the lagging run alone
- [x] `cd web && npx tsc -b` — clean
- [x] `npx eslint` + `npx prettier --check` on touched files — clean
- [x] Full suite: `npx vitest run` — 215 files / 2372 tests passing
- [ ] Manual: student push → open submissions (red) → Sync now → run completes → button relaxes to "Refresh submissions" without reload; a fresh push turns it red again

Plan: `docs/plans/2026-07-24-002-fix-sync-now-button-stuck-red-plan.md`