### PR TITLE
fix(web): deep-link the OAuth org grant when an organization is missing

### DIFF
--- a/web/src/auth/constants.test.ts
+++ b/web/src/auth/constants.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { githubOAuthGrantUrl } from "./constants"
+
+describe("githubOAuthGrantUrl", () => {
+  it("deep-links this app's authorization page, where the per-org Grant lives", () => {
+    expect(githubOAuthGrantUrl("Ov23liEXAMPLE")).toBe(
+      "https://github.com/settings/connections/applications/Ov23liEXAMPLE",
+    )
+  })
+
+  it("falls back to the authorized-apps list when no client id is injected", () => {
+    expect(githubOAuthGrantUrl("")).toBe(
+      "https://github.com/settings/connections/applications",
+    )
+  })
+})

--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -30,6 +30,15 @@ export const githubOrgOAuthPolicyUrl = (org: string) =>
 export const GITHUB_OAUTH_CLIENT_ID: string =
   import.meta.env.VITE_GITHUB_CLIENT_ID ?? ""
 
+const GITHUB_OAUTH_APPS_URL =
+  "https://github.com/settings/connections/applications"
+
+// This app's own entry on the user's authorized-apps page — the only place the
+// per-org "Grant" button lives (discussions #352, #403). Without an injected
+// client id (self-hosted/dev builds) only the app list is knowable.
+export const githubOAuthGrantUrl = (clientId = GITHUB_OAUTH_CLIENT_ID) =>
+  clientId ? `${GITHUB_OAUTH_APPS_URL}/${clientId}` : GITHUB_OAUTH_APPS_URL
+
 export const GITHUB_OAUTH_WORKER_BASE =
   import.meta.env.VITE_GITHUB_OAUTH_WORKER_BASE ??
   "https://tiny-bonus-7dc1.fifty-foundation.workers.dev"

--- a/web/src/components/MissingOrgNotice.test.tsx
+++ b/web/src/components/MissingOrgNotice.test.tsx
@@ -41,7 +41,7 @@ afterEach(() => {
 
 describe("MissingOrgNotice", () => {
   it("links the app's own GitHub authorization page in a new tab", () => {
-    render(<MissingOrgNotice refreshing={false} onRefresh={vi.fn()} />)
+    render(<MissingOrgNotice onRefresh={vi.fn()} />)
 
     const link = grantLink()
     expect(link?.getAttribute("href")).toContain(
@@ -51,22 +51,16 @@ describe("MissingOrgNotice", () => {
   })
 
   it("stays collapsed by default and opens on request", () => {
-    const { unmount } = render(
-      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} />,
-    )
+    const { unmount } = render(<MissingOrgNotice onRefresh={vi.fn()} />)
     expect(disclosure()?.open).toBe(false)
     unmount()
 
-    render(
-      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} defaultOpen />,
-    )
+    render(<MissingOrgNotice onRefresh={vi.fn()} defaultOpen />)
     expect(disclosure()?.open).toBe(true)
   })
 
   it("spells out the grant steps", () => {
-    render(
-      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} defaultOpen />,
-    )
+    render(<MissingOrgNotice onRefresh={vi.fn()} defaultOpen />)
 
     expect(screen.getByText("orgs.missingNotice.steps.grant")).toBeTruthy()
     expect(screen.getByText("orgs.missingNotice.steps.refresh")).toBeTruthy()
@@ -77,7 +71,7 @@ describe("MissingOrgNotice", () => {
   })
 
   it("expands and collapses on a single click", () => {
-    render(<MissingOrgNotice refreshing={false} onRefresh={vi.fn()} />)
+    render(<MissingOrgNotice onRefresh={vi.fn()} />)
     const summary = screen.getByText("orgs.missingNotice.title")
 
     // React owns `open`, so the native toggle must be suppressed — sharing that
@@ -91,25 +85,18 @@ describe("MissingOrgNotice", () => {
     expect(disclosure()?.open).toBe(false)
   })
 
-  it("refreshes without letting the click toggle the disclosure", () => {
-    const onRefresh = vi.fn()
-    render(<MissingOrgNotice refreshing={false} onRefresh={onRefresh} />)
+  it("keeps no refresh control of its own — the list owns that", () => {
+    render(<MissingOrgNotice onRefresh={vi.fn()} defaultOpen />)
 
-    // The refresh control sits inside <summary>, so the click's default action
-    // (toggling the disclosure) has to be suppressed. fireEvent returns false
-    // when preventDefault was called.
-    const defaultAllowed = fireEvent.click(
-      screen.getByText("orgs.missingNotice.refresh"),
-    )
-    expect(onRefresh).toHaveBeenCalledTimes(1)
-    expect(defaultAllowed).toBe(false)
+    // A refresh button here reads as the fix for a missing org, which it isn't
+    // (the grant is), and hides behind the collapsed disclosure.
+    expect(screen.queryByText("orgs.newOrg.refresh")).toBeNull()
+    expect(screen.queryByText("orgs.missingNotice.refresh")).toBeNull()
   })
 
   it("refreshes once when the teacher returns from the grant page", () => {
     const onRefresh = vi.fn()
-    render(
-      <MissingOrgNotice refreshing={false} onRefresh={onRefresh} defaultOpen />,
-    )
+    render(<MissingOrgNotice onRefresh={onRefresh} defaultOpen />)
 
     document.dispatchEvent(new Event("visibilitychange"))
     expect(onRefresh).not.toHaveBeenCalled()
@@ -123,9 +110,7 @@ describe("MissingOrgNotice", () => {
   })
 
   it("offers re-authorization for a token that predates the membership", () => {
-    render(
-      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} defaultOpen />,
-    )
+    render(<MissingOrgNotice onRefresh={vi.fn()} defaultOpen />)
 
     fireEvent.click(screen.getByText("auth.reauthorize"))
     expect(startWebFlow).toHaveBeenCalledTimes(1)

--- a/web/src/components/MissingOrgNotice.test.tsx
+++ b/web/src/components/MissingOrgNotice.test.tsx
@@ -74,8 +74,7 @@ describe("MissingOrgNotice", () => {
     render(<MissingOrgNotice onRefresh={vi.fn()} />)
     const summary = screen.getByText("orgs.missingNotice.title")
 
-    // React owns `open`, so the native toggle must be suppressed — sharing that
-    // state with the element is what makes a closed disclosure need two clicks.
+    // React owns `open`, so the native toggle must be suppressed.
     // fireEvent returns false when preventDefault was called.
     expect(fireEvent.click(summary)).toBe(false)
     expect(screen.getByText("orgs.missingNotice.steps.grant")).toBeTruthy()
@@ -88,10 +87,7 @@ describe("MissingOrgNotice", () => {
   it("keeps no refresh control of its own — the list owns that", () => {
     render(<MissingOrgNotice onRefresh={vi.fn()} defaultOpen />)
 
-    // A refresh button here reads as the fix for a missing org, which it isn't
-    // (the grant is), and hides behind the collapsed disclosure.
     expect(screen.queryByText("orgs.newOrg.refresh")).toBeNull()
-    expect(screen.queryByText("orgs.missingNotice.refresh")).toBeNull()
   })
 
   it("refreshes once when the teacher returns from the grant page", () => {

--- a/web/src/components/MissingOrgNotice.test.tsx
+++ b/web/src/components/MissingOrgNotice.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+const startWebFlow = vi.fn()
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({ startWebFlow }),
+}))
+
+import MissingOrgNotice from "./MissingOrgNotice"
+
+const grantLink = () =>
+  screen.getByText("orgs.missingNotice.manageOauth").closest("a")
+
+const disclosure = () =>
+  document.querySelector("details") as HTMLDetailsElement | null
+
+// The grant CTA is a real anchor; happy-dom would otherwise try to navigate to
+// github.com when a test clicks it.
+const blockNavigation = (e: Event) => {
+  if ((e.target as HTMLElement | null)?.closest("a")) e.preventDefault()
+}
+
+beforeEach(() => {
+  startWebFlow.mockReset()
+  document.addEventListener("click", blockNavigation)
+})
+
+afterEach(() => {
+  document.removeEventListener("click", blockNavigation)
+  cleanup()
+})
+
+describe("MissingOrgNotice", () => {
+  it("links the app's own GitHub authorization page in a new tab", () => {
+    render(<MissingOrgNotice refreshing={false} onRefresh={vi.fn()} />)
+
+    const link = grantLink()
+    expect(link?.getAttribute("href")).toContain(
+      "https://github.com/settings/connections/applications",
+    )
+    expect(link?.getAttribute("target")).toBe("_blank")
+  })
+
+  it("stays collapsed by default and opens on request", () => {
+    const { unmount } = render(
+      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} />,
+    )
+    expect(disclosure()?.open).toBe(false)
+    unmount()
+
+    render(
+      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} defaultOpen />,
+    )
+    expect(disclosure()?.open).toBe(true)
+  })
+
+  it("spells out the grant steps", () => {
+    render(
+      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} defaultOpen />,
+    )
+
+    expect(screen.getByText("orgs.missingNotice.steps.grant")).toBeTruthy()
+    expect(screen.getByText("orgs.missingNotice.steps.approve")).toBeTruthy()
+    expect(screen.getByText("orgs.missingNotice.steps.refresh")).toBeTruthy()
+  })
+
+  it("expands and collapses on a single click", () => {
+    render(<MissingOrgNotice refreshing={false} onRefresh={vi.fn()} />)
+    const summary = screen.getByText("orgs.missingNotice.title")
+
+    // React owns `open`, so the native toggle must be suppressed — sharing that
+    // state with the element is what makes a closed disclosure need two clicks.
+    // fireEvent returns false when preventDefault was called.
+    expect(fireEvent.click(summary)).toBe(false)
+    expect(screen.getByText("orgs.missingNotice.steps.grant")).toBeTruthy()
+    expect(disclosure()?.open).toBe(true)
+
+    fireEvent.click(summary)
+    expect(disclosure()?.open).toBe(false)
+  })
+
+  it("refreshes without letting the click toggle the disclosure", () => {
+    const onRefresh = vi.fn()
+    render(<MissingOrgNotice refreshing={false} onRefresh={onRefresh} />)
+
+    // The refresh control sits inside <summary>, so the click's default action
+    // (toggling the disclosure) has to be suppressed. fireEvent returns false
+    // when preventDefault was called.
+    const defaultAllowed = fireEvent.click(
+      screen.getByText("orgs.missingNotice.refresh"),
+    )
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    expect(defaultAllowed).toBe(false)
+  })
+
+  it("refreshes once when the teacher returns from the grant page", () => {
+    const onRefresh = vi.fn()
+    render(
+      <MissingOrgNotice refreshing={false} onRefresh={onRefresh} defaultOpen />,
+    )
+
+    document.dispatchEvent(new Event("visibilitychange"))
+    expect(onRefresh).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText("orgs.missingNotice.manageOauth"))
+    document.dispatchEvent(new Event("visibilitychange"))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(new Event("visibilitychange"))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("offers re-authorization for a token that predates the membership", () => {
+    render(
+      <MissingOrgNotice refreshing={false} onRefresh={vi.fn()} defaultOpen />,
+    )
+
+    fireEvent.click(screen.getByText("auth.reauthorize"))
+    expect(startWebFlow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/MissingOrgNotice.test.tsx
+++ b/web/src/components/MissingOrgNotice.test.tsx
@@ -69,8 +69,11 @@ describe("MissingOrgNotice", () => {
     )
 
     expect(screen.getByText("orgs.missingNotice.steps.grant")).toBeTruthy()
-    expect(screen.getByText("orgs.missingNotice.steps.approve")).toBeTruthy()
     expect(screen.getByText("orgs.missingNotice.steps.refresh")).toBeTruthy()
+    // The rarer causes (owner approval, SSO) hide behind a help tooltip.
+    expect(
+      screen.getByLabelText("orgs.missingNotice.steps.grantHelp"),
+    ).toBeTruthy()
   })
 
   it("expands and collapses on a single click", () => {

--- a/web/src/components/MissingOrgNotice.tsx
+++ b/web/src/components/MissingOrgNotice.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ExternalLink, Info, RefreshCw } from "lucide-react"
+import { ChevronDown, ExternalLink, Info } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -11,13 +11,12 @@ import useRefreshOnReturn from "@/hooks/useRefreshOnReturn"
 // this OAuth app was granted, and the per-org "Grant" lives on the app's own
 // authorization page, which teachers can't guess (discussions #352, #403). The
 // rarer causes (owner approval, SAML SSO, a token predating the membership) sit
-// behind tooltips so the common path stays two steps.
+// behind tooltips so the common path stays two steps. `onRefresh` is not a
+// button here — the list owns that control; this arms it for the return trip.
 function MissingOrgNotice({
-  refreshing,
   onRefresh,
   defaultOpen = false,
 }: {
-  refreshing: boolean
   onRefresh: () => void
   defaultOpen?: boolean
 }) {
@@ -45,24 +44,6 @@ function MissingOrgNotice({
         <span className="min-w-0 flex-1 truncate font-medium text-base-content">
           {t("orgs.missingNotice.title")}
         </span>
-        <Button
-          variant="outline"
-          size="xs"
-          loading={refreshing}
-          onClick={(e) => {
-            // Inside <summary>: suppress the native toggle and keep the click
-            // from reaching the handler above, so refreshing doesn't also
-            // expand/collapse the disclosure.
-            e.preventDefault()
-            e.stopPropagation()
-            onRefresh()
-          }}
-        >
-          {!refreshing && <RefreshCw aria-hidden="true" className="size-3.5" />}
-          {refreshing
-            ? t("orgs.missingNotice.refreshing")
-            : t("orgs.missingNotice.refresh")}
-        </Button>
         <ChevronDown
           aria-hidden="true"
           className="size-4 shrink-0 text-base-content/50 transition-transform group-open:rotate-180"

--- a/web/src/components/MissingOrgNotice.tsx
+++ b/web/src/components/MissingOrgNotice.tsx
@@ -1,23 +1,45 @@
 import { ChevronDown, ExternalLink, Info, RefreshCw } from "lucide-react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { githubOAuthGrantUrl } from "@/auth/constants"
+import { useGithubAuth } from "@/auth/useGithubAuth"
 import { Button } from "@/components/ui"
+import useRefreshOnReturn from "@/hooks/useRefreshOnReturn"
 
-// Collapsible notice explaining that GitHub only surfaces orgs the OAuth grant
-// covers, with a link to manage that access and a refresh. Shared by the orgs
-// page and the new-org modal so the "grant access" fix is always one click away
-// when an org is missing.
+// A missing org is almost never a membership problem: GitHub only reports orgs
+// this OAuth app was granted, and the per-org "Grant" lives on the app's own
+// authorization page, which teachers can't guess (discussions #352, #403).
+// Rendered open when the org list is empty, collapsed otherwise.
 function MissingOrgNotice({
   refreshing,
   onRefresh,
+  defaultOpen = false,
 }: {
   refreshing: boolean
   onRefresh: () => void
+  defaultOpen?: boolean
 }) {
   const { t } = useTranslation()
+  const { startWebFlow } = useGithubAuth()
+  const [open, setOpen] = useState(defaultOpen)
+  const armRefreshOnReturn = useRefreshOnReturn(onRefresh)
+
   return (
-    <details className="group rounded-xl border border-info/20 bg-info/5">
-      <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-sm">
+    <details
+      open={open}
+      className="group rounded-xl border border-info/20 bg-info/5"
+    >
+      <summary
+        // Controlled disclosure: driving <details> from its toggle event fights
+        // React's `open` prop (closed sections need two clicks), so intercept
+        // the summary click and own the state here — as LanguageSwitcher does.
+        onClick={(e) => {
+          e.preventDefault()
+          setOpen((wasOpen) => !wasOpen)
+        }}
+        className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-sm"
+      >
         <Info aria-hidden="true" className="size-4 shrink-0 text-info" />
         <span className="min-w-0 flex-1 truncate font-medium text-base-content">
           {t("orgs.missingNotice.title")}
@@ -27,9 +49,11 @@ function MissingOrgNotice({
           size="xs"
           disabled={refreshing}
           onClick={(e) => {
-            // The button lives inside <summary>; stop the click from toggling
-            // the disclosure so refreshing doesn't also expand/collapse it.
+            // Inside <summary>: suppress the native toggle and keep the click
+            // from reaching the handler above, so refreshing doesn't also
+            // expand/collapse the disclosure.
             e.preventDefault()
+            e.stopPropagation()
             onRefresh()
           }}
         >
@@ -51,18 +75,33 @@ function MissingOrgNotice({
         <p className="text-sm leading-6 text-base-content/70">
           {t("orgs.missingNotice.body")}
         </p>
-        <Button
-          as="a"
-          href="https://github.com/settings/connections/applications"
-          target="_blank"
-          rel="noreferrer"
-          variant="info"
-          size="sm"
-          className="mt-3"
-        >
-          {t("orgs.missingNotice.manageOauth")}
-          <ExternalLink aria-hidden="true" className="size-4" />
-        </Button>
+        <ol className="mt-3 list-decimal space-y-1.5 ps-5 text-sm leading-6 text-base-content/70">
+          <li>{t("orgs.missingNotice.steps.grant")}</li>
+          <li>{t("orgs.missingNotice.steps.approve")}</li>
+          <li>{t("orgs.missingNotice.steps.refresh")}</li>
+        </ol>
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Button
+            as="a"
+            href={githubOAuthGrantUrl()}
+            target="_blank"
+            rel="noreferrer"
+            variant="primary"
+            onClick={() => armRefreshOnReturn()}
+          >
+            {t("orgs.missingNotice.manageOauth")}
+            <ExternalLink aria-hidden="true" className="size-4" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => void startWebFlow()}>
+            {t("auth.reauthorize")}
+          </Button>
+        </div>
+        <p className="mt-3 text-xs leading-5 text-base-content/60">
+          {t("orgs.missingNotice.ssoHint")}
+        </p>
+        <p className="mt-1 text-xs leading-5 text-base-content/60">
+          {t("orgs.missingNotice.pendingHint")}
+        </p>
       </div>
     </details>
   )

--- a/web/src/components/MissingOrgNotice.tsx
+++ b/web/src/components/MissingOrgNotice.tsx
@@ -7,12 +7,9 @@ import { useGithubAuth } from "@/auth/useGithubAuth"
 import { Button, HelpTooltip } from "@/components/ui"
 import useRefreshOnReturn from "@/hooks/useRefreshOnReturn"
 
-// A missing org is almost never a membership problem: GitHub only reports orgs
-// this OAuth app was granted, and the per-org "Grant" lives on the app's own
-// authorization page, which teachers can't guess (discussions #352, #403). The
-// rarer causes (owner approval, SAML SSO, a token predating the membership) sit
-// behind tooltips so the common path stays two steps. `onRefresh` is not a
-// button here — the list owns that control; this arms it for the return trip.
+// GitHub only reports orgs this OAuth app was granted, and the per-org "Grant"
+// lives on the app's own authorization page, which teachers can't guess
+// (discussions #352, #403).
 function MissingOrgNotice({
   onRefresh,
   defaultOpen = false,
@@ -31,9 +28,8 @@ function MissingOrgNotice({
       className="group rounded-xl border border-info/20 bg-info/5"
     >
       <summary
-        // Controlled disclosure: driving <details> from its toggle event fights
-        // React's `open` prop (closed sections need two clicks), so intercept
-        // the summary click and own the state here — as LanguageSwitcher does.
+        // React owns `open`; letting the native toggle through too would need
+        // two clicks to reopen.
         onClick={(e) => {
           e.preventDefault()
           setOpen((wasOpen) => !wasOpen)
@@ -69,7 +65,7 @@ function MissingOrgNotice({
             rel="noreferrer"
             variant="primary"
             size="sm"
-            onClick={() => armRefreshOnReturn()}
+            onClick={armRefreshOnReturn}
           >
             {t("orgs.missingNotice.manageOauth")}
             <ExternalLink aria-hidden="true" className="size-4" />

--- a/web/src/components/MissingOrgNotice.tsx
+++ b/web/src/components/MissingOrgNotice.tsx
@@ -4,13 +4,14 @@ import { useTranslation } from "react-i18next"
 
 import { githubOAuthGrantUrl } from "@/auth/constants"
 import { useGithubAuth } from "@/auth/useGithubAuth"
-import { Button } from "@/components/ui"
+import { Button, HelpTooltip } from "@/components/ui"
 import useRefreshOnReturn from "@/hooks/useRefreshOnReturn"
 
 // A missing org is almost never a membership problem: GitHub only reports orgs
 // this OAuth app was granted, and the per-org "Grant" lives on the app's own
-// authorization page, which teachers can't guess (discussions #352, #403).
-// Rendered open when the org list is empty, collapsed otherwise.
+// authorization page, which teachers can't guess (discussions #352, #403). The
+// rarer causes (owner approval, SAML SSO, a token predating the membership) sit
+// behind tooltips so the common path stays two steps.
 function MissingOrgNotice({
   refreshing,
   onRefresh,
@@ -38,16 +39,16 @@ function MissingOrgNotice({
           e.preventDefault()
           setOpen((wasOpen) => !wasOpen)
         }}
-        className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-sm"
+        className="flex cursor-pointer list-none items-center gap-2 rounded-xl px-4 py-2.5 text-sm hover:bg-info/10"
       >
         <Info aria-hidden="true" className="size-4 shrink-0 text-info" />
         <span className="min-w-0 flex-1 truncate font-medium text-base-content">
           {t("orgs.missingNotice.title")}
         </span>
         <Button
-          variant="ghost"
+          variant="outline"
           size="xs"
-          disabled={refreshing}
+          loading={refreshing}
           onClick={(e) => {
             // Inside <summary>: suppress the native toggle and keep the click
             // from reaching the handler above, so refreshing doesn't also
@@ -57,10 +58,7 @@ function MissingOrgNotice({
             onRefresh()
           }}
         >
-          <RefreshCw
-            aria-hidden="true"
-            className={["size-3.5", refreshing ? "animate-spin" : ""].join(" ")}
-          />
+          {!refreshing && <RefreshCw aria-hidden="true" className="size-3.5" />}
           {refreshing
             ? t("orgs.missingNotice.refreshing")
             : t("orgs.missingNotice.refresh")}
@@ -75,33 +73,35 @@ function MissingOrgNotice({
         <p className="text-sm leading-6 text-base-content/70">
           {t("orgs.missingNotice.body")}
         </p>
-        <ol className="mt-3 list-decimal space-y-1.5 ps-5 text-sm leading-6 text-base-content/70">
-          <li>{t("orgs.missingNotice.steps.grant")}</li>
-          <li>{t("orgs.missingNotice.steps.approve")}</li>
+        <ol className="mt-2 list-decimal space-y-1 ps-5 text-sm leading-6 text-base-content/70">
+          <li>
+            {t("orgs.missingNotice.steps.grant")}
+            <HelpTooltip help={t("orgs.missingNotice.steps.grantHelp")} />
+          </li>
           <li>{t("orgs.missingNotice.steps.refresh")}</li>
         </ol>
-        <div className="mt-4 flex flex-wrap items-center gap-2">
+        <div className="mt-3 flex flex-wrap items-center gap-2">
           <Button
             as="a"
             href={githubOAuthGrantUrl()}
             target="_blank"
             rel="noreferrer"
             variant="primary"
+            size="sm"
             onClick={() => armRefreshOnReturn()}
           >
             {t("orgs.missingNotice.manageOauth")}
             <ExternalLink aria-hidden="true" className="size-4" />
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => void startWebFlow()}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void startWebFlow()}
+          >
             {t("auth.reauthorize")}
           </Button>
+          <HelpTooltip help={t("orgs.missingNotice.reauthorizeHelp")} />
         </div>
-        <p className="mt-3 text-xs leading-5 text-base-content/60">
-          {t("orgs.missingNotice.ssoHint")}
-        </p>
-        <p className="mt-1 text-xs leading-5 text-base-content/60">
-          {t("orgs.missingNotice.pendingHint")}
-        </p>
       </div>
     </details>
   )

--- a/web/src/components/modals/NewOrgModal.test.tsx
+++ b/web/src/components/modals/NewOrgModal.test.tsx
@@ -76,6 +76,12 @@ function renderModal(orgs: Classroom50OrgSummary[]) {
   )
 }
 
+// Row order as rendered, so sort assertions don't depend on the input order.
+const orgOrder = () =>
+  Array.from(document.querySelectorAll("li button > span > span:first-child"))
+    .map((el) => el.textContent)
+    .filter((text): text is string => Boolean(text))
+
 beforeEach(() => {
   navigate.mockReset()
   plansResult = { byLogin: {}, pending: new Set() }
@@ -192,5 +198,96 @@ describe("NewOrgModal", () => {
     expect(refresh.closest("details")).toBeNull()
     fireEvent.click(refresh)
     expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("sorts by login, since GitHub's membership order is arbitrary", () => {
+    plansResult = {
+      byLogin: { zeta: "team", alpha: "team", mid: "team" },
+      pending: new Set(),
+    }
+    renderModal([summary("zeta"), summary("alpha"), summary("mid")])
+
+    expect(orgOrder()).toEqual(["alpha", "mid", "zeta"])
+    expect(screen.queryByText("orgs.newOrg.newBadge")).toBeNull()
+  })
+
+  it("floats an org that appears after opening to the top, badged New", () => {
+    plansResult = {
+      byLogin: { alpha: "team", zeta: "team" },
+      pending: new Set(),
+    }
+    const { rerender } = renderModal([summary("alpha")])
+    expect(orgOrder()).toEqual(["alpha"])
+
+    // The grant-page return refreshes the list mid-open; zeta wasn't in the
+    // snapshot taken when the modal mounted, so it's the just-granted one.
+    rerender(
+      <NewOrgModal
+        open
+        needsSetupOrgs={[summary("alpha"), summary("zeta")]}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(orgOrder()).toEqual(["zeta", "alpha"])
+    expect(screen.getAllByText("orgs.newOrg.newBadge")).toHaveLength(1)
+  })
+
+  it("badges nothing when the list was empty on open", () => {
+    // No baseline to contrast against — every org would otherwise look new.
+    const { rerender } = renderModal([])
+    plansResult = {
+      byLogin: { alpha: "team", zeta: "team" },
+      pending: new Set(),
+    }
+    rerender(
+      <NewOrgModal
+        open
+        needsSetupOrgs={[summary("zeta"), summary("alpha")]}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(orgOrder()).toEqual(["alpha", "zeta"])
+    expect(screen.queryByText("orgs.newOrg.newBadge")).toBeNull()
+  })
+
+  it("resets the New baseline when the modal is reopened", () => {
+    plansResult = {
+      byLogin: { alpha: "team", zeta: "team" },
+      pending: new Set(),
+    }
+    const orgs = [summary("alpha"), summary("zeta")]
+    const { rerender } = renderModal([summary("alpha")])
+    rerender(
+      <NewOrgModal
+        open
+        needsSetupOrgs={orgs}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getAllByText("orgs.newOrg.newBadge")).toHaveLength(1)
+
+    const reopen = (open: boolean) =>
+      rerender(
+        <NewOrgModal
+          open={open}
+          needsSetupOrgs={orgs}
+          refreshing={false}
+          onRefresh={vi.fn()}
+          onClose={vi.fn()}
+        />,
+      )
+    reopen(false)
+    reopen(true)
+
+    expect(screen.queryByText("orgs.newOrg.newBadge")).toBeNull()
+    expect(orgOrder()).toEqual(["alpha", "zeta"])
   })
 })

--- a/web/src/components/modals/NewOrgModal.test.tsx
+++ b/web/src/components/modals/NewOrgModal.test.tsx
@@ -172,4 +172,25 @@ describe("NewOrgModal", () => {
     expect(screen.getByText("orgs.newOrg.allSetUp")).toBeTruthy()
     expect(screen.getByText("orgs.missingNotice.title")).toBeTruthy()
   })
+
+  it("refreshes from the list header, outside the notice disclosure", () => {
+    const onRefresh = vi.fn()
+    plansResult = { byLogin: { acme: "team" }, pending: new Set() }
+    render(
+      <NewOrgModal
+        open
+        needsSetupOrgs={[summary("acme")]}
+        refreshing={false}
+        onRefresh={onRefresh}
+        onClose={vi.fn()}
+      />,
+    )
+
+    const refresh = screen.getByText("orgs.newOrg.refresh")
+    // Must sit beside the list heading, not inside the collapsible notice —
+    // otherwise it reads as the fix for a missing org and can be hidden.
+    expect(refresh.closest("details")).toBeNull()
+    fireEvent.click(refresh)
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
 })

--- a/web/src/components/modals/NewOrgModal.test.tsx
+++ b/web/src/components/modals/NewOrgModal.test.tsx
@@ -34,6 +34,12 @@ vi.mock("@/hooks/useNeedsSetupPlans", () => ({
   default: () => plansResult,
 }))
 
+// MissingOrgNotice (rendered inside the modal) offers re-authorization, and
+// useGithubAuth throws outside its provider.
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({ startWebFlow: vi.fn() }),
+}))
+
 import NewOrgModal from "./NewOrgModal"
 
 const summary = (

--- a/web/src/components/modals/NewOrgModal.test.tsx
+++ b/web/src/components/modals/NewOrgModal.test.tsx
@@ -200,6 +200,34 @@ describe("NewOrgModal", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1)
   })
 
+  it("mounts the notice only while open, so defaultOpen sees the loaded list", () => {
+    plansResult = { byLogin: { acme: "team" }, pending: new Set() }
+    const { rerender } = render(
+      <NewOrgModal
+        open={false}
+        needsSetupOrgs={[]}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    // Modal renders children regardless of `open`, so without the guard the
+    // notice would latch defaultOpen from the pre-load empty list.
+    expect(screen.queryByText("orgs.missingNotice.title")).toBeNull()
+
+    rerender(
+      <NewOrgModal
+        open
+        needsSetupOrgs={[summary("acme")]}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("orgs.missingNotice.title")).toBeTruthy()
+    expect(document.querySelector("details")?.open).toBe(false)
+  })
+
   it("sorts by login, since GitHub's membership order is arbitrary", () => {
     plansResult = {
       byLogin: { zeta: "team", alpha: "team", mid: "team" },

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router"
-import { ExternalLink } from "lucide-react"
+import { ExternalLink, RefreshCw } from "lucide-react"
 import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -63,7 +63,6 @@ function NewOrgModal({
 
         <div className="mt-6">
           <MissingOrgNotice
-            refreshing={refreshing}
             onRefresh={onRefresh}
             // Nothing to set up means a missing grant is the likeliest answer,
             // so don't make the teacher find the disclosure first.
@@ -71,80 +70,96 @@ function NewOrgModal({
           />
         </div>
 
+        <div className="mt-6 flex items-center justify-between gap-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+            {needsSetupOrgs.length > 0
+              ? t("orgs.newOrg.pickPrompt", { count: needsSetupOrgs.length })
+              : null}
+          </p>
+          <Button
+            variant="outline"
+            size="xs"
+            loading={refreshing}
+            onClick={onRefresh}
+          >
+            {!refreshing && (
+              <RefreshCw aria-hidden="true" className="size-3.5" />
+            )}
+            {refreshing
+              ? t("orgs.newOrg.refreshing")
+              : t("orgs.newOrg.refresh")}
+          </Button>
+        </div>
+
         {needsSetupOrgs.length === 0 ? (
-          <p className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+          <p className="mt-2 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
             {t("orgs.newOrg.allSetUp")}
           </p>
         ) : (
-          <>
-            <p className="mt-6 text-xs font-semibold uppercase tracking-wide text-base-content/60">
-              {t("orgs.newOrg.pickPrompt", { count: needsSetupOrgs.length })}
-            </p>
-            <ul
-              ref={listRef}
-              className="scroll-fade-y mt-2 flex max-h-80 flex-col gap-2"
-            >
-              {needsSetupOrgs.map((summary) => {
-                const { org } = summary
-                const planName = plans[org.login]
-                const planLoading = pendingPlans.has(org.login)
-                const isFree = classifyPlan(planName) === "free"
-                return (
-                  <li key={org.id}>
-                    <button
-                      type="button"
-                      disabled={planLoading}
-                      onClick={() =>
-                        isFree
-                          ? setFreePlanOrg(org.login)
-                          : handleSelect(org.login)
-                      }
-                      className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200 disabled:cursor-wait disabled:opacity-60 disabled:hover:bg-transparent"
-                    >
-                      <img
-                        src={org.avatar_url}
-                        alt=""
-                        className="size-9 shrink-0 rounded-lg border border-base-300"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate font-semibold">
-                          {org.login}
-                        </span>
-                        {org.description && (
-                          <span className="block truncate text-sm text-base-content/60">
-                            {org.description}
-                          </span>
-                        )}
+          <ul
+            ref={listRef}
+            className="scroll-fade-y mt-2 flex max-h-80 flex-col gap-2"
+          >
+            {needsSetupOrgs.map((summary) => {
+              const { org } = summary
+              const planName = plans[org.login]
+              const planLoading = pendingPlans.has(org.login)
+              const isFree = classifyPlan(planName) === "free"
+              return (
+                <li key={org.id}>
+                  <button
+                    type="button"
+                    disabled={planLoading}
+                    onClick={() =>
+                      isFree
+                        ? setFreePlanOrg(org.login)
+                        : handleSelect(org.login)
+                    }
+                    className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200 disabled:cursor-wait disabled:opacity-60 disabled:hover:bg-transparent"
+                  >
+                    <img
+                      src={org.avatar_url}
+                      alt=""
+                      className="size-9 shrink-0 rounded-lg border border-base-300"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-semibold">
+                        {org.login}
                       </span>
-                      {planName && !isFree && (
-                        <PlanBadge
-                          name={planName}
-                          title={t("orgs.card.planTitlePaid")}
-                          className="shrink-0"
-                        />
-                      )}
-                      {planLoading ? (
-                        <Spinner size="sm" className="shrink-0" />
-                      ) : isFree ? (
-                        <>
-                          <Badge tone="warning" size="sm" className="shrink-0">
-                            {t("orgs.newOrg.notSupportedBadge")}
-                          </Badge>
-                          <span className="btn btn-outline btn-xs shrink-0">
-                            {t("orgs.newOrg.details")}
-                          </span>
-                        </>
-                      ) : (
-                        <span className="btn btn-primary btn-xs shrink-0">
-                          {t("orgs.newOrg.setUp")}
+                      {org.description && (
+                        <span className="block truncate text-sm text-base-content/60">
+                          {org.description}
                         </span>
                       )}
-                    </button>
-                  </li>
-                )
-              })}
-            </ul>
-          </>
+                    </span>
+                    {planName && !isFree && (
+                      <PlanBadge
+                        name={planName}
+                        title={t("orgs.card.planTitlePaid")}
+                        className="shrink-0"
+                      />
+                    )}
+                    {planLoading ? (
+                      <Spinner size="sm" className="shrink-0" />
+                    ) : isFree ? (
+                      <>
+                        <Badge tone="warning" size="sm" className="shrink-0">
+                          {t("orgs.newOrg.notSupportedBadge")}
+                        </Badge>
+                        <span className="btn btn-outline btn-xs shrink-0">
+                          {t("orgs.newOrg.details")}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="btn btn-primary btn-xs shrink-0">
+                        {t("orgs.newOrg.setUp")}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
         )}
 
         <div className="modal-action">

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -12,11 +12,9 @@ import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import useScrollFade from "@/hooks/useScrollFade"
 import { classifyPlan } from "@/lib/orgPlan"
 
-// The pickable orgs plus the control that reloads them. Mounted only while the
-// modal is open, so the "which orgs did we start with" snapshot resets on every
-// open: GitHub exposes no grant timestamp, so an org that shows up mid-session
-// (the notice's auto-refresh after a grant) is the closest thing to
-// "just granted" — those sort first and carry a New badge.
+// The pickable orgs plus the control that reloads them. GitHub exposes no grant
+// timestamp, so an org that appears mid-open (the notice's auto-refresh after a
+// grant) is the closest thing to "just granted": it sorts first with a New badge.
 function OrgPicker({
   needsSetupOrgs,
   refreshing,
@@ -45,8 +43,7 @@ function OrgPicker({
   )
 
   // Newly appeared first, then A-Z — GitHub returns memberships in no useful
-  // order, and the home page already sorts by name. Not memoized: this list is
-  // a handful of rows and feeds nothing but the render below.
+  // order, and the home page already sorts by name.
   const sorted = [...needsSetupOrgs].sort(
     (a, b) =>
       Number(newLogins.has(b.org.login)) - Number(newLogins.has(a.org.login)) ||
@@ -55,12 +52,12 @@ function OrgPicker({
 
   return (
     <>
-      <div className="mt-6 flex items-center justify-between gap-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
-          {needsSetupOrgs.length > 0
-            ? t("orgs.newOrg.pickPrompt", { count: needsSetupOrgs.length })
-            : null}
-        </p>
+      <div className="mt-6 flex items-center justify-end gap-3">
+        {needsSetupOrgs.length > 0 && (
+          <p className="me-auto text-xs font-semibold uppercase tracking-wide text-base-content/60">
+            {t("orgs.newOrg.pickPrompt", { count: needsSetupOrgs.length })}
+          </p>
+        )}
         <Button
           variant="outline"
           size="xs"
@@ -68,8 +65,7 @@ function OrgPicker({
           onClick={onRefresh}
         >
           {/* Spin the icon rather than Button's `loading` spinner: at btn-xs
-              daisyUI's loading-xs outsizes this 14px icon. The adjacent label
-              announces the busy state, so the icon stays aria-hidden. */}
+              daisyUI's loading-xs outsizes this 14px icon. */}
           <RefreshCw
             aria-hidden="true"
             className={cx("size-3.5", refreshing && "animate-spin")}

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -62,7 +62,13 @@ function NewOrgModal({
         </div>
 
         <div className="mt-6">
-          <MissingOrgNotice refreshing={refreshing} onRefresh={onRefresh} />
+          <MissingOrgNotice
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            // Nothing to set up means a missing grant is the likeliest answer,
+            // so don't make the teacher find the disclosure first.
+            defaultOpen={needsSetupOrgs.length === 0}
+          />
         </div>
 
         {needsSetupOrgs.length === 0 ? (

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import PlanBadge from "@/components/PlanBadge"
 import MissingOrgNotice from "@/components/MissingOrgNotice"
 import FreePlanInfoModal from "@/components/modals/FreePlanInfoModal"
-import { Badge, Button, Modal, Spinner } from "@/components/ui"
+import { Badge, Button, Modal, Spinner, cx } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import useScrollFade from "@/hooks/useScrollFade"
@@ -79,12 +79,16 @@ function NewOrgModal({
           <Button
             variant="outline"
             size="xs"
-            loading={refreshing}
+            disabled={refreshing}
             onClick={onRefresh}
           >
-            {!refreshing && (
-              <RefreshCw aria-hidden="true" className="size-3.5" />
-            )}
+            {/* Spin the icon rather than Button's `loading` spinner: at btn-xs
+                daisyUI's loading-xs outsizes this 14px icon. The adjacent label
+                announces the busy state, so the icon stays aria-hidden. */}
+            <RefreshCw
+              aria-hidden="true"
+              className={cx("size-3.5", refreshing && "animate-spin")}
+            />
             {refreshing
               ? t("orgs.newOrg.refreshing")
               : t("orgs.newOrg.refresh")}

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -12,6 +12,149 @@ import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import useScrollFade from "@/hooks/useScrollFade"
 import { classifyPlan } from "@/lib/orgPlan"
 
+// The pickable orgs plus the control that reloads them. Mounted only while the
+// modal is open, so the "which orgs did we start with" snapshot resets on every
+// open: GitHub exposes no grant timestamp, so an org that shows up mid-session
+// (the notice's auto-refresh after a grant) is the closest thing to
+// "just granted" — those sort first and carry a New badge.
+function OrgPicker({
+  needsSetupOrgs,
+  refreshing,
+  onRefresh,
+  onSelect,
+  onFreePlan,
+}: {
+  needsSetupOrgs: Classroom50OrgSummary[]
+  refreshing: boolean
+  onRefresh: () => void
+  onSelect: (login: string) => void
+  onFreePlan: (login: string) => void
+}) {
+  const { t } = useTranslation()
+  const listRef = useScrollFade<HTMLUListElement>()
+  const logins = needsSetupOrgs.map((summary) => summary.org.login)
+  const { byLogin: plans, pending: pendingPlans } = useNeedsSetupPlans(logins)
+  const [seenOnOpen] = useState(() => new Set(logins))
+
+  // An empty snapshot has nothing to contrast against (the list hadn't loaded),
+  // so wait for a baseline rather than flagging every org as new.
+  const newLogins = new Set(
+    seenOnOpen.size === 0
+      ? []
+      : logins.filter((login) => !seenOnOpen.has(login)),
+  )
+
+  // Newly appeared first, then A-Z — GitHub returns memberships in no useful
+  // order, and the home page already sorts by name. Not memoized: this list is
+  // a handful of rows and feeds nothing but the render below.
+  const sorted = [...needsSetupOrgs].sort(
+    (a, b) =>
+      Number(newLogins.has(b.org.login)) - Number(newLogins.has(a.org.login)) ||
+      a.org.login.localeCompare(b.org.login),
+  )
+
+  return (
+    <>
+      <div className="mt-6 flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+          {needsSetupOrgs.length > 0
+            ? t("orgs.newOrg.pickPrompt", { count: needsSetupOrgs.length })
+            : null}
+        </p>
+        <Button
+          variant="outline"
+          size="xs"
+          disabled={refreshing}
+          onClick={onRefresh}
+        >
+          {/* Spin the icon rather than Button's `loading` spinner: at btn-xs
+              daisyUI's loading-xs outsizes this 14px icon. The adjacent label
+              announces the busy state, so the icon stays aria-hidden. */}
+          <RefreshCw
+            aria-hidden="true"
+            className={cx("size-3.5", refreshing && "animate-spin")}
+          />
+          {refreshing ? t("orgs.newOrg.refreshing") : t("orgs.newOrg.refresh")}
+        </Button>
+      </div>
+
+      {needsSetupOrgs.length === 0 ? (
+        <p className="mt-2 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+          {t("orgs.newOrg.allSetUp")}
+        </p>
+      ) : (
+        <ul
+          ref={listRef}
+          className="scroll-fade-y mt-2 flex max-h-80 flex-col gap-2"
+        >
+          {sorted.map((summary) => {
+            const { org } = summary
+            const planName = plans[org.login]
+            const planLoading = pendingPlans.has(org.login)
+            const isFree = classifyPlan(planName) === "free"
+            return (
+              <li key={org.id}>
+                <button
+                  type="button"
+                  disabled={planLoading}
+                  onClick={() =>
+                    isFree ? onFreePlan(org.login) : onSelect(org.login)
+                  }
+                  className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200 disabled:cursor-wait disabled:opacity-60 disabled:hover:bg-transparent"
+                >
+                  <img
+                    src={org.avatar_url}
+                    alt=""
+                    className="size-9 shrink-0 rounded-lg border border-base-300"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-semibold">
+                      {org.login}
+                    </span>
+                    {org.description && (
+                      <span className="block truncate text-sm text-base-content/60">
+                        {org.description}
+                      </span>
+                    )}
+                  </span>
+                  {newLogins.has(org.login) && (
+                    <Badge tone="success" size="sm" className="shrink-0">
+                      {t("orgs.newOrg.newBadge")}
+                    </Badge>
+                  )}
+                  {planName && !isFree && (
+                    <PlanBadge
+                      name={planName}
+                      title={t("orgs.card.planTitlePaid")}
+                      className="shrink-0"
+                    />
+                  )}
+                  {planLoading ? (
+                    <Spinner size="sm" className="shrink-0" />
+                  ) : isFree ? (
+                    <>
+                      <Badge tone="warning" size="sm" className="shrink-0">
+                        {t("orgs.newOrg.notSupportedBadge")}
+                      </Badge>
+                      <span className="btn btn-outline btn-xs shrink-0">
+                        {t("orgs.newOrg.details")}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="btn btn-primary btn-xs shrink-0">
+                      {t("orgs.newOrg.setUp")}
+                    </span>
+                  )}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </>
+  )
+}
+
 // Modal that lets a teacher start Classroom 50 setup on an existing GitHub org.
 // GitHub orgs can't be created client-side, so this lists the orgs the user
 // already owns that lack a classroom50 config repo (needs_setup) and routes the
@@ -34,13 +177,7 @@ function NewOrgModal({
   const { t } = useTranslation()
   const navigate = useNavigate()
   const titleId = useId()
-  const listRef = useScrollFade<HTMLUListElement>()
   const [freePlanOrg, setFreePlanOrg] = useState<string | null>(null)
-
-  const logins = needsSetupOrgs.map((summary) => summary.org.login)
-  const { byLogin: plans, pending: pendingPlans } = useNeedsSetupPlans(
-    open ? logins : [],
-  )
 
   const handleSelect = (login: string) => {
     onClose()
@@ -70,100 +207,14 @@ function NewOrgModal({
           />
         </div>
 
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
-            {needsSetupOrgs.length > 0
-              ? t("orgs.newOrg.pickPrompt", { count: needsSetupOrgs.length })
-              : null}
-          </p>
-          <Button
-            variant="outline"
-            size="xs"
-            disabled={refreshing}
-            onClick={onRefresh}
-          >
-            {/* Spin the icon rather than Button's `loading` spinner: at btn-xs
-                daisyUI's loading-xs outsizes this 14px icon. The adjacent label
-                announces the busy state, so the icon stays aria-hidden. */}
-            <RefreshCw
-              aria-hidden="true"
-              className={cx("size-3.5", refreshing && "animate-spin")}
-            />
-            {refreshing
-              ? t("orgs.newOrg.refreshing")
-              : t("orgs.newOrg.refresh")}
-          </Button>
-        </div>
-
-        {needsSetupOrgs.length === 0 ? (
-          <p className="mt-2 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
-            {t("orgs.newOrg.allSetUp")}
-          </p>
-        ) : (
-          <ul
-            ref={listRef}
-            className="scroll-fade-y mt-2 flex max-h-80 flex-col gap-2"
-          >
-            {needsSetupOrgs.map((summary) => {
-              const { org } = summary
-              const planName = plans[org.login]
-              const planLoading = pendingPlans.has(org.login)
-              const isFree = classifyPlan(planName) === "free"
-              return (
-                <li key={org.id}>
-                  <button
-                    type="button"
-                    disabled={planLoading}
-                    onClick={() =>
-                      isFree
-                        ? setFreePlanOrg(org.login)
-                        : handleSelect(org.login)
-                    }
-                    className="flex w-full items-center gap-3 rounded-xl border border-base-300 p-3 text-start transition-colors hover:bg-base-200 disabled:cursor-wait disabled:opacity-60 disabled:hover:bg-transparent"
-                  >
-                    <img
-                      src={org.avatar_url}
-                      alt=""
-                      className="size-9 shrink-0 rounded-lg border border-base-300"
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-semibold">
-                        {org.login}
-                      </span>
-                      {org.description && (
-                        <span className="block truncate text-sm text-base-content/60">
-                          {org.description}
-                        </span>
-                      )}
-                    </span>
-                    {planName && !isFree && (
-                      <PlanBadge
-                        name={planName}
-                        title={t("orgs.card.planTitlePaid")}
-                        className="shrink-0"
-                      />
-                    )}
-                    {planLoading ? (
-                      <Spinner size="sm" className="shrink-0" />
-                    ) : isFree ? (
-                      <>
-                        <Badge tone="warning" size="sm" className="shrink-0">
-                          {t("orgs.newOrg.notSupportedBadge")}
-                        </Badge>
-                        <span className="btn btn-outline btn-xs shrink-0">
-                          {t("orgs.newOrg.details")}
-                        </span>
-                      </>
-                    ) : (
-                      <span className="btn btn-primary btn-xs shrink-0">
-                        {t("orgs.newOrg.setUp")}
-                      </span>
-                    )}
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
+        {open && (
+          <OrgPicker
+            needsSetupOrgs={needsSetupOrgs}
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            onSelect={handleSelect}
+            onFreePlan={setFreePlanOrg}
+          />
         )}
 
         <div className="modal-action">

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -194,23 +194,25 @@ function NewOrgModal({
           </div>
         </div>
 
-        <div className="mt-6">
-          <MissingOrgNotice
-            onRefresh={onRefresh}
-            // Nothing to set up means a missing grant is the likeliest answer,
-            // so don't make the teacher find the disclosure first.
-            defaultOpen={needsSetupOrgs.length === 0}
-          />
-        </div>
-
         {open && (
-          <OrgPicker
-            needsSetupOrgs={needsSetupOrgs}
-            refreshing={refreshing}
-            onRefresh={onRefresh}
-            onSelect={handleSelect}
-            onFreePlan={setFreePlanOrg}
-          />
+          <>
+            <div className="mt-6">
+              <MissingOrgNotice
+                onRefresh={onRefresh}
+                // Nothing to set up means a missing grant is the likeliest
+                // answer, so don't make the teacher find the disclosure first.
+                defaultOpen={needsSetupOrgs.length === 0}
+              />
+            </div>
+
+            <OrgPicker
+              needsSetupOrgs={needsSetupOrgs}
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              onSelect={handleSelect}
+              onFreePlan={setFreePlanOrg}
+            />
+          </>
         )}
 
         <div className="modal-action">

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -8,6 +8,7 @@ export {
   githubKeys,
   invalidateInviteQueries,
   invalidateClassroomTeam,
+  invalidateViewerOrgs,
 } from "./queries/keys"
 export {
   sleep,

--- a/web/src/github-core/queries/keys.test.ts
+++ b/web/src/github-core/queries/keys.test.ts
@@ -9,7 +9,7 @@ const invalidated = (client: QueryClient, key: readonly unknown[]) =>
   client.getQueryState(key)?.isInvalidated ?? false
 
 describe("invalidateViewerOrgs", () => {
-  it("drops every cache the org list derives", () => {
+  it("drops every cache the org list derives, and nothing else", () => {
     const client = new QueryClient()
     const seeded: Record<string, readonly unknown[]> = {
       memberships: ["orgs", "memberships"],
@@ -19,9 +19,12 @@ describe("invalidateViewerOrgs", () => {
       // "Updated …" line / last-modified sort.
       configRepo: githubKeys.repo("acme", CONFIG_REPO),
     }
-    // Repos other than classroom50 are the reason the config-repo sweep is
-    // predicate-scoped rather than a plain [.., "repo"] prefix.
+    // The per-org member lists also live under the ["orgs"] prefix, and
+    // orgMembersAll pages to exhaustion — a home-page refresh must not bill it.
     const untouched: Record<string, readonly unknown[]> = {
+      orgMembers: githubKeys.orgMembers("acme"),
+      orgMembersAll: githubKeys.orgMembersAll("acme"),
+      orgAdmins: githubKeys.orgAdmins("acme"),
       otherRepo: githubKeys.repo("acme", "some-assignment"),
       viewer: githubKeys.viewer(),
     }

--- a/web/src/github-core/queries/keys.test.ts
+++ b/web/src/github-core/queries/keys.test.ts
@@ -9,7 +9,7 @@ const invalidated = (client: QueryClient, key: readonly unknown[]) =>
   client.getQueryState(key)?.isInvalidated ?? false
 
 describe("invalidateViewerOrgs", () => {
-  it("drops every cache the org list derives, and nothing else", () => {
+  it("drops every cache the org list derives", () => {
     const client = new QueryClient()
     const seeded: Record<string, readonly unknown[]> = {
       memberships: ["orgs", "memberships"],
@@ -19,6 +19,8 @@ describe("invalidateViewerOrgs", () => {
       // "Updated …" line / last-modified sort.
       configRepo: githubKeys.repo("acme", CONFIG_REPO),
     }
+    // Repos other than classroom50 are the reason the config-repo sweep is
+    // predicate-scoped rather than a plain [.., "repo"] prefix.
     const untouched: Record<string, readonly unknown[]> = {
       otherRepo: githubKeys.repo("acme", "some-assignment"),
       viewer: githubKeys.viewer(),

--- a/web/src/github-core/queries/keys.test.ts
+++ b/web/src/github-core/queries/keys.test.ts
@@ -1,0 +1,39 @@
+import { QueryClient } from "@tanstack/react-query"
+import { describe, expect, it } from "vitest"
+
+import { CONFIG_REPO } from "@/util/configRepo"
+
+import { githubKeys, invalidateViewerOrgs } from "./keys"
+
+const invalidated = (client: QueryClient, key: readonly unknown[]) =>
+  client.getQueryState(key)?.isInvalidated ?? false
+
+describe("invalidateViewerOrgs", () => {
+  it("drops every cache the org list derives, and nothing else", () => {
+    const client = new QueryClient()
+    const seeded: Record<string, readonly unknown[]> = {
+      memberships: ["orgs", "memberships"],
+      summaries: ["orgs", "active-summaries"],
+      // Plan name: its own cache, so a Free -> Team upgrade needs this too.
+      details: githubKeys.orgDetails("acme"),
+      // "Updated …" line / last-modified sort.
+      configRepo: githubKeys.repo("acme", CONFIG_REPO),
+    }
+    const untouched: Record<string, readonly unknown[]> = {
+      otherRepo: githubKeys.repo("acme", "some-assignment"),
+      viewer: githubKeys.viewer(),
+    }
+    Object.values({ ...seeded, ...untouched }).forEach((key) =>
+      client.setQueryData(key, { ok: true }),
+    )
+
+    invalidateViewerOrgs(client)
+
+    Object.entries(seeded).forEach(([name, key]) =>
+      expect(invalidated(client, key), name).toBe(true),
+    )
+    Object.entries(untouched).forEach(([name, key]) =>
+      expect(invalidated(client, key), name).toBe(false),
+    )
+  })
+})

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -171,9 +171,12 @@ export const githubKeys = {
 // Refresh everything the viewer's org list derives from. The membership +
 // summary caches alone leave the per-org plan name and config-repo read on
 // their own 10-minute clocks, so a Free -> Team upgrade kept showing "Not
-// supported" after a refresh (#330).
+// supported" after a refresh (#330). The two org-list caches are named rather
+// than swept by the ["orgs"] prefix, which also matches the per-org member
+// lists (orgMembers/orgMembersAll/orgAdmins) the list doesn't derive from.
 export function invalidateViewerOrgs(queryClient: QueryClient) {
-  queryClient.invalidateQueries({ queryKey: ["orgs"] })
+  queryClient.invalidateQueries({ queryKey: ["orgs", "memberships"] })
+  queryClient.invalidateQueries({ queryKey: ["orgs", "active-summaries"] })
   queryClient.invalidateQueries({ queryKey: [...githubKeys.all, "orgs"] })
   queryClient.invalidateQueries({
     queryKey: [...githubKeys.all, "repo"],

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -1,5 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query"
 
+import { CONFIG_REPO } from "@/util/configRepo"
+
 // The cache-key factory for every github-core read. This is the leaf of the
 // queries module: every *Query sub-module imports these keys, and this file
 // imports nothing from them, so the split stays cycle-free (import-x/no-cycle).
@@ -164,6 +166,19 @@ export const githubKeys = {
   // The org's Actions spending budget classification (hard-stop cap set?).
   orgActionsBudget: (owner: string) =>
     [...githubKeys.all, "orgActionsBudget", owner] as const,
+}
+
+// Refresh everything the viewer's org list derives from. The membership +
+// summary caches alone leave the per-org plan name and config-repo read on
+// their own 10-minute clocks, so a Free -> Team upgrade kept showing "Not
+// supported" after a refresh (#330).
+export function invalidateViewerOrgs(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: ["orgs"] })
+  queryClient.invalidateQueries({ queryKey: [...githubKeys.all, "orgs"] })
+  queryClient.invalidateQueries({
+    queryKey: [...githubKeys.all, "repo"],
+    predicate: (query) => query.queryKey[3] === CONFIG_REPO,
+  })
 }
 
 // Refresh a single classroom team's members + pending invitations after a

--- a/web/src/hooks/useGetOrgs.test.tsx
+++ b/web/src/hooks/useGetOrgs.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+// Regression for "granted an org, came back, refresh fired, org still missing".
+//
+// The summaries query derives from the memberships query but keyed neither on it
+// nor its result, so one ["orgs"] invalidation refetched both in parallel and
+// the summaries queryFn ran against the PREVIOUS membership list — dropping the
+// org that was just granted until a second refresh.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+import { GitHubAPIError } from "@/github-core/errors"
+
+let activeLogins: string[] = []
+
+const membership = (login: string) => ({
+  state: "active",
+  role: "admin",
+  organization: {
+    login,
+    id: login.length,
+    avatar_url: "",
+    html_url: "",
+    description: "",
+  },
+})
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({
+    request: (path: string) => {
+      if (path.startsWith("/user/memberships/orgs")) {
+        return Promise.resolve(activeLogins.map(membership))
+      }
+      // No config repo yet -> needs_setup for an active admin, and no Pages
+      // probe (that path is non-admin only), so nothing leaves the mock.
+      return Promise.reject(
+        new GitHubAPIError({
+          status: 404,
+          url: `https://api.github.com${path}`,
+          message: "HTTP 404",
+          body: null,
+          rateLimit: {} as never,
+        }),
+      )
+    },
+  }),
+}))
+
+import useGetOrgs from "./useGetOrgs"
+
+const renderOrgs = (client: QueryClient) =>
+  renderHook(() => useGetOrgs(), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  })
+
+const logins = (data: ReturnType<typeof useGetOrgs>["data"]) =>
+  (data ?? []).map((summary) => summary.org.login)
+
+beforeEach(() => {
+  activeLogins = ["alpha"]
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useGetOrgs", () => {
+  it("surfaces a newly granted org on the first invalidation", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const { result } = renderOrgs(client)
+
+    await waitFor(() => expect(logins(result.current.data)).toEqual(["alpha"]))
+
+    // The grant happened on GitHub; the return trip invalidates once.
+    activeLogins = ["alpha", "zeta"]
+    await client.invalidateQueries({ queryKey: ["orgs"] })
+
+    await waitFor(() =>
+      expect(logins(result.current.data)).toEqual(["alpha", "zeta"]),
+    )
+  })
+
+  it("keeps showing the current list while a refresh is in flight", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const seen: (string | undefined)[] = []
+    const { result } = renderHook(
+      () => {
+        const orgs = useGetOrgs()
+        seen.push(
+          orgs.data === undefined ? undefined : logins(orgs.data).join(),
+        )
+        return orgs
+      },
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      },
+    )
+
+    await waitFor(() => expect(logins(result.current.data)).toEqual(["alpha"]))
+    seen.length = 0
+
+    activeLogins = ["alpha", "zeta"]
+    await client.invalidateQueries({ queryKey: ["orgs"] })
+    await waitFor(() =>
+      expect(logins(result.current.data)).toEqual(["alpha", "zeta"]),
+    )
+
+    // The membership change gives the summaries query a new key, so without
+    // kept-previous data `data` blanks for a render and the page flashes its
+    // full-screen spinner mid-refresh.
+    expect(seen).not.toContain(undefined)
+    expect(seen).not.toContain("")
+  })
+})

--- a/web/src/hooks/useGetOrgs.test.tsx
+++ b/web/src/hooks/useGetOrgs.test.tsx
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { GitHubAPIError } from "@/github-core/errors"
 
 let activeLogins: string[] = []
+const requests: string[] = []
 
 const membership = (login: string) => ({
   state: "active",
@@ -24,6 +25,7 @@ const membership = (login: string) => ({
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({
     request: (path: string) => {
+      requests.push(path)
       if (path.startsWith("/user/memberships/orgs")) {
         return Promise.resolve(activeLogins.map(membership))
       }
@@ -56,6 +58,7 @@ const logins = (data: ReturnType<typeof useGetOrgs>["data"]) =>
 
 beforeEach(() => {
   activeLogins = ["alpha"]
+  requests.length = 0
 })
 
 afterEach(() => {
@@ -109,10 +112,34 @@ describe("useGetOrgs", () => {
       expect(logins(result.current.data)).toEqual(["alpha", "zeta"]),
     )
 
-    // The membership change gives the summaries query a new key, so without
-    // kept-previous data `data` blanks for a render and the page flashes its
-    // full-screen spinner mid-refresh.
+    // A refresh must not blank `data`, or the page flashes its full-screen
+    // spinner mid-refresh.
     expect(seen).not.toContain(undefined)
     expect(seen).not.toContain("")
+  })
+
+  it("probes each org's config repo once per refresh", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const { result } = renderOrgs(client)
+    await waitFor(() => expect(logins(result.current.data)).toEqual(["alpha"]))
+
+    requests.length = 0
+    activeLogins = ["alpha", "zeta"]
+    await client.invalidateQueries({ queryKey: ["orgs"] })
+    await waitFor(() =>
+      expect(logins(result.current.data)).toEqual(["alpha", "zeta"]),
+    )
+
+    // Keying the summaries query on the membership list made the ["orgs"]
+    // prefix refetch the OLD key first, against the pre-refresh list — running
+    // the whole per-org fan-out twice and discarding the first pass.
+    expect(
+      requests.filter((path) => path.startsWith("/repos/alpha/")),
+    ).toHaveLength(1)
+    expect(
+      requests.filter((path) => path.startsWith("/user/memberships/orgs")),
+    ).toHaveLength(1)
   })
 })

--- a/web/src/hooks/useGetOrgs.test.tsx
+++ b/web/src/hooks/useGetOrgs.test.tsx
@@ -1,10 +1,6 @@
 // @vitest-environment happy-dom
-// Regression for "granted an org, came back, refresh fired, org still missing".
-//
-// The summaries query derives from the memberships query but keyed neither on it
-// nor its result, so one ["orgs"] invalidation refetched both in parallel and
-// the summaries queryFn ran against the PREVIOUS membership list — dropping the
-// org that was just granted until a second refresh.
+// Regression: the summaries query wasn't keyed on the membership list it derives
+// from, so a just-granted org stayed hidden until a second refresh.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"

--- a/web/src/hooks/useGetOrgs.ts
+++ b/web/src/hooks/useGetOrgs.ts
@@ -1,5 +1,9 @@
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import {
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query"
 import type { GitHubClient } from "@/github-core/client"
 import type { GitHubOrgMembership } from "@/github-core/types"
 import {
@@ -12,47 +16,46 @@ import {
 // duplicate calls.
 export const orgMembershipsQueryKey = ["orgs", "memberships"]
 
+const orgMembershipsQuery = (client: GitHubClient) => ({
+  queryKey: orgMembershipsQueryKey,
+  queryFn: () => listAuthedOrgMemberships(client),
+  staleTime: 10 * 60 * 1000,
+})
+
 const useOrgMemberships = (client: GitHubClient) =>
-  useQuery({
-    queryKey: orgMembershipsQueryKey,
-    queryFn: () => listAuthedOrgMemberships(client),
-    staleTime: 10 * 60 * 1000,
-  })
+  useQuery(orgMembershipsQuery(client))
+
+const fetchActiveSummaries = async (
+  queryClient: QueryClient,
+  client: GitHubClient,
+) => {
+  const list = await queryClient.fetchQuery(orgMembershipsQuery(client))
+  return Promise.all(
+    list
+      .filter((membership) => membership.state === "active")
+      .map((membership) => getClassroom50OrgSummary(client, membership)),
+  )
+}
 
 const useGetOrgs = () => {
   const client = useGitHubClient()
+  const queryClient = useQueryClient()
   const memberships = useOrgMemberships(client)
 
-  const active = (memberships.data ?? []).filter(
-    (membership) => membership.state === "active",
-  )
-
   const summaries = useQuery({
-    // Keyed on the membership list it derives from: an unkeyed queryFn would run
-    // against the stale list, dropping a just-granted org until a second refresh.
-    queryKey: [
-      "orgs",
-      "active-summaries",
-      active.map((m) => m.organization.login).join(","),
-    ],
-    enabled: memberships.data !== undefined,
-    queryFn: () =>
-      Promise.all(
-        active.map((membership) =>
-          getClassroom50OrgSummary(client, membership),
-        ),
-      ),
-    // The key changes with the membership list; without kept-previous data
-    // `data` blanks for a render and flashes the page's full-screen spinner.
-    placeholderData: keepPreviousData,
+    queryKey: ["orgs", "active-summaries"],
+    // Pull the membership list through the cache instead of deriving it from a
+    // render: keying on the list meant one invalidation refetched the old key
+    // against the pre-refresh list, running the whole fan-out twice and
+    // dropping a just-granted org until a second refresh.
+    queryFn: () => fetchActiveSummaries(queryClient, client),
     staleTime: 10 * 60 * 1000,
   })
 
   return {
     ...summaries,
-    // The summaries query is disabled until memberships resolve; a disabled
-    // query reports isLoading=false, so fold in the memberships fetch to keep
-    // the page's spinner covering the whole chain (no empty-state flash).
+    // The summaries fetch subsumes the memberships one, so fold the latter's
+    // states in to keep the page's spinner covering the whole chain.
     isLoading: memberships.isLoading || summaries.isLoading,
     isFetching: memberships.isFetching || summaries.isFetching,
   }

--- a/web/src/hooks/useGetOrgs.ts
+++ b/web/src/hooks/useGetOrgs.ts
@@ -28,10 +28,8 @@ const useGetOrgs = () => {
   )
 
   const summaries = useQuery({
-    // Keyed on the membership list it derives from, not just ["orgs"]: one
-    // invalidation refetches both, and an unkeyed summaries queryFn would run
-    // against the stale list — dropping a just-granted org until a second
-    // refresh.
+    // Keyed on the membership list it derives from: an unkeyed queryFn would run
+    // against the stale list, dropping a just-granted org until a second refresh.
     queryKey: [
       "orgs",
       "active-summaries",
@@ -44,8 +42,8 @@ const useGetOrgs = () => {
           getClassroom50OrgSummary(client, membership),
         ),
       ),
-    // The key changes whenever the membership list does, which would otherwise
-    // blank `data` for a render and flash the page's full-screen spinner.
+    // The key changes with the membership list; without kept-previous data
+    // `data` blanks for a render and flashes the page's full-screen spinner.
     placeholderData: (previous) => previous,
     staleTime: 10 * 60 * 1000,
   })

--- a/web/src/hooks/useGetOrgs.ts
+++ b/web/src/hooks/useGetOrgs.ts
@@ -1,5 +1,5 @@
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import type { GitHubClient } from "@/github-core/client"
 import type { GitHubOrgMembership } from "@/github-core/types"
 import {
@@ -44,7 +44,7 @@ const useGetOrgs = () => {
       ),
     // The key changes with the membership list; without kept-previous data
     // `data` blanks for a render and flashes the page's full-screen spinner.
-    placeholderData: (previous) => previous,
+    placeholderData: keepPreviousData,
     staleTime: 10 * 60 * 1000,
   })
 

--- a/web/src/hooks/useGetOrgs.ts
+++ b/web/src/hooks/useGetOrgs.ts
@@ -23,19 +23,30 @@ const useGetOrgs = () => {
   const client = useGitHubClient()
   const memberships = useOrgMemberships(client)
 
+  const active = (memberships.data ?? []).filter(
+    (membership) => membership.state === "active",
+  )
+
   const summaries = useQuery({
-    queryKey: ["orgs", "active-summaries"],
+    // Keyed on the membership list it derives from, not just ["orgs"]: one
+    // invalidation refetches both, and an unkeyed summaries queryFn would run
+    // against the stale list — dropping a just-granted org until a second
+    // refresh.
+    queryKey: [
+      "orgs",
+      "active-summaries",
+      active.map((m) => m.organization.login).join(","),
+    ],
     enabled: memberships.data !== undefined,
-    queryFn: () => {
-      const active = (memberships.data ?? []).filter(
-        (membership) => membership.state === "active",
-      )
-      return Promise.all(
+    queryFn: () =>
+      Promise.all(
         active.map((membership) =>
           getClassroom50OrgSummary(client, membership),
         ),
-      )
-    },
+      ),
+    // The key changes whenever the membership list does, which would otherwise
+    // blank `data` for a render and flash the page's full-screen spinner.
+    placeholderData: (previous) => previous,
     staleTime: 10 * 60 * 1000,
   })
 

--- a/web/src/hooks/useRefreshOnReturn.ts
+++ b/web/src/hooks/useRefreshOnReturn.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from "react"
 // Refreshes once when the tab regains focus, but only after arm() — GitHub's
 // grant page opens in a new tab, so coming back here is the only signal the
 // grant may have changed. Without it the org query's long staleTime keeps a
-// freshly granted org hidden until the teacher finds "Refresh list".
+// freshly granted org hidden until the teacher hits Refresh.
 export function useRefreshOnReturn(onRefresh: () => void) {
   const armed = useRef(false)
   const latest = useRef(onRefresh)

--- a/web/src/hooks/useRefreshOnReturn.ts
+++ b/web/src/hooks/useRefreshOnReturn.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useEffectEvent, useRef } from "react"
 
 // Refreshes once when the tab regains focus, but only after arm() — GitHub's
 // grant page opens in a new tab, so coming back here is the only signal the
@@ -6,18 +6,14 @@ import { useCallback, useEffect, useRef } from "react"
 // freshly granted org hidden until the teacher hits Refresh.
 export function useRefreshOnReturn(onRefresh: () => void) {
   const armed = useRef(false)
-  const latest = useRef(onRefresh)
+
+  const handleVisibility = useEffectEvent(() => {
+    if (!armed.current || document.visibilityState !== "visible") return
+    armed.current = false
+    onRefresh()
+  })
 
   useEffect(() => {
-    latest.current = onRefresh
-  }, [onRefresh])
-
-  useEffect(() => {
-    const handleVisibility = () => {
-      if (!armed.current || document.visibilityState !== "visible") return
-      armed.current = false
-      latest.current()
-    }
     document.addEventListener("visibilitychange", handleVisibility)
     return () =>
       document.removeEventListener("visibilitychange", handleVisibility)

--- a/web/src/hooks/useRefreshOnReturn.ts
+++ b/web/src/hooks/useRefreshOnReturn.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef } from "react"
+
+// Refreshes once when the tab regains focus, but only after arm() — GitHub's
+// grant page opens in a new tab, so coming back here is the only signal the
+// grant may have changed. Without it the org query's long staleTime keeps a
+// freshly granted org hidden until the teacher finds "Refresh list".
+export function useRefreshOnReturn(onRefresh: () => void) {
+  const armed = useRef(false)
+  const latest = useRef(onRefresh)
+
+  useEffect(() => {
+    latest.current = onRefresh
+  }, [onRefresh])
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (!armed.current || document.visibilityState !== "visible") return
+      armed.current = false
+      latest.current()
+    }
+    document.addEventListener("visibilitychange", handleVisibility)
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibility)
+  }, [])
+
+  return useCallback(() => {
+    armed.current = true
+  }, [])
+}
+
+export default useRefreshOnReturn

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -602,14 +602,13 @@
     },
     "missingNotice": {
       "title": "Not seeing your organization?",
-      "body": "GitHub only reports organizations you've granted Classroom 50 access to — an organization you belong to stays hidden here until that grant exists, even with a GitHub Education account.",
+      "body": "GitHub only lists organizations you've granted Classroom 50 access to — a GitHub Education account isn't enough on its own.",
       "steps": {
-        "grant": "Open your GitHub OAuth settings below and select Grant next to the organization.",
-        "approve": "If the organization restricts third-party apps, an organization owner has to approve the request instead — the same page shows Request access.",
-        "refresh": "Come back to this tab and refresh; the organization should appear."
+        "grant": "In your GitHub OAuth settings, select Grant next to the organization.",
+        "grantHelp": "If the organization restricts third-party apps you'll see Request access instead, and an organization owner has to approve it. With SAML single sign-on, use Configure SSO on that same page.",
+        "refresh": "Come back here and refresh the list."
       },
-      "ssoHint": "Using SAML single sign-on? On that same page, use Configure SSO to authorize the organization.",
-      "pendingHint": "Waiting on an invitation? Unaccepted invitations show up under pending invitations, not in this list.",
+      "reauthorizeHelp": "No organizations listed at all? Re-authorize — a token issued before you joined can't see them. An invitation you haven't accepted shows under pending invitations instead.",
       "manageOauth": "Manage GitHub OAuth access",
       "refreshing": "Refreshing…",
       "refresh": "Refresh list"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -602,7 +602,14 @@
     },
     "missingNotice": {
       "title": "Not seeing your organization?",
-      "body": "Classroom 50 can only show GitHub organizations that you have explicitly granted access to during sign-in. If an organization is missing, you may need to update your OAuth permissions.",
+      "body": "GitHub only reports organizations you've granted Classroom 50 access to — an organization you belong to stays hidden here until that grant exists, even with a GitHub Education account.",
+      "steps": {
+        "grant": "Open your GitHub OAuth settings below and select Grant next to the organization.",
+        "approve": "If the organization restricts third-party apps, an organization owner has to approve the request instead — the same page shows Request access.",
+        "refresh": "Come back to this tab and refresh; the organization should appear."
+      },
+      "ssoHint": "Using SAML single sign-on? On that same page, use Configure SSO to authorize the organization.",
+      "pendingHint": "Waiting on an invitation? Unaccepted invitations show up under pending invitations, not in this list.",
       "manageOauth": "Manage GitHub OAuth access",
       "refreshing": "Refreshing…",
       "refresh": "Refresh list"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -588,6 +588,8 @@
       "pickPrompt_other": "Organizations ready to set up ({{count}})",
       "createOnGitHub": "Create an organization on GitHub",
       "allSetUp": "All organizations we can see are already set up.",
+      "refresh": "Refresh",
+      "refreshing": "Refreshing…",
       "setUp": "Set up",
       "notSupportedBadge": "Not supported",
       "details": "Details",
@@ -609,9 +611,7 @@
         "refresh": "Come back here and refresh the list."
       },
       "reauthorizeHelp": "No organizations listed at all? Re-authorize — a token issued before you joined can't see them. An invitation you haven't accepted shows under pending invitations instead.",
-      "manageOauth": "Manage GitHub OAuth access",
-      "refreshing": "Refreshing…",
-      "refresh": "Refresh list"
+      "manageOauth": "Manage GitHub OAuth access"
     },
     "card": {
       "noAccessBadge": "No <code>classroom50</code> access",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -592,6 +592,7 @@
       "refreshing": "Refreshing…",
       "setUp": "Set up",
       "notSupportedBadge": "Not supported",
+      "newBadge": "New",
       "details": "Details",
       "freePlanInfo": {
         "title": "This organization is on the Free plan",

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -6,6 +6,7 @@ import { useAcceptOrgInvite } from "@/hooks/mutations/useAcceptOrgInvite"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useHiddenOrgs } from "@/context/hiddenOrgs/HiddenOrgsProvider"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
+import { invalidateViewerOrgs } from "@/github-core/queries"
 import type { GitHubOrgMembership } from "@/github-core/types"
 import useGetOrgs, { usePendingOrgInvites } from "@/hooks/useGetOrgs"
 import useOrgDisplayName from "@/hooks/useOrgDisplayName"
@@ -495,8 +496,7 @@ const OrgsPage = () => {
     }
   }, [filtered, sortKey, lastModified])
 
-  const handleRefresh = () =>
-    queryClient.invalidateQueries({ queryKey: ["orgs"] })
+  const handleRefresh = () => invalidateViewerOrgs(queryClient)
 
   const hasAnyOrgs = cl50Orgs.length > 0
   const hasInvites = pendingInvites.length > 0

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -31,7 +31,6 @@ import { GitHubLink } from "@/components/GitHubLink"
 import { Badge, Button, Card, Toolbar } from "@/components/ui"
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
-import MissingOrgNotice from "@/components/MissingOrgNotice"
 import Spinner from "@/components/Spinner"
 import { EnterDiv, PresenceCardDiv } from "@/lib/motionComponents"
 import { orgListPrefs, type OrgSortKey } from "@/lib/orgListPrefs"
@@ -630,17 +629,6 @@ const OrgsPage = () => {
                     {t("orgs.setUpFirst.cta")}
                   </Button>
                 }
-              />
-            )}
-
-            {/* Not only in the setup modal: a teacher whose org GitHub never
-                reported has no reason to open that modal (#403). A search that
-                matched nothing isn't a missing grant. */}
-            {!noSearchResults && (
-              <MissingOrgNotice
-                refreshing={isFetching}
-                onRefresh={handleRefresh}
-                defaultOpen={!hasAnyOrgs}
               />
             )}
           </>

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -31,6 +31,7 @@ import { GitHubLink } from "@/components/GitHubLink"
 import { Badge, Button, Card, Toolbar } from "@/components/ui"
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
+import MissingOrgNotice from "@/components/MissingOrgNotice"
 import Spinner from "@/components/Spinner"
 import { EnterDiv, PresenceCardDiv } from "@/lib/motionComponents"
 import { orgListPrefs, type OrgSortKey } from "@/lib/orgListPrefs"
@@ -629,6 +630,17 @@ const OrgsPage = () => {
                     {t("orgs.setUpFirst.cta")}
                   </Button>
                 }
+              />
+            )}
+
+            {/* Not only in the setup modal: a teacher whose org GitHub never
+                reported has no reason to open that modal (#403). A search that
+                matched nothing isn't a missing grant. */}
+            {!noSearchResults && (
+              <MissingOrgNotice
+                refreshing={isFetching}
+                onRefresh={handleRefresh}
+                defaultOpen={!hasAnyOrgs}
               />
             )}
           </>

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -19,6 +19,43 @@ GH_DEBUG=api gh teacher invite <org> <username>
 
 Commands with informational output also accept `--quiet` / `-q`.
 
+## My organization doesn't appear
+
+GitHub only reports organizations you've granted Classroom 50 access to. A
+GitHub Education account doesn't change this — an organization you own can stay
+invisible until that grant exists. Work through these in order:
+
+1. **Grant the organization.** Open
+   [Classroom 50's OAuth settings](https://github.com/settings/connections/applications/Ov23liDFFyDtm0pO5NN5)
+   and select **Grant** next to the organization. Classroom 50 also links this
+   from the "Not seeing your organization?" notice on its home page.
+2. **Have an owner approve it.** If the organization restricts third-party
+   applications, the same page offers **Request access** instead of **Grant**;
+   an owner then approves it under
+   `https://github.com/organizations/<org>/settings/oauth_application_policy`.
+3. **Authorize SAML SSO.** On that same page, use **Configure SSO** to authorize
+   the organization.
+4. **Accept the invitation.** An unaccepted invitation shows under pending
+   invitations, not in the organization list. Check
+   [your organizations](https://github.com/settings/organizations).
+5. **Sign out and back in.** A token issued before the membership existed
+   authenticates fine but can't see the organization.
+
+Then return to Classroom 50 and use **Refresh list** — the organization list is
+cached for ten minutes.
+
+To check independently from a terminal:
+
+```sh
+gh auth refresh -s read:org,admin:org
+gh api user/memberships/orgs --paginate \
+  --jq '.[] | [.organization.login, .state, .role] | @tsv'
+```
+
+The organization should be listed `active` (and `admin` if you're setting it
+up). The CLI token and the web app's token are separate, so a passing check here
+still leaves the browser grant to do.
+
 ## "Missing scope" / 403 on `gh teacher invite`
 
 Org invitations need the `admin:org` scope, which a plain `gh auth login`

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -41,7 +41,9 @@ At [classroom50.org](https://classroom50.org), sign in with GitHub using
 
 When authorizing, grant access to any organization you'll use with Classroom 50.
 If you don't own the organization, you may need to request access and have an
-owner approve it in the organization's OAuth settings.
+owner approve it in the organization's OAuth settings. If an organization you
+belong to is missing later, see
+[My organization doesn't appear](Troubleshooting#my-organization-doesnt-appear).
 
 ![Classroom 50 login flow](images/web_login_flow.png)
 
@@ -57,8 +59,9 @@ After signing in, you'll see the organizations you can use. Each shows a status:
 | **Needs service token** | Set up, but a service token is still required before score collection works. |
 | **Uninitialized** | Not set up yet. Appears under "Set up new organization". |
 
-Don't see your organization? Grant it access in Classroom 50's
-[OAuth settings](https://github.com/settings/connections/applications).
+Don't see your organization? GitHub only reports organizations you've granted
+Classroom 50 access to — see
+[My organization doesn't appear](Troubleshooting#my-organization-doesnt-appear).
 
 ## Set up an organization (one-time)
 


### PR DESCRIPTION
## Why

Teachers keep hitting the same wall: they have a valid org membership and GitHub Education credentials, but the org simply isn't there — because GitHub only reports orgs granted to the OAuth app, and the per-org **Grant** button lives on a page nobody can guess.

- #403 — self-resolved only after manually finding `github.com/settings/applications`.
- #352 — resolved only after a maintainer pasted the app-specific URL by hand.

#355 already shipped the right explanation, but it was in the wrong place: only inside the "Set up new organization" modal, collapsed, and linking the generic app list rather than this app's own page.

## What changed

**The grant is now one click.** `githubOAuthGrantUrl()` builds `settings/connections/applications/{clientId}` from the injected `VITE_GITHUB_CLIENT_ID`, falling back to the app list when it's unset so self-hosted and dev builds still work. The production client ID stays out of source.

**Concise, self-service copy.** One line of cause plus two steps. The rarer causes — restricted-org owner approval, SAML SSO, a token predating the membership, an unaccepted invite — sit behind `HelpTooltip`s instead of five paragraphs.

**Refresh belongs to the list.** It moved out of the notice's `<summary>` (where it read as *the fix* for a missing org, and hid behind a toggle teachers never opened) onto the list header, shortened to "Refresh".

**A just-granted org lands on top.** GitHub exposes no grant timestamp, so the picker snapshots logins on open: anything appearing after a mid-session refresh is what you just granted. It sorts first with a **New** badge; the rest go A-Z (the list was previously unsorted, unlike the home page).

**Four real bugs found while testing this flow:**

1. `Refresh` invalidated only the `["orgs"]` prefix, leaving each org's plan name and `classroom50` repo read on their own 10-minute clocks — so a Free -> Team upgrade kept showing "Not supported" (#330). Now single-sourced in `invalidateViewerOrgs`.
2. The summaries query wasn't keyed on the membership list it derives from, so one invalidation refetched both in parallel and summaries ran against the *previous* list — a just-granted org needed **two** refreshes to appear.
3. **One refresh ran the entire per-org fan-out twice.** Fixing (2) by keying the summaries query on the membership signature left that key still matched by the `["orgs"]` prefix, so an invalidation refetched the *old* key against the pre-refresh list and then refetched again once the key changed — the first pass discarded, ~2 wasted requests per already-active org. The membership list now comes through the cache inside the queryFn, so the key is stable and the signature-keying is gone entirely.
4. **`invalidateViewerOrgs` swept caches the org list doesn't derive from.** The `["orgs"]` prefix also matches the per-org member lists, and `orgMembersAll` pages to exhaustion — so a home-page Refresh silently billed a full member-list re-page on the next visit to Members or the roster. The two org-list caches are named explicitly now.

**Notice mounting.** `Modal` renders children regardless of `open`, so the notice mounted on the first `OrgsPage` render — while `needsSetupOrgs` was still empty — and `defaultOpen` latched open for the session, never reflecting the loaded list. It now sits inside the same `{open && …}` guard as the picker.

**Docs.** New "My organization doesn't appear" section in `wiki/Troubleshooting.md` covering all five causes plus a `gh api user/memberships/orgs` check; the two teacher-guide mentions now point there.

## Test plan

- [x] `tsc -b`, `eslint`, `prettier`, `depcruise`, `audit_i18n.py --strict` clean
- [x] 2391 tests pass (219 files); 4 new test files
- [x] Behavior-bearing changes written red-first, and the trickiest guards mutation-checked (revert the fix -> test fails): new-first sort, membership-keyed summaries, and the one-probe-per-refresh request count (fails with `length 1 but got 2` on the old shape)
- [x] Manually walked grant -> return -> auto-refresh against a real org
- [ ] Reviewer: confirm the notice reads well at mobile width (button row wraps)
