### PR TITLE
fix: close the roster.csv formula-guard, padded-id, and i18n gaps

### DIFF
--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -526,8 +526,11 @@ func checkFieldLengths(line int, record []string) error {
 // cell strconv itself rejects, which was fatal before this change too.
 //
 // The usable set mirrors the web app's parseGitHubId (web/src/util/identity.ts):
-// digits only after trimming, positive, and <= 2^53-1, past which the web side
-// can no longer represent an id exactly.
+// positive, and <= 2^53-1, past which the web side can no longer represent an id
+// exactly. A zero-padded cell is the one deliberate difference: the web rejects
+// it (its id-keyed joins compare the raw string, which padding breaks) while Go
+// resolves it and EncodeRoster writes it back canonically — so a rewrite repairs
+// the cell instead of stranding it, and the two readers converge.
 func parseGitHubID(s string) (int64, error) {
 	id, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
 	if err != nil {

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -78,23 +78,28 @@ func TestParseRoster_GitHubIDShapeMatchesWeb(t *testing.T) {
 
 // A signed cell resolves to the same account and is rewritten canonically, so the
 // two readers converge rather than diverge: Go normalizes "+42" to "42", which the
-// web reader then accepts.
-func TestParseRoster_SignedGitHubIDNormalizes(t *testing.T) {
-	in := []byte("username,first_name,last_name,email,section,github_id,role\n" +
-		"alice,A,A,,s,+42,student\n")
-	rows, err := ParseRoster(in)
-	if err != nil {
-		t.Fatalf("ParseRoster: %v", err)
-	}
-	if rows[0].GitHubID != 42 {
-		t.Errorf("GitHubID = %d, want 42", rows[0].GitHubID)
-	}
-	encoded, err := EncodeRoster(rows)
-	if err != nil {
-		t.Fatalf("EncodeRoster: %v", err)
-	}
-	if !strings.Contains(string(encoded), ",42,") {
-		t.Errorf("want a canonical 42 on rewrite, got:\n%s", encoded)
+// web reader then accepts. Same for a zero-padded cell, which the web deliberately
+// rejects (its id joins compare the raw string) and a CLI rewrite repairs.
+func TestParseRoster_NonCanonicalGitHubIDNormalizes(t *testing.T) {
+	for _, tc := range []struct{ cell, want string }{
+		{"+42", ",42,"},
+		{"0000583231", ",583231,"},
+	} {
+		t.Run(tc.cell, func(t *testing.T) {
+			in := []byte("username,first_name,last_name,email,section,github_id,role\n" +
+				"alice,A,A,,s," + tc.cell + ",student\n")
+			rows, err := ParseRoster(in)
+			if err != nil {
+				t.Fatalf("ParseRoster: %v", err)
+			}
+			encoded, err := EncodeRoster(rows)
+			if err != nil {
+				t.Fatalf("EncodeRoster: %v", err)
+			}
+			if !strings.Contains(string(encoded), tc.want) {
+				t.Errorf("want a canonical %s on rewrite, got:\n%s", tc.want, encoded)
+			}
+		})
 	}
 }
 

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -56,8 +56,9 @@ func TestParseRoster_HeaderOnly(t *testing.T) {
 }
 
 func TestParseRoster_GitHubIDShapeMatchesWeb(t *testing.T) {
-	// Both readers trim, then require digits only, so a whitespace-padded cell is
-	// valid on both sides. Pinned because ParseInt alone would reject it.
+	// Both readers trim, so a WHITESPACE-padded cell is valid on both sides.
+	// Pinned because ParseInt alone would reject it. Zero padding is the one
+	// deliberate divergence (see parseGitHubID).
 	in := []byte("username,first_name,last_name,email,section,github_id,role\n" +
 		"alice,A,A,,s, 42 ,student\n" +
 		"bob,B,B,,s,9007199254740991,student\n")
@@ -805,6 +806,40 @@ func TestFullRosterHeader(t *testing.T) {
 	gotHeader, _, _ := strings.Cut(string(encoded), "\n")
 	if gotHeader != want {
 		t.Fatalf("EncodeRoster header = %q, want %q", gotHeader, want)
+	}
+}
+
+// TestEncodeRoster_DefangsEveryColumnButGitHubID is the Go leg of the
+// formula-guard lockstep (the web leg lives in web/src/util/rosterCsv.test.ts).
+// The guarded set and the trigger set are hand-mirrored across the two writers,
+// so a one-sided change must fail here rather than leave both suites green while
+// a guarded cell stops being un-defanged by the other reader.
+func TestEncodeRoster_DefangsEveryColumnButGitHubID(t *testing.T) {
+	row := RosterRow{
+		Username: "=u", FirstName: "=f", LastName: "=l",
+		Email: "=e@x.io", Section: "=s", GitHubID: 583231, Role: "=student",
+	}
+	encoded, err := EncodeRoster([]RosterRow{row})
+	if err != nil {
+		t.Fatalf("EncodeRoster: %v", err)
+	}
+	_, data, _ := strings.Cut(string(encoded), "\n")
+	for _, want := range []string{"'=u", "'=f", "'=l", "'=e@x.io", "'=s", "'=student"} {
+		if !strings.Contains(data, want) {
+			t.Errorf("want defanged %q in:\n%s", want, data)
+		}
+	}
+	if !strings.Contains(data, ",583231,") {
+		t.Errorf("github_id must round-trip byte-exact, got:\n%s", data)
+	}
+
+	for _, trigger := range []byte{'=', '+', '-', '@', '\t', '\r'} {
+		if !isFormulaTrigger(trigger) {
+			t.Errorf("isFormulaTrigger(%q) = false, want true", trigger)
+		}
+	}
+	if isFormulaTrigger('\'') || isFormulaTrigger('a') {
+		t.Error("isFormulaTrigger must not match a non-trigger byte")
 	}
 }
 

--- a/web/src/domain/orgMembers/inviteMemberToOrg.ts
+++ b/web/src/domain/orgMembers/inviteMemberToOrg.ts
@@ -2,7 +2,7 @@ import type { GitHubClient } from "@/github-core/client"
 import { createOrgInvitation } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { getUserById } from "@/github-core/queries"
-import { isMalformedGitHubId, parseGitHubId } from "@/util/students"
+import { isMalformedGitHubId, resolveGitHubId } from "@/util/students"
 import type { OrgMemberRow } from "@/util/orgMembers"
 import { logger } from "@/lib/logger"
 import i18n from "@/i18n"
@@ -23,7 +23,7 @@ export async function inviteMemberToOrg(
   input: { org: string; row: OrgMemberRow },
 ): Promise<InviteToOrgResult> {
   const { org, row } = input
-  const inviteeId = parseGitHubId(row.github_id)
+  const inviteeId = resolveGitHubId(row.github_id)
   if (inviteeId === null) {
     const who = row.username || row.email
     throw new Error(

--- a/web/src/domain/orgMembers/inviteMemberToOrg.ts
+++ b/web/src/domain/orgMembers/inviteMemberToOrg.ts
@@ -5,6 +5,7 @@ import { getUserById } from "@/github-core/queries"
 import { isMalformedGitHubId, parseGitHubId } from "@/util/students"
 import type { OrgMemberRow } from "@/util/orgMembers"
 import { logger } from "@/lib/logger"
+import i18n from "@/i18n"
 
 const log = logger.scope("orgMembers:inviteMemberToOrg")
 
@@ -27,8 +28,11 @@ export async function inviteMemberToOrg(
     const who = row.username || row.email
     throw new Error(
       isMalformedGitHubId(row.github_id)
-        ? `Can't invite ${who}: "${row.github_id.trim()}" isn't a valid GitHub id. Fix the github_id cell in roster.csv.`
-        : `Can't invite ${who}: no GitHub id on file.`,
+        ? i18n.t("orgMembers.inviteMalformedId", {
+            who,
+            githubId: row.github_id.trim(),
+          })
+        : i18n.t("orgMembers.inviteMissingId", { who }),
     )
   }
 

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -2439,6 +2439,28 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
     })
   })
 
+  it("canonicalizes a zero-padded github_id from its own digits, not the login", async () => {
+    // A padded cell already addresses account 127826836, so the repair must come
+    // from the cell — re-deriving it from the login would repoint the row onto
+    // whoever holds that login now (a recycled login after a rename).
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + "student1,,,,,0127826836,student\n",
+      users: {},
+      teamHas: [{ login: "student1", id: 999 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.noop).toBe(false)
+    const repaired = rowsFromCsv(committed.content!).find(
+      (r) => r.username === "student1",
+    )
+    expect(repaired?.github_id).toBe("127826836")
+  })
+
   it("never overwrites an existing github_id (renamed-login safety)", async () => {
     // The CSV row already has an id; a team member sharing the login but a
     // DIFFERENT id must not repoint the row onto the other account.
@@ -3056,6 +3078,42 @@ describe("inviteRosterStudents — fresh invites for not_in_org students", () =>
 
     expect(res.invited).toEqual([{ username: "octocat", role: "student" }])
     expect(invitations).toEqual([{ invitee_id: 1, role: "direct_member" }])
+  })
+
+  it("resolves a zero-padded github_id to its account, never via the login", async () => {
+    // The cell addresses account 1 unambiguously. Falling back to GET
+    // /users/{login} would invite whoever holds that login today, which is what
+    // storing an immutable id is for.
+    const { client, invitations } = makeInviteClient({
+      members: [],
+      users: { octocat: { id: 999 } },
+    })
+
+    const res = await inviteRosterStudents(client, {
+      org: "acme",
+      classroom: "cs101",
+      students: [{ username: "octocat", github_id: "0000001" }],
+    })
+
+    expect(res.invited).toEqual([{ username: "octocat", role: "student" }])
+    expect(invitations).toEqual([{ invitee_id: 1, role: "direct_member" }])
+  })
+
+  it("refuses a malformed github_id instead of falling back to the login", async () => {
+    const { client, invitations } = makeInviteClient({
+      members: [],
+      users: { octocat: { id: 999 } },
+    })
+
+    const res = await inviteRosterStudents(client, {
+      org: "acme",
+      classroom: "cs101",
+      students: [{ username: "octocat", github_id: "1e3" }],
+    })
+
+    expect(res.invited).toEqual([])
+    expect(invitations).toEqual([])
+    expect(res.failed[0]?.message).toMatch(/isn't a valid GitHub id/)
   })
 
   it("resolves the id from the username when github_id is missing", async () => {

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -29,7 +29,7 @@ import {
   type StudentCsvRow,
 } from "@/util/rosterCsv"
 import { rosterPath, legacyRosterPath } from "@/util/rosterPath"
-import { parseGitHubId } from "@/util/students"
+import { resolveGitHubId } from "@/util/students"
 import {
   log,
   rosterWriteTree,
@@ -268,7 +268,7 @@ export async function enrollStudentInClassroom(
   // membership too (else a separate team-add leaves the student team-pending
   // until they accept a second invite). ensureOrgMembership swallows the benign
   // already-member/already-pending 422.
-  const inviteeId = parseGitHubId(result.student.github_id)
+  const inviteeId = resolveGitHubId(result.student.github_id)
   if (inviteeId !== null) {
     try {
       const teamId = (await teamPromise).id

--- a/web/src/domain/students/inviteRoster.ts
+++ b/web/src/domain/students/inviteRoster.ts
@@ -7,10 +7,11 @@ import { getErrorMessage } from "@/github-core/errorMessage"
 import { assertClassroomNotArchived } from "../classrooms"
 import { getUser, sleep, REPO_READ_CONCURRENCY } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
-import { parseGitHubId } from "@/util/students"
+import { resolveGitHubId } from "@/util/students"
 import { mapWithConcurrency } from "@/util/concurrency"
 import { githubOrgRoleForRole, type ClassroomRole } from "@/util/teamRoster"
 import { retryDeferred, resolveTeamIdByRole } from "./rosterPrimitives"
+import i18n from "@/i18n"
 
 export type InviteRosterStudentsInput = {
   org: string
@@ -111,9 +112,22 @@ export async function inviteRosterStudents(
     | { skip: "already-member" | "already-pending" }
   > => {
     const { username, role } = target
-    const inviteeId =
-      parseGitHubId(target.github_id ?? "") ??
-      (await getUser(client, username)).id
+    // A present cell resolves to its account even when spelled non-canonically;
+    // only a BLANK one may fall back to the mutable login. Falling back for an
+    // unusable cell would send the org invite (and its team, hence repo access)
+    // to whoever holds that login today, which is what github_id exists to
+    // prevent — the same reasoning as runRosterImport's id threading.
+    const raw = (target.github_id ?? "").trim()
+    const resolvedId = resolveGitHubId(raw)
+    if (raw !== "" && resolvedId === null) {
+      throw new Error(
+        i18n.t("students.inviteRosterMalformedId", {
+          username,
+          githubId: raw,
+        }),
+      )
+    }
+    const inviteeId = resolvedId ?? (await getUser(client, username)).id
     const teamId = teamIdByRole[role]
     const result = await ensureOrgMembership(client, {
       org,

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -12,7 +12,7 @@ import {
   getConfigRepoBranch,
 } from "@/github-core/configRepoReads"
 import { rosterClaimSet } from "@/util/identity"
-import { parseGitHubId } from "@/util/students"
+import { parseGitHubId, resolveGitHubId } from "@/util/students"
 import { prefixCommit } from "@/util/commit"
 import {
   normalizeStudentRow,
@@ -123,8 +123,8 @@ export async function syncRosterFromTeam(
     // Only usable when a login maps to exactly one member — a duplicate login
     // (shouldn't happen on one team, but be safe) is left un-backfilled rather
     // than guess. A VALID existing id is never overwritten (a renamed login must
-    // not silently repoint an id onto a different account); a malformed one is,
-    // since it addresses no account and repointing it can't hijack one.
+    // not silently repoint an id onto a different account); a cell that addresses
+    // no account is, since repointing it can't hijack one.
     const loginCounts = new Map<string, number>()
     for (const m of members) {
       const k = m.login.toLowerCase()
@@ -152,11 +152,16 @@ export async function syncRosterFromTeam(
         (loginKey && pendingRoleKeys.has(loginKey)) ||
         (emailKey ? pendingRoleKeys.has(emailKey) : false)
       const role = teamRole ?? (fullyRead && !hasPendingRole ? "" : s.role)
-      // Backfill a blank OR malformed id (see the idByLogin block above).
-      const backfilledId =
-        parseGitHubId(s.github_id) === null && loginKey
-          ? idByLogin.get(loginKey)
-          : undefined
+      // Canonicalize a cell that already addresses an account (a zero-padded
+      // one) from its OWN digits; only a cell addressing no account falls back
+      // to the login, where a recycled login could otherwise repoint the row
+      // onto a different person.
+      const canonicalId = parseGitHubId(s.github_id)
+      const resolvedId = resolveGitHubId(s.github_id)
+      let backfilledId: string | undefined
+      if (canonicalId !== null) backfilledId = undefined
+      else if (resolvedId !== null) backfilledId = String(resolvedId)
+      else if (loginKey) backfilledId = idByLogin.get(loginKey)
 
       let next = s
       if (role !== s.role) {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1985,6 +1985,8 @@
   },
   "orgMembers": {
     "heading": "Members",
+    "inviteMissingId": "Can't invite {{who}}: no GitHub id on file.",
+    "inviteMalformedId": "Can't invite {{who}}: \"{{githubId}}\" isn't a valid GitHub id. Fix the github_id cell in roster.csv.",
     "subtitle": "Everyone in the <orgLink>{{org}}</orgLink> GitHub organization and the classrooms they belong to.",
     "manageMembersOnGitHub": "Manage organization members on GitHub",
     "discrepancy_one": "{{count}} student is on a roster but not an organization member.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -309,6 +309,7 @@
     "changeRoleFailed": "Couldn't change {{label}}'s role: {{error}}",
     "manageOwnerOnly": "Managing invitations and membership is available to organization owners only.",
     "inviteRosterFailed": "Couldn't invite {{label}}: {{error}}",
+    "inviteRosterMalformedId": "Can't invite {{username}}: \"{{githubId}}\" isn't a valid GitHub id. Fix the github_id cell in roster.csv.",
     "inviteRosterNoUsername": "{{label}} has no GitHub username on file — add one before inviting.",
     "inviteRosterDeferred": "GitHub rate-limited the invitation to {{label}} — try again shortly.",
     "inviteRosterNoneSent": "No invitation was sent to {{label}} — try again.",

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -13,7 +13,7 @@ import {
   type BulkUnenrollRosterResult,
 } from "@/domain/roster/bulkUnenrollRoster"
 import { resendClassroomInvite } from "@/domain/students"
-import { isMalformedGitHubId, parseGitHubId } from "@/util/students"
+import { isMalformedGitHubId, resolveGitHubId } from "@/util/students"
 import { sortRolesByRank } from "@/util/teamRoster"
 import {
   BulkResultSection,
@@ -241,7 +241,7 @@ const RosterBulkActionsBar = ({
         tick(label)
         continue
       }
-      const inviteeId = parseGitHubId(row.github_id)
+      const inviteeId = resolveGitHubId(row.github_id)
       if (inviteeId === null || !row.username) {
         skipped.push({
           key: row.key,

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -19,7 +19,7 @@ import { getErrorMessage } from "@/github-core/errorMessage"
 import {
   isMalformedGitHubId,
   nameFromParts,
-  parseGitHubId,
+  resolveGitHubId,
 } from "@/util/students"
 import { rosterRowInitials } from "@/util/memberRow"
 import {
@@ -316,7 +316,7 @@ const RosterMemberModal = ({
 
   const handleResend = async () => {
     if (resending) return
-    const inviteeId = parseGitHubId(row.github_id)
+    const inviteeId = resolveGitHubId(row.github_id)
     if (inviteeId === null || !row.username) {
       const username = row.username || row.email
       onError(

--- a/web/src/util/csv.ts
+++ b/web/src/util/csv.ts
@@ -6,6 +6,9 @@
 // round-trip byte-exact (ids, tokens, hashes, timestamps).
 const FORMULA_LEAD = /^[=+\-@\t\r]/
 
+// Hand-mirrors the CLI's isFormulaTrigger; a drift test pins the two together.
+export const FORMULA_LEAD_SOURCE = FORMULA_LEAD.source
+
 export function escapeCsvFormulaInjection(value: string): string {
   if (!value) return value
   if (value.startsWith("'") && FORMULA_LEAD.test(value.slice(1))) return value

--- a/web/src/util/csv.ts
+++ b/web/src/util/csv.ts
@@ -11,3 +11,13 @@ export function escapeCsvFormulaInjection(value: string): string {
   if (value.startsWith("'") && FORMULA_LEAD.test(value.slice(1))) return value
   return FORMULA_LEAD.test(value) ? `'${value}` : value
 }
+
+// Inverse of escapeCsvFormulaInjection, mirroring the gh-teacher CLI's
+// undefangCSVCell: strip the guard quote so the in-memory value is the real one
+// rather than the on-disk representation. Only the exact `'<trigger>` shape is
+// stripped, so a user-typed apostrophe ("'tis") survives.
+export function unescapeCsvFormulaInjection(value: string): string {
+  return value.startsWith("'") && FORMULA_LEAD.test(value.slice(1))
+    ? value.slice(1)
+    : value
+}

--- a/web/src/util/identity.test.ts
+++ b/web/src/util/identity.test.ts
@@ -123,10 +123,12 @@ describe("parseGitHubId", () => {
     )
   })
 
-  // The parsed number drops the padding, so it no longer equals the string
-  // memberIdSet/rosterClaimSet compare on.
-  it("accepts a zero-padded id, dropping the padding", () => {
-    expect(parseGitHubId("0583231")).toBe(583231)
+  // A padded id parses but never equals the raw string the id-keyed joins compare
+  // (String(member.id) is unpadded), so it would invite the right account while
+  // reading as unenrolled. Rejecting routes it to the malformed-id repair path.
+  it("rejects a zero-padded id, which the identity joins could never match", () => {
+    expect(parseGitHubId("0583231")).toBeNull()
+    expect(parseGitHubId("007")).toBeNull()
   })
 })
 

--- a/web/src/util/identity.test.ts
+++ b/web/src/util/identity.test.ts
@@ -5,6 +5,7 @@ import {
   memberIdSet,
   memberIdentitySets,
   parseGitHubId,
+  resolveGitHubId,
   rosterClaimSet,
   studentKey,
 } from "./identity"
@@ -124,11 +125,46 @@ describe("parseGitHubId", () => {
   })
 
   // A padded id parses but never equals the raw string the id-keyed joins compare
-  // (String(member.id) is unpadded), so it would invite the right account while
-  // reading as unenrolled. Rejecting routes it to the malformed-id repair path.
+  // (String(member.id) is unpadded), so it would read as unenrolled forever.
+  // Actions use resolveGitHubId, which does resolve it.
   it("rejects a zero-padded id, which the identity joins could never match", () => {
     expect(parseGitHubId("0583231")).toBeNull()
     expect(parseGitHubId("007")).toBeNull()
+  })
+})
+
+describe("resolveGitHubId", () => {
+  it("resolves a zero-padded cell to the account it addresses", () => {
+    expect(resolveGitHubId("0583231")).toBe(583231)
+    expect(resolveGitHubId("007")).toBe(7)
+    expect(resolveGitHubId(" 0042 ")).toBe(42)
+  })
+
+  it("agrees with parseGitHubId on every canonical cell", () => {
+    for (const cell of ["583231", " 42 ", String(Number.MAX_SAFE_INTEGER)]) {
+      expect(resolveGitHubId(cell)).toBe(parseGitHubId(cell))
+    }
+  })
+
+  // Tolerating padding must not widen into coercion: these address no account,
+  // so resolving one would invite a stranger.
+  it("still refuses a cell that addresses no account", () => {
+    for (const cell of [
+      "",
+      "   ",
+      "0",
+      "000",
+      "-5",
+      "+42",
+      "1e3",
+      "0x10",
+      "12.5",
+      "octocat",
+      "9007199254740993",
+    ]) {
+      expect(resolveGitHubId(cell)).toBeNull()
+    }
+    expect(resolveGitHubId(undefined)).toBeNull()
   })
 })
 

--- a/web/src/util/identity.ts
+++ b/web/src/util/identity.ts
@@ -32,17 +32,16 @@ export function isSameGitHubUser(
   )
 }
 
-// Parse a roster row's github_id into a positive numeric id, else null. Accepts
-// only a canonical digit string: `Number()` alone would coerce a malformed cell
-// like "1e3" or "0x10" into a valid-LOOKING id (1000, 16) that callers then send
-// as `invitee_id`, inviting a stranger into the org.
+// Whether a github_id cell is spelled the way this app stores one: a canonical
+// digit string. `Number()` alone would coerce a malformed cell like "1e3" or
+// "0x10" into a valid-LOOKING id (1000, 16) that callers then send as
+// `invitee_id`, inviting a stranger into the org.
 //
-// A leading zero is rejected too, even though it parses. `String(member.id)` is
-// never padded, and the id-keyed joins (memberIdSet, rosterClaimSet, and the
-// membership/"Mark enrolled" comparisons) match the RAW cell — so "0583231"
-// would invite the right account while reading as unenrolled forever. Rejecting
-// routes it to the malformed-id message and the backfill, which rewrites the
-// cell canonically from the login.
+// This is the JOIN predicate, so a leading zero is rejected even though it
+// parses: `String(member.id)` is never padded and the id-keyed joins
+// (memberIdSet, rosterClaimSet, and the membership/"Mark enrolled"
+// comparisons) match the RAW cell, so "0583231" would read as unenrolled
+// forever. Use resolveGitHubId to act on such a cell.
 export function parseGitHubId(githubId: string): number | null {
   const trimmed = githubId.trim()
   if (!/^[1-9]\d*$/.test(trimmed)) return null
@@ -50,9 +49,22 @@ export function parseGitHubId(githubId: string): number | null {
   return Number.isSafeInteger(id) ? id : null
 }
 
-// A github_id that is present but rejected by parseGitHubId. Distinguished from
-// a blank one because a corrupted cell needs a different remedy than an absent
-// one ("re-add them to the roster" would not fix it).
+// The account a github_id cell addresses, tolerating a non-canonical spelling
+// the join predicate refuses. Only leading zeros are tolerated — "0583231" and
+// "583231" are the same account, unambiguously.
+//
+// Callers taking an ACTION (invite, resend, enroll) want this one: the
+// alternative is falling back to the mutable login, which after a rename can
+// carry repo access to whoever took the freed login. Mirrors the Go reader,
+// which resolves the same cells and rewrites them canonically on the next
+// write, so both tools converge on the account rather than on the spelling.
+export function resolveGitHubId(githubId: string | undefined): number | null {
+  return parseGitHubId((githubId ?? "").trim().replace(/^0+(?=\d)/, ""))
+}
+
+// A github_id that is present but not canonical (see parseGitHubId).
+// Distinguished from a blank one because a corrupted cell needs a different
+// remedy than an absent one ("re-add them to the roster" would not fix it).
 export function isMalformedGitHubId(githubId: string | undefined): boolean {
   const trimmed = githubId?.trim() ?? ""
   return trimmed !== "" && parseGitHubId(trimmed) === null

--- a/web/src/util/identity.ts
+++ b/web/src/util/identity.ts
@@ -33,14 +33,21 @@ export function isSameGitHubUser(
 }
 
 // Parse a roster row's github_id into a positive numeric id, else null. Accepts
-// only a plain digit string: `Number()` alone would coerce a malformed cell like
-// "1e3" or "0x10" into a valid-LOOKING id (1000, 16) that callers then send as
-// `invitee_id`, inviting a stranger into the org.
+// only a canonical digit string: `Number()` alone would coerce a malformed cell
+// like "1e3" or "0x10" into a valid-LOOKING id (1000, 16) that callers then send
+// as `invitee_id`, inviting a stranger into the org.
+//
+// A leading zero is rejected too, even though it parses. `String(member.id)` is
+// never padded, and the id-keyed joins (memberIdSet, rosterClaimSet, and the
+// membership/"Mark enrolled" comparisons) match the RAW cell — so "0583231"
+// would invite the right account while reading as unenrolled forever. Rejecting
+// routes it to the malformed-id message and the backfill, which rewrites the
+// cell canonically from the login.
 export function parseGitHubId(githubId: string): number | null {
   const trimmed = githubId.trim()
-  if (!/^\d+$/.test(trimmed)) return null
+  if (!/^[1-9]\d*$/.test(trimmed)) return null
   const id = Number(trimmed)
-  return Number.isSafeInteger(id) && id > 0 ? id : null
+  return Number.isSafeInteger(id) ? id : null
 }
 
 // A github_id that is present but rejected by parseGitHubId. Distinguished from

--- a/web/src/util/rosterCsv.test.ts
+++ b/web/src/util/rosterCsv.test.ts
@@ -284,24 +284,43 @@ describe("stringifyStudentsCsv", () => {
     expect(parseStudentsCsv(stringifyStudentsCsv(rows))).toEqual(rows)
   })
 
-  // Formula guarding defangs free text AND email (a verified GitHub email is
-  // member-controlled), but must NOT touch github_id, which round-trips exact.
-  it("defangs formula-leading free-text and email cells", () => {
-    const csv = stringifyStudentsCsv([
-      normalizeStudentRow({
-        username: "user",
-        first_name: "=1+1",
-        last_name: "-x",
-        section: "@SUM(1)",
-        email: "=a@evil.com",
-        github_id: "583231",
-      }),
-    ])
+  // Every column except github_id is defanged, matching the Go writer's set. The
+  // guard quote lives in the STORED value, so the read path strips it back off —
+  // a teacher never sees the escaping we added.
+  it("defangs every column but github_id, and undefangs on read", () => {
+    const row = normalizeStudentRow({
+      username: "user",
+      first_name: "=1+1",
+      last_name: "-x",
+      section: "@SUM(1)",
+      email: "=a@evil.com",
+      github_id: "583231",
+      role: "=student",
+    })
+    const csv = stringifyStudentsCsv([row])
     const data = csv.split("\n")[1]
     expect(data).toContain("'=1+1")
     expect(data).toContain("'-x")
     expect(data).toContain("'@SUM(1)")
     expect(data).toContain("'=a@evil.com")
+    expect(data).toContain("'=student")
+    expect(data).toContain(",583231,")
+    expect(parseStudentsCsv(csv)[0]).toEqual(row)
+  })
+
+  it("defangs a formula-leading username", () => {
+    const csv = stringifyStudentsCsv([
+      normalizeStudentRow({ username: "=cmd|'/c calc'!A1", email: "a@x.io" }),
+    ])
+    expect(csv.split("\n")[1]).toMatch(/^'=cmd/)
+  })
+
+  // A user-typed apostrophe is not our escaping, so it must survive the read.
+  it("leaves a leading apostrophe that isn't a formula guard alone", () => {
+    const row = normalizeStudentRow({ username: "user", last_name: "'tis" })
+    expect(parseStudentsCsv(stringifyStudentsCsv([row]))[0].last_name).toBe(
+      "'tis",
+    )
   })
 
   // github_id round-trips byte-exact, valid or not: the identity join compares the

--- a/web/src/util/rosterCsv.test.ts
+++ b/web/src/util/rosterCsv.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  FORMULA_GUARDED_FIELDS,
   STUDENT_CSV_FIELDS,
   formatRosterProblems,
   normalizeStudentRow,
@@ -9,11 +10,30 @@ import {
   stringifyStudentsCsv,
   type StudentCsvRow,
 } from "./rosterCsv"
+import { FORMULA_LEAD_SOURCE } from "./csv"
 
 // Characterization tests for the roster.csv parse/serialize layer that every
 // roster import, sync, and write goes through.
 
 const HEADER = STUDENT_CSV_FIELDS.join(",")
+
+// The guard is only useful if both writers defang the same columns on the same
+// triggers: a cell one side guards and the other doesn't un-defang keeps the
+// quote as data. Pinning the source-of-truth constants (mirroring the header
+// lockstep in students.test.ts) fails loudly on a one-sided change instead of
+// leaving both suites green.
+describe("csv formula-guard lockstep (web leg)", () => {
+  it("guards every canonical column except github_id", () => {
+    expect([...FORMULA_GUARDED_FIELDS]).toEqual(
+      STUDENT_CSV_FIELDS.filter((f) => f !== "github_id"),
+    )
+  })
+
+  // Mirrors isFormulaTrigger in cli/gh-teacher/internal/configrepo/students_csv.go.
+  it("matches the Go trigger set verbatim", () => {
+    expect(FORMULA_LEAD_SOURCE).toBe("^[=+\\-@\\t\\r]")
+  })
+})
 
 const row = (over: Partial<StudentCsvRow> = {}): StudentCsvRow =>
   normalizeStudentRow({

--- a/web/src/util/rosterCsv.ts
+++ b/web/src/util/rosterCsv.ts
@@ -1,6 +1,9 @@
 import Papa from "papaparse"
 
-import { escapeCsvFormulaInjection } from "@/util/csv"
+import {
+  escapeCsvFormulaInjection,
+  unescapeCsvFormulaInjection,
+} from "@/util/csv"
 
 // The pure roster.csv parse/serialize layer, lifted out of the mutation module
 // so problem detection lives next to the other pure roster helpers (teamRoster)
@@ -23,17 +26,21 @@ export type StudentCsvRow = Record<StudentCsvField, string>
 export function normalizeStudentRow(
   row: Partial<Record<StudentCsvField, unknown>>,
 ): StudentCsvRow {
+  const cell = (value: unknown) =>
+    unescapeCsvFormulaInjection(String(value ?? "").trim())
   return {
-    username: String(row.username ?? "").trim(),
-    first_name: String(row.first_name ?? "").trim(),
-    last_name: String(row.last_name ?? "").trim(),
-    email: String(row.email ?? "").trim(),
-    section: String(row.section ?? "").trim(),
+    username: cell(row.username),
+    first_name: cell(row.first_name),
+    last_name: cell(row.last_name),
+    email: cell(row.email),
+    section: cell(row.section),
+    // Not undefanged: github_id is never guarded on write, so a leading quote
+    // here is the teacher's own (malformed) value, not our escaping.
     github_id: String(row.github_id ?? "").trim(),
     // Best-effort recorded metadata (teacher/ta/student, or ""), refreshed
     // from the classroom's GitHub teams on sync. A pre-role file has no role
     // column, so this coerces to "".
-    role: String(row.role ?? "").trim(),
+    role: cell(row.role),
   }
 }
 
@@ -153,15 +160,19 @@ function tooFewFieldsAreTrailingOnly(
     )
 }
 
-// Which student fields to defang. Applied to name/section free text AND email —
-// email is a member-controlled GitHub profile field written verbatim by
-// syncRosterFromTeam/bulk import, so a formula-leading verified email (e.g.
-// `=1+1@evil.com`) would otherwise reach roster.csv and execute on open.
+// Which student fields to defang: every column except github_id. Free text is the
+// obvious case, but email matters too — it's a member-controlled GitHub profile
+// field written verbatim by syncRosterFromTeam/bulk import, so a formula-leading
+// verified email (e.g. `=1+1@evil.com`) would otherwise reach roster.csv and
+// execute on open. `username` and `role` can't hold a formula lead through any
+// normal path (isLikelyGithubUsername forbids one; roles are a fixed vocabulary),
+// so guarding them is a no-op for valid data — but the Go writer defangs the same
+// six columns, and a set that only ALMOST matches is the kind of drift nobody
+// notices. Keep them in lockstep.
 //
-// NOTE: this writes the leading quote into the STORED value, so any consumer of
-// roster.csv (this app's parse layer, the gh-teacher CLI) must tolerate it on
-// these fields. Email matching keys on the normalized (trim+lowercase) email, so
-// guarding the cell doesn't affect match-by-email.
+// NOTE: this writes the leading quote into the STORED value, so parseRosterCsv
+// strips it back off on read (mirroring the CLI's undefang) and matching keys on
+// normalized values, so guarding a cell doesn't affect the joins.
 //
 // github_id must stay out: it has to round-trip byte-exact for the identity join,
 // and the Go reader parses that column as a number, so a defang quote there would
@@ -169,10 +180,12 @@ function tooFewFieldsAreTrailingOnly(
 // value into it — every writer uses String(<GitHub id>), and an uploaded roster's
 // github_id is ignored on import (parseRosterImportFile).
 const FORMULA_GUARDED_FIELDS = [
+  "username",
   "first_name",
   "last_name",
-  "section",
   "email",
+  "section",
+  "role",
 ] as const
 
 export function stringifyStudentsCsv(rows: StudentCsvRow[]) {

--- a/web/src/util/rosterCsv.ts
+++ b/web/src/util/rosterCsv.ts
@@ -164,11 +164,8 @@ function tooFewFieldsAreTrailingOnly(
 // obvious case, but email matters too — it's a member-controlled GitHub profile
 // field written verbatim by syncRosterFromTeam/bulk import, so a formula-leading
 // verified email (e.g. `=1+1@evil.com`) would otherwise reach roster.csv and
-// execute on open. `username` and `role` can't hold a formula lead through any
-// normal path (isLikelyGithubUsername forbids one; roles are a fixed vocabulary),
-// so guarding them is a no-op for valid data — but the Go writer defangs the same
-// six columns, and a set that only ALMOST matches is the kind of drift nobody
-// notices. Keep them in lockstep.
+// execute on open. Must stay in lockstep with the Go writer's set (a drift test
+// pins both).
 //
 // NOTE: this writes the leading quote into the STORED value, so parseRosterCsv
 // strips it back off on read (mirroring the CLI's undefang) and matching keys on
@@ -176,10 +173,8 @@ function tooFewFieldsAreTrailingOnly(
 //
 // github_id must stay out: it has to round-trip byte-exact for the identity join,
 // and the Go reader parses that column as a number, so a defang quote there would
-// fail the whole roster rather than one cell. Nothing writes an attacker-chosen
-// value into it — every writer uses String(<GitHub id>), and an uploaded roster's
-// github_id is ignored on import (parseRosterImportFile).
-const FORMULA_GUARDED_FIELDS = [
+// fail the whole roster rather than one cell.
+export const FORMULA_GUARDED_FIELDS = [
   "username",
   "first_name",
   "last_name",

--- a/web/src/util/students.ts
+++ b/web/src/util/students.ts
@@ -3,9 +3,10 @@ import {
   isMalformedGitHubId,
   isSameGitHubUser,
   parseGitHubId,
+  resolveGitHubId,
 } from "@/util/identity"
 
-export { isMalformedGitHubId, isSameGitHubUser, parseGitHubId }
+export { isMalformedGitHubId, isSameGitHubUser, parseGitHubId, resolveGitHubId }
 
 export const capitalize = (s: string) =>
   s ? s.charAt(0).toUpperCase() + s.slice(1) : ""


### PR DESCRIPTION
## Summary

The three follow-ups #411 named and deliberately left out of scope, plus the fixes from a review pass over them. All are pre-existing, all touch the same `roster.csv` identity/serialization surface, and each is small enough that a separate PR per item would be more overhead than review value — but they are separate commits, so they can be dropped individually.

### 1. Every roster column the Go writer defangs is now defanged on the web side too

`FORMULA_GUARDED_FIELDS` covered four of the six free-text columns, leaving `username` and `role` unguarded while `cli/gh-teacher`'s `EncodeRoster` defangs all six.

Neither column can hold a formula lead through a normal path — `isLikelyGithubUsername` forbids a leading `=`/`+`/`-`/`@`, and roles are a fixed vocabulary — so **this changes nothing for valid data**. It is worth closing anyway because a guarded set that only _almost_ matches its counterpart is exactly the drift nobody notices until a new writer bypasses the validation. Commit 4 adds the test that makes that claim executable.

This also closes an asymmetry on the **read** side. The guard quote is written into the _stored_ value, and the Go reader has always stripped it back off (`undefangCSVCell`) while the web parse layer never did — so a CLI-written `'=1+1` was displayed and re-stored with the quote intact. `normalizeStudentRow` now undefangs, mirroring the CLI, so the in-memory value is the real one rather than the on-disk representation. A user-typed apostrophe (`'tis`) is untouched, since only the exact `'<trigger>` shape is stripped.

To correct an earlier version of this description: the quote did **not** accumulate across round trips. `escapeCsvFormulaInjection` has always early-returned on an already-guarded value, so a second quote was never added — the defect was display/in-memory fidelity only. That same early return is also what makes this commit's stored-representation change safe for an **older** release: a web or CLI build without the undefang reads `'=foo` verbatim and writes it back byte-identical, so no version guard is needed.

`github_id` stays out of the guarded set, for the reason #411 established: it must round-trip byte-exact for the identity join, and the Go reader parses that column as a number, so a quote there would fail the whole roster rather than one cell.

### 2. A zero-padded `github_id` no longer matches the identity joins — but still addresses its account

`"0583231"` parsed to `583231`, so an invite reached the **right** account — which is why this survived review twice. But every id-keyed join compares the **raw cell** against `String(member.id)`, which is never padded:

* `memberIdSet` / `rosterClaimSet` — member-status classification
* the "Mark enrolled" gate
* the org-members and team-sync joins

So the row read as _unenrolled forever_ while looking perfectly valid to the teacher: invites work, enrollment never registers.

`parseGitHubId` therefore tightened from `^\d+$` to `^[1-9]\d*$` (which also subsumes the separate `"0"` and `id > 0` checks) — but that function was doing two jobs, and the tightening is only correct for one of them. It is the **join predicate**, where the canonical spelling is the whole point. It was also the gate on every **action**, where the question is a different one: which account does this cell address? For a padded cell that answer is unambiguous, so commit 4 splits the two:

* `parseGitHubId` — strict. The joins, the "needs attention" classification, and `isMalformedGitHubId` keep using it, so a padded row still surfaces the malformed-id message and still routes to the backfill.
* `resolveGitHubId` — tolerates leading zeros only. The invite, resend, and enroll paths use it, so they act on the account rather than on the spelling.

**Go deliberately diverges from the strict predicate** and keeps resolving a padded cell, because `EncodeRoster` writes it back canonically — so a CLI rewrite _repairs_ the roster instead of stranding it. With `resolveGitHubId` the web now converges on the same account for actions, the same way `"+42"` already normalizes to `42`.

### 3. The org-invite refusal messages are translated

Both branches of `inviteMemberToOrg`'s refusal were English string literals thrown from the domain layer, against the repo rule that user-facing strings go through `t()`. This is the one message a teacher actually sees when an invite is refused, so it was the worst place to leave untranslated. Routed through the i18n singleton, matching the existing pattern in `util/templateAccessError.ts` for a non-component module.

### 4. Review follow-up: the padded-cell fallout, and drift tests for both claims

A review pass over commits 1–3 found that tightening `parseGitHubId` (commit 2) landed differently on each of its consumers, in opposite directions. This commit fixes all of them, plus the two "keep them in lockstep" claims that had no executable guard.

**One invite path became less safe.** `inviteRosterStudents` resolved `parseGitHubId(github_id) ?? (await getUser(client, username)).id`, so a newly-rejected padded cell fell through to the **login** — the one identifier that does not survive a rename. If that login had been freed and re-registered, the org invitation (carrying a classroom team, hence repo access) would go to whoever holds it now, and the teacher would see a normal success row. It now refuses a present-but-unusable cell the way `inviteMemberToOrg` and the resend paths already do; the login fallback is reserved for a genuinely **blank** cell.

**Two paths became needlessly strict.** Both resend paths (`RosterBulkActionsBar`, `RosterMemberModal.handleResend`) hard-refused with "Fix the github_id cell in roster.csv" for a cell the app could act on — and the promised backfill can't reach those rows anyway, since `idByLogin` is built only from **active** team members, so a *pending* invitee never self-repairs. Since the UI exposes no `github_id` editor, the teacher's only remedy was hand-editing the file on GitHub. All four action paths (both resends, `inviteMemberToOrg`, `enrollment`) now use `resolveGitHubId`.

**The backfill's safety premise had gone stale.** `syncRosterFromTeam` overwrites a row's `github_id` whenever `parseGitHubId` returns null, justified by a comment from #411: *"a malformed one is [overwritten], since it addresses no account and repointing it can't hijack one."* That stopped being true for a padded cell, which does address an account — so a recycled login could silently rebind the row to a different person, and every later invite, role change, and removal would follow the wrong principal. The backfill now canonicalizes a resolvable cell from its **own digits** and falls back to the login only for a cell that genuinely addresses nothing, which restores the invariant instead of leaving the comment false.

**Both lockstep claims are now tests.** The guarded-column set and the formula-trigger set were hand-mirrored across the two writers with nothing enforcing it — so a one-sided change would keep both suites green while a guarded cell stopped being un-defanged by the other reader, reopening the very bug commit 1 fixes. The web leg derives the guarded set from `STUDENT_CSV_FIELDS` minus `github_id` and pins the trigger source; `TestEncodeRoster_DefangsEveryColumnButGitHubID` is the Go leg. This mirrors how `FullRosterHeader` is already pinned three ways.

Also in this commit, since the files were open: the `FORMULA_GUARDED_FIELDS` comment is trimmed to the constraints the code can't express, and `TestParseRoster_GitHubIDShapeMatchesWeb`'s comment no longer claims both readers "require digits only" — true before commit 2, not after.

## Test plan

* **web:** `npm run check` clean — `tsc -b`, eslint (0 errors), prettier, **221 files / 2454 tests** (was 2444); `arch:validate` no violations (742 modules).
* **cli:** `go build ./...`, `go test ./...` (all packages), `gofmt -l` clean.
* **skeleton:** `pytest cli/gh-teacher/skeleton_tests -q` — 601 pass.
* **i18n audit:** `python3 src/locales/audit_i18n.py` — PASS (no missing, dead, or hardcoded strings), which covers the two new `orgMembers.*` keys and `students.inviteRosterMalformedId`.
* New coverage: every column defanged and undefanged on read; a formula-leading `username`; a user-typed apostrophe surviving the round trip; a padded/signed id normalizing canonically through the Go writer; and the two drift tests above.
* **Consumer-level coverage for the padded cell**, which commit 2 lacked — the tightening was proven only in `parseGitHubId`'s unit tests, so nothing exercised the classification that actually moved. Now: `syncRosterFromTeam` canonicalizes a padded cell from its own digits **while the login maps to a different id** (the hijack case), `inviteRosterStudents` invites by id with `GET /users/{login}` never consulted, and a malformed cell is refused rather than falling back. Plus direct `resolveGitHubId` coverage, including the values it must still refuse (`"0"`, `"000"`, `"+42"`, `"1e3"`, `"0x10"`, over 2^53-1).

## Risk

Low, and each commit reverts independently.

The behavior a user could notice is on the padded-`github_id` path. Such a row still shows the malformed-id message instead of silently misclassifying the student — that is the intended outcome, since the row was already broken, just invisibly — but every action on it (invite, resend, enroll) keeps working by id, and the next sync repairs the cell from its own digits.

Commits 1 and 3 are no-ops for valid data. Commit 4's invite/resend changes are the ones to read closely: they change **which GitHub account receives an org invitation**, and passing tests only prove which id we send, not what GitHub does with it.

**Watch after deploy:** the first roster write (cells should be byte-identical apart from rows the action touched), any `"isn't a valid GitHub id"` report naming a padded value, and the sync's `idBackfills` count — a padded row should now be repaired to its own digits rather than to whatever id currently holds its login.

## Note for the release PR

The `cli/**` half of this PR is comment- and test-only — `parseGitHubID`'s body is byte-identical to `main`. release-please is path-scoped, so the squashed `fix:` title will still write a Bug Fixes entry into `cli/CHANGELOG.md` for behavior the CLI deliberately did not change. Flagging it rather than splitting: the divergence comment and its tests belong next to the code they describe.
