### PR TITLE
fix: name the real cause when an org blocks student repo creation

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -706,20 +706,18 @@ func is403OrgRepoCreationDenied(httpErr *githubapi.HTTPError) bool {
 }
 
 // orgRepoCreationDeniedError is the shared remedy for that refusal, kept in one
-// place so both creation paths word it identically. Hedged (`often because`)
-// because the cause is inferred from GitHub's message text alone — a pending
-// invitation or an enterprise policy produce the same string — and it names
-// "Private" while leaving "Public" unchecked, since public student repos would
-// expose coursework. The enterprise caveat matters: re-running organization
-// setup can silently no-op on an enterprise-pinned org.
+// place so both creation paths word it identically. Hedged ("may not allow")
+// because the cause is inferred from GitHub's message text alone: a pending
+// invitation or an enterprise policy produce the same string. Names private (not
+// public) creation, since public student repos would expose coursework, and
+// mentions the enterprise override because re-running org setup can silently
+// no-op. Kept in step with the web copy at accept.templateErrors.*.
 func orgRepoCreationDeniedError(org string, cause error) error {
-	return fmt.Errorf("cannot create your assignment repository in `%s`. This is often because the "+
-		"organization doesn't let its members create private repositories. Ask your "+
-		"teacher to check, under the org's Settings → Member privileges → Repository "+
-		"creation, that members may create repositories and \"Private\" is checked "+
-		"(leave \"Public\" unchecked), or to re-run organization setup — then run accept "+
-		"again. If an enterprise policy pins that setting, only an enterprise owner "+
-		"can change it: %w", org, cause)
+	return fmt.Errorf("cannot create your assignment repository in `%s`. The organization may not "+
+		"allow members to create private repositories. Ask your teacher to allow private "+
+		"(not public) repository creation in the organization's member privileges, or to "+
+		"re-run organization setup, then run accept again. An enterprise policy can "+
+		"override this setting: %w", org, cause)
 }
 
 // reportAccepted writes the success header + clone instructions on stdout

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -708,16 +708,18 @@ func is403OrgRepoCreationDenied(httpErr *githubapi.HTTPError) bool {
 // orgRepoCreationDeniedError is the shared remedy for that refusal, kept in one
 // place so both creation paths word it identically. Hedged ("may not allow")
 // because the cause is inferred from GitHub's message text alone: a pending
-// invitation or an enterprise policy produce the same string. Names private (not
-// public) creation, since public student repos would expose coursework, and
-// mentions the enterprise override because re-running org setup can silently
-// no-op. Kept in step with the web copy at accept.templateErrors.*.
+// invitation or an enterprise policy produce the same string. Deliberately a
+// diagnosis rather than a how-to, since the student running accept can't change
+// an org setting; the full remedy lives in the wiki's Troubleshooting page and
+// the teacher-facing web notice. Kept in step with the web copy at
+// accept.templateErrors.orgRepoCreationDenied, except that the wrapped cause
+// still trails GitHub's raw text: that is the Go convention here (and keeps the
+// error chain), and a terminal reader expects the API detail after the colon,
+// whereas the web alert suppresses it to avoid contradicting the diagnosis.
 func orgRepoCreationDeniedError(org string, cause error) error {
-	return fmt.Errorf("cannot create your assignment repository in `%s`. The organization may not "+
-		"allow members to create private repositories. Ask your teacher to allow private "+
-		"(not public) repository creation in the organization's member privileges, or to "+
-		"re-run organization setup, then run accept again. An enterprise policy can "+
-		"override this setting: %w", org, cause)
+	return fmt.Errorf("`%s` may not allow members to create private repositories, so your "+
+		"assignment repository couldn't be created. Ask your teacher to enable it, "+
+		"then run accept again: %w", org, cause)
 }
 
 // reportAccepted writes the success header + clone instructions on stdout

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -668,54 +668,52 @@ func classroomFromRepo(repoName string) string {
 	return repoName
 }
 
-// is422AlreadyExists matches "already exists" (case-insensitive) in
-// the 422 message or any Errors[] item.
-func is422AlreadyExists(httpErr *githubapi.HTTPError) bool {
-	if strings.Contains(strings.ToLower(httpErr.Message), "already exists") {
+// httpErrorMentions reports whether needle (lower-case) appears in the error's
+// top-level message or in any Errors[] item. GitHub puts the reason in either
+// slot depending on the endpoint.
+func httpErrorMentions(httpErr *githubapi.HTTPError, needle string) bool {
+	if strings.Contains(strings.ToLower(httpErr.Message), needle) {
 		return true
 	}
 	for _, item := range httpErr.Errors {
-		if strings.Contains(strings.ToLower(item.Message), "already exists") {
+		if strings.Contains(strings.ToLower(item.Message), needle) {
 			return true
 		}
 	}
 	return false
+}
+
+func is422AlreadyExists(httpErr *githubapi.HTTPError) bool {
+	return httpErrorMentions(httpErr, "already exists")
 }
 
 // The one 403 message GitHub was observed to return when the destination org
-// refuses the create (issue #413). Mirrors the web app's
-// isOrgRepoCreationDenied; add a variant only alongside a cited GitHub response
-// showing the same cause, since the plausible alternatives (enterprise or
-// ruleset blocks) are ones this remedy cannot fix.
+// refuses the create (issue #413). Add a variant only alongside a cited GitHub
+// response showing the same cause, since the plausible alternatives (enterprise
+// or ruleset blocks) are ones this remedy cannot fix.
 const orgRepoCreationDeniedSignature = "admin access to the organization"
 
-// is403OrgRepoCreationDenied matches the destination-org repo-creation refusal
-// in the message or any Errors[] item. Message matching only: every caller must
-// exclude a throttle with ghutil.IsRateLimited first, since a rate limit also
-// surfaces as 403.
-func is403OrgRepoCreationDenied(httpErr *githubapi.HTTPError) bool {
-	if strings.Contains(strings.ToLower(httpErr.Message), orgRepoCreationDeniedSignature) {
-		return true
+// is403OrgRepoCreationDenied reports whether err is the destination org refusing
+// to let a member create the repo. Owns its own exclusions (mirroring the web's
+// isOrgRepoCreationDenied) so no call site can forget one: a rate limit also
+// surfaces as 403, and rendering a throttle as "your org blocks repo creation" is
+// the mislabeling #413 exists to remove.
+func is403OrgRepoCreationDenied(err error) bool {
+	httpErr, ok := errors.AsType[*githubapi.HTTPError](err)
+	if !ok || httpErr.StatusCode != http.StatusForbidden {
+		return false
 	}
-	for _, item := range httpErr.Errors {
-		if strings.Contains(strings.ToLower(item.Message), orgRepoCreationDeniedSignature) {
-			return true
-		}
+	if ghutil.IsRateLimited(err) {
+		return false
 	}
-	return false
+	return httpErrorMentions(httpErr, orgRepoCreationDeniedSignature)
 }
 
-// orgRepoCreationDeniedError is the shared remedy for that refusal, kept in one
-// place so both creation paths word it identically. Hedged ("may not allow")
-// because the cause is inferred from GitHub's message text alone: a pending
-// invitation or an enterprise policy produce the same string. Deliberately a
-// diagnosis rather than a how-to, since the student running accept can't change
-// an org setting; the full remedy lives in the wiki's Troubleshooting page and
-// the teacher-facing web notice. Kept in step with the web copy at
-// accept.templateErrors.orgRepoCreationDenied, except that the wrapped cause
-// still trails GitHub's raw text: that is the Go convention here (and keeps the
-// error chain), and a terminal reader expects the API detail after the colon,
-// whereas the web alert suppresses it to avoid contradicting the diagnosis.
+// orgRepoCreationDeniedError is the shared remedy, kept in step with the web copy
+// at accept.templateErrors.orgRepoCreationDenied (see that key's factory for why
+// it hedges and stays a diagnosis rather than a how-to). Unlike the web alert this
+// lets the wrapped cause trail GitHub's raw text: a terminal reader expects the
+// API detail after the colon, and it keeps the error chain intact.
 func orgRepoCreationDeniedError(org string, cause error) error {
 	return fmt.Errorf("`%s` may not allow members to create private repositories, so your "+
 		"assignment repository couldn't be created. Ask your teacher to enable it, "+
@@ -831,10 +829,8 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 					tmpl.Owner, tmpl.Repo)
 			case http.StatusForbidden:
 				// The refusal is about the destination org, not the template, so
-				// it is classified here rather than blamed on `tmpl`. A throttle
-				// also surfaces as 403, and rendering that as "your org blocks
-				// repo creation" is the mislabeling #413 reports.
-				if !ghutil.IsRateLimited(err) && is403OrgRepoCreationDenied(httpErr) {
+				// it is classified here rather than blamed on `tmpl`.
+				if is403OrgRepoCreationDenied(err) {
 					return "", "", "", false, orgRepoCreationDeniedError(org, err)
 				}
 			}
@@ -919,9 +915,8 @@ func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, ve
 				}
 			case http.StatusForbidden:
 				// Serves both the template-less shim path and empty_repo, which
-				// previously wrapped this 403 raw. Guarded against a throttle for
-				// the same reason as the templated path.
-				if !ghutil.IsRateLimited(err) && is403OrgRepoCreationDenied(httpErr) {
+				// previously wrapped this 403 raw.
+				if is403OrgRepoCreationDenied(err) {
 					return "", "", "", false, orgRepoCreationDeniedError(org, err)
 				}
 			}

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/foundation50/classroom50-cli-shared/contract"
 	"github.com/foundation50/classroom50-cli-shared/ghui"
+	"github.com/foundation50/classroom50-cli-shared/ghutil"
 	"github.com/foundation50/gh-student/internal/assignments"
 	"github.com/foundation50/gh-student/internal/classroomcfg"
 	"github.com/foundation50/gh-student/internal/githubapi"
@@ -681,6 +682,46 @@ func is422AlreadyExists(httpErr *githubapi.HTTPError) bool {
 	return false
 }
 
+// The one 403 message GitHub was observed to return when the destination org
+// refuses the create (issue #413). Mirrors the web app's
+// isOrgRepoCreationDenied; add a variant only alongside a cited GitHub response
+// showing the same cause, since the plausible alternatives (enterprise or
+// ruleset blocks) are ones this remedy cannot fix.
+const orgRepoCreationDeniedSignature = "admin access to the organization"
+
+// is403OrgRepoCreationDenied matches the destination-org repo-creation refusal
+// in the message or any Errors[] item. Message matching only: every caller must
+// exclude a throttle with ghutil.IsRateLimited first, since a rate limit also
+// surfaces as 403.
+func is403OrgRepoCreationDenied(httpErr *githubapi.HTTPError) bool {
+	if strings.Contains(strings.ToLower(httpErr.Message), orgRepoCreationDeniedSignature) {
+		return true
+	}
+	for _, item := range httpErr.Errors {
+		if strings.Contains(strings.ToLower(item.Message), orgRepoCreationDeniedSignature) {
+			return true
+		}
+	}
+	return false
+}
+
+// orgRepoCreationDeniedError is the shared remedy for that refusal, kept in one
+// place so both creation paths word it identically. Hedged (`often because`)
+// because the cause is inferred from GitHub's message text alone — a pending
+// invitation or an enterprise policy produce the same string — and it names
+// "Private" while leaving "Public" unchecked, since public student repos would
+// expose coursework. The enterprise caveat matters: re-running organization
+// setup can silently no-op on an enterprise-pinned org.
+func orgRepoCreationDeniedError(org string, cause error) error {
+	return fmt.Errorf("cannot create your assignment repository in `%s`. This is often because the "+
+		"organization doesn't let its members create private repositories. Ask your "+
+		"teacher to check, under the org's Settings → Member privileges → Repository "+
+		"creation, that members may create repositories and \"Private\" is checked "+
+		"(leave \"Public\" unchecked), or to re-run organization setup — then run accept "+
+		"again. If an enterprise policy pins that setting, only an enterprise owner "+
+		"can change it: %w", org, cause)
+}
+
 // reportAccepted writes the success header + clone instructions on stdout
 // (machine-stable, scriptable). The per-step spinners already rendered
 // human-channel progress, so this doesn't duplicate the headline onto stderr.
@@ -788,6 +829,14 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 			case http.StatusNotFound:
 				return "", "", "", false, fmt.Errorf("template `%s/%s` is not accessible to you — ask your teacher to make it public or grant your account access",
 					tmpl.Owner, tmpl.Repo)
+			case http.StatusForbidden:
+				// The refusal is about the destination org, not the template, so
+				// it is classified here rather than blamed on `tmpl`. A throttle
+				// also surfaces as 403, and rendering that as "your org blocks
+				// repo creation" is the mislabeling #413 reports.
+				if !ghutil.IsRateLimited(err) && is403OrgRepoCreationDenied(httpErr) {
+					return "", "", "", false, orgRepoCreationDeniedError(org, err)
+				}
 			}
 		}
 		return "", "", "", false, fmt.Errorf("POST %s: %w", createPath, err)
@@ -858,12 +907,24 @@ func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, ve
 
 	var created GeneratedRepo
 	if err := client.Post(createPath, bytes.NewReader(createBody), &created); err != nil {
-		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok && httpErr.StatusCode == http.StatusUnprocessableEntity && is422AlreadyExists(httpErr) {
-			getPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(newRepoName))
-			if getErr := client.Get(getPath, &created); getErr != nil {
-				return "", "", "", false, fmt.Errorf("POST %s returned 422 and follow-up GET %s failed: %w", createPath, getPath, getErr)
+		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok {
+			switch httpErr.StatusCode {
+			case http.StatusUnprocessableEntity:
+				if is422AlreadyExists(httpErr) {
+					getPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(newRepoName))
+					if getErr := client.Get(getPath, &created); getErr != nil {
+						return "", "", "", false, fmt.Errorf("POST %s returned 422 and follow-up GET %s failed: %w", createPath, getPath, getErr)
+					}
+					return created.HTMLURL, created.FullName, defaultBranchOrMain(created.DefaultBranch), true, nil
+				}
+			case http.StatusForbidden:
+				// Serves both the template-less shim path and empty_repo, which
+				// previously wrapped this 403 raw. Guarded against a throttle for
+				// the same reason as the templated path.
+				if !ghutil.IsRateLimited(err) && is403OrgRepoCreationDenied(httpErr) {
+					return "", "", "", false, orgRepoCreationDeniedError(org, err)
+				}
 			}
-			return created.HTMLURL, created.FullName, defaultBranchOrMain(created.DefaultBranch), true, nil
 		}
 		return "", "", "", false, fmt.Errorf("POST %s: %w", createPath, err)
 	}

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -1036,8 +1036,8 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 	}
 
 	// The remedy wording IS this change's deliverable (#413 is a wording defect),
-	// so assert every load-bearing clause: the hedge, both member-privilege
-	// controls, and the enterprise-pin caveat.
+	// so assert every load-bearing clause: the hedge, private-only creation, and
+	// the enterprise override.
 	assertRemedy := func(t *testing.T, err error) {
 		t.Helper()
 		if err == nil {
@@ -1046,10 +1046,9 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 		msg := err.Error()
 		for _, want := range []string{
 			"o",
-			"often because",
-			"Member privileges",
-			`"Private" is checked`,
-			`leave "Public" unchecked`,
+			"may not allow",
+			"member privileges",
+			"private (not public)",
 			"re-run organization setup",
 			"enterprise",
 		} {
@@ -1101,7 +1100,7 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 				if err == nil {
 					t.Fatal("err = nil, want the raw failure")
 				}
-				if strings.Contains(err.Error(), "Member privileges") {
+				if strings.Contains(err.Error(), "member privileges") {
 					t.Errorf("err = %q, want a throttle to stay unclassified", err)
 				}
 			}
@@ -1113,7 +1112,7 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 		if err == nil {
 			t.Fatal("err = nil, want the raw failure")
 		}
-		if strings.Contains(err.Error(), "Member privileges") {
+		if strings.Contains(err.Error(), "member privileges") {
 			t.Errorf("err = %q, want an unrelated 403 to stay unclassified", err)
 		}
 	})

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/ghutil"
 	"github.com/foundation50/gh-student/internal/assignments"
 	"github.com/foundation50/gh-student/internal/classroomcfg"
+	"github.com/foundation50/gh-student/internal/githubapi"
 	"github.com/foundation50/gh-student/internal/ui"
 )
 
@@ -990,4 +992,129 @@ func TestCreateEmptyPrivateAssignmentRepoInOrg_Bare(t *testing.T) {
 	if createBody["auto_init"] != false {
 		t.Errorf("create body = %v, want auto_init:false for a bare repo", createBody)
 	}
+}
+
+// Issue #413: the destination org refuses the create because it doesn't let its
+// members create repositories, but both creation paths fell through to a bare
+// `POST %s: %w` wrap — so a student saw GitHub's raw text with no remedy.
+func TestOrgRepoCreationDenied(t *testing.T) {
+	const orgDenied = "You need admin access to the organization before adding a repository to it."
+
+	// go-gh populates HTTPError.Message only from a JSON body, so the stub must
+	// set Content-Type and write the status before the body.
+	forbid := func(message string, headers map[string]string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			for name, value := range headers {
+				w.Header().Set(name, value)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprintf(w, `{"message":%q}`, message)
+		}
+	}
+
+	serve := func(t *testing.T, path string, handler http.HandlerFunc) githubapi.Client {
+		t.Helper()
+		mux := http.NewServeMux()
+		mux.HandleFunc(path, handler)
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+		return newTestRESTClient(t, server)
+	}
+
+	tmpl := assignments.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "main"}
+
+	templated := func(client githubapi.Client) error {
+		var out bytes.Buffer
+		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl)
+		return err
+	}
+	templateless := func(client githubapi.Client, autoInit bool) error {
+		var out bytes.Buffer
+		_, _, _, _, err := createEmptyPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "solo", "o", autoInit)
+		return err
+	}
+
+	// The remedy wording IS this change's deliverable (#413 is a wording defect),
+	// so assert every load-bearing clause: the hedge, both member-privilege
+	// controls, and the enterprise-pin caveat.
+	assertRemedy := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("err = nil, want the member-privileges remedy")
+		}
+		msg := err.Error()
+		for _, want := range []string{
+			"o",
+			"often because",
+			"Member privileges",
+			`"Private" is checked`,
+			`leave "Public" unchecked`,
+			"re-run organization setup",
+			"enterprise",
+		} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("err = %q, want it to contain %q", msg, want)
+			}
+		}
+	}
+
+	t.Run("403 on generate names the org's member privileges", func(t *testing.T) {
+		assertRemedy(t, templated(serve(t, "/repos/cs50/hello-template/generate", forbid(orgDenied, nil))))
+	})
+
+	t.Run("403 in the Errors[] items also matches", func(t *testing.T) {
+		client := serve(t, "/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprintf(w, `{"message":"Repository creation failed","errors":[{"message":%q}]}`, orgDenied)
+		})
+		assertRemedy(t, templated(client))
+	})
+
+	for _, tc := range []struct {
+		name     string
+		autoInit bool
+	}{
+		{"auto_init (template-less shim)", true},
+		{"bare (empty_repo)", false},
+	} {
+		t.Run("403 on POST orgs/{org}/repos: "+tc.name, func(t *testing.T) {
+			assertRemedy(t, templateless(serve(t, "/orgs/o/repos", forbid(orgDenied, nil)), tc.autoInit))
+		})
+	}
+
+	// A throttled 403 must stay a rate limit; rendering it as "your org blocks
+	// repo creation" is the exact mislabeling this change exists to remove.
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"x-ratelimit-remaining: 0", map[string]string{"X-RateLimit-Remaining": "0"}},
+		{"Retry-After", map[string]string{"Retry-After": "60"}},
+	} {
+		t.Run("a rate-limited 403 is not the org-denied message ("+tc.name+")", func(t *testing.T) {
+			for _, err := range []error{
+				templated(serve(t, "/repos/cs50/hello-template/generate", forbid(orgDenied, tc.headers))),
+				templateless(serve(t, "/orgs/o/repos", forbid(orgDenied, tc.headers)), true),
+			} {
+				if err == nil {
+					t.Fatal("err = nil, want the raw failure")
+				}
+				if strings.Contains(err.Error(), "Member privileges") {
+					t.Errorf("err = %q, want a throttle to stay unclassified", err)
+				}
+			}
+		})
+	}
+
+	t.Run("an unrelated 403 stays unclassified", func(t *testing.T) {
+		err := templated(serve(t, "/repos/cs50/hello-template/generate", forbid("Resource protected by organization SAML enforcement.", nil)))
+		if err == nil {
+			t.Fatal("err = nil, want the raw failure")
+		}
+		if strings.Contains(err.Error(), "Member privileges") {
+			t.Errorf("err = %q, want an unrelated 403 to stay unclassified", err)
+		}
+	})
 }

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -1035,30 +1035,34 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 		return err
 	}
 
-	// The remedy wording IS this change's deliverable (#413 is a wording defect),
-	// so assert every load-bearing clause: the hedge, private-only creation, and
-	// the enterprise override.
+	// The wording IS this change's deliverable (#413 is a wording defect), so
+	// assert every load-bearing clause: the org name, the hedge, the cause, and
+	// the one action the student can take. Deliberately NOT the fix instructions:
+	// a student can't change an org setting, so those live in the wiki and the
+	// teacher-facing web notice.
 	assertRemedy := func(t *testing.T, err error) {
 		t.Helper()
 		if err == nil {
-			t.Fatal("err = nil, want the member-privileges remedy")
+			t.Fatal("err = nil, want the org repo-creation message")
 		}
 		msg := err.Error()
 		for _, want := range []string{
-			"o",
+			"`o`",
 			"may not allow",
-			"member privileges",
-			"private (not public)",
-			"re-run organization setup",
-			"enterprise",
+			"private repositories",
+			"Ask your teacher",
 		} {
 			if !strings.Contains(msg, want) {
 				t.Errorf("err = %q, want it to contain %q", msg, want)
 			}
 		}
+		// The remedy #413 reports as useless must never appear.
+		if strings.Contains(msg, "assignment setup") {
+			t.Errorf("err = %q, must not blame assignment setup", msg)
+		}
 	}
 
-	t.Run("403 on generate names the org's member privileges", func(t *testing.T) {
+	t.Run("403 on generate names the org and the likely cause", func(t *testing.T) {
 		assertRemedy(t, templated(serve(t, "/repos/cs50/hello-template/generate", forbid(orgDenied, nil))))
 	})
 
@@ -1100,7 +1104,7 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 				if err == nil {
 					t.Fatal("err = nil, want the raw failure")
 				}
-				if strings.Contains(err.Error(), "member privileges") {
+				if strings.Contains(err.Error(), "may not allow") {
 					t.Errorf("err = %q, want a throttle to stay unclassified", err)
 				}
 			}
@@ -1112,7 +1116,7 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 		if err == nil {
 			t.Fatal("err = nil, want the raw failure")
 		}
-		if strings.Contains(err.Error(), "member privileges") {
+		if strings.Contains(err.Error(), "may not allow") {
 			t.Errorf("err = %q, want an unrelated 403 to stay unclassified", err)
 		}
 	})

--- a/cli/gh-teacher/init_repo.go
+++ b/cli/gh-teacher/init_repo.go
@@ -36,6 +36,12 @@ func applyOrgMemberDefaults(client githubapi.Client, out, errOut io.Writer, org,
 	settings := orgpolicy.MemberDefaultSettings(plan)
 	combined := make(map[string]any, len(settings))
 	for _, s := range settings {
+		// Verify-only fields are derived by GitHub, not writable: on Team/Free
+		// sending a granular repo-creation boolean 422s the whole request. They
+		// are still verified on the read-back below.
+		if !s.IsWritable() {
+			continue
+		}
 		combined[s.Field] = s.Value
 	}
 	body, err := json.Marshal(combined)
@@ -169,6 +175,9 @@ func applyOrgMemberDefaultsPerField(client githubapi.Client, out, errOut io.Writ
 	settings := orgpolicy.MemberDefaultSettings(plan)
 	var applied []string
 	for i, s := range settings {
+		if !s.IsWritable() {
+			continue
+		}
 		body, encErr := json.Marshal(map[string]any{s.Field: s.Value})
 		if encErr != nil {
 			return false, nil, fmt.Errorf("encode body: %w", encErr)

--- a/cli/gh-teacher/init_repo.go
+++ b/cli/gh-teacher/init_repo.go
@@ -39,7 +39,7 @@ func applyOrgMemberDefaults(client githubapi.Client, out, errOut io.Writer, org,
 		// Verify-only fields are derived by GitHub, not writable: on Team/Free
 		// sending a granular repo-creation boolean 422s the whole request. They
 		// are still verified on the read-back below.
-		if !s.IsWritable() {
+		if s.VerifyOnly {
 			continue
 		}
 		combined[s.Field] = s.Value
@@ -175,7 +175,7 @@ func applyOrgMemberDefaultsPerField(client githubapi.Client, out, errOut io.Writ
 	settings := orgpolicy.MemberDefaultSettings(plan)
 	var applied []string
 	for i, s := range settings {
-		if !s.IsWritable() {
+		if s.VerifyOnly {
 			continue
 		}
 		body, encErr := json.Marshal(map[string]any{s.Field: s.Value})
@@ -224,8 +224,13 @@ func applyOrgMemberDefaultsPerField(client githubapi.Client, out, errOut io.Writ
 // lockdown half-applied, naming the policies that landed and those at failedIdx
 // onward that weren't attempted, so a teacher can reconcile or re-run.
 func reportPartialMemberDefaults(errOut io.Writer, org string, settings []orgpolicy.MemberDefaultSetting, applied []string, failedIdx int, settingsURL string) {
+	// Verify-only fields are never attempted by design (GitHub derives them), so
+	// listing them would tell a teacher to go set values the API rejects.
 	notAttempted := make([]string, 0, len(settings)-failedIdx)
 	for _, s := range settings[failedIdx:] {
+		if s.VerifyOnly {
+			continue
+		}
 		notAttempted = append(notAttempted, s.Desc)
 	}
 	appliedList := "none"

--- a/cli/gh-teacher/init_repo_test.go
+++ b/cli/gh-teacher/init_repo_test.go
@@ -343,12 +343,21 @@ func TestApplyOrgMemberDefaults_HappyPath(t *testing.T) {
 	if gotBody["default_repository_permission"] != "none" {
 		t.Errorf("default_repository_permission = %v, want none", gotBody["default_repository_permission"])
 	}
-	if gotBody["members_can_create_private_repositories"] != true {
-		t.Errorf("members_can_create_private_repositories = %v, want true", gotBody["members_can_create_private_repositories"])
+	// On Team the granular repo-creation booleans are DERIVED from the master
+	// switch, and sending one is rejected: 422 "Private-only repository creation
+	// policy is not allowed for this organization." So they must be absent from
+	// the body (they are still verified on the read-back).
+	for _, f := range []string{
+		"members_can_create_private_repositories",
+		"members_can_create_public_repositories",
+	} {
+		if _, ok := gotBody[f]; ok {
+			t.Errorf("Team-plan PATCH must not send derived field %s (GitHub 422s it)", f)
+		}
 	}
-	// The master repo-creation switch must be sent true: on Team the granular
-	// private boolean is slaved to it, so omitting it leaves BOTH options OFF,
-	// breaking gh student accept.
+	// The master repo-creation switch must be sent true: GitHub resolves it to
+	// members_allowed_repository_creation_type="all", which turns BOTH granular
+	// booleans on. Omitting it leaves both OFF, breaking gh student accept.
 	if gotBody["members_can_create_repositories"] != true {
 		t.Errorf("members_can_create_repositories = %v, want true (master switch; without it Team leaves both repo-creation options off)", gotBody["members_can_create_repositories"])
 	}
@@ -368,10 +377,8 @@ func TestApplyOrgMemberDefaults_HappyPath(t *testing.T) {
 		}
 	}
 	// Enterprise-only fields must be OMITTED on a Team plan (Team doesn't
-	// expose them). members_can_create_public_repositories=false is
-	// enterpriseOnly because "private repos only" is Enterprise-Cloud-only.
+	// expose them).
 	for _, f := range []string{
-		"members_can_create_public_repositories",
 		"members_can_create_internal_repositories",
 		"members_can_view_dependency_insights",
 		"members_can_invite_outside_collaborators",
@@ -380,6 +387,7 @@ func TestApplyOrgMemberDefaults_HappyPath(t *testing.T) {
 			t.Errorf("enterprise-only field %s must NOT be in the Team-plan PATCH body", f)
 		}
 	}
+
 	// Pages creation is ENFORCED true so the config repo's public Pages
 	// site can publish — a regression to false would break the
 	// unauthenticated assignments.json fetch.

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -36,21 +36,12 @@ type MemberDefaultSetting struct {
 	// members_can_create_public_repositories is NOT enterprise-only: it must be
 	// audited on every plan, only with a different value. See nonEnterpriseOverrides.
 	enterpriseOnly bool
-	// Writable is false for a field whose desired value is real and verifiable
-	// but that must NOT be sent in the PATCH, because GitHub derives it. Only
-	// Team/Free's granular repo-creation booleans qualify — see
-	// nonEnterpriseOverrides. Zero value (false) would mean "skip", so callers
-	// must read this through IsWritable.
-	writable *bool
+	// VerifyOnly marks a field whose desired value is real and verifiable but
+	// that must NOT be sent in PATCH /orgs/{org}, because GitHub derives it.
+	// Only Team/Free's granular repo-creation booleans qualify — see
+	// nonEnterpriseOverrides.
+	VerifyOnly bool
 }
-
-// IsWritable reports whether the setting may be sent in PATCH /orgs/{org}.
-// Defaults to true; only nonEnterpriseOverrides marks a field verify-only.
-func (s MemberDefaultSetting) IsWritable() bool {
-	return s.writable == nil || *s.writable
-}
-
-func boolPtr(b bool) *bool { return &b }
 
 // nonEnterpriseOverrides holds settings whose desired VALUE and writability
 // depend on the plan, rather than being skipped off-enterprise. Only repo
@@ -71,19 +62,13 @@ func boolPtr(b bool) *bool { return &b }
 // members_allowed_repository_creation_type="all" and thereby sets both booleans
 // true. So both granular fields are verify-only here: still audited, never sent.
 // Mirrors the web's NON_ENTERPRISE_OVERRIDES.
-var nonEnterpriseOverrides = map[string]struct {
-	Value     any
-	Desc      string
-	ManualFix string
-	Critical  bool
-	Writable  bool
-}{
+var nonEnterpriseOverrides = map[string]MemberDefaultSetting{
 	"members_can_create_private_repositories": {
-		Value:     true,
-		Desc:      "private repo creation enabled",
-		ManualFix: `under "Repository creation", allow members to create repositories — on this plan "Private" is enabled together with "Public"`,
-		Critical:  false,
-		Writable:  false,
+		Value:      true,
+		Desc:       "private repo creation enabled",
+		ManualFix:  `under "Repository creation", allow members to create repositories — on this plan "Private" is enabled together with "Public"`,
+		Critical:   false,
+		VerifyOnly: true,
 	},
 	"members_can_create_public_repositories": {
 		Value:     true,
@@ -91,8 +76,8 @@ var nonEnterpriseOverrides = map[string]struct {
 		ManualFix: `under "Repository creation", allow members to create repositories — on this plan "Public" cannot be unchecked while "Private" is checked`,
 		// An enabling field, like private-repo creation: the master switch
 		// already carries the critical verdict for repo creation being off.
-		Critical: false,
-		Writable: false,
+		Critical:   false,
+		VerifyOnly: true,
 	},
 }
 
@@ -112,11 +97,11 @@ func MemberDefaultSettings(plan string) []MemberDefaultSetting {
 			continue
 		}
 		if o, ok := nonEnterpriseOverrides[s.Field]; ok {
-			s.Value = o.Value
-			s.Desc = o.Desc
-			s.ManualFix = o.ManualFix
-			s.Critical = o.Critical
-			s.writable = boolPtr(o.Writable)
+			// Field, enterpriseOnly and the rest of the canonical entry stay; the
+			// override supplies only the plan-dependent half.
+			o.Field = s.Field
+			o.enterpriseOnly = s.enterpriseOnly
+			s = o
 		}
 		filtered = append(filtered, s)
 	}

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -33,17 +33,74 @@ type MemberDefaultSetting struct {
 	//   - members_can_create_internal_repositories (internal is Enterprise).
 	//   - members_can_view_dependency_insights (no Team control).
 	//   - members_can_invite_outside_collaborators (Team: owners only).
-	//   - members_can_create_public_repositories=false ("private only"): on
-	//     Team/Free GitHub couples public+private into one "all or none"
-	//     choice, and the student flow REQUIRES private creation, so forcing
-	//     public off is impossible there. Enterprise-Cloud-only.
+	// members_can_create_public_repositories is NOT enterprise-only: it must be
+	// audited on every plan, only with a different value. See nonEnterpriseOverrides.
 	enterpriseOnly bool
+	// Writable is false for a field whose desired value is real and verifiable
+	// but that must NOT be sent in the PATCH, because GitHub derives it. Only
+	// Team/Free's granular repo-creation booleans qualify — see
+	// nonEnterpriseOverrides. Zero value (false) would mean "skip", so callers
+	// must read this through IsWritable.
+	writable *bool
+}
+
+// IsWritable reports whether the setting may be sent in PATCH /orgs/{org}.
+// Defaults to true; only nonEnterpriseOverrides marks a field verify-only.
+func (s MemberDefaultSetting) IsWritable() bool {
+	return s.writable == nil || *s.writable
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// nonEnterpriseOverrides holds settings whose desired VALUE and writability
+// depend on the plan, rather than being skipped off-enterprise. Only repo
+// creation qualifies.
+//
+// Team/Free expose "Repository creation" as a single all-or-none choice: the
+// granular public/private booleans are slaved to the master switch, so the
+// private-only lockdown Enterprise Cloud allows is unreachable. Since
+// `student accept` needs private creation, the desired end state there is BOTH
+// booleans true.
+//
+// Getting there is the subtle part, verified against the live API: any PATCH
+// carrying the granular members_can_create_private_repositories is rejected from
+// the all-off state with 422 "Private-only repository creation policy is not
+// allowed for this organization." — including one that also sets
+// members_can_create_public_repositories=true in the same request. The only
+// accepted write is the master switch alone, which GitHub resolves to
+// members_allowed_repository_creation_type="all" and thereby sets both booleans
+// true. So both granular fields are verify-only here: still audited, never sent.
+// Mirrors the web's NON_ENTERPRISE_OVERRIDES.
+var nonEnterpriseOverrides = map[string]struct {
+	Value     any
+	Desc      string
+	ManualFix string
+	Critical  bool
+	Writable  bool
+}{
+	"members_can_create_private_repositories": {
+		Value:     true,
+		Desc:      "private repo creation enabled",
+		ManualFix: `under "Repository creation", allow members to create repositories — on this plan "Private" is enabled together with "Public"`,
+		Critical:  false,
+		Writable:  false,
+	},
+	"members_can_create_public_repositories": {
+		Value:     true,
+		Desc:      "public repo creation enabled (Team/Free couples it to private)",
+		ManualFix: `under "Repository creation", allow members to create repositories — on this plan "Public" cannot be unchecked while "Private" is checked`,
+		// An enabling field, like private-repo creation: the master switch
+		// already carries the critical verdict for repo creation being off.
+		Critical: false,
+		Writable: false,
+	},
 }
 
 // MemberDefaultSettings returns the member policies to apply for the given
-// plan, dropping enterprise-only settings on non-enterprise plans. Pass the
-// plan slug from preflight; an empty/unknown plan is treated as non-enterprise
-// (conservative — only include Enterprise-only fields when sure).
+// plan, dropping enterprise-only settings and applying nonEnterpriseOverrides on
+// non-enterprise plans. Pass the plan slug from preflight; an empty/unknown plan
+// is treated as non-enterprise (conservative — only include Enterprise-only
+// fields when sure).
 func MemberDefaultSettings(plan string) []MemberDefaultSetting {
 	all := allMemberDefaultSettings()
 	if plan == "enterprise" {
@@ -53,6 +110,13 @@ func MemberDefaultSettings(plan string) []MemberDefaultSetting {
 	for _, s := range all {
 		if s.enterpriseOnly {
 			continue
+		}
+		if o, ok := nonEnterpriseOverrides[s.Field]; ok {
+			s.Value = o.Value
+			s.Desc = o.Desc
+			s.ManualFix = o.ManualFix
+			s.Critical = o.Critical
+			s.writable = boolPtr(o.Writable)
 		}
 		filtered = append(filtered, s)
 	}
@@ -110,12 +174,15 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 			ManualFix: `under "Repository creation", check "Private" — without it, gh student accept can't create student repos`,
 		},
 		{
-			Field:          "members_can_create_public_repositories",
-			Value:          false,
-			Desc:           "public repo creation disabled",
-			ManualFix:      `under "Repository creation", restrict members to private repositories only (GitHub Enterprise Cloud only)`,
-			Critical:       true,
-			enterpriseOnly: true,
+			// Enterprise Cloud only: narrows repo creation to private-only. On
+			// Team/Free GitHub couples public+private into one all-or-none
+			// choice, so this flips to true there (nonEnterpriseOverrides) and
+			// must still be SENT — omitting it 422s the whole PATCH.
+			Field:     "members_can_create_public_repositories",
+			Value:     false,
+			Desc:      "public repo creation disabled",
+			ManualFix: `under "Repository creation", restrict members to private repositories only (GitHub Enterprise Cloud only)`,
+			Critical:  true,
 		},
 		{
 			Field:          "members_can_create_internal_repositories",

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy_test.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy_test.go
@@ -7,11 +7,12 @@ import (
 
 func TestMemberDefaultSettings_PlanFilter(t *testing.T) {
 	enterpriseOnlyFields := map[string]bool{
-		"members_can_create_public_repositories":   true,
 		"members_can_create_internal_repositories": true,
 		"members_can_view_dependency_insights":     true,
 		"members_can_invite_outside_collaborators": true,
 	}
+	// Not enterprise-only: sent on every plan, with a plan-dependent value.
+	const planDependentField = "members_can_create_public_repositories"
 
 	// Enterprise gets the full canonical set, including the
 	// enterprise-only fields.
@@ -29,6 +30,17 @@ func TestMemberDefaultSettings_PlanFilter(t *testing.T) {
 			t.Errorf("enterprise plan should include enterprise-only field %s", f)
 		}
 	}
+	// Enterprise keeps the private-only lockdown.
+	for _, s := range ent {
+		if s.Field == planDependentField {
+			if s.Value != false {
+				t.Errorf("%s on enterprise = %v, want false (private-only)", s.Field, s.Value)
+			}
+			if !s.Critical {
+				t.Errorf("%s on enterprise should stay critical", s.Field)
+			}
+		}
+	}
 
 	// Team/Free/unknown plans must exclude the enterprise-only fields
 	// (Team doesn't expose those toggles).
@@ -37,10 +49,38 @@ func TestMemberDefaultSettings_PlanFilter(t *testing.T) {
 		if len(got) != len(full)-len(enterpriseOnlyFields) {
 			t.Errorf("plan %q should drop %d enterprise-only settings; got %d of %d", plan, len(enterpriseOnlyFields), len(got), len(full))
 		}
+		var sawPlanDependent bool
 		for _, s := range got {
 			if enterpriseOnlyFields[s.Field] {
 				t.Errorf("plan %q must not include enterprise-only field %s", plan, s.Field)
 			}
+			if s.Field != planDependentField {
+				continue
+			}
+			sawPlanDependent = true
+			// Team/Free couple public+private into one all-or-none choice, and
+			// the student flow requires private creation — so public must be
+			// enabled AND sent. Omitting it makes GitHub recompute the
+			// deprecated members_allowed_repository_creation_type as "private"
+			// and reject the whole PATCH with 422 "Private-only repository
+			// creation policy is not allowed for this organization."
+			if s.Value != true {
+				t.Errorf("%s on plan %q = %v, want true (coupled to private)", s.Field, plan, s.Value)
+			}
+			// The master switch owns the critical repo-creation verdict.
+			if s.Critical {
+				t.Errorf("%s on plan %q should be non-critical", s.Field, plan)
+			}
+		}
+		if !sawPlanDependent {
+			t.Errorf("plan %q must still send %s", plan, planDependentField)
+		}
+	}
+
+	// Overriding must not mutate the canonical list shared with enterprise.
+	for _, s := range MemberDefaultSettings("enterprise") {
+		if s.Field == planDependentField && s.Value != false {
+			t.Errorf("%s leaked the non-enterprise override into the canonical list", s.Field)
 		}
 	}
 }

--- a/web/src/components/OrgRepoCreationNotice.test.tsx
+++ b/web/src/components/OrgRepoCreationNotice.test.tsx
@@ -18,9 +18,9 @@ import {
 } from "@tanstack/react-router"
 
 // Real i18n (English is bundled at init) rather than a key-returning stub: the
-// copy IS this unit's deliverable — the remedy has to name both controls and
-// disclose the enterprise pin — and <Trans> renders nothing under a stubbed
-// useTranslation.
+// copy IS this unit's deliverable (the remedy has to scope to private creation
+// and disclose the enterprise override), and <Trans> renders nothing under a
+// stubbed useTranslation.
 import "@/i18n"
 import { OrgRepoCreationNotice } from "./OrgRepoCreationNotice"
 
@@ -69,8 +69,8 @@ const orgResponse = (over: Record<string, unknown> = {}) => ({
 
 // Distinguishing fragments of the two remedies. The master switch and the
 // private checkbox are different controls, so the copy must not be shared.
-const MASTER = /doesn't let its members create repositories/
-const PRIVATE = /doesn't let its members create private repositories/
+const MASTER = /doesn't allow members to create repositories/
+const PRIVATE = /doesn't allow members to create private repositories/
 const ACTION = "Organization settings"
 
 describe("OrgRepoCreationNotice", () => {
@@ -89,10 +89,10 @@ describe("OrgRepoCreationNotice", () => {
     expect(alert.textContent).toMatch(MASTER)
     expect(alert.textContent).not.toMatch(PRIVATE)
 
-    // Load-bearing clauses, not styling: name Private, keep Public locked down,
-    // and disclose that the remedy can be pinned out of reach.
-    expect(alert.textContent).toContain('check "Private"')
-    expect(alert.textContent).toContain('leave "Public" unchecked')
+    // Load-bearing clauses, not styling: ask for private creation only (public
+    // student repos would expose coursework), and disclose that the remedy can
+    // be overridden out of reach.
+    expect(alert.textContent).toContain("private (not public)")
     expect(alert.textContent).toContain("enterprise")
     expect(alert.textContent).toContain("acme")
   })
@@ -105,7 +105,7 @@ describe("OrgRepoCreationNotice", () => {
 
     const alert = await screen.findByRole("alert")
     expect(alert.textContent).toMatch(PRIVATE)
-    expect(alert.textContent).toContain('check "Private"')
+    expect(alert.textContent).toContain("private (not public)")
     expect(alert.textContent).toContain("enterprise")
   })
 

--- a/web/src/components/OrgRepoCreationNotice.test.tsx
+++ b/web/src/components/OrgRepoCreationNotice.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+const planDetails = vi.fn()
+vi.mock("@/hooks/useGetOrgPlanDetails", () => ({
+  default: () => planDetails(),
+}))
+
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router"
+
+// Real i18n (English is bundled at init) rather than a key-returning stub: the
+// copy IS this unit's deliverable — the remedy has to name both controls and
+// disclose the enterprise pin — and <Trans> renders nothing under a stubbed
+// useTranslation.
+import "@/i18n"
+import { OrgRepoCreationNotice } from "./OrgRepoCreationNotice"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+// The notice's action is a RouterButton (createLink(Button)), which needs a live
+// router — so render inside an isolated in-memory tree rather than stubbing Link.
+// Mirrors RouterButton.test.tsx's harness.
+function renderInRouter(node: ReactNode) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <>{node}</>,
+  })
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/$org/settings",
+    component: () => <div>settings</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, settingsRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  })
+  return render(<RouterProvider router={router as unknown as never} />)
+}
+
+// A GET /orgs/{org} response carrying only the fields the hook reads. The other
+// audited lockdown fields sit at their desired values so a test asserts the
+// repo-creation verdict rather than unrelated drift.
+const orgResponse = (over: Record<string, unknown> = {}) => ({
+  data: {
+    login: "acme",
+    id: 1,
+    plan: { name: "team" },
+    members_can_create_repositories: true,
+    members_can_create_private_repositories: true,
+    ...over,
+  },
+  isPending: false,
+  isError: false,
+})
+
+// Distinguishing fragments of the two remedies. The master switch and the
+// private checkbox are different controls, so the copy must not be shared.
+const MASTER = /doesn't let its members create repositories/
+const PRIVATE = /doesn't let its members create private repositories/
+const ACTION = "Organization settings"
+
+describe("OrgRepoCreationNotice", () => {
+  it("warns, naming the master switch, when repo creation is off", async () => {
+    planDetails.mockReturnValue(
+      orgResponse({
+        // Team/Free slaves the granular booleans to the master switch, so a real
+        // response has both off.
+        members_can_create_repositories: false,
+        members_can_create_private_repositories: false,
+      }),
+    )
+    renderInRouter(<OrgRepoCreationNotice org="acme" />)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toMatch(MASTER)
+    expect(alert.textContent).not.toMatch(PRIVATE)
+
+    // Load-bearing clauses, not styling: name Private, keep Public locked down,
+    // and disclose that the remedy can be pinned out of reach.
+    expect(alert.textContent).toContain('check "Private"')
+    expect(alert.textContent).toContain('leave "Public" unchecked')
+    expect(alert.textContent).toContain("enterprise")
+    expect(alert.textContent).toContain("acme")
+  })
+
+  it("warns, naming the private checkbox, when only private creation is off", async () => {
+    planDetails.mockReturnValue(
+      orgResponse({ members_can_create_private_repositories: false }),
+    )
+    renderInRouter(<OrgRepoCreationNotice org="acme" />)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toMatch(PRIVATE)
+    expect(alert.textContent).toContain('check "Private"')
+    expect(alert.textContent).toContain("enterprise")
+  })
+
+  it("stays silent when both switches are on", () => {
+    planDetails.mockReturnValue(orgResponse())
+    renderInRouter(<OrgRepoCreationNotice org="acme" />)
+
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  // Fails open: GitHub omits the member-privilege fields for a non-admin, and a
+  // teacher who can't read the setting can't be told anything useful about it.
+  // This is the one consumer that inverts classifyDefaults' fail-closed reading,
+  // so without this case every non-admin teacher would see the warning.
+  it("stays silent when the fields are absent (non-admin response)", () => {
+    planDetails.mockReturnValue({
+      data: { login: "acme", id: 1 },
+      isPending: false,
+      isError: false,
+    })
+    renderInRouter(<OrgRepoCreationNotice org="acme" />)
+
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("stays silent while loading and when the read errored", () => {
+    planDetails.mockReturnValue({
+      data: undefined,
+      isPending: true,
+      isError: false,
+    })
+    const { unmount } = renderInRouter(<OrgRepoCreationNotice org="acme" />)
+    expect(screen.queryByRole("alert")).toBeNull()
+    unmount()
+
+    planDetails.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isError: true,
+    })
+    renderInRouter(<OrgRepoCreationNotice org="acme" />)
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("stays silent without an org", () => {
+    planDetails.mockReturnValue(
+      orgResponse({ members_can_create_repositories: false }),
+    )
+    renderInRouter(<OrgRepoCreationNotice org={undefined} />)
+
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("offers the in-app org-setup re-run and the manual member-privileges link", async () => {
+    planDetails.mockReturnValue(
+      orgResponse({
+        members_can_create_repositories: false,
+        members_can_create_private_repositories: false,
+      }),
+    )
+    renderInRouter(<OrgRepoCreationNotice org="acme" />)
+
+    // The in-app repair is the primary action: hand-fixing one toggle leaves the
+    // rest of the audited lockdown unapplied.
+    const action = await screen.findByText(ACTION)
+    expect(action.closest("a")?.getAttribute("href")).toBe("/acme/settings")
+
+    const manual = screen
+      .getAllByRole("link")
+      .find((el) =>
+        el.getAttribute("href")?.includes("/settings/member_privileges"),
+      )
+    expect(manual?.getAttribute("href")).toContain("acme")
+  })
+})

--- a/web/src/components/OrgRepoCreationNotice.tsx
+++ b/web/src/components/OrgRepoCreationNotice.tsx
@@ -12,7 +12,7 @@ import { memberPrivilegesUrl } from "@/orgPolicy/desiredState"
 // The primary action is the in-app organization-setup re-run, not the GitHub
 // toggle: hand-fixing one checkbox leaves the rest of the audited lockdown
 // unapplied. The manual link stays as the secondary path, and the copy keeps the
-// enterprise-pin caveat because the re-run can silently no-op.
+// enterprise-override caveat because the re-run can silently no-op.
 //
 // This is the assignment-scoped view of the same signal OrgPreflightNotice shows
 // owners on ClassesPage — keep the two copies in step.

--- a/web/src/components/OrgRepoCreationNotice.tsx
+++ b/web/src/components/OrgRepoCreationNotice.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, Settings } from "lucide-react"
 import { Trans, useTranslation } from "react-i18next"
 
-import { EmphasisLtr, RouterButton } from "@/components/ui"
+import { Alert, EmphasisLtr, RouterButton } from "@/components/ui"
 import useOrgRepoCreationWarning from "@/hooks/useOrgRepoCreationWarning"
 import { memberPrivilegesUrl } from "@/orgPolicy/desiredState"
 
@@ -35,9 +35,9 @@ export const OrgRepoCreationNotice = ({
   if (!org || !warning.show) return null
 
   return (
-    <div
-      role="alert"
-      className={`alert alert-warning alert-soft flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}
+    <Alert
+      tone="warning"
+      className={`flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}
     >
       <div className="flex items-start gap-2">
         <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
@@ -73,7 +73,7 @@ export const OrgRepoCreationNotice = ({
         <Settings className="size-4" aria-hidden="true" />
         {t("components.notices.orgRepoCreation.action")}
       </RouterButton>
-    </div>
+    </Alert>
   )
 }
 

--- a/web/src/components/OrgRepoCreationNotice.tsx
+++ b/web/src/components/OrgRepoCreationNotice.tsx
@@ -1,27 +1,21 @@
 import { AlertTriangle, Settings } from "lucide-react"
 import { Trans, useTranslation } from "react-i18next"
 
-import { Alert, EmphasisLtr, RouterButton } from "@/components/ui"
+import { Alert, cx, EmphasisLtr, RouterButton } from "@/components/ui"
 import useOrgRepoCreationWarning from "@/hooks/useOrgRepoCreationWarning"
 import { memberPrivilegesUrl } from "@/orgPolicy/desiredState"
 
 // Warns a teacher that the org will refuse student repo creation, before a
-// student hits the accept-time 403. A warning rather than an error: the org may
-// be mid-setup, and nothing is broken yet.
+// student hits the accept-time 403. A warning, not an error: the org may be
+// mid-setup and nothing is broken yet. Renders nothing when the hook is silent.
 //
 // The primary action is the in-app organization-setup re-run, not the GitHub
 // toggle: hand-fixing one checkbox leaves the rest of the audited lockdown
-// unapplied. The manual link stays as the secondary path, and the copy keeps the
+// unapplied. The manual link stays the secondary path, and the copy keeps the
 // enterprise-override caveat because the re-run can silently no-op.
 //
 // This is the assignment-scoped view of the same signal OrgPreflightNotice shows
 // owners on ClassesPage — keep the two copies in step.
-//
-// The org read lives inside this component deliberately: mounting it only inside
-// a staff-gated subtree is what keeps a student from both seeing the warning and
-// firing a read they could never act on. Renders nothing when the setting is
-// enabled, unreadable (GitHub omits member-privilege fields for non-admins), or
-// still loading.
 export const OrgRepoCreationNotice = ({
   org,
   className = "mb-6",
@@ -37,7 +31,10 @@ export const OrgRepoCreationNotice = ({
   return (
     <Alert
       tone="warning"
-      className={`flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}
+      className={cx(
+        "flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between",
+        className,
+      )}
     >
       <div className="flex items-start gap-2">
         <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />

--- a/web/src/components/OrgRepoCreationNotice.tsx
+++ b/web/src/components/OrgRepoCreationNotice.tsx
@@ -1,0 +1,80 @@
+import { AlertTriangle, Settings } from "lucide-react"
+import { Trans, useTranslation } from "react-i18next"
+
+import { EmphasisLtr, RouterButton } from "@/components/ui"
+import useOrgRepoCreationWarning from "@/hooks/useOrgRepoCreationWarning"
+import { memberPrivilegesUrl } from "@/orgPolicy/desiredState"
+
+// Warns a teacher that the org will refuse student repo creation, before a
+// student hits the accept-time 403. A warning rather than an error: the org may
+// be mid-setup, and nothing is broken yet.
+//
+// The primary action is the in-app organization-setup re-run, not the GitHub
+// toggle: hand-fixing one checkbox leaves the rest of the audited lockdown
+// unapplied. The manual link stays as the secondary path, and the copy keeps the
+// enterprise-pin caveat because the re-run can silently no-op.
+//
+// This is the assignment-scoped view of the same signal OrgPreflightNotice shows
+// owners on ClassesPage — keep the two copies in step.
+//
+// The org read lives inside this component deliberately: mounting it only inside
+// a staff-gated subtree is what keeps a student from both seeing the warning and
+// firing a read they could never act on. Renders nothing when the setting is
+// enabled, unreadable (GitHub omits member-privilege fields for non-admins), or
+// still loading.
+export const OrgRepoCreationNotice = ({
+  org,
+  className = "mb-6",
+}: {
+  org: string | undefined
+  className?: string
+}) => {
+  const { t } = useTranslation()
+  const warning = useOrgRepoCreationWarning(org)
+
+  if (!org || !warning.show) return null
+
+  return (
+    <div
+      role="alert"
+      className={`alert alert-warning alert-soft flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <span className="text-sm">
+          <Trans
+            i18nKey={
+              warning.field === "master"
+                ? "components.notices.orgRepoCreation.master"
+                : "components.notices.orgRepoCreation.private"
+            }
+            values={{ org }}
+            components={{
+              org: <EmphasisLtr />,
+              memberPrivileges: (
+                <a
+                  className="link"
+                  href={memberPrivilegesUrl(org)}
+                  target="_blank"
+                  rel="noreferrer"
+                />
+              ),
+            }}
+          />
+        </span>
+      </div>
+      <RouterButton
+        to="/$org/settings"
+        params={{ org }}
+        variant="warning"
+        size="sm"
+        className="whitespace-nowrap sm:shrink-0"
+      >
+        <Settings className="size-4" aria-hidden="true" />
+        {t("components.notices.orgRepoCreation.action")}
+      </RouterButton>
+    </div>
+  )
+}
+
+export default OrgRepoCreationNotice

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -2266,3 +2266,195 @@ describe("createAssignmentRepo (bare / empty_repo)", () => {
     expect(getCreateBody()).toMatchObject({ auto_init: true })
   })
 })
+
+// Issue #413: GitHub refuses the create because the *destination* org doesn't let
+// its members create repositories, but the old code classified every 403/404 by
+// where the template lived — so the student got the in-org template message and
+// its "ask your teacher to re-run assignment setup" remedy, which cannot fix it.
+describe("createAssignmentRepo destination-org refusal (#413)", () => {
+  const ORG_DENIED =
+    "You need admin access to the organization before adding a repository to it."
+
+  const forbidden = (
+    path: string,
+    message: string,
+    over: Partial<{ remaining: number | null; status: number }> = {},
+  ) =>
+    new GitHubAPIError({
+      status: over.status ?? 403,
+      url: path,
+      message,
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: over.remaining ?? null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+    })
+
+  // Rejects the create call, resolves the confirming GET (the 422 path needs it).
+  const clientRejecting = (createPath: string, err: unknown): GitHubClient =>
+    ({
+      request: <T>(path: string) => {
+        if (path === createPath) return Promise.reject(err) as Promise<T>
+        return Promise.resolve({
+          name: "hw1-alice",
+          default_branch: "main",
+        } as T)
+      },
+      requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    }) as GitHubClient
+
+  const generatePath = "/repos/tpl/starter/generate"
+  const orgReposPath = "/orgs/cs50/repos"
+
+  const acceptTemplated = (templateOwner: string, err: unknown) =>
+    createAssignmentRepo({
+      client: clientRejecting(`/repos/${templateOwner}/starter/generate`, err),
+      templateOwner,
+      templateRepo: "starter",
+      owner: "cs50",
+      name: "hw1-alice",
+      fallbackBranch: "main",
+    })
+
+  const acceptTemplateless = (err: unknown, bare: boolean) =>
+    createAssignmentRepo({
+      client: clientRejecting(orgReposPath, err),
+      owner: "cs50",
+      name: "hw1-alice",
+      fallbackBranch: "main",
+      bare,
+    })
+
+  // The whole point of the fix: the destination classification wins regardless of
+  // where the template lives, because the refusal is about the destination org.
+  it.each([
+    ["an in-org template", "cs50"],
+    ["an out-of-org template", "tpl"],
+  ])("names the destination org for %s", async (_label, templateOwner) => {
+    await expect(
+      acceptTemplated(
+        templateOwner,
+        forbidden(`/repos/${templateOwner}/starter/generate`, ORG_DENIED),
+      ),
+    ).rejects.toMatchObject({
+      name: "TemplateAccessError",
+      localized: {
+        key: "accept.templateErrors.orgRepoCreationDenied",
+        params: { org: "cs50", status: 403 },
+      },
+    })
+  })
+
+  it.each([
+    ["auto_init", false],
+    ["bare", true],
+  ])(
+    "classifies the refusal on the template-less %s path",
+    async (_l, bare) => {
+      await expect(
+        acceptTemplateless(forbidden(orgReposPath, ORG_DENIED), bare),
+      ).rejects.toMatchObject({
+        name: "TemplateAccessError",
+        localized: { key: "accept.templateErrors.orgRepoCreationDenied" },
+      })
+    },
+  )
+
+  it("still yields the in-org template message for a plain 403", async () => {
+    await expect(
+      acceptTemplated(
+        "cs50",
+        forbidden(generatePath, "Must have admin rights"),
+      ),
+    ).rejects.toMatchObject({
+      localized: { key: "accept.templateErrors.inOrg" },
+    })
+  })
+
+  it("still yields the out-of-org template message for a 404", async () => {
+    await expect(
+      acceptTemplated(
+        "tpl",
+        forbidden(generatePath, "Not Found", { status: 404 }),
+      ),
+    ).rejects.toMatchObject({
+      localized: { key: "accept.templateErrors.outOfOrg" },
+    })
+  })
+
+  // A throttled 403 must keep surfacing as a rate limit ("wait a minute"), not as
+  // "your org blocks repo creation" — the exact mislabeling this change removes.
+  it("rethrows a rate-limited 403 raw on both paths", async () => {
+    await expect(
+      acceptTemplated(
+        "cs50",
+        forbidden(generatePath, ORG_DENIED, { remaining: 0 }),
+      ),
+    ).rejects.toMatchObject({ name: "GitHubAPIError", status: 403 })
+
+    await expect(
+      acceptTemplateless(
+        forbidden(orgReposPath, ORG_DENIED, { remaining: 0 }),
+        false,
+      ),
+    ).rejects.toMatchObject({ name: "GitHubAPIError", status: 403 })
+  })
+
+  it("still returns already-accepted on a 422 for both paths", async () => {
+    const templated = await createAssignmentRepo({
+      client: clientRejecting(
+        generatePath,
+        new GitHubAPIError({
+          status: 422,
+          url: generatePath,
+          message: "Unprocessable",
+          body: null,
+          rateLimit: {
+            limit: null,
+            remaining: null,
+            used: null,
+            reset: null,
+            resource: null,
+            retryAfter: null,
+          },
+        }),
+      ),
+      templateOwner: "tpl",
+      templateRepo: "starter",
+      owner: "cs50",
+      name: "hw1-alice",
+      fallbackBranch: "main",
+    })
+    expect(templated.kind).toBe("already-accepted")
+
+    const templateless = await createAssignmentRepo({
+      client: clientRejecting(
+        orgReposPath,
+        new GitHubAPIError({
+          status: 422,
+          url: orgReposPath,
+          message: "Unprocessable",
+          body: null,
+          rateLimit: {
+            limit: null,
+            remaining: null,
+            used: null,
+            reset: null,
+            resource: null,
+            retryAfter: null,
+          },
+        }),
+      ),
+      owner: "cs50",
+      name: "hw1-alice",
+      fallbackBranch: "main",
+      bare: true,
+    })
+    expect(templateless.kind).toBe("already-accepted")
+  })
+})

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { readFileSync } from "node:fs"
 import path from "node:path"
 
@@ -19,6 +19,10 @@ import {
   TEMPLATE_READ_STAFF_ROLES,
   verifyTemplateAccess,
 } from "./assignments"
+// Not on the @/domain/assignments barrel (the wrapper is internal scaffolding),
+// so reach the module directly rather than widening the public surface.
+import { withAcceptStep } from "./assignments/accessPrimitives"
+import { localizedError } from "@/types/localizedMessage"
 import type { GitHubClient } from "@/github-core/client"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { Assignment } from "@/types/classroom"
@@ -2456,5 +2460,114 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
       bare: true,
     })
     expect(templateless.kind).toBe("already-accepted")
+  })
+})
+
+// The Pages-backed accept steps (assignment, autograder) read GitHub Pages via
+// plain fetch, so every failure there is a non-GitHubAPIError. Their advice is
+// actionable and NOT retryable — an unpublished or malformed autograder never
+// resolves by trying again — so withAcceptStep must relay the error's own
+// descriptor rather than collapsing it to the step-level "safe to retry" line.
+describe("withAcceptStep on a non-GitHubAPIError", () => {
+  const label = { key: "accept.steps.autograder" }
+  const actions = { key: "accept.stepActions.autograder" }
+
+  it("relays a descriptor the thrown error already names", async () => {
+    const updates: unknown[] = []
+    const named = {
+      key: "pagesErrors.autograderMalformed",
+      params: { autograderName: "checks" },
+    }
+
+    await expect(
+      withAcceptStep(
+        {
+          id: "autograder",
+          label,
+          actions,
+          onStepUpdate: (u) => updates.push(u),
+        },
+        () => Promise.reject(localizedError(named)),
+      ),
+    ).rejects.toMatchObject({ localized: named })
+
+    expect(updates.at(-1)).toMatchObject({
+      id: "autograder",
+      status: "error",
+      error: named,
+    })
+  })
+
+  it("falls back to the step-level message for an unnamed throw", async () => {
+    const updates: unknown[] = []
+
+    await expect(
+      withAcceptStep(
+        {
+          id: "autograder",
+          label,
+          actions,
+          onStepUpdate: (u) => updates.push(u),
+        },
+        () => Promise.reject(new TypeError("Failed to fetch")),
+      ),
+    ).rejects.toBeInstanceOf(TypeError)
+
+    expect(updates.at(-1)).toMatchObject({
+      status: "error",
+      error: { key: "accept.stepErrors.unexpected", params: { label } },
+    })
+  })
+})
+
+// The Pages readers are the source of those descriptors, so assert them here
+// rather than only through the step wrapper.
+describe("resolveAutograderWorkflow Pages failures", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const stubFetch = (init: { status: number; body?: string }) => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        status: init.status,
+        ok: init.status >= 200 && init.status < 300,
+        text: () => Promise.resolve(init.body ?? ""),
+      })) as unknown as typeof fetch
+  }
+
+  const resolve = () =>
+    resolveAutograderWorkflow({
+      org: "cs50",
+      classroom: "cs101",
+      autograder: "checks",
+      branch: "main",
+      configBranch: "main",
+    })
+
+  it("names the not-published remedy on a 404", async () => {
+    stubFetch({ status: 404 })
+    await expect(resolve()).rejects.toMatchObject({
+      localized: { key: "pagesErrors.notPublished" },
+    })
+  })
+
+  it("names the malformed-YAML remedy when the workflow has no jobs", async () => {
+    stubFetch({ status: 200, body: "name: not a workflow\n" })
+    await expect(resolve()).rejects.toMatchObject({
+      localized: {
+        key: "pagesErrors.autograderMalformed",
+        params: { autograderName: "checks" },
+      },
+    })
+  })
+
+  it("names the deploy-in-flight remedy for an empty body", async () => {
+    stubFetch({ status: 200, body: "   " })
+    await expect(resolve()).rejects.toMatchObject({
+      localized: { key: "pagesErrors.deployInFlight" },
+    })
   })
 })

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -22,7 +22,8 @@ import {
 // Not on the @/domain/assignments barrel (the wrapper is internal scaffolding),
 // so reach the module directly rather than widening the public surface.
 import { withAcceptStep } from "./assignments/accessPrimitives"
-import { localizedError } from "@/types/localizedMessage"
+import { extractAssignments } from "@/github-core/queries"
+import { localizedError, localizedMessageOf } from "@/types/localizedMessage"
 import type { GitHubClient } from "@/github-core/client"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { Assignment } from "@/types/classroom"
@@ -1903,10 +1904,19 @@ describe("assertAssignmentModeCoherent", () => {
     ).not.toThrow()
   })
 
-  it("rejects a group-shaped size with a non-group mode", () => {
-    expect(() => assertAssignmentModeCoherent("hw", "individual", 2)).toThrow(
-      /max_group_size 2 but mode "individual"/,
-    )
+  // Thrown OUTSIDE withAcceptStep, so the error alert is the only place a
+  // student sees it — it must name its message or the page falls back to the
+  // generic "something went wrong" with no reason and no remedy.
+  it("rejects a group-shaped size with a non-group mode, naming the remedy", () => {
+    expect(() => assertAssignmentModeCoherent("hw", "individual", 2)).toThrow()
+    try {
+      assertAssignmentModeCoherent("hw", "individual", 2)
+    } catch (err) {
+      expect(localizedMessageOf(err)).toEqual({
+        key: "accept.errors.incoherentMode",
+        params: { slug: "hw", maxGroupSize: 2, mode: "individual" },
+      })
+    }
   })
 })
 
@@ -2025,6 +2035,8 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
 
   it("throws when the read-back still reports admin after a push grant", async () => {
     const { client } = makeClient({ permission: "admin", role_name: "admin" })
+    // Thrown inside a step, so without its own descriptor the checklist would
+    // relabel it "safe to retry" — wrong for a grant only a teacher can fix.
     await expect(
       addFounderCollaborator({
         client,
@@ -2033,7 +2045,12 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         username,
         permission: "push",
       }),
-    ).rejects.toThrow(/"push"/)
+    ).rejects.toMatchObject({
+      localized: {
+        key: "accept.errors.founderAccessMismatch",
+        params: { username, permission: "push", effective: "admin" },
+      },
+    })
   })
 
   it("throws when the read-back is maintain for a push grant (the guard's boundary)", async () => {
@@ -2049,7 +2066,12 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         username,
         permission: "push",
       }),
-    ).rejects.toThrow(/"push"/)
+    ).rejects.toMatchObject({
+      localized: {
+        key: "accept.errors.founderAccessMismatch",
+        params: { permission: "push", role: "maintain" },
+      },
+    })
   })
 
   it("resolves for an org owner whose read-back stays admin after a push grant", async () => {
@@ -2569,5 +2591,41 @@ describe("resolveAutograderWorkflow Pages failures", () => {
     await expect(resolve()).rejects.toMatchObject({
       localized: { key: "pagesErrors.deployInFlight" },
     })
+  })
+})
+
+// These throw inside a step, so before they named their message the unexpected
+// branch relabeled them "safe to retry" — actively wrong, since neither a
+// version mismatch nor a malformed manifest resolves by retrying.
+describe("extractAssignments manifest guards", () => {
+  it("names the unsupported-version remedy", () => {
+    try {
+      extractAssignments({ version: 2, assignments: [] } as never)
+      expect.unreachable("expected a throw")
+    } catch (err) {
+      expect(localizedMessageOf(err)).toEqual({
+        key: "pagesErrors.manifestVersionUnsupported",
+        params: { version: "2" },
+      })
+    }
+  })
+
+  it("names the invalid-shape remedy", () => {
+    try {
+      extractAssignments({ version: 1, assignments: "nope" } as never)
+      expect.unreachable("expected a throw")
+    } catch (err) {
+      expect(localizedMessageOf(err)).toEqual({
+        key: "pagesErrors.manifestInvalidShape",
+      })
+    }
+  })
+
+  it("passes a bare v1 array and a valid v1 object through", () => {
+    const entry = { slug: "hw1" } as never
+    expect(extractAssignments([entry] as never)).toEqual([entry])
+    expect(
+      extractAssignments({ version: 1, assignments: [entry] } as never),
+    ).toEqual([entry])
   })
 })

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -21,6 +21,7 @@ import { isOwnerGitHubOrgRole } from "@/authz"
 import {
   log,
   withAcceptStep,
+  AcceptStepError,
   repoContentsPathExists,
   resolveConfigRepoDefaultBranch,
   freshRepoNotReadyError,
@@ -148,9 +149,12 @@ function grantFounderAccessStep(params: {
   return withAcceptStep(
     {
       id: "access",
-      label: "Granting you access to your repository",
-      actions: `Your repository ${org}/${repo} was created, but adding you (${username}) as a collaborator failed. This usually means your GitHub username changed or you left ${org}. Confirm you're a member of ${org}, then use "Re-run setup".`,
-      doneMessage: "Granted you access to your repository",
+      label: { key: "accept.steps.access" },
+      actions: {
+        key: "accept.stepActions.access",
+        params: { org, repo, username },
+      },
+      doneMessage: { key: "accept.stepDone.access" },
       onStepUpdate,
     },
     async () => {
@@ -211,9 +215,12 @@ async function provisionAcceptedRepo(params: {
   await withAcceptStep(
     {
       id: "setup",
-      label: "Setting up autograding",
-      actions: `Your repository ${org}/${repo.name} exists, but writing the setup files to branch "${branch}" failed. The repository may still be initializing — wait a minute and use "Re-run setup".`,
-      doneMessage: "Autograding configured",
+      label: { key: "accept.steps.setup" },
+      actions: {
+        key: "accept.stepActions.setup",
+        params: { org, repo: repo.name, branch },
+      },
+      doneMessage: { key: "accept.stepDone.setup" },
       onStepUpdate,
     },
     () =>
@@ -250,10 +257,9 @@ export async function acceptAssignment(params: {
   const user = await withAcceptStep(
     {
       id: "account",
-      label: "Checking your GitHub account",
-      actions:
-        "Couldn't read your GitHub account. Sign out and sign back in, then accept again.",
-      doneMessage: "Checked your GitHub account",
+      label: { key: "accept.steps.account" },
+      actions: { key: "accept.stepActions.account" },
+      doneMessage: { key: "accept.stepDone.account" },
       onStepUpdate,
     },
     () => getAuthenticatedUser(client),
@@ -268,10 +274,9 @@ export async function acceptAssignment(params: {
   const membership = await withAcceptStep(
     {
       id: "membership",
-      label: "Confirming your classroom membership",
-      actions:
-        "Couldn't confirm your membership. If your organization uses single sign-on (SSO), authorize it for this org (or open this link from your LMS), then accept again. Otherwise ask your teacher to confirm your invitation.",
-      doneMessage: "Confirmed your classroom membership",
+      label: { key: "accept.steps.membership" },
+      actions: { key: "accept.stepActions.membership" },
+      doneMessage: { key: "accept.stepDone.membership" },
       onStepUpdate,
     },
     () => acceptAndVerifyOrgMembership(client, org),
@@ -285,9 +290,15 @@ export async function acceptAssignment(params: {
   const assignment = await withAcceptStep(
     {
       id: "assignment",
-      label: `Looking up ${assignmentSlug}`,
-      actions: `Couldn't load assignment "${assignmentSlug}" for ${org}/${classroom}. Check the link, or ask your teacher to confirm the assignment is published.`,
-      doneMessage: `Found assignment ${assignmentSlug}`,
+      label: { key: "accept.steps.assignment" },
+      actions: {
+        key: "accept.stepActions.assignment",
+        params: { assignmentSlug, org, classroom },
+      },
+      doneMessage: {
+        key: "accept.stepDone.assignment",
+        params: { assignmentSlug },
+      },
       onStepUpdate,
     },
     () => fetchAssignmentFromPages(org, classroom, assignmentSlug, secret),
@@ -307,9 +318,10 @@ export async function acceptAssignment(params: {
   // both. Fail closed rather than half-apply (template content with no
   // control files). Mirrors the CLI's guard.
   if (isEmptyRepo && assignment.template) {
-    throw new Error(
-      `Assignment "${assignmentSlug}" sets both empty_repo and a template — the entry is invalid; ask your teacher to re-run assignment setup.`,
-    )
+    throw new AcceptStepError({
+      key: "accept.errors.emptyRepoWithTemplate",
+      params: { assignmentSlug },
+    })
   }
 
   // Best-effort: resolve the template owner's immutable id (org or user). Never
@@ -335,9 +347,12 @@ export async function acceptAssignment(params: {
     : await withAcceptStep(
         {
           id: "autograder",
-          label: "Resolving the autograder",
-          actions: `Couldn't resolve the autograder for "${assignmentSlug}". Ask your teacher to confirm it's published, then accept again.`,
-          doneMessage: "Resolved the autograder",
+          label: { key: "accept.steps.autograder" },
+          actions: {
+            key: "accept.stepActions.autograder",
+            params: { assignmentSlug },
+          },
+          doneMessage: { key: "accept.stepDone.autograder" },
           onStepUpdate,
         },
         () =>
@@ -355,7 +370,7 @@ export async function acceptAssignment(params: {
     onStepUpdate?.({
       id: "autograder",
       status: "complete",
-      message: "Autograding is disabled for this assignment",
+      message: { key: "accept.stepDone.autograderDisabled" },
     })
   }
 
@@ -381,9 +396,15 @@ export async function acceptAssignment(params: {
   const created = await withAcceptStep(
     {
       id: "repo",
-      label: "Creating your repository",
-      actions: `Couldn't create ${org}/${studentRepoNameValue}. Confirm you're a member of ${org} and ask your teacher to verify the assignment's template repository is configured correctly, then accept again.`,
-      doneMessage: `Created ${org}/${studentRepoNameValue}`,
+      label: { key: "accept.steps.repo" },
+      actions: {
+        key: "accept.stepActions.repo",
+        params: { org, repo: studentRepoNameValue },
+      },
+      doneMessage: {
+        key: "accept.stepDone.repo",
+        params: { org, repo: studentRepoNameValue },
+      },
       onStepUpdate,
     },
     () =>
@@ -415,7 +436,10 @@ export async function acceptAssignment(params: {
       onStepUpdate?.({
         id: "repo",
         status: "complete",
-        message: `Repository already exists: ${org}/${created.repo.name}`,
+        message: {
+          key: "accept.stepDone.repoExists",
+          params: { org, repo: created.repo.name },
+        },
       })
       try {
         await patchRepoSurface(client, org, created.repo.name)
@@ -452,7 +476,7 @@ export async function acceptAssignment(params: {
     onStepUpdate?.({
       id: "setup",
       status: "complete",
-      message: "No setup needed — this assignment uses an empty repository",
+      message: { key: "accept.stepDone.setupSkippedEmptyRepo" },
     })
 
     return {
@@ -532,7 +556,10 @@ export async function acceptAssignment(params: {
       onStepUpdate?.({
         id: "repo",
         status: "complete",
-        message: `Repository already exists: ${org}/${created.repo.name}`,
+        message: {
+          key: "accept.stepDone.repoExists",
+          params: { org, repo: created.repo.name },
+        },
       })
       onStepUpdate?.({ id: "access", status: "complete" })
       onStepUpdate?.({ id: "setup", status: "complete" })
@@ -554,7 +581,10 @@ export async function acceptAssignment(params: {
     onStepUpdate?.({
       id: "repo",
       status: "complete",
-      message: `Found incomplete setup: ${org}/${created.repo.name}`,
+      message: {
+        key: "accept.stepDone.repoIncomplete",
+        params: { org, repo: created.repo.name },
+      },
     })
 
     await provisionAcceptedRepo({

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -96,18 +96,22 @@ export async function withAcceptStep<T>(
       throw new AcceptStepError(message, cause)
     }
 
-    if (err instanceof TemplateAccessError) {
-      log.warn(`accept step "${id}" failed (typed)`, { step: id })
-      onStepUpdate?.({ id, status: "error", error: err.localizedStep })
-      throw err
-    }
-    if (err instanceof AcceptStepError) {
-      log.warn(`accept step "${id}" failed (typed)`, { step: id })
-      onStepUpdate?.({ id, status: "error", error: err.localized })
+    if (err instanceof TemplateAccessError || err instanceof AcceptStepError) {
+      log.warn("accept step failed (typed)", { step: id })
+      // TemplateAccessError carries a shorter form for the checklist row, which
+      // sits beside six others and can't absorb a paragraph.
+      onStepUpdate?.({
+        id,
+        status: "error",
+        error:
+          err instanceof TemplateAccessError
+            ? err.localizedStep
+            : err.localized,
+      })
       throw err
     }
     if (err instanceof GitHubAPIError) {
-      log.error(`Accept step "${id}" failed`, { err })
+      log.error("accept step failed", { step: id, err })
 
       if (err.isRateLimited) {
         fail({ key: "accept.stepErrors.rateLimited", params: { label } }, err)
@@ -129,7 +133,7 @@ export async function withAcceptStep<T>(
     // unpublished assignment or malformed autograder is actionable advice a
     // generic "safe to retry" line would throw away. Rethrown unwrapped so the
     // outage classifier still sees the original error, not a wrapper.
-    log.error(`accept step "${id}" failed (unexpected)`, { err })
+    log.error("accept step failed (unexpected)", { step: id, err })
     onStepUpdate?.({
       id,
       status: "error",

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -9,6 +9,7 @@ import { githubOrgOAuthPolicyUrl } from "@/auth/constants"
 import { TemplateAccessError } from "@/util/templateAccessError"
 import {
   describeLocalizedMessage,
+  localizedMessageOf,
   type LocalizedMessage,
 } from "@/types/localizedMessage"
 import { prefixCommit } from "@/util/commit"
@@ -123,14 +124,19 @@ export async function withAcceptStep<T>(
       )
     }
     // Unexpected non-GitHub error (network/parse/etc.): surface it so the
-    // checklist row leaves "running" instead of spinning forever. GitHub never
-    // saw this request, so there is no status or remedy to name — the row shows
-    // the step's own label with an error icon.
+    // checklist row leaves "running" instead of spinning forever. A thrown error
+    // that already names its own message keeps it — the Pages readers do, and an
+    // unpublished assignment or malformed autograder is actionable advice a
+    // generic "safe to retry" line would throw away. Rethrown unwrapped so the
+    // outage classifier still sees the original error, not a wrapper.
     log.error(`accept step "${id}" failed (unexpected)`, { err })
     onStepUpdate?.({
       id,
       status: "error",
-      error: { key: "accept.stepErrors.unexpected", params: { label } },
+      error: localizedMessageOf(err) ?? {
+        key: "accept.stepErrors.unexpected",
+        params: { label },
+      },
     })
     throw err
   }

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -7,6 +7,10 @@ import { isDefiniteOutageError } from "@/lib/githubHealth/githubHealthStore"
 import type { GitHubRepo } from "@/github-core/types"
 import { githubOrgOAuthPolicyUrl } from "@/auth/constants"
 import { TemplateAccessError } from "@/util/templateAccessError"
+import {
+  describeLocalizedMessage,
+  type LocalizedMessage,
+} from "@/types/localizedMessage"
 import { prefixCommit } from "@/util/commit"
 import { logger } from "@/lib/logger"
 
@@ -20,12 +24,17 @@ export const ACCEPT_COMMIT_SUBJECT = prefixCommit(
   "Initialize .classroom50.yaml and autograde workflow (gh student accept)",
 )
 
-// Student-facing accept failure: the accept page renders `error.message`
-// verbatim, so a raw GitHub "Not Found" never reaches a student.
+// Student-facing accept failure: `localized` names the message the accept page
+// renders, so a raw GitHub "Not Found" never reaches a student. `Error.message`
+// keeps a diagnostic form for logs and outage classification (which unwraps
+// `.cause`), but the view renders `localized`, never this.
 export class AcceptStepError extends Error {
-  constructor(message: string, cause?: unknown) {
-    super(message)
+  localized: LocalizedMessage
+
+  constructor(localized: LocalizedMessage, cause?: unknown) {
+    super(describeLocalizedMessage(localized))
     this.name = "AcceptStepError"
+    this.localized = localized
     if (cause !== undefined) {
       this.cause = cause
     }
@@ -49,8 +58,8 @@ export type AcceptStepUpdate = {
   status: AcceptStepStatus
   // Step label; on resolution can override the default (e.g., "Repository
   // already exists").
-  message?: string
-  error?: string
+  message?: LocalizedMessage
+  error?: LocalizedMessage
 }
 
 export type OnAcceptStepUpdate = (update: AcceptStepUpdate) => void
@@ -58,14 +67,15 @@ export type OnAcceptStepUpdate = (update: AcceptStepUpdate) => void
 // Run one accept step, emitting progress around it. Translates a raw
 // GitHubAPIError into a student-facing, actionable message (`actions`) so a
 // bare "Not Found" never reaches the student; already-friendly errors pass
-// through untouched.
+// through untouched. Every message is a `{ key, params }` descriptor — this
+// layer names messages, the accept page renders them.
 export async function withAcceptStep<T>(
   params: {
     id: AcceptStepId
-    label: string
-    actions: string
+    label: LocalizedMessage
+    actions: LocalizedMessage
     onStepUpdate?: OnAcceptStepUpdate
-    doneMessage?: string
+    doneMessage?: LocalizedMessage
   },
   fn: () => Promise<T>,
 ): Promise<T> {
@@ -80,40 +90,47 @@ export async function withAcceptStep<T>(
     onStepUpdate?.({ id, status: "complete", message: doneMessage ?? label })
     return result
   } catch (err) {
-    const fail = (message: string, cause?: unknown): never => {
+    const fail = (message: LocalizedMessage, cause?: unknown): never => {
       onStepUpdate?.({ id, status: "error", error: message })
       throw new AcceptStepError(message, cause)
     }
 
-    if (err instanceof TemplateAccessError || err instanceof AcceptStepError) {
-      log.warn(`accept step "${label}" failed (typed)`, { step: id })
-      onStepUpdate?.({ id, status: "error", error: err.message })
+    if (err instanceof TemplateAccessError) {
+      log.warn(`accept step "${id}" failed (typed)`, { step: id })
+      onStepUpdate?.({ id, status: "error", error: err.localizedStep })
+      throw err
+    }
+    if (err instanceof AcceptStepError) {
+      log.warn(`accept step "${id}" failed (typed)`, { step: id })
+      onStepUpdate?.({ id, status: "error", error: err.localized })
       throw err
     }
     if (err instanceof GitHubAPIError) {
-      log.error(`Accept step "${label}" failed`, { err })
+      log.error(`Accept step "${id}" failed`, { err })
 
       if (err.isRateLimited) {
-        fail(
-          `${label} hit GitHub's rate limit. Wait a minute, then try accepting again.`,
-          err,
-        )
+        fail({ key: "accept.stepErrors.rateLimited", params: { label } }, err)
       }
       if (err.isUnauthorized) {
-        fail(
-          `${label} failed because your GitHub session expired (HTTP 401). Sign out and sign back in, then accept again.`,
-          err,
-        )
+        fail({ key: "accept.stepErrors.unauthorized", params: { label } }, err)
       }
-      fail(`${label} failed (HTTP ${err.status}). ${actions}`, err)
+      fail(
+        {
+          key: "accept.stepErrors.generic",
+          params: { label, status: err.status, actions },
+        },
+        err,
+      )
     }
     // Unexpected non-GitHub error (network/parse/etc.): surface it so the
-    // checklist row leaves "running" instead of spinning forever.
-    log.error(`accept step "${label}" failed (unexpected)`, { err })
+    // checklist row leaves "running" instead of spinning forever. GitHub never
+    // saw this request, so there is no status or remedy to name — the row shows
+    // the step's own label with an error icon.
+    log.error(`accept step "${id}" failed (unexpected)`, { err })
     onStepUpdate?.({
       id,
       status: "error",
-      error: err instanceof Error ? err.message : "Unexpected error",
+      error: { key: "accept.stepErrors.unexpected", params: { label } },
     })
     throw err
   }

--- a/web/src/domain/assignments/autograderYaml.ts
+++ b/web/src/domain/assignments/autograderYaml.ts
@@ -140,7 +140,6 @@ export async function resolveAutograderWorkflow(params: {
 
   const workflow = await fetchTextWithFriendlyErrors(
     pagesAutograderUrl({ org, classroom, name: autograderName, secret }),
-    `autograder ${autograderName}`,
     { key: "pagesErrors.autograderLabel", params: { autograderName } },
   )
 

--- a/web/src/domain/assignments/autograderYaml.ts
+++ b/web/src/domain/assignments/autograderYaml.ts
@@ -1,6 +1,7 @@
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { classroomPagesSegment } from "@/util/secret"
 import { fetchTextWithFriendlyErrors } from "../queries/assignments"
+import { localizedError } from "@/types/localizedMessage"
 
 export function createClassroom50Yaml(params: {
   classroom: string
@@ -140,12 +141,14 @@ export async function resolveAutograderWorkflow(params: {
   const workflow = await fetchTextWithFriendlyErrors(
     pagesAutograderUrl({ org, classroom, name: autograderName, secret }),
     `autograder ${autograderName}`,
+    { key: "pagesErrors.autograderLabel", params: { autograderName } },
   )
 
   if (!workflow.includes("jobs:")) {
-    throw new Error(
-      `Autograder ${autograderName} may be malformed YAML. Ask your teacher to check the file in the config repo.`,
-    )
+    throw localizedError({
+      key: "pagesErrors.autograderMalformed",
+      params: { autograderName },
+    })
   }
 
   return workflow

--- a/web/src/domain/assignments/permissions.ts
+++ b/web/src/domain/assignments/permissions.ts
@@ -2,6 +2,7 @@ import type { GitHubClient } from "@/github-core/client"
 import type { AssignmentMode } from "@/types/classroom"
 import type { GitHubRepo } from "@/github-core/types"
 import { getRepoPermissionForUser } from "@/github-core/queries"
+import { localizedError } from "@/types/localizedMessage"
 
 // Grant the founder their repo role and verify it took: a repo creator holds
 // admin, so an individual self-downgrade GitHub silently ignores looks like
@@ -40,9 +41,17 @@ export async function addFounderCollaborator(params: {
       isOwner,
     )
   ) {
-    throw new Error(
-      `Expected ${username} to have "${permission}" access on ${owner}/${repo}, but GitHub reports "${effective.permission}" (role "${effective.role_name}") — a repo creator holds admin and a self-downgrade may be blocked by org policy. Ask your teacher to set your access to "${permission}".`,
-    )
+    throw localizedError({
+      key: "accept.errors.founderAccessMismatch",
+      params: {
+        username,
+        permission,
+        owner,
+        repo,
+        effective: effective.permission ?? "none",
+        role: effective.role_name ?? "unknown",
+      },
+    })
   }
 }
 
@@ -83,9 +92,10 @@ export function assertAssignmentModeCoherent(
   maxGroupSize: number | undefined,
 ): void {
   if ((maxGroupSize ?? 0) > 0 && mode !== "group") {
-    throw new Error(
-      `Assignment "${slug}" has max_group_size ${maxGroupSize} but mode "${mode}" (want "group") — its published metadata is inconsistent. Ask your teacher to re-run assignment setup.`,
-    )
+    throw localizedError({
+      key: "accept.errors.incoherentMode",
+      params: { slug, maxGroupSize: maxGroupSize ?? 0, mode },
+    })
   }
 }
 

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -93,19 +93,18 @@ export async function createAssignmentRepo(params: {
       }
       if (err.isForbidden || err.isNotFound) {
         const inOrg = templateOwner.toLowerCase() === owner.toLowerCase()
-        // The only signal that GitHub reworded the destination-org refusal: the
-        // match stops firing, students silently get the template message again,
-        // and the tests can't catch it (they assert our own fixture).
-        log.warn(
-          "accept: template-copy refused, classified by template location",
-          {
+        // Tripwire for GitHub rewording the destination-org 403: the match stops
+        // firing, students silently get the template message again, and the tests
+        // can't catch it (they assert our own fixture). A 404 is not evidence of
+        // that, so it stays out of the warn.
+        if (err.isForbidden) {
+          log.warn("accept: repo create 403 fell through to template blame", {
             org: owner,
             templateOwner,
             inOrg,
-            status: err.status,
             githubMessage: err.message,
-          },
-        )
+          })
+        }
         throw inOrg
           ? inOrgTemplateError(
               templateOwner,
@@ -197,19 +196,19 @@ async function createEmptyAssignmentRepo(params: {
       }
     }
 
-    // Template-less and empty_repo assignments hit this path, where the same
-    // destination-org refusal used to rethrow raw and degrade to the generic
-    // step text.
-    if (err instanceof GitHubAPIError && isOrgRepoCreationDenied(err)) {
-      throw orgRepoCreationDeniedError(owner, err.status, err.message)
-    }
-
-    if (err instanceof GitHubAPIError && err.isForbidden) {
-      log.warn("accept: repo create refused, no classification matched", {
-        org: owner,
-        status: err.status,
-        githubMessage: err.message,
-      })
+    if (err instanceof GitHubAPIError) {
+      // Template-less and empty_repo assignments hit this path, where the same
+      // destination-org refusal used to rethrow raw and degrade to generic text.
+      if (isOrgRepoCreationDenied(err)) {
+        throw orgRepoCreationDeniedError(owner, err.status, err.message)
+      }
+      if (err.isForbidden) {
+        // Same tripwire as the templated path above.
+        log.warn("accept: repo create 403 fell through unclassified", {
+          org: owner,
+          githubMessage: err.message,
+        })
+      }
     }
 
     throw err

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -5,8 +5,11 @@ import { DEFAULT_BRANCH } from "@/util/configRepo"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
   inOrgTemplateError,
+  isOrgRepoCreationDenied,
+  orgRepoCreationDeniedError,
   outOfOrgTemplateError,
 } from "@/util/templateAccessError"
+import { log } from "./accessPrimitives"
 import { withGitConflictRetry } from "../classrooms"
 import { createAssignment } from "./createEdit"
 
@@ -81,8 +84,28 @@ export async function createAssignmentRepo(params: {
       if (err.isRateLimited) {
         throw err
       }
+      // The destination org refusing the create is independent of where the
+      // template lives, so it is classified before the in-org/out-of-org split —
+      // which would otherwise blame the template for a destination problem
+      // (issue #413). `owner` is the destination org, not templateOwner.
+      if (isOrgRepoCreationDenied(err)) {
+        throw orgRepoCreationDeniedError(owner, err.status, err.message)
+      }
       if (err.isForbidden || err.isNotFound) {
         const inOrg = templateOwner.toLowerCase() === owner.toLowerCase()
+        // The only signal that GitHub reworded the destination-org refusal: the
+        // match stops firing, students silently get the template message again,
+        // and the tests can't catch it (they assert our own fixture).
+        log.warn(
+          "accept: template-copy refused, classified by template location",
+          {
+            org: owner,
+            templateOwner,
+            inOrg,
+            status: err.status,
+            githubMessage: err.message,
+          },
+        )
         throw inOrg
           ? inOrgTemplateError(
               templateOwner,
@@ -172,6 +195,21 @@ async function createEmptyAssignmentRepo(params: {
         kind: "already-accepted",
         repo: existing,
       }
+    }
+
+    // Template-less and empty_repo assignments hit this path, where the same
+    // destination-org refusal used to rethrow raw and degrade to the generic
+    // step text.
+    if (err instanceof GitHubAPIError && isOrgRepoCreationDenied(err)) {
+      throw orgRepoCreationDeniedError(owner, err.status, err.message)
+    }
+
+    if (err instanceof GitHubAPIError && err.isForbidden) {
+      log.warn("accept: repo create refused, no classification matched", {
+        org: owner,
+        status: err.status,
+        githubMessage: err.message,
+      })
     }
 
     throw err

--- a/web/src/domain/queries/assignments.ts
+++ b/web/src/domain/queries/assignments.ts
@@ -8,6 +8,11 @@ import {
 import type { Assignment } from "@/types/classroom"
 import { decodeBase64Utf8 } from "@/util/github"
 import { CONFIG_REPO } from "@/util/configRepo"
+import {
+  localizedError,
+  withLocalizedMessage,
+  type LocalizedMessage,
+} from "@/types/localizedMessage"
 
 export type GetAssignmentsFileInput = {
   org: string
@@ -44,24 +49,38 @@ export async function getAssignmentsFile(
 export async function fetchTextWithFriendlyErrors(
   url: string,
   label: string,
+  // Names `label` for a descriptor-aware renderer (the accept page). Optional so
+  // the English `label` stays the fallback for any other consumer.
+  labelMessage?: LocalizedMessage,
 ): Promise<string> {
   const response = await fetch(url)
+  const named = (key: string, params?: Record<string, string | number>) => ({
+    key,
+    params: { ...params, label: labelMessage ?? label },
+  })
 
   if (response.status === 404) {
-    throw new Error(
-      `${label} is not published yet. Ask your teacher to confirm the file exists in the config repo and that publish-pages.yaml has been run.`,
+    throw withLocalizedMessage(
+      new Error(
+        `${label} is not published yet. Ask your teacher to confirm the file exists in the config repo and that publish-pages.yaml has been run.`,
+      ),
+      named("pagesErrors.notPublished"),
     )
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${label}: ${response.status}`)
+    throw withLocalizedMessage(
+      new Error(`Failed to fetch ${label}: ${response.status}`),
+      named("pagesErrors.fetchFailed", { status: response.status }),
+    )
   }
 
   const text = await response.text()
 
   if (!text.trim()) {
-    throw new Error(
-      "Pages deployment may still be in flight. Retry in a minute.",
+    throw withLocalizedMessage(
+      new Error("Pages deployment may still be in flight. Retry in a minute."),
+      { key: "pagesErrors.deployInFlight" },
     )
   }
 
@@ -82,7 +101,10 @@ export async function fetchAssignmentFromPages(
   const assignment = assignments.find((entry) => entry.slug === assignmentSlug)
 
   if (!assignment) {
-    throw new Error(`Assignment ${assignmentSlug} was not found.`)
+    throw localizedError({
+      key: "pagesErrors.assignmentNotInManifest",
+      params: { assignmentSlug },
+    })
   }
 
   return assignment

--- a/web/src/domain/queries/assignments.ts
+++ b/web/src/domain/queries/assignments.ts
@@ -8,11 +8,7 @@ import {
 import type { Assignment } from "@/types/classroom"
 import { decodeBase64Utf8 } from "@/util/github"
 import { CONFIG_REPO } from "@/util/configRepo"
-import {
-  localizedError,
-  withLocalizedMessage,
-  type LocalizedMessage,
-} from "@/types/localizedMessage"
+import { localizedError, type LocalizedMessage } from "@/types/localizedMessage"
 
 export type GetAssignmentsFileInput = {
   org: string
@@ -46,42 +42,29 @@ export async function getAssignmentsFile(
   return JSON.parse(json) as AssignmentsFile
 }
 
+// `label` names what failed for the reader (e.g. the autograder). It is a
+// descriptor, not English, so the message renders in the student's language; the
+// thrown errors carry the diagnostic form in `Error.message` for logs.
 export async function fetchTextWithFriendlyErrors(
   url: string,
-  label: string,
-  // Names `label` for a descriptor-aware renderer (the accept page). Optional so
-  // the English `label` stays the fallback for any other consumer.
-  labelMessage?: LocalizedMessage,
+  label: LocalizedMessage,
 ): Promise<string> {
   const response = await fetch(url)
-  const named = (key: string, params?: Record<string, string | number>) => ({
-    key,
-    params: { ...params, label: labelMessage ?? label },
-  })
+  const named = (key: string, params?: Record<string, string | number>) =>
+    localizedError({ key, params: { ...params, label } })
 
   if (response.status === 404) {
-    throw withLocalizedMessage(
-      new Error(
-        `${label} is not published yet. Ask your teacher to confirm the file exists in the config repo and that publish-pages.yaml has been run.`,
-      ),
-      named("pagesErrors.notPublished"),
-    )
+    throw named("pagesErrors.notPublished")
   }
 
   if (!response.ok) {
-    throw withLocalizedMessage(
-      new Error(`Failed to fetch ${label}: ${response.status}`),
-      named("pagesErrors.fetchFailed", { status: response.status }),
-    )
+    throw named("pagesErrors.fetchFailed", { status: response.status })
   }
 
   const text = await response.text()
 
   if (!text.trim()) {
-    throw withLocalizedMessage(
-      new Error("Pages deployment may still be in flight. Retry in a minute."),
-      { key: "pagesErrors.deployInFlight" },
-    )
+    throw localizedError({ key: "pagesErrors.deployInFlight" })
   }
 
   return text

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -143,13 +143,9 @@ export function createGitHubClient(args: {
           ? body.message
           : `GitHub API request failed with ${res.status}`
 
-      // Trace the failure with non-sensitive fields only: the status, the
-      // endpoint, GitHub's request id for support correlation, and — for a 422
-      // — the validation reasons. Never the whole body (it can carry IP allow
-      // lists or SAML detail); `githubValidationReasons` extracts only the
-      // `errors[].message`/`.field`/`.code` triples, which is the difference
-      // between "PATCH /orgs 422" and "Private-only repository creation policy
-      // is not allowed for this organization."
+      // Non-sensitive fields only — never the whole body, which can carry IP
+      // allow lists or SAML detail. A 422 also gets its validation reasons (see
+      // githubValidationReasons for why those are worth the extra field).
       log.debug("api error", {
         method,
         path,

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -2,6 +2,7 @@ import {
   GitHubAPIError,
   githubNonJsonResponseError,
   readGitHubRateLimitHeaders,
+  githubValidationReasons,
 } from "./errors"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_GITHUB_CLIENT } from "@/lib/logScopes"
@@ -142,13 +143,21 @@ export function createGitHubClient(args: {
           ? body.message
           : `GitHub API request failed with ${res.status}`
 
-      // Trace the failure with non-sensitive fields only (never the body): the
-      // status, the endpoint, and GitHub's request id for support correlation.
+      // Trace the failure with non-sensitive fields only: the status, the
+      // endpoint, GitHub's request id for support correlation, and — for a 422
+      // — the validation reasons. Never the whole body (it can carry IP allow
+      // lists or SAML detail); `githubValidationReasons` extracts only the
+      // `errors[].message`/`.field`/`.code` triples, which is the difference
+      // between "PATCH /orgs 422" and "Private-only repository creation policy
+      // is not allowed for this organization."
       log.debug("api error", {
         method,
         path,
         status: res.status,
         requestId: res.headers.get("x-github-request-id"),
+        ...(res.status === 422
+          ? { validation: githubValidationReasons(body) }
+          : {}),
       })
 
       throw new GitHubAPIError({

--- a/web/src/github-core/errors.test.ts
+++ b/web/src/github-core/errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   GitHubAPIError,
+  githubValidationReasons,
   isDefinitiveGitHubStatus,
   parseSsoAuthorizationUrl,
   retryTransientGitHubError,
@@ -319,5 +320,58 @@ describe("tolerateGitHubError", () => {
       ),
     ).rejects.toThrow("HTTP 500")
     expect(ran).toBe(false)
+  })
+})
+
+// A 422's `errors` payload is the difference between "PATCH /orgs 422" and
+// "Private-only repository creation policy is not allowed for this
+// organization." The client logs this (and only this) so the next validation
+// failure is diagnosable from the console.
+describe("githubValidationReasons", () => {
+  it("reads the bare-string shape the org endpoint returns", () => {
+    expect(
+      githubValidationReasons({
+        message: "Validation Failed",
+        errors:
+          "Private-only repository creation policy is not allowed for this organization.",
+      }),
+    ).toBe(
+      "Private-only repository creation policy is not allowed for this organization.",
+    )
+  })
+
+  it("reads the array-of-objects shape, prefixing the field", () => {
+    expect(
+      githubValidationReasons({
+        errors: [
+          {
+            resource: "Org",
+            field: "members_can_create_repositories",
+            code: "invalid",
+            message: "is invalid",
+          },
+          { resource: "Org", code: "custom", message: "second reason" },
+        ],
+      }),
+    ).toBe("members_can_create_repositories: is invalid; second reason")
+  })
+
+  it("falls back to the code when no message is present", () => {
+    expect(
+      githubValidationReasons({
+        errors: [{ field: "name", code: "already_exists" }],
+      }),
+    ).toBe("name: already_exists")
+  })
+
+  it("returns undefined when there is nothing to report", () => {
+    expect(
+      githubValidationReasons({ message: "Validation Failed" }),
+    ).toBeUndefined()
+    expect(githubValidationReasons({ errors: [] })).toBeUndefined()
+    expect(githubValidationReasons({ errors: "" })).toBeUndefined()
+    expect(githubValidationReasons({ errors: [{}] })).toBeUndefined()
+    expect(githubValidationReasons(null)).toBeUndefined()
+    expect(githubValidationReasons("nope")).toBeUndefined()
   })
 })

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -192,6 +192,36 @@ export function isDefinitiveGitHubStatus(status: number): boolean {
   return status === 401 || status === 403 || status === 404
 }
 
+// A 422 body's validation reasons, as a short human string. GitHub's `errors`
+// is either an array of `{ resource, field, code, message }` objects or (on the
+// org endpoint) a bare string, so both shapes are handled. Returns undefined
+// when the body carries none, so the log line stays clean.
+//
+// Deliberately narrow: only the `message`/`field`/`code` triples, never the
+// whole body — a body can name an IP allow list or SAML enforcement.
+export function githubValidationReasons(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined
+  const errors = (body as { errors?: unknown }).errors
+  if (typeof errors === "string") return errors || undefined
+  if (!Array.isArray(errors)) return undefined
+
+  const reasons = errors
+    .map((item) => {
+      if (typeof item === "string") return item
+      if (typeof item !== "object" || item === null) return ""
+      const { field, code, message } = item as Record<string, unknown>
+      const text = typeof message === "string" && message ? message : ""
+      const codeText = typeof code === "string" && code ? code : ""
+      const fieldText = typeof field === "string" && field ? field : ""
+      const detail = text || codeText
+      if (!detail) return ""
+      return fieldText ? `${fieldText}: ${detail}` : detail
+    })
+    .filter(Boolean)
+
+  return reasons.length > 0 ? reasons.join("; ") : undefined
+}
+
 export function readGitHubRateLimitHeaders(res: Response): GitHubRateLimit {
   const numberHeader = (name: string) => {
     const value = res.headers.get(name)

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -205,16 +205,17 @@ export function githubValidationReasons(body: unknown): string | undefined {
   if (typeof errors === "string") return errors || undefined
   if (!Array.isArray(errors)) return undefined
 
+  const str = (value: unknown) => (typeof value === "string" ? value : "")
   const reasons = errors
     .map((item) => {
       if (typeof item === "string") return item
       if (typeof item !== "object" || item === null) return ""
       const { field, code, message } = item as Record<string, unknown>
-      const text = typeof message === "string" && message ? message : ""
-      const codeText = typeof code === "string" && code ? code : ""
-      const fieldText = typeof field === "string" && field ? field : ""
-      const detail = text || codeText
+      // `code` is GitHub's machine reason (e.g. "already_exists"), used when the
+      // item carries no prose.
+      const detail = str(message) || str(code)
       if (!detail) return ""
+      const fieldText = str(field)
       return fieldText ? `${fieldText}: ${detail}` : detail
     })
     .filter(Boolean)

--- a/web/src/github-core/orgChecks.ts
+++ b/web/src/github-core/orgChecks.ts
@@ -8,7 +8,12 @@ import type { GitHubClient } from "./client"
 import { GitHubAPIError } from "./errors"
 import {
   classifyDefaults,
+  isWritable,
   memberDefaultSettings,
+  MEMBERS_CAN_CREATE_INTERNAL_REPOSITORIES,
+  MEMBERS_CAN_CREATE_PRIVATE_REPOSITORIES,
+  MEMBERS_CAN_CREATE_PUBLIC_REPOSITORIES,
+  MEMBERS_CAN_CREATE_REPOSITORIES,
   type ClassifyResult,
   type MemberDefaultSetting,
 } from "@/orgPolicy/desiredState"
@@ -386,17 +391,16 @@ export type OrgDefaultsRepairResult = {
   message: string
 }
 
-// The PATCH body for a set of settings. Skips verify-only fields (`writable:
-// false`): on Team/Free the granular repo-creation booleans are derived from the
-// master switch, and sending one makes GitHub reject the whole request with 422
-// "Private-only repository creation policy is not allowed for this organization."
-// They are still classified on the read-back, just never written.
+// The PATCH body for a set of settings, skipping verify-only fields: on Team/Free
+// the granular repo-creation booleans are derived from the master switch, and
+// sending one makes GitHub reject the whole request with 422 "Private-only
+// repository creation policy is not allowed for this organization." They are
+// still classified on the read-back, just never written.
 function orgDefaultsBody(
   settings: MemberDefaultSetting[],
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {}
-  for (const s of settings) {
-    if (s.writable === false) continue
+  for (const s of settings.filter(isWritable)) {
     body[s.field] = s.value
   }
   return body
@@ -518,11 +522,11 @@ export async function repairOrgDefaults(
 // makes GitHub recompute that legacy field from the partial input and silently
 // reset the omitted ones. They must always be PATCHed together.
 // (https://github.com/integrations/terraform-provider-github/issues/3429)
-const REPO_CREATION_FIELDS = new Set([
-  "members_can_create_repositories",
-  "members_can_create_private_repositories",
-  "members_can_create_public_repositories",
-  "members_can_create_internal_repositories",
+const REPO_CREATION_FIELDS = new Set<string>([
+  MEMBERS_CAN_CREATE_REPOSITORIES,
+  MEMBERS_CAN_CREATE_PRIVATE_REPOSITORIES,
+  MEMBERS_CAN_CREATE_PUBLIC_REPOSITORIES,
+  MEMBERS_CAN_CREATE_INTERNAL_REPOSITORIES,
 ])
 
 // Per-field fallback for when the combined PATCH is rejected. Sends each field
@@ -566,20 +570,14 @@ async function repairOrgDefaultsPerField(
       const body = orgDefaultsBody(repoCreation)
       // On Team/Free only the master switch is writable, so the group can reduce
       // to one field; if every member is verify-only there is nothing to send.
-      if (Object.keys(body).length > 0) {
-        const accepted = await patchBody(body)
+      if (Object.keys(body).length > 0 && !(await patchBody(body))) {
         // Only writable fields can be "rejected" — a verify-only field was never
         // attempted, so marking it rejected would suppress the enterprise-pinned
         // signal that the read-back is supposed to produce.
-        if (!accepted) {
-          for (const s of repoCreation) {
-            if (s.writable !== false) rejected.add(s.field)
-          }
-        }
+        for (const s of repoCreation.filter(isWritable)) rejected.add(s.field)
       }
     }
-    for (const s of rest) {
-      if (s.writable === false) continue
+    for (const s of rest.filter(isWritable)) {
       const accepted = await patchBody({ [s.field]: s.value })
       if (!accepted) rejected.add(s.field)
     }

--- a/web/src/github-core/orgChecks.ts
+++ b/web/src/github-core/orgChecks.ts
@@ -386,11 +386,19 @@ export type OrgDefaultsRepairResult = {
   message: string
 }
 
+// The PATCH body for a set of settings. Skips verify-only fields (`writable:
+// false`): on Team/Free the granular repo-creation booleans are derived from the
+// master switch, and sending one makes GitHub reject the whole request with 422
+// "Private-only repository creation policy is not allowed for this organization."
+// They are still classified on the read-back, just never written.
 function orgDefaultsBody(
   settings: MemberDefaultSetting[],
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {}
-  for (const s of settings) body[s.field] = s.value
+  for (const s of settings) {
+    if (s.writable === false) continue
+    body[s.field] = s.value
+  }
   return body
 }
 
@@ -555,10 +563,23 @@ async function repairOrgDefaultsPerField(
 
   try {
     if (repoCreation.length > 0) {
-      const accepted = await patchBody(orgDefaultsBody(repoCreation))
-      if (!accepted) for (const s of repoCreation) rejected.add(s.field)
+      const body = orgDefaultsBody(repoCreation)
+      // On Team/Free only the master switch is writable, so the group can reduce
+      // to one field; if every member is verify-only there is nothing to send.
+      if (Object.keys(body).length > 0) {
+        const accepted = await patchBody(body)
+        // Only writable fields can be "rejected" — a verify-only field was never
+        // attempted, so marking it rejected would suppress the enterprise-pinned
+        // signal that the read-back is supposed to produce.
+        if (!accepted) {
+          for (const s of repoCreation) {
+            if (s.writable !== false) rejected.add(s.field)
+          }
+        }
+      }
     }
     for (const s of rest) {
+      if (s.writable === false) continue
       const accepted = await patchBody({ [s.field]: s.value })
       if (!accepted) rejected.add(s.field)
     }

--- a/web/src/github-core/orgDefaults.test.ts
+++ b/web/src/github-core/orgDefaults.test.ts
@@ -129,14 +129,65 @@ describe("repairOrgDefaults", () => {
     expect(result.unenforced).toHaveLength(0)
     // One combined PATCH, no per-field.
     expect(patchBodies).toHaveLength(1)
-    expect(Object.keys(patchBodies[0]).length).toBe(11)
+    // 12 in scope, minus the 2 derived repo-creation booleans.
+    expect(Object.keys(patchBodies[0]).length).toBe(10)
   })
 
-  it("sends only 11 fields on a team plan", async () => {
+  // Regression (the 422 that broke "Fix it"): on Team/Free the granular
+  // repo-creation booleans are DERIVED from the master switch, and any PATCH
+  // carrying one is rejected with "Private-only repository creation policy is not
+  // allowed for this organization." Sending the master switch alone makes GitHub
+  // resolve the legacy field to "all", turning both booleans on.
+  it("sends only the master switch for repo creation on a team plan", async () => {
     const { client, patchBodies } = makeClient({ readback: enforced("team") })
     await repairOrgDefaults(client, "acme", "team")
-    expect(Object.keys(patchBodies[0])).not.toContain(
+    expect(patchBodies[0].members_can_create_repositories).toBe(true)
+    for (const derived of [
+      "members_can_create_private_repositories",
       "members_can_create_public_repositories",
+      "members_can_create_internal_repositories",
+    ]) {
+      expect(Object.keys(patchBodies[0])).not.toContain(derived)
+    }
+  })
+
+  // Enterprise Cloud DOES accept the granular booleans, and the private-only
+  // lockdown is the whole point there, so they must still be written.
+  it("writes the granular booleans on an enterprise plan", async () => {
+    const { client, patchBodies } = makeClient({
+      readback: enforced("enterprise"),
+    })
+    await repairOrgDefaults(client, "acme", "enterprise")
+    expect(patchBodies[0].members_can_create_public_repositories).toBe(false)
+    expect(patchBodies[0].members_can_create_private_repositories).toBe(true)
+  })
+
+  // The grouped sub-PATCH must not reintroduce the 422 it exists to recover from.
+  it("sends only the master switch in the team fallback", async () => {
+    const { client, patchBodies } = makeClient({
+      combinedPatch: () => Promise.reject(httpError(422)),
+      readback: enforced("team"),
+    })
+    await repairOrgDefaults(client, "acme", "team")
+    const grouped = patchBodies
+      .slice(1)
+      .find((b) => "members_can_create_repositories" in b)
+    expect(grouped).toBeDefined()
+    expect(Object.keys(grouped!)).toEqual(["members_can_create_repositories"])
+  })
+
+  // A field never attempted must not be recorded as API-rejected, or the
+  // enterprise-pinned signal (unenforced despite an accepted write) is lost.
+  it("attributes a still-drifted derived field to the enterprise-pinned signal", async () => {
+    const live = enforced("team")
+    live.members_can_create_private_repositories = false
+    const { client } = makeClient({
+      combinedPatch: () => Promise.reject(httpError(422)),
+      readback: live,
+    })
+    const result = await repairOrgDefaults(client, "acme", "team")
+    expect(result.enterprisePinned.map((s) => s.field)).toContain(
+      "members_can_create_private_repositories",
     )
   })
 

--- a/web/src/github-core/queries/pagesReads.ts
+++ b/web/src/github-core/queries/pagesReads.ts
@@ -6,7 +6,7 @@ import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError } from "../errors"
 import { classroomPagesSegment } from "@/util/secret"
 import { log } from "./shared"
-import { withLocalizedMessage } from "@/types/localizedMessage"
+import { localizedError, withLocalizedMessage } from "@/types/localizedMessage"
 
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url, {
@@ -86,15 +86,14 @@ export function extractAssignments(json: AssignmentsJson): Assignment[] {
   if (Array.isArray(json)) return json
 
   if (json.version !== undefined && json.version !== 1) {
-    throw new Error(
-      `This classroom uses assignments.json v${json.version}, but this client only supports v1. Please update classroom50.`,
-    )
+    throw localizedError({
+      key: "pagesErrors.manifestVersionUnsupported",
+      params: { version: String(json.version) },
+    })
   }
 
   if (!Array.isArray(json.assignments)) {
-    throw new Error(
-      "assignments.json has an invalid v1 shape. Ask your teacher to check classroom50 configuration.",
-    )
+    throw localizedError({ key: "pagesErrors.manifestInvalidShape" })
   }
 
   return json.assignments

--- a/web/src/github-core/queries/pagesReads.ts
+++ b/web/src/github-core/queries/pagesReads.ts
@@ -6,6 +6,7 @@ import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError } from "../errors"
 import { classroomPagesSegment } from "@/util/secret"
 import { log } from "./shared"
+import { withLocalizedMessage } from "@/types/localizedMessage"
 
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url, {
@@ -13,13 +14,22 @@ export async function fetchJson<T>(url: string): Promise<T> {
   })
 
   if (response.status === 404) {
-    throw new Error(
-      "The classroom may not exist yet, or publish-pages.yaml may not have run.",
+    throw withLocalizedMessage(
+      new Error(
+        "The classroom may not exist yet, or publish-pages.yaml may not have run.",
+      ),
+      { key: "pagesErrors.classroomNotPublished" },
     )
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.status}`)
+    throw withLocalizedMessage(
+      new Error(`Failed to fetch ${url}: ${response.status}`),
+      {
+        key: "pagesErrors.classroomFetchFailed",
+        params: { status: response.status },
+      },
+    )
   }
 
   return response.json() as Promise<T>

--- a/web/src/github-core/queries/pagesReads.ts
+++ b/web/src/github-core/queries/pagesReads.ts
@@ -6,7 +6,7 @@ import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError } from "../errors"
 import { classroomPagesSegment } from "@/util/secret"
 import { log } from "./shared"
-import { localizedError, withLocalizedMessage } from "@/types/localizedMessage"
+import { localizedError } from "@/types/localizedMessage"
 
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url, {
@@ -14,22 +14,14 @@ export async function fetchJson<T>(url: string): Promise<T> {
   })
 
   if (response.status === 404) {
-    throw withLocalizedMessage(
-      new Error(
-        "The classroom may not exist yet, or publish-pages.yaml may not have run.",
-      ),
-      { key: "pagesErrors.classroomNotPublished" },
-    )
+    throw localizedError({ key: "pagesErrors.classroomNotPublished" })
   }
 
   if (!response.ok) {
-    throw withLocalizedMessage(
-      new Error(`Failed to fetch ${url}: ${response.status}`),
-      {
-        key: "pagesErrors.classroomFetchFailed",
-        params: { status: response.status },
-      },
-    )
+    throw localizedError({
+      key: "pagesErrors.classroomFetchFailed",
+      params: { status: response.status },
+    })
   }
 
   return response.json() as Promise<T>

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -216,6 +216,11 @@ export type GitHubOrgDetails = {
     filled_seats: number
     seats: number
   }
+  // Member-privilege repo-creation booleans. Like `plan`, GitHub omits these for
+  // a non-admin reader, so absent is distinct from false — a consumer that acts
+  // on "off" must check for an explicit `false`.
+  members_can_create_repositories?: boolean
+  members_can_create_private_repositories?: boolean
 }
 
 export type GitHubWorkflowRun = {

--- a/web/src/hooks/mutations/useRepairOrgPolicyConcern.ts
+++ b/web/src/hooks/mutations/useRepairOrgPolicyConcern.ts
@@ -28,6 +28,12 @@ export function useRepairOrgPolicyConcern(
       void queryClient.invalidateQueries({
         queryKey: githubKeys.orgAuditPrefix(org),
       })
+      // A repair can flip member privileges, which the teacher pre-flight
+      // warnings read off the shared org query (10-minute staleTime). Without
+      // this they keep warning about a setting that was just fixed.
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgDetails(org),
+      })
     },
   })
 }

--- a/web/src/hooks/useOrgRepoCreationWarning.ts
+++ b/web/src/hooks/useOrgRepoCreationWarning.ts
@@ -1,13 +1,9 @@
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
-import { classifyDefaults } from "@/orgPolicy/desiredState"
-
-// The two member-privilege fields that decide whether a student can create their
-// assignment repository. The master switch gates repo creation at all; the
-// private switch decides whether the private repo accept asks for is allowed. On
-// Team/Free the granular booleans are slaved to the master switch, which is why
-// the verdicts come from classifyDefaults rather than a hand-rolled read.
-const MASTER_SWITCH = "members_can_create_repositories"
-const PRIVATE_SWITCH = "members_can_create_private_repositories"
+import {
+  classifyDefaults,
+  MEMBERS_CAN_CREATE_PRIVATE_REPOSITORIES,
+  MEMBERS_CAN_CREATE_REPOSITORIES,
+} from "@/orgPolicy/desiredState"
 
 export type OrgRepoCreationWarning =
   | { show: false }
@@ -19,11 +15,18 @@ export type OrgRepoCreationWarning =
 // Whether to warn a teacher that the org will refuse student repo creation,
 // before a student hits the accept-time 403 (issue #413).
 //
-// Reuses the org-policy seam: `classifyDefaults` is the single source of truth
-// for interpreting a GET /orgs/{org} response, already marks the master switch
-// `critical`, and already encodes the Team/Free master-switch slaving. This is the
-// assignment-scoped view of the same signal OrgPreflightNotice shows owners on
-// ClassesPage — keep the two copies in step.
+// Scope comes from `classifyDefaults`, the single source of truth for which
+// settings apply to a plan, so a field the plan filters out can never warn.
+//
+// Fails open on the value: warn only when GitHub reports the field as explicitly
+// `false`. This deliberately inverts `classifyDefaults`' fail-closed reading,
+// where an absent field counts as unenforced — right for an audit, wrong here,
+// because GitHub omits the member-privilege fields for non-admins and a teacher
+// who cannot read the setting cannot be told anything useful about it.
+//
+// The read is shared: `useGetOrgPlanDetails` keys on githubKeys.orgDetails with a
+// 10-minute staleTime, and every org-scoped page already issues it, so mounting
+// the notice on several surfaces costs no extra request.
 const useOrgRepoCreationWarning = (
   org: string | undefined,
 ): OrgRepoCreationWarning => {
@@ -31,23 +34,23 @@ const useOrgRepoCreationWarning = (
 
   if (!org || isPending || isError || !data) return { show: false }
 
-  // Deliberately inverts classifyDefaults' fail-closed reading for this one
-  // consumer: there, an absent field reads as unenforced (`live[field] === value`
-  // is false), which is right for an audit. Here it would fire on every
-  // non-admin, since GitHub omits the member-privilege fields for them — and a
-  // teacher who can't read the setting can't be told anything useful about it.
-  // So warn only when the field is explicitly false.
-  const live = data as unknown as Record<string, unknown>
-  const explicitlyOff = (field: string) => live[field] === false
+  const inScope = new Set(
+    classifyDefaults(
+      data as unknown as Record<string, unknown>,
+      data.plan?.name,
+    ).verdicts.map((v) => v.setting.field),
+  )
 
-  const { verdicts } = classifyDefaults(live, data.plan?.name)
-  const unenforced = (field: string) =>
-    verdicts.some((v) => v.setting.field === field && !v.enforced)
-
-  if (unenforced(MASTER_SWITCH) && explicitlyOff(MASTER_SWITCH)) {
+  if (
+    inScope.has(MEMBERS_CAN_CREATE_REPOSITORIES) &&
+    data.members_can_create_repositories === false
+  ) {
     return { show: true, field: "master" }
   }
-  if (unenforced(PRIVATE_SWITCH) && explicitlyOff(PRIVATE_SWITCH)) {
+  if (
+    inScope.has(MEMBERS_CAN_CREATE_PRIVATE_REPOSITORIES) &&
+    data.members_can_create_private_repositories === false
+  ) {
     return { show: true, field: "private" }
   }
   return { show: false }

--- a/web/src/hooks/useOrgRepoCreationWarning.ts
+++ b/web/src/hooks/useOrgRepoCreationWarning.ts
@@ -1,0 +1,56 @@
+import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
+import { classifyDefaults } from "@/orgPolicy/desiredState"
+
+// The two member-privilege fields that decide whether a student can create their
+// assignment repository. The master switch gates repo creation at all; the
+// private switch decides whether the private repo accept asks for is allowed. On
+// Team/Free the granular booleans are slaved to the master switch, which is why
+// the verdicts come from classifyDefaults rather than a hand-rolled read.
+const MASTER_SWITCH = "members_can_create_repositories"
+const PRIVATE_SWITCH = "members_can_create_private_repositories"
+
+export type OrgRepoCreationWarning =
+  | { show: false }
+  // Which field is off decides the copy: the master switch and the private
+  // checkbox are different controls with different remedies, so one shared
+  // message would name the wrong one half the time.
+  | { show: true; field: "master" | "private" }
+
+// Whether to warn a teacher that the org will refuse student repo creation,
+// before a student hits the accept-time 403 (issue #413).
+//
+// Reuses the org-policy seam: `classifyDefaults` is the single source of truth
+// for interpreting a GET /orgs/{org} response, already marks the master switch
+// `critical`, and already encodes the Team/Free master-switch slaving. This is the
+// assignment-scoped view of the same signal OrgPreflightNotice shows owners on
+// ClassesPage — keep the two copies in step.
+const useOrgRepoCreationWarning = (
+  org: string | undefined,
+): OrgRepoCreationWarning => {
+  const { data, isPending, isError } = useGetOrgPlanDetails(org)
+
+  if (!org || isPending || isError || !data) return { show: false }
+
+  // Deliberately inverts classifyDefaults' fail-closed reading for this one
+  // consumer: there, an absent field reads as unenforced (`live[field] === value`
+  // is false), which is right for an audit. Here it would fire on every
+  // non-admin, since GitHub omits the member-privilege fields for them — and a
+  // teacher who can't read the setting can't be told anything useful about it.
+  // So warn only when the field is explicitly false.
+  const live = data as unknown as Record<string, unknown>
+  const explicitlyOff = (field: string) => live[field] === false
+
+  const { verdicts } = classifyDefaults(live, data.plan?.name)
+  const unenforced = (field: string) =>
+    verdicts.some((v) => v.setting.field === field && !v.enforced)
+
+  if (unenforced(MASTER_SWITCH) && explicitlyOff(MASTER_SWITCH)) {
+    return { show: true, field: "master" }
+  }
+  if (unenforced(PRIVATE_SWITCH) && explicitlyOff(PRIVATE_SWITCH)) {
+    return { show: true, field: "private" }
+  }
+  return { show: false }
+}
+
+export default useOrgRepoCreationWarning

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2144,6 +2144,11 @@
         "empty": "This classroom has no students yet. An assignment's accept link only works for students who are members of the <org>{{org}}</org> organization, so add and enroll students before sharing it.",
         "manageRoster": "Manage roster",
         "addStudents": "Add students"
+      },
+      "orgRepoCreation": {
+        "master": "<org>{{org}}</org> doesn't let its members create repositories, so accepting an assignment will fail for every student. Re-run organization setup, or under <memberPrivileges>Member privileges → Repository creation</memberPrivileges> allow members to create repositories and check \"Private\" (leave \"Public\" unchecked). If an enterprise policy pins that setting, only an enterprise owner can change it.",
+        "private": "<org>{{org}}</org> doesn't let its members create private repositories, so accepting an assignment will fail for every student. Re-run organization setup, or under <memberPrivileges>Member privileges → Repository creation</memberPrivileges> check \"Private\" (leave \"Public\" unchecked). If an enterprise policy pins that setting, only an enterprise owner can change it.",
+        "action": "Organization settings"
       }
     },
     "confirmModal": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1620,11 +1620,11 @@
     "notPublished": "{{label}} is not published yet. Ask your teacher to confirm the file exists in the config repo and that the publish workflow has been run.",
     "fetchFailed": "Couldn't load {{label}} (HTTP {{status}}). Ask your teacher to confirm the classroom is published, then try again.",
     "deployInFlight": "The classroom's published files may still be deploying. Wait a minute, then try again.",
-    "classroomNotPublished": "This classroom isn't published yet — it may not exist, or the publish workflow may not have run. Ask your teacher to publish it, then try again.",
+    "classroomNotPublished": "This classroom isn't published yet. It may not exist, or the publish workflow may not have run. Ask your teacher to publish it, then try again.",
     "classroomFetchFailed": "Couldn't load this classroom's published files (HTTP {{status}}). Ask your teacher to confirm the classroom is published, then try again.",
     "assignmentNotInManifest": "Assignment \"{{assignmentSlug}}\" isn't in this classroom's published assignments. Check the link, or ask your teacher to publish the assignment.",
     "autograderMalformed": "Autograder \"{{autograderName}}\" may be malformed YAML. Ask your teacher to check the file in the config repo.",
-    "manifestVersionUnsupported": "This classroom publishes its assignments in a newer format (v{{version}}) than this version of Classroom 50 understands. Reload the page; if that doesn't help, ask your teacher to update Classroom 50.",
+    "manifestVersionUnsupported": "This classroom uses a newer assignment format (v{{version}}) than this copy of Classroom 50 supports. Reload the page, or ask your teacher to update Classroom 50.",
     "manifestInvalidShape": "This classroom's published assignment list is malformed. Ask your teacher to check the Classroom 50 configuration."
   },
   "accept": {
@@ -1655,7 +1655,7 @@
       "outOfOrg": "Couldn't copy the template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} This is often because the {{owner}} organization restricts third-party apps — ask your teacher to approve the Classroom 50 app for {{owner}} (or make the template public), then accept again.",
       "inOrg": "Couldn't copy the private template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} Ask your teacher to re-run assignment setup, then accept again.",
       "orgRepoCreationDeniedStep": "{{org}} wouldn't let your repository be created (HTTP {{status}}).",
-      "orgRepoCreationDenied": "Couldn't create your repository in {{org}} (HTTP {{status}}).{{detail}} This is often because {{org}} doesn't let its members create private repositories. Ask your teacher to check, under {{org}}'s Settings → Member privileges → Repository creation, that members may create repositories and \"Private\" is checked (leave \"Public\" unchecked), or to re-run organization setup in Classroom 50 — then accept again. If an enterprise policy pins that setting, only an enterprise owner can change it."
+      "orgRepoCreationDenied": "Couldn't create your repository in {{org}} (HTTP {{status}}).{{detail}} {{org}} may not allow members to create private repositories. Ask your teacher to allow private (not public) repository creation in {{org}}'s member privileges, or to re-run organization setup, then accept again. An enterprise policy can override this setting."
     },
     "notFound": {
       "badge": "Assignment unavailable",
@@ -1685,7 +1685,7 @@
       "repoIncomplete": "Found incomplete setup: {{org}}/{{repo}}",
       "access": "Granted you access to your repository",
       "setup": "Autograding configured",
-      "setupSkippedEmptyRepo": "No setup needed — this assignment uses an empty repository"
+      "setupSkippedEmptyRepo": "No setup needed: this assignment uses an empty repository"
     },
     "stepActions": {
       "account": "Couldn't read your GitHub account. Sign out and sign back in, then accept again.",
@@ -1694,7 +1694,7 @@
       "autograder": "Couldn't resolve the autograder for \"{{assignmentSlug}}\". Ask your teacher to confirm it's published, then accept again.",
       "repo": "Couldn't create {{org}}/{{repo}}. Confirm you're a member of {{org}} and ask your teacher to verify the assignment's template repository is configured correctly, then accept again.",
       "access": "Your repository {{org}}/{{repo}} was created, but adding you ({{username}}) as a collaborator failed. This usually means your GitHub username changed or you left {{org}}. Confirm you're a member of {{org}}, then use \"Re-run setup\".",
-      "setup": "Your repository {{org}}/{{repo}} exists, but writing the setup files to branch \"{{branch}}\" failed. The repository may still be initializing — wait a minute and use \"Re-run setup\"."
+      "setup": "Your repository {{org}}/{{repo}} exists, but writing the setup files to branch \"{{branch}}\" failed. It may still be initializing. Wait a minute, then use \"Re-run setup\"."
     },
     "stepErrors": {
       "rateLimited": "{{label}} hit GitHub's rate limit. Wait a minute, then try accepting again.",
@@ -1703,9 +1703,9 @@
       "unexpected": "{{label}} failed unexpectedly. This is safe to retry."
     },
     "errors": {
-      "emptyRepoWithTemplate": "Assignment \"{{assignmentSlug}}\" sets both an empty repository and a template — the entry is invalid; ask your teacher to re-run assignment setup.",
-      "incoherentMode": "Assignment \"{{slug}}\" has a group size of {{maxGroupSize}} but is set up as \"{{mode}}\" — its published metadata is inconsistent. Ask your teacher to re-run assignment setup.",
-      "founderAccessMismatch": "Your repository {{owner}}/{{repo}} was created, but GitHub reports your access as \"{{effective}}\" (role \"{{role}}\") instead of \"{{permission}}\". A repository's creator holds admin access, and organization policy can block stepping that down. Ask your teacher to set {{username}}'s access to \"{{permission}}\"."
+      "emptyRepoWithTemplate": "Assignment \"{{assignmentSlug}}\" sets both an empty repository and a template, which isn't valid. Ask your teacher to re-run assignment setup.",
+      "incoherentMode": "Assignment \"{{slug}}\" has a group size of {{maxGroupSize}} but is set up as \"{{mode}}\", so its published settings are inconsistent. Ask your teacher to re-run assignment setup.",
+      "founderAccessMismatch": "Your repository {{owner}}/{{repo}} was created, but GitHub reports your access as \"{{effective}}\" (role \"{{role}}\") instead of \"{{permission}}\". Ask your teacher to set {{username}}'s access to \"{{permission}}\"."
     },
     "progress": {
       "error": "Setup failed — review the steps",
@@ -2160,8 +2160,8 @@
         "addStudents": "Add students"
       },
       "orgRepoCreation": {
-        "master": "<org>{{org}}</org> doesn't let its members create repositories, so accepting an assignment will fail for every student. Re-run organization setup, or under <memberPrivileges>Member privileges → Repository creation</memberPrivileges> allow members to create repositories and check \"Private\" (leave \"Public\" unchecked). If an enterprise policy pins that setting, only an enterprise owner can change it.",
-        "private": "<org>{{org}}</org> doesn't let its members create private repositories, so accepting an assignment will fail for every student. Re-run organization setup, or under <memberPrivileges>Member privileges → Repository creation</memberPrivileges> check \"Private\" (leave \"Public\" unchecked). If an enterprise policy pins that setting, only an enterprise owner can change it.",
+        "master": "<org>{{org}}</org> doesn't allow members to create repositories, so no student can accept an assignment. Re-run organization setup, or allow private (not public) repository creation under <memberPrivileges>Member privileges</memberPrivileges>. An enterprise policy can override this setting.",
+        "private": "<org>{{org}}</org> doesn't allow members to create private repositories, so no student can accept an assignment. Re-run organization setup, or allow private (not public) repository creation under <memberPrivileges>Member privileges</memberPrivileges>. An enterprise policy can override this setting.",
         "action": "Organization settings"
       }
     },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1641,7 +1641,9 @@
     "templateErrors": {
       "githubSaid": " GitHub said: \"{{message}}\".",
       "outOfOrg": "Couldn't copy the template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} This is often because the {{owner}} organization restricts third-party apps — ask your teacher to approve the Classroom 50 app for {{owner}} (or make the template public), then accept again.",
-      "inOrg": "Couldn't copy the private template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} Ask your teacher to re-run assignment setup, then accept again."
+      "inOrg": "Couldn't copy the private template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} Ask your teacher to re-run assignment setup, then accept again.",
+      "orgRepoCreationDeniedStep": "{{org}} wouldn't let your repository be created (HTTP {{status}}).",
+      "orgRepoCreationDenied": "Couldn't create your repository in {{org}} (HTTP {{status}}).{{detail}} This is often because {{org}} doesn't let its members create private repositories. Ask your teacher to check, under {{org}}'s Settings → Member privileges → Repository creation, that members may create repositories and \"Private\" is checked (leave \"Public\" unchecked), or to re-run organization setup in Classroom 50 — then accept again. If an enterprise policy pins that setting, only an enterprise owner can change it."
     },
     "notFound": {
       "badge": "Assignment unavailable",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1623,7 +1623,9 @@
     "classroomNotPublished": "This classroom isn't published yet — it may not exist, or the publish workflow may not have run. Ask your teacher to publish it, then try again.",
     "classroomFetchFailed": "Couldn't load this classroom's published files (HTTP {{status}}). Ask your teacher to confirm the classroom is published, then try again.",
     "assignmentNotInManifest": "Assignment \"{{assignmentSlug}}\" isn't in this classroom's published assignments. Check the link, or ask your teacher to publish the assignment.",
-    "autograderMalformed": "Autograder \"{{autograderName}}\" may be malformed YAML. Ask your teacher to check the file in the config repo."
+    "autograderMalformed": "Autograder \"{{autograderName}}\" may be malformed YAML. Ask your teacher to check the file in the config repo.",
+    "manifestVersionUnsupported": "This classroom publishes its assignments in a newer format (v{{version}}) than this version of Classroom 50 understands. Reload the page; if that doesn't help, ask your teacher to update Classroom 50.",
+    "manifestInvalidShape": "This classroom's published assignment list is malformed. Ask your teacher to check the Classroom 50 configuration."
   },
   "accept": {
     "githubUser": "GitHub user",
@@ -1701,7 +1703,9 @@
       "unexpected": "{{label}} failed unexpectedly. This is safe to retry."
     },
     "errors": {
-      "emptyRepoWithTemplate": "Assignment \"{{assignmentSlug}}\" sets both an empty repository and a template — the entry is invalid; ask your teacher to re-run assignment setup."
+      "emptyRepoWithTemplate": "Assignment \"{{assignmentSlug}}\" sets both an empty repository and a template — the entry is invalid; ask your teacher to re-run assignment setup.",
+      "incoherentMode": "Assignment \"{{slug}}\" has a group size of {{maxGroupSize}} but is set up as \"{{mode}}\" — its published metadata is inconsistent. Ask your teacher to re-run assignment setup.",
+      "founderAccessMismatch": "Your repository {{owner}}/{{repo}} was created, but GitHub reports your access as \"{{effective}}\" (role \"{{role}}\") instead of \"{{permission}}\". A repository's creator holds admin access, and organization policy can block stepping that down. Ask your teacher to set {{username}}'s access to \"{{permission}}\"."
     },
     "progress": {
       "error": "Setup failed — review the steps",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1660,6 +1660,37 @@
       "access": "Granting you access",
       "setup": "Setting up autograding"
     },
+    "stepDone": {
+      "account": "Checked your GitHub account",
+      "membership": "Confirmed your classroom membership",
+      "assignment": "Found assignment {{assignmentSlug}}",
+      "autograder": "Resolved the autograder",
+      "autograderDisabled": "Autograding is disabled for this assignment",
+      "repo": "Created {{org}}/{{repo}}",
+      "repoExists": "Repository already exists: {{org}}/{{repo}}",
+      "repoIncomplete": "Found incomplete setup: {{org}}/{{repo}}",
+      "access": "Granted you access to your repository",
+      "setup": "Autograding configured",
+      "setupSkippedEmptyRepo": "No setup needed — this assignment uses an empty repository"
+    },
+    "stepActions": {
+      "account": "Couldn't read your GitHub account. Sign out and sign back in, then accept again.",
+      "membership": "Couldn't confirm your membership. If your organization uses single sign-on (SSO), authorize it for this org (or open this link from your LMS), then accept again. Otherwise ask your teacher to confirm your invitation.",
+      "assignment": "Couldn't load assignment \"{{assignmentSlug}}\" for {{org}}/{{classroom}}. Check the link, or ask your teacher to confirm the assignment is published.",
+      "autograder": "Couldn't resolve the autograder for \"{{assignmentSlug}}\". Ask your teacher to confirm it's published, then accept again.",
+      "repo": "Couldn't create {{org}}/{{repo}}. Confirm you're a member of {{org}} and ask your teacher to verify the assignment's template repository is configured correctly, then accept again.",
+      "access": "Your repository {{org}}/{{repo}} was created, but adding you ({{username}}) as a collaborator failed. This usually means your GitHub username changed or you left {{org}}. Confirm you're a member of {{org}}, then use \"Re-run setup\".",
+      "setup": "Your repository {{org}}/{{repo}} exists, but writing the setup files to branch \"{{branch}}\" failed. The repository may still be initializing — wait a minute and use \"Re-run setup\"."
+    },
+    "stepErrors": {
+      "rateLimited": "{{label}} hit GitHub's rate limit. Wait a minute, then try accepting again.",
+      "unauthorized": "{{label}} failed because your GitHub session expired (HTTP 401). Sign out and sign back in, then accept again.",
+      "generic": "{{label}} failed (HTTP {{status}}). {{actions}}",
+      "unexpected": "{{label}} failed unexpectedly. This is safe to retry."
+    },
+    "errors": {
+      "emptyRepoWithTemplate": "Assignment \"{{assignmentSlug}}\" sets both an empty repository and a template — the entry is invalid; ask your teacher to re-run assignment setup."
+    },
     "progress": {
       "error": "Setup failed — review the steps",
       "complete": "Assignment accepted",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1655,7 +1655,7 @@
       "outOfOrg": "Couldn't copy the template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} This is often because the {{owner}} organization restricts third-party apps — ask your teacher to approve the Classroom 50 app for {{owner}} (or make the template public), then accept again.",
       "inOrg": "Couldn't copy the private template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} Ask your teacher to re-run assignment setup, then accept again.",
       "orgRepoCreationDeniedStep": "{{org}} wouldn't let your repository be created (HTTP {{status}}).",
-      "orgRepoCreationDenied": "Couldn't create your repository in {{org}} (HTTP {{status}}).{{detail}} {{org}} may not allow members to create private repositories. Ask your teacher to allow private (not public) repository creation in {{org}}'s member privileges, or to re-run organization setup, then accept again. An enterprise policy can override this setting."
+      "orgRepoCreationDenied": "{{org}} may not allow members to create private repositories, so your repository couldn't be created (HTTP {{status}}). Ask your teacher to enable it, then accept again."
     },
     "notFound": {
       "badge": "Assignment unavailable",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1615,6 +1615,16 @@
       "cancelFailed": "Couldn't cancel the invitation for {{who}}: {{error}}"
     }
   },
+  "pagesErrors": {
+    "autograderLabel": "Autograder \"{{autograderName}}\"",
+    "notPublished": "{{label}} is not published yet. Ask your teacher to confirm the file exists in the config repo and that the publish workflow has been run.",
+    "fetchFailed": "Couldn't load {{label}} (HTTP {{status}}). Ask your teacher to confirm the classroom is published, then try again.",
+    "deployInFlight": "The classroom's published files may still be deploying. Wait a minute, then try again.",
+    "classroomNotPublished": "This classroom isn't published yet — it may not exist, or the publish workflow may not have run. Ask your teacher to publish it, then try again.",
+    "classroomFetchFailed": "Couldn't load this classroom's published files (HTTP {{status}}). Ask your teacher to confirm the classroom is published, then try again.",
+    "assignmentNotInManifest": "Assignment \"{{assignmentSlug}}\" isn't in this classroom's published assignments. Check the link, or ask your teacher to publish the assignment.",
+    "autograderMalformed": "Autograder \"{{autograderName}}\" may be malformed YAML. Ask your teacher to check the file in the config repo."
+  },
   "accept": {
     "githubUser": "GitHub user",
     "avatarAlt": "{{name}}'s GitHub avatar",

--- a/web/src/orgPolicy/audit.test.ts
+++ b/web/src/orgPolicy/audit.test.ts
@@ -125,8 +125,8 @@ describe("buildOrgAuditReport", () => {
     expect(report.unenforcedDefaults).toHaveLength(0)
     expect(report.manualUnreadable).toHaveLength(4)
     // The full member-default list is surfaced so teachers see every permission
-    // we set, all enforced here (11 on a team plan).
-    expect(report.defaultVerdicts).toHaveLength(11)
+    // we set, all enforced here (12 on a team plan).
+    expect(report.defaultVerdicts).toHaveLength(12)
     expect(report.defaultVerdicts.every((v) => v.enforced)).toBe(true)
   })
 

--- a/web/src/orgPolicy/desiredState.test.ts
+++ b/web/src/orgPolicy/desiredState.test.ts
@@ -12,11 +12,14 @@ import {
 // audit depend on.
 
 const ENTERPRISE_ONLY_FIELDS = [
-  "members_can_create_public_repositories",
   "members_can_create_internal_repositories",
   "members_can_view_dependency_insights",
   "members_can_invite_outside_collaborators",
 ]
+
+// Not enterprise-only: sent on every plan, with a plan-dependent VALUE. Omitting
+// it off-enterprise is what made GitHub 422 the repo-creation PATCH.
+const PLAN_DEPENDENT_FIELD = "members_can_create_public_repositories"
 
 const NON_CRITICAL_FIELDS = [
   "members_can_create_private_repositories",
@@ -39,10 +42,10 @@ describe("memberDefaultSettings", () => {
   })
 
   it.each(["team", "free", "", undefined])(
-    "returns 11 fields with no enterprise-only fields on %s",
+    "returns 12 fields with no enterprise-only fields on %s",
     (plan) => {
       const settings = memberDefaultSettings(plan)
-      expect(settings).toHaveLength(11)
+      expect(settings).toHaveLength(12)
       const fields = settings.map((s) => s.field)
       for (const ent of ENTERPRISE_ONLY_FIELDS) {
         expect(fields).not.toContain(ent)
@@ -50,7 +53,67 @@ describe("memberDefaultSettings", () => {
     },
   )
 
-  it("marks exactly the three enabling fields non-critical, everything else critical", () => {
+  // Team/Free expose "Repository creation" as one all-or-none choice, so the
+  // private-only lockdown isn't reachable and public creation must be enabled
+  // (and sent) alongside private. Sending the private boolean WITHOUT this field
+  // makes GitHub recompute the deprecated legacy field as "private" and reject
+  // the whole PATCH: 422 "Private-only repository creation policy is not allowed
+  // for this organization."
+  it.each(["team", "free", "", undefined])(
+    "enables public repo creation on %s, and keeps it in scope",
+    (plan) => {
+      const setting = memberDefaultSettings(plan).find(
+        (s) => s.field === PLAN_DEPENDENT_FIELD,
+      )
+      expect(setting).toBeDefined()
+      expect(setting?.value).toBe(true)
+      // The master switch already carries the critical verdict for repo creation.
+      expect(setting?.critical).toBe(false)
+    },
+  )
+
+  // Both granular booleans are verify-only off-enterprise: GitHub derives them
+  // from the master switch and 422s any PATCH that carries one. The master switch
+  // itself stays writable — it's the only accepted write.
+  it.each(["team", "free", "", undefined])(
+    "marks the granular repo-creation booleans verify-only on %s",
+    (plan) => {
+      const byField = new Map(
+        memberDefaultSettings(plan).map((s) => [s.field, s]),
+      )
+      expect(byField.get(PLAN_DEPENDENT_FIELD)?.writable).toBe(false)
+      expect(
+        byField.get("members_can_create_private_repositories")?.writable,
+      ).toBe(false)
+      expect(byField.get("members_can_create_repositories")?.writable).not.toBe(
+        false,
+      )
+    },
+  )
+
+  it("keeps every enterprise setting writable", () => {
+    for (const s of memberDefaultSettings("enterprise")) {
+      expect(s.writable, `${s.field} writability`).not.toBe(false)
+    }
+  })
+
+  it("keeps the private-only lockdown on enterprise", () => {
+    const setting = memberDefaultSettings("enterprise").find(
+      (s) => s.field === PLAN_DEPENDENT_FIELD,
+    )
+    expect(setting?.value).toBe(false)
+    expect(setting?.critical).toBe(true)
+  })
+
+  it("does not mutate the canonical list when overriding", () => {
+    memberDefaultSettings("team")
+    const afterOverride = memberDefaultSettings("enterprise").find(
+      (s) => s.field === PLAN_DEPENDENT_FIELD,
+    )
+    expect(afterOverride?.value).toBe(false)
+  })
+
+  it("marks exactly the three enabling fields non-critical on enterprise, everything else critical", () => {
     for (const s of memberDefaultSettings("enterprise")) {
       const expectCritical = !NON_CRITICAL_FIELDS.includes(s.field)
       expect(s.critical, `${s.field} criticality`).toBe(expectCritical)
@@ -95,14 +158,30 @@ describe("classifyDefaults", () => {
   it("ignores enterprise-only fields on team plan even when their live value is wrong", () => {
     const live = enforcedLive("team")
     // A wrong value for an enterprise-only field must not affect a team verdict.
-    live.members_can_create_public_repositories = true
+    live.members_can_view_dependency_insights = true
     const { verdicts, criticalMissed } = classifyDefaults(live, "team")
-    expect(verdicts).toHaveLength(11)
+    expect(verdicts).toHaveLength(12)
     expect(
       verdicts.some(
-        (v) => v.setting.field === "members_can_create_public_repositories",
+        (v) => v.setting.field === "members_can_view_dependency_insights",
       ),
     ).toBe(false)
+    expect(criticalMissed).toBe(false)
+  })
+
+  // Public repo creation IS in scope off-enterprise, just inverted: Team/Free
+  // must have it ON (coupled to private), so public creation being OFF there is
+  // drift the audit reports rather than a field it ignores.
+  it("reports public repo creation as drift on team when it is off", () => {
+    const live = enforcedLive("team")
+    live.members_can_create_public_repositories = false
+    const { verdicts, criticalMissed } = classifyDefaults(live, "team")
+    const verdict = verdicts.find(
+      (v) => v.setting.field === "members_can_create_public_repositories",
+    )
+    expect(verdict?.enforced).toBe(false)
+    // Non-critical there: the master switch owns the critical repo-creation
+    // verdict, so this alone must not fail the whole audit.
     expect(criticalMissed).toBe(false)
   })
 

--- a/web/src/orgPolicy/desiredState.test.ts
+++ b/web/src/orgPolicy/desiredState.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   classifyDefaults,
+  isWritable,
   manualHardeningSteps,
   memberDefaultSettings,
 } from "./desiredState"
@@ -81,21 +82,35 @@ describe("memberDefaultSettings", () => {
       const byField = new Map(
         memberDefaultSettings(plan).map((s) => [s.field, s]),
       )
-      expect(byField.get(PLAN_DEPENDENT_FIELD)?.writable).toBe(false)
+      expect(isWritable(byField.get(PLAN_DEPENDENT_FIELD)!)).toBe(false)
       expect(
-        byField.get("members_can_create_private_repositories")?.writable,
+        isWritable(byField.get("members_can_create_private_repositories")!),
       ).toBe(false)
-      expect(byField.get("members_can_create_repositories")?.writable).not.toBe(
-        false,
+      expect(isWritable(byField.get("members_can_create_repositories")!)).toBe(
+        true,
       )
     },
   )
 
   it("keeps every enterprise setting writable", () => {
     for (const s of memberDefaultSettings("enterprise")) {
-      expect(s.writable, `${s.field} writability`).not.toBe(false)
+      expect(isWritable(s), `${s.field} writability`).toBe(true)
     }
   })
+
+  // The remedy for the private checkbox must not survive off-enterprise: that
+  // checkbox can't be set independently there, so the canonical wording would
+  // send a teacher somewhere useless. Parity with the CLI mirror's override.
+  it.each(["team", "free", "", undefined])(
+    "rewords the private-repo manual fix on %s",
+    (plan) => {
+      const setting = memberDefaultSettings(plan).find(
+        (s) => s.field === "members_can_create_private_repositories",
+      )
+      expect(setting?.manualFix).toContain("enabled together with")
+      expect(setting?.manualFix).not.toContain('check "Private"')
+    },
+  )
 
   it("keeps the private-only lockdown on enterprise", () => {
     const setting = memberDefaultSettings("enterprise").find(

--- a/web/src/orgPolicy/desiredState.ts
+++ b/web/src/orgPolicy/desiredState.ts
@@ -8,6 +8,16 @@
 
 export type MemberDefaultValue = boolean | string
 
+// The repo-creation field names, exported because the write path, the audit and
+// the teacher pre-flight warning all need to name them.
+export const MEMBERS_CAN_CREATE_REPOSITORIES = "members_can_create_repositories"
+export const MEMBERS_CAN_CREATE_PRIVATE_REPOSITORIES =
+  "members_can_create_private_repositories"
+export const MEMBERS_CAN_CREATE_PUBLIC_REPOSITORIES =
+  "members_can_create_public_repositories"
+export const MEMBERS_CAN_CREATE_INTERNAL_REPOSITORIES =
+  "members_can_create_internal_repositories"
+
 export type MemberDefaultSetting = {
   field: string
   value: MemberDefaultValue
@@ -15,11 +25,10 @@ export type MemberDefaultSetting = {
   manualFix: string
   critical: boolean
   enterpriseOnly: boolean
-  // False for a field whose desired value is real and verifiable but that must
-  // NOT be sent in the PATCH, because GitHub derives it. Only Team/Free's
-  // granular repo-creation booleans qualify: see NON_ENTERPRISE_OVERRIDES.
-  // Undefined means writable.
-  writable?: boolean
+  // Marks a field whose desired value is real and verifiable but that must NOT
+  // be sent in the PATCH, because GitHub derives it. Only Team/Free's granular
+  // repo-creation booleans qualify: see NON_ENTERPRISE_OVERRIDES.
+  verifyOnly?: boolean
 }
 
 // The 15 member-default fields, in the CLI's order. Criticality and
@@ -188,11 +197,14 @@ const ALL_MEMBER_DEFAULT_SETTINGS: readonly MemberDefaultSetting[] = [
 const NON_ENTERPRISE_OVERRIDES: Readonly<
   Record<string, Partial<MemberDefaultSetting>>
 > = {
-  members_can_create_private_repositories: {
-    // Derived from the master switch on this plan, so verify but never write.
-    writable: false,
+  [MEMBERS_CAN_CREATE_PRIVATE_REPOSITORIES]: {
+    // The canonical remedy names a "Private" checkbox that can't be set
+    // independently on this plan, so it would send a teacher somewhere useless.
+    manualFix:
+      'under "Repository creation", allow members to create repositories — on this plan "Private" is enabled together with "Public"',
+    verifyOnly: true,
   },
-  members_can_create_public_repositories: {
+  [MEMBERS_CAN_CREATE_PUBLIC_REPOSITORIES]: {
     value: true,
     desc: "public repo creation enabled (Team/Free couples it to private)",
     manualFix:
@@ -200,8 +212,14 @@ const NON_ENTERPRISE_OVERRIDES: Readonly<
     // An enabling field, like private-repo creation: the master switch already
     // carries the critical verdict for repo creation being off.
     critical: false,
-    writable: false,
+    verifyOnly: true,
   },
+}
+
+// Whether a setting may be sent in PATCH /orgs/{org}. Mirrors the CLI's
+// MemberDefaultSetting.VerifyOnly so the write paths can't drift.
+export function isWritable(setting: MemberDefaultSetting): boolean {
+  return !setting.verifyOnly
 }
 
 // memberDefaultSettings returns the in-scope settings for a plan. "enterprise"

--- a/web/src/orgPolicy/desiredState.ts
+++ b/web/src/orgPolicy/desiredState.ts
@@ -15,12 +15,19 @@ export type MemberDefaultSetting = {
   manualFix: string
   critical: boolean
   enterpriseOnly: boolean
+  // False for a field whose desired value is real and verifiable but that must
+  // NOT be sent in the PATCH, because GitHub derives it. Only Team/Free's
+  // granular repo-creation booleans qualify: see NON_ENTERPRISE_OVERRIDES.
+  // Undefined means writable.
+  writable?: boolean
 }
 
 // The 15 member-default fields, in the CLI's order. Criticality and
 // enterprise-only flags mirror the CLI: critical marks lockdown fields whose
 // absence re-opens the org-wide repo-admin danger; enterprise-only fields have
-// no member-privileges toggle on Team/Free, so init skips them there.
+// no member-privileges toggle on Team/Free, so init skips them there. A field
+// whose desired VALUE (rather than applicability) differs off-enterprise is
+// handled by NON_ENTERPRISE_OVERRIDES instead.
 const ALL_MEMBER_DEFAULT_SETTINGS: readonly MemberDefaultSetting[] = [
   {
     field: "default_repository_permission",
@@ -52,13 +59,16 @@ const ALL_MEMBER_DEFAULT_SETTINGS: readonly MemberDefaultSetting[] = [
     enterpriseOnly: false,
   },
   {
+    // Enterprise Cloud only: narrows repo creation to private-only. On Team/Free
+    // that choice doesn't exist and the desired value flips to `true`, and the
+    // field becomes verify-only — see NON_ENTERPRISE_OVERRIDES.
     field: "members_can_create_public_repositories",
     value: false,
     desc: "public repo creation disabled",
     manualFix:
       'under "Repository creation", restrict members to private repositories only (GitHub Enterprise Cloud only)',
     critical: true,
-    enterpriseOnly: true,
+    enterpriseOnly: false,
   },
   {
     field: "members_can_create_internal_repositories",
@@ -157,16 +167,59 @@ const ALL_MEMBER_DEFAULT_SETTINGS: readonly MemberDefaultSetting[] = [
   },
 ]
 
-// memberDefaultSettings returns the in-scope settings for a plan. Only
-// "enterprise" gets all 15; every other plan (team/free/unknown) is treated as
-// non-enterprise and the 4 enterprise-only fields are filtered out, leaving 11.
+// Settings whose DESIRED VALUE (and writability) depend on the plan, rather than
+// being skipped off-enterprise. Only repo creation qualifies.
+//
+// Team/Free expose "Repository creation" as a single all-or-none choice: the
+// granular public/private booleans are slaved to the master switch, so the
+// private-only lockdown Enterprise Cloud allows is unreachable. Since
+// `student accept` needs private creation, the desired end state on Team/Free is
+// BOTH booleans true.
+//
+// Getting there is the subtle part, verified against the live API: any PATCH that
+// carries the granular `members_can_create_private_repositories` is rejected from
+// the all-off state with 422 "Private-only repository creation policy is not
+// allowed for this organization." — including one that also sets
+// `members_can_create_public_repositories: true` in the same request. The only
+// accepted write is the master switch alone, which GitHub resolves to
+// `members_allowed_repository_creation_type: "all"` and thereby sets both
+// booleans true. So both granular fields are `writable: false` here: still
+// audited (the values are real and drift is worth reporting), never sent.
+const NON_ENTERPRISE_OVERRIDES: Readonly<
+  Record<string, Partial<MemberDefaultSetting>>
+> = {
+  members_can_create_private_repositories: {
+    // Derived from the master switch on this plan, so verify but never write.
+    writable: false,
+  },
+  members_can_create_public_repositories: {
+    value: true,
+    desc: "public repo creation enabled (Team/Free couples it to private)",
+    manualFix:
+      'under "Repository creation", allow members to create repositories — on this plan "Public" cannot be unchecked while "Private" is checked',
+    // An enabling field, like private-repo creation: the master switch already
+    // carries the critical verdict for repo creation being off.
+    critical: false,
+    writable: false,
+  },
+}
+
+// memberDefaultSettings returns the in-scope settings for a plan. "enterprise"
+// gets all 15 verbatim; every other plan (team/free/unknown) is treated as
+// non-enterprise, which drops the 3 enterprise-only fields and applies
+// NON_ENTERPRISE_OVERRIDES, leaving 12.
 export function memberDefaultSettings(
   plan: string | undefined,
 ): MemberDefaultSetting[] {
   if (plan === "enterprise") {
     return [...ALL_MEMBER_DEFAULT_SETTINGS]
   }
-  return ALL_MEMBER_DEFAULT_SETTINGS.filter((s) => !s.enterpriseOnly)
+  return ALL_MEMBER_DEFAULT_SETTINGS.filter((s) => !s.enterpriseOnly).map(
+    (s) => {
+      const override = NON_ENTERPRISE_OVERRIDES[s.field]
+      return override ? { ...s, ...override } : s
+    },
+  )
 }
 
 export type DefaultVerdict = {

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -99,7 +99,16 @@ vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
   return {
     ...actual,
-    useTranslation: () => ({ t: (key: string) => key }),
+    // Renders the key plus its resolved params, so a test can tell a resolved
+    // descriptor (params already substituted) from a leaked raw key.
+    useTranslation: () => ({
+      t: (key: string, params?: Record<string, string | number>) =>
+        params
+          ? `${key}:${Object.entries(params)
+              .map(([name, value]) => `${name}=${String(value)}`)
+              .join(",")}`
+          : key,
+    }),
   }
 })
 
@@ -270,6 +279,121 @@ describe("AcceptAssignmentPage secret selection", () => {
       "cs101",
       undefined,
     )
+  })
+})
+
+describe("AcceptAssignmentPage step messages", () => {
+  // Every step label, done-message, and remedy is a { key, params } descriptor
+  // resolved here — the domain never assembles English, so a non-English student
+  // no longer watches translated placeholders flip to English mid-run.
+  const STEP_IDS = [
+    "account",
+    "membership",
+    "assignment",
+    "autograder",
+    "repo",
+    "access",
+    "setup",
+  ] as const
+
+  const renderWithStepFailure = async (
+    id: (typeof STEP_IDS)[number],
+    error: { key: string; params?: Record<string, string | number> },
+  ) => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    acceptAssignment.mockImplementation(
+      (params: { onStepUpdate?: (u: unknown) => void }) => {
+        params.onStepUpdate?.({ id, status: "error", error })
+        return Promise.reject(
+          Object.assign(new Error("diagnostic"), {
+            localized: error,
+          }),
+        )
+      },
+    )
+    renderPage(client)
+    fireEvent.click(screen.getByRole("button", { name: "accept.acceptButton" }))
+    await waitFor(() =>
+      expect(screen.queryByText("accept.errorTitle")).not.toBeNull(),
+    )
+  }
+
+  it.each(STEP_IDS)(
+    "renders the resolved remedy, not a raw key, for the %s step",
+    async (id) => {
+      await renderWithStepFailure(id, {
+        key: "accept.stepErrors.generic",
+        params: { label: `accept.steps.${id}`, status: 403 },
+      })
+
+      // Present once in the checklist row and once in the error alert.
+      expect(
+        screen.queryAllByText(
+          `accept.stepErrors.generic:label=accept.steps.${id},status=403`,
+        ).length,
+      ).toBeGreaterThan(0)
+      // The pending placeholder for the failed step is replaced, not appended.
+      expect(screen.queryByText(`accept.steps.${id}`)).toBeNull()
+    },
+  )
+
+  it("renders a nested descriptor param (GitHub's own words) in the alert", async () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    acceptAssignment.mockRejectedValue(
+      Object.assign(new Error("diagnostic"), {
+        localized: {
+          key: "accept.templateErrors.orgRepoCreationDenied",
+          params: {
+            org: "acme",
+            status: 403,
+            detail: {
+              key: "accept.templateErrors.githubSaid",
+              params: { message: "You need admin access" },
+            },
+          },
+        },
+      }),
+    )
+    renderPage(client)
+    fireEvent.click(screen.getByRole("button", { name: "accept.acceptButton" }))
+    await waitFor(() =>
+      expect(screen.queryByText("accept.errorTitle")).not.toBeNull(),
+    )
+
+    expect(
+      screen.queryByText(
+        "accept.templateErrors.orgRepoCreationDenied:org=acme,status=403,detail=accept.templateErrors.githubSaid:message=You need admin access",
+      ),
+    ).not.toBeNull()
+  })
+
+  it("falls back to the generic copy for an error carrying no descriptor", async () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    acceptAssignment.mockRejectedValue(new TypeError("Failed to fetch"))
+    renderPage(client)
+    fireEvent.click(screen.getByRole("button", { name: "accept.acceptButton" }))
+    await waitFor(() =>
+      expect(screen.queryByText("accept.errorTitle")).not.toBeNull(),
+    )
+
+    expect(screen.queryByText("accept.errorGeneric")).not.toBeNull()
+    // The browser's own English never reaches the student.
+    expect(screen.queryByText("Failed to fetch")).toBeNull()
   })
 })
 

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -20,6 +20,11 @@ import { useId, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import confetti from "canvas-confetti"
 import { type AcceptStepId, type AcceptStepStatus } from "@/domain/assignments"
+import {
+  localizedMessageOf,
+  resolveLocalizedMessage,
+  type LocalizedMessage,
+} from "@/types/localizedMessage"
 import { useAcceptAndVerifyMembership } from "@/hooks/mutations/useAcceptAndVerifyMembership"
 import {
   classifyMembershipError,
@@ -224,8 +229,9 @@ const modeLabelKey: Record<string, string> = {
   group: "accept.modeGroup",
 }
 
-// Pending-state placeholders; once a step emits, the live withAcceptStep
-// message (assignments.ts) overrides these, so they only need loose parity.
+// Pending-state placeholders. Once a step emits, the domain sends the same
+// `accept.steps.*` key back as a { key, params } descriptor — one source of
+// truth for every step label (see AGENTS.md's `{ key, params }` rule).
 const ACCEPT_STEP_ORDER: { id: AcceptStepId; labelKey: string }[] = [
   { id: "account", labelKey: "accept.steps.account" },
   { id: "membership", labelKey: "accept.steps.membership" },
@@ -238,7 +244,11 @@ const ACCEPT_STEP_ORDER: { id: AcceptStepId; labelKey: string }[] = [
 
 type StepState = Record<
   AcceptStepId,
-  { status: AcceptStepStatus; message?: string; error?: string }
+  {
+    status: AcceptStepStatus
+    message?: LocalizedMessage
+    error?: LocalizedMessage
+  }
 >
 
 const initialStepState: StepState = ACCEPT_STEP_ORDER.reduce((acc, step) => {
@@ -282,7 +292,9 @@ const StepRow = ({
   label: string
   state: StepState[AcceptStepId]
 }) => {
-  const text = state.error ?? state.message ?? label
+  const { t } = useTranslation()
+  const deferred = state.error ?? state.message
+  const text = deferred ? resolveLocalizedMessage(t, deferred) : label
 
   return (
     <div className="flex items-center gap-3 text-sm">
@@ -616,6 +628,11 @@ const AcceptAssignmentPage = () => {
     })
   }
 
+  // Accept errors name their message ({ key, params }) rather than carrying
+  // assembled English, so the remedy renders in the student's language. An error
+  // with no descriptor (a browser network throw) falls back to the generic copy.
+  const acceptError = localizedMessageOf(acceptMutation.error)
+
   if (loadingAssignments || isLoadingRepo || loadingOrgMembership) {
     return (
       <AcceptLayout>
@@ -769,8 +786,8 @@ const AcceptAssignmentPage = () => {
                 <div>
                   <div className="font-bold">{t("accept.errorTitle")}</div>
                   <div className="mt-1 whitespace-pre-wrap text-sm">
-                    {acceptMutation.error instanceof Error
-                      ? acceptMutation.error.message
+                    {acceptError
+                      ? resolveLocalizedMessage(t, acceptError)
                       : t("accept.errorGeneric")}
                   </div>
                   {outageHint.isOutage(acceptMutation.error) && (

--- a/web/src/pages/AssignmentsPage.test.tsx
+++ b/web/src/pages/AssignmentsPage.test.tsx
@@ -45,6 +45,23 @@ vi.mock("@/hooks/useGetClassAssignments", () => ({
 vi.mock("@/hooks/useEmptyRosterWarning", () => ({
   default: () => ({ show: false, hasRosterRows: false }),
 }))
+const orgRepoCreationWarning = vi.fn()
+vi.mock("@/hooks/useOrgRepoCreationWarning", () => ({
+  default: () => orgRepoCreationWarning(),
+}))
+// The notice's own copy/placement is covered in OrgRepoCreationNotice.test.tsx;
+// here it stands in for "did the page mount it", so stub it to its i18n key.
+vi.mock("@/components/OrgRepoCreationNotice", async () => {
+  const { default: useWarning } =
+    await import("@/hooks/useOrgRepoCreationWarning")
+  return {
+    OrgRepoCreationNotice: () => {
+      const warning = useWarning(undefined)
+      if (!warning.show) return null
+      return <div>{`components.notices.orgRepoCreation.${warning.field}`}</div>
+    },
+  }
+})
 vi.mock("@/context/classroomRole/ClassroomRoleProvider", () => ({
   useClassroomRoleContext: () => ({ role: "teacher" }),
 }))
@@ -57,6 +74,7 @@ vi.mock("@/pages/assignments/AssignmentsToolbar", () => ({
 import { TeacherAssignmentsView } from "./AssignmentsPage"
 
 beforeEach(() => {
+  orgRepoCreationWarning.mockReturnValue({ show: false })
   studentCount.mockReset()
   getStudents.mockReset()
   getClassroom.mockReset()
@@ -102,5 +120,38 @@ describe("Assignments header student count", () => {
     render(<TeacherAssignmentsView org="acme" classroom="cs101" />)
     expect(screen.getByText("…")).toBeTruthy()
     expect(screen.queryByText(/assignments\.studentCount/)).toBeNull()
+  })
+})
+
+// The drift-after-creation case: a teacher who created assignments before the
+// setting flipped never reopens create or edit, so without the list surface the
+// warning never reaches them and students accept days later.
+describe("Assignments org repo-creation warning", () => {
+  const renderView = () => {
+    studentCount.mockReturnValue({
+      studentCount: 1,
+      isLoading: false,
+      isError: false,
+    })
+    render(<TeacherAssignmentsView org="acme" classroom="cs101" />)
+  }
+
+  it("renders the notice when the org blocks repo creation", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
+    renderView()
+    expect(
+      screen.queryByText("components.notices.orgRepoCreation.master"),
+    ).not.toBeNull()
+  })
+
+  it("renders nothing when the hook is silent", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: false })
+    renderView()
+    expect(
+      screen.queryByText("components.notices.orgRepoCreation.master"),
+    ).toBeNull()
+    expect(
+      screen.queryByText("components.notices.orgRepoCreation.private"),
+    ).toBeNull()
   })
 })

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -19,6 +19,7 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
+import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
 import { ClaimTeacherNotice } from "./classes/ClaimTeacherNotice"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { ReuseFromClassroomModal } from "@/components/modals/ReuseFromClassroomModal"
@@ -200,6 +201,10 @@ export const TeacherAssignmentsView = ({
           hasRosterRows={emptyRoster.hasRosterRows}
         />
       ) : null}
+      {/* Catches the drift-after-creation case the create/edit pages can't: a
+          teacher who created assignments before the setting flipped never
+          reopens those forms, and students accept days later. */}
+      <OrgRepoCreationNotice org={org} />
       {showToolbar && (
         <AssignmentsToolbar
           query={query}

--- a/web/src/pages/CreateAssignmentPage.test.tsx
+++ b/web/src/pages/CreateAssignmentPage.test.tsx
@@ -58,12 +58,29 @@ vi.mock("@/components/RequireRole", () => ({
 vi.mock("@/components/EmptyRosterNotice", () => ({
   EmptyRosterNotice: () => null,
 }))
+// The notice's own copy/placement is covered in OrgRepoCreationNotice.test.tsx;
+// here it stands in for "did the page mount it", so stub it to its i18n key.
+vi.mock("@/components/OrgRepoCreationNotice", async () => {
+  const { default: useWarning } =
+    await import("@/hooks/useOrgRepoCreationWarning")
+  return {
+    OrgRepoCreationNotice: () => {
+      const warning = useWarning(undefined)
+      if (!warning.show) return null
+      return <div>{`components.notices.orgRepoCreation.${warning.field}`}</div>
+    },
+  }
+})
 
 vi.mock("@/hooks/useDocumentTitle", () => ({
   useDocumentTitle: () => undefined,
 }))
 vi.mock("@/hooks/useGetClassAssignments", () => ({
   default: () => ({ data: { assignments: [] } }),
+}))
+const orgRepoCreationWarning = vi.fn()
+vi.mock("@/hooks/useOrgRepoCreationWarning", () => ({
+  default: () => orgRepoCreationWarning(),
 }))
 vi.mock("@/hooks/useEmptyRosterWarning", () => ({
   default: () => ({ show: false, hasRosterRows: true }),
@@ -122,6 +139,7 @@ const succeedWith = (result: unknown) =>
   act(() => lastMutateOptions?.onSuccess?.(result, { slug: "hw1" }))
 
 beforeEach(() => {
+  orgRepoCreationWarning.mockReturnValue({ show: false })
   mutateAsync.mockClear()
   lastMutateOptions = null
   navigateMock.mockClear()
@@ -217,5 +235,23 @@ describe("CreateAssignmentPage templateGrantWarning surfacing", () => {
     succeedWith({ newCommitSha: "sha" })
     expect(screen.queryByText(WARNING)).toBeNull()
     expect(navigateMock).toHaveBeenCalled()
+  })
+})
+
+describe("CreateAssignmentPage org repo-creation warning", () => {
+  it("renders the notice when the org blocks repo creation", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: true, field: "private" })
+    render(<CreateAssignmentPage />)
+    expect(
+      screen.queryByText("components.notices.orgRepoCreation.private"),
+    ).not.toBeNull()
+  })
+
+  it("renders nothing when the hook is silent", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: false })
+    render(<CreateAssignmentPage />)
+    expect(
+      screen.queryByText("components.notices.orgRepoCreation.private"),
+    ).toBeNull()
   })
 })

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -7,6 +7,7 @@ import MissingParams from "@/components/MissingParams"
 import RequireRole from "@/components/RequireRole"
 import { AnimatedAlert, Button } from "@/components/ui"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
+import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
 import CreateAssignmentForm from "@/pages/assignments/CreateAssignmentForm"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useCreateAssignment } from "@/hooks/mutations/useCreateAssignment"
@@ -76,6 +77,7 @@ const CreateAssignmentPage = () => {
             hasRosterRows={emptyRoster.hasRosterRows}
           />
         ) : null}
+        <OrgRepoCreationNotice org={org} />
         <AnimatedAlert tone="error" show={errorShown}>
           {errorContent.kind === "outage" ? (
             <GitHubStatusNote statusDescription={outageStatusDescription} />

--- a/web/src/pages/EditAssignmentPage.test.tsx
+++ b/web/src/pages/EditAssignmentPage.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    useParams: () => ({
+      org: "acme",
+      classroom: "cs101",
+      assignment: "hello-python",
+    }),
+    useRouter: () => ({ history: { back: vi.fn() } }),
+  }
+})
+
+const role = vi.fn()
+vi.mock("@/context/classroomRole/ClassroomRoleProvider", () => ({
+  useClassroomRoleContext: () => ({ role: role() }),
+}))
+
+const orgRepoCreationWarning = vi.fn()
+vi.mock("@/hooks/useOrgRepoCreationWarning", () => ({
+  default: () => orgRepoCreationWarning(),
+}))
+// The notice's own copy is covered in OrgRepoCreationNotice.test.tsx; here it
+// stands in for "did the page mount it, and did it fire the org read".
+vi.mock("@/components/OrgRepoCreationNotice", async () => {
+  const { default: useWarning } =
+    await import("@/hooks/useOrgRepoCreationWarning")
+  return {
+    OrgRepoCreationNotice: () => {
+      const warning = useWarning(undefined)
+      if (!warning.show) return null
+      return <div>{`components.notices.orgRepoCreation.${warning.field}`}</div>
+    },
+  }
+})
+
+vi.mock("@/components/PageShell", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+vi.mock("@/components/PageHeader", () => ({ default: () => null }))
+vi.mock("@/components/breadcrumb", () => ({ default: () => null }))
+vi.mock("./assignments/EditAssignmentForm", () => ({ default: () => null }))
+// EditAssignmentFormStudent is defined in the page module itself, so it can't be
+// stubbed — stub the auth context it reads instead, keeping the student branch on
+// its real render path (which is what the R12 assertion below is about).
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({ user: { id: 1, login: "student" } }),
+}))
+vi.mock("@/hooks/useGetAssignmentRepo", () => ({
+  default: () => ({ data: null, isLoading: false }),
+}))
+vi.mock("@/hooks/useGetPublicAssignment", () => ({
+  default: () => ({ data: null, isLoading: false }),
+}))
+vi.mock("@/hooks/useDotClassroom50", () => ({
+  default: () => ({ data: null, isLoading: false }),
+}))
+vi.mock("@/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: () => undefined,
+}))
+vi.mock("@/hooks/useGetClassAssignments", () => ({
+  default: () => ({
+    data: { assignments: [{ slug: "hello-python", name: "Hello Python" }] },
+  }),
+}))
+vi.mock("@/hooks/useGetClassroom", () => ({
+  default: () => ({ data: { name: "CS 101", active: true } }),
+}))
+
+import EditAssignmentPage from "./EditAssignmentPage"
+
+beforeEach(() => {
+  orgRepoCreationWarning.mockReturnValue({ show: false })
+  role.mockReturnValue("teacher")
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const NOTICE = "components.notices.orgRepoCreation.master"
+
+// This page has no RequireRole wrapper and renders a student form on the student
+// branch, so the notice's placement inside the isStaff branch is the only thing
+// keeping a student from seeing a warning about org member privileges — and from
+// firing an org read they could never act on.
+describe("EditAssignmentPage org repo-creation warning", () => {
+  it("renders the notice for a staff role", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
+    render(<EditAssignmentPage />)
+    expect(screen.queryByText(NOTICE)).not.toBeNull()
+  })
+
+  it("is absent for a student, even when the org blocks repo creation", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
+    role.mockReturnValue("student")
+    render(<EditAssignmentPage />)
+
+    expect(screen.queryByText(NOTICE)).toBeNull()
+    // Not merely hidden: the org read never runs for a student.
+    expect(orgRepoCreationWarning).not.toHaveBeenCalled()
+  })
+
+  it("renders nothing for staff when the hook is silent", () => {
+    render(<EditAssignmentPage />)
+    expect(screen.queryByText(NOTICE)).toBeNull()
+  })
+})

--- a/web/src/pages/EditAssignmentPage.test.tsx
+++ b/web/src/pages/EditAssignmentPage.test.tsx
@@ -97,8 +97,9 @@ const NOTICE = "components.notices.orgRepoCreation.master"
 
 // This page has no RequireRole wrapper and renders a student form on the student
 // branch, so the notice's placement inside the isStaff branch is the only thing
-// keeping a student from seeing a warning about org member privileges — and from
-// firing an org read they could never act on.
+// keeping a student from seeing a warning about org member privileges they can't
+// act on. (It does not save a request: every org-scoped page's sidebar already
+// issues the same shared org read, for students too.)
 describe("EditAssignmentPage org repo-creation warning", () => {
   it("renders the notice for a staff role", () => {
     orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
@@ -112,7 +113,7 @@ describe("EditAssignmentPage org repo-creation warning", () => {
     render(<EditAssignmentPage />)
 
     expect(screen.queryByText(NOTICE)).toBeNull()
-    // Not merely hidden: the org read never runs for a student.
+    // Not merely hidden by CSS: the notice never mounts on the student branch.
     expect(orgRepoCreationWarning).not.toHaveBeenCalled()
   })
 

--- a/web/src/pages/EditAssignmentPage.tsx
+++ b/web/src/pages/EditAssignmentPage.tsx
@@ -5,6 +5,7 @@ import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
+import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
 import { Spinner } from "@/components/Spinner"
 import { Alert, AnimatedAlert, Button, Card } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -217,37 +218,40 @@ const EditAssignmentPage = () => {
         </ArchivedClassroomNotice>
       )}
       {isStaff && org && classroom && assignment && (
-        <EditAssignmentForm
-          org={org}
-          classroom={classroom}
-          assignment={assignment}
-          defaultData={assignmentData}
-          readOnly={archived || !canAuthor}
-          onCancel={() => {
-            router.history.back()
-          }}
-          onMutate={() => {
-            // Clear prior banners so a re-edit never shows stale state.
-            setEditSuccess(false)
-            setEditWarning("")
-            setEditError("")
-          }}
-          onError={(error) => {
-            setEditError(error.message)
-            window.scrollTo({ top: 0, behavior: "smooth" })
-          }}
-          onSuccess={(result) => {
-            // Surface a non-fatal template-grant warning inline; else show
-            // the success banner.
-            if (result?.templateGrantWarning) {
-              setEditWarning(result.templateGrantWarning)
-            } else {
-              setEditSuccess(true)
-              setTimeout(() => setEditSuccess(false), 3000)
-            }
-            window.scrollTo({ top: 0, behavior: "smooth" })
-          }}
-        />
+        <>
+          <OrgRepoCreationNotice org={org} />
+          <EditAssignmentForm
+            org={org}
+            classroom={classroom}
+            assignment={assignment}
+            defaultData={assignmentData}
+            readOnly={archived || !canAuthor}
+            onCancel={() => {
+              router.history.back()
+            }}
+            onMutate={() => {
+              // Clear prior banners so a re-edit never shows stale state.
+              setEditSuccess(false)
+              setEditWarning("")
+              setEditError("")
+            }}
+            onError={(error) => {
+              setEditError(error.message)
+              window.scrollTo({ top: 0, behavior: "smooth" })
+            }}
+            onSuccess={(result) => {
+              // Surface a non-fatal template-grant warning inline; else show
+              // the success banner.
+              if (result?.templateGrantWarning) {
+                setEditWarning(result.templateGrantWarning)
+              } else {
+                setEditSuccess(true)
+                setTimeout(() => setEditSuccess(false), 3000)
+              }
+              window.scrollTo({ top: 0, behavior: "smooth" })
+            }}
+          />
+        </>
       )}
       {isStudent && org && classroom && assignment && (
         <EditAssignmentFormStudent

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -107,6 +107,12 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
         queryKey: githubKeys.orgActionsMode(org),
       })
       void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      // Setup applies the member-default lockdown, so refresh the shared org
+      // query the teacher pre-flight warnings read (the `["orgs"]` key above is
+      // a different, non-github-prefixed list).
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.orgDetails(org),
+      })
     },
   })
 

--- a/web/src/pages/submissions/AcceptLinkModal.test.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+    Trans: ({ i18nKey }: { i18nKey: string }) => <span>{i18nKey}</span>,
+  }
+})
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+  }
+})
+
+const orgRepoCreationWarning = vi.fn()
+vi.mock("@/hooks/useOrgRepoCreationWarning", () => ({
+  default: () => orgRepoCreationWarning(),
+}))
+// The notice's own copy is covered in OrgRepoCreationNotice.test.tsx; here it
+// stands in for "did the modal mount it".
+vi.mock("@/components/OrgRepoCreationNotice", async () => {
+  const { default: useWarning } =
+    await import("@/hooks/useOrgRepoCreationWarning")
+  return {
+    OrgRepoCreationNotice: () => {
+      const warning = useWarning(undefined)
+      if (!warning.show) return null
+      return <div>{`components.notices.orgRepoCreation.${warning.field}`}</div>
+    },
+  }
+})
+// RouterButton is createLink(Button) and needs a live router; the modal's own
+// affordances are not what these tests assert.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+  }
+})
+
+import { AcceptLinkModal } from "./AcceptLinkModal"
+
+const NOTICE = "components.notices.orgRepoCreation.master"
+const ROSTER_WARNING = "submissions.accept.warnNoStudents"
+
+beforeEach(() => {
+  orgRepoCreationWarning.mockReturnValue({ show: false })
+  // happy-dom's <dialog> lacks showModal/close.
+  HTMLDialogElement.prototype.showModal = vi.fn()
+  HTMLDialogElement.prototype.close = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const renderModal = (
+  summary?: Parameters<typeof AcceptLinkModal>[0]["summary"],
+) =>
+  render(
+    <AcceptLinkModal
+      open
+      onClose={() => {}}
+      url="https://classroom50.org/acme/cs101/hw1"
+      cli="gh student accept acme cs101 hw1"
+      hasSecret={false}
+      org="acme"
+      classroom="cs101"
+      classroomName="CS 101"
+      summary={summary}
+    />,
+  )
+
+// The share modal is the last moment before students hit the accept-time 403, so
+// a teacher who is about to hand out the link learns the org will refuse it.
+describe("AcceptLinkModal org repo-creation warning", () => {
+  it("warns when the org blocks repo creation", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
+    renderModal({
+      resolved: true,
+      warnNoStudents: false,
+      acceptableStudents: 3,
+    })
+
+    expect(screen.queryByText(NOTICE)).not.toBeNull()
+  })
+
+  it("renders nothing when the org allows repo creation", () => {
+    renderModal({
+      resolved: true,
+      warnNoStudents: false,
+      acceptableStudents: 3,
+    })
+
+    expect(screen.queryByText(NOTICE)).toBeNull()
+  })
+
+  // The two conditions are independent — an empty roster and a locked-down org
+  // are separate blockers, and fixing one doesn't fix the other — so neither
+  // notice may suppress the other.
+  it("shows both notices alongside an empty roster", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
+    renderModal({ resolved: true, warnNoStudents: true, acceptableStudents: 0 })
+
+    expect(screen.queryByText(NOTICE)).not.toBeNull()
+    expect(screen.queryByText(ROSTER_WARNING)).not.toBeNull()
+  })
+
+  // The roster summary is omitted when the classroom hasn't resolved; the org
+  // warning has its own read and must not be gated on it.
+  it("still warns when no roster summary is available", () => {
+    orgRepoCreationWarning.mockReturnValue({ show: true, field: "private" })
+    renderModal(undefined)
+
+    expect(
+      screen.queryByText("components.notices.orgRepoCreation.private"),
+    ).not.toBeNull()
+  })
+})

--- a/web/src/pages/submissions/AcceptLinkModal.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.tsx
@@ -74,10 +74,9 @@ export function AcceptLinkModal({
         />
 
         {/* Sharing the link is the last moment before students hit the
-            accept-time 403, and an org that refuses member repo creation breaks
-            every accept regardless of how ready the roster is — so this sits
-            beside the roster notice rather than replacing it. No margin: the
-            wrapper's `gap-4` owns the spacing. */}
+            accept-time 403, and a locked-down org breaks every accept however
+            ready the roster is — so this sits beside the roster notice rather
+            than replacing it. No margin: the wrapper's `gap-4` owns the spacing. */}
         <OrgRepoCreationNotice org={org} className="" />
 
         {hasSecret ? (

--- a/web/src/pages/submissions/AcceptLinkModal.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.tsx
@@ -11,6 +11,7 @@ import {
   rtlFlip,
 } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
 import type { AcceptShareSummary } from "./acceptShareSummary"
 
 // The "How students accept" content, moved out of the page into a modal so the
@@ -71,6 +72,13 @@ export function AcceptLinkModal({
           classroom={classroom}
           classroomName={classroomName}
         />
+
+        {/* Sharing the link is the last moment before students hit the
+            accept-time 403, and an org that refuses member repo creation breaks
+            every accept regardless of how ready the roster is — so this sits
+            beside the roster notice rather than replacing it. No margin: the
+            wrapper's `gap-4` owns the spacing. */}
+        <OrgRepoCreationNotice org={org} className="" />
 
         {hasSecret ? (
           <p className="text-sm text-base-content/70">

--- a/web/src/types/localizedMessage.test.ts
+++ b/web/src/types/localizedMessage.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  describeLocalizedMessage,
+  localizedMessageOf,
+  resolveLocalizedMessage,
+  type TranslateFn,
+} from "./localizedMessage"
+
+// Stand-in for i18next: renders the key with {{param}} substitution so a test
+// can tell a resolved sentence from a leaked raw key.
+const t: TranslateFn = (key, params) => {
+  const body = `[${key}]`
+  if (!params) return body
+  const rendered = Object.entries(params)
+    .map(([name, value]) => `${name}:${String(value)}`)
+    .join("|")
+  return `${body}{${rendered}}`
+}
+
+describe("resolveLocalizedMessage", () => {
+  it("resolves a bare key", () => {
+    expect(resolveLocalizedMessage(t, { key: "a.b" })).toBe("[a.b]")
+  })
+
+  it("passes scalar params through", () => {
+    expect(
+      resolveLocalizedMessage(t, {
+        key: "a.b",
+        params: { org: "cs50", status: 403 },
+      }),
+    ).toBe("[a.b]{org:cs50|status:403}")
+  })
+
+  it("resolves a nested message param before the parent key", () => {
+    expect(
+      resolveLocalizedMessage(t, {
+        key: "parent",
+        params: {
+          detail: { key: "child", params: { message: "denied" } },
+        },
+      }),
+    ).toBe("[parent]{detail:[child]{message:denied}}")
+  })
+})
+
+describe("localizedMessageOf", () => {
+  it("returns the carried message", () => {
+    const err = Object.assign(new Error("diagnostic"), {
+      localized: { key: "a.b" },
+    })
+    expect(localizedMessageOf(err)).toEqual({ key: "a.b" })
+  })
+
+  it("returns undefined for a plain error, a non-object, and a malformed carrier", () => {
+    expect(localizedMessageOf(new Error("plain"))).toBeUndefined()
+    expect(localizedMessageOf("nope")).toBeUndefined()
+    expect(localizedMessageOf(null)).toBeUndefined()
+    expect(
+      localizedMessageOf(
+        Object.assign(new Error("x"), { localized: { key: 1 } }),
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe("describeLocalizedMessage", () => {
+  it("keeps the key and its params readable for logs", () => {
+    expect(
+      describeLocalizedMessage({
+        key: "accept.templateErrors.orgRepoCreationDenied",
+        params: { org: "cs50", status: 403 },
+      }),
+    ).toBe("accept.templateErrors.orgRepoCreationDenied (org=cs50, status=403)")
+  })
+
+  it("flattens a nested message", () => {
+    expect(
+      describeLocalizedMessage({
+        key: "parent",
+        params: { detail: { key: "child" } },
+      }),
+    ).toBe("parent (detail=child)")
+  })
+})

--- a/web/src/types/localizedMessage.ts
+++ b/web/src/types/localizedMessage.ts
@@ -71,3 +71,24 @@ export function describeLocalizedMessage(message: LocalizedMessage): string {
     .join(", ")
   return detail ? `${message.key} (${detail})` : message.key
 }
+
+// Attach a deferred message to an error the view may render. Additive on
+// purpose: `fallbackMessage` keeps `Error.message` as-is for consumers that
+// still render it, while a descriptor-aware view (the accept page) resolves
+// `localized` instead. Lets a layer below the view name a message without
+// owning a translator.
+export function withLocalizedMessage<E extends Error>(
+  err: E,
+  localized: LocalizedMessage,
+): E {
+  return Object.assign(err, { localized })
+}
+
+// A new error that carries only a deferred message. `Error.message` is the
+// diagnostic form, so logs stay readable.
+export function localizedError(localized: LocalizedMessage): Error {
+  return withLocalizedMessage(
+    new Error(describeLocalizedMessage(localized)),
+    localized,
+  )
+}

--- a/web/src/types/localizedMessage.ts
+++ b/web/src/types/localizedMessage.ts
@@ -1,0 +1,73 @@
+// A user-facing message that has been *named* but not yet rendered: a
+// translation key plus its interpolation params. Layers below the view carry
+// this instead of assembled English, so a non-English student never sees a
+// hardcoded sentence. Mirrors github-core's CheckDetail so the codebase has one
+// idea of a deferred string; a param may itself be a LocalizedMessage, which is
+// how a clause (e.g. GitHub's own words) nests inside a sentence without
+// splitting either key into fragments.
+export type LocalizedMessage = {
+  key: string
+  params?: Record<string, LocalizedParam>
+}
+
+export type LocalizedParam = string | number | LocalizedMessage
+
+// The one thing a resolver needs from i18next, so this leaf module stays free of
+// an i18n dependency (and of any view-layer import).
+export type TranslateFn = (
+  key: string,
+  params?: Record<string, string | number>,
+) => string
+
+function isLocalizedMessage(value: LocalizedParam): value is LocalizedMessage {
+  return typeof value === "object" && value !== null && "key" in value
+}
+
+// Render a deferred message at the view layer, resolving nested params first.
+export function resolveLocalizedMessage(
+  t: TranslateFn,
+  message: LocalizedMessage,
+): string {
+  const params = message.params
+  if (!params) return t(message.key)
+  const resolved: Record<string, string | number> = {}
+  for (const [name, value] of Object.entries(params)) {
+    resolved[name] = isLocalizedMessage(value)
+      ? resolveLocalizedMessage(t, value)
+      : value
+  }
+  return t(message.key, resolved)
+}
+
+// The deferred message an error carries, if any. Duck-typed rather than keyed
+// off the error classes: this leaf module can't import domain/ or util/, and the
+// view only needs "does this error name a message?".
+export function localizedMessageOf(err: unknown): LocalizedMessage | undefined {
+  if (typeof err !== "object" || err === null) return undefined
+  const candidate = (err as { localized?: unknown }).localized
+  if (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    typeof (candidate as LocalizedMessage).key === "string"
+  ) {
+    return candidate as LocalizedMessage
+  }
+  return undefined
+}
+
+// Diagnostic (never rendered) form of a deferred message, used as the `message`
+// of an Error that carries one. Keeps logs and any `err.message` reader useful
+// without assembling English below the view layer.
+export function describeLocalizedMessage(message: LocalizedMessage): string {
+  const params = message.params
+  if (!params) return message.key
+  const detail = Object.entries(params)
+    .map(([name, value]) => {
+      const rendered = isLocalizedMessage(value)
+        ? describeLocalizedMessage(value)
+        : String(value)
+      return `${name}=${rendered}`
+    })
+    .join(", ")
+  return detail ? `${message.key} (${detail})` : message.key
+}

--- a/web/src/types/localizedMessage.ts
+++ b/web/src/types/localizedMessage.ts
@@ -72,12 +72,10 @@ export function describeLocalizedMessage(message: LocalizedMessage): string {
   return detail ? `${message.key} (${detail})` : message.key
 }
 
-// Attach a deferred message to an error the view may render. Additive on
-// purpose: `fallbackMessage` keeps `Error.message` as-is for consumers that
-// still render it, while a descriptor-aware view (the accept page) resolves
-// `localized` instead. Lets a layer below the view name a message without
-// owning a translator.
-export function withLocalizedMessage<E extends Error>(
+// Attach a deferred message to an error. Additive on purpose: `Error.message`
+// stays as-is for log/outage consumers, while a descriptor-aware view (the accept
+// page) resolves `localized` instead.
+function withLocalizedMessage<E extends Error>(
   err: E,
   localized: LocalizedMessage,
 ): E {

--- a/web/src/util/templateAccessError.test.ts
+++ b/web/src/util/templateAccessError.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest"
 
 import { resolveLocalizedMessage } from "@/types/localizedMessage"
+import { GitHubAPIError } from "@/github-core/errors"
 import en from "@/locales/en.json"
 
 import {
   TemplateAccessError,
   inOrgTemplateError,
+  isOrgRepoCreationDenied,
+  orgRepoCreationDeniedError,
   outOfOrgTemplateError,
 } from "./templateAccessError"
 
@@ -89,7 +92,7 @@ describe("inOrgTemplateError", () => {
 })
 
 describe("TemplateAccessError", () => {
-  // The error is thrown across layers that read `.message` (the logger,
+  // The error crosses layers that read `.message` (the logger,
   // githubHealthStore) — keeping it populated means nothing loses the signal
   // when the view stops rendering it.
   it("keeps a diagnostic Error.message naming the key", () => {
@@ -100,5 +103,156 @@ describe("TemplateAccessError", () => {
   it("defaults localizedStep to the full message when none is given", () => {
     const err = inOrgTemplateError("cs50", "hw1", 403)
     expect(err.localizedStep).toBe(err.localized)
+  })
+})
+
+// The destination-org refusal (#413): GitHub refuses the repo create because the
+// org doesn't let its members create repositories. There is no structured signal
+// for it, so the predicate matches the one observed message and guards against
+// the other 403 causes, each of which has a different remedy.
+describe("isOrgRepoCreationDenied", () => {
+  const forbidden = (
+    message: string,
+    over: Partial<{
+      status: number
+      remaining: number | null
+      retryAfter: number | null
+      ssoHeader: string | null
+      acceptedScopes: string | null
+      oauthScopes: string | null
+    }> = {},
+  ) =>
+    new GitHubAPIError({
+      status: over.status ?? 403,
+      url: "/orgs/cs50/repos",
+      message,
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: over.remaining ?? null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: over.retryAfter ?? null,
+      },
+      ssoHeader: over.ssoHeader ?? null,
+      acceptedScopes: over.acceptedScopes ?? null,
+      oauthScopes: over.oauthScopes ?? null,
+    })
+
+  const OBSERVED =
+    "You need admin access to the organization before adding a repository to it."
+
+  it("is true for the observed GitHub message", () => {
+    expect(isOrgRepoCreationDenied(forbidden(OBSERVED))).toBe(true)
+  })
+
+  it("matches case-insensitively", () => {
+    expect(
+      isOrgRepoCreationDenied(
+        forbidden("You need ADMIN ACCESS TO THE ORGANIZATION first."),
+      ),
+    ).toBe(true)
+  })
+
+  it("is false for a rate-limited 403", () => {
+    expect(isOrgRepoCreationDenied(forbidden(OBSERVED, { remaining: 0 }))).toBe(
+      false,
+    )
+    expect(
+      isOrgRepoCreationDenied(forbidden(OBSERVED, { retryAfter: 60 })),
+    ).toBe(false)
+  })
+
+  it("is false for an SSO-required 403", () => {
+    expect(
+      isOrgRepoCreationDenied(
+        forbidden(OBSERVED, {
+          ssoHeader: "required; url=https://github.com/orgs/cs50/sso",
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false for a scope-gap 403", () => {
+    expect(
+      isOrgRepoCreationDenied(
+        forbidden(OBSERVED, {
+          acceptedScopes: "admin:org",
+          oauthScopes: "repo, read:user",
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false for a 403 with an unrelated message", () => {
+    expect(
+      isOrgRepoCreationDenied(
+        forbidden("Resource protected by organization SAML enforcement."),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false for a 404 (a destination refusal is always a 403)", () => {
+    expect(isOrgRepoCreationDenied(forbidden(OBSERVED, { status: 404 }))).toBe(
+      false,
+    )
+  })
+})
+
+describe("orgRepoCreationDeniedError", () => {
+  it("names the destination org, not the template, and its own key", () => {
+    const err = orgRepoCreationDeniedError("cs50", 403, "You need admin access")
+
+    expect(err).toBeInstanceOf(TemplateAccessError)
+    expect(err.localized.key).toBe(
+      "accept.templateErrors.orgRepoCreationDenied",
+    )
+    expect(err.localized.key).not.toBe("accept.templateErrors.inOrg")
+    expect(err.localized.params).toMatchObject({ org: "cs50", status: 403 })
+  })
+
+  it("carries a short, distinct step message for the checklist row", () => {
+    const err = orgRepoCreationDeniedError("cs50", 403)
+
+    expect(err.localizedStep.key).toBe(
+      "accept.templateErrors.orgRepoCreationDeniedStep",
+    )
+    expect(err.localizedStep).not.toBe(err.localized)
+    // The seven-row checklist can't absorb the full remedy paragraph.
+    expect(resolveLocalizedMessage(t, err.localizedStep).length).toBeLessThan(
+      resolveLocalizedMessage(t, err.localized).length,
+    )
+  })
+
+  it("nests GitHub's own words, and omits the clause when absent", () => {
+    expect(
+      orgRepoCreationDeniedError("cs50", 403, "You need admin access").localized
+        .params?.detail,
+    ).toEqual({
+      key: "accept.templateErrors.githubSaid",
+      params: { message: "You need admin access" },
+    })
+    expect(
+      orgRepoCreationDeniedError("cs50", 403).localized.params?.detail,
+    ).toBe("")
+  })
+
+  it("resolves to copy that hedges, names both controls, and drops the wrong remedy", () => {
+    const rendered = resolveLocalizedMessage(
+      t,
+      orgRepoCreationDeniedError("cs50", 403).localized,
+    )
+
+    // R2: the cause is inferred from message text, so the copy must not assert it.
+    expect(rendered).toContain("often because")
+    // R3: name Private, and keep Public locked down.
+    expect(rendered).toContain('"Private" is checked')
+    expect(rendered).toContain('leave "Public" unchecked')
+    // R4: the remedy can itself no-op on an enterprise-pinned org.
+    expect(rendered).toContain("enterprise")
+    // R1: the remedy #413 reports as useless must be gone.
+    expect(rendered).not.toContain("re-run assignment setup")
+    expect(rendered).toContain("cs50")
   })
 })

--- a/web/src/util/templateAccessError.test.ts
+++ b/web/src/util/templateAccessError.test.ts
@@ -1,13 +1,32 @@
 import { describe, expect, it } from "vitest"
 
+import { resolveLocalizedMessage } from "@/types/localizedMessage"
+import en from "@/locales/en.json"
+
 import {
   TemplateAccessError,
   inOrgTemplateError,
   outOfOrgTemplateError,
 } from "./templateAccessError"
 
+// Resolve a { key, params } descriptor against the real en.json so a test can
+// assert the copy a student actually sees without the factories assembling it.
+const t = (key: string, params?: Record<string, string | number>): string => {
+  const template = key
+    .split(".")
+    .reduce<unknown>(
+      (node, segment) => (node as Record<string, unknown>)?.[segment],
+      en,
+    )
+  if (typeof template !== "string")
+    throw new Error(`missing en.json key: ${key}`)
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+    String(params?.[name] ?? ""),
+  )
+}
+
 describe("outOfOrgTemplateError", () => {
-  it("appends GitHub's message when provided", () => {
+  it("names the out-of-org key and nests GitHub's message", () => {
     const err = outOfOrgTemplateError(
       "acme",
       "hw1",
@@ -16,34 +35,70 @@ describe("outOfOrgTemplateError", () => {
     )
 
     expect(err).toBeInstanceOf(TemplateAccessError)
-    expect(err.message).toContain("acme/hw1")
-    expect(err.message).toContain("HTTP 403")
-    expect(err.message).toContain('GitHub said: "IP allow list enabled".')
-    expect(err.message).toContain("restricts third-party apps")
+    expect(err.localized).toEqual({
+      key: "accept.templateErrors.outOfOrg",
+      params: {
+        owner: "acme",
+        repo: "hw1",
+        status: 403,
+        detail: {
+          key: "accept.templateErrors.githubSaid",
+          params: { message: "IP allow list enabled" },
+        },
+      },
+    })
+
+    const rendered = resolveLocalizedMessage(t, err.localized)
+    expect(rendered).toContain("acme/hw1")
+    expect(rendered).toContain("HTTP 403")
+    expect(rendered).toContain('GitHub said: "IP allow list enabled".')
+    expect(rendered).toContain("restricts third-party apps")
   })
 
   it("omits the GitHub-said detail when no message is provided", () => {
     const err = outOfOrgTemplateError("acme", "hw1", 404)
 
-    expect(err.message).not.toContain("GitHub said:")
-    expect(err.message).toContain("HTTP 404")
+    expect(err.localized.params?.detail).toBe("")
+    const rendered = resolveLocalizedMessage(t, err.localized)
+    expect(rendered).not.toContain("GitHub said:")
+    expect(rendered).toContain("HTTP 404")
   })
 })
 
 describe("inOrgTemplateError", () => {
-  it("appends GitHub's message when provided", () => {
+  it("names the in-org key and nests GitHub's message", () => {
     const err = inOrgTemplateError("cs50", "hw1", 403, "Must have admin rights")
 
     expect(err).toBeInstanceOf(TemplateAccessError)
-    expect(err.message).toContain("cs50/hw1")
-    expect(err.message).toContain("HTTP 403")
-    expect(err.message).toContain('GitHub said: "Must have admin rights".')
-    expect(err.message).toContain("re-run assignment setup")
+    expect(err.localized.key).toBe("accept.templateErrors.inOrg")
+
+    const rendered = resolveLocalizedMessage(t, err.localized)
+    expect(rendered).toContain("cs50/hw1")
+    expect(rendered).toContain("HTTP 403")
+    expect(rendered).toContain('GitHub said: "Must have admin rights".')
+    expect(rendered).toContain("re-run assignment setup")
   })
 
   it("omits the GitHub-said detail when no message is provided", () => {
     const err = inOrgTemplateError("cs50", "hw1", 403)
 
-    expect(err.message).not.toContain("GitHub said:")
+    expect(resolveLocalizedMessage(t, err.localized)).not.toContain(
+      "GitHub said:",
+    )
+  })
+})
+
+describe("TemplateAccessError", () => {
+  // The error is thrown across layers that read `.message` (the logger,
+  // githubHealthStore) — keeping it populated means nothing loses the signal
+  // when the view stops rendering it.
+  it("keeps a diagnostic Error.message naming the key", () => {
+    const err = inOrgTemplateError("cs50", "hw1", 403)
+    expect(err.message).toContain("accept.templateErrors.inOrg")
+  })
+
+  it("defaults localizedStep to the full message when none is given", () => {
+    const err = inOrgTemplateError("cs50", "hw1", 403)
+    expect(err.localizedStep).toBe(err.localized)
   })
 })

--- a/web/src/util/templateAccessError.test.ts
+++ b/web/src/util/templateAccessError.test.ts
@@ -245,10 +245,10 @@ describe("orgRepoCreationDeniedError", () => {
     )
 
     // R2: the cause is inferred from message text, so the copy must not assert it.
-    expect(rendered).toContain("often because")
-    // R3: name Private, and keep Public locked down.
-    expect(rendered).toContain('"Private" is checked')
-    expect(rendered).toContain('leave "Public" unchecked')
+    expect(rendered).toContain("may not allow")
+    // R3: ask for private creation only, so the remedy can't widen the org into
+    // allowing public student repos.
+    expect(rendered).toContain("private (not public)")
     // R4: the remedy can itself no-op on an enterprise-pinned org.
     expect(rendered).toContain("enterprise")
     // R1: the remedy #413 reports as useless must be gone.

--- a/web/src/util/templateAccessError.test.ts
+++ b/web/src/util/templateAccessError.test.ts
@@ -225,20 +225,26 @@ describe("orgRepoCreationDeniedError", () => {
     )
   })
 
-  it("nests GitHub's own words, and omits the clause when absent", () => {
-    expect(
-      orgRepoCreationDeniedError("cs50", 403, "You need admin access").localized
-        .params?.detail,
-    ).toEqual({
-      key: "accept.templateErrors.githubSaid",
-      params: { message: "You need admin access" },
-    })
-    expect(
-      orgRepoCreationDeniedError("cs50", 403).localized.params?.detail,
-    ).toBe("")
+  // GitHub's words are the one thing NOT relayed to the student on this path:
+  // "You need admin access to the organization" reads as "you lack admin",
+  // contradicting the diagnosis. They still reach Error.message for triage.
+  it("keeps GitHub's words out of the rendered copy but in the diagnostic message", () => {
+    const err = orgRepoCreationDeniedError(
+      "cs50",
+      403,
+      "You need admin access to the organization before adding a repository to it.",
+    )
+
+    expect(resolveLocalizedMessage(t, err.localized)).not.toContain(
+      "admin access",
+    )
+    expect(resolveLocalizedMessage(t, err.localizedStep)).not.toContain(
+      "admin access",
+    )
+    expect(err.message).toContain("admin access to the organization")
   })
 
-  it("resolves to copy that hedges, names both controls, and drops the wrong remedy", () => {
+  it("resolves to short copy that hedges, names the org, and drops the wrong remedy", () => {
     const rendered = resolveLocalizedMessage(
       t,
       orgRepoCreationDeniedError("cs50", 403).localized,
@@ -246,13 +252,18 @@ describe("orgRepoCreationDeniedError", () => {
 
     // R2: the cause is inferred from message text, so the copy must not assert it.
     expect(rendered).toContain("may not allow")
-    // R3: ask for private creation only, so the remedy can't widen the org into
-    // allowing public student repos.
-    expect(rendered).toContain("private (not public)")
-    // R4: the remedy can itself no-op on an enterprise-pinned org.
-    expect(rendered).toContain("enterprise")
+    expect(rendered).toContain("cs50")
     // R1: the remedy #413 reports as useless must be gone.
     expect(rendered).not.toContain("re-run assignment setup")
-    expect(rendered).toContain("cs50")
+
+    // A student can't change an org setting, so the student-facing copy stays a
+    // diagnosis: no settings path, no private/public checkbox guidance, no
+    // enterprise caveat. Those live in OrgRepoCreationNotice (which a teacher
+    // sees) and the Troubleshooting wiki. Kept short so a teacher reading a
+    // screenshot gets the cause at a glance.
+    expect(rendered).not.toContain("Member privileges")
+    expect(rendered).not.toContain("private (not public)")
+    expect(rendered).not.toContain("enterprise")
+    expect(rendered.length).toBeLessThan(240)
   })
 })

--- a/web/src/util/templateAccessError.ts
+++ b/web/src/util/templateAccessError.ts
@@ -116,9 +116,17 @@ export function orgRepoCreationDeniedError(
   status: number,
   githubMessage?: string,
 ): TemplateAccessError {
-  const params = { org, status, detail: githubSaid(githubMessage) }
   return new TemplateAccessError(
-    { key: "accept.templateErrors.orgRepoCreationDenied", params },
-    { key: "accept.templateErrors.orgRepoCreationDeniedStep", params },
+    {
+      key: "accept.templateErrors.orgRepoCreationDenied",
+      params: { org, status, detail: githubSaid(githubMessage) },
+    },
+    // The step key interpolates only org and status, so it must not carry the
+    // detail clause: nothing would render it and the two keys' params would be
+    // coupled.
+    {
+      key: "accept.templateErrors.orgRepoCreationDeniedStep",
+      params: { org, status },
+    },
   )
 }

--- a/web/src/util/templateAccessError.ts
+++ b/web/src/util/templateAccessError.ts
@@ -1,13 +1,16 @@
+import { GitHubAPIError } from "@/github-core/errors"
 import {
   describeLocalizedMessage,
   type LocalizedMessage,
 } from "@/types/localizedMessage"
 
 // An accept-time failure that needs teacher action (not a retry the student can
-// do). `localized` names the full remedy the accept page renders; `localizedStep`
-// is a one-sentence form for the progress checklist row, which sits beside six
-// other rows and can't absorb a paragraph. `Error.message` stays populated with a
-// diagnostic (never-rendered) form so logs and githubHealthStore keep working.
+// do). Covers a template that can't be copied and a destination org that refuses
+// the create — the class name predates the second case. `localized` names the
+// full remedy the accept page renders; `localizedStep` is a one-sentence form for
+// the progress checklist row, which sits beside six other rows and can't absorb a
+// paragraph. `Error.message` stays populated with a diagnostic (never-rendered)
+// form so logs and githubHealthStore keep working.
 export class TemplateAccessError extends Error {
   localized: LocalizedMessage
   localizedStep: LocalizedMessage
@@ -67,4 +70,43 @@ export function inOrgTemplateError(
       detail: githubSaid(githubMessage),
     },
   })
+}
+
+// The one 403 message GitHub was observed to return when the *destination* org
+// refuses the create (issue #413). Matched as a substring, case-insensitively.
+const ORG_REPO_CREATION_DENIED_SIGNATURE = "admin access to the organization"
+
+// A 403 that is the destination org refusing to let a member create the repo.
+//
+// There is no structured signal for this refusal — unlike the SSO gate and the
+// scope gap, which are header-derived — so the message text is the only
+// discriminator available. Deliberately matches the single observed string: a
+// speculative variant like "repository creation is disabled" most plausibly
+// denotes an enterprise or ruleset block, which this error's remedy cannot fix,
+// so matching it would be confidently wrong.
+//
+// The three exclusions matter as much as the match: each is also a 403 with its
+// own, different remedy, and `isSsoRequired`/`isScopeGap` are header-derived and
+// therefore definitive. Without them, an SSO-gated 403 that happened to carry
+// this phrase would send a teacher to widen member privileges while the real gate
+// stayed in place.
+export function isOrgRepoCreationDenied(err: GitHubAPIError): boolean {
+  if (!err.isForbidden) return false
+  if (err.isRateLimited || err.isSsoRequired || err.isScopeGap) return false
+  return err.message.toLowerCase().includes(ORG_REPO_CREATION_DENIED_SIGNATURE)
+}
+
+// Destination-org refusal: the org doesn't let its members create repositories.
+// `org` is the classroom org the repo was being created in — never the template
+// owner, which is the misattribution #413 reports.
+export function orgRepoCreationDeniedError(
+  org: string,
+  status: number,
+  githubMessage?: string,
+): TemplateAccessError {
+  const params = { org, status, detail: githubSaid(githubMessage) }
+  return new TemplateAccessError(
+    { key: "accept.templateErrors.orgRepoCreationDenied", params },
+    { key: "accept.templateErrors.orgRepoCreationDeniedStep", params },
+  )
 }

--- a/web/src/util/templateAccessError.ts
+++ b/web/src/util/templateAccessError.ts
@@ -96,9 +96,21 @@ export function isOrgRepoCreationDenied(err: GitHubAPIError): boolean {
   return err.message.toLowerCase().includes(ORG_REPO_CREATION_DENIED_SIGNATURE)
 }
 
-// Destination-org refusal: the org doesn't let its members create repositories.
-// `org` is the classroom org the repo was being created in — never the template
-// owner, which is the misattribution #413 reports.
+// The destination-org refusal (#413). `org` is the classroom org the repo was
+// being created in, never the template owner, which is the misattribution the
+// issue reports.
+//
+// `localized` is deliberately a diagnosis, not a how-to: a student can't change
+// an org setting, so the remedy's detail (private-not-public, the enterprise
+// override, the settings path) lives where a teacher can act on it, in
+// OrgRepoCreationNotice and the Troubleshooting wiki. Short student copy also
+// means a teacher reading a screenshot gets the cause immediately.
+//
+// GitHub's own words are the one thing NOT relayed to the student here (unlike
+// the two template errors): "You need admin access to the organization" reads as
+// "you, the student, lack admin", contradicting the diagnosis above. It still
+// reaches `Error.message` through `describeLocalizedMessage`, so logs and the
+// activity trail keep it for triage.
 export function orgRepoCreationDeniedError(
   org: string,
   status: number,

--- a/web/src/util/templateAccessError.ts
+++ b/web/src/util/templateAccessError.ts
@@ -1,13 +1,34 @@
-import i18n from "@/i18n"
+import {
+  describeLocalizedMessage,
+  type LocalizedMessage,
+} from "@/types/localizedMessage"
 
-// A template-generate failure at accept time, with a plain-text message the
-// accept page renders as-is. Messages point students at their teacher (they
-// can't approve an OAuth app or grant team read themselves).
+// An accept-time failure that needs teacher action (not a retry the student can
+// do). `localized` names the full remedy the accept page renders; `localizedStep`
+// is a one-sentence form for the progress checklist row, which sits beside six
+// other rows and can't absorb a paragraph. `Error.message` stays populated with a
+// diagnostic (never-rendered) form so logs and githubHealthStore keep working.
 export class TemplateAccessError extends Error {
-  constructor(message: string) {
-    super(message)
+  localized: LocalizedMessage
+  localizedStep: LocalizedMessage
+
+  constructor(localized: LocalizedMessage, localizedStep?: LocalizedMessage) {
+    super(describeLocalizedMessage(localized))
     this.name = "TemplateAccessError"
+    this.localized = localized
+    this.localizedStep = localizedStep ?? localized
   }
+}
+
+// GitHub's own words, quoted into a remedy. Not translatable (it's GitHub's
+// English), so it nests as a param rather than being assembled here.
+function githubSaid(githubMessage?: string): LocalizedMessage | string {
+  return githubMessage
+    ? {
+        key: "accept.templateErrors.githubSaid",
+        params: { message: githubMessage },
+      }
+    : ""
 }
 
 // Out-of-org template: the owning org likely restricts third-party apps, but a
@@ -19,17 +40,15 @@ export function outOfOrgTemplateError(
   status: number,
   githubMessage?: string,
 ): TemplateAccessError {
-  const detail = githubMessage
-    ? i18n.t("accept.templateErrors.githubSaid", { message: githubMessage })
-    : ""
-  return new TemplateAccessError(
-    i18n.t("accept.templateErrors.outOfOrg", {
+  return new TemplateAccessError({
+    key: "accept.templateErrors.outOfOrg",
+    params: {
       owner: templateOwner,
       repo: templateRepo,
       status,
-      detail,
-    }),
-  )
+      detail: githubSaid(githubMessage),
+    },
+  })
 }
 
 // In-org template: the classroom team likely lacks read on a private template.
@@ -39,15 +58,13 @@ export function inOrgTemplateError(
   status: number,
   githubMessage?: string,
 ): TemplateAccessError {
-  const detail = githubMessage
-    ? i18n.t("accept.templateErrors.githubSaid", { message: githubMessage })
-    : ""
-  return new TemplateAccessError(
-    i18n.t("accept.templateErrors.inOrg", {
+  return new TemplateAccessError({
+    key: "accept.templateErrors.inOrg",
+    params: {
       owner: templateOwner,
       repo: templateRepo,
       status,
-      detail,
-    }),
-  )
+      detail: githubSaid(githubMessage),
+    },
+  })
 }

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -117,14 +117,14 @@ Only applies to assignments with a template. Check, in order:
 
 A 403 when a student's repository is created. Despite the wording, the student
 does **not** need admin access, and this is usually **not** a problem with the
-template or the assignment — it's the classroom organization refusing to let its
+template or the assignment. The classroom organization is refusing to let its
 members create repositories, so re-running *assignment* setup can't fix it.
 
 Fix it in the org, under Settings → Member privileges → Repository creation:
 
 1. Tick **Repository creation** so members may create repositories.
-2. Tick **Private**, and leave **Public** unchecked — students' coursework and
-   any reference solutions should not be publicly visible.
+2. Tick **Private**, and leave **Public** unchecked: students' coursework and any
+   reference solutions should not be publicly visible.
 3. Have the student accept again.
 
 Re-running **organization setup** in Classroom 50 (Organization settings →

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -113,6 +113,33 @@ Only applies to assignments with a template. Check, in order:
 3. **The `<assignment>` argument matches the registered slug** (case is
    normalized; spelling must be exact).
 
+## "You need admin access to the organization before adding a repository to it."
+
+A 403 when a student's repository is created. Despite the wording, the student
+does **not** need admin access, and this is usually **not** a problem with the
+template or the assignment — it's the classroom organization refusing to let its
+members create repositories, so re-running *assignment* setup can't fix it.
+
+Fix it in the org, under Settings → Member privileges → Repository creation:
+
+1. Tick **Repository creation** so members may create repositories.
+2. Tick **Private**, and leave **Public** unchecked — students' coursework and
+   any reference solutions should not be publicly visible.
+3. Have the student accept again.
+
+Re-running **organization setup** in Classroom 50 (Organization settings →
+Re-run setup) applies this along with the rest of the audited lockdown, so it's
+the better fix if the org has drifted in other ways too.
+
+If an enterprise policy pins repository creation at the enterprise level, the
+org-level toggle is ignored and only an enterprise owner can change it. In that
+case the re-run reports success but the setting stays off.
+
+Other causes produce the same message, so if repository creation is already
+enabled, check that the student's org invitation was accepted (a pending invitee
+can't create a repository) and that they're a member rather than an outside
+collaborator.
+
 ## "Could not find `.classroom50.yaml`" on `gh student submit`
 
 `submit` reads that file at the repo root. If it's missing, you're likely running


### PR DESCRIPTION
## Summary

Closes #413. When a student accepted an assignment and GitHub refused to create the repository, Classroom 50 told them *"Ask your teacher to re-run assignment setup, then accept again."* Re-running assignment setup can never fix it: the refusal is a **destination-org** member-privilege problem, and assignment setup does not touch org member privileges. The reporter and an instructor both followed that instruction and both failed, across 78 students in three orgs.

This PR fixes the misclassification on both accept clients, warns teachers before students fail, and fixes the in-app remedy it points them at, which turned out to be broken on Team and Free plans.

## Two independent defects

**1. The accept-time 403 was classified by where the template lived, not by what GitHub refused.** `createAssignmentRepo` branched every 403/404 on `templateOwner === owner`, so a destination-org refusal landed on the in-org **template** message and its useless remedy. The template-less and `empty_repo` path was worse: it rethrew the 403 raw and degraded to generic step text. `gh student accept` had the identical gap, special-casing only 404 and 422.

**2. "Re-run organization setup", the remedy we point teachers at, was itself broken on Team and Free.** Discovered while verifying this fix against a real Team org. The repair sent `{members_can_create_repositories: true, members_can_create_private_repositories: true}`, because `members_can_create_public_repositories` was filtered out as enterprise-only. GitHub recomputes the deprecated `members_allowed_repository_creation_type` from that partial input, gets `private`, and private-only is Enterprise-Cloud-only, so it rejected the whole PATCH with `422 Validation Failed — "Private-only repository creation policy is not allowed for this organization."` That sank the combined PATCH *and* the grouped per-field fallback, so **"Fix it" silently did nothing on every Team/Free org whose repo creation was off**. Verified against the live API: the only accepted write off-enterprise is the master switch alone, which GitHub resolves to `all`, turning both granular booleans on. Sending the granular booleans is rejected even when public is explicitly `true` in the same request.

## Changes

**Accept-time classification** (`web/src/util/templateAccessError.ts`, `web/src/domain/assignments/repoCreation.ts`, `cli/gh-student/accept.go`) — a new `isOrgRepoCreationDenied` predicate matches the one observed GitHub message and is guarded against the other 403 causes (rate limit, SAML SSO gate, OAuth scope gap), each of which has a different remedy. The new branch sits **before** the in-org/out-of-org template split, because the refusal is about the destination org and is independent of where the template lives, and it is passed `owner`, never `templateOwner`. Both creation paths in both clients are covered. Every creation 403 that reaches a fallback is now logged at warn level, which is the only available signal if GitHub rewords the string, since the tests assert our own fixture.

**Localized accept error surface** (`web/src/types/localizedMessage.ts` and the accept path) — `AGENTS.md` requires errors from `domain/` to carry `{ key, params }`, and adding a third English-assembling factory would have entrenched the convention it forbids. This refactor pays for itself independently: `accept.steps.*` keys already existed and were already translated, but the domain's English `label:` literals shadowed them the moment a step emitted, so a non-English student watched the checklist flip to English mid-run. Step labels now have exactly one source.

**Teacher pre-flight warning** (`web/src/hooks/useOrgRepoCreationWarning.ts`, `web/src/components/OrgRepoCreationNotice.tsx`) — derived from `classifyDefaults`, the existing single source of truth for reading a `GET /orgs/{org}` response, so it inherits the Team/Free master-switch coupling rather than re-deriving it. Shown on Create, Edit and the Assignments list, plus the share-link modal, which is the last moment before a teacher hands out a link that cannot work. The Assignments list matters most: it catches drift after creation, which is the reporter's own situation, where a teacher never reopens the create or edit form and students accept days later. It fails open, warning only when a field is explicitly `false`, because GitHub omits member-privilege fields for non-admins and a teacher who cannot read the setting cannot be told anything useful about it.

**Team/Free repair fix** (`web/src/orgPolicy/desiredState.ts`, `web/src/github-core/orgChecks.ts`, `cli/gh-teacher/internal/orgpolicy/orgpolicy.go`, `cli/gh-teacher/init_repo.go`) — a new `writable: false` marker makes the two granular repo-creation booleans **verify-only** off enterprise: still audited and reported as drift, never sent. Enterprise keeps writing them, since private-only is the whole point there. Public creation is now `true` and non-critical off enterprise, reflecting that Team and Free expose repository creation as one all-or-none choice; left critical, every Team org would fail its audit for a state that is correct there.

**422 diagnosability** (`web/src/github-core/client.ts`, `web/src/github-core/errors.ts`) — the client logged only status, path and request id, so GitHub's `errors` payload never surfaced, which is exactly why defect 2 looked inexplicable. `githubValidationReasons` extracts only the `message`/`field`/`code` triples, never the whole body, which can name IP allow lists or SAML enforcement.

**Docs** (`wiki/Troubleshooting.md`) — a section keyed on the exact 403 text, covering the real cause, the fix, and that an enterprise policy can pin the setting so the re-run reports success while the setting stays off.

## Three further defects found while reviewing this branch

A simplification pass over the diff surfaced these, all fixed here:

**The teacher warnings kept firing for up to ten minutes after a successful repair.** The new notice reads the shared org query (`githubKeys.orgDetails`, 10-minute `staleTime`), and nothing invalidated it after a repair: `useRepairOrgPolicyConcern` invalidated only the audit prefix, and `RerunOrgSetup` invalidated `["orgs"]`, which does not match `["github","orgs",org]`. So a teacher fixed the org and the warning stayed up. Both sites now invalidate it.

**The CLI told teachers to set fields GitHub rejects.** After the verify-only change, `reportPartialMemberDefaults` still listed derived repo-creation fields as "not yet attempted" when a transient error aborted the per-field fallback mid-loop.

**The two org-policy mirrors had drifted on one remedy string.** The Go override reworded the private-repo `manualFix` off enterprise (the canonical wording names a "Private" checkbox that cannot be set independently on Team/Free), but the web side did not, so `gh teacher` and the web audit gave teachers different instructions for the same field and plan. Now identical, with a test that fails if they drift again.

The same pass also deduplicated the Go message-matching predicates, moved the throttle guard inside the 403 classifier so no call site can forget it (the web mirror already owned its exclusions), dropped a redundant English `label` parameter that had already drifted from its i18n twin, and single-sourced the verify-only rule behind one exported predicate.

## Copy

The student message is deliberately a **diagnosis, not a how-to**, because a student cannot change an org setting: *"{org} may not allow members to create private repositories, so your repository couldn't be created (HTTP {status}). Ask your teacher to enable it, then accept again."* The fix instructions live where a teacher can act on them. It hedges ("may not allow") because the cause is inferred from message text alone: a pending invitation or an enterprise policy produce the same string.

GitHub's own words are the one thing not relayed to the student here, unlike the two template errors: *"You need admin access to the organization"* reads as "**you** lack admin" and contradicts the diagnosis. It still reaches `Error.message` for logs and triage.

No existing `en.json` key changed and none were removed, verified by script, so no published locale pack is re-machine-translated. 40 keys added.

## Scope note

The plan for #413 listed `desiredState.ts`, `repairOrgDefaults` and the org audit as explicit non-goals, so this branch carries a second logical change. I kept it here because the broken remedy is the one this PR tells teachers to use, and shipping the message without it would point them at a button that does nothing on the most common plan. Happy to split it onto its own branch if you would rather keep the PRs separate.

## Verification

- `cd web && npm run check` green: 225 files, 2540 tests, no dependency-cruiser violations, prettier clean.
- `go build ./... && go test ./...` green in all three Go modules; `golangci-lint run` 0 issues and `golangci-lint fmt --diff` empty.
- `python3 web/src/locales/audit_i18n.py --strict` PASS.
- New tests fail on `main` and pass here: four routing tests in `assignments.test.ts`, seven in `accept_orchestration_test.go`, and the Pages-remedy regression test, each confirmed red by reverting the fix.
- **Live API**, against a real Team org: reset to the all-off state, confirmed the old body returns the 422 above, then confirmed the app's new combined PATCH succeeds and lands `members_allowed_repository_creation_type: "all"` with `members_can_create_private_repositories: true`.
- Mutation-tested the three riskiest simplifications to confirm their tests still bite: neutering the internalized rate-limit guard fails exactly the two throttle cases, and reverting the mirror-drift fix fails the four new parity cases.

One correction worth recording, since an earlier revision of this description claimed otherwise: mounting the notice inside a staff-gated subtree does **not** save an org read. `SidebarFooter` already issues the same `GET /orgs/{org}` on every org-scoped page, for students too, so the notice is a pure cache hit on all four surfaces (zero incremental requests) and the placement earns its keep only by not showing a student a warning they cannot act on. The comment and the test rationale that asserted the stronger claim were corrected.

## Test plan

- [ ] In a Team org, clear both Repository creation checkboxes. Confirm Create, Edit, Assignments and the share-link modal all warn, and that a student sees the new message naming the org rather than "re-run assignment setup".
- [ ] Repeat the accept with a template-less assignment and an `empty_repo` assignment; both previously fell through to generic step text.
- [ ] Repeat via `gh student accept`.
- [ ] With repo creation still off, use **Re-run setup** on the Org Settings page and confirm it now succeeds instead of failing silently.
- [ ] Confirm a rate-limited, SSO-gated or scope-gap 403 still produces its own message, not the org-denied one.
- [ ] Switch to a non-English locale and run a failing accept: every step label and the remedy stay translated, where today the labels start translated and flip to English as steps emit.
- [ ] Confirm a non-admin teacher, for whom GitHub omits the member-privilege fields, sees no warning anywhere.
- [ ] With repo creation off, click **Fix it** on the org-policy audit and confirm the assignment-page warnings clear immediately rather than persisting for the 10-minute cache window.
