### PR TITLE
fix(web): name the feedback PR consequence when pausing autograding

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1254,11 +1254,11 @@
       "applying": "Updating…",
       "toggleLabel": "Pause autograding for all student repositories",
       "toggleHint": "Turning this on stops student pushes from being graded (no Actions minutes). The classroom50 config repo keeps working. Turn off to resume.",
-      "pausedNotice": "Paused — student pushes aren't graded. Re-running org setup won't resume until you turn this off.",
+      "pausedNotice": "Paused — student pushes aren't graded and feedback pull requests won't open. Re-running org setup won't resume until you turn this off.",
       "disabledNotice": "Actions are off for the whole org, so nothing runs. Re-run org setup or enable Actions on GitHub.",
       "unknownNotice": "Couldn't read this org's Actions permissions — you may lack owner rights, or an enterprise policy controls them.",
       "confirmTitle": "Pause autograding for the whole organization?",
-      "confirmBody": "Student submissions won't be graded until you resume. The classroom50 config repo keeps working. Reversible any time.",
+      "confirmBody": "Student submissions won't be graded until you resume, and feedback pull requests won't open. The classroom50 config repo keeps working. Reversible any time.",
       "confirmButton": "Pause autograding",
       "toggleFailed": "Couldn't update Actions permissions: {{message}}"
     },


### PR DESCRIPTION
## Summary

Pausing autograding restricts org Actions to the `classroom50` config repo, which blocks the autograde shim in every student repo — and with it the **Ensure Feedback PR** step of `autograde-runner.yaml`. Both pause strings named only grading, so the teacher making the decision was never told that the feedback pull request workflow stops too.

This adds the consequence to the two places that already speak about pausing: the confirm dialog (before the teacher commits to it) and the persistent paused notice (for as long as the pause lasts).

Found while root-causing #419, which is a separate bug in the same area — the org-policy audit reads an intentional pause as policy drift. That fix is not included here.

## Changes

- `orgSettings.actions.confirmBody` — now reads "Student submissions won't be graded until you resume, and feedback pull requests won't open."
- `orgSettings.actions.pausedNotice` — now reads "Paused — student pushes aren't graded and feedback pull requests won't open."

No new keys, so the i18n key count is unchanged at 1897 and the machine-translation workflow picks up the changed English for the target packs on its own.

## Test plan

- [x] `npm run check` passes — `tsc -b`, `eslint` (0 errors), `prettier --check`, `arch:validate` (no violations across 749 modules), `vitest run` (2540 tests, 225 files)
- [x] `audit_i18n.py --strict` passes — 0 missing, 0 dead, 0 hardcoded
- [x] No test asserts either string and no `OrgActionsSection` test file exists, so this is copy-only with no test surface to update
- [ ] Reviewer sanity check: open Org Settings on an org you own, toggle "Pause autograding for all student repositories", and confirm the new clause reads correctly in both the confirm dialog and the paused callout