### PR TITLE
feat(web): warn when a paused org blocks the feedback pull request

### DIFF
--- a/web/src/components/FeedbackPrNotice.test.tsx
+++ b/web/src/components/FeedbackPrNotice.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+const getOrgActionsMode = vi.fn()
+const isOrgOwner = vi.fn()
+
+vi.mock("@/github-core/mutations", () => ({
+  getOrgActionsMode: () => getOrgActionsMode(),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useOptionalGitHubClient: () => ({ request: vi.fn(), requestRaw: vi.fn() }),
+}))
+vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
+  useIsOrgOwner: () => isOrgOwner(),
+}))
+
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+// Real i18n rather than a key-returning stub: the copy IS this unit's
+// deliverable (it has to explain WHY the PR won't open and reassure that
+// existing PRs survive), and <Trans> renders nothing under a stubbed
+// useTranslation. Mirrors OrgRepoCreationNotice.test.tsx.
+import "@/i18n"
+import { FeedbackPrNotice } from "./FeedbackPrNotice"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+// The banner variant's action is a RouterButton, which needs a live router.
+function renderInRouter(node: ReactNode) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <>{node}</>,
+  })
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/$org/settings",
+    component: () => <div>settings</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, settingsRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  })
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router as unknown as never} />
+    </QueryClientProvider>,
+  )
+}
+
+const OWNER = {
+  isOwner: true,
+  isPending: false,
+  isError: false,
+  retry: () => {},
+}
+const WANTS = { feedback_pr: true, empty_repo: false }
+
+const asOwnerWith = (mode: string) => {
+  isOrgOwner.mockReturnValue(OWNER)
+  getOrgActionsMode.mockResolvedValue(mode)
+}
+
+describe("FeedbackPrNotice", () => {
+  it("warns and names the pause as the cause", async () => {
+    asOwnerWith("paused")
+    renderInRouter(<FeedbackPrNotice org="acme" assignment={WANTS} />)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toMatch(/Autograding is paused/)
+    expect(alert.textContent).toContain("acme")
+
+    // Load-bearing clauses, not styling: explain that the PR is opened by the
+    // autograder inside the student repo (so the coupling is understandable),
+    // and reassure that already-open PRs remain reviewable — otherwise a
+    // teacher may think pausing destroyed in-flight review work.
+    expect(alert.textContent).toMatch(/inside each student repository/)
+    expect(alert.textContent).toMatch(/stay open and reviewable/)
+  })
+
+  it("distinguishes org-wide disabled Actions from a pause", async () => {
+    asOwnerWith("disabled")
+    renderInRouter(<FeedbackPrNotice org="acme" assignment={WANTS} />)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toMatch(/GitHub Actions is off/)
+    expect(alert.textContent).not.toMatch(/Autograding is paused/)
+  })
+
+  it("stays silent when autograding is active", async () => {
+    asOwnerWith("active")
+    renderInRouter(<FeedbackPrNotice org="acme" assignment={WANTS} />)
+    await waitFor(() => expect(getOrgActionsMode).toHaveBeenCalled())
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("stays silent when the assignment doesn't want a feedback PR", async () => {
+    asOwnerWith("paused")
+    renderInRouter(
+      <FeedbackPrNotice
+        org="acme"
+        assignment={{ feedback_pr: false, empty_repo: false }}
+      />,
+    )
+    // Never reads: the subject opted out, so there is nothing to warn about.
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("stays silent without an org", () => {
+    asOwnerWith("paused")
+    renderInRouter(<FeedbackPrNotice org={undefined} assignment={WANTS} />)
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("offers the in-app org settings action in the banner variant", async () => {
+    asOwnerWith("paused")
+    renderInRouter(<FeedbackPrNotice org="acme" assignment={WANTS} />)
+
+    const action = await screen.findByText("Organization settings")
+    expect(action.closest("a")?.getAttribute("href")).toBe("/acme/settings")
+  })
+
+  // The inline variant sits beside the toggle it annotates, where a page-width
+  // navigation button would outweigh the control.
+  it("omits the navigation action in the inline variant", async () => {
+    asOwnerWith("paused")
+    renderInRouter(
+      <FeedbackPrNotice org="acme" assignment={WANTS} variant="inline" />,
+    )
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toMatch(/Autograding is paused/)
+    expect(screen.queryByText("Organization settings")).toBeNull()
+  })
+})

--- a/web/src/components/FeedbackPrNotice.tsx
+++ b/web/src/components/FeedbackPrNotice.tsx
@@ -1,0 +1,85 @@
+import { AlertTriangle, Settings } from "lucide-react"
+import { Trans, useTranslation } from "react-i18next"
+
+import { Alert, cx, EmphasisLtr, RouterButton } from "@/components/ui"
+import useFeedbackPrWarning from "@/hooks/useFeedbackPrWarning"
+import type { FeedbackPrSubject } from "@/hooks/useFeedbackPrWarning"
+
+// Warns a teacher that the Feedback PR won't open because org-wide autograding
+// is paused (or Actions are off). A warning, not an error: nothing is broken and
+// the pause is usually deliberate — it just has a consequence the assignment
+// form never mentioned. Renders nothing when the hook is silent.
+//
+// `variant` exists because the two mount points differ structurally: the form
+// mounts it beside a single toggle, where a page-width alert with a navigation
+// button would visually outweigh the control it annotates.
+export const FeedbackPrNotice = ({
+  org,
+  assignment,
+  variant = "banner",
+  className,
+}: {
+  org: string | undefined
+  assignment: FeedbackPrSubject
+  variant?: "banner" | "inline"
+  className?: string
+}) => {
+  const { t } = useTranslation()
+  const warning = useFeedbackPrWarning(org, assignment)
+
+  if (!org || !warning.show) return null
+
+  // Explicit map rather than a `…${reason}` template: a dynamically built key is
+  // invisible to the i18n audit's static scan, which then reports both keys DEAD.
+  const messageKey =
+    warning.reason === "paused"
+      ? "components.notices.feedbackPr.paused"
+      : "components.notices.feedbackPr.disabled"
+
+  const message = (
+    <Trans
+      i18nKey={messageKey}
+      values={{ org }}
+      components={{ org: <EmphasisLtr /> }}
+    />
+  )
+
+  if (variant === "inline") {
+    return (
+      <Alert
+        tone="warning"
+        className={cx("flex items-start gap-2", className ?? "mt-2")}
+      >
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <span className="text-sm">{message}</span>
+      </Alert>
+    )
+  }
+
+  return (
+    <Alert
+      tone="warning"
+      className={cx(
+        "flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between",
+        className ?? "mb-6",
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <span className="text-sm">{message}</span>
+      </div>
+      <RouterButton
+        to="/$org/settings"
+        params={{ org }}
+        variant="warning"
+        size="sm"
+        className="whitespace-nowrap sm:shrink-0"
+      >
+        <Settings className="size-4" aria-hidden="true" />
+        {t("components.notices.feedbackPr.action")}
+      </RouterButton>
+    </Alert>
+  )
+}
+
+export default FeedbackPrNotice

--- a/web/src/hooks/useFeedbackPrWarning.test.tsx
+++ b/web/src/hooks/useFeedbackPrWarning.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+const getOrgActionsMode = vi.fn()
+const optionalClient = vi.fn()
+const isOrgOwner = vi.fn()
+
+vi.mock("@/github-core/mutations", () => ({
+  getOrgActionsMode: (...args: unknown[]) => getOrgActionsMode(...args),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useOptionalGitHubClient: () => optionalClient(),
+}))
+vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
+  useIsOrgOwner: () => isOrgOwner(),
+}))
+
+import useFeedbackPrWarning from "./useFeedbackPrWarning"
+import type {
+  FeedbackPrSubject,
+  FeedbackPrWarning,
+} from "./useFeedbackPrWarning"
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+const OWNER = {
+  isOwner: true,
+  isPending: false,
+  isError: false,
+  retry: () => {},
+}
+const NON_OWNER = {
+  isOwner: false,
+  isPending: false,
+  isError: false,
+  retry: () => {},
+}
+const CLIENT = { request: vi.fn(), requestRaw: vi.fn() }
+
+// The assignment opts into the Feedback PR — the subject case that can warn.
+const WANTS: FeedbackPrSubject = { feedback_pr: true, empty_repo: false }
+
+// Retries off so a rejected read settles immediately instead of backing off.
+const wrapper = ({ children }: { children: ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function setup({
+  mode = "active",
+  owner = OWNER,
+  client = CLIENT as unknown,
+}: { mode?: string; owner?: typeof OWNER; client?: unknown } = {}) {
+  isOrgOwner.mockReturnValue(owner)
+  optionalClient.mockReturnValue(client)
+  getOrgActionsMode.mockResolvedValue(mode)
+}
+
+// Settles the query before asserting, so a `show: false` assertion can't pass
+// merely because the read was still in flight.
+async function verdict(
+  // No default: a destructuring/parameter default fires on an explicit
+  // `undefined`, which would silently substitute an org and never exercise the
+  // no-org path.
+  org: string | undefined,
+  subject: FeedbackPrSubject = WANTS,
+): Promise<FeedbackPrWarning> {
+  const { result } = renderHook(() => useFeedbackPrWarning(org, subject), {
+    wrapper,
+  })
+  // One microtask-plus tick is enough for an already-resolved queryFn to land.
+  await waitFor(() => expect(result.current).toBeDefined())
+  return result.current
+}
+
+describe("useFeedbackPrWarning", () => {
+  it("warns when the org is paused", async () => {
+    setup({ mode: "paused" })
+    const { result } = renderHook(() => useFeedbackPrWarning("acme", WANTS), {
+      wrapper,
+    })
+    await waitFor(() =>
+      expect(result.current).toEqual({ show: true, reason: "paused" }),
+    )
+  })
+
+  it("warns when org Actions are disabled entirely", async () => {
+    setup({ mode: "disabled" })
+    const { result } = renderHook(() => useFeedbackPrWarning("acme", WANTS), {
+      wrapper,
+    })
+    await waitFor(() =>
+      expect(result.current).toEqual({ show: true, reason: "disabled" }),
+    )
+  })
+
+  it("stays silent when autograding is active", async () => {
+    setup({ mode: "active" })
+    expect(await verdict("acme")).toEqual({ show: false })
+  })
+
+  // Fails open. A read we could not perform must never produce a red warning:
+  // getOrgActionsMode swallows a 403/5xx to "unknown", so warning here would
+  // fire on every org whose policy we cannot see.
+  it("stays silent when the mode is unknown", async () => {
+    setup({ mode: "unknown" })
+    expect(await verdict("acme")).toEqual({ show: false })
+  })
+
+  it("stays silent on the very first render, before the read settles", () => {
+    setup({ mode: "paused" })
+    const { result } = renderHook(() => useFeedbackPrWarning("acme", WANTS), {
+      wrapper,
+    })
+    expect(result.current).toEqual({ show: false })
+  })
+
+  // The endpoint is admin-only, so a non-owner has no readable signal at all.
+  it("stays silent for a non-owner viewer, and issues no request", async () => {
+    setup({ mode: "paused", owner: NON_OWNER })
+    expect(await verdict("acme")).toEqual({ show: false })
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+  })
+
+  // The form also renders where GitHub auth isn't ready. An advisory warning
+  // must never break the form it annotates.
+  it("stays silent with no GitHub client, and issues no request", async () => {
+    setup({ mode: "paused", client: null })
+    expect(await verdict("acme")).toEqual({ show: false })
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+  })
+
+  // Subject config, not environment: an assignment that never wanted the
+  // Feedback PR must not be warned about it.
+  it("stays silent when the assignment has feedback_pr off", async () => {
+    setup({ mode: "paused" })
+    expect(
+      await verdict("acme", { feedback_pr: false, empty_repo: false }),
+    ).toEqual({ show: false })
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+  })
+
+  // An absent flag reads as false on the wire (the CLI omits it), so it must be
+  // treated the same as an explicit false.
+  it("stays silent when feedback_pr is absent", async () => {
+    setup({ mode: "paused" })
+    expect(await verdict("acme", {})).toEqual({ show: false })
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+  })
+
+  // An empty repo has no baseline commit, so the Feedback PR is structurally
+  // off regardless of the org's Actions policy.
+  it("stays silent for an empty-repo assignment", async () => {
+    setup({ mode: "paused" })
+    expect(
+      await verdict("acme", { feedback_pr: true, empty_repo: true }),
+    ).toEqual({ show: false })
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+  })
+
+  it("stays silent without an org, and issues no request", async () => {
+    setup({ mode: "paused" })
+    getOrgActionsMode.mockClear()
+    expect(await verdict(undefined)).toEqual({ show: false })
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/hooks/useFeedbackPrWarning.ts
+++ b/web/src/hooks/useFeedbackPrWarning.ts
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
+import { githubKeys } from "@/github-core/queries"
+import { getOrgActionsMode } from "@/github-core/mutations"
+
+export type FeedbackPrWarning =
+  | { show: false }
+  // Which state blocked it decides the copy: a pause is one toggle away from
+  // resuming, while org-wide disabled Actions need a different remedy.
+  | { show: true; reason: "paused" | "disabled" }
+
+// The assignment's own opt-in. Both flags gate the warning: an assignment that
+// never wanted the Feedback PR, or an empty repo that structurally cannot have
+// one, is not affected by the org's Actions policy.
+export type FeedbackPrSubject = {
+  feedback_pr?: boolean
+  empty_repo?: boolean
+}
+
+// Whether to warn a teacher that the Feedback PR won't open, because org-wide
+// autograding is paused (or Actions are off entirely).
+//
+// The PR is created by the autograde runner inside the student repo, not by this
+// app, so anything that stops the student repo's workflow also silently stops
+// the Feedback PR. Pausing restricts org Actions to the config repo, which
+// blocks every student shim.
+//
+// Fails open: warn only on an explicit paused/disabled. `getOrgActionsMode`
+// swallows a read failure to "unknown", and a teacher who cannot read the policy
+// cannot be told anything useful about it — so unknown, in-flight, and
+// non-owner viewers are all silent.
+//
+// Reach is org owners only, by construction: /orgs/{org}/actions/permissions is
+// admin-only. Classroom roles are team-derived and independent of org admin
+// standing, so a non-owner teacher or head-TA gets silence here.
+//
+// Uses the OPTIONAL client rather than useGetOrgActionsMode: this hook mounts
+// inside the assignment form, which also renders in contexts with no GitHub auth
+// (and with no org at all), where the strict accessor throws. An advisory
+// warning must never be able to break the form it annotates.
+const useFeedbackPrWarning = (
+  org: string | undefined,
+  subject: FeedbackPrSubject,
+): FeedbackPrWarning => {
+  const client = useOptionalGitHubClient()
+  const { isOwner } = useIsOrgOwner()
+  const wantsFeedbackPr = subject.feedback_pr === true && !subject.empty_repo
+  const shouldRead =
+    Boolean(org) && Boolean(client) && isOwner && wantsFeedbackPr
+
+  const { data: mode, isPending } = useQuery({
+    queryKey: githubKeys.orgActionsMode(org ?? ""),
+    queryFn: () => getOrgActionsMode(client!, org!),
+    enabled: shouldRead,
+    staleTime: 60 * 1000,
+  })
+
+  // Guard before reading `mode` rather than trusting the disabled query to leave
+  // it undefined: a warm cache entry from an earlier owner session would
+  // otherwise leak a verdict to a viewer we just decided has no signal.
+  if (!shouldRead || isPending) return { show: false }
+  if (mode === "paused") return { show: true, reason: "paused" }
+  if (mode === "disabled") return { show: true, reason: "disabled" }
+  return { show: false }
+}
+
+export default useFeedbackPrWarning

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2163,6 +2163,11 @@
         "master": "<org>{{org}}</org> doesn't allow members to create repositories, so no student can accept an assignment. Re-run organization setup, or allow private (not public) repository creation under <memberPrivileges>Member privileges</memberPrivileges>. An enterprise policy can override this setting.",
         "private": "<org>{{org}}</org> doesn't allow members to create private repositories, so no student can accept an assignment. Re-run organization setup, or allow private (not public) repository creation under <memberPrivileges>Member privileges</memberPrivileges>. An enterprise policy can override this setting.",
         "action": "Organization settings"
+      },
+      "feedbackPr": {
+        "paused": "Autograding is paused for <org>{{org}}</org>, so feedback pull requests won't open. The pull request is created by the autograder inside each student repository, which is blocked while paused. Existing feedback pull requests stay open and reviewable.",
+        "disabled": "GitHub Actions is off for <org>{{org}}</org>, so feedback pull requests won't open. The pull request is created by the autograder inside each student repository, which can't run while Actions is off. Existing feedback pull requests stay open and reviewable.",
+        "action": "Organization settings"
       }
     },
     "confirmModal": {

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -971,6 +971,7 @@ const SubmissionsPageContent = () => {
         filtered={hasActiveFilter}
         onClearFilters={clearFilters}
         emptyRepo={isEmptyRepoAssignment}
+        feedbackPr={assignmentInfo?.feedback_pr ?? false}
         initialLoading={initialLoading}
         nonSubmittersLoading={
           !nonSubmittersReady &&

--- a/web/src/pages/assignments/DetailsSection.tsx
+++ b/web/src/pages/assignments/DetailsSection.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react"
 import { useTranslation } from "react-i18next"
 import { slugify } from "@/util/slug"
 import { Card, FormField, Input, Textarea } from "@/components/ui"
+import { FeedbackPrNotice } from "@/components/FeedbackPrNotice"
 import { TemplateField } from "./TemplateField"
 import { FieldLabel, ToggleRow } from "./AdvancedRuntimeFields"
 import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
@@ -314,6 +315,17 @@ export const DetailsSection = ({
                             ? t("assignments.form.feedbackPrEmptyRepoHelp")
                             : t("assignments.form.feedbackPrHelp")
                         }
+                      />
+                      {/* A paused org blocks the PR, but unlike empty_repo the
+                          block is transient — leave the toggle settable so the
+                          flag persists for when autograding resumes. */}
+                      <FeedbackPrNotice
+                        org={org}
+                        assignment={{
+                          feedback_pr: field.state.value,
+                          empty_repo: emptyRepo,
+                        }}
+                        variant="inline"
                       />
                     </div>
                   )}

--- a/web/src/pages/assignments/FeedbackPrWarning.wired.test.tsx
+++ b/web/src/pages/assignments/FeedbackPrWarning.wired.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactElement } from "react"
+
+// Wired-path coverage for the paused-org Feedback PR warning. The unit tests
+// prove the verdict and the notice in isolation; this proves the notice actually
+// reaches the assignment form. It matters because EVERY failure mode of this
+// feature is silence — a provider mounted in the wrong place, a subject object
+// assembled wrong, or a gate that never opens all look identical to "working"
+// in a green suite.
+
+const getOrgActionsMode = vi.fn()
+const isOrgOwner = vi.fn()
+
+vi.mock("@/github-core/mutations", () => ({
+  getOrgActionsMode: () => getOrgActionsMode(),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useOptionalGitHubClient: () => ({ request: vi.fn(), requestRaw: vi.fn() }),
+}))
+vi.mock("@/context/githubOrgRole/useIsOrgOwner", () => ({
+  useIsOrgOwner: () => isOrgOwner(),
+}))
+
+// TemplateField needs a GitHubAuthProvider and is irrelevant here.
+vi.mock("./TemplateField", () => ({
+  TemplateField: () => null,
+}))
+
+// Real i18n: the warning copy is the deliverable, and <Trans> renders nothing
+// under a stubbed useTranslation.
+import "@/i18n"
+import CreateAssignmentForm from "./CreateAssignmentForm"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const OWNER = {
+  isOwner: true,
+  isPending: false,
+  isError: false,
+  retry: () => {},
+}
+const NON_OWNER = {
+  isOwner: false,
+  isPending: false,
+  isError: false,
+  retry: () => {},
+}
+
+const renderForm = (ui: ReactElement) =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      {ui}
+    </QueryClientProvider>,
+  )
+
+const PAUSED_COPY = /Autograding is paused/
+
+const asViewer = (owner: typeof OWNER, mode: string) => {
+  isOrgOwner.mockReturnValue(owner)
+  getOrgActionsMode.mockResolvedValue(mode)
+}
+
+describe("Feedback PR warning on the assignment form", () => {
+  it("warns beside the toggle when the org is paused", async () => {
+    asViewer(OWNER, "paused")
+
+    renderForm(<CreateAssignmentForm org="acme" onSubmit={() => {}} />)
+
+    // feedback_pr defaults ON at create, so the warning applies immediately.
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toMatch(PAUSED_COPY)
+  })
+
+  it("stays silent when autograding is active", async () => {
+    asViewer(OWNER, "active")
+
+    renderForm(<CreateAssignmentForm org="acme" onSubmit={() => {}} />)
+
+    await waitFor(() => expect(getOrgActionsMode).toHaveBeenCalled())
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("stays silent for a non-owner author even when paused", async () => {
+    asViewer(NON_OWNER, "paused")
+
+    renderForm(<CreateAssignmentForm org="acme" onSubmit={() => {}} />)
+
+    // Documents the accepted limitation: the Actions-permissions read is
+    // admin-only, so team-based teachers and head-TAs get no signal.
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  // The form must also render where GitHub auth isn't ready — an advisory
+  // warning must never break the surface it annotates.
+  it("renders the form without an org and stays silent", () => {
+    asViewer(OWNER, "paused")
+
+    renderForm(<CreateAssignmentForm onSubmit={() => {}} />)
+
+    expect(getOrgActionsMode).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  // The pause is transient, so the manifest flag must stay settable — unlike the
+  // empty_repo case, which locks the toggle off structurally.
+  it("leaves the toggle operable while blocked, and drops the warning when opted out", async () => {
+    const user = userEvent.setup()
+    asViewer(OWNER, "paused")
+
+    const { container } = renderForm(
+      <CreateAssignmentForm org="acme" onSubmit={() => {}} />,
+    )
+
+    const toggle = container.querySelector<HTMLInputElement>("#feedback_pr")
+    expect(toggle).not.toBeNull()
+    expect(toggle?.disabled).toBe(false)
+    expect(toggle?.checked).toBe(true)
+    expect((await screen.findByRole("alert")).textContent).toMatch(PAUSED_COPY)
+
+    // Turning the feature off removes the warning: it is about this
+    // assignment's opt-in, not the org in the abstract.
+    await user.click(toggle!)
+    expect(toggle?.checked).toBe(false)
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+})

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -22,6 +22,12 @@ vi.mock("@/hooks/useGetRepoCollaborators", () => ({
 vi.mock("@/hooks/useGetFeedbackPr", () => ({
   default: () => ({ refetch: vi.fn() }),
 }))
+// The Review modal explains an org Actions block as the reason no PR exists;
+// irrelevant to row rendering, and it owns a useQuery this provider-free test
+// doesn't mount.
+vi.mock("@/hooks/useFeedbackPrWarning", () => ({
+  default: () => ({ show: false }),
+}))
 vi.mock("@/hooks/useTriggerRegrade", () => ({
   default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),
 }))

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -56,6 +56,7 @@ import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsM
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
 import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
 import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
+import useFeedbackPrWarning from "@/hooks/useFeedbackPrWarning"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import type { Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
@@ -126,7 +127,17 @@ const HistoryLink = ({
 // workflow) when one exists, else opens an info modal. The PR is the source of
 // truth. The /pulls lookup is deferred until Review is clicked (an eager per-row
 // query would fan out to one request per repo on mount); on click we refetch.
-const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
+const ReviewButton = ({
+  org,
+  repo,
+  feedbackPr,
+}: {
+  org: string
+  repo: string
+  // The assignment's feedback_pr opt-in, so a blocked org can explain why no PR
+  // exists instead of the generic "not opened yet" message.
+  feedbackPr?: boolean
+}) => {
   const { t } = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
@@ -134,6 +145,13 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   // enabled: false — driven by refetch() on click, never on mount.
   const { refetch } = useGetFeedbackPr(org, repo, false)
+  // Why the PR is missing, when the org's Actions policy is the cause. The
+  // button stays enabled either way: a PR opened before the pause is still
+  // reachable and reviewable.
+  const blocked = useFeedbackPrWarning(org, {
+    feedback_pr: feedbackPr,
+    empty_repo: false,
+  })
 
   const handleReview = async () => {
     setResolving(true)
@@ -198,6 +216,19 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
                 components={{ repo: <MonoLtr /> }}
               />
             </p>
+            {blocked.show && (
+              <p className="mt-2 text-sm leading-6 text-base-content/70">
+                <Trans
+                  i18nKey={
+                    blocked.reason === "paused"
+                      ? "components.notices.feedbackPr.paused"
+                      : "components.notices.feedbackPr.disabled"
+                  }
+                  values={{ org }}
+                  components={{ org: <EmphasisLtr /> }}
+                />
+              </p>
+            )}
           </>
         )}
         <div className="modal-action">
@@ -424,6 +455,7 @@ const SubmissionsTable = ({
   filtered = false,
   onClearFilters,
   emptyRepo = false,
+  feedbackPr = false,
   initialLoading = false,
   nonSubmittersLoading = false,
   page = 0,
@@ -461,6 +493,9 @@ const SubmissionsTable = ({
   // empty_repo assignment: never autogrades, so score badges and the
   // Feedback-PR/regrade actions are hidden (repos + accept state stay useful).
   emptyRepo?: boolean
+  // The assignment's feedback_pr opt-in, so the Review modal can name an org
+  // Actions block as the reason no PR exists.
+  feedbackPr?: boolean
   // Core data (snapshot + roster) is still loading on first paint; render a
   // loading state rather than the "no submissions" empty state, which would
   // otherwise flash before data arrives.
@@ -710,7 +745,7 @@ const SubmissionsTable = ({
               />
               {!emptyRepo && (
                 <>
-                  <ReviewButton org={org} repo={repo} />
+                  <ReviewButton org={org} repo={repo} feedbackPr={feedbackPr} />
                   <ActionIconLink
                     href={safeHttpUrl(rest.release)}
                     icon={ScrollText}


### PR DESCRIPTION
## Summary

The feedback pull request is opened by the **Ensure Feedback PR** step of `autograde-runner.yaml`, running inside each *student* repo. Pausing autograding restricts org Actions to the `classroom50` config repo, so every student repo's shim is blocked — and the feedback PR silently stops opening. Until now the only hint lived on the org settings page, never next to the assignment's own toggle.

This surfaces the consequence where the teacher is actually working: inline beside the `feedback_pr` toggle, and inside the Review modal when no PR is found. Follows #420, which added the same consequence to the pause confirm dialog and paused notice.

## Design notes

**Fails open.** The warning fires only on an explicit `paused` or `disabled`. An unreadable policy (`getOrgActionsMode` swallows a 403/5xx to `"unknown"`), an in-flight read, or a viewer with no signal all stay silent — a teacher who cannot read the setting cannot act on it, so warning them would be noise. This mirrors the stance in `useOrgRepoCreationWarning`.

**Reach is org owners only, by construction.** `/orgs/{org}/actions/permissions` is admin-only. Classroom roles are team-derived and independent of org admin standing, so a non-owner teacher or head-TA gets silence. Accepted for this iteration and covered by a test that documents it; delivering the warning to non-owner staff needs an owner-independent signal and is out of scope.

**One mount point per screen.** `CreateAssignmentPage` and `EditAssignmentPage` both render `DetailsSection` through the form, so a page-level banner *plus* the inline notice would show the same warning twice. Only the inline placement is wired.

**The toggle stays settable while blocked.** Unlike `empty_repo` — which locks it off structurally — a pause is transient, so the manifest flag must persist for when autograding resumes. The Review button likewise stays enabled: a PR opened before the pause is still reviewable.

**Known blind spot, documented in the hook:** `getOrgActionsMode` reports a teacher-curated `selected` allow-list as `active`, so an allow-list that excludes student repos reads as silence. Closing that needs a wider read than the pause-provenance signal.

## Changes

- `web/src/hooks/useFeedbackPrWarning.ts` — discriminated verdict (`{ show: false } | { show: true, reason }`), owner-gated, fails open
- `web/src/components/FeedbackPrNotice.tsx` — `banner` and `inline` variants, following the `OrgRepoCreationNotice` pattern
- `web/src/pages/assignments/DetailsSection.tsx` — inline notice beside the toggle
- `web/src/pages/submissions/SubmissionsTable.tsx` + `SubmissionsPage.tsx` — reason in the Review modal's empty state, `feedbackPr` threaded alongside the existing `emptyRepo` prop
- 3 new i18n keys under `components.notices.feedbackPr.*`

## Test plan

- [x] `npm run check` passes — 2563 tests / 228 files (23 new), 0 lint errors, no dependency violations
- [x] `audit_i18n.py --strict` passes — 0 dead, 0 missing, 0 hardcoded
- [x] Verdict unit tests cover the full `actionsMode` matrix, with explicit cases asserting that `unknown`, a pending read, a non-owner viewer, and a missing GitHub client each produce silence and issue no request
- [x] Wired-path tests assert the notice actually renders in the real assignment form for a paused owner org — every failure mode of this design is silence, so isolated unit tests alone could not catch a dead wiring path
- [ ] Reviewer sanity check: pause autograding on an org you own, open an assignment with the feedback PR enabled, and confirm the inline warning appears and the toggle is still clickable