### PR TITLE
feat(web): teacher tools to open and repair Feedback PRs

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/scripts/ensure_feedback_pr.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/ensure_feedback_pr.py
@@ -203,7 +203,8 @@ def pr_body(head: str, release_url: str) -> str:
     """
     return "\n".join([
         ":wave:! Classroom 50 opened this pull request as a place for your "
-        "teacher to leave feedback on your work. It updates automatically. "
+        "teacher to leave feedback on your work. It stays up to date "
+        "automatically as you push. "
         "**Don't close or merge this pull request** unless your teacher tells you to.",
         "",
         f"Each commit is automatically graded — the latest autograding result "
@@ -232,8 +233,8 @@ def pr_body(head: str, release_url: str) -> str:
         "comment box below.",
         "",
         f"The base branch (`{BASE_BRANCH}`) is frozen at the starter so the diff "
-        f"always reflects the full body of work. The PR is managed automatically "
-        f"by the autograde runner; merging it is the teacher-side "
+        f"always reflects the full body of work. The PR is kept up to date "
+        f"automatically; merging it is the teacher-side "
         f"\"grading done\" signal.",
         "</details>",
     ])

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -189,7 +189,8 @@ func FeedbackLabelForMode(mode string) (name, color string) {
 func FeedbackPRBody(head, releaseURL string) string {
 	return strings.Join([]string{
 		":wave:! Classroom 50 opened this pull request as a place for your " +
-			"teacher to leave feedback on your work. It updates automatically. " +
+			"teacher to leave feedback on your work. It stays up to date " +
+			"automatically as you push. " +
 			"**Don't close or merge this pull request** unless your teacher tells you to.",
 		"",
 		"Each commit is automatically graded — the latest autograding result " +
@@ -218,8 +219,8 @@ func FeedbackPRBody(head, releaseURL string) string {
 			"comment box below.",
 		"",
 		"The base branch (`" + FeedbackBaseBranch + "`) is frozen at the starter so the diff " +
-			"always reflects the full body of work. The PR is managed automatically " +
-			"by the autograde runner; merging it is the teacher-side " +
+			"always reflects the full body of work. The PR is kept up to date " +
+			"automatically; merging it is the teacher-side " +
 			"\"grading done\" signal.",
 		"</details>",
 	}, "\n")

--- a/cli/shared/contract/testdata/feedback_pr_body.golden
+++ b/cli/shared/contract/testdata/feedback_pr_body.golden
@@ -1,4 +1,4 @@
-:wave:! Classroom 50 opened this pull request as a place for your teacher to leave feedback on your work. It updates automatically. **Don't close or merge this pull request** unless your teacher tells you to.
+:wave:! Classroom 50 opened this pull request as a place for your teacher to leave feedback on your work. It stays up to date automatically as you push. **Don't close or merge this pull request** unless your teacher tells you to.
 
 Each commit is automatically graded — the latest autograding result is [here](RELEASE_URL).
 
@@ -17,5 +17,5 @@ Use this PR to leave feedback:
 - The [latest autograding result](RELEASE_URL) has the per-test detail behind that status.
 - This page is an overview — commits, line comments, and a general comment box below.
 
-The base branch (`feedback`) is frozen at the starter so the diff always reflects the full body of work. The PR is managed automatically by the autograde runner; merging it is the teacher-side "grading done" signal.
+The base branch (`feedback`) is frozen at the starter so the diff always reflects the full body of work. The PR is kept up to date automatically; merging it is the teacher-side "grading done" signal.
 </details>

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -52,7 +52,11 @@ export {
 export { acceptAssignment } from "./assignments/accept"
 export {
   repairFeedbackPullRequest,
+  openAllFeedbackPullRequests,
   type RepairFeedbackPrResult,
+  type OpenAllFeedbackPrsSummary,
+  type OpenAllRepoResult,
+  type OpenAllProgress,
 } from "./assignments/feedbackPr"
 export {
   submitAssignment,

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -51,6 +51,10 @@ export {
 } from "./assignments/permissions"
 export { acceptAssignment } from "./assignments/accept"
 export {
+  repairFeedbackPullRequest,
+  type RepairFeedbackPrResult,
+} from "./assignments/feedbackPr"
+export {
   submitAssignment,
   normalizeRepoPath,
   isReservedUploadPath,

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -12,10 +12,12 @@ import type { GitHubRepo } from "@/github-core/types"
 import {
   getBranchRefRepo,
   getCommitByRepo,
-  getOldestCommitShaForPath,
   withFreshRepoRetry,
 } from "@/github-core/queries"
-import { ensureFeedbackPullRequest } from "./feedbackPr"
+import {
+  ensureFeedbackPullRequest,
+  resolveFeedbackBaselineSha,
+} from "./feedbackPr"
 import { fetchAssignmentFromPages } from "../queries/assignments"
 import { getAuthenticatedUser } from "../queries/users"
 import { acceptAndVerifyOrgMembership } from "../users"
@@ -282,12 +284,7 @@ async function resolveFeedbackBaseSha(params: {
   committedSha: string | null
 }): Promise<string | null> {
   const { client, org, repo, committedSha } = params
-  const oldest = await getOldestCommitShaForPath(
-    client,
-    org,
-    repo,
-    ".classroom50.yaml",
-  ).catch(() => null)
+  const oldest = await resolveFeedbackBaselineSha(client, org, repo)
   return oldest ?? committedSha
 }
 

--- a/web/src/domain/assignments/feedbackPr.test.ts
+++ b/web/src/domain/assignments/feedbackPr.test.ts
@@ -7,6 +7,7 @@ import {
   feedbackLabelForMode,
   feedbackPrBody,
   ensureFeedbackPullRequest,
+  repairFeedbackPullRequest,
 } from "./feedbackPr"
 import { FEEDBACK_BASE_BRANCH } from "@/util/feedbackPr"
 import type { GitHubClient } from "@/github-core/client"
@@ -428,5 +429,152 @@ describe("ensureFeedbackPullRequest", () => {
     expect(list?.url).toContain(`base=${FEEDBACK_BASE_BRANCH}`)
     // Owner-qualified by the helper, so callers pass a bare branch name.
     expect(list?.url).toContain("head=o%3Amain")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Teacher-side repair (issue #347). It resolves its own branch (repo default)
+// and baseline SHA (.classroom50.yaml marker) before delegating to the SAME
+// ensureFeedbackPullRequest, so these scenarios focus on that resolution and
+// the unsupported verdicts; the ensure behavior itself is covered above.
+// ---------------------------------------------------------------------------
+
+// Extends the fakeClient's routes with the two reads repair adds:
+// GET /repos/o/r (repo object -> default_branch) and the marker commit history.
+function fakeRepairClient(opts: {
+  repoMissing?: boolean
+  defaultBranch?: string
+  markerCommits?: string[] // oldest resolves to markerCommits[last]
+  existingPr?: { number: number; state: string }
+}) {
+  const calls: Call[] = []
+  let refPatched = false
+
+  const request = vi.fn(
+    async (url: string, init?: { method?: string; body?: unknown }) => {
+      const method = init?.method ?? "GET"
+      calls.push({ url, method, body: init?.body })
+
+      if (url === "/repos/o/r") {
+        if (opts.repoMissing) throw apiError(404, "Not Found")
+        return { default_branch: opts.defaultBranch ?? "main" }
+      }
+      if (url.startsWith("/repos/o/r/commits?path=")) {
+        // getOldestCommitShaForPath returns newest-first; it takes the last.
+        return (opts.markerCommits ?? []).map((sha) => ({ sha }))
+      }
+      if (url.startsWith("/repos/o/r/pulls?")) {
+        return opts.existingPr ? [opts.existingPr] : []
+      }
+      const head = opts.defaultBranch ?? "main"
+      if (url === "/repos/o/r/pulls" && method === "POST") {
+        if (!refPatched) {
+          throw validationError(`No commits between feedback and ${head}`)
+        }
+        return {
+          number: 1,
+          state: "open",
+          html_url: "https://github.com/o/r/pull/1",
+        }
+      }
+      if (url === "/repos/o/r/git/refs" && method === "POST") return {}
+      if (url === `/repos/o/r/git/ref/heads/${head}`) {
+        return { object: { sha: "accept-sha" } }
+      }
+      if (url === "/repos/o/r/git/commits/accept-sha") {
+        return { sha: "accept-sha", tree: { sha: "tree-sha" } }
+      }
+      if (url === "/repos/o/r/git/commits" && method === "POST") {
+        return { sha: "empty-sha" }
+      }
+      if (url === `/repos/o/r/git/refs/heads/${head}` && method === "PATCH") {
+        refPatched = true
+        return {}
+      }
+      if (url === "/repos/o/r/labels" && method === "POST") return {}
+      if (url === "/repos/o/r/issues/1/labels" && method === "POST") return []
+      throw new Error(`unexpected request: ${method} ${url}`)
+    },
+  )
+
+  const client = { request } as unknown as GitHubClient
+  return { client, calls }
+}
+
+describe("repairFeedbackPullRequest", () => {
+  it("resolves the baseline from the marker and opens the PR against the repo default branch", async () => {
+    const { client, calls } = fakeRepairClient({
+      defaultBranch: "master",
+      markerCommits: ["newer-sha", "accept-sha"],
+    })
+    const result = await repairFeedbackPullRequest({
+      client,
+      org: "o",
+      repo: "r",
+      mode: "individual",
+    })
+    expect(result).toEqual({ ok: true, created: true })
+
+    // Base frozen at the OLDEST marker commit (not the newest), the same rule
+    // as accept and the runner.
+    const refCreate = calls.find(
+      (c) => c.url === "/repos/o/r/git/refs" && c.method === "POST",
+    )
+    expect(refCreate?.body).toEqual({
+      ref: `refs/heads/${FEEDBACK_BASE_BRANCH}`,
+      sha: "accept-sha",
+    })
+    // Head is the repo's settled default branch, not a guessed "main".
+    const pr = calls
+      .filter((c) => c.url === "/repos/o/r/pulls" && c.method === "POST")
+      .at(-1)?.body as Record<string, string>
+    expect(pr.head).toBe("master")
+  })
+
+  it("is read-only when a Feedback PR already exists", async () => {
+    const { client, calls } = fakeRepairClient({
+      markerCommits: ["accept-sha"],
+      existingPr: { number: 7, state: "open" },
+    })
+    const result = await repairFeedbackPullRequest({
+      client,
+      org: "o",
+      repo: "r",
+      mode: "individual",
+    })
+    expect(result).toEqual({ ok: true, created: false })
+    expect(writeCalls(calls)).toHaveLength(0)
+  })
+
+  it("reports unsupported when the repo has no baseline marker (e.g. empty_repo)", async () => {
+    const { client, calls } = fakeRepairClient({ markerCommits: [] })
+    const result = await repairFeedbackPullRequest({
+      client,
+      org: "o",
+      repo: "r",
+      mode: "individual",
+    })
+    expect(result).toEqual({
+      ok: false,
+      reason: "no-baseline",
+      unsupported: true,
+    })
+    // Never attempts any write when there's nothing to anchor the base on.
+    expect(writeCalls(calls)).toHaveLength(0)
+  })
+
+  it("reports unsupported (repo-not-found) when the repo doesn't exist", async () => {
+    const { client } = fakeRepairClient({ repoMissing: true })
+    const result = await repairFeedbackPullRequest({
+      client,
+      org: "o",
+      repo: "r",
+      mode: "individual",
+    })
+    expect(result).toEqual({
+      ok: false,
+      reason: "repo-not-found",
+      unsupported: true,
+    })
   })
 })

--- a/web/src/domain/assignments/feedbackPr.test.ts
+++ b/web/src/domain/assignments/feedbackPr.test.ts
@@ -8,6 +8,7 @@ import {
   feedbackPrBody,
   ensureFeedbackPullRequest,
   repairFeedbackPullRequest,
+  openAllFeedbackPullRequests,
 } from "./feedbackPr"
 import { FEEDBACK_BASE_BRANCH } from "@/util/feedbackPr"
 import type { GitHubClient } from "@/github-core/client"
@@ -576,5 +577,109 @@ describe("repairFeedbackPullRequest", () => {
       reason: "repo-not-found",
       unsupported: true,
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bulk open (issue #347). A per-repo scriptable client drives each repo to a
+// distinct outcome so the summary classification and progress reporting are
+// exercised end to end over repairFeedbackPullRequest.
+// ---------------------------------------------------------------------------
+
+// The repo name is the 2nd path segment: /repos/o/<repo>/...
+const repoOf = (url: string) => url.split("/")[3]
+
+// Behaviors keyed by repo name:
+//  - "created-*": has a marker + diff, no existing PR -> creates.
+//  - "existed-*": an existing PR short-circuits -> existed.
+//  - "nomarker-*": the marker commit history is empty -> unsupported.
+//  - "missing-*": GET /repos 404s -> unsupported (repo-not-found).
+//  - "fail-*": the PR create hard-fails -> failed.
+function fakeBatchClient() {
+  const request = vi.fn(
+    async (url: string, init?: { method?: string; body?: unknown }) => {
+      const method = init?.method ?? "GET"
+      const repo = repoOf(url)
+      const base = `/repos/o/${repo}`
+
+      if (url === base) {
+        if (repo.startsWith("missing")) throw apiError(404, "Not Found")
+        return { default_branch: "main" }
+      }
+      if (url.startsWith(`${base}/commits?path=`)) {
+        // Empty history for the no-marker repos; one baseline commit otherwise.
+        return repo.startsWith("nomarker") ? [] : [{ sha: "accept-sha" }]
+      }
+      if (url.startsWith(`${base}/pulls?`)) {
+        return repo.startsWith("existed") ? [{ number: 7, state: "open" }] : []
+      }
+      if (url === `${base}/pulls` && method === "POST") {
+        if (repo.startsWith("fail")) {
+          throw apiError(403, "Resource not accessible by integration")
+        }
+        // A diff exists (headHasDiff) so no empty commit is needed.
+        return { number: 1, state: "open", html_url: `https://x/${repo}/1` }
+      }
+      if (url === `${base}/git/refs` && method === "POST") return {}
+      if (url === `${base}/git/ref/heads/${FEEDBACK_BASE_BRANCH}`) {
+        throw apiError(404, "Not Found")
+      }
+      if (url === `${base}/labels` && method === "POST") return {}
+      if (url === `${base}/issues/1/labels` && method === "POST") return []
+      throw new Error(`unexpected request: ${method} ${url}`)
+    },
+  )
+  return { client: { request } as unknown as GitHubClient }
+}
+
+describe("openAllFeedbackPullRequests", () => {
+  it("classifies each repo and reports progress to completion", async () => {
+    const { client } = fakeBatchClient()
+    const repos = [
+      "created-a",
+      "created-b",
+      "existed-a",
+      "nomarker-a",
+      "missing-a",
+      "fail-a",
+    ]
+    const progress: number[] = []
+
+    const summary = await openAllFeedbackPullRequests({
+      client,
+      org: "o",
+      repos,
+      mode: "individual",
+      onProgress: (p) => progress.push(p.done),
+    })
+
+    expect(summary.total).toBe(6)
+    expect(summary.created).toBe(2)
+    expect(summary.existed).toBe(1)
+    expect(summary.unsupported.map((r) => r.repo).toSorted()).toEqual([
+      "missing-a",
+      "nomarker-a",
+    ])
+    expect(summary.failed.map((r) => r.repo)).toEqual(["fail-a"])
+    // Progress fires once per repo and reaches the total.
+    expect(progress).toHaveLength(6)
+    expect(Math.max(...progress)).toBe(6)
+  })
+
+  it("handles an empty repo list without any requests", async () => {
+    const { client } = fakeBatchClient()
+    const summary = await openAllFeedbackPullRequests({
+      client,
+      org: "o",
+      repos: [],
+      mode: "individual",
+    })
+    expect(summary).toMatchObject({
+      total: 0,
+      created: 0,
+      existed: 0,
+    })
+    expect(summary.failed).toEqual([])
+    expect(client.request).not.toHaveBeenCalled()
   })
 })

--- a/web/src/domain/assignments/feedbackPr.test.ts
+++ b/web/src/domain/assignments/feedbackPr.test.ts
@@ -358,7 +358,12 @@ describe("ensureFeedbackPullRequest", () => {
       mode: "individual",
     })
     expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.reason).toContain("student-chosen-sha")
+    if (!result.ok) {
+      expect(result.reason).toContain("student-chosen-sha")
+      // The stable code is what lets the bulk flow classify this as blocked
+      // (never-retryable) rather than a retryable failure.
+      expect(result.code).toBe("base-mismatch")
+    }
     expect(
       calls.filter((c) => c.url === "/repos/o/r/pulls" && c.method === "POST"),
     ).toHaveLength(0)
@@ -594,6 +599,8 @@ const repoOf = (url: string) => url.split("/")[3]
 //  - "existed-*": an existing PR short-circuits -> existed.
 //  - "nomarker-*": the marker commit history is empty -> unsupported.
 //  - "missing-*": GET /repos 404s -> unsupported (repo-not-found).
+//  - "blocked-*": the feedback ref already exists at a NON-baseline SHA (a
+//    student pre-created it) -> base-mismatch -> blocked (never retryable).
 //  - "fail-*": the PR create hard-fails -> failed.
 function fakeBatchClient() {
   const request = vi.fn(
@@ -620,8 +627,19 @@ function fakeBatchClient() {
         // A diff exists (headHasDiff) so no empty commit is needed.
         return { number: 1, state: "open", html_url: `https://x/${repo}/1` }
       }
-      if (url === `${base}/git/refs` && method === "POST") return {}
+      if (url === `${base}/git/refs` && method === "POST") {
+        // A student pre-created the branch: ref create 422s already-exists.
+        if (repo.startsWith("blocked")) {
+          throw validationError("Reference already exists")
+        }
+        return {}
+      }
       if (url === `${base}/git/ref/heads/${FEEDBACK_BASE_BRANCH}`) {
+        // Read-back after an already-exists: blocked repos point at a
+        // student-chosen SHA (mismatch); others 404 (fresh create path).
+        if (repo.startsWith("blocked")) {
+          return { object: { sha: "student-chosen-sha" } }
+        }
         throw apiError(404, "Not Found")
       }
       if (url === `${base}/labels` && method === "POST") return {}
@@ -641,6 +659,7 @@ describe("openAllFeedbackPullRequests", () => {
       "existed-a",
       "nomarker-a",
       "missing-a",
+      "blocked-a",
       "fail-a",
     ]
     const progress: number[] = []
@@ -653,17 +672,20 @@ describe("openAllFeedbackPullRequests", () => {
       onProgress: (p) => progress.push(p.done),
     })
 
-    expect(summary.total).toBe(6)
+    expect(summary.total).toBe(7)
     expect(summary.created).toBe(2)
     expect(summary.existed).toBe(1)
     expect(summary.unsupported.map((r) => r.repo).toSorted()).toEqual([
       "missing-a",
       "nomarker-a",
     ])
+    // The never-retryable base-mismatch is a distinct bucket, NOT `failed`, so
+    // the modal's "re-run to retry" copy can't cover it.
+    expect(summary.blocked.map((r) => r.repo)).toEqual(["blocked-a"])
     expect(summary.failed.map((r) => r.repo)).toEqual(["fail-a"])
     // Progress fires once per repo and reaches the total.
-    expect(progress).toHaveLength(6)
-    expect(Math.max(...progress)).toBe(6)
+    expect(progress).toHaveLength(7)
+    expect(Math.max(...progress)).toBe(7)
   })
 
   it("handles an empty repo list without any requests", async () => {

--- a/web/src/domain/assignments/feedbackPr.ts
+++ b/web/src/domain/assignments/feedbackPr.ts
@@ -100,8 +100,17 @@ export function feedbackPrBody(head: string, releaseUrl: string): string {
   ].join("\n")
 }
 
+// A stable, non-message reason for an ensure/repair failure, so callers can
+// classify without parsing English:
+//   base-mismatch  the `feedback` branch is frozen at the wrong SHA — NEVER
+//                  retryable; only an org admin deleting the branch fixes it.
+//   transient      anything else (a GitHub outage, rate limit, or git-data
+//                  lag) — retryable, so re-running can recover it.
+export type FeedbackPrFailureCode = "base-mismatch" | "transient"
+
 export type EnsureFeedbackPrResult =
-  { ok: true; created: boolean } | { ok: false; reason: string }
+  | { ok: true; created: boolean }
+  | { ok: false; reason: string; code: FeedbackPrFailureCode }
 
 // The frozen base doesn't point where it must. Never retried: unlike git-data
 // lag this can't resolve itself, and only an org admin deleting the branch fixes
@@ -168,6 +177,10 @@ export async function ensureFeedbackPullRequest(
     return {
       ok: false,
       reason: err instanceof Error ? err.message : "Unexpected error",
+      code:
+        err instanceof FeedbackBaseMismatchError
+          ? "base-mismatch"
+          : "transient",
     }
   }
 }
@@ -418,19 +431,27 @@ export async function repairFeedbackPullRequest(params: {
   })
 }
 
-// The outcome of one repo in a bulk open, classified for the summary.
-export type OpenAllOutcome = "created" | "existed" | "unsupported" | "failed"
+// The outcome of one repo in a bulk open, classified for the summary. The
+// three failure shapes are deliberately distinct because their remedies are:
+//   unsupported  no Feedback PR is possible for this repo (no baseline marker /
+//                repo missing) — nothing to retry.
+//   blocked      the `feedback` branch is frozen at the wrong SHA — only an org
+//                admin deleting the branch fixes it; re-running never will.
+//   failed       a transient error (outage / rate limit / lag) — re-running the
+//                action retries just the repos still missing a PR.
+export type OpenAllOutcome =
+  "created" | "existed" | "unsupported" | "blocked" | "failed"
 
 export type OpenAllProgress = {
   done: number
   total: number
 }
 
-// Per-repo result kept for the summary's failure/unsupported detail lists.
+// Per-repo result kept for the summary's detail lists.
 export type OpenAllRepoResult = {
   repo: string
   outcome: OpenAllOutcome
-  // Present for "failed"/"unsupported": the reason to show the teacher.
+  // Present for the non-success outcomes: the reason to show the teacher.
   reason?: string
 }
 
@@ -439,6 +460,7 @@ export type OpenAllFeedbackPrsSummary = {
   created: number
   existed: number
   unsupported: OpenAllRepoResult[]
+  blocked: OpenAllRepoResult[]
   failed: OpenAllRepoResult[]
   results: OpenAllRepoResult[]
 }
@@ -476,6 +498,10 @@ export async function openAllFeedbackPullRequests(params: {
           result = { repo, outcome: r.created ? "created" : "existed" }
         } else if ("unsupported" in r) {
           result = { repo, outcome: "unsupported", reason: r.reason }
+        } else if (r.code === "base-mismatch") {
+          // Never-retryable: an org admin must delete the mis-frozen branch.
+          // Keep it out of `failed` so the "re-run to retry" copy stays honest.
+          result = { repo, outcome: "blocked", reason: r.reason }
         } else {
           result = { repo, outcome: "failed", reason: r.reason }
         }
@@ -497,6 +523,7 @@ export async function openAllFeedbackPullRequests(params: {
     created: results.filter((r) => r.outcome === "created").length,
     existed: results.filter((r) => r.outcome === "existed").length,
     unsupported: results.filter((r) => r.outcome === "unsupported"),
+    blocked: results.filter((r) => r.outcome === "blocked"),
     failed: results.filter((r) => r.outcome === "failed"),
     results,
   }

--- a/web/src/domain/assignments/feedbackPr.ts
+++ b/web/src/domain/assignments/feedbackPr.ts
@@ -11,10 +11,13 @@ import { is422NoCommitsBetween } from "@/github-core/errors"
 import {
   getBranchRefRepo,
   getCommitByRepo,
+  getOldestCommitShaForPath,
   isFreshRepoLagError,
   listPullRequestsByBaseHead,
   withFreshRepoRetry,
 } from "@/github-core/queries"
+import { getRepo } from "@/github-core/repoReads"
+import type { AssignmentMode } from "@/types/classroom"
 import { prefixCommit } from "@/util/commit"
 import { FEEDBACK_BASE_BRANCH } from "@/util/feedbackPr"
 import { logger } from "@/lib/logger"
@@ -339,5 +342,75 @@ async function pushEmptyCommit(params: {
     repo,
     branch,
     commitSha: commit.sha,
+  })
+}
+
+// The baseline commit to freeze `feedback` at: the OLDEST commit touching the
+// .classroom50.yaml marker (the accept commit), or null when the marker can't
+// be resolved — the same rule the runner's baseline_sha() applies. Read-only
+// and 404/lag-tolerant (any read failure collapses to null) so callers decide
+// what to do with an unresolvable baseline. Accept adds a just-committed-SHA
+// fallback on top; the teacher repair has no such fallback and defers instead.
+export async function resolveFeedbackBaselineSha(
+  client: GitHubClient,
+  org: string,
+  repo: string,
+): Promise<string | null> {
+  return getOldestCommitShaForPath(
+    client,
+    org,
+    repo,
+    ".classroom50.yaml",
+  ).catch(() => null)
+}
+
+// A teacher-initiated repair returns the ensure result, plus an "unsupported"
+// verdict for a repo that structurally can't have a Feedback PR (no baseline
+// marker — e.g. an empty_repo assignment), which the UI explains rather than
+// surfacing as a transient failure to retry.
+export type RepairFeedbackPrResult =
+  EnsureFeedbackPrResult | { ok: false; reason: string; unsupported: true }
+
+// Repair a missing Feedback PR from the teacher's side (issue #347): a teacher
+// (org admin) runs the SAME idempotent ensureFeedbackPullRequest as accept,
+// with their own token, when the student's accept-time attempt failed
+// (GitHub outage / transient error) or the repo predates the feature. Resolves
+// its own {branch, baseline SHA, mode}: the settled default branch from the
+// repo object, the baseline from the .classroom50.yaml marker.
+//
+// Reuses ensureFeedbackPullRequest so a teacher-repaired PR is byte-identical
+// to an accept-time or runner-opened one and the runner still adopts it by
+// base+head. Deliberately does NOT widen the base-mismatch guard: a `feedback`
+// branch frozen at the wrong SHA still defers (an org admin must delete it),
+// never force-updates.
+export async function repairFeedbackPullRequest(params: {
+  client: GitHubClient
+  org: string
+  repo: string
+  mode: AssignmentMode
+}): Promise<RepairFeedbackPrResult> {
+  const { client, org, repo, mode } = params
+
+  const repoInfo = await getRepo(client, org, repo)
+  if (!repoInfo) {
+    return { ok: false, reason: "repo-not-found", unsupported: true }
+  }
+  const branch = repoInfo.default_branch || "main"
+
+  const acceptCommitSha = await resolveFeedbackBaselineSha(client, org, repo)
+  if (!acceptCommitSha) {
+    // No .classroom50.yaml marker means no frozen baseline to open the PR
+    // against (an empty_repo assignment, or a repo that isn't a Classroom 50
+    // assignment repo). The runner refuses the same case.
+    return { ok: false, reason: "no-baseline", unsupported: true }
+  }
+
+  return ensureFeedbackPullRequest({
+    client,
+    owner: org,
+    repo,
+    branch,
+    acceptCommitSha,
+    mode,
   })
 }

--- a/web/src/domain/assignments/feedbackPr.ts
+++ b/web/src/domain/assignments/feedbackPr.ts
@@ -63,7 +63,8 @@ export function feedbackLabelForMode(mode: string): {
 export function feedbackPrBody(head: string, releaseUrl: string): string {
   return [
     ":wave:! Classroom 50 opened this pull request as a place for your " +
-      "teacher to leave feedback on your work. It updates automatically. " +
+      "teacher to leave feedback on your work. It stays up to date " +
+      "automatically as you push. " +
       "**Don't close or merge this pull request** unless your teacher tells you to.",
     "",
     "Each commit is automatically graded — the latest autograding result " +
@@ -92,8 +93,8 @@ export function feedbackPrBody(head: string, releaseUrl: string): string {
       "comment box below.",
     "",
     `The base branch (\`${FEEDBACK_BASE_BRANCH}\`) is frozen at the starter so the diff ` +
-      "always reflects the full body of work. The PR is managed automatically " +
-      "by the autograde runner; merging it is the teacher-side " +
+      "always reflects the full body of work. The PR is kept up to date " +
+      "automatically; merging it is the teacher-side " +
       '"grading done" signal.',
     "</details>",
   ].join("\n")

--- a/web/src/domain/assignments/feedbackPr.ts
+++ b/web/src/domain/assignments/feedbackPr.ts
@@ -15,9 +15,11 @@ import {
   isFreshRepoLagError,
   listPullRequestsByBaseHead,
   withFreshRepoRetry,
+  REPO_READ_CONCURRENCY,
 } from "@/github-core/queries"
 import { getRepo } from "@/github-core/repoReads"
 import type { AssignmentMode } from "@/types/classroom"
+import { mapWithConcurrency } from "@/util/concurrency"
 import { prefixCommit } from "@/util/commit"
 import { FEEDBACK_BASE_BRANCH } from "@/util/feedbackPr"
 import { logger } from "@/lib/logger"
@@ -413,4 +415,88 @@ export async function repairFeedbackPullRequest(params: {
     acceptCommitSha,
     mode,
   })
+}
+
+// The outcome of one repo in a bulk open, classified for the summary.
+export type OpenAllOutcome = "created" | "existed" | "unsupported" | "failed"
+
+export type OpenAllProgress = {
+  done: number
+  total: number
+}
+
+// Per-repo result kept for the summary's failure/unsupported detail lists.
+export type OpenAllRepoResult = {
+  repo: string
+  outcome: OpenAllOutcome
+  // Present for "failed"/"unsupported": the reason to show the teacher.
+  reason?: string
+}
+
+export type OpenAllFeedbackPrsSummary = {
+  total: number
+  created: number
+  existed: number
+  unsupported: OpenAllRepoResult[]
+  failed: OpenAllRepoResult[]
+  results: OpenAllRepoResult[]
+}
+
+// Open a Feedback PR on EVERY assignment repo in one teacher action (issue
+// #347): a bounded-concurrency fan-out of repairFeedbackPullRequest over
+// `repos`. Idempotent by construction — a repo that already has a PR (any
+// state) short-circuits as "existed", so re-running is safe and only fills the
+// gaps. A single repo's failure is caught and recorded, never aborting the
+// batch (repairFeedbackPullRequest doesn't throw; the try/catch guards an
+// unexpected throw so mapWithConcurrency's all-or-nothing reject can't sink the
+// whole run). `onProgress` fires after each repo settles so the UI can show a
+// live count.
+export async function openAllFeedbackPullRequests(params: {
+  client: GitHubClient
+  org: string
+  repos: string[]
+  mode: AssignmentMode
+  onProgress?: (progress: OpenAllProgress) => void
+  signal?: AbortSignal
+}): Promise<OpenAllFeedbackPrsSummary> {
+  const { client, org, repos, mode, onProgress, signal } = params
+  const total = repos.length
+  let done = 0
+
+  const results = await mapWithConcurrency(
+    repos,
+    REPO_READ_CONCURRENCY,
+    async (repo): Promise<OpenAllRepoResult> => {
+      if (signal?.aborted) return { repo, outcome: "failed", reason: "aborted" }
+      let result: OpenAllRepoResult
+      try {
+        const r = await repairFeedbackPullRequest({ client, org, repo, mode })
+        if (r.ok) {
+          result = { repo, outcome: r.created ? "created" : "existed" }
+        } else if ("unsupported" in r) {
+          result = { repo, outcome: "unsupported", reason: r.reason }
+        } else {
+          result = { repo, outcome: "failed", reason: r.reason }
+        }
+      } catch (err) {
+        result = {
+          repo,
+          outcome: "failed",
+          reason: err instanceof Error ? err.message : String(err),
+        }
+      }
+      done++
+      onProgress?.({ done, total })
+      return result
+    },
+  )
+
+  return {
+    total,
+    created: results.filter((r) => r.outcome === "created").length,
+    existed: results.filter((r) => r.outcome === "existed").length,
+    unsupported: results.filter((r) => r.outcome === "unsupported"),
+    failed: results.filter((r) => r.outcome === "failed"),
+    results,
+  }
 }

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -66,8 +66,11 @@ export const githubKeys = {
   collaborators: (org: string, repo: string) =>
     [...githubKeys.all, "collaborators", org, repo] as const,
 
+  // Prefix for every repo's open-pulls entry: a bulk action invalidates all of
+  // them at once.
+  openPullsAll: () => [...githubKeys.all, "open-pulls"] as const,
   openPulls: (owner: string, repo: string) =>
-    [...githubKeys.all, "open-pulls", owner, repo] as const,
+    [...githubKeys.openPullsAll(), owner, repo] as const,
 
   branchRef: (org: string) => [...githubKeys.all, "branchRef", org] as const,
   commitTree: (org: string, branchSha: string) =>

--- a/web/src/hooks/mutations/useOpenAllFeedbackPrs.test.ts
+++ b/web/src/hooks/mutations/useOpenAllFeedbackPrs.test.ts
@@ -30,6 +30,7 @@ const summary = (
   created: 1,
   existed: 0,
   unsupported: [],
+  blocked: [],
   failed: [],
   results: [],
   ...over,

--- a/web/src/hooks/mutations/useOpenAllFeedbackPrs.test.ts
+++ b/web/src/hooks/mutations/useOpenAllFeedbackPrs.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import type { OpenAllFeedbackPrsSummary } from "@/domain/assignments"
+
+const openAllFeedbackPullRequests =
+  vi.fn<(...args: unknown[]) => Promise<OpenAllFeedbackPrsSummary>>()
+
+vi.mock("@/domain/assignments", () => ({
+  openAllFeedbackPullRequests: (...args: unknown[]) =>
+    openAllFeedbackPullRequests(...args),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useOpenAllFeedbackPrs } from "./useOpenAllFeedbackPrs"
+
+const ORG = "cs50"
+const OPEN_PULLS_PREFIX = ["github", "open-pulls"]
+
+const summary = (
+  over: Partial<OpenAllFeedbackPrsSummary> = {},
+): OpenAllFeedbackPrsSummary => ({
+  total: 1,
+  created: 1,
+  existed: 0,
+  unsupported: [],
+  failed: [],
+  results: [],
+  ...over,
+})
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useOpenAllFeedbackPrs", () => {
+  it("surfaces progress from the batch and invalidates open-pulls when PRs were created", async () => {
+    openAllFeedbackPullRequests.mockImplementation(
+      async (...args: unknown[]) => {
+        const { onProgress } = args[0] as {
+          onProgress?: (p: unknown) => void
+        }
+        onProgress?.({ done: 2, total: 2 })
+        return summary({ total: 2, created: 2 })
+      },
+    )
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useOpenAllFeedbackPrs(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ org: ORG, repos: ["a", "b"], mode: "individual" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.progress).toEqual({ done: 2, total: 2 })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: OPEN_PULLS_PREFIX })
+  })
+
+  it("does not invalidate when nothing was created", async () => {
+    openAllFeedbackPullRequests.mockResolvedValue(
+      summary({ total: 3, created: 0, existed: 3 }),
+    )
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useOpenAllFeedbackPrs(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ org: ORG, repos: ["a"], mode: "group" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: OPEN_PULLS_PREFIX })
+  })
+
+  it("passes org/repos/mode through to the domain batch", async () => {
+    openAllFeedbackPullRequests.mockResolvedValue(summary())
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useOpenAllFeedbackPrs(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ org: ORG, repos: ["a", "b"], mode: "group" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(openAllFeedbackPullRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org: ORG,
+        repos: ["a", "b"],
+        mode: "group",
+        onProgress: expect.any(Function),
+      }),
+    )
+  })
+})

--- a/web/src/hooks/mutations/useOpenAllFeedbackPrs.ts
+++ b/web/src/hooks/mutations/useOpenAllFeedbackPrs.ts
@@ -1,0 +1,69 @@
+import { useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { openAllFeedbackPullRequests } from "@/domain/assignments"
+import type {
+  OpenAllFeedbackPrsSummary,
+  OpenAllProgress,
+} from "@/domain/assignments"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { githubKeys } from "@/github-core/queries"
+import type { AssignmentMode } from "@/types/classroom"
+
+export type OpenAllFeedbackPrsInput = {
+  org: string
+  repos: string[]
+  mode: AssignmentMode
+}
+
+// Bulk-open a Feedback PR on every assignment repo (issue #347). Wraps the
+// domain fan-out and exposes live `progress` (a plain useState updated from the
+// batch's onProgress) alongside the mutation, so a modal can render an "X of N"
+// bar while it runs. Idempotent: a repo that already has a PR is counted, not
+// duplicated.
+//
+// On completion we invalidate the open-pulls cache for the changed repos so any
+// open Review lookups re-read. The Review button resolves on click (not on
+// mount), so a broad prefix invalidation is cheap here — most entries aren't
+// cached — and keeps the per-repo bookkeeping out of the hot path.
+export function useOpenAllFeedbackPrs() {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+  const [progress, setProgress] = useState<OpenAllProgress | null>(null)
+
+  const mutation = useMutation<
+    OpenAllFeedbackPrsSummary,
+    Error,
+    OpenAllFeedbackPrsInput
+  >({
+    mutationFn: ({ org, repos, mode }) => {
+      setProgress({ done: 0, total: repos.length })
+      return openAllFeedbackPullRequests({
+        client,
+        org,
+        repos,
+        mode,
+        onProgress: setProgress,
+      })
+    },
+    onSuccess: (summary) => {
+      if (summary.created > 0) {
+        void queryClient.invalidateQueries({
+          queryKey: [...githubKeys.all, "open-pulls"],
+        })
+      }
+    },
+  })
+
+  return {
+    ...mutation,
+    progress,
+    // Clear progress + result when reopening the modal for a fresh run.
+    reset: () => {
+      setProgress(null)
+      mutation.reset()
+    },
+  }
+}
+
+export default useOpenAllFeedbackPrs

--- a/web/src/hooks/mutations/useOpenAllFeedbackPrs.ts
+++ b/web/src/hooks/mutations/useOpenAllFeedbackPrs.ts
@@ -49,7 +49,7 @@ export function useOpenAllFeedbackPrs() {
     onSuccess: (summary) => {
       if (summary.created > 0) {
         void queryClient.invalidateQueries({
-          queryKey: [...githubKeys.all, "open-pulls"],
+          queryKey: githubKeys.openPullsAll(),
         })
       }
     },

--- a/web/src/hooks/mutations/useRepairFeedbackPr.test.ts
+++ b/web/src/hooks/mutations/useRepairFeedbackPr.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import type { RepairFeedbackPrResult } from "@/domain/assignments"
+
+const repairFeedbackPullRequest =
+  vi.fn<(...args: unknown[]) => Promise<RepairFeedbackPrResult>>()
+
+vi.mock("@/domain/assignments", () => ({
+  repairFeedbackPullRequest: (...args: unknown[]) =>
+    repairFeedbackPullRequest(...args),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+
+import { useRepairFeedbackPr } from "./useRepairFeedbackPr"
+
+const ORG = "cs50"
+const REPO = "cs50-hw1-alice"
+const OPEN_PULLS_KEY = ["github", "open-pulls", ORG, REPO]
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useRepairFeedbackPr", () => {
+  it("invalidates the row's open-pulls read when a PR was created", async () => {
+    repairFeedbackPullRequest.mockResolvedValue({ ok: true, created: true })
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useRepairFeedbackPr(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ org: ORG, repo: REPO, mode: "individual" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: OPEN_PULLS_KEY })
+  })
+
+  it("does not invalidate when the PR already existed (created: false)", async () => {
+    repairFeedbackPullRequest.mockResolvedValue({ ok: true, created: false })
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useRepairFeedbackPr(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ org: ORG, repo: REPO, mode: "individual" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: OPEN_PULLS_KEY })
+  })
+
+  it("does not invalidate on an unsupported verdict", async () => {
+    repairFeedbackPullRequest.mockResolvedValue({
+      ok: false,
+      reason: "no-baseline",
+      unsupported: true,
+    })
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useRepairFeedbackPr(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ org: ORG, repo: REPO, mode: "individual" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toMatchObject({ ok: false })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: OPEN_PULLS_KEY })
+  })
+
+  it("passes org/repo/mode through to the domain repair", async () => {
+    repairFeedbackPullRequest.mockResolvedValue({ ok: true, created: true })
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useRepairFeedbackPr(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ org: ORG, repo: REPO, mode: "group" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(repairFeedbackPullRequest).toHaveBeenCalledWith({
+      client: expect.anything(),
+      org: ORG,
+      repo: REPO,
+      mode: "group",
+    })
+  })
+})

--- a/web/src/hooks/mutations/useRepairFeedbackPr.ts
+++ b/web/src/hooks/mutations/useRepairFeedbackPr.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { repairFeedbackPullRequest } from "@/domain/assignments"
+import type { RepairFeedbackPrResult } from "@/domain/assignments"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { githubKeys } from "@/github-core/queries"
+import type { AssignmentMode } from "@/types/classroom"
+
+export type RepairFeedbackPrInput = {
+  org: string
+  repo: string
+  mode: AssignmentMode
+}
+
+// Teacher-side repair for a missing Feedback PR (issue #347): re-run the same
+// idempotent ensureFeedbackPullRequest as accept, with the teacher's token,
+// when a student's accept-time attempt failed (GitHub outage / transient) or
+// the repo predates the feature. The domain function never throws — it returns
+// {ok:false} (retryable) or {unsupported:true} (no baseline) — so the call
+// site maps the reason to copy. On a created PR we invalidate the row's
+// openPulls read so useGetFeedbackPr picks it up regardless of the modal's
+// fate (per ./README.md: cache consistency lives in the hook).
+export function useRepairFeedbackPr() {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<RepairFeedbackPrResult, Error, RepairFeedbackPrInput>({
+    mutationFn: ({ org, repo, mode }) =>
+      repairFeedbackPullRequest({ client, org, repo, mode }),
+    onSuccess: (result, { org, repo }) => {
+      if (result.ok && result.created) {
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.openPulls(org, repo),
+        })
+      }
+    },
+  })
+}
+
+export default useRepairFeedbackPr

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1946,6 +1946,28 @@
       "repoNotFound": "Couldn't find the repository {{repo}} — the student may not have accepted yet.",
       "failed": "Couldn't open the Feedback PR: {{reason}}"
     },
+    "openAllPrs": {
+      "menuLabel": "Open all Feedback PRs",
+      "title": "Open Feedback PRs for every repo",
+      "titleEmptyRoster": "Add students to the roster first",
+      "confirmBody_one": "This opens a Feedback PR on the <b>{{count}}</b> assignment repository for <b>{{name}}</b> that doesn't have one yet. Repos that already have a Feedback PR are left untouched.",
+      "confirmBody_other": "This opens a Feedback PR on each of the <b>{{count}}</b> assignment repositories for <b>{{name}}</b> that don't have one yet. Repos that already have a Feedback PR are left untouched.",
+      "confirmHint": "It runs from your browser, one repository at a time, so it may take a while for a large class. Keep this tab open until it finishes.",
+      "confirmLabel_one": "Open PR",
+      "confirmLabel_other": "Open PRs",
+      "running": "Opening… {{done}} of {{total}}",
+      "summaryLead": "Finished processing <b>{{total}}</b> repositories.",
+      "summaryOpened_one": "{{count}} Feedback PR opened",
+      "summaryOpened_other": "{{count}} Feedback PRs opened",
+      "summaryExisted_one": "{{count}} repository already had one",
+      "summaryExisted_other": "{{count}} repositories already had one",
+      "summaryUnsupported_one": "{{count}} repository skipped (no assignment baseline)",
+      "summaryUnsupported_other": "{{count}} repositories skipped (no assignment baseline)",
+      "summaryFailed_one": "{{count}} repository failed",
+      "summaryFailed_other": "{{count}} repositories failed",
+      "failedTitle": "These repositories couldn't be processed:",
+      "failedHint": "This is often a transient GitHub error — run the action again to retry only the repositories still missing a PR."
+    },
     "rowRegrade": {
       "title": "Regrade this submission",
       "titleInFlight": "Regrade in progress…",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1944,6 +1944,7 @@
       "alreadyExists": "A Feedback PR already exists for {{repo}}.",
       "noBaseline": "This repository has no assignment baseline, so a Feedback PR can't be opened for it (for example, an empty-repo assignment). Nothing to repair.",
       "repoNotFound": "Couldn't find the repository {{repo}} — the student may not have accepted yet.",
+      "baseMismatch": "The feedback branch on this repository points at the wrong commit, so opening the PR here would show an empty diff. An org admin must delete the feedback branch before it can be re-created correctly. Re-running won't fix this.",
       "failed": "Couldn't open the Feedback PR: {{reason}}"
     },
     "openAllPrs": {
@@ -1963,10 +1964,14 @@
       "summaryExisted_other": "{{count}} repositories already had one",
       "summaryUnsupported_one": "{{count}} repository skipped (no assignment baseline)",
       "summaryUnsupported_other": "{{count}} repositories skipped (no assignment baseline)",
+      "summaryBlocked_one": "{{count}} repository blocked (needs an org admin)",
+      "summaryBlocked_other": "{{count}} repositories blocked (need an org admin)",
       "summaryFailed_one": "{{count}} repository failed",
       "summaryFailed_other": "{{count}} repositories failed",
       "failedTitle": "These repositories couldn't be processed:",
-      "failedHint": "This is often a transient GitHub error — run the action again to retry only the repositories still missing a PR."
+      "failedHint": "This is often a transient GitHub error — run the action again to retry only the repositories still missing a PR.",
+      "blockedTitle": "These repositories need an org admin:",
+      "blockedHint": "Their feedback branch points at the wrong commit, so opening the PR would show an empty diff. An org admin must delete each feedback branch before re-running this action — retrying alone won't fix them."
     },
     "rowRegrade": {
       "title": "Regrade this submission",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1936,6 +1936,16 @@
       "emptyBody": "No Feedback PR has been opened for <repo>{{repo}}</repo> yet. It's opened when the student accepts the assignment — so if there's nothing to review, the student may not have accepted yet, the assignment may have the Feedback PR disabled, or opening it was deferred (it retries on re-accept, or on the first graded submission).",
       "openRepoPrs": "Open repo PRs"
     },
+    "repairPr": {
+      "hint": "If the student accepted but opening the PR failed (a GitHub outage or transient error), you can open it now.",
+      "repair": "Repair Feedback PR",
+      "repairing": "Repairing…",
+      "created": "Opened the Feedback PR for {{repo}}.",
+      "alreadyExists": "A Feedback PR already exists for {{repo}}.",
+      "noBaseline": "This repository has no assignment baseline, so a Feedback PR can't be opened for it (for example, an empty-repo assignment). Nothing to repair.",
+      "repoNotFound": "Couldn't find the repository {{repo}} — the student may not have accepted yet.",
+      "failed": "Couldn't open the Feedback PR: {{reason}}"
+    },
     "rowRegrade": {
       "title": "Regrade this submission",
       "titleInFlight": "Regrade in progress…",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -16,6 +16,7 @@ import SubmissionsControls from "@/pages/submissions/SubmissionsControls"
 import { SubmissionsActionsMenu } from "@/pages/submissions/SubmissionsActionsMenu"
 import { AcceptLinkModal } from "@/pages/submissions/AcceptLinkModal"
 import { MetricsModal } from "@/pages/submissions/MetricsModal"
+import { OpenAllFeedbackPrsModal } from "@/pages/submissions/OpenAllFeedbackPrsModal"
 import { DataFreshness } from "@/pages/submissions/DataFreshness"
 import { ConfirmModal } from "@/components/modals"
 import {
@@ -23,6 +24,7 @@ import {
   DEFAULT_PAGE_SIZE,
   acceptedRosterCount,
   acceptedUsernames,
+  assignmentRepoNames,
   buildScoresCsvRows,
   buildSectionLookup,
   classAverage,
@@ -244,6 +246,7 @@ const SubmissionsPageContent = () => {
   // accept disclosure.
   const [metricsOpen, setMetricsOpen] = useState(false)
   const [acceptOpen, setAcceptOpen] = useState(false)
+  const [openAllPrsOpen, setOpenAllPrsOpen] = useState(false)
 
   // Scope the collector's scores to the CURRENT roster (see rosterScopedRows).
   // Gate on a resolved roster so a transient load/permission failure falls back
@@ -463,6 +466,30 @@ const SubmissionsPageContent = () => {
     [orgRepos, classroom, assignment, students],
   )
   const acceptedAvailable = !isGroupAssignment && orgRepos != null
+
+  // Every existing assignment repo name (individual + group), for the bulk
+  // "Open all Feedback PRs" action. Derived from the already-loaded org repo
+  // list, so no extra reads. Only meaningful for a live-capable owner on a
+  // non-empty_repo assignment (the action is hidden otherwise).
+  const allAssignmentRepos = useMemo(
+    () =>
+      assignmentRepoNames({
+        isGroup: isGroupAssignment,
+        repos: orgRepos,
+        classroom: classroom ?? "",
+        assignment: assignment ?? "",
+        students,
+        siblingSlugs,
+      }),
+    [
+      isGroupAssignment,
+      orgRepos,
+      classroom,
+      assignment,
+      students,
+      siblingSlugs,
+    ],
+  )
 
   // Group repos that exist but have no submission yet: for group assignments the
   // repo is named after the founder (not each member), so acceptance can't be
@@ -948,6 +975,14 @@ const SubmissionsPageContent = () => {
             onMetrics={liveCapable ? undefined : () => setMetricsOpen(true)}
             onCollect={() => collectScores.collect()}
             onRegradeAll={() => setRegradeConfirmOpen(true)}
+            // Bulk-open Feedback PRs: owner-only (needs admin on every repo,
+            // like the live reads), never for empty_repo (no PRs), and only
+            // when there are repos to target.
+            onOpenAllPrs={
+              isOwner && !isEmptyRepoAssignment && allAssignmentRepos.length > 0
+                ? () => setOpenAllPrsOpen(true)
+                : undefined
+            }
             viewHref={viewRun?.html_url || viewWorkflowUrl}
             viewLabel={viewLabel}
             onDownloadCsv={downloadScoresCsv}
@@ -1042,6 +1077,14 @@ const SubmissionsPageContent = () => {
         classroom={classroom}
         classroomName={classroomMeta?.name || classroomMeta?.short_name}
         summary={acceptShareSummary}
+      />
+      <OpenAllFeedbackPrsModal
+        open={openAllPrsOpen}
+        onClose={() => setOpenAllPrsOpen(false)}
+        org={org}
+        assignmentName={assignmentInfo?.name ?? assignment}
+        mode={isGroupAssignment ? "group" : "individual"}
+        repos={allAssignmentRepos}
       />
     </PageShell>
   )

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -1,0 +1,193 @@
+import { useId } from "react"
+import { Trans, useTranslation } from "react-i18next"
+import { GitPullRequest } from "lucide-react"
+
+import { Alert, Button, Modal, Spinner } from "@/components/ui"
+import useOpenAllFeedbackPrs from "@/hooks/mutations/useOpenAllFeedbackPrs"
+import type { AssignmentMode } from "@/types/classroom"
+
+// Bulk "Open all Feedback PRs" for an assignment (issue #347). Three states in
+// one dialog: confirm (repo count), running (live X/N progress, dismissal
+// blocked), and summary (opened / already had one / failed). Idempotent — a
+// repo that already has a PR is reported as "already had one", never
+// duplicated — so re-running is safe.
+export function OpenAllFeedbackPrsModal({
+  open,
+  onClose,
+  org,
+  assignmentName,
+  mode,
+  repos,
+}: {
+  open: boolean
+  onClose: () => void
+  org: string
+  assignmentName: string
+  mode: AssignmentMode
+  // Every existing assignment repo NAME (individual + group), enumerated by the
+  // page from the org repo list.
+  repos: string[]
+}) {
+  const { t } = useTranslation()
+  const titleId = useId()
+  const {
+    mutate,
+    isPending,
+    data: summary,
+    progress,
+    reset,
+  } = useOpenAllFeedbackPrs()
+
+  const count = repos.length
+  const running = isPending
+  const closeDisabled = running
+
+  const handleClose = () => {
+    if (closeDisabled) return
+    onClose()
+    // Clear the prior run so reopening starts at the confirm state.
+    reset()
+  }
+
+  const handleRun = () => {
+    mutate({ org, repos, mode })
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      size="md"
+      closeDisabled={closeDisabled}
+      aria-labelledby={titleId}
+    >
+      <h3 id={titleId} className="flex items-center gap-2 text-lg font-bold">
+        <GitPullRequest aria-hidden="true" className="size-5" />
+        {t("submissions.openAllPrs.title")}
+      </h3>
+
+      {/* Summary — the run finished. */}
+      {summary ? (
+        <div className="mt-3 space-y-3">
+          <p className="text-sm leading-6 text-base-content/70">
+            <Trans
+              i18nKey="submissions.openAllPrs.summaryLead"
+              values={{ total: summary.total }}
+              components={{ b: <span className="font-semibold" /> }}
+            />
+          </p>
+          <ul className="space-y-1 text-sm">
+            <li>
+              {t("submissions.openAllPrs.summaryOpened", {
+                count: summary.created,
+              })}
+            </li>
+            <li>
+              {t("submissions.openAllPrs.summaryExisted", {
+                count: summary.existed,
+              })}
+            </li>
+            {summary.unsupported.length > 0 && (
+              <li>
+                {t("submissions.openAllPrs.summaryUnsupported", {
+                  count: summary.unsupported.length,
+                })}
+              </li>
+            )}
+            {summary.failed.length > 0 && (
+              <li className="text-error">
+                {t("submissions.openAllPrs.summaryFailed", {
+                  count: summary.failed.length,
+                })}
+              </li>
+            )}
+          </ul>
+          {summary.failed.length > 0 && (
+            <Alert tone="warning">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">
+                  {t("submissions.openAllPrs.failedTitle")}
+                </p>
+                <ul className="max-h-40 overflow-y-auto text-xs">
+                  {summary.failed.map((f) => (
+                    <li key={f.repo} className="font-mono">
+                      {f.repo}
+                      {f.reason ? ` — ${f.reason}` : ""}
+                    </li>
+                  ))}
+                </ul>
+                <p className="text-xs text-base-content/70">
+                  {t("submissions.openAllPrs.failedHint")}
+                </p>
+              </div>
+            </Alert>
+          )}
+        </div>
+      ) : running ? (
+        /* Running — live progress. */
+        <div className="mt-4 space-y-3">
+          <p className="flex items-center gap-2 text-sm text-base-content/70">
+            <Spinner size="xs" />
+            {t("submissions.openAllPrs.running", {
+              done: progress?.done ?? 0,
+              total: progress?.total ?? count,
+            })}
+          </p>
+          <progress
+            className="progress progress-primary w-full"
+            value={progress?.done ?? 0}
+            max={progress?.total ?? count}
+          />
+        </div>
+      ) : (
+        /* Confirm. */
+        <div className="mt-3 space-y-2 text-sm leading-6 text-base-content/70">
+          <p>
+            <Trans
+              i18nKey="submissions.openAllPrs.confirmBody"
+              values={{ count, name: assignmentName }}
+              components={{
+                b: <span className="font-semibold text-base-content" />,
+              }}
+            />
+          </p>
+          <p>{t("submissions.openAllPrs.confirmHint")}</p>
+        </div>
+      )}
+
+      <div className="modal-action">
+        {summary ? (
+          <Button size="sm" onClick={handleClose}>
+            {t("common.close")}
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={running}
+              onClick={handleClose}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              loading={running}
+              loadingLabel={t("submissions.openAllPrs.running", {
+                done: progress?.done ?? 0,
+                total: progress?.total ?? count,
+              })}
+              disabled={running || count === 0}
+              onClick={handleRun}
+            >
+              {t("submissions.openAllPrs.confirmLabel", { count })}
+            </Button>
+          </>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+export default OpenAllFeedbackPrsModal

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -4,7 +4,39 @@ import { GitPullRequest } from "lucide-react"
 
 import { Alert, Button, Modal, Spinner } from "@/components/ui"
 import useOpenAllFeedbackPrs from "@/hooks/mutations/useOpenAllFeedbackPrs"
+import type { OpenAllRepoResult } from "@/domain/assignments"
 import type { AssignmentMode } from "@/types/classroom"
+
+// A warning Alert listing the repos in one non-success bucket (blocked /
+// failed). `showReason` appends each repo's reason inline (the failed bucket).
+function RepoListAlert({
+  repos,
+  title,
+  hint,
+  showReason,
+}: {
+  repos: OpenAllRepoResult[]
+  title: string
+  hint: string
+  showReason?: boolean
+}) {
+  return (
+    <Alert tone="warning">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{title}</p>
+        <ul className="max-h-40 overflow-y-auto text-xs">
+          {repos.map((r) => (
+            <li key={r.repo} className="font-mono">
+              {r.repo}
+              {showReason && r.reason ? ` — ${r.reason}` : ""}
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-base-content/70">{hint}</p>
+      </div>
+    </Alert>
+  )
+}
 
 // Bulk "Open all Feedback PRs" for an assignment (issue #347). Three states in
 // one dialog: confirm (repo count), running (live X/N progress, dismissal
@@ -40,10 +72,9 @@ export function OpenAllFeedbackPrsModal({
 
   const count = repos.length
   const running = isPending
-  const closeDisabled = running
 
   const handleClose = () => {
-    if (closeDisabled) return
+    if (running) return
     onClose()
     // Clear the prior run so reopening starts at the confirm state.
     reset()
@@ -58,7 +89,7 @@ export function OpenAllFeedbackPrsModal({
       open={open}
       onClose={handleClose}
       size="md"
-      closeDisabled={closeDisabled}
+      closeDisabled={running}
       aria-labelledby={titleId}
     >
       <h3 id={titleId} className="flex items-center gap-2 text-lg font-bold">
@@ -110,43 +141,19 @@ export function OpenAllFeedbackPrsModal({
             )}
           </ul>
           {summary.blocked.length > 0 && (
-            <Alert tone="warning">
-              <div className="space-y-1">
-                <p className="text-sm font-medium">
-                  {t("submissions.openAllPrs.blockedTitle")}
-                </p>
-                <ul className="max-h-40 overflow-y-auto text-xs">
-                  {summary.blocked.map((b) => (
-                    <li key={b.repo} className="font-mono">
-                      {b.repo}
-                    </li>
-                  ))}
-                </ul>
-                <p className="text-xs text-base-content/70">
-                  {t("submissions.openAllPrs.blockedHint")}
-                </p>
-              </div>
-            </Alert>
+            <RepoListAlert
+              repos={summary.blocked}
+              title={t("submissions.openAllPrs.blockedTitle")}
+              hint={t("submissions.openAllPrs.blockedHint")}
+            />
           )}
           {summary.failed.length > 0 && (
-            <Alert tone="warning">
-              <div className="space-y-1">
-                <p className="text-sm font-medium">
-                  {t("submissions.openAllPrs.failedTitle")}
-                </p>
-                <ul className="max-h-40 overflow-y-auto text-xs">
-                  {summary.failed.map((f) => (
-                    <li key={f.repo} className="font-mono">
-                      {f.repo}
-                      {f.reason ? ` — ${f.reason}` : ""}
-                    </li>
-                  ))}
-                </ul>
-                <p className="text-xs text-base-content/70">
-                  {t("submissions.openAllPrs.failedHint")}
-                </p>
-              </div>
-            </Alert>
+            <RepoListAlert
+              repos={summary.failed}
+              title={t("submissions.openAllPrs.failedTitle")}
+              hint={t("submissions.openAllPrs.failedHint")}
+              showReason
+            />
           )}
         </div>
       ) : running ? (

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -94,6 +94,13 @@ export function OpenAllFeedbackPrsModal({
                 })}
               </li>
             )}
+            {summary.blocked.length > 0 && (
+              <li className="text-warning">
+                {t("submissions.openAllPrs.summaryBlocked", {
+                  count: summary.blocked.length,
+                })}
+              </li>
+            )}
             {summary.failed.length > 0 && (
               <li className="text-error">
                 {t("submissions.openAllPrs.summaryFailed", {
@@ -102,6 +109,25 @@ export function OpenAllFeedbackPrsModal({
               </li>
             )}
           </ul>
+          {summary.blocked.length > 0 && (
+            <Alert tone="warning">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">
+                  {t("submissions.openAllPrs.blockedTitle")}
+                </p>
+                <ul className="max-h-40 overflow-y-auto text-xs">
+                  {summary.blocked.map((b) => (
+                    <li key={b.repo} className="font-mono">
+                      {b.repo}
+                    </li>
+                  ))}
+                </ul>
+                <p className="text-xs text-base-content/70">
+                  {t("submissions.openAllPrs.blockedHint")}
+                </p>
+              </div>
+            </Alert>
+          )}
           {summary.failed.length > 0 && (
             <Alert tone="warning">
               <div className="space-y-1">

--- a/web/src/pages/submissions/ReviewButton.test.tsx
+++ b/web/src/pages/submissions/ReviewButton.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) =>
+        opts && "reason" in opts
+          ? `${key}:${String(opts.reason)}`
+          : opts && "repo" in opts
+            ? `${key}:${String(opts.repo)}`
+            : key,
+    }),
+  }
+})
+
+// The row's data hooks and the toast provider are stubbed so the test targets
+// only ReviewButton's own review/repair branching.
+const refetch = vi.fn()
+const mutate = vi.fn()
+const notify = vi.fn()
+
+vi.mock("@/hooks/useGetFeedbackPr", () => ({
+  default: () => ({ refetch }),
+}))
+vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
+  default: () => ({ mutate, isPending: false }),
+}))
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify }),
+}))
+
+import { ReviewButton } from "./ReviewButton"
+
+const ORG = "acme"
+const REPO = "cs101-hw1-alice"
+
+// Open the empty-PR modal: no open PR -> Review shows the modal with Repair.
+async function openRepairModal(user: ReturnType<typeof userEvent.setup>) {
+  refetch.mockResolvedValueOnce({ data: null, error: null })
+  await user.click(screen.getByTitle("submissions.table.review"))
+  await screen.findByText("submissions.reviewModal.emptyTitle")
+}
+
+beforeEach(() => {
+  refetch.mockReset()
+  mutate.mockReset()
+  notify.mockReset()
+  vi.stubGlobal("open", vi.fn())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("ReviewButton — repair flow", () => {
+  it("on a created PR: toasts success, closes, refetches and opens the PR", async () => {
+    const user = userEvent.setup()
+    // The repair resolves created:true; the follow-up refetch returns the PR.
+    mutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({ ok: true, created: true }),
+    )
+    render(<ReviewButton org={ORG} repo={REPO} mode="individual" />)
+    await openRepairModal(user)
+
+    refetch.mockResolvedValueOnce({
+      data: { html_url: "https://github.com/acme/cs101-hw1-alice/pull/1" },
+    })
+    await user.click(screen.getByText("submissions.repairPr.repair"))
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tone: "success",
+          message: `submissions.repairPr.created:${REPO}`,
+        }),
+      ),
+    )
+    await waitFor(() =>
+      expect(window.open).toHaveBeenCalledWith(
+        "https://github.com/acme/cs101-hw1-alice/pull/1",
+        "_blank",
+        "noopener,noreferrer",
+      ),
+    )
+  })
+
+  it("on an already-existing PR: toasts alreadyExists (created:false)", async () => {
+    const user = userEvent.setup()
+    mutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({ ok: true, created: false }),
+    )
+    render(<ReviewButton org={ORG} repo={REPO} mode="individual" />)
+    await openRepairModal(user)
+
+    refetch.mockResolvedValueOnce({ data: null })
+    await user.click(screen.getByText("submissions.repairPr.repair"))
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `submissions.repairPr.alreadyExists:${REPO}`,
+        }),
+      ),
+    )
+  })
+
+  it("maps an unsupported no-baseline verdict to terminal modal copy", async () => {
+    const user = userEvent.setup()
+    mutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({ ok: false, reason: "no-baseline", unsupported: true }),
+    )
+    render(<ReviewButton org={ORG} repo={REPO} mode="individual" />)
+    await openRepairModal(user)
+
+    await user.click(screen.getByText("submissions.repairPr.repair"))
+
+    expect(
+      await screen.findByText("submissions.repairPr.noBaseline"),
+    ).toBeTruthy()
+    // Repair button is hidden once an error message is shown.
+    expect(screen.queryByText("submissions.repairPr.repair")).toBeNull()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it("maps a repo-not-found verdict to terminal modal copy", async () => {
+    const user = userEvent.setup()
+    mutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({
+        ok: false,
+        reason: "repo-not-found",
+        unsupported: true,
+      }),
+    )
+    render(<ReviewButton org={ORG} repo={REPO} mode="individual" />)
+    await openRepairModal(user)
+
+    await user.click(screen.getByText("submissions.repairPr.repair"))
+
+    expect(
+      await screen.findByText(`submissions.repairPr.repoNotFound:${REPO}`),
+    ).toBeTruthy()
+  })
+
+  it("maps a blocked base-mismatch code to terminal modal copy (not retryable)", async () => {
+    const user = userEvent.setup()
+    mutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({
+        ok: false,
+        reason: "feedback branch is at X, not the baseline",
+        code: "base-mismatch",
+      }),
+    )
+    render(<ReviewButton org={ORG} repo={REPO} mode="individual" />)
+    await openRepairModal(user)
+
+    await user.click(screen.getByText("submissions.repairPr.repair"))
+
+    expect(
+      await screen.findByText("submissions.repairPr.baseMismatch"),
+    ).toBeTruthy()
+  })
+
+  it("maps a transient failure to the retryable failed copy with the reason", async () => {
+    const user = userEvent.setup()
+    mutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({ ok: false, reason: "GitHub 500", code: "transient" }),
+    )
+    render(<ReviewButton org={ORG} repo={REPO} mode="individual" />)
+    await openRepairModal(user)
+
+    await user.click(screen.getByText("submissions.repairPr.repair"))
+
+    expect(
+      await screen.findByText("submissions.repairPr.failed:GitHub 500"),
+    ).toBeTruthy()
+  })
+
+  it("surfaces an unexpected mutation error in the modal", async () => {
+    const user = userEvent.setup()
+    mutate.mockImplementation((_vars, opts) =>
+      opts.onError(new Error("network down")),
+    )
+    render(<ReviewButton org={ORG} repo={REPO} mode="individual" />)
+    await openRepairModal(user)
+
+    await user.click(screen.getByText("submissions.repairPr.repair"))
+
+    expect(await screen.findByText("network down")).toBeTruthy()
+  })
+})

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -1,0 +1,188 @@
+import { MessageCircle } from "lucide-react"
+import { useId, useRef, useState } from "react"
+import { Trans, useTranslation } from "react-i18next"
+
+import { Button, Modal, MonoLtr } from "@/components/ui"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
+import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
+import type { AssignmentMode } from "@/types/classroom"
+
+// Review action: links to the open Feedback PR (opened at accept time, or by
+// the autograde runner) when one exists; when none does, offers a teacher-side
+// Repair that re-runs the same idempotent ensure flow with the teacher's token
+// (issue #347 — recovers a PR a student's accept-time attempt failed to open).
+// The PR is the source of truth. The /pulls lookup is deferred until Review is
+// clicked (an eager per-row query would fan out to one request per repo on
+// mount); on click we refetch.
+export const ReviewButton = ({
+  org,
+  repo,
+  mode,
+}: {
+  org: string
+  repo: string
+  mode: AssignmentMode
+}) => {
+  const { t } = useTranslation()
+  const { notify } = useToast()
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
+  const titleId = useId()
+  const [resolving, setResolving] = useState(false)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  // enabled: false — driven by refetch() on click, never on mount.
+  const { refetch } = useGetFeedbackPr(org, repo, false)
+  const repair = useRepairFeedbackPr()
+
+  const handleReview = async () => {
+    setResolving(true)
+    try {
+      // getOpenPullRequests maps 404 -> [], so a non-404 failure surfaces as
+      // `error`; show it rather than the misleading "no PR yet" message.
+      const { data: pr, error } = await refetch()
+      if (error) {
+        setErrorMsg(error instanceof Error ? error.message : String(error))
+        dialogRef.current?.showModal()
+      } else if (pr) {
+        window.open(pr.html_url, "_blank", "noopener,noreferrer")
+      } else {
+        setErrorMsg(null)
+        dialogRef.current?.showModal()
+      }
+    } finally {
+      setResolving(false)
+    }
+  }
+
+  // Map the domain's failure to friendly copy. Structural verdicts
+  // (`no-baseline` / `repo-not-found` — no Feedback PR is possible for this
+  // repo) and the blocked `base-mismatch` (only an org admin can fix it) are
+  // terminal messages shown in the modal, not retryable toasts. Everything else
+  // is a transient failure the teacher can retry.
+  const repairReasonMessage = (
+    result: Extract<
+      ReturnType<typeof useRepairFeedbackPr>["data"],
+      { ok: false }
+    >,
+  ) => {
+    if ("unsupported" in result) {
+      return result.reason === "no-baseline"
+        ? t("submissions.repairPr.noBaseline")
+        : t("submissions.repairPr.repoNotFound", { repo })
+    }
+    if (result.code === "base-mismatch") {
+      return t("submissions.repairPr.baseMismatch")
+    }
+    return t("submissions.repairPr.failed", { reason: result.reason })
+  }
+
+  const handleRepair = () => {
+    repair.mutate(
+      { org, repo, mode },
+      {
+        onSuccess: async (result) => {
+          if (result.ok) {
+            notify({
+              tone: "success",
+              durationMs: 5000,
+              message: result.created
+                ? t("submissions.repairPr.created", { repo })
+                : t("submissions.repairPr.alreadyExists", { repo }),
+            })
+            dialogRef.current?.close()
+            // The PR now exists (created or adopted): resolve and open it.
+            const { data: pr } = await refetch()
+            if (pr) window.open(pr.html_url, "_blank", "noopener,noreferrer")
+            return
+          }
+          setErrorMsg(repairReasonMessage(result))
+        },
+        onError: (err) => {
+          setErrorMsg(err instanceof Error ? err.message : String(err))
+        },
+      },
+    )
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="text-base-content/70 disabled:opacity-60"
+        disabled={resolving}
+        loading={resolving}
+        loadingLabel={t("submissions.table.review")}
+        onClick={handleReview}
+        aria-label={t("submissions.table.reviewAria")}
+        title={t("submissions.table.review")}
+      >
+        {!resolving && <MessageCircle aria-hidden="true" className="size-4" />}
+      </Button>
+      <Modal
+        dialogRef={dialogRef}
+        size="md"
+        hideCloseButton
+        aria-labelledby={titleId}
+      >
+        {errorMsg ? (
+          <>
+            <h3 id={titleId} className="text-lg font-bold">
+              {t("submissions.reviewModal.errorTitle")}
+            </h3>
+            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
+              {errorMsg}
+            </p>
+          </>
+        ) : (
+          <>
+            <h3 id={titleId} className="text-lg font-bold">
+              {t("submissions.reviewModal.emptyTitle")}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-base-content/70">
+              <Trans
+                i18nKey="submissions.reviewModal.emptyBody"
+                values={{ repo }}
+                components={{ repo: <MonoLtr /> }}
+              />
+            </p>
+            <p className="mt-3 text-sm leading-6 text-base-content/70">
+              {t("submissions.repairPr.hint")}
+            </p>
+          </>
+        )}
+        <div className="modal-action">
+          <a
+            className="btn btn-ghost btn-sm"
+            href={`https://github.com/${org}/${repo}/pulls`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {t("submissions.reviewModal.openRepoPrs")}
+          </a>
+          {!errorMsg && (
+            <Button
+              size="sm"
+              loading={repair.isPending}
+              loadingLabel={t("submissions.repairPr.repairing")}
+              onClick={handleRepair}
+            >
+              {t("submissions.repairPr.repair")}
+            </Button>
+          )}
+          <Button
+            variant={errorMsg ? undefined : "ghost"}
+            size="sm"
+            disabled={repair.isPending}
+            onClick={() => dialogRef.current?.close()}
+          >
+            {t("common.close")}
+          </Button>
+        </div>
+      </Modal>
+    </>
+  )
+}
+
+export default ReviewButton

--- a/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
@@ -56,3 +56,26 @@ describe("SubmissionsActionsMenu — Metrics item", () => {
     expect(screen.queryByText("submissions.menu.metrics")).not.toBeNull()
   })
 })
+
+describe("SubmissionsActionsMenu — Open all Feedback PRs item", () => {
+  it("shows the item only when onOpenAllPrs is provided (owner, non-empty_repo)", () => {
+    const { rerender } = render(<SubmissionsActionsMenu {...baseProps} />)
+    expect(screen.queryByText("submissions.openAllPrs.menuLabel")).toBeNull()
+    rerender(<SubmissionsActionsMenu {...baseProps} onOpenAllPrs={() => {}} />)
+    expect(
+      screen.queryByText("submissions.openAllPrs.menuLabel"),
+    ).not.toBeNull()
+  })
+
+  it("hides the item for an empty_repo assignment even if a handler is passed", () => {
+    render(
+      <SubmissionsActionsMenu
+        {...baseProps}
+        emptyRepo
+        onOpenAllPrs={() => {}}
+      />,
+    )
+    // The whole !emptyRepo block (incl. this item) is gone for empty_repo.
+    expect(screen.queryByText("submissions.openAllPrs.menuLabel")).toBeNull()
+  })
+})

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -4,6 +4,7 @@ import {
   DownloadCloud,
   ExternalLink,
   FileDown,
+  GitPullRequest,
   RefreshCw,
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
@@ -26,6 +27,7 @@ export function SubmissionsActionsMenu({
   onMetrics,
   onCollect,
   onRegradeAll,
+  onOpenAllPrs,
   viewHref,
   viewLabel,
   onDownloadCsv,
@@ -48,6 +50,10 @@ export function SubmissionsActionsMenu({
   onMetrics?: () => void
   onCollect: () => void
   onRegradeAll: () => void
+  // Opens the "Open all Feedback PRs" modal. Omitted (hidden) when the viewer
+  // can't write every repo (non-owner) or the assignment has no Feedback PRs
+  // (empty_repo).
+  onOpenAllPrs?: () => void
   viewHref: string
   viewLabel: string
   onDownloadCsv: () => void
@@ -167,6 +173,27 @@ export function SubmissionsActionsMenu({
                 {viewLabel}
               </a>
             </li>
+            {onOpenAllPrs && (
+              <li>
+                <button
+                  type="button"
+                  disabled={disabledActions}
+                  title={
+                    emptyRoster
+                      ? t("submissions.openAllPrs.titleEmptyRoster")
+                      : t("submissions.openAllPrs.title")
+                  }
+                  onClick={() => {
+                    closeMenu()
+                    if (disabledActions) return
+                    onOpenAllPrs()
+                  }}
+                >
+                  <GitPullRequest aria-hidden="true" className="size-4" />
+                  {t("submissions.openAllPrs.menuLabel")}
+                </button>
+              </li>
+            )}
             <div
               className="my-1 border-t border-base-content/10"
               role="separator"

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -123,6 +123,35 @@ export function SubmissionsActionsMenu({
             role="separator"
           />
         )}
+        {/* Open all Feedback PRs — the bulk PR action leads the menu. Its own
+            group (owner-only, non-empty_repo), above the grading actions. */}
+        {!emptyRepo && onOpenAllPrs && (
+          <>
+            <li>
+              <button
+                type="button"
+                disabled={disabledActions}
+                title={
+                  emptyRoster
+                    ? t("submissions.openAllPrs.titleEmptyRoster")
+                    : t("submissions.openAllPrs.title")
+                }
+                onClick={() => {
+                  closeMenu()
+                  if (disabledActions) return
+                  onOpenAllPrs()
+                }}
+              >
+                <GitPullRequest aria-hidden="true" className="size-4" />
+                {t("submissions.openAllPrs.menuLabel")}
+              </button>
+            </li>
+            <div
+              className="my-1 border-t border-base-content/10"
+              role="separator"
+            />
+          </>
+        )}
         {/* Collect stays for empty_repo assignments: it's org-wide and
             collect_scores.py skips this assignment server-side (see the
             SubmissionsPage comment). Only grading actions hide. */}
@@ -173,33 +202,12 @@ export function SubmissionsActionsMenu({
                 {viewLabel}
               </a>
             </li>
-            {onOpenAllPrs && (
-              <li>
-                <button
-                  type="button"
-                  disabled={disabledActions}
-                  title={
-                    emptyRoster
-                      ? t("submissions.openAllPrs.titleEmptyRoster")
-                      : t("submissions.openAllPrs.title")
-                  }
-                  onClick={() => {
-                    closeMenu()
-                    if (disabledActions) return
-                    onOpenAllPrs()
-                  }}
-                >
-                  <GitPullRequest aria-hidden="true" className="size-4" />
-                  {t("submissions.openAllPrs.menuLabel")}
-                </button>
-              </li>
-            )}
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
-            />
           </>
         )}
+        <div
+          className="my-1 border-t border-base-content/10"
+          role="separator"
+        />
         <li>
           <button
             type="button"

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -22,6 +22,12 @@ vi.mock("@/hooks/useGetRepoCollaborators", () => ({
 vi.mock("@/hooks/useGetFeedbackPr", () => ({
   default: () => ({ refetch: vi.fn() }),
 }))
+vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
+  default: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify: vi.fn() }),
+}))
 vi.mock("@/hooks/useTriggerRegrade", () => ({
   default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),
 }))

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -56,8 +56,10 @@ import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsM
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
 import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
 import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
+import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
-import type { Student } from "@/types/classroom"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import type { AssignmentMode, Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 
 const formatDateTime = (datetime: string) =>
@@ -122,18 +124,31 @@ const HistoryLink = ({
     </span>
   )
 
-// Review action: links to the open Feedback PR (opened by the autograde
-// workflow) when one exists, else opens an info modal. The PR is the source of
-// truth. The /pulls lookup is deferred until Review is clicked (an eager per-row
-// query would fan out to one request per repo on mount); on click we refetch.
-const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
+// Review action: links to the open Feedback PR (opened at accept time, or by
+// the autograde runner) when one exists; when none does, offers a teacher-side
+// Repair that re-runs the same idempotent ensure flow with the teacher's token
+// (issue #347 — recovers a PR a student's accept-time attempt failed to open).
+// The PR is the source of truth. The /pulls lookup is deferred until Review is
+// clicked (an eager per-row query would fan out to one request per repo on
+// mount); on click we refetch.
+const ReviewButton = ({
+  org,
+  repo,
+  mode,
+}: {
+  org: string
+  repo: string
+  mode: AssignmentMode
+}) => {
   const { t } = useTranslation()
+  const { notify } = useToast()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const [resolving, setResolving] = useState(false)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   // enabled: false — driven by refetch() on click, never on mount.
   const { refetch } = useGetFeedbackPr(org, repo, false)
+  const repair = useRepairFeedbackPr()
 
   const handleReview = async () => {
     setResolving(true)
@@ -153,6 +168,44 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
     } finally {
       setResolving(false)
     }
+  }
+
+  // Map the domain's reason code to friendly copy. A `no-baseline` /
+  // `repo-not-found` verdict is structural (no Feedback PR is possible for this
+  // repo), so it stays in the modal rather than as a retryable toast.
+  const repairReasonMessage = (reason: string) =>
+    reason === "no-baseline"
+      ? t("submissions.repairPr.noBaseline")
+      : reason === "repo-not-found"
+        ? t("submissions.repairPr.repoNotFound", { repo })
+        : t("submissions.repairPr.failed", { reason })
+
+  const handleRepair = () => {
+    repair.mutate(
+      { org, repo, mode },
+      {
+        onSuccess: async (result) => {
+          if (result.ok) {
+            notify({
+              tone: "success",
+              durationMs: 5000,
+              message: result.created
+                ? t("submissions.repairPr.created", { repo })
+                : t("submissions.repairPr.alreadyExists", { repo }),
+            })
+            dialogRef.current?.close()
+            // The PR now exists (created or adopted): resolve and open it.
+            const { data: pr } = await refetch()
+            if (pr) window.open(pr.html_url, "_blank", "noopener,noreferrer")
+            return
+          }
+          setErrorMsg(repairReasonMessage(result.reason))
+        },
+        onError: (err) => {
+          setErrorMsg(err instanceof Error ? err.message : String(err))
+        },
+      },
+    )
   }
 
   return (
@@ -198,6 +251,9 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
                 components={{ repo: <MonoLtr /> }}
               />
             </p>
+            <p className="mt-3 text-sm leading-6 text-base-content/70">
+              {t("submissions.repairPr.hint")}
+            </p>
           </>
         )}
         <div className="modal-action">
@@ -209,7 +265,22 @@ const ReviewButton = ({ org, repo }: { org: string; repo: string }) => {
           >
             {t("submissions.reviewModal.openRepoPrs")}
           </a>
-          <Button size="sm" onClick={() => dialogRef.current?.close()}>
+          {!errorMsg && (
+            <Button
+              size="sm"
+              loading={repair.isPending}
+              loadingLabel={t("submissions.repairPr.repairing")}
+              onClick={handleRepair}
+            >
+              {t("submissions.repairPr.repair")}
+            </Button>
+          )}
+          <Button
+            variant={errorMsg ? undefined : "ghost"}
+            size="sm"
+            disabled={repair.isPending}
+            onClick={() => dialogRef.current?.close()}
+          >
             {t("common.close")}
           </Button>
         </div>
@@ -710,7 +781,11 @@ const SubmissionsTable = ({
               />
               {!emptyRepo && (
                 <>
-                  <ReviewButton org={org} repo={repo} />
+                  <ReviewButton
+                    org={org}
+                    repo={repo}
+                    mode={isGroup ? "group" : "individual"}
+                  />
                   <ActionIconLink
                     href={safeHttpUrl(rest.release)}
                     icon={ScrollText}

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -2,12 +2,11 @@ import {
   ChevronRight,
   GitCommitHorizontal,
   Inbox,
-  MessageCircle,
   RefreshCw,
   ScrollText,
   SearchX,
 } from "lucide-react"
-import { Fragment, useId, useMemo, useRef, useState } from "react"
+import { Fragment, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
 import GitHub from "@/assets/github.svg?react"
@@ -24,8 +23,6 @@ import {
   Badge,
   Button,
   EmphasisLtr,
-  Modal,
-  MonoLtr,
   Spinner,
   TablePagination,
   rtlFlip,
@@ -55,11 +52,9 @@ import { ConfirmModal } from "@/components/modals"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
 import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
-import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
-import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
+import { ReviewButton } from "@/pages/submissions/ReviewButton"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
-import { useToast } from "@/context/notifications/NotificationProvider"
-import type { AssignmentMode, Student } from "@/types/classroom"
+import type { Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 
 const formatDateTime = (datetime: string) =>
@@ -131,164 +126,6 @@ const HistoryLink = ({
 // The PR is the source of truth. The /pulls lookup is deferred until Review is
 // clicked (an eager per-row query would fan out to one request per repo on
 // mount); on click we refetch.
-const ReviewButton = ({
-  org,
-  repo,
-  mode,
-}: {
-  org: string
-  repo: string
-  mode: AssignmentMode
-}) => {
-  const { t } = useTranslation()
-  const { notify } = useToast()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const titleId = useId()
-  const [resolving, setResolving] = useState(false)
-  const [errorMsg, setErrorMsg] = useState<string | null>(null)
-  // enabled: false — driven by refetch() on click, never on mount.
-  const { refetch } = useGetFeedbackPr(org, repo, false)
-  const repair = useRepairFeedbackPr()
-
-  const handleReview = async () => {
-    setResolving(true)
-    try {
-      // getOpenPullRequests maps 404 -> [], so a non-404 failure surfaces as
-      // `error`; show it rather than the misleading "no PR yet" message.
-      const { data: pr, error } = await refetch()
-      if (error) {
-        setErrorMsg(error instanceof Error ? error.message : String(error))
-        dialogRef.current?.showModal()
-      } else if (pr) {
-        window.open(pr.html_url, "_blank", "noopener,noreferrer")
-      } else {
-        setErrorMsg(null)
-        dialogRef.current?.showModal()
-      }
-    } finally {
-      setResolving(false)
-    }
-  }
-
-  // Map the domain's reason code to friendly copy. A `no-baseline` /
-  // `repo-not-found` verdict is structural (no Feedback PR is possible for this
-  // repo), so it stays in the modal rather than as a retryable toast.
-  const repairReasonMessage = (reason: string) =>
-    reason === "no-baseline"
-      ? t("submissions.repairPr.noBaseline")
-      : reason === "repo-not-found"
-        ? t("submissions.repairPr.repoNotFound", { repo })
-        : t("submissions.repairPr.failed", { reason })
-
-  const handleRepair = () => {
-    repair.mutate(
-      { org, repo, mode },
-      {
-        onSuccess: async (result) => {
-          if (result.ok) {
-            notify({
-              tone: "success",
-              durationMs: 5000,
-              message: result.created
-                ? t("submissions.repairPr.created", { repo })
-                : t("submissions.repairPr.alreadyExists", { repo }),
-            })
-            dialogRef.current?.close()
-            // The PR now exists (created or adopted): resolve and open it.
-            const { data: pr } = await refetch()
-            if (pr) window.open(pr.html_url, "_blank", "noopener,noreferrer")
-            return
-          }
-          setErrorMsg(repairReasonMessage(result.reason))
-        },
-        onError: (err) => {
-          setErrorMsg(err instanceof Error ? err.message : String(err))
-        },
-      },
-    )
-  }
-
-  return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="square"
-        className="text-base-content/70 disabled:opacity-60"
-        disabled={resolving}
-        loading={resolving}
-        loadingLabel={t("submissions.table.review")}
-        onClick={handleReview}
-        aria-label={t("submissions.table.reviewAria")}
-        title={t("submissions.table.review")}
-      >
-        {!resolving && <MessageCircle aria-hidden="true" className="size-4" />}
-      </Button>
-      <Modal
-        dialogRef={dialogRef}
-        size="md"
-        hideCloseButton
-        aria-labelledby={titleId}
-      >
-        {errorMsg ? (
-          <>
-            <h3 id={titleId} className="text-lg font-bold">
-              {t("submissions.reviewModal.errorTitle")}
-            </h3>
-            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
-              {errorMsg}
-            </p>
-          </>
-        ) : (
-          <>
-            <h3 id={titleId} className="text-lg font-bold">
-              {t("submissions.reviewModal.emptyTitle")}
-            </h3>
-            <p className="mt-2 text-sm leading-6 text-base-content/70">
-              <Trans
-                i18nKey="submissions.reviewModal.emptyBody"
-                values={{ repo }}
-                components={{ repo: <MonoLtr /> }}
-              />
-            </p>
-            <p className="mt-3 text-sm leading-6 text-base-content/70">
-              {t("submissions.repairPr.hint")}
-            </p>
-          </>
-        )}
-        <div className="modal-action">
-          <a
-            className="btn btn-ghost btn-sm"
-            href={`https://github.com/${org}/${repo}/pulls`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            {t("submissions.reviewModal.openRepoPrs")}
-          </a>
-          {!errorMsg && (
-            <Button
-              size="sm"
-              loading={repair.isPending}
-              loadingLabel={t("submissions.repairPr.repairing")}
-              onClick={handleRepair}
-            >
-              {t("submissions.repairPr.repair")}
-            </Button>
-          )}
-          <Button
-            variant={errorMsg ? undefined : "ghost"}
-            size="sm"
-            disabled={repair.isPending}
-            onClick={() => dialogRef.current?.close()}
-          >
-            {t("common.close")}
-          </Button>
-        </div>
-      </Modal>
-    </>
-  )
-}
-
 // Per-row regrade: dispatches regrade.yaml scoped to one owner, tracked via
 // useTriggerRegrade (icon shows progress; disabled while any regrade is in
 // flight). Only kicks off grading — the gradebook refreshes on the next collect.

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -9,6 +9,7 @@ import {
   acceptedRosterCount,
   acceptedUsernames,
   applyStatusSelection,
+  assignmentRepoNames,
   buildGroupDisplayItems,
   buildGroupRosterDisplayItems,
   buildRosterDisplayItems,
@@ -553,6 +554,72 @@ describe("existingGroupRepos", () => {
   it("returns an empty list for null/undefined repos", () => {
     expect(existingGroupRepos(null, "cs101", "hw1")).toEqual([])
     expect(existingGroupRepos(undefined, "cs101", "hw1")).toEqual([])
+  })
+})
+
+describe("assignmentRepoNames", () => {
+  const roster = [
+    student({ username: "alice" }),
+    student({ username: "bob" }),
+    student({ username: "charlie" }),
+  ]
+
+  it("forward-constructs individual repo names for accepted students only", () => {
+    const repos = [
+      repo("cs101-hw1-alice"),
+      repo("cs101-hw1-bob"),
+      repo("cs101-hw2-alice"), // sibling assignment
+      repo("unrelated"),
+    ]
+    const names = assignmentRepoNames({
+      isGroup: false,
+      repos,
+      classroom: "cs101",
+      assignment: "hw1",
+      students: roster,
+    }).toSorted()
+    // charlie has no hw1 repo; hw2/unrelated are excluded.
+    expect(names).toEqual(["cs101-hw1-alice", "cs101-hw1-bob"])
+  })
+
+  it("uses reverse-parsed group repo names for a group assignment", () => {
+    const repos = [
+      repo("cs101-hw1-team-rocket"),
+      repo("cs101-hw1-team-magma"),
+      repo("cs101-hw2-team-aqua"),
+    ]
+    const names = assignmentRepoNames({
+      isGroup: true,
+      repos,
+      classroom: "cs101",
+      assignment: "hw1",
+      students: [],
+    }).toSorted()
+    expect(names).toEqual(["cs101-hw1-team-magma", "cs101-hw1-team-rocket"])
+  })
+
+  it("guards a group assignment against a slug-extending sibling", () => {
+    const names = assignmentRepoNames({
+      isGroup: true,
+      repos: [repo("cs101-hw1-bonus-team")],
+      classroom: "cs101",
+      assignment: "hw1",
+      students: [],
+      siblingSlugs: ["hw1", "hw1-bonus"],
+    })
+    expect(names).toEqual([])
+  })
+
+  it("returns an empty list when the org repo list isn't loaded", () => {
+    expect(
+      assignmentRepoNames({
+        isGroup: false,
+        repos: null,
+        classroom: "cs101",
+        assignment: "hw1",
+        students: roster,
+      }),
+    ).toEqual([])
   })
 })
 

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -438,6 +438,32 @@ export function hasAccepted(username: string, accepted: Set<string>): boolean {
   return accepted.has(username.trim().toLowerCase())
 }
 
+// All existing assignment repo names for a bulk per-repo teacher action (e.g.
+// opening every Feedback PR — issue #347). Mode-aware: individual repos are
+// forward-constructed per accepted student (studentRepoName), group repos come
+// from existingGroupRepos (reverse-parsed, sibling-guarded). Deduped and
+// lowercased to match the org repo list. Empty when the inputs aren't ready.
+export function assignmentRepoNames(params: {
+  isGroup: boolean
+  repos: GitHubRepo[] | null | undefined
+  classroom: string
+  assignment: string
+  students: Student[]
+  siblingSlugs?: string[]
+}): string[] {
+  const { isGroup, repos, classroom, assignment, students, siblingSlugs } =
+    params
+  if (isGroup) {
+    return existingGroupRepos(repos, classroom, assignment, siblingSlugs).map(
+      (r) => r.repoName,
+    )
+  }
+  const accepted = acceptedUsernames(repos, classroom, assignment, students)
+  return [...accepted].map((login) =>
+    studentRepoName(classroom, assignment, login),
+  )
+}
+
 // An existing group repo derived from the org repo list, keyed by its founder
 // (the `<owner>` segment of `<classroom>-<assignment>-<owner>`).
 export type GroupRepo = { owner: string; repoName: string }


### PR DESCRIPTION
## Summary

Improves the automated PR experience for teachers now that the Feedback PR is opened at accept time (decoupled from the autograder, issue #347). Adds two teacher-side recovery/management tools and makes the PR body agnostic about who opened it.

- **Per-row repair** — when a student's accept-time Feedback PR failed to open (a GitHub outage or transient error), the Submissions table's Review action offers a **Repair Feedback PR** button that re-runs the same idempotent `ensureFeedbackPullRequest` flow with the teacher's token, instead of a dead-end pointing at the repo's PR list. Lives in its own `ReviewButton.tsx`.

- **Bulk open** — a new **Open all Feedback PRs** item in the Actions menu opens a Feedback PR on every existing assignment repo in one action: a bounded-concurrency fan-out over the same idempotent flow, with a live progress modal (X of N) and a per-outcome summary. Idempotent, so re-running only fills the gaps. Owner-only and hidden for empty-repo assignments.

- **Honest outcome buckets** — the bulk summary distinguishes opened / already-had-one / skipped (no baseline) / **blocked** / failed. A student-precreated `feedback` branch throws the never-retryable base-mismatch; it now lands in a distinct **blocked** bucket that names the real fix (an org admin must delete the branch), rather than the retryable **failed** bucket whose "re-run to retry" copy would loop the teacher forever. Backed by a stable `code` (`base-mismatch` | `transient`) on the domain result.

- **Agnostic PR body** — the Feedback PR body no longer implies GitHub Actions maintains it ("stays up to date automatically as you push", "kept up to date automatically"), since accept clients now open it too. Updated in lockstep across the Go, Python, and TypeScript copies and the shared golden.

- **Menu reorder** — the Actions menu leads with Open all Feedback PRs, then the grading actions (Collect / Regrade all), then Download, each in its own divided group.

## Design notes

The whole feature reuses the existing `ensureFeedbackPullRequest` so a teacher-opened PR is byte-identical to an accept-time or runner-opened one and the runner still adopts it by base+head. The base-mismatch guard is unchanged: a `feedback` branch frozen at the wrong SHA still defers to an org admin rather than being force-updated. Architecture boundaries are respected — the mutation hooks own `useQueryClient` / `githubKeys`; the domain layer stays free of view imports.

## Review follow-ups (addressed in this PR)

A `ce-code-review` pass flagged four items, all resolved: extracted `ReviewButton` into its own file (dropping `SubmissionsTable.tsx` from 1020 back to 858 lines and splitting its two concerns), gave the never-retryable base-mismatch its own `blocked` outcome/copy, and added a `ReviewButton` repair-flow test covering every branch.

## Test plan

- [x] `npm run check` in `web/` — tsc, eslint (0 errors), prettier, arch:validate, and 2682 vitest tests (incl. the i18n keyAudit and the new ReviewButton repair-flow test) pass.
- [x] Go `cli/shared` + `cli/gh-teacher` build and tests pass (Feedback PR contract parity + golden).
- [x] Python `cli/gh-teacher/skeleton_tests` — 603 passed (incl. `test_ensure_feedback_pr.py` body parity).
- [ ] Manual: on a live classroom, Repair a repo missing its PR; Open all Feedback PRs across a mix of repos (some with a PR, some without, one with a mis-frozen `feedback` branch) and confirm the summary buckets (opened / existing / blocked / failed).