### PR TITLE
feat(cli): open and repair Feedback PRs from the teacher CLI

### DIFF
--- a/cli/gh-student/internal/classroomcfg/metadata.go
+++ b/cli/gh-student/internal/classroomcfg/metadata.go
@@ -29,9 +29,10 @@ import (
 // Feedback-PR baseline as "the commit that introduced .classroom50.yaml", not
 // by matching the commit subject. Every accept client (this CLI, the web GUI,
 // any future client) MUST create this file in its accept commit; the commit
-// subject carries no contract. Mirrored runner-side as
-// runner.ACCEPT_MARKER_PATH (cli/gh-teacher/skeleton/dotgithub/scripts/runner.py).
-const MetadataPath = ".classroom50.yaml"
+// subject carries no contract. Aliased to the shared contract constant so the
+// runner-side ACCEPT_MARKER_PATH and the teacher CLI can't drift from it
+// (cli/gh-teacher/skeleton/dotgithub/scripts/runner.py).
+const MetadataPath = contract.MetadataPath
 
 // AutogradeWorkflowPath is the in-repo destination for the autograde shim
 // written at accept time.

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -22,6 +22,7 @@ import (
 	"github.com/foundation50/gh-teacher/internal/cliutil"
 	"github.com/foundation50/gh-teacher/internal/configrepo"
 	"github.com/foundation50/gh-teacher/internal/configwrite"
+	"github.com/foundation50/gh-teacher/internal/feedbackpr"
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 	"github.com/foundation50/gh-teacher/internal/output"
 	"github.com/foundation50/gh-teacher/internal/validate"
@@ -54,6 +55,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(assignmentRemoveCmd())
 	cmd.AddCommand(assignmentListCmd())
 	cmd.AddCommand(assignmentTestCmd())
+	cmd.AddCommand(feedbackpr.NewCmd())
 	return cmd
 }
 

--- a/cli/gh-teacher/internal/feedbackpr/ensure.go
+++ b/cli/gh-teacher/internal/feedbackpr/ensure.go
@@ -62,12 +62,11 @@ func isFeedbackPRRetryable(err error) bool {
 // token and the teacher CLI's client (which has no Patch verb — PATCH goes
 // through Request). Keep behavior in lockstep with that file and the runner's
 // ensure_feedback_pr.py.
-func ensureFeedbackPullRequest(client githubapi.Client, org, repoName, mode string) error {
-	branch, err := defaultBranch(client, org, repoName)
-	if err != nil {
-		return err
-	}
-
+//
+// branch is the repo's settled default branch (the head the PR opens against),
+// resolved once by the caller from the same repo-object read that gates
+// not-accepted-yet, so this never re-fetches it.
+func ensureFeedbackPullRequest(client githubapi.Client, org, repoName, branch, mode string) error {
 	acceptSHA := memoizeSHA(func() (string, error) { return acceptCommitSHA(client, org, repoName) })
 
 	var lastErr error
@@ -138,10 +137,7 @@ func tryEnsureFeedbackPullRequest(client githubapi.Client, org, repoName, branch
 
 	// Label best-effort: the PR is in place, so a label failure never fails
 	// the step (mirrors the runner's check=False label step).
-	if err := labelFeedbackPR(client, org, repoName, prNumber, mode); err != nil {
-		// Non-fatal; the PR exists. Swallow — the summary reports the open.
-		_ = err
-	}
+	_ = labelFeedbackPR(client, org, repoName, prNumber, mode)
 	return nil
 }
 
@@ -155,22 +151,6 @@ func feedbackPRRaceOr(client githubapi.Client, org, repoName, branch string, cre
 		return errAlreadyExists
 	}
 	return createErr
-}
-
-// defaultBranch reads the repo's settled default branch (the branch the accept
-// commit actually landed on — may be `master`, not a pre-guessed `main`).
-func defaultBranch(client githubapi.Client, org, repoName string) (string, error) {
-	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(repoName))
-	var repo struct {
-		DefaultBranch string `json:"default_branch"`
-	}
-	if err := client.Get(path, &repo); err != nil {
-		return "", fmt.Errorf("GET %s: %w", path, err)
-	}
-	if repo.DefaultBranch == "" {
-		return "main", nil
-	}
-	return repo.DefaultBranch, nil
 }
 
 // acceptCommitSHA recovers the accept commit — the earliest commit touching the

--- a/cli/gh-teacher/internal/feedbackpr/ensure.go
+++ b/cli/gh-teacher/internal/feedbackpr/ensure.go
@@ -16,10 +16,10 @@ import (
 )
 
 // metadataPath is the in-repo accept marker whose introducing commit anchors
-// the frozen `feedback` base. Kept as a local const (not shared) to avoid
-// widening cli/shared; byte-identical with classroomcfg.MetadataPath
-// (cli/gh-student) and the runner's ACCEPT_MARKER_PATH.
-const metadataPath = ".classroom50.yaml"
+// the frozen `feedback` base. Aliased to the shared contract constant so this
+// fourth reader can't drift from the student CLI, the runner
+// (ACCEPT_MARKER_PATH), and the web GUI.
+const metadataPath = contract.MetadataPath
 
 // errBaseMismatch marks the never-retryable poisoned-base case: the `feedback`
 // branch is frozen at a commit other than the accept SHA (a student
@@ -60,8 +60,15 @@ func isFeedbackPRRetryable(err error) bool {
 //
 // Ports the accept-side flow (cli/gh-student/feedback_pr.go) to the teacher
 // token and the teacher CLI's client (which has no Patch verb — PATCH goes
-// through Request). Keep behavior in lockstep with that file and the runner's
-// ensure_feedback_pr.py.
+// through Request). Keep the GitHub-facing sequence in lockstep with that file
+// and the runner's ensure_feedback_pr.py — but note two DELIBERATE divergences
+// from the student port, so a future sync doesn't "fix" them back: (1) the
+// success/exists/mismatch outcomes are returned as the errAlreadyExists /
+// errBaseMismatch sentinels (the student side returns plain nil for "exists")
+// so run()'s summary can bucket them; (2) verbose/UI reporting lives in the
+// caller, not here. A parity guard would be a shared core returning a typed
+// outcome; until then, treat any behavioral edit here as one to mirror in the
+// student CLI and the runner.
 //
 // branch is the repo's settled default branch (the head the PR opens against),
 // resolved once by the caller from the same repo-object read that gates
@@ -153,11 +160,17 @@ func feedbackPRRaceOr(client githubapi.Client, org, repoName, branch string, cre
 	return createErr
 }
 
-// acceptCommitSHA recovers the accept commit — the earliest commit touching the
-// .classroom50.yaml marker — the same resolution rule the runner's
-// baseline_sha() applies, so the feedback base frozen here matches what the
-// runner later verifies. The history is walked to exhaustion rather than
-// trusting one page.
+// acceptCommitSHA recovers the accept commit — the oldest commit touching the
+// .classroom50.yaml marker — via the commits API, the same rule the web GUI's
+// getOldestCommitShaForPath uses. Both are checkout-less API clients, so they
+// approximate the runner's git-side baseline_sha() (which uses
+// `git log --reverse --first-parent --diff-filter=A`, i.e. the oldest commit
+// that *added* the marker on the mainline). The two agree in the normal
+// single-add case; they can differ only when the marker is deleted-and-readded
+// or added off the mainline, in which case the runner's base-SHA check refuses
+// to adopt the frozen branch (a mismatch an org admin resolves). The history is
+// walked to exhaustion rather than trusting one page — a wrong (newer) SHA is
+// worse than a slow read once the marker's history exceeds one page.
 func acceptCommitSHA(client githubapi.Client, org, repoName string) (string, error) {
 	commits, err := githubapi.PaginateAll[struct {
 		SHA string `json:"sha"`

--- a/cli/gh-teacher/internal/feedbackpr/ensure.go
+++ b/cli/gh-teacher/internal/feedbackpr/ensure.go
@@ -1,0 +1,416 @@
+package feedbackpr
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/classroom50-cli-shared/ghutil"
+	"github.com/foundation50/gh-teacher/internal/githubapi"
+)
+
+// metadataPath is the in-repo accept marker whose introducing commit anchors
+// the frozen `feedback` base. Kept as a local const (not shared) to avoid
+// widening cli/shared; byte-identical with classroomcfg.MetadataPath
+// (cli/gh-student) and the runner's ACCEPT_MARKER_PATH.
+const metadataPath = ".classroom50.yaml"
+
+// errBaseMismatch marks the never-retryable poisoned-base case: the `feedback`
+// branch is frozen at a commit other than the accept SHA (a student
+// pre-created it), so only an org admin deleting the branch can fix it. The
+// caller routes it to the distinct "blocked" bucket rather than the retryable
+// "failed" one. errAlreadyExists marks the idempotent no-op (a Feedback PR
+// already exists in some state) so the summary can count it apart from a fresh
+// open.
+var (
+	errBaseMismatch  = errors.New("feedback base mismatch")
+	errAlreadyExists = errors.New("feedback PR already exists")
+)
+
+func isBaseMismatch(err error) bool  { return errors.Is(err, errBaseMismatch) }
+func isAlreadyExists(err error) bool { return errors.Is(err, errAlreadyExists) }
+
+// feedbackPRAttempts / isFeedbackPRRetryable bound retries of the whole ensure
+// against GitHub's post-create git-data lag. The ensure is idempotent (a PR in
+// any state short-circuits, the base ref tolerates already-exists at the right
+// SHA), so a retry after a partial write is safe. Mirrors the accept-side CLI
+// (cli/gh-student/feedback_pr.go).
+const feedbackPRAttempts = 3
+
+func isFeedbackPRRetryable(err error) bool {
+	if ghutil.IsHTTPNotFound(err) || ghutil.IsHTTPStatus(err, http.StatusConflict) {
+		return true
+	}
+	httpErr, ok := errors.AsType[*githubapi.HTTPError](err)
+	return ok && httpErr.StatusCode >= 500
+}
+
+// ensureFeedbackPullRequest opens the assignment's Feedback PR on org/repoName
+// idempotently — base = the frozen `feedback` branch at the repo's accept
+// commit, head = its default branch — retrying the whole sequence through
+// GitHub's post-create git-data lag. Returns nil after opening a PR,
+// errAlreadyExists when one already exists (no writes), errBaseMismatch when
+// the `feedback` branch is frozen at the wrong SHA, or a transient error.
+//
+// Ports the accept-side flow (cli/gh-student/feedback_pr.go) to the teacher
+// token and the teacher CLI's client (which has no Patch verb — PATCH goes
+// through Request). Keep behavior in lockstep with that file and the runner's
+// ensure_feedback_pr.py.
+func ensureFeedbackPullRequest(client githubapi.Client, org, repoName, mode string) error {
+	branch, err := defaultBranch(client, org, repoName)
+	if err != nil {
+		return err
+	}
+
+	acceptSHA := memoizeSHA(func() (string, error) { return acceptCommitSHA(client, org, repoName) })
+
+	var lastErr error
+	for attempt := range feedbackPRAttempts {
+		err := tryEnsureFeedbackPullRequest(client, org, repoName, branch, mode, acceptSHA)
+		if err == nil || isAlreadyExists(err) {
+			return err
+		}
+		lastErr = err
+		if !isFeedbackPRRetryable(err) {
+			return err
+		}
+		if attempt < feedbackPRAttempts-1 {
+			time.Sleep(ghutil.BackoffDelay(attempt))
+		}
+	}
+	return lastErr
+}
+
+// memoizeSHA resolves at most once across retries; a failed resolution is not
+// cached (it's one of the transient conditions the retry exists for).
+func memoizeSHA(resolve func() (string, error)) func() (string, error) {
+	var cached string
+	return func() (string, error) {
+		if cached != "" {
+			return cached, nil
+		}
+		sha, err := resolve()
+		if err != nil {
+			return "", err
+		}
+		cached = sha
+		return sha, nil
+	}
+}
+
+func tryEnsureFeedbackPullRequest(client githubapi.Client, org, repoName, branch, mode string, resolveAcceptSHA func() (string, error)) error {
+	if exists, err := feedbackPRExists(client, org, repoName, branch); err != nil {
+		return err
+	} else if exists {
+		return errAlreadyExists
+	}
+
+	acceptSHA, err := resolveAcceptSHA()
+	if err != nil {
+		return err
+	}
+	if err := createFeedbackBaseRef(client, org, repoName, acceptSHA); err != nil {
+		return err
+	}
+
+	prNumber, err := createFeedbackPR(client, org, repoName, branch)
+	if err != nil {
+		if !isNoCommitsBetween(err) {
+			return feedbackPRRaceOr(client, org, repoName, branch, err)
+		}
+		// Zero diff is the normal case for an un-pushed repo: GitHub refuses a
+		// PR with no commits between base and head, so land one empty commit
+		// (same tree; `[skip ci]` keeps the shim quiet) and retry once.
+		if err := pushFeedbackEmptyCommit(client, org, repoName, branch); err != nil {
+			return err
+		}
+		prNumber, err = createFeedbackPR(client, org, repoName, branch)
+		if err != nil {
+			return feedbackPRRaceOr(client, org, repoName, branch, err)
+		}
+	}
+
+	// Label best-effort: the PR is in place, so a label failure never fails
+	// the step (mirrors the runner's check=False label step).
+	if err := labelFeedbackPR(client, org, repoName, prNumber, mode); err != nil {
+		// Non-fatal; the PR exists. Swallow — the summary reports the open.
+		_ = err
+	}
+	return nil
+}
+
+// feedbackPRRaceOr swallows createErr when the PR turns out to exist after all
+// (two concurrent opens can both pass the existence probe; the loser gets a 422
+// "already exists"). The original error survives when the re-query finds
+// nothing, so a genuine failure is never masked. Mirrors the runner's
+// existing_pr_url re-query.
+func feedbackPRRaceOr(client githubapi.Client, org, repoName, branch string, createErr error) error {
+	if exists, err := feedbackPRExists(client, org, repoName, branch); err == nil && exists {
+		return errAlreadyExists
+	}
+	return createErr
+}
+
+// defaultBranch reads the repo's settled default branch (the branch the accept
+// commit actually landed on — may be `master`, not a pre-guessed `main`).
+func defaultBranch(client githubapi.Client, org, repoName string) (string, error) {
+	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(repoName))
+	var repo struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := client.Get(path, &repo); err != nil {
+		return "", fmt.Errorf("GET %s: %w", path, err)
+	}
+	if repo.DefaultBranch == "" {
+		return "main", nil
+	}
+	return repo.DefaultBranch, nil
+}
+
+// acceptCommitSHA recovers the accept commit — the earliest commit touching the
+// .classroom50.yaml marker — the same resolution rule the runner's
+// baseline_sha() applies, so the feedback base frozen here matches what the
+// runner later verifies. The history is walked to exhaustion rather than
+// trusting one page.
+func acceptCommitSHA(client githubapi.Client, org, repoName string) (string, error) {
+	commits, err := githubapi.PaginateAll[struct {
+		SHA string `json:"sha"`
+	}](client, 100, 100, func(page int) string {
+		return fmt.Sprintf("repos/%s/%s/commits?path=%s&per_page=100&page=%d",
+			url.PathEscape(org), url.PathEscape(repoName),
+			url.QueryEscape(metadataPath), page)
+	}, nil)
+	if err != nil {
+		return "", err
+	}
+	if len(commits) == 0 {
+		return "", fmt.Errorf("no commits touch %s in %s/%s", metadataPath, org, repoName)
+	}
+	// Newest-first, so the last entry is the accept commit.
+	return commits[len(commits)-1].SHA, nil
+}
+
+// feedbackPRExists reports whether a Feedback PR (base=feedback, head=branch)
+// exists in ANY state. Closed/merged count: reopening is teacher/runner
+// territory, and a re-created PR would demand a second empty commit.
+func feedbackPRExists(client githubapi.Client, org, repoName, branch string) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s/pulls?base=%s&head=%s&state=all&per_page=1",
+		url.PathEscape(org), url.PathEscape(repoName),
+		url.QueryEscape(contract.FeedbackBaseBranch),
+		url.QueryEscape(org+":"+branch))
+	var prs []struct {
+		Number int `json:"number"`
+	}
+	if err := client.Get(path, &prs); err != nil {
+		return false, fmt.Errorf("GET %s: %w", path, err)
+	}
+	return len(prs) > 0, nil
+}
+
+// createFeedbackBaseRef freezes the `feedback` branch at the accept commit. An
+// already-existing ref is only adopted once it READS BACK at acceptSHA: the org
+// ruleset locks updates/deletion but leaves creation open, so a student can
+// pre-create `feedback` at a commit of their choosing; opening the PR over that
+// base would hand the teacher a diff the student picked. A mismatch returns
+// errBaseMismatch (routed to the blocked bucket).
+func createFeedbackBaseRef(client githubapi.Client, org, repoName, acceptSHA string) error {
+	body, err := json.Marshal(map[string]string{
+		"ref": "refs/heads/" + contract.FeedbackBaseBranch,
+		"sha": acceptSHA,
+	})
+	if err != nil {
+		return fmt.Errorf("encoding feedback ref body: %w", err)
+	}
+	path := fmt.Sprintf("repos/%s/%s/git/refs", url.PathEscape(org), url.PathEscape(repoName))
+	if err := client.Post(path, bytes.NewReader(body), nil); err != nil {
+		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok && is422AlreadyExists(httpErr) {
+			return verifyFeedbackBaseRef(client, org, repoName, acceptSHA)
+		}
+		return fmt.Errorf("POST %s: %w", path, err)
+	}
+	return nil
+}
+
+// verifyFeedbackBaseRef confirms the existing `feedback` branch points at
+// acceptSHA. A read failure is NOT treated as a match: an unverifiable base is
+// as unsafe as a wrong one (same rule as the runner's existing_base_sha, which
+// raises on anything but a genuine 404).
+func verifyFeedbackBaseRef(client githubapi.Client, org, repoName, acceptSHA string) error {
+	sha, err := branchTipSHA(client, org, repoName, contract.FeedbackBaseBranch)
+	if err != nil {
+		return err
+	}
+	if sha != acceptSHA {
+		return fmt.Errorf("%w: %s branch is at %s, not the expected baseline %s — an org admin must delete it so it can be re-frozen correctly",
+			errBaseMismatch, contract.FeedbackBaseBranch, sha, acceptSHA)
+	}
+	return nil
+}
+
+// branchTipSHA reads one branch's tip via the SINGULAR git/ref/heads/<branch>
+// endpoint: the plural form matches by prefix, so a branch whose name prefixes
+// another would silently resolve to the wrong ref.
+func branchTipSHA(client githubapi.Client, org, repoName, branch string) (string, error) {
+	path := fmt.Sprintf("repos/%s/%s/git/ref/heads/%s",
+		url.PathEscape(org), url.PathEscape(repoName), url.PathEscape(branch))
+	var ref struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := client.Get(path, &ref); err != nil {
+		return "", fmt.Errorf("GET %s: %w", path, err)
+	}
+	return ref.Object.SHA, nil
+}
+
+// createFeedbackPR opens the Feedback PR and returns its number. Title and body
+// come from the shared contract, so whichever side creates the PR, teachers and
+// the runner's backfill_release_link see the same thing.
+func createFeedbackPR(client githubapi.Client, org, repoName, branch string) (int, error) {
+	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/latest", org, repoName)
+	body, err := json.Marshal(map[string]string{
+		"base":  contract.FeedbackBaseBranch,
+		"head":  branch,
+		"title": contract.FeedbackPRTitle,
+		"body":  contract.FeedbackPRBody(branch, releaseURL),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("encoding feedback PR body: %w", err)
+	}
+	path := fmt.Sprintf("repos/%s/%s/pulls", url.PathEscape(org), url.PathEscape(repoName))
+	var created struct {
+		Number int `json:"number"`
+	}
+	if err := client.Post(path, bytes.NewReader(body), &created); err != nil {
+		return 0, fmt.Errorf("POST %s: %w", path, err)
+	}
+	return created.Number, nil
+}
+
+// isNoCommitsBetween matches GitHub's 422 refusal of a zero-diff PR ("No
+// commits between feedback and main") — the signal to land the empty commit and
+// retry.
+func isNoCommitsBetween(err error) bool {
+	httpErr, ok := errors.AsType[*githubapi.HTTPError](err)
+	return ok && has422Message(httpErr, "no commits between")
+}
+
+// pushFeedbackEmptyCommit fast-forwards `branch` by one empty commit (same tree
+// as the current head) so a zero-diff Feedback PR has a commit to exist on.
+// force stays false: losing the ref race to a student's instant first push
+// means the runner opens the PR on that submission instead — overwriting their
+// work is never acceptable. The teacher client has no Patch verb, so the ref
+// update goes through Request(PATCH).
+func pushFeedbackEmptyCommit(client githubapi.Client, org, repoName, branch string) error {
+	headSHA, err := branchTipSHA(client, org, repoName, branch)
+	if err != nil {
+		return err
+	}
+
+	commitPath := fmt.Sprintf("repos/%s/%s/git/commits/%s",
+		url.PathEscape(org), url.PathEscape(repoName), url.PathEscape(headSHA))
+	var head struct {
+		Tree struct {
+			SHA string `json:"sha"`
+		} `json:"tree"`
+	}
+	if err := client.Get(commitPath, &head); err != nil {
+		return fmt.Errorf("GET %s: %w", commitPath, err)
+	}
+
+	createBody, err := json.Marshal(map[string]any{
+		"message": contract.FeedbackOpenCommitMessage(),
+		"tree":    head.Tree.SHA,
+		"parents": []string{headSHA},
+	})
+	if err != nil {
+		return fmt.Errorf("encoding empty commit body: %w", err)
+	}
+	createPath := fmt.Sprintf("repos/%s/%s/git/commits", url.PathEscape(org), url.PathEscape(repoName))
+	var created struct {
+		SHA string `json:"sha"`
+	}
+	if err := client.Post(createPath, bytes.NewReader(createBody), &created); err != nil {
+		return fmt.Errorf("POST %s: %w", createPath, err)
+	}
+
+	patchBody, err := json.Marshal(map[string]any{"sha": created.SHA, "force": false})
+	if err != nil {
+		return fmt.Errorf("encoding ref update body: %w", err)
+	}
+	patchPath := fmt.Sprintf("repos/%s/%s/git/refs/heads/%s",
+		url.PathEscape(org), url.PathEscape(repoName), url.PathEscape(branch))
+	resp, err := client.Request(http.MethodPatch, patchPath, bytes.NewReader(patchBody))
+	if err != nil {
+		return fmt.Errorf("PATCH %s: %w", patchPath, err)
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+// labelFeedbackPR pins the mode label on the PR, creating the label first so
+// its color matches the runner's. Both steps tolerate already-exists; the
+// caller treats any error as non-fatal.
+func labelFeedbackPR(client githubapi.Client, org, repoName string, prNumber int, mode string) error {
+	name, color := contract.FeedbackLabelForMode(mode)
+
+	labelBody, err := json.Marshal(map[string]string{
+		"name":        name,
+		"color":       color,
+		"description": "Classroom 50 teacher-managed feedback PR",
+	})
+	if err != nil {
+		return fmt.Errorf("encoding label body: %w", err)
+	}
+	labelPath := fmt.Sprintf("repos/%s/%s/labels", url.PathEscape(org), url.PathEscape(repoName))
+	if err := client.Post(labelPath, bytes.NewReader(labelBody), nil); err != nil {
+		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); !ok || !is422AlreadyExists(httpErr) {
+			return fmt.Errorf("POST %s: %w", labelPath, err)
+		}
+	}
+
+	addBody, err := json.Marshal(map[string][]string{"labels": {name}})
+	if err != nil {
+		return fmt.Errorf("encoding add-labels body: %w", err)
+	}
+	addPath := fmt.Sprintf("repos/%s/%s/issues/%d/labels",
+		url.PathEscape(org), url.PathEscape(repoName), prNumber)
+	if err := client.Post(addPath, bytes.NewReader(addBody), nil); err != nil {
+		return fmt.Errorf("POST %s: %w", addPath, err)
+	}
+	return nil
+}
+
+// is422AlreadyExists / has422Message classify GitHub's 422s by message text
+// (the only signal — errors[].code is the generic "custom"). Local copies of
+// the accept-side helpers (cli/gh-student/accept.go).
+func is422AlreadyExists(httpErr *githubapi.HTTPError) bool {
+	return has422Message(httpErr, "already exists")
+}
+
+func has422Message(httpErr *githubapi.HTTPError, needle string) bool {
+	return httpErr.StatusCode == http.StatusUnprocessableEntity &&
+		httpErrorMentions(httpErr, needle)
+}
+
+// httpErrorMentions reports whether needle (lower-case) appears in the error's
+// top-level message or any Errors[] item; GitHub puts the reason in either slot
+// depending on the endpoint.
+func httpErrorMentions(httpErr *githubapi.HTTPError, needle string) bool {
+	if strings.Contains(strings.ToLower(httpErr.Message), needle) {
+		return true
+	}
+	for _, item := range httpErr.Errors {
+		if strings.Contains(strings.ToLower(item.Message), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/gh-teacher/internal/feedbackpr/ensure_test.go
+++ b/cli/gh-teacher/internal/feedbackpr/ensure_test.go
@@ -22,10 +22,13 @@ type ensureServer struct {
 	existingPRState string // non-empty -> the base+head PR list returns one PR in that state
 	refExists       bool   // POST /git/refs 422 "Reference already exists"
 	existingBaseSHA string // GET /git/ref/heads/feedback SHA when refExists ("" -> read 404s)
+	refReadStatus   int    // when refExists and non-zero, GET /git/ref/heads/feedback returns this status (overrides existingBaseSHA)
 	headHasDiff     bool   // first pulls POST succeeds immediately (no zero-diff 422)
 	failPRCreate    bool   // every pulls POST 403
 	prCreateRace    bool   // pulls POST 422 "already exists" and the NEXT list reports one
 	failLabelAdd    bool   // POST /issues/{n}/labels fails
+	failRefPatch    bool   // PATCH /git/refs/heads/main 422 (lost the fast-forward race)
+	retryablePRList int    // fail the first N GET /pulls with a retryable 502, then behave normally
 
 	prListStates []string
 
@@ -35,6 +38,7 @@ type ensureServer struct {
 	refPatches    int
 	prCreates     int
 	labelAdds     int
+	prListCalls   int
 
 	lastCommitMessage string
 	lastCommitTree    string
@@ -55,6 +59,13 @@ func (s *ensureServer) mux(t *testing.T) *http.ServeMux {
 
 	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
+			s.prListCalls++
+			// Ride out the whole-ensure retry: fail the first N existence
+			// probes with a retryable 502, then behave normally.
+			if s.prListCalls <= s.retryablePRList {
+				write422or403(w, http.StatusBadGateway, `{"message":"Server Error"}`)
+				return
+			}
 			s.prListStates = append(s.prListStates, r.URL.Query().Get("state"))
 			if s.existingPRState != "" || (s.prCreateRace && s.prCreates > 0) {
 				state := s.existingPRState
@@ -104,6 +115,10 @@ func (s *ensureServer) mux(t *testing.T) *http.ServeMux {
 
 	mux.HandleFunc("/repos/o/r/git/ref/heads/feedback", func(w http.ResponseWriter, _ *http.Request) {
 		s.refReads++
+		if s.refReadStatus != 0 {
+			write422or403(w, s.refReadStatus, `{"message":"Server Error"}`)
+			return
+		}
 		if s.existingBaseSHA == "" {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = io.WriteString(w, `{"message":"Not Found"}`)
@@ -137,6 +152,12 @@ func (s *ensureServer) mux(t *testing.T) *http.ServeMux {
 			return
 		}
 		s.refPatches++
+		if s.failRefPatch {
+			// Lost the fast-forward race (a student pushed between our
+			// branch-tip read and this PATCH): GitHub 422s a non-fast-forward.
+			write422or403(w, http.StatusUnprocessableEntity, `{"message":"Update is not a fast forward"}`)
+			return
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"ref": "refs/heads/main"})
 	})
 
@@ -337,5 +358,70 @@ func TestEnsure_GroupLabel(t *testing.T) {
 	}
 	if len(s.lastAddedLabels) != 1 || s.lastAddedLabels[0] != "Group Assignment" {
 		t.Errorf("added labels = %v, want [Group Assignment]", s.lastAddedLabels)
+	}
+}
+
+// TestEnsure_RetryableFailureThenSuccess pins the whole-ensure retry loop (the
+// reason this package rides out GitHub's post-create git-data lag): the first
+// existence probe 502s (retryable), so the ensure retries and the second
+// attempt opens the PR. Without the loop this would surface the 502 as a
+// failure.
+func TestEnsure_RetryableFailureThenSuccess(t *testing.T) {
+	s := &ensureServer{retryablePRList: 1, headHasDiff: true}
+	if err := runEnsure(t, s, contract.ModeIndividual); err != nil {
+		t.Fatalf("a retryable 502 on attempt 1 should be ridden out, got %v", err)
+	}
+	if s.prListCalls < 2 {
+		t.Errorf("existence probe called %d times, want >=2 (a retry after the 502)", s.prListCalls)
+	}
+	if s.prCreates == 0 {
+		t.Error("PR never created after the retry succeeded")
+	}
+}
+
+// TestEnsure_RefPatchFailureSurfacesError pins the lost-ref-race path the
+// force:false empty commit is built around: when a student pushes between our
+// branch-tip read and the fast-forward PATCH, GitHub 422s the non-fast-forward,
+// and the ensure surfaces that as a (failed-bucket) error rather than opening a
+// PR over a stale head. 422 is non-retryable, so a re-run — by which point the
+// student's push gives the head a diff — heals it.
+func TestEnsure_RefPatchFailureSurfacesError(t *testing.T) {
+	s := &ensureServer{failRefPatch: true}
+	err := runEnsure(t, s, contract.ModeIndividual)
+	if err == nil {
+		t.Fatal("want an error when the fast-forward PATCH loses the race, got nil")
+	}
+	if isAlreadyExists(err) || isBaseMismatch(err) {
+		t.Errorf("a lost ref race must be a plain (failed) error, got %v", err)
+	}
+	if s.commitCreates != 1 {
+		t.Errorf("empty commit created %d times, want 1 (created before the failing PATCH)", s.commitCreates)
+	}
+	// The retried create must never run: the head never fast-forwarded, so
+	// opening a PR now would be over the stale head.
+	if s.prCreates != 1 {
+		t.Errorf("pulls POST attempted %d times, want 1 (no create after the PATCH failed)", s.prCreates)
+	}
+}
+
+// TestEnsure_UnverifiableBaseIsNotAdopted pins the safety rule that an
+// unverifiable existing base is as unsafe as a wrong one: after the ref-create
+// 422 (already exists), a NON-404 read-back error (here a 500) must fail the
+// ensure — never silently adopt the branch and open a PR over an unverified
+// base.
+func TestEnsure_UnverifiableBaseIsNotAdopted(t *testing.T) {
+	s := &ensureServer{refExists: true, refReadStatus: http.StatusInternalServerError}
+	err := runEnsure(t, s, contract.ModeIndividual)
+	if err == nil {
+		t.Fatal("want an error when the existing base can't be verified, got nil")
+	}
+	if isAlreadyExists(err) || isBaseMismatch(err) {
+		t.Errorf("an unverifiable base must be a plain error, not exists/mismatch, got %v", err)
+	}
+	if s.refReads == 0 {
+		t.Error("the existing feedback ref was never read back")
+	}
+	if s.prCreates != 0 {
+		t.Errorf("PR created (%d times) over an unverified base", s.prCreates)
 	}
 }

--- a/cli/gh-teacher/internal/feedbackpr/ensure_test.go
+++ b/cli/gh-teacher/internal/feedbackpr/ensure_test.go
@@ -178,7 +178,7 @@ func runEnsure(t *testing.T, s *ensureServer, mode string) error {
 	server := httptest.NewServer(s.mux(t))
 	t.Cleanup(server.Close)
 	client := githubtest.NewTestClient(t, server)
-	return ensureFeedbackPullRequest(client, "o", "r", mode)
+	return ensureFeedbackPullRequest(client, "o", "r", "main", mode)
 }
 
 // TestEnsure_FreshOpen pins the full sequence on an un-pushed repo: freeze the

--- a/cli/gh-teacher/internal/feedbackpr/ensure_test.go
+++ b/cli/gh-teacher/internal/feedbackpr/ensure_test.go
@@ -1,0 +1,341 @@
+package feedbackpr
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/gh-teacher/internal/githubtest"
+)
+
+// ensureServer is a scriptable GitHub double for the teacher-side ensure flow
+// on o/r (default branch `main`, accept commit `accept-sha`, tree `tree-sha`).
+// Ported from the accept-side double (cli/gh-student/feedback_pr_test.go),
+// adapted to the teacher CLI: the repo object read (for the settled default
+// branch) is served, and the ref PATCH goes through the same endpoint. Knobs
+// select the scenario; the counters let tests assert idempotency.
+type ensureServer struct {
+	existingPRState string // non-empty -> the base+head PR list returns one PR in that state
+	refExists       bool   // POST /git/refs 422 "Reference already exists"
+	existingBaseSHA string // GET /git/ref/heads/feedback SHA when refExists ("" -> read 404s)
+	headHasDiff     bool   // first pulls POST succeeds immediately (no zero-diff 422)
+	failPRCreate    bool   // every pulls POST 403
+	prCreateRace    bool   // pulls POST 422 "already exists" and the NEXT list reports one
+	failLabelAdd    bool   // POST /issues/{n}/labels fails
+
+	prListStates []string
+
+	refCreates    int
+	refReads      int
+	commitCreates int
+	refPatches    int
+	prCreates     int
+	labelAdds     int
+
+	lastCommitMessage string
+	lastCommitTree    string
+	lastRefBody       map[string]string
+	lastPRBody        map[string]string
+	lastAddedLabels   []string
+}
+
+func (s *ensureServer) mux(t *testing.T) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// The settled default branch read (teacher CLI resolves it from the repo
+	// object rather than being handed `main` up front).
+	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"default_branch": "main"})
+	})
+
+	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			s.prListStates = append(s.prListStates, r.URL.Query().Get("state"))
+			if s.existingPRState != "" || (s.prCreateRace && s.prCreates > 0) {
+				state := s.existingPRState
+				if state == "" {
+					state = "open"
+				}
+				_ = json.NewEncoder(w).Encode([]map[string]any{{"number": 7, "state": state}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+		s.prCreates++
+		body, _ := io.ReadAll(r.Body)
+		var pr map[string]string
+		_ = json.Unmarshal(body, &pr)
+		s.lastPRBody = pr
+		if s.failPRCreate {
+			write422or403(w, http.StatusForbidden, `{"message":"Resource not accessible by integration"}`)
+			return
+		}
+		if s.prCreateRace {
+			write422or403(w, http.StatusUnprocessableEntity, `{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for o:main."}]}`)
+			return
+		}
+		if !s.headHasDiff && s.refPatches == 0 {
+			write422or403(w, http.StatusUnprocessableEntity, `{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"No commits between feedback and main"}]}`)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"number": 1})
+	})
+
+	mux.HandleFunc("/repos/o/r/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		s.refCreates++
+		body, _ := io.ReadAll(r.Body)
+		var ref map[string]string
+		_ = json.Unmarshal(body, &ref)
+		s.lastRefBody = ref
+		if s.refExists {
+			write422or403(w, http.StatusUnprocessableEntity, `{"message":"Reference already exists"}`)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ref": "refs/heads/feedback"})
+	})
+
+	mux.HandleFunc("/repos/o/r/git/ref/heads/feedback", func(w http.ResponseWriter, _ *http.Request) {
+		s.refReads++
+		if s.existingBaseSHA == "" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"Not Found"}`)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": s.existingBaseSHA}})
+	})
+
+	mux.HandleFunc("/repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": "accept-sha"}})
+	})
+	mux.HandleFunc("/repos/o/r/git/commits/accept-sha", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"tree": map[string]string{"sha": "tree-sha"}})
+	})
+	mux.HandleFunc("/repos/o/r/git/commits", func(w http.ResponseWriter, r *http.Request) {
+		s.commitCreates++
+		body, _ := io.ReadAll(r.Body)
+		var commit struct {
+			Message string `json:"message"`
+			Tree    string `json:"tree"`
+		}
+		_ = json.Unmarshal(body, &commit)
+		s.lastCommitMessage = commit.Message
+		s.lastCommitTree = commit.Tree
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"sha": "empty-sha"})
+	})
+	mux.HandleFunc("/repos/o/r/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		s.refPatches++
+		_ = json.NewEncoder(w).Encode(map[string]any{"ref": "refs/heads/main"})
+	})
+
+	mux.HandleFunc("/repos/o/r/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/r/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		s.labelAdds++
+		body, _ := io.ReadAll(r.Body)
+		var add struct {
+			Labels []string `json:"labels"`
+		}
+		_ = json.Unmarshal(body, &add)
+		s.lastAddedLabels = add.Labels
+		if s.failLabelAdd {
+			write422or403(w, http.StatusForbidden, `{"message":"Resource not accessible by integration"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `[]`)
+	})
+
+	// Commit-history read for the accept SHA (oldest-first-touching-marker).
+	mux.HandleFunc("/repos/o/r/commits", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"sha": "newer"}, {"sha": "accept-sha"}})
+	})
+
+	return mux
+}
+
+func write422or403(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, body)
+}
+
+func runEnsure(t *testing.T, s *ensureServer, mode string) error {
+	t.Helper()
+	server := httptest.NewServer(s.mux(t))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+	return ensureFeedbackPullRequest(client, "o", "r", mode)
+}
+
+// TestEnsure_FreshOpen pins the full sequence on an un-pushed repo: freeze the
+// base at the accept commit, hit the zero-diff 422, land ONE empty commit (the
+// head's own tree, [skip ci] in the message), fast-forward, retry the create,
+// label it. Returns nil (a fresh open).
+func TestEnsure_FreshOpen(t *testing.T) {
+	s := &ensureServer{}
+	if err := runEnsure(t, s, contract.ModeIndividual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.refCreates != 1 {
+		t.Errorf("feedback ref created %d times, want 1", s.refCreates)
+	}
+	if s.prCreates != 2 {
+		t.Errorf("pulls POST attempted %d times, want 2 (zero-diff 422, then success)", s.prCreates)
+	}
+	if s.commitCreates != 1 || s.refPatches != 1 {
+		t.Errorf("empty commit %d / ref patch %d, want 1/1", s.commitCreates, s.refPatches)
+	}
+	if s.lastCommitTree != "tree-sha" {
+		t.Errorf("empty commit tree = %q, want the head's own tree tree-sha", s.lastCommitTree)
+	}
+	if want := contract.FeedbackOpenCommitMessage(); s.lastCommitMessage != want {
+		t.Errorf("empty commit message = %q, want %q", s.lastCommitMessage, want)
+	}
+	if s.lastRefBody["sha"] != "accept-sha" {
+		t.Errorf("feedback base frozen at %q, want accept-sha", s.lastRefBody["sha"])
+	}
+	if s.lastPRBody["base"] != contract.FeedbackBaseBranch || s.lastPRBody["head"] != "main" {
+		t.Errorf("PR base/head = %q/%q, want %q/main", s.lastPRBody["base"], s.lastPRBody["head"], contract.FeedbackBaseBranch)
+	}
+	if s.lastPRBody["title"] != contract.FeedbackPRTitle {
+		t.Errorf("PR title = %q, want %q", s.lastPRBody["title"], contract.FeedbackPRTitle)
+	}
+	if !strings.Contains(s.lastPRBody["body"], "https://github.com/o/r/releases/latest") {
+		t.Error("PR body lacks the releases/latest URL; the runner would clobber it")
+	}
+	if len(s.lastAddedLabels) != 1 || s.lastAddedLabels[0] != "Individual Assignment" {
+		t.Errorf("added labels = %v, want [Individual Assignment]", s.lastAddedLabels)
+	}
+}
+
+// TestEnsure_ExistingPRIsAlreadyExists pins idempotency: a PR in ANY state
+// short-circuits before any write and returns errAlreadyExists (counted as
+// "already had one", never re-opened).
+func TestEnsure_ExistingPRIsAlreadyExists(t *testing.T) {
+	for _, state := range []string{"open", "closed", "merged"} {
+		t.Run(state, func(t *testing.T) {
+			s := &ensureServer{existingPRState: state}
+			err := runEnsure(t, s, contract.ModeIndividual)
+			if !isAlreadyExists(err) {
+				t.Fatalf("err = %v, want errAlreadyExists", err)
+			}
+			if s.refCreates+s.commitCreates+s.refPatches+s.prCreates+s.labelAdds != 0 {
+				t.Errorf("writes on an already-PR'd repo: refs=%d commits=%d patches=%d prs=%d labels=%d",
+					s.refCreates, s.commitCreates, s.refPatches, s.prCreates, s.labelAdds)
+			}
+			if len(s.prListStates) == 0 || s.prListStates[0] != "all" {
+				t.Errorf("PR lookup used state=%v, want state=all", s.prListStates)
+			}
+		})
+	}
+}
+
+// TestEnsure_RefExistsAtAcceptSHAIsTolerated pins the heal path: a feedback
+// branch surviving a prior interrupted run at the SAME accept commit is adopted
+// (read back), not an error.
+func TestEnsure_RefExistsAtAcceptSHAIsTolerated(t *testing.T) {
+	s := &ensureServer{refExists: true, existingBaseSHA: "accept-sha"}
+	if err := runEnsure(t, s, contract.ModeIndividual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.refReads == 0 {
+		t.Error("existing feedback ref adopted without reading its SHA back")
+	}
+	if s.prCreates == 0 {
+		t.Error("PR never created after tolerating the existing ref")
+	}
+}
+
+// TestEnsure_RefExistsAtWrongSHAIsBlocked is the poisoned-base guard: a
+// student-precreated `feedback` at a different SHA returns errBaseMismatch (the
+// blocked bucket), never opening a PR over the wrong base.
+func TestEnsure_RefExistsAtWrongSHAIsBlocked(t *testing.T) {
+	s := &ensureServer{refExists: true, existingBaseSHA: "student-chosen-sha"}
+	err := runEnsure(t, s, contract.ModeIndividual)
+	if !isBaseMismatch(err) {
+		t.Fatalf("err = %v, want errBaseMismatch", err)
+	}
+	if !strings.Contains(err.Error(), "student-chosen-sha") {
+		t.Errorf("error should name the unexpected base SHA, got %v", err)
+	}
+	if s.prCreates != 0 {
+		t.Errorf("PR created (%d times) over an unverified base", s.prCreates)
+	}
+}
+
+// TestEnsure_LostCreateRaceIsAlreadyExists pins the concurrent-open case: the
+// loser gets GitHub's "already exists" 422 and re-querying finds the PR, so it
+// resolves as errAlreadyExists, not a failure.
+func TestEnsure_LostCreateRaceIsAlreadyExists(t *testing.T) {
+	s := &ensureServer{prCreateRace: true, headHasDiff: true}
+	if err := runEnsure(t, s, contract.ModeIndividual); !isAlreadyExists(err) {
+		t.Fatalf("err = %v, want errAlreadyExists", err)
+	}
+}
+
+// TestEnsure_LabelFailureDoesNotFail pins the best-effort label: the PR is in
+// place, so a label failure never fails the open.
+func TestEnsure_LabelFailureDoesNotFail(t *testing.T) {
+	s := &ensureServer{failLabelAdd: true}
+	if err := runEnsure(t, s, contract.ModeIndividual); err != nil {
+		t.Fatalf("a label failure must not fail the open, got %v", err)
+	}
+	if s.labelAdds == 0 {
+		t.Error("label add was never attempted")
+	}
+}
+
+// TestEnsure_PriorEmptyCommitNotDuplicated pins PR-first ordering: when the
+// head already moved past the accept SHA, the first create succeeds and no new
+// empty commit is pushed.
+func TestEnsure_PriorEmptyCommitNotDuplicated(t *testing.T) {
+	s := &ensureServer{headHasDiff: true}
+	if err := runEnsure(t, s, contract.ModeIndividual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.commitCreates != 0 || s.refPatches != 0 {
+		t.Errorf("empty commit pushed (%d commits, %d patches) though the PR could open directly", s.commitCreates, s.refPatches)
+	}
+	if s.prCreates != 1 {
+		t.Errorf("pulls POST attempted %d times, want 1", s.prCreates)
+	}
+}
+
+// TestEnsure_CreateFailureSurfacesError pins that a hard 403 comes back as a
+// (failed-bucket) error.
+func TestEnsure_CreateFailureSurfacesError(t *testing.T) {
+	s := &ensureServer{failPRCreate: true}
+	err := runEnsure(t, s, contract.ModeIndividual)
+	if err == nil {
+		t.Fatal("want an error when the PR create hard-fails, got nil")
+	}
+	if isAlreadyExists(err) || isBaseMismatch(err) {
+		t.Errorf("a 403 must be a plain (failed) error, got %v", err)
+	}
+}
+
+// TestEnsure_GroupLabel pins the group-mode label so the runner (same table)
+// recognizes the PR as its own.
+func TestEnsure_GroupLabel(t *testing.T) {
+	s := &ensureServer{}
+	if err := runEnsure(t, s, contract.ModeGroup); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s.lastAddedLabels) != 1 || s.lastAddedLabels[0] != "Group Assignment" {
+		t.Errorf("added labels = %v, want [Group Assignment]", s.lastAddedLabels)
+	}
+}

--- a/cli/gh-teacher/internal/feedbackpr/feedbackpr.go
+++ b/cli/gh-teacher/internal/feedbackpr/feedbackpr.go
@@ -1,0 +1,323 @@
+// Package feedbackpr implements `gh teacher assignment feedback-pr`: open (or
+// repair) the long-lived Feedback PR on every existing student repo for an
+// assignment, retroactively and idempotently, from the teacher's side.
+//
+// This is the CLI twin of the web app's "Open all Feedback PRs" / per-row
+// Repair (issue #347): the Feedback PR is opened at accept time now, so a
+// GitHub outage or a repo that predates the feature can leave a student
+// without one. Running this re-runs the same idempotent ensure flow — the one
+// `gh student accept` and the autograde runner use — with the teacher's token,
+// so the PR it produces is byte-identical and the runner still adopts it by
+// base+head. Only NewCmd is exported.
+package feedbackpr
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/gh-teacher/internal/assignment"
+	"github.com/foundation50/gh-teacher/internal/cliutil"
+	"github.com/foundation50/gh-teacher/internal/configrepo"
+	"github.com/foundation50/gh-teacher/internal/githubapi"
+)
+
+func NewCmd() *cobra.Command {
+	var (
+		user  string
+		quiet bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "feedback-pr <org> <classroom> <assignment>",
+		Short: "Open or repair the Feedback PR on every student repo for an assignment",
+		Long: "Open (or repair) the Feedback PR on every existing student repo for an\n" +
+			"assignment, retroactively and idempotently.\n\n" +
+			"The Feedback PR is normally opened at accept time (by `gh student\n" +
+			"accept` / the web app) or by the autograde runner. A GitHub outage, a\n" +
+			"transient error, or a repo that predates the feature can leave a student\n" +
+			"without one. This command re-runs the SAME idempotent ensure flow with\n" +
+			"your (teacher) token: base = the frozen `feedback` branch at the repo's\n" +
+			"accept commit, head = the default branch. The PR it produces is\n" +
+			"byte-identical to an accept-time or runner-opened one, so the runner\n" +
+			"still adopts it and teachers never see two.\n\n" +
+			"Enrollment comes from the classroom GitHub team (the same source\n" +
+			"`gh teacher download` uses); the expected <classroom>-<assignment>-<user>\n" +
+			"repo is derived for each member and skipped when it doesn't exist yet\n" +
+			"(not accepted). Pass --user to target a single student's repo.\n\n" +
+			"Idempotent: a repo that already has a Feedback PR (in any state) is left\n" +
+			"as-is, so re-running only fills the gaps. A student-precreated `feedback`\n" +
+			"branch frozen at the wrong commit is reported as BLOCKED — an org admin\n" +
+			"must delete that branch before the PR can open; re-running never fixes\n" +
+			"it. Requires owner/admin access to the org's repos.",
+		Example: "  gh teacher assignment feedback-pr cs50-fall-2026 cs-principles hello\n" +
+			"  gh teacher assignment feedback-pr --user alice cs50-fall-2026 cs-principles hello",
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			org := strings.TrimSpace(args[0])
+			classroom := strings.TrimSpace(args[1])
+			assignmentSlug := strings.TrimSpace(args[2])
+			if org == "" || classroom == "" || assignmentSlug == "" {
+				return fmt.Errorf("invalid arguments: org, classroom, and assignment must all be non-empty")
+			}
+
+			client, err := githubapi.RequireAuthClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			// verbose is a persistent flag on the root command (main.go); read it
+			// here and thread it down rather than reaching for a package global.
+			verbose, _ := cmd.Flags().GetBool("verbose")
+
+			return run(client, cmd.OutOrStdout(), cmd.ErrOrStderr(),
+				runParams{
+					org:        org,
+					classroom:  classroom,
+					assignment: assignmentSlug,
+					user:       strings.TrimSpace(user),
+					quiet:      quiet,
+					verbose:    verbose,
+				})
+		},
+	}
+
+	cmd.Flags().StringVar(&user, "user", "", "Repair a single student's repo (their <classroom>-<assignment>-<user> repo) instead of every team member's")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress informational output (per-repo and summary lines); errors still go to stderr")
+	return cmd
+}
+
+type runParams struct {
+	org, classroom, assignment string
+	user                       string
+	quiet, verbose             bool
+}
+
+// outcome is one repo's classified result, kept for the summary. The blocked /
+// failed split matters because their remedies differ: blocked needs an org
+// admin (never retryable), failed is transient (re-run fills the gap). Mirrors
+// the web bulk summary's buckets (web/src/domain/assignments/feedbackPr.ts).
+type outcome int
+
+const (
+	outcomeCreated outcome = iota // opened a new Feedback PR
+	outcomeExisted                // already had one (any state) — idempotent no-op
+	outcomeBlocked                // `feedback` frozen at the wrong SHA — org admin must delete it
+	outcomeFailed                 // transient error — re-running retries
+)
+
+type repoResult struct {
+	repo    string
+	outcome outcome
+	reason  string // set for blocked/failed
+}
+
+// run enumerates the assignment's student repos from the classroom team and
+// fans the idempotent ensure flow over each existing one, serially (matching
+// every other teacher command; GitHub's secondary-rate-limit budget makes a
+// concurrent fan-out a liability, not a win). Returns a non-nil error when any
+// repo is blocked or failed so scripts see a non-zero exit.
+func run(client githubapi.Client, out, errOut io.Writer, p runParams) error {
+	branch, err := configrepo.ResolveConfigRepoBranch(client, p.org)
+	if err != nil {
+		return err
+	}
+
+	assignments, err := configrepo.LoadAssignments(client, p.org, p.classroom, branch)
+	if err != nil {
+		return err
+	}
+	entry, ok := findAssignment(assignments, p.assignment)
+	if !ok {
+		return fmt.Errorf("assignment %q is not registered in %s/%s/%s — run `gh teacher assignment add %s %s %s --name <name> --template <owner>/<repo>` first",
+			p.assignment, p.org, configrepo.ConfigRepoName, assignment.AssignmentsFilePath(p.classroom), p.org, p.classroom, p.assignment)
+	}
+
+	// A bare repo has no baseline commit to freeze `feedback` at, and an
+	// assignment with feedback_pr off never gets a PR — the runner and web
+	// refuse the same cases. Fail loudly rather than churn through every repo
+	// only to report "no baseline" on each.
+	if entry.EmptyRepo {
+		return fmt.Errorf("assignment %q is an empty_repo assignment: it has no baseline commit, so no Feedback PR is possible", p.assignment)
+	}
+	if !entry.FeedbackPR {
+		return fmt.Errorf("assignment %q has feedback_pr disabled: no Feedback PR is opened for its repos", p.assignment)
+	}
+
+	repos, err := targetRepos(client, p, branch)
+	if err != nil {
+		return err
+	}
+	if len(repos) == 0 {
+		if !p.quiet {
+			_, _ = fmt.Fprintf(out, "%s: no repos to process\n", p.org)
+		}
+		return nil
+	}
+
+	var results []repoResult
+	for _, repo := range repos {
+		exists, err := repoExistsOnOrg(client, p.org, repo)
+		if err != nil {
+			results = append(results, repoResult{repo: repo, outcome: outcomeFailed, reason: err.Error()})
+			_, _ = fmt.Fprintf(errOut, "%s: probe failed: %v\n", repo, err)
+			continue
+		}
+		if !exists {
+			// Enrolled but not accepted yet (or a group teammate who joined a
+			// founder's repo and owns none). Not a failure — nothing to open.
+			// On the explicit --user path the teacher named this one repo, so a
+			// missing repo is the answer they asked for: report it unconditionally.
+			if p.user != "" {
+				_, _ = fmt.Fprintf(out, "%s does not exist — %s has not accepted %s yet\n", repo, p.user, p.assignment)
+			} else if p.verbose && !p.quiet {
+				_, _ = fmt.Fprintf(out, "Skipped %s (no repo — not accepted yet?)\n", repo)
+			}
+			continue
+		}
+
+		res := ensureOne(client, p.org, repo, entry.Mode)
+		results = append(results, res)
+		reportRepo(out, res, p.quiet, p.verbose)
+	}
+
+	return summarize(out, errOut, p, results)
+}
+
+// ensureOne runs the idempotent ensure flow for one repo and classifies the
+// result into a summary bucket.
+func ensureOne(client githubapi.Client, org, repo, mode string) repoResult {
+	err := ensureFeedbackPullRequest(client, org, repo, mode)
+	switch {
+	case err == nil:
+		// created vs existed is threaded out of the ensure via a sentinel so
+		// the summary can distinguish an opened PR from an idempotent no-op.
+		return repoResult{repo: repo, outcome: outcomeCreated}
+	case isAlreadyExists(err):
+		return repoResult{repo: repo, outcome: outcomeExisted}
+	case isBaseMismatch(err):
+		return repoResult{repo: repo, outcome: outcomeBlocked, reason: err.Error()}
+	default:
+		return repoResult{repo: repo, outcome: outcomeFailed, reason: err.Error()}
+	}
+}
+
+// targetRepos resolves the repo names to process: a single --user repo, or the
+// derived repo for every classroom-team member.
+func targetRepos(client githubapi.Client, p runParams, branch string) ([]string, error) {
+	if p.user != "" {
+		return []string{contract.AssignmentRepoName(p.classroom, p.assignment, p.user)}, nil
+	}
+
+	teamSlug, err := configrepo.ResolveClassroomTeamSlug(client, p.org, p.classroom, branch)
+	if err != nil {
+		return nil, err
+	}
+	logins, err := configrepo.ListTeamMembers(client, p.org, teamSlug)
+	if err != nil {
+		return nil, fmt.Errorf("list team %q members: %w", teamSlug, err)
+	}
+	repos := make([]string, 0, len(logins))
+	for _, login := range logins {
+		repos = append(repos, contract.AssignmentRepoName(p.classroom, p.assignment, login))
+	}
+	return repos, nil
+}
+
+// findAssignment returns the entry for slug (case-insensitive: the slug flows
+// into repo names lowercased, so a mixed-case argument still matches).
+func findAssignment(assignments assignment.AssignmentsJSON, slug string) (assignment.AssignmentEntry, bool) {
+	for _, entry := range assignments.Assignments {
+		if strings.EqualFold(entry.Slug, slug) {
+			return entry, true
+		}
+	}
+	return assignment.AssignmentEntry{}, false
+}
+
+// repoExistsOnOrg returns true iff GET /repos/{org}/{repo} returns 200. 404 ->
+// false. Other errors propagate so a network/auth failure isn't silently
+// treated as "not accepted".
+func repoExistsOnOrg(client githubapi.Client, org, repo string) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(repo))
+	if err := client.Get(path, nil); err != nil {
+		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("GET %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// reportRepo prints one repo's per-line outcome on the human channel.
+func reportRepo(out io.Writer, res repoResult, quiet, verbose bool) {
+	if quiet {
+		return
+	}
+	switch res.outcome {
+	case outcomeCreated:
+		_, _ = fmt.Fprintf(out, "Opened Feedback PR on %s\n", res.repo)
+	case outcomeExisted:
+		if verbose {
+			_, _ = fmt.Fprintf(out, "%s already has a Feedback PR\n", res.repo)
+		}
+	case outcomeBlocked:
+		_, _ = fmt.Fprintf(out, "Blocked: %s (%s)\n", res.repo, res.reason)
+	case outcomeFailed:
+		_, _ = fmt.Fprintf(out, "Failed: %s (%s)\n", res.repo, res.reason)
+	}
+}
+
+// summarize prints the aggregate counts plus the blocked/failed detail lists,
+// and returns a non-nil error when any repo is blocked or failed.
+func summarize(out, errOut io.Writer, p runParams, results []repoResult) error {
+	var created, existed int
+	var blocked, failed []repoResult
+	for _, r := range results {
+		switch r.outcome {
+		case outcomeCreated:
+			created++
+		case outcomeExisted:
+			existed++
+		case outcomeBlocked:
+			blocked = append(blocked, r)
+		case outcomeFailed:
+			failed = append(failed, r)
+		}
+	}
+
+	if !p.quiet {
+		_, _ = fmt.Fprintf(out, "%s: %d opened, %d already had one, %d blocked, %d failed (of %d repo(s))\n",
+			p.org, created, existed, len(blocked), len(failed), len(results))
+	}
+
+	if len(blocked) > 0 {
+		_, _ = fmt.Fprintln(errOut, "Blocked (an org admin must delete the mis-frozen `feedback` branch, then re-run):")
+		for _, r := range blocked {
+			_, _ = fmt.Fprintf(errOut, "  %s: %s\n", r.repo, r.reason)
+		}
+	}
+	if len(failed) > 0 {
+		_, _ = fmt.Fprintln(errOut, "Failed (transient — re-run to retry just these):")
+		for _, r := range failed {
+			_, _ = fmt.Fprintf(errOut, "  %s: %s\n", r.repo, r.reason)
+		}
+	}
+
+	switch {
+	case len(failed) > 0 && len(blocked) > 0:
+		return fmt.Errorf("%d repo(s) failed and %d blocked; see stderr above", len(failed), len(blocked))
+	case len(failed) > 0:
+		return fmt.Errorf("%d of %d repo(s) failed", len(failed), len(results))
+	case len(blocked) > 0:
+		return fmt.Errorf("%d of %d repo(s) blocked by a mis-frozen `feedback` branch (an org admin must delete it)", len(blocked), len(results))
+	}
+	return nil
+}

--- a/cli/gh-teacher/internal/feedbackpr/feedbackpr.go
+++ b/cli/gh-teacher/internal/feedbackpr/feedbackpr.go
@@ -164,13 +164,17 @@ func run(client githubapi.Client, out, errOut io.Writer, p runParams) error {
 
 	var results []repoResult
 	for _, repo := range repos {
-		exists, err := repoExistsOnOrg(client, p.org, repo)
+		// One repo-object read serves both purposes: distinguish
+		// not-accepted-yet (404) from a real error, and hand the ensure the
+		// settled default branch it needs (the branch the accept commit landed
+		// on — may be `master`). Folding the two avoids a second identical GET.
+		branch, notFound, err := defaultBranch(client, p.org, repo)
 		if err != nil {
 			results = append(results, repoResult{repo: repo, outcome: outcomeFailed, reason: err.Error()})
 			_, _ = fmt.Fprintf(errOut, "%s: probe failed: %v\n", repo, err)
 			continue
 		}
-		if !exists {
+		if notFound {
 			// Enrolled but not accepted yet (or a group teammate who joined a
 			// founder's repo and owns none). Not a failure — nothing to open.
 			// On the explicit --user path the teacher named this one repo, so a
@@ -183,7 +187,7 @@ func run(client githubapi.Client, out, errOut io.Writer, p runParams) error {
 			continue
 		}
 
-		res := ensureOne(client, p.org, repo, entry.Mode)
+		res := ensureOne(client, p.org, repo, branch, entry.Mode)
 		results = append(results, res)
 		reportRepo(out, res, p.quiet, p.verbose)
 	}
@@ -193,12 +197,10 @@ func run(client githubapi.Client, out, errOut io.Writer, p runParams) error {
 
 // ensureOne runs the idempotent ensure flow for one repo and classifies the
 // result into a summary bucket.
-func ensureOne(client githubapi.Client, org, repo, mode string) repoResult {
-	err := ensureFeedbackPullRequest(client, org, repo, mode)
+func ensureOne(client githubapi.Client, org, repo, branch, mode string) repoResult {
+	err := ensureFeedbackPullRequest(client, org, repo, branch, mode)
 	switch {
 	case err == nil:
-		// created vs existed is threaded out of the ensure via a sentinel so
-		// the summary can distinguish an opened PR from an idempotent no-op.
 		return repoResult{repo: repo, outcome: outcomeCreated}
 	case isAlreadyExists(err):
 		return repoResult{repo: repo, outcome: outcomeExisted}
@@ -242,18 +244,27 @@ func findAssignment(assignments assignment.AssignmentsJSON, slug string) (assign
 	return assignment.AssignmentEntry{}, false
 }
 
-// repoExistsOnOrg returns true iff GET /repos/{org}/{repo} returns 200. 404 ->
-// false. Other errors propagate so a network/auth failure isn't silently
-// treated as "not accepted".
-func repoExistsOnOrg(client githubapi.Client, org, repo string) (bool, error) {
-	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(repo))
-	if err := client.Get(path, nil); err != nil {
-		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
-			return false, nil
-		}
-		return false, fmt.Errorf("GET %s: %w", path, err)
+// defaultBranch reads the repo's settled default branch (the branch the accept
+// commit landed on — may be `master`, not a pre-guessed `main`), and reports
+// whether the repo is missing. A 404 -> notFound=true (enrolled but not
+// accepted yet), so this one read both gates the skip and hands the ensure the
+// head branch it needs. Any other error propagates so a network/auth failure
+// isn't mistaken for "not accepted".
+func defaultBranch(client githubapi.Client, org, repoName string) (branch string, notFound bool, err error) {
+	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(repoName))
+	var repo struct {
+		DefaultBranch string `json:"default_branch"`
 	}
-	return true, nil
+	if err := client.Get(path, &repo); err != nil {
+		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("GET %s: %w", path, err)
+	}
+	if repo.DefaultBranch == "" {
+		return "main", false, nil
+	}
+	return repo.DefaultBranch, false, nil
 }
 
 // reportRepo prints one repo's per-line outcome on the human channel.

--- a/cli/gh-teacher/internal/feedbackpr/feedbackpr_test.go
+++ b/cli/gh-teacher/internal/feedbackpr/feedbackpr_test.go
@@ -1,0 +1,307 @@
+package feedbackpr
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/foundation50/gh-teacher/internal/githubtest"
+)
+
+// assignmentsJSON is a minimal v1 assignments.json with one feedback_pr
+// assignment (`hello`) plus optional extra entries the test appends.
+func assignmentsJSON(t *testing.T, entries string) string {
+	t.Helper()
+	return `{"schema":"classroom50/assignments/v1","assignments":[` + entries + `]}`
+}
+
+const helloEntry = `{"slug":"hello","name":"Hello","mode":"individual","autograder":"default","feedback_pr":true}`
+
+// classroomMux wires the config-repo reads (repo object, assignments.json,
+// classroom.json 404 -> derived team slug), the team-member list, and, for
+// each repo in repoStates, the per-repo existence probe and (for existing
+// repos) a fresh-open ensure sequence. repoStates maps a repo name to one of
+// "missing" (404 probe), "fresh" (opens a PR), or "existing" (already has one).
+func classroomMux(t *testing.T, assignments string, members []string, repoStates map[string]string) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Config repo object (default branch) — must not collide with the student
+	// assignment repos, so register the exact path.
+	mux.HandleFunc("/repos/o/classroom50", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"default_branch": "main"})
+	})
+
+	// Config-repo contents: assignments.json served; classroom.json 404s so
+	// the team slug derives to classroom50-<short>.
+	mux.HandleFunc("/repos/o/classroom50/contents/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/repos/o/classroom50/contents/")
+		if path == "cs/assignments.json" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"content":  base64.StdEncoding.EncodeToString([]byte(assignments)),
+				"encoding": "base64",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	// Derived classroom team members. Skipped when members is nil so a --user
+	// test can register a fail-if-hit handler and pin that the team lookup is
+	// not consulted.
+	if members != nil {
+		mux.HandleFunc("/orgs/o/teams/classroom50-cs/members", func(w http.ResponseWriter, _ *http.Request) {
+			out := make([]map[string]any, 0, len(members))
+			for _, m := range members {
+				out = append(out, map[string]any{"login": m})
+			}
+			_ = json.NewEncoder(w).Encode(out)
+		})
+	}
+
+	for repo, state := range repoStates {
+		mountRepo(mux, repo, state)
+	}
+	return mux
+}
+
+// mountRepo registers the existence probe plus (for a "fresh" repo) the full
+// ensure sequence under /repos/o/<repo>/. "missing" 404s the probe; "existing"
+// answers the base+head PR list with one open PR (idempotent no-op).
+func mountRepo(mux *http.ServeMux, repo, state string) {
+	base := "/repos/o/" + repo
+
+	mux.HandleFunc(base, func(w http.ResponseWriter, _ *http.Request) {
+		if state == "missing" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"Not Found"}`)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"default_branch": "main"})
+	})
+	if state == "missing" {
+		return
+	}
+
+	mux.HandleFunc(base+"/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if state == "existing" {
+				_ = json.NewEncoder(w).Encode([]map[string]any{{"number": 7, "state": "open"}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+		// Fresh open: head already has a diff, so the first create succeeds.
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"number": 1})
+	})
+	// Freeze the base and read commit history for the accept SHA.
+	mux.HandleFunc(base+"/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ref": "refs/heads/feedback"})
+	})
+	mux.HandleFunc(base+"/commits", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"sha": "newer"}, {"sha": "accept-sha"}})
+	})
+	// Label steps (best-effort).
+	mux.HandleFunc(base+"/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{}`)
+	})
+	mux.HandleFunc(base+"/issues/1/labels", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `[]`)
+	})
+}
+
+func runCmd(t *testing.T, mux *http.ServeMux, p runParams) (string, string, error) {
+	t.Helper()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+	var out, errOut bytes.Buffer
+	err := run(client, &out, &errOut, p)
+	return out.String(), errOut.String(), err
+}
+
+func params(overrides func(*runParams)) runParams {
+	p := runParams{org: "o", classroom: "cs", assignment: "hello"}
+	if overrides != nil {
+		overrides(&p)
+	}
+	return p
+}
+
+// TestRun_BulkOpensMissingSkipsExistingAndUnaccepted pins the happy bulk path:
+// one repo without a PR is opened, one that already has one is counted as
+// existed, and an unaccepted (no-repo) member is silently skipped (not a
+// failure).
+func TestRun_BulkOpensMissingSkipsExistingAndUnaccepted(t *testing.T) {
+	mux := classroomMux(t, assignmentsJSON(t, helloEntry),
+		[]string{"alice", "bob", "carol"},
+		map[string]string{
+			"cs-hello-alice": "fresh",
+			"cs-hello-bob":   "existing",
+			"cs-hello-carol": "missing",
+		})
+
+	out, _, err := runCmd(t, mux, params(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "1 opened, 1 already had one, 0 blocked, 0 failed (of 2 repo(s))") {
+		t.Errorf("summary not as expected:\n%s", out)
+	}
+	if !strings.Contains(out, "Opened Feedback PR on cs-hello-alice") {
+		t.Errorf("missing per-repo open line:\n%s", out)
+	}
+}
+
+// TestRun_UserTargetsSingleRepo pins --user: only that student's repo is
+// touched, and the team lookup is NOT consulted (a handler that fails the test
+// if hit pins the intent directly).
+func TestRun_UserTargetsSingleRepo(t *testing.T) {
+	mux := classroomMux(t, assignmentsJSON(t, helloEntry),
+		nil, // team list must not be consulted with --user
+		map[string]string{"cs-hello-alice": "fresh"})
+	mux.HandleFunc("/orgs/o/teams/classroom50-cs/members", func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("team members must not be listed on the --user path")
+	})
+
+	out, _, err := runCmd(t, mux, params(func(p *runParams) { p.user = "alice" }))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "1 opened, 0 already had one, 0 blocked, 0 failed (of 1 repo(s))") {
+		t.Errorf("summary not as expected:\n%s", out)
+	}
+}
+
+// TestRun_UserMissingRepoIsReported pins that a --user target who hasn't
+// accepted is reported (not a silent no-op): the one repo the teacher named is
+// the answer they asked for.
+func TestRun_UserMissingRepoIsReported(t *testing.T) {
+	mux := classroomMux(t, assignmentsJSON(t, helloEntry),
+		nil, map[string]string{"cs-hello-alice": "missing"})
+
+	out, _, err := runCmd(t, mux, params(func(p *runParams) { p.user = "alice" }))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "cs-hello-alice does not exist") || !strings.Contains(out, "alice has not accepted hello") {
+		t.Errorf("missing --user repo not reported:\n%s", out)
+	}
+}
+
+// TestRun_ProbeFailureIsFailedBucketAndExitsNonZero pins the transient-failure
+// path end to end: a repo whose probe 500s lands in the failed bucket, the
+// stderr detail names it, and the command exits non-zero.
+func TestRun_ProbeFailureIsFailedBucketAndExitsNonZero(t *testing.T) {
+	mux := classroomMux(t, assignmentsJSON(t, helloEntry), []string{"alice"}, nil)
+	mux.HandleFunc("/repos/o/cs-hello-alice", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"message":"boom"}`)
+	})
+
+	out, errOut, err := runCmd(t, mux, params(nil))
+	if err == nil {
+		t.Fatal("want a non-nil error when a repo fails, got nil")
+	}
+	if !strings.Contains(out, "0 opened, 0 already had one, 0 blocked, 1 failed (of 1 repo(s))") {
+		t.Errorf("summary not as expected:\n%s", out)
+	}
+	if !strings.Contains(errOut, "probe failed") || !strings.Contains(errOut, "cs-hello-alice") {
+		t.Errorf("failed stderr detail not as expected:\n%s", errOut)
+	}
+}
+
+// TestRun_BlockedBaseMismatch pins the blocked bucket: a student-precreated
+// `feedback` at the wrong SHA lands in blocked (not failed), the summary and
+// stderr name it, and the command exits non-zero.
+func TestRun_BlockedBaseMismatch(t *testing.T) {
+	mux := classroomMux(t, assignmentsJSON(t, helloEntry),
+		[]string{"alice"}, nil)
+	// Custom repo wiring: probe 200, no PR, ref create 422 already-exists, and
+	// the read-back reports a student-chosen SHA (not accept-sha).
+	base := "/repos/o/cs-hello-alice"
+	mux.HandleFunc(base, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"default_branch": "main"})
+	})
+	mux.HandleFunc(base+"/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+	mux.HandleFunc(base+"/commits", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"sha": "accept-sha"}})
+	})
+	mux.HandleFunc(base+"/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+		write422or403(w, http.StatusUnprocessableEntity, `{"message":"Reference already exists"}`)
+	})
+	mux.HandleFunc(base+"/git/ref/heads/feedback", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": "student-chosen-sha"}})
+	})
+
+	out, errOut, err := runCmd(t, mux, params(nil))
+	if err == nil {
+		t.Fatal("want a non-nil error when a repo is blocked, got nil")
+	}
+	if !strings.Contains(out, "0 opened, 0 already had one, 1 blocked, 0 failed") {
+		t.Errorf("summary not as expected:\n%s", out)
+	}
+	if !strings.Contains(errOut, "cs-hello-alice") || !strings.Contains(errOut, "org admin") {
+		t.Errorf("blocked stderr detail not as expected:\n%s", errOut)
+	}
+}
+
+// TestRun_EmptyRepoAssignmentRefused pins the up-front guard: an empty_repo
+// assignment has no baseline, so the command refuses rather than churning.
+func TestRun_EmptyRepoAssignmentRefused(t *testing.T) {
+	entry := `{"slug":"bare","name":"Bare","mode":"individual","autograder":"default","empty_repo":true}`
+	mux := classroomMux(t, assignmentsJSON(t, entry), nil, nil)
+	_, _, err := runCmd(t, mux, params(func(p *runParams) { p.assignment = "bare" }))
+	if err == nil || !strings.Contains(err.Error(), "empty_repo") {
+		t.Fatalf("want an empty_repo refusal, got %v", err)
+	}
+}
+
+// TestRun_FeedbackPRDisabledRefused pins the guard for an assignment with
+// feedback_pr off (absent -> false): no PR is opened for its repos.
+func TestRun_FeedbackPRDisabledRefused(t *testing.T) {
+	entry := `{"slug":"quiz","name":"Quiz","mode":"individual","autograder":"default"}`
+	mux := classroomMux(t, assignmentsJSON(t, entry), nil, nil)
+	_, _, err := runCmd(t, mux, params(func(p *runParams) { p.assignment = "quiz" }))
+	if err == nil || !strings.Contains(err.Error(), "feedback_pr disabled") {
+		t.Fatalf("want a feedback_pr-disabled refusal, got %v", err)
+	}
+}
+
+// TestRun_UnregisteredAssignmentRefused pins the not-registered error.
+func TestRun_UnregisteredAssignmentRefused(t *testing.T) {
+	mux := classroomMux(t, assignmentsJSON(t, helloEntry), nil, nil)
+	_, _, err := runCmd(t, mux, params(func(p *runParams) { p.assignment = "nope" }))
+	if err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("want a not-registered error, got %v", err)
+	}
+}
+
+// TestNewCmd_Wiring pins the command shape (name, arg count, flags) so the
+// registration in assignmentcmd stays valid.
+func TestNewCmd_Wiring(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "feedback-pr <org> <classroom> <assignment>" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+	if cmd.Flags().Lookup("user") == nil || cmd.Flags().Lookup("quiet") == nil {
+		t.Error("expected --user and --quiet flags")
+	}
+	if err := cmd.Args(cmd, []string{"o", "cs"}); err == nil {
+		t.Error("want an arg-count error for 2 args (needs 3)")
+	}
+	if err := cmd.Args(cmd, []string{"o", "cs", "hello"}); err != nil {
+		t.Errorf("3 args should be accepted, got %v", err)
+	}
+}

--- a/cli/gh-teacher/internal/feedbackpr/feedbackpr_test.go
+++ b/cli/gh-teacher/internal/feedbackpr/feedbackpr_test.go
@@ -257,6 +257,62 @@ func TestRun_BlockedBaseMismatch(t *testing.T) {
 	}
 }
 
+// TestRun_NonMainDefaultBranch pins that the head branch is resolved from the
+// repo's settled default branch, not a hardcoded `main`: a repo whose default
+// is `master` is probed, opened, and counted against the org:master head. The
+// whole reason defaultBranch reads the repo object is this case.
+func TestRun_NonMainDefaultBranch(t *testing.T) {
+	// classroomMux must not register cs-hello-alice (it would hardcode main and
+	// collide), so pass no repoStates and wire the master repo by hand.
+	mux := classroomMux(t, assignmentsJSON(t, helloEntry), []string{"alice"}, nil)
+	base := "/repos/o/cs-hello-alice"
+	mux.HandleFunc(base, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"default_branch": "master"})
+	})
+	var listedHead, prHead string
+	mux.HandleFunc(base+"/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			listedHead = r.URL.Query().Get("head")
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var pr map[string]string
+		_ = json.Unmarshal(body, &pr)
+		prHead = pr["head"]
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"number": 1})
+	})
+	mux.HandleFunc(base+"/commits", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"sha": "accept-sha"}})
+	})
+	mux.HandleFunc(base+"/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ref": "refs/heads/feedback"})
+	})
+	mux.HandleFunc(base+"/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{}`)
+	})
+	mux.HandleFunc(base+"/issues/1/labels", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `[]`)
+	})
+
+	out, _, err := runCmd(t, mux, params(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "1 opened, 0 already had one, 0 blocked, 0 failed (of 1 repo(s))") {
+		t.Errorf("summary not as expected:\n%s", out)
+	}
+	if listedHead != "o:master" {
+		t.Errorf("existence probe head = %q, want o:master", listedHead)
+	}
+	if prHead != "master" {
+		t.Errorf("PR head = %q, want master", prHead)
+	}
+}
+
 // TestRun_EmptyRepoAssignmentRefused pins the up-front guard: an empty_repo
 // assignment has no baseline, so the command refuses rather than churning.
 func TestRun_EmptyRepoAssignmentRefused(t *testing.T) {

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -98,6 +98,16 @@ const (
 	// ensure_feedback_pr.py's `--title` and the web GUI so the runner and both
 	// accept clients produce indistinguishable PRs.
 	FeedbackPRTitle = "Feedback"
+
+	// MetadataPath is the in-repo accept marker (`.classroom50.yaml`) every
+	// accept client writes in its accept commit. It doubles as the Feedback-PR
+	// baseline anchor: the runner and the checkout-less API clients resolve the
+	// frozen `feedback` base as "the (oldest) commit touching this path", so the
+	// commit subject carries no contract — only the path does. Hand-mirrored with
+	// NO compile-time link in runner.py (ACCEPT_MARKER_PATH), the web GUI, and
+	// schemas/repo-config-v1.schema.json — keep byte-identical; contract_test.go
+	// pins the Go half.
+	MetadataPath = ".classroom50.yaml"
 )
 
 // requiredOAuthScopes is the unified OAuth scope set both CLIs request on top

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -57,6 +57,12 @@ func TestContractLiterals(t *testing.T) {
 		// (classroom50-feedback-base-lock) — changing it strands them.
 		{"FeedbackBaseBranch", FeedbackBaseBranch, "feedback"},
 		{"FeedbackPRTitle", FeedbackPRTitle, "Feedback"},
+		// MetadataPath is mirrored, with NO compile-time link, in runner.py
+		// (ACCEPT_MARKER_PATH), the web GUI, and
+		// schemas/repo-config-v1.schema.json. It anchors the Feedback-PR
+		// baseline, so a drift silently breaks base-SHA resolution across
+		// tools. Update every copy in lockstep on change.
+		{"MetadataPath", MetadataPath, ".classroom50.yaml"},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {


### PR DESCRIPTION
## Summary

Adds the CLI counterpart to the web app's teacher Feedback-PR tools (#434, issue #347): a bulk, idempotent command that opens or repairs the long-lived Feedback PR on every existing student repo for an assignment, from the teacher's side.

- **New command** `gh teacher assignment feedback-pr <org> <classroom> <assignment>` (flags `--user <login>`, `-q/--quiet`). Enumerates repos the same way `gh teacher download` does — classroom team members → derived `<classroom>-<assignment>-<user>` repos — and runs the ensure flow on each. A single repo-object read both skips a not-yet-accepted repo and supplies the PR head branch. `--user` narrows to a single student (and reports plainly when they haven't accepted).
- **Reuses the canonical ensure flow** ported from `cli/gh-student/feedback_pr.go`: freeze the `feedback` base at the accept commit, open the PR (landing one `[skip ci]` empty commit on the zero-diff 422), label it — all via the shared `cli/shared/contract` constants, so the PR is byte-identical to an accept-time or runner-opened one and the runner still adopts it by base+head. The teacher client has no `Patch` verb, so the ref update goes through `Request(http.MethodPatch, ...)`. Two divergences from the student port are deliberate and now documented in the code: the success/exists/mismatch outcomes are returned as sentinels so the summary can bucket them, and reporting lives in the caller.
- **Honest outcome buckets** in the summary: opened / already-had-one / blocked / failed. A student-precreated `feedback` branch frozen at the wrong SHA is never-retryable and lands in **blocked** (an org admin must delete it), kept out of the retryable **failed** bucket — mirroring the split PR #434 made. Blocked or failed exits non-zero.
- **Up-front guards**: refuses `empty_repo` and `feedback_pr`-disabled assignments (no baseline / no PR possible), matching the runner and web.
- **Shared contract**: the accept marker `.classroom50.yaml` is promoted to `contract.MetadataPath` (pinned in `contract_test.go`) so this fourth reader can't drift from the student CLI, the runner's `ACCEPT_MARKER_PATH`, and the web GUI. `acceptCommitSHA` resolves the base via the commits API (oldest-touching), matching the web GUI's checkout-less rule — the code comment now says so accurately, rather than claiming parity with the runner's git-side `--diff-filter=A` baseline.

Serial fan-out (like every other teacher command; a concurrent fan-out would fight GitHub's secondary-rate-limit budget). No Python/schema changes; the one shared-Go change is the additive `contract.MetadataPath` const above.

## Test plan

- `go build ./...`, `go test ./...`, `golangci-lint run`, and `golangci-lint fmt --diff` all pass in `cli/gh-teacher/`, `cli/gh-student/`, and `cli/shared/`.
- New `internal/feedbackpr` tests: the ported ensure cases (fresh open, existing-in-any-state idempotency, base-mismatch blocked, unverifiable base, lost-create race, best-effort label, prior-empty-commit-not-duplicated, hard-failure surfaced, group label) plus command-level coverage (bulk open/existed/skip-unaccepted, `--user` targeting + team-lookup-skip + missing-repo report, blocked bucket + non-zero exit, failed bucket + non-zero exit, empty_repo / feedback_pr-disabled / unregistered refusals, command wiring).
- Added edge coverage from review: the whole-ensure retry loop (retryable failure then success), the lost ref-race PATCH surfacing a failed-bucket error without opening a PR over a stale head, a non-404 read-back error never adopting an unverifiable base, and a non-`main` (`master`) default branch opening against the `org:master` head.
- Manual: `gh teacher assignment feedback-pr --help` renders the intended help.