### PR TITLE
feat: restrict assignment accept to enrolled classroom members

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -229,6 +229,68 @@ type AcceptStatus struct {
 	StatusCode int
 }
 
+// classroomStudentTeamSlug derives the student team slug `classroom50-<short>`.
+// A student can't read classroom.json for the GitHub-assigned slug, so it's
+// derived; on a slug-collision rewrite the derived slug 404s and reads as
+// non-member, so a miss never grants false access. Byte-mirrors the web
+// classroomTeamSlug and the teacher CLI's classroomTeamName — a cross-tool
+// contract with no compile-time link; keep in lockstep.
+func classroomStudentTeamSlug(classroom string) string {
+	return contract.ConfigRepoName + "-" + classroom
+}
+
+// classroomStaffTeamSlugs derives the staff team slugs, including the legacy
+// `-instructor` team so a not-yet-migrated classroom's staffer still reads as
+// enrolled.
+func classroomStaffTeamSlugs(classroom string) []string {
+	base := contract.ConfigRepoName + "-" + classroom
+	return []string{
+		base + "-teacher",
+		base + "-instructor",
+		base + "-hta",
+		base + "-ta",
+	}
+}
+
+// isActiveTeamMember reports whether the authed user is an active member of the
+// team. 2xx + active => true, a definitive 404 => false; any other error (e.g.
+// transient) propagates so the caller fails OPEN rather than blocking a real
+// student on a blip.
+func isActiveTeamMember(client githubapi.Client, org, teamSlug, username string) (bool, error) {
+	path := fmt.Sprintf("orgs/%s/teams/%s/memberships/%s",
+		url.PathEscape(org), url.PathEscape(teamSlug), url.PathEscape(username))
+	var resp struct {
+		State string `json:"state"`
+	}
+	if err := client.Get(path, &resp); err != nil {
+		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok {
+			if httpErr.StatusCode == http.StatusNotFound {
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("GET %s: %w", path, err)
+	}
+	return resp.State == "active", nil
+}
+
+// assertEnrolledOrStaff enforces that the authed user is enrolled in the
+// classroom — on its student team, or holding a staff role — before accept.
+// A transient read propagates (fail-open); only a set of definitive answers
+// with no membership blocks, with a clear roster remedy.
+func assertEnrolledOrStaff(client githubapi.Client, org, classroom, username string) error {
+	slugs := append([]string{classroomStudentTeamSlug(classroom)}, classroomStaffTeamSlugs(classroom)...)
+	for _, slug := range slugs {
+		member, err := isActiveTeamMember(client, org, slug, username)
+		if err != nil {
+			return err
+		}
+		if member {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s/%s: this assignment isn't available to you; ask your teacher if you think this is a mistake", org, classroom)
+}
+
 // acceptOrgInvite PATCHes the user's pending org membership to "active".
 func acceptOrgInvite(client githubapi.Client, org string) (AcceptStatus, error) {
 	body, err := json.Marshal(map[string]string{"state": "active"})
@@ -280,6 +342,18 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	if err != nil {
 		return fmt.Errorf("retrieving authed user: %w", err)
 	}
+
+	// Enrollment gate: a plain org member who isn't on this classroom's student
+	// team (and holds no staff role) can't accept. Mirrors the web accept gate
+	// and the student list; org owners bypass (they administer every classroom).
+	// Advisory like every client-side gate — GitHub's private-template
+	// permission is the hard boundary — but it fails early with a clear message.
+	if !isOwner {
+		if err := assertEnrolledOrStaff(client, org, classroom, username); err != nil {
+			return err
+		}
+	}
+
 	acceptedAt := time.Now().UTC().Format(time.RFC3339)
 
 	// 1) Look up the assignment entry on the public Pages site (no token).

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -229,29 +229,6 @@ type AcceptStatus struct {
 	StatusCode int
 }
 
-// classroomStudentTeamSlug derives the student team slug `classroom50-<short>`.
-// A student can't read classroom.json for the GitHub-assigned slug, so it's
-// derived; on a slug-collision rewrite the derived slug 404s and reads as
-// non-member, so a miss never grants false access. Byte-mirrors the web
-// classroomTeamSlug and the teacher CLI's classroomTeamName — a cross-tool
-// contract with no compile-time link; keep in lockstep.
-func classroomStudentTeamSlug(classroom string) string {
-	return contract.ConfigRepoName + "-" + classroom
-}
-
-// classroomStaffTeamSlugs derives the staff team slugs, including the legacy
-// `-instructor` team so a not-yet-migrated classroom's staffer still reads as
-// enrolled.
-func classroomStaffTeamSlugs(classroom string) []string {
-	base := contract.ConfigRepoName + "-" + classroom
-	return []string{
-		base + "-teacher",
-		base + "-instructor",
-		base + "-hta",
-		base + "-ta",
-	}
-}
-
 // isActiveTeamMember reports whether the authed user is an active member of the
 // team. 2xx + active => true, a definitive 404 => false; any other error (e.g.
 // transient) propagates so the caller fails OPEN rather than blocking a real
@@ -275,11 +252,12 @@ func isActiveTeamMember(client githubapi.Client, org, teamSlug, username string)
 
 // assertEnrolledOrStaff enforces that the authed user is enrolled in the
 // classroom — on its student team, or holding a staff role — before accept.
-// A transient read propagates (fail-open); only a set of definitive answers
-// with no membership blocks, with a clear roster remedy.
+// The slug set is single-sourced from contract.ClassroomTeamSlugs (student
+// first). A transient read propagates (fail-open); membership short-circuits to
+// nil before any later probe can error, so an enrolled student is never blocked
+// by an unrelated blip. Only a full set of definitive non-member answers blocks.
 func assertEnrolledOrStaff(client githubapi.Client, org, classroom, username string) error {
-	slugs := append([]string{classroomStudentTeamSlug(classroom)}, classroomStaffTeamSlugs(classroom)...)
-	for _, slug := range slugs {
+	for _, slug := range contract.ClassroomTeamSlugs(classroom) {
 		member, err := isActiveTeamMember(client, org, slug, username)
 		if err != nil {
 			return err

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -318,6 +318,9 @@ func TestAssertEnrolledOrStaff(t *testing.T) {
 		{"ta staff member enrolled", map[string]bool{taSlug: true}, nil, false},
 		{"active member on no team rejected", map[string]bool{}, nil, true},
 		{"transient read fails open (propagates)", map[string]bool{}, map[string]bool{studentSlug: true}, true},
+		// Student-team match must short-circuit BEFORE a later staff-team probe
+		// can error, so an enrolled student is never blocked by an unrelated blip.
+		{"student member short-circuits past a transient staff probe", map[string]bool{studentSlug: true}, map[string]bool{taSlug: true}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -294,3 +294,60 @@ func TestInviteFounder_OwnerTolerated(t *testing.T) {
 		t.Fatalf("owner push grant reading back as admin should be tolerated, got: %v", err)
 	}
 }
+
+// TestAssertEnrolledOrStaff pins the classroom-enrollment accept gate: a
+// student-team member or any staff-team member passes; an active org member on
+// no classroom team is rejected with a roster remedy; a transient (non-404)
+// read fails OPEN by propagating the error rather than falsely blocking.
+func TestAssertEnrolledOrStaff(t *testing.T) {
+	const (
+		org       = "cs50"
+		classroom = "cs-fall"
+		user      = "alice"
+	)
+	studentSlug := "classroom50-" + classroom
+	taSlug := "classroom50-" + classroom + "-ta"
+
+	cases := []struct {
+		name           string
+		activeMembers  map[string]bool
+		transientTeams map[string]bool
+		wantErr        bool
+	}{
+		{"student-team member enrolled", map[string]bool{studentSlug: true}, nil, false},
+		{"ta staff member enrolled", map[string]bool{taSlug: true}, nil, false},
+		{"active member on no team rejected", map[string]bool{}, nil, true},
+		{"transient read fails open (propagates)", map[string]bool{}, map[string]bool{studentSlug: true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/orgs/"+org+"/teams/", func(w http.ResponseWriter, r *http.Request) {
+				parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/orgs/"+org+"/teams/"), "/memberships/")
+				slug := parts[0]
+				switch {
+				case tc.transientTeams[slug]:
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(`{}`))
+				case tc.activeMembers[slug]:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"state":"active"}`))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{}`))
+				}
+			})
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+			client := newTestRESTClient(t, server)
+
+			err := assertEnrolledOrStaff(client, org, classroom, user)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -235,3 +235,56 @@ func FeedbackPRBody(head, releaseURL string) string {
 		"</details>",
 	}, "\n")
 }
+
+// StaffRole is a per-classroom staff role backing the web GUI's in-app roles.
+// Each maps to a `secret` GitHub team named `classroom50-<short>-<role>`.
+// Mirrors web StaffRole (web/src/types/classroom.ts) and gh-teacher
+// configrepo.StaffRole — a cross-tool contract with no compile-time link.
+type StaffRole string
+
+const (
+	RoleTeacher StaffRole = "teacher"
+	RoleHeadTA  StaffRole = "hta"
+	RoleTA      StaffRole = "ta"
+	// RoleInstructor is the legacy name for RoleTeacher, kept so pre-rename
+	// classrooms (whose team slug says "instructor") still resolve on read.
+	RoleInstructor StaffRole = "instructor"
+)
+
+// StaffRolesWithLegacy is every staff role INCLUDING the legacy instructor
+// alias, for reads (membership probes, slug enumeration) that must recognize a
+// not-yet-migrated `-instructor` team. Mirrors web STAFF_ROLES_WITH_LEGACY.
+var StaffRolesWithLegacy = []StaffRole{
+	RoleTeacher,
+	RoleInstructor,
+	RoleHeadTA,
+	RoleTA,
+}
+
+// ClassroomStudentTeamSlug is the single source of the student team slug
+// `classroom50-<short>`. The short-name is canonical (lowercase alnum +
+// hyphens), so the slug equals the name. Byte-mirrors web classroomTeamSlug and
+// gh-teacher classroomTeamName — keep in lockstep (pinned by contract_test.go).
+func ClassroomStudentTeamSlug(shortName string) string {
+	return ConfigRepoName + "-" + shortName
+}
+
+// StaffTeamSlug is the single source of a staff-role team slug
+// `classroom50-<short>-<role>`. Byte-mirrors web classroomTeamSlug(short, role)
+// and gh-teacher staffTeamName.
+func StaffTeamSlug(shortName string, role StaffRole) string {
+	return ConfigRepoName + "-" + shortName + "-" + string(role)
+}
+
+// ClassroomTeamSlugs is the full set of team slugs whose membership means a
+// user is enrolled in a classroom: the student team plus every staff team
+// (including the legacy instructor team). Single-sources the "is enrolled?"
+// slug enumeration so a role change can't drift the gate. Ordered
+// student-first so a sequential caller can short-circuit on the common case.
+func ClassroomTeamSlugs(shortName string) []string {
+	slugs := []string{ClassroomStudentTeamSlug(shortName)}
+	for _, role := range StaffRolesWithLegacy {
+		slugs = append(slugs, StaffTeamSlug(shortName, role))
+	}
+	return slugs
+}

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -71,6 +71,42 @@ func TestContractLiterals(t *testing.T) {
 	}
 }
 
+// TestClassroomTeamSlugs pins the team-slug formula and the full enrolled-set
+// enumeration. These are byte-mirrored, with NO compile-time link, in the web
+// GUI (web/src/util/teamSlug.ts classroomTeamSlug / classroomTeamSlugs) and
+// gh-teacher (internal/configrepo/team.go classroomTeamName / staffTeamName).
+// The set is ordered student-first and includes the legacy instructor team so a
+// not-yet-migrated staffer still reads as enrolled. Update every copy in
+// lockstep on change.
+func TestClassroomTeamSlugs(t *testing.T) {
+	if got := ClassroomStudentTeamSlug("cs101"); got != "classroom50-cs101" {
+		t.Errorf("ClassroomStudentTeamSlug = %q, want %q", got, "classroom50-cs101")
+	}
+	if got := StaffTeamSlug("cs101", RoleTeacher); got != "classroom50-cs101-teacher" {
+		t.Errorf("StaffTeamSlug(teacher) = %q, want %q", got, "classroom50-cs101-teacher")
+	}
+	if got := StaffTeamSlug("cs101", RoleInstructor); got != "classroom50-cs101-instructor" {
+		t.Errorf("StaffTeamSlug(instructor) = %q, want %q", got, "classroom50-cs101-instructor")
+	}
+	// A classroom short-name may contain hyphens; the slug must not mangle them.
+	want := []string{
+		"classroom50-cs-principles",
+		"classroom50-cs-principles-teacher",
+		"classroom50-cs-principles-instructor",
+		"classroom50-cs-principles-hta",
+		"classroom50-cs-principles-ta",
+	}
+	got := ClassroomTeamSlugs("cs-principles")
+	if len(got) != len(want) {
+		t.Fatalf("ClassroomTeamSlugs len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ClassroomTeamSlugs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // TestAssignmentRepoName pins the lowercasing of all three segments and the
 // prefix/name relationship (owner is recoverable by stripping the prefix).
 // Cross-language agreement with the Python mirrors is enforced separately by

--- a/web/src/domain/assignments/accept.enrollment.test.ts
+++ b/web/src/domain/assignments/accept.enrollment.test.ts
@@ -93,4 +93,17 @@ describe("assertEnrolledOrStaff", () => {
       assertEnrolledOrStaff(client, org, classroom, user),
     ).rejects.toBeInstanceOf(GitHubAPIError)
   })
+
+  it("a definitive member resolves even when a sibling probe errors transiently", async () => {
+    // Regression: a parallel probe set must not let an unrelated transient
+    // failure block an enrolled student. Student-team member + a 500 on the
+    // staff probe must still resolve (enrolled wins over the sibling blip).
+    const client = makeClient({
+      activeTeams: [studentSlug],
+      transientTeams: [taSlug],
+    })
+    await expect(
+      assertEnrolledOrStaff(client, org, classroom, user),
+    ).resolves.toBeUndefined()
+  })
 })

--- a/web/src/domain/assignments/accept.enrollment.test.ts
+++ b/web/src/domain/assignments/accept.enrollment.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { assertEnrolledOrStaff } from "./accept"
+import type { GitHubClient } from "@/github-core/client"
+import { GitHubAPIError } from "@/github-core/errors"
+
+// A 404 GitHubAPIError shaped like the real membership-read miss (isNotFound).
+function notFound(path: string): GitHubAPIError {
+  return new GitHubAPIError({
+    status: 404,
+    url: path,
+    message: "Not Found",
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
+function serverError(path: string): GitHubAPIError {
+  return new GitHubAPIError({
+    status: 500,
+    url: path,
+    message: "Server Error",
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
+// Build a client whose team-membership reads succeed for `activeTeams`, 404 for
+// everything else, and 500 for `transientTeams` (to exercise fail-open).
+function makeClient(opts: {
+  activeTeams?: string[]
+  transientTeams?: string[]
+}): GitHubClient {
+  const active = new Set(opts.activeTeams ?? [])
+  const transient = new Set(opts.transientTeams ?? [])
+  const request = vi.fn(async (path: string) => {
+    const match = /\/teams\/([^/]+)\/memberships\//.exec(path)
+    const slug = match ? decodeURIComponent(match[1]) : ""
+    if (transient.has(slug)) throw serverError(path)
+    if (active.has(slug)) return { state: "active" }
+    throw notFound(path)
+  })
+  return { request } as unknown as GitHubClient
+}
+
+describe("assertEnrolledOrStaff", () => {
+  const org = "cs50"
+  const classroom = "cs-fall"
+  const user = "alice"
+  const studentSlug = `classroom50-${classroom}`
+  const taSlug = `classroom50-${classroom}-ta`
+
+  it("passes for a student-team member", async () => {
+    const client = makeClient({ activeTeams: [studentSlug] })
+    await expect(
+      assertEnrolledOrStaff(client, org, classroom, user),
+    ).resolves.toBeUndefined()
+  })
+
+  it("passes for a staff-team member (bypass)", async () => {
+    const client = makeClient({ activeTeams: [taSlug] })
+    await expect(
+      assertEnrolledOrStaff(client, org, classroom, user),
+    ).resolves.toBeUndefined()
+  })
+
+  it("throws a localized notEnrolled error for a non-member (all definitive 404)", async () => {
+    const client = makeClient({ activeTeams: [] })
+    await expect(
+      assertEnrolledOrStaff(client, org, classroom, user),
+    ).rejects.toMatchObject({
+      localized: { key: "accept.notEnrolled.error" },
+    })
+  })
+
+  it("fails open: a transient (non-404) read propagates instead of blocking", async () => {
+    const client = makeClient({ transientTeams: [studentSlug] })
+    await expect(
+      assertEnrolledOrStaff(client, org, classroom, user),
+    ).rejects.toBeInstanceOf(GitHubAPIError)
+  })
+})

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -22,8 +22,7 @@ import { fetchAssignmentFromPages } from "../queries/assignments"
 import { getAuthenticatedUser } from "../queries/users"
 import { acceptAndVerifyOrgMembership } from "../users"
 import { isOwnerGitHubOrgRole } from "@/authz"
-import { classroomTeamSlug } from "@/util/teamSlug"
-import { STAFF_ROLES_WITH_LEGACY } from "@/types/classroom"
+import { classroomTeamSlugs } from "@/util/teamSlug"
 import { GitHubAPIError } from "@/github-core/errors"
 import {
   log,
@@ -392,27 +391,35 @@ async function isActiveTeamMember(
 // Enforce that the viewer is enrolled in this classroom before accept: on the
 // `classroom50-<classroom>` student team, OR holding a staff role
 // (teacher/hta/ta, incl. the legacy `-instructor` team). Owners are filtered by
-// the caller. The student-team slug is derived (a student can't read
-// classroom.json for the GitHub-assigned slug); a slug-collision rewrite 404s
-// and reads as non-member, so a miss never grants false access. A transient
-// read rethrows (fail-open) rather than blocking; the definitive block is a
-// localized AcceptStepError only when every probe returns a definitive answer.
+// the caller. The slug set is single-sourced from classroomTeamSlugs. The slugs
+// are derived (a student can't read classroom.json for the GitHub-assigned
+// slug); a slug-collision rewrite 404s and reads as non-member, so a miss never
+// grants false access.
+//
+// Fail-OPEN semantics: a definitive membership on ANY probe means enrolled,
+// even if a sibling probe hit a transient error — so an enrolled student is
+// never blocked by an unrelated blip. Only when every probe returns a
+// definitive non-member do we block; a transient error with no definitive
+// member rethrows so the flow surfaces a retryable failure rather than a
+// wrongful "not enrolled".
 export async function assertEnrolledOrStaff(
   client: GitHubClient,
   org: string,
   classroom: string,
   username: string,
 ): Promise<void> {
-  const slugs = [
-    classroomTeamSlug(classroom),
-    ...STAFF_ROLES_WITH_LEGACY.map((role) =>
-      classroomTeamSlug(classroom, role),
+  const results = await Promise.allSettled(
+    classroomTeamSlugs(classroom).map((slug) =>
+      isActiveTeamMember(client, org, slug, username),
     ),
-  ]
-  const results = await Promise.all(
-    slugs.map((slug) => isActiveTeamMember(client, org, slug, username)),
   )
-  if (results.some(Boolean)) return
+  const isMember = (r: (typeof results)[number]) =>
+    r.status === "fulfilled" && r.value
+  if (results.some(isMember)) return
+  // No definitive membership. If any probe failed transiently, fail open by
+  // rethrowing that error (retryable) instead of a wrongful not-enrolled block.
+  const rejected = results.find((r) => r.status === "rejected")
+  if (rejected && rejected.status === "rejected") throw rejected.reason
   throw new AcceptStepError({ key: "accept.notEnrolled.error" })
 }
 

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -22,6 +22,9 @@ import { fetchAssignmentFromPages } from "../queries/assignments"
 import { getAuthenticatedUser } from "../queries/users"
 import { acceptAndVerifyOrgMembership } from "../users"
 import { isOwnerGitHubOrgRole } from "@/authz"
+import { classroomTeamSlug } from "@/util/teamSlug"
+import { STAFF_ROLES_WITH_LEGACY } from "@/types/classroom"
+import { GitHubAPIError } from "@/github-core/errors"
 import {
   log,
   withAcceptStep,
@@ -364,6 +367,55 @@ async function openFeedbackPrStep(params: {
   })
 }
 
+// Self-scoped "is the viewer active on this team?" probe. 2xx + active =>
+// member, a definitive 404 => non-member; any other status (transient) throws
+// so the caller fails OPEN rather than blocking a real student on a blip.
+async function isActiveTeamMember(
+  client: GitHubClient,
+  org: string,
+  teamSlug: string,
+  username: string,
+): Promise<boolean> {
+  try {
+    const membership = await client.request<{ state?: string }>(
+      `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+        teamSlug,
+      )}/memberships/${encodeURIComponent(username)}`,
+    )
+    return membership.state === "active"
+  } catch (err) {
+    if (err instanceof GitHubAPIError && err.isNotFound) return false
+    throw err
+  }
+}
+
+// Enforce that the viewer is enrolled in this classroom before accept: on the
+// `classroom50-<classroom>` student team, OR holding a staff role
+// (teacher/hta/ta, incl. the legacy `-instructor` team). Owners are filtered by
+// the caller. The student-team slug is derived (a student can't read
+// classroom.json for the GitHub-assigned slug); a slug-collision rewrite 404s
+// and reads as non-member, so a miss never grants false access. A transient
+// read rethrows (fail-open) rather than blocking; the definitive block is a
+// localized AcceptStepError only when every probe returns a definitive answer.
+export async function assertEnrolledOrStaff(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  username: string,
+): Promise<void> {
+  const slugs = [
+    classroomTeamSlug(classroom),
+    ...STAFF_ROLES_WITH_LEGACY.map((role) =>
+      classroomTeamSlug(classroom, role),
+    ),
+  ]
+  const results = await Promise.all(
+    slugs.map((slug) => isActiveTeamMember(client, org, slug, username)),
+  )
+  if (results.some(Boolean)) return
+  throw new AcceptStepError({ key: "accept.notEnrolled.error" })
+}
+
 export async function acceptAssignment(params: {
   client: GitHubClient
   org: string
@@ -399,6 +451,13 @@ export async function acceptAssignment(params: {
   // can't create their repo). Verifying here means a SAML-SSO-gated 403 surfaces
   // as an actionable step failure right away (with the SSO/HTTP status) instead
   // of a confusing downstream repo/access failure.
+  //
+  // Also enforce classroom enrollment: a plain org member who isn't on this
+  // classroom's student team (and holds no staff role) can't accept — the same
+  // rule the student list and a private template already imply, made consistent
+  // for public templates too. Org owners bypass (they administer every
+  // classroom). Advisory like every client-side gate; GitHub's private-template
+  // permission remains the hard boundary.
   const membership = await withAcceptStep(
     {
       id: "membership",
@@ -407,7 +466,13 @@ export async function acceptAssignment(params: {
       doneMessage: { key: "accept.stepDone.membership" },
       onStepUpdate,
     },
-    () => acceptAndVerifyOrgMembership(client, org),
+    async () => {
+      const verified = await acceptAndVerifyOrgMembership(client, org)
+      if (!isOwnerGitHubOrgRole(verified.role)) {
+        await assertEnrolledOrStaff(client, org, classroom, username)
+      }
+      return verified
+    },
   )
 
   // An org owner who creates the repo holds admin and can't self-downgrade to

--- a/web/src/hooks/useClassroomEnrollment.integration.test.tsx
+++ b/web/src/hooks/useClassroomEnrollment.integration.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import { GitHubAPIError } from "@/github-core/errors"
+
+// Same team-membership harness shape as useClassroomRole's integration test:
+// each per-role team responder is switchable so we can compose enrollment
+// verdicts. `<classroom>` (no suffix) is the students team.
+type Resp = "active" | "404" | "500"
+let teacherResp: Resp = "404"
+let instructorResp: Resp = "404"
+let htaResp: Resp = "404"
+let taResp: Resp = "404"
+let studentResp: Resp = "404"
+// Optional latch so a test can hold a probe in flight and assert the loading
+// gate before it settles.
+let studentGate: Promise<void> | null = null
+
+const err = (status: number, url: string) =>
+  new GitHubAPIError({
+    status,
+    url,
+    message: `boom ${status}`,
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+
+const respond = (url: string, r: Resp) => {
+  if (r === "active") return Promise.resolve({ state: "active" })
+  return Promise.reject(err(r === "404" ? 404 : 500, url))
+}
+
+const request = vi.fn(async (url: string) => {
+  if (url.includes("-teacher/memberships/")) return respond(url, teacherResp)
+  if (url.includes("-instructor/memberships/"))
+    return respond(url, instructorResp)
+  if (url.includes("-hta/memberships/")) return respond(url, htaResp)
+  if (url.includes("-ta/memberships/")) return respond(url, taResp)
+  if (url.includes("/memberships/")) {
+    if (studentGate) await studentGate
+    return respond(url, studentResp)
+  }
+  return Promise.resolve({})
+})
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request }),
+}))
+vi.mock("@/context/roleView/RoleViewProvider", () => ({
+  useRoleView: () => ({ viewAs: null, setViewAs: () => {} }),
+}))
+
+// Imported AFTER the mocks so the hook picks up the mocked client.
+import { useClassroomEnrollment } from "./useClassroomEnrollment"
+
+const wrapper = ({ children }: PropsWithChildren) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0, gcTime: 0 } },
+  })
+  return createElement(QueryClientProvider, { client }, children)
+}
+
+const renderEnrollment = (username: string | undefined = "u") =>
+  renderHook(() => useClassroomEnrollment("acme", "cs101", username), {
+    wrapper,
+  })
+
+beforeEach(() => {
+  teacherResp = "404"
+  instructorResp = "404"
+  htaResp = "404"
+  taResp = "404"
+  studentResp = "404"
+  studentGate = null
+  request.mockClear()
+})
+
+describe("useClassroomEnrollment", () => {
+  it("enrolled when the student-team membership is active", async () => {
+    studentResp = "active"
+    const { result } = renderEnrollment()
+    await waitFor(() => expect(result.current.verdict).toBe("enrolled"))
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("enrolled (staff bypass) when a staff-team membership is active", async () => {
+    taResp = "active"
+    const { result } = renderEnrollment()
+    await waitFor(() => expect(result.current.verdict).toBe("enrolled"))
+  })
+
+  it("not-enrolled once all reads settle as definitive non-member", async () => {
+    const { result } = renderEnrollment()
+    await waitFor(() => {
+      expect(result.current.verdict).toBe("not-enrolled")
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+
+  it("holds isLoading (no flash) while the student read is in flight, then flips to not-enrolled", async () => {
+    // The anti-flash guarantee: until the probe settles, isLoading is true so
+    // the page shows the spinner rather than the accept card. It must NOT
+    // report a premature not-enrolled verdict during the in-flight window.
+    let release!: () => void
+    studentGate = new Promise<void>((res) => {
+      release = res
+    })
+    const { result } = renderEnrollment()
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+    expect(result.current.verdict).not.toBe("not-enrolled")
+
+    release()
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.verdict).toBe("not-enrolled")
+    })
+  })
+
+  it("fails open to unresolved (not not-enrolled) when the student read errors non-404", async () => {
+    studentResp = "500"
+    const { result } = renderEnrollment()
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false)
+        expect(result.current.verdict).toBe("unresolved")
+      },
+      { timeout: 5000 },
+    )
+  })
+
+  it("does not pin isLoading when disabled (no username)", async () => {
+    const { result } = renderEnrollment(undefined)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+})

--- a/web/src/hooks/useClassroomEnrollment.ts
+++ b/web/src/hooks/useClassroomEnrollment.ts
@@ -22,7 +22,7 @@ export function useClassroomEnrollment(
   org: string | undefined,
   classroom: string | undefined,
   username: string | undefined,
-): { verdict: EnrollmentVerdict; isLoading: boolean; refetch: () => void } {
+): { verdict: EnrollmentVerdict; isLoading: boolean } {
   const client = useGitHubClient()
   const enabled = Boolean(org && classroom && username)
   const studentSlug = org && classroom ? classroomTeamSlug(classroom) : ""
@@ -36,11 +36,11 @@ export function useClassroomEnrollment(
   // student-team probe collapses a non-member to the "student" default, so it
   // can't tell an enrolled student from an outsider — the dedicated
   // studentQuery above supplies that signal.
-  const {
-    role,
-    isLoading: loadingRole,
-    refetch: refetchRole,
-  } = useClassroomRole(org, classroom, username)
+  const { role, isLoading: loadingRole } = useClassroomRole(
+    org,
+    classroom,
+    username,
+  )
 
   const isStaff = role === "teacher" || role === "hta" || role === "ta"
   const student = membershipFromQuery(
@@ -59,13 +59,7 @@ export function useClassroomEnrollment(
     verdict = "unresolved"
   }
 
-  const { refetch: refetchStudent } = studentQuery
-  const refetch = () => {
-    void refetchStudent()
-    refetchRole()
-  }
-
-  return { verdict, isLoading, refetch }
+  return { verdict, isLoading }
 }
 
 export default useClassroomEnrollment

--- a/web/src/hooks/useClassroomEnrollment.ts
+++ b/web/src/hooks/useClassroomEnrollment.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { classroomTeamSlug } from "@/util/teamSlug"
+import { membershipFromQuery } from "@/authz"
+import { teamMembershipQuery, useClassroomRole } from "./useClassroomRole"
+
+// A settled enrollment verdict for the accept gate. "unresolved" means a team
+// read is still in flight or a transient error left the verdict unknown — the
+// caller must fail OPEN on it (never lock out a real student on a blip).
+export type EnrollmentVerdict = "enrolled" | "not-enrolled" | "unresolved"
+
+// Whether the viewer may accept in this classroom: enrolled = on the
+// `classroom50-<classroom>` student team, OR holding a classroom staff role
+// (teacher/hta/ta). Org owners are NOT resolved here — that bypass lives at the
+// call site, which already holds the org membership.
+//
+// The student-team slug is derived (a student can't read classroom.json for the
+// GitHub-assigned slug); on a slug-collision rewrite the derived slug 404s and
+// reads as non-member, so a miss never grants false access — the same
+// safe-degrade useClassroomRole relies on.
+export function useClassroomEnrollment(
+  org: string | undefined,
+  classroom: string | undefined,
+  username: string | undefined,
+): { verdict: EnrollmentVerdict; isLoading: boolean; refetch: () => void } {
+  const client = useGitHubClient()
+  const enabled = Boolean(org && classroom && username)
+  const studentSlug = org && classroom ? classroomTeamSlug(classroom) : ""
+
+  const studentQuery = useQuery({
+    ...teamMembershipQuery(client, org ?? "", studentSlug, username ?? ""),
+    enabled,
+  })
+
+  // Reuse the full role resolution for the staff bypass (teacher/hta/ta). Its
+  // student-team probe collapses a non-member to the "student" default, so it
+  // can't tell an enrolled student from an outsider — the dedicated
+  // studentQuery above supplies that signal.
+  const {
+    role,
+    isLoading: loadingRole,
+    refetch: refetchRole,
+  } = useClassroomRole(org, classroom, username)
+
+  const isStaff = role === "teacher" || role === "hta" || role === "ta"
+  const student = membershipFromQuery(
+    studentQuery.isSuccess,
+    studentQuery.error,
+  )
+
+  const isLoading = studentQuery.fetchStatus === "fetching" || loadingRole
+
+  let verdict: EnrollmentVerdict
+  if (isStaff || student === "member") {
+    verdict = "enrolled"
+  } else if (student === "non-member" && !loadingRole) {
+    verdict = "not-enrolled"
+  } else {
+    verdict = "unresolved"
+  }
+
+  const { refetch: refetchStudent } = studentQuery
+  const refetch = () => {
+    void refetchStudent()
+    refetchRole()
+  }
+
+  return { verdict, isLoading, refetch }
+}
+
+export default useClassroomEnrollment

--- a/web/src/hooks/useClassroomEnrollment.ts
+++ b/web/src/hooks/useClassroomEnrollment.ts
@@ -48,7 +48,15 @@ export function useClassroomEnrollment(
     studentQuery.error,
   )
 
-  const isLoading = studentQuery.fetchStatus === "fetching" || loadingRole
+  // Loading = the student probe is fetching (incl. retries) OR its result isn't
+  // in yet while enabled, OR the staff-role reads are still resolving. Holding
+  // on the enabled-but-not-yet-settled window is what prevents the accept card
+  // from flashing before the verdict lands and then flipping to "not available".
+  const studentSettled = studentQuery.isSuccess || studentQuery.isError
+  const isLoading =
+    studentQuery.fetchStatus === "fetching" ||
+    (enabled && !studentSettled) ||
+    loadingRole
 
   let verdict: EnrollmentVerdict
   if (isStaff || student === "member") {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1714,6 +1714,12 @@
       "title": "This assignment is locked",
       "body": "Your teacher has locked <assignment>{{assignment}}</assignment>, so it can't be accepted right now. Check back later or ask your teacher to unlock it."
     },
+    "notEnrolled": {
+      "badge": "Unavailable",
+      "title": "This assignment isn't available to you",
+      "body": "Ask your teacher if you think this is a mistake.",
+      "error": "This assignment isn't available to you. Ask your teacher if you think this is a mistake."
+    },
     "steps": {
       "account": "Checking your GitHub account",
       "membership": "Confirming your classroom membership",

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -17,6 +17,9 @@ const pagesAssignmentsSpy =
   vi.fn<(org?: string, classroom?: string, secret?: string) => void>()
 const searchParams: { k?: string } = { k: "test-secret" }
 let studentClassroomsData: Array<{ classroom: string; secret?: string }> = []
+// Enrollment-gate inputs, reset per test. Default: active member, enrolled.
+let orgRole = "member"
+let enrollmentVerdict: "enrolled" | "not-enrolled" | "unresolved" = "enrolled"
 
 vi.mock("@/domain/assignments", () => ({
   acceptAssignment: (...args: unknown[]) => acceptAssignment(...args),
@@ -56,9 +59,16 @@ vi.mock("@/hooks/useGetRepo", () => ({
 }))
 vi.mock("@/hooks/useGetOwnOrgMembership", () => ({
   default: () => ({
-    data: { state: "active" },
+    data: { state: "active", role: orgRole },
     isLoading: false,
     error: null,
+    refetch: vi.fn(),
+  }),
+}))
+vi.mock("@/hooks/useClassroomEnrollment", () => ({
+  useClassroomEnrollment: () => ({
+    verdict: enrollmentVerdict,
+    isLoading: false,
     refetch: vi.fn(),
   }),
 }))
@@ -160,6 +170,8 @@ beforeEach(() => {
   pagesAssignmentsSpy.mockReset()
   searchParams.k = "test-secret"
   studentClassroomsData = []
+  orgRole = "member"
+  enrollmentVerdict = "enrolled"
   __resetGitHubHealthForTest()
 })
 
@@ -472,5 +484,54 @@ describe("AcceptAssignmentPage outage hint", () => {
       new Error("Couldn't copy the template — ask your teacher."),
     )
     expect(screen.queryByText(STATUS_LINK)).toBeNull()
+  })
+})
+
+describe("AcceptAssignmentPage enrollment gate", () => {
+  const renderWith = () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    renderPage(client)
+  }
+
+  it("blocks a member who is not enrolled in the classroom", () => {
+    enrollmentVerdict = "not-enrolled"
+    renderWith()
+    expect(screen.queryByText("accept.notEnrolled.title")).not.toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "accept.acceptButton" }),
+    ).toBeNull()
+  })
+
+  it("lets an enrolled student reach the accept card", () => {
+    enrollmentVerdict = "enrolled"
+    renderWith()
+    expect(screen.queryByText("accept.notEnrolled.title")).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "accept.acceptButton" }),
+    ).not.toBeNull()
+  })
+
+  it("lets an org owner bypass the gate even when not enrolled", () => {
+    enrollmentVerdict = "not-enrolled"
+    orgRole = "admin"
+    renderWith()
+    expect(screen.queryByText("accept.notEnrolled.title")).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "accept.acceptButton" }),
+    ).not.toBeNull()
+  })
+
+  it("fails open on an unresolved verdict (a transient team read)", () => {
+    enrollmentVerdict = "unresolved"
+    renderWith()
+    expect(screen.queryByText("accept.notEnrolled.title")).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "accept.acceptButton" }),
+    ).not.toBeNull()
   })
 })

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -69,7 +69,6 @@ vi.mock("@/hooks/useClassroomEnrollment", () => ({
   useClassroomEnrollment: () => ({
     verdict: enrollmentVerdict,
     isLoading: false,
-    refetch: vi.fn(),
   }),
 }))
 vi.mock("@/hooks/mutations/useAcceptAndVerifyMembership", () => ({

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -32,6 +32,8 @@ import {
   MembershipError,
 } from "@/components/MembershipError"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
+import { useClassroomEnrollment } from "@/hooks/useClassroomEnrollment"
+import { isOwnerGitHubOrgRole } from "@/authz"
 import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { formatDueDateTime, isPastDue } from "@/util/formatDate"
@@ -261,6 +263,51 @@ const AssignmentLocked = ({
                   ),
                 }}
               />
+            </p>
+          </div>
+
+          <div className="divider my-0" />
+
+          <div className="space-y-3">
+            <label className="label p-0 text-base font-semibold">
+              {t("accept.signedInAs")}
+            </label>
+
+            <UserInfo user={user} />
+          </div>
+        </Card.Body>
+      </AcceptCard>
+    </AcceptLayout>
+  )
+}
+
+// Shown when the viewer is an active org member but is NOT enrolled in this
+// classroom (not on the `classroom50-<classroom>` student team) and holds no
+// staff role. Enrollment is derived from live team-membership reads, the same
+// signal roster/role resolution uses; a student can't read classroom.json, so
+// the slug is derived (a miss reads as non-member — never false access). This
+// is a listing-and-flow guard consistent with the client-side model: the hard
+// boundary for a private template is still GitHub's own template permission.
+// Kept intentionally terse — it states the assignment isn't available without
+// explaining the enrollment mechanics.
+const NotEnrolled = ({ user }: { user: GitHubUser | null }) => {
+  const { t } = useTranslation()
+  return (
+    <AcceptLayout>
+      <AcceptCard>
+        <Card.Body className="gap-8">
+          <div>
+            <span className="badge badge-warning badge-soft gap-2">
+              <Lock aria-hidden="true" className="size-4" />
+              {t("accept.notEnrolled.badge")}
+            </span>
+
+            <h1 className="mt-6 text-2xl font-bold">
+              {t("accept.notEnrolled.title")}
+            </h1>
+
+            <p className="mt-2 text-base text-base-content/70">
+              {t("accept.notEnrolled.body")}
             </p>
           </div>
 
@@ -609,6 +656,17 @@ const AcceptAssignmentPage = () => {
   const { user } = useGithubAuth()
   const username = user?.login
 
+  // Enrollment gate: a student may only accept in a classroom they're enrolled
+  // in (on the `classroom50-<classroom>` student team). Staff bypass via the
+  // verdict; org owners bypass at the check below. Fail-OPEN on "unresolved" (a
+  // transient team read) so a blip can't lock out a real student — the domain
+  // membership step and GitHub's private-template permission still gate.
+  const { verdict: enrollmentVerdict } = useClassroomEnrollment(
+    org,
+    classroom,
+    username,
+  )
+
   const { data: assignmentsData, isLoading: loadingAssignmentsData } =
     usePagesAssignments(org, classroom, secret, !loadingSecret)
   const loadingAssignments = loadingSecret || loadingAssignmentsData
@@ -761,6 +819,17 @@ const AcceptAssignmentPage = () => {
         <Spinner size="xl" label={t("accept.loadingAssignment")} />
       </AcceptLayout>
     )
+  }
+
+  // Not enrolled in this classroom (and not staff): the assignment isn't
+  // available to this student. Org owners bypass (they administer every
+  // classroom). Only a SETTLED "not-enrolled" verdict blocks; "unresolved"
+  // falls through (fail-open).
+  if (
+    enrollmentVerdict === "not-enrolled" &&
+    !isOwnerGitHubOrgRole(orgInvite.role)
+  ) {
+    return <NotEnrolled user={user} />
   }
 
   if (!assignmentData) {

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -659,13 +659,13 @@ const AcceptAssignmentPage = () => {
   // Enrollment gate: a student may only accept in a classroom they're enrolled
   // in (on the `classroom50-<classroom>` student team). Staff bypass via the
   // verdict; org owners bypass at the check below. Fail-OPEN on "unresolved" (a
-  // transient team read) so a blip can't lock out a real student — the domain
-  // membership step and GitHub's private-template permission still gate.
-  const { verdict: enrollmentVerdict } = useClassroomEnrollment(
-    org,
-    classroom,
-    username,
-  )
+  // settled-but-indeterminate team read) so a blip can't lock out a real
+  // student — the domain membership step and GitHub's private-template
+  // permission still gate. While the read is still in flight we hold the
+  // spinner (loadingEnrollment below) rather than flashing the accept card and
+  // then flipping to "not available".
+  const { verdict: enrollmentVerdict, isLoading: loadingEnrollment } =
+    useClassroomEnrollment(org, classroom, username)
 
   const { data: assignmentsData, isLoading: loadingAssignmentsData } =
     usePagesAssignments(org, classroom, secret, !loadingSecret)
@@ -746,7 +746,12 @@ const AcceptAssignmentPage = () => {
   // with no descriptor (a browser network throw) falls back to the generic copy.
   const acceptError = localizedMessageOf(acceptMutation.error)
 
-  if (loadingAssignments || isLoadingRepo || loadingOrgMembership) {
+  if (
+    loadingAssignments ||
+    isLoadingRepo ||
+    loadingOrgMembership ||
+    loadingEnrollment
+  ) {
     return (
       <AcceptLayout>
         <Spinner size="xl" label={t("accept.loadingAssignment")} />

--- a/web/src/util/teamSlug.test.ts
+++ b/web/src/util/teamSlug.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   classroomTeamSlug,
+  classroomTeamSlugs,
   resolveClassroomRoleSlug,
   parseClassroomTeamSlug,
   parseStudentClassroomSlug,
@@ -21,6 +22,21 @@ describe("classroomTeamSlug", () => {
       "classroom50-cs101-instructor",
     )
     expect(classroomTeamSlug("cs101", "ta")).toBe("classroom50-cs101-ta")
+  })
+})
+
+// The enrolled-set enumeration, student-first and legacy-inclusive. Byte-mirrors
+// the CLI's contract.ClassroomTeamSlugs — a drift here would let the accept
+// gate and the CLI disagree on who counts as enrolled.
+describe("classroomTeamSlugs", () => {
+  it("returns the student team then every staff team (incl. legacy instructor)", () => {
+    expect(classroomTeamSlugs("cs-principles")).toEqual([
+      "classroom50-cs-principles",
+      "classroom50-cs-principles-teacher",
+      "classroom50-cs-principles-instructor",
+      "classroom50-cs-principles-hta",
+      "classroom50-cs-principles-ta",
+    ])
   })
 })
 

--- a/web/src/util/teamSlug.ts
+++ b/web/src/util/teamSlug.ts
@@ -31,6 +31,23 @@ export function classroomTeamSlug(
     : `${CONFIG_REPO}-${classroom}-${role}`
 }
 
+// The full set of team slugs whose active membership means a user is enrolled
+// in a classroom: the student team plus every staff team (including the legacy
+// `-instructor` team so a not-yet-migrated staffer still reads as enrolled).
+// Single-sources the "is enrolled?" slug enumeration — the accept gate (the
+// self-scoped enrollment probe and the accept-flow guard) derives its slugs
+// here rather than re-listing roles, so a role change can't drift the gate.
+// Ordered student-first so a caller can short-circuit on the common case.
+// Byte-mirrors the CLI's contract.ClassroomTeamSlugs — keep in lockstep.
+export function classroomTeamSlugs(classroom: string): string[] {
+  return [
+    classroomTeamSlug(classroom),
+    ...STAFF_ROLES_WITH_LEGACY.map((role) =>
+      classroomTeamSlug(classroom, role),
+    ),
+  ]
+}
+
 // The authoritative per-classroom team slug for a role, preferring the slug
 // GitHub actually assigned (stored in classroom.json — GitHub can rewrite a slug
 // on a name collision) and falling back to the derived classroomTeamSlug when


### PR DESCRIPTION
## Summary

Enforces classroom enrollment at accept time so a plain org member can no longer accept a classroom's assignment they aren't enrolled in. Enrollment = active membership in the classroom student team (`classroom50-<classroom>`); classroom staff (teacher/hta/ta) and org owners bypass the gate.

The gate is applied consistently in all three places accept can happen:

- Web UI — a concise "This assignment isn't available to you" screen on `AcceptAssignmentPage` (new `useClassroomEnrollment` hook), shown before the accept CTA.
- Web accept flow — an enrollment check inside the `membership` step of `acceptAssignment()`, so a direct mutation is covered too, throwing a localized error.
- Student CLI — the same student-team/staff check in `gh student accept`, failing early with a clear message instead of a confusing downstream failure.

This is **advisory**, consistent with the app's client-side model: it fails **open** on a transient team read (a blip can't lock out a real student), and the hard access boundary for a private template remains GitHub's own template permission. It makes public-template classrooms behave like private ones and gives a clear message either way.

The student-facing copy follows access-denied UX best practice: plain non-technical language, neutral non-blaming tone, and no leaked enrollment mechanics, resource names, or role structure (details are logged, not shown).

## Test plan

- [x] `web`: `npm run check` (tsc, eslint, prettier, arch:validate, 2713 vitest tests) passes.
- [x] `cli/gh-student`: `go build ./...`, `go test ./...`, `gofmt -l` (clean), `go vet` (clean).
- [x] New tests cover enrolled / staff-bypass / owner-bypass / not-enrolled / transient-fail-open across the web page, the web domain flow, and the CLI.
- [ ] Manual: as an org member NOT on classroom B's team, opening a classroom B accept link shows the unavailable screen; an enrolled student and staff can still accept.