### PR TITLE
feat(web): make settings section headings linkable via URL hash

### DIFF
--- a/web/src/components/status/TokenHealthChip.tsx
+++ b/web/src/components/status/TokenHealthChip.tsx
@@ -63,7 +63,7 @@ export function tokenChipVisible(entry: {
 
 // A per-org service-token health chip. Rendered only for owned orgs on the home
 // page; clicking deep-links into that org's Service Token settings pane
-// (?focus=serviceToken) so a multi-org teacher rotates without hunting.
+// (#service-token) so a multi-org teacher rotates without hunting.
 //
 // A healthy ("ok") token renders NOTHING — re-emphasizing "all good" is noise;
 // the absence of a chip is itself the healthy signal. "unknown" stays visible
@@ -111,7 +111,7 @@ export function TokenHealthChip({
     <Link
       to="/$org/settings"
       params={{ org }}
-      search={{ focus: "serviceToken" }}
+      hash="service-token"
       aria-label={t("serviceTokenHealth.chip.rotateAria", { org })}
       className="no-underline"
     >

--- a/web/src/components/ui/SectionAnchorHeading.test.tsx
+++ b/web/src/components/ui/SectionAnchorHeading.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (k: string, opts?: { section?: string }) =>
+      opts?.section ? `${k}:${opts.section}` : k,
+  }),
+}))
+
+const navigate = vi.fn<(opts?: unknown) => Promise<void>>(() =>
+  Promise.resolve(),
+)
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}))
+
+import { SectionAnchorHeading } from "./SectionAnchorHeading"
+
+afterEach(() => {
+  cleanup()
+  navigate.mockClear()
+})
+
+describe("SectionAnchorHeading", () => {
+  it("renders a heading whose text links to the section hash", () => {
+    render(
+      <SectionAnchorHeading anchorId="danger-zone">
+        Danger
+      </SectionAnchorHeading>,
+    )
+    const link = screen.getByRole("link", {
+      name: "common.linkToSection:Danger",
+    })
+    expect(link.getAttribute("href")).toBe("#danger-zone")
+  })
+
+  it("updates the hash on click (letting the hook own the scroll)", async () => {
+    render(
+      <SectionAnchorHeading anchorId="danger-zone">
+        Danger
+      </SectionAnchorHeading>,
+    )
+    await userEvent.click(screen.getByRole("link"))
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+    const arg = navigate.mock.calls[0][0] as {
+      to: string
+      hash: string
+      replace: boolean
+      state: (prev: Record<string, unknown>) => { scrollNonce?: number }
+    }
+    expect(arg.to).toBe(".")
+    expect(arg.hash).toBe("danger-zone")
+    expect(arg.replace).toBe(true)
+    // A fresh, strictly-increasing scrollNonce is stamped so an identical-hash
+    // re-click always re-fires (never a same-millisecond collision).
+    const first = arg.state({}).scrollNonce as number
+    const second = arg.state({}).scrollNonce as number
+    expect(first).toEqual(expect.any(Number))
+    expect(second).toBeGreaterThan(first)
+  })
+})

--- a/web/src/components/ui/SectionAnchorHeading.tsx
+++ b/web/src/components/ui/SectionAnchorHeading.tsx
@@ -1,15 +1,22 @@
-import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
-import { Link } from "@tanstack/react-router"
+import { useNavigate } from "@tanstack/react-router"
 
-// A section heading that doubles as its own anchor: the heading text itself is a
-// link that sets the URL hash to `anchorId`, which useHashSectionHighlight picks
-// up to scroll + highlight the section — and the hash stays in the URL so the
-// position is shareable/bookmarkable. A hover underline is the only affordance,
-// so the row stays as tight as a plain heading (no extra icon pushing an
-// adjacent tooltip away).
+// Monotonic per-session counter so every click stamps a distinct scrollNonce —
+// unlike Date.now(), which can repeat within a millisecond and let the hook's
+// dedupe guard swallow a legitimate re-click.
+let scrollSeq = 0
+
+// A section heading that doubles as its own anchor: the heading text is a link
+// that updates the URL hash to `anchorId` (shareable/bookmarkable). The actual
+// smooth scroll + highlight is owned solely by useHashSectionHighlight, keyed on
+// the hash change — so there is exactly one scroll per click and no competing
+// animations.
 //
-// `to="."` keeps the current path (and search); only the hash changes.
+// preventDefault blocks the browser's instant fragment jump; a `scrollNonce` in
+// history state makes an identical-hash re-click still register as a change the
+// hook reacts to (TanStack #3437 otherwise no-ops a same-hash navigation).
+// `replace: true` keeps repeated in-page section clicks from piling up
+// back-button history entries.
 export function SectionAnchorHeading({
   anchorId,
   children,
@@ -17,26 +24,31 @@ export function SectionAnchorHeading({
   as: Tag = "h2",
 }: {
   anchorId: string
-  children: ReactNode
+  children: string
   className?: string
   as?: "h2" | "h3"
 }) {
   const { t } = useTranslation()
-  const label =
-    typeof children === "string"
-      ? t("common.linkToSection", { section: children })
-      : t("common.linkToSectionGeneric")
+  const navigate = useNavigate()
 
   return (
     <Tag className={className}>
-      <Link
-        to="."
-        hash={anchorId}
-        aria-label={label}
+      <a
+        href={`#${anchorId}`}
+        aria-label={t("common.linkToSection", { section: children })}
         className="no-underline hover:underline"
+        onClick={(e) => {
+          e.preventDefault()
+          void navigate({
+            to: ".",
+            hash: anchorId,
+            replace: true,
+            state: (prev) => ({ ...prev, scrollNonce: ++scrollSeq }),
+          })
+        }}
       >
         {children}
-      </Link>
+      </a>
     </Tag>
   )
 }

--- a/web/src/components/ui/SectionAnchorHeading.tsx
+++ b/web/src/components/ui/SectionAnchorHeading.tsx
@@ -6,17 +6,15 @@ import { useNavigate } from "@tanstack/react-router"
 // dedupe guard swallow a legitimate re-click.
 let scrollSeq = 0
 
-// A section heading that doubles as its own anchor: the heading text is a link
-// that updates the URL hash to `anchorId` (shareable/bookmarkable). The actual
-// smooth scroll + highlight is owned solely by useHashSectionHighlight, keyed on
-// the hash change — so there is exactly one scroll per click and no competing
-// animations.
+// A section heading whose text is a link that sets the URL hash to `anchorId`
+// (shareable/bookmarkable). useHashSectionHighlight owns the resulting scroll +
+// highlight, so there is exactly one scroll per click.
 //
 // preventDefault blocks the browser's instant fragment jump; a `scrollNonce` in
 // history state makes an identical-hash re-click still register as a change the
-// hook reacts to (TanStack #3437 otherwise no-ops a same-hash navigation).
-// `replace: true` keeps repeated in-page section clicks from piling up
-// back-button history entries.
+// hook reacts to (TanStack otherwise no-ops a same-hash navigation).
+// `replace: true` keeps repeated in-page section clicks off the back-button
+// history.
 export function SectionAnchorHeading({
   anchorId,
   children,

--- a/web/src/components/ui/SectionAnchorHeading.tsx
+++ b/web/src/components/ui/SectionAnchorHeading.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import { Link } from "@tanstack/react-router"
+
+// A section heading that doubles as its own anchor: the heading text itself is a
+// link that sets the URL hash to `anchorId`, which useHashSectionHighlight picks
+// up to scroll + highlight the section — and the hash stays in the URL so the
+// position is shareable/bookmarkable. A hover underline is the only affordance,
+// so the row stays as tight as a plain heading (no extra icon pushing an
+// adjacent tooltip away).
+//
+// `to="."` keeps the current path (and search); only the hash changes.
+export function SectionAnchorHeading({
+  anchorId,
+  children,
+  className,
+  as: Tag = "h2",
+}: {
+  anchorId: string
+  children: ReactNode
+  className?: string
+  as?: "h2" | "h3"
+}) {
+  const { t } = useTranslation()
+  const label =
+    typeof children === "string"
+      ? t("common.linkToSection", { section: children })
+      : t("common.linkToSectionGeneric")
+
+  return (
+    <Tag className={className}>
+      <Link
+        to="."
+        hash={anchorId}
+        aria-label={label}
+        className="no-underline hover:underline"
+      >
+        {children}
+      </Link>
+    </Tag>
+  )
+}
+
+export default SectionAnchorHeading

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -12,6 +12,8 @@ export type {
 
 export { RouterButton } from "./RouterButton"
 
+export { SectionAnchorHeading } from "./SectionAnchorHeading"
+
 export { Card, CardBody, CardTitle, CardActions } from "./Card"
 export type { CardProps } from "./Card"
 

--- a/web/src/hooks/useHashSectionHighlight.test.ts
+++ b/web/src/hooks/useHashSectionHighlight.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+
+let hashValue = ""
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
+    select({ location: { hash: hashValue } }),
+}))
+
+import { useHashSectionHighlight } from "./useHashSectionHighlight"
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  hashValue = ""
+  document.body.innerHTML = ""
+  // rAF isn't provided by fake timers; make it synchronous so the scroll retry
+  // resolves within the test.
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    cb(0)
+    return 0
+  })
+  vi.stubGlobal("cancelAnimationFrame", () => {})
+})
+
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe("useHashSectionHighlight", () => {
+  it("returns null and does nothing when there is no hash", () => {
+    const { result } = renderHook(() => useHashSectionHighlight())
+    expect(result.current).toBeNull()
+  })
+
+  it("scrolls the matching section and highlights it", () => {
+    const scrollIntoView = vi.fn()
+    const el = document.createElement("section")
+    el.id = "service-token"
+    el.scrollIntoView = scrollIntoView
+    document.body.appendChild(el)
+
+    hashValue = "service-token"
+    const { result } = renderHook(() => useHashSectionHighlight())
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    })
+    expect(result.current).toBe("service-token")
+  })
+
+  it("drops the highlight after the timeout", () => {
+    const el = document.createElement("section")
+    el.id = "danger-zone"
+    el.scrollIntoView = vi.fn()
+    document.body.appendChild(el)
+
+    hashValue = "danger-zone"
+    const { result } = renderHook(() => useHashSectionHighlight())
+    expect(result.current).toBe("danger-zone")
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it("still highlights when the element is not mounted yet", () => {
+    hashValue = "not-mounted-yet"
+    const { result } = renderHook(() => useHashSectionHighlight())
+    expect(result.current).toBe("not-mounted-yet")
+  })
+})

--- a/web/src/hooks/useHashSectionHighlight.test.ts
+++ b/web/src/hooks/useHashSectionHighlight.test.ts
@@ -1,18 +1,20 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, renderHook } from "@testing-library/react"
+import { act, cleanup, renderHook } from "@testing-library/react"
 
 let hashValue = ""
+let scrollNonce: number | undefined
 
 vi.mock("@tanstack/react-router", () => ({
   useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
-    select({ location: { hash: hashValue } }),
+    select({ location: { hash: hashValue, state: { scrollNonce } } }),
 }))
 
 import { useHashSectionHighlight } from "./useHashSectionHighlight"
 
 beforeEach(() => {
   vi.useFakeTimers()
+  scrollNonce = undefined
   hashValue = ""
   document.body.innerHTML = ""
   // rAF isn't provided by fake timers; make it synchronous so the scroll retry
@@ -25,6 +27,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   vi.runOnlyPendingTimers()
   vi.useRealTimers()
   vi.unstubAllGlobals()
@@ -73,5 +76,27 @@ describe("useHashSectionHighlight", () => {
     hashValue = "not-mounted-yet"
     const { result } = renderHook(() => useHashSectionHighlight())
     expect(result.current).toBe("not-mounted-yet")
+  })
+
+  it("re-scrolls on a bumped scrollNonce even when the hash is unchanged", () => {
+    const scrollIntoView = vi.fn()
+    const el = document.createElement("section")
+    el.id = "service-token"
+    el.scrollIntoView = scrollIntoView
+    document.body.appendChild(el)
+
+    hashValue = "service-token"
+    scrollNonce = 1
+    const { rerender } = renderHook(() => useHashSectionHighlight())
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    // Same hash, new nonce (an identical-hash re-click) re-fires the scroll.
+    scrollNonce = 2
+    rerender()
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+
+    // A re-render with no nonce change does NOT scroll again.
+    rerender()
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
   })
 })

--- a/web/src/hooks/useHashSectionHighlight.ts
+++ b/web/src/hooks/useHashSectionHighlight.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react"
+import { useRouterState } from "@tanstack/react-router"
+
+// How long the target section keeps its highlight ring after a hash deep-link.
+const HIGHLIGHT_MS = 2000
+
+// The ring recipe a section applies while it is the hash deep-link target.
+// One source so every Settings section highlights identically.
+export function sectionHighlightClass(active: boolean): string {
+  return active
+    ? "ring-2 ring-primary ring-offset-2 ring-offset-base-100 transition-shadow"
+    : "transition-shadow"
+}
+
+// Generic hash-fragment deep-link for Settings section headings: when the URL
+// carries `#service-token` (etc.) — whether from a cross-page link or a click on
+// the section's own anchor heading — scroll the matching `id` into view and
+// briefly highlight it. Returns the currently-highlighted id so a section can
+// gate its ring on `id === highlightedId`.
+//
+// The hash is left in the URL so it stays shareable/bookmarkable. The scroll
+// retries on a rAF because a section can mount after its data loads, so the
+// element may not exist on the tick the hash first arrives.
+export function useHashSectionHighlight(): string | null {
+  const hash = useRouterState({ select: (s) => s.location.hash })
+  const [highlightedId, setHighlightedId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!hash) return
+
+    let raf = 0
+    let clearTimer = 0
+    const target = hash
+
+    const tryScroll = (attempt: number) => {
+      const el = document.getElementById(target)
+      if (!el) {
+        // Element not mounted yet (data still loading); retry for a few frames.
+        if (attempt < 30)
+          raf = window.requestAnimationFrame(() => tryScroll(attempt + 1))
+        return
+      }
+      el.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
+    tryScroll(0)
+
+    setHighlightedId(target)
+    clearTimer = window.setTimeout(() => setHighlightedId(null), HIGHLIGHT_MS)
+
+    return () => {
+      window.cancelAnimationFrame(raf)
+      window.clearTimeout(clearTimer)
+    }
+  }, [hash])
+
+  return highlightedId
+}
+
+export default useHashSectionHighlight

--- a/web/src/hooks/useHashSectionHighlight.ts
+++ b/web/src/hooks/useHashSectionHighlight.ts
@@ -12,25 +12,22 @@ export function sectionHighlightClass(active: boolean): string {
     : "transition-shadow"
 }
 
-// Generic hash-fragment deep-link for Settings section headings: when the URL
-// carries `#service-token` (etc.) — whether from a cross-page link or a click on
-// the section's own anchor heading — scroll the matching `id` into view and
-// briefly highlight it. Returns the currently-highlighted id so a section can
-// gate its ring on `id === highlightedId`.
+// Scrolls the `#id` section into view and briefly highlights it on a hash
+// deep-link (from a cross-page link or a click on the section's own anchor
+// heading). Returns the highlighted id so a section can gate its ring.
 //
 // This is the single owner of the deep-link scroll, so a click never competes
-// with a second scroll. The hash is left in the URL so it stays shareable. The
-// scroll retries on a rAF because a section can mount after its data loads, so
-// the element may not exist on the tick the hash first arrives.
-//
-// `scrollNonce` (from history state, bumped by SectionAnchorHeading on click)
-// makes an identical-hash re-click still re-fire the effect, since TanStack
-// otherwise no-ops a same-hash navigation and the `hash` dep wouldn't change.
+// with a second scroll; the hash is left in the URL so it stays shareable. The
+// scroll retries on a rAF because a section can mount after its data loads.
+// `scrollNonce` (history state, bumped by SectionAnchorHeading) lets an
+// identical-hash re-click re-fire, since TanStack no-ops a same-hash navigation.
 export function useHashSectionHighlight(): string | null {
-  const hash = useRouterState({ select: (s) => s.location.hash })
-  const scrollNonce = useRouterState({
-    select: (s) =>
-      (s.location.state as { scrollNonce?: number } | undefined)?.scrollNonce,
+  const { hash, scrollNonce } = useRouterState({
+    select: (s) => ({
+      hash: s.location.hash,
+      scrollNonce: (s.location.state as { scrollNonce?: number } | undefined)
+        ?.scrollNonce,
+    }),
   })
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
   // The (hash, nonce) we last acted on, so a re-render (e.g. the highlight

--- a/web/src/hooks/useHashSectionHighlight.ts
+++ b/web/src/hooks/useHashSectionHighlight.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useRouterState } from "@tanstack/react-router"
 
 // How long the target section keeps its highlight ring after a hash deep-link.
@@ -18,15 +18,31 @@ export function sectionHighlightClass(active: boolean): string {
 // briefly highlight it. Returns the currently-highlighted id so a section can
 // gate its ring on `id === highlightedId`.
 //
-// The hash is left in the URL so it stays shareable/bookmarkable. The scroll
-// retries on a rAF because a section can mount after its data loads, so the
-// element may not exist on the tick the hash first arrives.
+// This is the single owner of the deep-link scroll, so a click never competes
+// with a second scroll. The hash is left in the URL so it stays shareable. The
+// scroll retries on a rAF because a section can mount after its data loads, so
+// the element may not exist on the tick the hash first arrives.
+//
+// `scrollNonce` (from history state, bumped by SectionAnchorHeading on click)
+// makes an identical-hash re-click still re-fire the effect, since TanStack
+// otherwise no-ops a same-hash navigation and the `hash` dep wouldn't change.
 export function useHashSectionHighlight(): string | null {
   const hash = useRouterState({ select: (s) => s.location.hash })
+  const scrollNonce = useRouterState({
+    select: (s) =>
+      (s.location.state as { scrollNonce?: number } | undefined)?.scrollNonce,
+  })
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
+  // The (hash, nonce) we last acted on, so a re-render (e.g. the highlight
+  // state change) can't fire a second scroll for the same navigation — one
+  // smooth scroll per click, never a competing pair.
+  const lastKey = useRef<string | null>(null)
 
   useEffect(() => {
     if (!hash) return
+    const key = `${hash}\u0000${scrollNonce ?? ""}`
+    if (lastKey.current === key) return
+    lastKey.current = key
 
     let raf = 0
     let clearTimer = 0
@@ -51,7 +67,7 @@ export function useHashSectionHighlight(): string | null {
       window.cancelAnimationFrame(raf)
       window.clearTimeout(clearTimer)
     }
-  }, [hash])
+  }, [hash, scrollNonce])
 
   return highlightedId
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -39,7 +39,6 @@
     "openOrgOnGitHub": "Open {{org}} on GitHub",
     "dismissNotification": "Dismiss notification",
     "linkToSection": "Link to {{section}}",
-    "linkToSectionGeneric": "Link to this section",
     "pagination": {
       "show": "Show",
       "entries": "entries",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -38,6 +38,8 @@
     "skipToMainContent": "Skip to main content",
     "openOrgOnGitHub": "Open {{org}} on GitHub",
     "dismissNotification": "Dismiss notification",
+    "linkToSection": "Link to {{section}}",
+    "linkToSectionGeneric": "Link to this section",
     "pagination": {
       "show": "Show",
       "entries": "entries",

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -4,12 +4,16 @@ import { Button, HelpTooltip, Input, Modal, cx } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
-import { useParams, useSearch, useNavigate } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useSaveServiceToken } from "@/hooks/mutations/useSaveServiceToken"
 import { useRenameServiceToken } from "@/hooks/mutations/useRenameServiceToken"
 import useGetServiceTokenStatus from "@/hooks/useGetServiceTokenStatus"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
+import {
+  useHashSectionHighlight,
+  sectionHighlightClass,
+} from "@/hooks/useHashSectionHighlight"
 import { serviceTokenName, randomTokenHash } from "@/util/serviceTokenName"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import RequireRole from "@/components/RequireRole"
@@ -388,11 +392,9 @@ function SetTokenModal({
   )
 }
 
-export const OrgSettingsPane = () => {
+export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
   const { t } = useTranslation()
   const { org } = useParams({ strict: false })
-  const search = useSearch({ strict: false }) as { focus?: string }
-  const navigate = useNavigate()
   const { notify } = useToast()
 
   const { data: tokenStatus, isLoading: tokenStatusLoading } =
@@ -423,30 +425,6 @@ export const OrgSettingsPane = () => {
 
   const [modalOpen, setModalOpen] = useState(false)
 
-  // Deep-link from the org list's token-health chip (`?focus=serviceToken`):
-  // scroll the section into view, highlight it, and open the set-token modal so
-  // a multi-org teacher lands directly on the rotate flow. Runs once on mount,
-  // then strips the param (replace) so the one-shot link is consumed exactly
-  // once — a later remount (navigate away and back, refresh) or a dismissal
-  // won't re-pop the modal or leave a stale ?focus in history.
-  const focusServiceToken = search?.focus === "serviceToken"
-  const [highlight, setHighlight] = useState(false)
-  useEffect(() => {
-    if (!focusServiceToken) return
-    setHighlight(true)
-    setModalOpen(true)
-    document
-      .getElementById("service-token-section")
-      ?.scrollIntoView({ behavior: "smooth", block: "start" })
-    void navigate({
-      to: ".",
-      search: (prev) => ({ ...prev, focus: undefined }),
-      replace: true,
-    })
-    const id = window.setTimeout(() => setHighlight(false), 2000)
-    return () => window.clearTimeout(id)
-  }, [focusServiceToken, navigate])
-
   const openModal = () => {
     saveMutation.reset()
     setModalOpen(true)
@@ -475,14 +453,10 @@ export const OrgSettingsPane = () => {
 
   return (
     <SettingsSection
-      id="service-token-section"
+      id="service-token"
       title={t("orgSettings.serviceToken.title")}
       titleAdornment={<HelpTooltip help={t("orgSettings.serviceToken.help")} />}
-      className={
-        highlight
-          ? "ring-2 ring-primary ring-offset-2 ring-offset-base-100 transition-shadow"
-          : "transition-shadow"
-      }
+      className={sectionHighlightClass(highlighted ?? false)}
     >
       {tokenStatusLoading ? (
         <p className="text-sm text-base-content/60">
@@ -552,6 +526,7 @@ const OrgSettingsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.organizationSettings"))
   const { org } = useParams({ strict: false })
+  const highlightedId = useHashSectionHighlight()
 
   return (
     <PageShell page="classes" settings selected="settings">
@@ -575,11 +550,23 @@ const OrgSettingsPage = () => {
           }
         />
         <div className="mt-8 space-y-8">
-          <OrgSettingsPane />
-          {org && <OrgActionsSection key={`actions-${org}`} org={org} />}
-          {org && <OrgPolicyAuditPane key={org} org={org} />}
-          {org && <RerunOrgSetup org={org} />}
-          {org && <TeardownSection org={org} />}
+          <OrgSettingsPane highlighted={highlightedId === "service-token"} />
+          {org && (
+            <OrgActionsSection
+              key={`actions-${org}`}
+              org={org}
+              highlightedId={highlightedId}
+            />
+          )}
+          {org && (
+            <OrgPolicyAuditPane
+              key={org}
+              org={org}
+              highlightedId={highlightedId}
+            />
+          )}
+          {org && <RerunOrgSetup org={org} highlightedId={highlightedId} />}
+          {org && <TeardownSection org={org} highlightedId={highlightedId} />}
         </div>
       </RequireRole>
     </PageShell>

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -555,18 +555,28 @@ const OrgSettingsPage = () => {
             <OrgActionsSection
               key={`actions-${org}`}
               org={org}
-              highlightedId={highlightedId}
+              highlighted={highlightedId === "github-actions"}
             />
           )}
           {org && (
             <OrgPolicyAuditPane
               key={org}
               org={org}
-              highlightedId={highlightedId}
+              highlighted={highlightedId === "org-policy"}
             />
           )}
-          {org && <RerunOrgSetup org={org} highlightedId={highlightedId} />}
-          {org && <TeardownSection org={org} highlightedId={highlightedId} />}
+          {org && (
+            <RerunOrgSetup
+              org={org}
+              highlighted={highlightedId === "rerun-org-setup"}
+            />
+          )}
+          {org && (
+            <TeardownSection
+              org={org}
+              highlighted={highlightedId === "danger-zone"}
+            />
+          )}
         </div>
       </RequireRole>
     </PageShell>

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -255,7 +255,7 @@ function HideOrgMenu({
               <Link
                 to="/$org/settings"
                 params={{ org: org.login }}
-                search={{ focus: "serviceToken" }}
+                hash="service-token"
                 onClick={closeMenu}
               >
                 <KeyRound aria-hidden="true" className="size-4" />

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -24,10 +24,20 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
     Link: ({
       children,
       params,
+      hash,
     }: {
       children: React.ReactNode
       params?: { org?: string }
-    }) => <a href={`/${params?.org ?? ""}/settings`}>{children}</a>,
+      hash?: string
+    }) => (
+      <a href={`/${params?.org ?? ""}/settings${hash ? `#${hash}` : ""}`}>
+        {children}
+      </a>
+    ),
+    // The page calls useHashSectionHighlight, which reads router state; stub it
+    // out here so the section renders without a RouterProvider.
+    useRouterState: () => "",
+    useNavigate: () => () => Promise.resolve(),
   }
 })
 
@@ -40,10 +50,16 @@ vi.mock("@/components/ui", async (importActual) => {
     RouterButton: ({
       children,
       params,
+      hash,
     }: {
       children: React.ReactNode
       params?: { org?: string }
-    }) => <a href={`/${params?.org ?? ""}/settings`}>{children}</a>,
+      hash?: string
+    }) => (
+      <a href={`/${params?.org ?? ""}/settings${hash ? `#${hash}` : ""}`}>
+        {children}
+      </a>
+    ),
   }
 })
 
@@ -171,6 +187,8 @@ describe("SettingsPage service tokens", () => {
     expect(screen.getByText("cs50")).toBeTruthy()
     expect(screen.getByText("classroom50-token-42-ab12")).toBeTruthy()
     const manage = screen.getByText("settings.serviceTokens.manage")
-    expect(manage.closest("a")?.getAttribute("href")).toBe("/cs50/settings")
+    expect(manage.closest("a")?.getAttribute("href")).toBe(
+      "/cs50/settings#service-token",
+    )
   })
 })

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2,7 +2,13 @@ import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useHiddenOrgs } from "@/context/hiddenOrgs/HiddenOrgsProvider"
-import { Button, Card, RouterButton } from "@/components/ui"
+import {
+  Button,
+  Card,
+  RouterButton,
+  SectionAnchorHeading,
+  cx,
+} from "@/components/ui"
 import { useTranslation } from "react-i18next"
 import { useMemo } from "react"
 import useGetOrgs from "@/hooks/useGetOrgs"
@@ -10,12 +16,16 @@ import {
   isOwnedReadyOrg,
   useOrgServiceTokenHealth,
 } from "@/hooks/useOrgServiceTokenHealth"
+import {
+  useHashSectionHighlight,
+  sectionHighlightClass,
+} from "@/hooks/useHashSectionHighlight"
 import { TokenHealthChip } from "@/components/status/TokenHealthChip"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
 // token (a non-owner can't read/set it). The section reads token health for
 // exactly this set.
-function ServiceTokensSection() {
+function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
   const { t } = useTranslation()
   const { data: orgs = [], isLoading } = useGetOrgs()
 
@@ -31,9 +41,19 @@ function ServiceTokensSection() {
   const { byOrg } = useOrgServiceTokenHealth(ownedReady, !isLoading)
 
   return (
-    <Card radius="xl" shadow={false}>
+    <Card
+      id="service-tokens"
+      radius="xl"
+      shadow={false}
+      className={cx(
+        "scroll-mt-24",
+        sectionHighlightClass(highlighted ?? false),
+      )}
+    >
       <Card.Body>
-        <Card.Title>{t("settings.serviceTokens.heading")}</Card.Title>
+        <SectionAnchorHeading anchorId="service-tokens" className="card-title">
+          {t("settings.serviceTokens.heading")}
+        </SectionAnchorHeading>
         <p className="text-sm text-base-content/70">
           {t("settings.serviceTokens.subheading")}
         </p>
@@ -86,7 +106,7 @@ function ServiceTokensSection() {
                   <RouterButton
                     to="/$org/settings"
                     params={{ org: login }}
-                    search={{ focus: "serviceToken" }}
+                    hash="service-token"
                     variant="outline"
                     size="sm"
                     className="shrink-0"
@@ -111,6 +131,7 @@ const SettingsPage = () => {
   useDocumentTitle(t("documentTitle.settings"))
   const { hidden, unhide } = useHiddenOrgs()
   const hiddenLogins = [...hidden].sort((a, b) => a.localeCompare(b))
+  const highlightedId = useHashSectionHighlight()
 
   return (
     <PageShell page="orgs" selected="settings">
@@ -119,11 +140,21 @@ const SettingsPage = () => {
         subtitle={t("settings.page.subheading")}
       />
 
-      <ServiceTokensSection />
+      <ServiceTokensSection highlighted={highlightedId === "service-tokens"} />
 
-      <Card radius="xl" shadow={false}>
+      <Card
+        id="hidden-orgs"
+        radius="xl"
+        shadow={false}
+        className={cx(
+          "scroll-mt-24",
+          sectionHighlightClass(highlightedId === "hidden-orgs"),
+        )}
+      >
         <Card.Body>
-          <Card.Title>{t("settings.hiddenOrgs.heading")}</Card.Title>
+          <SectionAnchorHeading anchorId="hidden-orgs" className="card-title">
+            {t("settings.hiddenOrgs.heading")}
+          </SectionAnchorHeading>
           <p className="text-sm text-base-content/70">
             {t("settings.hiddenOrgs.subheading")}
           </p>

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -15,6 +15,7 @@ import useGetOrgActionsUsage from "@/hooks/useGetOrgActionsUsage"
 import useGetOrgActionsBudget from "@/hooks/useGetOrgActionsBudget"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import { useSetOrgActionsMode } from "@/hooks/mutations/useSetOrgActionsMode"
+import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
 import SettingsSection from "./SettingsSection"
 
 const ACTIONS_ANCHOR = "github-actions"
@@ -119,7 +120,13 @@ const ActionsUsagePanel = ({ org }: { org: string }) => {
 // paid minutes it would bill) while the config repo's own workflows keep
 // running. A live-derived toggle: it reflects whatever the org policy reports,
 // with no separate stored state.
-const OrgActionsSection = ({ org }: { org: string }) => {
+const OrgActionsSection = ({
+  org,
+  highlightedId,
+}: {
+  org: string
+  highlightedId?: string | null
+}) => {
   const { t } = useTranslation()
   const { notify } = useToast()
   const runToggle = useSafeSubmit()
@@ -156,6 +163,7 @@ const OrgActionsSection = ({ org }: { org: string }) => {
   return (
     <SettingsSection
       id={ACTIONS_ANCHOR}
+      className={sectionHighlightClass(highlightedId === ACTIONS_ANCHOR)}
       title={t("orgSettings.actions.title")}
       description={t("orgSettings.actions.description")}
       titleAdornment={

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -122,10 +122,10 @@ const ActionsUsagePanel = ({ org }: { org: string }) => {
 // with no separate stored state.
 const OrgActionsSection = ({
   org,
-  highlightedId,
+  highlighted,
 }: {
   org: string
-  highlightedId?: string | null
+  highlighted?: boolean
 }) => {
   const { t } = useTranslation()
   const { notify } = useToast()
@@ -163,7 +163,7 @@ const OrgActionsSection = ({
   return (
     <SettingsSection
       id={ACTIONS_ANCHOR}
-      className={sectionHighlightClass(highlightedId === ACTIONS_ANCHOR)}
+      className={sectionHighlightClass(highlighted ?? false)}
       title={t("orgSettings.actions.title")}
       description={t("orgSettings.actions.description")}
       titleAdornment={

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -475,10 +475,10 @@ function AuditBody({
 
 const OrgPolicyAuditPane = ({
   org,
-  highlightedId,
+  highlighted,
 }: {
   org: string
-  highlightedId?: string | null
+  highlighted?: boolean
 }) => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
@@ -568,7 +568,7 @@ const OrgPolicyAuditPane = ({
   return (
     <SettingsSection
       id={ORG_POLICY_ANCHOR}
-      className={sectionHighlightClass(highlightedId === ORG_POLICY_ANCHOR)}
+      className={sectionHighlightClass(highlighted ?? false)}
       title={t("orgSettings.audit.title")}
       titleAdornment={
         <PlanBadge

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -36,6 +36,7 @@ import { REPAIRABLE_CONCERNS } from "@/orgPolicy/repair"
 import type { RepairResult } from "@/orgPolicy/repair"
 import { mergeUnresolved, readUnresolved } from "@/orgPolicy/unresolvedStore"
 import type { CheckState } from "@/github-core/orgChecks"
+import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
 import SettingsSection from "./SettingsSection"
 import { UnenforcedDefaultsList } from "./UnenforcedDefaultsList"
 import {
@@ -49,6 +50,9 @@ import { CalloutDiv } from "@/lib/motionComponents"
 // the API-less manual steps. Each drifted, API-repairable concern gets an
 // owner-gated "Fix it"; Re-run Setup is the "repair everything" alternative.
 // Mirrors the service-token pane's banner shape.
+
+// DOM anchor for this section, used as its SettingsSection id + hash deep-link.
+const ORG_POLICY_ANCHOR = "org-policy"
 
 const VERDICT_BANNER: Record<
   AuditVerdict,
@@ -469,7 +473,13 @@ function AuditBody({
   )
 }
 
-const OrgPolicyAuditPane = ({ org }: { org: string }) => {
+const OrgPolicyAuditPane = ({
+  org,
+  highlightedId,
+}: {
+  org: string
+  highlightedId?: string | null
+}) => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const runFix = useSafeSubmit()
@@ -557,6 +567,8 @@ const OrgPolicyAuditPane = ({ org }: { org: string }) => {
 
   return (
     <SettingsSection
+      id={ORG_POLICY_ANCHOR}
+      className={sectionHighlightClass(highlightedId === ORG_POLICY_ANCHOR)}
       title={t("orgSettings.audit.title")}
       titleAdornment={
         <PlanBadge

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -60,10 +60,10 @@ const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
 // per-concern audit (U5/U6).
 const RerunOrgSetup = ({
   org,
-  highlightedId,
+  highlighted,
 }: {
   org: string
-  highlightedId?: string | null
+  highlighted?: boolean
 }) => {
   const { t } = useTranslation()
   const runRerun = useSafeSubmit()
@@ -153,9 +153,7 @@ const RerunOrgSetup = ({
   return (
     <SettingsSection
       id={RERUN_ORG_SETUP_ANCHOR}
-      className={sectionHighlightClass(
-        highlightedId === RERUN_ORG_SETUP_ANCHOR,
-      )}
+      className={sectionHighlightClass(highlighted ?? false)}
       title={t("orgSettings.rerun.title")}
       description={t("orgSettings.rerun.description")}
       action={

--- a/web/src/pages/orgSettings/RerunOrgSetup.tsx
+++ b/web/src/pages/orgSettings/RerunOrgSetup.tsx
@@ -15,6 +15,7 @@ import {
   initialInitSteps,
 } from "./initStepBoard"
 import SettingsSection from "./SettingsSection"
+import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
 import { CalloutDiv } from "@/lib/motionComponents"
 import {
   SkeletonOverwriteModal,
@@ -57,7 +58,13 @@ const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
 // by the page's <RequireRole allow="owner"> (see TeardownSection); shows the
 // wizard's badge board. The "repair everything" path complementing the
 // per-concern audit (U5/U6).
-const RerunOrgSetup = ({ org }: { org: string }) => {
+const RerunOrgSetup = ({
+  org,
+  highlightedId,
+}: {
+  org: string
+  highlightedId?: string | null
+}) => {
   const { t } = useTranslation()
   const runRerun = useSafeSubmit()
 
@@ -146,6 +153,9 @@ const RerunOrgSetup = ({ org }: { org: string }) => {
   return (
     <SettingsSection
       id={RERUN_ORG_SETUP_ANCHOR}
+      className={sectionHighlightClass(
+        highlightedId === RERUN_ORG_SETUP_ANCHOR,
+      )}
       title={t("orgSettings.rerun.title")}
       description={t("orgSettings.rerun.description")}
       action={

--- a/web/src/pages/orgSettings/SettingsSection.tsx
+++ b/web/src/pages/orgSettings/SettingsSection.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren, ReactNode } from "react"
 
-import { Card } from "@/components/ui"
+import { Card, SectionAnchorHeading, cx } from "@/components/ui"
 
 // Standardized wrapper for each Org Settings group (Service Token, Organization
 // Policy, Re-run Setup, Danger Zone) so the page reads as consistent sections.
@@ -45,14 +45,26 @@ const SettingsSection = ({
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <h2
-              className={[
-                "text-lg font-semibold",
-                isDanger ? "text-error" : "",
-              ].join(" ")}
-            >
-              {title}
-            </h2>
+            {id ? (
+              <SectionAnchorHeading
+                anchorId={id}
+                className={cx(
+                  "text-lg font-semibold",
+                  isDanger ? "text-error" : "",
+                )}
+              >
+                {title}
+              </SectionAnchorHeading>
+            ) : (
+              <h2
+                className={[
+                  "text-lg font-semibold",
+                  isDanger ? "text-error" : "",
+                ].join(" ")}
+              >
+                {title}
+              </h2>
+            )}
             {titleAdornment}
           </div>
           {description && (

--- a/web/src/pages/orgSettings/SettingsSection.tsx
+++ b/web/src/pages/orgSettings/SettingsSection.tsx
@@ -35,12 +35,12 @@ const SettingsSection = ({
       radius="2xl"
       shadow={false}
       bordered={!isDanger}
-      className={[
+      className={cx(
         isDanger
           ? "scroll-mt-24 border border-error/30 bg-error/5 p-6"
           : "scroll-mt-24 p-6",
-        className ?? "",
-      ].join(" ")}
+        className,
+      )}
     >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
@@ -57,10 +57,10 @@ const SettingsSection = ({
               </SectionAnchorHeading>
             ) : (
               <h2
-                className={[
+                className={cx(
                   "text-lg font-semibold",
-                  isDanger ? "text-error" : "",
-                ].join(" ")}
+                  isDanger && "text-error",
+                )}
               >
                 {title}
               </h2>

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -31,10 +31,10 @@ const DANGER_ZONE_ANCHOR = "danger-zone"
 // inline owner re-check is needed here.
 const TeardownSection = ({
   org,
-  highlightedId,
+  highlighted,
 }: {
   org: string
-  highlightedId?: string | null
+  highlighted?: boolean
 }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -68,7 +68,7 @@ const TeardownSection = ({
     <SettingsSection
       tone="danger"
       id={DANGER_ZONE_ANCHOR}
-      className={sectionHighlightClass(highlightedId === DANGER_ZONE_ANCHOR)}
+      className={sectionHighlightClass(highlighted ?? false)}
       title={t("orgSettings.teardown.title")}
       titleAdornment={
         <TriangleAlert aria-hidden="true" className="size-5 text-error" />

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -14,18 +14,28 @@ import {
 } from "@/domain/teardown"
 import { usePlanTeardown } from "@/hooks/mutations/usePlanTeardown"
 import { useExecuteTeardown } from "@/hooks/mutations/useExecuteTeardown"
+import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
 import SettingsSection from "./SettingsSection"
 import { CalloutDiv, CalloutText } from "@/lib/motionComponents"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("orgSettings:TeardownSection")
 
+// DOM anchor for this section, used as its SettingsSection id + hash deep-link.
+const DANGER_ZONE_ANCHOR = "danger-zone"
+
 // Teardown / org reset: deletes ALL repos in the org (mirroring the CLI's
 // `gh teacher teardown`), marker-gated and behind a typed-org-name confirmation.
 // Owner-gated by the page's <RequireRole allow="owner"> (RequireOwner renders
 // children only for a resolved owner, with its own spinner/retry surface), so no
 // inline owner re-check is needed here.
-const TeardownSection = ({ org }: { org: string }) => {
+const TeardownSection = ({
+  org,
+  highlightedId,
+}: {
+  org: string
+  highlightedId?: string | null
+}) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
 
@@ -57,6 +67,8 @@ const TeardownSection = ({ org }: { org: string }) => {
   return (
     <SettingsSection
       tone="danger"
+      id={DANGER_ZONE_ANCHOR}
+      className={sectionHighlightClass(highlightedId === DANGER_ZONE_ANCHOR)}
       title={t("orgSettings.teardown.title")}
       titleAdornment={
         <TriangleAlert aria-hidden="true" className="size-5 text-error" />

--- a/web/src/routes/_authed/$org/settings/index.tsx
+++ b/web/src/routes/_authed/$org/settings/index.tsx
@@ -3,11 +3,4 @@ import { createFileRoute } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/_authed/$org/settings/")({
   component: OrgSettingsPage,
-  // `?focus=serviceToken` deep-links from the org list's token-health chip
-  // straight to the Service Token pane (scroll + expand + highlight).
-  validateSearch: (
-    search: Record<string, unknown>,
-  ): { focus?: "serviceToken" } => {
-    return search.focus === "serviceToken" ? { focus: "serviceToken" } : {}
-  },
 })


### PR DESCRIPTION
## Summary

Generalizes the one-off `?focus=serviceToken` search-param deep-link into a reusable URL-hash convention so every Settings section heading is a shareable, bookmarkable anchor.

- A new `useHashSectionHighlight` hook reads the router hash and, whenever the URL carries `#service-token` / `#github-actions` / `#org-policy` / `#rerun-org-setup` / `#danger-zone` (Org Settings) or `#service-tokens` / `#hidden-orgs` (user Settings), smoothly scrolls the matching section into view and briefly highlights it. The hash stays in the URL so the position is shareable.
- A new `SectionAnchorHeading` UI primitive makes each section heading its own anchor: the heading text is a link that updates the hash. `useHashSectionHighlight` is the single owner of the scroll, so every click — first or repeat — is a consistent smooth scroll (no native instant-jump competing with the animation). A monotonic `scrollNonce` in history state lets an identical-hash re-click re-fire, and clicks use `replace` history so section navigation does not pile up back-button entries.
- The three existing deep-link sites (token-health chip, the user Settings "Manage" button, and the org card "Manage token" dropdown) now use `hash="service-token"` instead of `search={{ focus: "serviceToken" }}`, and the now-unused `focus` `validateSearch` was removed from the settings route.
- Landing on `#service-token` now scrolls + highlights consistently with every other section (the previous deep-link modal auto-open was dropped).

## Test plan

- [ ] `npm run check` in `web/` passes (tsc, eslint, prettier, arch:validate, vitest) — verified locally, 2783 tests green.
- [ ] From the org list, clicking a token-health chip / "Manage token" lands on `/$org/settings#service-token`, scrolls, and highlights.
- [ ] Hovering any Settings heading shows the underline; clicking it updates the URL to `#<section>` and smoothly scrolls there — including re-clicking the same heading after scrolling away.
- [ ] The `#hash` remains in the address bar after clicking (shareable/bookmarkable).