### PR TITLE
feat(web): add teacher download of student submissions (single + bulk)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-router": "^1.170.18",
         "canvas-confetti": "^1.9.4",
         "i18next": "^26.3.6",
+        "jszip": "^3.10.1",
         "libsodium-wrappers": "^0.8.4",
         "lucide-react": "^1.25.0",
         "motion": "^12.42.2",
@@ -5250,6 +5251,12 @@
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -7167,6 +7174,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7204,6 +7217,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "4.1.1",
@@ -7889,6 +7908,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7956,6 +7987,15 @@
       "license": "ISC",
       "dependencies": {
         "libsodium": "^0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -9239,6 +9279,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/papaparse": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
@@ -9488,6 +9534,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9603,6 +9655,27 @@
         "@types/react": ">=18",
         "react": ">=18"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -9815,6 +9888,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9948,6 +10027,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -10138,6 +10223,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -10833,6 +10927,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-router": "^1.170.18",
     "canvas-confetti": "^1.9.4",
     "i18next": "^26.3.6",
+    "jszip": "^3.10.1",
     "libsodium-wrappers": "^0.8.4",
     "lucide-react": "^1.25.0",
     "motion": "^12.42.2",

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/github-core/client"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { missingScopes } from "@/auth/scopes"
+import { GITHUB_OAUTH_WORKER_BASE } from "@/auth/constants"
 import { observeResponse } from "@/lib/diagnostics/observed"
 import { logger } from "@/lib/logger"
 
@@ -71,7 +72,11 @@ export function GitHubProvider({
   const client = useMemo(() => {
     if (!token) return null
     log.debug("creating GitHub client for new token")
-    return createGitHubClient({ token, onResponse })
+    return createGitHubClient({
+      token,
+      archiveBaseUrl: GITHUB_OAUTH_WORKER_BASE,
+      onResponse,
+    })
   }, [token, onResponse])
 
   // Only surface the observation when it matches the live token.

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -2116,6 +2116,8 @@ describe("createAssignmentRepo", () => {
         return Promise.reject(new Error(`unexpected: ${path}`))
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
 
     const result = await createAssignmentRepo({
@@ -2159,6 +2161,8 @@ describe("createAssignmentRepo", () => {
         } as T)
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
 
     const result = await createAssignmentRepo({
@@ -2333,6 +2337,8 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
         } as T)
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }) as GitHubClient
 
   const generatePath = "/repos/tpl/starter/generate"

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -2116,8 +2116,7 @@ describe("createAssignmentRepo", () => {
         return Promise.reject(new Error(`unexpected: ${path}`))
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
 
     const result = await createAssignmentRepo({
@@ -2161,8 +2160,7 @@ describe("createAssignmentRepo", () => {
         } as T)
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
 
     const result = await createAssignmentRepo({
@@ -2337,8 +2335,7 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
         } as T)
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }) as GitHubClient
 
   const generatePath = "/repos/tpl/starter/generate"

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -71,6 +71,7 @@ export {
 } from "./assignments/submit"
 export {
   downloadAllSubmissions,
+  streamSubmissionsToDirectory,
   ZipAssemblyError,
   BULK_DOWNLOAD_WARN_THRESHOLD,
   type DownloadAllProgress,

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -71,6 +71,8 @@ export {
 } from "./assignments/submit"
 export {
   downloadAllSubmissions,
+  ZipAssemblyError,
+  BULK_DOWNLOAD_WARN_THRESHOLD,
   type DownloadAllProgress,
   type DownloadAllResult,
   type DownloadAllSummary,

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -69,3 +69,11 @@ export {
   type UploadFile,
   type SubmitAssignmentResult,
 } from "./assignments/submit"
+export {
+  downloadAllSubmissions,
+  type DownloadAllProgress,
+  type DownloadAllResult,
+  type DownloadAllSummary,
+  type DownloadRepoResult,
+  type DownloadOutcome,
+} from "./assignments/downloadSubmissions"

--- a/web/src/domain/assignments/downloadSubmissions.test.ts
+++ b/web/src/domain/assignments/downloadSubmissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
+import JSZip from "jszip"
 
-import { downloadAllSubmissions } from "./downloadSubmissions"
+import { downloadAllSubmissions, ZipAssemblyError } from "./downloadSubmissions"
 import { fetchRepoArchive } from "@/github-core/repoArchiveReads"
 import type { GitHubClient } from "@/github-core/client"
 
@@ -103,6 +104,34 @@ describe("downloadAllSubmissions", () => {
     )
 
     await run(["Alice"])
-    expect(mockedFetch).toHaveBeenCalledWith(client, "org", "cs101-hw1-alice")
+    expect(mockedFetch).toHaveBeenCalledWith(
+      client,
+      "org",
+      "cs101-hw1-alice",
+      expect.objectContaining({ signal: undefined }),
+    )
+  })
+
+  it("dedupes owners case-insensitively so entries aren't duplicated", async () => {
+    mockedFetch.mockImplementation((_c, _org, repo) =>
+      Promise.resolve(archive(repo)),
+    )
+
+    const { summary } = await run(["alice", "Alice", "bob"])
+    expect(summary.total).toBe(2)
+    expect(summary.fetched).toBe(2)
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("throws ZipAssemblyError when the combined zip can't be built", async () => {
+    mockedFetch.mockImplementation((_c, _org, repo) =>
+      Promise.resolve(archive(repo)),
+    )
+    const spy = vi
+      .spyOn(JSZip.prototype, "generateAsync")
+      .mockRejectedValueOnce(new Error("oom"))
+
+    await expect(run(["alice"])).rejects.toBeInstanceOf(ZipAssemblyError)
+    spy.mockRestore()
   })
 })

--- a/web/src/domain/assignments/downloadSubmissions.test.ts
+++ b/web/src/domain/assignments/downloadSubmissions.test.ts
@@ -47,7 +47,9 @@ describe("downloadAllSubmissions", () => {
 
   it("records an empty (missing) repo and excludes it, without aborting", async () => {
     mockedFetch.mockImplementation((_c, _org, repo) =>
-      repo.includes("bob") ? Promise.resolve(null) : Promise.resolve(archive(repo)),
+      repo.includes("bob")
+        ? Promise.resolve(null)
+        : Promise.resolve(archive(repo)),
     )
 
     const { summary } = await run(["alice", "bob"])

--- a/web/src/domain/assignments/downloadSubmissions.test.ts
+++ b/web/src/domain/assignments/downloadSubmissions.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import { downloadAllSubmissions } from "./downloadSubmissions"
+import { fetchRepoArchive } from "@/github-core/repoArchiveReads"
+import type { GitHubClient } from "@/github-core/client"
+
+vi.mock("@/github-core/repoArchiveReads", () => ({
+  fetchRepoArchive: vi.fn(),
+}))
+
+const mockedFetch = vi.mocked(fetchRepoArchive)
+const client = {} as GitHubClient
+
+const archive = (repo: string) => ({
+  bytes: new Uint8Array([80, 75]).buffer,
+  filename: `${repo}.zip`,
+})
+
+const run = (owners: string[], onProgress?: (p: unknown) => void) =>
+  downloadAllSubmissions({
+    client,
+    org: "org",
+    classroom: "cs101",
+    assignment: "hw1",
+    owners,
+    onProgress: onProgress as never,
+  })
+
+beforeEach(() => {
+  mockedFetch.mockReset()
+})
+
+describe("downloadAllSubmissions", () => {
+  it("packages one entry per fetched owner and counts them", async () => {
+    mockedFetch.mockImplementation((_c, _org, repo) =>
+      Promise.resolve(archive(repo)),
+    )
+
+    const { blob, summary } = await run(["alice", "bob"])
+    expect(summary.total).toBe(2)
+    expect(summary.fetched).toBe(2)
+    expect(summary.empty).toHaveLength(0)
+    expect(summary.failed).toHaveLength(0)
+    expect(blob).toBeInstanceOf(Blob)
+    expect(blob.size).toBeGreaterThan(0)
+  })
+
+  it("records an empty (missing) repo and excludes it, without aborting", async () => {
+    mockedFetch.mockImplementation((_c, _org, repo) =>
+      repo.includes("bob") ? Promise.resolve(null) : Promise.resolve(archive(repo)),
+    )
+
+    const { summary } = await run(["alice", "bob"])
+    expect(summary.fetched).toBe(1)
+    expect(summary.empty.map((r) => r.owner)).toEqual(["bob"])
+    expect(summary.results).toHaveLength(2)
+  })
+
+  it("records a failed repo and still packages the rest", async () => {
+    mockedFetch.mockImplementation((_c, _org, repo) =>
+      repo.includes("bob")
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve(archive(repo)),
+    )
+
+    const { summary } = await run(["alice", "bob"])
+    expect(summary.fetched).toBe(1)
+    expect(summary.failed.map((r) => r.owner)).toEqual(["bob"])
+    expect(summary.failed[0].reason).toBe("boom")
+  })
+
+  it("fires onProgress once per owner with increasing done", async () => {
+    mockedFetch.mockImplementation((_c, _org, repo) =>
+      Promise.resolve(archive(repo)),
+    )
+    const seen: { done: number; total: number }[] = []
+
+    await run(["alice", "bob", "carol"], (p) =>
+      seen.push(p as { done: number; total: number }),
+    )
+    expect(seen).toHaveLength(3)
+    expect(seen.map((p) => p.done)).toEqual([1, 2, 3])
+    expect(seen.every((p) => p.total === 3)).toBe(true)
+  })
+
+  it("returns an empty summary and makes no calls for no owners", async () => {
+    const { summary } = await run([])
+    expect(summary).toEqual({
+      total: 0,
+      fetched: 0,
+      empty: [],
+      failed: [],
+      results: [],
+    })
+    expect(mockedFetch).not.toHaveBeenCalled()
+  })
+
+  it("derives the repo name from classroom-assignment-owner", async () => {
+    mockedFetch.mockImplementation((_c, _org, repo) =>
+      Promise.resolve(archive(repo)),
+    )
+
+    await run(["Alice"])
+    expect(mockedFetch).toHaveBeenCalledWith(client, "org", "cs101-hw1-alice")
+  })
+})

--- a/web/src/domain/assignments/downloadSubmissions.ts
+++ b/web/src/domain/assignments/downloadSubmissions.ts
@@ -35,18 +35,12 @@ export type DownloadAllResult = {
   summary: DownloadAllSummary
 }
 
-// Soft ceiling on how many submissions one bulk run packages. The whole
-// combined zip is built in browser memory (every archive buffered, then a
-// second full copy from generateAsync), so a very large class can exhaust the
-// tab. The UI warns past this in the confirm step; it's advisory, not enforced
-// here — a teacher who accepts the warning still gets the full run. The
-// directory-extract path streams to disk and isn't subject to this limit.
+// Advisory confirm-step threshold: past this, the combined zip is large enough
+// to risk exhausting the tab (whole archive built in memory). Not enforced.
 export const BULK_DOWNLOAD_WARN_THRESHOLD = 100
 
-// Thrown when the combined zip can't be assembled (typically an allocation
-// failure because the class is too large to hold in memory). Distinct from a
-// per-repo network failure so the UI can tell the teacher the class is too big
-// rather than showing a generic error after every archive already downloaded.
+// Combined-zip assembly failed (usually OOM on a large class). Distinct from a
+// per-repo failure so the UI can say "too big" instead of a generic error.
 export class ZipAssemblyError extends Error {
   constructor(cause: unknown) {
     super("Failed to assemble the combined submissions archive", { cause })
@@ -54,8 +48,8 @@ export class ZipAssemblyError extends Error {
   }
 }
 
-// Case-insensitive dedupe (matching the lowercased repo name) so a duplicated
-// owner can't produce two identical entries.
+// Case-insensitive dedupe (GitHub logins aren't case-sensitive) so a repeated
+// owner can't yield two identical entries.
 function dedupeOwners(owners: string[]): string[] {
   const seen = new Set<string>()
   return owners.filter((owner) => {
@@ -99,10 +93,9 @@ function summarize(
   }
 }
 
-// Shared fan-out: fetch every owner's latest archive at bounded concurrency,
-// invoking `onArchive` with the bytes for each fetched repo (to zip or write to
-// disk), reporting progress, and never letting one repo's failure abort the
-// batch.
+// Shared fan-out: fetch each owner's archive at bounded concurrency, invoking
+// `onArchive` with each fetched repo's bytes; one repo's failure is recorded,
+// never aborting the batch.
 async function fanOutArchives(params: {
   client: GitHubClient
   org: string
@@ -147,12 +140,8 @@ async function fanOutArchives(params: {
   )
 }
 
-// Download EVERY submitting owner's latest submission into ONE combined zip
-// (the fallback path where the File System Access API is unavailable). A
-// bounded fan-out fetches each repo's archive; each fetched archive is stored —
-// not re-inflated — as a nested `<owner>.zip` entry, so it stays lossless. A
-// missing/empty repo is skipped and a single repo's failure is recorded rather
-// than aborting the batch. `onProgress` fires after each repo settles.
+// Fallback path (no File System Access API): fetch every submission and store
+// each losslessly as a nested `<owner>.zip` in one combined in-memory zip.
 export async function downloadAllSubmissions(params: {
   client: GitHubClient
   org: string
@@ -185,11 +174,8 @@ export async function downloadAllSubmissions(params: {
   return { blob, summary: summarize(owners, results) }
 }
 
-// Download EVERY submitting owner's latest submission directly into a
-// teacher-chosen directory (Chromium File System Access path). Each fetched
-// archive is streamed to `<owner>.zip` in the picked folder as it arrives, so
-// nothing accumulates in memory — no combined-zip ceiling, no OOM risk. Same
-// skip/failure semantics and progress reporting as the combined-zip path.
+// Chromium path: stream each submission straight to `<owner>.zip` in the picked
+// folder as it arrives — nothing buffered, so no combined-zip ceiling.
 export async function streamSubmissionsToDirectory(params: {
   client: GitHubClient
   org: string

--- a/web/src/domain/assignments/downloadSubmissions.ts
+++ b/web/src/domain/assignments/downloadSubmissions.ts
@@ -1,0 +1,103 @@
+import JSZip from "jszip"
+
+import { fetchRepoArchive } from "@/github-core/repoArchiveReads"
+import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
+import { mapWithConcurrency } from "@/util/concurrency"
+import { studentRepoName } from "@/util/studentRepo"
+import type { GitHubClient } from "@/github-core/client"
+
+export type DownloadAllProgress = {
+  done: number
+  total: number
+}
+
+// Per-owner outcome: `fetched` packaged into the combined zip, `empty` was a
+// missing/never-pushed repo (skipped), `failed` errored (recorded, not fatal).
+export type DownloadOutcome = "fetched" | "empty" | "failed"
+
+export type DownloadRepoResult = {
+  owner: string
+  outcome: DownloadOutcome
+  reason?: string
+}
+
+export type DownloadAllSummary = {
+  total: number
+  fetched: number
+  empty: DownloadRepoResult[]
+  failed: DownloadRepoResult[]
+  results: DownloadRepoResult[]
+}
+
+export type DownloadAllResult = {
+  blob: Blob
+  summary: DownloadAllSummary
+}
+
+// Download EVERY submitting owner's latest submission into one combined zip
+// (single teacher action). A bounded fan-out (REPO_READ_CONCURRENCY) fetches
+// each repo's archive; each fetched archive is stored — not re-inflated — as a
+// nested `<owner>.zip` entry, so a large class stays lossless and cheap to
+// package. A missing/empty repo is skipped, and a single repo's failure is
+// recorded rather than aborting the batch. `onProgress` fires after each repo
+// settles so the UI can show a live count.
+export async function downloadAllSubmissions(params: {
+  client: GitHubClient
+  org: string
+  classroom: string
+  assignment: string
+  owners: string[]
+  onProgress?: (progress: DownloadAllProgress) => void
+  signal?: AbortSignal
+}): Promise<DownloadAllResult> {
+  const { client, org, classroom, assignment, owners, onProgress, signal } =
+    params
+  const total = owners.length
+  let done = 0
+
+  const zip = new JSZip()
+
+  const results = await mapWithConcurrency(
+    owners,
+    REPO_READ_CONCURRENCY,
+    async (owner): Promise<DownloadRepoResult> => {
+      let result: DownloadRepoResult
+      if (signal?.aborted) {
+        result = { owner, outcome: "failed", reason: "aborted" }
+      } else {
+        try {
+          const repo = studentRepoName(classroom, assignment, owner)
+          const archive = await fetchRepoArchive(client, org, repo)
+          result = archive
+            ? { owner, outcome: "fetched" }
+            : { owner, outcome: "empty" }
+          if (archive) {
+            zip.file(`${owner}.zip`, archive.bytes)
+          }
+        } catch (err) {
+          result = {
+            owner,
+            outcome: "failed",
+            reason: err instanceof Error ? err.message : String(err),
+          }
+        }
+      }
+      done++
+      onProgress?.({ done, total })
+      return result
+    },
+  )
+
+  const blob = await zip.generateAsync({ type: "blob" })
+
+  return {
+    blob,
+    summary: {
+      total,
+      fetched: results.filter((r) => r.outcome === "fetched").length,
+      empty: results.filter((r) => r.outcome === "empty"),
+      failed: results.filter((r) => r.outcome === "failed"),
+      results,
+    },
+  }
+}

--- a/web/src/domain/assignments/downloadSubmissions.ts
+++ b/web/src/domain/assignments/downloadSubmissions.ts
@@ -34,6 +34,24 @@ export type DownloadAllResult = {
   summary: DownloadAllSummary
 }
 
+// Soft ceiling on how many submissions one bulk run packages. The whole
+// combined zip is built in browser memory (every archive buffered, then a
+// second full copy from generateAsync), so a very large class can exhaust the
+// tab. The UI warns past this in the confirm step; it's advisory, not enforced
+// here — a teacher who accepts the warning still gets the full run.
+export const BULK_DOWNLOAD_WARN_THRESHOLD = 100
+
+// Thrown when the combined zip can't be assembled (typically an allocation
+// failure because the class is too large to hold in memory). Distinct from a
+// per-repo network failure so the UI can tell the teacher the class is too big
+// rather than showing a generic error after every archive already downloaded.
+export class ZipAssemblyError extends Error {
+  constructor(cause: unknown) {
+    super("Failed to assemble the combined submissions archive", { cause })
+    this.name = "ZipAssemblyError"
+  }
+}
+
 // Download EVERY submitting owner's latest submission into one combined zip
 // (single teacher action). A bounded fan-out (REPO_READ_CONCURRENCY) fetches
 // each repo's archive; each fetched archive is stored — not re-inflated — as a
@@ -50,8 +68,16 @@ export async function downloadAllSubmissions(params: {
   onProgress?: (progress: DownloadAllProgress) => void
   signal?: AbortSignal
 }): Promise<DownloadAllResult> {
-  const { client, org, classroom, assignment, owners, onProgress, signal } =
-    params
+  const { client, org, classroom, assignment, onProgress, signal } = params
+  // Dedupe (case-insensitively, matching the lowercased repo name) so a
+  // duplicated owner can't add two identical entries to the combined zip.
+  const seen = new Set<string>()
+  const owners = params.owners.filter((owner) => {
+    const key = owner.toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
   const total = owners.length
   let done = 0
 
@@ -63,11 +89,11 @@ export async function downloadAllSubmissions(params: {
     async (owner): Promise<DownloadRepoResult> => {
       let result: DownloadRepoResult
       if (signal?.aborted) {
-        result = { owner, outcome: "failed", reason: "aborted" }
+        result = { owner, outcome: "empty", reason: "cancelled" }
       } else {
         try {
           const repo = studentRepoName(classroom, assignment, owner)
-          const archive = await fetchRepoArchive(client, org, repo)
+          const archive = await fetchRepoArchive(client, org, repo, { signal })
           result = archive
             ? { owner, outcome: "fetched" }
             : { owner, outcome: "empty" }
@@ -75,10 +101,19 @@ export async function downloadAllSubmissions(params: {
             zip.file(`${owner}.zip`, archive.bytes)
           }
         } catch (err) {
+          // A user cancel (abort) is not a repo failure — classify it so the
+          // summary doesn't report cancelled repos as failures.
+          const aborted =
+            signal?.aborted ||
+            (err instanceof DOMException && err.name === "AbortError")
           result = {
             owner,
-            outcome: "failed",
-            reason: err instanceof Error ? err.message : String(err),
+            outcome: aborted ? "empty" : "failed",
+            reason: aborted
+              ? "cancelled"
+              : err instanceof Error
+                ? err.message
+                : String(err),
           }
         }
       }
@@ -88,7 +123,14 @@ export async function downloadAllSubmissions(params: {
     },
   )
 
-  const blob = await zip.generateAsync({ type: "blob" })
+  let blob: Blob
+  try {
+    blob = await zip.generateAsync({ type: "blob" })
+  } catch (err) {
+    // Every archive already downloaded; the failure is assembling them (most
+    // likely an out-of-memory allocation for a very large class).
+    throw new ZipAssemblyError(err)
+  }
 
   return {
     blob,

--- a/web/src/domain/assignments/downloadSubmissions.ts
+++ b/web/src/domain/assignments/downloadSubmissions.ts
@@ -3,6 +3,7 @@ import JSZip from "jszip"
 import { fetchRepoArchive } from "@/github-core/repoArchiveReads"
 import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
 import { mapWithConcurrency } from "@/util/concurrency"
+import { writeFileToDirectory } from "@/util/fileSystemAccess"
 import { studentRepoName } from "@/util/studentRepo"
 import type { GitHubClient } from "@/github-core/client"
 
@@ -11,8 +12,8 @@ export type DownloadAllProgress = {
   total: number
 }
 
-// Per-owner outcome: `fetched` packaged into the combined zip, `empty` was a
-// missing/never-pushed repo (skipped), `failed` errored (recorded, not fatal).
+// Per-owner outcome: `fetched` packaged/written, `empty` was a missing/never-
+// pushed repo (skipped), `failed` errored (recorded, not fatal).
 export type DownloadOutcome = "fetched" | "empty" | "failed"
 
 export type DownloadRepoResult = {
@@ -38,7 +39,8 @@ export type DownloadAllResult = {
 // combined zip is built in browser memory (every archive buffered, then a
 // second full copy from generateAsync), so a very large class can exhaust the
 // tab. The UI warns past this in the confirm step; it's advisory, not enforced
-// here — a teacher who accepts the warning still gets the full run.
+// here — a teacher who accepts the warning still gets the full run. The
+// directory-extract path streams to disk and isn't subject to this limit.
 export const BULK_DOWNLOAD_WARN_THRESHOLD = 100
 
 // Thrown when the combined zip can't be assembled (typically an allocation
@@ -52,13 +54,105 @@ export class ZipAssemblyError extends Error {
   }
 }
 
-// Download EVERY submitting owner's latest submission into one combined zip
-// (single teacher action). A bounded fan-out (REPO_READ_CONCURRENCY) fetches
-// each repo's archive; each fetched archive is stored — not re-inflated — as a
-// nested `<owner>.zip` entry, so a large class stays lossless and cheap to
-// package. A missing/empty repo is skipped, and a single repo's failure is
-// recorded rather than aborting the batch. `onProgress` fires after each repo
-// settles so the UI can show a live count.
+// Case-insensitive dedupe (matching the lowercased repo name) so a duplicated
+// owner can't produce two identical entries.
+function dedupeOwners(owners: string[]): string[] {
+  const seen = new Set<string>()
+  return owners.filter((owner) => {
+    const key = owner.toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+// Classify a caught per-owner error: a user cancel (abort) is not a repo
+// failure, so it's recorded as skipped rather than inflating the failed bucket.
+function classifyOwnerError(
+  owner: string,
+  err: unknown,
+  aborted: boolean,
+): DownloadRepoResult {
+  const isAbort =
+    aborted || (err instanceof DOMException && err.name === "AbortError")
+  return {
+    owner,
+    outcome: isAbort ? "empty" : "failed",
+    reason: isAbort
+      ? "cancelled"
+      : err instanceof Error
+        ? err.message
+        : String(err),
+  }
+}
+
+function summarize(
+  owners: string[],
+  results: DownloadRepoResult[],
+): DownloadAllSummary {
+  return {
+    total: owners.length,
+    fetched: results.filter((r) => r.outcome === "fetched").length,
+    empty: results.filter((r) => r.outcome === "empty"),
+    failed: results.filter((r) => r.outcome === "failed"),
+    results,
+  }
+}
+
+// Shared fan-out: fetch every owner's latest archive at bounded concurrency,
+// invoking `onArchive` with the bytes for each fetched repo (to zip or write to
+// disk), reporting progress, and never letting one repo's failure abort the
+// batch.
+async function fanOutArchives(params: {
+  client: GitHubClient
+  org: string
+  classroom: string
+  assignment: string
+  owners: string[]
+  onArchive: (owner: string, bytes: ArrayBuffer) => Promise<void> | void
+  onProgress?: (progress: DownloadAllProgress) => void
+  signal?: AbortSignal
+}): Promise<DownloadRepoResult[]> {
+  const { client, org, classroom, assignment, owners, onArchive } = params
+  const total = owners.length
+  let done = 0
+
+  return mapWithConcurrency(
+    owners,
+    REPO_READ_CONCURRENCY,
+    async (owner): Promise<DownloadRepoResult> => {
+      let result: DownloadRepoResult
+      if (params.signal?.aborted) {
+        result = { owner, outcome: "empty", reason: "cancelled" }
+      } else {
+        try {
+          const repo = studentRepoName(classroom, assignment, owner)
+          const archive = await fetchRepoArchive(client, org, repo, {
+            signal: params.signal,
+          })
+          if (archive) {
+            await onArchive(owner, archive.bytes)
+            result = { owner, outcome: "fetched" }
+          } else {
+            result = { owner, outcome: "empty" }
+          }
+        } catch (err) {
+          result = classifyOwnerError(owner, err, !!params.signal?.aborted)
+        }
+      }
+      done++
+      params.onProgress?.({ done, total })
+      return result
+    },
+  )
+}
+
+// Download EVERY submitting owner's latest submission into ONE combined zip
+// (the fallback path where the File System Access API is unavailable). A
+// bounded fan-out fetches each repo's archive; each fetched archive is stored —
+// not re-inflated — as a nested `<owner>.zip` entry, so it stays lossless. A
+// missing/empty repo is skipped and a single repo's failure is recorded rather
+// than aborting the batch. `onProgress` fires after each repo settles.
 export async function downloadAllSubmissions(params: {
   client: GitHubClient
   org: string
@@ -68,60 +162,16 @@ export async function downloadAllSubmissions(params: {
   onProgress?: (progress: DownloadAllProgress) => void
   signal?: AbortSignal
 }): Promise<DownloadAllResult> {
-  const { client, org, classroom, assignment, onProgress, signal } = params
-  // Dedupe (case-insensitively, matching the lowercased repo name) so a
-  // duplicated owner can't add two identical entries to the combined zip.
-  const seen = new Set<string>()
-  const owners = params.owners.filter((owner) => {
-    const key = owner.toLowerCase()
-    if (seen.has(key)) return false
-    seen.add(key)
-    return true
-  })
-  const total = owners.length
-  let done = 0
-
+  const owners = dedupeOwners(params.owners)
   const zip = new JSZip()
 
-  const results = await mapWithConcurrency(
+  const results = await fanOutArchives({
+    ...params,
     owners,
-    REPO_READ_CONCURRENCY,
-    async (owner): Promise<DownloadRepoResult> => {
-      let result: DownloadRepoResult
-      if (signal?.aborted) {
-        result = { owner, outcome: "empty", reason: "cancelled" }
-      } else {
-        try {
-          const repo = studentRepoName(classroom, assignment, owner)
-          const archive = await fetchRepoArchive(client, org, repo, { signal })
-          result = archive
-            ? { owner, outcome: "fetched" }
-            : { owner, outcome: "empty" }
-          if (archive) {
-            zip.file(`${owner}.zip`, archive.bytes)
-          }
-        } catch (err) {
-          // A user cancel (abort) is not a repo failure — classify it so the
-          // summary doesn't report cancelled repos as failures.
-          const aborted =
-            signal?.aborted ||
-            (err instanceof DOMException && err.name === "AbortError")
-          result = {
-            owner,
-            outcome: aborted ? "empty" : "failed",
-            reason: aborted
-              ? "cancelled"
-              : err instanceof Error
-                ? err.message
-                : String(err),
-          }
-        }
-      }
-      done++
-      onProgress?.({ done, total })
-      return result
+    onArchive: (owner, bytes) => {
+      zip.file(`${owner}.zip`, bytes)
     },
-  )
+  })
 
   let blob: Blob
   try {
@@ -132,14 +182,32 @@ export async function downloadAllSubmissions(params: {
     throw new ZipAssemblyError(err)
   }
 
-  return {
-    blob,
-    summary: {
-      total,
-      fetched: results.filter((r) => r.outcome === "fetched").length,
-      empty: results.filter((r) => r.outcome === "empty"),
-      failed: results.filter((r) => r.outcome === "failed"),
-      results,
-    },
-  }
+  return { blob, summary: summarize(owners, results) }
+}
+
+// Download EVERY submitting owner's latest submission directly into a
+// teacher-chosen directory (Chromium File System Access path). Each fetched
+// archive is streamed to `<owner>.zip` in the picked folder as it arrives, so
+// nothing accumulates in memory — no combined-zip ceiling, no OOM risk. Same
+// skip/failure semantics and progress reporting as the combined-zip path.
+export async function streamSubmissionsToDirectory(params: {
+  client: GitHubClient
+  org: string
+  classroom: string
+  assignment: string
+  owners: string[]
+  directory: FileSystemDirectoryHandle
+  onProgress?: (progress: DownloadAllProgress) => void
+  signal?: AbortSignal
+}): Promise<DownloadAllSummary> {
+  const owners = dedupeOwners(params.owners)
+
+  const results = await fanOutArchives({
+    ...params,
+    owners,
+    onArchive: (owner, bytes) =>
+      writeFileToDirectory(params.directory, `${owner}.zip`, bytes),
+  })
+
+  return summarize(owners, results)
 }

--- a/web/src/domain/classrooms.test.ts
+++ b/web/src/domain/classrooms.test.ts
@@ -34,12 +34,14 @@ const apiError = (status: number, rateLimit: Partial<GitHubRateLimit> = {}) =>
 const clientReturning = (body: unknown): GitHubClient => ({
   request: vi.fn(),
   requestRaw: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  requestBinary: vi.fn(),
 })
 
 // A client whose requestRaw rejects on every call with the given error.
 const clientRejecting = (err: unknown): GitHubClient => ({
   request: vi.fn(),
   requestRaw: vi.fn().mockRejectedValue(err),
+  requestBinary: vi.fn(),
 })
 
 describe("assertClassroomNotArchived", () => {
@@ -89,7 +91,11 @@ describe("assertClassroomNotArchived", () => {
       .mockResolvedValueOnce(
         JSON.stringify({ short_name: "cs101", active: true }),
       )
-    const client: GitHubClient = { request: vi.fn(), requestRaw }
+    const client: GitHubClient = {
+      request: vi.fn(),
+      requestRaw,
+      requestBinary: vi.fn(),
+    }
     await expect(
       assertClassroomNotArchived(client, "acme", "cs101"),
     ).resolves.toBeUndefined()

--- a/web/src/domain/classrooms.test.ts
+++ b/web/src/domain/classrooms.test.ts
@@ -34,14 +34,14 @@ const apiError = (status: number, rateLimit: Partial<GitHubRateLimit> = {}) =>
 const clientReturning = (body: unknown): GitHubClient => ({
   request: vi.fn(),
   requestRaw: vi.fn().mockResolvedValue(JSON.stringify(body)),
-  requestBinary: vi.fn(),
+  fetchArchive: vi.fn(),
 })
 
 // A client whose requestRaw rejects on every call with the given error.
 const clientRejecting = (err: unknown): GitHubClient => ({
   request: vi.fn(),
   requestRaw: vi.fn().mockRejectedValue(err),
-  requestBinary: vi.fn(),
+  fetchArchive: vi.fn(),
 })
 
 describe("assertClassroomNotArchived", () => {
@@ -94,7 +94,7 @@ describe("assertClassroomNotArchived", () => {
     const client: GitHubClient = {
       request: vi.fn(),
       requestRaw,
-      requestBinary: vi.fn(),
+      fetchArchive: vi.fn(),
     }
     await expect(
       assertClassroomNotArchived(client, "acme", "cs101"),

--- a/web/src/domain/teardown.test.ts
+++ b/web/src/domain/teardown.test.ts
@@ -217,6 +217,7 @@ function makeClient(opts: Opts) {
   const client: GitHubClient = {
     request: request as unknown as GitHubClient["request"],
     requestRaw: requestRaw as unknown as GitHubClient["requestRaw"],
+    requestBinary: vi.fn() as unknown as GitHubClient["requestBinary"],
   }
   return { client, deletes, teamDeletes }
 }
@@ -372,6 +373,7 @@ describe("executeTeardown", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: requestRaw as unknown as GitHubClient["requestRaw"],
+      requestBinary: vi.fn() as unknown as GitHubClient["requestBinary"],
     }
     const plan = await planTeardown(client, "acme")
     expect(plan.repoNames).not.toContain("cs101-hw1-late")
@@ -422,6 +424,7 @@ describe("executeTeardown", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: requestRaw as unknown as GitHubClient["requestRaw"],
+      requestBinary: vi.fn() as unknown as GitHubClient["requestBinary"],
     }
     const plan = await planTeardown(client, "acme")
     const result = await executeTeardown(client, plan)

--- a/web/src/domain/teardown.test.ts
+++ b/web/src/domain/teardown.test.ts
@@ -217,7 +217,7 @@ function makeClient(opts: Opts) {
   const client: GitHubClient = {
     request: request as unknown as GitHubClient["request"],
     requestRaw: requestRaw as unknown as GitHubClient["requestRaw"],
-    requestBinary: vi.fn() as unknown as GitHubClient["requestBinary"],
+    fetchArchive: vi.fn() as unknown as GitHubClient["fetchArchive"],
   }
   return { client, deletes, teamDeletes }
 }
@@ -373,7 +373,7 @@ describe("executeTeardown", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: requestRaw as unknown as GitHubClient["requestRaw"],
-      requestBinary: vi.fn() as unknown as GitHubClient["requestBinary"],
+      fetchArchive: vi.fn() as unknown as GitHubClient["fetchArchive"],
     }
     const plan = await planTeardown(client, "acme")
     expect(plan.repoNames).not.toContain("cs101-hw1-late")
@@ -424,7 +424,7 @@ describe("executeTeardown", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: requestRaw as unknown as GitHubClient["requestRaw"],
-      requestBinary: vi.fn() as unknown as GitHubClient["requestBinary"],
+      fetchArchive: vi.fn() as unknown as GitHubClient["fetchArchive"],
     }
     const plan = await planTeardown(client, "acme")
     const result = await executeTeardown(client, plan)

--- a/web/src/github-core/client.test.ts
+++ b/web/src/github-core/client.test.ts
@@ -312,6 +312,32 @@ describe("createGitHubClient fetchArchive (archive proxy)", () => {
     )
   })
 
+  it("refuses to send the token to a non-https proxy", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      archiveBaseUrl: "http://evil.example",
+    })
+    await expect(client.fetchArchive("o", "r")).rejects.toThrow(/https/i)
+  })
+
+  it("allows an http localhost proxy for dev", async () => {
+    const fetchSpy =
+      vi.fn<(url: string, init?: RequestInit) => Promise<Response>>()
+    fetchSpy.mockResolvedValue(
+      new Response(new Uint8Array([1]), { status: 200 }),
+    )
+    vi.stubGlobal("fetch", fetchSpy)
+    const client = createGitHubClient({
+      token: "t",
+      archiveBaseUrl: "http://localhost:8787",
+    })
+
+    await client.fetchArchive("o", "r")
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "http://localhost:8787/repos/o/r/zipball",
+    )
+  })
+
   it("counts the call exactly once", async () => {
     stubBinaryFetch(200, new Uint8Array([1]))
     const client = createGitHubClient({ token: "t", archiveBaseUrl: BASE })

--- a/web/src/github-core/client.test.ts
+++ b/web/src/github-core/client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { DEFAULT_REQUEST_TIMEOUT_MS, createGitHubClient } from "./client"
+import { getApiCallCount } from "@/lib/diagnostics/rateLimit"
 
 // Drive aborts with REAL short timeouts, not vitest fake timers: @sinonjs
 // fake-timers doesn't mock AbortSignal.timeout, so advancing would never abort.
@@ -218,5 +219,67 @@ describe("createGitHubClient non-JSON response (GitHub-outage shape)", () => {
     expect((err as { requestId: string | null }).requestId).toBe("ABCD:1234:EF")
     // The raw HTML body is still dropped.
     expect((err as Error).message).not.toContain("proxy error")
+  })
+})
+
+describe("createGitHubClient requestBinary (archive downloads)", () => {
+  function stubBinaryFetch(
+    status: number,
+    body: BodyInit,
+    headers: Record<string, string> = {},
+  ): void {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(new Response(body, { status, headers })),
+    )
+  }
+
+  it("returns the response body as an ArrayBuffer for a 200", async () => {
+    const payload = new Uint8Array([80, 75, 3, 4]) // "PK\x03\x04" (zip magic)
+    stubBinaryFetch(200, payload, {
+      "content-type": "application/zip",
+    })
+    const client = createGitHubClient({ token: "t" })
+
+    const { bytes } = await client.requestBinary("/repos/o/r/zipball")
+    expect(bytes).toBeInstanceOf(ArrayBuffer)
+    expect(new Uint8Array(bytes)).toEqual(payload)
+  })
+
+  it("extracts filename from Content-Disposition", async () => {
+    stubBinaryFetch(200, new Uint8Array([1]), {
+      "content-disposition": "attachment; filename=owner-repo-abc123.zip",
+    })
+    const client = createGitHubClient({ token: "t" })
+
+    const { filename } = await client.requestBinary("/repos/o/r/zipball")
+    expect(filename).toBe("owner-repo-abc123.zip")
+  })
+
+  it("returns undefined filename when Content-Disposition is absent", async () => {
+    stubBinaryFetch(200, new Uint8Array([1]))
+    const client = createGitHubClient({ token: "t" })
+
+    const { filename } = await client.requestBinary("/repos/o/r/zipball")
+    expect(filename).toBeUndefined()
+  })
+
+  it("throws a GitHubAPIError on a non-2xx", async () => {
+    stubBinaryFetch(404, JSON.stringify({ message: "Not Found" }), {
+      "content-type": "application/json",
+    })
+    const client = createGitHubClient({ token: "t" })
+
+    await expect(
+      client.requestBinary("/repos/o/missing/zipball"),
+    ).rejects.toMatchObject({ name: "GitHubAPIError", status: 404 })
+  })
+
+  it("counts the call exactly once", async () => {
+    stubBinaryFetch(200, new Uint8Array([1]))
+    const client = createGitHubClient({ token: "t" })
+
+    const before = getApiCallCount()
+    await client.requestBinary("/repos/o/r/zipball")
+    expect(getApiCallCount()).toBe(before + 1)
   })
 })

--- a/web/src/github-core/client.test.ts
+++ b/web/src/github-core/client.test.ts
@@ -222,7 +222,9 @@ describe("createGitHubClient non-JSON response (GitHub-outage shape)", () => {
   })
 })
 
-describe("createGitHubClient requestBinary (archive downloads)", () => {
+describe("createGitHubClient fetchArchive (archive proxy)", () => {
+  const BASE = "https://worker.example"
+
   function stubBinaryFetch(
     status: number,
     body: BodyInit,
@@ -235,31 +237,59 @@ describe("createGitHubClient requestBinary (archive downloads)", () => {
 
   it("returns the response body as an ArrayBuffer for a 200", async () => {
     const payload = new Uint8Array([80, 75, 3, 4]) // "PK\x03\x04" (zip magic)
-    stubBinaryFetch(200, payload, {
-      "content-type": "application/zip",
-    })
-    const client = createGitHubClient({ token: "t" })
+    stubBinaryFetch(200, payload, { "content-type": "application/zip" })
+    const client = createGitHubClient({ token: "t", archiveBaseUrl: BASE })
 
-    const { bytes } = await client.requestBinary("/repos/o/r/zipball")
+    const { bytes } = await client.fetchArchive("o", "r")
     expect(bytes).toBeInstanceOf(ArrayBuffer)
     expect(new Uint8Array(bytes)).toEqual(payload)
+  })
+
+  it("requests the proxy's zipball path with a Bearer token", async () => {
+    const fetchSpy =
+      vi.fn<(url: string, init?: RequestInit) => Promise<Response>>()
+    fetchSpy.mockResolvedValue(
+      new Response(new Uint8Array([1]), { status: 200 }),
+    )
+    vi.stubGlobal("fetch", fetchSpy)
+    const client = createGitHubClient({ token: "secret", archiveBaseUrl: BASE })
+
+    await client.fetchArchive("o", "r")
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe(`${BASE}/repos/o/r/zipball`)
+    expect((init?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer secret",
+    )
+  })
+
+  it("appends the ref when provided", async () => {
+    const fetchSpy =
+      vi.fn<(url: string, init?: RequestInit) => Promise<Response>>()
+    fetchSpy.mockResolvedValue(
+      new Response(new Uint8Array([1]), { status: 200 }),
+    )
+    vi.stubGlobal("fetch", fetchSpy)
+    const client = createGitHubClient({ token: "t", archiveBaseUrl: BASE })
+
+    await client.fetchArchive("o", "r", { ref: "main" })
+    expect(fetchSpy.mock.calls[0][0]).toBe(`${BASE}/repos/o/r/zipball/main`)
   })
 
   it("extracts filename from Content-Disposition", async () => {
     stubBinaryFetch(200, new Uint8Array([1]), {
       "content-disposition": "attachment; filename=owner-repo-abc123.zip",
     })
-    const client = createGitHubClient({ token: "t" })
+    const client = createGitHubClient({ token: "t", archiveBaseUrl: BASE })
 
-    const { filename } = await client.requestBinary("/repos/o/r/zipball")
+    const { filename } = await client.fetchArchive("o", "r")
     expect(filename).toBe("owner-repo-abc123.zip")
   })
 
   it("returns undefined filename when Content-Disposition is absent", async () => {
     stubBinaryFetch(200, new Uint8Array([1]))
-    const client = createGitHubClient({ token: "t" })
+    const client = createGitHubClient({ token: "t", archiveBaseUrl: BASE })
 
-    const { filename } = await client.requestBinary("/repos/o/r/zipball")
+    const { filename } = await client.fetchArchive("o", "r")
     expect(filename).toBeUndefined()
   })
 
@@ -267,19 +297,27 @@ describe("createGitHubClient requestBinary (archive downloads)", () => {
     stubBinaryFetch(404, JSON.stringify({ message: "Not Found" }), {
       "content-type": "application/json",
     })
-    const client = createGitHubClient({ token: "t" })
+    const client = createGitHubClient({ token: "t", archiveBaseUrl: BASE })
 
-    await expect(
-      client.requestBinary("/repos/o/missing/zipball"),
-    ).rejects.toMatchObject({ name: "GitHubAPIError", status: 404 })
+    await expect(client.fetchArchive("o", "missing")).rejects.toMatchObject({
+      name: "GitHubAPIError",
+      status: 404,
+    })
+  })
+
+  it("throws when no archive proxy is configured", async () => {
+    const client = createGitHubClient({ token: "t" })
+    await expect(client.fetchArchive("o", "r")).rejects.toThrow(
+      /archive proxy/i,
+    )
   })
 
   it("counts the call exactly once", async () => {
     stubBinaryFetch(200, new Uint8Array([1]))
-    const client = createGitHubClient({ token: "t" })
+    const client = createGitHubClient({ token: "t", archiveBaseUrl: BASE })
 
     const before = getApiCallCount()
-    await client.requestBinary("/repos/o/r/zipball")
+    await client.fetchArchive("o", "r")
     expect(getApiCallCount()).toBe(before + 1)
   })
 })

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -247,13 +247,33 @@ export function createGitHubClient(args: {
         throw new Error("archive proxy is not configured")
       }
 
+      // Guard before attaching the token: only send the OAuth bearer to an
+      // https origin (or localhost for dev). A misconfigured archiveBaseUrl
+      // (http://, or a wrong host from a bad env) would otherwise exfiltrate a
+      // broadly-scoped token. Fail closed rather than send.
+      const base = new URL(args.archiveBaseUrl)
+      const isLocalhost =
+        base.hostname === "localhost" ||
+        base.hostname === "127.0.0.1" ||
+        base.hostname === "[::1]"
+      if (base.protocol !== "https:" && !isLocalhost) {
+        throw new Error("archive proxy must be an https origin")
+      }
+
       // Count against the diagnostics overlay like any other GitHub call, even
       // though this one hops through the proxy.
       countApiCall()
 
+      // Encode each path segment (defense-in-depth): owners are GitHub logins
+      // and repo is computed today, but a future ref caller could carry `/`,
+      // `..`, or query chars. `ref` legitimately contains `/`, so encode its
+      // segments individually.
+      const encodedRef = options?.ref
+        ? options.ref.split("/").map(encodeURIComponent).join("/")
+        : ""
       const path =
-        `/repos/${owner}/${repo}/zipball` +
-        (options?.ref ? `/${options.ref}` : "")
+        `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/zipball` +
+        (encodedRef ? `/${encodedRef}` : "")
       const url = `${args.archiveBaseUrl.replace(/\/$/, "")}${path}`
 
       // Archives are larger than API responses; default to a generous timeout.
@@ -315,19 +335,35 @@ export function createGitHubClient(args: {
   }
 }
 
-// Pull the `filename` out of a Content-Disposition header (e.g.
-// `attachment; filename=owner-repo-sha.zip`), stripping optional quotes. GitHub
-// sends this on archive downloads so we can name the saved file sensibly.
-// Returns undefined when the header is absent or carries no filename.
+// Pull the `filename` out of a Content-Disposition header, preferring the
+// RFC 5987 `filename*=charset'lang'value` form (which wins per RFC 6266) over a
+// plain `filename="value"`, stripping optional quotes and the charset/lang
+// prefix. GitHub sends this on archive downloads so we can name the saved file
+// sensibly. Returns undefined when the header is absent or carries no filename.
 function parseContentDispositionFilename(
   header: string | null,
 ): string | undefined {
   if (!header) return undefined
-  const match = /filename\*?=(?:UTF-8''|")?([^";]+)"?/i.exec(header)
-  if (!match) return undefined
+
+  // Prefer filename* (extended, may carry non-ASCII); fall back to filename.
+  const ext = /filename\*=\s*(?:([\w-]+)'[^']*')?"?([^";]+?)"?\s*(?:;|$)/i.exec(
+    header,
+  )
+  if (ext) {
+    const value = ext[2].trim()
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+
+  const plain = /filename=\s*"?([^";]+?)"?\s*(?:;|$)/i.exec(header)
+  if (!plain) return undefined
+  const value = plain[1].trim()
   try {
-    return decodeURIComponent(match[1].trim())
+    return decodeURIComponent(value)
   } catch {
-    return match[1].trim()
+    return value
   }
 }

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -23,6 +23,19 @@ export type GitHubClient = {
   ) => Promise<T>
 
   requestRaw: (path: string, options?: GitHubRequestOptions) => Promise<string>
+
+  requestBinary: (
+    path: string,
+    options?: GitHubRequestOptions,
+  ) => Promise<GitHubBinaryResponse>
+}
+
+// A binary response body plus the filename GitHub advertised for it (parsed
+// from Content-Disposition). Used for archive downloads (zipball/tarball),
+// which the JSON/text paths can't carry.
+export type GitHubBinaryResponse = {
+  bytes: ArrayBuffer
+  filename?: string
 }
 
 export type GitHubRequestOptions = {
@@ -56,7 +69,8 @@ export function createGitHubClient(args: {
     options: GitHubRequestOptions = { method: "GET" },
   ): Promise<Response> {
     // Count every outbound call at the single choke point (covers request +
-    // requestRaw) — before the fetch, so a thrown/timed-out call still counts.
+    // requestRaw + requestBinary) — before the fetch, so a thrown/timed-out
+    // call still counts.
     countApiCall()
 
     const url = path.startsWith("http")
@@ -213,5 +227,37 @@ export function createGitHubClient(args: {
 
       return await res.text()
     },
+
+    async requestBinary(path: string, options?: GitHubRequestOptions) {
+      const res = await requestInternal(path, {
+        method: options?.method ?? "GET",
+        ...options,
+        accept: options?.accept ?? "application/vnd.github+json",
+      })
+
+      const bytes = await res.arrayBuffer()
+      const filename = parseContentDispositionFilename(
+        res.headers.get("content-disposition"),
+      )
+
+      return { bytes, filename }
+    },
+  }
+}
+
+// Pull the `filename` out of a Content-Disposition header (e.g.
+// `attachment; filename=owner-repo-sha.zip`), stripping optional quotes. GitHub
+// sends this on archive downloads so we can name the saved file sensibly.
+// Returns undefined when the header is absent or carries no filename.
+function parseContentDispositionFilename(
+  header: string | null,
+): string | undefined {
+  if (!header) return undefined
+  const match = /filename\*?=(?:UTF-8''|")?([^";]+)"?/i.exec(header)
+  if (!match) return undefined
+  try {
+    return decodeURIComponent(match[1].trim())
+  } catch {
+    return match[1].trim()
   }
 }

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -24,9 +24,16 @@ export type GitHubClient = {
 
   requestRaw: (path: string, options?: GitHubRequestOptions) => Promise<string>
 
-  requestBinary: (
-    path: string,
-    options?: GitHubRequestOptions,
+  // Fetch a repo archive (zip) through the archive proxy Worker rather than
+  // api.github.com directly: the archive endpoint 302-redirects to
+  // codeload.github.com, which sends no CORS header, so a browser fetch of the
+  // bytes is blocked. The Worker follows the redirect server-side with this
+  // client's token and streams the bytes back with CORS. Returns null when the
+  // proxy is not configured.
+  fetchArchive: (
+    owner: string,
+    repo: string,
+    options?: { ref?: string; signal?: AbortSignal; timeoutMs?: number },
   ) => Promise<GitHubBinaryResponse>
 }
 
@@ -60,6 +67,9 @@ export type GitHubResponseSignal = {
 export function createGitHubClient(args: {
   token: string
   apiBaseUrl?: string
+  // Base URL of the archive-proxy Worker (see fetchArchive). When omitted,
+  // fetchArchive throws — archive download is unavailable without the proxy.
+  archiveBaseUrl?: string
   onResponse?: (signal: GitHubResponseSignal) => void
 }): GitHubClient {
   const apiBaseUrl = args.apiBaseUrl ?? "https://api.github.com"
@@ -69,8 +79,8 @@ export function createGitHubClient(args: {
     options: GitHubRequestOptions = { method: "GET" },
   ): Promise<Response> {
     // Count every outbound call at the single choke point (covers request +
-    // requestRaw + requestBinary) — before the fetch, so a thrown/timed-out
-    // call still counts.
+    // requestRaw; fetchArchive counts itself since it bypasses this proxy) —
+    // before the fetch, so a thrown/timed-out call still counts.
     countApiCall()
 
     const url = path.startsWith("http")
@@ -228,12 +238,72 @@ export function createGitHubClient(args: {
       return await res.text()
     },
 
-    async requestBinary(path: string, options?: GitHubRequestOptions) {
-      const res = await requestInternal(path, {
-        method: options?.method ?? "GET",
-        ...options,
-        accept: options?.accept ?? "application/vnd.github+json",
+    async fetchArchive(
+      owner: string,
+      repo: string,
+      options?: { ref?: string; signal?: AbortSignal; timeoutMs?: number },
+    ) {
+      if (!args.archiveBaseUrl) {
+        throw new Error("archive proxy is not configured")
+      }
+
+      // Count against the diagnostics overlay like any other GitHub call, even
+      // though this one hops through the proxy.
+      countApiCall()
+
+      const path =
+        `/repos/${owner}/${repo}/zipball` +
+        (options?.ref ? `/${options.ref}` : "")
+      const url = `${args.archiveBaseUrl.replace(/\/$/, "")}${path}`
+
+      // Archives are larger than API responses; default to a generous timeout.
+      const timeoutMs = options?.timeoutMs ?? 60000
+      const timeoutSignal =
+        timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined
+      const signal =
+        options?.signal && timeoutSignal
+          ? AbortSignal.any([options.signal, timeoutSignal])
+          : (options?.signal ?? timeoutSignal)
+
+      log.debug("archive request", { owner, repo, ref: options?.ref })
+
+      const res = await fetch(url, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${args.token}` },
+        signal,
       })
+
+      // Report token liveness like requestInternal so a revoked token still
+      // tears the session down when the proxy relays a 401.
+      args.onResponse?.({
+        status: res.status,
+        scopes: res.headers.get("x-oauth-scopes"),
+      })
+
+      if (!res.ok) {
+        const text = await res.text()
+        let body: unknown
+        try {
+          body = text ? JSON.parse(text) : null
+        } catch {
+          body = text
+        }
+        const message =
+          typeof body === "object" &&
+          body !== null &&
+          "message" in body &&
+          typeof body.message === "string"
+            ? body.message
+            : `Archive request failed with ${res.status}`
+        throw new GitHubAPIError({
+          status: res.status,
+          url,
+          message,
+          body,
+          rateLimit: readGitHubRateLimitHeaders(res),
+          requestId: res.headers.get("x-github-request-id"),
+        })
+      }
 
       const bytes = await res.arrayBuffer()
       const filename = parseContentDispositionFilename(

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -24,12 +24,10 @@ export type GitHubClient = {
 
   requestRaw: (path: string, options?: GitHubRequestOptions) => Promise<string>
 
-  // Fetch a repo archive (zip) through the archive proxy Worker rather than
-  // api.github.com directly: the archive endpoint 302-redirects to
-  // codeload.github.com, which sends no CORS header, so a browser fetch of the
-  // bytes is blocked. The Worker follows the redirect server-side with this
-  // client's token and streams the bytes back with CORS. Returns null when the
-  // proxy is not configured.
+  // Fetch a repo zip via the archive-proxy Worker: the GitHub archive endpoint
+  // 302s to codeload (no CORS header), so the Worker follows the redirect
+  // server-side with this token and streams bytes back with CORS. Throws if no
+  // proxy is configured.
   fetchArchive: (
     owner: string,
     repo: string,
@@ -37,9 +35,7 @@ export type GitHubClient = {
   ) => Promise<GitHubBinaryResponse>
 }
 
-// A binary response body plus the filename GitHub advertised for it (parsed
-// from Content-Disposition). Used for archive downloads (zipball/tarball),
-// which the JSON/text paths can't carry.
+// Binary body plus the filename GitHub advertised (from Content-Disposition).
 export type GitHubBinaryResponse = {
   bytes: ArrayBuffer
   filename?: string
@@ -100,13 +96,7 @@ export function createGitHubClient(args: {
 
     // Abort on whichever fires first: the caller's signal or the timeout. A
     // timeout surfaces as a rejected fetch, handled like any other rejection.
-    const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
-    const timeoutSignal =
-      timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined
-    const signal =
-      options.signal && timeoutSignal
-        ? AbortSignal.any([options.signal, timeoutSignal])
-        : (options.signal ?? timeoutSignal)
+    const signal = composeAbortSignal(options.signal, options.timeoutMs)
 
     const method = options.method ?? "GET"
     log.debug("request", { method, path })
@@ -150,22 +140,10 @@ export function createGitHubClient(args: {
     publishRateLimit(rateLimit)
 
     if (!res.ok) {
-      let body: unknown
-      const text = await res.text()
-
-      try {
-        body = text ? JSON.parse(text) : null
-      } catch {
-        body = text
-      }
-
-      const message =
-        typeof body === "object" &&
-        body !== null &&
-        "message" in body &&
-        typeof body.message === "string"
-          ? body.message
-          : `GitHub API request failed with ${res.status}`
+      const { body, message } = await parseErrorResponse(
+        res,
+        `GitHub API request failed with ${res.status}`,
+      )
 
       // Non-sensitive fields only — never the whole body, which can carry IP
       // allow lists or SAML detail. A 422 also gets its validation reasons (see
@@ -247,10 +225,8 @@ export function createGitHubClient(args: {
         throw new Error("archive proxy is not configured")
       }
 
-      // Guard before attaching the token: only send the OAuth bearer to an
-      // https origin (or localhost for dev). A misconfigured archiveBaseUrl
-      // (http://, or a wrong host from a bad env) would otherwise exfiltrate a
-      // broadly-scoped token. Fail closed rather than send.
+      // Fail closed rather than send the bearer to a non-https origin: a
+      // misconfigured base (http / wrong host) could exfiltrate the token.
       const base = new URL(args.archiveBaseUrl)
       const isLocalhost =
         base.hostname === "localhost" ||
@@ -264,10 +240,8 @@ export function createGitHubClient(args: {
       // though this one hops through the proxy.
       countApiCall()
 
-      // Encode each path segment (defense-in-depth): owners are GitHub logins
-      // and repo is computed today, but a future ref caller could carry `/`,
-      // `..`, or query chars. `ref` legitimately contains `/`, so encode its
-      // segments individually.
+      // Encode each segment (defense-in-depth for a future ref caller); encode
+      // ref per-segment since a ref legitimately contains `/`.
       const encodedRef = options?.ref
         ? options.ref.split("/").map(encodeURIComponent).join("/")
         : ""
@@ -277,13 +251,11 @@ export function createGitHubClient(args: {
       const url = `${args.archiveBaseUrl.replace(/\/$/, "")}${path}`
 
       // Archives are larger than API responses; default to a generous timeout.
-      const timeoutMs = options?.timeoutMs ?? 60000
-      const timeoutSignal =
-        timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined
-      const signal =
-        options?.signal && timeoutSignal
-          ? AbortSignal.any([options.signal, timeoutSignal])
-          : (options?.signal ?? timeoutSignal)
+      const signal = composeAbortSignal(
+        options?.signal,
+        options?.timeoutMs,
+        60000,
+      )
 
       log.debug("archive request", { owner, repo, ref: options?.ref })
 
@@ -301,20 +273,10 @@ export function createGitHubClient(args: {
       })
 
       if (!res.ok) {
-        const text = await res.text()
-        let body: unknown
-        try {
-          body = text ? JSON.parse(text) : null
-        } catch {
-          body = text
-        }
-        const message =
-          typeof body === "object" &&
-          body !== null &&
-          "message" in body &&
-          typeof body.message === "string"
-            ? body.message
-            : `Archive request failed with ${res.status}`
+        const { body, message } = await parseErrorResponse(
+          res,
+          `Archive request failed with ${res.status}`,
+        )
         throw new GitHubAPIError({
           status: res.status,
           url,
@@ -335,22 +297,51 @@ export function createGitHubClient(args: {
   }
 }
 
-// Pull the `filename` out of a Content-Disposition header, preferring the
-// RFC 5987 `filename*=charset'lang'value` form (which wins per RFC 6266) over a
-// plain `filename="value"`, stripping optional quotes and the charset/lang
-// prefix. GitHub sends this on archive downloads so we can name the saved file
-// sensibly. Returns undefined when the header is absent or carries no filename.
+// Compose the caller's abort signal with a timeout signal, aborting on whichever
+// fires first. `timeoutMs` 0 opts out of the timeout.
+function composeAbortSignal(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+  defaultMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+): AbortSignal | undefined {
+  const ms = timeoutMs ?? defaultMs
+  const timeoutSignal = ms > 0 ? AbortSignal.timeout(ms) : undefined
+  return callerSignal && timeoutSignal
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : (callerSignal ?? timeoutSignal)
+}
+
+// Parse a non-OK response body as JSON (falling back to raw text) and derive
+// the error message from its `message` field, else `fallback`.
+async function parseErrorResponse(
+  res: Response,
+  fallback: string,
+): Promise<{ body: unknown; message: string }> {
+  const text = await res.text()
+  let body: unknown
+  try {
+    body = text ? JSON.parse(text) : null
+  } catch {
+    body = text
+  }
+  const message =
+    typeof body === "object" &&
+    body !== null &&
+    "message" in body &&
+    typeof body.message === "string"
+      ? body.message
+      : fallback
+  return { body, message }
+}
+
+// Extract the filename from Content-Disposition, preferring RFC 5987
+// `filename*` over plain `filename` (RFC 6266). undefined if absent.
 function parseContentDispositionFilename(
   header: string | null,
 ): string | undefined {
   if (!header) return undefined
 
-  // Prefer filename* (extended, may carry non-ASCII); fall back to filename.
-  const ext = /filename\*=\s*(?:([\w-]+)'[^']*')?"?([^";]+?)"?\s*(?:;|$)/i.exec(
-    header,
-  )
-  if (ext) {
-    const value = ext[2].trim()
+  const safeDecode = (value: string) => {
     try {
       return decodeURIComponent(value)
     } catch {
@@ -358,12 +349,11 @@ function parseContentDispositionFilename(
     }
   }
 
+  const ext = /filename\*=\s*(?:([\w-]+)'[^']*')?"?([^";]+?)"?\s*(?:;|$)/i.exec(
+    header,
+  )
+  if (ext) return safeDecode(ext[2].trim())
+
   const plain = /filename=\s*"?([^";]+?)"?\s*(?:;|$)/i.exec(header)
-  if (!plain) return undefined
-  const value = plain[1].trim()
-  try {
-    return decodeURIComponent(value)
-  } catch {
-    return value
-  }
+  return plain ? safeDecode(plain[1].trim()) : undefined
 }

--- a/web/src/github-core/mutations.test.ts
+++ b/web/src/github-core/mutations.test.ts
@@ -269,6 +269,8 @@ describe("ensurePages alignment with checkPages", () => {
         ) as Promise<T>
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
   }
 
@@ -330,6 +332,8 @@ describe("ensureWorkflowPermissions org-policy conflict", () => {
         ) as Promise<T>
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
     return client
   }

--- a/web/src/github-core/mutations.test.ts
+++ b/web/src/github-core/mutations.test.ts
@@ -269,8 +269,7 @@ describe("ensurePages alignment with checkPages", () => {
         ) as Promise<T>
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
   }
 
@@ -332,8 +331,7 @@ describe("ensureWorkflowPermissions org-policy conflict", () => {
         ) as Promise<T>
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
     return client
   }

--- a/web/src/github-core/orgChecks.test.ts
+++ b/web/src/github-core/orgChecks.test.ts
@@ -64,6 +64,7 @@ function makeClient(routes: Record<string, unknown>): GitHubClient {
       return Promise.reject(new Error(`unexpected request: ${path}`))
     },
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
   }
 }
 
@@ -239,6 +240,8 @@ describe("checkBranchProtection", () => {
         return Promise.reject(new Error(`unexpected request: ${path}`))
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
     expect((await checkBranchProtection(client, "acme")).state).toBe("enforced")
     expect(
@@ -260,6 +263,8 @@ describe("checkBranchProtection", () => {
         return Promise.reject(new Error(`unexpected request: ${path}`))
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
     expect(
       (await checkBranchProtection(client, "acme", "classroom50", "develop"))

--- a/web/src/github-core/orgChecks.test.ts
+++ b/web/src/github-core/orgChecks.test.ts
@@ -64,7 +64,7 @@ function makeClient(routes: Record<string, unknown>): GitHubClient {
       return Promise.reject(new Error(`unexpected request: ${path}`))
     },
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
+    fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
   }
 }
 
@@ -240,8 +240,7 @@ describe("checkBranchProtection", () => {
         return Promise.reject(new Error(`unexpected request: ${path}`))
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
     expect((await checkBranchProtection(client, "acme")).state).toBe("enforced")
     expect(
@@ -263,8 +262,7 @@ describe("checkBranchProtection", () => {
         return Promise.reject(new Error(`unexpected request: ${path}`))
       },
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
     expect(
       (await checkBranchProtection(client, "acme", "classroom50", "develop"))

--- a/web/src/github-core/orgDefaults.test.ts
+++ b/web/src/github-core/orgDefaults.test.ts
@@ -110,6 +110,7 @@ function makeClient(opts: ClientOpts) {
   const client: GitHubClient = {
     request: request as unknown as GitHubClient["request"],
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
   }
   return { client, patchBodies, getPatchCount: () => patchCount }
 }
@@ -299,6 +300,7 @@ describe("repairOrgDefaults", () => {
           return Promise.reject(httpError(500)) // read-back fails
         }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
+      requestBinary: () => Promise.reject(new Error("x")),
     }
     const result = await repairOrgDefaults(client, "acme", "team")
     // A failed read-back must NOT be reported as a completed lockdown: it is

--- a/web/src/github-core/orgDefaults.test.ts
+++ b/web/src/github-core/orgDefaults.test.ts
@@ -110,7 +110,7 @@ function makeClient(opts: ClientOpts) {
   const client: GitHubClient = {
     request: request as unknown as GitHubClient["request"],
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
+    fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
   }
   return { client, patchBodies, getPatchCount: () => patchCount }
 }
@@ -300,7 +300,7 @@ describe("repairOrgDefaults", () => {
           return Promise.reject(httpError(500)) // read-back fails
         }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
-      requestBinary: () => Promise.reject(new Error("x")),
+      fetchArchive: () => Promise.reject(new Error("x")),
     }
     const result = await repairOrgDefaults(client, "acme", "team")
     // A failed read-back must NOT be reported as a completed lockdown: it is

--- a/web/src/github-core/repoArchiveReads.test.ts
+++ b/web/src/github-core/repoArchiveReads.test.ts
@@ -54,7 +54,11 @@ describe("fetchRepoArchive", () => {
     )
 
     await fetchRepoArchive(client, "org", "cs101-hw1-alice")
-    expect(client.fetchArchive).toHaveBeenCalledWith("org", "cs101-hw1-alice")
+    expect(client.fetchArchive).toHaveBeenCalledWith(
+      "org",
+      "cs101-hw1-alice",
+      expect.objectContaining({ signal: undefined }),
+    )
   })
 
   it("returns null when the repo 404s (missing/empty)", async () => {

--- a/web/src/github-core/repoArchiveReads.test.ts
+++ b/web/src/github-core/repoArchiveReads.test.ts
@@ -23,8 +23,11 @@ const apiError = (status: number) =>
   })
 
 const clientWith = (
-  impl: (path: string) => Promise<{ bytes: ArrayBuffer; filename?: string }>,
-): GitHubClient => ({ requestBinary: vi.fn(impl) }) as unknown as GitHubClient
+  impl: (
+    owner: string,
+    repo: string,
+  ) => Promise<{ bytes: ArrayBuffer; filename?: string }>,
+): GitHubClient => ({ fetchArchive: vi.fn(impl) }) as unknown as GitHubClient
 
 describe("fetchRepoArchive", () => {
   it("returns bytes and the header filename on success", async () => {
@@ -45,16 +48,13 @@ describe("fetchRepoArchive", () => {
     expect(result?.filename).toBe("cs101-hw1-alice.zip")
   })
 
-  it("hits the zipball endpoint for the given owner/repo", async () => {
+  it("fetches the archive for the given owner/repo", async () => {
     const client = clientWith(() =>
       Promise.resolve({ bytes: new Uint8Array([1]).buffer }),
     )
 
     await fetchRepoArchive(client, "org", "cs101-hw1-alice")
-    expect(client.requestBinary).toHaveBeenCalledWith(
-      "/repos/org/cs101-hw1-alice/zipball",
-      expect.objectContaining({ method: "GET" }),
-    )
+    expect(client.fetchArchive).toHaveBeenCalledWith("org", "cs101-hw1-alice")
   })
 
   it("returns null when the repo 404s (missing/empty)", async () => {

--- a/web/src/github-core/repoArchiveReads.test.ts
+++ b/web/src/github-core/repoArchiveReads.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import { fetchRepoArchive } from "./repoArchiveReads"
+import type { GitHubClient } from "./client"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const apiError = (status: number) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: noRateLimit,
+  })
+
+const clientWith = (
+  impl: (path: string) => Promise<{ bytes: ArrayBuffer; filename?: string }>,
+): GitHubClient => ({ requestBinary: vi.fn(impl) }) as unknown as GitHubClient
+
+describe("fetchRepoArchive", () => {
+  it("returns bytes and the header filename on success", async () => {
+    const bytes = new Uint8Array([80, 75]).buffer
+    const client = clientWith(() =>
+      Promise.resolve({ bytes, filename: "owner-repo-sha.zip" }),
+    )
+
+    const result = await fetchRepoArchive(client, "org", "cs101-hw1-alice")
+    expect(result).toEqual({ bytes, filename: "owner-repo-sha.zip" })
+  })
+
+  it("falls back to <repo>.zip when the header has no filename", async () => {
+    const bytes = new Uint8Array([1]).buffer
+    const client = clientWith(() => Promise.resolve({ bytes }))
+
+    const result = await fetchRepoArchive(client, "org", "cs101-hw1-alice")
+    expect(result?.filename).toBe("cs101-hw1-alice.zip")
+  })
+
+  it("hits the zipball endpoint for the given owner/repo", async () => {
+    const client = clientWith(() =>
+      Promise.resolve({ bytes: new Uint8Array([1]).buffer }),
+    )
+
+    await fetchRepoArchive(client, "org", "cs101-hw1-alice")
+    expect(client.requestBinary).toHaveBeenCalledWith(
+      "/repos/org/cs101-hw1-alice/zipball",
+      expect.objectContaining({ method: "GET" }),
+    )
+  })
+
+  it("returns null when the repo 404s (missing/empty)", async () => {
+    const client = clientWith(() => Promise.reject(apiError(404)))
+
+    const result = await fetchRepoArchive(client, "org", "cs101-hw1-nobody")
+    expect(result).toBeNull()
+  })
+
+  it("rethrows a non-tolerated error (e.g. 500)", async () => {
+    const client = clientWith(() => Promise.reject(apiError(500)))
+
+    await expect(
+      fetchRepoArchive(client, "org", "cs101-hw1-alice"),
+    ).rejects.toMatchObject({ status: 500 })
+  })
+})

--- a/web/src/github-core/repoArchiveReads.ts
+++ b/web/src/github-core/repoArchiveReads.ts
@@ -1,5 +1,6 @@
 import type { GitHubClient } from "./client"
 import { tolerateGitHubError } from "./errors"
+import { withGithubReadSlot, retryOnRateLimit } from "./queries"
 
 export type RepoArchive = {
   bytes: ArrayBuffer
@@ -12,13 +13,27 @@ export type RepoArchive = {
 // tolerate as `null` so a bulk download can skip it rather than aborting the
 // whole batch. `filename` falls back to `<repo>.zip` when GitHub omits the
 // Content-Disposition header.
+//
+// Routed through the shared read slot + rate-limit retry so a bulk fan-out
+// shares the one global per-repo budget (archives are heavier than JSON reads,
+// so bursting past it trips GitHub's secondary limits) and backs off once on a
+// throttle instead of dropping the repo into `failed`.
 export async function fetchRepoArchive(
   client: GitHubClient,
   owner: string,
   repo: string,
+  options?: { signal?: AbortSignal },
 ): Promise<RepoArchive | null> {
-  return tolerateGitHubError(async () => {
-    const { bytes, filename } = await client.fetchArchive(owner, repo)
-    return { bytes, filename: filename ?? `${repo}.zip` }
-  }, null)
+  return tolerateGitHubError(
+    () =>
+      withGithubReadSlot(() =>
+        retryOnRateLimit(async () => {
+          const { bytes, filename } = await client.fetchArchive(owner, repo, {
+            signal: options?.signal,
+          })
+          return { bytes, filename: filename ?? `${repo}.zip` }
+        }),
+      ),
+    null,
+  )
 }

--- a/web/src/github-core/repoArchiveReads.ts
+++ b/web/src/github-core/repoArchiveReads.ts
@@ -18,11 +18,7 @@ export async function fetchRepoArchive(
   repo: string,
 ): Promise<RepoArchive | null> {
   return tolerateGitHubError(async () => {
-    const { bytes, filename } = await client.requestBinary(
-      `/repos/${owner}/${repo}/zipball`,
-      // Archives are larger than API responses; give the fetch more headroom.
-      { method: "GET", timeoutMs: 60000 },
-    )
+    const { bytes, filename } = await client.fetchArchive(owner, repo)
     return { bytes, filename: filename ?? `${repo}.zip` }
   }, null)
 }

--- a/web/src/github-core/repoArchiveReads.ts
+++ b/web/src/github-core/repoArchiveReads.ts
@@ -7,17 +7,12 @@ export type RepoArchive = {
   filename: string
 }
 
-// Fetch a repo's latest source as a zip archive. No ref means GitHub archives
-// the default-branch HEAD — for an assignment repo that is the student's latest
-// push, i.e. their latest submission. A missing or empty repo 404s, which we
-// tolerate as `null` so a bulk download can skip it rather than aborting the
-// whole batch. `filename` falls back to `<repo>.zip` when GitHub omits the
-// Content-Disposition header.
-//
-// Routed through the shared read slot + rate-limit retry so a bulk fan-out
-// shares the one global per-repo budget (archives are heavier than JSON reads,
-// so bursting past it trips GitHub's secondary limits) and backs off once on a
-// throttle instead of dropping the repo into `failed`.
+// Fetch a repo's latest source zip. No ref → default-branch HEAD, i.e. the
+// student's latest push. Missing/empty repo 404s → null, so a bulk run skips it
+// instead of aborting. Routed through the shared read slot + rate-limit retry
+// so a fan-out shares the one per-repo budget (archives are heavy) and backs
+// off once on a throttle rather than dropping the repo to `failed`. `filename`
+// defaults to `<repo>.zip` when Content-Disposition is absent.
 export async function fetchRepoArchive(
   client: GitHubClient,
   owner: string,

--- a/web/src/github-core/repoArchiveReads.ts
+++ b/web/src/github-core/repoArchiveReads.ts
@@ -1,0 +1,28 @@
+import type { GitHubClient } from "./client"
+import { tolerateGitHubError } from "./errors"
+
+export type RepoArchive = {
+  bytes: ArrayBuffer
+  filename: string
+}
+
+// Fetch a repo's latest source as a zip archive. No ref means GitHub archives
+// the default-branch HEAD — for an assignment repo that is the student's latest
+// push, i.e. their latest submission. A missing or empty repo 404s, which we
+// tolerate as `null` so a bulk download can skip it rather than aborting the
+// whole batch. `filename` falls back to `<repo>.zip` when GitHub omits the
+// Content-Disposition header.
+export async function fetchRepoArchive(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+): Promise<RepoArchive | null> {
+  return tolerateGitHubError(async () => {
+    const { bytes, filename } = await client.requestBinary(
+      `/repos/${owner}/${repo}/zipball`,
+      // Archives are larger than API responses; give the fetch more headroom.
+      { method: "GET", timeoutMs: 60000 },
+    )
+    return { bytes, filename: filename ?? `${repo}.zip` }
+  }, null)
+}

--- a/web/src/github-core/rulesets.test.ts
+++ b/web/src/github-core/rulesets.test.ts
@@ -34,6 +34,7 @@ function makeClient(existing: Array<{ id: number; name: string }>) {
   const client: GitHubClient = {
     request: request as unknown as GitHubClient["request"],
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
   }
   return { client, calls }
 }
@@ -123,6 +124,7 @@ describe("repairRulesets", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
+      requestBinary: () => Promise.reject(new Error("x")),
     }
     const result = await repairRulesets(client, "acme")
     expect(result.status).toBe("warning")

--- a/web/src/github-core/rulesets.test.ts
+++ b/web/src/github-core/rulesets.test.ts
@@ -34,7 +34,7 @@ function makeClient(existing: Array<{ id: number; name: string }>) {
   const client: GitHubClient = {
     request: request as unknown as GitHubClient["request"],
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
+    fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
   }
   return { client, calls }
 }
@@ -124,7 +124,7 @@ describe("repairRulesets", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
-      requestBinary: () => Promise.reject(new Error("x")),
+      fetchArchive: () => Promise.reject(new Error("x")),
     }
     const result = await repairRulesets(client, "acme")
     expect(result.status).toBe("warning")

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
@@ -11,17 +11,27 @@ const downloadAllSubmissions =
   vi.fn<
     (...args: unknown[]) => Promise<{ blob: Blob; summary: DownloadAllSummary }>
   >()
+const streamSubmissionsToDirectory =
+  vi.fn<(...args: unknown[]) => Promise<DownloadAllSummary>>()
 const downloadBlob = vi.fn<(blob: Blob, filename: string) => void>()
+const supportsDirectoryPicker = vi.fn<() => boolean>()
+const pickDirectory = vi.fn<() => Promise<FileSystemDirectoryHandle | null>>()
 
 vi.mock("@/domain/assignments", () => ({
   downloadAllSubmissions: (...args: unknown[]) =>
     downloadAllSubmissions(...args),
+  streamSubmissionsToDirectory: (...args: unknown[]) =>
+    streamSubmissionsToDirectory(...args),
 }))
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({ request: vi.fn() }),
 }))
 vi.mock("@/util/downloadBlob", () => ({
   downloadBlob: (blob: Blob, filename: string) => downloadBlob(blob, filename),
+}))
+vi.mock("@/util/fileSystemAccess", () => ({
+  supportsDirectoryPicker: () => supportsDirectoryPicker(),
+  pickDirectory: () => pickDirectory(),
 }))
 
 import { useDownloadAllSubmissions } from "./useDownloadAllSubmissions"
@@ -55,6 +65,8 @@ function freshClient() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no File System Access API — the combined-zip fallback path.
+  supportsDirectoryPicker.mockReturnValue(false)
 })
 
 describe("useDownloadAllSubmissions", () => {
@@ -157,5 +169,60 @@ describe("useDownloadAllSubmissions", () => {
 
     hook.current.cancel()
     expect(captured?.aborted).toBe(true)
+  })
+
+  it("streams to the picked directory when the API is supported", async () => {
+    supportsDirectoryPicker.mockReturnValue(true)
+    const dir = {} as FileSystemDirectoryHandle
+    pickDirectory.mockResolvedValue(dir)
+    streamSubmissionsToDirectory.mockResolvedValue(summary())
+    const queryClient = freshClient()
+    const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["alice", "bob"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+
+    expect(streamSubmissionsToDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: dir,
+        signal: expect.any(AbortSignal),
+      }),
+    )
+    // Directory path streams to disk — no combined zip, no auto-download.
+    expect(downloadAllSubmissions).not.toHaveBeenCalled()
+    expect(downloadBlob).not.toHaveBeenCalled()
+    expect(hook.current.data).toEqual({
+      status: "done",
+      summary: summary(),
+      toDirectory: true,
+    })
+  })
+
+  it("returns cancelled (and does nothing) when the directory picker is dismissed", async () => {
+    supportsDirectoryPicker.mockReturnValue(true)
+    pickDirectory.mockResolvedValue(null)
+    const queryClient = freshClient()
+    const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["alice"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+
+    expect(hook.current.data).toEqual({ status: "cancelled" })
+    expect(streamSubmissionsToDirectory).not.toHaveBeenCalled()
+    expect(downloadAllSubmissions).not.toHaveBeenCalled()
   })
 })

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+import type { DownloadAllSummary } from "@/domain/assignments"
+
+const downloadAllSubmissions =
+  vi.fn<(...args: unknown[]) => Promise<{ blob: Blob; summary: DownloadAllSummary }>>()
+const downloadBlob = vi.fn<(blob: Blob, filename: string) => void>()
+
+vi.mock("@/domain/assignments", () => ({
+  downloadAllSubmissions: (...args: unknown[]) => downloadAllSubmissions(...args),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+vi.mock("@/util/downloadBlob", () => ({
+  downloadBlob: (blob: Blob, filename: string) => downloadBlob(blob, filename),
+}))
+
+import { useDownloadAllSubmissions } from "./useDownloadAllSubmissions"
+
+const ORG = "cs50"
+
+const summary = (over: Partial<DownloadAllSummary> = {}): DownloadAllSummary => ({
+  total: 2,
+  fetched: 2,
+  empty: [],
+  failed: [],
+  results: [],
+  ...over,
+})
+
+const result = (over: Partial<DownloadAllSummary> = {}) => ({
+  blob: new Blob(["z"]),
+  summary: summary(over),
+})
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useDownloadAllSubmissions", () => {
+  it("surfaces progress and downloads the combined zip on success", async () => {
+    downloadAllSubmissions.mockImplementation(async (...args: unknown[]) => {
+      const { onProgress } = args[0] as { onProgress?: (p: unknown) => void }
+      onProgress?.({ done: 2, total: 2 })
+      return result()
+    })
+    const queryClient = freshClient()
+    const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["alice", "bob"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+
+    expect(hook.current.progress).toEqual({ done: 2, total: 2 })
+    expect(downloadBlob).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "cs101-hw1-submissions.zip",
+    )
+  })
+
+  it("does not download when nothing was fetched", async () => {
+    downloadAllSubmissions.mockResolvedValue(
+      result({ total: 1, fetched: 0, empty: [{ owner: "a", outcome: "empty" }] }),
+    )
+    const queryClient = freshClient()
+    const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["a"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+
+    expect(downloadBlob).not.toHaveBeenCalled()
+  })
+
+  it("passes org/classroom/assignment/owners to the domain batch", async () => {
+    downloadAllSubmissions.mockResolvedValue(result())
+    const queryClient = freshClient()
+    const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["alice", "bob"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+
+    expect(downloadAllSubmissions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org: ORG,
+        classroom: "cs101",
+        assignment: "hw1",
+        owners: ["alice", "bob"],
+        onProgress: expect.any(Function),
+      }),
+    )
+  })
+})

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
@@ -130,7 +130,32 @@ describe("useDownloadAllSubmissions", () => {
         assignment: "hw1",
         owners: ["alice", "bob"],
         onProgress: expect.any(Function),
+        signal: expect.any(AbortSignal),
       }),
     )
+  })
+
+  it("exposes a cancel that aborts the in-flight run's signal", async () => {
+    let captured: AbortSignal | undefined
+    downloadAllSubmissions.mockImplementation(async (...args: unknown[]) => {
+      captured = (args[0] as { signal?: AbortSignal }).signal
+      return result()
+    })
+    const queryClient = freshClient()
+    const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["alice"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+    expect(captured?.aborted).toBe(false)
+
+    hook.current.cancel()
+    expect(captured?.aborted).toBe(true)
   })
 })

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
@@ -8,11 +8,14 @@ import { createElement } from "react"
 import type { DownloadAllSummary } from "@/domain/assignments"
 
 const downloadAllSubmissions =
-  vi.fn<(...args: unknown[]) => Promise<{ blob: Blob; summary: DownloadAllSummary }>>()
+  vi.fn<
+    (...args: unknown[]) => Promise<{ blob: Blob; summary: DownloadAllSummary }>
+  >()
 const downloadBlob = vi.fn<(blob: Blob, filename: string) => void>()
 
 vi.mock("@/domain/assignments", () => ({
-  downloadAllSubmissions: (...args: unknown[]) => downloadAllSubmissions(...args),
+  downloadAllSubmissions: (...args: unknown[]) =>
+    downloadAllSubmissions(...args),
 }))
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({ request: vi.fn() }),
@@ -25,7 +28,9 @@ import { useDownloadAllSubmissions } from "./useDownloadAllSubmissions"
 
 const ORG = "cs50"
 
-const summary = (over: Partial<DownloadAllSummary> = {}): DownloadAllSummary => ({
+const summary = (
+  over: Partial<DownloadAllSummary> = {},
+): DownloadAllSummary => ({
   total: 2,
   fetched: 2,
   empty: [],
@@ -81,7 +86,11 @@ describe("useDownloadAllSubmissions", () => {
 
   it("does not download when nothing was fetched", async () => {
     downloadAllSubmissions.mockResolvedValue(
-      result({ total: 1, fetched: 0, empty: [{ owner: "a", outcome: "empty" }] }),
+      result({
+        total: 1,
+        fetched: 0,
+        empty: [{ owner: "a", outcome: "empty" }],
+      }),
     )
     const queryClient = freshClient()
     const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.ts
@@ -20,20 +20,14 @@ export type DownloadAllSubmissionsInput = {
   owners: string[]
 }
 
-// Distinct from a null summary: the run never started because the user
-// dismissed the directory picker. Lets the modal reset quietly instead of
-// showing an empty summary.
+// User dismissed the directory picker before the run started — reset quietly.
 export type DownloadAllOutcome =
   | { status: "cancelled" }
   | { status: "done"; summary: DownloadAllSummary; toDirectory: boolean }
 
-// Download EVERY submitting owner's latest submission. Where the File System
-// Access API is available (Chromium), the teacher picks a destination folder
-// and each submission is streamed straight into it as `<owner>.zip` — no
-// in-memory combined zip, so a large class can't exhaust the tab. Elsewhere it
-// falls back to building one combined `<classroom>-<assignment>-submissions.zip`
-// and auto-downloading it. `progress` drives the live "X of N" bar; `cancel`
-// aborts an in-flight run (and its in-flight fetches).
+// Bulk download: Chromium streams each submission into a picked folder; other
+// browsers get one combined auto-downloaded zip. `progress` drives the bar;
+// `cancel` aborts the run and its in-flight fetches.
 export function useDownloadAllSubmissions() {
   const client = useGitHubClient()
   const [progress, setProgress] = useState<DownloadAllProgress | null>(null)
@@ -45,8 +39,8 @@ export function useDownloadAllSubmissions() {
     DownloadAllSubmissionsInput
   >({
     mutationFn: async ({ org, classroom, assignment, owners }) => {
-      // Pick the directory first, inside the click's transient activation,
-      // before any fetch. A null handle means the user cancelled the picker.
+      // Pick the directory first, inside the click's activation, before any
+      // fetch. Null means cancelled.
       const useDirectory = supportsDirectoryPicker()
       const directory = useDirectory ? await pickDirectory() : null
       if (useDirectory && !directory) {

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.ts
@@ -1,13 +1,17 @@
 import { useRef, useState } from "react"
 import { useMutation } from "@tanstack/react-query"
 
-import { downloadAllSubmissions } from "@/domain/assignments"
+import {
+  downloadAllSubmissions,
+  streamSubmissionsToDirectory,
+} from "@/domain/assignments"
 import type {
   DownloadAllProgress,
   DownloadAllSummary,
 } from "@/domain/assignments"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { downloadBlob } from "@/util/downloadBlob"
+import { pickDirectory, supportsDirectoryPicker } from "@/util/fileSystemAccess"
 
 export type DownloadAllSubmissionsInput = {
   org: string
@@ -16,29 +20,57 @@ export type DownloadAllSubmissionsInput = {
   owners: string[]
 }
 
-// Download EVERY submitting owner's latest submission as one combined zip
-// (issue: teacher bulk download). Wraps the domain fan-out and exposes live
-// `progress` (a plain useState updated from the batch's onProgress) alongside
-// the mutation, so a modal can render an "X of N" bar while it runs. On success
-// the combined blob is handed to the browser as
-// `<classroom>-<assignment>-submissions.zip`; the returned summary lets the
-// caller report fetched/empty/failed counts. `cancel` aborts an in-flight run
-// (the in-flight archive fetches are cancelled too), letting the modal offer a
-// Cancel button rather than trapping the teacher until it finishes.
+// Distinct from a null summary: the run never started because the user
+// dismissed the directory picker. Lets the modal reset quietly instead of
+// showing an empty summary.
+export type DownloadAllOutcome =
+  | { status: "cancelled" }
+  | { status: "done"; summary: DownloadAllSummary; toDirectory: boolean }
+
+// Download EVERY submitting owner's latest submission. Where the File System
+// Access API is available (Chromium), the teacher picks a destination folder
+// and each submission is streamed straight into it as `<owner>.zip` — no
+// in-memory combined zip, so a large class can't exhaust the tab. Elsewhere it
+// falls back to building one combined `<classroom>-<assignment>-submissions.zip`
+// and auto-downloading it. `progress` drives the live "X of N" bar; `cancel`
+// aborts an in-flight run (and its in-flight fetches).
 export function useDownloadAllSubmissions() {
   const client = useGitHubClient()
   const [progress, setProgress] = useState<DownloadAllProgress | null>(null)
   const abortRef = useRef<AbortController | null>(null)
 
   const mutation = useMutation<
-    DownloadAllSummary,
+    DownloadAllOutcome,
     Error,
     DownloadAllSubmissionsInput
   >({
     mutationFn: async ({ org, classroom, assignment, owners }) => {
+      // Pick the directory first, inside the click's transient activation,
+      // before any fetch. A null handle means the user cancelled the picker.
+      const useDirectory = supportsDirectoryPicker()
+      const directory = useDirectory ? await pickDirectory() : null
+      if (useDirectory && !directory) {
+        return { status: "cancelled" }
+      }
+
       const controller = new AbortController()
       abortRef.current = controller
       setProgress({ done: 0, total: owners.length })
+
+      if (directory) {
+        const summary = await streamSubmissionsToDirectory({
+          client,
+          org,
+          classroom,
+          assignment,
+          owners,
+          directory,
+          onProgress: setProgress,
+          signal: controller.signal,
+        })
+        return { status: "done", summary, toDirectory: true }
+      }
+
       const { blob, summary } = await downloadAllSubmissions({
         client,
         org,
@@ -51,7 +83,7 @@ export function useDownloadAllSubmissions() {
       if (summary.fetched > 0) {
         downloadBlob(blob, `${classroom}-${assignment}-submissions.zip`)
       }
-      return summary
+      return { status: "done", summary, toDirectory: false }
     },
   })
 

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { useMutation } from "@tanstack/react-query"
 
 import { downloadAllSubmissions } from "@/domain/assignments"
@@ -22,10 +22,13 @@ export type DownloadAllSubmissionsInput = {
 // the mutation, so a modal can render an "X of N" bar while it runs. On success
 // the combined blob is handed to the browser as
 // `<classroom>-<assignment>-submissions.zip`; the returned summary lets the
-// caller report fetched/empty/failed counts.
+// caller report fetched/empty/failed counts. `cancel` aborts an in-flight run
+// (the in-flight archive fetches are cancelled too), letting the modal offer a
+// Cancel button rather than trapping the teacher until it finishes.
 export function useDownloadAllSubmissions() {
   const client = useGitHubClient()
   const [progress, setProgress] = useState<DownloadAllProgress | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
 
   const mutation = useMutation<
     DownloadAllSummary,
@@ -33,6 +36,8 @@ export function useDownloadAllSubmissions() {
     DownloadAllSubmissionsInput
   >({
     mutationFn: async ({ org, classroom, assignment, owners }) => {
+      const controller = new AbortController()
+      abortRef.current = controller
       setProgress({ done: 0, total: owners.length })
       const { blob, summary } = await downloadAllSubmissions({
         client,
@@ -41,6 +46,7 @@ export function useDownloadAllSubmissions() {
         assignment,
         owners,
         onProgress: setProgress,
+        signal: controller.signal,
       })
       if (summary.fetched > 0) {
         downloadBlob(blob, `${classroom}-${assignment}-submissions.zip`)
@@ -52,7 +58,9 @@ export function useDownloadAllSubmissions() {
   return {
     ...mutation,
     progress,
+    cancel: () => abortRef.current?.abort(),
     reset: () => {
+      abortRef.current = null
       setProgress(null)
       mutation.reset()
     },

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.ts
@@ -1,0 +1,62 @@
+import { useState } from "react"
+import { useMutation } from "@tanstack/react-query"
+
+import { downloadAllSubmissions } from "@/domain/assignments"
+import type {
+  DownloadAllProgress,
+  DownloadAllSummary,
+} from "@/domain/assignments"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { downloadBlob } from "@/util/downloadBlob"
+
+export type DownloadAllSubmissionsInput = {
+  org: string
+  classroom: string
+  assignment: string
+  owners: string[]
+}
+
+// Download EVERY submitting owner's latest submission as one combined zip
+// (issue: teacher bulk download). Wraps the domain fan-out and exposes live
+// `progress` (a plain useState updated from the batch's onProgress) alongside
+// the mutation, so a modal can render an "X of N" bar while it runs. On success
+// the combined blob is handed to the browser as
+// `<classroom>-<assignment>-submissions.zip`; the returned summary lets the
+// caller report fetched/empty/failed counts.
+export function useDownloadAllSubmissions() {
+  const client = useGitHubClient()
+  const [progress, setProgress] = useState<DownloadAllProgress | null>(null)
+
+  const mutation = useMutation<
+    DownloadAllSummary,
+    Error,
+    DownloadAllSubmissionsInput
+  >({
+    mutationFn: async ({ org, classroom, assignment, owners }) => {
+      setProgress({ done: 0, total: owners.length })
+      const { blob, summary } = await downloadAllSubmissions({
+        client,
+        org,
+        classroom,
+        assignment,
+        owners,
+        onProgress: setProgress,
+      })
+      if (summary.fetched > 0) {
+        downloadBlob(blob, `${classroom}-${assignment}-submissions.zip`)
+      }
+      return summary
+    },
+  })
+
+  return {
+    ...mutation,
+    progress,
+    reset: () => {
+      setProgress(null)
+      mutation.reset()
+    },
+  }
+}
+
+export default useDownloadAllSubmissions

--- a/web/src/hooks/mutations/useDownloadSubmission.test.ts
+++ b/web/src/hooks/mutations/useDownloadSubmission.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+const fetchRepoArchive =
+  vi.fn<
+    (
+      ...args: unknown[]
+    ) => Promise<{ bytes: ArrayBuffer; filename: string } | null>
+  >()
+const downloadBlob = vi.fn<(blob: Blob, filename: string) => void>()
+const supportsSaveFilePicker = vi.fn<() => boolean>()
+const pickSaveFile =
+  vi.fn<(name: string) => Promise<FileSystemFileHandle | null>>()
+const writeToFileHandle =
+  vi.fn<(h: FileSystemFileHandle, d: BlobPart) => Promise<void>>()
+
+vi.mock("@/github-core/repoArchiveReads", () => ({
+  fetchRepoArchive: (...args: unknown[]) => fetchRepoArchive(...args),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request: vi.fn() }),
+}))
+vi.mock("@/util/downloadBlob", () => ({
+  downloadBlob: (blob: Blob, filename: string) => downloadBlob(blob, filename),
+}))
+vi.mock("@/util/fileSystemAccess", () => ({
+  supportsSaveFilePicker: () => supportsSaveFilePicker(),
+  pickSaveFile: (name: string) => pickSaveFile(name),
+  writeToFileHandle: (h: FileSystemFileHandle, d: BlobPart) =>
+    writeToFileHandle(h, d),
+}))
+
+import { useDownloadSubmission } from "./useDownloadSubmission"
+
+const bytes = new Uint8Array([80, 75]).buffer
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function freshClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+}
+
+const input = {
+  org: "cs50",
+  classroom: "cs101",
+  assignment: "hw1",
+  owner: "alice",
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  supportsSaveFilePicker.mockReturnValue(false)
+  fetchRepoArchive.mockResolvedValue({ bytes, filename: "x.zip" })
+})
+
+describe("useDownloadSubmission", () => {
+  it("auto-downloads with the derived filename when the picker is unsupported", async () => {
+    const { result } = renderHook(() => useDownloadSubmission(), {
+      wrapper: wrapperWith(freshClient()),
+    })
+
+    result.current.mutate(input)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(pickSaveFile).not.toHaveBeenCalled()
+    expect(downloadBlob).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "cs101-hw1-alice.zip",
+    )
+  })
+
+  it("writes to the picked file handle when supported", async () => {
+    supportsSaveFilePicker.mockReturnValue(true)
+    const handle = {} as FileSystemFileHandle
+    pickSaveFile.mockResolvedValue(handle)
+    const { result } = renderHook(() => useDownloadSubmission(), {
+      wrapper: wrapperWith(freshClient()),
+    })
+
+    result.current.mutate(input)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(pickSaveFile).toHaveBeenCalledWith("cs101-hw1-alice.zip")
+    expect(writeToFileHandle).toHaveBeenCalledWith(handle, bytes)
+    expect(downloadBlob).not.toHaveBeenCalled()
+  })
+
+  it("no-ops (no fetch) when the save picker is cancelled", async () => {
+    supportsSaveFilePicker.mockReturnValue(true)
+    pickSaveFile.mockResolvedValue(null)
+    const { result } = renderHook(() => useDownloadSubmission(), {
+      wrapper: wrapperWith(freshClient()),
+    })
+
+    result.current.mutate(input)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(fetchRepoArchive).not.toHaveBeenCalled()
+    expect(writeToFileHandle).not.toHaveBeenCalled()
+    expect(downloadBlob).not.toHaveBeenCalled()
+  })
+
+  it("throws no-submission for a missing/empty repo", async () => {
+    supportsSaveFilePicker.mockReturnValue(false)
+    fetchRepoArchive.mockResolvedValue(null)
+    const { result } = renderHook(() => useDownloadSubmission(), {
+      wrapper: wrapperWith(freshClient()),
+    })
+
+    result.current.mutate(input)
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe("no-submission")
+  })
+})

--- a/web/src/hooks/mutations/useDownloadSubmission.ts
+++ b/web/src/hooks/mutations/useDownloadSubmission.ts
@@ -1,0 +1,43 @@
+import { useMutation } from "@tanstack/react-query"
+
+import { fetchRepoArchive } from "@/github-core/repoArchiveReads"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { downloadBlob } from "@/util/downloadBlob"
+import { studentRepoName } from "@/util/studentRepo"
+
+export type DownloadSubmissionInput = {
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+}
+
+// Download one student's latest submission (their assignment repo's default
+// branch, zipped by GitHub) and hand the bytes to the browser as
+// `<classroom>-<assignment>-<owner>.zip`. A missing/empty repo resolves to a
+// null archive; the mutation errors so the caller can surface "nothing to
+// download".
+export function useDownloadSubmission() {
+  const client = useGitHubClient()
+
+  return useMutation({
+    mutationFn: async ({
+      org,
+      classroom,
+      assignment,
+      owner,
+    }: DownloadSubmissionInput) => {
+      const repo = studentRepoName(classroom, assignment, owner)
+      const archive = await fetchRepoArchive(client, org, repo)
+      if (!archive) {
+        throw new Error("no-submission")
+      }
+      downloadBlob(
+        new Blob([archive.bytes]),
+        `${classroom}-${assignment}-${owner}.zip`,
+      )
+    },
+  })
+}
+
+export default useDownloadSubmission

--- a/web/src/hooks/mutations/useDownloadSubmission.ts
+++ b/web/src/hooks/mutations/useDownloadSubmission.ts
@@ -3,6 +3,11 @@ import { useMutation } from "@tanstack/react-query"
 import { fetchRepoArchive } from "@/github-core/repoArchiveReads"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { downloadBlob } from "@/util/downloadBlob"
+import {
+  pickSaveFile,
+  supportsSaveFilePicker,
+  writeToFileHandle,
+} from "@/util/fileSystemAccess"
 import { studentRepoName } from "@/util/studentRepo"
 
 export type DownloadSubmissionInput = {
@@ -13,10 +18,12 @@ export type DownloadSubmissionInput = {
 }
 
 // Download one student's latest submission (their assignment repo's default
-// branch, zipped by GitHub) and hand the bytes to the browser as
-// `<classroom>-<assignment>-<owner>.zip`. A missing/empty repo resolves to a
-// null archive; the mutation errors so the caller can surface "nothing to
-// download".
+// branch, zipped by GitHub). Where the File System Access API is available
+// (Chromium), the teacher first picks the save location; elsewhere it falls
+// back to an automatic download into the browser's Downloads folder. Either way
+// the file is `<classroom>-<assignment>-<owner>.zip`. A missing/empty repo
+// resolves to a null archive; the mutation errors so the caller can surface
+// "nothing to download". A cancelled save picker is a benign no-op.
 export function useDownloadSubmission() {
   const client = useGitHubClient()
 
@@ -27,15 +34,26 @@ export function useDownloadSubmission() {
       assignment,
       owner,
     }: DownloadSubmissionInput) => {
+      const filename = `${classroom}-${assignment}-${owner}.zip`
+
+      // Open the picker first, inside the click's transient activation, before
+      // the archive fetch — otherwise the gesture would have expired by the
+      // time we call it. Null means the user cancelled the picker.
+      const usePicker = supportsSaveFilePicker()
+      const handle = usePicker ? await pickSaveFile(filename) : null
+      if (usePicker && !handle) return
+
       const repo = studentRepoName(classroom, assignment, owner)
       const archive = await fetchRepoArchive(client, org, repo)
       if (!archive) {
         throw new Error("no-submission")
       }
-      downloadBlob(
-        new Blob([archive.bytes]),
-        `${classroom}-${assignment}-${owner}.zip`,
-      )
+
+      if (handle) {
+        await writeToFileHandle(handle, archive.bytes)
+      } else {
+        downloadBlob(new Blob([archive.bytes]), filename)
+      }
     },
   })
 }

--- a/web/src/hooks/mutations/useDownloadSubmission.ts
+++ b/web/src/hooks/mutations/useDownloadSubmission.ts
@@ -17,13 +17,10 @@ export type DownloadSubmissionInput = {
   owner: string
 }
 
-// Download one student's latest submission (their assignment repo's default
-// branch, zipped by GitHub). Where the File System Access API is available
-// (Chromium), the teacher first picks the save location; elsewhere it falls
-// back to an automatic download into the browser's Downloads folder. Either way
-// the file is `<classroom>-<assignment>-<owner>.zip`. A missing/empty repo
-// resolves to a null archive; the mutation errors so the caller can surface
-// "nothing to download". A cancelled save picker is a benign no-op.
+// Download one student's latest submission. Chromium lets the teacher pick the
+// save location (picked first, inside the click's activation); other browsers
+// auto-download. A missing/empty repo → null archive → throws "no-submission"
+// so the caller can say "nothing to download". A cancelled picker is a no-op.
 export function useDownloadSubmission() {
   const client = useGitHubClient()
 
@@ -36,9 +33,8 @@ export function useDownloadSubmission() {
     }: DownloadSubmissionInput) => {
       const filename = `${classroom}-${assignment}-${owner}.zip`
 
-      // Open the picker first, inside the click's transient activation, before
-      // the archive fetch — otherwise the gesture would have expired by the
-      // time we call it. Null means the user cancelled the picker.
+      // Open the picker first, inside the click's activation, before the fetch
+      // — else the gesture would have expired. Null means cancelled.
       const usePicker = supportsSaveFilePicker()
       const handle = usePicker ? await pickSaveFile(filename) : null
       if (usePicker && !handle) return

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2050,9 +2050,13 @@
       "confirmBody_one": "This downloads the latest submission for the <b>{{count}}</b> student who has submitted <b>{{name}}</b>, bundled into a single zip.",
       "confirmBody_other": "This downloads the latest submissions for the <b>{{count}}</b> students who have submitted <b>{{name}}</b>, bundled into a single zip.",
       "confirmHint": "It runs from your browser, one repository at a time, so it may take a while for a large class. Keep this tab open until it finishes.",
+      "largeClassWarning": "This will download {{count}} submissions and build the combined zip in your browser, which can use a lot of memory and may be slow or fail for a very large class. Consider filtering by section first.",
       "confirmLabel_one": "Download submission",
       "confirmLabel_other": "Download submissions",
       "running": "Downloading… {{done}} of {{total}}",
+      "nothingDownloaded": "No file was downloaded — none of the selected students had a submission to fetch.",
+      "assemblyError": "Downloaded every submission, but the combined zip was too large to assemble in the browser. Try filtering by section and downloading in smaller batches.",
+      "runError": "The download couldn't be completed. Please try again.",
       "summaryLead": "Finished processing <b>{{total}}</b> submissions.",
       "summaryDownloaded_one": "{{count}} submission downloaded",
       "summaryDownloaded_other": "{{count}} submissions downloaded",
@@ -2080,7 +2084,9 @@
     },
     "rowDownload": {
       "title": "Download this submission",
-      "aria": "Download {{owner}}'s submission"
+      "aria": "Download {{owner}}'s submission",
+      "nothingToDownload": "{{owner}} has no submission to download yet.",
+      "error": "Couldn't download {{owner}}'s submission. Please try again."
     },
     "student": {
       "submittedAt": "Submitted {{date}}",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2043,6 +2043,28 @@
       "blockedTitle": "These repositories need an org admin:",
       "blockedHint": "Their feedback branch points at the wrong commit, so opening the PR would show an empty diff. An org admin must delete each feedback branch before re-running this action — retrying alone won't fix them."
     },
+    "downloadAll": {
+      "menuLabel": "Download all submissions",
+      "title": "Download every student's latest submission",
+      "titleDisabled": "No submissions to download yet",
+      "confirmBody_one": "This downloads the latest submission for the <b>{{count}}</b> student who has submitted <b>{{name}}</b>, bundled into a single zip.",
+      "confirmBody_other": "This downloads the latest submissions for the <b>{{count}}</b> students who have submitted <b>{{name}}</b>, bundled into a single zip.",
+      "confirmHint": "It runs from your browser, one repository at a time, so it may take a while for a large class. Keep this tab open until it finishes.",
+      "confirmLabel_one": "Download submission",
+      "confirmLabel_other": "Download submissions",
+      "running": "Downloading… {{done}} of {{total}}",
+      "summaryLead": "Finished processing <b>{{total}}</b> submissions.",
+      "summaryDownloaded_one": "{{count}} submission downloaded",
+      "summaryDownloaded_other": "{{count}} submissions downloaded",
+      "summaryEmpty_one": "{{count}} repository was empty (skipped)",
+      "summaryEmpty_other": "{{count}} repositories were empty (skipped)",
+      "summaryFailed_one": "{{count}} submission failed",
+      "summaryFailed_other": "{{count}} submissions failed",
+      "emptyTitle": "These repositories had nothing to download:",
+      "emptyHint": "The student accepted the assignment but hasn't pushed any work yet, so there's no submission to include.",
+      "failedTitle": "These submissions couldn't be downloaded:",
+      "failedHint": "This is often a transient GitHub error — run the action again to retry."
+    },
     "rowRegrade": {
       "title": "Regrade this submission",
       "titleInFlight": "Regrade in progress…",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2056,6 +2056,10 @@
       "confirmBody2": "Grading runs in the background and can take a few minutes; use <collectLabel>{{collectLabel}}</collectLabel> afterward to pull the new score.",
       "confirmLabel": "Regrade"
     },
+    "rowDownload": {
+      "title": "Download this submission",
+      "aria": "Download {{owner}}'s submission"
+    },
     "student": {
       "submittedAt": "Submitted {{date}}",
       "descriptionLabel": "Assignment details",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2060,6 +2060,8 @@
       "summaryLead": "Finished processing <b>{{total}}</b> submissions.",
       "summaryDownloaded_one": "{{count}} submission downloaded",
       "summaryDownloaded_other": "{{count}} submissions downloaded",
+      "summarySaved_one": "{{count}} submission saved to the folder you chose",
+      "summarySaved_other": "{{count}} submissions saved to the folder you chose",
       "summaryEmpty_one": "{{count}} repository was empty (skipped)",
       "summaryEmpty_other": "{{count}} repositories were empty (skipped)",
       "summaryFailed_one": "{{count}} submission failed",

--- a/web/src/orgPolicy/audit.test.ts
+++ b/web/src/orgPolicy/audit.test.ts
@@ -116,6 +116,7 @@ function makeClient(overrides: Routes = {}): GitHubClient {
       return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
     },
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
   }
 }
 
@@ -247,6 +248,8 @@ describe("buildOrgAuditReport", () => {
           return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
         },
         requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+        requestBinary: () =>
+          Promise.reject(new Error("unexpected requestBinary")),
       },
       "acme",
       "team",
@@ -424,6 +427,8 @@ describe("buildOrgAuditReport", () => {
           return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
         },
         requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+        requestBinary: () =>
+          Promise.reject(new Error("unexpected requestBinary")),
       },
       "acme",
       "team",
@@ -468,6 +473,8 @@ describe("buildOrgAuditReport", () => {
           return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
         },
         requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+        requestBinary: () =>
+          Promise.reject(new Error("unexpected requestBinary")),
       },
       "acme",
       "team",

--- a/web/src/orgPolicy/audit.test.ts
+++ b/web/src/orgPolicy/audit.test.ts
@@ -116,7 +116,7 @@ function makeClient(overrides: Routes = {}): GitHubClient {
       return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
     },
     requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-    requestBinary: () => Promise.reject(new Error("unexpected requestBinary")),
+    fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
   }
 }
 
@@ -248,8 +248,8 @@ describe("buildOrgAuditReport", () => {
           return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
         },
         requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-        requestBinary: () =>
-          Promise.reject(new Error("unexpected requestBinary")),
+        fetchArchive: () =>
+          Promise.reject(new Error("unexpected fetchArchive")),
       },
       "acme",
       "team",
@@ -427,8 +427,8 @@ describe("buildOrgAuditReport", () => {
           return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
         },
         requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-        requestBinary: () =>
-          Promise.reject(new Error("unexpected requestBinary")),
+        fetchArchive: () =>
+          Promise.reject(new Error("unexpected fetchArchive")),
       },
       "acme",
       "team",
@@ -473,8 +473,8 @@ describe("buildOrgAuditReport", () => {
           return Promise.reject(new Error(`unexpected: ${path}`)) as Promise<T>
         },
         requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-        requestBinary: () =>
-          Promise.reject(new Error("unexpected requestBinary")),
+        fetchArchive: () =>
+          Promise.reject(new Error("unexpected fetchArchive")),
       },
       "acme",
       "team",

--- a/web/src/orgPolicy/repair.test.ts
+++ b/web/src/orgPolicy/repair.test.ts
@@ -71,6 +71,8 @@ function makeClient(configRepoBranch = "main"): {
     client: {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     },
     calls,
   }
@@ -102,6 +104,8 @@ describe("repairConcern", () => {
         })
       }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
     const result = await repairConcern(client, "acme", "orgActions", "team")
     expect(result.unresolved).toBeUndefined()
@@ -118,6 +122,8 @@ describe("repairConcern", () => {
         return Promise.reject(httpError(403))
       }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
     const result = await repairConcern(client, "acme", "orgActions", "team")
     expect(result.unresolved?.transient).toBe(false)
@@ -149,6 +155,8 @@ describe("repairConcern", () => {
         return Promise.reject(rateLimited)
       }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
+      requestBinary: () =>
+        Promise.reject(new Error("unexpected requestBinary")),
     }
     const result = await repairConcern(client, "acme", "orgActions", "team")
     expect(result.unresolved?.transient).toBe(true)
@@ -207,6 +215,7 @@ describe("repairConcern", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
+      requestBinary: () => Promise.reject(new Error("x")),
     }
     const result = await repairConcern(
       client,
@@ -234,6 +243,7 @@ describe("repairConcern", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
+      requestBinary: () => Promise.reject(new Error("x")),
     }
     const result = await repairConcern(
       client,
@@ -302,6 +312,7 @@ describe("repairConcern", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
+      requestBinary: () => Promise.reject(new Error("x")),
     }
     const result = await repairConcern(client, "acme", "rulesets", "team")
     expect(result.unresolved).toBeDefined()

--- a/web/src/orgPolicy/repair.test.ts
+++ b/web/src/orgPolicy/repair.test.ts
@@ -71,8 +71,7 @@ function makeClient(configRepoBranch = "main"): {
     client: {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     },
     calls,
   }
@@ -104,8 +103,7 @@ describe("repairConcern", () => {
         })
       }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
     const result = await repairConcern(client, "acme", "orgActions", "team")
     expect(result.unresolved).toBeUndefined()
@@ -122,8 +120,7 @@ describe("repairConcern", () => {
         return Promise.reject(httpError(403))
       }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
     const result = await repairConcern(client, "acme", "orgActions", "team")
     expect(result.unresolved?.transient).toBe(false)
@@ -155,8 +152,7 @@ describe("repairConcern", () => {
         return Promise.reject(rateLimited)
       }) as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("unexpected requestRaw")),
-      requestBinary: () =>
-        Promise.reject(new Error("unexpected requestBinary")),
+      fetchArchive: () => Promise.reject(new Error("unexpected fetchArchive")),
     }
     const result = await repairConcern(client, "acme", "orgActions", "team")
     expect(result.unresolved?.transient).toBe(true)
@@ -215,7 +211,7 @@ describe("repairConcern", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
-      requestBinary: () => Promise.reject(new Error("x")),
+      fetchArchive: () => Promise.reject(new Error("x")),
     }
     const result = await repairConcern(
       client,
@@ -243,7 +239,7 @@ describe("repairConcern", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
-      requestBinary: () => Promise.reject(new Error("x")),
+      fetchArchive: () => Promise.reject(new Error("x")),
     }
     const result = await repairConcern(
       client,
@@ -312,7 +308,7 @@ describe("repairConcern", () => {
     const client: GitHubClient = {
       request: request as unknown as GitHubClient["request"],
       requestRaw: () => Promise.reject(new Error("x")),
-      requestBinary: () => Promise.reject(new Error("x")),
+      fetchArchive: () => Promise.reject(new Error("x")),
     }
     const result = await repairConcern(client, "acme", "rulesets", "team")
     expect(result.unresolved).toBeDefined()

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -34,6 +34,7 @@ import {
 } from "./orgActivity/ActivityToolbar"
 import { TimelineRow } from "./orgActivity/TimelineRow"
 import { WORKFLOW_LABEL_KEY } from "@/util/actionActivity"
+import { downloadBlob } from "@/util/downloadBlob"
 
 // Unified, owner-only org Activity view. Merges three sources into one filterable,
 // newest-first timeline:
@@ -107,12 +108,7 @@ const OrgActivityPage = () => {
   const exportCsv = () => {
     const csv = Papa.unparse(timelineToCsvRows(items), { header: true })
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = `${org ?? "org"}-activity.csv`
-    link.click()
-    URL.revokeObjectURL(url)
+    downloadBlob(blob, `${org ?? "org"}-activity.csv`)
   }
 
   const loading = commits.isLoading || runs.isLoading

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -57,6 +57,7 @@ import useGetStudents from "@/hooks/useGetStudents"
 import { useTeamRoster } from "@/hooks/useTeamRoster"
 import { getName, sortStudentsByName } from "@/util/students"
 import { studentRepoName } from "@/util/studentRepo"
+import { downloadBlob } from "@/util/downloadBlob"
 import { hasStudentEnrollment } from "@/util/classroomRoleUI"
 import type { Student } from "@/types/classroom"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
@@ -774,14 +775,7 @@ const SubmissionsPageContent = () => {
       type: "text/csv;charset=utf-8;",
     })
 
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-
-    link.href = url
-    link.download = `${classroom}-${assignment}-scores.csv`
-    link.click()
-
-    URL.revokeObjectURL(url)
+    downloadBlob(blob, `${classroom}-${assignment}-scores.csv`)
   }
 
   if (!org || !classroom || !assignment) {

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -502,14 +502,6 @@ const SubmissionsPageContent = () => {
     ],
   )
 
-  // Owners (student login or group founder) that actually pushed a submission —
-  // the set the bulk download fetches. Derived from the graded snapshot's rows,
-  // so never-accepted / accepted-no-push students are excluded (nothing to zip).
-  const downloadableOwners = useMemo(
-    () => scoresInfo.map((row) => row.owner),
-    [scoresInfo],
-  )
-
   // Group repos that exist but have no submission yet: for group assignments the
   // repo is named after the founder (not each member), so acceptance can't be
   // derived per student — instead surface every group repo from the org list
@@ -542,6 +534,15 @@ const SubmissionsPageContent = () => {
             rowInSection(row, sectionFilter, sectionByUsername),
           ),
     [scoresInfo, sectionFilter, sectionByUsername],
+  )
+
+  // Owners (student login or group founder) that actually pushed a submission —
+  // the set the bulk download fetches. Derived from the section-scoped rows so
+  // "Download all" matches the filtered view the teacher sees; never-accepted /
+  // accepted-no-push students are already excluded (they have no score row).
+  const downloadableOwners = useMemo(
+    () => scopedScores.map((row) => row.owner),
+    [scopedScores],
   )
   const scopedNonSubmitters = useMemo(
     () =>

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -17,6 +17,7 @@ import { SubmissionsActionsMenu } from "@/pages/submissions/SubmissionsActionsMe
 import { AcceptLinkModal } from "@/pages/submissions/AcceptLinkModal"
 import { MetricsModal } from "@/pages/submissions/MetricsModal"
 import { OpenAllFeedbackPrsModal } from "@/pages/submissions/OpenAllFeedbackPrsModal"
+import { DownloadAllSubmissionsModal } from "@/pages/submissions/DownloadAllSubmissionsModal"
 import { DataFreshness } from "@/pages/submissions/DataFreshness"
 import { ConfirmModal } from "@/components/modals"
 import {
@@ -254,6 +255,7 @@ const SubmissionsPageContent = () => {
   const [metricsOpen, setMetricsOpen] = useState(false)
   const [acceptOpen, setAcceptOpen] = useState(false)
   const [openAllPrsOpen, setOpenAllPrsOpen] = useState(false)
+  const [downloadAllOpen, setDownloadAllOpen] = useState(false)
 
   // Scope the collector's scores to the CURRENT roster (see rosterScopedRows).
   // Gate on a resolved roster so a transient load/permission failure falls back
@@ -498,6 +500,14 @@ const SubmissionsPageContent = () => {
       students,
       siblingSlugs,
     ],
+  )
+
+  // Owners (student login or group founder) that actually pushed a submission —
+  // the set the bulk download fetches. Derived from the graded snapshot's rows,
+  // so never-accepted / accepted-no-push students are excluded (nothing to zip).
+  const downloadableOwners = useMemo(
+    () => scoresInfo.map((row) => row.owner),
+    [scoresInfo],
   )
 
   // Group repos that exist but have no submission yet: for group assignments the
@@ -1011,6 +1021,8 @@ const SubmissionsPageContent = () => {
             viewLabel={viewLabel}
             onDownloadCsv={downloadScoresCsv}
             downloadDisabled={!scoresInfo.length && !nonSubmitters.length}
+            onDownloadAll={() => setDownloadAllOpen(true)}
+            downloadAllDisabled={downloadableOwners.length === 0}
             locked={isLockedAssignment}
             lockPending={setLock.isPending}
             // Lock/unlock is an authoring-tier action (teacher|hta), same gate
@@ -1152,6 +1164,15 @@ const SubmissionsPageContent = () => {
         assignmentName={assignmentInfo?.name ?? assignment}
         mode={isGroupAssignment ? "group" : "individual"}
         repos={allAssignmentRepos}
+      />
+      <DownloadAllSubmissionsModal
+        open={downloadAllOpen}
+        onClose={() => setDownloadAllOpen(false)}
+        org={org}
+        classroom={classroom}
+        assignment={assignment}
+        assignmentName={assignmentInfo?.name ?? assignment}
+        owners={downloadableOwners}
       />
     </PageShell>
   )

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -4,6 +4,10 @@ import { FileArchive } from "lucide-react"
 
 import { Alert, Button, Modal, Spinner } from "@/components/ui"
 import useDownloadAllSubmissions from "@/hooks/mutations/useDownloadAllSubmissions"
+import {
+  BULK_DOWNLOAD_WARN_THRESHOLD,
+  ZipAssemblyError,
+} from "@/domain/assignments"
 import type { DownloadRepoResult } from "@/domain/assignments"
 
 // A warning Alert listing the owners in one non-fetched bucket (empty /
@@ -65,15 +69,22 @@ export function DownloadAllSubmissionsModal({
     mutate,
     isPending,
     data: summary,
+    error,
     progress,
+    cancel,
     reset,
   } = useDownloadAllSubmissions()
 
   const count = owners.length
   const running = isPending
+  // Assembly (out-of-memory) failure is distinct from a per-repo failure: every
+  // archive downloaded but the combined zip couldn't be built. Anything else is
+  // an unexpected batch-level error.
+  const assemblyError = error instanceof ZipAssemblyError
 
   const handleClose = () => {
-    if (running) return
+    // Closing mid-run cancels the in-flight batch rather than trapping the user.
+    if (running) cancel()
     onClose()
     reset()
   }
@@ -87,7 +98,6 @@ export function DownloadAllSubmissionsModal({
       open={open}
       onClose={handleClose}
       size="md"
-      closeDisabled={running}
       aria-labelledby={titleId}
     >
       <h3 id={titleId} className="flex items-center gap-2 text-lg font-bold">
@@ -95,7 +105,15 @@ export function DownloadAllSubmissionsModal({
         {t("submissions.downloadAll.title")}
       </h3>
 
-      {summary ? (
+      {error ? (
+        <div className="mt-3 space-y-3">
+          <Alert tone="error">
+            {assemblyError
+              ? t("submissions.downloadAll.assemblyError")
+              : t("submissions.downloadAll.runError")}
+          </Alert>
+        </div>
+      ) : summary ? (
         <div className="mt-3 space-y-3">
           <p className="text-sm leading-6 text-base-content/70">
             <Trans
@@ -104,6 +122,11 @@ export function DownloadAllSubmissionsModal({
               components={{ b: <span className="font-semibold" /> }}
             />
           </p>
+          {summary.fetched === 0 && (
+            <Alert tone="warning">
+              {t("submissions.downloadAll.nothingDownloaded")}
+            </Alert>
+          )}
           <ul className="space-y-1 text-sm">
             <li>
               {t("submissions.downloadAll.summaryDownloaded", {
@@ -168,33 +191,32 @@ export function DownloadAllSubmissionsModal({
             />
           </p>
           <p>{t("submissions.downloadAll.confirmHint")}</p>
+          {count > BULK_DOWNLOAD_WARN_THRESHOLD && (
+            <Alert tone="warning">
+              {t("submissions.downloadAll.largeClassWarning", { count })}
+            </Alert>
+          )}
         </div>
       )}
 
       <div className="modal-action">
-        {summary ? (
+        {summary || error ? (
           <Button size="sm" onClick={handleClose}>
             {t("common.close")}
           </Button>
+        ) : running ? (
+          <Button variant="ghost" size="sm" onClick={handleClose}>
+            {t("common.cancel")}
+          </Button>
         ) : (
           <>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={running}
-              onClick={handleClose}
-            >
+            <Button variant="ghost" size="sm" onClick={handleClose}>
               {t("common.cancel")}
             </Button>
             <Button
               variant="primary"
               size="sm"
-              loading={running}
-              loadingLabel={t("submissions.downloadAll.running", {
-                done: progress?.done ?? 0,
-                total: progress?.total ?? count,
-              })}
-              disabled={running || count === 0}
+              disabled={count === 0}
               onClick={handleRun}
             >
               {t("submissions.downloadAll.confirmLabel", { count })}

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -1,0 +1,209 @@
+import { useId } from "react"
+import { Trans, useTranslation } from "react-i18next"
+import { FileArchive } from "lucide-react"
+
+import { Alert, Button, Modal, Spinner } from "@/components/ui"
+import useDownloadAllSubmissions from "@/hooks/mutations/useDownloadAllSubmissions"
+import type { DownloadRepoResult } from "@/domain/assignments"
+
+// A warning Alert listing the owners in one non-fetched bucket (empty /
+// failed). `showReason` appends each owner's reason inline (the failed bucket).
+function OwnerListAlert({
+  owners,
+  title,
+  hint,
+  showReason,
+}: {
+  owners: DownloadRepoResult[]
+  title: string
+  hint: string
+  showReason?: boolean
+}) {
+  return (
+    <Alert tone="warning">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{title}</p>
+        <ul className="max-h-40 overflow-y-auto text-xs">
+          {owners.map((r) => (
+            <li key={r.owner} className="font-mono">
+              {r.owner}
+              {showReason && r.reason ? ` — ${r.reason}` : ""}
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-base-content/70">{hint}</p>
+      </div>
+    </Alert>
+  )
+}
+
+// Bulk "Download all submissions" for an assignment. Three states in one
+// dialog: confirm (owner count), running (live X/N progress, dismissal
+// blocked), and summary (downloaded / empty / failed). The combined zip is
+// handed to the browser when the run finishes with at least one fetched repo.
+export function DownloadAllSubmissionsModal({
+  open,
+  onClose,
+  org,
+  classroom,
+  assignment,
+  assignmentName,
+  owners,
+}: {
+  open: boolean
+  onClose: () => void
+  org: string
+  classroom: string
+  assignment: string
+  assignmentName: string
+  // Every owner (student login or group owner) with a submission to fetch.
+  owners: string[]
+}) {
+  const { t } = useTranslation()
+  const titleId = useId()
+  const {
+    mutate,
+    isPending,
+    data: summary,
+    progress,
+    reset,
+  } = useDownloadAllSubmissions()
+
+  const count = owners.length
+  const running = isPending
+
+  const handleClose = () => {
+    if (running) return
+    onClose()
+    reset()
+  }
+
+  const handleRun = () => {
+    mutate({ org, classroom, assignment, owners })
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      size="md"
+      closeDisabled={running}
+      aria-labelledby={titleId}
+    >
+      <h3 id={titleId} className="flex items-center gap-2 text-lg font-bold">
+        <FileArchive aria-hidden="true" className="size-5" />
+        {t("submissions.downloadAll.title")}
+      </h3>
+
+      {summary ? (
+        <div className="mt-3 space-y-3">
+          <p className="text-sm leading-6 text-base-content/70">
+            <Trans
+              i18nKey="submissions.downloadAll.summaryLead"
+              values={{ total: summary.total }}
+              components={{ b: <span className="font-semibold" /> }}
+            />
+          </p>
+          <ul className="space-y-1 text-sm">
+            <li>
+              {t("submissions.downloadAll.summaryDownloaded", {
+                count: summary.fetched,
+              })}
+            </li>
+            {summary.empty.length > 0 && (
+              <li className="text-warning">
+                {t("submissions.downloadAll.summaryEmpty", {
+                  count: summary.empty.length,
+                })}
+              </li>
+            )}
+            {summary.failed.length > 0 && (
+              <li className="text-error">
+                {t("submissions.downloadAll.summaryFailed", {
+                  count: summary.failed.length,
+                })}
+              </li>
+            )}
+          </ul>
+          {summary.empty.length > 0 && (
+            <OwnerListAlert
+              owners={summary.empty}
+              title={t("submissions.downloadAll.emptyTitle")}
+              hint={t("submissions.downloadAll.emptyHint")}
+            />
+          )}
+          {summary.failed.length > 0 && (
+            <OwnerListAlert
+              owners={summary.failed}
+              title={t("submissions.downloadAll.failedTitle")}
+              hint={t("submissions.downloadAll.failedHint")}
+              showReason
+            />
+          )}
+        </div>
+      ) : running ? (
+        <div className="mt-4 space-y-3">
+          <p className="flex items-center gap-2 text-sm text-base-content/70">
+            <Spinner size="xs" />
+            {t("submissions.downloadAll.running", {
+              done: progress?.done ?? 0,
+              total: progress?.total ?? count,
+            })}
+          </p>
+          <progress
+            className="progress progress-primary w-full"
+            value={progress?.done ?? 0}
+            max={progress?.total ?? count}
+          />
+        </div>
+      ) : (
+        <div className="mt-3 space-y-2 text-sm leading-6 text-base-content/70">
+          <p>
+            <Trans
+              i18nKey="submissions.downloadAll.confirmBody"
+              values={{ count, name: assignmentName }}
+              components={{
+                b: <span className="font-semibold text-base-content" />,
+              }}
+            />
+          </p>
+          <p>{t("submissions.downloadAll.confirmHint")}</p>
+        </div>
+      )}
+
+      <div className="modal-action">
+        {summary ? (
+          <Button size="sm" onClick={handleClose}>
+            {t("common.close")}
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={running}
+              onClick={handleClose}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              loading={running}
+              loadingLabel={t("submissions.downloadAll.running", {
+                done: progress?.done ?? 0,
+                total: progress?.total ?? count,
+              })}
+              disabled={running || count === 0}
+              onClick={handleRun}
+            >
+              {t("submissions.downloadAll.confirmLabel", { count })}
+            </Button>
+          </>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+export default DownloadAllSubmissionsModal

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -41,10 +41,8 @@ function OwnerListAlert({
   )
 }
 
-// Bulk "Download all submissions" for an assignment. Three states in one
-// dialog: confirm (owner count), running (live X/N progress, dismissal
-// blocked), and summary (downloaded / empty / failed). The combined zip is
-// handed to the browser when the run finishes with at least one fetched repo.
+// Bulk "Download all submissions": confirm → running (live X/N, cancellable) →
+// summary (downloaded / empty / failed), or an error state.
 export function DownloadAllSubmissionsModal({
   open,
   onClose,
@@ -80,13 +78,11 @@ export function DownloadAllSubmissionsModal({
   // The run finished with a real result (not a picker cancel).
   const summary = outcome?.status === "done" ? outcome.summary : null
   const toDirectory = outcome?.status === "done" && outcome.toDirectory
-  // Assembly (out-of-memory) failure is distinct from a per-repo failure: every
-  // archive downloaded but the combined zip couldn't be built. Anything else is
-  // an unexpected batch-level error.
+  // Every archive downloaded but the combined zip couldn't be built (OOM);
+  // anything else is an unexpected batch error.
   const assemblyError = error instanceof ZipAssemblyError
 
-  // The user dismissed the directory picker before anything ran — close quietly
-  // rather than showing an empty summary.
+  // Picker dismissed before anything ran — close quietly, no empty summary.
   useEffect(() => {
     if (outcome?.status === "cancelled") {
       onClose()

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react"
+import { useEffect, useId } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { FileArchive } from "lucide-react"
 
@@ -68,7 +68,7 @@ export function DownloadAllSubmissionsModal({
   const {
     mutate,
     isPending,
-    data: summary,
+    data: outcome,
     error,
     progress,
     cancel,
@@ -77,10 +77,22 @@ export function DownloadAllSubmissionsModal({
 
   const count = owners.length
   const running = isPending
+  // The run finished with a real result (not a picker cancel).
+  const summary = outcome?.status === "done" ? outcome.summary : null
+  const toDirectory = outcome?.status === "done" && outcome.toDirectory
   // Assembly (out-of-memory) failure is distinct from a per-repo failure: every
   // archive downloaded but the combined zip couldn't be built. Anything else is
   // an unexpected batch-level error.
   const assemblyError = error instanceof ZipAssemblyError
+
+  // The user dismissed the directory picker before anything ran — close quietly
+  // rather than showing an empty summary.
+  useEffect(() => {
+    if (outcome?.status === "cancelled") {
+      onClose()
+      reset()
+    }
+  }, [outcome, onClose, reset])
 
   const handleClose = () => {
     // Closing mid-run cancels the in-flight batch rather than trapping the user.
@@ -129,9 +141,12 @@ export function DownloadAllSubmissionsModal({
           )}
           <ul className="space-y-1 text-sm">
             <li>
-              {t("submissions.downloadAll.summaryDownloaded", {
-                count: summary.fetched,
-              })}
+              {t(
+                toDirectory
+                  ? "submissions.downloadAll.summarySaved"
+                  : "submissions.downloadAll.summaryDownloaded",
+                { count: summary.fetched },
+              )}
             </li>
             {summary.empty.length > 0 && (
               <li className="text-warning">

--- a/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
@@ -19,6 +19,8 @@ const baseProps = {
   viewLabel: "submissions.menu.viewWorkflow",
   onDownloadCsv: () => {},
   downloadDisabled: false,
+  onDownloadAll: () => {},
+  downloadAllDisabled: false,
 }
 
 afterEach(() => cleanup())
@@ -77,6 +79,28 @@ describe("SubmissionsActionsMenu — Open all Feedback PRs item", () => {
     )
     // The whole !emptyRepo block (incl. this item) is gone for empty_repo.
     expect(screen.queryByText("submissions.openAllPrs.menuLabel")).toBeNull()
+  })
+})
+
+describe("SubmissionsActionsMenu — Download all submissions item", () => {
+  it("always shows the item (read-only, not owner-gated) and enables it when there are submissions", () => {
+    render(<SubmissionsActionsMenu {...baseProps} />)
+    const item = screen.getByText("submissions.downloadAll.menuLabel")
+    expect(item).not.toBeNull()
+    expect((item.closest("button") as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it("disables the item when there is nothing to download", () => {
+    render(<SubmissionsActionsMenu {...baseProps} downloadAllDisabled />)
+    const item = screen.getByText("submissions.downloadAll.menuLabel")
+    expect((item.closest("button") as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("stays visible for an empty_repo assignment (unlike Open all PRs)", () => {
+    render(<SubmissionsActionsMenu {...baseProps} emptyRepo />)
+    expect(
+      screen.queryByText("submissions.downloadAll.menuLabel"),
+    ).not.toBeNull()
   })
 })
 

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDown,
   DownloadCloud,
   ExternalLink,
+  FileArchive,
   FileDown,
   GitPullRequest,
   Lock,
@@ -34,6 +35,8 @@ export function SubmissionsActionsMenu({
   viewLabel,
   onDownloadCsv,
   downloadDisabled,
+  onDownloadAll,
+  downloadAllDisabled,
   locked = false,
   lockPending = false,
   onLockToggle,
@@ -63,6 +66,11 @@ export function SubmissionsActionsMenu({
   viewLabel: string
   onDownloadCsv: () => void
   downloadDisabled: boolean
+  // Opens the "Download all submissions" modal. Read-only (any viewer), so
+  // unlike Open-all-PRs it isn't owner-gated; hidden only when there's nothing
+  // to fetch (empty roster / no submissions), signalled via downloadAllDisabled.
+  onDownloadAll: () => void
+  downloadAllDisabled: boolean
   // Current locked state, for the Lock/Unlock item's label and icon.
   locked?: boolean
   // Whether a lock/unlock is mid-flight, to disable the item and show progress.
@@ -269,6 +277,25 @@ export function SubmissionsActionsMenu({
           >
             <FileDown aria-hidden="true" className="size-4" />
             {t("submissions.downloadCsv")}
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            disabled={downloadAllDisabled}
+            title={
+              downloadAllDisabled
+                ? t("submissions.downloadAll.titleDisabled")
+                : t("submissions.downloadAll.title")
+            }
+            onClick={() => {
+              closeMenu()
+              if (downloadAllDisabled) return
+              onDownloadAll()
+            }}
+          >
+            <FileArchive aria-hidden="true" className="size-4" />
+            {t("submissions.downloadAll.menuLabel")}
           </button>
         </li>
       </ul>

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -66,9 +66,8 @@ export function SubmissionsActionsMenu({
   viewLabel: string
   onDownloadCsv: () => void
   downloadDisabled: boolean
-  // Opens the "Download all submissions" modal. Read-only (any viewer), so
-  // unlike Open-all-PRs it isn't owner-gated; hidden only when there's nothing
-  // to fetch (empty roster / no submissions), signalled via downloadAllDisabled.
+  // Read-only (any viewer), so not owner-gated like Open-all-PRs; hidden only
+  // when there's nothing to fetch (via downloadAllDisabled).
   onDownloadAll: () => void
   downloadAllDisabled: boolean
   // Current locked state, for the Lock/Unlock item's label and icon.

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -31,6 +31,10 @@ vi.mock("@/context/notifications/NotificationProvider", () => ({
 vi.mock("@/hooks/useTriggerRegrade", () => ({
   default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),
 }))
+const downloadSubmission = vi.fn()
+vi.mock("@/hooks/mutations/useDownloadSubmission", () => ({
+  default: () => ({ mutate: downloadSubmission, isPending: false }),
+}))
 vi.mock("@/components/modals/GroupCollaboratorsModal", () => ({
   GroupCollaboratorsModal: () => null,
 }))
@@ -71,6 +75,7 @@ const scoreRow = (over: Partial<SubmissionRow> = {}): SubmissionRow => ({
 beforeEach(() => {
   collaborators.mockReset()
   collaborators.mockReturnValue({ data: undefined })
+  downloadSubmission.mockReset()
 })
 
 afterEach(cleanup)
@@ -183,5 +188,48 @@ describe("SubmissionsTable empty_repo score cell", () => {
       />,
     )
     expect(screen.queryByTitle("submissions.table.noGradingTitle")).toBeNull()
+  })
+})
+
+describe("SubmissionsTable per-row download", () => {
+  it("renders a download button for a submitter row and fires the hook on click", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+      />,
+    )
+    const btn = screen.getByTitle("submissions.rowDownload.title")
+    btn.click()
+    expect(downloadSubmission).toHaveBeenCalledWith({
+      org: "acme",
+      classroom: "cs101",
+      assignment: "hw1",
+      owner: "alice",
+    })
+  })
+
+  it("renders the download button even for an empty_repo assignment", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+        emptyRepo
+      />,
+    )
+    expect(screen.getByTitle("submissions.rowDownload.title")).toBeTruthy()
+  })
+
+  it("shows no download button for a non-submitter row", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set(["alice"])}
+      />,
+    )
+    expect(screen.queryByTitle("submissions.rowDownload.title")).toBeNull()
   })
 })

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -202,12 +202,15 @@ describe("SubmissionsTable per-row download", () => {
     )
     const btn = screen.getByTitle("submissions.rowDownload.title")
     btn.click()
-    expect(downloadSubmission).toHaveBeenCalledWith({
-      org: "acme",
-      classroom: "cs101",
-      assignment: "hw1",
-      owner: "alice",
-    })
+    expect(downloadSubmission).toHaveBeenCalledWith(
+      {
+        org: "acme",
+        classroom: "cs101",
+        assignment: "hw1",
+        owner: "alice",
+      },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    )
   })
 
   it("renders the download button even for an empty_repo assignment", () => {

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -274,7 +274,9 @@ const DownloadButton = ({
       aria-label={t("submissions.rowDownload.aria", { owner })}
       title={t("submissions.rowDownload.title")}
     >
-      {!download.isPending && <Download aria-hidden="true" className="size-4" />}
+      {!download.isPending && (
+        <Download aria-hidden="true" className="size-4" />
+      )}
     </Button>
   )
 }

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -241,10 +241,8 @@ const RegradeButton = ({
   )
 }
 
-// Per-row submission download: fetches the student's latest submission (their
-// assignment repo, zipped by GitHub) and hands it to the browser. Icon-only to
-// match the row's other actions; shows a spinner while fetching. Kept a button
-// (not a link) because it triggers an authenticated API fetch, not a navigation.
+// Per-row submission download. A button, not a link, because it triggers an
+// authenticated fetch, not a navigation.
 const DownloadButton = ({
   org,
   classroom,
@@ -275,9 +273,8 @@ const DownloadButton = ({
           { org, classroom, assignment, owner },
           {
             onError: (err) => {
-              // fetchRepoArchive resolves a missing/never-pushed repo to null,
-              // and the hook throws "no-submission" for it — surface that as a
-              // benign "nothing to download" rather than a hard error.
+              // "no-submission" (missing/never-pushed repo) is benign info,
+              // not an error.
               const nothing =
                 err instanceof Error && err.message === "no-submission"
               notify({

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -1,5 +1,6 @@
 import {
   ChevronRight,
+  Download,
   GitCommitHorizontal,
   Inbox,
   RefreshCw,
@@ -54,6 +55,7 @@ import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
 import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
 import { ReviewButton } from "@/pages/submissions/ReviewButton"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
+import useDownloadSubmission from "@/hooks/mutations/useDownloadSubmission"
 import type { Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 
@@ -235,6 +237,45 @@ const RegradeButton = ({
         onClose={() => setConfirmOpen(false)}
       />
     </>
+  )
+}
+
+// Per-row submission download: fetches the student's latest submission (their
+// assignment repo, zipped by GitHub) and hands it to the browser. Icon-only to
+// match the row's other actions; shows a spinner while fetching. Kept a button
+// (not a link) because it triggers an authenticated API fetch, not a navigation.
+const DownloadButton = ({
+  org,
+  classroom,
+  assignment,
+  owner,
+}: {
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+}) => {
+  const { t } = useTranslation()
+  const download = useDownloadSubmission()
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      shape="square"
+      className="text-base-content/70 disabled:opacity-60"
+      disabled={download.isPending}
+      loading={download.isPending}
+      loadingLabel={t("submissions.rowDownload.title")}
+      onClick={() => {
+        if (download.isPending) return
+        download.mutate({ org, classroom, assignment, owner })
+      }}
+      aria-label={t("submissions.rowDownload.aria", { owner })}
+      title={t("submissions.rowDownload.title")}
+    >
+      {!download.isPending && <Download aria-hidden="true" className="size-4" />}
+    </Button>
   )
 }
 
@@ -615,6 +656,12 @@ const SubmissionsTable = ({
                 title={t("submissions.table.commit")}
                 emptyLabel={t("submissions.table.noCommit")}
                 emptyTitle={t("submissions.table.noCommit")}
+              />
+              <DownloadButton
+                org={org}
+                classroom={classroom}
+                assignment={assignment}
+                owner={rest.owner}
               />
               {!emptyRepo && (
                 <>

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -56,6 +56,7 @@ import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
 import { ReviewButton } from "@/pages/submissions/ReviewButton"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import useDownloadSubmission from "@/hooks/mutations/useDownloadSubmission"
+import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 
@@ -256,6 +257,7 @@ const DownloadButton = ({
   owner: string
 }) => {
   const { t } = useTranslation()
+  const { notify } = useToast()
   const download = useDownloadSubmission()
 
   return (
@@ -269,7 +271,24 @@ const DownloadButton = ({
       loadingLabel={t("submissions.rowDownload.title")}
       onClick={() => {
         if (download.isPending) return
-        download.mutate({ org, classroom, assignment, owner })
+        download.mutate(
+          { org, classroom, assignment, owner },
+          {
+            onError: (err) => {
+              // fetchRepoArchive resolves a missing/never-pushed repo to null,
+              // and the hook throws "no-submission" for it — surface that as a
+              // benign "nothing to download" rather than a hard error.
+              const nothing =
+                err instanceof Error && err.message === "no-submission"
+              notify({
+                tone: nothing ? "info" : "error",
+                message: nothing
+                  ? t("submissions.rowDownload.nothingToDownload", { owner })
+                  : t("submissions.rowDownload.error", { owner }),
+              })
+            },
+          },
+        )
       }}
       aria-label={t("submissions.rowDownload.aria", { owner })}
       title={t("submissions.rowDownload.title")}

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -659,12 +659,6 @@ const SubmissionsTable = ({
                 emptyLabel={t("submissions.table.noCommit")}
                 emptyTitle={t("submissions.table.noCommit")}
               />
-              <DownloadButton
-                org={org}
-                classroom={classroom}
-                assignment={assignment}
-                owner={rest.owner}
-              />
               {!emptyRepo && (
                 <>
                   <ReviewButton
@@ -693,6 +687,12 @@ const SubmissionsTable = ({
                   />
                 </>
               )}
+              <DownloadButton
+                org={org}
+                classroom={classroom}
+                assignment={assignment}
+                owner={rest.owner}
+              />
             </div>
           </td>
         </tr>

--- a/web/src/util/downloadBlob.ts
+++ b/web/src/util/downloadBlob.ts
@@ -9,5 +9,8 @@ export function downloadBlob(blob: Blob, filename: string): void {
   link.download = filename
   link.click()
 
-  URL.revokeObjectURL(url)
+  // Defer the revoke: click() starts the download asynchronously, and revoking
+  // the object URL synchronously can cancel a large download in some browsers
+  // before it latches the blob.
+  setTimeout(() => URL.revokeObjectURL(url), 0)
 }

--- a/web/src/util/downloadBlob.ts
+++ b/web/src/util/downloadBlob.ts
@@ -9,8 +9,7 @@ export function downloadBlob(blob: Blob, filename: string): void {
   link.download = filename
   link.click()
 
-  // Defer the revoke: click() starts the download asynchronously, and revoking
-  // the object URL synchronously can cancel a large download in some browsers
-  // before it latches the blob.
+  // Defer revoke: click() downloads async; a sync revoke can cancel a large
+  // download before the blob is latched.
   setTimeout(() => URL.revokeObjectURL(url), 0)
 }

--- a/web/src/util/downloadBlob.ts
+++ b/web/src/util/downloadBlob.ts
@@ -1,0 +1,13 @@
+// Trigger a browser "save file" for an in-memory blob: the object-URL +
+// hidden-anchor + revoke dance, in one place so the CSV export and the
+// submission-archive downloads share a single recipe.
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+
+  link.href = url
+  link.download = filename
+  link.click()
+
+  URL.revokeObjectURL(url)
+}

--- a/web/src/util/fileSystemAccess.ts
+++ b/web/src/util/fileSystemAccess.ts
@@ -1,0 +1,97 @@
+// File System Access API helpers (Chromium-only). Where supported, these let
+// the teacher choose exactly where a download lands — a single file's path via
+// the save picker, or a folder to extract many submissions into — instead of
+// everything dropping into the browser's default Downloads folder. Callers must
+// feature-detect first and fall back to util/downloadBlob elsewhere (Firefox
+// and Safari do not implement these APIs).
+//
+// The picker calls must run inside a user gesture (a click handler), and must
+// be invoked before any long `await` so the gesture's transient activation is
+// still valid — call pickSaveFile / pickDirectory first, then fetch, then
+// write.
+
+// The DOM lib in this TS version ships the handle interfaces but not the
+// window entry points, so declare just what we use.
+declare global {
+  interface Window {
+    showSaveFilePicker?: (options?: {
+      suggestedName?: string
+      types?: Array<{ description?: string; accept: Record<string, string[]> }>
+    }) => Promise<FileSystemFileHandle>
+    showDirectoryPicker?: (options?: {
+      id?: string
+      mode?: "read" | "readwrite"
+    }) => Promise<FileSystemDirectoryHandle>
+  }
+}
+
+export function supportsSaveFilePicker(): boolean {
+  return typeof window !== "undefined" && "showSaveFilePicker" in window
+}
+
+export function supportsDirectoryPicker(): boolean {
+  return typeof window !== "undefined" && "showDirectoryPicker" in window
+}
+
+// A user cancelling a picker rejects with an AbortError; callers treat that as
+// a benign no-op rather than an error.
+export function isPickerAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError"
+}
+
+// Open the save-file picker for a `.zip`. Returns the handle, or null if the
+// user cancelled. Throws only on a genuine (non-abort) failure. Caller must
+// have checked supportsSaveFilePicker().
+export async function pickSaveFile(
+  suggestedName: string,
+): Promise<FileSystemFileHandle | null> {
+  try {
+    return await window.showSaveFilePicker!({
+      suggestedName,
+      types: [
+        {
+          description: "Zip archive",
+          accept: { "application/zip": [".zip"] },
+        },
+      ],
+    })
+  } catch (err) {
+    if (isPickerAbort(err)) return null
+    throw err
+  }
+}
+
+// Open the directory picker (readwrite). Returns the handle, or null if the
+// user cancelled. Caller must have checked supportsDirectoryPicker().
+export async function pickDirectory(): Promise<FileSystemDirectoryHandle | null> {
+  try {
+    return await window.showDirectoryPicker!({ mode: "readwrite" })
+  } catch (err) {
+    if (isPickerAbort(err)) return null
+    throw err
+  }
+}
+
+// Stream bytes to a picked file handle, then close it.
+export async function writeToFileHandle(
+  handle: FileSystemFileHandle,
+  data: BlobPart,
+): Promise<void> {
+  const writable = await handle.createWritable()
+  try {
+    await writable.write(data)
+  } finally {
+    await writable.close()
+  }
+}
+
+// Write a file directly into a picked directory, streaming to disk so nothing
+// accumulates in memory. Overwrites an existing same-named entry.
+export async function writeFileToDirectory(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+  data: BlobPart,
+): Promise<void> {
+  const handle = await dir.getFileHandle(name, { create: true })
+  await writeToFileHandle(handle, data)
+}

--- a/web/src/util/fileSystemAccess.ts
+++ b/web/src/util/fileSystemAccess.ts
@@ -1,14 +1,9 @@
-// File System Access API helpers (Chromium-only). Where supported, these let
-// the teacher choose exactly where a download lands — a single file's path via
-// the save picker, or a folder to extract many submissions into — instead of
-// everything dropping into the browser's default Downloads folder. Callers must
-// feature-detect first and fall back to util/downloadBlob elsewhere (Firefox
-// and Safari do not implement these APIs).
+// File System Access API helpers (Chromium-only): let the teacher choose where
+// a download lands. Callers must feature-detect and fall back to
+// util/downloadBlob elsewhere.
 //
-// The picker calls must run inside a user gesture (a click handler), and must
-// be invoked before any long `await` so the gesture's transient activation is
-// still valid — call pickSaveFile / pickDirectory first, then fetch, then
-// write.
+// Pickers require a user gesture, so call pickSaveFile / pickDirectory BEFORE
+// any long `await` (fetch, write) — the transient activation must still be live.
 
 // The DOM lib in this TS version ships the handle interfaces but not the
 // window entry points, so declare just what we use.
@@ -33,15 +28,13 @@ export function supportsDirectoryPicker(): boolean {
   return typeof window !== "undefined" && "showDirectoryPicker" in window
 }
 
-// A user cancelling a picker rejects with an AbortError; callers treat that as
-// a benign no-op rather than an error.
-export function isPickerAbort(err: unknown): boolean {
+// A cancelled picker rejects with an AbortError; callers treat that as a benign
+// no-op rather than an error.
+function isPickerAbort(err: unknown): boolean {
   return err instanceof DOMException && err.name === "AbortError"
 }
 
-// Open the save-file picker for a `.zip`. Returns the handle, or null if the
-// user cancelled. Throws only on a genuine (non-abort) failure. Caller must
-// have checked supportsSaveFilePicker().
+// Save-file picker for a `.zip`. Returns the handle, or null if cancelled.
 export async function pickSaveFile(
   suggestedName: string,
 ): Promise<FileSystemFileHandle | null> {
@@ -61,8 +54,7 @@ export async function pickSaveFile(
   }
 }
 
-// Open the directory picker (readwrite). Returns the handle, or null if the
-// user cancelled. Caller must have checked supportsDirectoryPicker().
+// Directory picker (readwrite). Returns the handle, or null if cancelled.
 export async function pickDirectory(): Promise<FileSystemDirectoryHandle | null> {
   try {
     return await window.showDirectoryPicker!({ mode: "readwrite" })
@@ -85,8 +77,8 @@ export async function writeToFileHandle(
   }
 }
 
-// Write a file directly into a picked directory, streaming to disk so nothing
-// accumulates in memory. Overwrites an existing same-named entry.
+// Write a file into a picked directory, streaming to disk. Overwrites any
+// same-named entry.
 export async function writeFileToDirectory(
   dir: FileSystemDirectoryHandle,
   name: string,


### PR DESCRIPTION
## Summary

Adds teacher-side download of student assignment submissions to the submissions view. Previously the only "download" actions produced CSV files and submission rows only linked out to GitHub; there was no way to pull a student's actual work for offline grading.

- **Per-student download** — each submitter row gets a download action (placed last in the row's action column) that fetches that student's latest submission as a `.zip`, named `<classroom>-<assignment>-<owner>.zip`.
- **Bulk download** — a "Download all submissions" action in the Actions menu bundles every submitting student's latest submission into one combined `.zip`, with a live "X of N" progress modal and a downloaded / empty / failed summary. It's read-only, so any staff viewer can run it; it's disabled when there are no submissions.

## How it works

All logic stays client-side and derives from GitHub, consistent with the app's no-backend contract:

- New lowest-layer reader fetches a repo's latest archive (default-branch HEAD = latest push), tolerating a missing/empty repo as "skipped".
- A domain orchestrator fans out over submitting owners at bounded concurrency, packages each fetched archive into one combined zip (via `jszip`), reports progress, and never lets a single repo's failure abort the batch.
- Server writes/reads go through hooks (`useDownloadSubmission`, `useDownloadAllSubmissions`); the object-URL save recipe is extracted into a shared `util/downloadBlob` now reused by the CSV export too.
- Because GitHub's archive endpoint 302-redirects to a host that sends no CORS header, the browser can't read archive bytes directly, so the archive request is routed through the app's existing OAuth proxy, which returns the bytes with proper CORS. This reuses existing infrastructure and adds no server-side state.

## Layering

Boundaries hold (verified by `arch:validate`): the new data-layer reader imports no domain/view code, the fan-out lives in `domain/`, server access goes through hooks, and no `useQueryClient` / `githubKeys` leak into pages/components.

## Deployment note

The archive request targets a new route on the app's existing GitHub OAuth proxy. That route must be deployed to the proxy before download works end-to-end; until then the archive request will fail against the live proxy. The rest of the app is unaffected.

## Test plan

- [x] `npm run check` green (tsc, eslint, prettier, arch:validate, 2811 vitest tests)
- [ ] Manual: on a classroom with a few accepted repos, per-row download yields `<classroom>-<assignment>-<owner>.zip`
- [ ] Manual: bulk download yields one combined `.zip` with an entry per submitting owner, shows progress, and reports a summary; never-accepted / accepted-no-push students are skipped
- [ ] Manual: the row action is disabled/absent for non-submitter rows and the bulk action is disabled when there are no submissions