### PR TITLE
refactor(web): consolidate worker-backed calls behind a generic proxy module

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -173,6 +173,8 @@ jobs:
       - run: npm run build
         env:
           VITE_GITHUB_CLIENT_ID: ${{ vars.VITE_GITHUB_CLIENT_ID }}
+          # GitHub proxy base; falls back to the baked-in default when unset.
+          VITE_GITHUB_PROXY_BASE: ${{ vars.VITE_GITHUB_PROXY_BASE }}
           # Tag name (web-vX.Y.Z); vite.config.ts strips the web-v prefix.
           VITE_APP_VERSION: ${{ needs.release-please.outputs.web_tag }}
           VITE_APP_COMMIT: ${{ steps.sha.outputs.value }}

--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -72,6 +72,8 @@ jobs:
           # Reuses the production client id — ensure preview.classroom50.org is
           # an allowed callback on that OAuth app.
           VITE_GITHUB_CLIENT_ID: ${{ vars.VITE_GITHUB_CLIENT_ID }}
+          # GitHub proxy base; falls back to the baked-in default when unset.
+          VITE_GITHUB_PROXY_BASE: ${{ vars.VITE_GITHUB_PROXY_BASE }}
 
       # GitHub Pages has no SPA rewrites; serve the app for unknown deep links.
       - name: Add SPA fallback

--- a/.github/workflows/web-deploy.yaml
+++ b/.github/workflows/web-deploy.yaml
@@ -68,6 +68,8 @@ jobs:
           # (Settings -> Secrets and variables -> Actions -> Variables)
           # is sufficient; no secret needed.
           VITE_GITHUB_CLIENT_ID: ${{ vars.VITE_GITHUB_CLIENT_ID }}
+          # GitHub proxy base; falls back to the baked-in default when unset.
+          VITE_GITHUB_PROXY_BASE: ${{ vars.VITE_GITHUB_PROXY_BASE }}
           # Release identity stamped into the build (see web/vite.config.ts).
           # A `web-v*` ref names the version; anything else (branch/SHA redeploy)
           # falls back to web/package.json. Commit + date give a precise build

--- a/web/README.md
+++ b/web/README.md
@@ -24,7 +24,7 @@ Sign-in requires a [GitHub OAuth app](https://github.com/settings/developers):
 - **Web flow**: set the app's authorization callback URL to `http://localhost:5173/login` for local development (`https://classroom50.org/login` in production).
 - **Device flow**: check "Enable Device Flow" in the OAuth app settings.
 
-The token exchange goes through a Cloudflare Worker proxy (which holds the client secret). It defaults to the Fifty Foundation worker; override with `VITE_GITHUB_OAUTH_WORKER_BASE` in `.env.local` if you run your own.
+Browser-blocked GitHub calls (the OAuth token exchange, which holds the client secret, and repo archive downloads, which codeload serves without CORS) go through a GitHub proxy. It defaults to the Fifty Foundation Cloudflare Worker; override with `VITE_GITHUB_PROXY_BASE` in `.env.local` if you run your own.
 
 If no `VITE_GITHUB_CLIENT_ID` is set, the app falls back to a client ID previously saved in the browser's localStorage (from older builds that had a client ID input on the login screen).
 

--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -38,7 +38,3 @@ const GITHUB_OAUTH_APPS_URL =
 // client id (self-hosted/dev builds) only the app list is knowable.
 export const githubOAuthGrantUrl = (clientId = GITHUB_OAUTH_CLIENT_ID) =>
   clientId ? `${GITHUB_OAUTH_APPS_URL}/${clientId}` : GITHUB_OAUTH_APPS_URL
-
-export const GITHUB_OAUTH_WORKER_BASE =
-  import.meta.env.VITE_GITHUB_OAUTH_WORKER_BASE ??
-  "https://tiny-bonus-7dc1.fifty-foundation.workers.dev"

--- a/web/src/auth/github-oauth-api.ts
+++ b/web/src/auth/github-oauth-api.ts
@@ -1,4 +1,8 @@
-import { GITHUB_OAUTH_WORKER_BASE } from "./constants"
+import {
+  GITHUB_PROXY_BASE,
+  PROXY_ROUTES,
+  proxyUrl,
+} from "@/github-core/workerProxy"
 import type { GithubDeviceCodeResponse, GithubTokenResponse } from "./types"
 
 // Must exactly match the OAuth App's registered callback URL (.../login).
@@ -60,7 +64,7 @@ export async function exchangeWebCode(input: {
   code: string
   verifier: string
 }) {
-  const res = await fetch(`${GITHUB_OAUTH_WORKER_BASE}/web/token`, {
+  const res = await fetch(proxyUrl(GITHUB_PROXY_BASE, PROXY_ROUTES.webToken), {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -83,17 +87,20 @@ export async function requestDeviceCode(input: {
   clientId: string
   scope: string
 }) {
-  const res = await fetch(`${GITHUB_OAUTH_WORKER_BASE}/device/code`, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
+  const res = await fetch(
+    proxyUrl(GITHUB_PROXY_BASE, PROXY_ROUTES.deviceCode),
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        client_id: input.clientId,
+        scope: input.scope,
+      }),
     },
-    body: JSON.stringify({
-      client_id: input.clientId,
-      scope: input.scope,
-    }),
-  })
+  )
 
   const data = await readJsonResponse<GithubDeviceCodeResponse>(res)
 
@@ -118,19 +125,22 @@ export async function pollDeviceToken(input: {
   deviceCode: string
   signal?: AbortSignal
 }) {
-  const res = await fetch(`${GITHUB_OAUTH_WORKER_BASE}/device/token`, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
+  const res = await fetch(
+    proxyUrl(GITHUB_PROXY_BASE, PROXY_ROUTES.deviceToken),
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      signal: input.signal,
+      body: JSON.stringify({
+        client_id: input.clientId,
+        device_code: input.deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
     },
-    signal: input.signal,
-    body: JSON.stringify({
-      client_id: input.clientId,
-      device_code: input.deviceCode,
-      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-    }),
-  })
+  )
 
   return readJsonResponse<GithubTokenResponse>(res)
 }

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/github-core/client"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { missingScopes } from "@/auth/scopes"
-import { GITHUB_OAUTH_WORKER_BASE } from "@/auth/constants"
+import { GITHUB_PROXY_BASE } from "@/github-core/workerProxy"
 import { observeResponse } from "@/lib/diagnostics/observed"
 import { logger } from "@/lib/logger"
 
@@ -74,7 +74,7 @@ export function GitHubProvider({
     log.debug("creating GitHub client for new token")
     return createGitHubClient({
       token,
-      archiveBaseUrl: GITHUB_OAUTH_WORKER_BASE,
+      archiveBaseUrl: GITHUB_PROXY_BASE,
       onResponse,
     })
   }, [token, onResponse])

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_GITHUB_CLIENT } from "@/lib/logScopes"
 import { countApiCall, publishRateLimit } from "@/lib/diagnostics/rateLimit"
+import { archivePath, assertSafeProxyBase, proxyUrl } from "./workerProxy"
 
 const log = logger.scope(LOG_SCOPE_GITHUB_CLIENT)
 
@@ -24,8 +25,8 @@ export type GitHubClient = {
 
   requestRaw: (path: string, options?: GitHubRequestOptions) => Promise<string>
 
-  // Fetch a repo zip via the archive-proxy Worker: the GitHub archive endpoint
-  // 302s to codeload (no CORS header), so the Worker follows the redirect
+  // Fetch a repo zip via the archive-proxy route: the GitHub archive endpoint
+  // 302s to codeload (no CORS header), so the proxy follows the redirect
   // server-side with this token and streams bytes back with CORS. Throws if no
   // proxy is configured.
   fetchArchive: (
@@ -63,7 +64,7 @@ export type GitHubResponseSignal = {
 export function createGitHubClient(args: {
   token: string
   apiBaseUrl?: string
-  // Base URL of the archive-proxy Worker (see fetchArchive). When omitted,
+  // Base URL of the archive proxy (see fetchArchive). When omitted,
   // fetchArchive throws — archive download is unavailable without the proxy.
   archiveBaseUrl?: string
   onResponse?: (signal: GitHubResponseSignal) => void
@@ -224,31 +225,15 @@ export function createGitHubClient(args: {
       if (!args.archiveBaseUrl) {
         throw new Error("archive proxy is not configured")
       }
+      assertSafeProxyBase(args.archiveBaseUrl)
 
-      // Fail closed rather than send the bearer to a non-https origin: a
-      // misconfigured base (http / wrong host) could exfiltrate the token.
-      const base = new URL(args.archiveBaseUrl)
-      const isLocalhost =
-        base.hostname === "localhost" ||
-        base.hostname === "127.0.0.1" ||
-        base.hostname === "[::1]"
-      if (base.protocol !== "https:" && !isLocalhost) {
-        throw new Error("archive proxy must be an https origin")
-      }
-
-      // Count against the diagnostics overlay like any other GitHub call, even
-      // though this one hops through the proxy.
+      // Count like any other GitHub call, even though this one hops the proxy.
       countApiCall()
 
-      // Encode each segment (defense-in-depth for a future ref caller); encode
-      // ref per-segment since a ref legitimately contains `/`.
-      const encodedRef = options?.ref
-        ? options.ref.split("/").map(encodeURIComponent).join("/")
-        : ""
-      const path =
-        `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/zipball` +
-        (encodedRef ? `/${encodedRef}` : "")
-      const url = `${args.archiveBaseUrl.replace(/\/$/, "")}${path}`
+      const url = proxyUrl(
+        args.archiveBaseUrl,
+        archivePath(owner, repo, options?.ref),
+      )
 
       // Archives are larger than API responses; default to a generous timeout.
       const signal = composeAbortSignal(

--- a/web/src/github-core/workerProxy.test.ts
+++ b/web/src/github-core/workerProxy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { archivePath, assertSafeProxyBase, proxyUrl } from "./workerProxy"
+
+describe("archivePath", () => {
+  it("builds the zipball path without a ref", () => {
+    expect(archivePath("o", "r")).toBe("/repos/o/r/zipball")
+  })
+
+  it("appends the ref when provided", () => {
+    expect(archivePath("o", "r", "main")).toBe("/repos/o/r/zipball/main")
+  })
+
+  it("encodes each ref segment but preserves the slash", () => {
+    expect(archivePath("o", "r", "feature/a b")).toBe(
+      "/repos/o/r/zipball/feature/a%20b",
+    )
+  })
+
+  it("percent-encodes owner and repo", () => {
+    expect(archivePath("a b", "c/d")).toBe("/repos/a%20b/c%2Fd/zipball")
+  })
+})
+
+describe("proxyUrl", () => {
+  it("joins base and path", () => {
+    expect(proxyUrl("https://host", "/web/token")).toBe(
+      "https://host/web/token",
+    )
+  })
+
+  it("strips a trailing slash on the base", () => {
+    expect(proxyUrl("https://host/", "/web/token")).toBe(
+      "https://host/web/token",
+    )
+  })
+})
+
+describe("assertSafeProxyBase", () => {
+  it("throws for a non-https, non-localhost origin", () => {
+    expect(() => assertSafeProxyBase("http://evil.example")).toThrow(/https/i)
+  })
+
+  it("allows an https origin", () => {
+    expect(() => assertSafeProxyBase("https://host.example")).not.toThrow()
+  })
+
+  it.each([
+    "http://localhost:8787",
+    "http://127.0.0.1:8787",
+    "http://[::1]:8787",
+  ])("allows the http localhost origin %s", (base) => {
+    expect(() => assertSafeProxyBase(base)).not.toThrow()
+  })
+})

--- a/web/src/github-core/workerProxy.ts
+++ b/web/src/github-core/workerProxy.ts
@@ -1,0 +1,43 @@
+// One boundary for every browser-blocked GitHub call the proxy fronts (OAuth
+// token exchange, repo-archive download). Keeping the base URL, route paths,
+// and token-safety guard here means a new proxy-backed use case adds one entry,
+// and the backend can move off Cloudflare Workers without touching call sites.
+
+// Public value, injected at build time; defaults to the Fifty Foundation worker.
+export const GITHUB_PROXY_BASE: string =
+  import.meta.env.VITE_GITHUB_PROXY_BASE ??
+  "https://classroom50.fifty-foundation.workers.dev"
+
+// Kept in lockstep with the deployed worker's ROUTES map (see cloudflare_worker.js).
+export const PROXY_ROUTES = {
+  webToken: "/web/token",
+  deviceCode: "/device/code",
+  deviceToken: "/device/token",
+} as const
+
+// Tolerates a trailing slash on the base so an override can't double-slash.
+export function proxyUrl(base: string, path: string): string {
+  return `${base.replace(/\/$/, "")}${path}`
+}
+
+export function archivePath(owner: string, repo: string, ref?: string): string {
+  // Encode per-segment: a ref legitimately contains `/`.
+  const encodedRef = ref ? ref.split("/").map(encodeURIComponent).join("/") : ""
+  return (
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/zipball` +
+    (encodedRef ? `/${encodedRef}` : "")
+  )
+}
+
+// Fail closed rather than send the bearer to a non-https origin, which could
+// exfiltrate the token. Localhost is exempt for dev against a local worker.
+export function assertSafeProxyBase(base: string): void {
+  const url = new URL(base)
+  const isLocalhost =
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "[::1]"
+  if (url.protocol !== "https:" && !isLocalhost) {
+    throw new Error("proxy base must be an https origin")
+  }
+}


### PR DESCRIPTION
## Summary

Decouples the app from Cloudflare-specific details by routing both worker-backed code paths through one boundary and giving the config a generic, non-OAuth name.

- **New boundary `web/src/github-core/workerProxy.ts`** owns everything proxy-specific: the base URL, the POST route paths (`PROXY_ROUTES`), the trailing-slash-safe `proxyUrl`, the `archivePath` builder, and the https/localhost token-safety guard (`assertSafeProxyBase`, previously inlined only in `fetchArchive`). A future worker-backed use case now adds one route/helper here instead of re-deriving all of it.

- **Rename (clean, no fallback):** `GITHUB_OAUTH_WORKER_BASE` -> `GITHUB_PROXY_BASE`, env var `VITE_GITHUB_OAUTH_WORKER_BASE` -> `VITE_GITHUB_PROXY_BASE`. The base moved from `auth/constants.ts` into `github-core/` since it's now shared config, not auth config (also avoids any `auth <-> github-core` cycle).

- **Call sites route through the boundary:** `auth/github-oauth-api.ts` (the 3 OAuth calls), `github-core/client.ts` `fetchArchive`, and `context/github/GitHubProvider.tsx`.

- **Deploy pipeline:** wired `VITE_GITHUB_PROXY_BASE` into all three build steps (`web-deploy`, `release-please`, `web-deploy-preview`) — it wasn't passed before. Falls back to the baked-in default when the repo variable is unset.

- **Default host** updated to `classroom50.fifty-foundation.workers.dev`.

No behavior change — same routes, same request shapes.

## Test plan

- [x] `npm run check` green: `tsc -b`, eslint (0 errors), prettier, `arch:validate` (no dependency violations — confirms the `github-core -> workerProxy` boundary is clean), and 2833/2833 vitest tests pass.
- [x] Added `web/src/github-core/workerProxy.test.ts` covering `archivePath`, `proxyUrl`, and `assertSafeProxyBase`.
- [ ] Deploy-side: ensure the `VITE_GITHUB_PROXY_BASE` repo variable is the full `https://` origin (the guard rejects non-https), and that the worker is reachable at the new host.