### PR TITLE
fix(cli): correct help text listing --template as required and other stale flag references

### DIFF
--- a/cli/gh-student/internal/invitecmd/group_membership.go
+++ b/cli/gh-student/internal/invitecmd/group_membership.go
@@ -106,7 +106,7 @@ func checkGroupSizeBeforeInvite(ctx context.Context, client githubapi.Client, or
 		}
 	}
 	if len(members) >= maxGroupSize {
-		return fmt.Errorf("group is full: %s/%s already has %d member(s), at the max of %d for this assignment — ask your teacher to raise --max-group-size if you need more",
+		return fmt.Errorf("group is full: %s/%s already has %d member(s), at the max of %d for this assignment — ask your teacher to raise the assignment's max group size if you need more",
 			org, repo, len(members), maxGroupSize)
 	}
 	return nil

--- a/cli/gh-student/internal/invitecmd/invite.go
+++ b/cli/gh-student/internal/invitecmd/invite.go
@@ -33,12 +33,13 @@ func NewCmd() *cobra.Command {
 			"the permission).\n\n" +
 			"When run from inside a group-assignment repo (one with a\n" +
 			".classroom50.yaml for a `mode: group` assignment), invite checks the\n" +
-			"assignment's --max-group-size (read from the teacher's published\n" +
-			"assignments.json) and refuses to add a new teammate once the group is\n" +
-			"full. This is an advisory guardrail for the honest case — it can be\n" +
-			"bypassed (e.g., via the GitHub UI), and the authoritative size/credit\n" +
-			"boundary is collection time. Run outside such a repo (or for an\n" +
-			"individual assignment / a TA invite), it just adds the collaborator.",
+			"assignment's configured maximum group size (read from the teacher's\n" +
+			"published assignments.json) and refuses to add a new teammate once the\n" +
+			"group is full. This is an advisory guardrail for the honest case — it\n" +
+			"can be bypassed (e.g., via the GitHub UI), and the authoritative\n" +
+			"size/credit boundary is collection time. Run outside such a repo (or\n" +
+			"for an individual assignment / a TA invite), it just adds the\n" +
+			"collaborator.",
 		Example: "  gh student invite cs50/cs50-fall-2026-hello-alice cs50-duck\n",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -777,7 +777,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		}
 	}
 	if resolved != nil && templatePrivate && inOrg && committedLocked {
-		_, _ = fmt.Fprintf(errOut, "Note: %q is locked, so the classroom student team was NOT granted read on the private template %s/%s — unlock it with `gh teacher assignment unlock %s %s %s` when you want students to accept again.\n",
+		_, _ = fmt.Fprintf(errOut, "Note: %q is locked, so the classroom student team was NOT granted read on the private template %s/%s — unlock it with `gh teacher assignment lock %s %s %s --unlock` when you want students to accept again.\n",
 			slug, resolved.Owner, resolved.Repo, org, classroom, slug)
 	}
 	if droppedTests > 0 {

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -88,10 +88,11 @@ func assignmentAddCmd() *cobra.Command {
 			"runs against — in <org>/classroom50/<classroom>/assignments.json.\n\n" +
 			"`<slug>` must match ^[a-z0-9][a-z0-9-]{1,38}$ (the same shape as\n" +
 			"classroom short-names) because student repos are named\n" +
-			"`<classroom>-<slug>-<username>`. Required flags: --name and\n" +
-			"--template. If the assignment slug already exists in\n" +
-			"assignments.json, this command replaces the entry in place\n" +
-			"(idempotent for repeated edits to the same assignment).\n\n" +
+			"`<classroom>-<slug>-<username>`. Only --name is required;\n" +
+			"--template is optional (omit it for a template-less assignment).\n" +
+			"If the assignment slug already exists in assignments.json, this\n" +
+			"command replaces the entry in place (idempotent for repeated\n" +
+			"edits to the same assignment).\n\n" +
 			"--empty-repo creates truly bare student repos: no README, no\n" +
 			".classroom50.yaml marker, no autograde workflow — for assignments\n" +
 			"where students build everything (including their own GitHub\n" +

--- a/cli/gh-teacher/internal/assignmentcmd/lock.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock.go
@@ -158,7 +158,7 @@ func runAssignmentLock(client githubapi.Client, out, errOut io.Writer, org, clas
 	// Unlock: re-grant the student team (and, per that path, the staff teams)
 	// read on the private template so students can accept again.
 	return grantClassroomTeamTemplateRead(client, out, errOut, org, classroom, branch, slug, template.Owner, template.Repo,
-		grantContext{verb: "unlocked", classroomNoun: "classroom", rerunHint: ", then re-run `gh teacher assignment unlock`"})
+		grantContext{verb: "unlocked", classroomNoun: "classroom", rerunHint: ", then re-run `gh teacher assignment lock ... --unlock`"})
 }
 
 // revokeClassroomTeamTemplateRead removes ONLY the classroom student team's

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -274,7 +274,7 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		// skip the grant and point the teacher at unlock instead of the usual
 		// "students can now accept" hint.
 		_, _ = fmt.Fprintf(errOut, "Note: %q is locked, so the target classroom student team was NOT granted read on its private template.\n", finalSlug)
-		_, _ = fmt.Fprintf(errOut, "Unlock it first: gh teacher assignment unlock %s %s %s\n", p.Org, p.To, finalSlug)
+		_, _ = fmt.Fprintf(errOut, "Unlock it first: gh teacher assignment lock %s %s %s --unlock\n", p.Org, p.To, finalSlug)
 	} else {
 		if err := grantReusedTemplateAccess(client, grantOut, errOut, p.Org, p.To, branch, finalSlug, copied.Template); err != nil {
 			return err


### PR DESCRIPTION
## Summary

Fixes [#450](https://github.com/foundation50/classroom50/issues/450) and a small class of related stale-prose bugs surfaced by auditing every cobra command in both CLIs.

- `assignment add` long help listed `--template` among the required flags, but only `--name` is required — `--template` is optional (template-less assignments are supported). Corrected the prose to match the flag registration and validation.
- Three teacher runtime notes told users to run `gh teacher assignment unlock <org> <classroom> <slug>`, a subcommand that does not exist (running it errors with `unknown command`). Unlock is `assignment lock <org> <classroom> <slug> --unlock`. Fixed the notes in `assignment add`, `assignment reuse`, and the shared unlock `rerunHint`.
- The student `invite` long help and its group-full error wrote `--max-group-size` in flag syntax, though `gh student invite` has no such flag — it is a teacher-set assignment field (`gh teacher assignment add --max-group-size`). Reworded to "the assignment's (configured) max group size" so students aren't pointed at a nonexistent local flag.

All changes are help/guidance strings only; no runtime behavior changes.

## Test plan

- [x] `go build ./... && go test ./...` passes in both `cli/gh-teacher` and `cli/gh-student`
- [x] Confirmed no test asserted any of the old strings
- [ ] `gh teacher assignment add --help` no longer lists `--template` as required
- [ ] The locked-template notes suggest `assignment lock ... --unlock`