### PR TITLE
feat(cli): skip autograde grade job when no autograder is configured

### DIFF
--- a/cli/gh-teacher/autograders_tests/test_inline_validator.py
+++ b/cli/gh-teacher/autograders_tests/test_inline_validator.py
@@ -58,6 +58,8 @@ def _run_validator(
     manifest: dict | None,
     submission_tag: str = "submit/2026-06-01T14-32-05Z-a1b2c3d",
     extra_env: dict | None = None,
+    pages_files: dict[str, bytes] | None = None,
+    probe_error: str | None = None,
 ) -> tuple[int, str, str, dict]:
     """Run the inline validator with hand-crafted env + fixtures.
 
@@ -65,6 +67,13 @@ def _run_validator(
     pointing at the local manifest fixture instead of GitHub Pages.
     Manifest=None → no file written, simulating a 404 (validator should fail
     gracefully).
+
+    pages_files: extra classroom-relative files to publish (e.g.
+    {"autograder.py": b"..."}) so the no-autograder probe finds them.
+
+    probe_error: raise for the no-autograder probe URLs (autograder.py /
+    *.tar.gz) to exercise fail-open. "urlerror" → URLError; "http503" → a
+    non-404 HTTPError. The manifest fetch is unaffected.
 
     Returns (exit_code, stdout, stderr, parsed-GITHUB_OUTPUT-as-dict).
     """
@@ -78,6 +87,10 @@ def _run_validator(
     classroom_dir.mkdir()
     if manifest is not None:
         (classroom_dir / "assignments.json").write_text(json.dumps(manifest))
+    for rel, content in (pages_files or {}).items():
+        target = classroom_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
 
     script_path = tmp_path / "validator.py"
     script_path.write_text(inline_script)
@@ -90,6 +103,7 @@ def _run_validator(
     # rather than intercept that, a tiny wrapper monkey-patches urlopen before
     # exec'ing the validator to serve the URL from the pages_root fixture.
 
+    probe_error_repr = repr(probe_error)
     wrapper = textwrap.dedent(f"""
     import urllib.request
     import urllib.error
@@ -97,6 +111,7 @@ def _run_validator(
     from pathlib import Path
 
     _PAGES_ROOT = Path({str(pages_root)!r})
+    _PROBE_ERROR = {probe_error_repr}
 
     _real_urlopen = urllib.request.urlopen
 
@@ -104,6 +119,12 @@ def _run_validator(
         url = req.full_url if hasattr(req, "full_url") else str(req)
         if url.startswith("https://test-org.github.io/classroom50/"):
             rel = url.removeprefix("https://test-org.github.io/classroom50/")
+            is_probe = rel.endswith("/autograder.py") or rel.endswith(".tar.gz")
+            if _PROBE_ERROR and is_probe:
+                if _PROBE_ERROR == "urlerror":
+                    raise urllib.error.URLError("simulated network failure")
+                if _PROBE_ERROR == "http503":
+                    raise urllib.error.HTTPError(url, 503, "Server Error", {{}}, None)
             target = _PAGES_ROOT / rel
             if not target.is_file():
                 raise urllib.error.HTTPError(url, 404, "Not Found", {{}}, None)
@@ -727,3 +748,106 @@ class TestReleaseAssetsValidation:
         )
         assert rc != 0
         assert "must not contain Unicode surrogates" in stderr
+
+
+# ---------------------------------------------------------------------------
+# No-autograder detection — emits no-autograder so grade/set-latest skip
+# when no autograder is configured.
+# ---------------------------------------------------------------------------
+
+
+class TestNoAutograderDetection:
+    def test_no_tests_no_autograders_skips(self, inline_script, tmp_path):
+        # No tests and neither Pages source published: both probes 404.
+        rc, _stdout, _stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(),
+        )
+        assert rc == 0
+        assert outputs["no-autograder"] == "true"
+
+    def test_declarative_tests_present_grades(self, inline_script, tmp_path):
+        # A non-empty tests array means there's something to grade.
+        rc, _stdout, _stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(tests=[
+                {"name": "t1", "type": "run", "run": "true", "points": 1},
+            ]),
+        )
+        assert rc == 0
+        assert outputs["no-autograder"] == "false"
+
+    def test_per_assignment_bundle_present_grades(self, inline_script, tmp_path):
+        # A published autograders/<slug>.tar.gz is a per-assignment override.
+        rc, _stdout, _stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(),
+            pages_files={"autograders/hello.tar.gz": b"\x1f\x8b bundle"},
+        )
+        assert rc == 0
+        assert outputs["no-autograder"] == "false"
+
+    def test_classroom_default_present_grades(self, inline_script, tmp_path):
+        # No bundle but a classroom-default autograder.py exists.
+        rc, _stdout, _stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(),
+            pages_files={"autograder.py": b"print('hi')\n"},
+        )
+        assert rc == 0
+        assert outputs["no-autograder"] == "false"
+
+    def test_probe_network_error_fails_open(self, inline_script, tmp_path):
+        # A URLError can't prove absence → grade (fail open).
+        rc, stdout, _stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(),
+            probe_error="urlerror",
+        )
+        assert rc == 0
+        assert outputs["no-autograder"] == "false"
+        assert "grading proceeds" in stdout
+
+    def test_probe_5xx_fails_open(self, inline_script, tmp_path):
+        # A non-404 status can't prove absence → grade (fail open).
+        rc, stdout, _stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(),
+            probe_error="http503",
+        )
+        assert rc == 0
+        assert outputs["no-autograder"] == "false"
+        assert "grading proceeds" in stdout
+
+    def test_secret_classroom_still_detects(self, inline_script, tmp_path):
+        # A secret shifts the Pages segment to <classroom>/<secret>; the probe
+        # (and manifest) URLs must follow it. Nothing published there → 404s.
+        secret = "abcd1234"
+        manifest = _manifest()
+        rc, _stdout, _stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=f"classroom: cs-test\nassignment: hello\nsecret: {secret}\n",
+            manifest=None,
+            pages_files={f"{secret}/assignments.json": json.dumps(manifest).encode()},
+        )
+        assert rc == 0
+        assert outputs["no-autograder"] == "true"
+
+    def test_empty_repo_hard_stops_before_detection(self, inline_script, tmp_path):
+        # empty_repo fails the read step before detection runs.
+        manifest = _manifest()
+        manifest["assignments"][0]["empty_repo"] = True
+        rc, _stdout, stderr, outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=manifest,
+        )
+        assert rc != 0
+        assert "empty-repository assignment" in stderr
+        assert "no-autograder" not in outputs

--- a/cli/gh-teacher/init_skeleton_test.go
+++ b/cli/gh-teacher/init_skeleton_test.go
@@ -217,6 +217,10 @@ func TestSkeletonFiles_AutogradeRunner(t *testing.T) {
 		// a dropped output would make every gate below read empty and
 		// re-grade the acceptance commit.
 		"is-acceptance",
+		// no-autograder gates the skip-when-nothing-configured path; a
+		// dropped output would read empty and grade every submission,
+		// re-spending Actions minutes on assignments with no autograder.
+		"no-autograder",
 	} {
 		if _, ok := outputsMap[out]; !ok {
 			t.Errorf("setup.outputs missing %q", out)
@@ -233,9 +237,13 @@ func TestSkeletonFiles_AutogradeRunner(t *testing.T) {
 	// exactly what this guard exists to prevent.
 	//
 	// grade is gated at the job level (set-latest needs grade, so it skips
-	// transitively).
-	if got, _ := nested(doc, "jobs", "grade", "if"); got != "needs.setup.outputs.is-acceptance != 'true'" {
-		t.Errorf("grade.if = %v, want \"needs.setup.outputs.is-acceptance != 'true'\" (acceptance-commit skip)", got)
+	// transitively). The gate also carries the no-autograder skip: an
+	// assignment with no declarative tests, no per-assignment bundle, and no
+	// classroom-default autograder.py has nothing to grade, so setup emits
+	// no-autograder=true and the grade job skips (fail-open — any probe error
+	// emits false and grades).
+	if got, _ := nested(doc, "jobs", "grade", "if"); got != "needs.setup.outputs.is-acceptance != 'true' && needs.setup.outputs.no-autograder != 'true'" {
+		t.Errorf("grade.if = %v, want the acceptance-commit + no-autograder skip gate", got)
 	}
 	// The setup checkout must use full history: _baseline_scan walks back
 	// to the commit that added .classroom50.yaml, and a shallow clone

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -57,6 +57,10 @@ jobs:
       mode:           ${{ steps.read.outputs.mode }}
       allowed-files:  ${{ steps.read.outputs.allowed-files }}
       release-assets: ${{ steps.read.outputs.release-assets }}
+      # 'true' -> no autograder configured (no declarative tests, no
+      # per-assignment bundle, no classroom-default autograder.py), so grade +
+      # set-latest skip. Fails OPEN: any probe error emits 'false' and grades.
+      no-autograder:  ${{ steps.read.outputs.no-autograder }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -564,6 +568,43 @@ jobs:
               if not submission_tag.startswith("submit/"):
                   fail(f"submission tag {submission_tag!r} does not match submit/*")
 
+          # === No-autograder detection ===
+          # Skip grade + set-latest when nothing is configured to grade,
+          # inverting resolve_entrypoint's fall-through: no declarative tests
+          # AND no per-assignment bundle AND no classroom-default autograder.py.
+          # runner.py's no_autograder() stays the fail-open backstop. FAIL OPEN
+          # here too — a probe that can't prove absence must grade — so any
+          # non-404 / network error falls open to grading.
+          # The bundle + classroom-default URL shapes mirror runner.py's
+          # bundle_url / classroom_default_autograder_url (pinned by
+          # contract_test.go); segment left un-quoted to match classroom_segment
+          # (both parts are regex-validated upstream).
+          # Non-retrying: the outcome is only ever acted on for a confirmed 404,
+          # so a transient 5xx falls open to grading anyway — no point spending
+          # get()'s retry ladder on a result we'd discard.
+          def probe_absent(url):
+              try:
+                  req = urllib.request.Request(url, headers={"User-Agent": "classroom50-autograde-runner"})
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      resp.read(1)
+                  return False
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      return True
+                  print(f"::warning::autograder probe GET {url}: HTTP {exc.code}; grading proceeds")
+                  return False
+              except urllib.error.URLError as exc:
+                  print(f"::warning::autograder probe GET {url}: {exc.reason}; grading proceeds")
+                  return False
+
+          has_tests = isinstance(tests, list) and len(tests) > 0
+          no_autograder = False
+          if not has_tests:
+              seg = classroom_segment(classroom, secret)
+              bundle = f"{base_url}/{seg}/autograders/{assignment}.tar.gz"
+              default_py = f"{base_url}/{seg}/autograder.py"
+              no_autograder = probe_absent(bundle) and probe_absent(default_py)
+
           emit("submission-tag", submission_tag)
           emit("runs-on", runs_on_json)
           emit("container", container_json)
@@ -581,11 +622,31 @@ jobs:
           emit("mode", mode)
           emit("allowed-files", allowed_files_json)
           emit("release-assets", release_assets_json)
+          emit("no-autograder", "true" if no_autograder else "false")
+
+      # === Autograde-skipped commit status ===
+      # Parallel to the acceptance-skip status: post an explicit
+      # classroom50/autograde success so a status-polling client can tell
+      # "skipped — no autograder configured" from "hasn't run yet".
+      # Best-effort; never fails the job.
+      - name: Autograde-skipped commit status
+        if: steps.read.outputs.no-autograder == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="success" \
+            -f context="classroom50/autograde" \
+            -f description="no autograder configured — autograding skipped" \
+            -f target_url="$RUN_URL" >/dev/null 2>&1 || true
 
   grade:
     needs: setup
-    # Skip for the acceptance commit (set-latest needs grade, so it skips too).
-    if: needs.setup.outputs.is-acceptance != 'true'
+    # Skip the acceptance commit and the no-autograder case (set-latest needs
+    # grade, so it skips too).
+    if: needs.setup.outputs.is-acceptance != 'true' && needs.setup.outputs.no-autograder != 'true'
     runs-on:   ${{ fromJSON(needs.setup.outputs.runs-on) }}
     container: ${{ fromJSON(needs.setup.outputs.container) }}
     timeout-minutes: 15
@@ -860,7 +921,9 @@ jobs:
   # reclaiming latest.
   set-latest:
     needs: [setup, grade]
-    if: needs.grade.result == 'success' && (needs.grade.outputs.status == 'success' || needs.grade.outputs.status == 'failure')
+    # Explicit no-autograder guard, defensive against a future change to
+    # grade's result semantics.
+    if: needs.setup.outputs.no-autograder != 'true' && needs.grade.result == 'success' && (needs.grade.outputs.status == 'success' || needs.grade.outputs.status == 'failure')
     runs-on: ubuntu-latest
     concurrency:
       group: classroom50-set-latest-${{ github.repository }}


### PR DESCRIPTION
Implements [#453](https://github.com/foundation50/classroom50/issues/453) proposal 2: skip the autograde `grade` (and `set-latest`) jobs when an assignment has nothing configured to grade, so courses that use Classroom 50 for repo/roster management but grade elsewhere stop spending Actions minutes on vacuous `0/0` runs.

## What changed

The "nothing to grade" decision now happens in the cheap `setup` job (which already fetches `assignments.json` from Pages) instead of only being discovered at runtime inside `runner.py`'s `grade` job. When an assignment has no declarative `tests`, no per-assignment autograder bundle on Pages, and no classroom-default `autograder.py`, `setup` emits `no-autograder=true`, and `grade` + `set-latest` skip on it — the same mechanism as the existing acceptance-commit skip.

- **Detection** lives in the `setup` job's `read` step: with no declarative `tests`, it probes the two Pages autograder sources (`autograders/<slug>.tar.gz` and the classroom-default `autograder.py`). All-404 → nothing to grade.
- **Fail-open by design:** the skip is only ever taken on a *confirmed 404*. Any network error or non-404 status falls open to grading, so a false negative can only cost an extra run, never drop a real submission. The probe is intentionally non-retrying — a transient 5xx already falls open, so spending the retry ladder on a discarded result buys nothing.
- **Status parity:** when the grade job is skipped, `setup` posts an explicit `classroom50/autograde` success ("no autograder configured — autograding skipped") so status-polling clients can tell it apart from "hasn't run yet", mirroring the acceptance-skip status.
- **`runner.py`'s `no_autograder()` vacuous-pass path is untouched** — it remains the fail-open backstop for hand-added workflows and re-runs.
- **`empty_repo` assignments are unaffected** — their existing hard-stop in `setup` takes precedence and is never rerouted through the new skip.

No schema field, teacher-facing setting, or migration — this is the zero-config default the issue describes. The per-assignment `autograde: false` toggle (proposal 1) is intentionally out of scope and tracked separately.

## Terminology

The status/verb follows GitHub Actions' own vocabulary for a conditionally-not-run job ("skipped") paired with the autograder domain's state term ("no autograder configured"), matching the phrasing already used in `runner.py` and `embed/autograder.py`.

## Testing

Added 8 cases to `autograders_tests/test_inline_validator.py` (`TestNoAutograderDetection`): no-tests + both sources 404 → skip; declarative tests present → grade; per-assignment bundle present → grade; classroom-default present → grade; network error and 5xx → fail-open grade; secret-classroom segment; and `empty_repo` hard-stop precedence. Full `autograders_tests` suite (358 tests) and `cli/shared` contract parity pass.