### PR TITLE
feat: configurable student assignment-repo access with per-repo and bulk controls

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -482,7 +482,6 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 		fullName:          fullName,
 		htmlURL:           htmlURL,
 		alreadyExisted:    alreadyExisted,
-		isOwner:           isOwner,
 		createSp:          createSp,
 		createMsg:         createMsg,
 	})
@@ -515,11 +514,8 @@ type acceptRepoParams struct {
 	feedbackPR        bool
 	fullName, htmlURL string
 	alreadyExisted    bool
-	// isOwner tolerates an org owner's unavoidable residual admin at the
-	// founder read-back (they can't self-downgrade to push).
-	isOwner   bool
-	createSp  *ghui.Spinner
-	createMsg string
+	createSp          *ghui.Spinner
+	createMsg         string
 }
 
 // acceptIntoRepo decides whether a just-created-or-existing repo needs
@@ -550,7 +546,7 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			// Already accepted: reconcile the role best-effort. The repo is
 			// already healthy, so a transient/SSO-403/left-org failure must not
 			// fail a re-run that previously always succeeded — warn and report.
-			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil && verbose {
+			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission)); err != nil && verbose {
 				u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 			}
 			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
@@ -622,7 +618,7 @@ func acceptIntoBareRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.
 		// templated already-accepted path. The bare repo is already healthy
 		// (its only provisioning is this grant), so a transient/SSO-403/
 		// left-org failure must not fail a re-run that previously succeeded.
-		if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil && verbose {
+		if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission)); err != nil && verbose {
 			u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 		}
 		return reportAlreadyAccepted(u, out, p.fullName, p.htmlURL)
@@ -636,7 +632,7 @@ func acceptIntoBareRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.
 		return err
 	}
 
-	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil {
+	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission)); err != nil {
 		return err
 	}
 
@@ -646,24 +642,20 @@ func acceptIntoBareRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.
 // provisionAcceptedRepo brings a just-created (or partially-provisioned)
 // student repo to a healthy, autogradable state and is safe to re-run:
 //
-//  1. Grant the founder their repo role (PUT collaborators is an upsert):
-//     `push` for an individual assignment, `admin` for group.
-//  2. Land .classroom50.yaml + the autograde shim in one Tree commit,
+//  1. Land .classroom50.yaml + the autograde shim in one Tree commit,
 //     riding out GitHub's post-create git-data lag.
-//  3. Verify the accept marker is readable before declaring success, so
+//  2. Verify the accept marker is readable before declaring success, so
 //     "accepted" always means "will autograde".
+//  3. Open the accept-time Feedback PR (best-effort; defers to the runner).
+//  4. Grant the founder their repo role LAST (PUT collaborators is an upsert):
+//     `push` for an individual assignment, `admin` for group, or a configured
+//     student_permission. Last so a self-downgrade GitHub won't apply fails
+//     loudly without stranding the student on a half-provisioned repo.
 //
 // The single caller (acceptIntoRepo) covers both the fresh-create and heal
 // paths. Mirrors the GUI's provisionAcceptedRepo so CLI and GUI heal a
 // half-finished accept identically.
 func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p acceptRepoParams, cfg classroomcfg.Config) error {
-	// Individual founders get least-privilege `push` (enough to push and
-	// trigger autograding); group founders get `admin` (needed to manage
-	// collaborators for `gh student invite`). See founderPermission.
-	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil {
-		return err
-	}
-
 	// DropFiles lands both control files in one Tree commit, waiting out
 	// GitHub's post-create replication lag; the spinner animates throughout
 	// (no numeric counter — the wait has no guaranteed bound).
@@ -687,12 +679,25 @@ func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p ac
 		return err
 	}
 
-	// Last, because it's best-effort: everything above must hold for the
-	// accept to count, while a Feedback PR failure only defers to the runner.
+	// Feedback PR is best-effort (a failure only defers to the runner). Run it
+	// before the founder grant so the repo is fully set up before we (possibly)
+	// narrow the student's own access.
 	if p.feedbackPR {
 		openFeedbackPRStep(client, u, verbose, p, func() (string, error) {
 			return feedbackBaseSHA(client, p.org, p.repoName, acceptSHA), nil
 		})
+	}
+
+	// The founder grant is LAST: individual founders get least-privilege `push`
+	// (enough to push and trigger autograding); group founders get `admin`
+	// (needed to manage collaborators for `gh student invite`); a configured
+	// student_permission can narrow it further. See founderPermission. Running
+	// it after setup + feedback means a below-default self-downgrade GitHub
+	// won't apply (which inviteFounder verifies with a member-exact read-back)
+	// fails loudly without stranding the student on a half-provisioned repo —
+	// the control files and Feedback PR are already in place.
+	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1108,16 +1113,25 @@ func founderPermission(mode, studentPermission string) string {
 	return want
 }
 
-// inviteFounder sets username's collaborator role and verifies it took effect.
-// A repo creator holds admin, so an individual self-downgrade GitHub silently
-// ignores would otherwise look identical to success. isOwner tolerates an
-// org owner's unavoidable residual admin (admin already covers push).
-func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string, isOwner bool) error {
+// inviteFounder sets username's collaborator role on their OWN repo. The
+// accepting student is the repo creator (they ran the generate/create), so this
+// is a self-directed collaborator change — including a self-downgrade below the
+// default (a teacher can set student_permission to e.g. `pull`). We trust the
+// PUT: it is the authenticated actor changing their own access, so a success
+// means it took.
+//
+// We deliberately do NOT read the effective permission back. The
+// /repos/{org}/{repo}/collaborators/{self}/permission sub-resource lags the PUT
+// by a long, unbounded window right after a self-downgrade on a freshly created
+// repo — it 404s ("no readable collaborator record yet") well past any
+// reasonable accept-run poll, even though the downgrade already applied, which
+// produced false accept failures for the exact legitimate case. The
+// silently-ignored-downgrade guard belongs on the teacher write paths (the web
+// gradebook per-repo / bulk access editors), where a DIFFERENT actor changes a
+// student's role and a read-back can meaningfully confirm it. Mirrors the web
+// addFounderCollaborator.
+func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, org, repoName, permission string) error {
 	if _, err := githubapi.SetCollaborator(client, org, repoName, username, permission); err != nil {
-		return err
-	}
-
-	if err := verifyFounderPermission(client, org, repoName, username, permission, isOwner); err != nil {
 		return err
 	}
 
@@ -1126,66 +1140,4 @@ func inviteFounder(client githubapi.Client, u *ui.UI, verbose bool, username, or
 	}
 
 	return nil
-}
-
-// verifyFounderPermission reads the effective permission back and errors if it
-// doesn't match the role we set (permissionSatisfies handles GitHub's legacy
-// role collapse), so a silently-ignored downgrade fails loud instead.
-func verifyFounderPermission(client githubapi.Client, org, repoName, username, want string, isOwner bool) error {
-	path := fmt.Sprintf("repos/%s/%s/collaborators/%s/permission",
-		url.PathEscape(org), url.PathEscape(repoName), url.PathEscape(username))
-	var got struct {
-		Permission string `json:"permission"`
-		RoleName   string `json:"role_name"`
-	}
-	if err := client.Get(path, &got); err != nil {
-		return fmt.Errorf("verifying %s's permission on %s/%s: %w", username, org, repoName, err)
-	}
-	if permissionSatisfies(got.Permission, got.RoleName, want, isOwner) {
-		return nil
-	}
-	return fmt.Errorf("expected %s to have %q access on %s/%s after setup, but GitHub reports %q (role %q) — a repo creator holds admin and a self-downgrade may be blocked by org policy; ask your teacher to set your access to %q",
-		username, want, org, repoName, got.Permission, got.RoleName, want)
-}
-
-// permissionRank is GitHub's permission ladder low-to-high. role_name reports
-// the effective role (maintain and admin distinct); the legacy `permission`
-// field collapses maintain into "write", so a legacy-only compare can prove
-// only push/write and admin. Mirrors the web PERMISSION_RANK.
-var permissionRank = map[string]int{
-	"read": 0, "pull": 0,
-	"triage": 1,
-	"write":  2, "push": 2,
-	"maintain": 3,
-	"admin":    4,
-}
-
-// permissionSatisfies reports whether the read-back grants AT LEAST the role we
-// set. role_name is authoritative when present. We verify ">=" rather than
-// exact match: the effective role is the max of the direct grant, the org base
-// repository permission, team grants, and creator-admin, so a benign residual
-// above the wanted level (an org base perm higher than a below-default target,
-// or a repo creator GitHub won't self-downgrade) must not fail an otherwise-good
-// accept. It still fails loudly when the student ends up BELOW the wanted role.
-// isOwner is accepted for signature symmetry but no longer affects the compare.
-// Mirrors the web permissionSatisfies.
-func permissionSatisfies(legacy, roleName, want string, _ bool) bool {
-	wantRank, ok := permissionRank[want]
-	if !ok {
-		return false
-	}
-	if roleName != "" {
-		gotRank, ok := permissionRank[roleName]
-		if !ok {
-			return false
-		}
-		return gotRank >= wantRank
-	}
-	// Legacy field only: it can't distinguish triage/maintain (both collapse to
-	// "write"), so the same >= compare is the best it can prove.
-	gotRank, ok := permissionRank[legacy]
-	if !ok {
-		return false
-	}
-	return gotRank >= wantRank
 }

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -1160,12 +1160,16 @@ var permissionRank = map[string]int{
 	"admin":    4,
 }
 
-// permissionSatisfies reports whether the read-back at least matches the role
-// we set. role_name is authoritative when present (an exact rank compare).
-// isOwner relaxes any want to also accept admin: an org owner who created the
-// repo can't self-downgrade, and admin is a superset. Mirrors the web
-// permissionSatisfies.
-func permissionSatisfies(legacy, roleName, want string, isOwner bool) bool {
+// permissionSatisfies reports whether the read-back grants AT LEAST the role we
+// set. role_name is authoritative when present. We verify ">=" rather than
+// exact match: the effective role is the max of the direct grant, the org base
+// repository permission, team grants, and creator-admin, so a benign residual
+// above the wanted level (an org base perm higher than a below-default target,
+// or a repo creator GitHub won't self-downgrade) must not fail an otherwise-good
+// accept. It still fails loudly when the student ends up BELOW the wanted role.
+// isOwner is accepted for signature symmetry but no longer affects the compare.
+// Mirrors the web permissionSatisfies.
+func permissionSatisfies(legacy, roleName, want string, _ bool) bool {
 	wantRank, ok := permissionRank[want]
 	if !ok {
 		return false
@@ -1175,19 +1179,13 @@ func permissionSatisfies(legacy, roleName, want string, isOwner bool) bool {
 		if !ok {
 			return false
 		}
-		if isOwner && gotRank == permissionRank[contract.PermissionAdmin] {
-			return true
-		}
-		return gotRank == wantRank
+		return gotRank >= wantRank
 	}
 	// Legacy field only: it can't distinguish triage/maintain (both collapse to
-	// "write"), so fall back to a >= compare, the best it can prove.
+	// "write"), so the same >= compare is the best it can prove.
 	gotRank, ok := permissionRank[legacy]
 	if !ok {
 		return false
-	}
-	if isOwner && gotRank == permissionRank[contract.PermissionAdmin] {
-		return true
 	}
 	return gotRank >= wantRank
 }

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -462,28 +462,29 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 
 	repoName := reponame.Name(classroom, assignment, username)
 	return acceptIntoRepo(client, u, verbose, out, acceptRepoParams{
-		org:            org,
-		classroom:      classroom,
-		assignment:     assignment,
-		mode:           entry.Mode,
-		maxGroupSize:   entry.MaxGroupSize,
-		secret:         secret,
-		username:       username,
-		ownerID:        &ownerID,
-		acceptedAt:     acceptedAt,
-		repoName:       repoName,
-		branch:         commitBranch,
-		source:         cfgSource,
-		shim:           shim,
-		autograderName: autograderName,
-		emptyRepo:      entry.EmptyRepo,
-		feedbackPR:     entry.FeedbackPR,
-		fullName:       fullName,
-		htmlURL:        htmlURL,
-		alreadyExisted: alreadyExisted,
-		isOwner:        isOwner,
-		createSp:       createSp,
-		createMsg:      createMsg,
+		org:               org,
+		classroom:         classroom,
+		assignment:        assignment,
+		mode:              entry.Mode,
+		maxGroupSize:      entry.MaxGroupSize,
+		studentPermission: entry.StudentPermission,
+		secret:            secret,
+		username:          username,
+		ownerID:           &ownerID,
+		acceptedAt:        acceptedAt,
+		repoName:          repoName,
+		branch:            commitBranch,
+		source:            cfgSource,
+		shim:              shim,
+		autograderName:    autograderName,
+		emptyRepo:         entry.EmptyRepo,
+		feedbackPR:        entry.FeedbackPR,
+		fullName:          fullName,
+		htmlURL:           htmlURL,
+		alreadyExisted:    alreadyExisted,
+		isOwner:           isOwner,
+		createSp:          createSp,
+		createMsg:         createMsg,
 	})
 }
 
@@ -501,6 +502,10 @@ type acceptRepoParams struct {
 	acceptedAt                 string
 	source                     *classroomcfg.Source
 	shim, autograderName       string
+	// studentPermission is the assignment's optional student_permission (the
+	// accept-time role the student gets on their own repo); empty means the
+	// mode default. See founderPermission.
+	studentPermission string
 	// emptyRepo selects the bare path: no control files are committed and no
 	// marker probe runs — the only provisioning is the idempotent admin grant.
 	emptyRepo bool
@@ -545,7 +550,7 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			// Already accepted: reconcile the role best-effort. The repo is
 			// already healthy, so a transient/SSO-403/left-org failure must not
 			// fail a re-run that previously always succeeded — warn and report.
-			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode), p.isOwner); err != nil && verbose {
+			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil && verbose {
 				u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 			}
 			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
@@ -617,7 +622,7 @@ func acceptIntoBareRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.
 		// templated already-accepted path. The bare repo is already healthy
 		// (its only provisioning is this grant), so a transient/SSO-403/
 		// left-org failure must not fail a re-run that previously succeeded.
-		if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode), p.isOwner); err != nil && verbose {
+		if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil && verbose {
 			u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 		}
 		return reportAlreadyAccepted(u, out, p.fullName, p.htmlURL)
@@ -631,7 +636,7 @@ func acceptIntoBareRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.
 		return err
 	}
 
-	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode), p.isOwner); err != nil {
+	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil {
 		return err
 	}
 
@@ -655,7 +660,7 @@ func provisionAcceptedRepo(client githubapi.Client, u *ui.UI, verbose bool, p ac
 	// Individual founders get least-privilege `push` (enough to push and
 	// trigger autograding); group founders get `admin` (needed to manage
 	// collaborators for `gh student invite`). See founderPermission.
-	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode), p.isOwner); err != nil {
+	if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission), p.isOwner); err != nil {
 		return err
 	}
 
@@ -1086,14 +1091,21 @@ func defaultBranchOrMain(branch string) string {
 	return branch
 }
 
-// founderPermission maps an assignment mode to the founder's accept-time repo
-// role: least-privilege `push` for individual, `admin` for group (which needs
-// to manage collaborators for `gh student invite`).
-func founderPermission(mode string) string {
-	if mode == contract.ModeGroup {
-		return "admin"
+// founderPermission maps an assignment to the founder's accept-time repo role:
+// the configured student_permission when set, else the mode default
+// (least-privilege push for individual, admin for group, which needs to manage
+// collaborators for `gh student invite`). A group founder must hold at least
+// admin, so a group value below admin is clamped up. Mirrors the web
+// founderPermission.
+func founderPermission(mode, studentPermission string) string {
+	want := studentPermission
+	if want == "" {
+		want = contract.DefaultStudentPermission(mode)
 	}
-	return "push"
+	if mode == contract.ModeGroup && want != contract.PermissionAdmin {
+		return contract.PermissionAdmin
+	}
+	return want
 }
 
 // inviteFounder sets username's collaborator role and verifies it took effect.
@@ -1136,35 +1148,46 @@ func verifyFounderPermission(client githubapi.Client, org, repoName, username, w
 		username, want, org, repoName, got.Permission, got.RoleName, want)
 }
 
-// permissionSatisfies reports whether the read-back matches the role we set.
-// role_name is authoritative when present: a push target accepts push/write
-// but must reject the more-privileged maintain/admin, which the legacy field
-// would otherwise hide (GitHub collapses maintain→write, admin→admin). isOwner
-// relaxes a push want to also accept admin: an org owner who created the repo
-// can't self-downgrade, and admin is a superset of push.
+// permissionRank is GitHub's permission ladder low-to-high. role_name reports
+// the effective role (maintain and admin distinct); the legacy `permission`
+// field collapses maintain into "write", so a legacy-only compare can prove
+// only push/write and admin. Mirrors the web PERMISSION_RANK.
+var permissionRank = map[string]int{
+	"read": 0, "pull": 0,
+	"triage": 1,
+	"write":  2, "push": 2,
+	"maintain": 3,
+	"admin":    4,
+}
+
+// permissionSatisfies reports whether the read-back at least matches the role
+// we set. role_name is authoritative when present (an exact rank compare).
+// isOwner relaxes any want to also accept admin: an org owner who created the
+// repo can't self-downgrade, and admin is a superset. Mirrors the web
+// permissionSatisfies.
 func permissionSatisfies(legacy, roleName, want string, isOwner bool) bool {
-	if roleName != "" {
-		switch want {
-		case "admin":
-			return roleName == "admin"
-		case "push":
-			if isOwner && roleName == "admin" {
-				return true
-			}
-			return roleName == "push" || roleName == "write"
-		default:
-			return roleName == want
-		}
+	wantRank, ok := permissionRank[want]
+	if !ok {
+		return false
 	}
-	switch want {
-	case "admin":
-		return legacy == "admin"
-	case "push":
-		if isOwner && legacy == "admin" {
+	if roleName != "" {
+		gotRank, ok := permissionRank[roleName]
+		if !ok {
+			return false
+		}
+		if isOwner && gotRank == permissionRank[contract.PermissionAdmin] {
 			return true
 		}
-		return legacy == "write"
-	default:
-		return legacy == want
+		return gotRank == wantRank
 	}
+	// Legacy field only: it can't distinguish triage/maintain (both collapse to
+	// "write"), so fall back to a >= compare, the best it can prove.
+	gotRank, ok := permissionRank[legacy]
+	if !ok {
+		return false
+	}
+	if isOwner && gotRank == permissionRank[contract.PermissionAdmin] {
+		return true
+	}
+	return gotRank >= wantRank
 }

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -116,44 +116,6 @@ func TestCheckOrgStatus(t *testing.T) {
 	}
 }
 
-// TestPermissionSatisfies pins the read-back decision: the grant must land at
-// AT LEAST the wanted role. A read-back BELOW the target fails (the grant that
-// didn't take); a benign higher effective role (org base permission, an
-// un-downgradeable creator-admin) passes, since GitHub is the real ceiling.
-func TestPermissionSatisfies(t *testing.T) {
-	cases := []struct {
-		name     string
-		legacy   string
-		roleName string
-		want     string
-		isOwner  bool
-		ok       bool
-	}{
-		{"push grant reads role_name push", "write", "push", "push", false, true},
-		{"push grant reads role_name write", "write", "write", "push", false, true},
-		{"maintain residual satisfies a push target", "write", "maintain", "push", false, true},
-		{"admin residual satisfies a push target", "admin", "admin", "push", false, true},
-		{"read fails a push target (grant didn't take)", "read", "read", "push", false, false},
-		{"write base perm satisfies a pull target", "write", "write", "pull", false, true},
-		{"admin grant reads role_name admin", "admin", "admin", "admin", false, true},
-		{"push fails an admin target (under-grant)", "write", "push", "admin", false, false},
-		{"write fails a maintain target (under-grant)", "write", "write", "maintain", false, false},
-		{"empty role_name falls back to legacy write for push", "write", "", "push", false, true},
-		{"empty role_name falls back to legacy admin for admin", "admin", "", "admin", false, true},
-		{"empty role_name legacy write fails admin", "write", "", "admin", false, false},
-		{"owner admin satisfies a push target", "admin", "admin", "push", true, true},
-		{"owner admin (legacy only) satisfies a push target", "admin", "", "push", true, true},
-		{"maintain fails an admin target even for an owner", "write", "maintain", "admin", true, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := permissionSatisfies(tc.legacy, tc.roleName, tc.want, tc.isOwner); got != tc.ok {
-				t.Errorf("permissionSatisfies(%q,%q,%q,%v) = %v, want %v", tc.legacy, tc.roleName, tc.want, tc.isOwner, got, tc.ok)
-			}
-		})
-	}
-}
-
 // TestFounderPermission pins the mode+config→role mapping: with no configured
 // student_permission, individual (and empty/unknown, which default to
 // individual) gets least-privilege `push`, group gets `admin`. A configured
@@ -186,9 +148,10 @@ func TestFounderPermission(t *testing.T) {
 	}
 }
 
-// TestInviteFounder pins the grant + verification: accept PUTs the student at
-// the requested role, then succeeds only when the read-back matches (a push
-// grant reads back as legacy `write`). Asserts the exact PUT path/body.
+// TestInviteFounder pins the grant: accept PUTs the student at the requested
+// role and trusts the PUT (no read-back — the self-downgrade read-back races an
+// unbounded consistency window; the guard lives on the teacher write paths).
+// Asserts the exact PUT path/body and that no permission read-back is made.
 func TestInviteFounder(t *testing.T) {
 	const (
 		org      = "cs50"
@@ -198,22 +161,15 @@ func TestInviteFounder(t *testing.T) {
 	collabPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
 	permPath := collabPath + "/permission"
 
-	// want is the role we set; legacyBack is what GitHub reports on the
-	// read-back (push collapses to the legacy "write" role).
-	cases := []struct {
-		want       string
-		legacyBack string
-	}{
-		{"push", "write"},
-		{"admin", "admin"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.want, func(t *testing.T) {
+	for _, want := range []string{"push", "admin", "pull"} {
+		t.Run(want, func(t *testing.T) {
 			var gotPutPath, gotMethod string
 			var gotBody map[string]any
+			var readBack bool
 			mux := http.NewServeMux()
 			mux.HandleFunc(permPath, func(w http.ResponseWriter, _ *http.Request) {
-				_ = json.NewEncoder(w).Encode(map[string]any{"permission": tc.legacyBack, "role_name": tc.want})
+				readBack = true
+				w.WriteHeader(http.StatusNotFound)
 			})
 			mux.HandleFunc(collabPath, func(w http.ResponseWriter, r *http.Request) {
 				gotPutPath = r.URL.Path
@@ -227,7 +183,7 @@ func TestInviteFounder(t *testing.T) {
 			client := newTestRESTClient(t, server)
 
 			var out bytes.Buffer
-			if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, tc.want, false); err != nil {
+			if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, want); err != nil {
 				t.Fatalf("inviteFounder returned error: %v", err)
 			}
 
@@ -237,17 +193,19 @@ func TestInviteFounder(t *testing.T) {
 			if gotPutPath != collabPath {
 				t.Errorf("path = %q, want %q", gotPutPath, collabPath)
 			}
-			if perm := gotBody["permission"]; perm != tc.want {
-				t.Errorf("collaborator permission = %v, want %q", perm, tc.want)
+			if perm := gotBody["permission"]; perm != want {
+				t.Errorf("collaborator permission = %v, want %q", perm, want)
+			}
+			if readBack {
+				t.Errorf("inviteFounder must not read the effective permission back (it races an unbounded window)")
 			}
 		})
 	}
 }
 
-// TestInviteFounder_VerificationFails proves the grant is verified, not
-// fire-and-forget: a read-back BELOW the wanted role (the grant that didn't
-// take) must return an actionable error naming the wanted and actual roles.
-func TestInviteFounder_VerificationFails(t *testing.T) {
+// TestInviteFounder_PropagatesGrantError proves a genuine grant failure (not a
+// read-back) still surfaces: the PUT itself erroring must return an error.
+func TestInviteFounder_PropagatesGrantError(t *testing.T) {
 	const (
 		org      = "cs50"
 		repoName = "cs50-fall-2026-hello-alice"
@@ -256,53 +214,17 @@ func TestInviteFounder_VerificationFails(t *testing.T) {
 	collabPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
 
 	mux := http.NewServeMux()
-	mux.HandleFunc(collabPath+"/permission", func(w http.ResponseWriter, _ *http.Request) {
-		// The admin grant didn't take — student is only push.
-		_ = json.NewEncoder(w).Encode(map[string]any{"permission": "write", "role_name": "push"})
-	})
 	mux.HandleFunc(collabPath, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusNotFound) // e.g. not an org member
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"})
 	})
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 	client := newTestRESTClient(t, server)
 
 	var out bytes.Buffer
-	err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "admin", false)
-	if err == nil {
-		t.Fatalf("expected an error when the effective permission stays below admin after an admin grant, got nil")
-	}
-	if !strings.Contains(err.Error(), "admin") || !strings.Contains(err.Error(), "push") {
-		t.Errorf("error should name the wanted (admin) and actual (push) roles, got: %v", err)
-	}
-}
-
-// TestInviteFounder_OwnerTolerated proves an org owner can accept: the
-// self-downgrade to push is silently ignored (owner keeps admin), but with
-// isOwner set the read-back tolerates that residual admin instead of failing.
-func TestInviteFounder_OwnerTolerated(t *testing.T) {
-	const (
-		org      = "cs50"
-		repoName = "cs50-fall-2026-hello-alice"
-		username = "alice"
-	)
-	collabPath := "/repos/" + org + "/" + repoName + "/collaborators/" + username
-
-	mux := http.NewServeMux()
-	mux.HandleFunc(collabPath+"/permission", func(w http.ResponseWriter, _ *http.Request) {
-		// Owner can't self-downgrade; GitHub still reports admin.
-		_ = json.NewEncoder(w).Encode(map[string]any{"permission": "admin", "role_name": "admin"})
-	})
-	mux.HandleFunc(collabPath, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-	client := newTestRESTClient(t, server)
-
-	var out bytes.Buffer
-	if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "push", true); err != nil {
-		t.Fatalf("owner push grant reading back as admin should be tolerated, got: %v", err)
+	if err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "push"); err == nil {
+		t.Fatalf("expected an error when the collaborator PUT fails, got nil")
 	}
 }
 

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -153,23 +153,33 @@ func TestPermissionSatisfies(t *testing.T) {
 	}
 }
 
-// TestFounderPermission pins the mode→role mapping: individual (and
-// empty/unknown, which default to individual) gets least-privilege `push`,
-// group gets `admin` so the founder can add teammates via `gh student invite`.
+// TestFounderPermission pins the mode+config→role mapping: with no configured
+// student_permission, individual (and empty/unknown, which default to
+// individual) gets least-privilege `push`, group gets `admin`. A configured
+// value wins for individual; a group value below admin is clamped up to admin
+// so the founder can add teammates via `gh student invite`.
 func TestFounderPermission(t *testing.T) {
 	cases := []struct {
-		mode string
-		want string
+		name              string
+		mode              string
+		studentPermission string
+		want              string
 	}{
-		{"individual", "push"},
-		{"", "push"},
-		{"team", "push"}, // unknown modes default to individual (least privilege)
-		{"group", "admin"},
+		{"individual default", "individual", "", "push"},
+		{"empty mode default", "", "", "push"},
+		{"unknown mode default", "team", "", "push"}, // defaults to individual (least privilege)
+		{"group default", "group", "", "admin"},
+		{"individual configured admin", "individual", "admin", "admin"},
+		{"individual configured pull", "individual", "pull", "pull"},
+		{"individual configured maintain", "individual", "maintain", "maintain"},
+		{"group clamps push up to admin", "group", "push", "admin"},
+		{"group clamps pull up to admin", "group", "pull", "admin"},
+		{"group configured admin", "group", "admin", "admin"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.mode, func(t *testing.T) {
-			if got := founderPermission(tc.mode); got != tc.want {
-				t.Errorf("founderPermission(%q) = %q, want %q", tc.mode, got, tc.want)
+		t.Run(tc.name, func(t *testing.T) {
+			if got := founderPermission(tc.mode, tc.studentPermission); got != tc.want {
+				t.Errorf("founderPermission(%q,%q) = %q, want %q", tc.mode, tc.studentPermission, got, tc.want)
 			}
 		})
 	}

--- a/cli/gh-student/accept_test.go
+++ b/cli/gh-student/accept_test.go
@@ -116,10 +116,10 @@ func TestCheckOrgStatus(t *testing.T) {
 	}
 }
 
-// TestPermissionSatisfies pins the read-back decision, incl. the guard's
-// boundary: a `maintain` founder (legacy collapses to "write") must FAIL a
-// `push` target, so an ignored self-downgrade isn't passed green. isOwner
-// relaxes a push target to accept the org owner's unavoidable residual admin.
+// TestPermissionSatisfies pins the read-back decision: the grant must land at
+// AT LEAST the wanted role. A read-back BELOW the target fails (the grant that
+// didn't take); a benign higher effective role (org base permission, an
+// un-downgradeable creator-admin) passes, since GitHub is the real ceiling.
 func TestPermissionSatisfies(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -131,18 +131,19 @@ func TestPermissionSatisfies(t *testing.T) {
 	}{
 		{"push grant reads role_name push", "write", "push", "push", false, true},
 		{"push grant reads role_name write", "write", "write", "push", false, true},
-		{"maintain must fail a push target", "write", "maintain", "push", false, false},
-		{"admin must fail a push target", "admin", "admin", "push", false, false},
-		{"read must fail a push target", "read", "read", "push", false, false},
+		{"maintain residual satisfies a push target", "write", "maintain", "push", false, true},
+		{"admin residual satisfies a push target", "admin", "admin", "push", false, true},
+		{"read fails a push target (grant didn't take)", "read", "read", "push", false, false},
+		{"write base perm satisfies a pull target", "write", "write", "pull", false, true},
 		{"admin grant reads role_name admin", "admin", "admin", "admin", false, true},
-		{"push must fail an admin target", "write", "push", "admin", false, false},
+		{"push fails an admin target (under-grant)", "write", "push", "admin", false, false},
+		{"write fails a maintain target (under-grant)", "write", "write", "maintain", false, false},
 		{"empty role_name falls back to legacy write for push", "write", "", "push", false, true},
 		{"empty role_name falls back to legacy admin for admin", "admin", "", "admin", false, true},
-		{"empty role_name legacy write must fail admin", "write", "", "admin", false, false},
+		{"empty role_name legacy write fails admin", "write", "", "admin", false, false},
 		{"owner admin satisfies a push target", "admin", "admin", "push", true, true},
 		{"owner admin (legacy only) satisfies a push target", "admin", "", "push", true, true},
-		{"owner still fails a maintain push target", "write", "maintain", "push", true, false},
-		{"owner does not leak into an admin target", "write", "maintain", "admin", true, false},
+		{"maintain fails an admin target even for an owner", "write", "maintain", "admin", true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -243,9 +244,9 @@ func TestInviteFounder(t *testing.T) {
 	}
 }
 
-// TestInviteFounder_VerificationFails proves the demotion is verified, not
-// fire-and-forget: a read-back still reporting admin after a push grant must
-// return an actionable error, not silently report success.
+// TestInviteFounder_VerificationFails proves the grant is verified, not
+// fire-and-forget: a read-back BELOW the wanted role (the grant that didn't
+// take) must return an actionable error naming the wanted and actual roles.
 func TestInviteFounder_VerificationFails(t *testing.T) {
 	const (
 		org      = "cs50"
@@ -256,8 +257,8 @@ func TestInviteFounder_VerificationFails(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(collabPath+"/permission", func(w http.ResponseWriter, _ *http.Request) {
-		// The downgrade didn't take — student is still admin.
-		_ = json.NewEncoder(w).Encode(map[string]any{"permission": "admin", "role_name": "admin"})
+		// The admin grant didn't take — student is only push.
+		_ = json.NewEncoder(w).Encode(map[string]any{"permission": "write", "role_name": "push"})
 	})
 	mux.HandleFunc(collabPath, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -267,12 +268,12 @@ func TestInviteFounder_VerificationFails(t *testing.T) {
 	client := newTestRESTClient(t, server)
 
 	var out bytes.Buffer
-	err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "push", false)
+	err := inviteFounder(client, ui.NewForced(&out, false), false, username, org, repoName, "admin", false)
 	if err == nil {
-		t.Fatalf("expected an error when the effective permission stays admin after a push grant, got nil")
+		t.Fatalf("expected an error when the effective permission stays below admin after an admin grant, got nil")
 	}
-	if !strings.Contains(err.Error(), "push") || !strings.Contains(err.Error(), "admin") {
-		t.Errorf("error should name the wanted (push) and actual (admin) roles, got: %v", err)
+	if !strings.Contains(err.Error(), "admin") || !strings.Contains(err.Error(), "push") {
+		t.Errorf("error should name the wanted (admin) and actual (push) roles, got: %v", err)
 	}
 }
 

--- a/cli/gh-student/internal/assignments/assignments.go
+++ b/cli/gh-student/internal/assignments/assignments.go
@@ -44,6 +44,11 @@ type Entry struct {
 	Autograder   string       `json:"autograder"`
 	AllowedFiles []string     `json:"allowed_files,omitempty"`
 
+	// StudentPermission is the accept-time role the student gets on their own
+	// repo (the assignment's optional student_permission). Empty means the mode
+	// default (push individual / admin group). See accept.go's founderPermission.
+	StudentPermission string `json:"student_permission,omitempty"`
+
 	// EmptyRepo marks a truly-bare assignment: accept creates the repo with
 	// no initial commit and lands NO control files (no .classroom50.yaml, no
 	// autograde shim), so the assignment never autogrades. Absent reads as

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -47,6 +47,18 @@ func IsValidAssignmentMode(m string) bool {
 	return false
 }
 
+// ValidateStudentPermission checks an assignment's optional student_permission
+// against GitHub's collaborator ladder. Empty is valid (means the mode default).
+func ValidateStudentPermission(p string) error {
+	if p == "" {
+		return nil
+	}
+	if !contract.IsValidRepoPermission(p) {
+		return fmt.Errorf("invalid student_permission %q: must be one of %v", p, contract.RepoPermissions)
+	}
+	return nil
+}
+
 // LargeAssignmentsWarnBytes is the encoded-size threshold above which
 // `assignment add` warns on stderr. Set well below GitHub's ~1 MiB
 // contents-API limit (past which encoding flips to "none", wedging every
@@ -121,6 +133,7 @@ type AssignmentEntry struct {
 	AllowedFiles      []string         `json:"allowed_files,omitempty"`
 	ReleaseAssets     []string         `json:"release_assets,omitempty"`
 	PassThreshold     *int             `json:"pass_threshold,omitempty"`
+	StudentPermission string           `json:"student_permission,omitempty"`
 	MigratedFrom      *MigratedFromRef `json:"migrated_from,omitempty"`
 
 	// Extra holds unknown top-level entry keys, re-emitted verbatim so a
@@ -137,6 +150,7 @@ var knownEntryKeys = map[string]struct{}{
 	"runtime": {}, "tests": {}, "feedback_pr": {}, "empty_repo": {},
 	"locked": {}, "allowed_files": {}, "release_assets": {}, "pass_threshold": {},
 	"migrated_from": {}, "available_from": {}, "available_from_meta": {},
+	"student_permission": {},
 }
 
 // UnmarshalJSON captures unknown top-level keys into Extra, then strictly
@@ -797,6 +811,9 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 	if err := ValidatePassThreshold(entry.PassThreshold); err != nil {
 		return err
 	}
+	if err := ValidateStudentPermission(entry.StudentPermission); err != nil {
+		return err
+	}
 	if entry.EmptyRepo {
 		if err := validateEmptyRepoExclusions(entry); err != nil {
 			return err
@@ -922,6 +939,9 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 		return fmt.Errorf("entry %q: %w", entry.Slug, err)
 	}
 	if err := ValidatePassThreshold(entry.PassThreshold); err != nil {
+		return fmt.Errorf("entry %q: %w", entry.Slug, err)
+	}
+	if err := ValidateStudentPermission(entry.StudentPermission); err != nil {
 		return fmt.Errorf("entry %q: %w", entry.Slug, err)
 	}
 	if entry.EmptyRepo {

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -524,6 +524,80 @@ func TestParseAssignments_PassThresholdRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAssignments_StudentPermissionRoundTrip(t *testing.T) {
+	// student_permission parses, survives a re-encode/re-parse, and an entry
+	// without the field decodes to the empty string (means the mode default).
+	in := []byte(`{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    {
+      "slug": "site",
+      "name": "Site",
+      "mode": "individual",
+      "autograder": "default",
+      "student_permission": "admin"
+    },
+    {
+      "slug": "off",
+      "name": "Off",
+      "mode": "individual",
+      "autograder": "default"
+    }
+  ]
+}`)
+	file, err := ParseAssignments(in)
+	if err != nil {
+		t.Fatalf("ParseAssignments: %v", err)
+	}
+	if got := file.Assignments[0].StudentPermission; got != "admin" {
+		t.Errorf("site.StudentPermission = %q, want admin", got)
+	}
+	if got := file.Assignments[1].StudentPermission; got != "" {
+		t.Errorf("off.StudentPermission = %q, want empty (field absent)", got)
+	}
+
+	encoded, err := EncodeAssignments(file)
+	if err != nil {
+		t.Fatalf("EncodeAssignments: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"student_permission": "admin"`) {
+		t.Errorf("encoded missing student_permission admin:\n%s", encoded)
+	}
+	again, err := ParseAssignments(encoded)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if got := again.Assignments[0].StudentPermission; got != "admin" {
+		t.Errorf("student_permission not stable across round-trip: %q", got)
+	}
+	if got := again.Assignments[1].StudentPermission; got != "" {
+		t.Errorf("absent student_permission should round-trip empty, got %q", got)
+	}
+}
+
+func TestValidateStudentPermission(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+	}{
+		{"", false}, // absent => mode default
+		{"pull", false},
+		{"triage", false},
+		{"push", false},
+		{"maintain", false},
+		{"admin", false},
+		{"owner", true},
+		{"Admin", true},
+		{"write", true},
+	}
+	for _, c := range cases {
+		err := ValidateStudentPermission(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ValidateStudentPermission(%q) err = %v, wantErr %v", c.in, err, c.wantErr)
+		}
+	}
+}
+
 func TestValidatePassThreshold(t *testing.T) {
 	ptr := func(n int) *int { return &n }
 	cases := []struct {

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -2,12 +2,54 @@ package assignment
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/foundation50/classroom50-cli-shared/contract"
 )
+
+// TestStudentPermissionEnumParity pins the student_permission allow-list across
+// its three hand-mirrored sources: the JSON schema enum (the declared source of
+// truth), the Go contract.RepoPermissions (what ValidateStudentPermission
+// enforces), and — via the shared list length — the ordered ladder. A one-sided
+// edit to any of them drifts the accept-time floor verification, so this fails
+// CI rather than surfacing as a CLI/GUI/schema disagreement. The web mirror
+// (REPO_PERMISSIONS) is pinned against the same schema enum by a vitest.
+func TestStudentPermissionEnumParity(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "schemas", "assignments-v1.schema.json"))
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		Defs struct {
+			Assignment struct {
+				Properties struct {
+					StudentPermission struct {
+						Enum []string `json:"enum"`
+					} `json:"student_permission"`
+				} `json:"properties"`
+			} `json:"assignment"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	schemaEnum := schema.Defs.Assignment.Properties.StudentPermission.Enum
+	if len(schemaEnum) == 0 {
+		t.Fatalf("schema student_permission.enum not found; did the $defs shape change?")
+	}
+	if !reflect.DeepEqual(schemaEnum, contract.RepoPermissions) {
+		t.Errorf("student_permission drift: schema enum %v != contract.RepoPermissions %v — update every mirror in lockstep (schema, Go contract, web REPO_PERMISSIONS)",
+			schemaEnum, contract.RepoPermissions)
+	}
+}
 
 func TestParseAssignments_Canonical(t *testing.T) {
 	in := []byte(`{

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -79,6 +79,7 @@ func assignmentAddCmd() *cobra.Command {
 		emptyRepo     bool
 		allowedFiles  []string
 		passThreshold int
+		studentPerm   string
 	)
 
 	cmd := &cobra.Command{
@@ -195,6 +196,10 @@ func assignmentAddCmd() *cobra.Command {
 			// passed, so an omitted flag stays nil (off) while an explicit
 			// --pass-threshold 0 is a real 0% threshold.
 			passThresholdPtr := passThresholdFromFlag(cmd.Flags().Changed("pass-threshold"), passThreshold)
+			studentPermVal := strings.TrimSpace(studentPerm)
+			if err := assignment.ValidateStudentPermission(studentPermVal); err != nil {
+				return err
+			}
 			if err := autograderseam.ValidateName(autograderVal); err != nil {
 				return err
 			}
@@ -251,6 +256,7 @@ func assignmentAddCmd() *cobra.Command {
 					EmptyRepo:         emptyRepo,
 					AllowedFiles:      allowedFiles,
 					PassThreshold:     passThresholdPtr,
+					StudentPermission: studentPermVal,
 				})
 		},
 	}
@@ -269,6 +275,7 @@ func assignmentAddCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&emptyRepo, "empty-repo", false, "Create truly bare student repos: no README/initial commit, no .classroom50.yaml marker, no autograde workflow — for assignments where students build the repo (including their own GitHub Actions) from scratch. Autograding and the Feedback PR are disabled and cannot be enabled later (the setting is immutable after creation). Mutually exclusive with --template, --tests, --feedback-pr, --allowed-files, and --pass-threshold.")
 	cmd.Flags().StringArrayVar(&allowedFiles, "allowed-files", nil, "Ordered .gitignore-style pattern (repeatable, order preserved) defining which files belong to the submission. Last match wins; `!` re-includes. Pass `--allowed-files '*' --allowed-files '!hello.py'` to allow only hello.py. The autograde runner removes disallowed files before grading (control files are always kept); `gh student submit` filters them too. Omit to allow every file.")
 	cmd.Flags().IntVar(&passThreshold, "pass-threshold", 0, "Opt-in passing bar as a percentage of max score (0–100): at/above it a gradebook client shows a submission as passing. Advisory/display-only — it does not change a student's score. Omit to leave it off (no passing concept); pass --pass-threshold 0 for an explicit 0%.")
+	cmd.Flags().StringVar(&studentPerm, "student-permission", "", "Optional collaborator role each student gets on their OWN assignment repo at accept time: one of pull, triage, push, maintain, admin. Omit for the default (push for individual, admin for group). Choose admin to let students manage repo settings and enable GitHub Pages. Applies to students who accept from now on; existing repos are unchanged. Caution: admin on a private repo also lets the student change its visibility.")
 	return cmd
 }
 
@@ -541,6 +548,7 @@ type addAssignmentParams struct {
 	EmptyRepo         bool
 	AllowedFiles      []string
 	PassThreshold     *int
+	StudentPermission string
 }
 
 // runAssignmentAdd validates template visibility and entry shape before the
@@ -614,6 +622,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		EmptyRepo:         p.EmptyRepo,
 		AllowedFiles:      allowedFiles,
 		PassThreshold:     passThreshold,
+		StudentPermission: p.StudentPermission,
 	}
 	if err := assignment.ValidateAssignmentEntry(entry); err != nil {
 		return err
@@ -626,6 +635,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		droppedTemplate      *assignment.TemplateRef
 		droppedAllowedCnt    int
 		droppedPassThreshold *int
+		droppedStudentPerm   string
 		// The locked state that actually landed (carried forward from a prior
 		// same-slug entry). Read after the commit to decide the template grant,
 		// since `entry` (rebuilt from flags) never carries Locked.
@@ -636,6 +646,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		droppedTemplate = nil
 		droppedAllowedCnt = 0
 		droppedPassThreshold = nil
+		droppedStudentPerm = ""
 		attemptEntry := entry
 		// Refuse on an archived classroom (active:false), mirroring the web.
 		// Checked at parentSHA so a concurrent unarchive is observed on retry.
@@ -710,6 +721,12 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		// is a non-nil pointer (real 0% bar), not a drop.
 		if hasPrev && entry.PassThreshold == nil && file.Assignments[prevIdx].PassThreshold != nil {
 			droppedPassThreshold = file.Assignments[prevIdx].PassThreshold
+		}
+		// Same footgun for student_permission (often set in the gradebook GUI):
+		// re-running add without --student-permission drops a prior value back
+		// to the mode default. Empty = omitted (warn if the prior entry set one).
+		if hasPrev && entry.StudentPermission == "" && file.Assignments[prevIdx].StudentPermission != "" {
+			droppedStudentPerm = file.Assignments[prevIdx].StudentPermission
 		}
 		// The CLI has no release-assets authoring flag. Preserve this typed field and
 		// unknown Extra keys when a same-slug add rebuilds the rest from flags. This
@@ -800,6 +817,11 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		_, _ = fmt.Fprintf(errOut,
 			"Warning: replacing %q dropped its pass_threshold (%d%%) — `assignment add` rewrites the whole entry, and you re-ran it without --pass-threshold. The passing bar (often set in the gradebook GUI) is now off. Pass --pass-threshold %d to keep it.\n",
 			slug, *droppedPassThreshold, *droppedPassThreshold)
+	}
+	if droppedStudentPerm != "" {
+		_, _ = fmt.Fprintf(errOut,
+			"Warning: replacing %q dropped its student_permission (%s) — `assignment add` rewrites the whole entry, and you re-ran it without --student-permission. New accepters revert to the mode default. Pass --student-permission %s to keep it.\n",
+			slug, droppedStudentPerm, droppedStudentPerm)
 	}
 	// Heads-up if the encoded file nears GitHub's ~1 MiB contents-API limit
 	// (past which encoding flips to "none", wedging future reads/writes).

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -44,6 +44,16 @@ const (
 	ModeIndividual = "individual"
 	ModeGroup      = "group"
 
+	// Repo collaborator permission levels, GitHub's low-to-high ladder. Used
+	// for an assignment's optional student_permission (the access the enrolled
+	// student gets on their own repo at accept time) and mirrored in the web
+	// RepoAccessPermission union and the assignments-v1 schema enum.
+	PermissionPull     = "pull"
+	PermissionTriage   = "triage"
+	PermissionPush     = "push"
+	PermissionMaintain = "maintain"
+	PermissionAdmin    = "admin"
+
 	// ResultFilename and ReleaseBodyFilename are the autograder's output
 	// artifacts in the student workspace: the required result.json (the grading
 	// payload collect-scores ingests) and the optional release-body.md. The
@@ -215,6 +225,34 @@ func FeedbackLabelForMode(mode string) (name, color string) {
 		return "Group Assignment", "5319E7"
 	}
 	return "Individual Assignment", "0E8A16"
+}
+
+// RepoPermissions is GitHub's collaborator permission ladder, low to high.
+// Single-sources the assignment student_permission allow-list; the web mirror
+// is RepoAccessPermission and the schema enum in assignments-v1.schema.json.
+var RepoPermissions = []string{
+	PermissionPull, PermissionTriage, PermissionPush, PermissionMaintain, PermissionAdmin,
+}
+
+// IsValidRepoPermission reports whether p is one of the RepoPermissions.
+func IsValidRepoPermission(p string) bool {
+	for _, allowed := range RepoPermissions {
+		if p == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// DefaultStudentPermission is the accept-time role a student gets on their own
+// repo when an assignment sets no student_permission: least-privilege push for
+// individual, admin for group (a group founder must manage collaborators).
+// Mirrors the web founderPermission default and gh-student's.
+func DefaultStudentPermission(mode string) string {
+	if strings.TrimSpace(strings.ToLower(mode)) == ModeGroup {
+		return PermissionAdmin
+	}
+	return PermissionPush
 }
 
 // FeedbackPRBody is the Feedback PR body, byte-identical with the output of

--- a/schemas/assignments-v1.schema.json
+++ b/schemas/assignments-v1.schema.json
@@ -170,6 +170,10 @@
             "invite_link": { "type": "string" },
             "migrated_at": { "type": "string" }
           }
+        },
+        "student_permission": {
+          "enum": ["pull", "triage", "push", "maintain", "admin"],
+          "description": "The collaborator role the enrolled student is granted on their OWN assignment repo at accept time (the old GitHub Classroom \"grant students admin access\" checkbox, generalized to GitHub's full ladder). ABSENT means the built-in default: `push` for `individual`, `admin` for `group`. This is accept-time provisioning only — it governs what NEW accepters get; it does not retroactively change repos already accepted (teachers adjust those with the gradebook's per-repo/bulk access controls). Group coherence: a group founder must hold at least `admin` to add teammates via `gh student invite`, so for `mode: group` any configured value below `admin` is clamped up to `admin` by every accept client — prefer omitting it (or writing `admin`) for group assignments. Caution: on a PRIVATE in-org repo, `admin` also lets the student change repo visibility (e.g. make it public) and settings."
         }
       },
       "allOf": [

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { ShieldCheck } from "lucide-react"
+
+import { Alert, Button, Modal, Select } from "@/components/ui"
+import { Spinner } from "@/components/Spinner"
+import {
+  BulkResultSection,
+  type BulkPhase,
+  type BulkProgress,
+  type BulkResultView,
+} from "@/components/bulk/resultView"
+import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
+import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
+import { mapWithConcurrency } from "@/util/concurrency"
+import { studentRepoName } from "@/util/studentRepo"
+import { getName } from "@/util/students"
+import { GitHubAPIError } from "@/github-core/errors"
+import type { RepoPermission, Student } from "@/types/classroom"
+import { REPO_PERMISSIONS } from "@/types/classroom"
+
+type BulkRepoAccessModalProps = {
+  open: boolean
+  onClose: () => void
+  org: string
+  classroom: string
+  assignment: string
+  // The accepted students (their own login = their repo's owner segment).
+  owners: string[]
+  students?: Student[]
+}
+
+const describeFailure = (reason: unknown): string | undefined => {
+  if (reason instanceof GitHubAPIError) {
+    if (reason.isRateLimited) return "rate limited"
+    if (reason.status === 403) return "forbidden"
+    if (reason.status === 404) return "repo or user not found"
+    return `HTTP ${reason.status}`
+  }
+  return reason instanceof Error ? reason.message : undefined
+}
+
+// Whole-assignment access editor: set every accepted student's role on their
+// OWN individual repo in one bounded fan-out. Sibling of the per-repo
+// RepoAccessModal; this one operates over the assignment's full accepted set.
+// Individual assignments only (a group repo's membership is founder-managed).
+export function BulkRepoAccessModal({
+  open,
+  onClose,
+  org,
+  classroom,
+  assignment,
+  owners,
+  students = [],
+}: BulkRepoAccessModalProps) {
+  const titleId = useId()
+  const { t } = useTranslation()
+  const addCollaboratorMutation = useAddRepoCollaborator()
+  const runningRef = useRef(false)
+
+  const [permission, setPermission] = useState<RepoPermission>("push")
+  const [phase, setPhase] = useState<BulkPhase>("idle")
+  const [progress, setProgress] = useState<BulkProgress>({
+    processed: 0,
+    total: 0,
+    message: "",
+  })
+  const [result, setResult] = useState<BulkResultView | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      setPermission("push")
+      setPhase("idle")
+      setResult(null)
+      setProgress({ processed: 0, total: 0, message: "" })
+    }
+  }, [open])
+
+  const total = owners.length
+  const displayFor = (login: string) => getName(login, students) || login
+
+  const permissionLabel = (level: RepoPermission) =>
+    t(`assignments.form.studentPermission.levels.${level}`)
+
+  const run = async () => {
+    if (runningRef.current || total === 0) return
+    runningRef.current = true
+    setPhase("working")
+    setResult(null)
+    let processed = 0
+    setProgress({ processed: 0, total, message: "" })
+
+    const outcomes = await mapWithConcurrency(
+      owners,
+      REPO_READ_CONCURRENCY,
+      async (owner) => {
+        const repo = studentRepoName(classroom, assignment, owner)
+        try {
+          await addCollaboratorMutation.mutateAsync({
+            org,
+            repo,
+            username: owner,
+            permission,
+          })
+          return { owner, ok: true as const }
+        } catch (err) {
+          return { owner, ok: false as const, detail: describeFailure(err) }
+        } finally {
+          processed += 1
+          setProgress({
+            processed,
+            total,
+            message: displayFor(owner),
+          })
+        }
+      },
+    )
+
+    const succeeded = outcomes.filter((o) => o.ok)
+    const failed = outcomes.filter((o) => !o.ok)
+
+    setResult({
+      headline: t("submissions.bulkAccess.resultHeadline", {
+        count: succeeded.length,
+        total,
+        level: permissionLabel(permission),
+      }),
+      sections: [
+        ...(failed.length
+          ? [
+              {
+                title: t("submissions.bulkAccess.failedSection", {
+                  count: failed.length,
+                }),
+                rows: failed.map((o) => ({
+                  key: o.owner,
+                  label: displayFor(o.owner),
+                  detail: "detail" in o ? o.detail : undefined,
+                })),
+              },
+            ]
+          : []),
+      ],
+    })
+    setPhase(failed.length ? "error" : "complete")
+    runningRef.current = false
+  }
+
+  const busy = phase === "working"
+  const pct = useMemo(
+    () =>
+      progress.total > 0
+        ? Math.round((progress.processed / progress.total) * 100)
+        : 0,
+    [progress],
+  )
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      closeDisabled={busy}
+      size="lg"
+      aria-labelledby={titleId}
+    >
+      <div className="flex items-start gap-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <ShieldCheck className="size-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("submissions.bulkAccess.title")}
+          </h3>
+          <p className="mt-1 text-sm text-base-content/70">
+            {t("submissions.bulkAccess.subtitle", { count: total })}
+          </p>
+        </div>
+      </div>
+
+      {phase === "idle" && (
+        <div className="mt-4 flex flex-col gap-4">
+          {total === 0 ? (
+            <Alert tone="info" className="text-sm">
+              {t("submissions.bulkAccess.noRepos")}
+            </Alert>
+          ) : (
+            <>
+              <label className="flex flex-col gap-1.5">
+                <span className="label font-bold">
+                  {t("submissions.bulkAccess.roleLabel")}
+                </span>
+                <Select
+                  className="w-full sm:max-w-xs"
+                  value={permission}
+                  onChange={(e) =>
+                    setPermission(e.target.value as RepoPermission)
+                  }
+                >
+                  {REPO_PERMISSIONS.map((level) => (
+                    <option key={level} value={level}>
+                      {permissionLabel(level)}
+                    </option>
+                  ))}
+                </Select>
+              </label>
+              <Alert tone="warning" className="text-sm">
+                {t("submissions.bulkAccess.warning", {
+                  level: permissionLabel(permission),
+                  count: total,
+                })}
+              </Alert>
+            </>
+          )}
+        </div>
+      )}
+
+      {busy && (
+        <div className="mt-6 flex flex-col items-center gap-3 py-6">
+          <Spinner label={t("submissions.bulkAccess.working")} />
+          <progress
+            className="progress progress-primary w-full"
+            value={pct}
+            max={100}
+          />
+          <p className="text-sm text-base-content/70">
+            {t("submissions.bulkAccess.progress", {
+              processed: progress.processed,
+              total: progress.total,
+            })}
+          </p>
+        </div>
+      )}
+
+      {(phase === "complete" || phase === "error") && result && (
+        <div className="mt-4 flex flex-col gap-4">
+          <Alert
+            tone={phase === "error" ? "warning" : "success"}
+            className="text-sm"
+          >
+            {result.headline}
+          </Alert>
+          {result.sections.map((section) => (
+            <BulkResultSection
+              key={section.title}
+              title={section.title}
+              rows={section.rows}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="modal-action">
+        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+          {phase === "complete" || phase === "error"
+            ? t("common.close")
+            : t("common.cancel")}
+        </Button>
+        {phase === "idle" && total > 0 && (
+          <Button variant="primary" onClick={() => void run()}>
+            {t("submissions.bulkAccess.apply")}
+          </Button>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+export default BulkRepoAccessModal

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { ShieldCheck } from "lucide-react"
 
 import { Alert, Button, Modal, Select } from "@/components/ui"
@@ -12,6 +13,7 @@ import {
 } from "@/components/bulk/resultView"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
 import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
+import { permissionSatisfies } from "@/domain/assignments/permissions"
 import { mapWithConcurrency } from "@/util/concurrency"
 import { studentRepoName } from "@/util/studentRepo"
 import { getName } from "@/util/students"
@@ -30,12 +32,37 @@ type BulkRepoAccessModalProps = {
   students?: Student[]
 }
 
-const describeFailure = (reason: unknown): string | undefined => {
+// A verified write that GitHub silently ignored: the PUT returned 204 but the
+// student's effective role didn't land on the target (the residual admin an
+// intended downgrade is meant to remove). Reported distinctly from a hard error.
+class AccessNotAppliedError extends Error {
+  readonly effective: string | undefined
+  constructor(effective: string | undefined) {
+    super(`access not applied (still ${effective ?? "unchanged"})`)
+    this.name = "AccessNotAppliedError"
+    this.effective = effective
+  }
+}
+
+// Map a rejected write to a localized reason for the result table. Reuses the
+// groupCollaborators failure vocabulary so this dialog stays consistent with
+// its per-repo sibling (RepoAccessModal) instead of assembling raw English.
+const describeFailure = (reason: unknown, t: TFunction): string | undefined => {
+  if (reason instanceof AccessNotAppliedError) {
+    return t("components.modals.repoAccess.notApplied", {
+      effective: reason.effective ?? "unknown",
+    })
+  }
   if (reason instanceof GitHubAPIError) {
-    if (reason.isRateLimited) return "rate limited"
-    if (reason.status === 403) return "forbidden"
-    if (reason.status === 404) return "repo or user not found"
-    return `HTTP ${reason.status}`
+    if (reason.isRateLimited)
+      return t("components.modals.groupCollaborators.failure.rateLimited")
+    if (reason.status === 403)
+      return t("components.modals.groupCollaborators.failure.forbidden")
+    if (reason.status === 404)
+      return t("components.modals.groupCollaborators.failure.notFound")
+    return t("components.modals.groupCollaborators.failure.httpStatus", {
+      status: reason.status,
+    })
   }
   return reason instanceof Error ? reason.message : undefined
 }
@@ -57,6 +84,17 @@ export function BulkRepoAccessModal({
   const { t } = useTranslation()
   const addCollaboratorMutation = useAddRepoCollaborator()
   const runningRef = useRef(false)
+  // Guards setState after unmount and lets an in-flight run stop launching new
+  // writes when the modal closes mid-fan-out (there's no per-request cancel
+  // token on the mutation, so we skip the remaining owners instead).
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      runningRef.current = false
+    }
+  }, [])
 
   const [permission, setPermission] = useState<RepoPermission>("push")
   const [phase, setPhase] = useState<BulkPhase>("idle")
@@ -69,6 +107,7 @@ export function BulkRepoAccessModal({
 
   useEffect(() => {
     if (!open) {
+      runningRef.current = false
       setPermission("push")
       setPhase("idle")
       setResult(null)
@@ -82,6 +121,11 @@ export function BulkRepoAccessModal({
   const permissionLabel = (level: RepoPermission) =>
     t(`assignments.form.studentPermission.levels.${level}`)
 
+  type Outcome =
+    | { owner: string; status: "ok" }
+    | { owner: string; status: "deferred" }
+    | { owner: string; status: "failed"; detail?: string }
+
   const run = async () => {
     if (runningRef.current || total === 0) return
     runningRef.current = true
@@ -90,41 +134,89 @@ export function BulkRepoAccessModal({
     let processed = 0
     setProgress({ processed: 0, total, message: "" })
 
+    // Set once we hit a secondary-rate-limit: stop launching NEW writes and
+    // report the untouched remainder as deferred rather than hammering GitHub
+    // into a deeper throttle (mirrors inviteRosterStudents' throttle handling).
+    let rateLimited = false
+
     const outcomes = await mapWithConcurrency(
       owners,
       REPO_READ_CONCURRENCY,
-      async (owner) => {
+      async (owner): Promise<Outcome> => {
+        // The modal closed/unmounted, or an earlier task tripped the rate
+        // limit: don't start another write; mark the rest deferred.
+        if (rateLimited || !mountedRef.current) {
+          processed += 1
+          if (mountedRef.current) {
+            setProgress({ processed, total, message: displayFor(owner) })
+          }
+          return { owner, status: "deferred" }
+        }
         const repo = studentRepoName(classroom, assignment, owner)
         try {
-          await addCollaboratorMutation.mutateAsync({
+          const { effective } = await addCollaboratorMutation.mutateAsync({
             org,
             repo,
             username: owner,
             permission,
+            verify: true,
           })
-          return { owner, ok: true as const }
+          // The owner segment is the enrolled student — an org member, so
+          // GitHub honors the direct grant exactly. A higher residual means the
+          // requested (typically lower) role was silently ignored, the exact
+          // over-access an intended lockdown must catch.
+          if (
+            effective &&
+            !permissionSatisfies(
+              effective.permission,
+              effective.role_name,
+              permission,
+              false,
+            )
+          ) {
+            throw new AccessNotAppliedError(
+              effective.role_name || effective.permission,
+            )
+          }
+          return { owner, status: "ok" }
         } catch (err) {
-          return { owner, ok: false as const, detail: describeFailure(err) }
+          if (err instanceof GitHubAPIError && err.isRateLimited) {
+            rateLimited = true
+            return { owner, status: "deferred" }
+          }
+          return { owner, status: "failed", detail: describeFailure(err, t) }
         } finally {
           processed += 1
-          setProgress({
-            processed,
-            total,
-            message: displayFor(owner),
-          })
+          if (mountedRef.current) {
+            setProgress({ processed, total, message: displayFor(owner) })
+          }
         }
       },
     )
 
-    const succeeded = outcomes.filter((o) => o.ok)
-    const failed = outcomes.filter((o) => !o.ok)
+    // The modal was closed mid-run: the fan-out finished (or bailed) but there's
+    // no live component to show a result on.
+    if (!mountedRef.current) {
+      runningRef.current = false
+      return
+    }
+
+    const succeeded = outcomes.filter((o) => o.status === "ok")
+    const deferred = outcomes.filter((o) => o.status === "deferred")
+    const failed = outcomes.filter((o) => o.status === "failed")
 
     setResult({
-      headline: t("submissions.bulkAccess.resultHeadline", {
-        count: succeeded.length,
-        total,
-        level: permissionLabel(permission),
-      }),
+      headline: rateLimited
+        ? t("submissions.bulkAccess.resultHeadlineThrottled", {
+            count: succeeded.length,
+            total,
+            level: permissionLabel(permission),
+          })
+        : t("submissions.bulkAccess.resultHeadline", {
+            count: succeeded.length,
+            total,
+            level: permissionLabel(permission),
+          }),
       sections: [
         ...(failed.length
           ? [
@@ -140,9 +232,23 @@ export function BulkRepoAccessModal({
               },
             ]
           : []),
+        ...(deferred.length
+          ? [
+              {
+                title: t("submissions.bulkAccess.deferredSection", {
+                  count: deferred.length,
+                }),
+                rows: deferred.map((o) => ({
+                  key: o.owner,
+                  label: displayFor(o.owner),
+                  detail: t("submissions.bulkAccess.deferredDetail"),
+                })),
+              },
+            ]
+          : []),
       ],
     })
-    setPhase(failed.length ? "error" : "complete")
+    setPhase(failed.length || deferred.length ? "error" : "complete")
     runningRef.current = false
   }
 

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -12,6 +12,7 @@ import {
   type BulkResultView,
 } from "@/components/bulk/resultView"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
+import { describeGitHubApiFailure } from "@/components/modals/collaboratorHelpers"
 import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
 import { permissionSatisfies } from "@/domain/assignments/permissions"
 import { mapWithConcurrency } from "@/util/concurrency"
@@ -53,13 +54,9 @@ const describeFailure = (reason: unknown, t: TFunction): string | undefined => {
       effective: reason.effective ?? "unknown",
     })
   }
+  const shared = describeGitHubApiFailure(reason, t)
+  if (shared) return shared
   if (reason instanceof GitHubAPIError) {
-    if (reason.isRateLimited)
-      return t("components.modals.groupCollaborators.failure.rateLimited")
-    if (reason.status === 403)
-      return t("components.modals.groupCollaborators.failure.forbidden")
-    if (reason.status === 404)
-      return t("components.modals.groupCollaborators.failure.notFound")
     return t("components.modals.groupCollaborators.failure.httpStatus", {
       status: reason.status,
     })

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -19,60 +19,27 @@ import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
 import useRemoveRepoCollaborator from "@/hooks/mutations/useRemoveRepoCollaborator"
-import { getName } from "@/util/students"
+import {
+  CollaboratorIdentity,
+  describeGitHubApiFailure,
+  normalizeUsername,
+  rejectedItems,
+} from "@/components/modals/collaboratorHelpers"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { Student } from "@/types/classroom"
 import { GROUP_SIZE_MIN } from "@/types/classroom"
 
-const normalizeUsername = (username: string) =>
-  username.trim().replace(/^@/, "").toLowerCase()
-
-// The usernames whose settled promise rejected, by index into the input list.
-const rejectedItems = <T,>(
-  results: PromiseSettledResult<unknown>[],
-  items: T[],
-): T[] =>
-  results.flatMap((result, i) =>
-    result.status === "rejected" ? [items[i]] : [],
-  )
-
 // Map a rejected add/remove to a human-readable reason. Collapsing every status
 // into "bad username" would hide real causes like a 429 or a 403.
 const describeFailure = (reason: unknown, t: TFunction): string | null => {
+  const shared = describeGitHubApiFailure(reason, t)
+  if (shared) return shared
   if (reason instanceof GitHubAPIError) {
-    if (reason.isRateLimited)
-      return t("components.modals.groupCollaborators.failure.rateLimited")
-    if (reason.status === 403)
-      return t("components.modals.groupCollaborators.failure.forbidden")
-    if (reason.status === 404)
-      return t("components.modals.groupCollaborators.failure.notFound")
     if (reason.status === 422)
       return t("components.modals.groupCollaborators.failure.conflict")
     return reason.message
   }
   return reason instanceof Error ? reason.message : null
-}
-
-// Two-line identity when we have a roster name (name + @handle), else just the
-// @handle. Shared by owner, member, and marked-for-removal rows.
-const CollaboratorIdentity = ({
-  login,
-  students,
-}: {
-  login: string
-  students: Student[]
-}) => {
-  const name = getName(login, students)
-  return name ? (
-    <>
-      <span className="block truncate text-sm font-medium">{name}</span>
-      <span className="block truncate font-mono text-xs text-base-content/70">
-        @{login}
-      </span>
-    </>
-  ) : (
-    <span className="block truncate font-mono text-sm">@{login}</span>
-  )
 }
 
 type GroupCollaboratorsModalProps = {

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -1,0 +1,613 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { Trans, useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
+import { Plus, Trash2, ShieldCheck } from "lucide-react"
+
+import GitHub from "@/assets/github.svg?react"
+import { Spinner } from "@/components/Spinner"
+import {
+  Alert,
+  AnimatedAlert,
+  Badge,
+  Button,
+  Input,
+  Modal,
+  Select,
+} from "@/components/ui"
+import { useGithubAuth } from "@/auth/useGithubAuth"
+import useGetRepo from "@/hooks/useGetRepo"
+import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
+import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
+import useRemoveRepoCollaborator from "@/hooks/mutations/useRemoveRepoCollaborator"
+import { getName } from "@/util/students"
+import { GitHubAPIError } from "@/github-core/errors"
+import type { GitHubUser } from "@/github-core/types"
+import type { RepoPermission, Student } from "@/types/classroom"
+import { REPO_PERMISSIONS } from "@/types/classroom"
+
+const normalizeUsername = (username: string) =>
+  username.trim().replace(/^@/, "").toLowerCase()
+
+// The effective role from a collaborator's permission booleans (the list
+// endpoint returns no role_name in our GitHubUser shape). Highest wins; triage
+// isn't modeled by the booleans, so it reads back as pull — acceptable, since a
+// no-op save is filtered out by the change diff.
+const permissionFromFlags = (
+  permissions: GitHubUser["permissions"],
+): RepoPermission => {
+  if (permissions.admin) return "admin"
+  if (permissions.maintain) return "maintain"
+  if (permissions.push) return "push"
+  return "pull"
+}
+
+const rejectedItems = <T,>(
+  results: PromiseSettledResult<unknown>[],
+  items: T[],
+): T[] =>
+  results.flatMap((result, i) =>
+    result.status === "rejected" ? [items[i]] : [],
+  )
+
+// Map a rejected write to a human reason; reuses the groupCollaborators failure
+// vocabulary so the two dialogs stay consistent.
+const describeFailure = (reason: unknown, t: TFunction): string | null => {
+  if (reason instanceof GitHubAPIError) {
+    if (reason.isRateLimited)
+      return t("components.modals.groupCollaborators.failure.rateLimited")
+    if (reason.status === 403)
+      return t("components.modals.groupCollaborators.failure.forbidden")
+    if (reason.status === 404)
+      return t("components.modals.groupCollaborators.failure.notFound")
+    if (reason.status === 422)
+      return t("components.modals.groupCollaborators.failure.conflict")
+    return reason.message
+  }
+  return reason instanceof Error ? reason.message : null
+}
+
+const CollaboratorIdentity = ({
+  login,
+  students,
+}: {
+  login: string
+  students: Student[]
+}) => {
+  const name = getName(login, students)
+  return name ? (
+    <>
+      <span className="block truncate text-sm font-medium">{name}</span>
+      <span className="block truncate font-mono text-xs text-base-content/70">
+        @{login}
+      </span>
+    </>
+  ) : (
+    <span className="block truncate font-mono text-sm">@{login}</span>
+  )
+}
+
+// One row's draft state: its target role, and whether it's staged for removal.
+type DraftEntry = {
+  login: string
+  permission: RepoPermission
+  markedForRemoval: boolean
+  // True for collaborators queued via the add box (not yet on the server).
+  isNew: boolean
+}
+
+type RepoAccessModalProps = {
+  open: boolean
+  onClose: () => void
+  org: string
+  repoName: string
+  // The enrolled student, from the repo-name `owner` segment (never inferred
+  // from admin permissions, since org owners hold admin on every repo).
+  ownerLogin: string
+  repoUrl?: string
+  assignmentName?: string
+  // Optional roster, to show full names alongside GitHub handles.
+  students?: Student[]
+}
+
+// Teacher-facing per-repo access editor: change the enrolled student's role and
+// add/remove arbitrary collaborators on one assignment repo. Sibling of
+// GroupCollaboratorsModal (which is founder-facing and size-capped); this one
+// is gated on the viewer's repo-admin and carries a per-row permission picker.
+export function RepoAccessModal({
+  open,
+  onClose,
+  org,
+  repoName,
+  ownerLogin,
+  repoUrl,
+  assignmentName,
+  students = [],
+}: RepoAccessModalProps) {
+  const titleId = useId()
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const savingRef = useRef(false)
+  const { user } = useGithubAuth()
+  const { t } = useTranslation()
+
+  const {
+    data: collaborators,
+    isLoading: loadingCollaborators,
+    refetch: refetchCollaborators,
+  } = useGetRepoCollaborators(org, repoName, { enabled: open })
+
+  const addCollaboratorMutation = useAddRepoCollaborator()
+  const removeCollaboratorMutation = useRemoveRepoCollaborator()
+
+  const [draft, setDraft] = useState<DraftEntry[]>([])
+  const [newCollaborator, setNewCollaborator] = useState("")
+  const [newPermission, setNewPermission] = useState<RepoPermission>("push")
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const [invalidLogins, setInvalidLogins] = useState<Set<string>>(
+    () => new Set(),
+  )
+
+  const ownerLoginResolved = normalizeUsername(ownerLogin)
+
+  // Manage access = repo admin (the viewer's effective permission, including
+  // inherited org-owner admin). Read from the repo object, not the
+  // affiliation=direct list, which omits inherited access.
+  const { data: repo } = useGetRepo(org, repoName, { enabled: open })
+  const viewerLogin = user?.login ? normalizeUsername(user.login) : null
+  const canManage = Boolean(viewerLogin && repo?.permissions?.admin === true)
+
+  // The server's current state, normalized. The owner sorts first.
+  const initialEntries = useMemo<DraftEntry[]>(() => {
+    const rows = (collaborators ?? []).map((c) => ({
+      login: normalizeUsername(c.login),
+      permission: permissionFromFlags(c.permissions),
+      markedForRemoval: false,
+      isNew: false,
+    }))
+    rows.sort((a, b) => {
+      if (a.login === ownerLoginResolved) return -1
+      if (b.login === ownerLoginResolved) return 1
+      return a.login.localeCompare(b.login)
+    })
+    return rows
+  }, [collaborators, ownerLoginResolved])
+
+  const initialByLogin = useMemo(() => {
+    const map = new Map<string, RepoPermission>()
+    for (const e of initialEntries) map.set(e.login, e.permission)
+    return map
+  }, [initialEntries])
+
+  // Seed the draft once per open and per repo change (the teacher table reuses
+  // one modal across rows). Keying on open+repoName — not the collaborators
+  // identity — stops a background refetch from clobbering unsaved edits.
+  const seededKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!open) {
+      seededKeyRef.current = null
+      return
+    }
+    if (loadingCollaborators) return
+    if (seededKeyRef.current === repoName) return
+    seededKeyRef.current = repoName
+    setDraft(initialEntries)
+  }, [open, repoName, loadingCollaborators, initialEntries])
+
+  useEffect(() => {
+    if (!open) {
+      setNewCollaborator("")
+      setNewPermission("push")
+      setSubmitError(null)
+      setSaved(false)
+      setInvalidLogins(new Set())
+    }
+  }, [open])
+
+  useEffect(
+    () => () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+    },
+    [],
+  )
+
+  const clearInvalid = (login: string) => {
+    const normalized = normalizeUsername(login)
+    setInvalidLogins((current) => {
+      if (!current.has(normalized)) return current
+      const next = new Set(current)
+      next.delete(normalized)
+      return next
+    })
+  }
+
+  const setPermission = (login: string, permission: RepoPermission) => {
+    setDraft((current) =>
+      current.map((e) => (e.login === login ? { ...e, permission } : e)),
+    )
+  }
+
+  const markRemoval = (login: string, removed: boolean) => {
+    clearInvalid(login)
+    setDraft((current) =>
+      // A queued (new) row is dropped outright; a server row is struck through.
+      removed
+        ? current.flatMap((e) =>
+            e.login === login
+              ? e.isNew
+                ? []
+                : [{ ...e, markedForRemoval: true }]
+              : [e],
+          )
+        : current.map((e) =>
+            e.login === login ? { ...e, markedForRemoval: false } : e,
+          ),
+    )
+  }
+
+  const addPending = () => {
+    const login = normalizeUsername(newCollaborator)
+    if (!login) return
+    const existing = draft.find((e) => e.login === login)
+    if (existing) {
+      // Re-adding a struck-through collaborator restores it at the new level.
+      setDraft((current) =>
+        current.map((e) =>
+          e.login === login
+            ? { ...e, markedForRemoval: false, permission: newPermission }
+            : e,
+        ),
+      )
+      setNewCollaborator("")
+      return
+    }
+    clearInvalid(login)
+    setDraft((current) => [
+      ...current,
+      {
+        login,
+        permission: newPermission,
+        markedForRemoval: false,
+        isNew: true,
+      },
+    ])
+    setNewCollaborator("")
+  }
+
+  const isSaving =
+    addCollaboratorMutation.isPending || removeCollaboratorMutation.isPending
+
+  // A change is: a new/restored collaborator, a struck-through server row, or a
+  // permission level that differs from the server's.
+  const hasChanges = useMemo(
+    () =>
+      draft.some((e) => {
+        if (e.isNew) return true
+        if (e.markedForRemoval) return true
+        return initialByLogin.get(e.login) !== e.permission
+      }),
+    [draft, initialByLogin],
+  )
+
+  const discardChanges = () => {
+    setInvalidLogins(new Set())
+    setSubmitError(null)
+    setNewCollaborator("")
+    setNewPermission("push")
+    setDraft(initialEntries)
+  }
+
+  const handleSave = async () => {
+    if (isSaving || savingRef.current) return
+    savingRef.current = true
+    try {
+      setSubmitError(null)
+      setInvalidLogins(new Set())
+      setSaved(false)
+
+      const toRemove = draft
+        .filter((e) => e.markedForRemoval && !e.isNew)
+        .map((e) => e.login)
+      // Adds AND level changes are the same PUT upsert.
+      const toUpsert = draft.filter(
+        (e) =>
+          !e.markedForRemoval &&
+          (e.isNew || initialByLogin.get(e.login) !== e.permission),
+      )
+
+      const removeResults = await Promise.allSettled(
+        toRemove.map(async (login) => {
+          await removeCollaboratorMutation.mutateAsync({
+            org,
+            repo: repoName,
+            username: login,
+          })
+          return login
+        }),
+      )
+
+      const upsertResults = await Promise.allSettled(
+        toUpsert.map(async (entry) => {
+          await addCollaboratorMutation.mutateAsync({
+            org,
+            repo: repoName,
+            username: entry.login,
+            permission: entry.permission,
+          })
+          return entry.login
+        }),
+      )
+
+      const failedRemoves = rejectedItems(removeResults, toRemove)
+      const failedUpserts = rejectedItems(
+        upsertResults,
+        toUpsert.map((e) => e.login),
+      )
+
+      if (failedRemoves.length || failedUpserts.length) {
+        setInvalidLogins(
+          new Set([...failedRemoves, ...failedUpserts].map(normalizeUsername)),
+        )
+        const firstReason =
+          [...upsertResults, ...removeResults].find(
+            (r) => r.status === "rejected",
+          ) ?? null
+        const detail =
+          firstReason && firstReason.status === "rejected"
+            ? describeFailure(firstReason.reason, t)
+            : null
+        setSubmitError(
+          t("components.modals.repoAccess.saveError", {
+            suffix: detail ? ` ${detail}` : "",
+          }),
+        )
+        await refetchCollaborators()
+        return
+      }
+
+      await refetchCollaborators()
+      setSaved(true)
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSaved(false), 3000)
+    } finally {
+      savingRef.current = false
+    }
+  }
+
+  const permissionLabel = (level: RepoPermission) =>
+    t(`assignments.form.studentPermission.levels.${level}`)
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      closeDisabled={isSaving}
+      size="xl"
+      aria-labelledby={titleId}
+    >
+      <div className="flex items-start gap-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <ShieldCheck className="size-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("components.modals.repoAccess.title")}
+          </h3>
+          {repoName && (
+            <a
+              className="link mt-1 inline-flex items-center gap-1.5 text-sm"
+              href={repoUrl || `https://github.com/${org}/${repoName}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <GitHub aria-hidden="true" className="size-4" />
+              {assignmentName
+                ? t("components.modals.repoAccess.viewRepoNamed", {
+                    name: assignmentName,
+                  })
+                : t("components.modals.groupCollaborators.viewRepository")}
+            </a>
+          )}
+        </div>
+      </div>
+
+      {loadingCollaborators ? (
+        <div className="flex py-10">
+          <Spinner
+            className="m-auto"
+            label={t("components.modals.repoAccess.loading")}
+          />
+        </div>
+      ) : (
+        <>
+          <AnimatedAlert tone="success" show={saved} className="mt-4 text-sm">
+            {t("components.modals.repoAccess.saved")}
+          </AnimatedAlert>
+          <AnimatedAlert
+            tone="error"
+            show={!!submitError}
+            className="mt-4 text-sm"
+          >
+            {submitError}
+          </AnimatedAlert>
+
+          {!canManage && (
+            <Alert tone="error" className="mt-4 text-sm">
+              {t("components.modals.repoAccess.needsAdmin")}
+            </Alert>
+          )}
+
+          <p className="mt-4 text-sm text-base-content/70">
+            <Trans
+              i18nKey="components.modals.repoAccess.adminWarning"
+              components={{ b: <span className="font-semibold" /> }}
+            />
+          </p>
+
+          <ul className="mt-3 divide-y divide-base-200 rounded-2xl border border-base-200">
+            {draft.map((entry) => {
+              const isOwner = entry.login === ownerLoginResolved
+              const isInvalid = invalidLogins.has(entry.login)
+              return (
+                <li
+                  key={entry.login}
+                  className={[
+                    "flex items-center gap-3 px-4 py-2.5",
+                    isInvalid ? "bg-error/5" : "",
+                    entry.markedForRemoval ? "bg-error/5" : "",
+                  ].join(" ")}
+                >
+                  <GitHub
+                    aria-hidden="true"
+                    className={[
+                      "size-5 shrink-0",
+                      isInvalid ? "text-error" : "text-base-content/70",
+                    ].join(" ")}
+                  />
+                  <span
+                    className={[
+                      "min-w-0 flex-1 leading-tight",
+                      entry.markedForRemoval
+                        ? "text-error line-through opacity-70"
+                        : "",
+                    ].join(" ")}
+                  >
+                    <CollaboratorIdentity
+                      login={entry.login}
+                      students={students}
+                    />
+                  </span>
+                  {isOwner && (
+                    <Badge tone="primary">
+                      {t("components.modals.repoAccess.studentBadge")}
+                    </Badge>
+                  )}
+                  {!entry.markedForRemoval && (
+                    <Select
+                      selectSize="sm"
+                      className="w-auto"
+                      disabled={!canManage}
+                      aria-label={t("components.modals.repoAccess.roleFor", {
+                        username: entry.login,
+                      })}
+                      value={entry.permission}
+                      onChange={(e) =>
+                        setPermission(
+                          entry.login,
+                          e.target.value as RepoPermission,
+                        )
+                      }
+                    >
+                      {REPO_PERMISSIONS.map((level) => (
+                        <option key={level} value={level}>
+                          {permissionLabel(level)}
+                        </option>
+                      ))}
+                    </Select>
+                  )}
+                  {/* The enrolled student is never removed here (that would
+                      orphan them from their own submission); their role can
+                      still be changed above. */}
+                  {canManage && !isOwner && !entry.markedForRemoval && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      shape="square"
+                      className="text-base-content/70 hover:text-error"
+                      aria-label={t("components.modals.repoAccess.removeUser", {
+                        username: entry.login,
+                      })}
+                      onClick={() => markRemoval(entry.login, true)}
+                    >
+                      <Trash2 aria-hidden="true" className="size-4" />
+                    </Button>
+                  )}
+                  {canManage && entry.markedForRemoval && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-error"
+                      onClick={() => markRemoval(entry.login, false)}
+                    >
+                      {t("components.modals.groupCollaborators.undo")}
+                    </Button>
+                  )}
+                </li>
+              )
+            })}
+
+            {draft.length === 0 && (
+              <li className="px-4 py-6 text-center text-sm text-base-content/70">
+                {t("components.modals.groupCollaborators.noCollaborators")}
+              </li>
+            )}
+          </ul>
+
+          {canManage && (
+            <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+              <Input
+                className="flex-1"
+                placeholder={t(
+                  "components.modals.groupCollaborators.addPlaceholder",
+                )}
+                aria-label={t(
+                  "components.modals.groupCollaborators.addAriaLabel",
+                )}
+                value={newCollaborator}
+                onChange={(e) => setNewCollaborator(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault()
+                    addPending()
+                  }
+                }}
+              />
+              <Select
+                selectSize="md"
+                className="w-auto"
+                aria-label={t("components.modals.repoAccess.newRole")}
+                value={newPermission}
+                onChange={(e) =>
+                  setNewPermission(e.target.value as RepoPermission)
+                }
+              >
+                {REPO_PERMISSIONS.map((level) => (
+                  <option key={level} value={level}>
+                    {permissionLabel(level)}
+                  </option>
+                ))}
+              </Select>
+              <Button variant="outline" onClick={addPending}>
+                <Plus aria-hidden="true" className="size-4" />
+                {t("components.modals.groupCollaborators.add")}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+
+      <div className="modal-action">
+        <Button variant="ghost" disabled={isSaving} onClick={() => onClose()}>
+          {t("common.cancel")}
+        </Button>
+        {canManage && hasChanges && (
+          <Button variant="ghost" disabled={isSaving} onClick={discardChanges}>
+            {t("components.modals.groupCollaborators.discardChanges")}
+          </Button>
+        )}
+        {canManage && (
+          <Button
+            variant="primary"
+            disabled={loadingCollaborators || isSaving || !hasChanges}
+            loading={isSaving}
+            loadingLabel={t("components.modals.repoAccess.save")}
+            onClick={() => void handleSave()}
+          >
+            {t("components.modals.repoAccess.save")}
+          </Button>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+export default RepoAccessModal

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -20,6 +20,7 @@ import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
 import useRemoveRepoCollaborator from "@/hooks/mutations/useRemoveRepoCollaborator"
 import { getName } from "@/util/students"
+import { permissionSatisfies } from "@/domain/assignments/permissions"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { GitHubUser } from "@/github-core/types"
 import type { RepoPermission, Student } from "@/types/classroom"
@@ -27,6 +28,27 @@ import { REPO_PERMISSIONS } from "@/types/classroom"
 
 const normalizeUsername = (username: string) =>
   username.trim().replace(/^@/, "").toLowerCase()
+
+// A collaborator PUT that returned 204 but whose read-back didn't land on the
+// requested role — GitHub silently ignored the write (typically a downgrade it
+// won't apply to a repo creator, leaving residual admin). Carried so handleSave
+// can flag the row and explain the effective role that stuck.
+class RepoAccessNotAppliedError extends Error {
+  readonly login: string
+  readonly requested: RepoPermission
+  readonly effective: string | undefined
+  constructor(
+    login: string,
+    requested: RepoPermission,
+    effective: string | undefined,
+  ) {
+    super(`access for ${login} not applied (still ${effective ?? "unchanged"})`)
+    this.name = "RepoAccessNotAppliedError"
+    this.login = login
+    this.requested = requested
+    this.effective = effective
+  }
+}
 
 // The effective role from a collaborator's permission booleans (the list
 // endpoint returns no role_name in our GitHubUser shape). Highest wins; triage
@@ -52,6 +74,11 @@ const rejectedItems = <T,>(
 // Map a rejected write to a human reason; reuses the groupCollaborators failure
 // vocabulary so the two dialogs stay consistent.
 const describeFailure = (reason: unknown, t: TFunction): string | null => {
+  if (reason instanceof RepoAccessNotAppliedError) {
+    return t("components.modals.repoAccess.notApplied", {
+      effective: reason.effective ?? "unknown",
+    })
+  }
   if (reason instanceof GitHubAPIError) {
     if (reason.isRateLimited)
       return t("components.modals.groupCollaborators.failure.rateLimited")
@@ -327,12 +354,35 @@ export function RepoAccessModal({
 
       const upsertResults = await Promise.allSettled(
         toUpsert.map(async (entry) => {
-          await addCollaboratorMutation.mutateAsync({
+          const isEnrolledStudent = entry.login === ownerLoginResolved
+          const { effective } = await addCollaboratorMutation.mutateAsync({
             org,
             repo: repoName,
             username: entry.login,
             permission: entry.permission,
+            verify: true,
           })
+          // The enrolled student is an org member, so GitHub honors the direct
+          // grant exactly — a mismatch means the write was silently ignored
+          // (e.g. a downgrade below a lingering creator/base admin), the exact
+          // over-access an intended lockdown must catch. An arbitrary added
+          // collaborator only needs the grant to take (>= is enough), so treat
+          // that read-back with owner-style tolerance.
+          if (
+            effective &&
+            !permissionSatisfies(
+              effective.permission,
+              effective.role_name,
+              entry.permission,
+              !isEnrolledStudent,
+            )
+          ) {
+            throw new RepoAccessNotAppliedError(
+              entry.login,
+              entry.permission,
+              effective.role_name || effective.permission,
+            )
+          }
           return entry.login
         }),
       )

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -19,15 +19,17 @@ import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
 import useRemoveRepoCollaborator from "@/hooks/mutations/useRemoveRepoCollaborator"
-import { getName } from "@/util/students"
+import {
+  CollaboratorIdentity,
+  describeGitHubApiFailure,
+  normalizeUsername,
+  rejectedItems,
+} from "@/components/modals/collaboratorHelpers"
 import { permissionSatisfies } from "@/domain/assignments/permissions"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { GitHubUser } from "@/github-core/types"
 import type { RepoPermission, Student } from "@/types/classroom"
 import { REPO_PERMISSIONS } from "@/types/classroom"
-
-const normalizeUsername = (username: string) =>
-  username.trim().replace(/^@/, "").toLowerCase()
 
 // A collaborator PUT that returned 204 but whose read-back didn't land on the
 // requested role — GitHub silently ignored the write (typically a downgrade it
@@ -63,14 +65,6 @@ const permissionFromFlags = (
   return "pull"
 }
 
-const rejectedItems = <T,>(
-  results: PromiseSettledResult<unknown>[],
-  items: T[],
-): T[] =>
-  results.flatMap((result, i) =>
-    result.status === "rejected" ? [items[i]] : [],
-  )
-
 // Map a rejected write to a human reason; reuses the groupCollaborators failure
 // vocabulary so the two dialogs stay consistent.
 const describeFailure = (reason: unknown, t: TFunction): string | null => {
@@ -79,38 +73,14 @@ const describeFailure = (reason: unknown, t: TFunction): string | null => {
       effective: reason.effective ?? "unknown",
     })
   }
+  const shared = describeGitHubApiFailure(reason, t)
+  if (shared) return shared
   if (reason instanceof GitHubAPIError) {
-    if (reason.isRateLimited)
-      return t("components.modals.groupCollaborators.failure.rateLimited")
-    if (reason.status === 403)
-      return t("components.modals.groupCollaborators.failure.forbidden")
-    if (reason.status === 404)
-      return t("components.modals.groupCollaborators.failure.notFound")
     if (reason.status === 422)
       return t("components.modals.groupCollaborators.failure.conflict")
     return reason.message
   }
   return reason instanceof Error ? reason.message : null
-}
-
-const CollaboratorIdentity = ({
-  login,
-  students,
-}: {
-  login: string
-  students: Student[]
-}) => {
-  const name = getName(login, students)
-  return name ? (
-    <>
-      <span className="block truncate text-sm font-medium">{name}</span>
-      <span className="block truncate font-mono text-xs text-base-content/70">
-        @{login}
-      </span>
-    </>
-  ) : (
-    <span className="block truncate font-mono text-sm">@{login}</span>
-  )
 }
 
 // One row's draft state: its target role, and whether it's staged for removal.
@@ -554,9 +524,8 @@ export function RepoAccessModal({
                       ))}
                     </Select>
                   )}
-                  {/* The enrolled student is never removed here (that would
-                      orphan them from their own submission); their role can
-                      still be changed above. */}
+                  {/* Removing the enrolled student would orphan them from
+                      their own submission; only their role can change. */}
                   {canManage && !isOwner && !entry.markedForRemoval && (
                     <Button
                       variant="ghost"

--- a/web/src/components/modals/collaboratorHelpers.tsx
+++ b/web/src/components/modals/collaboratorHelpers.tsx
@@ -1,0 +1,58 @@
+import type { TFunction } from "i18next"
+
+import { getName } from "@/util/students"
+import { GitHubAPIError } from "@/github-core/errors"
+import type { Student } from "@/types/classroom"
+
+export const normalizeUsername = (username: string) =>
+  username.trim().replace(/^@/, "").toLowerCase()
+
+// The items whose settled promise rejected, by index into the input list.
+export const rejectedItems = <T,>(
+  results: PromiseSettledResult<unknown>[],
+  items: T[],
+): T[] =>
+  results.flatMap((result, i) =>
+    result.status === "rejected" ? [items[i]] : [],
+  )
+
+// The common GitHubAPIError failure reasons shared by the collaborator dialogs,
+// using the groupCollaborators vocabulary. Returns undefined when the reason
+// isn't one of these cases, so each dialog can layer its own branches (a 422
+// conflict, an HTTP-status fallback, a "not applied" downgrade) around it.
+export const describeGitHubApiFailure = (
+  reason: unknown,
+  t: TFunction,
+): string | undefined => {
+  if (reason instanceof GitHubAPIError) {
+    if (reason.isRateLimited)
+      return t("components.modals.groupCollaborators.failure.rateLimited")
+    if (reason.status === 403)
+      return t("components.modals.groupCollaborators.failure.forbidden")
+    if (reason.status === 404)
+      return t("components.modals.groupCollaborators.failure.notFound")
+  }
+  return undefined
+}
+
+// Two-line identity when we have a roster name (name + @handle), else just the
+// @handle. Shared by owner, member, and marked-for-removal rows.
+export const CollaboratorIdentity = ({
+  login,
+  students,
+}: {
+  login: string
+  students: Student[]
+}) => {
+  const name = getName(login, students)
+  return name ? (
+    <>
+      <span className="block truncate text-sm font-medium">{name}</span>
+      <span className="block truncate font-mono text-xs text-base-content/70">
+        @{login}
+      </span>
+    </>
+  ) : (
+    <span className="block truncate font-mono text-sm">@{login}</span>
+  )
+}

--- a/web/src/components/ui/FormField.tsx
+++ b/web/src/components/ui/FormField.tsx
@@ -68,6 +68,7 @@ export function FormField({
   htmlFor,
   required = false,
   help,
+  labelExtra,
   error,
   hint,
   className,
@@ -79,6 +80,10 @@ export function FormField({
   htmlFor?: string
   required?: boolean
   help?: string
+  // Rendered in the label row immediately after the help tooltip — e.g. a
+  // "Learn more" link to external docs that the tooltip's plain-text bubble
+  // can't carry as a clickable element.
+  labelExtra?: ReactNode
   error?: ReactNode
   hint?: ReactNode
   className?: string
@@ -103,6 +108,7 @@ export function FormField({
           ) : null}
         </label>
         {help ? <HelpTooltip help={help} /> : null}
+        {labelExtra}
       </div>
 
       {children({ id, describedById, invalid })}

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -2016,10 +2016,13 @@ describe("assertAssignmentModeCoherent", () => {
   })
 })
 
-// permissionSatisfies decides whether the read-back after the grant matches the
-// role we set, accounting for GitHub collapsing push -> legacy "write". Guards
-// the verified self-demotion (a repo creator is admin until this downgrades it).
-describe("permissionSatisfies — verified founder demotion", () => {
+// permissionSatisfies decides whether the read-back after the grant grants AT
+// LEAST the role we set. It guards the case that matters — a grant that read
+// back BELOW the wanted role (the downgrade that didn't take) — while
+// tolerating a benign higher effective role (org base permission, a repo
+// creator GitHub won't self-downgrade). GitHub is the real ceiling; the
+// teacher's level is a floor.
+describe("permissionSatisfies — verified founder access floor", () => {
   it("accepts a push grant that reads back as legacy write", () => {
     expect(permissionSatisfies("write", "write", "push")).toBe(true)
     expect(permissionSatisfies("write", "push", "push")).toBe(true)
@@ -2029,18 +2032,20 @@ describe("permissionSatisfies — verified founder demotion", () => {
     expect(permissionSatisfies("admin", "admin", "admin")).toBe(true)
   })
 
-  it("rejects a still-admin read-back after a push grant (downgrade ignored)", () => {
-    expect(permissionSatisfies("admin", "admin", "push")).toBe(false)
+  it("tolerates a still-higher read-back after a lower grant (benign residual)", () => {
+    // The effective role is the max of the direct grant, org base permission,
+    // and creator-admin; a residual above the wanted floor is not a failure.
+    expect(permissionSatisfies("admin", "admin", "push")).toBe(true)
+    expect(permissionSatisfies("write", "maintain", "push")).toBe(true)
+    // want=pull with an org base permission of write reads back as write.
+    expect(permissionSatisfies("write", "write", "pull")).toBe(true)
+    expect(permissionSatisfies("admin", "admin", "pull")).toBe(true)
   })
 
-  it("rejects a maintain read-back for a push target (the guard's boundary)", () => {
-    // GitHub collapses maintain->legacy "write", so legacy alone would pass;
-    // the authoritative role_name must catch the still-over-privileged founder.
-    expect(permissionSatisfies("write", "maintain", "push")).toBe(false)
-  })
-
-  it("rejects a push read-back for an admin target (group under-grant)", () => {
+  it("rejects a read-back BELOW the wanted role (grant didn't take)", () => {
     expect(permissionSatisfies("write", "push", "admin")).toBe(false)
+    expect(permissionSatisfies("read", "read", "push")).toBe(false)
+    expect(permissionSatisfies("write", "write", "maintain")).toBe(false)
   })
 
   it("falls back to the legacy field when role_name is absent", () => {
@@ -2049,21 +2054,13 @@ describe("permissionSatisfies — verified founder demotion", () => {
     expect(permissionSatisfies("write", undefined, "admin")).toBe(false)
   })
 
-  it("rejects an under-grant (read only) for a push target", () => {
-    expect(permissionSatisfies("read", "read", "push")).toBe(false)
+  it("tolerates an unavoidable admin residual for a push target", () => {
+    expect(permissionSatisfies("admin", "admin", "push")).toBe(true)
+    expect(permissionSatisfies("admin", undefined, "push")).toBe(true)
   })
 
-  it("tolerates an owner's unavoidable admin for a push target when isOwner", () => {
-    expect(permissionSatisfies("admin", "admin", "push", true)).toBe(true)
-    expect(permissionSatisfies("admin", undefined, "push", true)).toBe(true)
-  })
-
-  it("still rejects a maintain read-back for a push target even for an owner", () => {
-    expect(permissionSatisfies("write", "maintain", "push", true)).toBe(false)
-  })
-
-  it("does not let isOwner leak into an admin target", () => {
-    expect(permissionSatisfies("write", "maintain", "admin", true)).toBe(false)
+  it("still rejects a below-target read-back for an admin target", () => {
+    expect(permissionSatisfies("write", "maintain", "admin")).toBe(false)
   })
 })
 
@@ -2129,10 +2126,10 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
     })
   })
 
-  it("throws when the read-back still reports admin after a push grant", async () => {
+  it("tolerates a higher residual role (admin) after a push grant", async () => {
+    // The effective role is the max of the direct grant, org base permission,
+    // and creator-admin; a residual above the wanted floor is not a failure.
     const { client } = makeClient({ permission: "admin", role_name: "admin" })
-    // Thrown inside a step, so without its own descriptor the checklist would
-    // relabel it "safe to retry" — wrong for a grant only a teacher can fix.
     await expect(
       addFounderCollaborator({
         client,
@@ -2141,18 +2138,13 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         username,
         permission: "push",
       }),
-    ).rejects.toMatchObject({
-      localized: {
-        key: "accept.errors.founderAccessMismatch",
-        params: { username, permission: "push", effective: "admin" },
-      },
-    })
+    ).resolves.toBeUndefined()
   })
 
-  it("throws when the read-back is maintain for a push grant (the guard's boundary)", async () => {
+  it("throws when the read-back is BELOW the wanted role (grant didn't take)", async () => {
     const { client } = makeClient({
       permission: "write",
-      role_name: "maintain",
+      role_name: "push",
     })
     await expect(
       addFounderCollaborator({
@@ -2160,12 +2152,12 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         owner,
         repo,
         username,
-        permission: "push",
+        permission: "admin",
       }),
     ).rejects.toMatchObject({
       localized: {
         key: "accept.errors.founderAccessMismatch",
-        params: { permission: "push", role: "maintain" },
+        params: { permission: "admin", role: "push" },
       },
     })
   })

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -2135,8 +2135,8 @@ describe("permissionSatisfies — owner floor vs member exact match", () => {
   })
 
   it("member: rejects a still-higher read-back (silently-ignored downgrade)", () => {
-    // The exact over-access finding #3: a below-default target on a
-    // student-created repo whose creator-admin GitHub won't lower.
+    // A below-default target on a student-created repo whose creator-admin
+    // GitHub won't lower.
     expect(permissionSatisfies("admin", "admin", "push", false)).toBe(false)
     expect(permissionSatisfies("admin", "admin", "pull", false)).toBe(false)
     expect(permissionSatisfies("write", "maintain", "push", false)).toBe(false)

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { readFileSync } from "node:fs"
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 
 import {
   addFounderCollaborator,
@@ -28,6 +29,7 @@ import { localizedError, localizedMessageOf } from "@/types/localizedMessage"
 import type { GitHubClient } from "@/github-core/client"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { Assignment } from "@/types/classroom"
+import { REPO_PERMISSIONS } from "@/types/classroom"
 
 const fullSource: Assignment = {
   slug: "hw1",
@@ -1061,6 +1063,96 @@ describe("editAssignment (preserved-entry integration)", () => {
       ),
     ).rejects.toThrow(/other-org\/secret-upstream in another org/)
   })
+
+  // buildAssignmentEntry's student_permission branch (clamp group up to admin,
+  // omit when it equals the mode default) is exercised through editAssignment's
+  // write, asserting the entry that lands in the committed assignments.json —
+  // the authoring-side clamp, distinct from the accept-time founderPermission
+  // clamp covered elsewhere.
+  function writtenEntry(committedContent: string): Assignment {
+    const written = JSON.parse(committedContent) as {
+      assignments: Assignment[]
+    }
+    return written.assignments.find((a) => a.slug === SLUG)!
+  }
+
+  it("individual + push (the default) omits student_permission", async () => {
+    const { client, committedContent } = makeClient()
+    await editAssignment(
+      client,
+      editInput({ mode: "individual", student_permission: "push" }),
+    )
+    expect(writtenEntry(committedContent()).student_permission).toBeUndefined()
+  })
+
+  it("individual + admin writes admin (a real above-default value)", async () => {
+    const { client, committedContent } = makeClient()
+    await editAssignment(
+      client,
+      editInput({ mode: "individual", student_permission: "admin" }),
+    )
+    expect(writtenEntry(committedContent()).student_permission).toBe("admin")
+  })
+
+  it("individual + a below-default value (pull) is written verbatim", async () => {
+    const { client, committedContent } = makeClient()
+    await editAssignment(
+      client,
+      editInput({ mode: "individual", student_permission: "pull" }),
+    )
+    expect(writtenEntry(committedContent()).student_permission).toBe("pull")
+  })
+
+  it("group + push clamps up to admin (which is the group default, so omitted not written as push)", async () => {
+    const { client, committedContent } = makeClient()
+    await editAssignment(
+      client,
+      editInput({
+        mode: "group",
+        max_group_size: 3,
+        student_permission: "push",
+      }),
+    )
+    // The clamp raises push -> admin; admin is the group default, so the entry
+    // omits it. The load-bearing assertion is that the raw below-admin value was
+    // NOT written through (a missing clamp would persist "push").
+    expect(writtenEntry(committedContent()).student_permission).toBeUndefined()
+  })
+
+  it("group + admin (the group default) omits student_permission", async () => {
+    const { client, committedContent } = makeClient()
+    await editAssignment(
+      client,
+      editInput({
+        mode: "group",
+        max_group_size: 3,
+        student_permission: "admin",
+      }),
+    )
+    expect(writtenEntry(committedContent()).student_permission).toBeUndefined()
+  })
+
+  it("group + a below-admin value ('') omits (clamped value equals the group default)", async () => {
+    const { client, committedContent } = makeClient()
+    await editAssignment(
+      client,
+      editInput({ mode: "group", max_group_size: 3, student_permission: "" }),
+    )
+    expect(writtenEntry(committedContent()).student_permission).toBeUndefined()
+  })
+
+  it("throws on an off-ladder student_permission value", async () => {
+    const { client } = makeClient()
+    await expect(
+      editAssignment(
+        client,
+        editInput({
+          mode: "individual",
+          student_permission: "owner" as unknown as string,
+        }),
+      ),
+    ).rejects.toThrow(/student_permission/)
+  })
 })
 
 describe("grantTeamTemplateRead (student + HTA/TA staff team eager grant)", () => {
@@ -2016,157 +2108,157 @@ describe("assertAssignmentModeCoherent", () => {
   })
 })
 
-// permissionSatisfies decides whether the read-back after the grant grants AT
-// LEAST the role we set. It guards the case that matters — a grant that read
-// back BELOW the wanted role (the downgrade that didn't take) — while
-// tolerating a benign higher effective role (org base permission, a repo
-// creator GitHub won't self-downgrade). GitHub is the real ceiling; the
-// teacher's level is a floor.
-describe("permissionSatisfies — verified founder access floor", () => {
-  it("accepts a push grant that reads back as legacy write", () => {
-    expect(permissionSatisfies("write", "write", "push")).toBe(true)
-    expect(permissionSatisfies("write", "push", "push")).toBe(true)
+// permissionSatisfies decides whether the read-back after the grant is the role
+// we set. isOwner picks the comparison: an org owner tolerates a benign higher
+// residual (">=", their inherited/creator admin can't be self-downgraded),
+// while a plain member must land EXACTLY on the target ("=="), so a
+// silently-ignored downgrade (residual admin an intended lockdown must remove)
+// fails loudly.
+describe("permissionSatisfies — owner floor vs member exact match", () => {
+  it("accepts a push grant that reads back as push (both roles)", () => {
+    expect(permissionSatisfies("write", "write", "push", false)).toBe(true)
+    expect(permissionSatisfies("write", "push", "push", false)).toBe(true)
   })
 
   it("accepts an admin grant that reads back as admin", () => {
-    expect(permissionSatisfies("admin", "admin", "admin")).toBe(true)
+    expect(permissionSatisfies("admin", "admin", "admin", false)).toBe(true)
+    expect(permissionSatisfies("admin", "admin", "admin", true)).toBe(true)
   })
 
-  it("tolerates a still-higher read-back after a lower grant (benign residual)", () => {
-    // The effective role is the max of the direct grant, org base permission,
-    // and creator-admin; a residual above the wanted floor is not a failure.
-    expect(permissionSatisfies("admin", "admin", "push")).toBe(true)
-    expect(permissionSatisfies("write", "maintain", "push")).toBe(true)
-    // want=pull with an org base permission of write reads back as write.
-    expect(permissionSatisfies("write", "write", "pull")).toBe(true)
-    expect(permissionSatisfies("admin", "admin", "pull")).toBe(true)
+  it("owner: tolerates a still-higher read-back after a lower grant", () => {
+    // An owner's effective role is the max of the direct grant, org base
+    // permission, and unavoidable inherited/creator admin.
+    expect(permissionSatisfies("admin", "admin", "push", true)).toBe(true)
+    expect(permissionSatisfies("write", "maintain", "push", true)).toBe(true)
+    expect(permissionSatisfies("write", "write", "pull", true)).toBe(true)
+    expect(permissionSatisfies("admin", "admin", "pull", true)).toBe(true)
   })
 
-  it("rejects a read-back BELOW the wanted role (grant didn't take)", () => {
-    expect(permissionSatisfies("write", "push", "admin")).toBe(false)
-    expect(permissionSatisfies("read", "read", "push")).toBe(false)
-    expect(permissionSatisfies("write", "write", "maintain")).toBe(false)
+  it("member: rejects a still-higher read-back (silently-ignored downgrade)", () => {
+    // The exact over-access finding #3: a below-default target on a
+    // student-created repo whose creator-admin GitHub won't lower.
+    expect(permissionSatisfies("admin", "admin", "push", false)).toBe(false)
+    expect(permissionSatisfies("admin", "admin", "pull", false)).toBe(false)
+    expect(permissionSatisfies("write", "maintain", "push", false)).toBe(false)
+  })
+
+  it("rejects a read-back BELOW the wanted role for both owner and member", () => {
+    expect(permissionSatisfies("write", "push", "admin", true)).toBe(false)
+    expect(permissionSatisfies("write", "push", "admin", false)).toBe(false)
+    expect(permissionSatisfies("read", "read", "push", true)).toBe(false)
+    expect(permissionSatisfies("write", "write", "maintain", false)).toBe(false)
   })
 
   it("falls back to the legacy field when role_name is absent", () => {
-    expect(permissionSatisfies("write", undefined, "push")).toBe(true)
-    expect(permissionSatisfies("admin", undefined, "admin")).toBe(true)
-    expect(permissionSatisfies("write", undefined, "admin")).toBe(false)
+    // Legacy collapses maintain into write, so it can only prove push/write and
+    // admin; the owner/member comparison choice is the same.
+    expect(permissionSatisfies("write", undefined, "push", false)).toBe(true)
+    expect(permissionSatisfies("admin", undefined, "admin", false)).toBe(true)
+    expect(permissionSatisfies("write", undefined, "admin", true)).toBe(false)
+    expect(permissionSatisfies("admin", undefined, "push", true)).toBe(true)
+    expect(permissionSatisfies("admin", undefined, "push", false)).toBe(false)
   })
 
-  it("tolerates an unavoidable admin residual for a push target", () => {
-    expect(permissionSatisfies("admin", "admin", "push")).toBe(true)
-    expect(permissionSatisfies("admin", undefined, "push")).toBe(true)
-  })
-
-  it("still rejects a below-target read-back for an admin target", () => {
-    expect(permissionSatisfies("write", "maintain", "admin")).toBe(false)
+  it("rejects an unknown read-back role, failing closed", () => {
+    expect(permissionSatisfies("", "", "push", true)).toBe(false)
+    expect(permissionSatisfies(undefined, undefined, "push", false)).toBe(false)
   })
 })
 
 // Drives addFounderCollaborator end-to-end (PUT grant -> read-back -> throw),
 // the web mirror of gh-student's TestInviteFounder / _VerificationFails.
-describe("addFounderCollaborator — grant + read-back verification", () => {
+// The web half of the student_permission enum lockstep guard: REPO_PERMISSIONS
+// must equal the schema's student_permission enum (the declared source of
+// truth). The Go half (contract.RepoPermissions vs the same enum) is pinned by
+// TestStudentPermissionEnumParity, so a one-sided edit to any of the three
+// mirrors fails CI here or there rather than silently drifting the accept-time
+// floor verification.
+describe("REPO_PERMISSIONS parity with assignments-v1 schema", () => {
+  const schemaPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../schemas/assignments-v1.schema.json",
+  )
+  const schema = JSON.parse(readFileSync(schemaPath, "utf-8")) as {
+    $defs: {
+      assignment: {
+        properties: { student_permission: { enum: string[] } }
+      }
+    }
+  }
+
+  it("matches the schema student_permission enum exactly and in order", () => {
+    const schemaEnum =
+      schema.$defs.assignment.properties.student_permission.enum
+    expect(schemaEnum).toEqual([...REPO_PERMISSIONS])
+  })
+})
+
+describe("addFounderCollaborator — self grant (PUT only, no read-back)", () => {
   const owner = "cs50"
   const repo = "cs50-fall-2026-hello-alice"
   const username = "alice"
   const collabPath = `/repos/${owner}/${repo}/collaborators/${username}`
   const permPath = `${collabPath}/permission`
 
-  // A mock client that records the collaborator PUT body and answers the
-  // permission read-back with `readback`.
-  function makeClient(readback: { permission?: string; role_name?: string }) {
+  // Records the collaborator PUT and flags whether the permission sub-resource
+  // was read back (it must NOT be — the self read-back races an unbounded
+  // window; the grant guard lives on the teacher write paths instead).
+  function makeClient() {
     const put = vi.fn()
+    let readBack = false
     const request = vi.fn(async (path: string, opts?: { method?: string }) => {
       if (path === collabPath && opts?.method === "PUT") {
         put(opts)
         return undefined
       }
-      if (path === permPath) return readback
+      if (path === permPath) {
+        readBack = true
+        return {}
+      }
       throw new Error(`unexpected request: ${opts?.method ?? "GET"} ${path}`)
     })
-    return { client: { request } as unknown as GitHubClient, request, put }
+    return {
+      client: { request } as unknown as GitHubClient,
+      request,
+      put,
+      readBack: () => readBack,
+    }
   }
 
-  it("PUTs push and succeeds when the read-back satisfies", async () => {
-    const { client, request } = makeClient({
-      permission: "write",
-      role_name: "push",
-    })
-    await expect(
-      addFounderCollaborator({
-        client,
-        owner,
-        repo,
-        username,
-        permission: "push",
-      }),
-    ).resolves.toBeUndefined()
-    expect(request).toHaveBeenCalledWith(collabPath, {
-      method: "PUT",
-      body: { permission: "push" },
-    })
-  })
+  it.each(["push", "admin", "pull"] as const)(
+    "PUTs the requested role (%s) and trusts it — no read-back",
+    async (permission) => {
+      const { client, request, readBack } = makeClient()
+      await expect(
+        addFounderCollaborator({ client, owner, repo, username, permission }),
+      ).resolves.toBeUndefined()
+      expect(request).toHaveBeenCalledWith(collabPath, {
+        method: "PUT",
+        body: { permission },
+      })
+      expect(readBack()).toBe(false)
+    },
+  )
 
-  it("PUTs admin for a group founder", async () => {
-    const { client, request } = makeClient({
-      permission: "admin",
-      role_name: "admin",
-    })
-    await addFounderCollaborator({
-      client,
-      owner,
-      repo,
-      username,
-      permission: "admin",
-    })
-    expect(request).toHaveBeenCalledWith(collabPath, {
-      method: "PUT",
-      body: { permission: "admin" },
-    })
-  })
-
-  it("tolerates a higher residual role (admin) after a push grant", async () => {
-    // The effective role is the max of the direct grant, org base permission,
-    // and creator-admin; a residual above the wanted floor is not a failure.
-    const { client } = makeClient({ permission: "admin", role_name: "admin" })
-    await expect(
-      addFounderCollaborator({
-        client,
-        owner,
-        repo,
-        username,
-        permission: "push",
-      }),
-    ).resolves.toBeUndefined()
-  })
-
-  it("throws when the read-back is BELOW the wanted role (grant didn't take)", async () => {
-    const { client } = makeClient({
-      permission: "write",
-      role_name: "push",
-    })
-    await expect(
-      addFounderCollaborator({
-        client,
-        owner,
-        repo,
-        username,
-        permission: "admin",
-      }),
-    ).rejects.toMatchObject({
-      localized: {
-        key: "accept.errors.founderAccessMismatch",
-        params: { permission: "admin", role: "push" },
+  it("propagates a genuine PUT failure (e.g. not an org member)", async () => {
+    const err = new GitHubAPIError({
+      status: 404,
+      url: collabPath,
+      message: "Not Found",
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
       },
     })
-  })
-
-  it("resolves for an org owner whose read-back stays admin after a push grant", async () => {
-    const { client, request } = makeClient({
-      permission: "admin",
-      role_name: "admin",
+    const request = vi.fn(async () => {
+      throw err
     })
+    const client = { request } as unknown as GitHubClient
     await expect(
       addFounderCollaborator({
         client,
@@ -2174,13 +2266,8 @@ describe("addFounderCollaborator — grant + read-back verification", () => {
         repo,
         username,
         permission: "push",
-        isOwner: true,
       }),
-    ).resolves.toBeUndefined()
-    expect(request).toHaveBeenCalledWith(collabPath, {
-      method: "PUT",
-      body: { permission: "push" },
-    })
+    ).rejects.toBe(err)
   })
 })
 

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1968,6 +1968,19 @@ describe("founderPermission — accept-time repo role", () => {
   it("grants admin for group assignments (founder manages collaborators)", () => {
     expect(founderPermission("group")).toBe("admin")
   })
+
+  it("honors a configured student_permission for individual", () => {
+    expect(founderPermission("individual", "admin")).toBe("admin")
+    expect(founderPermission("individual", "pull")).toBe("pull")
+    expect(founderPermission("individual", "maintain")).toBe("maintain")
+  })
+
+  it("clamps a group assignment up to admin even when configured lower", () => {
+    // A group founder must hold admin to add teammates via `gh student invite`.
+    expect(founderPermission("group", "push")).toBe("admin")
+    expect(founderPermission("group", "pull")).toBe("admin")
+    expect(founderPermission("group", "admin")).toBe("admin")
+  })
 })
 
 // Mirrors gh-student's assertModeCoherentForCreate: a group-shaped entry

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -1,5 +1,5 @@
 import type { GitHubClient } from "@/github-core/client"
-import type { AssignmentMode } from "@/types/classroom"
+import type { AssignmentMode, RepoPermission } from "@/types/classroom"
 import { getUser } from "@/github-core/queries"
 import { studentRepoName } from "@/util/studentRepo"
 import {
@@ -154,10 +154,20 @@ function grantFounderAccessStep(params: {
   repo: string
   username: string
   mode: AssignmentMode
+  studentPermission?: RepoPermission
   isOwner: boolean
   onStepUpdate?: OnAcceptStepUpdate
 }) {
-  const { client, org, repo, username, mode, isOwner, onStepUpdate } = params
+  const {
+    client,
+    org,
+    repo,
+    username,
+    mode,
+    studentPermission,
+    isOwner,
+    onStepUpdate,
+  } = params
   return withAcceptStep(
     {
       id: "access",
@@ -176,7 +186,7 @@ function grantFounderAccessStep(params: {
         owner: org,
         repo,
         username,
-        permission: founderPermission(mode),
+        permission: founderPermission(mode, studentPermission),
         isOwner,
       })
     },
@@ -192,6 +202,7 @@ async function provisionAcceptedRepo(params: {
   repo: GitHubRepo
   username: string
   mode: AssignmentMode
+  studentPermission?: RepoPermission
   branch: string
   metadataYaml: string
   autogradeYaml: string
@@ -207,6 +218,7 @@ async function provisionAcceptedRepo(params: {
     repo,
     username,
     mode,
+    studentPermission,
     branch,
     metadataYaml,
     autogradeYaml,
@@ -222,6 +234,7 @@ async function provisionAcceptedRepo(params: {
     repo: repo.name,
     username,
     mode,
+    studentPermission,
     isOwner,
     onStepUpdate,
   })
@@ -653,7 +666,10 @@ export async function acceptAssignment(params: {
           owner: org,
           repo: created.repo.name,
           username,
-          permission: founderPermission(assignment.mode),
+          permission: founderPermission(
+            assignment.mode,
+            assignment.student_permission,
+          ),
           isOwner,
         })
       } catch (err) {
@@ -674,6 +690,7 @@ export async function acceptAssignment(params: {
         repo: created.repo.name,
         username,
         mode: assignment.mode,
+        studentPermission: assignment.student_permission,
         isOwner,
         onStepUpdate,
       })
@@ -749,7 +766,10 @@ export async function acceptAssignment(params: {
           owner: org,
           repo: created.repo.name,
           username,
-          permission: founderPermission(assignment.mode),
+          permission: founderPermission(
+            assignment.mode,
+            assignment.student_permission,
+          ),
           isOwner,
         })
       } catch (err) {
@@ -821,6 +841,7 @@ export async function acceptAssignment(params: {
       repo: created.repo,
       username,
       mode: assignment.mode,
+      studentPermission: assignment.student_permission,
       branch: created.repo.default_branch || sourceBranch,
       metadataYaml,
       autogradeYaml,
@@ -858,6 +879,7 @@ export async function acceptAssignment(params: {
     repo,
     username,
     mode: assignment.mode,
+    studentPermission: assignment.student_permission,
     branch: targetBranch,
     metadataYaml,
     autogradeYaml,

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -155,19 +155,10 @@ function grantFounderAccessStep(params: {
   username: string
   mode: AssignmentMode
   studentPermission?: RepoPermission
-  isOwner: boolean
   onStepUpdate?: OnAcceptStepUpdate
 }) {
-  const {
-    client,
-    org,
-    repo,
-    username,
-    mode,
-    studentPermission,
-    isOwner,
-    onStepUpdate,
-  } = params
+  const { client, org, repo, username, mode, studentPermission, onStepUpdate } =
+    params
   return withAcceptStep(
     {
       id: "access",
@@ -187,7 +178,6 @@ function grantFounderAccessStep(params: {
         repo,
         username,
         permission: founderPermission(mode, studentPermission),
-        isOwner,
       })
     },
   )
@@ -208,7 +198,6 @@ async function provisionAcceptedRepo(params: {
   autogradeYaml: string
   // Open the accept-time Feedback PR after setup succeeds (issue #228).
   feedbackPr?: boolean
-  isOwner?: boolean
   rerenderShimForBranch?: (branch: string) => string
   onStepUpdate?: OnAcceptStepUpdate
 }) {
@@ -223,21 +212,9 @@ async function provisionAcceptedRepo(params: {
     metadataYaml,
     autogradeYaml,
     feedbackPr = false,
-    isOwner = false,
     rerenderShimForBranch,
     onStepUpdate,
   } = params
-
-  await grantFounderAccessStep({
-    client,
-    org,
-    repo: repo.name,
-    username,
-    mode,
-    studentPermission,
-    isOwner,
-    onStepUpdate,
-  })
 
   // Land the metadata + autograde shim, retrying through GitHub's post-generate
   // git-data lag (see commitAcceptFilesWithFreshRepoRetry).
@@ -264,8 +241,9 @@ async function provisionAcceptedRepo(params: {
       }),
   )
 
-  // Last, because it's best-effort: everything above must hold for the accept
-  // to count, while a Feedback PR failure only defers creation to the runner.
+  // Best-effort: a Feedback PR failure only defers creation to the runner, so it
+  // never throws. Runs before the founder grant so the repo is fully set up
+  // before we (possibly) narrow the student's own access.
   await openFeedbackPrStep({
     client,
     org,
@@ -280,6 +258,22 @@ async function provisionAcceptedRepo(params: {
       }),
     mode,
     feedbackPr,
+    onStepUpdate,
+  })
+
+  // The founder grant is LAST: it can narrow the student's role on their own
+  // repo (a below-default student_permission is a self-downgrade), and the
+  // member-exact read-back fails loudly when GitHub won't apply it. Running it
+  // after setup + feedback means such a failure can't strand the student on a
+  // half-provisioned repo — the control files and Feedback PR are already in
+  // place; only the final access narrowing is left to retry.
+  await grantFounderAccessStep({
+    client,
+    org,
+    repo: repo.name,
+    username,
+    mode,
+    studentPermission,
     onStepUpdate,
   })
 }
@@ -478,7 +472,7 @@ export async function acceptAssignment(params: {
   // for public templates too. Org owners bypass (they administer every
   // classroom). Advisory like every client-side gate; GitHub's private-template
   // permission remains the hard boundary.
-  const membership = await withAcceptStep(
+  await withAcceptStep(
     {
       id: "membership",
       label: { key: "accept.steps.membership" },
@@ -494,11 +488,6 @@ export async function acceptAssignment(params: {
       return verified
     },
   )
-
-  // An org owner who creates the repo holds admin and can't self-downgrade to
-  // the push we grant (org policy blocks it); tolerate that residual admin at
-  // the founder read-back so an owner can still accept.
-  const isOwner = isOwnerGitHubOrgRole(membership.role)
 
   const assignment = await withAcceptStep(
     {
@@ -659,6 +648,15 @@ export async function acceptAssignment(params: {
           params: { org, repo: created.repo.name },
         },
       })
+      // setup + feedback are structurally skipped for a bare repo; mark them
+      // complete before the (last) access reconcile so the checklist order is
+      // consistent with the templated path.
+      onStepUpdate?.({
+        id: "setup",
+        status: "complete",
+        message: { key: "accept.stepDone.setupSkippedEmptyRepo" },
+      })
+      skipFeedbackPrStep(onStepUpdate)
       try {
         await patchRepoSurface(client, org, created.repo.name)
         await addFounderCollaborator({
@@ -670,7 +668,6 @@ export async function acceptAssignment(params: {
             assignment.mode,
             assignment.student_permission,
           ),
-          isOwner,
         })
       } catch (err) {
         log.debug("accept: best-effort role reconcile failed (non-fatal)", {
@@ -681,9 +678,18 @@ export async function acceptAssignment(params: {
       }
       onStepUpdate?.({ id: "access", status: "complete" })
     } else {
-      // Fresh create: the grant hard-fails (an un-granted repo is a broken
-      // accept the student can't push to), inside the throwing step so the
-      // checklist surfaces the error and its recovery guidance.
+      // Fresh create: setup + feedback are structurally skipped for a bare repo
+      // (no control files, no Feedback PR), so mark them complete first and run
+      // the founder grant LAST — consistent with the templated path's ordering.
+      // The grant hard-fails (an un-granted repo is a broken accept the student
+      // can't push to), inside the throwing step so the checklist surfaces the
+      // error and its recovery guidance.
+      onStepUpdate?.({
+        id: "setup",
+        status: "complete",
+        message: { key: "accept.stepDone.setupSkippedEmptyRepo" },
+      })
+      skipFeedbackPrStep(onStepUpdate)
       await grantFounderAccessStep({
         client,
         org,
@@ -691,16 +697,9 @@ export async function acceptAssignment(params: {
         username,
         mode: assignment.mode,
         studentPermission: assignment.student_permission,
-        isOwner,
         onStepUpdate,
       })
     }
-    onStepUpdate?.({
-      id: "setup",
-      status: "complete",
-      message: { key: "accept.stepDone.setupSkippedEmptyRepo" },
-    })
-    skipFeedbackPrStep(onStepUpdate)
 
     return {
       status: alreadyAccepted ? "already-accepted" : "created",
@@ -758,27 +757,6 @@ export async function acceptAssignment(params: {
     const provisioned = hasMetadata && hasWorkflow
 
     if (provisioned) {
-      // Healthy already-accepted: reconcile the founder role best-effort. A
-      // transient failure must not fail a re-run that previously succeeded.
-      try {
-        await addFounderCollaborator({
-          client,
-          owner: org,
-          repo: created.repo.name,
-          username,
-          permission: founderPermission(
-            assignment.mode,
-            assignment.student_permission,
-          ),
-          isOwner,
-        })
-      } catch (err) {
-        log.debug("accept: best-effort role reconcile failed (non-fatal)", {
-          org,
-          repo: created.repo.name,
-          err,
-        })
-      }
       onStepUpdate?.({
         id: "repo",
         status: "complete",
@@ -787,7 +765,6 @@ export async function acceptAssignment(params: {
           params: { org, repo: created.repo.name },
         },
       })
-      onStepUpdate?.({ id: "access", status: "complete" })
       onStepUpdate?.({ id: "setup", status: "complete" })
       // Ensure the Feedback PR exists even on the healthy path: repos
       // accepted before the accept-time-PR feature get their PR by
@@ -811,6 +788,28 @@ export async function acceptAssignment(params: {
         feedbackPr: wantsFeedbackPr,
         onStepUpdate,
       })
+      // Reconcile the founder role LAST (best-effort): a transient failure must
+      // not fail a re-run that previously succeeded, and running it after setup
+      // + feedback keeps the access step last on every path.
+      try {
+        await addFounderCollaborator({
+          client,
+          owner: org,
+          repo: created.repo.name,
+          username,
+          permission: founderPermission(
+            assignment.mode,
+            assignment.student_permission,
+          ),
+        })
+      } catch (err) {
+        log.debug("accept: best-effort role reconcile failed (non-fatal)", {
+          org,
+          repo: created.repo.name,
+          err,
+        })
+      }
+      onStepUpdate?.({ id: "access", status: "complete" })
       return {
         status: "already-accepted",
         repo: created.repo,
@@ -846,7 +845,6 @@ export async function acceptAssignment(params: {
       metadataYaml,
       autogradeYaml,
       feedbackPr: wantsFeedbackPr,
-      isOwner,
       rerenderShimForBranch: rerenderShim,
       onStepUpdate,
     })
@@ -884,7 +882,6 @@ export async function acceptAssignment(params: {
     metadataYaml,
     autogradeYaml,
     feedbackPr: wantsFeedbackPr,
-    isOwner,
     rerenderShimForBranch: rerenderShim,
     onStepUpdate,
   })

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -5,7 +5,9 @@ import {
   GROUP_SIZE_MIN,
   PASS_THRESHOLD_MAX,
   PASS_THRESHOLD_MIN,
+  REPO_PERMISSIONS,
   assertAssignmentMode,
+  defaultStudentPermission,
 } from "@/types/classroom"
 import {
   getBranchRef,
@@ -112,6 +114,7 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   allowed_files: "managed",
   release_assets: "managed",
   pass_threshold: "managed",
+  student_permission: "managed",
   tests: "managed",
   // Written only by the CLI's `migrate`; the form never manages it, so it must
   // ride through a GUI edit untouched.
@@ -601,6 +604,27 @@ async function buildAssignmentEntry(
       )
     }
     entry.pass_threshold = threshold
+  }
+
+  // student_permission: opt-in accept-time role for the enrolled student on
+  // their own repo. Omit when it equals the mode default (absent = default
+  // everywhere downstream), and clamp a group assignment up to admin (a founder
+  // must manage members). Validate against the ladder so a bad value can't
+  // produce a file the CLI refuses to parse.
+  if (input.student_permission) {
+    if (!REPO_PERMISSIONS.includes(input.student_permission)) {
+      throw new Error(
+        `student_permission: must be one of ${REPO_PERMISSIONS.join(", ")} (got "${input.student_permission}").`,
+      )
+    }
+    const mode = assertAssignmentMode(input.mode)
+    const effective =
+      mode === "group" && input.student_permission !== "admin"
+        ? "admin"
+        : input.student_permission
+    if (effective !== defaultStudentPermission(mode)) {
+      entry.student_permission = effective
+    }
   }
 
   return { entry, needsTeamGrant }

--- a/web/src/domain/assignments/permissions.ts
+++ b/web/src/domain/assignments/permissions.ts
@@ -1,24 +1,32 @@
 import type { GitHubClient } from "@/github-core/client"
 import type { AssignmentMode, RepoPermission } from "@/types/classroom"
 import type { GitHubRepo } from "@/github-core/types"
-import { getRepoPermissionForUser } from "@/github-core/queries"
 import { defaultStudentPermission } from "@/types/classroom"
 import { localizedError } from "@/types/localizedMessage"
 
-// Grant the founder their repo role and verify it took: the grant must land at
-// AT LEAST the requested level (a lower read-back is a grant that didn't take).
-// A benign higher effective role (org base permission, or a repo creator GitHub
-// won't self-downgrade) passes, since GitHub is the real ceiling and the
-// teacher's level is a floor. isOwner is accepted for call-site symmetry with
-// the CLI but no longer affects the >= check. CLI-aligned with inviteFounder in
-// gh-student's accept.go.
+// Grant the accepting student their role on their OWN repo. The student is the
+// repo creator (they ran POST /generate), so this PUT is a self-directed
+// collaborator change — including a self-downgrade below the default (a teacher
+// can set student_permission to e.g. `pull`). We trust the PUT: it is the
+// authenticated actor changing their own access, so a 2xx means it took.
+//
+// We deliberately do NOT read the effective permission back here. The
+// /repos/{org}/{repo}/collaborators/{self}/permission sub-resource lags the PUT
+// by a long, unbounded window right after a self-downgrade on a freshly
+// generated repo — it 404s ("no readable collaborator record yet") well past
+// any reasonable accept-run poll, even though the downgrade already applied. A
+// read-back therefore produces false accept failures for the exact legitimate
+// case it was meant to allow. The silently-ignored-downgrade guard belongs on
+// the TEACHER write paths (the per-repo / bulk gradebook modals), where a
+// DIFFERENT actor changes a student's role and a read-back can meaningfully
+// confirm it; see addRepoCollaborator's `verify`. CLI-aligned with
+// inviteFounder in gh-student's accept.go.
 export async function addFounderCollaborator(params: {
   client: GitHubClient
   owner: string
   repo: string
   username: string
   permission: RepoPermission
-  isOwner?: boolean
 }) {
   const { client, owner, repo, username, permission } = params
 
@@ -28,29 +36,6 @@ export async function addFounderCollaborator(params: {
       permission,
     },
   })
-
-  const effective = await getRepoPermissionForUser({
-    client,
-    org: owner,
-    repo,
-    username,
-  })
-
-  if (
-    !permissionSatisfies(effective.permission, effective.role_name, permission)
-  ) {
-    throw localizedError({
-      key: "accept.errors.founderAccessMismatch",
-      params: {
-        username,
-        permission,
-        owner,
-        repo,
-        effective: effective.permission ?? "none",
-        role: effective.role_name ?? "unknown",
-      },
-    })
-  }
 }
 
 // The permission ladder low-to-high, so a read-back can be ranked against the
@@ -68,32 +53,36 @@ const PERMISSION_RANK: Record<string, number> = {
   admin: 4,
 }
 
-// Whether the read-back grants AT LEAST the role we set. role_name is
-// authoritative when present. We verify ">=" rather than exact match: the
-// effective role is the max of the direct grant, the org base repository
-// permission, team grants, and creator-admin, so a benign residual above the
-// wanted level (an org base perm higher than a below-default target, or a repo
-// creator GitHub won't self-downgrade) must not fail an otherwise-good accept.
-// The check still fails loudly when the student ends up BELOW the wanted role
-// (the grant that didn't take). GitHub is the real enforcer of any ceiling;
-// the teacher's level is a floor we guarantee. Mirrors gh-student's
-// permissionSatisfies.
+// Whether the read-back is the role we set. role_name is authoritative when
+// present. isOwner picks the comparison, because it decides whether a HIGHER
+// read-back is benign or a real failure:
+//
+//   - Org OWNER (isOwner): compare ">=". An owner holds unavoidable inherited
+//     admin (and can't self-downgrade below it when they created the repo), so
+//     a residual above the wanted level is benign — GitHub is the real ceiling
+//     and the teacher's level is a floor we guarantee. Only a read-back BELOW
+//     the wanted role (a grant that didn't take) fails.
+//   - Non-owner MEMBER (!isOwner): compare "==". GitHub honors the direct
+//     collaborator grant for a plain member, so the effective role should land
+//     exactly on the target. A higher read-back means a requested downgrade was
+//     silently ignored (e.g. a lingering creator/team/base grant), and for a
+//     BELOW-default target (a teacher deliberately narrowing access) that
+//     residual is exactly the over-access we must catch — so it fails loudly.
+//
+// Mirrors gh-student's permissionSatisfies.
 export function permissionSatisfies(
   legacy: string | undefined,
   roleName: string | undefined,
   want: RepoPermission,
+  isOwner: boolean,
 ): boolean {
   const wantRank = PERMISSION_RANK[want]
-  if (roleName) {
-    const gotRank = PERMISSION_RANK[roleName]
-    if (gotRank === undefined) return false
-    return gotRank >= wantRank
-  }
-  // Legacy field only: it can't distinguish triage/maintain (both collapse to
-  // "write"), so the same >= compare is the best it can prove.
-  const gotRank = PERMISSION_RANK[legacy ?? ""]
+  // role_name is exact (maintain/admin distinct); the legacy field collapses
+  // maintain into "write", so it can only prove push/write and admin — but the
+  // owner-vs-member comparison choice is the same for both.
+  const gotRank = PERMISSION_RANK[roleName || (legacy ?? "")]
   if (gotRank === undefined) return false
-  return gotRank >= wantRank
+  return isOwner ? gotRank >= wantRank : gotRank === wantRank
 }
 
 // Maps an assignment to the founder's accept-time repo role: the configured

--- a/web/src/domain/assignments/permissions.ts
+++ b/web/src/domain/assignments/permissions.ts
@@ -5,11 +5,13 @@ import { getRepoPermissionForUser } from "@/github-core/queries"
 import { defaultStudentPermission } from "@/types/classroom"
 import { localizedError } from "@/types/localizedMessage"
 
-// Grant the founder their repo role and verify it took: a repo creator holds
-// admin, so an individual self-downgrade GitHub silently ignores looks like
-// success. isOwner tolerates an unavoidable residual admin (an org owner can't
-// self-downgrade), since admin already covers push. CLI-aligned with
-// inviteFounder in gh-student's accept.go.
+// Grant the founder their repo role and verify it took: the grant must land at
+// AT LEAST the requested level (a lower read-back is a grant that didn't take).
+// A benign higher effective role (org base permission, or a repo creator GitHub
+// won't self-downgrade) passes, since GitHub is the real ceiling and the
+// teacher's level is a floor. isOwner is accepted for call-site symmetry with
+// the CLI but no longer affects the >= check. CLI-aligned with inviteFounder in
+// gh-student's accept.go.
 export async function addFounderCollaborator(params: {
   client: GitHubClient
   owner: string
@@ -18,7 +20,7 @@ export async function addFounderCollaborator(params: {
   permission: RepoPermission
   isOwner?: boolean
 }) {
-  const { client, owner, repo, username, permission, isOwner = false } = params
+  const { client, owner, repo, username, permission } = params
 
   await client.request(`/repos/${owner}/${repo}/collaborators/${username}`, {
     method: "PUT",
@@ -35,12 +37,7 @@ export async function addFounderCollaborator(params: {
   })
 
   if (
-    !permissionSatisfies(
-      effective.permission,
-      effective.role_name,
-      permission,
-      isOwner,
-    )
+    !permissionSatisfies(effective.permission, effective.role_name, permission)
   ) {
     throw localizedError({
       key: "accept.errors.founderAccessMismatch",
@@ -71,29 +68,31 @@ const PERMISSION_RANK: Record<string, number> = {
   admin: 4,
 }
 
-// Whether the read-back at least matches the role we set. role_name is
-// authoritative when present (an exact rank compare). isOwner relaxes any want
-// to also accept admin: an org owner who created the repo can't self-downgrade
-// (org policy blocks it), and admin is a superset. Mirrors gh-student's
+// Whether the read-back grants AT LEAST the role we set. role_name is
+// authoritative when present. We verify ">=" rather than exact match: the
+// effective role is the max of the direct grant, the org base repository
+// permission, team grants, and creator-admin, so a benign residual above the
+// wanted level (an org base perm higher than a below-default target, or a repo
+// creator GitHub won't self-downgrade) must not fail an otherwise-good accept.
+// The check still fails loudly when the student ends up BELOW the wanted role
+// (the grant that didn't take). GitHub is the real enforcer of any ceiling;
+// the teacher's level is a floor we guarantee. Mirrors gh-student's
 // permissionSatisfies.
 export function permissionSatisfies(
   legacy: string | undefined,
   roleName: string | undefined,
   want: RepoPermission,
-  isOwner = false,
 ): boolean {
   const wantRank = PERMISSION_RANK[want]
   if (roleName) {
     const gotRank = PERMISSION_RANK[roleName]
     if (gotRank === undefined) return false
-    if (isOwner && gotRank === PERMISSION_RANK.admin) return true
-    return gotRank === wantRank
+    return gotRank >= wantRank
   }
   // Legacy field only: it can't distinguish triage/maintain (both collapse to
-  // "write"), so fall back to a >= compare, which is the best it can prove.
+  // "write"), so the same >= compare is the best it can prove.
   const gotRank = PERMISSION_RANK[legacy ?? ""]
   if (gotRank === undefined) return false
-  if (isOwner && gotRank === PERMISSION_RANK.admin) return true
   return gotRank >= wantRank
 }
 

--- a/web/src/domain/assignments/permissions.ts
+++ b/web/src/domain/assignments/permissions.ts
@@ -1,7 +1,8 @@
 import type { GitHubClient } from "@/github-core/client"
-import type { AssignmentMode } from "@/types/classroom"
+import type { AssignmentMode, RepoPermission } from "@/types/classroom"
 import type { GitHubRepo } from "@/github-core/types"
 import { getRepoPermissionForUser } from "@/github-core/queries"
+import { defaultStudentPermission } from "@/types/classroom"
 import { localizedError } from "@/types/localizedMessage"
 
 // Grant the founder their repo role and verify it took: a repo creator holds
@@ -14,7 +15,7 @@ export async function addFounderCollaborator(params: {
   owner: string
   repo: string
   username: string
-  permission: "push" | "admin"
+  permission: RepoPermission
   isOwner?: boolean
 }) {
   const { client, owner, repo, username, permission, isOwner = false } = params
@@ -55,33 +56,59 @@ export async function addFounderCollaborator(params: {
   }
 }
 
-// Whether the read-back matches the role we set. role_name is authoritative
-// when present: a push target accepts push/write but must reject the
-// more-privileged maintain/admin the legacy field would hide (GitHub collapses
-// maintain->write, admin->admin). isOwner relaxes a push want to also accept
-// admin: an org owner who created the repo can't self-downgrade (org policy
-// blocks it), and admin is a superset of push. Mirrors gh-student's
+// The permission ladder low-to-high, so a read-back can be ranked against the
+// role we wanted. GitHub's role_name reports the effective role (with maintain
+// and admin distinct), while the legacy `permission` field collapses maintain
+// into "write" and only distinguishes admin — so ranking on role_name is exact
+// and ranking on the legacy field can only prove push/write and admin.
+const PERMISSION_RANK: Record<string, number> = {
+  read: 0,
+  pull: 0,
+  triage: 1,
+  write: 2,
+  push: 2,
+  maintain: 3,
+  admin: 4,
+}
+
+// Whether the read-back at least matches the role we set. role_name is
+// authoritative when present (an exact rank compare). isOwner relaxes any want
+// to also accept admin: an org owner who created the repo can't self-downgrade
+// (org policy blocks it), and admin is a superset. Mirrors gh-student's
 // permissionSatisfies.
 export function permissionSatisfies(
   legacy: string | undefined,
   roleName: string | undefined,
-  want: "push" | "admin",
+  want: RepoPermission,
   isOwner = false,
 ): boolean {
+  const wantRank = PERMISSION_RANK[want]
   if (roleName) {
-    if (want === "admin") return roleName === "admin"
-    if (isOwner && roleName === "admin") return true
-    return roleName === "push" || roleName === "write"
+    const gotRank = PERMISSION_RANK[roleName]
+    if (gotRank === undefined) return false
+    if (isOwner && gotRank === PERMISSION_RANK.admin) return true
+    return gotRank === wantRank
   }
-  if (want === "admin") return legacy === "admin"
-  if (isOwner && legacy === "admin") return true
-  return legacy === "write"
+  // Legacy field only: it can't distinguish triage/maintain (both collapse to
+  // "write"), so fall back to a >= compare, which is the best it can prove.
+  const gotRank = PERMISSION_RANK[legacy ?? ""]
+  if (gotRank === undefined) return false
+  if (isOwner && gotRank === PERMISSION_RANK.admin) return true
+  return gotRank >= wantRank
 }
 
-// Maps assignment mode to the founder's repo role: least-privilege `push` for
-// individual, `admin` for group. Mirrors gh-student's founderPermission.
-export function founderPermission(mode: AssignmentMode): "push" | "admin" {
-  return mode === "group" ? "admin" : "push"
+// Maps an assignment to the founder's accept-time repo role: the configured
+// student_permission when set, else the mode default (least-privilege push for
+// individual, admin for group). A group founder must hold at least admin to add
+// teammates via `gh student invite`, so a group value below admin is clamped up.
+// Mirrors gh-student's founderPermission.
+export function founderPermission(
+  mode: AssignmentMode,
+  studentPermission?: RepoPermission,
+): RepoPermission {
+  const want = studentPermission ?? defaultStudentPermission(mode)
+  if (mode === "group" && want !== "admin") return "admin"
+  return want
 }
 
 // Rejects a group-shaped entry (max_group_size >= 2) whose mode isn't `group`:

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -1,5 +1,6 @@
 import type { GitHubClient } from "@/github-core/client"
 import type { GitHubRepo } from "@/github-core/types"
+import type { RepoPermission } from "@/types/classroom"
 import { GitHubAPIError } from "@/github-core/errors"
 import { DEFAULT_BRANCH } from "@/util/configRepo"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
@@ -269,6 +270,10 @@ export type CreateAssignmentInput = {
   allowed_files?: string
   release_assets: string
   pass_threshold?: number
+  // Accept-time role for the enrolled student on their own repo. Undefined =
+  // the mode default (push individual / admin group). buildAssignmentEntry
+  // omits it when it equals the default and clamps group up to admin.
+  student_permission?: RepoPermission
   tests: AssignmentTestDraft[]
   // Whether the write path may attempt the owner-only template read-grant
   // (addRepositoryToTeam). Set from useCanAttemptTemplateGrant at the call site

--- a/web/src/github-core/mutations/collaborators.test.ts
+++ b/web/src/github-core/mutations/collaborators.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { addRepoCollaborator } from "./collaborators"
+import { GitHubAPIError } from "../errors"
+import type { GitHubClient } from "../client"
+
+const ORG = "cs50"
+const REPO = "cs50-fall-2026-hello-alice"
+const USER = "alice"
+const memberPath = `/orgs/${ORG}/members/${USER}`
+const collabPath = `/repos/${ORG}/${REPO}/collaborators/${USER}`
+const permPath = `${collabPath}/permission`
+
+function apiError(status: number): GitHubAPIError {
+  return new GitHubAPIError({
+    status,
+    url: permPath,
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
+// requestRaw handles the org-membership pre-check and the collaborator PUT;
+// request handles the effective-permission read-back. `readBack` is either the
+// value the /permission GET returns, or an error it throws (a lagging 404 or a
+// transient), so a test can drive the unverified path.
+function makeClient(opts: {
+  memberCheck?: "ok" | GitHubAPIError
+  put?: "ok" | GitHubAPIError
+  readBack?: { permission?: string; role_name?: string } | GitHubAPIError
+}) {
+  const { memberCheck = "ok", put = "ok", readBack } = opts
+  const requestRaw = vi.fn(async (path: string) => {
+    if (path === memberPath) {
+      if (memberCheck instanceof GitHubAPIError) throw memberCheck
+      return undefined
+    }
+    if (path === collabPath) {
+      if (put instanceof GitHubAPIError) throw put
+      return undefined
+    }
+    throw new Error(`unexpected requestRaw: ${path}`)
+  })
+  const request = vi.fn(async (path: string) => {
+    if (path === permPath) {
+      if (readBack instanceof GitHubAPIError) throw readBack
+      return readBack
+    }
+    throw new Error(`unexpected request: ${path}`)
+  })
+  return {
+    client: { request, requestRaw } as unknown as GitHubClient,
+    request,
+    requestRaw,
+  }
+}
+
+describe("addRepoCollaborator", () => {
+  it("without verify: PUTs the role and issues NO read-back", async () => {
+    const { client, request, requestRaw } = makeClient({})
+    const result = await addRepoCollaborator({
+      client,
+      org: ORG,
+      repo: REPO,
+      username: USER,
+      permission: "pull",
+    })
+    expect(result).toEqual({})
+    // The PUT went out with the requested role...
+    expect(requestRaw).toHaveBeenCalledWith(collabPath, {
+      method: "PUT",
+      body: { permission: "pull" },
+    })
+    // ...and the permission sub-resource was never read.
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it("with verify: reads the effective permission back and returns it", async () => {
+    const { client, request } = makeClient({
+      readBack: { permission: "read", role_name: "pull" },
+    })
+    const result = await addRepoCollaborator({
+      client,
+      org: ORG,
+      repo: REPO,
+      username: USER,
+      permission: "pull",
+      verify: true,
+    })
+    expect(result).toEqual({
+      effective: { permission: "read", role_name: "pull" },
+    })
+    expect(request).toHaveBeenCalledWith(permPath)
+  })
+
+  it("with verify: a lagging 404 read-back returns effective:undefined, not a failure", async () => {
+    // The /collaborators/{u}/permission sub-resource lags a fresh PUT by an
+    // unbounded window; a 404 there means "not readable yet", not that the
+    // (already-succeeded) write failed. The caller treats undefined as
+    // issued-but-unconfirmed and must NOT surface it as a failed write.
+    const { client } = makeClient({ readBack: apiError(404) })
+    const result = await addRepoCollaborator({
+      client,
+      org: ORG,
+      repo: REPO,
+      username: USER,
+      permission: "pull",
+      verify: true,
+    })
+    expect(result).toEqual({ effective: undefined })
+  })
+
+  it("with verify: a transient read-back error (5xx) is also unverified, not a failure", async () => {
+    const { client } = makeClient({ readBack: apiError(502) })
+    const result = await addRepoCollaborator({
+      client,
+      org: ORG,
+      repo: REPO,
+      username: USER,
+      permission: "push",
+      verify: true,
+    })
+    expect(result).toEqual({ effective: undefined })
+  })
+
+  it("propagates a definitive 404 from the org-membership pre-check (not a member)", async () => {
+    const err = apiError(404)
+    const { client, requestRaw } = makeClient({ memberCheck: err })
+    await expect(
+      addRepoCollaborator({
+        client,
+        org: ORG,
+        repo: REPO,
+        username: USER,
+        permission: "push",
+      }),
+    ).rejects.toBe(err)
+    // Blocked before the collaborator PUT.
+    expect(requestRaw).not.toHaveBeenCalledWith(collabPath, expect.anything())
+  })
+
+  it("propagates a genuine PUT failure (the write itself erroring)", async () => {
+    const err = apiError(422)
+    const { client } = makeClient({ put: err })
+    await expect(
+      addRepoCollaborator({
+        client,
+        org: ORG,
+        repo: REPO,
+        username: USER,
+        permission: "push",
+        verify: true,
+      }),
+    ).rejects.toBe(err)
+  })
+})

--- a/web/src/github-core/mutations/collaborators.ts
+++ b/web/src/github-core/mutations/collaborators.ts
@@ -1,20 +1,34 @@
 import type { GitHubClient } from "../client"
 import { GitHubAPIError } from "../errors"
 
-// After a collaborator PUT, GitHub reports the effective role here. A silently
-// ignored write (e.g. a downgrade GitHub won't apply to a repo creator, or a
-// higher team/base grant) returns 204 on the PUT but leaves this unchanged, so
-// callers that must confirm the grant took read it back.
+// The effective-permission read after a collaborator PUT. A silently ignored
+// write (a downgrade GitHub won't apply to a repo creator, or a higher team/base
+// grant) returns 204 on the PUT but leaves this unchanged, so callers that must
+// confirm the grant took read it back. Returns undefined when the sub-resource
+// can't be read yet: right after a fresh PUT this endpoint lags by a long,
+// unbounded window and 404s (or the read is otherwise transiently unavailable)
+// even though the write applied, so a non-readable result is UNVERIFIED, not a
+// failure — the accept path dropped its read-back entirely for this same reason.
 async function readEffectivePermission(params: {
   client: GitHubClient
   org: string
   repo: string
   username: string
-}): Promise<{ permission?: string; role_name?: string }> {
+}): Promise<{ permission?: string; role_name?: string } | undefined> {
   const { client, org, repo, username } = params
-  return client.request(
-    `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators/${encodeURIComponent(username)}/permission`,
-  )
+  try {
+    return await client.request(
+      `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators/${encodeURIComponent(username)}/permission`,
+    )
+  } catch (err) {
+    // The PUT already succeeded (checked by the caller); a failed read-back only
+    // means we can't confirm the effective role, so report it as unverified
+    // rather than turning a landed write into a spurious failure. A 404 is the
+    // common not-yet-readable case; a transient 5xx/rate-limit is treated the
+    // same — the write stands, verification is simply inconclusive.
+    if (err instanceof GitHubAPIError) return undefined
+    throw err
+  }
 }
 
 export async function addRepoCollaborator(params: {
@@ -25,7 +39,10 @@ export async function addRepoCollaborator(params: {
   permission?: "pull" | "triage" | "push" | "maintain" | "admin"
   // When set, read the effective permission back after the PUT and return it so
   // the caller can confirm the write actually landed (a bare 204 doesn't prove
-  // a downgrade took). Omitted for callers that only need the write issued.
+  // a downgrade took). `effective` is undefined when the read-back couldn't be
+  // read (the sub-resource lags a fresh PUT) — the write still stands, so the
+  // caller treats an undefined read-back as issued-but-unconfirmed, never as a
+  // failure. Omitted entirely for callers that only need the write issued.
   verify?: boolean
 }): Promise<{ effective?: { permission?: string; role_name?: string } }> {
   const {

--- a/web/src/github-core/mutations/collaborators.ts
+++ b/web/src/github-core/mutations/collaborators.ts
@@ -1,5 +1,6 @@
 import type { GitHubClient } from "../client"
 import { GitHubAPIError } from "../errors"
+import type { RepoPermission } from "@/types/classroom"
 
 // The effective-permission read after a collaborator PUT. A silently ignored
 // write (a downgrade GitHub won't apply to a repo creator, or a higher team/base
@@ -36,7 +37,7 @@ export async function addRepoCollaborator(params: {
   org: string
   repo: string
   username: string
-  permission?: "pull" | "triage" | "push" | "maintain" | "admin"
+  permission?: RepoPermission
   // When set, read the effective permission back after the PUT and return it so
   // the caller can confirm the write actually landed (a bare 204 doesn't prove
   // a downgrade took). `effective` is undefined when the read-back couldn't be

--- a/web/src/github-core/mutations/collaborators.ts
+++ b/web/src/github-core/mutations/collaborators.ts
@@ -1,14 +1,41 @@
 import type { GitHubClient } from "../client"
 import { GitHubAPIError } from "../errors"
 
+// After a collaborator PUT, GitHub reports the effective role here. A silently
+// ignored write (e.g. a downgrade GitHub won't apply to a repo creator, or a
+// higher team/base grant) returns 204 on the PUT but leaves this unchanged, so
+// callers that must confirm the grant took read it back.
+async function readEffectivePermission(params: {
+  client: GitHubClient
+  org: string
+  repo: string
+  username: string
+}): Promise<{ permission?: string; role_name?: string }> {
+  const { client, org, repo, username } = params
+  return client.request(
+    `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators/${encodeURIComponent(username)}/permission`,
+  )
+}
+
 export async function addRepoCollaborator(params: {
   client: GitHubClient
   org: string
   repo: string
   username: string
   permission?: "pull" | "triage" | "push" | "maintain" | "admin"
-}) {
-  const { client, org, repo, username, permission = "push" } = params
+  // When set, read the effective permission back after the PUT and return it so
+  // the caller can confirm the write actually landed (a bare 204 doesn't prove
+  // a downgrade took). Omitted for callers that only need the write issued.
+  verify?: boolean
+}): Promise<{ effective?: { permission?: string; role_name?: string } }> {
+  const {
+    client,
+    org,
+    repo,
+    username,
+    permission = "push",
+    verify = false,
+  } = params
 
   // Only a definitive 404 (not an org member) blocks the add; transient errors
   // (rate limit, 5xx, private-membership 403) fall through to the PUT rather
@@ -21,7 +48,7 @@ export async function addRepoCollaborator(params: {
     if (err instanceof GitHubAPIError && err.isNotFound) throw err
   }
 
-  const res = await client.requestRaw(
+  await client.requestRaw(
     `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/collaborators/${encodeURIComponent(username)}`,
     {
       method: "PUT",
@@ -31,7 +58,15 @@ export async function addRepoCollaborator(params: {
     },
   )
 
-  return res
+  if (!verify) return {}
+
+  const effective = await readEffectivePermission({
+    client,
+    org,
+    repo,
+    username,
+  })
+  return { effective }
 }
 
 export async function removeRepoCollaborator(params: {

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -46,7 +46,6 @@ export {
   commitQuery,
   repoQuery,
   getOrgRepos,
-  getRepoPermissionForUser,
   getOpenPullRequests,
   listPullRequestsByBaseHead,
 } from "./queries/repoRefReads"

--- a/web/src/github-core/queries/repoRefReads.ts
+++ b/web/src/github-core/queries/repoRefReads.ts
@@ -117,19 +117,6 @@ export async function getOrgRepos(client: GitHubClient, owner: string) {
   )
 }
 
-export async function getRepoPermissionForUser(params: {
-  client: GitHubClient
-  org: string
-  repo: string
-  username: string
-}): Promise<{ permission?: string; role_name?: string }> {
-  const { client, org, repo, username } = params
-
-  return client.request<{ permission?: string; role_name?: string }>(
-    `/repos/${org}/${repo}/collaborators/${username}/permission`,
-  )
-}
-
 // Open PRs on a student/group repo. The autograde workflow opens one Feedback
 // PR per repo, so the first open PR is that PR. 404 (repo not generated yet) ->
 // []. Tolerant so a missing repo reads as "no PR" rather than throwing.

--- a/web/src/hooks/mutations/useAddRepoCollaborator.ts
+++ b/web/src/hooks/mutations/useAddRepoCollaborator.ts
@@ -13,6 +13,7 @@ export function useAddRepoCollaborator() {
       repo: string
       username: string
       permission?: "pull" | "triage" | "push" | "maintain" | "admin"
+      verify?: boolean
     }) =>
       addRepoCollaborator({
         client,

--- a/web/src/hooks/mutations/useAddRepoCollaborator.ts
+++ b/web/src/hooks/mutations/useAddRepoCollaborator.ts
@@ -2,6 +2,7 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { githubKeys } from "@/github-core/queries"
 import { addRepoCollaborator } from "@/github-core/mutations"
+import type { RepoPermission } from "@/types/classroom"
 
 export function useAddRepoCollaborator() {
   const client = useGitHubClient()
@@ -12,7 +13,7 @@ export function useAddRepoCollaborator() {
       org: string
       repo: string
       username: string
-      permission?: "pull" | "triage" | "push" | "maintain" | "admin"
+      permission?: RepoPermission
       verify?: boolean
     }) =>
       addRepoCollaborator({

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1920,7 +1920,7 @@
       "assignment": "Looking up the assignment",
       "autograder": "Resolving the autograder",
       "repo": "Creating your repository",
-      "access": "Granting you access",
+      "access": "Setting your repository access",
       "setup": "Setting up autograding",
       "feedback": "Opening feedback pull request"
     },
@@ -1933,7 +1933,7 @@
       "repo": "Created {{org}}/{{repo}}",
       "repoExists": "Repository already exists: {{org}}/{{repo}}",
       "repoIncomplete": "Found incomplete setup: {{org}}/{{repo}}",
-      "access": "Granted you access to your repository",
+      "access": "Set your repository access",
       "setup": "Autograding configured",
       "setupSkippedEmptyRepo": "No setup needed: this assignment uses an empty repository",
       "feedback": "Feedback pull request ready",
@@ -1946,7 +1946,7 @@
       "assignment": "Couldn't load assignment \"{{assignmentSlug}}\" for {{org}}/{{classroom}}. Check the link, or ask your teacher to confirm the assignment is published.",
       "autograder": "Couldn't resolve the autograder for \"{{assignmentSlug}}\". Ask your teacher to confirm it's published, then accept again.",
       "repo": "Couldn't create {{org}}/{{repo}}. Confirm you're a member of {{org}} and ask your teacher to verify the assignment's template repository is configured correctly, then accept again.",
-      "access": "Your repository {{org}}/{{repo}} was created, but adding you ({{username}}) as a collaborator failed. This usually means your GitHub username changed or you left {{org}}. Confirm you're a member of {{org}}, then use \"Re-run setup\".",
+      "access": "Your repository {{org}}/{{repo}} was created, but setting your ({{username}}) access on it failed. This usually means your GitHub username changed or you left {{org}}. Confirm you're a member of {{org}}, then use \"Re-run setup\".",
       "setup": "Your repository {{org}}/{{repo}} exists, but writing the setup files to branch \"{{branch}}\" failed. It may still be initializing. Wait a minute, then use \"Re-run setup\"."
     },
     "stepErrors": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1957,8 +1957,7 @@
     },
     "errors": {
       "emptyRepoWithTemplate": "Assignment \"{{assignmentSlug}}\" sets both an empty repository and a template, which isn't valid. Ask your teacher to re-run assignment setup.",
-      "incoherentMode": "Assignment \"{{slug}}\" has a group size of {{maxGroupSize}} but is set up as \"{{mode}}\", so its published settings are inconsistent. Ask your teacher to re-run assignment setup.",
-      "founderAccessMismatch": "Your repository {{owner}}/{{repo}} was created, but GitHub reports your access as \"{{effective}}\" (role \"{{role}}\") instead of \"{{permission}}\". Ask your teacher to set {{username}}'s access to \"{{permission}}\"."
+      "incoherentMode": "Assignment \"{{slug}}\" has a group size of {{maxGroupSize}} but is set up as \"{{mode}}\", so its published settings are inconsistent. Ask your teacher to re-run assignment setup."
     },
     "progress": {
       "error": "Setup failed — review the steps",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1034,7 +1034,7 @@
         "maxGroupSizeInvalid": "Max group size must be a valid number.",
         "setupTimeoutRange": "Setup timeout must be 0 or a whole number of seconds from 1 through {{max}}.",
         "passThresholdRange": "Pass threshold must be a whole number between {{min}} and {{max}}.",
-        "studentPermissionInvalid": "Student repo access must be one of read, triage, write, maintain, or admin.",
+        "studentPermissionInvalid": "Student repo access must be one of pull, triage, push, maintain, or admin.",
         "releaseAssetsTooMany": "Choose at most {{max}} submission release files (currently {{count}}).",
         "releaseAssetsTooLarge": "Submission release file paths may total at most {{max}} UTF-8 bytes (8 KiB); currently {{bytes}}.",
         "releaseAssetsInvalidPath": "{{path}} is not an exact workspace-relative file path.",
@@ -2261,8 +2261,12 @@
       "working": "Updating repositories",
       "progress": "Updated {{processed}} of {{total}}",
       "resultHeadline": "Set {{count}} of {{total}} students to {{level}}.",
+      "resultHeadlineThrottled": "Set {{count}} of {{total}} students to {{level}} before GitHub rate-limited the request — re-run to finish the rest.",
       "failedSection_one": "{{count}} repository could not be updated",
-      "failedSection_other": "{{count}} repositories could not be updated"
+      "failedSection_other": "{{count}} repositories could not be updated",
+      "deferredSection_one": "{{count}} repository was not updated",
+      "deferredSection_other": "{{count}} repositories were not updated",
+      "deferredDetail": "Skipped — re-run to update."
     },
     "rowRegrade": {
       "title": "Regrade this submission",
@@ -2571,7 +2575,8 @@
           "rateLimited": "GitHub rate limit hit — wait a moment and try again.",
           "forbidden": "You don't have permission to change collaborators on this repository.",
           "notFound": "Username not found, or not a member of the GitHub organization.",
-          "conflict": "Already a collaborator, or the request was rejected by GitHub."
+          "conflict": "Already a collaborator, or the request was rejected by GitHub.",
+          "httpStatus": "GitHub returned an error (HTTP {{status}})."
         },
         "error": {
           "addAndRemove": "Some collaborators could not be added or removed.{{removedNote}} Check the highlighted usernames and Save again to retry.{{suffix}}",
@@ -2587,6 +2592,7 @@
         "needsAdmin": "You need admin access on this repository to change its collaborators.",
         "adminWarning": "Set each collaborator's role, or add and remove collaborators. <b>Admin</b> lets a collaborator change repository settings and, on a private repo, its visibility.",
         "studentBadge": "Student",
+        "notApplied": "GitHub kept the existing role ({{effective}}) — a repo creator can't be downgraded below admin. Ask the student to lower their own access, or transfer repo ownership.",
         "roleFor": "Role for {{username}}",
         "newRole": "Role for the new collaborator",
         "removeUser": "Remove {{username}}",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -955,6 +955,7 @@
       "emptyRepoLocked": "It can't be changed after creation.",
       "studentPermission": {
         "label": "Student repo access",
+        "learnMore": "Learn more",
         "help": "The role each student is granted on their own assignment repository at accept time. Push (write) is the default. Choose Admin to let students manage repository settings and enable GitHub Pages. This applies to students who accept from now on; use the gradebook to change repositories already created.",
         "groupHelp": "Group members join with at least admin so the group owner can add teammates. This applies to repositories created from now on; use the gradebook to change existing ones.",
         "default": "Default ({{level}})",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2151,6 +2151,8 @@
       "members": "Members",
       "openRepoLabel": "Open repository {{repo}}",
       "viewRepo": "View repo",
+      "manageAccess": "Manage repository access",
+      "manageAccessAria": "Manage repository access for {{owner}}",
       "viewCommit": "View latest commit",
       "commit": "Commit",
       "noCommit": "No commit yet",
@@ -2558,6 +2560,20 @@
           "add": "Some collaborators could not be added.{{removedNote}} Check the highlighted usernames and Save again to retry.{{suffix}}",
           "remove": "Some collaborators could not be removed.{{removedNote}} Check the highlighted usernames and Save again to retry.{{suffix}}"
         }
+      },
+      "repoAccess": {
+        "title": "Manage repository access",
+        "viewRepoNamed": "View {{name}} repository",
+        "loading": "Loading collaborators",
+        "saved": "Access updated!",
+        "needsAdmin": "You need admin access on this repository to change its collaborators.",
+        "adminWarning": "Set each collaborator's role, or add and remove collaborators. <b>Admin</b> lets a collaborator change repository settings and, on a private repo, its visibility.",
+        "studentBadge": "Student",
+        "roleFor": "Role for {{username}}",
+        "newRole": "Role for the new collaborator",
+        "removeUser": "Remove {{username}}",
+        "save": "Save access",
+        "saveError": "Some changes could not be saved. Check the highlighted collaborators and Save again to retry.{{suffix}}"
       },
       "reuseShell": {
         "copying": "Copying…",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2247,7 +2247,7 @@
       "failedHint": "This is often a transient GitHub error — run the action again to retry."
     },
     "bulkAccess": {
-      "menuLabel": "Set student repo access",
+      "menuLabel": "Update student repo access",
       "menuTitle": "Change every student's role on their own repository",
       "titleEmptyRoster": "No students have accepted yet",
       "title": "Set student repository access",
@@ -2590,7 +2590,7 @@
         "roleFor": "Role for {{username}}",
         "newRole": "Role for the new collaborator",
         "removeUser": "Remove {{username}}",
-        "save": "Save access",
+        "save": "Update access",
         "saveError": "Some changes could not be saved. Check the highlighted collaborators and Save again to retry.{{suffix}}"
       },
       "reuseShell": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2246,6 +2246,24 @@
       "failedTitle": "These submissions couldn't be downloaded:",
       "failedHint": "This is often a transient GitHub error — run the action again to retry."
     },
+    "bulkAccess": {
+      "menuLabel": "Set student repo access",
+      "menuTitle": "Change every student's role on their own repository",
+      "titleEmptyRoster": "No students have accepted yet",
+      "title": "Set student repository access",
+      "subtitle_one": "Applies to {{count}} student who has accepted this assignment.",
+      "subtitle_other": "Applies to {{count}} students who have accepted this assignment.",
+      "noRepos": "No students have accepted this assignment yet, so there are no repositories to change.",
+      "roleLabel": "Repository role",
+      "warning_one": "This sets {{count}} student's role on their own repository to {{level}}. Admin lets them change repository settings and, on a private repo, its visibility. Existing collaborators are not otherwise affected.",
+      "warning_other": "This sets {{count}} students' roles on their own repositories to {{level}}. Admin lets them change repository settings and, on a private repo, its visibility. Existing collaborators are not otherwise affected.",
+      "apply": "Apply to all",
+      "working": "Updating repositories",
+      "progress": "Updated {{processed}} of {{total}}",
+      "resultHeadline": "Set {{count}} of {{total}} students to {{level}}.",
+      "failedSection_one": "{{count}} repository could not be updated",
+      "failedSection_other": "{{count}} repositories could not be updated"
+    },
     "rowRegrade": {
       "title": "Regrade this submission",
       "titleInFlight": "Regrade in progress…",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -953,6 +953,19 @@
       "emptyRepo": "Empty repository",
       "emptyRepoHelp": "Create each student's repository completely empty: no starter files, no autograding, no feedback pull request. For assignments where students build everything from scratch, including their own GitHub Actions. This choice is permanent for the assignment.",
       "emptyRepoLocked": "It can't be changed after creation.",
+      "studentPermission": {
+        "label": "Student repo access",
+        "help": "The role each student is granted on their own assignment repository at accept time. Push (write) is the default. Choose Admin to let students manage repository settings and enable GitHub Pages. This applies to students who accept from now on; use the gradebook to change repositories already created.",
+        "groupHelp": "Group members join with at least admin so the group owner can add teammates. This applies to repositories created from now on; use the gradebook to change existing ones.",
+        "default": "Default ({{level}})",
+        "levels": {
+          "pull": "Read (pull)",
+          "triage": "Triage",
+          "push": "Write (push)",
+          "maintain": "Maintain",
+          "admin": "Admin"
+        }
+      },
       "advanced": "Advanced settings",
       "advancedHelp": "Optional grading and runtime settings. Blank fields use their documented defaults.",
       "dockerImage": "Docker image",
@@ -1021,6 +1034,7 @@
         "maxGroupSizeInvalid": "Max group size must be a valid number.",
         "setupTimeoutRange": "Setup timeout must be 0 or a whole number of seconds from 1 through {{max}}.",
         "passThresholdRange": "Pass threshold must be a whole number between {{min}} and {{max}}.",
+        "studentPermissionInvalid": "Student repo access must be one of read, triage, write, maintain, or admin.",
         "releaseAssetsTooMany": "Choose at most {{max}} submission release files (currently {{count}}).",
         "releaseAssetsTooLarge": "Submission release file paths may total at most {{max}} UTF-8 bytes (8 KiB); currently {{bytes}}.",
         "releaseAssetsInvalidPath": "{{path}} is not an exact workspace-relative file path.",

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -340,9 +340,9 @@ const ACCEPT_STEP_ORDER: { id: AcceptStepId; labelKey: string }[] = [
   { id: "assignment", labelKey: "accept.steps.assignment" },
   { id: "autograder", labelKey: "accept.steps.autograder" },
   { id: "repo", labelKey: "accept.steps.repo" },
-  { id: "access", labelKey: "accept.steps.access" },
   { id: "setup", labelKey: "accept.steps.setup" },
   { id: "feedback", labelKey: "accept.steps.feedback" },
+  { id: "access", labelKey: "accept.steps.access" },
 ]
 
 type StepState = Record<

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -142,6 +142,7 @@ const CreateAssignmentPage = () => {
                 pass_threshold: values.pass_threshold_enabled
                   ? values.pass_threshold
                   : undefined,
+                student_permission: values.student_permission || undefined,
                 classroom,
                 tests: values.tests,
               },

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -546,6 +546,7 @@ const SubmissionsPageContent = () => {
     () => scopedScores.map((row) => row.owner),
     [scopedScores],
   )
+  const acceptedOwners = useMemo(() => [...acceptedSet], [acceptedSet])
   const scopedNonSubmitters = useMemo(
     () =>
       sectionFilter === "all"
@@ -1194,7 +1195,7 @@ const SubmissionsPageContent = () => {
         org={org}
         classroom={classroom}
         assignment={assignment}
-        owners={[...acceptedSet]}
+        owners={acceptedOwners}
         students={students}
       />
     </PageShell>

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -18,6 +18,7 @@ import { AcceptLinkModal } from "@/pages/submissions/AcceptLinkModal"
 import { MetricsModal } from "@/pages/submissions/MetricsModal"
 import { OpenAllFeedbackPrsModal } from "@/pages/submissions/OpenAllFeedbackPrsModal"
 import { DownloadAllSubmissionsModal } from "@/pages/submissions/DownloadAllSubmissionsModal"
+import { BulkRepoAccessModal } from "@/components/modals/BulkRepoAccessModal"
 import { DataFreshness } from "@/pages/submissions/DataFreshness"
 import { ConfirmModal } from "@/components/modals"
 import {
@@ -256,6 +257,7 @@ const SubmissionsPageContent = () => {
   const [acceptOpen, setAcceptOpen] = useState(false)
   const [openAllPrsOpen, setOpenAllPrsOpen] = useState(false)
   const [downloadAllOpen, setDownloadAllOpen] = useState(false)
+  const [bulkAccessOpen, setBulkAccessOpen] = useState(false)
 
   // Scope the collector's scores to the CURRENT roster (see rosterScopedRows).
   // Gate on a resolved roster so a transient load/permission failure falls back
@@ -1024,6 +1026,17 @@ const SubmissionsPageContent = () => {
             downloadDisabled={!scoresInfo.length && !nonSubmitters.length}
             onDownloadAll={() => setDownloadAllOpen(true)}
             downloadAllDisabled={downloadableOwners.length === 0}
+            // Bulk set student repo access: owner-only (needs admin on every
+            // repo), individual assignments only (a group repo's membership is
+            // founder-managed), never empty_repo, and only when repos exist.
+            onBulkAccess={
+              isOwner &&
+              !isGroupAssignment &&
+              !isEmptyRepoAssignment &&
+              acceptedSet.size > 0
+                ? () => setBulkAccessOpen(true)
+                : undefined
+            }
             locked={isLockedAssignment}
             lockPending={setLock.isPending}
             // Lock/unlock is an authoring-tier action (teacher|hta), same gate
@@ -1174,6 +1187,15 @@ const SubmissionsPageContent = () => {
         assignment={assignment}
         assignmentName={assignmentInfo?.name ?? assignment}
         owners={downloadableOwners}
+      />
+      <BulkRepoAccessModal
+        open={bulkAccessOpen}
+        onClose={() => setBulkAccessOpen(false)}
+        org={org}
+        classroom={classroom}
+        assignment={assignment}
+        owners={[...acceptedSet]}
+        students={students}
       />
     </PageShell>
   )

--- a/web/src/pages/assignments/DetailsSection.tsx
+++ b/web/src/pages/assignments/DetailsSection.tsx
@@ -439,8 +439,7 @@ export const DetailsSection = ({
               {(field) => (
                 <form.Subscribe selector={(state) => state.values.mode}>
                   {(modeValue) => {
-                    const mode =
-                      modeValue === "group" ? "group" : "individual"
+                    const mode = modeValue === "group" ? "group" : "individual"
                     const defaultLevel = defaultStudentPermission(mode)
                     return (
                       <FormField

--- a/web/src/pages/assignments/DetailsSection.tsx
+++ b/web/src/pages/assignments/DetailsSection.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react"
 import { useTranslation } from "react-i18next"
+import { ExternalLink } from "lucide-react"
 import { slugify } from "@/util/slug"
 import { Card, FormField, Input, Select, Textarea } from "@/components/ui"
 import { TemplateField } from "./TemplateField"
@@ -11,6 +12,12 @@ import {
   defaultStudentPermission,
 } from "@/types/classroom"
 import type { AssignmentForm } from "./assignmentFormModel"
+
+// GitHub's own reference for the repo role ladder (read/triage/write/maintain/
+// admin), linked next to the Student repo access help so teachers can see what
+// each level grants.
+const REPO_ROLES_DOCS_URL =
+  "https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#repository-roles-for-organizations"
 
 const FormErrors = ({ form }: { form: AssignmentForm }) => (
   <form.Subscribe selector={(state) => [state.errors]}>
@@ -296,6 +303,76 @@ export const DetailsSection = ({
                 )
               }
             </form.Subscribe>
+
+            {/* Student repo access sits directly under Assignment type: the
+                mode drives its default (push individual / admin group) and its
+                help text. */}
+            <form.Field name="student_permission">
+              {(field) => (
+                <form.Subscribe selector={(state) => state.values.mode}>
+                  {(modeValue) => {
+                    const mode = modeValue === "group" ? "group" : "individual"
+                    const defaultLevel = defaultStudentPermission(mode)
+                    return (
+                      <FormField
+                        htmlFor={field.name}
+                        label={t("assignments.form.studentPermission.label")}
+                        help={
+                          mode === "group"
+                            ? t("assignments.form.studentPermission.groupHelp")
+                            : t("assignments.form.studentPermission.help")
+                        }
+                        labelExtra={
+                          <a
+                            className="link inline-flex items-center gap-1 text-sm font-normal text-base-content/60 hover:text-base-content"
+                            href={REPO_ROLES_DOCS_URL}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {t("assignments.form.studentPermission.learnMore")}
+                            <ExternalLink
+                              aria-hidden="true"
+                              className="size-3.5"
+                            />
+                          </a>
+                        }
+                      >
+                        {({ id, describedById }) => (
+                          <Select
+                            id={id}
+                            name={field.name}
+                            className="w-full sm:max-w-xs"
+                            aria-describedby={describedById}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(e) =>
+                              field.handleChange(
+                                e.target.value as typeof field.state.value,
+                              )
+                            }
+                          >
+                            <option value="">
+                              {t("assignments.form.studentPermission.default", {
+                                level: t(
+                                  `assignments.form.studentPermission.levels.${defaultLevel}`,
+                                ),
+                              })}
+                            </option>
+                            {REPO_PERMISSIONS.map((level) => (
+                              <option key={level} value={level}>
+                                {t(
+                                  `assignments.form.studentPermission.levels.${level}`,
+                                )}
+                              </option>
+                            ))}
+                          </Select>
+                        )}
+                      </FormField>
+                    )
+                  }}
+                </form.Subscribe>
+              )}
+            </form.Field>
           </div>
 
           <div className="flex flex-col gap-4">
@@ -432,59 +509,6 @@ export const DetailsSection = ({
                     </div>
                   ) : null}
                 </div>
-              )}
-            </form.Field>
-
-            <form.Field name="student_permission">
-              {(field) => (
-                <form.Subscribe selector={(state) => state.values.mode}>
-                  {(modeValue) => {
-                    const mode = modeValue === "group" ? "group" : "individual"
-                    const defaultLevel = defaultStudentPermission(mode)
-                    return (
-                      <FormField
-                        htmlFor={field.name}
-                        label={t("assignments.form.studentPermission.label")}
-                        help={
-                          mode === "group"
-                            ? t("assignments.form.studentPermission.groupHelp")
-                            : t("assignments.form.studentPermission.help")
-                        }
-                      >
-                        {({ id, describedById }) => (
-                          <Select
-                            id={id}
-                            name={field.name}
-                            className="w-full sm:max-w-xs"
-                            aria-describedby={describedById}
-                            value={field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) =>
-                              field.handleChange(
-                                e.target.value as typeof field.state.value,
-                              )
-                            }
-                          >
-                            <option value="">
-                              {t("assignments.form.studentPermission.default", {
-                                level: t(
-                                  `assignments.form.studentPermission.levels.${defaultLevel}`,
-                                ),
-                              })}
-                            </option>
-                            {REPO_PERMISSIONS.map((level) => (
-                              <option key={level} value={level}>
-                                {t(
-                                  `assignments.form.studentPermission.levels.${level}`,
-                                )}
-                              </option>
-                            ))}
-                          </Select>
-                        )}
-                      </FormField>
-                    )
-                  }}
-                </form.Subscribe>
               )}
             </form.Field>
           </div>

--- a/web/src/pages/assignments/DetailsSection.tsx
+++ b/web/src/pages/assignments/DetailsSection.tsx
@@ -1,10 +1,15 @@
 import type { Dispatch, SetStateAction } from "react"
 import { useTranslation } from "react-i18next"
 import { slugify } from "@/util/slug"
-import { Card, FormField, Input, Textarea } from "@/components/ui"
+import { Card, FormField, Input, Select, Textarea } from "@/components/ui"
 import { TemplateField } from "./TemplateField"
 import { FieldLabel, ToggleRow } from "./AdvancedRuntimeFields"
-import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
+import {
+  GROUP_SIZE_MAX,
+  GROUP_SIZE_MIN,
+  REPO_PERMISSIONS,
+  defaultStudentPermission,
+} from "@/types/classroom"
 import type { AssignmentForm } from "./assignmentFormModel"
 
 const FormErrors = ({ form }: { form: AssignmentForm }) => (
@@ -427,6 +432,60 @@ export const DetailsSection = ({
                     </div>
                   ) : null}
                 </div>
+              )}
+            </form.Field>
+
+            <form.Field name="student_permission">
+              {(field) => (
+                <form.Subscribe selector={(state) => state.values.mode}>
+                  {(modeValue) => {
+                    const mode =
+                      modeValue === "group" ? "group" : "individual"
+                    const defaultLevel = defaultStudentPermission(mode)
+                    return (
+                      <FormField
+                        htmlFor={field.name}
+                        label={t("assignments.form.studentPermission.label")}
+                        help={
+                          mode === "group"
+                            ? t("assignments.form.studentPermission.groupHelp")
+                            : t("assignments.form.studentPermission.help")
+                        }
+                      >
+                        {({ id, describedById }) => (
+                          <Select
+                            id={id}
+                            name={field.name}
+                            className="w-full sm:max-w-xs"
+                            aria-describedby={describedById}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(e) =>
+                              field.handleChange(
+                                e.target.value as typeof field.state.value,
+                              )
+                            }
+                          >
+                            <option value="">
+                              {t("assignments.form.studentPermission.default", {
+                                level: t(
+                                  `assignments.form.studentPermission.levels.${defaultLevel}`,
+                                ),
+                              })}
+                            </option>
+                            {REPO_PERMISSIONS.map((level) => (
+                              <option key={level} value={level}>
+                                {t(
+                                  `assignments.form.studentPermission.levels.${level}`,
+                                )}
+                              </option>
+                            ))}
+                          </Select>
+                        )}
+                      </FormField>
+                    )
+                  }}
+                </form.Subscribe>
               )}
             </form.Field>
           </div>

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -93,6 +93,7 @@ const EditAssignmentForm = ({
                 pass_threshold: values.pass_threshold_enabled
                   ? values.pass_threshold
                   : undefined,
+                student_permission: values.student_permission || undefined,
                 classroom,
                 tests: values.tests,
                 slug: assignment,

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -58,6 +58,7 @@ const base: CreateAssignmentFormValues = {
   release_assets: "",
   pass_threshold_enabled: false,
   pass_threshold: 80,
+  student_permission: "",
   tests: [],
 }
 

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -33,13 +33,14 @@ import {
   validateLanguageVersion,
 } from "@/util/runtime"
 import { utcIsoToDatetimeLocalValue } from "./formFieldHelpers"
-import type { Assignment } from "@/types/classroom"
+import type { Assignment, RepoPermission } from "@/types/classroom"
 import {
   GROUP_SIZE_MAX,
   GROUP_SIZE_MIN,
   DEFAULT_PASS_THRESHOLD,
   PASS_THRESHOLD_MAX,
   PASS_THRESHOLD_MIN,
+  REPO_PERMISSIONS,
 } from "@/types/classroom"
 
 // Which runtime environment the Advanced Settings form is configuring. A UI-
@@ -94,6 +95,11 @@ export type CreateAssignmentFormValues = {
   // an integer percentage 0–100; when disabled, no passing concept is written.
   pass_threshold_enabled: boolean
   pass_threshold: number
+  // The accept-time collaborator role the enrolled student gets on their own
+  // repo. "" = the mode default (push individual / admin group); a real value
+  // pins it. buildAssignmentEntry omits it when it equals the default and
+  // clamps group up to admin.
+  student_permission: "" | RepoPermission
   tests: AssignmentTestDraft[]
 }
 
@@ -287,6 +293,17 @@ export function validateAssignmentForm(
     }
   }
 
+  // Guard the permission picker against a hand-tampered value; empty is valid
+  // (means the mode default).
+  if (
+    value.student_permission !== "" &&
+    !REPO_PERMISSIONS.includes(value.student_permission)
+  ) {
+    errors.student_permission = t(
+      "assignments.form.validation.studentPermissionInvalid",
+    )
+  }
+
   return errors
 }
 
@@ -333,6 +350,7 @@ export function toSubmitValues(
     release_assets: isEmptyRepo ? "" : value.release_assets,
     pass_threshold_enabled: isEmptyRepo ? false : value.pass_threshold_enabled,
     pass_threshold: Number(value.pass_threshold),
+    student_permission: value.student_permission,
     tests: isEmptyRepo ? [] : value.tests,
   }
 }
@@ -374,6 +392,7 @@ export const useAssignmentForm = (
       release_assets: defaultValues?.release_assets || "",
       pass_threshold_enabled: defaultValues?.pass_threshold_enabled ?? false,
       pass_threshold: defaultValues?.pass_threshold ?? DEFAULT_PASS_THRESHOLD,
+      student_permission: defaultValues?.student_permission ?? "",
       tests: defaultValues?.tests || [],
     } satisfies CreateAssignmentFormValues,
     validators: {
@@ -447,6 +466,9 @@ export const assignmentToFormValues = (
     setup_timeout: setupTimeout,
     pass_threshold_enabled: typeof assignment.pass_threshold === "number",
     pass_threshold: assignment.pass_threshold ?? DEFAULT_PASS_THRESHOLD,
+    // Absent means the mode default; the form shows "Default" and the submit
+    // path re-omits it. A stored value pins the picker to that level.
+    student_permission: assignment.student_permission ?? "",
     allowed_files: allowedFilesToText(assignment.allowed_files),
     release_assets: releaseAssetsToText(assignment.release_assets),
     tests,

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -9,6 +9,7 @@ import {
   Lock,
   LockOpen,
   RefreshCw,
+  ShieldCheck,
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -37,6 +38,7 @@ export function SubmissionsActionsMenu({
   downloadDisabled,
   onDownloadAll,
   downloadAllDisabled,
+  onBulkAccess,
   locked = false,
   lockPending = false,
   onLockToggle,
@@ -70,6 +72,10 @@ export function SubmissionsActionsMenu({
   // when there's nothing to fetch (via downloadAllDisabled).
   onDownloadAll: () => void
   downloadAllDisabled: boolean
+  // Opens the whole-assignment "Set student repo access" modal. Omitted (item
+  // hidden) when the viewer can't write every repo (non-owner), for a group or
+  // empty_repo assignment, or when there are no accepted repos to target.
+  onBulkAccess?: () => void
   // Current locked state, for the Lock/Unlock item's label and icon.
   locked?: boolean
   // Whether a lock/unlock is mid-flight, to disable the item and show progress.
@@ -256,6 +262,33 @@ export function SubmissionsActionsMenu({
                 {locked
                   ? t("submissions.lock.unlockLabel")
                   : t("submissions.lock.lockLabel")}
+              </button>
+            </li>
+            <div
+              className="my-1 border-t border-base-content/10"
+              role="separator"
+            />
+          </>
+        )}
+        {onBulkAccess && (
+          <>
+            <li>
+              <button
+                type="button"
+                disabled={disabledActions}
+                title={
+                  emptyRoster
+                    ? t("submissions.bulkAccess.titleEmptyRoster")
+                    : t("submissions.bulkAccess.menuTitle")
+                }
+                onClick={() => {
+                  closeMenu()
+                  if (disabledActions) return
+                  onBulkAccess()
+                }}
+              >
+                <ShieldCheck aria-hidden="true" className="size-4" />
+                {t("submissions.bulkAccess.menuLabel")}
               </button>
             </li>
             <div

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -234,6 +234,35 @@ export function SubmissionsActionsMenu({
           className="my-1 border-t border-base-content/10"
           role="separator"
         />
+        {/* Update student repo access — an authoring-tier action, grouped with
+            Lock/Unlock above the CSV export. */}
+        {onBulkAccess && (
+          <>
+            <li>
+              <button
+                type="button"
+                disabled={disabledActions}
+                title={
+                  emptyRoster
+                    ? t("submissions.bulkAccess.titleEmptyRoster")
+                    : t("submissions.bulkAccess.menuTitle")
+                }
+                onClick={() => {
+                  closeMenu()
+                  if (disabledActions) return
+                  onBulkAccess()
+                }}
+              >
+                <ShieldCheck aria-hidden="true" className="size-4" />
+                {t("submissions.bulkAccess.menuLabel")}
+              </button>
+            </li>
+            <div
+              className="my-1 border-t border-base-content/10"
+              role="separator"
+            />
+          </>
+        )}
         {/* Lock / Unlock — an assignment-lifecycle action (teacher|hta), so the
             page omits onLockToggle for a viewer who can't author. Its own group,
             above the CSV export. */}
@@ -262,33 +291,6 @@ export function SubmissionsActionsMenu({
                 {locked
                   ? t("submissions.lock.unlockLabel")
                   : t("submissions.lock.lockLabel")}
-              </button>
-            </li>
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
-            />
-          </>
-        )}
-        {onBulkAccess && (
-          <>
-            <li>
-              <button
-                type="button"
-                disabled={disabledActions}
-                title={
-                  emptyRoster
-                    ? t("submissions.bulkAccess.titleEmptyRoster")
-                    : t("submissions.bulkAccess.menuTitle")
-                }
-                onClick={() => {
-                  closeMenu()
-                  if (disabledActions) return
-                  onBulkAccess()
-                }}
-              >
-                <ShieldCheck aria-hidden="true" className="size-4" />
-                {t("submissions.bulkAccess.menuLabel")}
               </button>
             </li>
             <div

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -6,6 +6,7 @@ import {
   RefreshCw,
   ScrollText,
   SearchX,
+  ShieldCheck,
 } from "lucide-react"
 import { Fragment, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
@@ -51,6 +52,7 @@ import {
 } from "@/pages/submissions/SubmissionsRows"
 import { ConfirmModal } from "@/components/modals"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
+import { RepoAccessModal } from "@/components/modals/RepoAccessModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
 import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
 import { ReviewButton } from "@/pages/submissions/ReviewButton"
@@ -458,6 +460,9 @@ const SubmissionsTable = ({
   // The owner (group founder) whose collaborators modal is open, or null.
   const [manageOwner, setManageOwner] = useState<string | null>(null)
 
+  // The individual student whose repo-access modal is open, or null.
+  const [accessOwner, setAccessOwner] = useState<string | null>(null)
+
   // The student whose profile modal is open (resolved from a row's username), or
   // null. Resolves to a roster Student for the richer detail view.
   const [profileUsername, setProfileUsername] = useState<string | null>(null)
@@ -682,6 +687,21 @@ const SubmissionsTable = ({
                     repo={repo}
                     mode={isGroup ? "group" : "individual"}
                   />
+                  {!isGroup && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      shape="square"
+                      className="text-base-content/70"
+                      aria-label={t("submissions.table.manageAccessAria", {
+                        owner: rest.owner,
+                      })}
+                      title={t("submissions.table.manageAccess")}
+                      onClick={() => setAccessOwner(rest.owner)}
+                    >
+                      <ShieldCheck aria-hidden="true" className="size-4" />
+                    </Button>
+                  )}
                   <ActionIconLink
                     href={safeHttpUrl(rest.release)}
                     icon={ScrollText}
@@ -888,6 +908,20 @@ const SubmissionsTable = ({
           ownerLogin={manageOwner}
           assignmentName={assignmentName}
           maxGroupSize={maxGroupSize}
+          students={students}
+        />
+      )}
+
+      {accessOwner && (
+        <RepoAccessModal
+          key={accessOwner}
+          open
+          onClose={() => setAccessOwner(null)}
+          org={org}
+          repoName={studentRepoName(classroom, assignment, accessOwner)}
+          repoUrl={studentRepoUrl(org, classroom, assignment, accessOwner)}
+          ownerLogin={accessOwner}
+          assignmentName={assignmentName}
           students={students}
         />
       )}

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -89,6 +89,34 @@ export function assertAssignmentMode(value: string): AssignmentMode {
   )
 }
 
+// GitHub's repo collaborator permission ladder, low to high. The contract type
+// for an assignment's student_permission and the gradebook's access controls;
+// mirrors the shared Go contract.RepoPermissions and the schema enum. Defined
+// here (a leaf types module) rather than imported from github-core so the
+// schema contract stays self-contained.
+export type RepoPermission =
+  | "pull"
+  | "triage"
+  | "push"
+  | "maintain"
+  | "admin"
+
+// Ordered low-to-high, so a UI can render the ladder and code can compare rank.
+export const REPO_PERMISSIONS: readonly RepoPermission[] = [
+  "pull",
+  "triage",
+  "push",
+  "maintain",
+  "admin",
+]
+
+// The accept-time role a student gets on their own repo when an assignment sets
+// no student_permission: least-privilege push for individual, admin for group
+// (a group founder must manage collaborators). Mirrors the CLI default.
+export function defaultStudentPermission(mode: AssignmentMode): RepoPermission {
+  return mode === "group" ? "admin" : "push"
+}
+
 // Mirrors one entry of classroom50/assignments/v1 — the shape gh-teacher writes
 // and parses strictly (unknown fields rejected).
 // Schema: https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json
@@ -165,6 +193,14 @@ export type Assignment = {
   // DEFAULT_PASS_THRESHOLD. In lockstep with the CLI's assignments-v1 schema
   // (`pass_threshold`, integer, omitempty).
   pass_threshold?: number
+  // The collaborator role the enrolled student is granted on their OWN repo at
+  // accept time (the old GitHub Classroom "grant students admin" checkbox,
+  // generalized). Absent = the mode default (push individual / admin group).
+  // Accept-time provisioning only: it governs NEW accepters, not repos already
+  // accepted (adjust those with the gradebook access controls). For group mode,
+  // a value below admin is clamped up to admin (a founder must manage members).
+  // In lockstep with the CLI's assignments-v1 schema (`student_permission`).
+  student_permission?: RepoPermission
   tests?: AssignmentTest[]
   // CLI migrate provenance. The GUI doesn't write it but must round-trip it.
   migrated_from?: MigratedFrom

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -94,12 +94,7 @@ export function assertAssignmentMode(value: string): AssignmentMode {
 // mirrors the shared Go contract.RepoPermissions and the schema enum. Defined
 // here (a leaf types module) rather than imported from github-core so the
 // schema contract stays self-contained.
-export type RepoPermission =
-  | "pull"
-  | "triage"
-  | "push"
-  | "maintain"
-  | "admin"
+export type RepoPermission = "pull" | "triage" | "push" | "maintain" | "admin"
 
 // Ordered low-to-high, so a UI can render the ladder and code can compare rank.
 export const REPO_PERMISSIONS: readonly RepoPermission[] = [


### PR DESCRIPTION
Closes the [Admin on assignment repos](https://github.com/foundation50/classroom50/discussions/465) request: teachers can now configure the collaborator role a student gets on their own assignment repository at accept time (the old GitHub Classroom "grant students admin access" checkbox, generalized to GitHub's full ladder), and adjust that access after the fact — per repository and in bulk across an assignment.

## What's new

A new optional `student_permission` field on an assignment (`pull` | `triage` | `push` | `maintain` | `admin`). Absent means the built-in default — `push` for individual, `admin` for group — so existing assignments are unchanged. It governs what *new* accepters get; it does not retroactively change repos already created.

Teachers set it three ways:

- **At authoring time** — a "Student repo access" picker on the assignment create/edit form, grouped under "Assignment type" (the mode drives its default and help text) with a "Learn more" link to GitHub's repository-roles docs; and a `--student-permission` flag on `gh teacher assignment add`.
- **Per repository** — a "Manage repository access" action on each gradebook row opens a modal to change the enrolled student's role and add/remove arbitrary collaborators.
- **In bulk** — an "Update student repo access" action in the gradebook menu applies a chosen role to every accepted student on their own repo, with progress, a per-repo result summary, and rate-limit deferral (a throttled remainder is reported as deferred, not failed).

## Notable behavior

For `group` assignments a configured value below `admin` is clamped up to `admin`, since a group founder must manage collaborators via `gh student invite`.

The founder-role grant is the **last** accept step (it runs after the repo's control files and Feedback PR are in place), so a grant issue can never leave a student on a half-provisioned repo.

The accepting student is the repo creator, so setting their own role — including a below-default self-downgrade like `pull` — is a self-directed collaborator change that we **trust from the successful PUT**. We deliberately do not read the effective permission back at accept time: right after a self-downgrade on a freshly generated repo, GitHub's `collaborators/{self}/permission` sub-resource lags by a long, unbounded window (it 404s well past any accept-run poll) even though the change already applied, so a read-back would fail an otherwise-good accept.

The silently-ignored-downgrade guard lives instead on the **teacher write paths** (the per-repo and bulk gradebook editors), where a *different* actor changes a student's role and a post-write read-back can meaningfully confirm it: the enrolled student is verified for an exact match (a residual higher role means the requested downgrade was ignored), while an arbitrary added collaborator only needs the grant to have taken. That read-back tolerates the same sub-resource lag — a non-readable result (a transient 404 right after the write) is treated as issued-but-unconfirmed, never as a failed write, so a landed change is not misreported.

Caution surfaced in the UI and CLI help: `admin` on a private repo also lets the student change its visibility.

## Contract

`student_permission` is added additively to `schemas/assignments-v1.schema.json` and mirrored in lockstep across the Go `AssignmentEntry` (with validation), the shared `contract` permission constants, and the web `Assignment` type / ownership map, so it round-trips cleanly through older and newer readers. A cross-source parity test pins the enum across the schema, the Go `contract.RepoPermissions`, and the web `REPO_PERMISSIONS` so a one-sided edit fails CI.

## Testing

`web` `npm run check` (tsc, eslint, prettier, arch:validate, vitest), `go build`/`go test`/`go vet`/`gofmt` across `cli/shared`, `cli/gh-teacher`, and `cli/gh-student`, and the Python schema/skeleton parity tests all pass. New unit tests cover the `student_permission` schema round-trip and enum parity, the mode/config→role mapping and group clamp (accept-time and authoring-side `buildAssignmentEntry`), the PUT-only self grant (no read-back, and a genuine grant error still propagates), the teacher-write `addRepoCollaborator` verify path (including a lagging read-back returning unverified rather than a failure), and the bulk action's partial-failure summary.
