### PR TITLE
refactor(web): rename classroom and assignment /edit routes and page components to settings

### DIFF
--- a/web/src/components/drawer/AssignmentSidebarMenu.tsx
+++ b/web/src/components/drawer/AssignmentSidebarMenu.tsx
@@ -93,7 +93,9 @@ export const AssignmentSidebarMenu = ({
   const onSubmission = onRoute(
     "/$org/$classroom/assignments/$assignment/submission",
   )
-  const onSettings = onRoute("/$org/$classroom/assignments/$assignment/edit")
+  const onSettings = onRoute(
+    "/$org/$classroom/assignments/$assignment/settings",
+  )
   const onAccept = onRoute("/$org/$classroom/assignments/$assignment/accept")
 
   // Students only: surface "Accept" until they have their repo. Hidden while
@@ -171,7 +173,7 @@ export const AssignmentSidebarMenu = ({
               </Tip>
               <Tip label={t("nav.settings")}>
                 <Link
-                  to="/$org/$classroom/assignments/$assignment/edit"
+                  to="/$org/$classroom/assignments/$assignment/settings"
                   params={{ org, classroom, assignment }}
                 >
                   <SidebarItemBody
@@ -214,7 +216,7 @@ export const AssignmentSidebarMenu = ({
               {isGroupAssignment && (
                 <Tip label={t("nav.manageGroup")}>
                   <Link
-                    to="/$org/$classroom/assignments/$assignment/edit"
+                    to="/$org/$classroom/assignments/$assignment/settings"
                     params={{ org, classroom, assignment }}
                   >
                     <SidebarItemBody

--- a/web/src/components/drawer/SidebarFooter.tsx
+++ b/web/src/components/drawer/SidebarFooter.tsx
@@ -82,7 +82,7 @@ export const SidebarFooter = () => {
       fuzzy: false,
     })
     const onStaffEdit = matchRoute({
-      to: "/$org/$classroom/assignments/$assignment/edit",
+      to: "/$org/$classroom/assignments/$assignment/settings",
       fuzzy: false,
     })
     // -> student view on a staff-only assignment page: land on the student

--- a/web/src/components/drawer/StaffSidebarMenu.test.tsx
+++ b/web/src/components/drawer/StaffSidebarMenu.test.tsx
@@ -63,7 +63,8 @@ const links = () =>
     .filter(Boolean)
 
 const hasRoster = () => links().some((to) => to === "/$org/$classroom/roster")
-const hasSettings = () => links().some((to) => to === "/$org/$classroom/edit")
+const hasSettings = () =>
+  links().some((to) => to === "/$org/$classroom/settings")
 const hasSkeleton = () => document.querySelector(".skeleton") !== null
 
 const renderMenu = () =>

--- a/web/src/components/drawer/StaffSidebarMenu.tsx
+++ b/web/src/components/drawer/StaffSidebarMenu.tsx
@@ -60,7 +60,10 @@ export const StaffSidebarMenu = ({
               </Tip>
               {canEditSettings && (
                 <Tip label={t("nav.settings")}>
-                  <Link to="/$org/$classroom/edit" params={{ org, classroom }}>
+                  <Link
+                    to="/$org/$classroom/settings"
+                    params={{ org, classroom }}
+                  >
                     <SidebarItemBody
                       label={t("nav.settings")}
                       icon={<Settings aria-hidden="true" />}

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -52,7 +52,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
     >
       {canManageGroup && classroom && assignment && (
         <Link
-          to="/$org/$classroom/assignments/$assignment/edit"
+          to="/$org/$classroom/assignments/$assignment/settings"
           params={{ org, classroom, assignment }}
           className="btn btn-ghost btn-sm btn-circle absolute end-3 top-3 z-10 text-base-content/70 hover:text-primary"
           aria-label={t("classes.repo.manageGroupAria", { assignment })}

--- a/web/src/pages/AssignmentSettingsPage.test.tsx
+++ b/web/src/pages/AssignmentSettingsPage.test.tsx
@@ -81,7 +81,7 @@ vi.mock("@/hooks/useGetClassroom", () => ({
   default: () => ({ data: { name: "CS 101", active: true } }),
 }))
 
-import EditAssignmentPage from "./EditAssignmentPage"
+import AssignmentSettingsPage from "./AssignmentSettingsPage"
 
 beforeEach(() => {
   orgRepoCreationWarning.mockReturnValue({ show: false })
@@ -100,17 +100,17 @@ const NOTICE = "components.notices.orgRepoCreation.master"
 // keeping a student from seeing a warning about org member privileges they can't
 // act on. (It does not save a request: every org-scoped page's sidebar already
 // issues the same shared org read, for students too.)
-describe("EditAssignmentPage org repo-creation warning", () => {
+describe("AssignmentSettingsPage org repo-creation warning", () => {
   it("renders the notice for a staff role", () => {
     orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
-    render(<EditAssignmentPage />)
+    render(<AssignmentSettingsPage />)
     expect(screen.queryByText(NOTICE)).not.toBeNull()
   })
 
   it("is absent for a student, even when the org blocks repo creation", () => {
     orgRepoCreationWarning.mockReturnValue({ show: true, field: "master" })
     role.mockReturnValue("student")
-    render(<EditAssignmentPage />)
+    render(<AssignmentSettingsPage />)
 
     expect(screen.queryByText(NOTICE)).toBeNull()
     // Not merely hidden by CSS: the notice never mounts on the student branch.
@@ -118,7 +118,7 @@ describe("EditAssignmentPage org repo-creation warning", () => {
   })
 
   it("renders nothing for staff when the hook is silent", () => {
-    render(<EditAssignmentPage />)
+    render(<AssignmentSettingsPage />)
     expect(screen.queryByText(NOTICE)).toBeNull()
   })
 })

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -168,7 +168,7 @@ const EditAssignmentFormStudent = ({
   )
 }
 
-const EditAssignmentPage = () => {
+const AssignmentSettingsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.assignmentSettings"))
   const { org, classroom, assignment } = useParams({ strict: false })
@@ -209,7 +209,7 @@ const EditAssignmentPage = () => {
               settingsLink: (
                 <Link
                   className="link"
-                  to="/$org/$classroom/edit"
+                  to="/$org/$classroom/settings"
                   params={{ org: org ?? "", classroom: classroom ?? "" }}
                 />
               ),
@@ -264,4 +264,4 @@ const EditAssignmentPage = () => {
   )
 }
 
-export default EditAssignmentPage
+export default AssignmentSettingsPage

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -187,7 +187,7 @@ export const TeacherAssignmentsView = ({
               settingsLink: (
                 <Link
                   className="link"
-                  to="/$org/$classroom/edit"
+                  to="/$org/$classroom/settings"
                   params={{ org, classroom }}
                 />
               ),

--- a/web/src/pages/ClassroomSettingsPage.tsx
+++ b/web/src/pages/ClassroomSettingsPage.tsx
@@ -121,7 +121,7 @@ const EditClassroomContent = ({
   )
 }
 
-const EditClassroomPage = () => {
+const ClassroomSettingsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.classroomSettings"))
   const { org, classroom } = useParams({ strict: false })
@@ -140,4 +140,4 @@ const EditClassroomPage = () => {
   )
 }
 
-export default EditClassroomPage
+export default ClassroomSettingsPage

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -537,7 +537,7 @@ const AssignmentsTable = ({
                 <td>
                   <Link
                     className="btn btn-circle btn-sm btn-ghost"
-                    to="/$org/$classroom/assignments/$assignment/edit"
+                    to="/$org/$classroom/assignments/$assignment/settings"
                     params={{
                       org,
                       classroom,

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -240,7 +240,7 @@ function ClassroomMenu({
             <Link
               role="menuitem"
               tabIndex={-1}
-              to="/$org/$classroom/edit"
+              to="/$org/$classroom/settings"
               params={{ org, classroom: slug }}
               className={menuItem}
               onClick={() => closeMenu()}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -28,14 +28,14 @@ import { Route as AuthedOrgPublishedIndexRouteImport } from './routes/_authed/$o
 import { Route as AuthedOrgSettingsIndexRouteImport } from './routes/_authed/$org/settings/index'
 import { Route as AuthedOrgSetupIndexRouteImport } from './routes/_authed/$org/setup/index'
 import { Route as AuthedOrgClassroomAssignmentsIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/index'
-import { Route as AuthedOrgClassroomEditIndexRouteImport } from './routes/_authed/$org/$classroom/edit/index'
 import { Route as AuthedOrgClassroomOnboardIndexRouteImport } from './routes/_authed/$org/$classroom/onboard/index'
 import { Route as AuthedOrgClassroomRosterIndexRouteImport } from './routes/_authed/$org/$classroom/roster/index'
+import { Route as AuthedOrgClassroomSettingsIndexRouteImport } from './routes/_authed/$org/$classroom/settings/index'
 import { Route as AuthedOrgClassesNewIndexRouteImport } from './routes/_authed/$org/classes/new/index'
 import { Route as AuthedOrgClassroomAssignmentsAssignmentIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/$assignment/index'
 import { Route as AuthedOrgClassroomAssignmentsNewIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/new/index'
 import { Route as AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/$assignment/accept/index'
-import { Route as AuthedOrgClassroomAssignmentsAssignmentEditIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/$assignment/edit/index'
+import { Route as AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/$assignment/settings/index'
 import { Route as AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/$assignment/submission/index'
 import { Route as AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRouteImport } from './routes/_authed/$org/$classroom/assignments/$assignment/submissions/index'
 
@@ -134,12 +134,6 @@ const AuthedOrgClassroomAssignmentsIndexRoute =
     path: '/assignments/',
     getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
-const AuthedOrgClassroomEditIndexRoute =
-  AuthedOrgClassroomEditIndexRouteImport.update({
-    id: '/edit/',
-    path: '/edit/',
-    getParentRoute: () => AuthedOrgClassroomRouteRoute,
-  } as any)
 const AuthedOrgClassroomOnboardIndexRoute =
   AuthedOrgClassroomOnboardIndexRouteImport.update({
     id: '/onboard/',
@@ -150,6 +144,12 @@ const AuthedOrgClassroomRosterIndexRoute =
   AuthedOrgClassroomRosterIndexRouteImport.update({
     id: '/roster/',
     path: '/roster/',
+    getParentRoute: () => AuthedOrgClassroomRouteRoute,
+  } as any)
+const AuthedOrgClassroomSettingsIndexRoute =
+  AuthedOrgClassroomSettingsIndexRouteImport.update({
+    id: '/settings/',
+    path: '/settings/',
     getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassesNewIndexRoute =
@@ -176,10 +176,10 @@ const AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute =
     path: '/assignments/$assignment/accept/',
     getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
-const AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute =
-  AuthedOrgClassroomAssignmentsAssignmentEditIndexRouteImport.update({
-    id: '/assignments/$assignment/edit/',
-    path: '/assignments/$assignment/edit/',
+const AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute =
+  AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRouteImport.update({
+    id: '/assignments/$assignment/settings/',
+    path: '/assignments/$assignment/settings/',
     getParentRoute: () => AuthedOrgClassroomRouteRoute,
   } as any)
 const AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute =
@@ -214,14 +214,14 @@ export interface FileRoutesByFullPath {
   '/$org/settings/': typeof AuthedOrgSettingsIndexRoute
   '/$org/setup/': typeof AuthedOrgSetupIndexRoute
   '/$org/$classroom/assignments/': typeof AuthedOrgClassroomAssignmentsIndexRoute
-  '/$org/$classroom/edit/': typeof AuthedOrgClassroomEditIndexRoute
   '/$org/$classroom/onboard/': typeof AuthedOrgClassroomOnboardIndexRoute
   '/$org/$classroom/roster/': typeof AuthedOrgClassroomRosterIndexRoute
+  '/$org/$classroom/settings/': typeof AuthedOrgClassroomSettingsIndexRoute
   '/$org/classes/new/': typeof AuthedOrgClassesNewIndexRoute
   '/$org/$classroom/assignments/$assignment/': typeof AuthedOrgClassroomAssignmentsAssignmentIndexRoute
   '/$org/$classroom/assignments/new/': typeof AuthedOrgClassroomAssignmentsNewIndexRoute
   '/$org/$classroom/assignments/$assignment/accept/': typeof AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute
-  '/$org/$classroom/assignments/$assignment/edit/': typeof AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute
+  '/$org/$classroom/assignments/$assignment/settings/': typeof AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute
   '/$org/$classroom/assignments/$assignment/submission/': typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute
   '/$org/$classroom/assignments/$assignment/submissions/': typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute
 }
@@ -242,14 +242,14 @@ export interface FileRoutesByTo {
   '/$org/settings': typeof AuthedOrgSettingsIndexRoute
   '/$org/setup': typeof AuthedOrgSetupIndexRoute
   '/$org/$classroom/assignments': typeof AuthedOrgClassroomAssignmentsIndexRoute
-  '/$org/$classroom/edit': typeof AuthedOrgClassroomEditIndexRoute
   '/$org/$classroom/onboard': typeof AuthedOrgClassroomOnboardIndexRoute
   '/$org/$classroom/roster': typeof AuthedOrgClassroomRosterIndexRoute
+  '/$org/$classroom/settings': typeof AuthedOrgClassroomSettingsIndexRoute
   '/$org/classes/new': typeof AuthedOrgClassesNewIndexRoute
   '/$org/$classroom/assignments/$assignment': typeof AuthedOrgClassroomAssignmentsAssignmentIndexRoute
   '/$org/$classroom/assignments/new': typeof AuthedOrgClassroomAssignmentsNewIndexRoute
   '/$org/$classroom/assignments/$assignment/accept': typeof AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute
-  '/$org/$classroom/assignments/$assignment/edit': typeof AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute
+  '/$org/$classroom/assignments/$assignment/settings': typeof AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute
   '/$org/$classroom/assignments/$assignment/submission': typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute
   '/$org/$classroom/assignments/$assignment/submissions': typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute
 }
@@ -274,14 +274,14 @@ export interface FileRoutesById {
   '/_authed/$org/settings/': typeof AuthedOrgSettingsIndexRoute
   '/_authed/$org/setup/': typeof AuthedOrgSetupIndexRoute
   '/_authed/$org/$classroom/assignments/': typeof AuthedOrgClassroomAssignmentsIndexRoute
-  '/_authed/$org/$classroom/edit/': typeof AuthedOrgClassroomEditIndexRoute
   '/_authed/$org/$classroom/onboard/': typeof AuthedOrgClassroomOnboardIndexRoute
   '/_authed/$org/$classroom/roster/': typeof AuthedOrgClassroomRosterIndexRoute
+  '/_authed/$org/$classroom/settings/': typeof AuthedOrgClassroomSettingsIndexRoute
   '/_authed/$org/classes/new/': typeof AuthedOrgClassesNewIndexRoute
   '/_authed/$org/$classroom/assignments/$assignment/': typeof AuthedOrgClassroomAssignmentsAssignmentIndexRoute
   '/_authed/$org/$classroom/assignments/new/': typeof AuthedOrgClassroomAssignmentsNewIndexRoute
   '/_authed/$org/$classroom/assignments/$assignment/accept/': typeof AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute
-  '/_authed/$org/$classroom/assignments/$assignment/edit/': typeof AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute
+  '/_authed/$org/$classroom/assignments/$assignment/settings/': typeof AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute
   '/_authed/$org/$classroom/assignments/$assignment/submission/': typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute
   '/_authed/$org/$classroom/assignments/$assignment/submissions/': typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute
 }
@@ -306,14 +306,14 @@ export interface FileRouteTypes {
     | '/$org/settings/'
     | '/$org/setup/'
     | '/$org/$classroom/assignments/'
-    | '/$org/$classroom/edit/'
     | '/$org/$classroom/onboard/'
     | '/$org/$classroom/roster/'
+    | '/$org/$classroom/settings/'
     | '/$org/classes/new/'
     | '/$org/$classroom/assignments/$assignment/'
     | '/$org/$classroom/assignments/new/'
     | '/$org/$classroom/assignments/$assignment/accept/'
-    | '/$org/$classroom/assignments/$assignment/edit/'
+    | '/$org/$classroom/assignments/$assignment/settings/'
     | '/$org/$classroom/assignments/$assignment/submission/'
     | '/$org/$classroom/assignments/$assignment/submissions/'
   fileRoutesByTo: FileRoutesByTo
@@ -334,14 +334,14 @@ export interface FileRouteTypes {
     | '/$org/settings'
     | '/$org/setup'
     | '/$org/$classroom/assignments'
-    | '/$org/$classroom/edit'
     | '/$org/$classroom/onboard'
     | '/$org/$classroom/roster'
+    | '/$org/$classroom/settings'
     | '/$org/classes/new'
     | '/$org/$classroom/assignments/$assignment'
     | '/$org/$classroom/assignments/new'
     | '/$org/$classroom/assignments/$assignment/accept'
-    | '/$org/$classroom/assignments/$assignment/edit'
+    | '/$org/$classroom/assignments/$assignment/settings'
     | '/$org/$classroom/assignments/$assignment/submission'
     | '/$org/$classroom/assignments/$assignment/submissions'
   id:
@@ -365,14 +365,14 @@ export interface FileRouteTypes {
     | '/_authed/$org/settings/'
     | '/_authed/$org/setup/'
     | '/_authed/$org/$classroom/assignments/'
-    | '/_authed/$org/$classroom/edit/'
     | '/_authed/$org/$classroom/onboard/'
     | '/_authed/$org/$classroom/roster/'
+    | '/_authed/$org/$classroom/settings/'
     | '/_authed/$org/classes/new/'
     | '/_authed/$org/$classroom/assignments/$assignment/'
     | '/_authed/$org/$classroom/assignments/new/'
     | '/_authed/$org/$classroom/assignments/$assignment/accept/'
-    | '/_authed/$org/$classroom/assignments/$assignment/edit/'
+    | '/_authed/$org/$classroom/assignments/$assignment/settings/'
     | '/_authed/$org/$classroom/assignments/$assignment/submission/'
     | '/_authed/$org/$classroom/assignments/$assignment/submissions/'
   fileRoutesById: FileRoutesById
@@ -520,13 +520,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsIndexRouteImport
       parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
-    '/_authed/$org/$classroom/edit/': {
-      id: '/_authed/$org/$classroom/edit/'
-      path: '/edit'
-      fullPath: '/$org/$classroom/edit/'
-      preLoaderRoute: typeof AuthedOrgClassroomEditIndexRouteImport
-      parentRoute: typeof AuthedOrgClassroomRouteRoute
-    }
     '/_authed/$org/$classroom/onboard/': {
       id: '/_authed/$org/$classroom/onboard/'
       path: '/onboard'
@@ -539,6 +532,13 @@ declare module '@tanstack/react-router' {
       path: '/roster'
       fullPath: '/$org/$classroom/roster/'
       preLoaderRoute: typeof AuthedOrgClassroomRosterIndexRouteImport
+      parentRoute: typeof AuthedOrgClassroomRouteRoute
+    }
+    '/_authed/$org/$classroom/settings/': {
+      id: '/_authed/$org/$classroom/settings/'
+      path: '/settings'
+      fullPath: '/$org/$classroom/settings/'
+      preLoaderRoute: typeof AuthedOrgClassroomSettingsIndexRouteImport
       parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/classes/new/': {
@@ -569,11 +569,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRouteImport
       parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
-    '/_authed/$org/$classroom/assignments/$assignment/edit/': {
-      id: '/_authed/$org/$classroom/assignments/$assignment/edit/'
-      path: '/assignments/$assignment/edit'
-      fullPath: '/$org/$classroom/assignments/$assignment/edit/'
-      preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentEditIndexRouteImport
+    '/_authed/$org/$classroom/assignments/$assignment/settings/': {
+      id: '/_authed/$org/$classroom/assignments/$assignment/settings/'
+      path: '/assignments/$assignment/settings'
+      fullPath: '/$org/$classroom/assignments/$assignment/settings/'
+      preLoaderRoute: typeof AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRouteImport
       parentRoute: typeof AuthedOrgClassroomRouteRoute
     }
     '/_authed/$org/$classroom/assignments/$assignment/submission/': {
@@ -596,13 +596,13 @@ declare module '@tanstack/react-router' {
 interface AuthedOrgClassroomRouteRouteChildren {
   AuthedOrgClassroomIndexRoute: typeof AuthedOrgClassroomIndexRoute
   AuthedOrgClassroomAssignmentsIndexRoute: typeof AuthedOrgClassroomAssignmentsIndexRoute
-  AuthedOrgClassroomEditIndexRoute: typeof AuthedOrgClassroomEditIndexRoute
   AuthedOrgClassroomOnboardIndexRoute: typeof AuthedOrgClassroomOnboardIndexRoute
   AuthedOrgClassroomRosterIndexRoute: typeof AuthedOrgClassroomRosterIndexRoute
+  AuthedOrgClassroomSettingsIndexRoute: typeof AuthedOrgClassroomSettingsIndexRoute
   AuthedOrgClassroomAssignmentsAssignmentIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentIndexRoute
   AuthedOrgClassroomAssignmentsNewIndexRoute: typeof AuthedOrgClassroomAssignmentsNewIndexRoute
   AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute
-  AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute
+  AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute
   AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute
   AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute: typeof AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute
 }
@@ -612,17 +612,17 @@ const AuthedOrgClassroomRouteRouteChildren: AuthedOrgClassroomRouteRouteChildren
     AuthedOrgClassroomIndexRoute: AuthedOrgClassroomIndexRoute,
     AuthedOrgClassroomAssignmentsIndexRoute:
       AuthedOrgClassroomAssignmentsIndexRoute,
-    AuthedOrgClassroomEditIndexRoute: AuthedOrgClassroomEditIndexRoute,
     AuthedOrgClassroomOnboardIndexRoute: AuthedOrgClassroomOnboardIndexRoute,
     AuthedOrgClassroomRosterIndexRoute: AuthedOrgClassroomRosterIndexRoute,
+    AuthedOrgClassroomSettingsIndexRoute: AuthedOrgClassroomSettingsIndexRoute,
     AuthedOrgClassroomAssignmentsAssignmentIndexRoute:
       AuthedOrgClassroomAssignmentsAssignmentIndexRoute,
     AuthedOrgClassroomAssignmentsNewIndexRoute:
       AuthedOrgClassroomAssignmentsNewIndexRoute,
     AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute:
       AuthedOrgClassroomAssignmentsAssignmentAcceptIndexRoute,
-    AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute:
-      AuthedOrgClassroomAssignmentsAssignmentEditIndexRoute,
+    AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute:
+      AuthedOrgClassroomAssignmentsAssignmentSettingsIndexRoute,
     AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute:
       AuthedOrgClassroomAssignmentsAssignmentSubmissionIndexRoute,
     AuthedOrgClassroomAssignmentsAssignmentSubmissionsIndexRoute:

--- a/web/src/routes/_authed/$org/$classroom/assignments/$assignment/edit/index.tsx
+++ b/web/src/routes/_authed/$org/$classroom/assignments/$assignment/edit/index.tsx
@@ -1,8 +1,0 @@
-import EditAssignmentPage from "@/pages/EditAssignmentPage"
-import { createFileRoute } from "@tanstack/react-router"
-
-export const Route = createFileRoute(
-  "/_authed/$org/$classroom/assignments/$assignment/edit/",
-)({
-  component: EditAssignmentPage,
-})

--- a/web/src/routes/_authed/$org/$classroom/assignments/$assignment/settings/index.tsx
+++ b/web/src/routes/_authed/$org/$classroom/assignments/$assignment/settings/index.tsx
@@ -1,0 +1,8 @@
+import AssignmentSettingsPage from "@/pages/AssignmentSettingsPage"
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute(
+  "/_authed/$org/$classroom/assignments/$assignment/settings/",
+)({
+  component: AssignmentSettingsPage,
+})

--- a/web/src/routes/_authed/$org/$classroom/edit/index.tsx
+++ b/web/src/routes/_authed/$org/$classroom/edit/index.tsx
@@ -1,6 +1,0 @@
-import EditClassroomPage from "@/pages/EditClassroomPage"
-import { createFileRoute } from "@tanstack/react-router"
-
-export const Route = createFileRoute("/_authed/$org/$classroom/edit/")({
-  component: EditClassroomPage,
-})

--- a/web/src/routes/_authed/$org/$classroom/settings/index.tsx
+++ b/web/src/routes/_authed/$org/$classroom/settings/index.tsx
@@ -1,0 +1,6 @@
+import ClassroomSettingsPage from "@/pages/ClassroomSettingsPage"
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/_authed/$org/$classroom/settings/")({
+  component: ClassroomSettingsPage,
+})


### PR DESCRIPTION
Renames the teacher-facing settings routes from `/edit` to `/settings`, for both the classroom-level and per-assignment settings pages, and renames the corresponding page components/files to match.

## Changes

- Route: `/$org/$classroom/edit` -> `/$org/$classroom/settings`
- Route: `/$org/$classroom/assignments/$assignment/edit` -> `/$org/$classroom/assignments/$assignment/settings`
- Component/file: `EditClassroomPage` -> `ClassroomSettingsPage`
- Component/file: `EditAssignmentPage` -> `AssignmentSettingsPage` (and its test)
- Updated every `to=` / `onRoute` / `matchRoute` reference across the sidebar menus, sidebar footer, org repos, assignments table, and classroom card, plus the regenerated `routeTree.gen.ts`.

The inner edit *forms* (`EditAssignmentForm`, `EditClassroomForm`) and the `useEditClassroom` hook are intentionally left as-is: they name the edit action, not the route/page.

## Verification

`npm run check` is green: `tsc -b`, `eslint`, `prettier --check`, `arch:validate`, and the full `vitest` suite (2913 tests / 263 files).

## Notes

Internal-only rename with no behavior change, so it's titled `refactor(web)` (no changelog/release entry). There is no redirect from the old `/edit` paths — existing bookmarks to those URLs will 404. Happy to add redirect routes if any of those URLs might be live.