### PR TITLE
feat(web): show all per-repo submission actions, disabling inapplicable ones

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2152,6 +2152,7 @@
       "openRepoLabel": "Open repository {{repo}}",
       "viewRepo": "View repo",
       "manageAccess": "Manage repository access",
+      "manageAccessNoRepo": "No repository yet — the student hasn't accepted",
       "manageAccessAria": "Manage repository access for {{owner}}",
       "viewCommit": "View latest commit",
       "commit": "Commit",
@@ -2172,6 +2173,7 @@
       "noGroupTitle": "This student isn't credited on any submitting group's repo. Group membership is read from each repo's collaborators at collection time, so a student who never joined a group — or whose group's membership couldn't be read on the last collection — appears here. Open the group repos to confirm before grading.",
       "submittedBy": "by {{name}}",
       "review": "Review",
+      "reviewNoRepo": "No repository yet — the student hasn't accepted",
       "reviewAria": "Open feedback pull request",
       "fullHistory": "Open the <repoLink>repository</repoLink> for the full commit history."
     },
@@ -2270,6 +2272,7 @@
     },
     "rowRegrade": {
       "title": "Regrade this submission",
+      "titleNoRepo": "No repository yet — the student hasn't accepted",
       "titleInFlight": "Regrade in progress…",
       "titleBlocked": "Another regrade is in progress",
       "titleCompleted": "Regrade started — grading runs in the background; collect to see new scores",
@@ -2283,6 +2286,7 @@
     },
     "rowDownload": {
       "title": "Download this submission",
+      "titleNoRepo": "No repository yet — the student hasn't accepted",
       "aria": "Download {{owner}}'s submission",
       "nothingToDownload": "{{owner}} has no submission to download yet.",
       "error": "Couldn't download {{owner}}'s submission. Please try again."

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -19,10 +19,14 @@ export const ReviewButton = ({
   org,
   repo,
   mode,
+  noRepo = false,
 }: {
   org: string
   repo: string
   mode: AssignmentMode
+  // No assignment repo exists yet (never-accepted non-submitter): there can be
+  // no Feedback PR to review or repair, so render the button disabled.
+  noRepo?: boolean
 }) => {
   const { t } = useTranslation()
   const { notify } = useToast()
@@ -35,6 +39,7 @@ export const ReviewButton = ({
   const repair = useRepairFeedbackPr()
 
   const handleReview = async () => {
+    if (noRepo) return
     setResolving(true)
     try {
       // getOpenPullRequests maps 404 -> [], so a non-404 failure surfaces as
@@ -111,12 +116,16 @@ export const ReviewButton = ({
         size="sm"
         shape="square"
         className="text-base-content/70 disabled:opacity-60"
-        disabled={resolving}
+        disabled={noRepo || resolving}
         loading={resolving}
         loadingLabel={t("submissions.table.review")}
         onClick={handleReview}
         aria-label={t("submissions.table.reviewAria")}
-        title={t("submissions.table.review")}
+        title={
+          noRepo
+            ? t("submissions.table.reviewNoRepo")
+            : t("submissions.table.review")
+        }
       >
         {!resolving && <MessageCircle aria-hidden="true" className="size-4" />}
       </Button>

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -1,0 +1,343 @@
+import {
+  Download,
+  GitCommitHorizontal,
+  RefreshCw,
+  ScrollText,
+  ShieldCheck,
+} from "lucide-react"
+import { useState } from "react"
+import { Trans, useTranslation } from "react-i18next"
+
+import GitHub from "@/assets/github.svg?react"
+import { safeHttpUrl } from "@/util/url"
+import { Button, EmphasisLtr } from "@/components/ui"
+import { ConfirmModal } from "@/components/modals"
+import { ActionIconLink } from "@/pages/submissions/SubmissionsRows"
+import { ReviewButton } from "@/pages/submissions/ReviewButton"
+import useTriggerRegrade from "@/hooks/useTriggerRegrade"
+import useDownloadSubmission from "@/hooks/mutations/useDownloadSubmission"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import type { AssignmentMode } from "@/types/classroom"
+
+// Per-row regrade: dispatches regrade.yaml scoped to one owner, tracked via
+// useTriggerRegrade (icon shows progress; disabled while any regrade is in
+// flight). Only kicks off grading — the gradebook refreshes on the next collect.
+export const RegradeButton = ({
+  org,
+  classroom,
+  assignment,
+  owner,
+  displayName,
+  noRepo = false,
+}: {
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+  // The student's display name (individual assignments) when known; falls back
+  // to `owner`. Omitted for group repos (owner is the founder/group).
+  displayName?: string
+  // No assignment repo exists yet (a never-accepted non-submitter): regrade has
+  // nothing to dispatch against, so the button renders disabled rather than
+  // hidden — the row still shows the full action set, greyed where inapplicable.
+  noRepo?: boolean
+}) => {
+  const { t } = useTranslation()
+  const { regrade, phase, anyRegrading } = useTriggerRegrade({
+    org,
+    classroom,
+    assignment,
+    owner,
+  })
+  const inFlight = phase === "dispatching" || phase === "running"
+  // Disable while ANY regrade (this row, another, or "Regrade all") is in flight:
+  // trackers share one regrade.yaml run list and bind by monotonic id, so a
+  // single outstanding dispatch keeps the binding unambiguous.
+  const blocked = anyRegrading && !inFlight
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const title = noRepo
+    ? t("submissions.rowRegrade.titleNoRepo")
+    : inFlight
+      ? t("submissions.rowRegrade.titleInFlight")
+      : blocked
+        ? t("submissions.rowRegrade.titleBlocked")
+        : phase === "completed"
+          ? t("submissions.rowRegrade.titleCompleted")
+          : phase === "failed"
+            ? t("submissions.rowRegrade.titleFailed")
+            : t("submissions.rowRegrade.title")
+
+  const handleClick = () => {
+    if (noRepo || inFlight || blocked) return
+    setConfirmOpen(true)
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="text-base-content/70 disabled:opacity-60"
+        disabled={noRepo || inFlight || blocked}
+        loading={inFlight}
+        loadingLabel={t("submissions.rowRegrade.title")}
+        onClick={handleClick}
+        aria-label={t("submissions.rowRegrade.aria", { owner })}
+        title={title}
+      >
+        {!inFlight && (
+          <RefreshCw
+            aria-hidden="true"
+            className={`size-4 ${phase === "completed" ? "text-success" : phase === "failed" ? "text-error" : ""}`}
+          />
+        )}
+      </Button>
+      <ConfirmModal
+        open={confirmOpen}
+        title={t("submissions.rowRegrade.confirmTitle", {
+          name: displayName || owner,
+        })}
+        description={
+          <>
+            <Trans
+              i18nKey={
+                displayName
+                  ? "submissions.rowRegrade.confirmBody1WithLogin"
+                  : "submissions.rowRegrade.confirmBody1"
+              }
+              values={{ name: displayName || owner, owner }}
+              components={{
+                name: <span className="font-semibold text-base-content" />,
+                owner: <EmphasisLtr className="font-normal" />,
+              }}
+            />
+            <br />
+            <br />
+            <Trans
+              i18nKey="submissions.rowRegrade.confirmBody2"
+              values={{ collectLabel: t("submissions.collect.label") }}
+              components={{
+                collectLabel: <span className="font-semibold" />,
+              }}
+            />
+          </>
+        }
+        confirmText="regrade"
+        confirmLabel={t("submissions.rowRegrade.confirmLabel")}
+        cancelLabel={t("common.cancel")}
+        dangerous={false}
+        needsConfirm={false}
+        onConfirm={async () => {
+          regrade()
+        }}
+        onClose={() => setConfirmOpen(false)}
+      />
+    </>
+  )
+}
+
+// Per-row submission download. A button, not a link, because it triggers an
+// authenticated fetch, not a navigation.
+export const DownloadButton = ({
+  org,
+  classroom,
+  assignment,
+  owner,
+  noRepo = false,
+}: {
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+  // No assignment repo exists yet: nothing to download, so render disabled.
+  noRepo?: boolean
+}) => {
+  const { t } = useTranslation()
+  const { notify } = useToast()
+  const download = useDownloadSubmission()
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      shape="square"
+      className="text-base-content/70 disabled:opacity-60"
+      disabled={noRepo || download.isPending}
+      loading={download.isPending}
+      loadingLabel={t("submissions.rowDownload.title")}
+      onClick={() => {
+        if (noRepo || download.isPending) return
+        download.mutate(
+          { org, classroom, assignment, owner },
+          {
+            onError: (err) => {
+              // "no-submission" (missing/never-pushed repo) is benign info,
+              // not an error.
+              const nothing =
+                err instanceof Error && err.message === "no-submission"
+              notify({
+                tone: nothing ? "info" : "error",
+                message: nothing
+                  ? t("submissions.rowDownload.nothingToDownload", { owner })
+                  : t("submissions.rowDownload.error", { owner }),
+              })
+            },
+          },
+        )
+      }}
+      aria-label={t("submissions.rowDownload.aria", { owner })}
+      title={
+        noRepo
+          ? t("submissions.rowDownload.titleNoRepo")
+          : t("submissions.rowDownload.title")
+      }
+    >
+      {!download.isPending && (
+        <Download aria-hidden="true" className="size-4" />
+      )}
+    </Button>
+  )
+}
+
+// The per-repo action cluster shared by every row family — submitted,
+// non-submitter, and group. Group and individual rows differ only in the
+// leading `header` (Open-repo link vs. Members + repo link), the `mode` passed
+// to Review, and whether the per-student Manage-access button applies; the tail
+// (commit -> Review -> [access] -> details -> Regrade -> Download) is identical,
+// so it lives here once rather than being hand-copied per branch.
+//
+// Actions split by what they actually need:
+//   - repo-only (Open repo, Review PR, Manage access, Regrade, Download): a repo
+//     exists the moment a student accepts, so these stay live for an
+//     accepted-not-submitted student and only disable when no repo exists at all.
+//   - submission-only (View commit, View details): tied to a specific attempt,
+//     so they render dimmed (via ActionIconLink's empty branch) until one lands.
+// `emptyRepo` assignments never autograde, so their PR/regrade/details actions
+// disable regardless (kept visible, greyed, so the row layout doesn't jump).
+export const RepoRowActions = ({
+  mode,
+  org,
+  classroom,
+  assignment,
+  owner,
+  repo,
+  hasRepo,
+  commit,
+  release,
+  emptyRepo,
+  displayName,
+  header,
+  onManageAccess,
+}: {
+  mode: AssignmentMode
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+  repo: string
+  // Whether an assignment repo exists (submitted, or accepted-not-submitted). A
+  // never-accepted individual non-submitter has none, so the repo-scoped actions
+  // disable. Group rows always have a repo.
+  hasRepo: boolean
+  // Latest attempt's commit/release URLs, when a submission exists.
+  commit?: string | null
+  release?: string | null
+  emptyRepo: boolean
+  displayName?: string
+  // The leading affordance for this row family (Open-repo link for individuals,
+  // Members + repo link for groups).
+  header: React.ReactNode
+  // Individual per-student Manage-access action; omitted for group rows (access
+  // is managed through the group Members modal instead).
+  onManageAccess?: () => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <>
+      {header}
+      <ActionIconLink
+        href={safeHttpUrl(commit)}
+        icon={GitCommitHorizontal}
+        label={t("submissions.table.viewCommit")}
+        title={t("submissions.table.commit")}
+        emptyLabel={t("submissions.table.noCommit")}
+        emptyTitle={t("submissions.table.noCommit")}
+      />
+      {!emptyRepo && (
+        <>
+          <ReviewButton org={org} repo={repo} mode={mode} noRepo={!hasRepo} />
+          {onManageAccess && (
+            <Button
+              variant="ghost"
+              size="sm"
+              shape="square"
+              className="text-base-content/70 disabled:opacity-60"
+              disabled={!hasRepo}
+              aria-label={t("submissions.table.manageAccessAria", { owner })}
+              title={
+                hasRepo
+                  ? t("submissions.table.manageAccess")
+                  : t("submissions.table.manageAccessNoRepo")
+              }
+              onClick={() => {
+                if (!hasRepo) return
+                onManageAccess()
+              }}
+            >
+              <ShieldCheck aria-hidden="true" className="size-4" />
+            </Button>
+          )}
+          <ActionIconLink
+            href={safeHttpUrl(release)}
+            icon={ScrollText}
+            label={t("submissions.table.viewDetails")}
+            title={t("submissions.table.details")}
+            emptyLabel={t("submissions.table.noDetailsLabel")}
+            emptyTitle={t("submissions.table.noDetails")}
+          />
+          <RegradeButton
+            org={org}
+            classroom={classroom}
+            assignment={assignment}
+            owner={owner}
+            displayName={displayName}
+            noRepo={!hasRepo}
+          />
+        </>
+      )}
+      <DownloadButton
+        org={org}
+        classroom={classroom}
+        assignment={assignment}
+        owner={owner}
+        noRepo={!hasRepo}
+      />
+    </>
+  )
+}
+
+// Convenience header for an individual row: a single Open-repo link, dimmed to a
+// disabled icon when no repo exists yet.
+export const IndividualRowHeader = ({
+  repo,
+  repoHref,
+  hasRepo,
+}: {
+  repo: string
+  repoHref: string
+  hasRepo: boolean
+}) => {
+  const { t } = useTranslation()
+  return (
+    <ActionIconLink
+      href={hasRepo ? repoHref : null}
+      icon={GitHub}
+      label={t("submissions.table.openRepoLabel", { repo })}
+      title={t("submissions.table.viewRepo")}
+      emptyLabel={t("submissions.table.openRepoLabel", { repo })}
+      emptyTitle={t("submissions.table.viewRepo")}
+    />
+  )
+}

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -22,13 +22,15 @@ import type { AssignmentMode } from "@/types/classroom"
 // Per-row regrade: dispatches regrade.yaml scoped to one owner, tracked via
 // useTriggerRegrade (icon shows progress; disabled while any regrade is in
 // flight). Only kicks off grading — the gradebook refreshes on the next collect.
+//
+// A never-accepted non-submitter (`noRepo`) renders a static disabled button and
+// deliberately does NOT mount the tracking hook or confirm modal: with no repo
+// there's nothing to regrade, and skipping the machinery avoids a per-row
+// sessionStorage read and a hidden confirm dialog on rosters full of
+// never-accepted students.
 export const RegradeButton = ({
-  org,
-  classroom,
-  assignment,
-  owner,
-  displayName,
   noRepo = false,
+  ...props
 }: {
   org: string
   classroom: string
@@ -37,10 +39,39 @@ export const RegradeButton = ({
   // The student's display name (individual assignments) when known; falls back
   // to `owner`. Omitted for group repos (owner is the founder/group).
   displayName?: string
-  // No assignment repo exists yet (a never-accepted non-submitter): regrade has
-  // nothing to dispatch against, so the button renders disabled rather than
-  // hidden — the row still shows the full action set, greyed where inapplicable.
   noRepo?: boolean
+}) => {
+  const { t } = useTranslation()
+  if (noRepo) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="text-base-content/70 disabled:opacity-60"
+        disabled
+        aria-label={t("submissions.rowRegrade.aria", { owner: props.owner })}
+        title={t("submissions.rowRegrade.titleNoRepo")}
+      >
+        <RefreshCw aria-hidden="true" className="size-4" />
+      </Button>
+    )
+  }
+  return <ActiveRegradeButton {...props} />
+}
+
+const ActiveRegradeButton = ({
+  org,
+  classroom,
+  assignment,
+  owner,
+  displayName,
+}: {
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+  displayName?: string
 }) => {
   const { t } = useTranslation()
   const { regrade, phase, anyRegrading } = useTriggerRegrade({
@@ -56,20 +87,18 @@ export const RegradeButton = ({
   const blocked = anyRegrading && !inFlight
   const [confirmOpen, setConfirmOpen] = useState(false)
 
-  const title = noRepo
-    ? t("submissions.rowRegrade.titleNoRepo")
-    : inFlight
-      ? t("submissions.rowRegrade.titleInFlight")
-      : blocked
-        ? t("submissions.rowRegrade.titleBlocked")
-        : phase === "completed"
-          ? t("submissions.rowRegrade.titleCompleted")
-          : phase === "failed"
-            ? t("submissions.rowRegrade.titleFailed")
-            : t("submissions.rowRegrade.title")
+  const title = inFlight
+    ? t("submissions.rowRegrade.titleInFlight")
+    : blocked
+      ? t("submissions.rowRegrade.titleBlocked")
+      : phase === "completed"
+        ? t("submissions.rowRegrade.titleCompleted")
+        : phase === "failed"
+          ? t("submissions.rowRegrade.titleFailed")
+          : t("submissions.rowRegrade.title")
 
   const handleClick = () => {
-    if (noRepo || inFlight || blocked) return
+    if (inFlight || blocked) return
     setConfirmOpen(true)
   }
 
@@ -80,7 +109,7 @@ export const RegradeButton = ({
         size="sm"
         shape="square"
         className="text-base-content/70 disabled:opacity-60"
-        disabled={noRepo || inFlight || blocked}
+        disabled={inFlight || blocked}
         loading={inFlight}
         loadingLabel={t("submissions.rowRegrade.title")}
         onClick={handleClick}
@@ -151,7 +180,6 @@ export const DownloadButton = ({
   classroom: string
   assignment: string
   owner: string
-  // No assignment repo exists yet: nothing to download, so render disabled.
   noRepo?: boolean
 }) => {
   const { t } = useTranslation()

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import GitHub from "@/assets/github.svg?react"
 import { getName, getInitials } from "@/util/students"
-import { studentRepoName, studentRepoUrl } from "@/util/studentRepo"
+import { studentRepoUrl } from "@/util/studentRepo"
 import Avatar from "@/components/avatar"
 import { Badge, Button } from "@/components/ui"
 import { nonSubmitterStatus } from "@/pages/submissions/dashboard"
@@ -237,40 +237,26 @@ export const GroupActionControls = ({
   )
 }
 
-// A roster student with no submission row: identity + status badge, plus a repo
-// link when they accepted an individual assignment (a repo exists to open).
+// A roster student with no submission row: identity + status badge. For an
+// individual assignment the caller passes the full per-repo action cluster
+// (`actions`) so a non-submitter shows the same affordances as a submitter,
+// disabled where inapplicable; a group non-submitter (no per-student repo)
+// falls back to an em-dash.
 export const NonSubmitterRow = ({
   student,
   students,
   isGroup,
   acceptedUsernames,
-  org,
-  classroom,
-  assignment,
   onProfile,
+  actions,
 }: {
   student: Student
   students: Student[]
   isGroup: boolean
   acceptedUsernames?: Set<string>
-  org: string
-  classroom: string
-  assignment: string
   onProfile: (username: string) => void
+  actions?: React.ReactNode
 }) => {
-  const { t } = useTranslation()
-  const accepted =
-    !isGroup &&
-    Boolean(
-      student.username &&
-      acceptedUsernames?.has(student.username.toLowerCase()),
-    )
-  const repo = accepted
-    ? studentRepoName(classroom, assignment, student.username)
-    : null
-  const repoHref = accepted
-    ? studentRepoUrl(org, classroom, assignment, student.username)
-    : null
   return (
     <tr>
       <td>
@@ -298,15 +284,8 @@ export const NonSubmitterRow = ({
       <td>—</td>
       <td>—</td>
       <td>
-        {repo && repoHref ? (
-          <ActionIconLink
-            href={repoHref}
-            icon={GitHub}
-            label={t("submissions.table.openRepoLabel", { repo })}
-            title={t("submissions.table.viewRepo")}
-            emptyLabel={t("submissions.table.openRepoLabel", { repo })}
-            emptyTitle={t("submissions.table.viewRepo")}
-          />
+        {actions ? (
+          <div className="flex items-center gap-1">{actions}</div>
         ) : (
           "—"
         )}

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -225,7 +225,7 @@ describe("SubmissionsTable per-row download", () => {
     expect(screen.getByTitle("submissions.rowDownload.title")).toBeTruthy()
   })
 
-  it("shows no download button for a non-submitter row", () => {
+  it("shows the download button for an accepted-not-submitted non-submitter", () => {
     render(
       <SubmissionsTable
         {...baseProps}
@@ -233,6 +233,124 @@ describe("SubmissionsTable per-row download", () => {
         acceptedUsernames={new Set(["alice"])}
       />,
     )
+    // The full per-repo action cluster now renders for non-submitters; an
+    // accepted student has a repo, so Download is enabled.
+    const btn = screen.getByTitle("submissions.rowDownload.title")
+    expect(btn.hasAttribute("disabled")).toBe(false)
+  })
+
+  it("disables the download button for a never-accepted non-submitter", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set()}
+      />,
+    )
+    // No repo exists, so Download shows but is disabled (via titleNoRepo).
+    const btn = screen.getByTitle("submissions.rowDownload.titleNoRepo")
+    expect(btn.hasAttribute("disabled")).toBe(true)
+  })
+})
+
+describe("SubmissionsTable non-submitter action cluster", () => {
+  it("shows the repo-scoped actions (Review, Manage access, Regrade) for a non-submitter", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set(["alice"])}
+      />,
+    )
+    expect(screen.getByTitle("submissions.table.review")).toBeTruthy()
+    expect(screen.getByTitle("submissions.table.manageAccess")).toBeTruthy()
+    expect(screen.getByTitle("submissions.rowRegrade.title")).toBeTruthy()
+  })
+
+  it("disables the repo-scoped actions for a never-accepted non-submitter", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set()}
+      />,
+    )
+    expect(
+      screen
+        .getByTitle("submissions.table.reviewNoRepo")
+        .hasAttribute("disabled"),
+    ).toBe(true)
+    expect(
+      screen
+        .getByTitle("submissions.table.manageAccessNoRepo")
+        .hasAttribute("disabled"),
+    ).toBe(true)
+    expect(
+      screen
+        .getByTitle("submissions.rowRegrade.titleNoRepo")
+        .hasAttribute("disabled"),
+    ).toBe(true)
+  })
+
+  it("hides grading actions for an empty_repo non-submitter but keeps repo + download", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set(["alice"])}
+        emptyRepo
+      />,
+    )
+    // empty_repo never autogrades: Review/Manage access/Regrade are hidden,
+    // but Open repo and Download stay.
+    expect(screen.queryByTitle("submissions.table.review")).toBeNull()
+    expect(screen.queryByTitle("submissions.rowRegrade.title")).toBeNull()
+    expect(
+      screen.getByRole("link", {
+        name: "submissions.table.openRepoLabel:cs101-hw1-alice",
+      }),
+    ).toBeTruthy()
+    expect(screen.getByTitle("submissions.rowDownload.title")).toBeTruthy()
+    // Manage access is one of the grading-tier actions hidden for empty_repo.
+    expect(screen.queryByTitle("submissions.table.manageAccess")).toBeNull()
+  })
+
+  it("shows an em-dash (no actions) while acceptance data is still loading", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={undefined}
+      />,
+    )
+    // acceptedUsernames === undefined means acceptance is unknown (org repo list
+    // not loaded): the row must not assert "hasn't accepted" with a disabled
+    // cluster, so no action controls render at all.
+    expect(screen.queryByTitle("submissions.table.review")).toBeNull()
+    expect(screen.queryByTitle("submissions.table.reviewNoRepo")).toBeNull()
     expect(screen.queryByTitle("submissions.rowDownload.title")).toBeNull()
+    expect(
+      screen.queryByTitle("submissions.rowDownload.titleNoRepo"),
+    ).toBeNull()
+  })
+
+  it("renders the shared action cluster for a group submitter row", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        isGroup
+        scores={[scoreRow({ owner: "team-rocket", usernames: ["alice"] })]}
+      />,
+    )
+    // Group rows go through the same RepoRowActions as individual rows, so the
+    // Review/Regrade/Download tail must be present (parity with the individual
+    // submitter row, which shares the component).
+    expect(screen.getByTitle("submissions.table.review")).toBeTruthy()
+    expect(screen.getByTitle("submissions.rowRegrade.title")).toBeTruthy()
+    expect(screen.getByTitle("submissions.rowDownload.title")).toBeTruthy()
+    // Members button (group header) is present; the per-student Manage-access
+    // button is not (group access is managed via the Members modal).
+    expect(screen.getByTitle("submissions.table.members")).toBeTruthy()
+    expect(screen.queryByTitle("submissions.table.manageAccess")).toBeNull()
   })
 })

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -1,17 +1,13 @@
 import {
   ChevronRight,
-  Download,
   GitCommitHorizontal,
   Inbox,
-  RefreshCw,
   ScrollText,
   SearchX,
-  ShieldCheck,
 } from "lucide-react"
 import { Fragment, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
-import GitHub from "@/assets/github.svg?react"
 import {
   getName,
   getInitials,
@@ -24,7 +20,6 @@ import Avatar from "@/components/avatar"
 import {
   Badge,
   Button,
-  EmphasisLtr,
   Spinner,
   TablePagination,
   rtlFlip,
@@ -43,22 +38,20 @@ import {
   PAGE_SIZE_OPTIONS,
 } from "@/pages/submissions/dashboard"
 import {
-  ActionIconLink,
   GroupActionControls,
   GroupMembers,
   GroupRepoRow,
   NonSubmitterRow,
   identitySubtitle,
 } from "@/pages/submissions/SubmissionsRows"
-import { ConfirmModal } from "@/components/modals"
+import {
+  IndividualRowHeader,
+  RepoRowActions,
+} from "@/pages/submissions/SubmissionsRowActions"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { RepoAccessModal } from "@/components/modals/RepoAccessModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
 import type { SubmissionAttempt, SubmissionRow } from "@/hooks/useGetScores"
-import { ReviewButton } from "@/pages/submissions/ReviewButton"
-import useTriggerRegrade from "@/hooks/useTriggerRegrade"
-import useDownloadSubmission from "@/hooks/mutations/useDownloadSubmission"
-import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Student } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
 
@@ -123,181 +116,6 @@ const HistoryLink = ({
       {label}
     </span>
   )
-
-// Review action: links to the open Feedback PR (opened at accept time, or by
-// the autograde runner) when one exists; when none does, offers a teacher-side
-// Repair that re-runs the same idempotent ensure flow with the teacher's token
-// (issue #347 — recovers a PR a student's accept-time attempt failed to open).
-// The PR is the source of truth. The /pulls lookup is deferred until Review is
-// clicked (an eager per-row query would fan out to one request per repo on
-// mount); on click we refetch.
-// Per-row regrade: dispatches regrade.yaml scoped to one owner, tracked via
-// useTriggerRegrade (icon shows progress; disabled while any regrade is in
-// flight). Only kicks off grading — the gradebook refreshes on the next collect.
-const RegradeButton = ({
-  org,
-  classroom,
-  assignment,
-  owner,
-  displayName,
-}: {
-  org: string
-  classroom: string
-  assignment: string
-  owner: string
-  // The student's display name (individual assignments) when known; falls back
-  // to `owner`. Omitted for group repos (owner is the founder/group).
-  displayName?: string
-}) => {
-  const { t } = useTranslation()
-  const { regrade, phase, anyRegrading } = useTriggerRegrade({
-    org,
-    classroom,
-    assignment,
-    owner,
-  })
-  const inFlight = phase === "dispatching" || phase === "running"
-  // Disable while ANY regrade (this row, another, or "Regrade all") is in flight:
-  // trackers share one regrade.yaml run list and bind by monotonic id, so a
-  // single outstanding dispatch keeps the binding unambiguous.
-  const blocked = anyRegrading && !inFlight
-  const [confirmOpen, setConfirmOpen] = useState(false)
-
-  const title = inFlight
-    ? t("submissions.rowRegrade.titleInFlight")
-    : blocked
-      ? t("submissions.rowRegrade.titleBlocked")
-      : phase === "completed"
-        ? t("submissions.rowRegrade.titleCompleted")
-        : phase === "failed"
-          ? t("submissions.rowRegrade.titleFailed")
-          : t("submissions.rowRegrade.title")
-
-  const handleClick = () => {
-    if (inFlight || blocked) return
-    setConfirmOpen(true)
-  }
-
-  return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="square"
-        className="text-base-content/70 disabled:opacity-60"
-        disabled={inFlight || blocked}
-        loading={inFlight}
-        loadingLabel={t("submissions.rowRegrade.title")}
-        onClick={handleClick}
-        aria-label={t("submissions.rowRegrade.aria", { owner })}
-        title={title}
-      >
-        {!inFlight && (
-          <RefreshCw
-            aria-hidden="true"
-            className={`size-4 ${phase === "completed" ? "text-success" : phase === "failed" ? "text-error" : ""}`}
-          />
-        )}
-      </Button>
-      <ConfirmModal
-        open={confirmOpen}
-        title={t("submissions.rowRegrade.confirmTitle", {
-          name: displayName || owner,
-        })}
-        description={
-          <>
-            <Trans
-              i18nKey={
-                displayName
-                  ? "submissions.rowRegrade.confirmBody1WithLogin"
-                  : "submissions.rowRegrade.confirmBody1"
-              }
-              values={{ name: displayName || owner, owner }}
-              components={{
-                name: <span className="font-semibold text-base-content" />,
-                owner: <EmphasisLtr className="font-normal" />,
-              }}
-            />
-            <br />
-            <br />
-            <Trans
-              i18nKey="submissions.rowRegrade.confirmBody2"
-              values={{ collectLabel: t("submissions.collect.label") }}
-              components={{
-                collectLabel: <span className="font-semibold" />,
-              }}
-            />
-          </>
-        }
-        confirmText="regrade"
-        confirmLabel={t("submissions.rowRegrade.confirmLabel")}
-        cancelLabel={t("common.cancel")}
-        dangerous={false}
-        needsConfirm={false}
-        onConfirm={async () => {
-          regrade()
-        }}
-        onClose={() => setConfirmOpen(false)}
-      />
-    </>
-  )
-}
-
-// Per-row submission download. A button, not a link, because it triggers an
-// authenticated fetch, not a navigation.
-const DownloadButton = ({
-  org,
-  classroom,
-  assignment,
-  owner,
-}: {
-  org: string
-  classroom: string
-  assignment: string
-  owner: string
-}) => {
-  const { t } = useTranslation()
-  const { notify } = useToast()
-  const download = useDownloadSubmission()
-
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      shape="square"
-      className="text-base-content/70 disabled:opacity-60"
-      disabled={download.isPending}
-      loading={download.isPending}
-      loadingLabel={t("submissions.rowDownload.title")}
-      onClick={() => {
-        if (download.isPending) return
-        download.mutate(
-          { org, classroom, assignment, owner },
-          {
-            onError: (err) => {
-              // "no-submission" (missing/never-pushed repo) is benign info,
-              // not an error.
-              const nothing =
-                err instanceof Error && err.message === "no-submission"
-              notify({
-                tone: nothing ? "info" : "error",
-                message: nothing
-                  ? t("submissions.rowDownload.nothingToDownload", { owner })
-                  : t("submissions.rowDownload.error", { owner }),
-              })
-            },
-          },
-        )
-      }}
-      aria-label={t("submissions.rowDownload.aria", { owner })}
-      title={t("submissions.rowDownload.title")}
-    >
-      {!download.isPending && (
-        <Download aria-hidden="true" className="size-4" />
-      )}
-    </Button>
-  )
-}
 
 // Expanded per-row history: every submission for a repo, newest first.
 const SubmissionHistory = ({
@@ -655,80 +473,49 @@ const SubmissionsTable = ({
           </td>
           <td>
             <div className="flex items-center gap-1">
-              {isGroup && (
-                <GroupActionControls
+              {isGroup ? (
+                <RepoRowActions
+                  mode="group"
+                  org={org}
+                  classroom={classroom}
+                  assignment={assignment}
+                  owner={rest.owner}
                   repo={repo}
-                  repoHref={repoHref}
-                  onManage={() => setManageOwner(rest.owner)}
+                  hasRepo
+                  commit={rest.commit}
+                  release={rest.release}
+                  emptyRepo={emptyRepo}
+                  header={
+                    <GroupActionControls
+                      repo={repo}
+                      repoHref={repoHref}
+                      onManage={() => setManageOwner(rest.owner)}
+                    />
+                  }
+                />
+              ) : (
+                <RepoRowActions
+                  mode="individual"
+                  org={org}
+                  classroom={classroom}
+                  assignment={assignment}
+                  owner={rest.owner}
+                  repo={repo}
+                  hasRepo
+                  commit={rest.commit}
+                  release={rest.release}
+                  emptyRepo={emptyRepo}
+                  displayName={getName(rest.owner, students) || undefined}
+                  header={
+                    <IndividualRowHeader
+                      repo={repo}
+                      repoHref={repoHref}
+                      hasRepo
+                    />
+                  }
+                  onManageAccess={() => setAccessOwner(rest.owner)}
                 />
               )}
-              {!isGroup && (
-                <ActionIconLink
-                  href={repoHref}
-                  icon={GitHub}
-                  label={t("submissions.table.openRepoLabel", { repo })}
-                  title={t("submissions.table.viewRepo")}
-                  emptyLabel={t("submissions.table.openRepoLabel", { repo })}
-                  emptyTitle={t("submissions.table.viewRepo")}
-                />
-              )}
-              <ActionIconLink
-                href={safeHttpUrl(rest.commit)}
-                icon={GitCommitHorizontal}
-                label={t("submissions.table.viewCommit")}
-                title={t("submissions.table.commit")}
-                emptyLabel={t("submissions.table.noCommit")}
-                emptyTitle={t("submissions.table.noCommit")}
-              />
-              {!emptyRepo && (
-                <>
-                  <ReviewButton
-                    org={org}
-                    repo={repo}
-                    mode={isGroup ? "group" : "individual"}
-                  />
-                  {!isGroup && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      shape="square"
-                      className="text-base-content/70"
-                      aria-label={t("submissions.table.manageAccessAria", {
-                        owner: rest.owner,
-                      })}
-                      title={t("submissions.table.manageAccess")}
-                      onClick={() => setAccessOwner(rest.owner)}
-                    >
-                      <ShieldCheck aria-hidden="true" className="size-4" />
-                    </Button>
-                  )}
-                  <ActionIconLink
-                    href={safeHttpUrl(rest.release)}
-                    icon={ScrollText}
-                    label={t("submissions.table.viewDetails")}
-                    title={t("submissions.table.details")}
-                    emptyLabel={t("submissions.table.noDetailsLabel")}
-                    emptyTitle={t("submissions.table.noDetails")}
-                  />
-                  <RegradeButton
-                    org={org}
-                    classroom={classroom}
-                    assignment={assignment}
-                    owner={rest.owner}
-                    displayName={
-                      isGroup
-                        ? undefined
-                        : getName(rest.owner, students) || undefined
-                    }
-                  />
-                </>
-              )}
-              <DownloadButton
-                org={org}
-                classroom={classroom}
-                assignment={assignment}
-                owner={rest.owner}
-              />
             </div>
           </td>
         </tr>
@@ -837,6 +624,57 @@ const SubmissionsTable = ({
               if (item.kind === "row") return renderSubmitterRow(item.row)
               if (item.kind === "nonSubmitter") {
                 const student = item.student
+                // Individual non-submitter: show the same per-repo action
+                // cluster as a submitter, disabled where inapplicable. A repo
+                // exists only if they accepted; a never-accepted student's
+                // repo-scoped actions render disabled. A group non-submitter has
+                // no per-student repo, so no actions (the row shows an em-dash).
+                //
+                // Acceptance is a tri-state: `acceptedUsernames` is undefined
+                // until the org repo list loads. Treat undefined as "unknown"
+                // and fall back to the em-dash (like the neutral "Not submitted"
+                // badge does), so the row never asserts "hasn't accepted" with a
+                // disabled cluster while acceptance is still resolving.
+                const login = student.username?.toLowerCase()
+                const acceptanceKnown = acceptedUsernames !== undefined
+                const accepted = Boolean(login && acceptedUsernames?.has(login))
+                const actions =
+                  !isGroup && student.username && acceptanceKnown ? (
+                    <RepoRowActions
+                      mode="individual"
+                      org={org}
+                      classroom={classroom}
+                      assignment={assignment}
+                      owner={student.username}
+                      repo={studentRepoName(
+                        classroom,
+                        assignment,
+                        student.username,
+                      )}
+                      hasRepo={accepted}
+                      emptyRepo={emptyRepo}
+                      displayName={
+                        getName(student.username, students) || undefined
+                      }
+                      header={
+                        <IndividualRowHeader
+                          repo={studentRepoName(
+                            classroom,
+                            assignment,
+                            student.username,
+                          )}
+                          repoHref={studentRepoUrl(
+                            org,
+                            classroom,
+                            assignment,
+                            student.username,
+                          )}
+                          hasRepo={accepted}
+                        />
+                      }
+                      onManageAccess={() => setAccessOwner(student.username)}
+                    />
+                  ) : undefined
                 return (
                   <NonSubmitterRow
                     key={`missing-${student.username || student.email || student.github_id}`}
@@ -844,10 +682,8 @@ const SubmissionsTable = ({
                     students={students}
                     isGroup={isGroup}
                     acceptedUsernames={acceptedUsernames}
-                    org={org}
-                    classroom={classroom}
-                    assignment={assignment}
                     onProfile={setProfileUsername}
+                    actions={actions}
                   />
                 )
               }

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -32,6 +32,7 @@ import {
   buildGroupDisplayItems,
   buildGroupRosterDisplayItems,
   buildSortedDisplayItems,
+  hasAccepted,
   pageBounds,
   paginateDisplayItems,
   paginationRange,
@@ -635,22 +636,31 @@ const SubmissionsTable = ({
                 // and fall back to the em-dash (like the neutral "Not submitted"
                 // badge does), so the row never asserts "hasn't accepted" with a
                 // disabled cluster while acceptance is still resolving.
-                const login = student.username?.toLowerCase()
-                const acceptanceKnown = acceptedUsernames !== undefined
-                const accepted = Boolean(login && acceptedUsernames?.has(login))
-                const actions =
-                  !isGroup && student.username && acceptanceKnown ? (
+                const showActions =
+                  !isGroup && Boolean(student.username) && acceptedUsernames
+
+                let actions: React.ReactNode
+                if (showActions) {
+                  const repoName = studentRepoName(
+                    classroom,
+                    assignment,
+                    student.username,
+                  )
+                  const repoHref = studentRepoUrl(
+                    org,
+                    classroom,
+                    assignment,
+                    student.username,
+                  )
+                  const accepted = hasAccepted(student.username, showActions)
+                  actions = (
                     <RepoRowActions
                       mode="individual"
                       org={org}
                       classroom={classroom}
                       assignment={assignment}
                       owner={student.username}
-                      repo={studentRepoName(
-                        classroom,
-                        assignment,
-                        student.username,
-                      )}
+                      repo={repoName}
                       hasRepo={accepted}
                       emptyRepo={emptyRepo}
                       displayName={
@@ -658,23 +668,15 @@ const SubmissionsTable = ({
                       }
                       header={
                         <IndividualRowHeader
-                          repo={studentRepoName(
-                            classroom,
-                            assignment,
-                            student.username,
-                          )}
-                          repoHref={studentRepoUrl(
-                            org,
-                            classroom,
-                            assignment,
-                            student.username,
-                          )}
+                          repo={repoName}
+                          repoHref={repoHref}
                           hasRepo={accepted}
                         />
                       }
                       onManageAccess={() => setAccessOwner(student.username)}
                     />
-                  ) : undefined
+                  )
+                }
                 return (
                   <NonSubmitterRow
                     key={`missing-${student.username || student.email || student.github_id}`}


### PR DESCRIPTION
## What

On the teacher assignment-submission page, most per-repo actions were hidden unless a student had submitted. This makes every row show the **full** per-repo action cluster, disabling the actions that aren't applicable rather than hiding them.

Actions split by what they actually need:

- **Repo-only** (Open repo, Review Feedback PR, Manage access, Regrade, Download): a repo exists the moment a student accepts, so these stay live for an accepted-not-submitted student and only disable (with an explanatory "No repository yet" tooltip) when no repo exists at all.
- **Submission-only** (View commit, View details): tied to a specific attempt, so they render dimmed until one lands.

`empty_repo` assignments keep hiding the grading-tier actions everywhere, consistent with submitted rows. Group non-submitters (no per-student repo) keep the em-dash fallback.

## How

Extracted a shared `RepoRowActions` component (in a new co-located `SubmissionsRowActions.tsx`) that renders the identical action tail once for the submitter, non-submitter, and group row families. The three families now differ only in an explicit `header` slot, the `mode` passed to Review, and whether the per-student Manage-access button applies — removing the hand-copied group/individual duplication that previously risked sibling-path drift. Moving the row-action components out also brought `SubmissionsTable.tsx` back under 1000 lines.

Added `noRepo` disabled states to `ReviewButton`, `RegradeButton`, `DownloadButton`, and the Manage-access button, plus the four `*NoRepo` i18n keys.

Acceptance is treated as a tri-state: while the org repo list is still loading (`acceptedUsernames` undefined), a non-submitter row renders the neutral em-dash instead of falsely asserting "hasn't accepted" — matching the neutral status badge on the same row. The acceptance check reuses the existing `hasAccepted()` helper (the shared source of truth used by the status badge and roster counts).

A repo-less row renders a static disabled Regrade button and does **not** mount the regrade tracking hook or its confirm modal — with no repo there's nothing to regrade, so this avoids a per-row `sessionStorage` read and a hidden confirm dialog on rosters full of never-accepted students.

## Testing

`npm run check` passes (tsc, eslint, prettier, arch:validate, vitest — 2919 tests). Added coverage for the accepted / never-accepted / empty_repo / acceptance-loading non-submitter states and group-submitter parity through the shared cluster.