### PR TITLE
feat(web): consolidate per-submission actions into a manage modal

### DIFF
--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -23,11 +23,11 @@ import {
   CollaboratorIdentity,
   describeGitHubApiFailure,
   normalizeUsername,
+  permissionFromFlags,
   rejectedItems,
 } from "@/components/modals/collaboratorHelpers"
 import { permissionSatisfies } from "@/domain/assignments/permissions"
 import { GitHubAPIError } from "@/github-core/errors"
-import type { GitHubUser } from "@/github-core/types"
 import type { RepoPermission, Student } from "@/types/classroom"
 import { REPO_PERMISSIONS } from "@/types/classroom"
 
@@ -50,19 +50,6 @@ class RepoAccessNotAppliedError extends Error {
     this.requested = requested
     this.effective = effective
   }
-}
-
-// The effective role from a collaborator's permission booleans (the list
-// endpoint returns no role_name in our GitHubUser shape). Highest wins; triage
-// isn't modeled by the booleans, so it reads back as pull — acceptable, since a
-// no-op save is filtered out by the change diff.
-const permissionFromFlags = (
-  permissions: GitHubUser["permissions"],
-): RepoPermission => {
-  if (permissions.admin) return "admin"
-  if (permissions.maintain) return "maintain"
-  if (permissions.push) return "push"
-  return "pull"
 }
 
 // Map a rejected write to a human reason; reuses the groupCollaborators failure

--- a/web/src/components/modals/collaboratorHelpers.tsx
+++ b/web/src/components/modals/collaboratorHelpers.tsx
@@ -2,7 +2,21 @@ import type { TFunction } from "i18next"
 
 import { getName } from "@/util/students"
 import { GitHubAPIError } from "@/github-core/errors"
-import type { Student } from "@/types/classroom"
+import type { GitHubUser } from "@/github-core/types"
+import type { RepoPermission, Student } from "@/types/classroom"
+
+// The effective role from a collaborator's permission booleans (the list
+// endpoint returns no role_name in our GitHubUser shape). Highest wins; triage
+// isn't modeled by the booleans, so it reads back as pull — acceptable, since a
+// no-op save is filtered out by the caller's change diff.
+export const permissionFromFlags = (
+  permissions: GitHubUser["permissions"],
+): RepoPermission => {
+  if (permissions.admin) return "admin"
+  if (permissions.maintain) return "maintain"
+  if (permissions.push) return "push"
+  return "pull"
+}
 
 export const normalizeUsername = (username: string) =>
   username.trim().replace(/^@/, "").toLowerCase()

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -92,6 +92,10 @@ export type GitHubRepo = {
   // don't rely on them.
   pushed_at?: string
   updated_at?: string
+  // Repo creation time. For an assignment repo this is when the student
+  // accepted (the repo is created on accept). Optional — older callers don't
+  // rely on it.
+  created_at?: string
   description?: string | null
   owner?: {
     login: string

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2155,19 +2155,16 @@
       "gradedAtTitle": "When the autograder last (re-)graded this submission. Regrading updates this without changing the submission time.",
       "liveLatest": "Latest push {{date}} · not yet graded",
       "liveLatestTitle": "A newer submission was pushed after the last collection, so it isn't graded yet. Run \"Sync submissions now\" to grade and score it.",
-      "membersAria": "View and manage group members",
       "members": "Members",
       "openRepoLabel": "Open repository {{repo}}",
       "viewRepo": "View repo",
       "manageAccess": "Manage repository access",
-      "manageAccessNoRepo": "No repository yet — the student hasn't accepted",
       "manageAccessAria": "Manage repository access for {{owner}}",
       "viewCommit": "View latest commit",
       "commit": "Commit",
       "noCommit": "No commit yet",
       "viewDetails": "View autograder details",
       "details": "Details",
-      "noDetailsLabel": "No autograder details yet",
       "noDetails": "No details yet",
       "noGradingTitle": "Autograding is disabled for this assignment",
       "resolvingNonSubmitters": "Checking who hasn't submitted yet…",
@@ -2181,7 +2178,6 @@
       "noGroupTitle": "This student isn't credited on any submitting group's repo. Group membership is read from each repo's collaborators at collection time, so a student who never joined a group — or whose group's membership couldn't be read on the last collection — appears here. Open the group repos to confirm before grading.",
       "submittedBy": "by {{name}}",
       "review": "Review",
-      "reviewNoRepo": "No repository yet — the student hasn't accepted",
       "reviewAria": "Open feedback pull request",
       "fullHistory": "Open the <repoLink>repository</repoLink> for the full commit history."
     },
@@ -2280,7 +2276,6 @@
     },
     "rowRegrade": {
       "title": "Regrade this submission",
-      "titleNoRepo": "No repository yet — the student hasn't accepted",
       "titleInFlight": "Regrade in progress…",
       "titleBlocked": "Another regrade is in progress",
       "titleCompleted": "Regrade started — grading runs in the background; collect to see new scores",
@@ -2294,10 +2289,20 @@
     },
     "rowDownload": {
       "title": "Download this submission",
-      "titleNoRepo": "No repository yet — the student hasn't accepted",
       "aria": "Download {{owner}}'s submission",
       "nothingToDownload": "{{owner}} has no submission to download yet.",
       "error": "Couldn't download {{owner}}'s submission. Please try again."
+    },
+    "manageModal": {
+      "open": "Manage submission",
+      "openAria": "Manage {{owner}}'s submission",
+      "commitDescription": "Open the latest commit on GitHub",
+      "reviewDescription": "Open the feedback pull request",
+      "accessDescription": "Edit the student's role and collaborators",
+      "detailsDescription": "Open the autograder result on GitHub",
+      "regradeDescription": "Re-run the autograder on the latest commit",
+      "downloadDescription": "Save the submission as a zip archive",
+      "membersDescription": "View and manage the group's members"
     },
     "student": {
       "submittedAt": "Submitted {{date}}",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2296,6 +2296,11 @@
     "manageModal": {
       "open": "Manage submission",
       "openAria": "Manage {{owner}}'s submission",
+      "accepted": "Accepted",
+      "lastPush": "Last push",
+      "access": "Access",
+      "collaborators_one": "{{count}} collaborator",
+      "collaborators_other": "{{count}} collaborators",
       "commitDescription": "Open the latest commit on GitHub",
       "reviewDescription": "Open the feedback pull request",
       "accessDescription": "Edit the student's role and collaborators",

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -67,6 +67,8 @@ describe("ManageSubmissionModal", () => {
       data: {
         created_at: "2026-06-01T09:00:00Z",
         pushed_at: "2026-06-20T10:00:00Z",
+        html_url: "https://github.com/acme/cs101-hw1-alice",
+        default_branch: "main",
       },
     })
     collaboratorsData.mockReturnValue({
@@ -103,6 +105,13 @@ describe("ManageSubmissionModal", () => {
     expect(
       screen.queryByText("submissions.manageModal.collaborators"),
     ).toBeNull()
+    // Both the commit action and the Last-push value link to the default-branch
+    // tip (the literal latest commit).
+    const latest = "https://github.com/acme/cs101-hw1-alice/commit/main"
+    const commitLinks = screen
+      .getAllByRole("link")
+      .filter((a) => a.getAttribute("href") === latest)
+    expect(commitLinks.length).toBe(2)
   })
 
   it("lists collaborators beyond the owner (e.g. a group repo)", () => {

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -116,6 +116,58 @@ describe("ManageSubmissionModal", () => {
     expect(commitLinks.length).toBe(2)
   })
 
+  it("falls the commit action back to the graded snapshot when the default-branch tip is unresolved", () => {
+    // repoData lacks html_url/default_branch, so latestCommitHref is undefined;
+    // the commit action falls back to the scores.json `commit` URL.
+    repoData.mockReturnValue({
+      data: { created_at: "2026-06-01T09:00:00Z" },
+    })
+    const graded = "https://github.com/acme/cs101-hw1-alice/commit/abc123"
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        repoHref="https://github.com/acme/cs101-hw1-alice"
+        isGroup={false}
+        students={[]}
+        action={{
+          ...individualAction,
+          commit: graded,
+          onManageAccess: vi.fn(),
+        }}
+      />,
+    )
+    expect(
+      screen
+        .getAllByRole("link")
+        .some((a) => a.getAttribute("href") === graded),
+    ).toBe(true)
+  })
+
+  it("disables the commit action when neither the tip nor a graded commit exists", () => {
+    // No repo tip and no scores.json commit: the row is a disabled button with
+    // the no-commit description rather than a link.
+    repoData.mockReturnValue({ data: { created_at: "2026-06-01T09:00:00Z" } })
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        repoHref="https://github.com/acme/cs101-hw1-alice"
+        isGroup={false}
+        students={[]}
+        action={{ ...individualAction, commit: null, onManageAccess: vi.fn() }}
+      />,
+    )
+    const commitRow = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent?.includes("submissions.table.viewCommit"))
+    expect(commitRow).toBeTruthy()
+    expect(commitRow?.hasAttribute("disabled")).toBe(true)
+    expect(commitRow?.textContent).toContain("submissions.table.noCommit")
+  })
+
   it("lists collaborators beyond the owner (e.g. a group repo)", () => {
     collaboratorsData.mockReturnValue({
       data: [

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -154,7 +154,7 @@ describe("ManageSubmissionModal", () => {
     expect(screen.getByText("@bob")).toBeTruthy()
   })
 
-  it("closes the hub, then opens the access editor when Manage access is chosen", async () => {
+  it("opens the access editor stacked on the hub, leaving the hub open", async () => {
     const user = userEvent.setup()
     const onManageAccess = vi.fn()
     const onClose = vi.fn()
@@ -174,10 +174,10 @@ describe("ManageSubmissionModal", () => {
         name: "submissions.table.manageAccessAria",
       }),
     )
-    // Hand-off, not a nested modal: the hub's onClose fires (dialog.close) and
-    // the dedicated editor callback runs.
+    // Stacked, not a hand-off: the editor opens (via the callback) while the hub
+    // stays open, so dismissing the editor returns here rather than closing all.
     expect(onManageAccess).toHaveBeenCalledOnce()
-    expect(onClose).toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
   })
 
   it("offers the group members hand-off and omits per-student access", async () => {

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -15,7 +15,17 @@ vi.mock("react-i18next", async (importOriginal) => {
 })
 
 // Only the hub's own composition/hand-off is under test; the per-action hooks
-// are stubbed so no GitHub/provider wiring is needed.
+// and detail reads are stubbed so no GitHub/provider wiring is needed.
+const repoData = vi.fn(() => ({ data: undefined }) as { data: unknown })
+const collaboratorsData = vi.fn(
+  () => ({ data: undefined }) as { data: unknown },
+)
+vi.mock("@/hooks/useGetRepo", () => ({
+  default: () => repoData(),
+}))
+vi.mock("@/hooks/useGetRepoCollaborators", () => ({
+  default: () => collaboratorsData(),
+}))
 vi.mock("@/hooks/useGetFeedbackPr", () => ({
   default: () => ({ refetch: vi.fn() }),
 }))
@@ -45,9 +55,96 @@ const individualAction = {
   emptyRepo: false,
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  repoData.mockReturnValue({ data: undefined })
+  collaboratorsData.mockReturnValue({ data: undefined })
+})
 
 describe("ManageSubmissionModal", () => {
+  it("shows accept/push time, owner access, and hides collaborators when the owner is alone", () => {
+    repoData.mockReturnValue({
+      data: {
+        created_at: "2026-06-01T09:00:00Z",
+        pushed_at: "2026-06-20T10:00:00Z",
+      },
+    })
+    collaboratorsData.mockReturnValue({
+      data: [
+        {
+          login: "alice",
+          permissions: {
+            admin: false,
+            maintain: false,
+            push: true,
+            pull: true,
+          },
+        },
+      ],
+    })
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        repoHref="https://github.com/acme/cs101-hw1-alice"
+        isGroup={false}
+        students={[]}
+        action={{ ...individualAction, onManageAccess: vi.fn() }}
+      />,
+    )
+    expect(screen.getByText("submissions.manageModal.accepted")).toBeTruthy()
+    expect(screen.getByText("submissions.manageModal.lastPush")).toBeTruthy()
+    // Owner is push -> Write (push) level label.
+    expect(
+      screen.getByText("assignments.form.studentPermission.levels.push"),
+    ).toBeTruthy()
+    // Only the owner is a collaborator, so the collaborators line is hidden.
+    expect(
+      screen.queryByText("submissions.manageModal.collaborators"),
+    ).toBeNull()
+  })
+
+  it("lists collaborators beyond the owner (e.g. a group repo)", () => {
+    collaboratorsData.mockReturnValue({
+      data: [
+        {
+          login: "alice",
+          permissions: { admin: true, maintain: true, push: true, pull: true },
+        },
+        {
+          login: "bob",
+          permissions: {
+            admin: false,
+            maintain: false,
+            push: true,
+            pull: true,
+          },
+        },
+      ],
+    })
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="cs101-hw1-team"
+        repo="cs101-hw1-team"
+        isGroup
+        students={[]}
+        onManageMembers={vi.fn()}
+        action={{
+          ...individualAction,
+          mode: "group",
+          owner: "alice",
+          repo: "cs101-hw1-team",
+        }}
+      />,
+    )
+    expect(
+      screen.getByText("submissions.manageModal.collaborators"),
+    ).toBeTruthy()
+    expect(screen.getByText("@bob")).toBeTruthy()
+  })
+
   it("closes the hub, then opens the access editor when Manage access is chosen", async () => {
     const user = userEvent.setup()
     const onManageAccess = vi.fn()
@@ -59,6 +156,7 @@ describe("ManageSubmissionModal", () => {
         repo="cs101-hw1-alice"
         repoHref="https://github.com/acme/cs101-hw1-alice"
         isGroup={false}
+        students={[]}
         action={{ ...individualAction, onManageAccess }}
       />,
     )
@@ -83,6 +181,7 @@ describe("ManageSubmissionModal", () => {
         repo="cs101-hw1-team"
         repoHref="https://github.com/acme/cs101-hw1-team"
         isGroup
+        students={[]}
         onManageMembers={onManageMembers}
         action={{
           ...individualAction,
@@ -110,6 +209,7 @@ describe("ManageSubmissionModal", () => {
         title="Alice"
         repo="cs101-hw1-alice"
         isGroup={false}
+        students={[]}
         action={{
           ...individualAction,
           hasRepo: false,

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -16,9 +16,11 @@ vi.mock("react-i18next", async (importOriginal) => {
 
 // Only the hub's own composition/hand-off is under test; the per-action hooks
 // and detail reads are stubbed so no GitHub/provider wiring is needed.
-const repoData = vi.fn(() => ({ data: undefined }) as { data: unknown })
+const repoData = vi.fn(
+  () => ({ data: undefined }) as { data: unknown; isLoading?: boolean },
+)
 const collaboratorsData = vi.fn(
-  () => ({ data: undefined }) as { data: unknown },
+  () => ({ data: undefined }) as { data: unknown; isLoading?: boolean },
 )
 vi.mock("@/hooks/useGetRepo", () => ({
   default: () => repoData(),
@@ -152,6 +154,24 @@ describe("ManageSubmissionModal", () => {
       screen.getByText("submissions.manageModal.collaborators"),
     ).toBeTruthy()
     expect(screen.getByText("@bob")).toBeTruthy()
+  })
+
+  it("shows a skeleton while the repo/collaborator reads are in flight", () => {
+    repoData.mockReturnValue({ data: undefined, isLoading: true })
+    collaboratorsData.mockReturnValue({ data: undefined, isLoading: true })
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        repoHref="https://github.com/acme/cs101-hw1-alice"
+        isGroup={false}
+        students={[]}
+        action={{ ...individualAction, onManageAccess: vi.fn() }}
+      />,
+    )
+    expect(document.querySelector(".skeleton")).toBeTruthy()
+    expect(screen.getByText("common.loading")).toBeTruthy()
   })
 
   it("opens the access editor stacked on the hub, leaving the hub open", async () => {

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) =>
+        opts && "repo" in opts ? `${key}:${String(opts.repo)}` : key,
+    }),
+  }
+})
+
+// Only the hub's own composition/hand-off is under test; the per-action hooks
+// are stubbed so no GitHub/provider wiring is needed.
+vi.mock("@/hooks/useGetFeedbackPr", () => ({
+  default: () => ({ refetch: vi.fn() }),
+}))
+vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
+  default: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify: vi.fn() }),
+}))
+vi.mock("@/hooks/useTriggerRegrade", () => ({
+  default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),
+}))
+vi.mock("@/hooks/mutations/useDownloadSubmission", () => ({
+  default: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+import { ManageSubmissionModal } from "./ManageSubmissionModal"
+
+const individualAction = {
+  mode: "individual" as const,
+  org: "acme",
+  classroom: "cs101",
+  assignment: "hw1",
+  owner: "alice",
+  repo: "cs101-hw1-alice",
+  hasRepo: true,
+  emptyRepo: false,
+}
+
+afterEach(cleanup)
+
+describe("ManageSubmissionModal", () => {
+  it("closes the hub, then opens the access editor when Manage access is chosen", async () => {
+    const user = userEvent.setup()
+    const onManageAccess = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <ManageSubmissionModal
+        onClose={onClose}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        repoHref="https://github.com/acme/cs101-hw1-alice"
+        isGroup={false}
+        action={{ ...individualAction, onManageAccess }}
+      />,
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "submissions.table.manageAccessAria",
+      }),
+    )
+    // Hand-off, not a nested modal: the hub's onClose fires (dialog.close) and
+    // the dedicated editor callback runs.
+    expect(onManageAccess).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("offers the group members hand-off and omits per-student access", async () => {
+    const user = userEvent.setup()
+    const onManageMembers = vi.fn()
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="cs101-hw1-team"
+        repo="cs101-hw1-team"
+        repoHref="https://github.com/acme/cs101-hw1-team"
+        isGroup
+        onManageMembers={onManageMembers}
+        action={{
+          ...individualAction,
+          mode: "group",
+          owner: "team",
+          repo: "cs101-hw1-team",
+        }}
+      />,
+    )
+    expect(
+      screen.queryByRole("button", {
+        name: "submissions.table.manageAccessAria",
+      }),
+    ).toBeNull()
+    await user.click(
+      screen.getByRole("button", { name: /submissions\.table\.members/ }),
+    )
+    expect(onManageMembers).toHaveBeenCalledOnce()
+  })
+
+  it("disables the repo-scoped actions when no repo exists yet", () => {
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        isGroup={false}
+        action={{
+          ...individualAction,
+          hasRepo: false,
+          onManageAccess: vi.fn(),
+        }}
+      />,
+    )
+    expect(
+      screen
+        .getByRole("button", { name: "submissions.rowDownload.aria" })
+        .hasAttribute("disabled"),
+    ).toBe(true)
+    expect(
+      screen
+        .getByRole("button", { name: "submissions.table.reviewAria" })
+        .hasAttribute("disabled"),
+    ).toBe(true)
+  })
+})

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -180,6 +180,25 @@ describe("ManageSubmissionModal", () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
+  it("hides its own box while a stacked sub-modal is open", () => {
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        repoHref="https://github.com/acme/cs101-hw1-alice"
+        isGroup={false}
+        students={[]}
+        subModalOpen
+        action={{ ...individualAction, onManageAccess: vi.fn() }}
+      />,
+    )
+    // The hub's dialog stays open (returns focus on editor close) but its box is
+    // hidden so the two modal boxes don't visibly layer.
+    const box = document.querySelector(".modal-box")
+    expect(box?.className).toContain("invisible")
+  })
+
   it("offers the group members hand-off and omits per-student access", async () => {
     const user = userEvent.setup()
     const onManageMembers = vi.fn()

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -144,9 +144,9 @@ const SubmissionDetails = ({
 // The submission hub: one entry point that gathers every per-submission action
 // behind the row's Manage control. It shows the identity + repo it acts on,
 // read-only context (accept/push time, access, collaborators), then the action
-// list. The rich access/members editors are not nested here — they hand off
-// (this modal closes and the caller opens the dedicated modal), so a dialog
-// never stacks on the hub.
+// list. The rich access/members editors open stacked on top of the hub (native
+// <dialog> nesting) with the hub left open, so dismissing the editor returns
+// here rather than all the way back to the table.
 //
 // Mounted only while a row is selected (the caller gates + remounts via `key`),
 // so it opens once on mount; Esc/backdrop/X fire onClose to clear the selection.
@@ -199,15 +199,14 @@ export const ManageSubmissionModal = ({
     dialogRef.current?.showModal()
   }, [])
 
-  // Access/members editors are separate modals; close the hub first so only one
-  // dialog is ever open (no modal-on-modal).
+  // Open the access/members editor stacked on top of the hub (native <dialog>
+  // supports nesting). We intentionally leave the hub open so dismissing the
+  // editor returns here rather than all the way back to the table.
   const handleManageAccess = () => {
-    dialogRef.current?.close()
     action.onManageAccess?.()
   }
 
   const handleManageMembers = () => {
-    dialogRef.current?.close()
     onManageMembers?.()
   }
 

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -145,8 +145,9 @@ const SubmissionDetails = ({
 // behind the row's Manage control. It shows the identity + repo it acts on,
 // read-only context (accept/push time, access, collaborators), then the action
 // list. The rich access/members editors open stacked on top of the hub (native
-// <dialog> nesting) with the hub left open, so dismissing the editor returns
-// here rather than all the way back to the table.
+// <dialog> nesting). The hub's <dialog> stays open so dismissing the editor
+// returns here rather than all the way back to the table, but its box is hidden
+// (`subModalOpen`) while the editor is up so the two boxes don't visibly stack.
 //
 // Mounted only while a row is selected (the caller gates + remounts via `key`),
 // so it opens once on mount; Esc/backdrop/X fire onClose to clear the selection.
@@ -158,6 +159,7 @@ export const ManageSubmissionModal = ({
   repoHref,
   isGroup,
   students,
+  subModalOpen = false,
   onManageMembers,
   action,
 }: {
@@ -171,11 +173,14 @@ export const ManageSubmissionModal = ({
   isGroup: boolean
   // Roster, for resolving collaborator display names in the details section.
   students: Student[]
-  // Group hand-off: closes the hub and opens the members modal. Individual
-  // access hand-off is carried on `action.onManageAccess`.
+  // True while a stacked editor (access/members) is presented. The hub stays
+  // open underneath (so closing the editor returns here) but hides its own box
+  // to avoid visibly layered modals.
+  subModalOpen?: boolean
+  // Opens the group members editor stacked on the hub.
   onManageMembers?: () => void
   // Everything SubmissionActionList needs, minus the access hand-off, which the
-  // hub wraps so it closes first (below).
+  // hub wraps (below).
   action: Omit<SubmissionActionListProps, "onManageAccess"> & {
     onManageAccess?: () => void
   }
@@ -215,6 +220,10 @@ export const ManageSubmissionModal = ({
       dialogRef={dialogRef}
       onClose={onClose}
       size="lg"
+      // Keep the dialog open but hide its box while a stacked editor is up, so
+      // the two modal boxes don't visibly layer. The editor renders its own
+      // backdrop on top; dismissing it un-hides this box.
+      boxClassName={subModalOpen ? "invisible" : undefined}
       aria-labelledby={titleId}
     >
       <h3 id={titleId} className="truncate pe-8 text-lg font-bold">

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useId, useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { UsersRound } from "lucide-react"
+
+import GitHub from "@/assets/github.svg?react"
+import { Modal, MonoLtr } from "@/components/ui"
+import {
+  SubmissionActionList,
+  type SubmissionActionListProps,
+} from "@/pages/submissions/SubmissionsRowActions"
+import { ActionListRow } from "@/pages/submissions/actionLayout"
+
+// The submission hub: one entry point that gathers every per-submission action
+// behind the row's Manage control. It shows the identity + repo it acts on,
+// then the action list. The rich access/members editors are not nested here —
+// they hand off (this modal closes and the caller opens the dedicated modal),
+// so a dialog never stacks on the hub.
+//
+// Mounted only while a row is selected (the caller gates + remounts via `key`),
+// so it opens once on mount; Esc/backdrop/X fire onClose to clear the selection.
+export const ManageSubmissionModal = ({
+  onClose,
+  title,
+  subtitle,
+  repo,
+  repoHref,
+  isGroup,
+  onManageMembers,
+  action,
+}: {
+  onClose: () => void
+  // The submission's display name (student name) or, for a group, the repo name.
+  title: string
+  // Secondary line under the title (e.g. GitHub login · section), when known.
+  subtitle?: string
+  repo: string
+  repoHref?: string
+  isGroup: boolean
+  // Group hand-off: closes the hub and opens the members modal. Individual
+  // access hand-off is carried on `action.onManageAccess`.
+  onManageMembers?: () => void
+  // Everything SubmissionActionList needs, minus the access hand-off, which the
+  // hub wraps so it closes first (below).
+  action: Omit<SubmissionActionListProps, "onManageAccess"> & {
+    onManageAccess?: () => void
+  }
+}) => {
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
+  const titleId = useId()
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    dialogRef.current?.showModal()
+  }, [])
+
+  // Access/members editors are separate modals; close the hub first so only one
+  // dialog is ever open (no modal-on-modal).
+  const handleManageAccess = () => {
+    dialogRef.current?.close()
+    action.onManageAccess?.()
+  }
+
+  const handleManageMembers = () => {
+    dialogRef.current?.close()
+    onManageMembers?.()
+  }
+
+  return (
+    <Modal
+      dialogRef={dialogRef}
+      onClose={onClose}
+      size="md"
+      aria-labelledby={titleId}
+    >
+      <h3 id={titleId} className="truncate pe-8 text-lg font-bold">
+        {title}
+      </h3>
+      {subtitle ? (
+        <p className="mt-0.5 truncate text-sm text-base-content/60">
+          {subtitle}
+        </p>
+      ) : null}
+      {repoHref ? (
+        <a
+          className="mt-2 inline-flex w-fit items-center gap-1.5 link link-hover"
+          href={repoHref}
+          target="_blank"
+          rel="noreferrer"
+          title={t("submissions.table.viewRepo")}
+        >
+          <GitHub aria-hidden="true" className="size-4 shrink-0" />
+          <MonoLtr className="text-sm">{repo}</MonoLtr>
+        </a>
+      ) : (
+        <p className="mt-2 inline-flex w-fit items-center gap-1.5 text-base-content/50">
+          <GitHub aria-hidden="true" className="size-4 shrink-0" />
+          <MonoLtr className="text-sm">{repo}</MonoLtr>
+        </p>
+      )}
+
+      <div className="mt-4 divide-y divide-base-200">
+        <SubmissionActionList
+          {...action}
+          onManageAccess={
+            action.onManageAccess ? handleManageAccess : undefined
+          }
+        />
+        {isGroup && onManageMembers ? (
+          <ActionListRow
+            icon={UsersRound}
+            title={t("submissions.table.members")}
+            description={t("submissions.manageModal.membersDescription")}
+            onClick={handleManageMembers}
+          />
+        ) : null}
+      </div>
+    </Modal>
+  )
+}
+
+export default ManageSubmissionModal

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -16,6 +16,7 @@ import {
   type SubmissionActionListProps,
 } from "@/pages/submissions/SubmissionsRowActions"
 import { ActionListRow } from "@/pages/submissions/actionLayout"
+import type { GitHubRepo } from "@/github-core/types"
 import type { Student } from "@/types/classroom"
 
 const formatDateTime = (iso: string) =>
@@ -26,8 +27,9 @@ const formatDateTime = (iso: string) =>
 
 // Read-only context above the action list: accept time (repo creation), last
 // push, the enrolled owner's effective access, and any extra collaborators.
-// Fetches lazily (only while the hub is open) — a closed hub costs no requests.
-// Collaborators beyond the owner are hidden when there are none, so an
+// Collaborators fetch lazily (only while the hub is open); the repo read is
+// lifted to the modal so its default-branch tip can also link the commit
+// action. Collaborators beyond the owner are hidden when there are none, so an
 // individual repo with just its student shows no collaborator line while a
 // group repo lists its members (one generalized case).
 const SubmissionDetails = ({
@@ -35,14 +37,17 @@ const SubmissionDetails = ({
   repo,
   owner,
   students,
+  repoData,
+  latestCommitHref,
 }: {
   org: string
   repo: string
   owner: string
   students: Student[]
+  repoData?: GitHubRepo
+  latestCommitHref?: string
 }) => {
   const { t } = useTranslation()
-  const { data: repoData } = useGetRepo(org, repo)
   const { data: collaborators } = useGetRepoCollaborators(org, repo)
 
   const ownerLogin = normalizeUsername(owner)
@@ -69,9 +74,23 @@ const SubmissionDetails = ({
     })
   }
   if (repoData?.pushed_at) {
+    const pushed = formatDateTime(repoData.pushed_at)
     rows.push({
       label: t("submissions.manageModal.lastPush"),
-      value: formatDateTime(repoData.pushed_at),
+      // Hyperlink to the latest commit when we can resolve it (somewhat
+      // redundant with the commit action, but a convenient jump from the time).
+      value: latestCommitHref ? (
+        <a
+          className="link link-hover"
+          href={latestCommitHref}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {pushed}
+        </a>
+      ) : (
+        pushed
+      ),
     })
   }
   if (ownerAccess) {
@@ -165,6 +184,17 @@ export const ManageSubmissionModal = ({
   const titleId = useId()
   const { t } = useTranslation()
 
+  // Lifted here (not in SubmissionDetails) so the repo's default-branch tip can
+  // link both the "Last push" row and the "View latest commit" action. Only
+  // fetched once the hub is open; skipped entirely when no repo exists yet.
+  const { data: repoData } = useGetRepo(action.org, repo, {
+    enabled: action.hasRepo,
+  })
+  const latestCommitHref =
+    repoData?.html_url && repoData.default_branch
+      ? `${repoData.html_url}/commit/${repoData.default_branch}`
+      : undefined
+
   useEffect(() => {
     dialogRef.current?.showModal()
   }, [])
@@ -220,12 +250,15 @@ export const ManageSubmissionModal = ({
           repo={repo}
           owner={action.owner}
           students={students}
+          repoData={repoData ?? undefined}
+          latestCommitHref={latestCommitHref}
         />
       ) : null}
 
       <div className="mt-4 divide-y divide-base-200">
         <SubmissionActionList
           {...action}
+          latestCommitHref={latestCommitHref}
           onManageAccess={
             action.onManageAccess ? handleManageAccess : undefined
           }

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -38,6 +38,7 @@ const SubmissionDetails = ({
   owner,
   students,
   repoData,
+  repoLoading,
   latestCommitHref,
 }: {
   org: string
@@ -45,10 +46,12 @@ const SubmissionDetails = ({
   owner: string
   students: Student[]
   repoData?: GitHubRepo
+  repoLoading?: boolean
   latestCommitHref?: string
 }) => {
   const { t } = useTranslation()
-  const { data: collaborators } = useGetRepoCollaborators(org, repo)
+  const { data: collaborators, isLoading: collaboratorsLoading } =
+    useGetRepoCollaborators(org, repo)
 
   const ownerLogin = normalizeUsername(owner)
   const ownerAccess = useMemo(() => {
@@ -104,6 +107,26 @@ const SubmissionDetails = ({
     })
   }
 
+  const loading = Boolean(repoLoading) || collaboratorsLoading
+
+  // While the repo/collaborator reads are in flight, render a skeleton in the
+  // panel's shape so the section reserves its space and doesn't pop in.
+  if (loading && rows.length === 0 && otherCollaborators.length === 0) {
+    return (
+      <div className="mt-4 rounded-box border border-base-content/10 bg-base-200/40 p-3">
+        <div className="flex flex-col gap-2.5" aria-hidden="true">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex items-center justify-between gap-4">
+              <span className="skeleton skeleton-shimmer h-4 w-20" />
+              <span className="skeleton skeleton-shimmer h-4 w-28" />
+            </div>
+          ))}
+        </div>
+        <span className="sr-only">{t("common.loading")}</span>
+      </div>
+    )
+  }
+
   if (rows.length === 0 && otherCollaborators.length === 0) return null
 
   return (
@@ -120,6 +143,21 @@ const SubmissionDetails = ({
             </dd>
           </div>
         ))}
+        {/* Access comes from the collaborators read; if the repo rows landed
+            first, hold its place with a skeleton rather than popping it in. */}
+        {collaboratorsLoading && !ownerAccess ? (
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-base-content/60">
+              {t("submissions.manageModal.access")}
+            </dt>
+            <dd>
+              <span
+                className="skeleton skeleton-shimmer inline-block h-4 w-16 align-middle"
+                aria-hidden="true"
+              />
+            </dd>
+          </div>
+        ) : null}
       </dl>
       {otherCollaborators.length > 0 ? (
         <div className="mt-2 border-t border-base-content/10 pt-2">
@@ -192,9 +230,13 @@ export const ManageSubmissionModal = ({
   // Lifted here (not in SubmissionDetails) so the repo's default-branch tip can
   // link both the "Last push" row and the "View latest commit" action. Only
   // fetched once the hub is open; skipped entirely when no repo exists yet.
-  const { data: repoData } = useGetRepo(action.org, repo, {
-    enabled: action.hasRepo,
-  })
+  const { data: repoData, isLoading: repoLoading } = useGetRepo(
+    action.org,
+    repo,
+    {
+      enabled: action.hasRepo,
+    },
+  )
   const latestCommitHref =
     repoData?.html_url && repoData.default_branch
       ? `${repoData.html_url}/commit/${repoData.default_branch}`
@@ -259,6 +301,7 @@ export const ManageSubmissionModal = ({
           owner={action.owner}
           students={students}
           repoData={repoData ?? undefined}
+          repoLoading={repoLoading}
           latestCommitHref={latestCommitHref}
         />
       ) : null}

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -1,20 +1,133 @@
-import { useEffect, useId, useRef } from "react"
+import { useEffect, useId, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { UsersRound } from "lucide-react"
 
 import GitHub from "@/assets/github.svg?react"
-import { Modal, MonoLtr } from "@/components/ui"
+import { Badge, Modal, MonoLtr } from "@/components/ui"
+import useGetRepo from "@/hooks/useGetRepo"
+import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
+import {
+  CollaboratorIdentity,
+  normalizeUsername,
+  permissionFromFlags,
+} from "@/components/modals/collaboratorHelpers"
 import {
   SubmissionActionList,
   type SubmissionActionListProps,
 } from "@/pages/submissions/SubmissionsRowActions"
 import { ActionListRow } from "@/pages/submissions/actionLayout"
+import type { Student } from "@/types/classroom"
+
+const formatDateTime = (iso: string) =>
+  new Date(iso).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  })
+
+// Read-only context above the action list: accept time (repo creation), last
+// push, the enrolled owner's effective access, and any extra collaborators.
+// Fetches lazily (only while the hub is open) — a closed hub costs no requests.
+// Collaborators beyond the owner are hidden when there are none, so an
+// individual repo with just its student shows no collaborator line while a
+// group repo lists its members (one generalized case).
+const SubmissionDetails = ({
+  org,
+  repo,
+  owner,
+  students,
+}: {
+  org: string
+  repo: string
+  owner: string
+  students: Student[]
+}) => {
+  const { t } = useTranslation()
+  const { data: repoData } = useGetRepo(org, repo)
+  const { data: collaborators } = useGetRepoCollaborators(org, repo)
+
+  const ownerLogin = normalizeUsername(owner)
+  const ownerAccess = useMemo(() => {
+    const found = collaborators?.find(
+      (c) => c.login.toLowerCase() === ownerLogin,
+    )
+    return found ? permissionFromFlags(found.permissions) : undefined
+  }, [collaborators, ownerLogin])
+
+  const otherCollaborators = useMemo(
+    () =>
+      (collaborators ?? [])
+        .filter((c) => c.login.toLowerCase() !== ownerLogin)
+        .map((c) => c.login),
+    [collaborators, ownerLogin],
+  )
+
+  const rows: { label: string; value: React.ReactNode }[] = []
+  if (repoData?.created_at) {
+    rows.push({
+      label: t("submissions.manageModal.accepted"),
+      value: formatDateTime(repoData.created_at),
+    })
+  }
+  if (repoData?.pushed_at) {
+    rows.push({
+      label: t("submissions.manageModal.lastPush"),
+      value: formatDateTime(repoData.pushed_at),
+    })
+  }
+  if (ownerAccess) {
+    rows.push({
+      label: t("submissions.manageModal.access"),
+      value: (
+        <Badge ghost>
+          {t(`assignments.form.studentPermission.levels.${ownerAccess}`)}
+        </Badge>
+      ),
+    })
+  }
+
+  if (rows.length === 0 && otherCollaborators.length === 0) return null
+
+  return (
+    <div className="mt-4 rounded-box border border-base-content/10 bg-base-200/40 p-3">
+      <dl className="flex flex-col gap-1.5 text-sm">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-center justify-between gap-4"
+          >
+            <dt className="text-base-content/60">{row.label}</dt>
+            <dd className="min-w-0 truncate text-end font-medium">
+              {row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      {otherCollaborators.length > 0 ? (
+        <div className="mt-2 border-t border-base-content/10 pt-2">
+          <p className="mb-1 text-sm text-base-content/60">
+            {t("submissions.manageModal.collaborators", {
+              count: otherCollaborators.length,
+            })}
+          </p>
+          <ul className="flex flex-col gap-1">
+            {otherCollaborators.map((login) => (
+              <li key={login} className="min-w-0">
+                <CollaboratorIdentity login={login} students={students} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  )
+}
 
 // The submission hub: one entry point that gathers every per-submission action
 // behind the row's Manage control. It shows the identity + repo it acts on,
-// then the action list. The rich access/members editors are not nested here —
-// they hand off (this modal closes and the caller opens the dedicated modal),
-// so a dialog never stacks on the hub.
+// read-only context (accept/push time, access, collaborators), then the action
+// list. The rich access/members editors are not nested here — they hand off
+// (this modal closes and the caller opens the dedicated modal), so a dialog
+// never stacks on the hub.
 //
 // Mounted only while a row is selected (the caller gates + remounts via `key`),
 // so it opens once on mount; Esc/backdrop/X fire onClose to clear the selection.
@@ -25,6 +138,7 @@ export const ManageSubmissionModal = ({
   repo,
   repoHref,
   isGroup,
+  students,
   onManageMembers,
   action,
 }: {
@@ -36,6 +150,8 @@ export const ManageSubmissionModal = ({
   repo: string
   repoHref?: string
   isGroup: boolean
+  // Roster, for resolving collaborator display names in the details section.
+  students: Student[]
   // Group hand-off: closes the hub and opens the members modal. Individual
   // access hand-off is carried on `action.onManageAccess`.
   onManageMembers?: () => void
@@ -69,7 +185,7 @@ export const ManageSubmissionModal = ({
     <Modal
       dialogRef={dialogRef}
       onClose={onClose}
-      size="md"
+      size="lg"
       aria-labelledby={titleId}
     >
       <h3 id={titleId} className="truncate pe-8 text-lg font-bold">
@@ -82,21 +198,30 @@ export const ManageSubmissionModal = ({
       ) : null}
       {repoHref ? (
         <a
-          className="mt-2 inline-flex w-fit items-center gap-1.5 link link-hover"
+          className="link link-hover mt-2 inline-flex w-fit max-w-full items-center gap-1.5"
           href={repoHref}
           target="_blank"
           rel="noreferrer"
           title={t("submissions.table.viewRepo")}
         >
           <GitHub aria-hidden="true" className="size-4 shrink-0" />
-          <MonoLtr className="text-sm">{repo}</MonoLtr>
+          <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
         </a>
       ) : (
-        <p className="mt-2 inline-flex w-fit items-center gap-1.5 text-base-content/50">
+        <p className="mt-2 inline-flex w-fit max-w-full items-center gap-1.5 text-base-content/50">
           <GitHub aria-hidden="true" className="size-4 shrink-0" />
-          <MonoLtr className="text-sm">{repo}</MonoLtr>
+          <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
         </p>
       )}
+
+      {action.hasRepo ? (
+        <SubmissionDetails
+          org={action.org}
+          repo={repo}
+          owner={action.owner}
+          students={students}
+        />
+      ) : null}
 
       <div className="mt-4 divide-y divide-base-200">
         <SubmissionActionList

--- a/web/src/pages/submissions/ReviewButton.test.tsx
+++ b/web/src/pages/submissions/ReviewButton.test.tsx
@@ -42,7 +42,9 @@ const REPO = "cs101-hw1-alice"
 // Open the empty-PR modal: no open PR -> Review shows the modal with Repair.
 async function openRepairModal(user: ReturnType<typeof userEvent.setup>) {
   refetch.mockResolvedValueOnce({ data: null, error: null })
-  await user.click(screen.getByTitle("submissions.table.review"))
+  await user.click(
+    screen.getByRole("button", { name: "submissions.table.reviewAria" }),
+  )
   await screen.findByText("submissions.reviewModal.emptyTitle")
 }
 

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -6,6 +6,7 @@ import { Button, Modal, MonoLtr } from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
 import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
+import { ActionListRow } from "@/pages/submissions/actionLayout"
 import type { AssignmentMode } from "@/types/classroom"
 
 // Review action: links to the open Feedback PR (opened at accept time, or by
@@ -25,7 +26,7 @@ export const ReviewButton = ({
   repo: string
   mode: AssignmentMode
   // No assignment repo exists yet (never-accepted non-submitter): there can be
-  // no Feedback PR to review or repair, so render the button disabled.
+  // no Feedback PR to review or repair, so render the row disabled.
   noRepo?: boolean
 }) => {
   const { t } = useTranslation()
@@ -111,24 +112,16 @@ export const ReviewButton = ({
 
   return (
     <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="square"
-        className="text-base-content/70 disabled:opacity-60"
-        disabled={noRepo || resolving}
+      <ActionListRow
+        icon={MessageCircle}
+        title={t("submissions.table.review")}
+        description={t("submissions.manageModal.reviewDescription")}
+        onClick={handleReview}
+        disabled={noRepo}
         loading={resolving}
         loadingLabel={t("submissions.table.review")}
-        onClick={handleReview}
-        aria-label={t("submissions.table.reviewAria")}
-        title={
-          noRepo
-            ? t("submissions.table.reviewNoRepo")
-            : t("submissions.table.review")
-        }
-      >
-        {!resolving && <MessageCircle aria-hidden="true" className="size-4" />}
-      </Button>
+        ariaLabel={t("submissions.table.reviewAria")}
+      />
       <Modal
         dialogRef={dialogRef}
         size="md"

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -257,10 +257,10 @@ export const RepoRowActions = ({
 }
 
 // The submission hub's body: every consolidated action as a labeled list row.
-// Simple actions (commit/details links, Review, Regrade, Download) run in place
-// via their existing components in `layout="list"`; the rich access/members
-// editors hand off — `onManageAccess` closes the hub and opens the dedicated
-// modal — so no dialog ever stacks on the hub.
+// Simple actions (commit/details links, Review, Regrade, Download) run in place;
+// the rich access/members editors open stacked on top of the hub (native
+// <dialog> nesting) via `onManageAccess`/`onManageMembers`, with the hub left
+// open underneath — see ManageSubmissionModal for the stacking rationale.
 //
 // Gating mirrors the old cluster: repo-only actions (Review, access, regrade,
 // download) disable only when no repo exists; submission-only links
@@ -282,8 +282,8 @@ export type SubmissionActionListProps = {
   release?: string | null
   emptyRepo: boolean
   displayName?: string
-  // Individual per-student Manage-access hand-off; omitted for group rows
-  // (access is managed through the group Members modal instead).
+  // Opens the individual per-student access editor (stacked on the hub);
+  // omitted for group rows (access is managed through the group Members editor).
   onManageAccess?: () => void
 }
 

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -275,6 +275,10 @@ export type SubmissionActionListProps = {
   repo: string
   hasRepo: boolean
   commit?: string | null
+  // The repo's true latest commit (default-branch tip). When present it links
+  // the "View latest commit" action, since `commit` is only the latest *graded*
+  // snapshot from scores.json and can lag a fresh push. Falls back to `commit`.
+  latestCommitHref?: string | null
   release?: string | null
   emptyRepo: boolean
   displayName?: string
@@ -292,13 +296,14 @@ export const SubmissionActionList = ({
   repo,
   hasRepo,
   commit,
+  latestCommitHref,
   release,
   emptyRepo,
   displayName,
   onManageAccess,
 }: SubmissionActionListProps) => {
   const { t } = useTranslation()
-  const commitHref = safeHttpUrl(commit)
+  const commitHref = latestCommitHref ?? safeHttpUrl(commit)
   const releaseHref = safeHttpUrl(release)
   return (
     <div className="flex flex-col">

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -3,6 +3,7 @@ import {
   GitCommitHorizontal,
   RefreshCw,
   ScrollText,
+  Settings2,
   ShieldCheck,
 } from "lucide-react"
 import { useState } from "react"
@@ -13,6 +14,7 @@ import { safeHttpUrl } from "@/util/url"
 import { Button, EmphasisLtr } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { ActionIconLink } from "@/pages/submissions/SubmissionsRows"
+import { ActionListRow } from "@/pages/submissions/actionLayout"
 import { ReviewButton } from "@/pages/submissions/ReviewButton"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import useDownloadSubmission from "@/hooks/mutations/useDownloadSubmission"
@@ -44,17 +46,14 @@ export const RegradeButton = ({
   const { t } = useTranslation()
   if (noRepo) {
     return (
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="square"
-        className="text-base-content/70 disabled:opacity-60"
+      <ActionListRow
+        icon={RefreshCw}
+        title={t("submissions.rowRegrade.title")}
+        description={t("submissions.manageModal.regradeDescription")}
+        onClick={() => {}}
         disabled
-        aria-label={t("submissions.rowRegrade.aria", { owner: props.owner })}
-        title={t("submissions.rowRegrade.titleNoRepo")}
-      >
-        <RefreshCw aria-hidden="true" className="size-4" />
-      </Button>
+        ariaLabel={t("submissions.rowRegrade.aria", { owner: props.owner })}
+      />
     )
   }
   return <ActiveRegradeButton {...props} />
@@ -104,25 +103,23 @@ const ActiveRegradeButton = ({
 
   return (
     <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="square"
-        className="text-base-content/70 disabled:opacity-60"
+      <ActionListRow
+        icon={RefreshCw}
+        title={t("submissions.rowRegrade.title")}
+        description={
+          // Surface live phase (in progress / blocked / completed / failed) so
+          // the hub reflects the same state the icon button used to show in its
+          // tooltip; falls back to the static description at rest.
+          inFlight || blocked || phase === "completed" || phase === "failed"
+            ? title
+            : t("submissions.manageModal.regradeDescription")
+        }
+        onClick={handleClick}
         disabled={inFlight || blocked}
         loading={inFlight}
         loadingLabel={t("submissions.rowRegrade.title")}
-        onClick={handleClick}
-        aria-label={t("submissions.rowRegrade.aria", { owner })}
-        title={title}
-      >
-        {!inFlight && (
-          <RefreshCw
-            aria-hidden="true"
-            className={`size-4 ${phase === "completed" ? "text-success" : phase === "failed" ? "text-error" : ""}`}
-          />
-        )}
-      </Button>
+        ariaLabel={t("submissions.rowRegrade.aria", { owner })}
+      />
       <ConfirmModal
         open={confirmOpen}
         title={t("submissions.rowRegrade.confirmTitle", {
@@ -186,65 +183,107 @@ export const DownloadButton = ({
   const { notify } = useToast()
   const download = useDownloadSubmission()
 
+  const start = () => {
+    if (noRepo || download.isPending) return
+    download.mutate(
+      { org, classroom, assignment, owner },
+      {
+        onError: (err) => {
+          // "no-submission" (missing/never-pushed repo) is benign info,
+          // not an error.
+          const nothing =
+            err instanceof Error && err.message === "no-submission"
+          notify({
+            tone: nothing ? "info" : "error",
+            message: nothing
+              ? t("submissions.rowDownload.nothingToDownload", { owner })
+              : t("submissions.rowDownload.error", { owner }),
+          })
+        },
+      },
+    )
+  }
+
   return (
-    <Button
-      variant="ghost"
-      size="sm"
-      shape="square"
-      className="text-base-content/70 disabled:opacity-60"
-      disabled={noRepo || download.isPending}
+    <ActionListRow
+      icon={Download}
+      title={t("submissions.rowDownload.title")}
+      description={t("submissions.manageModal.downloadDescription")}
+      onClick={start}
+      disabled={noRepo}
       loading={download.isPending}
       loadingLabel={t("submissions.rowDownload.title")}
-      onClick={() => {
-        if (noRepo || download.isPending) return
-        download.mutate(
-          { org, classroom, assignment, owner },
-          {
-            onError: (err) => {
-              // "no-submission" (missing/never-pushed repo) is benign info,
-              // not an error.
-              const nothing =
-                err instanceof Error && err.message === "no-submission"
-              notify({
-                tone: nothing ? "info" : "error",
-                message: nothing
-                  ? t("submissions.rowDownload.nothingToDownload", { owner })
-                  : t("submissions.rowDownload.error", { owner }),
-              })
-            },
-          },
-        )
-      }}
-      aria-label={t("submissions.rowDownload.aria", { owner })}
-      title={
-        noRepo
-          ? t("submissions.rowDownload.titleNoRepo")
-          : t("submissions.rowDownload.title")
-      }
-    >
-      {!download.isPending && (
-        <Download aria-hidden="true" className="size-4" />
-      )}
-    </Button>
+      ariaLabel={t("submissions.rowDownload.aria", { owner })}
+    />
   )
 }
 
-// The per-repo action cluster shared by every row family — submitted,
-// non-submitter, and group. Group and individual rows differ only in the
-// leading `header` (Open-repo link vs. Members + repo link), the `mode` passed
-// to Review, and whether the per-student Manage-access button applies; the tail
-// (commit -> Review -> [access] -> details -> Regrade -> Download) is identical,
-// so it lives here once rather than being hand-copied per branch.
-//
-// Actions split by what they actually need:
-//   - repo-only (Open repo, Review PR, Manage access, Regrade, Download): a repo
-//     exists the moment a student accepts, so these stay live for an
-//     accepted-not-submitted student and only disable when no repo exists at all.
-//   - submission-only (View commit, View details): tied to a specific attempt,
-//     so they render dimmed (via ActionIconLink's empty branch) until one lands.
-// `emptyRepo` assignments never autograde, so their PR/regrade/details actions
-// disable regardless (kept visible, greyed, so the row layout doesn't jump).
+// The per-repo Actions cell, shared by every row family (submitted,
+// non-submitter, group). It now holds just two affordances: the leading
+// Open-repo shortcut (`header`) and a single Manage trigger that opens the
+// submission hub (ManageSubmissionModal), where every other action —
+// commit, Review, access, details, regrade, download — lives as a labeled row.
+// Consolidating keeps the dense table to one GitHub-repo shortcut plus one
+// entry point that scales as we add actions, instead of a growing icon cluster.
 export const RepoRowActions = ({
+  owner,
+  header,
+  onManage,
+}: {
+  owner: string
+  // The leading affordance for this row family (Open-repo link for individuals,
+  // repo link for groups).
+  header: React.ReactNode
+  // Opens the submission hub for this row.
+  onManage: () => void
+}) => {
+  const { t } = useTranslation()
+  return (
+    <>
+      {header}
+      <Button
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="text-base-content/70"
+        onClick={onManage}
+        aria-label={t("submissions.manageModal.openAria", { owner })}
+        title={t("submissions.manageModal.open")}
+      >
+        <Settings2 aria-hidden="true" className="size-4" />
+      </Button>
+    </>
+  )
+}
+
+// The submission hub's body: every consolidated action as a labeled list row.
+// Simple actions (commit/details links, Review, Regrade, Download) run in place
+// via their existing components in `layout="list"`; the rich access/members
+// editors hand off — `onManageAccess` closes the hub and opens the dedicated
+// modal — so no dialog ever stacks on the hub.
+//
+// Gating mirrors the old cluster: repo-only actions (Review, access, regrade,
+// download) disable only when no repo exists; submission-only links
+// (commit, details) dim until an attempt lands; `emptyRepo` assignments omit
+// the PR/access/details/regrade actions entirely.
+export type SubmissionActionListProps = {
+  mode: AssignmentMode
+  org: string
+  classroom: string
+  assignment: string
+  owner: string
+  repo: string
+  hasRepo: boolean
+  commit?: string | null
+  release?: string | null
+  emptyRepo: boolean
+  displayName?: string
+  // Individual per-student Manage-access hand-off; omitted for group rows
+  // (access is managed through the group Members modal instead).
+  onManageAccess?: () => void
+}
+
+export const SubmissionActionList = ({
   mode,
   org,
   classroom,
@@ -256,74 +295,51 @@ export const RepoRowActions = ({
   release,
   emptyRepo,
   displayName,
-  header,
   onManageAccess,
-}: {
-  mode: AssignmentMode
-  org: string
-  classroom: string
-  assignment: string
-  owner: string
-  repo: string
-  // Whether an assignment repo exists (submitted, or accepted-not-submitted). A
-  // never-accepted individual non-submitter has none, so the repo-scoped actions
-  // disable. Group rows always have a repo.
-  hasRepo: boolean
-  // Latest attempt's commit/release URLs, when a submission exists.
-  commit?: string | null
-  release?: string | null
-  emptyRepo: boolean
-  displayName?: string
-  // The leading affordance for this row family (Open-repo link for individuals,
-  // Members + repo link for groups).
-  header: React.ReactNode
-  // Individual per-student Manage-access action; omitted for group rows (access
-  // is managed through the group Members modal instead).
-  onManageAccess?: () => void
-}) => {
+}: SubmissionActionListProps) => {
   const { t } = useTranslation()
+  const commitHref = safeHttpUrl(commit)
+  const releaseHref = safeHttpUrl(release)
   return (
-    <>
-      {header}
-      <ActionIconLink
-        href={safeHttpUrl(commit)}
+    <div className="flex flex-col">
+      <ActionListRow
         icon={GitCommitHorizontal}
-        label={t("submissions.table.viewCommit")}
-        title={t("submissions.table.commit")}
-        emptyLabel={t("submissions.table.noCommit")}
-        emptyTitle={t("submissions.table.noCommit")}
+        title={t("submissions.table.viewCommit")}
+        description={
+          commitHref
+            ? t("submissions.manageModal.commitDescription")
+            : t("submissions.table.noCommit")
+        }
+        href={commitHref ?? undefined}
+        onClick={commitHref ? undefined : () => {}}
+        disabled={!commitHref}
+        external
       />
       {!emptyRepo && (
         <>
           <ReviewButton org={org} repo={repo} mode={mode} noRepo={!hasRepo} />
           {onManageAccess && (
-            <Button
-              variant="ghost"
-              size="sm"
-              shape="square"
-              className="text-base-content/70 disabled:opacity-60"
+            <ActionListRow
+              icon={ShieldCheck}
+              title={t("submissions.table.manageAccess")}
+              description={t("submissions.manageModal.accessDescription")}
+              onClick={onManageAccess}
               disabled={!hasRepo}
-              aria-label={t("submissions.table.manageAccessAria", { owner })}
-              title={
-                hasRepo
-                  ? t("submissions.table.manageAccess")
-                  : t("submissions.table.manageAccessNoRepo")
-              }
-              onClick={() => {
-                if (!hasRepo) return
-                onManageAccess()
-              }}
-            >
-              <ShieldCheck aria-hidden="true" className="size-4" />
-            </Button>
+              ariaLabel={t("submissions.table.manageAccessAria", { owner })}
+            />
           )}
-          <ActionIconLink
-            href={safeHttpUrl(release)}
+          <ActionListRow
             icon={ScrollText}
-            label={t("submissions.table.viewDetails")}
-            title={t("submissions.table.details")}
-            emptyLabel={t("submissions.table.noDetailsLabel")}
-            emptyTitle={t("submissions.table.noDetails")}
+            title={t("submissions.table.viewDetails")}
+            description={
+              releaseHref
+                ? t("submissions.manageModal.detailsDescription")
+                : t("submissions.table.noDetails")
+            }
+            href={releaseHref ?? undefined}
+            onClick={releaseHref ? undefined : () => {}}
+            disabled={!releaseHref}
+            external
           />
           <RegradeButton
             org={org}
@@ -342,7 +358,7 @@ export const RepoRowActions = ({
         owner={owner}
         noRepo={!hasRepo}
       />
-    </>
+    </div>
   )
 }
 

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -1,4 +1,3 @@
-import { UsersRound } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import GitHub from "@/assets/github.svg?react"
@@ -199,41 +198,26 @@ export const GroupMembers = ({
   )
 }
 
-// Shared action cluster for a group repo: Members button (opens the manage
-// modal) + the repo link. Used by both the submitted score row and the
-// awaiting group-repo row so the two never drift (one recipe, one source).
+// Shared leading affordance for a group repo row: just the repo link. The
+// Members action moved into the submission hub (ManageSubmissionModal), so the
+// Actions cell keeps a single GitHub-repo shortcut like the individual rows.
 export const GroupActionControls = ({
   repo,
   repoHref,
-  onManage,
 }: {
   repo: string
   repoHref: string
-  onManage: () => void
 }) => {
   const { t } = useTranslation()
   return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="square"
-        className="text-base-content/70"
-        onClick={onManage}
-        aria-label={t("submissions.table.membersAria")}
-        title={t("submissions.table.members")}
-      >
-        <UsersRound aria-hidden="true" className="size-4" />
-      </Button>
-      <ActionIconLink
-        href={repoHref}
-        icon={GitHub}
-        label={t("submissions.table.openRepoLabel", { repo })}
-        title={t("submissions.table.viewRepo")}
-        emptyLabel={t("submissions.table.openRepoLabel", { repo })}
-        emptyTitle={t("submissions.table.viewRepo")}
-      />
-    </>
+    <ActionIconLink
+      href={repoHref}
+      icon={GitHub}
+      label={t("submissions.table.openRepoLabel", { repo })}
+      title={t("submissions.table.viewRepo")}
+      emptyLabel={t("submissions.table.openRepoLabel", { repo })}
+      emptyTitle={t("submissions.table.viewRepo")}
+    />
   )
 }
 
@@ -295,10 +279,9 @@ export const NonSubmitterRow = ({
 }
 
 // A group repo that exists but has no submission yet: repo + members (from the
-// collaborators cache) with an "awaiting submission" badge and the shared group
-// actions. Fetching is lazy — the Members modal loads collaborators on demand,
-// so a class with many formed-but-unpushed groups doesn't fan out one request
-// per row on mount (#245).
+// collaborators cache) with an "awaiting submission" badge. The Actions cell is
+// composed by the caller (`actions`) so this stays presentational and avoids a
+// cycle with SubmissionsRowActions (#245 keeps fetching lazy).
 export const GroupRepoRow = ({
   org,
   classroom,
@@ -306,7 +289,7 @@ export const GroupRepoRow = ({
   owner,
   repoName,
   students,
-  onManage,
+  actions,
 }: {
   org: string
   classroom: string
@@ -314,7 +297,7 @@ export const GroupRepoRow = ({
   owner: string
   repoName: string
   students: Student[]
-  onManage: () => void
+  actions: React.ReactNode
 }) => {
   const { t } = useTranslation()
   const repoHref = studentRepoUrl(org, classroom, assignment, owner)
@@ -338,13 +321,7 @@ export const GroupRepoRow = ({
       <td>—</td>
       <td>—</td>
       <td>
-        <div className="flex items-center gap-1">
-          <GroupActionControls
-            repo={repoName}
-            repoHref={repoHref}
-            onManage={onManage}
-          />
-        </div>
+        <div className="flex items-center gap-1">{actions}</div>
       </td>
     </tr>
   )

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { cleanup, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -37,6 +38,9 @@ vi.mock("@/hooks/mutations/useDownloadSubmission", () => ({
 }))
 vi.mock("@/components/modals/GroupCollaboratorsModal", () => ({
   GroupCollaboratorsModal: () => null,
+}))
+vi.mock("@/components/modals/RepoAccessModal", () => ({
+  RepoAccessModal: () => null,
 }))
 vi.mock("@/components/modals/StudentProfileModal", () => ({
   StudentProfileModal: () => null,
@@ -86,6 +90,14 @@ const baseProps = {
   org: "acme",
   classroom: "cs101",
   assignment: "hw1",
+}
+
+// Open the single row's submission hub (ManageSubmissionModal) by clicking its
+// Manage trigger, where the consolidated actions live.
+async function openHub(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    screen.getByRole("button", { name: "submissions.manageModal.openAria" }),
+  )
 }
 
 describe("SubmissionsTable non-submitter repo links", () => {
@@ -192,7 +204,8 @@ describe("SubmissionsTable empty_repo score cell", () => {
 })
 
 describe("SubmissionsTable per-row download", () => {
-  it("renders a download button for a submitter row and fires the hook on click", () => {
+  it("fires the download hook from the hub for a submitter row", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -200,8 +213,8 @@ describe("SubmissionsTable per-row download", () => {
         acceptedUsernames={new Set(["alice"])}
       />,
     )
-    const btn = screen.getByTitle("submissions.rowDownload.title")
-    btn.click()
+    await openHub(user)
+    screen.getByRole("button", { name: "submissions.rowDownload.aria" }).click()
     expect(downloadSubmission).toHaveBeenCalledWith(
       {
         org: "acme",
@@ -213,7 +226,8 @@ describe("SubmissionsTable per-row download", () => {
     )
   })
 
-  it("renders the download button even for an empty_repo assignment", () => {
+  it("offers download in the hub even for an empty_repo assignment", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -222,10 +236,14 @@ describe("SubmissionsTable per-row download", () => {
         emptyRepo
       />,
     )
-    expect(screen.getByTitle("submissions.rowDownload.title")).toBeTruthy()
+    await openHub(user)
+    expect(
+      screen.getByRole("button", { name: "submissions.rowDownload.aria" }),
+    ).toBeTruthy()
   })
 
-  it("shows the download button for an accepted-not-submitted non-submitter", () => {
+  it("enables download in the hub for an accepted-not-submitted non-submitter", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -233,13 +251,15 @@ describe("SubmissionsTable per-row download", () => {
         acceptedUsernames={new Set(["alice"])}
       />,
     )
-    // The full per-repo action cluster now renders for non-submitters; an
-    // accepted student has a repo, so Download is enabled.
-    const btn = screen.getByTitle("submissions.rowDownload.title")
+    await openHub(user)
+    const btn = screen.getByRole("button", {
+      name: "submissions.rowDownload.aria",
+    })
     expect(btn.hasAttribute("disabled")).toBe(false)
   })
 
-  it("disables the download button for a never-accepted non-submitter", () => {
+  it("disables download in the hub for a never-accepted non-submitter", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -247,14 +267,17 @@ describe("SubmissionsTable per-row download", () => {
         acceptedUsernames={new Set()}
       />,
     )
-    // No repo exists, so Download shows but is disabled (via titleNoRepo).
-    const btn = screen.getByTitle("submissions.rowDownload.titleNoRepo")
+    await openHub(user)
+    const btn = screen.getByRole("button", {
+      name: "submissions.rowDownload.aria",
+    })
     expect(btn.hasAttribute("disabled")).toBe(true)
   })
 })
 
-describe("SubmissionsTable non-submitter action cluster", () => {
-  it("shows the repo-scoped actions (Review, Manage access, Regrade) for a non-submitter", () => {
+describe("SubmissionsTable hub action list", () => {
+  it("shows the repo-scoped actions (Review, Manage access, Regrade) for a non-submitter", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -262,12 +285,22 @@ describe("SubmissionsTable non-submitter action cluster", () => {
         acceptedUsernames={new Set(["alice"])}
       />,
     )
-    expect(screen.getByTitle("submissions.table.review")).toBeTruthy()
-    expect(screen.getByTitle("submissions.table.manageAccess")).toBeTruthy()
-    expect(screen.getByTitle("submissions.rowRegrade.title")).toBeTruthy()
+    await openHub(user)
+    expect(
+      screen.getByRole("button", { name: "submissions.table.reviewAria" }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", {
+        name: "submissions.table.manageAccessAria",
+      }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "submissions.rowRegrade.aria" }),
+    ).toBeTruthy()
   })
 
-  it("disables the repo-scoped actions for a never-accepted non-submitter", () => {
+  it("disables the repo-scoped actions for a never-accepted non-submitter", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -275,24 +308,26 @@ describe("SubmissionsTable non-submitter action cluster", () => {
         acceptedUsernames={new Set()}
       />,
     )
+    await openHub(user)
     expect(
       screen
-        .getByTitle("submissions.table.reviewNoRepo")
+        .getByRole("button", { name: "submissions.table.reviewAria" })
         .hasAttribute("disabled"),
     ).toBe(true)
     expect(
       screen
-        .getByTitle("submissions.table.manageAccessNoRepo")
+        .getByRole("button", { name: "submissions.table.manageAccessAria" })
         .hasAttribute("disabled"),
     ).toBe(true)
     expect(
       screen
-        .getByTitle("submissions.rowRegrade.titleNoRepo")
+        .getByRole("button", { name: "submissions.rowRegrade.aria" })
         .hasAttribute("disabled"),
     ).toBe(true)
   })
 
-  it("hides grading actions for an empty_repo non-submitter but keeps repo + download", () => {
+  it("hides grading actions in the hub for an empty_repo non-submitter but keeps the repo shortcut + download", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -301,21 +336,32 @@ describe("SubmissionsTable non-submitter action cluster", () => {
         emptyRepo
       />,
     )
-    // empty_repo never autogrades: Review/Manage access/Regrade are hidden,
-    // but Open repo and Download stay.
-    expect(screen.queryByTitle("submissions.table.review")).toBeNull()
-    expect(screen.queryByTitle("submissions.rowRegrade.title")).toBeNull()
+    // The Open-repo shortcut stays inline in the row.
     expect(
       screen.getByRole("link", {
         name: "submissions.table.openRepoLabel:cs101-hw1-alice",
       }),
     ).toBeTruthy()
-    expect(screen.getByTitle("submissions.rowDownload.title")).toBeTruthy()
-    // Manage access is one of the grading-tier actions hidden for empty_repo.
-    expect(screen.queryByTitle("submissions.table.manageAccess")).toBeNull()
+    await openHub(user)
+    // empty_repo never autogrades: Review/Manage access/Regrade are hidden in
+    // the hub, but Download stays.
+    expect(
+      screen.queryByRole("button", { name: "submissions.table.reviewAria" }),
+    ).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "submissions.rowRegrade.aria" }),
+    ).toBeNull()
+    expect(
+      screen.queryByRole("button", {
+        name: "submissions.table.manageAccessAria",
+      }),
+    ).toBeNull()
+    expect(
+      screen.getByRole("button", { name: "submissions.rowDownload.aria" }),
+    ).toBeTruthy()
   })
 
-  it("shows an em-dash (no actions) while acceptance data is still loading", () => {
+  it("shows an em-dash (no Manage trigger) while acceptance data is still loading", () => {
     render(
       <SubmissionsTable
         {...baseProps}
@@ -326,15 +372,15 @@ describe("SubmissionsTable non-submitter action cluster", () => {
     // acceptedUsernames === undefined means acceptance is unknown (org repo list
     // not loaded): the row must not assert "hasn't accepted" with a disabled
     // cluster, so no action controls render at all.
-    expect(screen.queryByTitle("submissions.table.review")).toBeNull()
-    expect(screen.queryByTitle("submissions.table.reviewNoRepo")).toBeNull()
-    expect(screen.queryByTitle("submissions.rowDownload.title")).toBeNull()
     expect(
-      screen.queryByTitle("submissions.rowDownload.titleNoRepo"),
+      screen.queryByRole("button", {
+        name: "submissions.manageModal.openAria",
+      }),
     ).toBeNull()
   })
 
-  it("renders the shared action cluster for a group submitter row", () => {
+  it("renders the hub action list for a group submitter row", async () => {
+    const user = userEvent.setup()
     render(
       <SubmissionsTable
         {...baseProps}
@@ -342,15 +388,27 @@ describe("SubmissionsTable non-submitter action cluster", () => {
         scores={[scoreRow({ owner: "team-rocket", usernames: ["alice"] })]}
       />,
     )
-    // Group rows go through the same RepoRowActions as individual rows, so the
-    // Review/Regrade/Download tail must be present (parity with the individual
-    // submitter row, which shares the component).
-    expect(screen.getByTitle("submissions.table.review")).toBeTruthy()
-    expect(screen.getByTitle("submissions.rowRegrade.title")).toBeTruthy()
-    expect(screen.getByTitle("submissions.rowDownload.title")).toBeTruthy()
-    // Members button (group header) is present; the per-student Manage-access
-    // button is not (group access is managed via the Members modal).
-    expect(screen.getByTitle("submissions.table.members")).toBeTruthy()
-    expect(screen.queryByTitle("submissions.table.manageAccess")).toBeNull()
+    await openHub(user)
+    // Group rows open the same hub as individual rows, so the
+    // Review/Regrade/Download actions are present (parity).
+    expect(
+      screen.getByRole("button", { name: "submissions.table.reviewAria" }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "submissions.rowRegrade.aria" }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "submissions.rowDownload.aria" }),
+    ).toBeTruthy()
+    // The group Members hand-off is present; the per-student Manage-access
+    // action is not (group access is managed via the Members modal).
+    expect(
+      screen.getByRole("button", { name: /submissions\.table\.members/ }),
+    ).toBeTruthy()
+    expect(
+      screen.queryByRole("button", {
+        name: "submissions.table.manageAccessAria",
+      }),
+    ).toBeNull()
   })
 })

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -20,6 +20,9 @@ const collaborators = vi.fn()
 vi.mock("@/hooks/useGetRepoCollaborators", () => ({
   default: (...a: unknown[]) => collaborators(...a),
 }))
+vi.mock("@/hooks/useGetRepo", () => ({
+  default: () => ({ data: undefined }),
+}))
 vi.mock("@/hooks/useGetFeedbackPr", () => ({
   default: () => ({ refetch: vi.fn() }),
 }))

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -49,6 +49,7 @@ import {
   IndividualRowHeader,
   RepoRowActions,
 } from "@/pages/submissions/SubmissionsRowActions"
+import { ManageSubmissionModal } from "@/pages/submissions/ManageSubmissionModal"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { RepoAccessModal } from "@/components/modals/RepoAccessModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
@@ -89,6 +90,21 @@ const ScoreBadge = ({
 
 type IconComponent = React.ComponentType<{ className?: string }>
 
+// The row context the submission hub (ManageSubmissionModal) renders from,
+// captured when the row's Manage control is clicked. `title`/`subtitle` are the
+// identity to show; the rest gate and target the per-action rows.
+type ManageSubmissionContext = {
+  owner: string
+  isGroup: boolean
+  title: string
+  subtitle?: string
+  repo: string
+  repoHref: string
+  hasRepo: boolean
+  commit?: string | null
+  release?: string | null
+  displayName?: string
+}
 // Inline commit/details link in the expanded history row: external link when a
 // URL is present, else dimmed non-clickable text (label shown beside the icon,
 // unlike the icon-only row-action above).
@@ -278,6 +294,12 @@ const SubmissionsTable = ({
 
   // The owner (group founder) whose collaborators modal is open, or null.
   const [manageOwner, setManageOwner] = useState<string | null>(null)
+
+  // The submission whose hub (ManageSubmissionModal) is open, or null. Carries
+  // the row's context so the hub can render identity, repo, and the per-action
+  // gating without re-deriving it.
+  const [manageSubmission, setManageSubmission] =
+    useState<ManageSubmissionContext | null>(null)
 
   // The individual student whose repo-access modal is open, or null.
   const [accessOwner, setAccessOwner] = useState<string | null>(null)
@@ -476,37 +498,26 @@ const SubmissionsTable = ({
             <div className="flex items-center gap-1">
               {isGroup ? (
                 <RepoRowActions
-                  mode="group"
-                  org={org}
-                  classroom={classroom}
-                  assignment={assignment}
                   owner={rest.owner}
-                  repo={repo}
-                  hasRepo
-                  commit={rest.commit}
-                  release={rest.release}
-                  emptyRepo={emptyRepo}
                   header={
-                    <GroupActionControls
-                      repo={repo}
-                      repoHref={repoHref}
-                      onManage={() => setManageOwner(rest.owner)}
-                    />
+                    <GroupActionControls repo={repo} repoHref={repoHref} />
+                  }
+                  onManage={() =>
+                    setManageSubmission({
+                      owner: rest.owner,
+                      isGroup: true,
+                      title: repo,
+                      repo,
+                      repoHref,
+                      hasRepo: true,
+                      commit: rest.commit,
+                      release: rest.release,
+                    })
                   }
                 />
               ) : (
                 <RepoRowActions
-                  mode="individual"
-                  org={org}
-                  classroom={classroom}
-                  assignment={assignment}
                   owner={rest.owner}
-                  repo={repo}
-                  hasRepo
-                  commit={rest.commit}
-                  release={rest.release}
-                  emptyRepo={emptyRepo}
-                  displayName={getName(rest.owner, students) || undefined}
                   header={
                     <IndividualRowHeader
                       repo={repo}
@@ -514,7 +525,24 @@ const SubmissionsTable = ({
                       hasRepo
                     />
                   }
-                  onManageAccess={() => setAccessOwner(rest.owner)}
+                  onManage={() =>
+                    setManageSubmission({
+                      owner: rest.owner,
+                      isGroup: false,
+                      title: getName(rest.owner, students) || rest.owner,
+                      subtitle: identitySubtitle(
+                        getName(rest.owner, students),
+                        rest.owner,
+                        getSection(rest.owner, students),
+                      ),
+                      repo,
+                      repoHref,
+                      hasRepo: true,
+                      commit: rest.commit,
+                      release: rest.release,
+                      displayName: getName(rest.owner, students) || undefined,
+                    })
+                  }
                 />
               )}
             </div>
@@ -655,17 +683,7 @@ const SubmissionsTable = ({
                   const accepted = hasAccepted(student.username, showActions)
                   actions = (
                     <RepoRowActions
-                      mode="individual"
-                      org={org}
-                      classroom={classroom}
-                      assignment={assignment}
                       owner={student.username}
-                      repo={repoName}
-                      hasRepo={accepted}
-                      emptyRepo={emptyRepo}
-                      displayName={
-                        getName(student.username, students) || undefined
-                      }
                       header={
                         <IndividualRowHeader
                           repo={repoName}
@@ -673,7 +691,25 @@ const SubmissionsTable = ({
                           hasRepo={accepted}
                         />
                       }
-                      onManageAccess={() => setAccessOwner(student.username)}
+                      onManage={() =>
+                        setManageSubmission({
+                          owner: student.username,
+                          isGroup: false,
+                          title:
+                            getName(student.username, students) ||
+                            student.username,
+                          subtitle: identitySubtitle(
+                            getName(student.username, students),
+                            student.username,
+                            student.section,
+                          ),
+                          repo: repoName,
+                          repoHref,
+                          hasRepo: accepted,
+                          displayName:
+                            getName(student.username, students) || undefined,
+                        })
+                      }
                     />
                   )
                 }
@@ -690,6 +726,12 @@ const SubmissionsTable = ({
                 )
               }
               const { owner, repoName } = item.repo
+              const groupRepoHref = studentRepoUrl(
+                org,
+                classroom,
+                assignment,
+                owner,
+              )
               return (
                 <GroupRepoRow
                   key={`group-${repoName}`}
@@ -699,7 +741,27 @@ const SubmissionsTable = ({
                   owner={owner}
                   repoName={repoName}
                   students={students}
-                  onManage={() => setManageOwner(owner)}
+                  actions={
+                    <RepoRowActions
+                      owner={owner}
+                      header={
+                        <GroupActionControls
+                          repo={repoName}
+                          repoHref={groupRepoHref}
+                        />
+                      }
+                      onManage={() =>
+                        setManageSubmission({
+                          owner,
+                          isGroup: true,
+                          title: repoName,
+                          repo: repoName,
+                          repoHref: groupRepoHref,
+                          hasRepo: true,
+                        })
+                      }
+                    />
+                  }
                 />
               )
             })}
@@ -734,6 +796,41 @@ const SubmissionsTable = ({
           />
         )}
       </EnterDiv>
+
+      {manageSubmission && (
+        <ManageSubmissionModal
+          key={`manage-${manageSubmission.owner}`}
+          onClose={() => setManageSubmission(null)}
+          title={manageSubmission.title}
+          subtitle={manageSubmission.subtitle}
+          repo={manageSubmission.repo}
+          repoHref={
+            manageSubmission.hasRepo ? manageSubmission.repoHref : undefined
+          }
+          isGroup={manageSubmission.isGroup}
+          onManageMembers={
+            manageSubmission.isGroup
+              ? () => setManageOwner(manageSubmission.owner)
+              : undefined
+          }
+          action={{
+            mode: manageSubmission.isGroup ? "group" : "individual",
+            org,
+            classroom,
+            assignment,
+            owner: manageSubmission.owner,
+            repo: manageSubmission.repo,
+            hasRepo: manageSubmission.hasRepo,
+            commit: manageSubmission.commit,
+            release: manageSubmission.release,
+            emptyRepo,
+            displayName: manageSubmission.displayName,
+            onManageAccess: manageSubmission.isGroup
+              ? undefined
+              : () => setAccessOwner(manageSubmission.owner),
+          }}
+        />
+      )}
 
       {isGroup && manageOwner && (
         <GroupCollaboratorsModal

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -809,6 +809,10 @@ const SubmissionsTable = ({
           }
           isGroup={manageSubmission.isGroup}
           students={students}
+          subModalOpen={
+            accessOwner === manageSubmission.owner ||
+            manageOwner === manageSubmission.owner
+          }
           onManageMembers={
             manageSubmission.isGroup
               ? () => setManageOwner(manageSubmission.owner)

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -808,6 +808,7 @@ const SubmissionsTable = ({
             manageSubmission.hasRepo ? manageSubmission.repoHref : undefined
           }
           isGroup={manageSubmission.isGroup}
+          students={students}
           onManageMembers={
             manageSubmission.isGroup
               ? () => setManageOwner(manageSubmission.owner)

--- a/web/src/pages/submissions/actionLayout.tsx
+++ b/web/src/pages/submissions/actionLayout.tsx
@@ -1,0 +1,85 @@
+import { ChevronRight, ExternalLink } from "lucide-react"
+
+import { Button } from "@/components/ui"
+import { rtlFlip } from "@/components/ui"
+
+type IconComponent = React.ComponentType<{ className?: string }>
+
+// A labeled action row for the submission hub: leading icon, title + optional
+// description, trailing affordance (an external-link glyph for links, else a
+// chevron). Renders as an <a> when `href` is set, otherwise a <button> driving
+// `onClick`. Disabled state dims and inerts it.
+export const ActionListRow = ({
+  icon: Icon,
+  title,
+  description,
+  href,
+  onClick,
+  disabled = false,
+  loading = false,
+  loadingLabel,
+  ariaLabel,
+  external = false,
+}: {
+  icon: IconComponent
+  title: string
+  description?: string
+  href?: string | null
+  onClick?: () => void
+  disabled?: boolean
+  loading?: boolean
+  loadingLabel?: string
+  ariaLabel?: string
+  // Link actions leave the app (open a repo/commit/PR in a new tab); mark them
+  // so the row shows an external-link glyph instead of the navigational chevron.
+  external?: boolean
+}) => {
+  const trailing = external ? (
+    <ExternalLink aria-hidden="true" className="size-4 shrink-0 opacity-60" />
+  ) : (
+    <ChevronRight
+      aria-hidden="true"
+      className={`size-4 shrink-0 opacity-40 ${rtlFlip}`}
+    />
+  )
+
+  const body = (
+    <>
+      {!loading && <Icon className="size-5 shrink-0 text-base-content/70" />}
+      <span className="flex min-w-0 flex-col items-start text-start">
+        <span className="font-medium">{title}</span>
+        {description ? (
+          <span className="text-xs font-normal text-base-content/60">
+            {description}
+          </span>
+        ) : null}
+      </span>
+      <span className="ms-auto">{trailing}</span>
+    </>
+  )
+
+  const shared = {
+    variant: "ghost" as const,
+    className: "w-full justify-start gap-3 h-auto py-2.5 normal-case",
+    disabled,
+    loading,
+    loadingLabel,
+    "aria-label": ariaLabel,
+  }
+
+  return href !== undefined ? (
+    <Button
+      as="a"
+      href={href ?? undefined}
+      target="_blank"
+      rel="noreferrer"
+      {...shared}
+    >
+      {body}
+    </Button>
+  ) : (
+    <Button onClick={onClick} {...shared}>
+      {body}
+    </Button>
+  )
+}


### PR DESCRIPTION
## What & why

The teacher gradebook's per-submission Actions cell had up to seven icon-only buttons per row, and we expect to add more. This consolidates them behind a single **Manage** control that opens a submission hub, keeping only the Open-repo shortcut inline. The hub scales as we add actions instead of growing the icon cluster, and gives each action a labeled home with room for context.

## The hub

Clicking Manage opens `ManageSubmissionModal`, which shows:

- **Identity + repo** — student name/section (or group repo), with the repo name as a "View repo" GitHub link (truncates, so long assignment repo names don't blow out the layout).

- **Read-only details** — accept time (repo creation), last push (hyperlinked to the latest commit), the enrolled owner's effective access, and any collaborators beyond the owner (hidden when there are none, which generalizes cleanly across individual vs group repos). These fetch lazily and show a loading skeleton so they don't pop in.

- **Actions** — View latest commit, Review feedback PR, Manage access, View autograder details, Regrade, Download (plus Manage members for groups), each as a labeled row reusing the existing hooks and confirm/repair flows.

## Details worth noting

The "View latest commit" action and the "Last push" time both link to the repo's default-branch tip (`html_url/commit/<default_branch>`) rather than the scores.json commit, which is only the latest *graded* snapshot and can lag a fresh push.

The access/members editors open **stacked on top of** the hub (native `<dialog>` nesting): the hub stays open underneath so dismissing the editor returns to the hub rather than the table, and the hub's box is hidden while the editor is up so the two modal boxes don't visibly layer.

Retired the now-dead icon-layout branches and their i18n keys; shared `permissionFromFlags` via `collaboratorHelpers`.

## Verification

`npm run check` is green: tsc, eslint (0 errors), prettier, arch:validate (dependency-cruiser + boundaries), i18n audit, and the full vitest suite (2934 tests, incl. new tests for the hub, stacking, box-hiding, latest-commit linking, and the loading skeleton).
