### PR TITLE
feat(cli): surface roster role column and note dual staff/student roles

### DIFF
--- a/cli/gh-teacher/internal/roster/list.go
+++ b/cli/gh-teacher/internal/roster/list.go
@@ -18,7 +18,11 @@ import (
 
 // rosterListEntry is the `--json` view of one roster.csv row. Field names
 // mirror the CSV columns. github_id is always present; 0 for an unresolved row
-// — consumers branch on `github_id == 0`, not key presence.
+// — consumers branch on `github_id == 0`, not key presence. role is a display
+// snapshot of the account's highest team-derived role ("teacher"/"ta"/
+// "student", or "" when unknown); the teams remain the enrollment/role
+// authority. An account holding several roles (dual roles aren't disallowed)
+// reads as its highest one here while still being an enrolled student.
 type rosterListEntry struct {
 	Username  string `json:"username"`
 	FirstName string `json:"first_name"`
@@ -26,6 +30,7 @@ type rosterListEntry struct {
 	Email     string `json:"email"`
 	Section   string `json:"section"`
 	GitHubID  int64  `json:"github_id"`
+	Role      string `json:"role"`
 }
 
 func rosterListCmd() *cobra.Command {
@@ -39,11 +44,17 @@ func rosterListCmd() *cobra.Command {
 		Long: "List every student row in\n" +
 			"<org>/classroom50/<classroom>/roster.csv.\n\n" +
 			"Default output is an aligned table on stdout (username, name,\n" +
-			"email, section, github_id) with a one-line\n" +
+			"email, section, github_id, role) with a one-line\n" +
 			"`<org>/<repo>/<classroom>/roster.csv: N student(s)` summary\n" +
 			"on stderr.\n\n" +
+			"The `role` column is a display snapshot of the account's\n" +
+			"highest team-derived role (teacher/ta/student, or empty when\n" +
+			"unknown) refreshed on sync; the classroom's GitHub teams — not\n" +
+			"this column — remain the enrollment/role authority. An account\n" +
+			"holding several roles (dual roles aren't disallowed) reads as\n" +
+			"its highest one here while still being an enrolled student.\n\n" +
 			"Pass --json for the full array of\n" +
-			"{username, first_name, last_name, email, section, github_id}\n" +
+			"{username, first_name, last_name, email, section, github_id, role}\n" +
 			"objects. Pass --quiet for one username per line on stdout (no\n" +
 			"table, no stderr summary) -- pipeable into `xargs`, `grep`, or\n" +
 			"an agent loop. --json takes precedence over --quiet.\n\n" +
@@ -72,7 +83,7 @@ func rosterListCmd() *cobra.Command {
 			return runRosterList(client, cmd.OutOrStdout(), cmd.ErrOrStderr(), org, classroom, asJSON, quiet)
 		},
 	}
-	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the full JSON array of {username, first_name, last_name, email, section, github_id} objects instead of the table")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the full JSON array of {username, first_name, last_name, email, section, github_id, role} objects instead of the table")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print one username per line (no table, no stderr summary)")
 	return cmd
 }
@@ -102,6 +113,7 @@ func runRosterList(client githubapi.Client, out, errOut io.Writer, org, classroo
 				Email:     r.Email,
 				Section:   r.Section,
 				GitHubID:  r.GitHubID,
+				Role:      r.Role,
 			})
 		}
 		data, err := output.JSONPretty(entries)
@@ -129,16 +141,17 @@ func runRosterList(client githubapi.Client, out, errOut io.Writer, org, classroo
 // discoverable; the "no students" signal is the stderr summary.
 func writeRosterTable(out io.Writer, rows []configrepo.RosterRow) {
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "USERNAME\tNAME\tEMAIL\tSECTION\tGITHUB_ID")
+	_, _ = fmt.Fprintln(tw, "USERNAME\tNAME\tEMAIL\tSECTION\tGITHUB_ID\tROLE")
 	for _, r := range rows {
 		name := strings.TrimSpace(r.FirstName + " " + r.LastName)
 		githubID := ""
 		if r.GitHubID != 0 {
 			githubID = strconv.FormatInt(r.GitHubID, 10)
 		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			dashIfEmpty(r.Username), dashIfEmpty(name),
-			dashIfEmpty(r.Email), dashIfEmpty(r.Section), dashIfEmpty(githubID))
+			dashIfEmpty(r.Email), dashIfEmpty(r.Section), dashIfEmpty(githubID),
+			dashIfEmpty(r.Role))
 	}
 	_ = tw.Flush()
 }

--- a/cli/gh-teacher/internal/roster/list_test.go
+++ b/cli/gh-teacher/internal/roster/list_test.go
@@ -224,6 +224,65 @@ func TestRunRosterList(t *testing.T) {
 		}
 	})
 
+	t.Run("role column surfaces in the table and --json", func(t *testing.T) {
+		csv := "username,first_name,last_name,email,section,github_id,role\n" +
+			"alice,Alice,Andersson,alice@example.edu,section-1,111,student\n" +
+			"prof,Pat,Prof,,,222,teacher\n"
+		mock := &rosterListMock{files: map[string]string{"cs-principles/roster.csv": csv}}
+		server := httptest.NewServer(mock.handler(t))
+		t.Cleanup(server.Close)
+		client := githubtest.NewTestClient(t, server)
+
+		var tableOut, tableErr bytes.Buffer
+		if err := runRosterList(client, &tableOut, &tableErr, "o", "cs-principles", false, false); err != nil {
+			t.Fatalf("runRosterList table: %v", err)
+		}
+		if !strings.Contains(tableOut.String(), "ROLE") {
+			t.Errorf("table header missing ROLE column\n%s", tableOut.String())
+		}
+		for _, want := range []string{"student", "teacher"} {
+			if !strings.Contains(tableOut.String(), want) {
+				t.Errorf("table missing role %q\n%s", want, tableOut.String())
+			}
+		}
+
+		var jsonOut, jsonErr bytes.Buffer
+		if err := runRosterList(client, &jsonOut, &jsonErr, "o", "cs-principles", true, false); err != nil {
+			t.Fatalf("runRosterList --json: %v", err)
+		}
+		var got []rosterListEntry
+		if err := json.Unmarshal(jsonOut.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal json: %v\n%s", err, jsonOut.String())
+		}
+		if len(got) != 2 || got[0].Role != "student" || got[1].Role != "teacher" {
+			t.Errorf("entries = %#v, want alice=student, prof=teacher", got)
+		}
+	})
+
+	t.Run("pre-role roster reads role as empty (dash in table, \"\" in json)", func(t *testing.T) {
+		// rosterCSVTwoStudents is the legacy 6-column shape (no role column).
+		mock := &rosterListMock{files: map[string]string{
+			"cs-principles/roster.csv": rosterCSVTwoStudents,
+		}}
+		server := httptest.NewServer(mock.handler(t))
+		t.Cleanup(server.Close)
+		client := githubtest.NewTestClient(t, server)
+
+		var out, errOut bytes.Buffer
+		if err := runRosterList(client, &out, &errOut, "o", "cs-principles", true, false); err != nil {
+			t.Fatalf("runRosterList --json: %v", err)
+		}
+		var got []rosterListEntry
+		if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal json: %v\n%s", err, out.String())
+		}
+		for _, e := range got {
+			if e.Role != "" {
+				t.Errorf("pre-role row %q got role %q, want empty", e.Username, e.Role)
+			}
+		}
+	})
+
 	t.Run("missing roster errors and points at classroom add", func(t *testing.T) {
 		mock := &rosterListMock{files: map[string]string{}}
 		server := httptest.NewServer(mock.handler(t))

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -69,6 +69,11 @@ func rosterAddCmd() *cobra.Command {
 			"member of <org> (and doesn't already have a pending invite),\n" +
 			"this command sends an org invitation (same path `gh teacher\n" +
 			"invite` uses).\n\n" +
+			"Adding a user who is already a teacher/TA on this classroom is\n" +
+			"not disallowed: they become an enrolled student too and show\n" +
+			"both roles in the app. The roster's `role` column records only\n" +
+			"their highest role (e.g. teacher), so a later sync rewriting it\n" +
+			"doesn't change the student enrollment.\n\n" +
 			"Returns non-zero on: classroom directory missing, roster\n" +
 			"missing or malformed, GitHub user not found, or after 5\n" +
 			"failed rebase attempts against a concurrently-edited\n" +
@@ -361,7 +366,54 @@ func runRosterAdd(client githubapi.Client, out, errOut io.Writer, org, classroom
 		return fmt.Errorf("roster row committed and org invite sent, but adding %s to the classroom team failed: %w", login, err)
 	}
 	_, _ = fmt.Fprintf(out, "%s: added %s to classroom team %s\n", org, login, team.Slug)
+
+	// Dual-role note (best-effort): a user already on a staff team can also be a
+	// student — Classroom 50 doesn't currently disallow this. Note it so the
+	// teacher isn't surprised when the auto-sync rewrites this row's `role` cell
+	// to the highest-precedence role (e.g. teacher). The student enrollment is
+	// NOT lost — the roster `role` column is only a highest-role snapshot, never
+	// the enrollment authority. A read failure here is swallowed: the add
+	// already landed, and the note is advisory.
+	if staffRole, ok := staffRoleForLogin(client, org, classroom, branch, login); ok {
+		_, _ = fmt.Fprintf(errOut,
+			"Note: %s is also a %s on classroom %s. Dual roles aren't disallowed — they'll show both roles in the app and stay an enrolled student, but the automatic sync records their highest role (%s) in the roster's `role` column. That doesn't change the student enrollment.\n",
+			login, staffRole, classroom, staffRole)
+	}
 	return nil
+}
+
+// staffRoleForLogin reports the highest-precedence staff role (teacher > hta >
+// ta) the login already holds on this classroom, or ("", false) when they're on
+// no staff team (or the check can't be completed). Best-effort and never
+// fatal: it reads classroom.json ONCE for the persisted staff-team slugs and
+// membership-checks each. A missing classroom/team block, an unresolved slug,
+// or any read error yields ("", false) so the caller silently skips the
+// advisory note rather than failing an add that already succeeded.
+func staffRoleForLogin(client githubapi.Client, org, classroom, branch, login string) (configrepo.StaffRole, bool) {
+	loginKey := strings.ToLower(strings.TrimSpace(login))
+	if loginKey == "" {
+		return "", false
+	}
+	c, ok, err := configrepo.LoadClassroom(client, org, classroom, branch)
+	if err != nil || !ok {
+		return "", false
+	}
+	for _, role := range configrepo.StaffRoles {
+		team := c.Teams.RefForRole(role)
+		if team == nil || team.Slug == "" {
+			continue
+		}
+		members, err := configrepo.ListTeamMembers(client, org, team.Slug)
+		if err != nil {
+			continue
+		}
+		for _, m := range members {
+			if strings.ToLower(strings.TrimSpace(m)) == loginKey {
+				return role, true
+			}
+		}
+	}
+	return "", false
 }
 
 // runRosterUpdate edits an existing roster row only: it never invites or

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -367,13 +367,8 @@ func runRosterAdd(client githubapi.Client, out, errOut io.Writer, org, classroom
 	}
 	_, _ = fmt.Fprintf(out, "%s: added %s to classroom team %s\n", org, login, team.Slug)
 
-	// Dual-role note (best-effort): a user already on a staff team can also be a
-	// student — Classroom 50 doesn't currently disallow this. Note it so the
-	// teacher isn't surprised when the auto-sync rewrites this row's `role` cell
-	// to the highest-precedence role (e.g. teacher). The student enrollment is
-	// NOT lost — the roster `role` column is only a highest-role snapshot, never
-	// the enrollment authority. A read failure here is swallowed: the add
-	// already landed, and the note is advisory.
+	// Dual-role note: best-effort and advisory (a read failure here is swallowed
+	// — the add already landed). See staffRoleForLogin for the rationale.
 	if staffRole, ok := staffRoleForLogin(client, org, classroom, branch, login); ok {
 		_, _ = fmt.Fprintf(errOut,
 			"Note: %s is also a %s on classroom %s. Dual roles aren't disallowed — they'll show both roles in the app and stay an enrolled student, but the automatic sync records their highest role (%s) in the roster's `role` column. That doesn't change the student enrollment.\n",

--- a/cli/gh-teacher/internal/roster/roster_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/roster_cmd_test.go
@@ -529,3 +529,135 @@ func TestRunRosterAdd_PreservesMalformedRow(t *testing.T) {
 		t.Errorf("added student aristotea missing from written roster: %#v", rows)
 	}
 }
+
+// dualRoleAddMock extends rosterAddMock with classroom.json (carrying staff-team
+// refs) and staff-team member endpoints, so runRosterAdd's best-effort
+// dual-role check can resolve teams and find (or not find) the target on them.
+// staffMembers maps a team slug -> the logins it lists.
+type dualRoleAddMock struct {
+	*rosterWriteMock
+	classroomJSON string
+	staffMembers  map[string][]string
+}
+
+func (m *dualRoleAddMock) handler(t *testing.T) http.Handler {
+	t.Helper()
+	base := m.rosterWriteMock.handler(t).(*http.ServeMux)
+	base.HandleFunc("/users/", func(w http.ResponseWriter, r *http.Request) {
+		login := strings.TrimPrefix(r.URL.Path, "/users/")
+		_ = json.NewEncoder(w).Encode(map[string]any{"login": login, "id": 999})
+	})
+	base.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+	// classroom.json read (ResolveClassroomTeam / ResolveClassroomStaffTeam).
+	base.HandleFunc("/repos/o/classroom50/contents/ai26/classroom.json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"content":  base64.StdEncoding.EncodeToString([]byte(m.classroomJSON)),
+			"encoding": "base64",
+		})
+	})
+	// Staff-team member lists (ListTeamMembers) + team membership PUTs (the
+	// classroom-team add in runRosterAdd). A slug not in staffMembers 404s on
+	// /members -> ListTeamMembers treats it as empty.
+	base.HandleFunc("/orgs/o/teams/", func(w http.ResponseWriter, r *http.Request) {
+		rest := strings.TrimPrefix(r.URL.Path, "/orgs/o/teams/")
+		slug, tail, _ := strings.Cut(rest, "/")
+		// PUT .../memberships/<user>: the classroom-team add. Accept it.
+		if strings.HasPrefix(tail, "memberships/") {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"state": "active"})
+			return
+		}
+		if tail != "members" {
+			http.NotFound(w, r)
+			return
+		}
+		logins, ok := m.staffMembers[slug]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		var members []map[string]any
+		for _, l := range logins {
+			members = append(members, map[string]any{"login": l, "id": 1})
+		}
+		_ = json.NewEncoder(w).Encode(members)
+	})
+	return base
+}
+
+// classroomJSONWithStaffTeams builds a classroom.json carrying the student team
+// plus all three staff-team refs, so the dual-role check can resolve slugs.
+func classroomJSONWithStaffTeams(t *testing.T, classroom string) string {
+	t.Helper()
+	c := map[string]any{
+		"name": classroom,
+		"team": map[string]any{"id": 1, "slug": "classroom50-" + classroom},
+		"teams": map[string]any{
+			"teacher": map[string]any{"id": 2, "slug": "classroom50-" + classroom + "-teacher"},
+			"hta":     map[string]any{"id": 3, "slug": "classroom50-" + classroom + "-hta"},
+			"ta":      map[string]any{"id": 4, "slug": "classroom50-" + classroom + "-ta"},
+		},
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal classroom.json: %v", err)
+	}
+	return string(b)
+}
+
+// TestRunRosterAdd_DualRoleNote: adding a user already on the teacher staff team
+// prints the advisory dual-role note to stderr; a plain new student does not.
+func TestRunRosterAdd_DualRoleNote(t *testing.T) {
+	roster := "username,first_name,last_name,email,section,github_id,role\n"
+
+	t.Run("existing staff member gets the dual-role note", func(t *testing.T) {
+		mock := &dualRoleAddMock{
+			rosterWriteMock: &rosterWriteMock{files: map[string]string{
+				"ai26/roster.csv": roster,
+			}},
+			classroomJSON: classroomJSONWithStaffTeams(t, "ai26"),
+			staffMembers: map[string][]string{
+				"classroom50-ai26-teacher": {"prof"},
+			},
+		}
+		server := httptest.NewServer(mock.handler(t))
+		t.Cleanup(server.Close)
+		client := githubtest.NewTestClient(t, server)
+
+		var out, errOut bytes.Buffer
+		if err := runRosterAdd(client, &out, &errOut, "o", "ai26", "prof", "", "", "", ""); err != nil {
+			t.Fatalf("runRosterAdd: %v", err)
+		}
+		if !strings.Contains(errOut.String(), "Dual roles aren't disallowed") {
+			t.Errorf("stderr missing the dual-role note:\n%s", errOut.String())
+		}
+		if !strings.Contains(errOut.String(), "teacher") {
+			t.Errorf("dual-role note should name the teacher role:\n%s", errOut.String())
+		}
+	})
+
+	t.Run("plain new student gets no dual-role note", func(t *testing.T) {
+		mock := &dualRoleAddMock{
+			rosterWriteMock: &rosterWriteMock{files: map[string]string{
+				"ai26/roster.csv": roster,
+			}},
+			classroomJSON: classroomJSONWithStaffTeams(t, "ai26"),
+			// No staff-team members: every staff-team read 404s -> empty.
+			staffMembers: map[string][]string{},
+		}
+		server := httptest.NewServer(mock.handler(t))
+		t.Cleanup(server.Close)
+		client := githubtest.NewTestClient(t, server)
+
+		var out, errOut bytes.Buffer
+		if err := runRosterAdd(client, &out, &errOut, "o", "ai26", "newbie", "", "", "", ""); err != nil {
+			t.Fatalf("runRosterAdd: %v", err)
+		}
+		if strings.Contains(errOut.String(), "Dual roles aren't disallowed") {
+			t.Errorf("a plain student must not get the dual-role note:\n%s", errOut.String())
+		}
+	})
+}

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -216,10 +216,18 @@ build your own automations against it.
 
 ### As a teacher, can I test an assignment as a student?
 
-You can accept your own assignment, but as an organization owner you'll keep
-`admin` on the repository (GitHub won't let an owner reduce their own access to
-`write`), so it won't match a real student's setup. To test the exact student
-experience, use a separate GitHub account that you add to the classroom as a
+You can — Classroom 50 doesn't currently disallow one account holding both a
+staff and a student role. Add yourself to the roster with `gh teacher roster
+add` (or the web app) while remaining on a staff team; you'll then show **both**
+roles and be graded as a student. (Your in-app access stays at your highest
+role, and the `roster.csv` `role` column records that highest role — an
+automatic sync may rewrite it, which doesn't affect your student enrollment. See
+[Dual roles](gh-teacher#dual-roles-staff-who-are-also-students).)
+
+One caveat: as an **organization owner** you keep `admin` on your own assignment
+repo (GitHub won't let an owner reduce their own access to `write`), so it won't
+match a real student's `write`-level setup. To test the exact student
+experience, use a **separate** GitHub account added to the classroom as a
 student.
 
 ## Migrating from GitHub Classroom

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -93,6 +93,22 @@ Check under `https://github.com/orgs/<org>/people` — you should show **Owner**
 Not errors — the desired state already exists. The CLI reports them clearly and
 exits 0, so invite commands are safe to re-run in scripts.
 
+## A student's `role` flipped to `teacher` after `roster add`
+
+Expected when the account is on **both** a staff team and the student team.
+Classroom 50 doesn't currently disallow dual roles (usually a teacher adding
+themselves as a student), and the classroom's GitHub teams — not the `role`
+column — are the enrollment authority. The automatic sync refreshes that column
+to the account's **highest** role (`teacher > hta > ta > student`), so you'll
+see a commit like `[Classroom 50] Sync 0 members into roster: <classroom>`
+rewrite an empty/`""` role to `teacher`.
+
+The student enrollment is unchanged: the account still shows a student badge
+(alongside the staff one), is graded as a student, and can be unenrolled from
+the student side. `roster add` prints a note when the target is already staff.
+See [Dual roles](gh-teacher#dual-roles-staff-who-are-also-students). For a
+"pure" student, use a separate GitHub account.
+
 ## "Assignment already accepted" on `gh student accept`
 
 You've already accepted; the repo is at

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -276,8 +276,10 @@ gh teacher roster list <org> <classroom> [--json] [--quiet]
 ```
 
 Default is an aligned table (empty cells show as `-`). `--json` emits full row
-objects (`github_id` is `0` when unresolved); `--quiet` prints one username per
-line. Read-only.
+objects (`github_id` is `0` when unresolved; `role` is `""` when unknown);
+`--quiet` prints one username per line. The `role` column is a display snapshot
+of the account's highest team-derived role — see
+[Dual roles](#dual-roles-staff-who-are-also-students). Read-only.
 
 ### `roster add`
 
@@ -340,6 +342,37 @@ gh teacher staff remove <org> <classroom> <username> [--role teacher|hta|ta]
 `--role` defaults to `teacher`. `add` self-heals a classroom that predates staff
 teams (creating and recording the missing team). `remove` doesn't touch org
 membership and is idempotent.
+
+### Dual roles (staff who are also students)
+
+Classroom 50 does not currently disallow a single account holding more than one
+role in a classroom — most commonly a teacher or TA who also adds themselves to
+the roster to preview the student experience. In practice this only arises on
+the teacher's side: `staff add` and `roster add` each manage their own GitHub
+team, so running both for one account leaves it on both teams. There's no guard
+against it, so it's worth knowing how the app behaves.
+
+The classroom's GitHub teams are the authority for enrollment and role; the
+`role` column in `roster.csv` is only a display snapshot. With that in mind:
+
+- **Roster view** — team memberships are unioned, so the account shows **all**
+  its role badges and appears under each role's filter.
+- **In-app access** — the **highest** role wins (`teacher > hta > ta > student`),
+  so a teacher-who-is-also-a-student keeps teacher-level access. "View as" only
+  downgrades the preview locally; it never grants access.
+- **`role` column / `roster list`** — records the single **highest** role. The
+  automatic sync refreshes it, so you may see a commit rewrite an empty/`""`
+  role to `teacher` shortly after `roster add`. That's the snapshot updating,
+  not a change to enrollment — nothing reads this column to decide access.
+- **Grades & submissions** — an account with a student enrollment is always
+  listed as a student. (A pure-staff account only appears in submissions once it
+  has actually accepted an assignment repo.)
+- **Unenroll** — drops only the student side (the roster row and student-team
+  membership); any staff role stays intact.
+
+`roster add` prints a note when the target is already staff, so the later
+`role`-column rewrite isn't a surprise. If you want a "pure" student view with no
+staff access, use a separate GitHub account for student testing.
 
 ## `assignment`
 


### PR DESCRIPTION
Closes #394.

Classroom 50 does not currently disallow a single account holding both a staff and a student role in a classroom — most commonly a teacher or TA who also adds themselves to the roster to preview the student experience. Because `staff add` and `roster add` each manage their own GitHub team, running both for one account leaves it on both teams, and the automatic sync then records the account's highest role in the `roster.csv` `role` column. That rewrite looked like a lost student enrollment in #394, when it is only the display snapshot updating. This change makes the behavior visible and documents it, without changing the enrollment authority (the GitHub teams).

## Changes

**CLI (`gh teacher`)**

- `roster list` now surfaces the `role` column in both the table (`ROLE`) and `--json` (additive `role` field, honoring the additive-schema contract). It reads `""` for legacy pre-role rosters.
- `roster add` prints a best-effort note when the target already holds a staff role, so the later `role`-column rewrite isn't a surprise. The staff-team read is non-fatal — a failure is swallowed since the add already landed.

**Docs (wiki)**

- New "Dual roles (staff who are also students)" section in `gh-teacher.md` documenting the behavior and its impacts, grounded in the code paths: roster view unions roles, in-app access uses the highest role, the `role` column is a highest-role snapshot, grades/submissions still count a student-enrolled account as a student, and unenroll drops only the student side.
- `FAQ.md` and `Troubleshooting.md` reframed and cross-linked to the new section.

## Verification

`go build ./...`, `go vet`, `go test ./...`, and `golangci-lint run` all pass for the CLI module.