### PR TITLE
feat(web): persistent app shell with animated navigation and smoother loading

### DIFF
--- a/web/src/components/PageShell.tsx
+++ b/web/src/components/PageShell.tsx
@@ -1,15 +1,17 @@
 import type { ReactNode } from "react"
 
-const DEFAULT_CONTENT_CLASS = "p-6 bg-base-200 2xl:px-8"
+// Padding-only frame on top of the shell. The base background + full height now
+// live on the persistent drawer-content container (DrawerContent), so a short
+// page still covers the viewport. `contentClassName` overrides the padding.
+const DEFAULT_CONTENT_CLASS = "p-6 2xl:px-8"
 
-// Per-page content frame. The drawer + sidebar now live once in the persistent
+// Per-page content frame. The drawer + sidebar live once in the persistent
 // AppShell (rendered by the `_authed` layout route), so a page only supplies its
 // own content and padding here — it no longer wraps the drawer or declares its
 // sidebar active state (that's route-derived in useSidebarNav).
 //
-// contentClassName overrides the default tight p-6 frame. The one vertical
-// rhythm (sections as direct children spaced by gap-6) is kept so pages don't
-// hand-roll per-block margins.
+// The one vertical rhythm (sections as direct children spaced by gap-6) is kept
+// so pages don't hand-roll per-block margins.
 export default function PageShell({
   children,
   contentClassName = DEFAULT_CONTENT_CLASS,

--- a/web/src/components/PageShell.tsx
+++ b/web/src/components/PageShell.tsx
@@ -1,46 +1,25 @@
 import type { ReactNode } from "react"
 
-import Drawer, {
-  DrawerContent,
-  DrawerSidebar,
-  DrawerToggle,
-} from "@/components/drawer"
-
 const DEFAULT_CONTENT_CLASS = "p-6 bg-base-200 2xl:px-8"
 
-// Every drawer page repeated the Drawer/toggle/content/sidebar structure;
-// PageShell owns it so pages render only their content.
+// Per-page content frame. The drawer + sidebar now live once in the persistent
+// AppShell (rendered by the `_authed` layout route), so a page only supplies its
+// own content and padding here — it no longer wraps the drawer or declares its
+// sidebar active state (that's route-derived in useSidebarNav).
 //
-// contentClassName overrides the DrawerContent padding — the default (a tight
-// p-6 frame with only a modest 2xl gutter) now covers every page, including the
-// former owner-page variants. The DrawerSidebar props (page/selected/settings)
-// are threaded through unchanged; PR 4 will replace them with route-derived
-// active-state.
+// contentClassName overrides the default tight p-6 frame. The one vertical
+// rhythm (sections as direct children spaced by gap-6) is kept so pages don't
+// hand-roll per-block margins.
 export default function PageShell({
   children,
   contentClassName = DEFAULT_CONTENT_CLASS,
-  page,
-  selected,
-  settings,
 }: {
   children: ReactNode
   contentClassName?: string
-  page?: string
-  selected?: string
-  settings?: boolean
 }) {
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <DrawerToggle />
-        <DrawerContent className={contentClassName}>
-          {/* One vertical rhythm for every page: sections are direct children
-              spaced by gap-6, so pages don't hand-roll per-block margins (the
-              org homepage's look, now the default). */}
-          <div className="flex flex-col gap-6">{children}</div>
-        </DrawerContent>
-        <DrawerSidebar page={page} selected={selected} settings={settings} />
-      </Drawer>
+    <div className={contentClassName}>
+      <div className="flex flex-col gap-6">{children}</div>
     </div>
   )
 }

--- a/web/src/components/drawer/AssignmentSidebarMenu.tsx
+++ b/web/src/components/drawer/AssignmentSidebarMenu.tsx
@@ -168,6 +168,7 @@ export const AssignmentSidebarMenu = ({
                     label={t("nav.submissions")}
                     icon={<UsersRound aria-hidden="true" />}
                     active={onSubmissions}
+                    groupId="assignment"
                   />
                 </Link>
               </Tip>
@@ -180,6 +181,7 @@ export const AssignmentSidebarMenu = ({
                     label={t("nav.settings")}
                     icon={<Settings aria-hidden="true" />}
                     active={onSettings}
+                    groupId="assignment"
                   />
                 </Link>
               </Tip>
@@ -197,6 +199,7 @@ export const AssignmentSidebarMenu = ({
                       label={t("nav.acceptAssignment")}
                       icon={<FilePlus2 aria-hidden="true" />}
                       active={onAccept}
+                      groupId="assignment"
                     />
                   </Link>
                 </Tip>
@@ -210,6 +213,7 @@ export const AssignmentSidebarMenu = ({
                     label={t("nav.mySubmission")}
                     icon={<FileCheck2 aria-hidden="true" />}
                     active={onSubmission}
+                    groupId="assignment"
                   />
                 </Link>
               </Tip>
@@ -223,6 +227,7 @@ export const AssignmentSidebarMenu = ({
                       label={t("nav.manageGroup")}
                       icon={<UsersRound aria-hidden="true" />}
                       active={onSettings}
+                      groupId="assignment"
                     />
                   </Link>
                 </Tip>

--- a/web/src/components/drawer/DrawerChrome.tsx
+++ b/web/src/components/drawer/DrawerChrome.tsx
@@ -1,23 +1,37 @@
 import { Menu } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { type ReactNode } from "react"
-import { MOBILE_DRAWER_ID, useSidebarCollapse } from "./collapseContext"
+import { Outlet } from "@tanstack/react-router"
+import Drawer, { MOBILE_DRAWER_ID, useSidebarCollapse } from "./collapseContext"
 import {
   SidebarContent,
   SidebarContentClasses,
   SidebarContentOrgs,
 } from "./SidebarContent"
+import { useSidebarNav } from "./useSidebarNav"
 
-export const DrawerContent = ({
-  children,
-  className,
-}: {
-  children: ReactNode
-  className?: string
-}) => {
+// Persistent app shell: the drawer chrome + rail mount ONCE here and page
+// content flows through <Outlet/>, so navigating between pages swaps only the
+// content while the sidebar (and its motion `layoutId` highlight) stays mounted
+// and glides. Rendered by the `_authed` layout route. `topSlot` is app-wide
+// chrome (banners) that renders above page content, inside the scroll area.
+export const AppShell = ({ topSlot }: { topSlot?: ReactNode }) => (
+  <div className="min-h-screen">
+    <Drawer>
+      <DrawerToggle />
+      <DrawerContent>
+        {topSlot}
+        <Outlet />
+      </DrawerContent>
+      <DrawerSidebar />
+    </Drawer>
+  </div>
+)
+
+export const DrawerContent = ({ children }: { children: ReactNode }) => {
   const { t } = useTranslation()
   return (
-    <div className={`${className} drawer-content`}>
+    <div className="drawer-content">
       <a
         href="#main-content"
         className="btn btn-primary btn-sm sr-only focus:not-sr-only focus:fixed focus:top-3 focus:start-3 focus:z-50"
@@ -40,13 +54,14 @@ export const DrawerToggle = () => (
   <input id={MOBILE_DRAWER_ID} type="checkbox" className="drawer-toggle" />
 )
 
-export const DrawerSidebar = ({
-  selected = "",
-  page = "",
-  settings = false,
-}) => {
+// The rail lives in the persistent `_authed` shell, so it derives its active
+// state from the current route (see useSidebarNav) rather than per-page props —
+// this keeps the single motion `layoutId` highlight element mounted across
+// navigations so it glides between rows instead of remounting.
+export const DrawerSidebar = () => {
   const { collapsed } = useSidebarCollapse()
   const { t } = useTranslation()
+  const { page, selected, settings } = useSidebarNav()
   return (
     <div className="drawer-side z-40">
       <label

--- a/web/src/components/drawer/DrawerChrome.tsx
+++ b/web/src/components/drawer/DrawerChrome.tsx
@@ -35,7 +35,10 @@ export const AppShell = ({ topSlot }: { topSlot?: ReactNode }) => (
 export const DrawerContent = ({ children }: { children: ReactNode }) => {
   const { t } = useTranslation()
   return (
-    <div className="drawer-content">
+    // The base background + full-height live here (not on the per-page frame) so
+    // it always covers the viewport even when a page's content is shorter than
+    // the window — the page frame (PageShell) only owns padding on top of this.
+    <div className="drawer-content min-h-screen bg-base-200">
       <a
         href="#main-content"
         className="btn btn-primary btn-sm sr-only focus:not-sr-only focus:fixed focus:top-3 focus:start-3 focus:z-50"

--- a/web/src/components/drawer/DrawerChrome.tsx
+++ b/web/src/components/drawer/DrawerChrome.tsx
@@ -2,13 +2,17 @@ import { Menu } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { type ReactNode } from "react"
 import { Outlet } from "@tanstack/react-router"
+import { AnimatePresence, motion } from "motion/react"
 import Drawer, { MOBILE_DRAWER_ID, useSidebarCollapse } from "./collapseContext"
 import {
   SidebarContent,
   SidebarContentClasses,
   SidebarContentOrgs,
 } from "./SidebarContent"
+import { ClassroomLogo, ExpandSidebarButton } from "./primitives"
+import { SidebarFooter } from "./SidebarFooter"
 import { useSidebarNav } from "./useSidebarNav"
+import { sidebarLevelVariants } from "@/lib/motion"
 
 // Persistent app shell: the drawer chrome + rail mount ONCE here and page
 // content flows through <Outlet/>, so navigating between pages swaps only the
@@ -55,13 +59,18 @@ export const DrawerToggle = () => (
 )
 
 // The rail lives in the persistent `_authed` shell, so it derives its active
-// state from the current route (see useSidebarNav) rather than per-page props —
-// this keeps the single motion `layoutId` highlight element mounted across
-// navigations so it glides between rows instead of remounting.
+// state from the current route (see useSidebarNav) rather than per-page props.
+// Two coordinated animations live here:
+//   - The active-row highlight is a single motion `layoutId` pill that stays
+//     mounted across navigations and glides between rows (see SidebarItemBody).
+//   - The menu BODY swaps on a level change (orgs -> classes -> classroom ->
+//     assignment) via one AnimatePresence keyed by `levelKey`. The chrome (logo,
+//     expand button, footer) sits OUTSIDE that presence so it stays put while
+//     only the menu cross-fades/slides.
 export const DrawerSidebar = () => {
   const { collapsed } = useSidebarCollapse()
   const { t } = useTranslation()
-  const { page, selected, settings } = useSidebarNav()
+  const { page, selected, settings, levelKey } = useSidebarNav()
   return (
     <div className="drawer-side z-40">
       <label
@@ -77,13 +86,26 @@ export const DrawerSidebar = () => {
             : "w-60 min-w-30 [&>div]:px-6"
         }`}
       >
-        {page === "classes" ? (
-          <SidebarContentClasses selected={selected} settings={settings} />
-        ) : page === "orgs" ? (
-          <SidebarContentOrgs selected={selected} />
-        ) : (
-          <SidebarContent selected={selected} />
-        )}
+        <ClassroomLogo />
+        <ExpandSidebarButton />
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={levelKey}
+            variants={sidebarLevelVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
+            {page === "classes" ? (
+              <SidebarContentClasses selected={selected} settings={settings} />
+            ) : page === "orgs" ? (
+              <SidebarContentOrgs selected={selected} />
+            ) : (
+              <SidebarContent selected={selected} />
+            )}
+          </motion.div>
+        </AnimatePresence>
+        <SidebarFooter />
       </nav>
     </div>
   )

--- a/web/src/components/drawer/DrawerChrome.tsx
+++ b/web/src/components/drawer/DrawerChrome.tsx
@@ -1,7 +1,7 @@
 import { Menu } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { type ReactNode } from "react"
-import { Outlet } from "@tanstack/react-router"
+import { Outlet, useRouterState } from "@tanstack/react-router"
 import { AnimatePresence, motion } from "motion/react"
 import Drawer, { MOBILE_DRAWER_ID, useSidebarCollapse } from "./collapseContext"
 import {
@@ -12,7 +12,26 @@ import {
 import { ClassroomLogo, ExpandSidebarButton } from "./primitives"
 import { SidebarFooter } from "./SidebarFooter"
 import { useSidebarNav } from "./useSidebarNav"
-import { sidebarLevelVariants } from "@/lib/motion"
+import { sidebarLevelVariants, pageContentVariants } from "@/lib/motion"
+
+// Replays a subtle enter animation on each route swap. Keying the motion element
+// by pathname remounts it, so it plays `initial -> animate` once per navigation
+// — no AnimatePresence/exit, so the incoming page never waits behind an outgoing
+// one (navigation stays instant). Banners stay outside this so they don't
+// re-animate on every navigation.
+const PageTransition = ({ children }: { children: ReactNode }) => {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  return (
+    <motion.div
+      key={pathname}
+      variants={pageContentVariants}
+      initial="initial"
+      animate="animate"
+    >
+      {children}
+    </motion.div>
+  )
+}
 
 // Persistent app shell: the drawer chrome + rail mount ONCE here and page
 // content flows through <Outlet/>, so navigating between pages swaps only the
@@ -25,7 +44,9 @@ export const AppShell = ({ topSlot }: { topSlot?: ReactNode }) => (
       <DrawerToggle />
       <DrawerContent>
         {topSlot}
-        <Outlet />
+        <PageTransition>
+          <Outlet />
+        </PageTransition>
       </DrawerContent>
       <DrawerSidebar />
     </Drawer>

--- a/web/src/components/drawer/MyClasses.tsx
+++ b/web/src/components/drawer/MyClasses.tsx
@@ -42,6 +42,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
                 active={
                   !onSettings && !onPublished && !onMembers && !onActivity
                 }
+                groupId="org"
               />
             </Link>
           </Tip>
@@ -53,6 +54,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
                 label={t("nav.published")}
                 icon={<Globe aria-hidden="true" />}
                 active={onPublished}
+                groupId="org"
               />
             </Link>
           </Tip>
@@ -64,6 +66,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
                 label={t("nav.members")}
                 icon={<UsersRound aria-hidden="true" />}
                 active={onMembers}
+                groupId="org"
               />
             </Link>
           </Tip>
@@ -75,6 +78,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
                 label={t("nav.activity")}
                 icon={<Activity aria-hidden="true" />}
                 active={onActivity}
+                groupId="org"
               />
             </Link>
           </Tip>
@@ -86,6 +90,7 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
                 label={t("nav.settings")}
                 icon={<Settings aria-hidden="true" />}
                 active={onSettings}
+                groupId="org"
               />
             </Link>
           </Tip>

--- a/web/src/components/drawer/MyOrgs.tsx
+++ b/web/src/components/drawer/MyOrgs.tsx
@@ -14,6 +14,7 @@ export const MyOrgs = ({ settings = false }) => {
               label={t("nav.organizations")}
               icon={<BookText aria-hidden="true" />}
               active={!settings}
+              groupId="orgs"
             />
           </Link>
         </Tip>
@@ -23,6 +24,7 @@ export const MyOrgs = ({ settings = false }) => {
               label={t("nav.settings")}
               icon={<Settings aria-hidden="true" />}
               active={settings}
+              groupId="orgs"
             />
           </Link>
         </Tip>

--- a/web/src/components/drawer/SidebarContent.tsx
+++ b/web/src/components/drawer/SidebarContent.tsx
@@ -1,43 +1,15 @@
 import { useParams } from "@tanstack/react-router"
-import { AnimatePresence, motion } from "motion/react"
-import type { ReactNode } from "react"
 import useGetClassroom from "@/hooks/useGetClassroom"
-import { sidebarLevelVariants } from "@/lib/motion"
-import {
-  ClassroomLogo,
-  ExpandSidebarButton,
-  AllClasses,
-  SidebarClassInfo,
-} from "./primitives"
+import { AllClasses, SidebarClassInfo } from "./primitives"
 import { AssignmentSidebarMenu } from "./AssignmentSidebarMenu"
 import { StaffSidebarMenu } from "./StaffSidebarMenu"
-import { SidebarFooter } from "./SidebarFooter"
 import { MyClasses } from "./MyClasses"
 import { MyOrgs } from "./MyOrgs"
 
-// Swaps the menu region on a level change (orgs -> classes -> classroom ->
-// assignment). `levelKey` drives AnimatePresence so the outgoing level slides
-// out while the incoming one slides in; the shared chrome (logo, footer) around
-// this stays put. mode="wait" avoids two menus overlapping mid-swap.
-const LevelMenu = ({
-  levelKey,
-  children,
-}: {
-  levelKey: string
-  children: ReactNode
-}) => (
-  <AnimatePresence mode="wait" initial={false}>
-    <motion.div
-      key={levelKey}
-      variants={sidebarLevelVariants}
-      initial="initial"
-      animate="animate"
-      exit="exit"
-    >
-      {children}
-    </motion.div>
-  </AnimatePresence>
-)
+// Level bodies only (no logo/footer chrome — that stays mounted in
+// DrawerSidebar, outside the AnimatePresence that swaps these). Each composer
+// renders the menu for one nav level; DrawerSidebar cross-fades between them on
+// a level change.
 
 export const SidebarContent = ({ selected }: { selected: string }) => {
   const { org, classroom, assignment } = useParams({ strict: false })
@@ -47,37 +19,21 @@ export const SidebarContent = ({ selected }: { selected: string }) => {
   // actions (and a back link) instead of the classroom menu.
   if (org && classroom && assignment) {
     return (
-      <>
-        <ClassroomLogo />
-        <ExpandSidebarButton />
-        <LevelMenu levelKey={`assignment:${assignment}`}>
-          <AssignmentSidebarMenu
-            org={org}
-            classroom={classroom}
-            assignment={assignment}
-          />
-        </LevelMenu>
-        <SidebarFooter />
-      </>
+      <AssignmentSidebarMenu
+        org={org}
+        classroom={classroom}
+        assignment={assignment}
+      />
     )
   }
 
   return (
     <>
-      <ClassroomLogo />
-      <ExpandSidebarButton />
       {org && <AllClasses org={org} />}
       <SidebarClassInfo classInfo={classData} />
       {org && classroom && (
-        <LevelMenu levelKey={`classroom:${classroom}`}>
-          <StaffSidebarMenu
-            selected={selected}
-            org={org}
-            classroom={classroom}
-          />
-        </LevelMenu>
+        <StaffSidebarMenu selected={selected} org={org} classroom={classroom} />
       )}
-      <SidebarFooter />
     </>
   )
 }
@@ -89,27 +45,9 @@ export const SidebarContentClasses = ({
   selected: string
   settings?: boolean
 }) => {
-  return (
-    <>
-      <ClassroomLogo />
-      <ExpandSidebarButton />
-      <LevelMenu levelKey="classes">
-        <MyClasses selected={selected} settings={settings} />
-      </LevelMenu>
-      <SidebarFooter />
-    </>
-  )
+  return <MyClasses selected={selected} settings={settings} />
 }
 
 export const SidebarContentOrgs = ({ selected }: { selected: string }) => {
-  return (
-    <>
-      <ClassroomLogo />
-      <ExpandSidebarButton />
-      <LevelMenu levelKey="orgs">
-        <MyOrgs settings={selected === "settings"} />
-      </LevelMenu>
-      <SidebarFooter />
-    </>
-  )
+  return <MyOrgs settings={selected === "settings"} />
 }

--- a/web/src/components/drawer/SidebarContent.tsx
+++ b/web/src/components/drawer/SidebarContent.tsx
@@ -1,5 +1,8 @@
 import { useParams } from "@tanstack/react-router"
+import { AnimatePresence, motion } from "motion/react"
+import type { ReactNode } from "react"
 import useGetClassroom from "@/hooks/useGetClassroom"
+import { sidebarLevelVariants } from "@/lib/motion"
 import {
   ClassroomLogo,
   ExpandSidebarButton,
@@ -12,6 +15,30 @@ import { SidebarFooter } from "./SidebarFooter"
 import { MyClasses } from "./MyClasses"
 import { MyOrgs } from "./MyOrgs"
 
+// Swaps the menu region on a level change (orgs -> classes -> classroom ->
+// assignment). `levelKey` drives AnimatePresence so the outgoing level slides
+// out while the incoming one slides in; the shared chrome (logo, footer) around
+// this stays put. mode="wait" avoids two menus overlapping mid-swap.
+const LevelMenu = ({
+  levelKey,
+  children,
+}: {
+  levelKey: string
+  children: ReactNode
+}) => (
+  <AnimatePresence mode="wait" initial={false}>
+    <motion.div
+      key={levelKey}
+      variants={sidebarLevelVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+    >
+      {children}
+    </motion.div>
+  </AnimatePresence>
+)
+
 export const SidebarContent = ({ selected }: { selected: string }) => {
   const { org, classroom, assignment } = useParams({ strict: false })
   const { data: classData } = useGetClassroom(org, classroom)
@@ -23,11 +50,13 @@ export const SidebarContent = ({ selected }: { selected: string }) => {
       <>
         <ClassroomLogo />
         <ExpandSidebarButton />
-        <AssignmentSidebarMenu
-          org={org}
-          classroom={classroom}
-          assignment={assignment}
-        />
+        <LevelMenu levelKey={`assignment:${assignment}`}>
+          <AssignmentSidebarMenu
+            org={org}
+            classroom={classroom}
+            assignment={assignment}
+          />
+        </LevelMenu>
         <SidebarFooter />
       </>
     )
@@ -40,7 +69,13 @@ export const SidebarContent = ({ selected }: { selected: string }) => {
       {org && <AllClasses org={org} />}
       <SidebarClassInfo classInfo={classData} />
       {org && classroom && (
-        <StaffSidebarMenu selected={selected} org={org} classroom={classroom} />
+        <LevelMenu levelKey={`classroom:${classroom}`}>
+          <StaffSidebarMenu
+            selected={selected}
+            org={org}
+            classroom={classroom}
+          />
+        </LevelMenu>
       )}
       <SidebarFooter />
     </>
@@ -58,7 +93,9 @@ export const SidebarContentClasses = ({
     <>
       <ClassroomLogo />
       <ExpandSidebarButton />
-      <MyClasses selected={selected} settings={settings} />
+      <LevelMenu levelKey="classes">
+        <MyClasses selected={selected} settings={settings} />
+      </LevelMenu>
       <SidebarFooter />
     </>
   )
@@ -69,7 +106,9 @@ export const SidebarContentOrgs = ({ selected }: { selected: string }) => {
     <>
       <ClassroomLogo />
       <ExpandSidebarButton />
-      <MyOrgs settings={selected === "settings"} />
+      <LevelMenu levelKey="orgs">
+        <MyOrgs settings={selected === "settings"} />
+      </LevelMenu>
       <SidebarFooter />
     </>
   )

--- a/web/src/components/drawer/StaffSidebarMenu.tsx
+++ b/web/src/components/drawer/StaffSidebarMenu.tsx
@@ -35,6 +35,7 @@ export const StaffSidebarMenu = ({
               label={t("nav.assignments")}
               icon={<BookText aria-hidden="true" />}
               active={selected === "assignments"}
+              groupId="staff"
             />
           </Link>
         </Tip>
@@ -55,6 +56,7 @@ export const StaffSidebarMenu = ({
                     label={t("nav.roster")}
                     icon={<UsersRound aria-hidden="true" />}
                     active={selected === "roster"}
+                    groupId="staff"
                   />
                 </Link>
               </Tip>
@@ -68,6 +70,7 @@ export const StaffSidebarMenu = ({
                       label={t("nav.settings")}
                       icon={<Settings aria-hidden="true" />}
                       active={selected === "settings"}
+                      groupId="staff"
                     />
                   </Link>
                 </Tip>

--- a/web/src/components/drawer/index.tsx
+++ b/web/src/components/drawer/index.tsx
@@ -3,7 +3,12 @@
 // and the per-context composers); this file preserves the original public
 // surface so `@/components/drawer` importers are unchanged.
 export { default } from "./collapseContext"
-export { DrawerContent, DrawerToggle, DrawerSidebar } from "./DrawerChrome"
+export {
+  AppShell,
+  DrawerContent,
+  DrawerToggle,
+  DrawerSidebar,
+} from "./DrawerChrome"
 export { ClassroomLogo, AllClasses, SidebarClassInfo } from "./primitives"
 export { StaffSidebarMenu } from "./StaffSidebarMenu"
 export { SidebarFooter } from "./SidebarFooter"

--- a/web/src/components/drawer/primitives.tsx
+++ b/web/src/components/drawer/primitives.tsx
@@ -7,13 +7,16 @@ import {
 import { Link, useParams } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { type ReactNode } from "react"
+import { motion } from "motion/react"
 import type { Classroom } from "@/types/classroom"
 import { useSidebarCollapse } from "./collapseContext"
 import {
   navItemClass,
+  sidebarActivePillClass,
   sidebarTooltip,
   sidebarIconButton,
 } from "./sidebarClasses"
+import { sidebarPillTransition } from "@/lib/motion"
 import { rtlFlip } from "@/components/ui"
 
 export const Tip = ({
@@ -34,14 +37,21 @@ export const Tip = ({
 
 // Inner markup of a sidebar nav row. Callers keep their own typed <Link to
 // params> around this so router type inference stays intact.
+//
+// The active highlight is a single shared-`layoutId` pill per menu (`groupId`),
+// so moving `active` between rows FLIP-glides it rather than snapping. The
+// global MotionConfig reducedMotion="user" turns that into an instant swap when
+// the user prefers reduced motion.
 export const SidebarItemBody = ({
   label,
   icon,
   active,
+  groupId = "sidebar",
 }: {
   label: string
   icon: ReactNode
   active: boolean
+  groupId?: string
 }) => {
   const { collapsed } = useSidebarCollapse()
   return (
@@ -49,8 +59,16 @@ export const SidebarItemBody = ({
       aria-current={active ? "page" : undefined}
       className={navItemClass(active, collapsed)}
     >
-      <span className="shrink-0">{icon}</span>
-      {!collapsed && <span className="truncate">{label}</span>}
+      {active && (
+        <motion.span
+          aria-hidden="true"
+          layoutId={`${groupId}-active-pill`}
+          className={sidebarActivePillClass}
+          transition={sidebarPillTransition}
+        />
+      )}
+      <span className="relative z-10 shrink-0">{icon}</span>
+      {!collapsed && <span className="relative z-10 truncate">{label}</span>}
     </li>
   )
 }

--- a/web/src/components/drawer/sidebarClasses.ts
+++ b/web/src/components/drawer/sidebarClasses.ts
@@ -3,7 +3,6 @@
 // Row layout only. The active surface (accent border + filled background) is a
 // separate shared-`layoutId` pill (see `sidebarActivePillClass`) that glides
 // between rows, so the row keeps just its box + a hover hint for inactive rows.
-// `relative` anchors the absolutely-positioned pill; `z` lifts icon/label above it.
 export const navItemClass = (active: boolean, collapsed: boolean) =>
   `relative flex items-center gap-2 rounded-box px-2 py-2 ${
     collapsed ? "justify-center" : ""

--- a/web/src/components/drawer/sidebarClasses.ts
+++ b/web/src/components/drawer/sidebarClasses.ts
@@ -1,13 +1,23 @@
 // Sidebar class-name recipes (dark rail). Single source so a token rename lands once.
 
+// Row layout only. The active surface (accent border + filled background) is a
+// separate shared-`layoutId` pill (see `sidebarActivePillClass`) that glides
+// between rows, so the row keeps just its box + a hover hint for inactive rows.
+// `relative` anchors the absolutely-positioned pill; `z` lifts icon/label above it.
 export const navItemClass = (active: boolean, collapsed: boolean) =>
-  `flex items-center gap-2 rounded-box border-s-2 px-2 py-2 transition-colors ${
+  `relative flex items-center gap-2 rounded-box px-2 py-2 ${
     collapsed ? "justify-center" : ""
   } ${
     active
-      ? "border-[var(--sidebar-accent)] bg-[var(--sidebar-surface)]"
-      : "border-transparent hover:bg-[var(--sidebar-surface)]/60"
+      ? ""
+      : "rounded-box transition-colors hover:bg-[var(--sidebar-surface)]/60"
   }`
+
+// The gliding active pill: fills the row with the accent left-border + surface.
+// Rendered as an absolutely-positioned sibling behind the row content and shared
+// across rows by `layoutId`, so page switches FLIP-tween it into place.
+export const sidebarActivePillClass =
+  "absolute inset-0 rounded-box border-s-2 border-[var(--sidebar-accent)] bg-[var(--sidebar-surface)]"
 
 // Shared sidebar tooltip tokens (dark rail): bubble + text colors every
 // collapsed-sidebar tooltip uses.

--- a/web/src/components/drawer/useSidebarNav.test.tsx
+++ b/web/src/components/drawer/useSidebarNav.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+// Drive the two router reads the hook depends on. useParams supplies the
+// org/classroom/assignment scope; useRouterState({select}) is called with a
+// state whose `matches` carry the route ids the hook matches against.
+const params = vi.fn<() => Record<string, string | undefined>>(() => ({}))
+const matchedRouteIds = vi.fn<() => string[]>(() => [])
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => params(),
+  useRouterState: ({
+    select,
+  }: {
+    select: (s: { matches: { routeId: string }[] }) => unknown
+  }) => select({ matches: matchedRouteIds().map((routeId) => ({ routeId })) }),
+}))
+
+import { useSidebarNav } from "./useSidebarNav"
+
+const run = (p: Record<string, string | undefined>, ids: string[]) => {
+  params.mockReturnValue(p)
+  matchedRouteIds.mockReturnValue(ids)
+  return renderHook(() => useSidebarNav()).result.current
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("useSidebarNav — route -> page/selected", () => {
+  it("no org: orgs list is the default row", () => {
+    expect(run({}, ["/_authed/"])).toMatchObject({
+      page: "orgs",
+      selected: "",
+      settings: false,
+    })
+  })
+
+  it("no org: account settings selects settings", () => {
+    expect(run({}, ["/_authed/settings/"])).toMatchObject({
+      page: "orgs",
+      selected: "settings",
+      settings: true,
+    })
+  })
+
+  it("org, no classroom: classes home is the default row", () => {
+    expect(run({ org: "acme" }, ["/_authed/$org/"])).toMatchObject({
+      page: "classes",
+      selected: "",
+      settings: false,
+    })
+  })
+
+  it.each([
+    ["/_authed/$org/published/", "published", false],
+    ["/_authed/$org/members/", "members", false],
+    ["/_authed/$org/activity/", "activity", false],
+    ["/_authed/$org/settings/", "settings", true],
+  ])("classes level %s -> %s", (routeId, selected, settings) => {
+    expect(run({ org: "acme" }, [routeId])).toMatchObject({
+      page: "classes",
+      selected,
+      settings,
+    })
+  })
+
+  it("classroom level: assignments is the default row", () => {
+    expect(
+      run({ org: "acme", classroom: "cs101" }, [
+        "/_authed/$org/$classroom/assignments/",
+      ]),
+    ).toMatchObject({ page: "", selected: "assignments", settings: false })
+  })
+
+  it.each([
+    ["/_authed/$org/$classroom/roster/", "roster"],
+    ["/_authed/$org/$classroom/settings/", "settings"],
+  ])("classroom level %s -> %s", (routeId, selected) => {
+    expect(run({ org: "acme", classroom: "cs101" }, [routeId])).toMatchObject({
+      page: "",
+      selected,
+    })
+  })
+})
+
+describe("useSidebarNav — levelKey (menu-swap identity)", () => {
+  it("is stable within a level but scoped per org/classroom/assignment", () => {
+    const orgs = run({}, ["/_authed/"]).levelKey
+    const classes = run({ org: "acme" }, ["/_authed/$org/"]).levelKey
+    const classroom = run({ org: "acme", classroom: "cs101" }, [
+      "/_authed/$org/$classroom/assignments/",
+    ]).levelKey
+    const assignment = run(
+      { org: "acme", classroom: "cs101", assignment: "hw1" },
+      ["/_authed/$org/$classroom/assignments/$assignment/"],
+    ).levelKey
+
+    // Each level is a distinct key (so AnimatePresence swaps between them)...
+    expect(new Set([orgs, classes, classroom, assignment]).size).toBe(4)
+    expect(classes).toBe("classes:acme")
+    expect(classroom).toBe("classroom:acme/cs101")
+    expect(assignment).toBe("assignment:acme/cs101/hw1")
+  })
+
+  it("stays constant across a within-classroom navigation (so the highlight glides)", () => {
+    const onAssignments = run({ org: "acme", classroom: "cs101" }, [
+      "/_authed/$org/$classroom/assignments/",
+    ]).levelKey
+    const onRoster = run({ org: "acme", classroom: "cs101" }, [
+      "/_authed/$org/$classroom/roster/",
+    ]).levelKey
+    expect(onAssignments).toBe(onRoster)
+  })
+
+  it("changes when the classroom changes (so the menu body swaps)", () => {
+    const a = run({ org: "acme", classroom: "cs101" }, [
+      "/_authed/$org/$classroom/assignments/",
+    ]).levelKey
+    const b = run({ org: "acme", classroom: "cs303" }, [
+      "/_authed/$org/$classroom/assignments/",
+    ]).levelKey
+    expect(a).not.toBe(b)
+  })
+})

--- a/web/src/components/drawer/useSidebarNav.ts
+++ b/web/src/components/drawer/useSidebarNav.ts
@@ -1,0 +1,60 @@
+import { useParams, useRouterState } from "@tanstack/react-router"
+
+export type SidebarNav = {
+  // Which top-level menu the rail shows: the org list ("orgs"), the org's
+  // class/admin menu ("classes"), or the classroom/assignment menu ("").
+  page: "orgs" | "classes" | ""
+  // Active row within that menu.
+  selected: string
+  settings: boolean
+}
+
+// Route-derived sidebar state. The rail now lives in the persistent `_authed`
+// shell (it no longer remounts per page), so it can't take `selected` as a prop
+// from the page — it reads the active row from the current route instead. This
+// replaces the old per-page PageShell props (page/selected/settings) with one
+// source of truth, matched by route id so a renamed path fails loudly rather
+// than silently mis-highlighting.
+export const useSidebarNav = (): SidebarNav => {
+  const { org, classroom } = useParams({ strict: false })
+  const routeIds = useRouterState({
+    select: (s) => s.matches.map((m) => m.routeId as string),
+  })
+  const on = (id: string) => routeIds.includes(id)
+
+  // Level: no org -> the orgs list; org but no classroom -> the class/admin
+  // menu; inside a classroom -> the classroom/assignment menu (page "").
+  const page: SidebarNav["page"] = !org ? "orgs" : !classroom ? "classes" : ""
+
+  // Orgs level (top): only the account Settings page is "selected"; the orgs
+  // list itself is the default row.
+  if (page === "orgs") {
+    const settings = on("/_authed/settings/")
+    return { page, selected: settings ? "settings" : "", settings }
+  }
+
+  // Classes level ($org/*): the org admin menu (classes home, published,
+  // members, activity, settings).
+  if (page === "classes") {
+    if (on("/_authed/$org/settings/"))
+      return { page, selected: "settings", settings: true }
+    if (on("/_authed/$org/published/"))
+      return { page, selected: "published", settings: false }
+    if (on("/_authed/$org/members/"))
+      return { page, selected: "members", settings: false }
+    if (on("/_authed/$org/activity/"))
+      return { page, selected: "activity", settings: false }
+    // classes list, create-classroom, import, setup all sit under the classes
+    // home row.
+    return { page, selected: "", settings: false }
+  }
+
+  // Classroom level ($org/$classroom/*): the classroom/assignment menu. Inside
+  // an assignment the AssignmentSidebarMenu self-derives its active row via
+  // useMatchRoute, so only the classroom-scoped rows need a `selected` here.
+  if (on("/_authed/$org/$classroom/roster/"))
+    return { page, selected: "roster", settings: false }
+  if (on("/_authed/$org/$classroom/settings/"))
+    return { page, selected: "settings", settings: false }
+  return { page, selected: "assignments", settings: false }
+}

--- a/web/src/components/drawer/useSidebarNav.ts
+++ b/web/src/components/drawer/useSidebarNav.ts
@@ -22,32 +22,35 @@ export type SidebarNav = {
 // source of truth, matched by route id so a renamed path fails loudly rather
 // than silently mis-highlighting.
 
-// Route id -> active row for the org "classes" level. The settings route also
-// flips the `settings` flag; every other row is a plain selection. Missing from
-// the table (classes list, create, import, setup) falls through to the home row.
-const CLASSES_ROW: Record<string, { selected: string; settings?: boolean }> = {
-  "/_authed/$org/settings/": { selected: "settings", settings: true },
-  "/_authed/$org/published/": { selected: "published" },
-  "/_authed/$org/members/": { selected: "members" },
-  "/_authed/$org/activity/": { selected: "activity" },
-}
+// Route id -> active row for the org "classes" level, as ordered [id, row]
+// tuples (built once at module scope, not per render). The settings route also
+// flips the `settings` flag; every other row is a plain selection. A route
+// missing from the table (classes list, create, import, setup) falls through to
+// the home row.
+const CLASSES_ROWS: [string, { selected: string; settings?: boolean }][] = [
+  ["/_authed/$org/settings/", { selected: "settings", settings: true }],
+  ["/_authed/$org/published/", { selected: "published" }],
+  ["/_authed/$org/members/", { selected: "members" }],
+  ["/_authed/$org/activity/", { selected: "activity" }],
+]
 
 // Route id -> active row for the classroom level. Inside an assignment the
 // AssignmentSidebarMenu self-derives its own active row, so only these
 // classroom-scoped rows need mapping here; the default is the assignments list.
-const CLASSROOM_ROW: Record<string, string> = {
-  "/_authed/$org/$classroom/roster/": "roster",
-  "/_authed/$org/$classroom/settings/": "settings",
-}
+const CLASSROOM_ROWS: [string, string][] = [
+  ["/_authed/$org/$classroom/roster/", "roster"],
+  ["/_authed/$org/$classroom/settings/", "settings"],
+]
 
 export const useSidebarNav = (): SidebarNav => {
   const { org, classroom, assignment } = useParams({ strict: false })
-  // Keep the selector returning an array (router structural-sharing compares it
-  // by value, avoiding needless re-renders); build the Set for O(1) lookups here.
+  // The selector returns an array (router structural-sharing compares it by
+  // value, avoiding needless re-renders). It's tiny (a handful of matched route
+  // ids), so a direct `.includes` against the small route tables is cheaper than
+  // allocating a Set per render.
   const routeIds = useRouterState({
     select: (s) => s.matches.map((m) => m.routeId as string),
   })
-  const matched = new Set(routeIds)
 
   // Level: no org -> the orgs list; org but no classroom -> the class/admin
   // menu; inside a classroom -> the classroom/assignment menu (page "").
@@ -68,13 +71,13 @@ export const useSidebarNav = (): SidebarNav => {
   // Orgs level (top): only the account Settings page is "selected"; the orgs
   // list itself is the default row.
   if (page === "orgs") {
-    const settings = matched.has("/_authed/settings/")
+    const settings = routeIds.includes("/_authed/settings/")
     return { page, selected: settings ? "settings" : "", settings, levelKey }
   }
 
   // Classes level ($org/*): the org admin menu.
   if (page === "classes") {
-    const hit = Object.entries(CLASSES_ROW).find(([id]) => matched.has(id))?.[1]
+    const hit = CLASSES_ROWS.find(([id]) => routeIds.includes(id))?.[1]
     return {
       page,
       selected: hit?.selected ?? "",
@@ -84,9 +87,7 @@ export const useSidebarNav = (): SidebarNav => {
   }
 
   // Classroom level ($org/$classroom/*): the classroom/assignment menu.
-  const classroomRow = Object.entries(CLASSROOM_ROW).find(([id]) =>
-    matched.has(id),
-  )?.[1]
+  const classroomRow = CLASSROOM_ROWS.find(([id]) => routeIds.includes(id))?.[1]
   return {
     page,
     selected: classroomRow ?? "assignments",

--- a/web/src/components/drawer/useSidebarNav.ts
+++ b/web/src/components/drawer/useSidebarNav.ts
@@ -21,12 +21,33 @@ export type SidebarNav = {
 // replaces the old per-page PageShell props (page/selected/settings) with one
 // source of truth, matched by route id so a renamed path fails loudly rather
 // than silently mis-highlighting.
+
+// Route id -> active row for the org "classes" level. The settings route also
+// flips the `settings` flag; every other row is a plain selection. Missing from
+// the table (classes list, create, import, setup) falls through to the home row.
+const CLASSES_ROW: Record<string, { selected: string; settings?: boolean }> = {
+  "/_authed/$org/settings/": { selected: "settings", settings: true },
+  "/_authed/$org/published/": { selected: "published" },
+  "/_authed/$org/members/": { selected: "members" },
+  "/_authed/$org/activity/": { selected: "activity" },
+}
+
+// Route id -> active row for the classroom level. Inside an assignment the
+// AssignmentSidebarMenu self-derives its own active row, so only these
+// classroom-scoped rows need mapping here; the default is the assignments list.
+const CLASSROOM_ROW: Record<string, string> = {
+  "/_authed/$org/$classroom/roster/": "roster",
+  "/_authed/$org/$classroom/settings/": "settings",
+}
+
 export const useSidebarNav = (): SidebarNav => {
   const { org, classroom, assignment } = useParams({ strict: false })
+  // Keep the selector returning an array (router structural-sharing compares it
+  // by value, avoiding needless re-renders); build the Set for O(1) lookups here.
   const routeIds = useRouterState({
     select: (s) => s.matches.map((m) => m.routeId as string),
   })
-  const on = (id: string) => routeIds.includes(id)
+  const matched = new Set(routeIds)
 
   // Level: no org -> the orgs list; org but no classroom -> the class/admin
   // menu; inside a classroom -> the classroom/assignment menu (page "").
@@ -47,37 +68,29 @@ export const useSidebarNav = (): SidebarNav => {
   // Orgs level (top): only the account Settings page is "selected"; the orgs
   // list itself is the default row.
   if (page === "orgs") {
-    const settings = on("/_authed/settings/")
+    const settings = matched.has("/_authed/settings/")
+    return { page, selected: settings ? "settings" : "", settings, levelKey }
+  }
+
+  // Classes level ($org/*): the org admin menu.
+  if (page === "classes") {
+    const hit = Object.entries(CLASSES_ROW).find(([id]) => matched.has(id))?.[1]
     return {
       page,
-      selected: settings ? "settings" : "",
-      settings,
+      selected: hit?.selected ?? "",
+      settings: hit?.settings ?? false,
       levelKey,
     }
   }
 
-  // Classes level ($org/*): the org admin menu (classes home, published,
-  // members, activity, settings).
-  if (page === "classes") {
-    if (on("/_authed/$org/settings/"))
-      return { page, selected: "settings", settings: true, levelKey }
-    if (on("/_authed/$org/published/"))
-      return { page, selected: "published", settings: false, levelKey }
-    if (on("/_authed/$org/members/"))
-      return { page, selected: "members", settings: false, levelKey }
-    if (on("/_authed/$org/activity/"))
-      return { page, selected: "activity", settings: false, levelKey }
-    // classes list, create-classroom, import, setup all sit under the classes
-    // home row.
-    return { page, selected: "", settings: false, levelKey }
+  // Classroom level ($org/$classroom/*): the classroom/assignment menu.
+  const classroomRow = Object.entries(CLASSROOM_ROW).find(([id]) =>
+    matched.has(id),
+  )?.[1]
+  return {
+    page,
+    selected: classroomRow ?? "assignments",
+    settings: false,
+    levelKey,
   }
-
-  // Classroom level ($org/$classroom/*): the classroom/assignment menu. Inside
-  // an assignment the AssignmentSidebarMenu self-derives its active row via
-  // useMatchRoute, so only the classroom-scoped rows need a `selected` here.
-  if (on("/_authed/$org/$classroom/roster/"))
-    return { page, selected: "roster", settings: false, levelKey }
-  if (on("/_authed/$org/$classroom/settings/"))
-    return { page, selected: "settings", settings: false, levelKey }
-  return { page, selected: "assignments", settings: false, levelKey }
 }

--- a/web/src/components/drawer/useSidebarNav.ts
+++ b/web/src/components/drawer/useSidebarNav.ts
@@ -7,6 +7,12 @@ export type SidebarNav = {
   // Active row within that menu.
   selected: string
   settings: boolean
+  // Stable identity of the current nav LEVEL (not the page). Constant while
+  // navigating within a level so the highlight glides; changes only on a level
+  // change (orgs -> classes -> classroom -> assignment) so AnimatePresence
+  // cross-fades the menu body. Scoped by org/classroom/assignment so switching
+  // classrooms is also a level swap.
+  levelKey: string
 }
 
 // Route-derived sidebar state. The rail now lives in the persistent `_authed`
@@ -16,7 +22,7 @@ export type SidebarNav = {
 // source of truth, matched by route id so a renamed path fails loudly rather
 // than silently mis-highlighting.
 export const useSidebarNav = (): SidebarNav => {
-  const { org, classroom } = useParams({ strict: false })
+  const { org, classroom, assignment } = useParams({ strict: false })
   const routeIds = useRouterState({
     select: (s) => s.matches.map((m) => m.routeId as string),
   })
@@ -26,35 +32,52 @@ export const useSidebarNav = (): SidebarNav => {
   // menu; inside a classroom -> the classroom/assignment menu (page "").
   const page: SidebarNav["page"] = !org ? "orgs" : !classroom ? "classes" : ""
 
+  // Level identity for the menu-swap animation. Assignment is its own level
+  // (distinct menu); everything else keys on its scope so a same-level nav keeps
+  // the body mounted (highlight glides) while a level change swaps it.
+  const levelKey =
+    org && classroom && assignment
+      ? `assignment:${org}/${classroom}/${assignment}`
+      : org && classroom
+        ? `classroom:${org}/${classroom}`
+        : org
+          ? `classes:${org}`
+          : "orgs"
+
   // Orgs level (top): only the account Settings page is "selected"; the orgs
   // list itself is the default row.
   if (page === "orgs") {
     const settings = on("/_authed/settings/")
-    return { page, selected: settings ? "settings" : "", settings }
+    return {
+      page,
+      selected: settings ? "settings" : "",
+      settings,
+      levelKey,
+    }
   }
 
   // Classes level ($org/*): the org admin menu (classes home, published,
   // members, activity, settings).
   if (page === "classes") {
     if (on("/_authed/$org/settings/"))
-      return { page, selected: "settings", settings: true }
+      return { page, selected: "settings", settings: true, levelKey }
     if (on("/_authed/$org/published/"))
-      return { page, selected: "published", settings: false }
+      return { page, selected: "published", settings: false, levelKey }
     if (on("/_authed/$org/members/"))
-      return { page, selected: "members", settings: false }
+      return { page, selected: "members", settings: false, levelKey }
     if (on("/_authed/$org/activity/"))
-      return { page, selected: "activity", settings: false }
+      return { page, selected: "activity", settings: false, levelKey }
     // classes list, create-classroom, import, setup all sit under the classes
     // home row.
-    return { page, selected: "", settings: false }
+    return { page, selected: "", settings: false, levelKey }
   }
 
   // Classroom level ($org/$classroom/*): the classroom/assignment menu. Inside
   // an assignment the AssignmentSidebarMenu self-derives its active row via
   // useMatchRoute, so only the classroom-scoped rows need a `selected` here.
   if (on("/_authed/$org/$classroom/roster/"))
-    return { page, selected: "roster", settings: false }
+    return { page, selected: "roster", settings: false, levelKey }
   if (on("/_authed/$org/$classroom/settings/"))
-    return { page, selected: "settings", settings: false }
-  return { page, selected: "assignments", settings: false }
+    return { page, selected: "settings", settings: false, levelKey }
+  return { page, selected: "assignments", settings: false, levelKey }
 }

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -102,3 +102,30 @@ export function NoSearchResults({
     />
   )
 }
+
+// Placeholder rows for a list/table body while its data loads. Shared so list
+// pages skeleton-in consistently (content fades into place) instead of a
+// centered spinner that content then jumps to replace. Decorative — hidden from
+// assistive tech; the surrounding container carries the aria-busy signal.
+export function SkeletonRows({
+  rows = 5,
+  className = "divide-y divide-base-200",
+}: {
+  rows?: number
+  className?: string
+}) {
+  return (
+    <div className={className} aria-hidden="true">
+      {Array.from({ length: rows }, (_, i) => (
+        <div key={i} className="flex items-center gap-3 px-6 py-4">
+          <div className="skeleton skeleton-shimmer size-8 shrink-0 rounded-full" />
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <div className="skeleton skeleton-shimmer h-4 w-40" />
+            <div className="skeleton skeleton-shimmer h-3 w-24" />
+          </div>
+          <div className="skeleton skeleton-shimmer h-6 w-20 shrink-0" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/status/RouteProgressBar.test.tsx
+++ b/web/src/components/status/RouteProgressBar.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, render } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+// Control the global in-flight count directly. useIsFetching is the only signal
+// the bar reacts to, so mocking it lets fake timers drive the show/hide logic
+// deterministically without wiring real queries.
+let fetchingCount = 0
+vi.mock("@tanstack/react-query", () => ({
+  useIsFetching: () => fetchingCount,
+}))
+
+// Render the animated bar as a plain element and no-op the motion value/animate
+// helpers; the test targets the timer + visibility logic (Finding #1), not the
+// tween. AnimatePresence just renders its children so `visible` maps to DOM
+// presence synchronously.
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  motion: {
+    div: (props: Record<string, unknown>) => <div {...props} />,
+  },
+  useMotionValue: () => ({ set: () => {} }),
+  animate: () => ({ stop: () => {} }),
+}))
+
+import { RouteProgressBar } from "./RouteProgressBar"
+
+const bar = () => document.querySelector(".bg-primary")
+
+let rerender: (ui: ReactNode) => void = () => {}
+
+const mount = () => {
+  const view = render(<RouteProgressBar />)
+  rerender = view.rerender
+}
+
+// Change the mocked in-flight count and re-render the SAME instance so its
+// effect re-runs with the new value (a fresh render() would mount a new tree).
+const setFetching = (n: number) => {
+  act(() => {
+    fetchingCount = n
+    rerender(<RouteProgressBar />)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  fetchingCount = 0
+})
+
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("RouteProgressBar", () => {
+  it("stays hidden while nothing is fetching", () => {
+    mount()
+    act(() => vi.advanceTimersByTime(500))
+    expect(bar()).toBeNull()
+  })
+
+  it("does not flash for a fetch that settles within the show delay", () => {
+    mount()
+    setFetching(1)
+    act(() => vi.advanceTimersByTime(100)) // < SHOW_DELAY_MS (120)
+    setFetching(0)
+    act(() => vi.advanceTimersByTime(200))
+    expect(bar()).toBeNull()
+  })
+
+  it("reveals the bar after the show delay while fetching", () => {
+    mount()
+    setFetching(1)
+    expect(bar()).toBeNull()
+    act(() => vi.advanceTimersByTime(120))
+    expect(bar()).not.toBeNull()
+  })
+
+  it("reveals on schedule even as the fetch count churns (Finding #1 regression)", () => {
+    mount()
+    setFetching(1)
+    // A staggered burst: the count keeps changing before the 120ms reveal.
+    // The show-timer must NOT reset on each change, or the bar never appears.
+    act(() => vi.advanceTimersByTime(50))
+    setFetching(2)
+    act(() => vi.advanceTimersByTime(50))
+    setFetching(3)
+    act(() => vi.advanceTimersByTime(30)) // total 130ms > SHOW_DELAY_MS
+    expect(bar()).not.toBeNull()
+  })
+
+  it("hides again after fetches settle", () => {
+    mount()
+    setFetching(1)
+    act(() => vi.advanceTimersByTime(120))
+    expect(bar()).not.toBeNull()
+    setFetching(0)
+    act(() => vi.advanceTimersByTime(200)) // > HIDE_DELAY_MS (180)
+    expect(bar()).toBeNull()
+  })
+})

--- a/web/src/components/status/RouteProgressBar.test.tsx
+++ b/web/src/components/status/RouteProgressBar.test.tsx
@@ -12,9 +12,9 @@ vi.mock("@tanstack/react-query", () => ({
 }))
 
 // Render the animated bar as a plain element and no-op the motion value/animate
-// helpers; the test targets the timer + visibility logic (Finding #1), not the
-// tween. AnimatePresence just renders its children so `visible` maps to DOM
-// presence synchronously.
+// helpers; the test targets the timer + visibility logic, not the tween.
+// AnimatePresence just renders its children so `visible` maps to DOM presence
+// synchronously.
 vi.mock("motion/react", () => ({
   AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
   motion: {
@@ -80,7 +80,7 @@ describe("RouteProgressBar", () => {
     expect(bar()).not.toBeNull()
   })
 
-  it("reveals on schedule even as the fetch count churns (Finding #1 regression)", () => {
+  it("reveals on schedule even as the fetch count churns", () => {
     mount()
     setFetching(1)
     // A staggered burst: the count keeps changing before the 120ms reveal.

--- a/web/src/components/status/RouteProgressBar.tsx
+++ b/web/src/components/status/RouteProgressBar.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState } from "react"
 import { useIsFetching } from "@tanstack/react-query"
-import { AnimatePresence, motion, useMotionValue, animate } from "motion/react"
+import {
+  AnimatePresence,
+  motion,
+  useMotionValue,
+  animate,
+  type AnimationPlaybackControls,
+} from "motion/react"
 import { EASE_OUT } from "@/lib/motion"
 
 // A thin top-of-viewport progress bar bound to React Query's global in-flight
@@ -26,6 +32,8 @@ export function RouteProgressBar() {
   const progress = useMotionValue(0)
   const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The running fill tween, held so unmount can stop its frame loop.
+  const anim = useRef<AnimationPlaybackControls | null>(null)
 
   useEffect(() => {
     if (active) {
@@ -44,7 +52,7 @@ export function RouteProgressBar() {
           setVisible(true)
           // Trickle toward 90% — never reaches 100% until fetches settle, so a
           // long request keeps advancing without ever "finishing" early.
-          animate(progress, 0.9, { duration: 8, ease: EASE_OUT })
+          anim.current = animate(progress, 0.9, { duration: 8, ease: EASE_OUT })
         }, SHOW_DELAY_MS)
       }
       return
@@ -57,7 +65,7 @@ export function RouteProgressBar() {
     }
     // Complete + fade a shown bar, armed once via the hide-timer ref guard.
     if (visible && !hideTimer.current) {
-      animate(progress, 1, { duration: 0.2, ease: EASE_OUT })
+      anim.current = animate(progress, 1, { duration: 0.2, ease: EASE_OUT })
       hideTimer.current = setTimeout(() => {
         hideTimer.current = null
         setVisible(false)
@@ -66,11 +74,13 @@ export function RouteProgressBar() {
     }
   }, [active, visible, progress])
 
-  // Clear timers only on unmount — never in a per-run cleanup (see above).
+  // Clear timers and stop the fill tween only on unmount — never in a per-run
+  // cleanup (see above), which would defeat the churn-proof reveal.
   useEffect(
     () => () => {
       if (showTimer.current) clearTimeout(showTimer.current)
       if (hideTimer.current) clearTimeout(hideTimer.current)
+      anim.current?.stop()
     },
     [],
   )

--- a/web/src/components/status/RouteProgressBar.tsx
+++ b/web/src/components/status/RouteProgressBar.tsx
@@ -9,34 +9,34 @@ import { EASE_OUT } from "@/lib/motion"
 // signal. The bar trickles toward ~90% while fetches are in flight, then snaps
 // to 100% and fades out when they settle, mimicking a native app's route load.
 //
-// Care taken against render loops: the fill is a Motion value animated
-// imperatively (no per-frame setState); React state holds only the coarse
-// visible/hidden flag, flipped at most twice per load cycle. A short show-delay
-// keeps a burst of cached reads from flashing the bar.
+// Render-loop / churn safety: the fill is a Motion value animated imperatively
+// (no per-frame setState); React state holds only the coarse visible flag,
+// flipped at most twice per load cycle. Crucially the effect does NOT clear the
+// timers in a per-run cleanup — `fetching` changes on every query start/finish,
+// so a staggered burst of reads (this app's norm) would otherwise keep clearing
+// and rescheduling the show-timer and the bar would never appear. Instead each
+// timer is armed once per transition (guarded by its ref) and only cleared on
+// unmount, so the 120ms reveal survives fetch-count churn.
 const SHOW_DELAY_MS = 120
 const HIDE_DELAY_MS = 180
 
 export function RouteProgressBar() {
-  const fetching = useIsFetching()
+  const active = useIsFetching() > 0
   const [visible, setVisible] = useState(false)
   const progress = useMotionValue(0)
   const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
-    const clearTimers = () => {
-      if (showTimer.current) clearTimeout(showTimer.current)
-      if (hideTimer.current) clearTimeout(hideTimer.current)
-      showTimer.current = null
-      hideTimer.current = null
-    }
-
-    if (fetching > 0) {
+    if (active) {
+      // A new load (or a resumed one): cancel any pending fade-out.
       if (hideTimer.current) {
         clearTimeout(hideTimer.current)
         hideTimer.current = null
       }
-      // Delay the reveal so instant cache hits don't flash a bar.
+      // Arm the reveal once. The show-timer ref guard means later `active`
+      // re-runs during the same load don't reset the 120ms delay, so a
+      // churny multi-fetch page still reveals the bar on schedule.
       if (!visible && !showTimer.current) {
         showTimer.current = setTimeout(() => {
           showTimer.current = null
@@ -47,14 +47,15 @@ export function RouteProgressBar() {
           animate(progress, 0.9, { duration: 8, ease: EASE_OUT })
         }, SHOW_DELAY_MS)
       }
-      return clearTimers
+      return
     }
 
-    // Fetches settled: cancel a pending reveal, or complete + fade a shown bar.
+    // Fetches settled: cancel a pending (not-yet-shown) reveal outright.
     if (showTimer.current) {
       clearTimeout(showTimer.current)
       showTimer.current = null
     }
+    // Complete + fade a shown bar, armed once via the hide-timer ref guard.
     if (visible && !hideTimer.current) {
       animate(progress, 1, { duration: 0.2, ease: EASE_OUT })
       hideTimer.current = setTimeout(() => {
@@ -63,8 +64,16 @@ export function RouteProgressBar() {
         progress.set(0)
       }, HIDE_DELAY_MS)
     }
-    return clearTimers
-  }, [fetching, visible, progress])
+  }, [active, visible, progress])
+
+  // Clear timers only on unmount — never in a per-run cleanup (see above).
+  useEffect(
+    () => () => {
+      if (showTimer.current) clearTimeout(showTimer.current)
+      if (hideTimer.current) clearTimeout(hideTimer.current)
+    },
+    [],
+  )
 
   return (
     <AnimatePresence>

--- a/web/src/components/status/RouteProgressBar.tsx
+++ b/web/src/components/status/RouteProgressBar.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from "react"
+import { useIsFetching } from "@tanstack/react-query"
+import { AnimatePresence, motion, useMotionValue, animate } from "motion/react"
+import { EASE_OUT } from "@/lib/motion"
+
+// A thin top-of-viewport progress bar bound to React Query's global in-flight
+// count. This app fetches data in components (no route loaders), so the router
+// has no pending phase to hook — the fetch count is the real "page is loading"
+// signal. The bar trickles toward ~90% while fetches are in flight, then snaps
+// to 100% and fades out when they settle, mimicking a native app's route load.
+//
+// Care taken against render loops: the fill is a Motion value animated
+// imperatively (no per-frame setState); React state holds only the coarse
+// visible/hidden flag, flipped at most twice per load cycle. A short show-delay
+// keeps a burst of cached reads from flashing the bar.
+const SHOW_DELAY_MS = 120
+const HIDE_DELAY_MS = 180
+
+export function RouteProgressBar() {
+  const fetching = useIsFetching()
+  const [visible, setVisible] = useState(false)
+  const progress = useMotionValue(0)
+  const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const clearTimers = () => {
+      if (showTimer.current) clearTimeout(showTimer.current)
+      if (hideTimer.current) clearTimeout(hideTimer.current)
+      showTimer.current = null
+      hideTimer.current = null
+    }
+
+    if (fetching > 0) {
+      if (hideTimer.current) {
+        clearTimeout(hideTimer.current)
+        hideTimer.current = null
+      }
+      // Delay the reveal so instant cache hits don't flash a bar.
+      if (!visible && !showTimer.current) {
+        showTimer.current = setTimeout(() => {
+          showTimer.current = null
+          progress.set(0.08)
+          setVisible(true)
+          // Trickle toward 90% — never reaches 100% until fetches settle, so a
+          // long request keeps advancing without ever "finishing" early.
+          animate(progress, 0.9, { duration: 8, ease: EASE_OUT })
+        }, SHOW_DELAY_MS)
+      }
+      return clearTimers
+    }
+
+    // Fetches settled: cancel a pending reveal, or complete + fade a shown bar.
+    if (showTimer.current) {
+      clearTimeout(showTimer.current)
+      showTimer.current = null
+    }
+    if (visible && !hideTimer.current) {
+      animate(progress, 1, { duration: 0.2, ease: EASE_OUT })
+      hideTimer.current = setTimeout(() => {
+        hideTimer.current = null
+        setVisible(false)
+        progress.set(0)
+      }, HIDE_DELAY_MS)
+    }
+    return clearTimers
+  }, [fetching, visible, progress])
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="fixed inset-x-0 top-0 z-[60] h-0.5 origin-left bg-primary"
+          style={{ scaleX: progress }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0, transition: { duration: 0.15 } }}
+          aria-hidden="true"
+        />
+      )}
+    </AnimatePresence>
+  )
+}

--- a/web/src/context/roleView/RoleViewProvider.tsx
+++ b/web/src/context/roleView/RoleViewProvider.tsx
@@ -47,8 +47,10 @@ function readStored(
   return raw === "hta" || raw === "ta" || raw === "student" ? raw : null
 }
 
-// Scoped to one org (remounts on org change via `key`) and one classroom
-// (re-synced below), so the preview never leaks across orgs or classrooms.
+// Scoped to one org + classroom (re-synced below on either change), so the
+// preview never leaks across orgs or classrooms. Stays mounted across
+// navigation so the persistent app shell isn't torn down on an org/classroom
+// switch.
 export function RoleViewProvider({
   org,
   classroom,
@@ -61,13 +63,17 @@ export function RoleViewProvider({
     readStored(org, classroom),
   )
 
-  // On classroom change (the provider stays mounted across intra-org
-  // navigation), re-read this classroom's stored preview so one set in classroom
-  // A never bleeds into classroom B.
-  const prevClassroomRef = useRef(classroom)
+  // Re-read the stored preview whenever the org OR classroom changes (the
+  // provider now stays mounted across org and classroom navigation, so it can't
+  // rely on a remount to reset). Keeping it mounted lets the persistent app
+  // shell's sidebar animate the menu-level swap on those navigations. The lens
+  // stays isolated per org+classroom: a preview set in one never bleeds into
+  // another, and org-less routes read `null` (inert).
+  const prevScopeRef = useRef(keyFor(org, classroom))
   useEffect(() => {
-    if (prevClassroomRef.current !== classroom) {
-      prevClassroomRef.current = classroom
+    const scope = keyFor(org, classroom)
+    if (prevScopeRef.current !== scope) {
+      prevScopeRef.current = scope
       setViewAsState(readStored(org, classroom))
     }
   }, [org, classroom])

--- a/web/src/hooks/useGetClasses.ts
+++ b/web/src/hooks/useGetClasses.ts
@@ -20,7 +20,6 @@ const useGetClasses = (org: string | undefined) => {
     // empty state: an empty `classes` array during the fetch is otherwise
     // indistinguishable from a genuinely empty org.
     isLoading: classesQuery.isLoading,
-    isError: classesQuery.isError,
   }
 }
 

--- a/web/src/hooks/useGetClasses.ts
+++ b/web/src/hooks/useGetClasses.ts
@@ -16,6 +16,11 @@ const useGetClasses = (org: string | undefined) => {
           (c) => c.type === "dir" && c.name !== ".github",
         )
       : [],
+    // Surfaced so a caller can show a loading state instead of flashing its
+    // empty state: an empty `classes` array during the fetch is otherwise
+    // indistinguishable from a genuinely empty org.
+    isLoading: classesQuery.isLoading,
+    isError: classesQuery.isError,
   }
 }
 

--- a/web/src/lib/motion.ts
+++ b/web/src/lib/motion.ts
@@ -139,10 +139,11 @@ export const sidebarLevelVariants: Variants = {
 }
 
 // Page-content entrance for a route swap in the persistent shell: a gentle
-// fade + short rise so a new view eases in rather than snapping. Deliberately
-// enter-only (no exit) with mode="popLayout"/"sync" so the incoming page isn't
-// held behind an outgoing one — keeps navigation feeling instant, not gated on
-// an exit animation. Kept subtle so it layers cleanly over per-page skeletons.
+// fade + short rise so a new view eases in rather than snapping. Enter-only (no
+// exit): the consumer (PageTransition) remounts it per route via a `key` rather
+// than wrapping it in AnimatePresence, so there's no exit to wait on and the
+// incoming page is never held behind an outgoing one. Kept subtle so it layers
+// cleanly over per-page skeletons.
 export const pageContentVariants: Variants = {
   initial: { opacity: 0, y: 6 },
   animate: {

--- a/web/src/lib/motion.ts
+++ b/web/src/lib/motion.ts
@@ -127,3 +127,17 @@ export const sidebarLevelVariants: Variants = {
     transition: { duration: DURATION.fast, ease: EASE_OUT },
   },
 }
+
+// Page-content entrance for a route swap in the persistent shell: a gentle
+// fade + short rise so a new view eases in rather than snapping. Deliberately
+// enter-only (no exit) with mode="popLayout"/"sync" so the incoming page isn't
+// held behind an outgoing one — keeps navigation feeling instant, not gated on
+// an exit animation. Kept subtle so it layers cleanly over per-page skeletons.
+export const pageContentVariants: Variants = {
+  initial: { opacity: 0, y: 6 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: DURATION.slow, ease: EASE_OUT },
+  },
+}

--- a/web/src/lib/motion.ts
+++ b/web/src/lib/motion.ts
@@ -22,6 +22,16 @@ export const staggerTransition = (index: number): Transition => ({
   delay: Math.min(index, 8) * 0.06,
 })
 
+// Parent container that orchestrates a staggered entrance for its motion
+// children WITHOUT threading an index into each: set on a `motion` wrapper with
+// `initial="initial" animate="animate"`, and children using `enterExit` (same
+// variant keys) cascade in. Preferred over per-child `staggerTransition` when
+// the children can't take a `transition` prop (e.g. wrapped in a typed <Card>).
+export const listStagger: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+}
+
 export const enterExit: Variants = {
   initial: { opacity: 0, scale: 0.96 },
   animate: {

--- a/web/src/lib/motion.ts
+++ b/web/src/lib/motion.ts
@@ -100,3 +100,30 @@ export const crossFade: Variants = {
   animate: { opacity: 1, transition: { duration: DURATION.base } },
   exit: { opacity: 0, transition: { duration: DURATION.fast } },
 }
+
+// Sidebar active-highlight glide. The pill is a single shared-`layoutId`
+// element, so switching pages FLIP-tweens it from the old row to the new one
+// (a spring reads more like a physical slider than a linear ease here).
+export const sidebarPillTransition: Transition = {
+  type: "spring",
+  stiffness: 520,
+  damping: 42,
+  mass: 0.7,
+}
+
+// Level swap for the sidebar menu (orgs -> classes -> classroom -> assignment):
+// the outgoing menu fades out while the incoming one slides in from a small
+// horizontal offset, reading as "descending into" the next level.
+export const sidebarLevelVariants: Variants = {
+  initial: { opacity: 0, x: 8 },
+  animate: {
+    opacity: 1,
+    x: 0,
+    transition: { duration: DURATION.slow, ease: EASE_OUT },
+  },
+  exit: {
+    opacity: 0,
+    x: -8,
+    transition: { duration: DURATION.fast, ease: EASE_OUT },
+  },
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2412,7 +2412,6 @@
     "exportCsv": "Export CSV",
     "searchPlaceholder": "Search activity...",
     "searchLabel": "Search activity",
-    "loading": "Loading activity...",
     "loadOlder": "Load older",
     "partialError": "Some activity couldn't be loaded. Showing what's available.",
     "filters": {
@@ -2469,7 +2468,6 @@
     "filterByClassroomLabel": "Filter by classroom",
     "filterAllClassrooms": "All classrooms",
     "filterNoClassroom": "No classroom",
-    "loading": "Loading members...",
     "loadError": "Couldn't load organization members.",
     "noMatch": "No members match your search.",
     "noMembersInClassroom": "No members in {{classroom}}.",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,7 @@ import { NotificationProvider } from "./context/notifications/NotificationProvid
 import { HiddenOrgsProvider } from "./context/hiddenOrgs/HiddenOrgsProvider"
 import { ActionActivityProvider } from "./context/actions/ActionActivityProvider"
 import { ActionsBanner } from "./components/status/ActionsBanner"
+import { RouteProgressBar } from "./components/status/RouteProgressBar"
 import { LanguagePackUpdateToaster } from "./components/settings/LanguagePackUpdateToaster"
 import App from "./App"
 import { appVersion, formatAppVersion } from "./version"
@@ -89,6 +90,7 @@ createRoot(document.getElementById("root")!).render(
             <ActionActivityProvider>
               <NotificationProvider>
                 <HiddenOrgsProvider>
+                  <RouteProgressBar />
                   <App />
                   <ActionsBanner />
                   <LanguagePackUpdateToaster />

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -189,7 +189,7 @@ const AssignmentSettingsPage = () => {
   )
 
   return (
-    <PageShell selected="assignments">
+    <PageShell>
       <Breadcrumb endpoint={t("documentTitle.assignmentSettings")} />
       <AnimatedAlert tone="error" show={!!editError}>
         {editError}

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -274,7 +274,7 @@ const AssignmentsPage = () => {
   const isStudent = role === "student"
 
   return (
-    <PageShell selected="assignments">
+    <PageShell>
       <Breadcrumb endpoint={t("nav.assignments")} />
       {org && classroom && (
         <ClaimTeacherNotice org={org} classroom={classroom} />

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -179,7 +179,7 @@ const ClassesPage = () => {
   }
 
   return (
-    <PageShell page="classes" selected="assignments">
+    <PageShell>
       <PageHeader
         loading={roleLoading}
         title={isStaff ? t("classes.myClasses") : t("classes.myAssignments")}

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -161,7 +161,7 @@ const ClassesPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.classes"))
   const { org } = useParams({ strict: false })
-  const { classes } = useGetClasses(org)
+  const { classes, isLoading: classesLoading } = useGetClasses(org)
   const { isStaff, isNonStaff, isLoading: roleLoading } = useOrgStaff(org)
   const { data: membership, isLoading: loadingMembership } =
     useGetOwnOrgMembership(org)
@@ -190,7 +190,10 @@ const ClassesPage = () => {
         <JoinOrgCard org={org} />
       )}
       {isOwner && <OrgPreflightNotice org={org} />}
-      {roleLoading ? (
+      {/* Hold the skeleton until BOTH the role and (for staff) the class list
+          resolve — otherwise a staff view flashes the "no classrooms" empty
+          state on the empty-while-loading array before the classes arrive. */}
+      {roleLoading || (isStaff && classesLoading) ? (
         <div className="grid grid-cols-12 gap-4">
           {Array.from({ length: 3 }).map((_, i) => (
             <div

--- a/web/src/pages/ClassroomSettingsPage.tsx
+++ b/web/src/pages/ClassroomSettingsPage.tsx
@@ -127,7 +127,7 @@ const ClassroomSettingsPage = () => {
   const { org, classroom } = useParams({ strict: false })
 
   return (
-    <PageShell selected="settings">
+    <PageShell>
       <Breadcrumb endpoint={t("nav.settings")} />
       <RequireRole allow="teacher">
         {!org || !classroom ? (

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -68,7 +68,7 @@ const CreateAssignmentPage = () => {
     return <MissingParams message={t("assignments.missingOrgOrClassroom")} />
   }
   return (
-    <PageShell selected="assignments">
+    <PageShell>
       <Breadcrumb endpoint={t("assignments.createBreadcrumb")} />
       <RequireRole allow="author">
         <PageHeader title={t("assignments.createHeading")} />

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -44,7 +44,7 @@ const CreateClassroomPage = () => {
   }
 
   return (
-    <PageShell page="classes" selected="classes">
+    <PageShell>
       <Breadcrumb endpoint={t("documentTitle.newClassroom")} />
       <RequireRole allow="owner">
         <PageHeader title={t("classes.createTitle")} />

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -119,7 +119,7 @@ const OrgActivityPage = () => {
     filters.types.size > 0
 
   return (
-    <PageShell page="classes" selected="activity">
+    <PageShell>
       <RequireRole allow="owner">
         <PageHeader
           title={t("orgActivity.heading")}

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -5,10 +5,10 @@ import { useQuery } from "@tanstack/react-query"
 import Papa from "papaparse"
 import { Activity } from "lucide-react"
 
-import { AnimatedAlert, Card, Spinner, Button } from "@/components/ui"
+import { AnimatedAlert, Card, Button } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
-import { EmptyState } from "@/components/list"
+import { EmptyState, SkeletonRows } from "@/components/list"
 import RequireRole from "@/components/RequireRole"
 import { DiagnosticsDialog } from "@/components/DiagnosticsDialog"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -154,10 +154,9 @@ const OrgActivityPage = () => {
 
         {items.length === 0 ? (
           loading ? (
-            <div className="mt-4 flex items-center justify-center gap-3 px-6 py-12 text-base-content/70">
-              <Spinner size="md" />
-              <span className="text-sm">{t("orgActivity.loading")}</span>
-            </div>
+            <Card className="mt-4 w-full overflow-hidden" aria-busy>
+              <SkeletonRows rows={6} />
+            </Card>
           ) : (
             <EmptyState
               className="mt-4 rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center"

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -17,9 +17,9 @@ import {
   Card,
   Input,
   Select,
-  Spinner,
   rtlFlip,
 } from "@/components/ui"
+import { SkeletonRows } from "@/components/list"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -455,12 +455,9 @@ const OrgMembersPage = () => {
             </Select>
           </div>
 
-          <Card className="mt-4 w-full overflow-hidden">
+          <Card className="mt-4 w-full overflow-hidden" aria-busy={isLoading}>
             {isLoading ? (
-              <div className="flex items-center justify-center gap-3 px-6 py-12 text-base-content/70">
-                <Spinner size="md" />
-                <span className="text-sm">{t("orgMembers.loading")}</span>
-              </div>
+              <SkeletonRows rows={6} />
             ) : isError ? (
               <div className="px-6 py-10 text-center text-sm text-error">
                 {t("orgMembers.loadError")}

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -370,7 +370,7 @@ const OrgMembersPage = () => {
 
   return (
     <>
-      <PageShell page="classes" selected="members">
+      <PageShell>
         <RequireRole allow="owner">
           <PageHeader
             title={t("orgMembers.heading")}

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -576,7 +576,7 @@ const OrgSettingsPage = () => {
   const highlightedId = useHashSectionHighlight()
 
   return (
-    <PageShell page="classes" settings selected="settings">
+    <PageShell>
       <RequireRole allow="owner">
         <PageHeader
           title={t("orgSettings.page.heading")}

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -354,7 +354,7 @@ const OrgSetupPage = () => {
   }
 
   return (
-    <PageShell page="classes" selected="assignments">
+    <PageShell>
       <PageHeader
         title={t("setup.pageHeading")}
         subtitle={t("setup.pageSubheading")}

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -575,7 +575,7 @@ const OrgsPage = () => {
 
   return (
     <>
-      <PageShell page="orgs">
+      <PageShell>
         {isLoading ? (
           <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
             <Spinner size="lg" className="text-primary" />

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -37,7 +37,7 @@ import {
   User,
 } from "lucide-react"
 import OrgDetailsModal from "@/components/modals/OrgDetailsModal"
-import { AnimatePresence } from "motion/react"
+import { AnimatePresence, motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
@@ -46,6 +46,7 @@ import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
 import Spinner from "@/components/Spinner"
 import { EnterDiv, PresenceCardDiv } from "@/lib/motionComponents"
+import { listStagger } from "@/lib/motion"
 import { orgListPrefs, type OrgSortKey } from "@/lib/orgListPrefs"
 import { useListPrefsState } from "@/lib/listPrefs"
 import { formatRelativeToNow } from "@/util/formatDate"
@@ -658,8 +659,13 @@ const OrgsPage = () => {
                 onClear={() => setSearch("")}
               />
             ) : sorted.length > 0 ? (
-              <div className="grid grid-cols-12 gap-4">
-                <AnimatePresence mode="popLayout" initial={false}>
+              <motion.div
+                className="grid grid-cols-12 gap-4"
+                variants={listStagger}
+                initial="initial"
+                animate="animate"
+              >
+                <AnimatePresence mode="popLayout">
                   {sorted.map((summary) => {
                     const updatedIso = lastModified[summary.org.login]
                     const updatedAgo = updatedIso
@@ -682,7 +688,7 @@ const OrgsPage = () => {
                     )
                   })}
                 </AnimatePresence>
-              </div>
+              </motion.div>
             ) : needsSetupOrgs.length > 0 ? (
               <EmptyState
                 title={t("orgs.setUpFirst.title")}

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -451,7 +451,7 @@ const PublishedResourcesPage = () => {
   const { org } = useParams({ strict: false })
 
   return (
-    <PageShell page="classes" selected="published">
+    <PageShell>
       <RequireRole>
         <PageHeader
           title={t("published.pageHeading")}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -134,7 +134,7 @@ const SettingsPage = () => {
   const highlightedId = useHashSectionHighlight()
 
   return (
-    <PageShell page="orgs" selected="settings">
+    <PageShell>
       <PageHeader
         title={t("settings.page.heading")}
         subtitle={t("settings.page.subheading")}

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -266,7 +266,7 @@ const StudentListPage = () => {
   const { org = "", classroom = "" } = useParams({ strict: false })
 
   return (
-    <PageShell selected="roster">
+    <PageShell>
       <Breadcrumb endpoint={t("nav.roster")} />
       <RequireRole>
         <StudentListContent org={org} classroom={classroom} />

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -275,7 +275,7 @@ const StudentSubmissionPage = () => {
   const description = assignmentDescription(assignmentData)
 
   return (
-    <PageShell selected="assignments">
+    <PageShell>
       <Breadcrumb endpoint={t("nav.mySubmission")} />
       <PageHeader
         title={

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -799,7 +799,7 @@ const SubmissionsPageContent = () => {
   }
 
   return (
-    <PageShell selected="assignments">
+    <PageShell>
       <Breadcrumb endpoint={t("nav.submissions")} />
       {emptyRoster.show && (
         <EmptyRosterNotice

--- a/web/src/pages/migration/ImportClassroomPage.tsx
+++ b/web/src/pages/migration/ImportClassroomPage.tsx
@@ -128,7 +128,7 @@ export const ImportClassroomPage = () => {
   }
 
   return (
-    <PageShell page="import" selected="assignments">
+    <PageShell>
       <PageHeader
         title={t("migration.title")}
         subtitle={<p className="max-w-2xl">{t("migration.subtitle")}</p>}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -6,6 +6,11 @@ export const router = createRouter({
   routeTree,
   // "/" in local dev; set via --base flag in the GitHub Pages build
   basepath: import.meta.env.BASE_URL,
+  // Preload a route's component code on hover/touch intent so the code-split
+  // chunk is ready by click. Data still loads via each page's useQuery hooks
+  // (this app has no route loaders by design), so this warms code, not data —
+  // the React-Query-backed top progress bar covers the data-fetch phase.
+  defaultPreload: "intent",
   context: {
     auth: {
       user: null,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -15,12 +15,14 @@ import { LOG_SCOPE_ROUTER } from "@/lib/logScopes"
 const log = logger.scope(LOG_SCOPE_ROUTER)
 
 const RootComponent = () => {
-  // Scope "view as" to the current org (reset across orgs via the key); the
-  // provider re-syncs on classroom change. Reading params at the root keeps the
-  // provider inside the router.
+  // Scope "view as" to the current org+classroom. The provider re-syncs on
+  // org/classroom change (no React `key`) so it stays mounted across
+  // navigation — keeping the persistent app shell alive so its sidebar can
+  // animate menu-level swaps. Reading params at the root keeps the provider
+  // inside the router.
   const { org, classroom } = useParams({ strict: false })
   return (
-    <RoleViewProvider key={org ?? "no-org"} org={org} classroom={classroom}>
+    <RoleViewProvider org={org} classroom={classroom}>
       <Outlet />
     </RoleViewProvider>
   )

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
+import { createFileRoute, redirect, useParams } from "@tanstack/react-router"
+import { type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
 import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
@@ -7,7 +8,10 @@ import { OfflineBanner } from "@/components/OfflineBanner"
 import { GitHubStatusBanner } from "@/components/GitHubStatusBanner"
 import { UpdateAvailableBanner } from "@/components/UpdateAvailableBanner"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
+import { GitHubOrgRoleProvider } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
+import { ClassroomRoleProvider } from "@/context/classroomRole/ClassroomRoleProvider"
 import { Spinner } from "@/components/Spinner"
+import { AppShell } from "@/components/drawer"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_ROUTER } from "@/lib/logScopes"
 
@@ -54,14 +58,38 @@ function AuthedLayout() {
   }
 
   return (
-    <>
-      <OfflineBanner />
-      <GitHubStatusBanner />
-      <ScopeWarningBanner />
-      <SkeletonDriftBanner />
-      <BudgetCreatedBanner />
-      <UpdateAvailableBanner />
-      <Outlet />
-    </>
+    <AuthedShell
+      topSlot={
+        <>
+          <OfflineBanner />
+          <GitHubStatusBanner />
+          <ScopeWarningBanner />
+          <SkeletonDriftBanner />
+          <BudgetCreatedBanner />
+          <UpdateAvailableBanner />
+        </>
+      }
+    />
+  )
+}
+
+// The role providers now wrap the PERSISTENT shell (sidebar + Outlet) rather
+// than the per-level layout routes: the hoisted sidebar reads the classroom/org
+// role, and it lives above $org/$classroom, so the providers must too. Both are
+// param-tolerant (reads disable to `unresolved` off-route), and keys reset the
+// resolution when the org/classroom changes so a stale role never leaks across
+// boundaries. Child pages + layout gates read this single instance.
+function AuthedShell({ topSlot }: { topSlot?: ReactNode }) {
+  const { org, classroom } = useParams({ strict: false })
+  return (
+    <GitHubOrgRoleProvider key={org ?? "no-org"} org={org}>
+      <ClassroomRoleProvider
+        key={`${org ?? "no-org"}/${classroom ?? "no-classroom"}`}
+        org={org}
+        classroom={classroom}
+      >
+        <AppShell topSlot={topSlot} />
+      </ClassroomRoleProvider>
+    </GitHubOrgRoleProvider>
   )
 }

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -75,19 +75,17 @@ function AuthedLayout() {
 
 // The role providers now wrap the PERSISTENT shell (sidebar + Outlet) rather
 // than the per-level layout routes: the hoisted sidebar reads the classroom/org
-// role, and it lives above $org/$classroom, so the providers must too. Both are
-// param-tolerant (reads disable to `unresolved` off-route), and keys reset the
-// resolution when the org/classroom changes so a stale role never leaks across
-// boundaries. Child pages + layout gates read this single instance.
+// role, and it lives above $org/$classroom, so the providers must too. They take
+// org/classroom as PROPS (no React `key`): both re-resolve from their query keys
+// when the params change, so keeping them mounted — instead of remounting on a
+// key change — lets the shell's sidebar AnimatePresence survive an org/classroom
+// switch and animate the menu-level swap. Reads disable to `unresolved`
+// off-route, so a stale role never leaks across boundaries.
 function AuthedShell({ topSlot }: { topSlot?: ReactNode }) {
   const { org, classroom } = useParams({ strict: false })
   return (
-    <GitHubOrgRoleProvider key={org ?? "no-org"} org={org}>
-      <ClassroomRoleProvider
-        key={`${org ?? "no-org"}/${classroom ?? "no-classroom"}`}
-        org={org}
-        classroom={classroom}
-      >
+    <GitHubOrgRoleProvider org={org}>
+      <ClassroomRoleProvider org={org} classroom={classroom}>
         <AppShell topSlot={topSlot} />
       </ClassroomRoleProvider>
     </GitHubOrgRoleProvider>

--- a/web/src/routes/_authed/$org/$classroom/route.tsx
+++ b/web/src/routes/_authed/$org/$classroom/route.tsx
@@ -1,21 +1,17 @@
-import { createFileRoute, Outlet, useParams } from "@tanstack/react-router"
-import { ClassroomRoleProvider } from "@/context/classroomRole/ClassroomRoleProvider"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
 import { PermissionErrorBoundary } from "@/components/PermissionErrorBoundary"
 
 export const Route = createFileRoute("/_authed/$org/$classroom")({
   component: ClassroomLayout,
 })
 
-// Classroom boundary: resolve the effective classroom role ONCE and share it
-// with every child page + guard via context, so child surfaces read the role
-// from context rather than each re-running resolution.
+// The effective classroom role is now resolved once at the `_authed` shell
+// (ClassroomRoleProvider wraps the persistent sidebar + Outlet there), so this
+// boundary only keeps the classroom-scoped permission error surface.
 function ClassroomLayout() {
-  const { org, classroom } = useParams({ from: "/_authed/$org/$classroom" })
   return (
     <PermissionErrorBoundary>
-      <ClassroomRoleProvider org={org} classroom={classroom}>
-        <Outlet />
-      </ClassroomRoleProvider>
+      <Outlet />
     </PermissionErrorBoundary>
   )
 }

--- a/web/src/routes/_authed/$org/route.tsx
+++ b/web/src/routes/_authed/$org/route.tsx
@@ -9,10 +9,7 @@ import {
 import { Spinner } from "@/components/Spinner"
 import useGetOwnOrgMembership from "@/hooks/useGetOwnOrgMembership"
 import { useOrgClassroom50Status } from "@/hooks/useOrgClassroom50Status"
-import {
-  GitHubOrgRoleProvider,
-  useGitHubOrgRole,
-} from "@/context/githubOrgRole/GitHubOrgRoleProvider"
+import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { can } from "@/authz"
 
 export const Route = createFileRoute("/_authed/$org")({
@@ -23,16 +20,10 @@ export const Route = createFileRoute("/_authed/$org")({
 // initialized is sent to setup instead of landing on empty pages that 404 under
 // the hood. Students/non-admins are never redirected — a 404 on the private
 // config repo is expected for them, so gating would lock them out of their org.
+//
+// The org role provider now wraps the `_authed` shell above this route, so this
+// layout reads the role directly (no local provider needed).
 function OrgLayout() {
-  const { org } = useParams({ from: "/_authed/$org" })
-  return (
-    <GitHubOrgRoleProvider org={org}>
-      <OrgLayoutInner />
-    </GitHubOrgRoleProvider>
-  )
-}
-
-function OrgLayoutInner() {
   const { org } = useParams({ from: "/_authed/$org" })
   // Match the setup route by matched-route id, not a pathname suffix: a suffix
   // check (endsWith("/setup")) both collides with any path segment named
@@ -43,8 +34,8 @@ function OrgLayoutInner() {
   })
 
   const { isLoading: loadingMembership } = useGetOwnOrgMembership(org)
-  // Gate on the org-role capability (provider mounted by OrgLayout) rather than
-  // re-deriving the admin literal from membership.
+  // Gate on the org-role capability (from the shell's provider above) rather
+  // than re-deriving the admin literal from membership.
   const { githubOrgRole } = useGitHubOrgRole()
   const isAdmin = can("manageOrg", { githubOrgRole })
 


### PR DESCRIPTION
## What & why

Reworks the drawer/navigation into a persistent app shell so the app feels native rather than reloading a page on every click, and smooths the loading experience so views ease in instead of popping.

The sidebar now mounts once in the `_authed` layout (with `<Outlet/>` for page content) instead of being re-rendered per page inside `PageShell`. That single change unlocks the animations below and is the idiomatic TanStack Router pattern for a persistent shell.

## Navigation UX

The active-row highlight is a single shared-`layoutId` pill that **glides** between items within a menu instead of snapping. Changing levels (orgs → classes → classroom → assignment) cross-fades/slides the menu body via one `AnimatePresence` keyed by a route-derived `levelKey`, while the logo and footer stay put. Same-org navigations (including clicking the logo to reach `/`) keep the shell mounted so these animate; the orgs grid now staggers its entrance on load.

Sidebar active state is derived from the route (`useSidebarNav`) rather than passed as `page`/`selected`/`settings` props, so pages render content only. The org/classroom role providers moved up to wrap the persistent shell; they re-resolve from their query keys on param change (no React `key` remount), and the `RoleViewProvider` "view as" lens re-syncs per org+classroom scope instead of remounting — preserving preview isolation while keeping the shell alive.

## Loading experience

A React-Query-driven top progress bar (this app fetches in components, not route loaders, so the in-flight count is the real loading signal), an enter-only page-content transition on route swaps, preload-on-intent for route code, and shared `SkeletonRows` replacing centered spinners on the members and activity lists. Also fixes the classrooms page flashing its empty state before data arrives, and keeps the page background covering the full viewport.

## Notes

All motion honors `prefers-reduced-motion` via the existing app-level `MotionConfig`. Ran `ce-code-review`; addressed every finding — notably a progress-bar timer that reset under fetch churn (now armed once, cleared only on unmount) — and added tests for the progress bar (incl. a churn regression) and the `useSidebarNav` route mapping.

`npm run check` is green (tsc, eslint, prettier, dependency-cruiser, 2957 vitest tests).