### PR TITLE
fix(web): refresh assignment settings and re-disable Save after a save

### DIFF
--- a/web/src/hooks/mutations/createEditMutations.test.ts
+++ b/web/src/hooks/mutations/createEditMutations.test.ts
@@ -160,7 +160,7 @@ describe("useCreateAssignment", () => {
 })
 
 describe("useEditAssignment", () => {
-  it("forwards onWrite and delegates to the domain write, but does NOT invalidate (edit path relies on its own refetch)", async () => {
+  it("invalidates the assignments.json listing, forwards onWrite, and delegates to the domain write", async () => {
     const queryClient = freshClient()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
     const onWrite = vi.fn()
@@ -168,18 +168,35 @@ describe("useEditAssignment", () => {
       wrapper: wrapperWith(queryClient),
     })
 
-    result.current.mutate({ slug: "hw1", name: "HW1" } as never)
+    result.current.mutate({
+      slug: "hw1",
+      name: "HW1",
+      org: ORG,
+      classroom: CLASSROOM,
+    } as never)
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(editAssignmentWithConflictRetry).toHaveBeenCalledWith(
       expect.anything(),
-      { slug: "hw1", name: "HW1", canGrantTemplateAccess: true },
+      {
+        slug: "hw1",
+        name: "HW1",
+        org: ORG,
+        classroom: CLASSROOM,
+        canGrantTemplateAccess: true,
+      },
     )
     expect(onWrite).toHaveBeenCalledWith(
       { newCommitSha: "sha-ea" },
-      { slug: "hw1", name: "HW1" },
+      { slug: "hw1", name: "HW1", org: ORG, classroom: CLASSROOM },
     )
-    expect(invalidate).not.toHaveBeenCalled()
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.jsonFile(
+        ORG,
+        CONFIG_REPO,
+        `${CLASSROOM}/assignments.json`,
+      ),
+    })
   })
 
   it("runs the hook-level onMutate before the write settles", async () => {

--- a/web/src/hooks/mutations/useEditAssignment.ts
+++ b/web/src/hooks/mutations/useEditAssignment.ts
@@ -1,20 +1,23 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   editAssignmentWithConflictRetry,
   type CreateAssignmentInput,
   type CreateAssignmentResult,
 } from "@/domain/assignments"
+import { githubKeys } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useCanAttemptTemplateGrant } from "@/context/githubOrgRole/useIsOrgOwner"
+import { CONFIG_REPO } from "@/util/configRepo"
 
-// Save an assignment's settings. This edit path historically does NOT invalidate
-// the assignments cache (the page relies on its own refetch/staleTime), so the
-// hook preserves that and owns only the unmount-safe deploy-tracking `onWrite`
-// follow-up (its translated label comes from the call site, keeping the hook
-// t()-free). `onMutate` is hook-level (React Query forbids it as a call-site
-// option) so the caller's pre-flight banner reset runs before the write. UI
-// (success/warning banners, scroll) stays at the call site — see ./README.md.
+// Save an assignment's settings. The hook owns the assignments.json listing
+// invalidate (unmount-safe — the edited values must reload even if the editor
+// navigates away, since the persistent app shell no longer remounts the page to
+// force a refetch) plus the unmount-safe deploy-tracking `onWrite` follow-up (its
+// translated label comes from the call site, keeping the hook t()-free).
+// `onMutate` is hook-level (React Query forbids it as a call-site option) so the
+// caller's pre-flight banner reset runs before the write. UI (success/warning
+// banners, scroll) stays at the call site — see ./README.md.
 export function useEditAssignment(opts?: {
   onWrite?: (
     result: CreateAssignmentResult,
@@ -24,6 +27,7 @@ export function useEditAssignment(opts?: {
 }) {
   const { onWrite, onMutate } = opts ?? {}
   const client = useGitHubClient()
+  const queryClient = useQueryClient()
   // Attempt the owner-only template read-grant unless the org role is a
   // confirmed non-owner (see useCanAttemptTemplateGrant).
   const canGrantTemplateAccess = useCanAttemptTemplateGrant()
@@ -40,6 +44,13 @@ export function useEditAssignment(opts?: {
       }),
     onMutate,
     onSuccess: (result, input) => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(
+          input.org,
+          CONFIG_REPO,
+          `${input.classroom}/assignments.json`,
+        ),
+      })
       onWrite?.(result, input)
     },
   })

--- a/web/src/hooks/mutations/useEditAssignment.ts
+++ b/web/src/hooks/mutations/useEditAssignment.ts
@@ -11,13 +11,13 @@ import { useCanAttemptTemplateGrant } from "@/context/githubOrgRole/useIsOrgOwne
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Save an assignment's settings. The hook owns the assignments.json listing
-// invalidate (unmount-safe — the edited values must reload even if the editor
-// navigates away, since the persistent app shell no longer remounts the page to
-// force a refetch) plus the unmount-safe deploy-tracking `onWrite` follow-up (its
-// translated label comes from the call site, keeping the hook t()-free).
-// `onMutate` is hook-level (React Query forbids it as a call-site option) so the
-// caller's pre-flight banner reset runs before the write. UI (success/warning
-// banners, scroll) stays at the call site — see ./README.md.
+// invalidate (unmount-safe — the persistent app shell no longer remounts the
+// page, so a stale cache would otherwise linger until a hard refresh) plus the
+// unmount-safe deploy-tracking `onWrite` follow-up (its translated label comes
+// from the call site, keeping the hook t()-free). `onMutate` is hook-level
+// (React Query forbids it as a call-site option) so the caller's pre-flight
+// banner reset runs before the write. UI (success/warning banners, scroll)
+// stays at the call site — see ./README.md.
 export function useEditAssignment(opts?: {
   onWrite?: (
     result: CreateAssignmentResult,

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -353,10 +353,8 @@ describe("assignment setup timeout", () => {
   })
 })
 
-// After a successful save, the edit form re-baselines to the saved values so
-// the "Save Changes" button returns to disabled (nothing pending), then
-// re-enables once the teacher edits again. Create mode navigates away on
-// success, so this reset is edit-only.
+// After a successful save the edit form re-baselines to the saved values, so
+// the "Save Changes" button re-disables (nothing pending) until the next edit.
 describe("edit form re-disables Save after a successful save", () => {
   const renderForm = (
     onSubmit: (values: CreateAssignmentFormValues) => void | Promise<void>,
@@ -384,7 +382,6 @@ describe("edit form re-disables Save after a successful save", () => {
     const name = screen.getByRole("textbox", {
       name: "assignments.form.name",
     })
-    // Unchanged form -> Save disabled (isDefaultValue).
     expect(saveButton().disabled).toBe(true)
 
     await user.type(name, " updated")
@@ -393,11 +390,8 @@ describe("edit form re-disables Save after a successful save", () => {
     await user.click(saveButton())
     expect(onSubmit).toHaveBeenCalledTimes(1)
 
-    // Saved values are the new baseline, so Save falls back to disabled without
-    // navigating away.
     await vi.waitFor(() => expect(saveButton().disabled).toBe(true))
 
-    // A further edit re-enables it.
     await user.type(name, " again")
     expect(saveButton().disabled).toBe(false)
   })
@@ -414,7 +408,7 @@ describe("edit form re-disables Save after a successful save", () => {
     await user.click(saveButton())
     expect(onSubmit).toHaveBeenCalledTimes(1)
 
-    // A rejected write must NOT re-baseline, so the button stays enabled.
+    // A rejected write must not re-baseline, so Save stays enabled.
     await vi.waitFor(() => expect(saveButton().disabled).toBe(false))
   })
 })

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -353,6 +353,71 @@ describe("assignment setup timeout", () => {
   })
 })
 
+// After a successful save, the edit form re-baselines to the saved values so
+// the "Save Changes" button returns to disabled (nothing pending), then
+// re-enables once the teacher edits again. Create mode navigates away on
+// success, so this reset is edit-only.
+describe("edit form re-disables Save after a successful save", () => {
+  const renderForm = (
+    onSubmit: (values: CreateAssignmentFormValues) => void | Promise<void>,
+  ) =>
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <CreateAssignmentForm
+          edit
+          defaultValues={assignmentToFormValues(baseAssignment)}
+          onSubmit={onSubmit}
+        />
+      </QueryClientProvider>,
+    )
+
+  const saveButton = () =>
+    screen.getByRole("button", {
+      name: "assignments.form.saveChanges",
+    }) as HTMLButtonElement
+
+  it("disables Save on success, then re-enables on the next edit", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    renderForm(onSubmit)
+
+    const name = screen.getByRole("textbox", {
+      name: "assignments.form.name",
+    })
+    // Unchanged form -> Save disabled (isDefaultValue).
+    expect(saveButton().disabled).toBe(true)
+
+    await user.type(name, " updated")
+    expect(saveButton().disabled).toBe(false)
+
+    await user.click(saveButton())
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+
+    // Saved values are the new baseline, so Save falls back to disabled without
+    // navigating away.
+    await vi.waitFor(() => expect(saveButton().disabled).toBe(true))
+
+    // A further edit re-enables it.
+    await user.type(name, " again")
+    expect(saveButton().disabled).toBe(false)
+  })
+
+  it("keeps the form dirty and re-submittable when the save fails", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockRejectedValue(new Error("boom"))
+    renderForm(onSubmit)
+
+    const name = screen.getByRole("textbox", {
+      name: "assignments.form.name",
+    })
+    await user.type(name, " updated")
+    await user.click(saveButton())
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+
+    // A rejected write must NOT re-baseline, so the button stays enabled.
+    await vi.waitFor(() => expect(saveButton().disabled).toBe(false))
+  })
+})
 // Built-in runtime options (language versions + apt) are disabled when the
 // runner targets self-hosted: the grade job skips managed setup there
 // (runner.environment != 'self-hosted'), so those options wouldn't apply.

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -75,10 +75,9 @@ const CreateAssignmentForm = ({
       onSubmit={(e) => {
         e.preventDefault()
         e.stopPropagation()
-        // handleSubmit re-throws whatever onSubmit rejected with (in edit mode,
-        // the mutateAsync failure). The failure is already surfaced by the
-        // caller's onError banner and the form's own submit state, so swallow it
-        // here to avoid an unhandled rejection.
+        // handleSubmit re-throws an onSubmit rejection (an edit-mode mutateAsync
+        // failure); the caller's onError banner already surfaces it, so swallow
+        // it here to avoid an unhandled rejection.
         void form.handleSubmit().catch(() => {})
       }}
     >

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -75,7 +75,11 @@ const CreateAssignmentForm = ({
       onSubmit={(e) => {
         e.preventDefault()
         e.stopPropagation()
-        form.handleSubmit()
+        // handleSubmit re-throws whatever onSubmit rejected with (in edit mode,
+        // the mutateAsync failure). The failure is already surfaced by the
+        // caller's onError banner and the form's own submit state, so swallow it
+        // here to avoid an unhandled rejection.
+        void form.handleSubmit().catch(() => {})
       }}
     >
       {/* readOnly disables every descendant control. */}

--- a/web/src/pages/assignments/EditAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.test.tsx
@@ -2,9 +2,9 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, expect, it, vi } from "vitest"
 
-const mutate = vi.fn()
+const mutateAsync = vi.fn().mockResolvedValue({})
 vi.mock("@/hooks/mutations/useEditAssignment", () => ({
-  useEditAssignment: () => ({ isPending: false, mutate }),
+  useEditAssignment: () => ({ isPending: false, mutateAsync }),
 }))
 vi.mock("@/hooks/useTrackPublishDeploy", () => ({
   useTrackPublishDeploy: () => vi.fn(),
@@ -62,7 +62,7 @@ vi.mock("./CreateAssignmentForm", () => ({
 
 import EditAssignmentForm from "./EditAssignmentForm"
 
-beforeEach(() => mutate.mockClear())
+beforeEach(() => mutateAsync.mockClear())
 
 it("passes grading form fields through the edit boundary", () => {
   render(
@@ -80,7 +80,7 @@ it("passes grading form fields through the edit boundary", () => {
     />,
   )
   fireEvent.click(screen.getByRole("button", { name: "submit" }))
-  expect(mutate).toHaveBeenCalledWith(
+  expect(mutateAsync).toHaveBeenCalledWith(
     expect.objectContaining({
       setup_timeout: 300,
       release_assets: "plots/chart.png",

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -65,8 +65,8 @@ const EditAssignmentForm = ({
           slug={assignment}
           onCancel={onCancel}
           defaultValues={assignmentToFormValues(defaultData)}
-          onSubmit={(values) => {
-            editAssignmentMutation.mutate(
+          onSubmit={async (values) => {
+            await editAssignmentMutation.mutateAsync(
               {
                 name: values.name,
                 mode: values.mode,

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -468,8 +468,18 @@ export const useAssignmentForm = (
         return Object.keys(errors).length > 0 ? { fields: errors } : undefined
       },
     },
-    onSubmit: async ({ value }) => {
+    onSubmit: async ({ value, formApi }) => {
       await onSubmit(toSubmitValues(value))
+      // Edit mode: re-baseline to what we just saved so `isDefaultValue` reads
+      // true again — the Save button returns to disabled, and a later edit
+      // re-enables it. `reset(value)` keeps the raw form values (not the
+      // submit-shaped ones) as the new pristine baseline, so the visible fields
+      // are unchanged. Skipped on create, where the page navigates away on
+      // success. Only runs when the awaited onSubmit resolves, so a failed write
+      // (which rejects) leaves the form dirty and re-submittable.
+      if (slugContext?.edit) {
+        formApi.reset(value)
+      }
     },
   })
 

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -470,13 +470,10 @@ export const useAssignmentForm = (
     },
     onSubmit: async ({ value, formApi }) => {
       await onSubmit(toSubmitValues(value))
-      // Edit mode: re-baseline to what we just saved so `isDefaultValue` reads
-      // true again — the Save button returns to disabled, and a later edit
-      // re-enables it. `reset(value)` keeps the raw form values (not the
-      // submit-shaped ones) as the new pristine baseline, so the visible fields
-      // are unchanged. Skipped on create, where the page navigates away on
-      // success. Only runs when the awaited onSubmit resolves, so a failed write
-      // (which rejects) leaves the form dirty and re-submittable.
+      // Re-baseline to the just-saved values so `isDefaultValue` reads true
+      // again — the Save button re-disables until the next edit. Awaited, so a
+      // failed write (which rejects) leaves the form dirty and re-submittable.
+      // Create navigates away on success, so this is edit-only.
       if (slugContext?.edit) {
         formApi.reset(value)
       }


### PR DESCRIPTION
## Problem

On the assignment settings page, saving changes left the page showing stale state: reopening the editor (or clicking Cancel and returning) still showed the pre-edit values until a hard refresh, and the "Save Changes" button stayed clickable after a successful save.

The root cause is the persistent app shell from #486. Previously, in-app navigation remounted the settings page, so its assignments query refetched. `useEditAssignment` relied on that remount-driven refetch and deliberately did not invalidate the cache. With the shell now mounted once and content flowing through `Outlet`, navigation no longer tears down the React Query cache, so the assignments query kept serving its stale cached value for the full 10-minute `staleTime` until a hard refresh.

## Fix

Invalidate the `assignments.json` listing on a successful edit, mirroring `useCreateAssignment` / `useEditClassroom` (which already invalidate their config listing so an edit lands regardless of the editor navigating away).

Re-baseline the form to the just-saved values on a successful write so the "Save Changes" button returns to disabled (nothing pending) and re-enables on the next edit — matching `EditClassroomForm` / `EditStudentForm`. The editor stays on the page (consistent with classroom settings) rather than navigating away. A failed save rejects, so the form stays dirty and re-submittable.

To make the awaited submit reflect real success/failure, `EditAssignmentForm` now uses `mutateAsync` (was fire-and-forget `mutate`), preserving the page's `onSuccess` / `onError` banner callbacks. The form's submit handler swallows the re-thrown rejection to avoid an unhandled promise (this also fixes a latent unhandled-rejection on the create path).

## Tests

Added rendered coverage: after a successful edit save the Save button re-disables and re-enables on the next edit; a failed save keeps the form dirty and re-submittable. Updated the `useEditAssignment` unit test to assert the new invalidation.

## Verification

`npm run check` green — tsc, eslint, prettier, arch:validate, 2968 tests pass.