### PR TITLE
feat(web): add a motion preference and consolidate browser settings

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -62,6 +62,24 @@
           }
         } catch (e) {}
       })()
+      // Anti-flash: apply the resolved reduced-motion verdict before the app
+      // renders so a motion-off user never sees a first-paint animation. Mirrors
+      // motionReduced/resolveInitialMotionPref in src/hooks/useReducedMotion.ts.
+      ;(function () {
+        try {
+          var pref = localStorage.getItem("classroom50:motion")
+          var reduced =
+            pref === "off"
+              ? true
+              : pref === "on"
+                ? false
+                : window.matchMedia &&
+                  window.matchMedia("(prefers-reduced-motion: reduce)").matches
+          if (reduced) {
+            document.documentElement.setAttribute("data-reduce-motion", "true")
+          }
+        } catch (e) {}
+      })()
     </script>
   </head>
   <body>

--- a/web/src/hooks/useReducedMotion.test.ts
+++ b/web/src/hooks/useReducedMotion.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment happy-dom
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+
+import {
+  MOTION_STORAGE_KEY,
+  motionReduced,
+  resolveInitialMotionPref,
+  storedMotionPref,
+  useReducedMotion,
+  type MotionPref,
+} from "./useReducedMotion"
+
+// The anti-flash inline script in index.html hand-mirrors the motion resolver
+// (same storage key + the three pref values + the OS media query), so the
+// pre-mount paint matches what React resolves. Guard the contract here like the
+// theme anti-flash drift test — the drift symptom (a first-paint animation for a
+// motion-off user) is nearly invisible in review.
+describe("motion anti-flash contract (index.html <-> useReducedMotion)", () => {
+  const indexHtml = readFileSync(path.join(process.cwd(), "index.html"), "utf8")
+
+  it("index.html references the same storage key", () => {
+    expect(indexHtml).toContain(MOTION_STORAGE_KEY)
+  })
+
+  it("index.html branches on the same pref values and OS query", () => {
+    expect(indexHtml).toContain('=== "off"')
+    expect(indexHtml).toContain('=== "on"')
+    expect(indexHtml).toContain("(prefers-reduced-motion: reduce)")
+    expect(indexHtml).toContain("data-reduce-motion")
+  })
+})
+
+describe("motionReduced", () => {
+  it("off always reduces; on never reduces; system follows the OS", () => {
+    expect(motionReduced("off", false)).toBe(true)
+    expect(motionReduced("off", true)).toBe(true)
+    expect(motionReduced("on", true)).toBe(false)
+    expect(motionReduced("on", false)).toBe(false)
+    expect(motionReduced("system", true)).toBe(true)
+    expect(motionReduced("system", false)).toBe(false)
+  })
+})
+
+// Drive a `prefers-reduced-motion: reduce` result plus a captured change
+// listener so tests can flip the OS preference at runtime. matchMedia isn't
+// implemented in happy-dom, so install a minimal stub.
+function stubMatchMedia(initialReduced: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>()
+  let matches = initialReduced
+  window.matchMedia = ((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) =>
+      listeners.add(cb),
+    removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) =>
+      listeners.delete(cb),
+  })) as unknown as typeof window.matchMedia
+  return {
+    listenerCount: () => listeners.size,
+    emit(reduced: boolean) {
+      matches = reduced
+      for (const cb of listeners)
+        cb({ matches: reduced } as MediaQueryListEvent)
+    },
+  }
+}
+
+function attr() {
+  return document.documentElement.getAttribute("data-reduce-motion")
+}
+
+// happy-dom (v15) doesn't back window.localStorage here, so install a minimal
+// in-memory store — the same shape the useTheme tests use.
+function installLocalStorage() {
+  const store = new Map<string, string>()
+  const localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size
+    },
+  }
+  Object.defineProperty(window, "localStorage", {
+    value: localStorage,
+    configurable: true,
+  })
+}
+
+describe("useReducedMotion", () => {
+  beforeEach(() => {
+    installLocalStorage()
+    document.documentElement.removeAttribute("data-reduce-motion")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (window as { matchMedia?: unknown }).matchMedia
+  })
+
+  describe("resolveInitialMotionPref / storedMotionPref", () => {
+    it("prefers an explicit stored choice", () => {
+      window.localStorage.setItem(MOTION_STORAGE_KEY, "off")
+      expect(resolveInitialMotionPref()).toBe("off")
+      expect(storedMotionPref()).toBe("off")
+    })
+
+    it("defaults to system when unset", () => {
+      expect(resolveInitialMotionPref()).toBe("system")
+      expect(storedMotionPref()).toBeNull()
+    })
+
+    it("ignores a corrupt stored value", () => {
+      window.localStorage.setItem(MOTION_STORAGE_KEY, "sometimes")
+      expect(resolveInitialMotionPref()).toBe("system")
+      expect(storedMotionPref()).toBeNull()
+    })
+  })
+
+  it("sets the <html> attribute when system resolves to a reducing OS", () => {
+    stubMatchMedia(true)
+    renderHook(() => useReducedMotion())
+    expect(attr()).toBe("true")
+  })
+
+  it("leaves the attribute off when system resolves to a non-reducing OS", () => {
+    stubMatchMedia(false)
+    const { result } = renderHook(() => useReducedMotion())
+    expect(attr()).toBeNull()
+    expect(result.current.reduced).toBe(false)
+  })
+
+  it("off forces the attribute on even when the OS does not reduce", () => {
+    stubMatchMedia(false)
+    const { result } = renderHook(() => useReducedMotion())
+    act(() => result.current.setPref("off"))
+    expect(attr()).toBe("true")
+    expect(result.current.reduced).toBe(true)
+    expect(window.localStorage.getItem(MOTION_STORAGE_KEY)).toBe("off")
+  })
+
+  it("on forces the attribute off even when the OS reduces", () => {
+    stubMatchMedia(true)
+    const { result } = renderHook(() => useReducedMotion())
+    expect(attr()).toBe("true")
+    act(() => result.current.setPref("on"))
+    expect(attr()).toBeNull()
+    expect(result.current.reduced).toBe(false)
+    expect(window.localStorage.getItem(MOTION_STORAGE_KEY)).toBe("on")
+  })
+
+  it("clears the key (not a sentinel) when returning to system", () => {
+    stubMatchMedia(false)
+    const { result } = renderHook(() => useReducedMotion())
+    act(() => result.current.setPref("off"))
+    expect(window.localStorage.getItem(MOTION_STORAGE_KEY)).toBe("off")
+    act(() => result.current.setPref("system"))
+    expect(window.localStorage.getItem(MOTION_STORAGE_KEY)).toBeNull()
+    expect(result.current.pref).toBe("system")
+  })
+
+  it("tracks OS changes while on system, and ignores them once overridden", () => {
+    const mql = stubMatchMedia(false)
+    const { result } = renderHook(() => useReducedMotion())
+
+    act(() => mql.emit(true))
+    expect(result.current.reduced).toBe(true)
+    expect(attr()).toBe("true")
+
+    // Force "on": later OS reduce signals no longer reduce.
+    act(() => result.current.setPref("on"))
+    act(() => mql.emit(true))
+    expect(result.current.reduced).toBe(false)
+    expect(attr()).toBeNull()
+  })
+
+  it("follows a cross-tab write and resets to system on a clear/corrupt value", () => {
+    stubMatchMedia(false)
+    const { result } = renderHook(() => useReducedMotion())
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: MOTION_STORAGE_KEY,
+          newValue: "off",
+        }),
+      )
+    })
+    expect(result.current.pref).toBe("off")
+
+    // A clear (null) or corrupt value resets to the default.
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: MOTION_STORAGE_KEY,
+          newValue: null,
+        }),
+      )
+    })
+    expect(result.current.pref).toBe("system")
+
+    // An unrelated key is ignored.
+    act(() => result.current.setPref("off"))
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "other", newValue: "system" }),
+      )
+    })
+    expect(result.current.pref).toBe("off")
+  })
+
+  it("removes the OS and storage listeners on unmount", () => {
+    const mql = stubMatchMedia(false)
+    const removeStorage = vi.spyOn(window, "removeEventListener")
+    const { unmount } = renderHook(() => useReducedMotion())
+    expect(mql.listenerCount()).toBe(1)
+
+    unmount()
+    expect(mql.listenerCount()).toBe(0)
+    expect(removeStorage).toHaveBeenCalledWith("storage", expect.any(Function))
+  })
+
+  it("exposes the tri-state pref value", () => {
+    stubMatchMedia(false)
+    const prefs: MotionPref[] = ["system", "on", "off"]
+    const { result } = renderHook(() => useReducedMotion())
+    for (const p of prefs) {
+      act(() => result.current.setPref(p))
+      expect(result.current.pref).toBe(p)
+    }
+  })
+})

--- a/web/src/hooks/useReducedMotion.ts
+++ b/web/src/hooks/useReducedMotion.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { localStorageOrNull } from "@/lib/webStorage"
+
+// Client-side motion preference. Mirrors the `useTheme` pattern: one
+// localStorage key, resolved on mount, applied by toggling an attribute on
+// <html>. Three states, so a user can override the OS in EITHER direction —
+// force motion off on a machine that doesn't set `prefers-reduced-motion`, or
+// force it on despite an OS-level reduce setting:
+//   - "system" (default): follow the OS `prefers-reduced-motion` media query.
+//   - "on":  always animate, ignoring the OS.
+//   - "off": never animate.
+// The RESOLVED verdict (a single boolean) drives both motion layers at once:
+//   - CSS: `data-reduce-motion="true"` on <html> feeds the attribute-scoped
+//     safety net in index.css (a sibling of the `@media (prefers-reduced-motion)`
+//     rule), neutralizing every CSS transition/animation.
+//   - Motion JS: the boolean flips <MotionConfig reducedMotion> between "always"
+//     and "user" (see main.tsx), so JS variants collapse too.
+export const MOTION_STORAGE_KEY = "classroom50:motion"
+
+export type MotionPref = "system" | "on" | "off"
+
+const PREFS: readonly MotionPref[] = ["system", "on", "off"] as const
+const DEFAULT_PREF: MotionPref = "system"
+
+const isMotionPref = (v: string | null): v is MotionPref =>
+  v !== null && (PREFS as readonly string[]).includes(v)
+
+// The stored explicit choice, or null when unset/corrupt (→ "system"). Kept in
+// sync with the anti-flash inline script in index.html, which reads the same key.
+export function storedMotionPref(): MotionPref | null {
+  const stored = localStorageOrNull()?.getItem(MOTION_STORAGE_KEY) ?? null
+  return isMotionPref(stored) ? stored : null
+}
+
+export function resolveInitialMotionPref(): MotionPref {
+  return storedMotionPref() ?? DEFAULT_PREF
+}
+
+function osPrefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false
+  return (
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false
+  )
+}
+
+// Fold the tri-state preference + the OS signal into the single "should we
+// suppress motion" verdict that both CSS and Motion consume.
+export function motionReduced(pref: MotionPref, osReduced: boolean): boolean {
+  if (pref === "off") return true
+  if (pref === "on") return false
+  return osReduced
+}
+
+function applyReducedMotion(reduced: boolean) {
+  if (typeof document === "undefined") return
+  const root = document.documentElement
+  if (reduced) root.setAttribute("data-reduce-motion", "true")
+  else root.removeAttribute("data-reduce-motion")
+}
+
+export function useReducedMotion() {
+  const [pref, setPrefState] = useState<MotionPref>(resolveInitialMotionPref)
+  const [osReduced, setOsReduced] = useState<boolean>(osPrefersReducedMotion)
+
+  const reduced = motionReduced(pref, osReduced)
+
+  // Reflect the resolved verdict onto <html> for the CSS layer. The first run
+  // re-asserts what the anti-flash script already applied; subsequent runs
+  // track pref/OS changes.
+  useEffect(() => {
+    applyReducedMotion(reduced)
+  }, [reduced])
+
+  // Track the OS preference (matters only while pref === "system", but the
+  // boolean is cheap to keep current) and any choice made in another tab.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const mql = window.matchMedia?.("(prefers-reduced-motion: reduce)")
+    const onOsChange = (event: MediaQueryListEvent) =>
+      setOsReduced(event.matches)
+    mql?.addEventListener("change", onOsChange)
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== MOTION_STORAGE_KEY) return
+      // A cross-tab clear (null) or corrupt value resets to the default.
+      setPrefState(isMotionPref(event.newValue) ? event.newValue : DEFAULT_PREF)
+    }
+    window.addEventListener("storage", onStorage)
+
+    return () => {
+      mql?.removeEventListener("change", onOsChange)
+      window.removeEventListener("storage", onStorage)
+    }
+  }, [])
+
+  const setPref = useCallback((next: MotionPref) => {
+    setPrefState(next)
+    const store = localStorageOrNull()
+    // "system" is the absence of an explicit choice, so clear the key rather
+    // than storing a sentinel — matches how the resolver treats a missing key.
+    if (next === "system") store?.removeItem(MOTION_STORAGE_KEY)
+    else store?.setItem(MOTION_STORAGE_KEY, next)
+  }, [])
+
+  return useMemo(() => ({ pref, reduced, setPref }), [pref, reduced, setPref])
+}

--- a/web/src/hooks/useTheme.test.ts
+++ b/web/src/hooks/useTheme.test.ts
@@ -158,6 +158,67 @@ describe("useTheme", () => {
     expect(result.current.isDark).toBe(true)
   })
 
+  describe("tri-state preference (setThemePref)", () => {
+    it("defaults pref to system when nothing is stored", () => {
+      stubMatchMedia(false)
+      const { result } = renderHook(() => useTheme())
+      expect(result.current.pref).toBe("system")
+    })
+
+    it("reflects a stored explicit theme as the pref", () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, "sumi-dark")
+      stubMatchMedia(false)
+      const { result } = renderHook(() => useTheme())
+      expect(result.current.pref).toBe("sumi-dark")
+    })
+
+    it("pins light/dark: sets pref, resolves theme, and persists", () => {
+      stubMatchMedia(false)
+      const { result } = renderHook(() => useTheme())
+      act(() => result.current.setThemePref("sumi-dark"))
+      expect(result.current.pref).toBe("sumi-dark")
+      expect(result.current.theme).toBe("sumi-dark")
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("sumi-dark")
+    })
+
+    it("system clears the stored key and re-resolves from the OS", () => {
+      const mql = stubMatchMedia(true) // OS prefers dark
+      const { result } = renderHook(() => useTheme())
+
+      act(() => result.current.setThemePref("sumi")) // pin light
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("sumi")
+
+      act(() => result.current.setThemePref("system"))
+      expect(result.current.pref).toBe("system")
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull()
+      // Back to following the OS (dark).
+      expect(result.current.theme).toBe("sumi-dark")
+
+      // And OS changes are followed again once back on system.
+      act(() => mql.emit(false))
+      expect(result.current.theme).toBe("sumi")
+    })
+
+    it("resets pref to system on a cross-tab clear", () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, "sumi-dark")
+      stubMatchMedia(false)
+      const { result } = renderHook(() => useTheme())
+      expect(result.current.pref).toBe("sumi-dark")
+
+      act(() => {
+        window.localStorage.removeItem(THEME_STORAGE_KEY)
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: THEME_STORAGE_KEY,
+            newValue: null,
+          }),
+        )
+      })
+      expect(result.current.pref).toBe("system")
+      expect(result.current.theme).toBe("sumi")
+    })
+  })
+
   it("follows OS changes only while no explicit choice is stored", () => {
     const mql = stubMatchMedia(false)
     const { result } = renderHook(() => useTheme())

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -8,6 +8,11 @@ export const THEME_STORAGE_KEY = "classroom50:theme"
 
 export type Theme = "sumi" | "sumi-dark"
 
+// The user's *preference*, distinct from the resolved `Theme`. "system" means
+// no explicit choice (follow the OS `prefers-color-scheme`); the concrete themes
+// pin light/dark. Stored as the theme name, or absent for "system".
+export type ThemePref = "system" | Theme
+
 const LIGHT: Theme = "sumi"
 const DARK: Theme = "sumi-dark"
 
@@ -22,6 +27,12 @@ export function resolveInitialTheme(): Theme {
     "(prefers-color-scheme: dark)",
   )?.matches
   return prefersDark ? DARK : LIGHT
+}
+
+// The preference to show in a settings control: the stored theme, or "system"
+// when nothing explicit is stored (the app then tracks the OS).
+export function resolveInitialThemePref(): ThemePref {
+  return storedTheme() ?? "system"
 }
 
 function storedTheme(): Theme | null {
@@ -57,6 +68,11 @@ function applyThemeAnimated(theme: Theme) {
 
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(resolveInitialTheme)
+  // The preference the UI shows: "system" while no explicit choice is stored
+  // (the app then follows the OS), else the stored theme. Tracked alongside the
+  // resolved `theme` so a settings control can offer System/Light/Dark while the
+  // rest of the app keeps consuming the concrete resolved theme.
+  const [pref, setPrefState] = useState<ThemePref>(resolveInitialThemePref)
 
   // Only an explicit user toggle cross-fades. Apply the active theme to <html>
   // here without animating: the first run re-asserts what the anti-flash script
@@ -71,9 +87,10 @@ export function useTheme() {
     applyTheme(theme)
   }, [theme])
 
-  // While the user has made no explicit choice, follow the OS and any choice
-  // made in another tab. Both listeners are no-ops once a value is stored, so a
-  // tab holding an explicit choice ignores cross-tab writes too.
+  // Follow external theme changes. The OS listener only applies while no
+  // explicit choice is stored (a stored light/dark pins the theme against OS
+  // drift); the storage listener always mirrors a cross-tab write, including a
+  // clear back to "system".
   useEffect(() => {
     if (typeof window === "undefined") return
 
@@ -87,6 +104,11 @@ export function useTheme() {
       if (event.key !== THEME_STORAGE_KEY) return
       if (event.newValue === LIGHT || event.newValue === DARK) {
         setThemeState(event.newValue)
+        setPrefState(event.newValue)
+      } else if (event.newValue === null) {
+        // A cross-tab reset to "system": drop back to following the OS.
+        setPrefState("system")
+        setThemeState(resolveInitialTheme())
       }
     }
     window.addEventListener("storage", onStorage)
@@ -103,6 +125,7 @@ export function useTheme() {
     // [theme] effect) keeps OS/cross-tab-driven changes instant.
     applyThemeAnimated(next)
     setThemeState(next)
+    setPrefState(next)
     if (typeof window !== "undefined") {
       window.localStorage.setItem(THEME_STORAGE_KEY, next)
     }
@@ -114,5 +137,36 @@ export function useTheme() {
     [persist, theme],
   )
 
-  return { theme, isDark: theme === DARK, setTheme, toggleTheme }
+  // Set the tri-state preference. "system" clears the stored choice (rather than
+  // storing a sentinel — the resolver treats a missing key as "system") and
+  // resolves the concrete theme from the current OS setting; the change still
+  // cross-fades since it's an explicit user action.
+  const setThemePref = useCallback(
+    (next: ThemePref) => {
+      if (next !== "system") {
+        persist(next)
+        return
+      }
+      setPrefState("system")
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(THEME_STORAGE_KEY)
+      }
+      const resolved = resolveInitialTheme()
+      setThemeState(resolved)
+      // Only cross-fade when the resolved theme actually differs — picking
+      // "system" while already showing the OS theme shouldn't fire a no-op
+      // View Transition.
+      if (resolved !== theme) applyThemeAnimated(resolved)
+    },
+    [persist, theme],
+  )
+
+  return {
+    theme,
+    pref,
+    isDark: theme === DARK,
+    setTheme,
+    setThemePref,
+    toggleTheme,
+  }
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -159,6 +159,10 @@ body {
     animation: none;
   }
 }
+[data-reduce-motion="true"]::view-transition-old(root),
+[data-reduce-motion="true"]::view-transition-new(root) {
+  animation: none;
+}
 
 /* Loading skeletons: a moving sheen sweeping left-to-right signals "loading"
    more clearly than a static block. Layered over daisyUI's `skeleton` base via
@@ -232,11 +236,17 @@ body {
   transform: scale(0.97);
 }
 
-/* Global safety net: honor an explicit reduced-motion preference everywhere,
-   even for animations that forgot their own guard. Near-instant rather than
-   truly 0ms so single-run transitions still fire their end events. Functional
-   spinners (daisyUI `.loading`, Tailwind `animate-spin`) are exempted so they
-   keep spinning during real async work — a frozen loading ring reads as a hang. */
+/* Global safety net: honor a reduced-motion preference everywhere, even for
+   animations that forgot their own guard. Two triggers share one rule:
+     - `@media (prefers-reduced-motion: reduce)` — the OS-level preference;
+     - `html[data-reduce-motion="true"]` — the in-app override (useReducedMotion
+       sets the attribute when the user picks "off", or "system" resolves to a
+       reducing OS), so a user can suppress motion without an OS setting.
+   Near-instant rather than truly 0ms so single-run transitions still fire their
+   end events. Functional spinners (daisyUI `.loading`, Tailwind `animate-spin`)
+   are exempted so they keep spinning during real async work — a frozen loading
+   ring reads as a hang. The JS variants collapse in parallel via <MotionConfig
+   reducedMotion> in main.tsx, which the same hook drives. */
 @media (prefers-reduced-motion: reduce) {
   *:not(.loading):not(.animate-spin),
   *::before,
@@ -246,6 +256,14 @@ body {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+[data-reduce-motion="true"] *:not(.loading):not(.animate-spin),
+[data-reduce-motion="true"] *::before,
+[data-reduce-motion="true"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
 }
 
 /* ── WCAG 2.1 AA contrast overrides ────────────────────────────────────────

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -846,6 +846,12 @@
       "heading": "Settings",
       "subheading": "Preferences for this browser. Nothing here is shared with your organizations."
     },
+    "groups": {
+      "preferences": "Preferences",
+      "preferencesDescription": "Display and interaction settings for this browser.",
+      "organizations": "Organizations",
+      "organizationsDescription": "Manage your organizations and home page."
+    },
     "hiddenOrgs": {
       "heading": "Hidden organizations",
       "subheading": "Organizations you've hidden from your home page. Unhide one to show it again.",
@@ -859,6 +865,32 @@
       "empty": "No organizations with Classroom 50 set up yet.",
       "expires": "Expires {{date}}",
       "manage": "Manage"
+    },
+    "motion": {
+      "heading": "Animations",
+      "subheading": "Control interface motion such as page transitions, menus, and other animated effects.",
+      "system": "System",
+      "systemHint": "Follow your device's reduce-motion setting.",
+      "on": "On",
+      "onHint": "Always animate.",
+      "off": "Off",
+      "offHint": "Turn off all animations.",
+      "groupAria": "Animation preference"
+    },
+    "appearance": {
+      "heading": "Appearance",
+      "subheading": "Choose a light or dark theme, or follow your device's setting.",
+      "system": "System",
+      "systemHint": "Follow your device's light/dark setting.",
+      "light": "Light",
+      "lightHint": "Always use the light theme.",
+      "dark": "Dark",
+      "darkHint": "Always use the dark theme.",
+      "groupAria": "Theme preference"
+    },
+    "language": {
+      "heading": "Language",
+      "subheading": "Switch languages or install a translated language pack."
     }
   },
   "assignments": {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -26,6 +26,7 @@ import { recordError } from "./lib/activity/activityStore"
 import { retryTransientGitHubError } from "./github-core/errors"
 import { recordGitHubFailure, recordGitHubSuccess } from "./lib/githubHealth"
 import { RateLimitOverlay } from "./components/dev/RateLimitOverlay"
+import { useReducedMotion } from "./hooks/useReducedMotion"
 
 // Safe query defaults so a new `useQuery` can't silently inherit React Query's
 // aggressive built-ins (staleTime:0 + refetchOnWindowFocus:true + retry:3). Every
@@ -81,9 +82,21 @@ console.info(
   `Classroom 50 — ${formatAppVersion()} — built ${appVersion.buildDate}`,
 )
 
+// Bridges the user's motion preference into Motion's JS layer. `reducedMotion`
+// flips between "always" (collapse every JS variant) and "user" (still honor the
+// OS query), matching the CSS layer the same hook drives via <html> attribute.
+function MotionPreferenceProvider({ children }: { children: React.ReactNode }) {
+  const { reduced } = useReducedMotion()
+  return (
+    <MotionConfig reducedMotion={reduced ? "always" : "user"}>
+      {children}
+    </MotionConfig>
+  )
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <MotionConfig reducedMotion="user">
+    <MotionPreferenceProvider>
       <QueryClientProvider client={client}>
         <GitHubAuthProvider>
           <GitHubClientProviderFromAuth>
@@ -106,6 +119,6 @@ createRoot(document.getElementById("root")!).render(
           </GitHubClientProviderFromAuth>
         </GitHubAuthProvider>
       </QueryClientProvider>
-    </MotionConfig>
+    </MotionPreferenceProvider>
   </StrictMode>,
 )

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -10,6 +10,12 @@ vi.mock("@/components/PageShell", () => ({
     <div>{children}</div>
   ),
 }))
+// LanguageSwitcher pulls in the full language/registry stack (useLanguage reads
+// i18n.language, which this suite's react-i18next mock doesn't provide); it has
+// its own tests, so stub it here to keep this suite focused on the page.
+vi.mock("@/components/settings/LanguageSwitcher", () => ({
+  LanguageSwitcher: () => <div data-testid="language-switcher" />,
+}))
 vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
 vi.mock("react-i18next", async (importActual) => {
   const actual = await importActual<typeof import("react-i18next")>()

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -21,6 +21,9 @@ import {
   sectionHighlightClass,
 } from "@/hooks/useHashSectionHighlight"
 import { TokenHealthChip } from "@/components/status/TokenHealthChip"
+import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
+import { useTheme, type ThemePref } from "@/hooks/useTheme"
+import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
 // token (a non-owner can't read/set it). The section reads token health for
@@ -41,8 +44,147 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
   const { byOrg } = useOrgServiceTokenHealth(ownedReady, !isLoading)
 
   return (
-    <Card
+    <SettingsSectionCard
       id="service-tokens"
+      heading={t("settings.serviceTokens.heading")}
+      subheading={t("settings.serviceTokens.subheading")}
+      highlighted={highlighted}
+    >
+      {isLoading ? (
+        <p className="text-sm text-base-content/60">
+          {t("settings.serviceTokens.loading")}
+        </p>
+      ) : ownedReady.length === 0 ? (
+        <p className="text-sm text-base-content/60">
+          {t("settings.serviceTokens.empty")}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {ownedReady.map((login) => {
+            const entry = byOrg[login]
+            const expiresAgo =
+              entry?.expiresAt && !Number.isNaN(Date.parse(entry.expiresAt))
+                ? new Date(entry.expiresAt).toLocaleDateString()
+                : undefined
+            return (
+              <li
+                key={login}
+                className="flex flex-col gap-2 rounded-lg border border-base-300 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <span className="truncate font-mono text-sm font-semibold">
+                    {login}
+                  </span>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-base-content/60">
+                    {entry && (
+                      <TokenHealthChip
+                        org={login}
+                        health={entry.health}
+                        loading={entry.loading}
+                      />
+                    )}
+                    {entry?.tokenName && (
+                      <span className="font-mono">{entry.tokenName}</span>
+                    )}
+                    {expiresAgo && (
+                      <span>
+                        {t("settings.serviceTokens.expires", {
+                          date: expiresAgo,
+                        })}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <RouterButton
+                  to="/$org/settings"
+                  params={{ org: login }}
+                  hash="service-token"
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0"
+                >
+                  {t("settings.serviceTokens.manage")}
+                </RouterButton>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </SettingsSectionCard>
+  )
+}
+
+// A single-choice preference rendered as an accessible radio group. Shared by
+// the Appearance and Animations sections (identical shape: labeled options with
+// a hint, current value + setter). `name` scopes the radios so the two groups
+// don't collide.
+function PreferenceRadioGroup<T extends string>({
+  name,
+  legend,
+  value,
+  onChange,
+  options,
+}: {
+  name: string
+  legend: string
+  value: T
+  onChange: (next: T) => void
+  options: { value: T; label: string; hint: string }[]
+}) {
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="sr-only">{legend}</legend>
+      {options.map((option) => {
+        const id = `${name}-${option.value}`
+        const hintId = `${id}-hint`
+        return (
+          <label
+            key={option.value}
+            htmlFor={id}
+            className="flex cursor-pointer items-start gap-3 rounded-lg border border-base-300 px-3 py-2 has-[:checked]:border-primary has-[:checked]:bg-primary/5"
+          >
+            <input
+              id={id}
+              type="radio"
+              name={name}
+              className="radio radio-sm radio-primary mt-0.5"
+              value={option.value}
+              checked={value === option.value}
+              onChange={() => onChange(option.value)}
+              aria-label={option.label}
+              aria-describedby={hintId}
+            />
+            <span className="flex flex-col">
+              <span className="text-sm font-medium">{option.label}</span>
+              <span id={hintId} className="text-xs text-base-content/60">
+                {option.hint}
+              </span>
+            </span>
+          </label>
+        )
+      })}
+    </fieldset>
+  )
+}
+
+// Card shell for a settings section: an anchor heading + subheading over its
+// body. Matches the Service-tokens / Hidden-orgs sections.
+function SettingsSectionCard({
+  id,
+  heading,
+  subheading,
+  highlighted,
+  children,
+}: {
+  id: string
+  heading: string
+  subheading: string
+  highlighted?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <Card
+      id={id}
       radius="xl"
       shadow={false}
       className={cx(
@@ -51,86 +193,186 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
       )}
     >
       <Card.Body>
-        <SectionAnchorHeading anchorId="service-tokens" className="card-title">
-          {t("settings.serviceTokens.heading")}
+        <SectionAnchorHeading anchorId={id} as="h3" className="card-title">
+          {heading}
         </SectionAnchorHeading>
-        <p className="text-sm text-base-content/70">
-          {t("settings.serviceTokens.subheading")}
-        </p>
-
-        {isLoading ? (
-          <p className="mt-4 text-sm text-base-content/60">
-            {t("settings.serviceTokens.loading")}
-          </p>
-        ) : ownedReady.length === 0 ? (
-          <p className="mt-4 text-sm text-base-content/60">
-            {t("settings.serviceTokens.empty")}
-          </p>
-        ) : (
-          <ul className="mt-4 flex flex-col gap-2">
-            {ownedReady.map((login) => {
-              const entry = byOrg[login]
-              const expiresAgo =
-                entry?.expiresAt && !Number.isNaN(Date.parse(entry.expiresAt))
-                  ? new Date(entry.expiresAt).toLocaleDateString()
-                  : undefined
-              return (
-                <li
-                  key={login}
-                  className="flex flex-col gap-2 rounded-lg border border-base-300 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
-                >
-                  <div className="flex min-w-0 flex-col gap-1">
-                    <span className="truncate font-mono text-sm font-semibold">
-                      {login}
-                    </span>
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-base-content/60">
-                      {entry && (
-                        <TokenHealthChip
-                          org={login}
-                          health={entry.health}
-                          loading={entry.loading}
-                        />
-                      )}
-                      {entry?.tokenName && (
-                        <span className="font-mono">{entry.tokenName}</span>
-                      )}
-                      {expiresAgo && (
-                        <span>
-                          {t("settings.serviceTokens.expires", {
-                            date: expiresAgo,
-                          })}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  <RouterButton
-                    to="/$org/settings"
-                    params={{ org: login }}
-                    hash="service-token"
-                    variant="outline"
-                    size="sm"
-                    className="shrink-0"
-                  >
-                    {t("settings.serviceTokens.manage")}
-                  </RouterButton>
-                </li>
-              )
-            })}
-          </ul>
-        )}
+        <p className="text-sm text-base-content/70">{subheading}</p>
+        <div className="mt-4">{children}</div>
       </Card.Body>
     </Card>
   )
 }
 
-// User settings scoped to this browser (client-side only). Today it manages the
-// set of organizations hidden from the home page; other per-browser prefs
-// (theme, language) still live in the sidebar footer.
+// Groups related setting cards under a small heading + description, so the page
+// reads as clusters (Preferences, Organizations) rather than a flat list.
+function SettingsGroup({
+  heading,
+  description,
+  children,
+}: {
+  heading: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-0.5">
+        <h2 className="text-lg font-semibold">{heading}</h2>
+        <p className="text-sm text-base-content/60">{description}</p>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+// Theme preference (System / Light / Dark), persisted per-browser via useTheme.
+// "System" follows the OS `prefers-color-scheme`. Mirrored quick-access toggle
+// lives in the sidebar footer.
+function AppearanceSection({ highlighted }: { highlighted?: boolean }) {
+  const { t } = useTranslation()
+  const { pref, setThemePref } = useTheme()
+
+  const options: { value: ThemePref; label: string; hint: string }[] = [
+    {
+      value: "system",
+      label: t("settings.appearance.system"),
+      hint: t("settings.appearance.systemHint"),
+    },
+    {
+      value: "sumi",
+      label: t("settings.appearance.light"),
+      hint: t("settings.appearance.lightHint"),
+    },
+    {
+      value: "sumi-dark",
+      label: t("settings.appearance.dark"),
+      hint: t("settings.appearance.darkHint"),
+    },
+  ]
+
+  return (
+    <SettingsSectionCard
+      id="appearance"
+      heading={t("settings.appearance.heading")}
+      subheading={t("settings.appearance.subheading")}
+      highlighted={highlighted}
+    >
+      <PreferenceRadioGroup
+        name="theme-pref"
+        legend={t("settings.appearance.groupAria")}
+        value={pref}
+        onChange={setThemePref}
+        options={options}
+      />
+    </SettingsSectionCard>
+  )
+}
+
+// Language + language-pack management. Reuses the same LanguageSwitcher the
+// profile-menu Language dialog renders, so the two stay in lockstep.
+function LanguageSection({ highlighted }: { highlighted?: boolean }) {
+  const { t } = useTranslation()
+  return (
+    <SettingsSectionCard
+      id="language"
+      heading={t("settings.language.heading")}
+      subheading={t("settings.language.subheading")}
+      highlighted={highlighted}
+    >
+      <LanguageSwitcher />
+    </SettingsSectionCard>
+  )
+}
+
+// Interface-motion preference (System / On / Off), persisted per-browser via
+// useReducedMotion. The hook drives both the CSS (<html data-reduce-motion>)
+// and Motion JS layers.
+function MotionSection({ highlighted }: { highlighted?: boolean }) {
+  const { t } = useTranslation()
+  const { pref, setPref } = useReducedMotion()
+
+  const options: { value: MotionPref; label: string; hint: string }[] = [
+    {
+      value: "system",
+      label: t("settings.motion.system"),
+      hint: t("settings.motion.systemHint"),
+    },
+    {
+      value: "on",
+      label: t("settings.motion.on"),
+      hint: t("settings.motion.onHint"),
+    },
+    {
+      value: "off",
+      label: t("settings.motion.off"),
+      hint: t("settings.motion.offHint"),
+    },
+  ]
+
+  return (
+    <SettingsSectionCard
+      id="motion"
+      heading={t("settings.motion.heading")}
+      subheading={t("settings.motion.subheading")}
+      highlighted={highlighted}
+    >
+      <PreferenceRadioGroup
+        name="motion-pref"
+        legend={t("settings.motion.groupAria")}
+        value={pref}
+        onChange={setPref}
+        options={options}
+      />
+    </SettingsSectionCard>
+  )
+}
+
+// Organizations hidden from the home page, with an Unhide affordance.
+function HiddenOrgsSection({ highlighted }: { highlighted?: boolean }) {
+  const { t } = useTranslation()
+  const { hidden, unhide } = useHiddenOrgs()
+  const hiddenLogins = [...hidden].sort((a, b) => a.localeCompare(b))
+
+  return (
+    <SettingsSectionCard
+      id="hidden-orgs"
+      heading={t("settings.hiddenOrgs.heading")}
+      subheading={t("settings.hiddenOrgs.subheading")}
+      highlighted={highlighted}
+    >
+      {hiddenLogins.length === 0 ? (
+        <p className="text-sm text-base-content/60">
+          {t("settings.hiddenOrgs.empty")}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {hiddenLogins.map((login) => (
+            <li
+              key={login}
+              className="flex items-center justify-between gap-3 rounded-lg border border-base-300 px-3 py-2"
+            >
+              <span className="truncate font-mono text-sm font-semibold">
+                {login}
+              </span>
+              <Button variant="outline" size="sm" onClick={() => unhide(login)}>
+                {t("settings.hiddenOrgs.unhide")}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SettingsSectionCard>
+  )
+}
+
+// User settings scoped to this browser (client-side only), grouped into
+// Organizations (hidden orgs, service tokens) and Preferences (animations,
+// appearance, language). Groups and the cards within them are ordered
+// alphabetically by their displayed heading. Theme and language also have
+// quick-access affordances in the sidebar footer.
 const SettingsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.settings"))
-  const { hidden, unhide } = useHiddenOrgs()
-  const hiddenLogins = [...hidden].sort((a, b) => a.localeCompare(b))
   const highlightedId = useHashSectionHighlight()
 
   return (
@@ -140,52 +382,26 @@ const SettingsPage = () => {
         subtitle={t("settings.page.subheading")}
       />
 
-      <ServiceTokensSection highlighted={highlightedId === "service-tokens"} />
+      <div className="flex flex-col gap-8">
+        <SettingsGroup
+          heading={t("settings.groups.organizations")}
+          description={t("settings.groups.organizationsDescription")}
+        >
+          <HiddenOrgsSection highlighted={highlightedId === "hidden-orgs"} />
+          <ServiceTokensSection
+            highlighted={highlightedId === "service-tokens"}
+          />
+        </SettingsGroup>
 
-      <Card
-        id="hidden-orgs"
-        radius="xl"
-        shadow={false}
-        className={cx(
-          "scroll-mt-24",
-          sectionHighlightClass(highlightedId === "hidden-orgs"),
-        )}
-      >
-        <Card.Body>
-          <SectionAnchorHeading anchorId="hidden-orgs" className="card-title">
-            {t("settings.hiddenOrgs.heading")}
-          </SectionAnchorHeading>
-          <p className="text-sm text-base-content/70">
-            {t("settings.hiddenOrgs.subheading")}
-          </p>
-
-          {hiddenLogins.length === 0 ? (
-            <p className="mt-4 text-sm text-base-content/60">
-              {t("settings.hiddenOrgs.empty")}
-            </p>
-          ) : (
-            <ul className="mt-4 flex flex-col gap-2">
-              {hiddenLogins.map((login) => (
-                <li
-                  key={login}
-                  className="flex items-center justify-between gap-3 rounded-lg border border-base-300 px-3 py-2"
-                >
-                  <span className="truncate font-mono text-sm font-semibold">
-                    {login}
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => unhide(login)}
-                  >
-                    {t("settings.hiddenOrgs.unhide")}
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </Card.Body>
-      </Card>
+        <SettingsGroup
+          heading={t("settings.groups.preferences")}
+          description={t("settings.groups.preferencesDescription")}
+        >
+          <MotionSection highlighted={highlightedId === "motion"} />
+          <AppearanceSection highlighted={highlightedId === "appearance"} />
+          <LanguageSection highlighted={highlightedId === "language"} />
+        </SettingsGroup>
+      </div>
     </PageShell>
   )
 }


### PR DESCRIPTION
## Summary

Adds an in-app animation (motion) preference and consolidates the per-browser display settings onto the Settings page, building on the recent persistent-shell / animated-navigation work.

## Motion preference

A new `useReducedMotion` hook exposes a **System / On / Off** preference (`classroom50:motion` in localStorage), layered over the OS `prefers-reduced-motion` so a user can override it in either direction. The single resolved boolean drives both motion layers at once: CSS via a `data-reduce-motion` attribute on `<html>` (a sibling of the existing `@media (prefers-reduced-motion)` safety net), and Motion's JS variants via `<MotionConfig reducedMotion>` in `main.tsx`. An anti-flash inline script in `index.html` applies the verdict before React mounts, mirroring the resolver (guarded by a drift test, like the theme anti-flash contract).

## Settings consolidation

Theme and language move onto the Settings page alongside the new Animations control, and `useTheme` gains a follow-system option (`System / Light / Dark`). The quick-access theme toggle and Language dialog stay in the profile menu. The five cards are grouped into **Organizations** and **Preferences**, and both the groups and the cards within them are ordered alphabetically by their displayed heading. Shared `SettingsGroup` / `SettingsSectionCard` / `PreferenceRadioGroup` primitives keep the sections consistent.

## Notes

Modals are intentionally left to daisyUI's built-in enter/exit animation; this change does not touch it. All new user-facing strings go through `t()` with keys in `en.json`.

## Testing

`npm run check` (tsc, eslint, prettier, arch:validate, vitest) passes: 272 files / 2988 tests. `audit_i18n.py --strict` passes with no missing or dead keys.
