### PR TITLE
feat(web): add axe-in-render a11y harness and back VPAT 3.1.1 automatically

### DIFF
--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -115,6 +115,22 @@ jobs:
             web/VPAT-INT.md
           if-no-files-found: warn
 
+      # Emit the criterion-tagged accessibility inventory (status + bound checks)
+      # and upload it. The bindings themselves are enforced by the a11y tests in
+      # `npm test`; this artifact is a downloadable rendering of that guarded
+      # state. `if: always()` so it's produced even when a later step fails.
+      - name: Generate a11y inventory
+        if: always()
+        run: npm run audit:a11y:inventory
+
+      - name: Upload a11y inventory
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-inventory
+          path: web/a11y-inventory.json
+          if-no-files-found: warn
+
       # Unit tests for the i18n audit tool itself. Its detection logic is
       # entirely regex-driven, so these lock down the source-of-truth behavior
       # (missing-key hard-fail, --strict flip, key-form capture, plural base,

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -41,6 +41,11 @@ VPAT.md
 VPAT-INT.md
 vpat-report.json
 
+# Generated accessibility inventory (criterion status + bound checks). Rendering
+# of guarded state (vpatAutomated.test.ts enforces the bindings); CI artifact,
+# never committed.
+a11y-inventory.json
+
 # Local dev launcher (machine-specific paths)
 dev.sh
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -43,6 +43,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
+        "axe-core": "^4.12.1",
         "babel-plugin-react-compiler": "^1.0.0",
         "daisyui": "^5.7.14",
         "dependency-cruiser": "^18.1.0",
@@ -61,7 +62,8 @@
         "typescript-eslint": "^8.65.0",
         "vite": "^8.2.0",
         "vite-plugin-svgr": "^5.2.0",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7148,6 +7150,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -8211,6 +8223,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -8899,6 +8918,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9627,6 +9656,20 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10266,6 +10309,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-to-js": {
@@ -11338,6 +11394,37 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/watskeburt": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
     "arch:validate": "depcruise src --config .dependency-cruiser.cjs",
     "audit:contrast": "npx vite-node scripts/genContrastAudit.ts",
     "audit:vpat": "npx vite-node scripts/genVpatReport.ts",
+    "audit:a11y": "vitest run src/test/axe.test.tsx src/test/a11yStructural.test.tsx src/util/vpatAutomated.test.ts",
+    "audit:a11y:inventory": "npx vite-node scripts/genA11yInventory.ts",
     "arch:graph": "depcruise src --config .dependency-cruiser.cjs --output-type dot | dot -T svg > dependency-graph.svg",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -56,6 +58,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
+    "axe-core": "^4.12.1",
     "babel-plugin-react-compiler": "^1.0.0",
     "daisyui": "^5.7.14",
     "dependency-cruiser": "^18.1.0",
@@ -74,7 +77,8 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^8.2.0",
     "vite-plugin-svgr": "^5.2.0",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "vitest-axe": "^0.1.0"
   },
   "overrides": {
     "eslint-plugin-jsx-a11y": {

--- a/web/scripts/genA11yInventory.ts
+++ b/web/scripts/genA11yInventory.ts
@@ -1,0 +1,32 @@
+// Writes a11y-inventory.json — a criterion-tagged snapshot of what the VPAT is
+// backed by: each criterion's status, evidence kind, and (for automated ones)
+// the hermetic check that binds it. Gitignored and uploaded as a CI artifact,
+// mirroring the contrast/VPAT report pattern; it's a rendering of guarded state
+// (vpatAutomated.test.ts enforces the bindings), never committed. Run via
+// `npm run audit:a11y:inventory`.
+
+import { writeFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { buildVpatReport } from "../src/util/vpatReport"
+import { AUTOMATED_CRITERIA } from "../src/util/vpatAutomated"
+
+const report = buildVpatReport()
+const inventory = {
+  schema: "a11y-inventory/v1",
+  generated: report.generated,
+  summary: report.summary,
+  criteria: report.criteria.map((c) => ({
+    id: c.id,
+    name: c.name,
+    status: c.status,
+    evidence: c.evidence ?? null,
+    boundCheck: AUTOMATED_CRITERIA[c.id]?.check ?? null,
+  })),
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const outPath = path.join(path.resolve(here, ".."), "a11y-inventory.json")
+writeFileSync(outPath, JSON.stringify(inventory, null, 2) + "\n", "utf8")
+console.log(`Wrote ${outPath}`)

--- a/web/src/test/a11yStructural.test.tsx
+++ b/web/src/test/a11yStructural.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { cleanup, render } from "@testing-library/react"
+
+import { Alert, Button, Card } from "@/components/ui"
+import { renderAndAxe } from "./axe"
+import { hasSingleH1 } from "@/util/a11yStructural"
+
+afterEach(cleanup)
+
+// Render-based structural checks that back the `automated` VPAT verdicts. These
+// assert DOM-observable facts (roles, names, heading structure, ARIA validity)
+// on representative accessible primitives. happy-dom has no layout engine, so
+// pixel reflow and computed focus rings are NOT asserted here — those criteria
+// stay Not Evaluated (see the plan's Open Questions), and the VPAT remarks state
+// exactly what was and wasn't machine-checked.
+
+describe("structural a11y — headings", () => {
+  it("a well-formed section renders exactly one h1 (2.4.6 / 1.3.1)", () => {
+    const { container } = render(
+      <div>
+        <h1>Accessibility</h1>
+        <h2>Color contrast</h2>
+        <h2>Conformance report</h2>
+      </div>,
+    )
+    const levels = Array.from(
+      container.querySelectorAll("h1,h2,h3,h4,h5,h6"),
+    ).map((h) => Number(h.tagName[1]))
+    expect(hasSingleH1(levels)).toBe(true)
+  })
+})
+
+describe("structural a11y — axe-clean primitives (4.1.2 Name, Role, Value)", () => {
+  it("Button exposes an accessible name and valid role", async () => {
+    const { results } = await renderAndAxe(<Button>Download report</Button>)
+    expect(results).toHaveNoViolations()
+  })
+
+  it("Alert content carries valid roles/ARIA", async () => {
+    const { results } = await renderAndAxe(
+      <Alert tone="info">Heads up: this is informational.</Alert>,
+    )
+    expect(results).toHaveNoViolations()
+  })
+
+  it("a Card with a labelled control is violation-free", async () => {
+    const { results } = await renderAndAxe(
+      <Card>
+        <Card.Body>
+          <Button aria-label="Open details">i</Button>
+        </Card.Body>
+      </Card>,
+    )
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/web/src/test/a11yStructural.test.tsx
+++ b/web/src/test/a11yStructural.test.tsx
@@ -4,7 +4,8 @@ import { cleanup, render } from "@testing-library/react"
 
 import { Alert, Button, Card } from "@/components/ui"
 import { renderAndAxe } from "./axe"
-import { hasSingleH1 } from "@/util/a11yStructural"
+import { documentHasLang, hasSingleH1 } from "@/util/a11yStructural"
+import { applyDocumentDirection } from "@/i18n/direction"
 
 afterEach(cleanup)
 
@@ -53,5 +54,22 @@ describe("structural a11y — axe-clean primitives (4.1.2 Name, Role, Value)", (
       </Card>,
     )
     expect(results).toHaveNoViolations()
+  })
+})
+
+// The runtime half of the 3.1.1 (Language of Page) binding: the static <html
+// lang> in index.html is checked in vpatAutomated.test.ts; this proves the
+// i18n layer keeps document.documentElement.lang in sync, so the criterion's
+// remark ("...updates it to match the active language at runtime") is fully
+// backed by a check and can't silently drift (adversarial finding #1).
+describe("structural a11y — 3.1.1 runtime <html lang> sync", () => {
+  it("applyDocumentDirection sets a non-empty lang on <html>", () => {
+    applyDocumentDirection("en")
+    expect(documentHasLang(document.documentElement.lang)).toBe(true)
+    expect(document.documentElement.lang).toBe("en")
+
+    applyDocumentDirection("ar-EG")
+    expect(documentHasLang(document.documentElement.lang)).toBe(true)
+    expect(document.documentElement.lang).toBe("ar-EG")
   })
 })

--- a/web/src/test/axe.test.tsx
+++ b/web/src/test/axe.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { cleanup } from "@testing-library/react"
+
+import { Button } from "@/components/ui"
+import { renderAndAxe } from "./axe"
+
+afterEach(cleanup)
+
+// Proves the harness both passes clean markup AND actually catches a violation —
+// a matcher that silently passed everything would make every `automated` verdict
+// worthless.
+describe("renderAndAxe", () => {
+  it("reports zero violations for an accessible primitive", async () => {
+    const { results } = await renderAndAxe(<Button>Save</Button>)
+    expect(results).toHaveNoViolations()
+  })
+
+  it("catches a real violation (an informative image with no alt)", async () => {
+    // eslint-disable-next-line jsx-a11y/alt-text -- deliberate violation fixture
+    const { results } = await renderAndAxe(<img src="/x.png" />)
+    expect(results.violations.length).toBeGreaterThan(0)
+    expect(results.violations.map((v) => v.id)).toContain("image-alt")
+  })
+})

--- a/web/src/test/axe.ts
+++ b/web/src/test/axe.ts
@@ -1,0 +1,51 @@
+// Hermetic axe-in-render test helper (plan -003- U1 / -004-).
+//
+// Wraps @testing-library/react render + axe-core so a test can assert a rendered
+// subtree has zero accessibility violations. This is the `automated` evidence
+// source behind the VPAT: a criterion backed by an axe/structural check flips to
+// `automated` Supports only while its check here stays green (per-criterion
+// binding, plan KTD2).
+//
+// Runs under happy-dom — a test using this MUST opt in with
+// `// @vitest-environment happy-dom` (mirroring the repo's DOM-test convention,
+// e.g. components/ui/Badge.test.tsx). Test infra under src/test/, not app code.
+
+import type { ReactElement } from "react"
+import { render } from "@testing-library/react"
+import { axe } from "vitest-axe"
+import * as matchers from "vitest-axe/matchers"
+import type { AxeMatchers } from "vitest-axe/matchers"
+import { expect } from "vitest"
+import type { AxeResults, RunOptions } from "axe-core"
+
+// Teach vitest's `expect` about the axe matcher registered below, so `tsc`
+// accepts `expect(results).toHaveNoViolations()` (the runtime extend alone
+// doesn't add the type). Interface-merge onto vitest's own interfaces; the
+// empty-body merge is an interface extension, not a redundant declaration.
+declare module "vitest" {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface Assertion extends AxeMatchers {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining extends AxeMatchers {}
+}
+
+// Register `toHaveNoViolations` once, on import. Cheap + idempotent, so any test
+// file importing this helper gets the matcher without a separate setup file.
+expect.extend(matchers)
+
+/**
+ * Render `ui` and run axe over the resulting container.
+ *
+ * Returns both the axe results (assert with `expect(results).toHaveNoViolations()`)
+ * and the RTL container, so a caller can make further structural assertions on
+ * the same tree. `axeOptions` forwards axe-core run options (e.g. to scope
+ * `runOnly` to specific rules for a criterion-focused check).
+ */
+export async function renderAndAxe(
+  ui: ReactElement,
+  axeOptions?: RunOptions,
+): Promise<{ results: AxeResults; container: HTMLElement }> {
+  const { container } = render(ui)
+  const results = await axe(container, axeOptions)
+  return { results, container }
+}

--- a/web/src/test/axe.ts
+++ b/web/src/test/axe.ts
@@ -22,6 +22,7 @@ import type { AxeResults, RunOptions } from "axe-core"
 // accepts `expect(results).toHaveNoViolations()` (the runtime extend alone
 // doesn't add the type). Interface-merge onto vitest's own interfaces; the
 // empty-body merge is an interface extension, not a redundant declaration.
+// (Drop this block if a future vitest-axe ships its own extend-expect types.)
 declare module "vitest" {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface Assertion extends AxeMatchers {}

--- a/web/src/util/a11yStructural.test.ts
+++ b/web/src/util/a11yStructural.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  documentHasLang,
+  hasNoSkippedHeadingLevels,
+  hasSingleH1,
+  meetsTargetSize,
+} from "./a11yStructural"
+
+describe("a11yStructural predicates", () => {
+  it("hasSingleH1: exactly one h1", () => {
+    expect(hasSingleH1([1, 2, 2, 3])).toBe(true)
+    expect(hasSingleH1([1, 1])).toBe(false)
+    expect(hasSingleH1([2, 3])).toBe(false)
+    expect(hasSingleH1([])).toBe(false)
+  })
+
+  it("hasNoSkippedHeadingLevels: no jump deeper than +1", () => {
+    expect(hasNoSkippedHeadingLevels([1, 2, 3, 2])).toBe(true)
+    expect(hasNoSkippedHeadingLevels([1, 3])).toBe(false) // skips h2
+    expect(hasNoSkippedHeadingLevels([])).toBe(true)
+    expect(hasNoSkippedHeadingLevels([2, 2, 1])).toBe(true) // shallower is fine
+  })
+
+  it("documentHasLang: non-empty lang", () => {
+    expect(documentHasLang("en")).toBe(true)
+    expect(documentHasLang("en-US")).toBe(true)
+    expect(documentHasLang("")).toBe(false)
+    expect(documentHasLang("   ")).toBe(false)
+    expect(documentHasLang(null)).toBe(false)
+    expect(documentHasLang(undefined)).toBe(false)
+  })
+
+  it("meetsTargetSize: 24x24 minimum", () => {
+    expect(meetsTargetSize(24, 24)).toBe(true)
+    expect(meetsTargetSize(40, 40)).toBe(true)
+    expect(meetsTargetSize(20, 44)).toBe(false)
+    expect(meetsTargetSize(44, 20)).toBe(false)
+  })
+})

--- a/web/src/util/a11yStructural.ts
+++ b/web/src/util/a11yStructural.ts
@@ -15,6 +15,10 @@ export function hasSingleH1(headingLevels: number[]): boolean {
 /**
  * True when heading levels never jump deeper by more than one at a time
  * (a well-formed outline; supports 1.3.1). An empty list is vacuously true.
+ *
+ * Staged for the heading-remediation unit (umbrella U7): not yet bound to a
+ * criterion in AUTOMATED_CRITERIA — it becomes the check behind 1.3.1 / 2.4.6
+ * once the heading structure across the app's views is clean.
  */
 export function hasNoSkippedHeadingLevels(headingLevels: number[]): boolean {
   let prev = 0

--- a/web/src/util/a11yStructural.ts
+++ b/web/src/util/a11yStructural.ts
@@ -1,0 +1,36 @@
+// Pure, DOM-free predicates for the machine-checkable structural WCAG facts
+// (plan -004- U2). Inputs are already-extracted data (heading levels, a lang
+// string, a size), so these stay a util/ leaf and unit-test directly. The
+// render-based checks that actually walk a mounted DOM live in
+// src/test/a11yStructural.test.tsx and feed these predicates.
+
+/** WCAG 2.5.8 Target Size (Minimum): interactive targets are >= 24x24 CSS px. */
+export const TARGET_SIZE_MIN = 24
+
+/** True when the page has exactly one <h1> (2.4.6 / document outline). */
+export function hasSingleH1(headingLevels: number[]): boolean {
+  return headingLevels.filter((l) => l === 1).length === 1
+}
+
+/**
+ * True when heading levels never jump deeper by more than one at a time
+ * (a well-formed outline; supports 1.3.1). An empty list is vacuously true.
+ */
+export function hasNoSkippedHeadingLevels(headingLevels: number[]): boolean {
+  let prev = 0
+  for (const level of headingLevels) {
+    if (prev !== 0 && level > prev + 1) return false
+    prev = level
+  }
+  return true
+}
+
+/** True when the document carries a non-empty `lang` (3.1.1 Language of Page). */
+export function documentHasLang(langAttr: string | null | undefined): boolean {
+  return typeof langAttr === "string" && langAttr.trim().length > 0
+}
+
+/** True when a target meets the 24x24 CSS px minimum (2.5.8). */
+export function meetsTargetSize(width: number, height: number): boolean {
+  return width >= TARGET_SIZE_MIN && height >= TARGET_SIZE_MIN
+}

--- a/web/src/util/vpatAutomated.test.ts
+++ b/web/src/util/vpatAutomated.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { CONTRAST_CRITERION_IDS, CRITERIA } from "./vpatModel"
+import { buildVpatReport } from "./vpatReport"
+import { AUTOMATED_CRITERIA } from "./vpatAutomated"
+import { documentHasLang } from "./a11yStructural"
+
+// U3 (map integrity) + U5 (per-criterion binding guard) for the `automated`
+// VPAT verdicts. Each `automated` criterion must (a) be a real, non-contrast
+// criterion and (b) have its backing check re-run and pass here — so a
+// regression fails this test and the divergence can't merge (plan KTD2).
+
+const modelIds = new Set(CRITERIA.map((c) => c.id))
+
+describe("AUTOMATED_CRITERIA map integrity (U3)", () => {
+  it("references only real criteria in the model", () => {
+    for (const id of Object.keys(AUTOMATED_CRITERIA)) {
+      expect(modelIds.has(id), `${id} not in CRITERIA`).toBe(true)
+    }
+  })
+
+  it("never lists a contrast criterion (those are derived, KTD5)", () => {
+    for (const id of CONTRAST_CRITERION_IDS) {
+      expect(
+        AUTOMATED_CRITERIA[id],
+        `${id} must not be automated`,
+      ).toBeUndefined()
+    }
+  })
+
+  it("every entry has a non-empty check name and remark", () => {
+    for (const [id, b] of Object.entries(AUTOMATED_CRITERIA)) {
+      expect(b.check.length, `${id} check`).toBeGreaterThan(0)
+      expect(b.remark.length, `${id} remark`).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("per-criterion binding guard (U5)", () => {
+  // Reverse closure: every criterion the model tags `automated` must have a
+  // binding here — no verdict without a backing check.
+  it("every automated criterion in the model has a binding", () => {
+    const report = buildVpatReport()
+    for (const c of report.criteria) {
+      if (c.evidence === "automated") {
+        expect(
+          AUTOMATED_CRITERIA[c.id],
+          `${c.id} is tagged automated but has no bound check`,
+        ).toBeDefined()
+      }
+    }
+  })
+
+  // The actual backing check for 3.1.1: the shipped index.html declares lang.
+  it("3.1.1 — index.html declares a non-empty <html lang>", () => {
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const repoWeb = path.resolve(here, "..", "..")
+    const html = readFileSync(path.join(repoWeb, "index.html"), "utf8")
+    const match = /<html[^>]*\blang="([^"]*)"/i.exec(html)
+    expect(match, "no <html lang> in index.html").not.toBeNull()
+    expect(documentHasLang(match?.[1])).toBe(true)
+  })
+})

--- a/web/src/util/vpatAutomated.ts
+++ b/web/src/util/vpatAutomated.ts
@@ -1,0 +1,33 @@
+// The criterion -> backing-check binding (plan -004- U3).
+//
+// The single source that ties an `automated` VPAT verdict to the check that
+// establishes it. vpatModel.ts flips exactly these criteria to `automated`
+// Supports (U4); vpatAutomated.test.ts asserts each one's check is green and
+// that the model never tags a criterion `automated` without an entry here (U5).
+//
+// Deliberately conservative (plan KTD4): a criterion is listed ONLY when a
+// hermetic check fully establishes it in the current tree. Criteria that are
+// only partially machine-verifiable (e.g. axe-clean on some primitives but not
+// every flow) stay Not Evaluated until remediation (umbrella U7-U10) makes a
+// whole-surface check green. Contrast criteria (1.4.3/1.4.6/1.4.11) are never
+// listed here — they are derived from the contrast audit (backbone KTD4/KTD5).
+//
+// Pure data leaf: no DOM, no app imports beyond the criterion id space.
+
+export type AutomatedBinding = {
+  /** Short name of the hermetic check that backs this verdict (for the guard). */
+  check: string
+  /** The VPAT remark stating what was machine-checked (and any residual gap). */
+  remark: string
+}
+
+export const AUTOMATED_CRITERIA: Record<string, AutomatedBinding> = {
+  "3.1.1": {
+    check: "documentHasLang(index.html + runtime <html lang>)",
+    remark:
+      "The page ships with a valid `lang` on the root <html> element and the " +
+      "app updates it to match the active language at runtime. Verified " +
+      "automatically (index.html carries lang; the i18n layer keeps " +
+      "document.documentElement.lang in sync).",
+  },
+}

--- a/web/src/util/vpatAutomated.ts
+++ b/web/src/util/vpatAutomated.ts
@@ -23,7 +23,9 @@ export type AutomatedBinding = {
 
 export const AUTOMATED_CRITERIA: Record<string, AutomatedBinding> = {
   "3.1.1": {
-    check: "documentHasLang(index.html + runtime <html lang>)",
+    check:
+      "index.html declares <html lang> (vpatAutomated.test.ts) + i18n keeps " +
+      "document.documentElement.lang in sync (a11yStructural.test.tsx)",
     remark:
       "The page ships with a valid `lang` on the root <html> element and the " +
       "app updates it to match the active language at runtime. Verified " +

--- a/web/src/util/vpatModel.test.ts
+++ b/web/src/util/vpatModel.test.ts
@@ -108,4 +108,10 @@ describe("vpatModel — criteria integrity", () => {
       expect(c?.evidence, `${id} evidence`).toBe("contrast")
     }
   })
+
+  it("marks 3.1.1 Language of Page as automated Supports (U4)", () => {
+    const c = CRITERIA.find((x) => x.id === "3.1.1")
+    expect(c?.status).toBe("supports")
+    expect(c?.evidence).toBe("automated")
+  })
 })

--- a/web/src/util/vpatModel.ts
+++ b/web/src/util/vpatModel.ts
@@ -250,8 +250,13 @@ export const CRITERIA: Criterion[] = [
     name: "Language of Page",
     level: "A",
     principle: "Understandable",
-    status: "notEvaluated",
-    remark: NOT_EVALUATED_REMARK,
+    status: "supports",
+    evidence: "automated",
+    remark:
+      "The page ships with a valid `lang` on the root <html> element and the " +
+      "app updates it to match the active language at runtime. Verified " +
+      "automatically (index.html carries lang; the i18n layer keeps " +
+      "document.documentElement.lang in sync).",
   },
   {
     id: "3.2.3",


### PR DESCRIPTION
## Summary

Stands up the **Tier-1 hermetic accessibility harness** (plan `docs/plans/2026-08-04-004-...`, umbrella U1) and wires the first machine-verifiable criterion into the VPAT as `automated` evidence — the follow-up to the VPAT backbone in #496.

- **`renderAndAxe` helper** (`src/test/axe.ts`) — `vitest-axe` + `axe-core` over a `@testing-library/react` render, under happy-dom. A harness test proves it both passes clean markup **and** catches a real violation (a missing-alt `<img>`), so it can't silently green-light everything.
- **Structural predicates** (`src/util/a11yStructural.ts`, pure leaf) — single-`<h1>`, no-skipped-heading-levels, non-empty `lang`, 24px target size — each unit-tested with true and false cases; plus render-based axe checks on representative accessible primitives.
- **Criterion→check binding** (`src/util/vpatAutomated.ts`) + a guard that re-runs each `automated` criterion's check and asserts the model never tags a criterion `automated` without a bound check (plan KTD2 — a regression fails that criterion's test, so the divergence can't merge).
- **3.1.1 Language of Page → `automated` Supports**, backed by a check that `index.html` declares `<html lang>` (the app also keeps it in sync at runtime). This is the only criterion that flips — see below.
- **`audit:a11y` script**, a gitignored criterion-tagged `a11y-inventory.json`, and a CI generate + upload step (mirroring the contrast/VPAT artifacts).

`cd web && npm run check` is green (**3176 tests**, up from 3160) and the i18n strict audit passes.

## Why only one criterion flipped

Per the plan's honesty rule (KTD4), a criterion flips to `automated` Supports **only when a hermetic check fully establishes it in the current tree**. `3.1.1` is a whole-document fact and fully verifiable. Others are only *partially* machine-checkable today — axe is clean on core primitives, but that isn't a whole-flow guarantee — so they stay **Not Evaluated** rather than overclaim. happy-dom also has no layout engine, so pixel reflow (1.4.10) and computed focus rings (2.4.7) can't be honestly asserted here. More criteria flip as the remediation units clear their surfaces.

## Follow-ups (unchanged from the umbrella plan)

- **U2 / U7–U10** — jsx-a11y ratchet + remediation of the ~30 advisory warnings; each cleared surface lets more criteria flip.
- **U11** — manual keyboard/screen-reader assessment (`evidence: "manual"`).
- **U12** — scheduled GitHub accessibility-scanner (needs a PAT secret).

## Type of change

- [x] New feature

## Checklist

- [x] Web: `cd web && npm run check` (green; 3176 tests). i18n strict audit passes.
- [ ] Cross-binary contract — n/a (web-only; no schema touched).
- [ ] CLI command/flag — n/a.
- [x] Commits follow Conventional Commits.
