### PR TITLE
fix(web): hide decorative loading skeletons from AT and name the org-notice link

### DIFF
--- a/web/src/components/OrgRepoCreationNotice.test.tsx
+++ b/web/src/components/OrgRepoCreationNotice.test.tsx
@@ -179,5 +179,9 @@ describe("OrgRepoCreationNotice", () => {
         el.getAttribute("href")?.includes("/settings/member_privileges"),
       )
     expect(manual?.getAttribute("href")).toContain("acme")
+    // The Trans-injected anchor carries an explicit accessible name (it has no
+    // JSX children), so a screen reader announces its purpose + new-tab hint.
+    expect(manual?.getAttribute("aria-label")).toMatch(/member privileges/i)
+    expect(manual?.getAttribute("aria-label")).toMatch(/new tab/i)
   })
 })

--- a/web/src/components/OrgRepoCreationNotice.tsx
+++ b/web/src/components/OrgRepoCreationNotice.tsx
@@ -54,6 +54,9 @@ export const OrgRepoCreationNotice = ({
                   href={memberPrivilegesUrl(org)}
                   target="_blank"
                   rel="noreferrer"
+                  aria-label={t(
+                    "components.notices.orgRepoCreation.memberPrivilegesLabel",
+                  )}
                 />
               ),
             }}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2720,6 +2720,7 @@
       "orgRepoCreation": {
         "master": "<org>{{org}}</org> doesn't allow members to create repositories, so no student can accept an assignment. Re-run organization setup, or allow private (not public) repository creation under <memberPrivileges>Member privileges</memberPrivileges>. An enterprise policy can override this setting.",
         "private": "<org>{{org}}</org> doesn't allow members to create private repositories, so no student can accept an assignment. Re-run organization setup, or allow private (not public) repository creation under <memberPrivileges>Member privileges</memberPrivileges>. An enterprise policy can override this setting.",
+        "memberPrivilegesLabel": "Member privileges (opens GitHub organization settings in a new tab)",
         "action": "Organization settings"
       }
     },

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -315,7 +315,9 @@ const ReleaseDateBadge = ({ assignment }: { assignment: Assignment }) => {
 const SkeletonRows = ({ rows = 4 }: { rows?: number }) => (
   <>
     {Array.from({ length: rows }).map((_, i) => (
-      <tr key={i}>
+      // Decorative loading placeholder — hidden from assistive tech so a screen
+      // reader announces the table's busy state, not rows of empty cells.
+      <tr key={i} aria-hidden="true">
         <td>
           <div className="skeleton skeleton-shimmer h-4 w-40" />
         </td>
@@ -376,7 +378,7 @@ const AssignmentsTable = ({
       key={loading ? "loading" : "loaded"}
       className="overflow-x-auto rounded-box border border-base-content/5 bg-base-100"
     >
-      <table className="table">
+      <table className="table" aria-busy={loading}>
         <caption className="sr-only">{t("assignments.table.caption")}</caption>
         <thead>
           <tr>

--- a/web/src/pages/students/RosterPreviewTable.test.tsx
+++ b/web/src/pages/students/RosterPreviewTable.test.tsx
@@ -177,5 +177,26 @@ describe("RosterPreviewTable change highlighting", () => {
     expect(screen.getByText("ada")).toBeTruthy()
     // ...but no role Select renders while loading (its change is unknown yet).
     expect(container.querySelector("select")).toBeNull()
+    // The table announces its busy state, and the decorative skeleton rows are
+    // hidden from assistive tech (no rows of empty cells read aloud).
+    expect(container.querySelector("table")?.getAttribute("aria-busy")).toBe(
+      "true",
+    )
+    for (const tr of container.querySelectorAll("tbody tr")) {
+      expect(tr.getAttribute("aria-hidden")).toBe("true")
+    }
+  })
+
+  it("clears aria-busy once loaded", () => {
+    const { container } = render(
+      <RosterPreviewTable
+        rows={rows}
+        rolesByUser={{}}
+        onRoleChange={vi.fn()}
+      />,
+    )
+    expect(container.querySelector("table")?.getAttribute("aria-busy")).toBe(
+      "false",
+    )
   })
 })

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -104,7 +104,7 @@ export const RosterPreviewTable = ({
   const { t } = useTranslation()
   return (
     <div className="max-h-80 overflow-auto rounded-box border border-base-300">
-      <table className="table table-sm">
+      <table className="table table-sm" aria-busy={loading}>
         <thead>
           <tr>
             <th scope="col">#</th>
@@ -118,7 +118,8 @@ export const RosterPreviewTable = ({
         <tbody>
           {loading
             ? rows.map((row, index) => (
-                <tr key={row.username.toLowerCase()}>
+                // Decorative loading placeholder — hidden from assistive tech.
+                <tr key={row.username.toLowerCase()} aria-hidden="true">
                   <td>{index + 1}</td>
                   <td>
                     <code>{row.username}</code>


### PR DESCRIPTION
## Summary

Genuine accessibility fixes surfaced by the labeling workstream (umbrella `-003-` U7), shipped as a small, safe subset — **no lint ratchet** (see below).

- **Decorative loading skeletons are hidden from assistive tech.** The skeleton loading rows in the assignments table and the roster-preview table are marked `aria-hidden="true"`, and the tables set `aria-busy` while loading — so a screen reader announces the busy state instead of reading rows of empty cells.
- **The org-notice member-privileges link now has an accessible name.** `OrgRepoCreationNotice`'s link is injected by `<Trans>` (no JSX children), so it tripped `anchor-has-content`. It now carries an explicit `aria-label` naming its purpose and its new-tab behavior — clearing the warning honestly.

Render tests assert the busy/hidden states (both loading and loaded) and the link's accessible name. `cd web && npm run check` is green (3178 tests) and the i18n audit passes.

## Why no ratchet (scope note)

U7 planned to drive `control-has-associated-label` to zero and flip it to `error`. Execution found that rule **over-fires on non-interactive `<td>` cells** (11 of 13 warnings are decorative skeleton/content cells), and neither `aria-hidden` (doesn't satisfy the rule) nor the rule's `ignoreElements` option (backfired — inflated the count) cleanly zeroes it. Rather than push fake `aria-label`s onto decorative cells or force a heavier rule-scoping decision inside execution, this PR ships only the **two genuine improvements** and leaves `control-has-associated-label` / `label-has-associated-control` advisory. Ratcheting them is deferred to a follow-up that decides the rule-scoping approach deliberately.

## Type of change

- [x] Bug fix (accessibility)

## Checklist

- [x] Web: `cd web && npm run check` (green; 3178 tests). i18n strict audit passes.
- [ ] Cross-binary contract — n/a.
- [ ] CLI command/flag — n/a.
- [x] Commits follow Conventional Commits.
