### PR TITLE
feat(web): ratchet the jsx-a11y label rules to blocking

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -59,7 +59,10 @@ export default defineConfig([
       // advisory-warning convention (react-hooks/no-console above).
       "jsx-a11y/alt-text": "warn",
       "jsx-a11y/anchor-ambiguous-text": "warn",
-      "jsx-a11y/anchor-has-content": "warn",
+      // Blocking (ratcheted): these three labeling rules are at zero and a
+      // regression is a real a11y defect (an unnamed control/link/label). The
+      // rest of the jsx-a11y set stays advisory until its own remediation lands.
+      "jsx-a11y/anchor-has-content": "error",
       "jsx-a11y/anchor-is-valid": "warn",
       "jsx-a11y/aria-activedescendant-has-tabindex": "warn",
       "jsx-a11y/aria-props": "warn",
@@ -68,13 +71,13 @@ export default defineConfig([
       "jsx-a11y/aria-unsupported-elements": "warn",
       "jsx-a11y/autocomplete-valid": "warn",
       "jsx-a11y/click-events-have-key-events": "warn",
-      "jsx-a11y/control-has-associated-label": "warn",
+      "jsx-a11y/control-has-associated-label": "error",
       "jsx-a11y/heading-has-content": "warn",
       "jsx-a11y/html-has-lang": "warn",
       "jsx-a11y/iframe-has-title": "warn",
       "jsx-a11y/img-redundant-alt": "warn",
       "jsx-a11y/interactive-supports-focus": "warn",
-      "jsx-a11y/label-has-associated-control": "warn",
+      "jsx-a11y/label-has-associated-control": "error",
       "jsx-a11y/media-has-caption": "warn",
       "jsx-a11y/mouse-events-have-key-events": "warn",
       "jsx-a11y/no-access-key": "warn",

--- a/web/src/components/RequireRole.test.tsx
+++ b/web/src/components/RequireRole.test.tsx
@@ -29,7 +29,9 @@ vi.mock("@/components/RoleResolvingFallback", () => ({
 }))
 vi.mock("@/components/QueryErrorAlert", () => ({
   QueryErrorAlert: ({ onRetry }: { onRetry: () => void }) => (
-    <button data-testid="error-retry" onClick={onRetry} />
+    <button data-testid="error-retry" onClick={onRetry}>
+      Retry
+    </button>
   ),
 }))
 vi.mock("react-i18next", () => ({

--- a/web/src/components/ui/SkeletonCell.test.tsx
+++ b/web/src/components/ui/SkeletonCell.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { cleanup, render } from "@testing-library/react"
+
+import { SkeletonCell } from "./SkeletonCell"
+
+afterEach(cleanup)
+
+// SkeletonCell is a decorative loading placeholder. The load-bearing facts are
+// that the <td> is hidden from assistive tech (also what clears the now-blocking
+// control-has-associated-label rule) and that the bar utilities compose onto the
+// skeleton div.
+describe("SkeletonCell", () => {
+  it("hides the cell from assistive tech", () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <tr>
+            <SkeletonCell bar="h-4 w-40" />
+          </tr>
+        </tbody>
+      </table>,
+    )
+    const td = container.querySelector("td")
+    expect(td?.getAttribute("aria-hidden")).toBe("true")
+  })
+
+  it("composes the bar utilities onto the skeleton div", () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <tr>
+            <SkeletonCell bar="ms-auto h-8 w-16" />
+          </tr>
+        </tbody>
+      </table>,
+    )
+    const bar = container.querySelector("td > div")
+    expect(bar?.className).toContain("skeleton")
+    expect(bar?.className).toContain("ms-auto")
+    expect(bar?.className).toContain("h-8")
+  })
+
+  it("applies optional cell-level layout", () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <tr>
+            <SkeletonCell bar="h-4 w-40" tdClassName="text-end" />
+          </tr>
+        </tbody>
+      </table>,
+    )
+    expect(container.querySelector("td")?.className).toContain("text-end")
+  })
+})

--- a/web/src/components/ui/SkeletonCell.tsx
+++ b/web/src/components/ui/SkeletonCell.tsx
@@ -1,0 +1,25 @@
+import { cx } from "./cx"
+
+// A decorative loading-skeleton table cell. `aria-hidden` is on the <td> itself
+// (not just the row) for two reasons: it hides the placeholder from assistive
+// tech so a screen reader announces the table's busy state instead of rows of
+// empty cells, AND jsx-a11y/control-has-associated-label inspects the cell — the
+// attribute is what clears that (now blocking) rule for an empty skeleton cell.
+//
+// `bar` is the skeleton bar's size/position utilities (e.g. "h-4 w-40",
+// "ms-auto h-8 w-16"); `tdClassName` is optional layout on the cell itself.
+
+export type SkeletonCellProps = {
+  bar: string
+  tdClassName?: string
+}
+
+export function SkeletonCell({ bar, tdClassName }: SkeletonCellProps) {
+  return (
+    <td aria-hidden="true" className={tdClassName}>
+      <div className={cx("skeleton skeleton-shimmer", bar)} />
+    </td>
+  )
+}
+
+export default SkeletonCell

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -53,6 +53,9 @@ export type { FileDropzoneProps, PickedFile } from "./FileDropzone"
 export { StatCard } from "./StatCard"
 export type { StatCardProps } from "./StatCard"
 
+export { SkeletonCell } from "./SkeletonCell"
+export type { SkeletonCellProps } from "./SkeletonCell"
+
 export { TablePagination } from "./TablePagination"
 export type { TablePaginationProps } from "./TablePagination"
 

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -27,7 +27,7 @@ import { useSetAssignmentLock } from "@/hooks/mutations/useSetAssignmentLock"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import type { Assignment } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
-import { Badge, Button, EmphasisLtr } from "@/components/ui"
+import { Badge, Button, EmphasisLtr, SkeletonCell } from "@/components/ui"
 
 const DeleteAssignmentButton = ({
   org,
@@ -312,27 +312,18 @@ const ReleaseDateBadge = ({ assignment }: { assignment: Assignment }) => {
   )
 }
 
-// One decorative skeleton cell. `aria-hidden` is on the <td> itself (not just
-// the row) because jsx-a11y/control-has-associated-label inspects the cell — the
-// attribute both hides the placeholder from AT and satisfies the rule.
-const SkeletonCell = ({ className }: { className: string }) => (
-  <td aria-hidden="true">
-    <div className={`skeleton skeleton-shimmer ${className}`} />
-  </td>
-)
-
 const SkeletonRows = ({ rows = 4 }: { rows?: number }) => (
   <>
     {Array.from({ length: rows }).map((_, i) => (
       // Decorative loading placeholder — hidden from assistive tech so a screen
       // reader announces the table's busy state, not rows of empty cells.
       <tr key={i} aria-hidden="true">
-        <SkeletonCell className="h-4 w-40" />
-        <SkeletonCell className="h-4 w-24" />
-        <SkeletonCell className="h-6 w-28" />
-        <SkeletonCell className="h-6 w-28" />
-        <SkeletonCell className="h-4 w-56" />
-        <SkeletonCell className="ms-auto h-8 w-16" />
+        <SkeletonCell bar="h-4 w-40" />
+        <SkeletonCell bar="h-4 w-24" />
+        <SkeletonCell bar="h-6 w-28" />
+        <SkeletonCell bar="h-6 w-28" />
+        <SkeletonCell bar="h-4 w-56" />
+        <SkeletonCell bar="ms-auto h-8 w-16" />
       </tr>
     ))}
   </>

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -312,30 +312,27 @@ const ReleaseDateBadge = ({ assignment }: { assignment: Assignment }) => {
   )
 }
 
+// One decorative skeleton cell. `aria-hidden` is on the <td> itself (not just
+// the row) because jsx-a11y/control-has-associated-label inspects the cell — the
+// attribute both hides the placeholder from AT and satisfies the rule.
+const SkeletonCell = ({ className }: { className: string }) => (
+  <td aria-hidden="true">
+    <div className={`skeleton skeleton-shimmer ${className}`} />
+  </td>
+)
+
 const SkeletonRows = ({ rows = 4 }: { rows?: number }) => (
   <>
     {Array.from({ length: rows }).map((_, i) => (
       // Decorative loading placeholder — hidden from assistive tech so a screen
       // reader announces the table's busy state, not rows of empty cells.
       <tr key={i} aria-hidden="true">
-        <td>
-          <div className="skeleton skeleton-shimmer h-4 w-40" />
-        </td>
-        <td>
-          <div className="skeleton skeleton-shimmer h-4 w-24" />
-        </td>
-        <td>
-          <div className="skeleton skeleton-shimmer h-6 w-28" />
-        </td>
-        <td>
-          <div className="skeleton skeleton-shimmer h-6 w-28" />
-        </td>
-        <td>
-          <div className="skeleton skeleton-shimmer h-4 w-56" />
-        </td>
-        <td>
-          <div className="skeleton skeleton-shimmer ms-auto h-8 w-16" />
-        </td>
+        <SkeletonCell className="h-4 w-40" />
+        <SkeletonCell className="h-4 w-24" />
+        <SkeletonCell className="h-6 w-28" />
+        <SkeletonCell className="h-6 w-28" />
+        <SkeletonCell className="h-4 w-56" />
+        <SkeletonCell className="ms-auto h-8 w-16" />
       </tr>
     ))}
   </>

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -524,11 +524,9 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                         </td>
 
                         <td>
-                          <div className="max-w-xs">
-                            <pre className="max-w-[12rem] truncate rounded bg-base-200 p-2 text-xs">
-                              {test.run || "-"}
-                            </pre>
-                          </div>
+                          <pre className="max-w-[12rem] truncate rounded bg-base-200 p-2 text-xs">
+                            {test.run || "-"}
+                          </pre>
                         </td>
 
                         <td>

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -207,6 +207,11 @@ const CreateClassroomForm = ({
         <form.Field name="protectPages">
           {(field) => (
             <div className="mt-2 rounded-box border border-base-200 p-4">
+              {/* Valid wrapping label: it contains its checkbox control and
+                  visible text. jsx-a11y can't see the text past its default
+                  depth (it sits in a nested <span>), so this is a false
+                  positive — the control IS associated. */}
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
               <label className="flex cursor-pointer items-start gap-3">
                 <input
                   type="checkbox"

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -124,16 +124,16 @@ export const RosterPreviewTable = ({
                   <td>
                     <code>{row.username}</code>
                   </td>
-                  <td>
+                  <td aria-hidden="true">
                     <div className="skeleton skeleton-shimmer h-4 w-28" />
                   </td>
-                  <td>
+                  <td aria-hidden="true">
                     <div className="skeleton skeleton-shimmer h-4 w-40" />
                   </td>
-                  <td>
+                  <td aria-hidden="true">
                     <div className="skeleton skeleton-shimmer h-4 w-16" />
                   </td>
-                  <td>
+                  <td aria-hidden="true">
                     <div className="skeleton skeleton-shimmer h-8 w-32" />
                   </td>
                 </tr>

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Select } from "@/components/ui"
+import { Select, SkeletonCell } from "@/components/ui"
 import type { ImportRosterRow } from "@/domain/students"
 import type { ClassroomRole } from "@/util/teamRoster"
 import {
@@ -124,18 +124,10 @@ export const RosterPreviewTable = ({
                   <td>
                     <code>{row.username}</code>
                   </td>
-                  <td aria-hidden="true">
-                    <div className="skeleton skeleton-shimmer h-4 w-28" />
-                  </td>
-                  <td aria-hidden="true">
-                    <div className="skeleton skeleton-shimmer h-4 w-40" />
-                  </td>
-                  <td aria-hidden="true">
-                    <div className="skeleton skeleton-shimmer h-4 w-16" />
-                  </td>
-                  <td aria-hidden="true">
-                    <div className="skeleton skeleton-shimmer h-8 w-32" />
-                  </td>
+                  <SkeletonCell bar="h-4 w-28" />
+                  <SkeletonCell bar="h-4 w-40" />
+                  <SkeletonCell bar="h-4 w-16" />
+                  <SkeletonCell bar="h-8 w-32" />
                 </tr>
               ))
             : rows.map((row, index) => {


### PR DESCRIPTION
## Summary

Completes the accessibility ratchet the labeling PRs (#497, #498) set up: drives the three jsx-a11y **labeling** rules to zero, then promotes them `warn`→`error` so an unnamed control, link, or label now **fails CI**.

The residual warnings were the rule over-firing on decorative `<td>` cells — resolved by the a11y-correct fix (hide the cell from assistive tech), verified against the rule's own source (`isHiddenFromScreenReader` is an early-return checked on the element, so `aria-hidden` on the `<td>` clears it — `aria-hidden` on the row, as in #498, does not).

- **Skeleton cells** in `AssignmentsTable` (via a small `SkeletonCell` helper) and `RosterPreviewTable` get `aria-hidden` on the `<td>` itself — hidden from AT *and* clears the rule.
- **`AutogradingTestsPane`**: dropped a redundant wrapper `<div>` so the command `<pre>` text falls within the rule's label-recursion depth (the `<pre>` keeps its own max-width/truncation — no visual change).
- **`CreateClassroomForm`**: one justified `eslint-disable` line — a valid wrapping label whose visible text sits past the rule's default depth (a false positive; the checkbox IS the associated control).
- **`RequireRole.test.tsx`**: the mock retry button gets visible text.
- **Ratchet**: `control-has-associated-label`, `anchor-has-content`, and `label-has-associated-control` flipped to `error`. The other ~15 jsx-a11y warnings stay advisory (U8–U10 territory).

`cd web && npm run check` is green (3178 tests), `eslint .` reports **0 errors**, and the i18n audit passes.

## Verification

Temporarily re-introducing an unlabeled control fails `eslint` under the promoted rules — the gate blocks a real regression (verified during development, not committed).

## Type of change

- [x] New feature (CI enforcement)

## Checklist

- [x] Web: `cd web && npm run check` (green; 3178 tests; 0 eslint errors). i18n audit passes.
- [ ] Cross-binary contract — n/a.
- [ ] CLI command/flag — n/a.
- [x] Commits follow Conventional Commits.
