### PR TITLE
feat(web): remediate keyboard/focus a11y and ratchet those rules

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -59,18 +59,21 @@ export default defineConfig([
       // advisory-warning convention (react-hooks/no-console above).
       "jsx-a11y/alt-text": "warn",
       "jsx-a11y/anchor-ambiguous-text": "warn",
-      // Blocking (ratcheted): these three labeling rules are at zero and a
-      // regression is a real a11y defect (an unnamed control/link/label). The
-      // rest of the jsx-a11y set stays advisory until its own remediation lands.
+      // Blocking (ratcheted): labeling rules (anchor-has-content,
+      // control-has-associated-label, label-has-associated-control) and
+      // keyboard/focus rules (anchor-is-valid, click-events-have-key-events,
+      // no-static-element-interactions, no-noninteractive-tabindex) are at zero;
+      // a regression is a real a11y defect. The rest stays advisory until its
+      // own remediation lands.
       "jsx-a11y/anchor-has-content": "error",
-      "jsx-a11y/anchor-is-valid": "warn",
+      "jsx-a11y/anchor-is-valid": "error",
       "jsx-a11y/aria-activedescendant-has-tabindex": "warn",
       "jsx-a11y/aria-props": "warn",
       "jsx-a11y/aria-proptypes": "warn",
       "jsx-a11y/aria-role": "warn",
       "jsx-a11y/aria-unsupported-elements": "warn",
       "jsx-a11y/autocomplete-valid": "warn",
-      "jsx-a11y/click-events-have-key-events": "warn",
+      "jsx-a11y/click-events-have-key-events": "error",
       "jsx-a11y/control-has-associated-label": "error",
       "jsx-a11y/heading-has-content": "warn",
       "jsx-a11y/html-has-lang": "warn",
@@ -88,9 +91,9 @@ export default defineConfig([
       "jsx-a11y/no-interactive-element-to-noninteractive-role": "warn",
       "jsx-a11y/no-noninteractive-element-interactions": "warn",
       "jsx-a11y/no-noninteractive-element-to-interactive-role": "warn",
-      "jsx-a11y/no-noninteractive-tabindex": "warn",
+      "jsx-a11y/no-noninteractive-tabindex": "error",
       "jsx-a11y/no-redundant-roles": "warn",
-      "jsx-a11y/no-static-element-interactions": "warn",
+      "jsx-a11y/no-static-element-interactions": "error",
       "jsx-a11y/role-has-required-aria-props": "warn",
       "jsx-a11y/role-supports-aria-props": "warn",
       "jsx-a11y/scope": "warn",

--- a/web/src/auth/LoginLanguageMenu.tsx
+++ b/web/src/auth/LoginLanguageMenu.tsx
@@ -88,6 +88,7 @@ export function LoginLanguageMenu() {
       </Button>{" "}
       <ul
         tabIndex={0}
+        role="menu"
         className="dropdown-content menu z-10 mt-1 max-h-80 w-60 flex-nowrap overflow-y-auto rounded-box border border-base-content/5 bg-base-100 p-1 shadow"
       >
         <li className="menu-title text-xs">

--- a/web/src/components/PermissionErrorBoundary.test.tsx
+++ b/web/src/components/PermissionErrorBoundary.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@/components/ui", async (importOriginal) => {
   return {
     ...actual,
     RouterButton: ({ children }: { children: React.ReactNode }) => (
-      <a>{children}</a>
+      <a href="/mock">{children}</a>
     ),
   }
 })

--- a/web/src/components/drawer/SidebarFooter.tsx
+++ b/web/src/components/drawer/SidebarFooter.tsx
@@ -184,23 +184,7 @@ export const SidebarFooter = () => {
       ) : null}
       <div
         ref={footerRef}
-        className={`relative cursor-pointer border-t border-neutral-content/20 py-3 transition-colors hover:bg-[var(--sidebar-surface)]/60 ${org ? "" : "mt-auto"}`}
-        onClick={() => setMenuOpen((open) => !open)}
-        role="button"
-        tabIndex={0}
-        aria-haspopup="menu"
-        aria-expanded={menuOpen}
-        aria-label={t("nav.accountMenu")}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault()
-            setMenuOpen((open) => !open)
-          }
-
-          if (event.key === "Escape") {
-            setMenuOpen(false)
-          }
-        }}
+        className={`relative border-t border-neutral-content/20 ${org ? "" : "mt-auto"}`}
       >
         <div
           className={`
@@ -215,7 +199,6 @@ export const SidebarFooter = () => {
             : "pointer-events-none translate-y-2 scale-95 opacity-0"
         }
       `}
-          onClick={(event) => event.stopPropagation()}
         >
           <ul className="menu w-full rounded-box border border-base-300 bg-base-100 p-2 text-base-content shadow-xl">
             {canPreviewRoles && (
@@ -359,8 +342,17 @@ export const SidebarFooter = () => {
           </ul>
         </div>
 
-        <div
-          className={`flex w-full items-center gap-2.5 text-start ${collapsed ? "flex-col justify-center" : "justify-start"}`}
+        <button
+          type="button"
+          onClick={() => setMenuOpen((open) => !open)}
+          onKeyDown={(event) => {
+            // Native <button> handles Enter/Space; Escape-to-close is not native.
+            if (event.key === "Escape") setMenuOpen(false)
+          }}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          aria-label={t("nav.accountMenu")}
+          className={`flex w-full cursor-pointer items-center gap-2.5 py-3 text-start transition-colors hover:bg-[var(--sidebar-surface)]/60 ${collapsed ? "flex-col justify-center" : "justify-start"}`}
           title={collapsed ? name : undefined}
         >
           <div className="avatar avatar-placeholder">
@@ -407,7 +399,7 @@ export const SidebarFooter = () => {
               )}
             </div>
           )}
-        </div>
+        </button>
       </div>
 
       {createPortal(

--- a/web/src/pages/AssignmentSettingsPage.test.tsx
+++ b/web/src/pages/AssignmentSettingsPage.test.tsx
@@ -15,7 +15,9 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-router")>()
   return {
     ...actual,
-    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    Link: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
     useParams: () => ({
       org: "acme",
       classroom: "cs101",

--- a/web/src/pages/AssignmentsPage.test.tsx
+++ b/web/src/pages/AssignmentsPage.test.tsx
@@ -20,7 +20,9 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-router")>()
   return {
     ...actual,
-    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    Link: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
     useParams: () => ({ org: "acme", classroom: "cs101" }),
   }
 })

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -66,6 +66,7 @@ const NewAssignmentButton = ({
           </Button>
           <ul
             tabIndex={0}
+            role="menu"
             className="dropdown-content menu z-10 mt-1 w-max rounded-box border border-base-content/5 bg-base-100 p-1 shadow"
           >
             <li>

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -48,6 +48,7 @@ const NewClassroomButton = ({ org }: { org: string }) => {
         </Button>
         <ul
           tabIndex={0}
+          role="menu"
           className="dropdown-content menu z-10 mt-1 w-max rounded-box border border-base-content/5 bg-base-100 p-1 shadow"
         >
           {/* FEATURE: github-classroom-migration — removable entry point (#312) */}

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -249,6 +249,7 @@ function HideOrgMenu({
         </Button>
         <ul
           tabIndex={0}
+          role="menu"
           className="menu dropdown-content z-10 mt-1 w-48 rounded-box border border-base-content/5 bg-base-100 p-1 shadow"
         >
           {canManageToken && (

--- a/web/src/pages/assignments/AdvancedRuntimeFields.tsx
+++ b/web/src/pages/assignments/AdvancedRuntimeFields.tsx
@@ -163,6 +163,7 @@ export const LanguageVersionField = ({
               {!disabled && (
                 <ul
                   tabIndex={0}
+                  role="menu"
                   className="dropdown-content menu z-10 mt-1 w-full rounded-box border border-base-content/5 bg-base-100 p-1 shadow"
                 >
                   {meta.versions.map((version) => (

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -15,7 +15,9 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-router")>()
   return {
     ...actual,
-    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    Link: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
     useNavigate: () => () => {},
   }
 })

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -256,6 +256,7 @@ const ClassroomList = ({
             </Button>
             <ul
               tabIndex={0}
+              role="menu"
               className="dropdown-content menu z-10 mt-1 w-max rounded-box border border-base-content/5 bg-base-100 p-1 shadow"
             >
               {/* FEATURE: github-classroom-migration — removable entry point (#312) */}

--- a/web/src/pages/submissions/AcceptLinkModal.test.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.test.tsx
@@ -16,7 +16,9 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-router")>()
   return {
     ...actual,
-    Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    Link: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
   }
 })
 
@@ -43,7 +45,9 @@ vi.mock("@/components/ui", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/components/ui")>()
   return {
     ...actual,
-    RouterButton: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+    RouterButton: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
   }
 })
 

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -131,6 +131,7 @@ export function SubmissionsActionsMenu({
       </Button>
       <ul
         tabIndex={0}
+        role="menu"
         className="dropdown-content menu z-10 mt-1 w-64 rounded-box border border-base-content/5 bg-base-100 p-1 shadow"
       >
         {/* Metrics — graded-snapshot stats; hidden in live view (onMetrics


### PR DESCRIPTION
## Summary

Implements umbrella U8 (keyboard/focus), following the proven fix→zero→flip ratchet from #499. Clears the four keyboard/focus `jsx-a11y` rules and promotes them to `error`.

- **7 daisyUI dropdown menus** (`<ul tabIndex={0} className="…menu…">` in `SubmissionsActionsMenu`, `LoginLanguageMenu`, `AssignmentsPage`, `ClassesPage`, `OrgsPage`, `ClassroomList`, `AdvancedRuntimeFields`) get **`role="menu"`** — a valid interactive role for the focusable list, clearing `no-noninteractive-tabindex` (verified against the rule) and improving the menus' ARIA.
- **`SidebarFooter` account trigger** was a `<div role="button" tabIndex onClick onKeyDown>` (hand-rolled keyboard handling). It's now a real **`<button>`**: native Enter/Space activation, Escape-to-close kept (not native), outside-click via the container `ref` intact. The popup menu stays a sibling (a `<button>` can't contain interactive descendants), and the now-vestigial `stopPropagation` on the popup container is removed — the trigger is no longer an ancestor of the menu, so clicks don't bubble to it. Clears `no-static-element-interactions` + `click-events-have-key-events` (both were the same line).
- **6 router-mock `<a>` test fixtures** get a valid `href` — clears `anchor-is-valid` (no test relies on the anchor role).
- **Ratchet:** `no-noninteractive-tabindex`, `no-static-element-interactions`, `click-events-have-key-events`, and `anchor-is-valid` flipped to `error`.

`cd web && npm run check` is green (3181 tests), `eslint .` reports **0 errors**, and the i18n audit passes.

## Verification note

The `SidebarFooter` change is behavior-bearing — the drawer tests (menu open/close, keyboard activation, Escape) pass. It's also **user-visible**, and I couldn't visually confirm the footer renders pixel-identical (no browser tooling in this environment); the clickable classes (`cursor-pointer`, `hover:bg`, `py-3`, full-width) were preserved on the new `<button>`. Worth a quick visual glance on the deployed preview.

## Type of change

- [x] New feature (a11y + CI enforcement)

## Checklist

- [x] Web: `cd web && npm run check` (green; 3181 tests; 0 eslint errors). i18n audit passes.
- [ ] Cross-binary contract — n/a.
- [ ] CLI command/flag — n/a.
- [x] Commits follow Conventional Commits.
