### PR TITLE
feat(web): report resize text and text spacing as automated Supports (1.4.4/1.4.12)

### DIFF
--- a/web/src/test/browserProjectWiring.test.ts
+++ b/web/src/test/browserProjectWiring.test.ts
@@ -39,10 +39,11 @@ describe("vitest browser-project wiring (a11y layout guards)", () => {
     )
   })
 
-  it("at least two browser guard files exist to be collected", () => {
+  it("at least four browser guard files exist to be collected", () => {
     const files = globSync("src/**/*.browser.test.tsx", { cwd: webRoot })
-    // 2.5.8 target size + 1.4.10 reflow. Fewer means a guard was renamed out of
-    // the collected glob and its VPAT criterion lost its backing check.
-    expect(files.length).toBeGreaterThanOrEqual(2)
+    // 2.5.8 target size, 1.4.10 reflow, 1.4.4 resize text, 1.4.12 text spacing.
+    // Fewer means a guard was renamed out of the collected glob and its VPAT
+    // criterion lost its backing check.
+    expect(files.length).toBeGreaterThanOrEqual(4)
   })
 })

--- a/web/src/test/resizeText.browser.test.tsx
+++ b/web/src/test/resizeText.browser.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest"
+import { cleanup, render } from "@testing-library/react"
+
+import "@/index.css"
+import { Card } from "@/components/ui"
+import { fitsViewportWidth } from "@/util/a11yStructural"
+
+// 1.4.4 Resize Text: text scales to 200% without loss of content. The browser-
+// testable proxy is that the app's text sizing is relative (rem/em), so bumping
+// the root font-size actually enlarges text AND the layout still fits its
+// container without clipping. Measured in real Chromium (happy-dom has no layout,
+// so font-size changes never reflow and the check would silently pass). This is
+// the representative-sample scope (KTD5): it proves the shared primitives scale,
+// not every route.
+const VIEWPORT = 320
+const ROOT_PX = 16
+const ZOOM = 2 // 200%
+
+beforeAll(() => {
+  document.documentElement.setAttribute("data-theme", "sumi")
+})
+
+afterEach(() => {
+  cleanup()
+  document.documentElement.style.fontSize = ""
+})
+
+function descendantWidths(root: Element): number[] {
+  return Array.from(root.querySelectorAll("*")).map(
+    (el) => el.getBoundingClientRect().width,
+  )
+}
+
+function sample() {
+  return (
+    <div style={{ width: VIEWPORT }}>
+      <Card>
+        <Card.Body>
+          <h2>Accessibility</h2>
+          <p data-testid="copy">
+            A paragraph of body copy that must remain fully visible when text is
+            enlarged to 200%, wrapping rather than clipping or overflowing.
+          </p>
+        </Card.Body>
+      </Card>
+    </div>
+  )
+}
+
+describe("1.4.4 Resize Text — 200% scaling on shared primitives", () => {
+  it("enlarging the root font to 200% actually scales text (relative units)", () => {
+    document.documentElement.style.fontSize = `${ROOT_PX}px`
+    const { getByTestId, rerender } = render(sample())
+    const before = getByTestId("copy").getBoundingClientRect().height
+
+    document.documentElement.style.fontSize = `${ROOT_PX * ZOOM}px`
+    rerender(sample())
+    const after = getByTestId("copy").getBoundingClientRect().height
+
+    // rem/em text grows with the root; a fixed-px design would not. Height, not
+    // width — the paragraph is width-constrained by the viewport and reflows down.
+    expect(after, `${before} -> ${after}`).toBeGreaterThan(before)
+  })
+
+  it("at 200% the sample still fits the viewport without horizontal overflow", () => {
+    document.documentElement.style.fontSize = `${ROOT_PX * ZOOM}px`
+    const { container } = render(sample())
+    const widths = descendantWidths(container)
+    const widest = Math.max(...widths)
+    expect(fitsViewportWidth(widths, VIEWPORT), `widest: ${widest}px`).toBe(
+      true,
+    )
+  })
+
+  // Fidelity: a fixed-height clipping box whose text overflows when enlarged must
+  // be detected, so a future measurement regression can't silently pass.
+  it("detects clipping when enlarged text overflows a fixed-height box (guard bites)", () => {
+    document.documentElement.style.fontSize = `${ROOT_PX * ZOOM}px`
+    const { getByTestId } = render(
+      <div
+        data-testid="clip"
+        style={{ height: 16, overflow: "hidden", width: VIEWPORT }}
+      >
+        <span style={{ fontSize: "2rem" }}>Text taller than its 16px box</span>
+      </div>,
+    )
+    const box = getByTestId("clip")
+    expect(box.scrollHeight).toBeGreaterThan(box.clientHeight)
+  })
+})

--- a/web/src/test/resizeText.browser.test.tsx
+++ b/web/src/test/resizeText.browser.test.tsx
@@ -51,15 +51,25 @@ describe("1.4.4 Resize Text — 200% scaling on shared primitives", () => {
   it("enlarging the root font to 200% actually scales text (relative units)", () => {
     document.documentElement.style.fontSize = `${ROOT_PX}px`
     const { getByTestId, rerender } = render(sample())
-    const before = getByTestId("copy").getBoundingClientRect().height
+    const copyBefore = getByTestId("copy")
+    const before = copyBefore.getBoundingClientRect().height
+    const fontBefore = parseFloat(getComputedStyle(copyBefore).fontSize)
 
     document.documentElement.style.fontSize = `${ROOT_PX * ZOOM}px`
     rerender(sample())
-    const after = getByTestId("copy").getBoundingClientRect().height
+    const copyAfter = getByTestId("copy")
+    const after = copyAfter.getBoundingClientRect().height
+    const fontAfter = parseFloat(getComputedStyle(copyAfter).fontSize)
 
     // rem/em text grows with the root; a fixed-px design would not. Height, not
     // width — the paragraph is width-constrained by the viewport and reflows down.
     expect(after, `${before} -> ${after}`).toBeGreaterThan(before)
+    // Pin that the text is genuinely relative-unit: the computed font-size must
+    // track the root (a px-hardcoded primitive would stay flat and fail here,
+    // catching a future regression away from rem/em text sizing).
+    expect(fontAfter, `font ${fontBefore} -> ${fontAfter}`).toBeGreaterThan(
+      fontBefore * 1.5,
+    )
   })
 
   it("at 200% the sample still fits the viewport without horizontal overflow", () => {

--- a/web/src/test/textSpacing.browser.test.tsx
+++ b/web/src/test/textSpacing.browser.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest"
+import { cleanup, render } from "@testing-library/react"
+import type { CSSProperties } from "react"
+
+import "@/index.css"
+import { Card } from "@/components/ui"
+
+// 1.4.12 Text Spacing: no loss of content when the user overrides line-height to
+// 1.5x, paragraph spacing to 2x, letter-spacing to 0.12em, and word-spacing to
+// 0.16em. Measured in real Chromium (happy-dom has no layout, so injected spacing
+// never changes box sizes and the check would silently pass). Representative-
+// sample scope (KTD5): proves the shared primitives absorb the overrides.
+
+// The WCAG 1.4.12 author-override metrics, as inline style (em-relative so they
+// track the WCAG ratios regardless of the element's font-size).
+const TEXT_SPACING: CSSProperties = {
+  lineHeight: 1.5,
+  letterSpacing: "0.12em",
+  wordSpacing: "0.16em",
+}
+
+beforeAll(() => {
+  document.documentElement.setAttribute("data-theme", "sumi")
+})
+afterEach(cleanup)
+
+// A container with no clipping is one whose content isn't cut off by a fixed size:
+// scroll size never exceeds client size on either axis.
+function isNotClipped(el: HTMLElement): boolean {
+  return el.scrollHeight <= el.clientHeight && el.scrollWidth <= el.clientWidth
+}
+
+describe("1.4.12 Text Spacing — WCAG author overrides on shared primitives", () => {
+  it("the sample absorbs the spacing overrides without clipping content", () => {
+    const { getByTestId } = render(
+      <div data-testid="host" style={{ width: 360, ...TEXT_SPACING }}>
+        <Card>
+          <Card.Body>
+            <h2 style={TEXT_SPACING}>Accessibility</h2>
+            <p style={{ marginBottom: "2em", ...TEXT_SPACING }}>
+              A paragraph of body copy that must stay fully visible when the
+              reader applies the WCAG text-spacing overrides — the container
+              grows to fit rather than clipping the text.
+            </p>
+          </Card.Body>
+        </Card>
+      </div>,
+    )
+    // The host is unconstrained in height, so applied spacing grows it rather than
+    // clipping: no descendant should overflow a fixed-size clipping ancestor.
+    const host = getByTestId("host")
+    expect(
+      isNotClipped(host),
+      `${host.scrollHeight}>${host.clientHeight}`,
+    ).toBe(true)
+  })
+
+  // Fidelity: a fixed-height clipping box whose text overflows once the spacing
+  // overrides are applied must be detected, so a regression can't silently pass.
+  it("detects clipping when spacing overflows a fixed-height box (guard bites)", () => {
+    const { getByTestId } = render(
+      <div
+        data-testid="clip"
+        style={{ height: 20, overflow: "hidden", width: 200, ...TEXT_SPACING }}
+      >
+        Several words of copy whose 1.5x line-height and letter and word spacing
+        push the text past a deliberately short twenty-pixel box.
+      </div>,
+    )
+    const box = getByTestId("clip")
+    expect(box.scrollHeight).toBeGreaterThan(box.clientHeight)
+  })
+})

--- a/web/src/test/textSpacing.browser.test.tsx
+++ b/web/src/test/textSpacing.browser.test.tsx
@@ -30,10 +30,44 @@ function isNotClipped(el: HTMLElement): boolean {
   return el.scrollHeight <= el.clientHeight && el.scrollWidth <= el.clientWidth
 }
 
+function spacedSample(spacing: CSSProperties) {
+  return (
+    <div data-testid="host" style={{ width: 360, ...spacing }}>
+      <Card>
+        <Card.Body>
+          <h2 style={spacing}>Accessibility</h2>
+          <p style={{ marginBottom: "2em", ...spacing }}>
+            A paragraph of body copy that must stay fully visible when the
+            reader applies the WCAG text-spacing overrides — the container grows
+            to fit rather than clipping the text.
+          </p>
+        </Card.Body>
+      </Card>
+    </div>
+  )
+}
+
 describe("1.4.12 Text Spacing — WCAG author overrides on shared primitives", () => {
-  it("the sample absorbs the spacing overrides without clipping content", () => {
+  it("the overrides actually take effect (taller layout than un-spaced)", () => {
+    // Guard against a tautological pass: prove the spacing changes layout at all.
+    // If TEXT_SPACING were a no-op (or silently dropped), these heights would be
+    // equal and this assertion would fail — so the constrained test below is real.
+    const bare = render(spacedSample({}))
+    const bareHeight = bare.getByTestId("host").scrollHeight
+    bare.unmount()
+
+    const { getByTestId } = render(spacedSample(TEXT_SPACING))
+    expect(getByTestId("host").scrollHeight).toBeGreaterThan(bareHeight)
+  })
+
+  it("a height-constrained container still shows all content with the overrides", () => {
+    // A realistically-sized container (not unbounded): tall enough for the spaced
+    // text, so a clip here would be a real 1.4.12 failure, not a tautology.
     const { getByTestId } = render(
-      <div data-testid="host" style={{ width: 360, ...TEXT_SPACING }}>
+      <div
+        data-testid="host"
+        style={{ width: 360, height: 320, overflow: "auto", ...TEXT_SPACING }}
+      >
         <Card>
           <Card.Body>
             <h2 style={TEXT_SPACING}>Accessibility</h2>
@@ -46,8 +80,6 @@ describe("1.4.12 Text Spacing — WCAG author overrides on shared primitives", (
         </Card>
       </div>,
     )
-    // The host is unconstrained in height, so applied spacing grows it rather than
-    // clipping: no descendant should overflow a fixed-size clipping ancestor.
     const host = getByTestId("host")
     expect(
       isNotClipped(host),

--- a/web/src/util/vpatAutomated.ts
+++ b/web/src/util/vpatAutomated.ts
@@ -84,4 +84,27 @@ export const AUTOMATED_CRITERIA: Record<string, AutomatedBinding> = {
       "browser and no element exceeds the width. Verified automatically on the " +
       "shared layout primitives; a per-route reflow sweep is a manual follow-up.",
   },
+  "1.4.4": {
+    check:
+      "enlarging the root font to 200% scales text (relative units) and the " +
+      "sample still fits the viewport in real Chromium (resizeText.browser.test.tsx)",
+    remark:
+      "Text resizes to 200% without loss of content: with the root font enlarged " +
+      "to 200% in a real browser, the shared primitives' text scales (relative " +
+      "units) and the layout still fits without clipping or horizontal overflow. " +
+      "Verified automatically on the shared primitives; a per-route zoom sweep is " +
+      "a manual follow-up.",
+  },
+  "1.4.12": {
+    check:
+      "the WCAG text-spacing overrides (line-height 1.5, letter 0.12em, word " +
+      "0.16em, paragraph 2em) apply without clipping in real Chromium " +
+      "(textSpacing.browser.test.tsx)",
+    remark:
+      "Content survives the WCAG 1.4.12 text-spacing overrides (line-height 1.5x, " +
+      "letter-spacing 0.12em, word-spacing 0.16em, paragraph spacing 2em): applied " +
+      "to the shared primitives in a real browser, the container grows to fit " +
+      "rather than clipping. Verified automatically on the shared primitives; a " +
+      "per-route sweep is a manual follow-up.",
+  },
 }

--- a/web/src/util/vpatModel.test.ts
+++ b/web/src/util/vpatModel.test.ts
@@ -116,7 +116,7 @@ describe("vpatModel — criteria integrity", () => {
     expect(c?.evidence).toBe("automated")
   })
 
-  it.each(["3.3.1", "3.3.2", "4.1.3", "2.5.8", "1.4.10"])(
+  it.each(["3.3.1", "3.3.2", "4.1.3", "2.5.8", "1.4.10", "1.4.4", "1.4.12"])(
     "marks %s as automated Supports with a specific remark",
     (id) => {
       const c = CRITERIA.find((x) => x.id === id)

--- a/web/src/util/vpatModel.ts
+++ b/web/src/util/vpatModel.ts
@@ -136,8 +136,14 @@ export const CRITERIA: Criterion[] = [
     name: "Resize Text",
     level: "AA",
     principle: "Perceivable",
-    status: "notEvaluated",
-    remark: NOT_EVALUATED_REMARK,
+    status: "supports",
+    evidence: "automated",
+    remark:
+      "Text resizes to 200% without loss of content: with the root font enlarged " +
+      "to 200% in a real browser, the shared primitives' text scales (relative " +
+      "units) and the layout still fits without clipping or horizontal overflow. " +
+      "Verified automatically on the shared primitives; a per-route zoom sweep is " +
+      "a manual follow-up.",
   },
   {
     id: "1.4.10",
@@ -157,8 +163,14 @@ export const CRITERIA: Criterion[] = [
     name: "Text Spacing",
     level: "AA",
     principle: "Perceivable",
-    status: "notEvaluated",
-    remark: NOT_EVALUATED_REMARK,
+    status: "supports",
+    evidence: "automated",
+    remark:
+      "Content survives the WCAG 1.4.12 text-spacing overrides (line-height 1.5x, " +
+      "letter-spacing 0.12em, word-spacing 0.16em, paragraph spacing 2em): applied " +
+      "to the shared primitives in a real browser, the container grows to fit " +
+      "rather than clipping. Verified automatically on the shared primitives; a " +
+      "per-route sweep is a manual follow-up.",
   },
   {
     id: "1.4.13",


### PR DESCRIPTION
## What

Extends the Playwright browser-project layout guards (landed in #504) to two more WCAG AA criteria, measured in real Chromium and flipped to `automated` Supports via the established guard → `AUTOMATED_CRITERIA` binding → model-flip pattern:

- **1.4.4 Resize Text (AA)** — enlarging the root font to 200% actually scales the shared primitives' text (relative units) and the layout still fits without clipping or horizontal overflow.
- **1.4.12 Text Spacing (AA)** — applying the WCAG author overrides (line-height 1.5×, letter-spacing 0.12em, word-spacing 0.16em, paragraph spacing 2em) grows the container to fit rather than clipping content.

## Why

Both criteria need a real layout engine — happy-dom applies no box model, so a font-size bump or spacing override changes nothing there and a happy-dom check would silently pass. Each guard carries a **negative fixture** (text overflowing a fixed-height clipping box) that must fail, so a future measurement-logic regression can't go green.

Both were previously `notEvaluated`; the app already satisfies them, so this is a lock-in — no app markup changed.

## Scope + honesty

Representative-sample, primitive-level verdicts (KTD5), and the binding remarks say so: per-route zoom and per-route spacing sweeps stay deferred to the manual pass.

## Hardening

The browser-project wiring meta-test's floor is raised from 2 to 4 collected `*.browser.test.tsx` guards, so renaming any guard out of the glob fails loudly rather than silently dropping its VPAT backing.

## Verification

`npm run check` green — 290 test files / 3214 tests (4 browser guards, the rest node/happy-dom), 0 lint errors, prettier clean. Generated `VPAT.md` shows both criteria as Supports.