### PR TITLE
refactor(web): consolidate a11y test harness and parallelize web CI

### DIFF
--- a/.github/actions/setup-web/action.yaml
+++ b/.github/actions/setup-web/action.yaml
@@ -1,0 +1,33 @@
+name: Setup web
+description: >
+  Check out is assumed done by the caller. Sets up Node and restores node_modules
+  from cache keyed on the lockfile, running `npm ci` only on a cache miss. Shared
+  by every web-ci lane so the install cost is paid once per lockfile, not re-run
+  cold in each parallel job.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v7
+      with:
+        node-version: 24
+        # npm's own download cache — complements the node_modules cache below
+        # (a node_modules miss still gets warm tarballs to install from).
+        cache: npm
+        cache-dependency-path: web/package-lock.json
+
+    # Cache the installed tree keyed on the exact lockfile. On a hit, node_modules
+    # is restored directly and `npm ci` is skipped entirely; on a miss (lockfile
+    # changed), install and let the cache repopulate for the next run.
+    - name: Cache node_modules
+      id: node-modules-cache
+      uses: actions/cache@v6
+      with:
+        path: web/node_modules
+        key: ${{ runner.os }}-node24-modules-${{ hashFiles('web/package-lock.json') }}
+
+    - name: Install dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: web
+      run: npm ci

--- a/.github/actions/setup-web/action.yaml
+++ b/.github/actions/setup-web/action.yaml
@@ -8,7 +8,8 @@ description: >
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v7
+    - id: node
+      uses: actions/setup-node@v7
       with:
         node-version: 24
         # npm's own download cache — complements the node_modules cache below
@@ -16,17 +17,26 @@ runs:
         cache: npm
         cache-dependency-path: web/package-lock.json
 
-    # Cache the installed tree keyed on the exact lockfile. On a hit, node_modules
-    # is restored directly and `npm ci` is skipped entirely; on a miss (lockfile
-    # changed), install and let the cache repopulate for the next run.
+    # Cache the installed tree keyed on the RESOLVED Node version + the exact
+    # lockfile. Keying on setup-node's resolved version (not a hardcoded string)
+    # means a runner Node bump automatically busts the cache, so a node_modules
+    # built against a different Node ABI can never be restored. On a hit,
+    # node_modules is restored directly and `npm ci` is skipped; on a miss, install
+    # and let the cache repopulate. restore-keys lets a lockfile-only change warm-
+    # start from the previous same-Node tree, while a Node change fully busts.
     - name: Cache node_modules
       id: node-modules-cache
       uses: actions/cache@v6
       with:
         path: web/node_modules
-        key: ${{ runner.os }}-node24-modules-${{ hashFiles('web/package-lock.json') }}
+        key: ${{ runner.os }}-node${{ steps.node.outputs.node-version }}-modules-${{ hashFiles('web/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node${{ steps.node.outputs.node-version }}-modules-
 
     - name: Install dependencies
+      # A restore-keys prefix hit sets cache-hit=false but still restores a (stale)
+      # node_modules, so gate the install on an EXACT-key hit only; npm ci is
+      # idempotent and reconciles a warm-but-outdated tree against the lockfile.
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: web

--- a/.github/workflows/cli-shared-ci.yaml
+++ b/.github/workflows/cli-shared-ci.yaml
@@ -35,7 +35,7 @@ jobs:
           git diff --exit-code go.mod go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           working-directory: cli/shared
           version: v2.12.2

--- a/.github/workflows/gh-student-ci.yaml
+++ b/.github/workflows/gh-student-ci.yaml
@@ -37,7 +37,7 @@ jobs:
           git diff --exit-code go.mod go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           working-directory: cli/gh-student
           version: v2.12.2

--- a/.github/workflows/gh-teacher-ci.yaml
+++ b/.github/workflows/gh-teacher-ci.yaml
@@ -37,7 +37,7 @@ jobs:
           git diff --exit-code go.mod go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           working-directory: cli/gh-teacher
           version: v2.12.2

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -50,7 +50,7 @@ jobs:
       # is needed here.)
       web_tag: ${{ steps.release.outputs['web--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -74,11 +74,13 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-  # The fast node/happy-dom test suite (the bulk of the tests). Sharded across a
-  # matrix because the suite is CPU-bound on the 4-vCPU runner (locally it runs in
-  # ~17s on 18 cores; ~96s here) — splitting the files across parallel runners
-  # halves the wall-clock. Needs no browser, so it never pays the Chromium
-  # download. Blob reports from each shard are merged in `test-merge` below.
+  # The fast node/happy-dom test suite (the bulk of the tests). Sharded 4x across
+  # a matrix because the suite is CPU-bound on the 4-vCPU runner (locally ~17s on
+  # 18 cores; ~96s here) — splitting the files across parallel runners cuts the
+  # wall-clock roughly 4x. Each shard is its own pass/fail gate: if any shard's
+  # tests fail, this job is `failure` and the ci gate goes red. No merge job — the
+  # merged report had no consumer (no coverage gate), so it was pure overhead.
+  # Needs no browser, so it never pays the Chromium download.
   test:
     name: Unit tests (node)
     runs-on: ubuntu-latest
@@ -86,43 +88,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-web
-      - name: Test (node project, shard ${{ matrix.shard }}/2)
-        # blob feeds the merge job; default keeps per-file logs visible in the
-        # shard (a bare --reporter=blob would silence them).
-        run: npm run test:node -- --reporter=blob --reporter=default --shard=${{ matrix.shard }}/2
-      - name: Upload blob report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: vitest-blob-${{ matrix.shard }}
-          path: web/.vitest-reports/*
-          include-hidden-files: true
-          retention-days: 1
-
-  # Fan-in for the sharded unit tests: merge the per-shard blob reports into one
-  # result so downstream sees a single unit-test verdict. Runs even if a shard
-  # went red (if: always) so the merged report reflects the real outcome.
-  test-merge:
-    name: Unit tests (merge shards)
-    if: ${{ !cancelled() }}
-    needs: test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/setup-web
-      - name: Download shard blob reports
-        uses: actions/download-artifact@v8
-        with:
-          path: web/.vitest-reports
-          pattern: vitest-blob-*
-          merge-multiple: true
-      - name: Merge reports
-        run: npx vitest --merge-reports
+      - name: Test (node project, shard ${{ matrix.shard }}/4)
+        run: npm run test:node -- --shard=${{ matrix.shard }}/4
 
   # The a11y layout guards (*.browser.test.tsx: target size, reflow, resize text,
   # text spacing) run in real Chromium via the vitest browser project. Isolated
@@ -251,7 +222,7 @@ jobs:
   ci:
     name: CI gate
     if: always()
-    needs: [static, test, test-merge, browser, locale, audits]
+    needs: [static, test, browser, locale, audits]
     runs-on: ubuntu-latest
     # No checkout — this is a pure aggregation job — so override the workflow-level
     # `web` working-directory default (that dir doesn't exist here) to the runner
@@ -263,9 +234,8 @@ jobs:
       - name: Verify all lanes succeeded
         run: |
           # `test` is the sharded matrix — it is `failure` if ANY shard's tests
-          # failed, so depending on it directly is the real unit-test gate.
-          # `test-merge` only produces the merged report; both must be green.
-          results="${{ needs.static.result }} ${{ needs.test.result }} ${{ needs.test-merge.result }} ${{ needs.browser.result }} ${{ needs.locale.result }} ${{ needs.audits.result }}"
+          # failed, so depending on it directly is the unit-test gate.
+          results="${{ needs.static.result }} ${{ needs.test.result }} ${{ needs.browser.result }} ${{ needs.locale.result }} ${{ needs.audits.result }}"
           echo "lane results: $results"
           for r in $results; do
             if [ "$r" != "success" ]; then

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -49,6 +49,7 @@ jobs:
   # cheap gates grouped into one lane so each doesn't pay a separate cold-runner
   # startup.
   static:
+    name: Static analysis (types, lint, arch, format)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -81,6 +82,7 @@ jobs:
   # The fast node/happy-dom test suite (the bulk of the tests). Needs no browser,
   # so it never pays the Chromium download.
   test:
+    name: Unit tests (node)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -99,6 +101,7 @@ jobs:
   # into its own lane so the ~90MB Playwright browser install is off the critical
   # path of every other check, and cached so repeat runs skip the download.
   browser:
+    name: A11y layout guards (Chromium)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -139,6 +142,7 @@ jobs:
   # strict key-coverage audit. Runs from the repo root (paths are repo-relative),
   # overriding the workflow-level `web` working-directory default.
   locale:
+    name: i18n locale audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -172,6 +176,7 @@ jobs:
   # and uploads them for download. Independent of the gates; its own lane so the
   # artifacts are always produced.
   audits:
+    name: Accessibility reports (contrast, VPAT, inventory)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -226,6 +231,7 @@ jobs:
   # skipped or failed lane fails the gate (a bare `needs` would let a skipped
   # lane pass). Pin THIS check in branch protection if required checks are added.
   ci:
+    name: CI gate
     if: always()
     needs: [static, test, browser, locale, audits]
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -74,17 +74,55 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-  # The fast node/happy-dom test suite (the bulk of the tests). Needs no browser,
-  # so it never pays the Chromium download.
+  # The fast node/happy-dom test suite (the bulk of the tests). Sharded across a
+  # matrix because the suite is CPU-bound on the 4-vCPU runner (locally it runs in
+  # ~17s on 18 cores; ~96s here) — splitting the files across parallel runners
+  # halves the wall-clock. Needs no browser, so it never pays the Chromium
+  # download. Blob reports from each shard are merged in `test-merge` below.
   test:
     name: Unit tests (node)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-web
+      - name: Test (node project, shard ${{ matrix.shard }}/2)
+        # blob feeds the merge job; default keeps per-file logs visible in the
+        # shard (a bare --reporter=blob would silence them).
+        run: npm run test:node -- --reporter=blob --reporter=default --shard=${{ matrix.shard }}/2
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: vitest-blob-${{ matrix.shard }}
+          path: web/.vitest-reports/*
+          include-hidden-files: true
+          retention-days: 1
+
+  # Fan-in for the sharded unit tests: merge the per-shard blob reports into one
+  # result so downstream sees a single unit-test verdict. Runs even if a shard
+  # went red (if: always) so the merged report reflects the real outcome.
+  test-merge:
+    name: Unit tests (merge shards)
+    if: ${{ !cancelled() }}
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-web
-      - name: Test (node project)
-        run: npm run test:node
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v8
+        with:
+          path: web/.vitest-reports
+          pattern: vitest-blob-*
+          merge-multiple: true
+      - name: Merge reports
+        run: npx vitest --merge-reports
 
   # The a11y layout guards (*.browser.test.tsx: target size, reflow, resize text,
   # text spacing) run in real Chromium via the vitest browser project. Isolated
@@ -213,7 +251,7 @@ jobs:
   ci:
     name: CI gate
     if: always()
-    needs: [static, test, browser, locale, audits]
+    needs: [static, test, test-merge, browser, locale, audits]
     runs-on: ubuntu-latest
     # No checkout — this is a pure aggregation job — so override the workflow-level
     # `web` working-directory default (that dir doesn't exist here) to the runner
@@ -224,7 +262,10 @@ jobs:
     steps:
       - name: Verify all lanes succeeded
         run: |
-          results="${{ needs.static.result }} ${{ needs.test.result }} ${{ needs.browser.result }} ${{ needs.locale.result }} ${{ needs.audits.result }}"
+          # `test` is the sharded matrix — it is `failure` if ANY shard's tests
+          # failed, so depending on it directly is the real unit-test gate.
+          # `test-merge` only produces the merged report; both must be green.
+          results="${{ needs.static.result }} ${{ needs.test.result }} ${{ needs.test-merge.result }} ${{ needs.browser.result }} ${{ needs.locale.result }} ${{ needs.audits.result }}"
           echo "lane results: $results"
           for r in $results; do
             if [ "$r" != "success" ]; then

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -54,12 +54,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: npm ci
+      - uses: ./.github/actions/setup-web
 
       # Full project type-check (tsc -b). Blocking: the build depends on this.
       - name: Typecheck
@@ -87,12 +82,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: npm ci
+      - uses: ./.github/actions/setup-web
       - name: Test (node project)
         run: npm run test:node
 
@@ -106,12 +96,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: npm ci
+      - uses: ./.github/actions/setup-web
 
       # Resolve the installed Playwright version to key the browser-binary cache;
       # a version bump invalidates the cache so the matching browser is fetched.
@@ -181,12 +166,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: npm ci
+      - uses: ./.github/actions/setup-web
 
       - name: Generate contrast audit report
         if: always()

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -229,6 +229,12 @@ jobs:
     if: always()
     needs: [static, test, browser, locale, audits]
     runs-on: ubuntu-latest
+    # No checkout — this is a pure aggregation job — so override the workflow-level
+    # `web` working-directory default (that dir doesn't exist here) to the runner
+    # workspace, or bash can't start.
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
     steps:
       - name: Verify all lanes succeeded
         run: |

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -2,10 +2,15 @@ name: web CI
 
 # Quality gate for the web app (web/): type-check, lint, format, tests, and an
 # i18n key audit (missing t() keys fail; dead/hardcoded strings are advisory).
-# The audit tool has its own pytest suite (i18n audit tests) that runs first so
-# a regex regression can't silently turn the audit into a permanent PASS.
-# Blocks merge and can't be bypassed like a local hook. Scoped to web/** so
-# it only runs when the frontend changes, independent of the Go/Python CI.
+# Fanned out into parallel role-jobs (static / test / browser / locale / audits)
+# joined by a single `ci` gate, so the Actions graph reads as a pipeline and the
+# expensive Playwright Chromium install is isolated to the one lane that needs it
+# instead of sitting on every run's critical path.
+#
+# The i18n audit tool has its own pytest suite (in the `locale` job) that runs
+# ahead of the gate it pins so a regex regression can't silently turn the audit
+# into a permanent PASS. Scoped to web/** so it only runs when the frontend
+# changes, independent of the Go/Python CI.
 #
 # Also triggered by the CLI-owned skeleton source (cli/gh-teacher/skeleton/
 # dotgithub/**): the web build bundles that tree, and skeleton.test.ts is the
@@ -35,31 +40,31 @@ concurrency:
 permissions:
   contents: read
 
+defaults:
+  run:
+    working-directory: web
+
 jobs:
-  check:
+  # Static analysis: type-check, lint, architecture boundaries, formatting. The
+  # cheap gates grouped into one lane so each doesn't pay a separate cold-runner
+  # startup.
+  static:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v7
-
       - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
-
       - run: npm ci
 
-      # Full project type-check (tsc -b). Blocking: the build depends on this
-      # staying green.
+      # Full project type-check (tsc -b). Blocking: the build depends on this.
       - name: Typecheck
         run: npm run typecheck
 
-      # ESLint. Fails on errors; advisory rules are configured as warnings in
-      # eslint.config.js and do not block.
+      # ESLint. Fails on errors; advisory rules are warnings and do not block.
       - name: Lint
         run: npm run lint
 
@@ -73,25 +78,114 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-      # The a11y layout guards (*.browser.test.tsx: 2.5.8 target size, 1.4.10
-      # reflow) run in a real Chromium via the vitest browser project, which needs
-      # Playwright's browser binary. Installed here, right before the tests that
-      # use it, so an earlier lint/type failure fails fast without the download.
+  # The fast node/happy-dom test suite (the bulk of the tests). Needs no browser,
+  # so it never pays the Chromium download.
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - name: Test (node project)
+        run: npm run test:node
+
+  # The a11y layout guards (*.browser.test.tsx: target size, reflow, resize text,
+  # text spacing) run in real Chromium via the vitest browser project. Isolated
+  # into its own lane so the ~90MB Playwright browser install is off the critical
+  # path of every other check, and cached so repeat runs skip the download.
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+
+      # Resolve the installed Playwright version to key the browser-binary cache;
+      # a version bump invalidates the cache so the matching browser is fetched.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+
+      # On a cache hit the browser binary is present but its OS deps may not be;
+      # `install-deps` is cheap and idempotent. On a miss, install the browser too.
+      - name: Install Playwright browser deps
+        run: npx playwright install-deps chromium
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
 
-      - name: Test
-        run: npm test
+      - name: Test (browser project)
+        run: npm run test:browser
 
-      # Generate the WCAG contrast audit report and attach it as a build
-      # artifact (never committed — it's a rendering of guaranteed-green state
-      # the contrast guard tests enforce). Downloadable from the run summary so
-      # a reviewer always has the current per-pair ratios. `if: always()` so the
-      # report is still produced when a later non-contrast step fails.
+  # i18n locale tooling: the audit tool's own pytest suites run ahead of the gate
+  # they pin (so a regex regression can't turn the audit into a no-op), then the
+  # strict key-coverage audit. Runs from the repo root (paths are repo-relative),
+  # overriding the workflow-level `web` working-directory default.
+  locale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+      - name: Install audit test deps
+        run: python -m pip install --quiet pytest
+
+      # Both locale-tooling pytest suites run ahead of the gates they pin
+      # (audit_i18n.py below; verify_locale.py in translate-locales.yaml) so a
+      # regex regression can't silently turn either gate into a no-op.
+      - name: i18n audit tests
+        run: python -m pytest web/src/locales/ -v
+
+      # i18n coverage gate (--strict): fails on MISSING/DEAD/SPLIT keys, physical
+      # directional classes, and hardcoded user-facing prose. See audit_i18n.py's
+      # module docstring for the coverage limits (green here is NOT "no hardcoded
+      # prose anywhere"). Uses the runner's python3; run from the repo root since
+      # the script resolves web/src relative to itself.
+      - name: i18n key audit
+        run: python3 web/src/locales/audit_i18n.py --strict
+
+  # Audit-report generation: renders the contrast / VPAT / a11y-inventory
+  # artifacts (never committed — renderings of guarded state the tests enforce)
+  # and uploads them for download. Independent of the gates; its own lane so the
+  # artifacts are always produced.
+  audits:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+
       - name: Generate contrast audit report
         if: always()
         run: npm run audit:contrast
-
       - name: Upload contrast audit report
         if: always()
         uses: actions/upload-artifact@v7
@@ -102,15 +196,9 @@ jobs:
             web/CONTRAST-AUDIT.md
           if-no-files-found: warn
 
-      # Generate the WCAG 2.2 VPAT / ACR (WCAG + INT editions) and attach it as
-      # a build artifact. Same discipline as the contrast report above: never
-      # committed — a rendering of guarded state (vpatGuard.test.ts + the
-      # contrast guard enforce the facts). `if: always()` so it's produced even
-      # when a later non-VPAT step fails.
       - name: Generate VPAT report
         if: always()
         run: npm run audit:vpat
-
       - name: Upload VPAT report
         if: always()
         uses: actions/upload-artifact@v7
@@ -122,14 +210,9 @@ jobs:
             web/VPAT-INT.md
           if-no-files-found: warn
 
-      # Emit the criterion-tagged accessibility inventory (status + bound checks)
-      # and upload it. The bindings themselves are enforced by the a11y tests in
-      # `npm test`; this artifact is a downloadable rendering of that guarded
-      # state. `if: always()` so it's produced even when a later step fails.
       - name: Generate a11y inventory
         if: always()
         run: npm run audit:a11y:inventory
-
       - name: Upload a11y inventory
         if: always()
         uses: actions/upload-artifact@v7
@@ -138,50 +221,22 @@ jobs:
           path: web/a11y-inventory.json
           if-no-files-found: warn
 
-      # Unit tests for the i18n audit tool itself. Its detection logic is
-      # entirely regex-driven, so these lock down the source-of-truth behavior
-      # (missing-key hard-fail, --strict flip, key-form capture, plural base,
-      # flatten/PLURAL_SUFFIXES parity with verify_locale.py) on inline
-      # fixtures -- a regex regression that silently stops catching a missing
-      # key fails here before it can turn the gate below into a permanent PASS.
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.14"
-
-      - name: Install audit test deps
-        working-directory: ${{ github.workspace }}
-        run: python -m pip install --quiet pytest
-
-      # Both locale-tooling pytest suites run ahead of the gates they pin
-      # (audit_i18n.py below; verify_locale.py in translate-locales.yaml) so a
-      # regex regression can't silently turn either gate into a no-op.
-      - name: i18n audit tests
-        working-directory: ${{ github.workspace }}
-        run: python -m pytest web/src/locales/ -v
-
-      # i18n coverage gate (--strict): fails on any of
-      #   1. MISSING keys  — a t("...") referencing a key absent from en.json
-      #      (renders the raw key / English fallback in every language),
-      #   2. DEAD keys      — an en.json key no source literal/prefix references
-      #      (translation dead weight; drifts packs),
-      #   3. SPLIT keys     — retired _prefix/_suffix sentence-fragment keys
-      #      (break word order in RTL and many LTR languages; always fails),
-      #   4. PHYSICAL directional classes — Tailwind utilities that don't
-      #      mirror under dir="rtl" (backstop behind the eslint rule), and
-      #   5. HARDCODED prose — user-facing string literals bypassing i18n.
-      # Dev-only UI (components/dev/) and a tiny allowlist of format examples are
-      # exempt from (5); see HARDCODED_IGNORE_PREFIXES / _ALLOWED_VALUES; a
-      # same-line `physical-ok` comment exempts a deliberate physical edge
-      # from (4).
-      # Coverage limits (green here is NOT "no hardcoded prose anywhere"): (5) is
-      # a heuristic over double-quoted aria-label/alt/title/placeholder + raw
-      # toast/setError/failDeviceFlow args only — it misses JSX children text,
-      # brace/template-literal attributes, and single-quoted attributes; (1)/(2)
-      # don't hold inside dynamic t(`prefix.${x}`) subtrees. See audit_i18n.py's
-      # module docstring. Uses the runner's preinstalled python3 (no third-party
-      # deps); run from the repo root since the script resolves web/src relative
-      # to itself.
-      - name: i18n key audit
-        working-directory: ${{ github.workspace }}
-        run: python3 web/src/locales/audit_i18n.py --strict
+  # Fan-in gate: a single required-status-friendly node that is green only when
+  # every lane succeeded. `if: always()` + explicit result inspection so a
+  # skipped or failed lane fails the gate (a bare `needs` would let a skipped
+  # lane pass). Pin THIS check in branch protection if required checks are added.
+  ci:
+    if: always()
+    needs: [static, test, browser, locale, audits]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all lanes succeeded
+        run: |
+          results="${{ needs.static.result }} ${{ needs.test.result }} ${{ needs.browser.result }} ${{ needs.locale.result }} ${{ needs.audits.result }}"
+          echo "lane results: $results"
+          for r in $results; do
+            if [ "$r" != "success" ]; then
+              echo "::error::a required lane did not succeed ($r)"
+              exit 1
+            fi
+          done

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -30,6 +30,9 @@ dist-ssr
 .vitest-attachments
 src/test/__screenshots__
 
+# Vitest blob reports (--reporter=blob, used for CI shard merging). Transient.
+.vitest-reports
+
 # Generated WCAG contrast audit artifacts. Never committed — renderings of
 # guaranteed-green state (the contrast guard tests enforce the facts). Produced
 # fresh as CI artifacts and emitted into dist/ by the Vite build (the JSON is the

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,8 @@
     "check": "tsc -b && eslint . && prettier --check . && npm run arch:validate && vitest run",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:node": "vitest run --project node",
+    "test:browser": "vitest run --project browser",
     "test:watch": "vitest",
     "missing": "tsc -p tsconfig.app.json --pretty false 2>&1 | grep -E \"TS(2304|2305|2307|2503|2552)\""
   },

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -424,6 +424,12 @@ function useGithubAuthState() {
         },
       },
     )
+    // Mount-once by design: this consumes the one-time OAuth redirect (code +
+    // state from the URL) and fires the single-use code exchange. Re-running on
+    // completeSignIn/exchangeCodeMutation/t identity changes would re-attempt the
+    // exchange with an already-spent code and fail — so the empty deps are
+    // intentional, not an omission.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // A bfcache restore freezes React state as-is with no effect re-run, so the

--- a/web/src/test/browserA11y.browser.test.tsx
+++ b/web/src/test/browserA11y.browser.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  descendantWidths,
+  rect,
+  renderInViewport,
+  setupBrowserA11y,
+  VIEWPORT,
+} from "./browserA11y"
+
+setupBrowserA11y()
+
+describe("browserA11y harness", () => {
+  it("renders in a real layout engine (non-zero measured width)", () => {
+    const { container } = renderInViewport(
+      <span style={{ display: "inline-block", width: 40 }}>hi</span>,
+    )
+    const span = container.querySelector("span") as HTMLElement
+    expect(rect(span).width).toBeGreaterThan(0)
+  })
+
+  it("renderInViewport constrains the wrapper to the given width", () => {
+    const { container } = renderInViewport(<span>x</span>, 200)
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(rect(wrapper).width).toBe(200)
+  })
+
+  it("descendantWidths returns one entry per descendant element", () => {
+    const { container } = renderInViewport(
+      <div>
+        <span>a</span>
+        <span>b</span>
+      </div>,
+    )
+    // wrapper div + inner div + 2 spans = 4 descendants under the container.
+    expect(descendantWidths(container).length).toBe(4)
+  })
+
+  it("exports VIEWPORT = 320", () => {
+    expect(VIEWPORT).toBe(320)
+  })
+})

--- a/web/src/test/browserA11y.tsx
+++ b/web/src/test/browserA11y.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeAll } from "vitest"
+import { cleanup, render } from "@testing-library/react"
+import type { ReactElement } from "react"
+
+// Shared harness for the browser-project a11y layout guards (2.5.8 target size,
+// 1.4.10 reflow, 1.4.4 resize text, 1.4.12 text spacing). These run in real
+// Chromium via the vitest browser project — happy-dom has no layout engine, so
+// measured boxes would all be 0 and the checks would silently pass. This module
+// centralizes the setup each guard used to repeat: the app stylesheet import (so
+// daisyUI/theme sizes are real), the `sumi` theme on <html>, and cleanup — plus
+// the DOM-measurement helpers. Test-infra, mirroring src/test/axe.ts; imported
+// only by *.browser.test.tsx, which only the browser project collects.
+
+// Importing the app CSS as a side effect gives the rendered primitives their
+// real daisyUI/theme sizing (a bare render would measure unstyled boxes).
+import "@/index.css"
+
+/** The narrow-viewport width used by the reflow / resize guards (px). */
+export const VIEWPORT = 320
+
+/**
+ * Wire the standard browser-guard lifecycle: apply the `sumi` theme to <html>
+ * before the suite (daisyUI reads it for real sizing) and clean up the rendered
+ * tree after each test. Call once at the top of a guard's module. (Not a React
+ * hook despite touching test lifecycle — named without the `use` prefix so the
+ * hooks lint rule doesn't misfire on a top-level call.)
+ */
+export function setupBrowserA11y() {
+  beforeAll(() => {
+    document.documentElement.setAttribute("data-theme", "sumi")
+  })
+  afterEach(cleanup)
+}
+
+/** An element's measured box in the real layout engine. */
+export function rect(el: Element): { width: number; height: number } {
+  const r = el.getBoundingClientRect()
+  return { width: r.width, height: r.height }
+}
+
+/** Measured widths of every descendant element under `root` (reflow checks). */
+export function descendantWidths(root: Element): number[] {
+  return Array.from(root.querySelectorAll("*")).map(
+    (el) => el.getBoundingClientRect().width,
+  )
+}
+
+/**
+ * Render `ui` inside a fixed-width container (default VIEWPORT) so a reflow /
+ * resize guard measures against a constrained viewport. Returns the RTL result;
+ * the container is the width-constrained wrapper.
+ */
+export function renderInViewport(ui: ReactElement, width: number = VIEWPORT) {
+  return render(<div style={{ width }}>{ui}</div>)
+}

--- a/web/src/test/reflow.browser.test.tsx
+++ b/web/src/test/reflow.browser.test.tsx
@@ -1,32 +1,26 @@
-import { afterEach, beforeAll, describe, expect, it } from "vitest"
-import { cleanup, render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
 
-import "@/index.css"
 import { Button, Card } from "@/components/ui"
 import { fitsViewportWidth } from "@/util/a11yStructural"
+import {
+  descendantWidths,
+  renderInViewport,
+  setupBrowserA11y,
+  VIEWPORT,
+} from "./browserA11y"
 
 // 1.4.10 Reflow: content fits a 320px-wide viewport without horizontal scroll.
 // Measured in real Chromium (happy-dom has no layout, so it never overflows and
-// a happy-dom "reflow" check would silently pass). We constrain a 320px container
-// and assert no descendant is wider than it — the representative-sample approach
-// (KTD5): this proves the shared layout primitives reflow, not every route.
-const VIEWPORT = 320
-
-beforeAll(() => {
-  document.documentElement.setAttribute("data-theme", "sumi")
-})
-afterEach(cleanup)
-
-function descendantWidths(root: Element): number[] {
-  return Array.from(root.querySelectorAll("*")).map(
-    (el) => el.getBoundingClientRect().width,
-  )
-}
+// a happy-dom "reflow" check would silently pass). renderInViewport constrains
+// the container to 320px and we assert no descendant is wider than it — the
+// representative-sample approach (KTD5): this proves the shared layout primitives
+// reflow, not every route.
+setupBrowserA11y()
 
 describe("1.4.10 Reflow — shared layout primitives at 320px", () => {
   it("a representative page composition has no element wider than 320px", () => {
-    const { container } = render(
-      <div style={{ width: VIEWPORT }}>
+    const { container } = renderInViewport(
+      <>
         <Card>
           <Card.Body>
             <h2>Accessibility</h2>
@@ -56,7 +50,7 @@ describe("1.4.10 Reflow — shared layout primitives at 320px", () => {
             </p>
           </Card.Body>
         </Card>
-      </div>,
+      </>,
     )
     const widths = descendantWidths(container)
     const widest = Math.max(...widths)
@@ -68,8 +62,10 @@ describe("1.4.10 Reflow — shared layout primitives at 320px", () => {
   // Fidelity: a fixed-width block wider than the viewport must fail, so a future
   // measurement-logic regression can't silently pass overflowing content.
   it("a fixed 500px block fails the 320px fit (guard bites)", () => {
-    const { container } = render(<div style={{ width: 500 }}>too wide</div>)
-    const widths = descendantWidths(container.parentElement ?? container)
+    const { container } = renderInViewport(
+      <div style={{ width: 500 }}>too wide</div>,
+    )
+    const widths = descendantWidths(container)
     expect(fitsViewportWidth([...widths, 500], VIEWPORT)).toBe(false)
   })
 })

--- a/web/src/test/resizeText.browser.test.tsx
+++ b/web/src/test/resizeText.browser.test.tsx
@@ -1,9 +1,9 @@
-import { afterEach, beforeAll, describe, expect, it } from "vitest"
-import { cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { render } from "@testing-library/react"
 
-import "@/index.css"
 import { Card } from "@/components/ui"
 import { fitsViewportWidth } from "@/util/a11yStructural"
+import { descendantWidths, setupBrowserA11y, VIEWPORT } from "./browserA11y"
 
 // 1.4.4 Resize Text: text scales to 200% without loss of content. The browser-
 // testable proxy is that the app's text sizing is relative (rem/em), so bumping
@@ -12,24 +12,16 @@ import { fitsViewportWidth } from "@/util/a11yStructural"
 // so font-size changes never reflow and the check would silently pass). This is
 // the representative-sample scope (KTD5): it proves the shared primitives scale,
 // not every route.
-const VIEWPORT = 320
 const ROOT_PX = 16
 const ZOOM = 2 // 200%
 
-beforeAll(() => {
-  document.documentElement.setAttribute("data-theme", "sumi")
-})
+setupBrowserA11y()
 
+// This guard mutates the root font-size, so it needs a reset beyond the shared
+// harness's cleanup (the harness owns theme + tree cleanup).
 afterEach(() => {
-  cleanup()
   document.documentElement.style.fontSize = ""
 })
-
-function descendantWidths(root: Element): number[] {
-  return Array.from(root.querySelectorAll("*")).map(
-    (el) => el.getBoundingClientRect().width,
-  )
-}
 
 function sample() {
   return (

--- a/web/src/test/targetSize.browser.test.tsx
+++ b/web/src/test/targetSize.browser.test.tsx
@@ -1,30 +1,21 @@
-import { afterEach, beforeAll, describe, expect, it } from "vitest"
-import { cleanup, render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
 
-import "@/index.css"
 import { Button } from "@/components/ui"
 import { meetsTargetSize, TARGET_SIZE_MIN } from "@/util/a11yStructural"
+import { rect, renderInViewport, setupBrowserA11y } from "./browserA11y"
 
 // 2.5.8 Target Size (Minimum): interactive targets are >= 24x24 CSS px. Measured
 // in a real Chromium layout engine (happy-dom reports 0 for every box, so this
 // check can only live in the browser project). daisyUI sizes come from the real
-// stylesheet, so the theme must be applied to <html>.
-beforeAll(() => {
-  document.documentElement.setAttribute("data-theme", "sumi")
-})
-afterEach(cleanup)
-
-function rect(el: Element) {
-  const r = el.getBoundingClientRect()
-  return { width: r.width, height: r.height }
-}
+// stylesheet + theme, both applied by the shared harness.
+setupBrowserA11y()
 
 describe("2.5.8 Target Size — shared Button primitive", () => {
   // md and sm are the default action sizes across the app; both must clear 24px.
   it.each(["md", "sm"] as const)(
     "a %s Button meets the 24x24 minimum",
     (size) => {
-      const { getByRole } = render(<Button size={size}>Save</Button>)
+      const { getByRole } = renderInViewport(<Button size={size}>Save</Button>)
       const { width, height } = rect(getByRole("button"))
       expect(
         meetsTargetSize(width, height),
@@ -34,7 +25,7 @@ describe("2.5.8 Target Size — shared Button primitive", () => {
   )
 
   it("an icon-only circle Button meets the 24x24 minimum", () => {
-    const { getByRole } = render(
+    const { getByRole } = renderInViewport(
       <Button shape="circle" aria-label="Settings">
         <span aria-hidden="true" className="size-4" />
       </Button>,
@@ -46,7 +37,7 @@ describe("2.5.8 Target Size — shared Button primitive", () => {
   // Fidelity: a deliberately tiny box must fail, so a future measurement-logic
   // regression can't silently pass every element.
   it("a 10x10 target fails the minimum (guard bites)", () => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderInViewport(
       <div data-testid="tiny" style={{ width: 10, height: 10 }} />,
     )
     const { width, height } = rect(getByTestId("tiny"))

--- a/web/src/test/textSpacing.browser.test.tsx
+++ b/web/src/test/textSpacing.browser.test.tsx
@@ -1,9 +1,9 @@
-import { afterEach, beforeAll, describe, expect, it } from "vitest"
-import { cleanup, render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { render } from "@testing-library/react"
 import type { CSSProperties } from "react"
 
-import "@/index.css"
 import { Card } from "@/components/ui"
+import { setupBrowserA11y } from "./browserA11y"
 
 // 1.4.12 Text Spacing: no loss of content when the user overrides line-height to
 // 1.5x, paragraph spacing to 2x, letter-spacing to 0.12em, and word-spacing to
@@ -19,10 +19,7 @@ const TEXT_SPACING: CSSProperties = {
   wordSpacing: "0.16em",
 }
 
-beforeAll(() => {
-  document.documentElement.setAttribute("data-theme", "sumi")
-})
-afterEach(cleanup)
+setupBrowserA11y()
 
 // A container with no clipping is one whose content isn't cut off by a fixed size:
 // scroll size never exceeds client size on either axis.


### PR DESCRIPTION
## What

Two behavior-preserving cleanups after the five merged a11y PRs, in two commits:

1. **Shared browser-test harness** (`refactor`). The four browser layout guards (target size, reflow, resize text, text spacing) each repeated the same setup — app CSS import, `sumi` theme, cleanup, the `VIEWPORT` constant, and `descendantWidths`/`rect` helpers. Extracted into `web/src/test/browserA11y.tsx` (mirroring `src/test/axe.ts`) so each guard is just its assertions.

2. **Parallel CI graph** (`ci`). Split the single sequential `check` job into parallel role-lanes — `static` (typecheck/lint/arch/format), `test` (node vitest), `browser` (Chromium guards), `locale` (i18n), `audits` (report generation) — joined by a single `ci` fan-in gate. Adds `test:node`/`test:browser` scripts for the split.

## Why

- The guard setup was copy-adapted four times (drift risk); one harness is the same move `axe.ts` already makes.
- The old single job rendered as one opaque node in the Actions graph and put the ~90 MB Playwright Chromium install on the critical path of **every** run. Now the graph reads as a pipeline, and Chromium is isolated to the `browser` lane and cached (keyed on the Playwright version), so the fast lanes never pay it.

## Approach notes

- Fan-out/fan-in via `needs:` is the standard GitHub Actions parallel shape; a dynamic matrix (the other common monorepo pattern) is deliberately **not** used — `web/` is a single package, so a small static set of role-lanes is the right size.
- The `ci` gate uses `if: always()` + explicit `needs.*.result` inspection so a skipped or failed lane fails the gate (a bare `needs` would let a skip pass).
- Verified against repo settings: `main`'s ruleset has no `required_status_checks` rule, so splitting the `check` job repoints no pinned status. If required checks are added later, pin the single `ci` gate.

## Scope + guarantees

Behavior-preserving: all 11 original gate commands are present across the new lanes, the same artifacts upload with the same names, and the guard/test counts are unchanged. The apparent per-guard duplications that remain (`resizeText`'s `sample()` factory for `rerender`, `textSpacing`'s `isNotClipped`) are intentional guard-specific divergences, left un-hoisted.

## Verification

`npm run check` green — 291 test files / 3219 tests, 0 lint errors, prettier clean; `test:node` confirmed browser-free; `actionlint` reports the workflow clean. Plan: `docs/plans/2026-08-05-002-refactor-web-ci-and-test-harness-consolidation-plan.md`.

Note: the graph rendering and Playwright cache behavior can only be fully confirmed on this PR's own CI run (the first run that exercises the split).