### PR TITLE
fix(ci): run test:node in deploy/release gates (no Chromium)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -161,8 +161,10 @@ jobs:
       - run: npm ci
 
       # Gate the deploy on the same suite as web-deploy.yaml (incl. the skeleton
-      # parity test that vite build can't catch).
-      - run: npm test
+      # parity test that vite build can't catch). test:node only — the browser
+      # a11y guards gate every PR via web-ci and need Chromium; the release
+      # deploy gate doesn't re-run them (no ~90MB browser install).
+      - run: npm run test:node
 
       # Resolve the SHA of the checked-out tag so the build stamps the commit
       # that was actually released, not github.sha (the main tip that triggered

--- a/.github/workflows/web-deploy-preview.yaml
+++ b/.github/workflows/web-deploy-preview.yaml
@@ -61,7 +61,10 @@ jobs:
 
       # Gate the deploy on the test suite (incl. skeleton parity), same as the
       # production deploy — a broken skeleton bundle must not reach preview.
-      - run: npm test
+      # test:node only: the browser a11y guards (2.5.8/1.4.10/1.4.4/1.4.12) gate
+      # every PR via web-ci and need Chromium; re-running them to gate a deploy
+      # adds the ~90MB browser install for no extra safety.
+      - run: npm run test:node
 
       # `npm run build` runs `tsc -b && vite build`; the type-check is
       # blocking. Served from the root of preview.classroom50.org, so the

--- a/.github/workflows/web-deploy.yaml
+++ b/.github/workflows/web-deploy.yaml
@@ -56,7 +56,9 @@ jobs:
       # parity test / buildSkeletonFiles throw detects a drifted bundle. Gating
       # the deploy on it keeps a broken skeleton from shipping even if web-ci
       # was skipped (the deploy is path-scoped to web/**, same as web-ci).
-      - run: npm test
+      # test:node only: the browser a11y guards gate every PR via web-ci and need
+      # Chromium; the deploy gate doesn't re-run them (no ~90MB browser install).
+      - run: npm run test:node
 
       # `npm run build` runs `tsc -b && vite build`; the type-check is
       # blocking, so a regression fails the deploy instead of silently


### PR DESCRIPTION
## What

The three deploy/release workflows (`web-deploy-preview`, `web-deploy`, `release-please`) run `npm test` as a pre-build gate. Switch them to `npm run test:node`.

## Why

#506 split vitest into `node` + `browser` projects, so plain `npm test` now also launches Chromium via the browser project. Those three workflows run `npm test` but never install the Playwright browser — so the post-merge **preview deploy went red** (`Executable doesn't exist at .../ms-playwright/...`), and `web-deploy` + `release-please` would hit the identical failure on their next run. `web-ci` was unaffected because it installs Chromium in its isolated `browser` lane.

The browser a11y guards (2.5.8 / 1.4.10 / 1.4.4 / 1.4.12) already gate **every PR** via `web-ci`, so re-running them to gate a deploy adds no safety — it just re-pays the ~90MB browser download. The deploy gate's job is "don't ship a broken build" (skeleton parity, type-check), which `test:node` + `build` fully covers.

## Verification

`npm run test:node` runs clean locally — 286 files / 3203 tests, no browser involvement, zero errors (the failing deploy showed 3203 passed **+ 1 browser-launch error**). `actionlint` clean on all three workflows; no bare `npm test` remains outside `web-ci`.