### PR TITLE
feat(web): scaffold the manual a11y assessment and add an accessibility statement

### DIFF
--- a/web/accessibility/manual-assessment.md
+++ b/web/accessibility/manual-assessment.md
@@ -1,0 +1,144 @@
+# Manual accessibility assessment — WCAG 2.2 AA
+
+Committed assessor checklist for the WCAG 2.2 success criteria that automated
+checks can't establish. These need a human keyboard + screen-reader pass; work
+down each section and record the verdict in the VPAT model.
+
+## How to record a result
+
+For each SC below, after assessing it, edit its entry in
+`web/src/util/vpatModel.ts`:
+
+- set `status` to `supports`, `partially`, or `doesNotSupport`;
+- add `evidence: "manual"`;
+- replace the remark with a specific, dated note (what you tested + the outcome),
+  e.g. `"2026-08-05 — VoiceOver/Safari + NVDA/Firefox: focus order on login,
+accept, submit follows visual order; no traps. Supports."`;
+- for any `partially` / `doesNotSupport`, open a tracked remediation follow-up.
+
+The VPAT integrity guard (`vpatGuard.test.ts`) already enforces that a `supports`
+verdict carries evidence, and the progress guard
+(`vpatManualAssessment.test.ts`) checks this checklist stays in lockstep with the
+model's still-outstanding set — so removing a section here while its SC is still
+`notEvaluated` (or vice versa) fails CI.
+
+## Test matrix
+
+- **Keyboard-only:** Tab / Shift+Tab / Enter / Space / arrow keys / Esc; no mouse.
+- **Screen readers (minimum):** VoiceOver + Safari (macOS), NVDA + Firefox
+  (Windows). JAWS is an open question (see plan `-004-`); add it if the committee
+  requires it.
+- **Primary flows to exercise each SC on:** login, accept assignment, submit,
+  roster management, org settings.
+
+---
+
+## Perceivable
+
+### 1.1.1 Non-text Content (A)
+
+- **Supports means:** every informative image/icon has a text alternative; decorative ones are hidden from AT.
+- **Keyboard:** n/a (content check).
+- **Screen reader:** navigate images/icons on each flow; confirm meaningful alt text is announced and decorative graphics are silent (not "image").
+
+### 1.3.1 Info and Relationships (A)
+
+- **Supports means:** structure conveyed visually (headings, lists, form labels, tables) is programmatically determinable.
+- **Keyboard:** tab through forms; confirm each field's label is associated.
+- **Screen reader:** use rotor/element list for headings, lists, form fields; confirm relationships match the visual structure.
+
+### 1.3.2 Meaningful Sequence (A)
+
+- **Supports means:** reading/navigation order matches the meaningful visual order.
+- **Keyboard:** Tab through each page; focus order follows the visual flow.
+- **Screen reader:** read the page top-to-bottom; the announced sequence makes sense.
+
+### 1.3.5 Identify Input Purpose (AA)
+
+- **Supports means:** inputs collecting user info use appropriate `autocomplete` tokens.
+- **Keyboard:** n/a.
+- **Screen reader / inspect:** check login/profile inputs expose the correct input purpose (autocomplete).
+
+### 1.4.13 Content on Hover or Focus (AA)
+
+- **Supports means:** hover/focus content (tooltips) is dismissable (Esc), hoverable, and persistent until dismissed.
+- **Keyboard:** focus a tooltip trigger (e.g. the help affordance in FormField); confirm the bubble shows, Esc dismisses it, and it doesn't vanish on pointer move into it.
+- **Screen reader:** confirm the tooltip content is reachable/announced.
+
+## Operable
+
+### 2.1.1 Keyboard (A)
+
+- **Supports means:** all functionality is operable by keyboard alone.
+- **Keyboard:** complete each primary flow with no mouse — every control reachable and actuatable.
+- **Screen reader:** n/a (keyboard check).
+
+### 2.1.2 No Keyboard Trap (A)
+
+- **Supports means:** focus can always move away from any component by keyboard.
+- **Keyboard:** enter modals, menus, and the toast region; confirm Tab/Esc always escapes; focus returns to the trigger on modal close.
+
+### 2.4.1 Bypass Blocks (A)
+
+- **Supports means:** a mechanism (skip link / landmarks) bypasses repeated blocks.
+- **Keyboard:** first Tab on a page reveals a "skip to main content" link that moves focus to main.
+- **Screen reader:** confirm landmark navigation (main/nav) works via the rotor.
+
+### 2.4.3 Focus Order (A)
+
+- **Supports means:** focus order preserves meaning and operability.
+- **Keyboard:** Tab through each flow; order is logical, no jumps that lose context.
+
+### 2.4.4 Link Purpose (In Context) (A)
+
+- **Supports means:** each link's purpose is clear from its text or context.
+- **Screen reader:** list links via the rotor; each is distinguishable and purposeful (no bare "click here"/"link").
+
+### 2.4.6 Headings and Labels (AA)
+
+- **Supports means:** headings and labels describe topic or purpose.
+- **Screen reader:** review the heading outline and form labels on each flow; they're descriptive and non-duplicative.
+
+### 2.4.7 Focus Visible (AA)
+
+- **Supports means:** the keyboard focus indicator is visible.
+- **Keyboard:** Tab through every interactive element; a clear focus ring is always visible (including on the custom Button/Input primitives).
+
+### 2.4.11 Focus Not Obscured (Minimum) (AA)
+
+- **Supports means:** a focused element is not entirely hidden by sticky headers/overlays.
+- **Keyboard:** Tab to elements near sticky UI (headers, banners, the toast region); the focused control stays at least partially visible.
+
+### 2.5.3 Label in Name (A)
+
+- **Supports means:** a control's accessible name contains its visible label text.
+- **Screen reader:** for controls with visible text, confirm the announced name includes that text (matters for voice-control users).
+
+## Understandable
+
+### 3.2.3 Consistent Navigation (AA)
+
+- **Supports means:** repeated navigation is in a consistent relative order across pages.
+- **Keyboard/visual:** the nav/drawer order is consistent across routes.
+
+### 3.2.4 Consistent Identification (AA)
+
+- **Supports means:** components with the same function are identified consistently.
+- **Screen reader:** the same action (e.g. "Sign out", icon buttons) has a consistent accessible name across the app.
+
+### 3.3.7 Redundant Entry (A)
+
+- **Supports means:** info already entered is auto-populated or available, not re-asked in the same process.
+- **Keyboard:** step through multi-step flows (e.g. classroom/assignment creation); previously entered data isn't needlessly re-requested.
+
+### 3.3.8 Accessible Authentication (Minimum) (AA)
+
+- **Supports means:** no cognitive-function test (e.g. remembering/transcribing) without an alternative; auth is delegated to GitHub OAuth/device-code.
+- **Keyboard + screen reader:** complete sign-in via the device-code/OAuth flow using keyboard + AT; confirm no app-imposed cognitive test and the flow is announced.
+
+## Robust
+
+### 4.1.2 Name, Role, Value (A)
+
+- **Supports means:** every UI component exposes a correct name, role, and state to AT.
+- **Screen reader:** for buttons, links, inputs, menus, modals, tabs on each flow, confirm the announced role + name + state (expanded/checked/invalid) is correct and updates on interaction.

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -6,7 +6,21 @@
     "pageSubtitle": "How the Classroom50 web app conforms to WCAG 2.2, checked automatically on every build.",
     "tab": {
       "contrast": "Color contrast",
-      "vpat": "Conformance report"
+      "vpat": "Conformance report",
+      "statement": "Statement"
+    },
+    "statement": {
+      "heading": "Accessibility statement",
+      "intro": "Classroom50 is committed to making its web app usable by everyone, including people who rely on assistive technology.",
+      "targetHeading": "Conformance target",
+      "target": "We aim to conform to the Web Content Accessibility Guidelines (WCAG) 2.2 at Level AA.",
+      "evidenceHeading": "How we evidence it",
+      "evidence": "Color contrast is verified by an automated audit on every build, and structural and layout criteria (labels, status messages, target size, reflow, resize, and text spacing) are enforced by automated checks in continuous integration. The remaining criteria are assessed by a manual keyboard and screen-reader pass.",
+      "limitationsHeading": "Known limitations",
+      "limitations": "Some success criteria that require human judgement are still awaiting their manual assessment and are reported as \"Not Evaluated\" in the conformance report until that pass is complete.",
+      "feedbackHeading": "Feedback",
+      "feedback": "If you encounter an accessibility barrier, please let us know via",
+      "feedbackLink": "the accessibility discussion"
     },
     "stat": {
       "pairs": "Color pairs",

--- a/web/src/pages/AccessibilityPage.tsx
+++ b/web/src/pages/AccessibilityPage.tsx
@@ -809,7 +809,40 @@ function ContrastSection() {
   )
 }
 
-type PanelKey = "contrast" | "vpat"
+type PanelKey = "contrast" | "vpat" | "statement"
+
+// The public accessibility statement: conformance target, how it's evidenced,
+// known limitations, and a feedback path. Prose is i18n-backed; the discussion
+// link is the feedback route (issue #493).
+function StatementSection() {
+  const { t } = useTranslation()
+  return (
+    <Card>
+      <Card.Body className="prose prose-sm max-w-none">
+        <h2>{t("accessibility.statement.heading")}</h2>
+        <p>{t("accessibility.statement.intro")}</p>
+        <h3>{t("accessibility.statement.targetHeading")}</h3>
+        <p>{t("accessibility.statement.target")}</p>
+        <h3>{t("accessibility.statement.evidenceHeading")}</h3>
+        <p>{t("accessibility.statement.evidence")}</p>
+        <h3>{t("accessibility.statement.limitationsHeading")}</h3>
+        <p>{t("accessibility.statement.limitations")}</p>
+        <h3>{t("accessibility.statement.feedbackHeading")}</h3>
+        <p>
+          {t("accessibility.statement.feedback")}{" "}
+          <a
+            href="https://github.com/foundation50/classroom50/discussions/493"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t("accessibility.statement.feedbackLink")}
+          </a>
+          .
+        </p>
+      </Card.Body>
+    </Card>
+  )
+}
 
 export default function AccessibilityPage() {
   const { t } = useTranslation()
@@ -819,6 +852,7 @@ export default function AccessibilityPage() {
   const tabs: { key: PanelKey; label: string }[] = [
     { key: "contrast", label: t("accessibility.tab.contrast") },
     { key: "vpat", label: t("accessibility.tab.vpat") },
+    { key: "statement", label: t("accessibility.tab.statement") },
   ]
 
   return (
@@ -847,7 +881,13 @@ export default function AccessibilityPage() {
         ))}
       </div>
 
-      {panel === "contrast" ? <ContrastSection /> : <VpatSection />}
+      {panel === "contrast" ? (
+        <ContrastSection />
+      ) : panel === "vpat" ? (
+        <VpatSection />
+      ) : (
+        <StatementSection />
+      )}
     </div>
   )
 }

--- a/web/src/util/vpatManualAssessment.test.ts
+++ b/web/src/util/vpatManualAssessment.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { CRITERIA, hasGenericRemark } from "./vpatModel"
+
+// Keeps the committed manual-assessment checklist (web/accessibility/
+// manual-assessment.md) in lockstep with the VPAT model. The checklist must have
+// exactly one section per still-outstanding SC — a `notEvaluated`, no-evidence
+// criterion (hasGenericRemark). As a human records a `manual` verdict in
+// vpatModel.ts, that SC drops out of the outstanding set and its checklist
+// section must be removed; a drifted checklist (missing an outstanding SC, or
+// keeping a section for an already-assessed one) fails here. This is coverage
+// tracking; the supports-requires-evidence rule is owned by vpatGuard.test.ts.
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const checklistPath = path.resolve(
+  here,
+  "..",
+  "..",
+  "accessibility",
+  "manual-assessment.md",
+)
+
+// The SC ids the model still needs a human to assess.
+const outstanding = CRITERIA.filter(hasGenericRemark)
+  .map((c) => c.id)
+  .sort()
+
+// The SC ids the checklist documents, from its `### N.N.N Name (Level)` headings.
+const checklist = readFileSync(checklistPath, "utf8")
+const documented = Array.from(checklist.matchAll(/^###\s+(\d+\.\d+\.\d+)\b/gm))
+  .map((m) => m[1])
+  .sort()
+
+describe("manual-assessment checklist ↔ VPAT model", () => {
+  it("documents exactly the still-outstanding SCs (no drift)", () => {
+    expect(documented).toEqual(outstanding)
+  })
+
+  it("has no duplicate SC sections", () => {
+    expect(new Set(documented).size).toBe(documented.length)
+  })
+
+  // Guards the "fully assessed" future: when nothing is outstanding, the
+  // checklist should be empty of SC sections and this still passes (both []).
+  it("stays consistent when the outstanding set is empty", () => {
+    if (outstanding.length === 0) {
+      expect(documented).toEqual([])
+    }
+  })
+})


### PR DESCRIPTION
## What

Sets up the human keyboard + screen-reader assessment (WCAG 2.2 U11) as a fill-in-the-blanks task, and ships the public accessibility statement.

- **Assessor checklist** (`web/accessibility/manual-assessment.md`) — one section per still-`notEvaluated` SC (19 today), each with what "supports" means, keyboard steps, and VoiceOver/NVDA steps, plus the primary flows to exercise (login / accept / submit / roster / org settings).
- **Progress guard** (`vpatManualAssessment.test.ts`) — keeps the checklist in lockstep with the VPAT model: it must document exactly the model's still-outstanding SC set. As a human records a `manual` verdict in `vpatModel.ts`, that SC drops out and its checklist section must be removed, or CI fails. Makes remaining work visible and partial progress landable.
- **Accessibility statement** — a Statement tab on `/accessibility` with the conformance target (WCAG 2.2 AA), how it's evidenced (automated + manual), known limitations, and a feedback path (discussion #493). All prose via `t()`.

## What this deliberately does NOT do

It does **not** produce the assessment verdicts. Those need a human keyboard + screen-reader pass an agent can't perform, and the VPAT design forbids fabricating `manual` verdicts — so the 19 SCs stay `notEvaluated`. This PR is the scaffold that turns the manual pass into "work down the checklist, flip each SC in the model." No new `manual`-verdict wiring was needed: the model/guard/renderer already ingest `manual` evidence.

## Verification

`npm run check` green — 292 test files / 3222 tests, 0 lint errors, prettier clean, i18n audit PASS (statement prose all `t()`-backed). Confirmed no verdicts changed (still 19 `notEvaluated`). Progress guard verified to bite bidirectionally on checklist↔model drift.

Plan: `docs/plans/2026-08-05-004-feat-web-manual-a11y-assessment-scaffold-plan.md`. The manual assessment itself is the standing human follow-up the checklist enables.