### PR TITLE
feat(web): dev-only auto-login from VITE_GITHUB_PAT

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -17,6 +17,14 @@ Requires Node/npm.
 
 3. `npm run dev` and open http://localhost:5173
 
+To skip the sign-in screen during local development, set a classic GitHub PAT in
+`.env.local` as `VITE_GITHUB_PAT` — the dev server validates it (same required
+scopes as the manual paste flow) and auto-signs-in on load. `vite.config.ts`
+hard-blanks this value for any non-development build, so it can never be inlined
+into a deployed bundle. It also never overrides an existing signed-in session.
+Still, don't set it for a production build you ship — a `VITE_*` value is inlined
+verbatim into the bundle, and that build-time strip is the only guard.
+
 ### GitHub OAuth app
 
 Sign-in requires a [GitHub OAuth app](https://github.com/settings/developers):

--- a/web/src/auth/useGithubAuth.autoLogin.test.tsx
+++ b/web/src/auth/useGithubAuth.autoLogin.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement, StrictMode } from "react"
+
+// Router is imported for the deep-link push effect; stub it so the test doesn't
+// pull the generated route tree.
+vi.mock("@/router", () => ({
+  default: { history: { push: vi.fn() } },
+}))
+
+const fetchGithubUserWithScopes =
+  vi.fn<(token: string) => Promise<{ user: unknown; scopes: string | null }>>()
+const fetchGithubUser = vi.fn<(token: string) => Promise<unknown>>()
+
+vi.mock("./github-user-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./github-user-api")>()
+  return {
+    ...actual,
+    fetchGithubUserWithScopes: (token: string) =>
+      fetchGithubUserWithScopes(token),
+    fetchGithubUser: (token: string) => fetchGithubUser(token),
+  }
+})
+
+const storage = {
+  token: null as string | null,
+  clientId: "",
+  scope: "",
+}
+const persistGithubToken = vi.fn<(token: string, scope?: string) => void>()
+
+vi.mock("./storage", () => ({
+  getStoredGithubToken: () => storage.token,
+  getStoredGithubClientId: () => storage.clientId,
+  getStoredGithubScope: () => storage.scope,
+  persistGithubToken: (token: string, scope?: string) =>
+    persistGithubToken(token, scope),
+  persistGithubClientId: vi.fn(),
+  clearGithubToken: vi.fn(),
+  saveOAuthSession: vi.fn(),
+  consumeOAuthSession: () => ({
+    verifier: null,
+    expectedState: null,
+    clientId: null,
+    scope: null,
+    returnTo: null,
+  }),
+}))
+
+import { GitHubAuthProvider, useGithubAuth } from "./useGithubAuth"
+import { GitHubUserFetchError } from "./github-user-api"
+
+const FULL_SCOPES = "read:user repo workflow admin:org delete_repo"
+
+function freshClient() {
+  return new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+}
+
+function wrapper(strict = false) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    const tree = createElement(
+      QueryClientProvider,
+      { client: freshClient() },
+      createElement(GitHubAuthProvider, null, children),
+    )
+    return strict ? createElement(StrictMode, null, tree) : tree
+  }
+}
+
+function setEnv(env: { DEV?: boolean; pat?: string }) {
+  vi.stubEnv("DEV", env.DEV ?? true)
+  // import.meta.env.VITE_GITHUB_PAT — vi.stubEnv drives import.meta.env in Vitest.
+  vi.stubEnv("VITE_GITHUB_PAT", env.pat ?? "")
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storage.token = null
+  storage.clientId = ""
+  storage.scope = ""
+  window.history.replaceState({}, "", "/")
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+// #6/#7: the dev auto-login effect end-to-end — the mount effect consumes
+// import.meta.env, validates, and reaches completeSignIn or logs on rejection.
+describe("dev auto-login effect wiring", () => {
+  it("auto-signs-in on mount with a valid env PAT (reaches completeSignIn)", async () => {
+    setEnv({ DEV: true, pat: "ghp_valid" })
+    fetchGithubUserWithScopes.mockResolvedValue({
+      user: { login: "octocat" },
+      scopes: FULL_SCOPES,
+    })
+    fetchGithubUser.mockResolvedValue({ login: "octocat" })
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    await waitFor(() => expect(result.current.token).toBe("ghp_valid"))
+    expect(persistGithubToken).toHaveBeenCalledWith("ghp_valid", FULL_SCOPES)
+    expect(result.current.screen).toBe("authed")
+    expect(fetchGithubUserWithScopes).toHaveBeenCalledWith("ghp_valid")
+  })
+
+  it("does NOT sign in and logs a warning when the env PAT is rejected (missing scopes)", async () => {
+    setEnv({ DEV: true, pat: "ghp_underscoped" })
+    fetchGithubUserWithScopes.mockResolvedValue({
+      user: { login: "octocat" },
+      scopes: "repo", // missing workflow/admin:org/read:user/delete_repo
+    })
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    await waitFor(() =>
+      expect(
+        warn.mock.calls.some((c) =>
+          String(c[0]).includes("VITE_GITHUB_PAT auto-login rejected"),
+        ),
+      ).toBe(true),
+    )
+    expect(result.current.token).toBeNull()
+    expect(persistGithubToken).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it("skips auto-login entirely when not a dev build", async () => {
+    setEnv({ DEV: false, pat: "ghp_valid" })
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    await waitFor(() => expect(result.current.status).not.toBe("loading"))
+    expect(fetchGithubUserWithScopes).not.toHaveBeenCalled()
+    expect(result.current.token).toBeNull()
+  })
+
+  it("does not override a stored session with the env PAT", async () => {
+    setEnv({ DEV: true, pat: "ghp_valid" })
+    storage.token = "stored-token"
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    await waitFor(() => expect(result.current.token).toBe("stored-token"))
+    expect(fetchGithubUserWithScopes).not.toHaveBeenCalled()
+  })
+
+  // #3: StrictMode double-invoke must not fire two validations before the async
+  // token lands (the didAutoLoginRef sentinel).
+  it("fires exactly one validation under StrictMode double-mount", async () => {
+    setEnv({ DEV: true, pat: "ghp_valid" })
+    fetchGithubUserWithScopes.mockResolvedValue({
+      user: { login: "octocat" },
+      scopes: FULL_SCOPES,
+    })
+    fetchGithubUser.mockResolvedValue({ login: "octocat" })
+
+    renderHook(() => useGithubAuth(), { wrapper: wrapper(true) })
+
+    await waitFor(() => expect(fetchGithubUserWithScopes).toHaveBeenCalled())
+    // The ref sentinel guards the second StrictMode pass; only one GET /user
+    // validation is dispatched despite the double-invoke.
+    expect(fetchGithubUserWithScopes).toHaveBeenCalledTimes(1)
+  })
+
+  // #5: a returning OAuth ?code owns sign-in for that load; the PAT auto-login
+  // must stand down so the two paths don't both drive completeSignIn.
+  it("skips the env-PAT auto-login when a ?code OAuth callback is present", async () => {
+    setEnv({ DEV: true, pat: "ghp_valid" })
+    window.history.replaceState({}, "", "/login?code=abc&state=xyz")
+
+    renderHook(() => useGithubAuth(), { wrapper: wrapper() })
+
+    // Give any async validation a chance to (not) fire.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(fetchGithubUserWithScopes).not.toHaveBeenCalled()
+  })
+})
+
+// #8: the submitPat -> validateAndSignInWithPat extraction preserves behavior:
+// blank tokens early-return; each reject branch surfaces via patError; a valid
+// token signs in.
+describe("submitPat (post-refactor behavior)", () => {
+  it("early-returns on a blank token without firing a validation", async () => {
+    setEnv({ DEV: false })
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.submitPat("   ")
+    await new Promise((r) => setTimeout(r, 0))
+    expect(fetchGithubUserWithScopes).not.toHaveBeenCalled()
+    expect(result.current.patError).toBeNull()
+  })
+
+  it("surfaces a fine-grained rejection via patError without signing in", async () => {
+    setEnv({ DEV: false })
+    fetchGithubUserWithScopes.mockResolvedValue({
+      user: { login: "octocat" },
+      scopes: null, // fine-grained: unverifiable
+    })
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.submitPat("github_pat_xxx")
+    await waitFor(() => expect(result.current.patError).not.toBeNull())
+    // Untranslated t() returns the key, locking the reject branch's message id.
+    expect(result.current.patError).toBe("auth.errorPatFineGrained")
+    expect(result.current.token).toBeNull()
+  })
+
+  it("surfaces a 401 rejection via patError", async () => {
+    setEnv({ DEV: false })
+    fetchGithubUserWithScopes.mockRejectedValue(new GitHubUserFetchError(401))
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.submitPat("ghp_bad")
+    await waitFor(() => expect(result.current.patError).not.toBeNull())
+    expect(result.current.patError).toBe("auth.errorPatRejected401")
+    expect(result.current.token).toBeNull()
+  })
+
+  it("signs in on a fully-scoped token", async () => {
+    setEnv({ DEV: false })
+    fetchGithubUserWithScopes.mockResolvedValue({
+      user: { login: "octocat" },
+      scopes: FULL_SCOPES,
+    })
+    fetchGithubUser.mockResolvedValue({ login: "octocat" })
+
+    const { result } = renderHook(() => useGithubAuth(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.submitPat("ghp_good")
+    await waitFor(() => expect(result.current.token).toBe("ghp_good"))
+    expect(result.current.screen).toBe("authed")
+  })
+})

--- a/web/src/auth/useGithubAuth.recovery.test.ts
+++ b/web/src/auth/useGithubAuth.recovery.test.ts
@@ -6,6 +6,7 @@ import {
   isValidationStuck,
   recoverStrandedExchange,
   resolveAuthStatus,
+  resolveDevAutoLoginPat,
   shouldExpireOnUserError,
   type AuthStatusInput,
 } from "./useGithubAuth"
@@ -94,6 +95,34 @@ describe("classifyPatResult", () => {
   })
 })
 
+// Dev-only VITE_GITHUB_PAT auto-login gate. It must be inert unless it's a dev
+// build with no stored session, so both a non-dev build and a present stored
+// token suppress it. A blank/whitespace var is a no-op; a real token is trimmed
+// to tolerate a trailing newline from a `.env.local` value.
+describe("resolveDevAutoLoginPat", () => {
+  const base = { isDev: true, hasStoredToken: false, envPat: "ghp_abc123" }
+
+  it("returns the trimmed token in a dev build with no stored token", () => {
+    expect(resolveDevAutoLoginPat({ ...base, envPat: "  ghp_abc123\n" })).toBe(
+      "ghp_abc123",
+    )
+  })
+
+  it("returns null in a production build even with a PAT set (never ship a bundled token)", () => {
+    expect(resolveDevAutoLoginPat({ ...base, isDev: false })).toBeNull()
+  })
+
+  it("returns null when a token is already stored (don't override a hand-signed-in session)", () => {
+    expect(resolveDevAutoLoginPat({ ...base, hasStoredToken: true })).toBeNull()
+  })
+
+  it("returns null when the var is unset, empty, or whitespace-only", () => {
+    expect(resolveDevAutoLoginPat({ ...base, envPat: undefined })).toBeNull()
+    expect(resolveDevAutoLoginPat({ ...base, envPat: "" })).toBeNull()
+    expect(resolveDevAutoLoginPat({ ...base, envPat: "   " })).toBeNull()
+  })
+})
+
 // The auth-status verdict for the router guard. Headline invariants (#185, #187):
 //   - An offline cold reload with a stored token but no cached user HOLDS at
 //     "loading" (session preserved) rather than bouncing to /login.
@@ -113,6 +142,7 @@ describe("resolveAuthStatus", () => {
     userErrorExpiresToken: false,
     userErrorIsTransient: false,
     hasUser: true,
+    autoLoginPending: false,
   }
 
   it("is 'loading' until stored auth has been read", () => {
@@ -124,6 +154,31 @@ describe("resolveAuthStatus", () => {
   it("is 'unauthenticated' with no token (even offline)", () => {
     expect(
       resolveAuthStatus({ ...authed, hasToken: false, isOnline: false }),
+    ).toBe("unauthenticated")
+  })
+
+  it("HOLDS at 'loading' while a dev auto-login is validating with no token yet (don't bounce a deep link to /login)", () => {
+    // The VITE_GITHUB_PAT token lands async in the mutation's onSuccess; between
+    // startup and sign-in there's a window with hasToken:false. autoLoginPending
+    // holds "loading" so the _authed guard doesn't eject a deep-linked dev load.
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        hasToken: false,
+        hasUser: false,
+        autoLoginPending: true,
+      }),
+    ).toBe("loading")
+  })
+
+  it("is 'unauthenticated' once a rejected auto-login settles (autoLoginPending back to false, still no token)", () => {
+    expect(
+      resolveAuthStatus({
+        ...authed,
+        hasToken: false,
+        hasUser: false,
+        autoLoginPending: false,
+      }),
     ).toBe("unauthenticated")
   })
 

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -120,6 +120,9 @@ export type AuthStatusInput = {
   // clear on its own, so holding would strand the user on a spinner forever.
   userErrorIsTransient: boolean
   hasUser: boolean
+  // A dev VITE_GITHUB_PAT auto-login is validating; its token lands async, so
+  // hold at "loading" rather than "unauthenticated" (see resolveAuthStatus).
+  autoLoginPending: boolean
 }
 
 // Whether a token holder is stranded on the loading hold with no way forward:
@@ -175,6 +178,9 @@ export function isValidationStuck(input: {
 // no branch can mask a truly dead token.
 export function resolveAuthStatus(input: AuthStatusInput): AuthStatus {
   if (!input.hasLoadedStoredAuth) return "loading"
+  // A dev auto-login's token lands async: hold "loading" in the startup gap so
+  // the guard doesn't bounce a deep link to /login. Never set in a prod build.
+  if (input.autoLoginPending && !input.hasToken) return "loading"
   if (!input.hasToken) return "unauthenticated"
   if (input.hasUser) return "authenticated"
   if (input.userErrorExpiresToken) return "unauthenticated"
@@ -213,6 +219,21 @@ export function classifyPatResult(scopes: string | null): PatResult {
   return { kind: "ok", scopes }
 }
 
+// Dev-only convenience: whether to auto-login from VITE_GITHUB_PAT on cold start.
+// Gated on DEV and no stored token, so it never overrides a hand-signed-in
+// session; the build-time token strip lives in vite.config.ts. Trimmed so a
+// trailing newline in a `.env.local` value still works; blank/whitespace is a no-op.
+export function resolveDevAutoLoginPat(input: {
+  isDev: boolean
+  hasStoredToken: boolean
+  envPat: string | undefined
+}): string | null {
+  if (!input.isDev) return null
+  if (input.hasStoredToken) return null
+  const token = input.envPat?.trim()
+  return token ? token : null
+}
+
 function sleep(ms: number, signal: AbortSignal) {
   return new Promise<void>((resolve) => {
     const timer = window.setTimeout(resolve, ms)
@@ -238,6 +259,9 @@ function useGithubAuthState() {
   // Deep link (#71) stashed at code-exchange, consumed by the status-driven
   // effect below so navigation runs against an authenticated router context.
   const pendingReturnToRef = useRef<string | null>(null)
+  // Latches so a StrictMode double-mount (or HMR re-mount) can't fire a second
+  // dev auto-login before the first token lands async. Never set in a prod build.
+  const didAutoLoginRef = useRef(false)
 
   const [screen, setScreen] = useState<GithubAuthScreen>("config")
   const [clientId, setClientId] = useState(GITHUB_OAUTH_CLIENT_ID)
@@ -250,6 +274,9 @@ function useGithubAuthState() {
   const [device, setDevice] = useState<DeviceAuthState | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [hasLoadedStoredAuth, setHasLoadedStoredAuth] = useState(false)
+  // Holds status at "loading" while a dev auto-login validates (see
+  // resolveAuthStatus). Dev-only; stays false in prod builds.
+  const [autoLoginPending, setAutoLoginPending] = useState(false)
   // Set when a live API 401 (revoked/expired token) tears the session down, so
   // /login can explain why the user was signed out. A deliberate signOut()
   // clears it.
@@ -317,6 +344,61 @@ function useGithubAuthState() {
     [queryClient],
   )
 
+  // Validate a token against GET /user + its X-OAuth-Scopes, then sign in or
+  // report why it was rejected. Shared by the manual PAT prompt (submitPat) and
+  // the dev auto-login so both apply identical scope rules. `onReject` gets an
+  // already-translated message; `onSettled` (optional) fires once either way, so
+  // the auto-login can release its loading hold.
+  const validateAndSignInWithPat = useCallback(
+    (
+      token: string,
+      onReject: (message: string) => void,
+      onSettled?: () => void,
+    ) => {
+      log.info("validating personal access token")
+      validatePatMutation.mutate(token, {
+        onSuccess: ({ scopes }) => {
+          const result = classifyPatResult(scopes)
+
+          // A fine-grained PAT (null header) carries no verifiable scopes; its
+          // per-resource permissions can't be checked here and typically fail
+          // mid-operation, so block it at entry rather than sign in on a token
+          // we can't vet.
+          if (result.kind === "fine-grained") {
+            log.warn("PAT rejected: fine-grained (unverifiable scopes)")
+            onReject(t("auth.errorPatFineGrained"))
+            return
+          }
+
+          if (result.kind === "missing") {
+            log.warn("PAT rejected: missing required scopes", {
+              missing: result.missing,
+            })
+            onReject(
+              t("auth.errorPatMissingScopes", {
+                scopes: result.missing.join(", "),
+              }),
+            )
+            return
+          }
+
+          completeSignIn({ access_token: token, scope: result.scopes })
+        },
+        onError: (err) => {
+          if (err instanceof GitHubUserFetchError && err.status === 401) {
+            log.warn("PAT rejected: 401 (invalid token)")
+            onReject(t("auth.errorPatRejected401"))
+            return
+          }
+          log.error("PAT validation failed", { err, record: true })
+          onReject(formatError(t, err, "api.github.com"))
+        },
+        onSettled,
+      })
+    },
+    [completeSignIn, validatePatMutation, t],
+  )
+
   // On unmount mid-flow, abort the device poll loop so it doesn't run after
   // teardown.
   useEffect(
@@ -341,9 +423,41 @@ function useGithubAuthState() {
       log.info("restored stored session")
       setToken(storedToken)
       setScreen("authed")
+    } else {
+      // Dev-only: skip the sign-in screen when VITE_GITHUB_PAT holds a valid PAT
+      // (see resolveDevAutoLoginPat), validated like the manual paste flow but
+      // logged instead of prompted. Two guards: didAutoLoginRef stops a
+      // StrictMode double-mount firing twice before the token lands, and a ?code
+      // on the URL means a returning OAuth redirect owns this load, so we defer
+      // to the code-exchange effect rather than both driving completeSignIn.
+      const hasOAuthCallback = new URLSearchParams(window.location.search).has(
+        "code",
+      )
+      const envPat = resolveDevAutoLoginPat({
+        isDev: import.meta.env.DEV,
+        hasStoredToken: false,
+        envPat: import.meta.env.VITE_GITHUB_PAT,
+      })
+      if (envPat && !hasOAuthCallback && !didAutoLoginRef.current) {
+        didAutoLoginRef.current = true
+        log.info("dev auto-login from VITE_GITHUB_PAT")
+        setAutoLoginPending(true)
+        validateAndSignInWithPat(
+          envPat,
+          (message) =>
+            log.warn("VITE_GITHUB_PAT auto-login rejected", { message }),
+          // Release the loading hold once validation settles either way, so a
+          // rejected token drops to the login screen instead of spinning.
+          () => setAutoLoginPending(false),
+        )
+      }
     }
 
     setHasLoadedStoredAuth(true)
+    // Mount-once: reads one-time startup state (stored session / env PAT).
+    // validateAndSignInWithPat is excluded so a later identity change can't
+    // re-fire the auto-login.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
@@ -691,48 +805,9 @@ function useGithubAuthState() {
       if (!token) return
 
       setPatError(null)
-
-      log.info("validating personal access token")
-      validatePatMutation.mutate(token, {
-        onSuccess: ({ scopes }) => {
-          const result = classifyPatResult(scopes)
-
-          // A fine-grained PAT (null header) carries no verifiable scopes; its
-          // per-resource permissions can't be checked here and typically fail
-          // mid-operation, so block it at entry rather than sign in on a token
-          // we can't vet.
-          if (result.kind === "fine-grained") {
-            log.warn("PAT rejected: fine-grained (unverifiable scopes)")
-            setPatError(t("auth.errorPatFineGrained"))
-            return
-          }
-
-          if (result.kind === "missing") {
-            log.warn("PAT rejected: missing required scopes", {
-              missing: result.missing,
-            })
-            setPatError(
-              t("auth.errorPatMissingScopes", {
-                scopes: result.missing.join(", "),
-              }),
-            )
-            return
-          }
-
-          completeSignIn({ access_token: token, scope: result.scopes })
-        },
-        onError: (err) => {
-          if (err instanceof GitHubUserFetchError && err.status === 401) {
-            log.warn("PAT rejected: 401 (invalid token)")
-            setPatError(t("auth.errorPatRejected401"))
-            return
-          }
-          log.error("PAT validation failed", { err, record: true })
-          setPatError(formatError(t, err, "api.github.com"))
-        },
-      })
+      validateAndSignInWithPat(token, setPatError)
     },
-    [completeSignIn, validatePatMutation, t],
+    [validateAndSignInWithPat],
   )
 
   // Shared teardown for both a deliberate sign-out and an involuntary expiry.
@@ -817,6 +892,7 @@ function useGithubAuthState() {
         userErrorExpiresToken: shouldExpireOnUserError(githubUserQuery.error),
         userErrorIsTransient: isTransientUserError(githubUserQuery.error),
         hasUser: Boolean(githubUserQuery.data),
+        autoLoginPending,
       }),
     [
       hasLoadedStoredAuth,
@@ -827,6 +903,7 @@ function useGithubAuthState() {
       githubUserQuery.isError,
       githubUserQuery.error,
       githubUserQuery.data,
+      autoLoginPending,
     ],
   )
 

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,5 +1,14 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_GITHUB_CLIENT_ID?: string
+  readonly VITE_GITHUB_PROXY_BASE?: string
+  // Dev-only auto-login (see resolveDevAutoLoginPat). vite.config.ts blanks this
+  // for any non-development build, so it can't reach a deployed bundle — but a
+  // VITE_* value is inlined verbatim, so never set it for a production build.
+  readonly VITE_GITHUB_PAT?: string
+}
+
 // Release identity injected at build time via Vite `define` (see vite.config.ts).
 // Use the `appVersion` helper (src/version.ts), not these globals directly.
 declare const __APP_VERSION__: string

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config"
+import { loadEnv } from "vite"
 import { playwright } from "@vitest/browser-playwright"
 import type { Plugin } from "vite"
 import react, { reactCompilerPreset } from "@vitejs/plugin-react"
@@ -339,11 +340,22 @@ function assessmentApiPlugin(): Plugin {
     },
   }
 }
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   define: {
     __APP_VERSION__: JSON.stringify(release.version),
     __APP_COMMIT__: JSON.stringify(release.commit),
     __APP_BUILD_DATE__: JSON.stringify(release.buildDate),
+    // VITE_GITHUB_PAT is a dev-only auto-login convenience (see
+    // resolveDevAutoLoginPat). Vite inlines every VITE_* value into the bundle,
+    // so a token left in .env.local during `vite build` would ship to every
+    // visitor — the runtime DEV guard stops *use*, not *embedding*. Hard-blank
+    // the literal for any non-development build so it can never leak.
+    "import.meta.env.VITE_GITHUB_PAT":
+      mode === "development"
+        ? JSON.stringify(
+            loadEnv(mode, path.resolve(__dirname), "").VITE_GITHUB_PAT ?? "",
+          )
+        : JSON.stringify(""),
   },
   plugins: [
     tanstackRouter({
@@ -402,4 +414,4 @@ export default defineConfig({
       },
     ],
   },
-})
+}))


### PR DESCRIPTION
## What

Adds a dev-only convenience: on a local dev build, if `VITE_GITHUB_PAT` holds a classic GitHub PAT, the app validates it at startup and signs in automatically, skipping the sign-in screen. Validation reuses the exact scope checks of the manual PAT paste flow (`classifyPatResult` / `missingScopes`), so an under-scoped or fine-grained token is rejected identically — logged to the console since there is no on-screen prompt during auto-login.

## Why

Speeds up the local dev loop — no repeated OAuth/device dance or PAT paste on every fresh session — without changing the deployed app's behavior at all.

## Safety

This is the sensitive part, so it is guarded twice. At runtime, `resolveDevAutoLoginPat` only fires under `import.meta.env.DEV` and never when a session is already stored (a hand-signed-in session always wins). At build time, `vite.config.ts` hard-blanks `import.meta.env.VITE_GITHUB_PAT` for any non-development build, so a stray token left in `.env.local` can never be inlined into a shipped bundle — the runtime guard is no longer the only defense. The token is never passed to a logger (only static strings and translated messages are logged) and never persisted in a production build.

Do not set `VITE_GITHUB_PAT` for a production build you ship; the build-time strip protects `dist/`, and the README and `vite-env.d.ts` now say so explicitly.

## Robustness

The startup effect is hardened for the dev environment it runs in: a `didAutoLoginRef` sentinel prevents React StrictMode's double-mount from firing two validations before the async token lands; an `autoLoginPending` flag holds auth status at `loading` (rather than momentarily `unauthenticated`) so a deep-linked dev load is not bounced through `/login` while validation is in flight; and the auto-login stands down when a `?code` OAuth callback is on the URL so the two sign-in paths never race.

## Tests

- New unit coverage for `resolveDevAutoLoginPat` (trim, prod-off, stored-token-wins, blank no-op) and for the new `resolveAuthStatus` `autoLoginPending` branch.
- New behavioral harness `useGithubAuth.autoLogin.test.tsx` (`renderHook` + `QueryClientProvider` + `GitHubAuthProvider`) exercising the effect wiring end-to-end, the StrictMode single-fire guard, the `?code` short-circuit, and the `submitPat` reject/success branches after the shared-callback extraction.
- Full `npm run check` passes (tsc, eslint, prettier, arch:validate); 3228 node tests pass.

## Follow-up

A CI grep of a production `vite build` output for a sentinel token value would prove the build-time strip end-to-end; noted as a testing gap rather than added here since it needs a real build in CI.