### PR TITLE
feat(web): add full-report and PDF downloads to the accessibility page

### DIFF
--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -201,7 +201,7 @@ jobs:
           path: |
             web/vpat-report.json
             web/VPAT.md
-            web/VPAT-INT.md
+            web/ACCESSIBILITY-REPORT.md
           if-no-files-found: warn
 
       - name: Generate a11y inventory

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -46,7 +46,6 @@ contrast-audit.json
 # guard enforce the facts), emitted into dist/ and uploaded as CI artifacts, so
 # never committed.
 VPAT.md
-VPAT-INT.md
 vpat-report.json
 ACCESSIBILITY-REPORT.md
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -48,6 +48,7 @@ contrast-audit.json
 VPAT.md
 VPAT-INT.md
 vpat-report.json
+ACCESSIBILITY-REPORT.md
 
 # Generated accessibility inventory (criterion status + bound checks). Rendering
 # of guarded state (vpatAutomated.test.ts enforces the bindings); CI artifact,

--- a/web/accessibility/README.md
+++ b/web/accessibility/README.md
@@ -21,8 +21,9 @@ overclaim — e.g. a `supports` with no evidence — so the rendered report can
 never drift from this file.
 
 Do **not** hand-edit the generated artifacts (`VPAT.md`, `VPAT-INT.md`,
-`vpat-report.json`, `contrast-audit.json`, `a11y-inventory.json`) — they are
-gitignored renderings. Edit `vpatVerdicts.json` (via the tool below) instead.
+`ACCESSIBILITY-REPORT.md`, `vpat-report.json`, `contrast-audit.json`,
+`a11y-inventory.json`) — they are gitignored renderings. Edit `vpatVerdicts.json`
+(via the tool below) instead.
 
 ## Verdict shape
 
@@ -93,10 +94,11 @@ redirects away and its write endpoint does not exist in a production build.
 
 From `web/` (outputs are gitignored; CI uploads them as artifacts and the Vite
 build emits them into `dist/`, served at `/VPAT.md`, `/VPAT-INT.md`,
-`/vpat-report.json`, `/CONTRAST-AUDIT.md`, `/contrast-audit.json`):
+`/ACCESSIBILITY-REPORT.md`, `/vpat-report.json`, `/CONTRAST-AUDIT.md`,
+`/contrast-audit.json`):
 
 ```bash
-npm run audit:vpat            # VPAT.md (WCAG) + VPAT-INT.md (508/EN 301 549) + vpat-report.json
+npm run audit:vpat            # VPAT.md (WCAG) + VPAT-INT.md (508/EN 301 549) + ACCESSIBILITY-REPORT.md (combined) + vpat-report.json
 npm run audit:contrast        # CONTRAST-AUDIT.md + contrast-audit.json
 npm run audit:a11y            # the automated a11y checks (axe + structural + bindings)
 npm run audit:a11y:inventory  # a11y-inventory.json (what each verdict is backed by)

--- a/web/accessibility/README.md
+++ b/web/accessibility/README.md
@@ -11,7 +11,7 @@ source of truth, rendered into several views.
 | **Manual verdicts**    | `accessibility/vpatVerdicts.json` (this dir) | The only hand-edited file: per-criterion human verdicts (`status`, `evidence: "manual"`, `assessed` date, `remark`).                                              |
 | **Base model**         | `src/util/a11y/vpatModel.ts`                 | The applicable WCAG 2.2 A/AA criteria + the overlay logic (`applyVerdicts`). Contrast rows are re-derived from the live audit; automated rows are set by tooling. |
 | **Assessor guidance**  | `src/util/a11y/assessmentGuidance.ts`        | The "how to test each SC" prose the `/assess` tool shows.                                                                                                         |
-| **Report renderer**    | `src/util/a11y/vpatReport.ts`                | Renders the ACR (VPAT 2.5Rev, WCAG + INT editions) and the canonical JSON from the model.                                                                         |
+| **Report renderer**    | `src/util/a11y/vpatReport.ts`                | Renders the ACR (VPAT 2.5Rev, WCAG edition) and the canonical JSON from the model.                                                                                |
 | **Automated bindings** | `src/util/a11y/vpatAutomated.ts`             | Ties each `automated` verdict to the hermetic check that establishes it.                                                                                          |
 
 All the a11y model/report code lives under `src/util/a11y/` (a pure leaf layer —
@@ -20,7 +20,7 @@ no app imports); the report generators live under `scripts/a11y/`. The guards
 overclaim — e.g. a `supports` with no evidence — so the rendered report can
 never drift from this file.
 
-Do **not** hand-edit the generated artifacts (`VPAT.md`, `VPAT-INT.md`,
+Do **not** hand-edit the generated artifacts (`VPAT.md`,
 `ACCESSIBILITY-REPORT.md`, `vpat-report.json`, `contrast-audit.json`,
 `a11y-inventory.json`) — they are gitignored renderings. Edit `vpatVerdicts.json`
 (via the tool below) instead.
@@ -93,12 +93,12 @@ redirects away and its write endpoint does not exist in a production build.
 ## Regenerate the reports
 
 From `web/` (outputs are gitignored; CI uploads them as artifacts and the Vite
-build emits them into `dist/`, served at `/VPAT.md`, `/VPAT-INT.md`,
+build emits them into `dist/`, served at `/VPAT.md`,
 `/ACCESSIBILITY-REPORT.md`, `/vpat-report.json`, `/CONTRAST-AUDIT.md`,
 `/contrast-audit.json`):
 
 ```bash
-npm run audit:vpat            # VPAT.md (WCAG) + VPAT-INT.md (508/EN 301 549) + ACCESSIBILITY-REPORT.md (combined) + vpat-report.json
+npm run audit:vpat            # VPAT.md (WCAG) + ACCESSIBILITY-REPORT.md (combined) + vpat-report.json
 npm run audit:contrast        # CONTRAST-AUDIT.md + contrast-audit.json
 npm run audit:a11y            # the automated a11y checks (axe + structural + bindings)
 npm run audit:a11y:inventory  # a11y-inventory.json (what each verdict is backed by)
@@ -108,9 +108,8 @@ The live, no-auth report is always at `/accessibility` in the running app.
 
 ## Report format
 
-The ACR follows **VPAT® 2.5Rev** (the ITI industry-standard template) in two
-editions — WCAG and INT (Section 508 + EN 301 549 + WCAG 2.2) — kept concise:
-a short preamble (product, date, evaluation methods, conformance terms), a
-one-line summary, and per-principle tables with columns **Criterion · Level ·
-Conformance Level · Assessed · Remarks**. The `Assessed` column carries each
-verdict's date so remarks stay focused on the finding.
+The ACR follows **VPAT® 2.5Rev** (the ITI industry-standard template), WCAG
+edition, kept concise: a short preamble (product, date, evaluation methods,
+conformance terms), a one-line summary, and per-principle tables with columns
+**Criterion · Level · Conformance Level · Assessed · Remarks**. The `Assessed`
+column carries each verdict's date so remarks stay focused on the finding.

--- a/web/scripts/a11y/genVpatReport.ts
+++ b/web/scripts/a11y/genVpatReport.ts
@@ -1,5 +1,6 @@
 // Writes vpat-report.json + VPAT.md (WCAG) + VPAT-INT.md (INT: Section 508 +
-// EN 301 549 + WCAG 2.2) from the pure renderers. Run via `npm run audit:vpat`
+// EN 301 549 + WCAG 2.2) + ACCESSIBILITY-REPORT.md (both editions + the contrast
+// audit in one file) from the pure renderers. Run via `npm run audit:vpat`
 // (vite-node resolves the `@/` alias + TS). The outputs are gitignored — never
 // committed — because they are renderings of guarded state (vpatGuard.test.ts +
 // the contrast guard enforce the facts). CI uploads them as build artifacts, and
@@ -12,6 +13,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import {
+  renderCombinedReport,
   renderVpatJson,
   renderVpatReport,
 } from "../../src/util/a11y/vpatReport"
@@ -24,6 +26,7 @@ const outputs: [string, string][] = [
   ["vpat-report.json", renderVpatJson()],
   ["VPAT.md", renderVpatReport("wcag")],
   ["VPAT-INT.md", renderVpatReport("int")],
+  ["ACCESSIBILITY-REPORT.md", renderCombinedReport()],
 ]
 for (const [name, body] of outputs) {
   const outPath = path.join(dir, name)

--- a/web/scripts/a11y/genVpatReport.ts
+++ b/web/scripts/a11y/genVpatReport.ts
@@ -1,12 +1,11 @@
-// Writes vpat-report.json + VPAT.md (WCAG) + VPAT-INT.md (INT: Section 508 +
-// EN 301 549 + WCAG 2.2) + ACCESSIBILITY-REPORT.md (both editions + the contrast
-// audit in one file) from the pure renderers. Run via `npm run audit:vpat`
+// Writes vpat-report.json + VPAT.md (WCAG) + ACCESSIBILITY-REPORT.md (the VPAT +
+// the contrast audit in one file) from the pure renderers. Run via `npm run audit:vpat`
 // (vite-node resolves the `@/` alias + TS). The outputs are gitignored — never
 // committed — because they are renderings of guarded state (vpatGuard.test.ts +
 // the contrast guard enforce the facts). CI uploads them as build artifacts, and
 // the Vite build emits them into dist/ (served at /vpat-report.json, /VPAT.md,
-// /VPAT-INT.md); this script is the local + CI generator. Content is built by
-// src/util/a11y/vpatReport.ts.
+// /ACCESSIBILITY-REPORT.md); this script is the local + CI generator. Content is
+// built by src/util/a11y/vpatReport.ts.
 
 import { writeFileSync } from "node:fs"
 import path from "node:path"
@@ -24,8 +23,7 @@ const dir = path.resolve(here, "..", "..")
 
 const outputs: [string, string][] = [
   ["vpat-report.json", renderVpatJson()],
-  ["VPAT.md", renderVpatReport("wcag")],
-  ["VPAT-INT.md", renderVpatReport("int")],
+  ["VPAT.md", renderVpatReport()],
   ["ACCESSIBILITY-REPORT.md", renderCombinedReport()],
 ]
 for (const [name, body] of outputs) {

--- a/web/src/components/dev/RateLimitOverlay.tsx
+++ b/web/src/components/dev/RateLimitOverlay.tsx
@@ -6,7 +6,9 @@
 // Rendered through a portal onto document.body (NOT inside the app's React root
 // subtree) and position:fixed, so from the website's perspective it doesn't
 // exist: it's outside the app's DOM tree, reserves no layout space, and can't be
-// matched by the app's own scroll containers or :has()/descendant selectors.
+// matched by the app's own scroll containers or :has()/descendant selectors. The
+// `dev-overlay` class lets the print stylesheet hide it (it sits outside #root,
+// so hiding #root alone wouldn't keep it out of a Save-as-PDF).
 
 import { useSyncExternalStore, useState, useEffect } from "react"
 import { createPortal } from "react-dom"
@@ -86,7 +88,7 @@ export function RateLimitOverlay() {
 
   return createPortal(
     <div
-      className="pointer-events-none fixed inset-x-0 bottom-0 z-[9999] flex justify-center"
+      className="dev-overlay pointer-events-none fixed inset-x-0 bottom-0 z-[9999] flex justify-center"
       role="status"
       aria-label="GitHub rate limit (dev)"
     >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -422,3 +422,141 @@ textarea::placeholder {
 [data-theme="sumi-dark"] .text-neutral-content\/70 {
   color: color-mix(in oklab, var(--color-neutral-content) 85%, transparent);
 }
+
+/* Print / Save-as-PDF of the full accessibility report. The report content is
+   portaled to <body> as a sibling of #root (see AccessibilityPage) and stays
+   hidden on screen; during print we hide #root (the app chrome — drawer, tabs,
+   buttons) and reveal the report so the PDF is just the report. Printed on white
+   with black text and visible table borders so the VPAT/contrast tables read as
+   a clean document regardless of the active theme. */
+.report-print {
+  display: none;
+}
+
+@media print {
+  /* A comfortable document margin; the swatch previews and status backgrounds
+     must survive the browser's default "don't print backgrounds" behavior. */
+  @page {
+    margin: 16mm 14mm;
+  }
+
+  /* Hide the whole app UI; only the portaled report prints. */
+  #root {
+    display: none !important;
+  }
+
+  .report-print {
+    display: block !important;
+    color: #111;
+    background: #fff;
+    font-size: 10pt;
+    line-height: 1.45;
+    /* Print the color swatches and any tinted cells, not just white boxes. */
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .report-print h1 {
+    font-size: 16pt;
+    font-weight: 700;
+    margin: 0 0 4pt;
+  }
+
+  .report-print h2 {
+    font-size: 12pt;
+    font-weight: 600;
+    margin: 14pt 0 5pt;
+    padding-bottom: 2pt;
+    border-bottom: 1px solid #ccc;
+  }
+
+  .report-print p {
+    margin: 0 0 6pt;
+  }
+
+  /* Muted preamble/date lines under a heading. */
+  .report-print .report-meta,
+  .report-print .report-sub {
+    color: #555;
+  }
+
+  .report-print .report-summary {
+    font-weight: 600;
+    margin-bottom: 10pt;
+  }
+
+  .report-print .mono {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  }
+
+  .report-print table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 8pt;
+    page-break-inside: auto;
+  }
+
+  .report-print th,
+  .report-print td {
+    border: 1px solid #bbb;
+    padding: 3pt 5pt;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .report-print th {
+    background: #f0f0f0;
+    font-weight: 600;
+  }
+
+  /* Right-align the numeric contrast columns. */
+  .report-print th.num,
+  .report-print td.num {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  /* Zebra striping for scanability across long conformance tables. */
+  .report-print tbody tr:nth-child(even) td {
+    background: #f7f7f7;
+  }
+
+  /* The live foreground-on-surface contrast preview, mirroring the on-screen
+     swatch so the PDF shows the actual rendered pair, not just hex codes. */
+  .report-print .contrast-swatch {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 22px;
+    border: 1px solid #999;
+    border-radius: 3px;
+    font-size: 9pt;
+    font-weight: 600;
+  }
+
+  /* Keep the preview cells tight so the swatch column doesn't sprawl. */
+  .report-print .contrast-table td:first-child,
+  .report-print .contrast-table th:first-child {
+    width: 1%;
+    white-space: nowrap;
+  }
+
+  .report-print thead {
+    display: table-header-group;
+  }
+
+  .report-print tr {
+    page-break-inside: avoid;
+  }
+
+  .report-print h1,
+  .report-print h2 {
+    page-break-after: avoid;
+  }
+
+  /* Start each major report document on a fresh page. */
+  .report-print .report-doc + .report-doc {
+    page-break-before: always;
+  }
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -440,8 +440,13 @@ textarea::placeholder {
     margin: 16mm 14mm;
   }
 
-  /* Hide the whole app UI; only the portaled report prints. */
-  #root {
+  /* Hide the whole app UI; only the portaled report prints. The TanStack Query
+     devtools ("debug dashboard") mount their own container (and a floating
+     toggle) that can sit outside #root, so hide those explicitly too — dev-only,
+     but they'd otherwise leak into the PDF during `npm run dev`. */
+  #root,
+  .tsqd-parent-container,
+  .tsqd-open-btn-container {
     display: none !important;
   }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -440,13 +440,13 @@ textarea::placeholder {
     margin: 16mm 14mm;
   }
 
-  /* Hide the whole app UI; only the portaled report prints. The TanStack Query
-     devtools ("debug dashboard") mount their own container (and a floating
-     toggle) that can sit outside #root, so hide those explicitly too — dev-only,
-     but they'd otherwise leak into the PDF during `npm run dev`. */
+  /* Hide the whole app UI; only the portaled report prints. Dev-only overlays
+     (the rate-limit "debug dashboard" and the query devtools) portal to <body>
+     outside #root, so hiding #root alone leaves them in the PDF — hide the
+     dev-overlay marker and the devtools container explicitly too. */
   #root,
-  .tsqd-parent-container,
-  .tsqd-open-btn-container {
+  .dev-overlay,
+  .tsqd-parent-container {
     display: none !important;
   }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -29,7 +29,21 @@
       "vpatIntTitle": "VPAT — INT / 508 edition",
       "vpatIntDesc": "The same conformance report framed for Section 508 and EN 301 549 procurement.",
       "contrastTitle": "Color contrast audit",
-      "contrastDesc": "Per-pair contrast ratios for every audited color, both themes."
+      "contrastDesc": "Per-pair contrast ratios for every audited color, both themes.",
+      "fullTitle": "Full report",
+      "fullDesc": "Both VPAT editions and the color contrast audit combined into one file.",
+      "pdfTitle": "Full report (PDF)",
+      "pdfDesc": "Print or save the full report as a PDF using your browser's print dialog.",
+      "pdfAction": "Print / Save as PDF"
+    },
+    "print": {
+      "reportTitle": "Accessibility Conformance Report — {{product}}",
+      "reportMeta": "Standard: WCAG {{standard}}, target Level {{target}}. Report date: {{date}}.",
+      "vpatSummary": "Summary ({{total}} applicable criteria): {{supports}} Supports, {{partially}} Partially Supports, {{doesNotSupport}} Does Not Support, {{notApplicable}} Not Applicable, {{notEvaluated}} Not Evaluated.",
+      "contrastTitle": "Color contrast audit",
+      "contrastMeta": "Per-pair WCAG contrast ratios for every audited color, both themes. Generated {{date}}.",
+      "colColors": "Colors (fg / bg)",
+      "belowMargin": "(below {{margin}}:1 recommended)"
     },
     "loadError": "Couldn't load the contrast audit report.",
     "summaryPass": "All {{total}} audited color pairs meet their WCAG contrast floor.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -7,7 +7,7 @@
       "contrast": "Color contrast",
       "vpat": "Conformance",
       "statement": "Statement",
-      "downloads": "Downloads"
+      "downloads": "Reports"
     },
     "statement": {
       "heading": "Accessibility statement",
@@ -22,8 +22,9 @@
       "updated": "Last reviewed {{date}}."
     },
     "downloads": {
-      "heading": "Download reports",
-      "action": "Download (.md)",
+      "heading": "Reports",
+      "markdownAction": "Markdown",
+      "pdfAction": "PDF",
       "vpatWcagTitle": "VPAT — WCAG edition",
       "vpatWcagDesc": "Accessibility Conformance Report against WCAG 2.2 (VPAT 2.5Rev).",
       "vpatIntTitle": "VPAT — INT / 508 edition",
@@ -31,13 +32,11 @@
       "contrastTitle": "Color contrast audit",
       "contrastDesc": "Per-pair contrast ratios for every audited color, both themes.",
       "fullTitle": "Full report",
-      "fullDesc": "Both VPAT editions and the color contrast audit combined into one file.",
-      "pdfTitle": "Full report (PDF)",
-      "pdfDesc": "Print or save the full report as a PDF using your browser's print dialog.",
-      "pdfAction": "Print / Save as PDF"
+      "fullDesc": "Both VPAT editions and the color contrast audit in one document."
     },
     "print": {
       "reportTitle": "Accessibility Conformance Report — {{product}}",
+      "reportIntTitle": "Accessibility Conformance Report (INT: Section 508 + EN 301 549 + WCAG 2.2) — {{product}}",
       "reportMeta": "Standard: WCAG {{standard}}, target Level {{target}}. Report date: {{date}}.",
       "vpatSummary": "Summary ({{total}} applicable criteria): {{supports}} Supports, {{partially}} Partially Supports, {{doesNotSupport}} Does Not Support, {{notApplicable}} Not Applicable, {{notEvaluated}} Not Evaluated.",
       "contrastTitle": "Color contrast audit",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -27,16 +27,13 @@
       "pdfAction": "PDF",
       "vpatWcagTitle": "VPAT — WCAG edition",
       "vpatWcagDesc": "Accessibility Conformance Report against WCAG 2.2 (VPAT 2.5Rev).",
-      "vpatIntTitle": "VPAT — INT / 508 edition",
-      "vpatIntDesc": "The same conformance report framed for Section 508 and EN 301 549 procurement.",
       "contrastTitle": "Color contrast audit",
       "contrastDesc": "Per-pair contrast ratios for every audited color, both themes.",
       "fullTitle": "Full report",
-      "fullDesc": "Both VPAT editions and the color contrast audit in one document."
+      "fullDesc": "The VPAT and the color contrast audit in one document."
     },
     "print": {
       "reportTitle": "Accessibility Conformance Report — {{product}}",
-      "reportIntTitle": "Accessibility Conformance Report (INT: Section 508 + EN 301 549 + WCAG 2.2) — {{product}}",
       "reportMeta": "Standard: WCAG {{standard}}, target Level {{target}}. Report date: {{date}}.",
       "vpatSummary": "Summary ({{total}} applicable criteria): {{supports}} Supports, {{partially}} Partially Supports, {{doesNotSupport}} Does Not Support, {{notApplicable}} Not Applicable, {{notEvaluated}} Not Evaluated.",
       "contrastTitle": "Color contrast audit",

--- a/web/src/pages/AccessibilityPage.tsx
+++ b/web/src/pages/AccessibilityPage.tsx
@@ -916,13 +916,7 @@ function DownloadsSection() {
             href="/VPAT.md"
             title={t("accessibility.downloads.vpatWcagTitle")}
             description={t("accessibility.downloads.vpatWcagDesc")}
-            onPrint={() => setPrintTarget("vpat-wcag")}
-          />
-          <DownloadRow
-            href="/VPAT-INT.md"
-            title={t("accessibility.downloads.vpatIntTitle")}
-            description={t("accessibility.downloads.vpatIntDesc")}
-            onPrint={() => setPrintTarget("vpat-int")}
+            onPrint={() => setPrintTarget("vpat")}
           />
           <DownloadRow
             href="/CONTRAST-AUDIT.md"
@@ -949,12 +943,10 @@ function DownloadsSection() {
 // window.print(). Built from the same JSON the page already fetches — the VPAT
 // Which report the browser print / Save-as-PDF should render. The full report
 // prints both documents; the others print just their own.
-type PrintTarget = "vpat-wcag" | "vpat-int" | "contrast" | "full"
+type PrintTarget = "vpat" | "contrast" | "full"
 
-// The VPAT conformance tables as print HTML, for one edition. Both editions
-// share one criteria set (the INT edition is a framing, not a re-assessment), so
-// only the title/framing differs — the verdicts are identical.
-function PrintableVpat({ vpat, title }: { vpat: Vpat; title: string }) {
+// The VPAT conformance tables as print HTML.
+function PrintableVpat({ vpat }: { vpat: Vpat }) {
   const { t } = useTranslation()
   const criteriaByPrinciple = useMemo(() => {
     const map = {} as Record<WcagPrinciple, Criterion[]>
@@ -965,7 +957,7 @@ function PrintableVpat({ vpat, title }: { vpat: Vpat; title: string }) {
 
   return (
     <section className="report-doc">
-      <h1>{title}</h1>
+      <h1>{t("accessibility.print.reportTitle", { product: vpat.product })}</h1>
       <p className="report-meta">
         {t("accessibility.print.reportMeta", {
           standard: vpat.standard,
@@ -1092,35 +1084,18 @@ function PrintableContrast({ contrast }: { contrast: Audit }) {
 // single source, never a separate assessment. Theme-agnostic (black on white,
 // bordered tables) so the PDF reads as a clean document regardless of theme.
 function PrintableReport({ target }: { target: PrintTarget | null }) {
-  const { t } = useTranslation()
   const { data: vpat = null } = useVpatReport()
   const { data: contrast = null } = useContrastAudit()
 
   // Nothing requested, or data not ready: nothing to print (and nothing to portal).
   if (!target || !vpat || !contrast) return null
 
-  const showWcag = target === "vpat-wcag" || target === "full"
-  const showInt = target === "vpat-int" || target === "full"
+  const showVpat = target === "vpat" || target === "full"
   const showContrast = target === "contrast" || target === "full"
 
   return createPortal(
     <div className="report-print" aria-hidden="true">
-      {showWcag && (
-        <PrintableVpat
-          vpat={vpat}
-          title={t("accessibility.print.reportTitle", {
-            product: vpat.product,
-          })}
-        />
-      )}
-      {showInt && (
-        <PrintableVpat
-          vpat={vpat}
-          title={t("accessibility.print.reportIntTitle", {
-            product: vpat.product,
-          })}
-        />
-      )}
+      {showVpat && <PrintableVpat vpat={vpat} />}
       {showContrast && <PrintableContrast contrast={contrast} />}
     </div>,
     document.body,

--- a/web/src/pages/AccessibilityPage.tsx
+++ b/web/src/pages/AccessibilityPage.tsx
@@ -846,16 +846,20 @@ function StatementSection() {
   )
 }
 
-// One downloadable report row: title + description + a download button. The
-// files are build-emitted into dist/ and served at their root path.
+// One report row: title + description + a Markdown download link and a PDF
+// (browser print / Save as PDF) button. The .md files are build-emitted into
+// dist/ and served at their root path; the PDF is rendered client-side from the
+// same source (see PrintableReport) and triggered via onPrint.
 function DownloadRow({
   href,
   title,
   description,
+  onPrint,
 }: {
   href: string
   title: string
   description: string
+  onPrint: () => void
 }) {
   const { t } = useTranslation()
   return (
@@ -864,53 +868,40 @@ function DownloadRow({
         <div className="font-medium">{title}</div>
         <p className="text-sm text-base-content/70">{description}</p>
       </div>
-      <Button
-        as="a"
-        href={href}
-        download
-        variant="outline"
-        size="sm"
-        className="shrink-0"
-      >
-        <Download aria-hidden="true" className="size-4" />
-        {t("accessibility.downloads.action")}
-      </Button>
-    </div>
-  )
-}
-
-// The full report as a browser print / Save-as-PDF, using the same row layout as
-// the download rows. The printable DOM is always mounted (hidden on screen); the
-// button just opens the browser print dialog, where the user picks "Save as PDF".
-function PrintReportRow() {
-  const { t } = useTranslation()
-  return (
-    <div className="flex flex-col gap-3 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between">
-      <div className="min-w-0">
-        <div className="font-medium">
-          {t("accessibility.downloads.pdfTitle")}
-        </div>
-        <p className="text-sm text-base-content/70">
-          {t("accessibility.downloads.pdfDesc")}
-        </p>
+      <div className="flex shrink-0 gap-2">
+        <Button as="a" href={href} download variant="outline" size="sm">
+          <Download aria-hidden="true" className="size-4" />
+          {t("accessibility.downloads.markdownAction")}
+        </Button>
+        <Button onClick={onPrint} variant="outline" size="sm">
+          <Printer aria-hidden="true" className="size-4" />
+          {t("accessibility.downloads.pdfAction")}
+        </Button>
       </div>
-      <Button
-        onClick={() => window.print()}
-        variant="outline"
-        size="sm"
-        className="shrink-0"
-      >
-        <Printer aria-hidden="true" className="size-4" />
-        {t("accessibility.downloads.pdfAction")}
-      </Button>
     </div>
   )
 }
 
 // A single place to find and download every report, so the report tabs stay
-// focused on reading rather than repeating download controls.
+// focused on reading rather than repeating download controls. Each row offers
+// Markdown (a build-emitted .md) and PDF (browser print of the client-rendered
+// report). The PDF flow sets a print target, waits one paint for the portaled
+// print DOM to render, then opens the print dialog and clears the target.
 function DownloadsSection() {
   const { t } = useTranslation()
+  const [printTarget, setPrintTarget] = useState<PrintTarget | null>(null)
+
+  useEffect(() => {
+    if (!printTarget) return
+    // Defer to the next frame so the portaled PrintableReport has painted the
+    // requested document before the browser snapshots it for the dialog.
+    const id = requestAnimationFrame(() => {
+      window.print()
+      setPrintTarget(null)
+    })
+    return () => cancelAnimationFrame(id)
+  }, [printTarget])
+
   return (
     <section
       className="flex flex-col gap-4"
@@ -925,25 +916,29 @@ function DownloadsSection() {
             href="/VPAT.md"
             title={t("accessibility.downloads.vpatWcagTitle")}
             description={t("accessibility.downloads.vpatWcagDesc")}
+            onPrint={() => setPrintTarget("vpat-wcag")}
           />
           <DownloadRow
             href="/VPAT-INT.md"
             title={t("accessibility.downloads.vpatIntTitle")}
             description={t("accessibility.downloads.vpatIntDesc")}
+            onPrint={() => setPrintTarget("vpat-int")}
           />
           <DownloadRow
             href="/CONTRAST-AUDIT.md"
             title={t("accessibility.downloads.contrastTitle")}
             description={t("accessibility.downloads.contrastDesc")}
+            onPrint={() => setPrintTarget("contrast")}
           />
           <DownloadRow
             href="/ACCESSIBILITY-REPORT.md"
             title={t("accessibility.downloads.fullTitle")}
             description={t("accessibility.downloads.fullDesc")}
+            onPrint={() => setPrintTarget("full")}
           />
-          <PrintReportRow />
         </Card.Body>
       </Card>
+      <PrintableReport target={printTarget} />
     </section>
   )
 }
@@ -952,146 +947,181 @@ function DownloadsSection() {
 // PDF. Kept in the DOM but hidden on screen (`.report-print` is display:none
 // except under @media print); the "Print / Save as PDF" control just calls
 // window.print(). Built from the same JSON the page already fetches — the VPAT
-// The full report, rendered as plain semantic HTML for browser print / Save as
-// PDF. Portaled to <body> (a sibling of #root) and hidden on screen; the "Print
-// / Save as PDF" control just calls window.print(). Portaling matters: the print
-// CSS hides #root, and if this lived inside #root a display:none ancestor would
-// hide it too (an ancestor's display:none can't be overridden by a descendant),
-// leaving a blank PDF. Built from the same JSON the page already fetches — the
-// VPAT (both editions share one criteria set) and the contrast audit — so the
-// PDF is a rendering of the single source, never a separate assessment.
-// Deliberately theme-agnostic (black on white, bordered tables) so the PDF reads
-// as a clean document regardless of the active theme.
-function PrintableReport() {
-  const { t } = useTranslation()
-  const { data: vpat = null } = useVpatReport()
-  const { data: contrast = null } = useContrastAudit()
+// Which report the browser print / Save-as-PDF should render. The full report
+// prints both documents; the others print just their own.
+type PrintTarget = "vpat-wcag" | "vpat-int" | "contrast" | "full"
 
+// The VPAT conformance tables as print HTML, for one edition. Both editions
+// share one criteria set (the INT edition is a framing, not a re-assessment), so
+// only the title/framing differs — the verdicts are identical.
+function PrintableVpat({ vpat, title }: { vpat: Vpat; title: string }) {
+  const { t } = useTranslation()
   const criteriaByPrinciple = useMemo(() => {
     const map = {} as Record<WcagPrinciple, Criterion[]>
     for (const p of PRINCIPLE_ORDER) map[p] = []
-    for (const c of vpat?.criteria ?? []) map[c.principle].push(c)
+    for (const c of vpat.criteria) map[c.principle].push(c)
     return map
   }, [vpat])
 
-  // Not ready yet: nothing to print (and nothing to portal).
-  if (!vpat || !contrast) return null
-
-  return createPortal(
-    <div className="report-print" aria-hidden="true">
-      <section className="report-doc">
-        <h1>
-          {t("accessibility.print.reportTitle", { product: vpat.product })}
-        </h1>
-        <p className="report-meta">
-          {t("accessibility.print.reportMeta", {
-            standard: vpat.standard,
-            target: vpat.target,
-            date: vpat.generated,
-          })}
-        </p>
-        <p className="report-summary">
-          {t("accessibility.print.vpatSummary", {
-            total: vpat.summary.total,
-            supports: vpat.summary.byStatus.supports,
-            partially: vpat.summary.byStatus.partially,
-            doesNotSupport: vpat.summary.byStatus.doesNotSupport,
-            notApplicable: vpat.summary.byStatus.notApplicable,
-            notEvaluated: vpat.summary.byStatus.notEvaluated,
-          })}
-        </p>
-        {PRINCIPLE_ORDER.filter((p) => criteriaByPrinciple[p].length > 0).map(
-          (principle) => (
-            <div key={principle}>
-              <h2>{principle}</h2>
-              <table>
-                <thead>
-                  <tr>
-                    <th>{t("accessibility.vpat.col.criterion")}</th>
-                    <th>{t("accessibility.vpat.col.level")}</th>
-                    <th>{t("accessibility.vpat.col.conformance")}</th>
-                    <th>{t("accessibility.vpat.col.assessed")}</th>
-                    <th>{t("accessibility.vpat.col.remarks")}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {criteriaByPrinciple[principle].map((c) => (
-                    <tr key={c.id}>
-                      <td>
-                        <span className="mono report-sub">{c.id}</span> {c.name}
-                      </td>
-                      <td className="mono">{c.level}</td>
-                      <td>{CONFORMANCE_LABEL[c.status]}</td>
-                      <td className="mono report-sub">
-                        {c.assessed ?? vpat.generated}
-                      </td>
-                      <td>{hasGenericRemark(c) ? "—" : c.remark}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ),
-        )}
-      </section>
-
-      <section className="report-doc">
-        <h1>{t("accessibility.print.contrastTitle")}</h1>
-        <p className="report-meta">
-          {t("accessibility.print.contrastMeta", { date: contrast.generated })}
-        </p>
-        {contrast.themes.map((th) => (
-          <div key={th.theme}>
-            <h2>{th.label}</h2>
-            <table className="contrast-table">
+  return (
+    <section className="report-doc">
+      <h1>{title}</h1>
+      <p className="report-meta">
+        {t("accessibility.print.reportMeta", {
+          standard: vpat.standard,
+          target: vpat.target,
+          date: vpat.generated,
+        })}
+      </p>
+      <p className="report-summary">
+        {t("accessibility.print.vpatSummary", {
+          total: vpat.summary.total,
+          supports: vpat.summary.byStatus.supports,
+          partially: vpat.summary.byStatus.partially,
+          doesNotSupport: vpat.summary.byStatus.doesNotSupport,
+          notApplicable: vpat.summary.byStatus.notApplicable,
+          notEvaluated: vpat.summary.byStatus.notEvaluated,
+        })}
+      </p>
+      {PRINCIPLE_ORDER.filter((p) => criteriaByPrinciple[p].length > 0).map(
+        (principle) => (
+          <div key={principle}>
+            <h2>{principle}</h2>
+            <table>
               <thead>
                 <tr>
-                  <th>{t("accessibility.col.preview")}</th>
-                  <th>{t("accessibility.col.pair")}</th>
-                  <th>{t("accessibility.col.description")}</th>
-                  <th>{t("accessibility.print.colColors")}</th>
-                  <th className="num">{t("accessibility.col.ratio")}</th>
-                  <th className="num">{t("accessibility.col.floor")}</th>
-                  <th>{t("accessibility.col.status")}</th>
+                  <th>{t("accessibility.vpat.col.criterion")}</th>
+                  <th>{t("accessibility.vpat.col.level")}</th>
+                  <th>{t("accessibility.vpat.col.conformance")}</th>
+                  <th>{t("accessibility.vpat.col.assessed")}</th>
+                  <th>{t("accessibility.vpat.col.remarks")}</th>
                 </tr>
               </thead>
               <tbody>
-                {th.rows.map((r) => (
-                  <tr key={r.id}>
+                {criteriaByPrinciple[principle].map((c) => (
+                  <tr key={c.id}>
                     <td>
-                      <span
-                        className="contrast-swatch"
-                        style={{
-                          backgroundColor: r.bgHex,
-                          color: r.fgHex,
-                        }}
-                      >
-                        {r.kind === "text" ? "Aa" : "▭"}
-                      </span>
+                      <span className="mono report-sub">{c.id}</span> {c.name}
                     </td>
-                    <td className="mono">{r.id}</td>
-                    <td>
-                      {r.label}
-                      <span className="report-sub"> ({r.size})</span>
-                    </td>
+                    <td className="mono">{c.level}</td>
+                    <td>{CONFORMANCE_LABEL[c.status]}</td>
                     <td className="mono report-sub">
-                      {r.fgHex} / {r.bgHex}
+                      {c.assessed ?? vpat.generated}
                     </td>
-                    <td className="num mono">{r.ratio.toFixed(2)}:1</td>
-                    <td className="num mono">{r.floor}:1</td>
-                    <td>
-                      {t(`accessibility.status.${r.status}`)}
-                      {r.withinMargin
-                        ? ` ${t("accessibility.print.belowMargin", { margin: r.margin })}`
-                        : ""}
-                    </td>
+                    <td>{hasGenericRemark(c) ? "—" : c.remark}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-        ))}
-      </section>
+        ),
+      )}
+    </section>
+  )
+}
+
+// The color-contrast audit as print HTML, including a live foreground-on-surface
+// preview swatch per pair (mirroring the on-screen preview).
+function PrintableContrast({ contrast }: { contrast: Audit }) {
+  const { t } = useTranslation()
+  return (
+    <section className="report-doc">
+      <h1>{t("accessibility.print.contrastTitle")}</h1>
+      <p className="report-meta">
+        {t("accessibility.print.contrastMeta", { date: contrast.generated })}
+      </p>
+      {contrast.themes.map((th) => (
+        <div key={th.theme}>
+          <h2>{th.label}</h2>
+          <table className="contrast-table">
+            <thead>
+              <tr>
+                <th>{t("accessibility.col.preview")}</th>
+                <th>{t("accessibility.col.pair")}</th>
+                <th>{t("accessibility.col.description")}</th>
+                <th>{t("accessibility.print.colColors")}</th>
+                <th className="num">{t("accessibility.col.ratio")}</th>
+                <th className="num">{t("accessibility.col.floor")}</th>
+                <th>{t("accessibility.col.status")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {th.rows.map((r) => (
+                <tr key={r.id}>
+                  <td>
+                    <span
+                      className="contrast-swatch"
+                      style={{ backgroundColor: r.bgHex, color: r.fgHex }}
+                    >
+                      {r.kind === "text" ? "Aa" : "▭"}
+                    </span>
+                  </td>
+                  <td className="mono">{r.id}</td>
+                  <td>
+                    {r.label}
+                    <span className="report-sub"> ({r.size})</span>
+                  </td>
+                  <td className="mono report-sub">
+                    {r.fgHex} / {r.bgHex}
+                  </td>
+                  <td className="num mono">{r.ratio.toFixed(2)}:1</td>
+                  <td className="num mono">{r.floor}:1</td>
+                  <td>
+                    {t(`accessibility.status.${r.status}`)}
+                    {r.withinMargin
+                      ? ` ${t("accessibility.print.belowMargin", { margin: r.margin })}`
+                      : ""}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </section>
+  )
+}
+
+// The report(s) selected by `target`, rendered as plain semantic HTML for
+// browser print / Save as PDF. Portaled to <body> (a sibling of #root) and
+// hidden on screen. Portaling matters: the print CSS hides #root, and if this
+// lived inside #root a display:none ancestor would hide it too (an ancestor's
+// display:none can't be overridden by a descendant), leaving a blank PDF. Built
+// from the same JSON the page already fetches — the VPAT (both editions share
+// one criteria set) and the contrast audit — so the PDF is a rendering of the
+// single source, never a separate assessment. Theme-agnostic (black on white,
+// bordered tables) so the PDF reads as a clean document regardless of theme.
+function PrintableReport({ target }: { target: PrintTarget | null }) {
+  const { t } = useTranslation()
+  const { data: vpat = null } = useVpatReport()
+  const { data: contrast = null } = useContrastAudit()
+
+  // Nothing requested, or data not ready: nothing to print (and nothing to portal).
+  if (!target || !vpat || !contrast) return null
+
+  const showWcag = target === "vpat-wcag" || target === "full"
+  const showInt = target === "vpat-int" || target === "full"
+  const showContrast = target === "contrast" || target === "full"
+
+  return createPortal(
+    <div className="report-print" aria-hidden="true">
+      {showWcag && (
+        <PrintableVpat
+          vpat={vpat}
+          title={t("accessibility.print.reportTitle", {
+            product: vpat.product,
+          })}
+        />
+      )}
+      {showInt && (
+        <PrintableVpat
+          vpat={vpat}
+          title={t("accessibility.print.reportIntTitle", {
+            product: vpat.product,
+          })}
+        />
+      )}
+      {showContrast && <PrintableContrast contrast={contrast} />}
     </div>,
     document.body,
   )
@@ -1115,7 +1145,6 @@ export default function AccessibilityPage() {
 
         <SectionPanel section={section} />
       </PageShell>
-      <PrintableReport />
     </DrawerShell>
   )
 }

--- a/web/src/pages/AccessibilityPage.tsx
+++ b/web/src/pages/AccessibilityPage.tsx
@@ -937,12 +937,8 @@ function DownloadsSection() {
   )
 }
 
-// The full report, rendered as plain semantic HTML for browser print / Save as
-// PDF. Kept in the DOM but hidden on screen (`.report-print` is display:none
-// except under @media print); the "Print / Save as PDF" control just calls
-// window.print(). Built from the same JSON the page already fetches — the VPAT
 // Which report the browser print / Save-as-PDF should render. The full report
-// prints both documents; the others print just their own.
+// prints every document; the others print just their own.
 type PrintTarget = "vpat" | "contrast" | "full"
 
 // The VPAT conformance tables as print HTML.
@@ -1079,10 +1075,10 @@ function PrintableContrast({ contrast }: { contrast: Audit }) {
 // hidden on screen. Portaling matters: the print CSS hides #root, and if this
 // lived inside #root a display:none ancestor would hide it too (an ancestor's
 // display:none can't be overridden by a descendant), leaving a blank PDF. Built
-// from the same JSON the page already fetches — the VPAT (both editions share
-// one criteria set) and the contrast audit — so the PDF is a rendering of the
-// single source, never a separate assessment. Theme-agnostic (black on white,
-// bordered tables) so the PDF reads as a clean document regardless of theme.
+// from the same JSON the page already fetches — the VPAT and the contrast audit
+// — so the PDF is a rendering of the single source, never a separate assessment.
+// Theme-agnostic (black on white, bordered tables) so the PDF reads as a clean
+// document regardless of theme.
 function PrintableReport({ target }: { target: PrintTarget | null }) {
   const { data: vpat = null } = useVpatReport()
   const { data: contrast = null } = useContrastAudit()

--- a/web/src/pages/AccessibilityPage.tsx
+++ b/web/src/pages/AccessibilityPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import type { ReactElement } from "react"
+import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 import { useRouterState } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
-import { Info, CircleDashed, Download } from "lucide-react"
+import { Info, CircleDashed, Download, Printer } from "lucide-react"
 
 import { Alert, Badge, Button, Card, Modal, Toolbar, cx } from "@/components/ui"
 import PageShell from "@/components/PageShell"
@@ -16,6 +17,7 @@ import {
 import type { BadgeTone } from "@/types/badgeTone"
 import {
   CONFORMANCE_TONE,
+  CONFORMANCE_LABEL,
   hasGenericRemark,
   PRINCIPLE_ORDER,
   type ConformanceLevel,
@@ -71,7 +73,13 @@ const STATUS_TONE: Record<ContrastStatus, BadgeTone> = {
 
 type Vpat = Pick<
   VpatReportJson,
-  "schema" | "product" | "generated" | "summary" | "criteria"
+  | "schema"
+  | "product"
+  | "generated"
+  | "summary"
+  | "criteria"
+  | "standard"
+  | "target"
 >
 
 // One shared fetch of the build-emitted vpat-report.json, so the conformance
@@ -85,6 +93,20 @@ function useVpatReport() {
       const res = await fetch("/vpat-report.json")
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       return res.json() as Promise<Vpat>
+    },
+    staleTime: Infinity,
+  })
+}
+
+// One shared fetch of the build-emitted contrast-audit.json (static asset), so
+// the contrast table and the printable full report read from a single request.
+function useContrastAudit() {
+  return useQuery({
+    queryKey: ["contrast-audit"],
+    queryFn: async (): Promise<Audit> => {
+      const res = await fetch("/contrast-audit.json")
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json() as Promise<Audit>
     },
     staleTime: Infinity,
   })
@@ -612,31 +634,14 @@ function VpatSection() {
 
 function ContrastSection() {
   const { t } = useTranslation()
-  const [audit, setAudit] = useState<Audit | null>(null)
-  const [error, setError] = useState(false)
-  const [activeTheme, setActiveTheme] = useState<string | null>(null)
+  const { data: audit = null, isError: error } = useContrastAudit()
+  // null = "no explicit pick yet"; the shown theme then defaults to the first.
+  // Deriving the shown theme (rather than syncing it in an effect) keeps the
+  // user's later choice sticky without a setState-in-effect.
+  const [pickedTheme, setPickedTheme] = useState<string | null>(null)
   const [selectedRow, setSelectedRow] = useState<Row | null>(null)
 
-  useEffect(() => {
-    let active = true
-    fetch("/contrast-audit.json")
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        return res.json() as Promise<Audit>
-      })
-      .then((data) => {
-        if (!active) return
-        setAudit(data)
-        setActiveTheme(data.themes[0]?.theme ?? null)
-      })
-      .catch(() => {
-        if (active) setError(true)
-      })
-    return () => {
-      active = false
-    }
-  }, [])
-
+  const activeTheme = pickedTheme ?? audit?.themes[0]?.theme ?? null
   const shownTheme = audit?.themes.find((th) => th.theme === activeTheme)
   const marginCount = audit?.summary.marginMisses ?? 0
 
@@ -678,7 +683,7 @@ function ContrastSection() {
                   role="tab"
                   aria-selected={th.theme === activeTheme}
                   className={tabClass(th.theme === activeTheme)}
-                  onClick={() => setActiveTheme(th.theme)}
+                  onClick={() => setPickedTheme(th.theme)}
                 >
                   {th.label}
                 </button>
@@ -874,6 +879,34 @@ function DownloadRow({
   )
 }
 
+// The full report as a browser print / Save-as-PDF, using the same row layout as
+// the download rows. The printable DOM is always mounted (hidden on screen); the
+// button just opens the browser print dialog, where the user picks "Save as PDF".
+function PrintReportRow() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col gap-3 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <div className="font-medium">
+          {t("accessibility.downloads.pdfTitle")}
+        </div>
+        <p className="text-sm text-base-content/70">
+          {t("accessibility.downloads.pdfDesc")}
+        </p>
+      </div>
+      <Button
+        onClick={() => window.print()}
+        variant="outline"
+        size="sm"
+        className="shrink-0"
+      >
+        <Printer aria-hidden="true" className="size-4" />
+        {t("accessibility.downloads.pdfAction")}
+      </Button>
+    </div>
+  )
+}
+
 // A single place to find and download every report, so the report tabs stay
 // focused on reading rather than repeating download controls.
 function DownloadsSection() {
@@ -903,9 +936,164 @@ function DownloadsSection() {
             title={t("accessibility.downloads.contrastTitle")}
             description={t("accessibility.downloads.contrastDesc")}
           />
+          <DownloadRow
+            href="/ACCESSIBILITY-REPORT.md"
+            title={t("accessibility.downloads.fullTitle")}
+            description={t("accessibility.downloads.fullDesc")}
+          />
+          <PrintReportRow />
         </Card.Body>
       </Card>
     </section>
+  )
+}
+
+// The full report, rendered as plain semantic HTML for browser print / Save as
+// PDF. Kept in the DOM but hidden on screen (`.report-print` is display:none
+// except under @media print); the "Print / Save as PDF" control just calls
+// window.print(). Built from the same JSON the page already fetches — the VPAT
+// The full report, rendered as plain semantic HTML for browser print / Save as
+// PDF. Portaled to <body> (a sibling of #root) and hidden on screen; the "Print
+// / Save as PDF" control just calls window.print(). Portaling matters: the print
+// CSS hides #root, and if this lived inside #root a display:none ancestor would
+// hide it too (an ancestor's display:none can't be overridden by a descendant),
+// leaving a blank PDF. Built from the same JSON the page already fetches — the
+// VPAT (both editions share one criteria set) and the contrast audit — so the
+// PDF is a rendering of the single source, never a separate assessment.
+// Deliberately theme-agnostic (black on white, bordered tables) so the PDF reads
+// as a clean document regardless of the active theme.
+function PrintableReport() {
+  const { t } = useTranslation()
+  const { data: vpat = null } = useVpatReport()
+  const { data: contrast = null } = useContrastAudit()
+
+  const criteriaByPrinciple = useMemo(() => {
+    const map = {} as Record<WcagPrinciple, Criterion[]>
+    for (const p of PRINCIPLE_ORDER) map[p] = []
+    for (const c of vpat?.criteria ?? []) map[c.principle].push(c)
+    return map
+  }, [vpat])
+
+  // Not ready yet: nothing to print (and nothing to portal).
+  if (!vpat || !contrast) return null
+
+  return createPortal(
+    <div className="report-print" aria-hidden="true">
+      <section className="report-doc">
+        <h1>
+          {t("accessibility.print.reportTitle", { product: vpat.product })}
+        </h1>
+        <p className="report-meta">
+          {t("accessibility.print.reportMeta", {
+            standard: vpat.standard,
+            target: vpat.target,
+            date: vpat.generated,
+          })}
+        </p>
+        <p className="report-summary">
+          {t("accessibility.print.vpatSummary", {
+            total: vpat.summary.total,
+            supports: vpat.summary.byStatus.supports,
+            partially: vpat.summary.byStatus.partially,
+            doesNotSupport: vpat.summary.byStatus.doesNotSupport,
+            notApplicable: vpat.summary.byStatus.notApplicable,
+            notEvaluated: vpat.summary.byStatus.notEvaluated,
+          })}
+        </p>
+        {PRINCIPLE_ORDER.filter((p) => criteriaByPrinciple[p].length > 0).map(
+          (principle) => (
+            <div key={principle}>
+              <h2>{principle}</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th>{t("accessibility.vpat.col.criterion")}</th>
+                    <th>{t("accessibility.vpat.col.level")}</th>
+                    <th>{t("accessibility.vpat.col.conformance")}</th>
+                    <th>{t("accessibility.vpat.col.assessed")}</th>
+                    <th>{t("accessibility.vpat.col.remarks")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {criteriaByPrinciple[principle].map((c) => (
+                    <tr key={c.id}>
+                      <td>
+                        <span className="mono report-sub">{c.id}</span> {c.name}
+                      </td>
+                      <td className="mono">{c.level}</td>
+                      <td>{CONFORMANCE_LABEL[c.status]}</td>
+                      <td className="mono report-sub">
+                        {c.assessed ?? vpat.generated}
+                      </td>
+                      <td>{hasGenericRemark(c) ? "—" : c.remark}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ),
+        )}
+      </section>
+
+      <section className="report-doc">
+        <h1>{t("accessibility.print.contrastTitle")}</h1>
+        <p className="report-meta">
+          {t("accessibility.print.contrastMeta", { date: contrast.generated })}
+        </p>
+        {contrast.themes.map((th) => (
+          <div key={th.theme}>
+            <h2>{th.label}</h2>
+            <table className="contrast-table">
+              <thead>
+                <tr>
+                  <th>{t("accessibility.col.preview")}</th>
+                  <th>{t("accessibility.col.pair")}</th>
+                  <th>{t("accessibility.col.description")}</th>
+                  <th>{t("accessibility.print.colColors")}</th>
+                  <th className="num">{t("accessibility.col.ratio")}</th>
+                  <th className="num">{t("accessibility.col.floor")}</th>
+                  <th>{t("accessibility.col.status")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {th.rows.map((r) => (
+                  <tr key={r.id}>
+                    <td>
+                      <span
+                        className="contrast-swatch"
+                        style={{
+                          backgroundColor: r.bgHex,
+                          color: r.fgHex,
+                        }}
+                      >
+                        {r.kind === "text" ? "Aa" : "▭"}
+                      </span>
+                    </td>
+                    <td className="mono">{r.id}</td>
+                    <td>
+                      {r.label}
+                      <span className="report-sub"> ({r.size})</span>
+                    </td>
+                    <td className="mono report-sub">
+                      {r.fgHex} / {r.bgHex}
+                    </td>
+                    <td className="num mono">{r.ratio.toFixed(2)}:1</td>
+                    <td className="num mono">{r.floor}:1</td>
+                    <td>
+                      {t(`accessibility.status.${r.status}`)}
+                      {r.withinMargin
+                        ? ` ${t("accessibility.print.belowMargin", { margin: r.margin })}`
+                        : ""}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+      </section>
+    </div>,
+    document.body,
   )
 }
 
@@ -927,6 +1115,7 @@ export default function AccessibilityPage() {
 
         <SectionPanel section={section} />
       </PageShell>
+      <PrintableReport />
     </DrawerShell>
   )
 }

--- a/web/src/util/a11y/accessibilitySections.ts
+++ b/web/src/util/a11y/accessibilitySections.ts
@@ -19,20 +19,20 @@ export const ACCESSIBILITY_SECTIONS: {
   navLabelKey: string
 }[] = [
   {
-    id: "conformance",
-    navLabelKey: "accessibility.nav.vpat",
-  },
-  {
     id: "color-contrast",
     navLabelKey: "accessibility.nav.contrast",
   },
   {
-    id: "statement",
-    navLabelKey: "accessibility.nav.statement",
+    id: "conformance",
+    navLabelKey: "accessibility.nav.vpat",
   },
   {
     id: "downloads",
     navLabelKey: "accessibility.nav.downloads",
+  },
+  {
+    id: "statement",
+    navLabelKey: "accessibility.nav.statement",
   },
 ]
 

--- a/web/src/util/a11y/vpatReport.test.ts
+++ b/web/src/util/a11y/vpatReport.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import { CONTRAST_CRITERION_IDS } from "./vpatModel"
-import { buildVpatReport, renderVpatJson, renderVpatReport } from "./vpatReport"
+import {
+  buildVpatReport,
+  renderCombinedReport,
+  renderVpatJson,
+  renderVpatReport,
+} from "./vpatReport"
 
 const FIXED = new Date("2026-08-04T00:00:00Z")
 
@@ -137,5 +142,26 @@ describe("renderVpatJson", () => {
     const parsed = JSON.parse(renderVpatJson(FIXED))
     expect(parsed.summary).toEqual(buildVpatReport(FIXED).summary)
     expect(parsed.generated).toBe("2026-08-04")
+  })
+})
+
+describe("renderCombinedReport", () => {
+  const md = renderCombinedReport(FIXED)
+
+  it("bundles both VPAT editions and the contrast audit", () => {
+    expect(md).toContain("VPAT® 2.5Rev — WCAG Edition")
+    expect(md).toContain(
+      "VPAT® 2.5Rev — INT Edition (Section 508 + EN 301 549 + WCAG 2.2)",
+    )
+    expect(md).toContain("# WCAG 2.2 Contrast Audit — Classroom50 web app")
+  })
+
+  it("separates the three documents with a horizontal rule", () => {
+    // Two rules join the three sections; more would signal an extra doc slipped in.
+    expect(md.match(/^---$/gm)?.length).toBe(2)
+  })
+
+  it("is deterministic for a fixed date", () => {
+    expect(renderCombinedReport(FIXED)).toBe(md)
   })
 })

--- a/web/src/util/a11y/vpatReport.test.ts
+++ b/web/src/util/a11y/vpatReport.test.ts
@@ -16,7 +16,7 @@ describe("buildVpatReport (JSON source of truth)", () => {
   it("carries schema, standard, editions, target, product, and date", () => {
     expect(report.schema).toBe("vpat-report/v1")
     expect(report.standard).toBe("WCAG 2.2")
-    expect(report.editions).toEqual(["2.5Rev-wcag", "2.5Rev-int"])
+    expect(report.editions).toEqual(["2.5Rev-wcag"])
     expect(report.target).toBe("AA")
     expect(report.product.length).toBeGreaterThan(0)
     expect(report.generated).toBe("2026-08-04")
@@ -73,8 +73,8 @@ describe("buildVpatReport (JSON source of truth)", () => {
   })
 })
 
-describe("renderVpatReport — WCAG edition", () => {
-  const md = renderVpatReport("wcag", FIXED)
+describe("renderVpatReport (WCAG edition)", () => {
+  const md = renderVpatReport(FIXED)
 
   it("states the format, standard, and date", () => {
     expect(md).toContain("VPAT® 2.5Rev — WCAG Edition")
@@ -89,6 +89,10 @@ describe("renderVpatReport — WCAG edition", () => {
     expect(md).toContain("## Robust")
   })
 
+  it("resolves the contrast criterion 1.4.3 to Supports from its single verdict", () => {
+    expect(md).toContain("| 1.4.3 Contrast (Minimum) | AA | Supports |")
+  })
+
   it("renders a row for every criterion in the report", () => {
     const report = buildVpatReport(FIXED)
     for (const c of report.criteria) {
@@ -97,43 +101,7 @@ describe("renderVpatReport — WCAG edition", () => {
   })
 
   it("is deterministic for a fixed date", () => {
-    expect(renderVpatReport("wcag", FIXED)).toBe(md)
-  })
-})
-
-describe("renderVpatReport — INT edition", () => {
-  const md = renderVpatReport("int", FIXED)
-
-  it("states the INT format and names the three incorporated standards", () => {
-    expect(md).toContain(
-      "VPAT® 2.5Rev — INT Edition (Section 508 + EN 301 549 + WCAG 2.2)",
-    )
-    expect(md).toContain("Section 508")
-    expect(md).toContain("EN 301 549")
-    expect(md).toContain("WCAG 2.2")
-  })
-
-  it("notes Section 508 Hardware is Not Applicable for a web app", () => {
-    expect(md).toContain("Chapter 4")
-    expect(md).toContain("Not Applicable")
-  })
-
-  it("shows each criterion with the same conformance word as the WCAG edition (single-source)", () => {
-    const wcag = renderVpatReport("wcag", FIXED)
-    // 1.4.3 (contrast) resolves to Supports in both editions from one verdict.
-    expect(wcag).toContain("| 1.4.3 Contrast (Minimum) | AA | Supports |")
-    expect(md).toContain("| 1.4.3 Contrast (Minimum) | AA | Supports |")
-  })
-
-  it("renders a row for every criterion in the report", () => {
-    const report = buildVpatReport(FIXED)
-    for (const c of report.criteria) {
-      expect(md, `INT row for ${c.id}`).toContain(`| ${c.id} ${c.name} |`)
-    }
-  })
-
-  it("is deterministic for a fixed date", () => {
-    expect(renderVpatReport("int", FIXED)).toBe(md)
+    expect(renderVpatReport(FIXED)).toBe(md)
   })
 })
 
@@ -148,17 +116,19 @@ describe("renderVpatJson", () => {
 describe("renderCombinedReport", () => {
   const md = renderCombinedReport(FIXED)
 
-  it("bundles both VPAT editions and the contrast audit", () => {
+  it("bundles the VPAT and the contrast audit", () => {
     expect(md).toContain("VPAT® 2.5Rev — WCAG Edition")
-    expect(md).toContain(
-      "VPAT® 2.5Rev — INT Edition (Section 508 + EN 301 549 + WCAG 2.2)",
-    )
     expect(md).toContain("# WCAG 2.2 Contrast Audit — Classroom50 web app")
   })
 
-  it("separates the three documents with a horizontal rule", () => {
-    // Two rules join the three sections; more would signal an extra doc slipped in.
-    expect(md.match(/^---$/gm)?.length).toBe(2)
+  it("does not include the dropped INT / 508 edition", () => {
+    expect(md).not.toContain("INT Edition")
+    expect(md).not.toContain("Section 508")
+  })
+
+  it("separates the two documents with a horizontal rule", () => {
+    // One rule joins the two sections; more would signal an extra doc slipped in.
+    expect(md.match(/^---$/gm)?.length).toBe(1)
   })
 
   it("is deterministic for a fixed date", () => {

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -3,14 +3,11 @@
 // `buildVpatReport()` produces the canonical JSON from vpatModel.ts, with the
 // contrast criteria (1.4.3/1.4.6/1.4.11) DERIVED from the live contrast audit
 // (KTD4) rather than hand-set — so the VPAT and the contrast report can never
-// disagree. `renderVpatReport(edition)` renders the same criteria set as either
-// the VPAT 2.5Rev WCAG edition or the INT edition (KTD6); both are views over
-// one model, never a second assessment. The INT edition (not 508) is the second
-// edition because ITI's 508 edition incorporates WCAG 2.0, while INT carries
-// WCAG 2.2 alongside 508 + EN 301 549 — so our WCAG 2.2 work maps correctly to
-// INT and still serves a US procurement office. Pure (no fs, no app imports) so
-// it stays a util/ leaf; the integrity guard (vpatGuard.test.ts) enforces the
-// same facts, so every rendering reflects guarded state.
+// disagree. `renderVpatReport()` renders that criteria set as the VPAT 2.5Rev
+// WCAG edition — a view over the model, never a second assessment. Pure (no fs,
+// no app imports) so it stays a util/ leaf; the integrity guard
+// (vpatGuard.test.ts) enforces the same facts, so every rendering reflects
+// guarded state.
 
 import { buildContrastAudit, renderContrastReport } from "./contrastReport"
 import {
@@ -23,13 +20,11 @@ import {
   type WcagPrinciple,
 } from "./vpatModel"
 
-export type VpatEdition = "wcag" | "int"
-
 export type VpatReportJson = {
   /** Bump when the JSON shape changes so consumers can guard. */
   schema: "vpat-report/v1"
   standard: "WCAG 2.2"
-  editions: ["2.5Rev-wcag", "2.5Rev-int"]
+  editions: ["2.5Rev-wcag"]
   target: "AA"
   product: string
   generated: string
@@ -113,7 +108,7 @@ export function buildVpatReport(
   return {
     schema: "vpat-report/v1",
     standard: "WCAG 2.2",
-    editions: ["2.5Rev-wcag", "2.5Rev-int"],
+    editions: ["2.5Rev-wcag"],
     target: "AA",
     product: PRODUCT,
     generated: now.toISOString().slice(0, 10),
@@ -142,13 +137,13 @@ function criterionRow(c: Criterion, fallbackDate: string): string {
   return `| ${c.id} ${c.name} | ${c.level} | ${CONFORMANCE_LABEL[c.status]} | ${date} | ${remark} |`
 }
 
-// Preamble shared by both editions: product, date, evaluation methods, and the
-// honest automated-vs-manual boundary a reviewer needs to weight the claims.
-function preamble(report: VpatReportJson, editionLabel: string): string[] {
+// Preamble: product, date, evaluation methods, and the honest automated-vs-
+// manual boundary a reviewer needs to weight the claims.
+function preamble(report: VpatReportJson): string[] {
   return [
     `# Accessibility Conformance Report — ${report.product}`,
     "",
-    `**Format:** VPAT® 2.5Rev — ${editionLabel}`,
+    `**Format:** VPAT® 2.5Rev — WCAG Edition`,
     `**Standard:** WCAG ${report.standard.replace("WCAG ", "")}, target Level ${report.target}`,
     `**Product:** ${report.product}`,
     `**Report date:** ${report.generated}`,
@@ -178,8 +173,7 @@ function summaryLine(report: VpatReportJson): string {
   )
 }
 
-// The per-principle WCAG 2.2 conformance tables, shared verbatim by both
-// editions — they differ only in preamble/intro, never in the verdicts.
+// The per-principle WCAG 2.2 conformance tables.
 function principleTables(report: VpatReportJson): string[] {
   const out: string[] = []
   for (const principle of PRINCIPLE_ORDER) {
@@ -197,66 +191,27 @@ function principleTables(report: VpatReportJson): string[] {
   return out
 }
 
-function renderWcagEdition(report: VpatReportJson): string {
-  return (
-    [
-      ...preamble(report, "WCAG Edition"),
-      summaryLine(report),
-      "",
-      ...principleTables(report),
-    ].join("\n") + "\n"
-  )
-}
-
-// The INT edition (VPAT 2.5Rev INT) incorporates Section 508, EN 301 549, and
-// WCAG 2.2 in one report. Because our conformance evidence is expressed against
-// WCAG 2.2 (the standard the app is actually tested to), the INT edition
-// presents the same per-principle WCAG 2.2 tables as the WCAG edition, under an
-// INT framing that states how the three standards relate. No criterion is
-// re-assessed (KTD6) — a US 508 / EU procurement office reads the same verdicts.
-function renderIntEdition(report: VpatReportJson): string {
-  return (
-    [
-      ...preamble(report, "INT Edition (Section 508 + EN 301 549 + WCAG 2.2)"),
-      summaryLine(report),
-      "",
-      "The INT edition incorporates three standards. This report expresses " +
-        "conformance against **WCAG 2.2** — the standard the product is tested " +
-        "to — which the other two reference: **Section 508** (US) incorporates " +
-        "WCAG 2.0 Level A/AA and **EN 301 549** (EU) incorporates WCAG 2.1; both " +
-        "are subsets of the WCAG 2.2 criteria reported below, so each verdict " +
-        "applies to the corresponding 508 / EN 301 549 provision. Chapter 4 " +
-        "(Hardware) of Section 508 is Not Applicable — Classroom50 is a " +
-        "browser-based web application with no hardware component.",
-      "",
-      ...principleTables(report),
-    ].join("\n") + "\n"
-  )
-}
-
-/** Render the Markdown ACR for the requested edition — derived from one model. */
-export function renderVpatReport(
-  edition: VpatEdition,
-  now = new Date(),
-): string {
+/** Render the Markdown ACR (VPAT 2.5Rev WCAG edition) — derived from one model. */
+export function renderVpatReport(now = new Date()): string {
   const report = buildVpatReport(now)
-  return edition === "wcag"
-    ? renderWcagEdition(report)
-    : renderIntEdition(report)
+  return (
+    [
+      ...preamble(report),
+      summaryLine(report),
+      "",
+      ...principleTables(report),
+    ].join("\n") + "\n"
+  )
 }
 
-// The complete accessibility report in one file: both VPAT editions and the
-// contrast audit, in the order a reviewer reads them (conformance first, the
-// 508/EN framing, then the contrast evidence the contrast criteria derive from).
-// A rendering over the same single sources as the individual downloads — never a
-// separate assessment — so it can't disagree with them.
+// The complete accessibility report in one file: the VPAT and the contrast
+// audit, in the order a reviewer reads them (conformance first, then the
+// contrast evidence the contrast criteria derive from). A rendering over the
+// same single sources as the individual downloads — never a separate assessment
+// — so it can't disagree with them.
 export function renderCombinedReport(now = new Date()): string {
-  const sections = [
-    renderVpatReport("wcag", now),
-    renderVpatReport("int", now),
-    renderContrastReport(now),
-  ]
-  // A horizontal rule between the three documents so their headings don't read
+  const sections = [renderVpatReport(now), renderContrastReport(now)]
+  // A horizontal rule between the two documents so their headings don't read
   // as one continuous report when concatenated.
   return sections.join("\n---\n\n")
 }

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -12,7 +12,7 @@
 // it stays a util/ leaf; the integrity guard (vpatGuard.test.ts) enforces the
 // same facts, so every rendering reflects guarded state.
 
-import { buildContrastAudit } from "./contrastReport"
+import { buildContrastAudit, renderContrastReport } from "./contrastReport"
 import {
   CONFORMANCE_LABEL,
   CONTRAST_CRITERION_IDS,
@@ -243,4 +243,20 @@ export function renderVpatReport(
   return edition === "wcag"
     ? renderWcagEdition(report)
     : renderIntEdition(report)
+}
+
+// The complete accessibility report in one file: both VPAT editions and the
+// contrast audit, in the order a reviewer reads them (conformance first, the
+// 508/EN framing, then the contrast evidence the contrast criteria derive from).
+// A rendering over the same single sources as the individual downloads — never a
+// separate assessment — so it can't disagree with them.
+export function renderCombinedReport(now = new Date()): string {
+  const sections = [
+    renderVpatReport("wcag", now),
+    renderVpatReport("int", now),
+    renderContrastReport(now),
+  ]
+  // A horizontal rule between the three documents so their headings don't read
+  // as one continuous report when concatenated.
+  return sections.join("\n---\n\n")
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,7 +16,11 @@ import {
   renderContrastJson,
   renderContrastReport,
 } from "./src/util/a11y/contrastReport"
-import { renderVpatJson, renderVpatReport } from "./src/util/a11y/vpatReport"
+import {
+  renderCombinedReport,
+  renderVpatJson,
+  renderVpatReport,
+} from "./src/util/a11y/vpatReport"
 import {
   buildCriteria,
   isValidAssessedDate,
@@ -125,8 +129,9 @@ function contrastAuditPlugin(): Plugin {
 // Publishes the WCAG 2.2 VPAT / ACR in the built site: vpat-report.json (the
 // source of truth the /accessibility page fetches) plus VPAT.md (WCAG edition)
 // and VPAT-INT.md (INT edition: Section 508 + EN 301 549 + WCAG 2.2), the
-// human-readable downloads. All three derive from src/util/a11y/vpatModel.ts at build
-// time — never committed — so they stay current with the shipped app;
+// human-readable downloads, and ACCESSIBILITY-REPORT.md (both editions + the
+// contrast audit in one file). All derive from src/util/a11y/vpatModel.ts at
+// build time — never committed — so they stay current with the shipped app;
 // vpatGuard.test.ts is the enforcement. Same dev + build wiring as the contrast
 // audit above.
 function vpatReportPlugin(): Plugin {
@@ -144,6 +149,11 @@ function vpatReportPlugin(): Plugin {
     {
       fileName: "VPAT-INT.md",
       source: renderVpatReport("int"),
+      type: "text/markdown; charset=utf-8",
+    },
+    {
+      fileName: "ACCESSIBILITY-REPORT.md",
+      source: renderCombinedReport(),
       type: "text/markdown; charset=utf-8",
     },
   ]

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -127,9 +127,8 @@ function contrastAuditPlugin(): Plugin {
 }
 
 // Publishes the WCAG 2.2 VPAT / ACR in the built site: vpat-report.json (the
-// source of truth the /accessibility page fetches) plus VPAT.md (WCAG edition)
-// and VPAT-INT.md (INT edition: Section 508 + EN 301 549 + WCAG 2.2), the
-// human-readable downloads, and ACCESSIBILITY-REPORT.md (both editions + the
+// source of truth the /accessibility page fetches) plus VPAT.md (the WCAG-
+// edition human-readable download) and ACCESSIBILITY-REPORT.md (the VPAT + the
 // contrast audit in one file). All derive from src/util/a11y/vpatModel.ts at
 // build time — never committed — so they stay current with the shipped app;
 // vpatGuard.test.ts is the enforcement. Same dev + build wiring as the contrast
@@ -143,12 +142,7 @@ function vpatReportPlugin(): Plugin {
     },
     {
       fileName: "VPAT.md",
-      source: renderVpatReport("wcag"),
-      type: "text/markdown; charset=utf-8",
-    },
-    {
-      fileName: "VPAT-INT.md",
-      source: renderVpatReport("int"),
+      source: renderVpatReport(),
       type: "text/markdown; charset=utf-8",
     },
     {


### PR DESCRIPTION
Adds two capabilities to the `/accessibility` **Reports** section (renamed from "Downloads") and drops the redundant VPAT INT / 508 edition.

## Full report (combined Markdown)

Adds `renderCombinedReport()` — a single `ACCESSIBILITY-REPORT.md` bundling the VPAT (WCAG edition) and the color-contrast audit, separated by a horizontal rule. It's emitted in dev, in the Vite build (`dist/`), and by `npm run audit:vpat`, matching how the other artifacts are published. Like every artifact here, it's a rendering of the single source of truth, so it can't disagree with the individual reports.

## PDF (browser print / Save as PDF)

Each report row now offers both a **Markdown** download and a **PDF** button. The PDF flow renders the selected report(s) as semantic HTML (built from the JSON the page already fetches, so the VPAT/contrast tables render as real tables — the shared Markdown component has no GFM table support), then opens the browser's print dialog behind a print stylesheet. The full-report PDF prints the VPAT + contrast audit; the per-report buttons print just their own. The color-contrast preview swatches are included in the PDF, and dev-only overlays (the rate-limit dashboard, query devtools) are excluded from print.

## Nav

Renames "Downloads" → "Reports" and reorders the nav to: Color contrast, Conformance, Reports, Statement.

## Drop the INT / 508 edition

Removes the second VPAT edition (renderer, download row, PDF target, `VPAT-INT.md` artifact, and strings). The single WCAG-edition VPAT already covers Section 508 and EN 301 549 (both subsets of WCAG 2.2), so the extra edition was redundant.

## Verification

`npm run check` (tsc, eslint, prettier, arch:validate, i18n key audit, node test suite) passes. The PDF output was verified end-to-end against the running dev server; regenerating the artifacts confirms no `VPAT-INT.md` is produced and no INT/508 text remains.