### PR TITLE
chore(web): silence vite native config-loader warnings

### DIFF
--- a/web/src/util/a11y/contrastModel.ts
+++ b/web/src/util/a11y/contrastModel.ts
@@ -15,7 +15,7 @@ import {
   ratioOver,
   toHex,
   type LinearRgb,
-} from "./contrast"
+} from "./contrast.ts"
 
 export type SizeClass = "body" | "large"
 export type Theme = "sumi" | "sumi-dark"

--- a/web/src/util/a11y/contrastReport.ts
+++ b/web/src/util/a11y/contrastReport.ts
@@ -13,7 +13,7 @@ import {
   SPEC_FLOOR,
   type SizeClass,
   type Theme,
-} from "./contrastModel"
+} from "./contrastModel.ts"
 
 export type ContrastStatus = "pass" | "fail" | "exempt"
 

--- a/web/src/util/a11y/vpatModel.ts
+++ b/web/src/util/a11y/vpatModel.ts
@@ -14,7 +14,7 @@
 // audit in vpatReport.ts (KTD4), so the two reports can never disagree.
 
 import type { BadgeTone } from "@/types/badgeTone"
-import verdicts from "../../../accessibility/vpatVerdicts.json"
+import verdicts from "../../../accessibility/vpatVerdicts.json" with { type: "json" }
 
 export type WcagPrinciple =
   "Perceivable" | "Operable" | "Understandable" | "Robust"

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -9,7 +9,7 @@
 // (vpatGuard.test.ts) enforces the same facts, so every rendering reflects
 // guarded state.
 
-import { buildContrastAudit, renderContrastReport } from "./contrastReport"
+import { buildContrastAudit, renderContrastReport } from "./contrastReport.ts"
 import {
   CONFORMANCE_LABEL,
   CONTRAST_CRITERION_IDS,
@@ -18,7 +18,7 @@ import {
   type ConformanceLevel,
   type Criterion,
   type WcagPrinciple,
-} from "./vpatModel"
+} from "./vpatModel.ts"
 
 export type VpatReportJson = {
   /** Bump when the JSON shape changes so consumers can guard. */

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,19 +15,19 @@ import { createRequire } from "node:module"
 import {
   renderContrastJson,
   renderContrastReport,
-} from "./src/util/a11y/contrastReport"
+} from "./src/util/a11y/contrastReport.ts"
 import {
   renderCombinedReport,
   renderVpatJson,
   renderVpatReport,
-} from "./src/util/a11y/vpatReport"
+} from "./src/util/a11y/vpatReport.ts"
 import {
   buildCriteria,
   isValidAssessedDate,
   type ManualVerdict,
   type VerdictOverlay,
-} from "./src/util/a11y/vpatModel"
-import { ASSESSMENT_GUIDANCE } from "./src/util/a11y/assessmentGuidance"
+} from "./src/util/a11y/vpatModel.ts"
+import { ASSESSMENT_GUIDANCE } from "./src/util/a11y/assessmentGuidance.ts"
 
 // Release identity, resolved once at build time and inlined as compile-time
 // constants (see src/vite-env.d.ts). Version is the single source of truth in
@@ -180,7 +180,7 @@ function vpatReportPlugin(): Plugin {
 // (automated/contrast) row.
 function assessmentApiPlugin(): Plugin {
   const verdictsPath = path.resolve(
-    __dirname,
+    import.meta.dirname,
     "accessibility/vpatVerdicts.json",
   )
 
@@ -378,7 +378,8 @@ export default defineConfig(({ mode }) => ({
     "import.meta.env.VITE_GITHUB_PAT":
       mode === "development"
         ? JSON.stringify(
-            loadEnv(mode, path.resolve(__dirname), "").VITE_GITHUB_PAT ?? "",
+            loadEnv(mode, path.resolve(import.meta.dirname), "")
+              .VITE_GITHUB_PAT ?? "",
           )
         : JSON.stringify(""),
   },
@@ -398,7 +399,7 @@ export default defineConfig(({ mode }) => ({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   server: {
@@ -406,7 +407,7 @@ export default defineConfig(({ mode }) => ({
       // src/skeleton/skeleton.ts imports the skeleton from
       // cli/gh-teacher/skeleton (outside web/), so the dev server must read the
       // monorepo root. `vite build` inlines the files regardless.
-      allow: [path.resolve(__dirname, "..")],
+      allow: [path.resolve(import.meta.dirname, "..")],
     },
   },
   test: {


### PR DESCRIPTION
`npm run dev` emitted a block of warnings about features unsupported by Vite's upcoming `configLoader: 'native'` default. This modernizes the config and the a11y report modules it imports so the warnings are gone, without opting into the native loader yet.

- `vite.config.ts`: replace `__dirname` with `import.meta.dirname` (all four uses), and add `.ts` extensions to the four `src/util/a11y/*` imports.
- `vpatModel.ts`: add an `with { type: "json" }` import attribute to the `vpatVerdicts.json` import.
- `contrastReport.ts`, `vpatReport.ts`, `contrastModel.ts`: add `.ts` extensions to their relative a11y imports.

The `.ts` extensions are safe because both `tsconfig.app.json` and `tsconfig.node.json` already set `allowImportingTsExtensions: true` with `moduleResolution: "bundler"`.

`npm run check` is green (`tsc -b`, eslint with 0 errors, prettier, `arch:validate`, and the node vitest suite — 3258 passed). The Playwright browser suite only fails locally because the Chromium binary isn't installed in the sandbox, which is unrelated to this change.

## Follow-up: actually opt into `configLoader: 'native'`

This PR only silences the warnings; it does not flip the loader. A deliberate follow-up should set `configLoader: 'native'` and verify the config still executes under Node's native TS loader (not just esbuild bundling). Keeping it separate isolates a config-execution behavior change behind its own CI run, and the real test is that `vite build` + `vite dev` work end-to-end, not just that a static warning is gone.

One extra change is needed there that this PR's static warnings did not flag: the `package.json` version read still uses a CJS `require`, which the native loader may not resolve the same way. Convert it to a JSON import with an attribute:

```ts
// createRequire(import.meta.url) + require("./package.json")  ->
import pkg from "./package.json" with { type: "json" }
```

Everything else (`import.meta.dirname`, `process.env`, `loadEnv`, the plugins) is already native-safe after this PR.