### PR TITLE
fix(web): stop a GitHub outage from showing as "You're offline"

### DIFF
--- a/web/src/hooks/useOnlineStatus.test.ts
+++ b/web/src/hooks/useOnlineStatus.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it, vi } from "vitest"
-import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
 
-import { useOnlineStatus } from "./useOnlineStatus"
+import { useOnlineStatus, __resetOnlineStatusForTest } from "./useOnlineStatus"
+import * as internetLiveness from "@/lib/internetLiveness"
 
 function setNavigatorOnLine(value: boolean) {
   Object.defineProperty(navigator, "onLine", {
@@ -11,38 +12,96 @@ function setNavigatorOnLine(value: boolean) {
   })
 }
 
+let livenessSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  __resetOnlineStatusForTest()
+  livenessSpy = vi.spyOn(internetLiveness, "checkInternetLiveness")
+})
+
+afterEach(() => {
+  setNavigatorOnLine(true)
+  vi.restoreAllMocks()
+})
+
 describe("useOnlineStatus", () => {
-  afterEach(() => {
-    setNavigatorOnLine(true)
-    vi.restoreAllMocks()
-  })
-
-  it("seeds from navigator.onLine", () => {
-    setNavigatorOnLine(false)
-    const { result } = renderHook(() => useOnlineStatus())
-    expect(result.current).toBe(false)
-  })
-
-  it("flips to offline when the offline event fires", () => {
+  it("starts online and doesn't probe while navigator reports online", () => {
     setNavigatorOnLine(true)
     const { result } = renderHook(() => useOnlineStatus())
     expect(result.current).toBe(true)
+    expect(livenessSpy).not.toHaveBeenCalled()
+  })
+
+  it("stays online on a spurious offline event when the probe still reaches the internet", async () => {
+    livenessSpy.mockResolvedValue(true)
+    setNavigatorOnLine(true)
+    const { result } = renderHook(() => useOnlineStatus())
+
+    await act(async () => {
+      setNavigatorOnLine(false)
+      window.dispatchEvent(new Event("offline"))
+    })
+
+    expect(livenessSpy).toHaveBeenCalled()
+    expect(result.current).toBe(true)
+  })
+
+  it("goes offline only after the liveness probe also fails", async () => {
+    livenessSpy.mockResolvedValue(false)
+    setNavigatorOnLine(true)
+    const { result } = renderHook(() => useOnlineStatus())
 
     act(() => {
       setNavigatorOnLine(false)
       window.dispatchEvent(new Event("offline"))
     })
-    expect(result.current).toBe(false)
+
+    await waitFor(() => expect(result.current).toBe(false))
   })
 
-  it("recovers to online when the online event fires", () => {
+  it("seeds a cold load that starts offline through the same corroborated path", async () => {
+    livenessSpy.mockResolvedValue(false)
     setNavigatorOnLine(false)
     const { result } = renderHook(() => useOnlineStatus())
-    expect(result.current).toBe(false)
+
+    await waitFor(() => expect(result.current).toBe(false))
+    expect(livenessSpy).toHaveBeenCalled()
+  })
+
+  it("recovers immediately on the online event without waiting for a probe", async () => {
+    livenessSpy.mockResolvedValue(false)
+    setNavigatorOnLine(false)
+    const { result } = renderHook(() => useOnlineStatus())
+    await waitFor(() => expect(result.current).toBe(false))
 
     act(() => {
       setNavigatorOnLine(true)
       window.dispatchEvent(new Event("online"))
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it("discards a stale offline probe that resolves after the link is restored", async () => {
+    let resolveProbe: (online: boolean) => void = () => {}
+    livenessSpy.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveProbe = resolve
+        }),
+    )
+    setNavigatorOnLine(false)
+    const { result } = renderHook(() => useOnlineStatus())
+
+    // Link comes back before the probe settles.
+    act(() => {
+      setNavigatorOnLine(true)
+      window.dispatchEvent(new Event("online"))
+    })
+    expect(result.current).toBe(true)
+
+    // The now-stale probe reports "offline"; it must be ignored.
+    await act(async () => {
+      resolveProbe(false)
     })
     expect(result.current).toBe(true)
   })

--- a/web/src/hooks/useOnlineStatus.test.ts
+++ b/web/src/hooks/useOnlineStatus.test.ts
@@ -68,10 +68,8 @@ describe("useOnlineStatus", () => {
   })
 
   it("reads offline synchronously on a cold load that started hard-offline (#187)", () => {
-    // Guards the auth contract: resolveAuthStatus depends on useOnlineStatus()
-    // being false on the FIRST render of an offline cold reload (no waiting for
-    // a probe) so it holds a valid session at "loading" instead of bouncing to
-    // /login. A pending probe must not delay this.
+    // resolveAuthStatus depends on this being false on the FIRST render (no
+    // waiting for the probe) to hold a valid session instead of redirecting.
     livenessSpy.mockReturnValue(new Promise<boolean>(() => {}))
     coldStart(false)
     const { result } = renderHook(() => useOnlineStatus())

--- a/web/src/hooks/useOnlineStatus.test.ts
+++ b/web/src/hooks/useOnlineStatus.test.ts
@@ -12,6 +12,14 @@ function setNavigatorOnLine(value: boolean) {
   })
 }
 
+// Simulate a cold page load in a given connectivity state: stage
+// navigator.onLine, then re-run the module seed so `confirmedOffline` captures
+// it exactly as it would at import time.
+function coldStart(online: boolean) {
+  setNavigatorOnLine(online)
+  __resetOnlineStatusForTest()
+}
+
 let livenessSpy: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
@@ -59,18 +67,43 @@ describe("useOnlineStatus", () => {
     await waitFor(() => expect(result.current).toBe(false))
   })
 
-  it("seeds a cold load that starts offline through the same corroborated path", async () => {
-    livenessSpy.mockResolvedValue(false)
-    setNavigatorOnLine(false)
+  it("reads offline synchronously on a cold load that started hard-offline (#187)", () => {
+    // Guards the auth contract: resolveAuthStatus depends on useOnlineStatus()
+    // being false on the FIRST render of an offline cold reload (no waiting for
+    // a probe) so it holds a valid session at "loading" instead of bouncing to
+    // /login. A pending probe must not delay this.
+    livenessSpy.mockReturnValue(new Promise<boolean>(() => {}))
+    coldStart(false)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(false)
+  })
+
+  it("still probes a cold offline start and clears it when a captive portal reaches the internet", async () => {
+    livenessSpy.mockResolvedValue(true)
+    coldStart(false)
     const { result } = renderHook(() => useOnlineStatus())
 
-    await waitFor(() => expect(result.current).toBe(false))
+    // Synchronously offline from the seed...
+    expect(result.current).toBe(false)
+    // ...then the probe confirms the internet is actually reachable and clears it.
+    await waitFor(() => expect(result.current).toBe(true))
     expect(livenessSpy).toHaveBeenCalled()
+  })
+
+  it("keeps a cold offline start offline when the probe also fails", async () => {
+    livenessSpy.mockResolvedValue(false)
+    coldStart(false)
+    const { result } = renderHook(() => useOnlineStatus())
+
+    expect(result.current).toBe(false)
+    // Stays offline after the probe confirms unreachability.
+    await waitFor(() => expect(livenessSpy).toHaveBeenCalled())
+    expect(result.current).toBe(false)
   })
 
   it("recovers immediately on the online event without waiting for a probe", async () => {
     livenessSpy.mockResolvedValue(false)
-    setNavigatorOnLine(false)
+    coldStart(false)
     const { result } = renderHook(() => useOnlineStatus())
     await waitFor(() => expect(result.current).toBe(false))
 
@@ -89,7 +122,7 @@ describe("useOnlineStatus", () => {
           resolveProbe = resolve
         }),
     )
-    setNavigatorOnLine(false)
+    coldStart(false)
     const { result } = renderHook(() => useOnlineStatus())
 
     // Link comes back before the probe settles.
@@ -104,6 +137,29 @@ describe("useOnlineStatus", () => {
       resolveProbe(false)
     })
     expect(result.current).toBe(true)
+  })
+
+  it("re-arms on a second offline event while a probe is still in flight", async () => {
+    // First probe never settles; a second offline event must start a fresh
+    // probe (new epoch) rather than being swallowed by the in-flight one.
+    coldStart(true)
+    livenessSpy.mockReturnValueOnce(new Promise<boolean>(() => {}))
+    livenessSpy.mockResolvedValueOnce(false)
+    const { result } = renderHook(() => useOnlineStatus())
+
+    act(() => {
+      setNavigatorOnLine(false)
+      window.dispatchEvent(new Event("offline"))
+    })
+    // First probe is pending -> still online.
+    expect(result.current).toBe(true)
+
+    await act(async () => {
+      window.dispatchEvent(new Event("offline"))
+    })
+    // Second probe resolved offline; its result applies.
+    expect(livenessSpy).toHaveBeenCalledTimes(2)
+    await waitFor(() => expect(result.current).toBe(false))
   })
 
   it("unsubscribes on unmount", () => {

--- a/web/src/hooks/useOnlineStatus.ts
+++ b/web/src/hooks/useOnlineStatus.ts
@@ -2,43 +2,30 @@ import { useSyncExternalStore } from "react"
 
 import { checkInternetLiveness } from "@/lib/internetLiveness"
 
-// Connectivity signal for the UI, deliberately conservative about declaring the
-// device offline. navigator.onLine is only a hint in BOTH directions:
-//
-//   - true  -> "probably reachable" (a captive portal / dead uplink still reads
-//              as online). We never treat this as a claim a specific host is up;
-//              GitHub's reachability is the GitHub-health detector's job.
-//   - false -> "the OS reports no link" — reliable for Wi-Fi off / cable
-//              unplugged / airplane mode, but browsers ALSO flip it false (and
-//              fire `offline`) on transient network-stack hiccups (a route drop,
-//              a VPN/proxy flap) while the device is actually still online.
-//
-// That false-positive `offline` is what made a GitHub incident surface as
-// "You're offline". So we no longer trust a *live* `offline` event blindly: we
-// corroborate with an independent internet-liveness probe (see
+// Connectivity signal for the UI, conservative about declaring the device
+// offline. navigator.onLine is only a hint: browsers flip it false (and fire
+// `offline`) on transient network-stack hiccups — a route drop, a VPN/proxy
+// flap — while the device is still online. That false-positive is what made a
+// GitHub incident surface as "You're offline". So a *live* `offline` event no
+// longer flips us directly; we corroborate with an internet-liveness probe (see
 // internetLiveness.ts) and only report offline when the probe also fails. An
 // `online` event is trusted immediately — it can only clear an offline state.
 //
-// The one signal we DO trust synchronously is the initial page-load reading:
-// `navigator.onLine === false` at mount seeds `confirmedOffline` so a cold load
-// on a hard-offline device (Wi-Fi off) reads offline on the very first render.
-// This preserves the auth guard's #187 contract — resolveAuthStatus depends on
-// useOnlineStatus() being false synchronously on an offline cold reload to hold
-// a valid session at "loading" instead of bouncing it to /login. The async
-// probe then only ever *clears* this seed (a captive portal that actually
-// reaches the internet), never newly asserts offline mid-session without the
-// probe confirming it.
+// The initial page-load reading IS trusted synchronously (see the seed below),
+// preserving the auth guard's #187 contract.
 //
 // Module-level store (not React state) so every subscriber reads one source via
-// useSyncExternalStore, and so the async probe result is shared rather than
-// re-run per component.
+// useSyncExternalStore and the async probe result is shared.
 
-// Seed from the synchronous page-load reading (see above). SSR has no
-// navigator, so default to online there.
+// Seed synchronously from navigator.onLine so a hard-offline cold load (Wi-Fi
+// off) reads offline on the first render — resolveAuthStatus (#187) depends on
+// this to hold a valid session at "loading" instead of bouncing it to /login.
+// The probe then only ever *clears* this seed (a captive portal that in fact
+// reaches the internet), never asserts offline mid-session on its own.
 let confirmedOffline =
   typeof navigator !== "undefined" ? !navigator.onLine : false
 // Bumped on every online/offline transition so a probe that resolves after the
-// state already moved on can't apply its stale verdict.
+// state moved on can't apply its stale verdict.
 let probeEpoch = 0
 const listeners = new Set<() => void>()
 
@@ -65,8 +52,8 @@ function handleOffline() {
   })
 }
 
-// A restored link is unambiguous good news; clear immediately and invalidate any
-// in-flight offline probe so it can't flip us back.
+// A restored link is unambiguous; clear immediately and bump the epoch so an
+// in-flight offline probe can't flip us back.
 function handleOnline() {
   probeEpoch++
   setConfirmedOffline(false)
@@ -97,15 +84,13 @@ function getServerSnapshot() {
   return true
 }
 
-// Live browser connectivity. True means "online (or at least reaching the wider
-// internet)"; false means a probe-confirmed hard-offline device. It never
-// claims a specific host is up — that's what the actual fetch is for.
+// True means online (or at least reaching the wider internet); false means a
+// probe-confirmed hard-offline device.
 export function useOnlineStatus(): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
-// Test-only reset so the module-level state doesn't leak between cases. Re-seeds
-// `confirmedOffline` from the current navigator.onLine, mirroring module load so
+// Test-only reset that re-seeds from navigator.onLine, mirroring module load so
 // a test can stage a cold-offline start by setting navigator.onLine then reset.
 export function __resetOnlineStatusForTest(): void {
   confirmedOffline =

--- a/web/src/hooks/useOnlineStatus.ts
+++ b/web/src/hooks/useOnlineStatus.ts
@@ -1,16 +1,80 @@
 import { useSyncExternalStore } from "react"
 
+import { checkInternetLiveness } from "@/lib/internetLiveness"
+
+// Connectivity signal for the UI, deliberately conservative about declaring the
+// device offline. navigator.onLine is only a hint in BOTH directions:
+//
+//   - true  -> "probably reachable" (a captive portal / dead uplink still reads
+//              as online). We never treat this as a claim a specific host is up;
+//              GitHub's reachability is the GitHub-health detector's job.
+//   - false -> "the OS reports no link" — reliable for Wi-Fi off / cable
+//              unplugged / airplane mode, but browsers ALSO flip it false (and
+//              fire `offline`) on transient network-stack hiccups (a route drop,
+//              a VPN/proxy flap) while the device is actually still online.
+//
+// That false-positive `offline` is what made a GitHub incident surface as
+// "You're offline". So we no longer trust `false` blindly: on an offline signal
+// we corroborate with an independent internet-liveness probe (see
+// internetLiveness.ts) and only report offline when the probe also fails. An
+// `online` event is trusted immediately — it can only clear an offline state.
+//
+// Module-level store (not React state) so every subscriber reads one source via
+// useSyncExternalStore, and so the async probe result is shared rather than
+// re-run per component.
+
+let confirmedOffline = false
+// Bumped on every online/offline transition so a probe that resolves after the
+// state already moved on can't apply its stale verdict.
+let probeEpoch = 0
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const listener of listeners) listener()
+}
+
+function setConfirmedOffline(next: boolean) {
+  if (confirmedOffline === next) return
+  confirmedOffline = next
+  emit()
+}
+
+// The browser reports no link. Corroborate before believing it: a real
+// hard-offline device fails the probe (-> offline); a spurious flip or captive
+// portal still reaches the internet (-> stay online, let GitHub reads speak).
+function handleOffline() {
+  const epoch = ++probeEpoch
+  void checkInternetLiveness().then((online) => {
+    // A later transition superseded this probe (e.g. `online` fired, or another
+    // `offline` re-armed) — discard its now-stale result.
+    if (epoch !== probeEpoch) return
+    setConfirmedOffline(!online)
+  })
+}
+
+// A restored link is unambiguous good news; clear immediately and invalidate any
+// in-flight offline probe so it can't flip us back.
+function handleOnline() {
+  probeEpoch++
+  setConfirmedOffline(false)
+}
+
 function subscribe(onChange: () => void) {
-  window.addEventListener("online", onChange)
-  window.addEventListener("offline", onChange)
+  listeners.add(onChange)
+  window.addEventListener("online", handleOnline)
+  window.addEventListener("offline", handleOffline)
+  // Seed from a cold load that started offline: navigator.onLine is synchronous,
+  // but confirmation is async, so kick the same corroborated path.
+  if (typeof navigator !== "undefined" && !navigator.onLine) handleOffline()
   return () => {
-    window.removeEventListener("online", onChange)
-    window.removeEventListener("offline", onChange)
+    listeners.delete(onChange)
+    window.removeEventListener("online", handleOnline)
+    window.removeEventListener("offline", handleOffline)
   }
 }
 
 function getSnapshot() {
-  return navigator.onLine
+  return !confirmedOffline
 }
 
 // SSR/tests without a navigator default to online so nothing renders an offline
@@ -19,13 +83,17 @@ function getServerSnapshot() {
   return true
 }
 
-// Live browser connectivity, driven by the online/offline events so an offline
-// state appears and clears without a reload. navigator.onLine is optimistic (a
-// captive portal reads as online), so treat only `false` as authoritative:
-// false means no network, true means "probably reachable" — never a claim that
-// a specific host is up (that's what the actual fetch is for).
+// Live browser connectivity. True means "online (or at least reaching the wider
+// internet)"; false means a probe-confirmed hard-offline device. It never
+// claims a specific host is up — that's what the actual fetch is for.
 export function useOnlineStatus(): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}
+
+// Test-only reset so the module-level state doesn't leak between cases.
+export function __resetOnlineStatusForTest(): void {
+  confirmedOffline = false
+  probeEpoch = 0
 }
 
 export default useOnlineStatus

--- a/web/src/hooks/useOnlineStatus.ts
+++ b/web/src/hooks/useOnlineStatus.ts
@@ -14,16 +14,29 @@ import { checkInternetLiveness } from "@/lib/internetLiveness"
 //              a VPN/proxy flap) while the device is actually still online.
 //
 // That false-positive `offline` is what made a GitHub incident surface as
-// "You're offline". So we no longer trust `false` blindly: on an offline signal
-// we corroborate with an independent internet-liveness probe (see
+// "You're offline". So we no longer trust a *live* `offline` event blindly: we
+// corroborate with an independent internet-liveness probe (see
 // internetLiveness.ts) and only report offline when the probe also fails. An
 // `online` event is trusted immediately — it can only clear an offline state.
+//
+// The one signal we DO trust synchronously is the initial page-load reading:
+// `navigator.onLine === false` at mount seeds `confirmedOffline` so a cold load
+// on a hard-offline device (Wi-Fi off) reads offline on the very first render.
+// This preserves the auth guard's #187 contract — resolveAuthStatus depends on
+// useOnlineStatus() being false synchronously on an offline cold reload to hold
+// a valid session at "loading" instead of bouncing it to /login. The async
+// probe then only ever *clears* this seed (a captive portal that actually
+// reaches the internet), never newly asserts offline mid-session without the
+// probe confirming it.
 //
 // Module-level store (not React state) so every subscriber reads one source via
 // useSyncExternalStore, and so the async probe result is shared rather than
 // re-run per component.
 
-let confirmedOffline = false
+// Seed from the synchronous page-load reading (see above). SSR has no
+// navigator, so default to online there.
+let confirmedOffline =
+  typeof navigator !== "undefined" ? !navigator.onLine : false
 // Bumped on every online/offline transition so a probe that resolves after the
 // state already moved on can't apply its stale verdict.
 let probeEpoch = 0
@@ -63,8 +76,9 @@ function subscribe(onChange: () => void) {
   listeners.add(onChange)
   window.addEventListener("online", handleOnline)
   window.addEventListener("offline", handleOffline)
-  // Seed from a cold load that started offline: navigator.onLine is synchronous,
-  // but confirmation is async, so kick the same corroborated path.
+  // A cold load that started offline already read offline synchronously (the
+  // `confirmedOffline` seed above). Still run the probe so a captive portal /
+  // spurious seed that actually reaches the internet gets cleared.
   if (typeof navigator !== "undefined" && !navigator.onLine) handleOffline()
   return () => {
     listeners.delete(onChange)
@@ -90,9 +104,12 @@ export function useOnlineStatus(): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
-// Test-only reset so the module-level state doesn't leak between cases.
+// Test-only reset so the module-level state doesn't leak between cases. Re-seeds
+// `confirmedOffline` from the current navigator.onLine, mirroring module load so
+// a test can stage a cold-offline start by setting navigator.onLine then reset.
 export function __resetOnlineStatusForTest(): void {
-  confirmedOffline = false
+  confirmedOffline =
+    typeof navigator !== "undefined" ? !navigator.onLine : false
   probeEpoch = 0
 }
 

--- a/web/src/lib/internetLiveness.test.ts
+++ b/web/src/lib/internetLiveness.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { checkInternetLiveness } from "./internetLiveness"
+
+// A resolved fetch (even an opaque no-cors response) means the round-trip
+// succeeded; a rejected one means that endpoint was unreachable.
+const reachable = (): Response => ({}) as unknown as Response
+const unreachable = () => Promise.reject(new TypeError("Failed to fetch"))
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("checkInternetLiveness", () => {
+  it("reports online when every probe resolves", async () => {
+    fetchMock.mockResolvedValue(reachable())
+    expect(await checkInternetLiveness()).toBe(true)
+  })
+
+  it("reports online when only one endpoint is reachable", async () => {
+    fetchMock
+      .mockImplementationOnce(unreachable)
+      .mockResolvedValueOnce(reachable())
+      .mockImplementationOnce(unreachable)
+    expect(await checkInternetLiveness()).toBe(true)
+  })
+
+  it("reports offline only when every endpoint is unreachable", async () => {
+    fetchMock.mockImplementation(unreachable)
+    expect(await checkInternetLiveness()).toBe(false)
+  })
+
+  it("reports offline when every probe times out", async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.reject(
+        new DOMException("The operation timed out", "TimeoutError"),
+      ),
+    )
+    expect(await checkInternetLiveness()).toBe(false)
+  })
+
+  it("probes multiple independent endpoints, none of them GitHub", async () => {
+    fetchMock.mockResolvedValue(reachable())
+    await checkInternetLiveness()
+    const urls = fetchMock.mock.calls.map((call) => String(call[0]))
+    expect(urls.length).toBeGreaterThan(1)
+    expect(urls.some((url) => url.includes("cloudflare"))).toBe(true)
+    expect(urls.every((url) => !url.includes("github"))).toBe(true)
+  })
+})

--- a/web/src/lib/internetLiveness.test.ts
+++ b/web/src/lib/internetLiveness.test.ts
@@ -54,4 +54,14 @@ describe("checkInternetLiveness", () => {
     expect(urls.some((url) => url.includes("cloudflare"))).toBe(true)
     expect(urls.every((url) => !url.includes("github"))).toBe(true)
   })
+
+  it("passes an abort signal and a no-store cache policy to every probe", async () => {
+    fetchMock.mockResolvedValue(reachable())
+    await checkInternetLiveness()
+    for (const call of fetchMock.mock.calls) {
+      const init = call[1] as RequestInit
+      expect(init.cache).toBe("no-store")
+      expect(init.signal).toBeInstanceOf(AbortSignal)
+    }
+  })
 })

--- a/web/src/lib/internetLiveness.ts
+++ b/web/src/lib/internetLiveness.ts
@@ -1,0 +1,62 @@
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("net:liveness")
+
+// Independent "is the internet reachable" probe, deliberately GitHub-agnostic.
+// It answers a different question than the GitHub-health detector: "does this
+// device have a working connection to the wider internet at all", so we can
+// tell a genuinely-offline device (show the offline banner) apart from a device
+// that is online but can't reach GitHub (show the GitHub-outage banner). Mixing
+// the two is what made a GitHub incident read as "You're offline".
+const PROBE_TIMEOUT_MS = 4_000
+
+// Reputable, independently-operated anycast endpoints. We race several and
+// treat ANY success as proof of connectivity, so one provider being blocked (a
+// corporate proxy, an ad/tracker blocklist catching gstatic, a regional
+// Cloudflare hiccup) can't produce a false "offline". None is GitHub, on
+// purpose — GitHub's own reachability is the GitHub-health detector's job.
+//
+// `no-cors` requests yield an opaque response we can't read, but that's fine: a
+// probe only needs the fetch to *resolve* (the network round-trip succeeded)
+// rather than throw. cloudflare-dns.com is CORS-open, so it can stay a normal
+// request. cache: "no-store" keeps every probe a real network round-trip.
+const PROBE_TARGETS: readonly { url: string; mode: RequestMode }[] = [
+  // Cloudflare edge liveness (tiny plaintext body at cdn-cgi/trace).
+  { url: "https://cloudflare.com/cdn-cgi/trace", mode: "no-cors" },
+  // Cloudflare DNS-over-HTTPS: CORS-open and doubles as a DNS-resolves check.
+  {
+    url: "https://cloudflare-dns.com/dns-query?name=cloudflare.com&type=A",
+    mode: "cors",
+  },
+  // Google's standard connectivity-check endpoint (returns HTTP 204).
+  { url: "https://www.gstatic.com/generate_204", mode: "no-cors" },
+]
+
+// True if the device can reach at least one reputable internet endpoint.
+//
+// Best-effort and fail-open on ambiguity: this gates a user-facing "You're
+// offline" banner, and a false offline (claiming no connection when there is
+// one) is worse than a missed one — the app's own GitHub reads will still fail
+// loudly if GitHub is the problem. So any single probe resolving counts as
+// online, and we only report offline when every probe fails or times out.
+export async function checkInternetLiveness(): Promise<boolean> {
+  const signal = AbortSignal.timeout(PROBE_TIMEOUT_MS)
+  try {
+    // Promise.any resolves on the first fulfilled probe and rejects only when
+    // ALL reject, which is exactly the "every endpoint unreachable" signal.
+    await Promise.any(
+      PROBE_TARGETS.map((target) =>
+        fetch(target.url, {
+          mode: target.mode,
+          cache: "no-store",
+          redirect: "follow",
+          signal,
+        }),
+      ),
+    )
+    return true
+  } catch {
+    log.debug("internet liveness probe: all endpoints unreachable")
+    return false
+  }
+}

--- a/web/src/lib/internetLiveness.ts
+++ b/web/src/lib/internetLiveness.ts
@@ -2,48 +2,35 @@ import { logger } from "@/lib/logger"
 
 const log = logger.scope("net:liveness")
 
-// Independent "is the internet reachable" probe, deliberately GitHub-agnostic.
-// It answers a different question than the GitHub-health detector: "does this
-// device have a working connection to the wider internet at all", so we can
-// tell a genuinely-offline device (show the offline banner) apart from a device
-// that is online but can't reach GitHub (show the GitHub-outage banner). Mixing
-// the two is what made a GitHub incident read as "You're offline".
+// Independent, GitHub-agnostic "is the wider internet reachable" probe. It lets
+// us tell a genuinely-offline device (show the offline banner) apart from a
+// device that's online but can't reach GitHub (the GitHub-outage banner's job).
+// Conflating the two is what made a GitHub incident read as "You're offline".
 const PROBE_TIMEOUT_MS = 4_000
 
-// Reputable, independently-operated anycast endpoints. We race several and
-// treat ANY success as proof of connectivity, so one provider being blocked (a
-// corporate proxy, an ad/tracker blocklist catching gstatic, a regional
-// Cloudflare hiccup) can't produce a false "offline". None is GitHub, on
-// purpose — GitHub's own reachability is the GitHub-health detector's job.
+// Reputable, independently-operated anycast endpoints, none of them GitHub. We
+// race several so one being blocked (a proxy, an ad-blocklist catching gstatic,
+// a regional Cloudflare hiccup) can't produce a false "offline".
 //
-// `no-cors` requests yield an opaque response we can't read, but that's fine: a
-// probe only needs the fetch to *resolve* (the network round-trip succeeded)
-// rather than throw. cloudflare-dns.com is CORS-open, so it can stay a normal
-// request. cache: "no-store" keeps every probe a real network round-trip.
+// `no-cors` yields an opaque response we can't read, but a liveness check only
+// needs the fetch to *resolve* — the round-trip succeeded — not to be readable.
 const PROBE_TARGETS: readonly { url: string; mode: RequestMode }[] = [
-  // Cloudflare edge liveness (tiny plaintext body at cdn-cgi/trace).
   { url: "https://cloudflare.com/cdn-cgi/trace", mode: "no-cors" },
-  // Cloudflare DNS-over-HTTPS: CORS-open and doubles as a DNS-resolves check.
+  // CORS-open, so it can stay a readable request; doubles as a DNS-resolves check.
   {
     url: "https://cloudflare-dns.com/dns-query?name=cloudflare.com&type=A",
     mode: "cors",
   },
-  // Google's standard connectivity-check endpoint (returns HTTP 204).
   { url: "https://www.gstatic.com/generate_204", mode: "no-cors" },
 ]
 
-// True if the device can reach at least one reputable internet endpoint.
-//
-// Best-effort and fail-open on ambiguity: this gates a user-facing "You're
-// offline" banner, and a false offline (claiming no connection when there is
-// one) is worse than a missed one — the app's own GitHub reads will still fail
-// loudly if GitHub is the problem. So any single probe resolving counts as
-// online, and we only report offline when every probe fails or times out.
+// True if the device can reach at least one endpoint. Fail-open on ambiguity: a
+// false "offline" is worse than a missed one (the app's own GitHub reads still
+// fail loudly), so only every probe failing or timing out reports offline.
 export async function checkInternetLiveness(): Promise<boolean> {
   const signal = AbortSignal.timeout(PROBE_TIMEOUT_MS)
   try {
-    // Promise.any resolves on the first fulfilled probe and rejects only when
-    // ALL reject, which is exactly the "every endpoint unreachable" signal.
+    // Promise.any rejects only when ALL reject — exactly "every endpoint down".
     await Promise.any(
       PROBE_TARGETS.map((target) =>
         fetch(target.url, {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1818,7 +1818,7 @@
   },
   "offline": {
     "title": "You're offline",
-    "body": "Classroom 50 works with live data from GitHub, so it needs a connection. This banner clears automatically when you're back online."
+    "body": "This device isn't connected to the internet. Classroom 50 needs a live connection to work. This banner clears automatically once you're back online."
   },
   "githubStatus": {
     "title": "GitHub may be having problems",


### PR DESCRIPTION
## Why

Users hit a GitHub outage (Pages publishing stuck) but the app showed the **"You're offline"** banner instead of the GitHub-outage banner — even though they were clearly online. The offline banner was driven solely by `navigator.onLine === false`, which browsers flip (and fire an `offline` event for) on transient network-stack hiccups — a route drop, a VPN/proxy flap — while the device is still online. So a GitHub incident could surface as a device-offline claim.

## What changed

Separate the two states so they can never be mixed up again:

- **Device offline** → `OfflineBanner` ("You're offline"), now confirmed by an independent internet-liveness probe.
- **Internet up but GitHub unreachable** → the existing `GitHubStatusBanner` ("GitHub may be having problems"), unchanged.

New `checkInternetLiveness()` (`web/src/lib/internetLiveness.ts`) races three reputable, non-GitHub anycast endpoints — Cloudflare `cdn-cgi/trace`, Cloudflare DNS-over-HTTPS, and Google's `generate_204` — and treats *any* success as online, so one blocked provider can't produce a false offline. It's best-effort and fail-open on ambiguity (a false "offline" is worse than a missed one; the app's own GitHub reads still fail loudly if GitHub is the problem).

`useOnlineStatus` no longer trusts a *live* `offline` event blindly: it corroborates with the probe and only reports offline when the probe also fails. An `online` event still clears immediately, and an epoch guard discards a stale probe that resolves after the link is restored.

The initial page-load reading is still trusted synchronously: `navigator.onLine === false` at mount seeds the store so a hard-offline cold load reads offline on the first render. This preserves the auth guard's #187 contract (`resolveAuthStatus` depends on `useOnlineStatus()` being `false` synchronously on an offline cold reload to hold a valid session at "loading" instead of bouncing it to `/login`). The async probe then only *clears* that seed for a captive portal that actually reaches the internet.

The offline banner copy was reworded from a GitHub-flavored explanation to a plain device/network statement, since it now means "this device has no connection," not "GitHub is unreachable."

## Testing

`npm run check` is green (`tsc`, eslint, prettier, arch:validate, 3270 vitest tests). New coverage: the liveness probe (race / single-reachable / all-fail / timeout / non-GitHub endpoints / abort-signal + no-store contract) and `useOnlineStatus` (spurious-flip stays online, offline only after the probe fails, the #187 synchronous cold-offline read, captive-portal clear, immediate online recovery, stale-probe discard, and in-flight re-arm).
