### PR TITLE
fix: reject an empty (commitless) template before accept

### DIFF
--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1071,11 +1071,10 @@ func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string,
 	if !isTemplate {
 		return assignment.TemplateRef{}, fmt.Errorf("`%s/%s` is not a template repository — toggle Settings → \"Template repository\" on the repo, then re-run", t.Owner, t.Repo)
 	}
-	// A commitless template (size 0) reports a phantom default_branch, so the
-	// empty-branch guard below never catches it; generate would 422 at accept.
-	// GitHub always returns size on GET /repos; if it ever omitted it, Go's zero
-	// value makes this fail closed (reject) — the deliberate opposite of the web
-	// verify path's fail-open === 0, since add is the last gate before write.
+	// Caught before the empty-branch guard below (which a commitless repo's
+	// phantom default_branch would slip past). Fail closed on an absent size —
+	// Go's zero value — the deliberate opposite of the web verify path's
+	// fail-open === 0, since `add` is the last gate before write.
 	if size == 0 {
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run", t.Owner, t.Repo)
 	}
@@ -1084,10 +1083,8 @@ func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string,
 		branch = defaultBranch
 	}
 	if branch == "" {
-		// Defensive fallback: a non-empty repo (size > 0) that still reports no
-		// default_branch is not expected — a commitless repo is already caught by
-		// the size guard above (it reports a phantom default_branch, not "") — but
-		// an empty on-disk Branch would trip `student accept`, so guard it anyway.
+		// Not expected once size > 0, but a blank on-disk Branch would trip
+		// `student accept`, so guard it anyway.
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch — pass --template %s/%s@<branch> explicitly", t.Owner, t.Repo, t.Owner, t.Repo)
 	}
 	return assignment.TemplateRef{Owner: t.Owner, Repo: t.Repo, Branch: branch}, nil

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1073,6 +1073,9 @@ func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string,
 	}
 	// A commitless template (size 0) reports a phantom default_branch, so the
 	// empty-branch guard below never catches it; generate would 422 at accept.
+	// GitHub always returns size on GET /repos; if it ever omitted it, Go's zero
+	// value makes this fail closed (reject) — the deliberate opposite of the web
+	// verify path's fail-open === 0, since add is the last gate before write.
 	if size == 0 {
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run", t.Owner, t.Repo)
 	}
@@ -1081,8 +1084,10 @@ func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string,
 		branch = defaultBranch
 	}
 	if branch == "" {
-		// Defensive: a fresh repo can return empty default_branch, and an
-		// empty on-disk Branch would trip `student accept`.
+		// Defensive fallback: a non-empty repo (size > 0) that still reports no
+		// default_branch is not expected — a commitless repo is already caught by
+		// the size guard above (it reports a phantom default_branch, not "") — but
+		// an empty on-disk Branch would trip `student accept`, so guard it anyway.
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch — pass --template %s/%s@<branch> explicitly", t.Owner, t.Repo, t.Owner, t.Repo)
 	}
 	return assignment.TemplateRef{Owner: t.Owner, Repo: t.Repo, Branch: branch}, nil

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1026,7 +1026,11 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 		DefaultBranch string `json:"default_branch"`
 		Private       bool   `json:"private"`
 		Fork          bool   `json:"fork"`
-		Parent        struct {
+		// Repo size in KB. 0 means no commits — an empty template can't be
+		// generated from (POST /generate 422s "is empty"), and GitHub reports a
+		// phantom default_branch for it, so size is the reliable emptiness signal.
+		Size   int `json:"size"`
+		Parent struct {
 			FullName string `json:"full_name"`
 		} `json:"parent"`
 	}
@@ -1037,7 +1041,7 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 		}
 		return assignment.TemplateRef{}, false, "", fmt.Errorf("GET %s: %w", path, err)
 	}
-	ref, err = resolveTemplateBranch(t, resp.IsTemplate, resp.DefaultBranch)
+	ref, err = resolveTemplateBranch(t, resp.IsTemplate, resp.DefaultBranch, resp.Size)
 	if err != nil {
 		return assignment.TemplateRef{}, false, "", err
 	}
@@ -1061,11 +1065,16 @@ func templateInOrg(templateOwner, org string) bool {
 }
 
 // resolveTemplateBranch picks the final assignment.TemplateRef from
-// --template + repo fields: not-a-template, explicit @branch,
-// default_branch fallback, or empty-default_branch guard.
-func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string) (assignment.TemplateRef, error) {
+// --template + repo fields: not-a-template, empty (commitless), explicit
+// @branch, default_branch fallback, or empty-default_branch guard.
+func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string, size int) (assignment.TemplateRef, error) {
 	if !isTemplate {
 		return assignment.TemplateRef{}, fmt.Errorf("`%s/%s` is not a template repository — toggle Settings → \"Template repository\" on the repo, then re-run", t.Owner, t.Repo)
+	}
+	// A commitless template (size 0) reports a phantom default_branch, so the
+	// empty-branch guard below never catches it; generate would 422 at accept.
+	if size == 0 {
+		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run", t.Owner, t.Repo)
 	}
 	branch := t.Branch
 	if branch == "" {

--- a/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
@@ -176,6 +176,7 @@ func TestResolveTemplateBranch(t *testing.T) {
 		arg         templateArg
 		isTemplate  bool
 		defaultBr   string
+		size        int
 		wantRef     assignment.TemplateRef
 		wantErrPart string // empty → expect success
 	}{
@@ -184,13 +185,23 @@ func TestResolveTemplateBranch(t *testing.T) {
 			arg:         templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate:  false,
 			defaultBr:   "main",
+			size:        0,
 			wantErrPart: "not a template repository",
+		},
+		{
+			name:        "empty template (no commits) rejected before branch resolution",
+			arg:         templateArg{Owner: "cs50", Repo: "hello-template"},
+			isTemplate:  true,
+			defaultBr:   "main", // GitHub reports a phantom default_branch for a commitless repo
+			size:        0,
+			wantErrPart: "has no commits",
 		},
 		{
 			name:       "explicit @branch retained even when default_branch differs",
 			arg:        templateArg{Owner: "cs50", Repo: "hello-template", Branch: "feature/foo"},
 			isTemplate: true,
 			defaultBr:  "main",
+			size:       1,
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "feature/foo"},
 		},
 		{
@@ -198,6 +209,7 @@ func TestResolveTemplateBranch(t *testing.T) {
 			arg:        templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate: true,
 			defaultBr:  "master",
+			size:       1,
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "master"},
 		},
 		{
@@ -205,6 +217,7 @@ func TestResolveTemplateBranch(t *testing.T) {
 			arg:        templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate: true,
 			defaultBr:  "main",
+			size:       1,
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "main"},
 		},
 		{
@@ -212,12 +225,13 @@ func TestResolveTemplateBranch(t *testing.T) {
 			arg:         templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate:  true,
 			defaultBr:   "",
+			size:        1,
 			wantErrPart: "has no default branch",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveTemplateBranch(tc.arg, tc.isTemplate, tc.defaultBr)
+			got, err := resolveTemplateBranch(tc.arg, tc.isTemplate, tc.defaultBr, tc.size)
 			if tc.wantErrPart != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil (returned %#v)", tc.wantErrPart, got)
@@ -472,6 +486,7 @@ func TestValidateTemplateRepo_CrossOrgFork(t *testing.T) {
 	t.Run("cross-org fork reports the parent org", func(t *testing.T) {
 		client := newClient(t, map[string]any{
 			"is_template":    true,
+			"size":           1,
 			"default_branch": "main",
 			"private":        true,
 			"fork":           true,
@@ -489,6 +504,7 @@ func TestValidateTemplateRepo_CrossOrgFork(t *testing.T) {
 	t.Run("same-org fork reports no parent", func(t *testing.T) {
 		client := newClient(t, map[string]any{
 			"is_template":    true,
+			"size":           1,
 			"default_branch": "main",
 			"private":        true,
 			"fork":           true,
@@ -506,6 +522,7 @@ func TestValidateTemplateRepo_CrossOrgFork(t *testing.T) {
 	t.Run("non-fork reports no parent", func(t *testing.T) {
 		client := newClient(t, map[string]any{
 			"is_template":    true,
+			"size":           1,
 			"default_branch": "main",
 			"private":        true,
 			"fork":           false,

--- a/cli/gh-teacher/internal/assignmentcmd/lock_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock_test.go
@@ -70,6 +70,7 @@ func newLockServer(t *testing.T, cfg lockServerConfig) (*httptest.Server, *lockF
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"is_template":    true,
+			"size":           1,
 			"default_branch": "main",
 			"private":        cfg.templatePrivate,
 		})

--- a/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse_test.go
@@ -100,7 +100,7 @@ func newReuseServer(t *testing.T, cfg reuseServerConfig) (*httptest.Server, *reu
 			_, _ = io.WriteString(w, `{"message":"Not Found"}`)
 			return
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "default_branch": "main", "private": cfg.templatePrivate})
+		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "size": 1, "default_branch": "main", "private": cfg.templatePrivate})
 	})
 
 	// Classroom-team grant: GET team membership probe + PUT grant.

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
@@ -76,7 +76,7 @@ func newTestCmdServer(t *testing.T, assignmentsBody string, autograderExists boo
 	})
 	// Template repo probe used by the runAssignmentAdd tests.
 	mux.HandleFunc("/repos/cs50/hello-template", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "default_branch": "main"})
+		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "size": 1, "default_branch": "main"})
 	})
 	mux.HandleFunc("/repos/o/classroom50/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
@@ -615,7 +615,7 @@ func archivedClassroomAddServer(t *testing.T, fix *testCmdFixture) *httptest.Ser
 	// The template probe runs (and must pass) before the build callback
 	// where ensureClassroomActive fires, so serve a valid template.
 	mux.HandleFunc("/repos/cs50/hello-template", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "default_branch": "main"})
+		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "size": 1, "default_branch": "main"})
 	})
 	mux.HandleFunc("/repos/o/classroom50/contents/cs-principles/classroom.json", func(w http.ResponseWriter, r *http.Request) {
 		body := `{"schema":"classroom50/classroom/v1","name":"CS Principles","short_name":"cs-principles","term":"","org":"o","active":false}`
@@ -660,7 +660,7 @@ func TestRunAssignmentAdd_WarnsOnNonMainTemplateBranch(t *testing.T) {
 		})
 	})
 	mux.HandleFunc("/repos/cs50/hello-template", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "default_branch": "master"})
+		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "size": 1, "default_branch": "master"})
 	})
 	mux.HandleFunc("/repos/o/classroom50/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
@@ -1133,7 +1133,7 @@ func newPrivateTemplateServer(t *testing.T, templateOwner string, templatePrivat
 	// Template probe — the test controls owner + visibility.
 	mux.HandleFunc("/repos/"+templateOwner+"/hello-template", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"is_template": true, "default_branch": "main", "private": templatePrivate,
+			"is_template": true, "size": 1, "default_branch": "main", "private": templatePrivate,
 		})
 	})
 	// commitTree write endpoints.
@@ -1277,7 +1277,7 @@ func TestRunAssignmentAdd_InOrgPrivateNoTeamErrors(t *testing.T) {
 		})
 	})
 	fresh.HandleFunc("/repos/o/hello-template", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "default_branch": "main", "private": true})
+		_ = json.NewEncoder(w).Encode(map[string]any{"is_template": true, "size": 1, "default_branch": "main", "private": true})
 	})
 	fresh.HandleFunc("/repos/o/classroom50/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1811,6 +1811,38 @@ describe("verifyTemplateAccess", () => {
     expect(result.kind).toBe("not-template")
   })
 
+  it("returns empty-template when the template has no commits (size 0)", async () => {
+    const client = clientReturning({
+      name: "tmpl",
+      full_name: `${ORG}/tmpl`,
+      private: false,
+      is_template: true,
+      // GitHub reports a phantom default_branch for a commitless repo, so the
+      // signal is size, not the branch.
+      default_branch: "main",
+      size: 0,
+    })
+
+    const result = await verifyTemplateAccess(client, ORG, "tmpl")
+
+    expect(result.kind).toBe("empty-template")
+  })
+
+  it("prefers not-template over empty-template when both apply (ordering)", async () => {
+    const client = clientReturning({
+      name: "tmpl",
+      full_name: `${ORG}/tmpl`,
+      private: false,
+      is_template: false,
+      default_branch: "main",
+      size: 0,
+    })
+
+    const result = await verifyTemplateAccess(client, ORG, "tmpl")
+
+    expect(result.kind).toBe("not-template")
+  })
+
   it("returns not-visible when the repo read 404s (getRepo -> null)", async () => {
     const client = clientReturning(() => {
       throw new GitHubAPIError({
@@ -2022,6 +2054,40 @@ describe("resolveTemplate (create/edit blocking path)", () => {
     const request = vi.fn(async () => result)
     return { request } as unknown as GitHubClient
   }
+
+  it("throws for an empty template (no commits, size 0)", async () => {
+    const client = clientReturning({
+      name: "tmpl",
+      full_name: `${ORG}/tmpl`,
+      private: false,
+      is_template: true,
+      default_branch: "main",
+      size: 0,
+    })
+
+    await expect(
+      resolveTemplate(client, ORG, ref(ORG, "tmpl")),
+    ).rejects.toThrow(/has no commits/)
+  })
+
+  it("resolves a template with commits (size > 0)", async () => {
+    const client = clientReturning({
+      name: "tmpl",
+      full_name: `${ORG}/tmpl`,
+      private: false,
+      is_template: true,
+      default_branch: "main",
+      size: 12,
+    })
+
+    const result = await resolveTemplate(client, ORG, ref(ORG, "tmpl"))
+
+    expect(result.template).toEqual({
+      owner: ORG,
+      repo: "tmpl",
+      branch: "main",
+    })
+  })
 
   it("allows a cross-org private fork (generate copies the fork's own objects)", async () => {
     // Verified against GitHub: generate does NOT need parent access, so a

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -202,6 +202,10 @@ export type TemplateAccessVerification =
   | { kind: "invalid"; message: string }
   | { kind: "not-visible"; owner: string; repo: string }
   | { kind: "not-template"; owner: string; repo: string }
+  // Template with no commits (size 0): GitHub's generate 422s "is empty" at
+  // accept. A commitless repo reports a phantom default_branch, so `no-branch`
+  // never catches it — size is the reliable signal. resolveTemplate rejects it.
+  | { kind: "empty-template"; owner: string; repo: string }
   // No usable branch: no @branch given and the repo has no default branch
   // (e.g., a commitless template). resolveTemplate rejects this too.
   | { kind: "no-branch"; owner: string; repo: string }
@@ -353,6 +357,11 @@ export async function verifyTemplateAccess(
   if (!repo.is_template) {
     return { kind: "not-template", owner: parsed.owner, repo: parsed.repo }
   }
+  // A template with no commits (size 0) reports a phantom default_branch, so
+  // the no-branch verdict below never catches it; generate would 422 at accept.
+  if (repo.size === 0) {
+    return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
+  }
 
   const inOrg = parsed.owner.toLowerCase() === org.toLowerCase()
   if (repo.private && !inOrg) {
@@ -434,6 +443,15 @@ export async function resolveTemplate(
   if (!repo.is_template) {
     throw new Error(
       `"${parsed.owner}/${parsed.repo}" is not a template repository — toggle Settings → "Template repository" on the repo, then retry.`,
+    )
+  }
+
+  // A commitless template (size 0) reports a phantom default_branch, so the
+  // no-default-branch guard below never fires; generate would 422 at accept.
+  // Fail closed here so the assignment is never written pointing at it.
+  if (repo.size === 0) {
+    throw new Error(
+      `Template "${parsed.owner}/${parsed.repo}" has no commits — add at least one commit (e.g. a README) so students can generate from it, then retry.`,
     )
   }
 

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -357,10 +357,8 @@ export async function verifyTemplateAccess(
   if (!repo.is_template) {
     return { kind: "not-template", owner: parsed.owner, repo: parsed.repo }
   }
-  // A template with no commits (size 0) reports a phantom default_branch, so
-  // the no-branch verdict below never catches it; generate would 422 at accept.
-  // GET /repos always returns size, so an absent value never reaches here; the
-  // strict === 0 only trips on an explicit 0 (fail open if GitHub ever omits it).
+  // Caught before no-branch: a commitless repo reports a phantom default_branch
+  // (see the empty-template verdict). Fail open on an absent size.
   if (repo.size === 0) {
     return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
   }
@@ -448,9 +446,8 @@ export async function resolveTemplate(
     )
   }
 
-  // A commitless template (size 0) reports a phantom default_branch, so the
-  // no-default-branch guard below never fires; generate would 422 at accept.
-  // Fail closed here so the assignment is never written pointing at it.
+  // Fail closed: never write an assignment pointing at a commitless template
+  // (see the empty-template verdict for why size, not default_branch).
   if (repo.size === 0) {
     throw new Error(
       `Template "${parsed.owner}/${parsed.repo}" has no commits — add at least one commit (e.g. a README) so students can generate from it, then retry.`,

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -359,6 +359,8 @@ export async function verifyTemplateAccess(
   }
   // A template with no commits (size 0) reports a phantom default_branch, so
   // the no-branch verdict below never catches it; generate would 422 at accept.
+  // GET /repos always returns size, so an absent value never reaches here; the
+  // strict === 0 only trips on an explicit 0 (fail open if GitHub ever omits it).
   if (repo.size === 0) {
     return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
   }

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -85,6 +85,11 @@ export type GitHubRepo = {
     private: boolean
   }
   default_branch: string
+  // Repo size in KB (GET /repos). 0 means the repo has no commits — a
+  // commitless template can't be generated from (GitHub's POST /generate 422s
+  // "is empty"), so the template pre-flight rejects it. GitHub reports a phantom
+  // default_branch for such a repo, so size is the reliable emptiness signal.
+  size?: number
   visibility?: "public" | "private" | "internal"
   archived?: boolean
   // Repository feature flags (GET /repos returns them). Used by the assignment

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1361,6 +1361,7 @@
       "okVerify": "Reachable in {{owner}} (branch <branch>{{branch}}</branch>). If {{owner}} restricts third-party apps, students can't copy it until an owner approves Classroom 50.",
       "notVisible": "{{owner}}/{{repo}} isn't visible to you. Make it public or copy it into {{org}}.",
       "notTemplate": "{{owner}}/{{repo}} isn't a template repo. Enable it in the repo's Settings.",
+      "emptyTemplate": "{{owner}}/{{repo}} is a template but has no commits. Add at least one commit (e.g. a README), then retry.",
       "restricted": "{{owner}} blocked access to {{repo}} (HTTP 403) — likely a third-party app restriction. Try, in order:",
       "restrictedItemApprove": "Approve Classroom 50 for {{owner}} (Org settings → Third-party access).",
       "restrictedItemFork": "If {{repo}} is a fork, approve Classroom 50 on the fork's upstream org too — a private fork's access follows the upstream org's policy.",

--- a/web/src/pages/assignments/TemplateField.test.tsx
+++ b/web/src/pages/assignments/TemplateField.test.tsx
@@ -322,3 +322,19 @@ describe("TemplateField — outage hint on inconclusive verdicts", () => {
     expect(screen.queryByText(STATUS_LINK)).toBeNull()
   })
 })
+
+describe("TemplateField — empty-template verdict", () => {
+  it("renders the empty-template error copy for a commitless template", async () => {
+    verifyTemplateAccess.mockResolvedValue({
+      kind: "empty-template",
+      owner: ORG,
+      repo: "tmpl",
+    })
+    renderField()
+    expect(
+      await screen.findByText("assignments.template.emptyTemplate", {
+        exact: false,
+      }),
+    ).toBeTruthy()
+  })
+})

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -499,6 +499,16 @@ function renderTemplateVerdict({
         </Note>
       )
 
+    case "empty-template":
+      return (
+        <Note tone="error" icon={AlertTriangle}>
+          {t("assignments.template.emptyTemplate", {
+            owner: verification.owner,
+            repo: verification.repo,
+          })}
+        </Note>
+      )
+
     case "restricted": {
       return (
         <Note


### PR DESCRIPTION
## Problem

A template repo with **zero commits** (e.g. created via the GitHub UI with no README) passed every template check but could not be generated from. GitHub's `POST /repos/{owner}/{repo}/generate` rejects a commitless source, so the failure surfaced at **student accept time** with confusing copy — long after the teacher could have fixed it with a single commit. This is the shape reported in [discussion #526](https://github.com/foundation50/classroom50/discussions/526).

Root cause: the verify/resolve paths keyed "no content" off the default branch, but GitHub reports a **phantom** `default_branch` (e.g. `main`) for a commitless repo, so the existing branch guards never fired.

## Fix

Reject an empty template up front, keyed off `repo.size === 0` — the reliable emptiness signal, independent of the phantom branch. The teacher is told to add a commit and retry, instead of a student hitting a dead end.

- **web** — new `empty-template` verdict in `verifyTemplateAccess` (renders an error note on the Template field) and a fail-closed throw in `resolveTemplate`, so an assignment can never be saved pointing at an empty template. Added `size` to `GitHubRepo`.

- **cli** — `assignment add` rejects a commitless template in `resolveTemplateBranch`, mirroring the web rule per the cross-tool-parity contract.

Ordering is preserved on both sides: a non-template empty repo still reports `not-template` first (more actionable). No `assignments.json` schema change is needed — this is a client-side pre-flight guard.

## Verified against GitHub

Against a live commitless template: `GET /repos` returns `size: 0` with `default_branch: "main"` (the phantom branch, confirming the old guard could not catch it), and `POST /.../generate` returns **HTTP 422** `"is empty"`.

## Testing

`go test ./...` (gh-teacher) green; `npm run check` green (tsc, eslint, prettier, arch:validate, 3275 vitest tests). New coverage: verify returns `empty-template`, ordering vs `not-template`, `resolveTemplate` throws on `size: 0` and resolves on `size > 0`, and the note renders.

## Follow-up (not in this PR)

A reply to [#526](https://github.com/foundation50/classroom50/discussions/526): an empty template yields **422**, whereas the reporter saw **404** — so their student's failure was likely a separate org-membership issue worth confirming alongside this fix.