### PR TITLE
fix: silence staff-team removal email by granting config-repo access after owner drop

### DIFF
--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -293,14 +293,12 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 
 // seedStaffTeams creates (or adopts) the staff teams (teacher, hta, ta) and
 // adds the acting teacher as teacher-team maintainer — shared by `classroom
-// add` and `classroom migrate`. It deliberately does NOT grant config-repo
-// access; the caller does that via GrantStaffTeamsConfigRepoAccess AFTER
-// dropping the auto-added creator from the non-teacher teams, so the drop
-// doesn't email the owner (see EnsureStaffTeams). Returns the resolved acting
-// login (empty when it couldn't be read) so the caller can drop that same user
-// from the non-teacher teams. The maintainer add is best-effort: a
-// CurrentUser/membership failure warns but doesn't fail creation (the teacher
-// can self-add via the web).
+// add` and `classroom migrate`. It does NOT grant config-repo access; the
+// caller does that via GrantStaffTeamsConfigRepoAccess after the creator drop
+// (see EnsureStaffTeams). Returns the resolved acting login (empty when it
+// couldn't be read) so the caller can drop that same user from the non-teacher
+// teams. The maintainer add is best-effort: a CurrentUser/membership failure
+// warns but doesn't fail creation (the teacher can self-add via the web).
 func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName string) (*configrepo.StaffTeamsRef, string, error) {
 	staffTeams, err := configrepo.EnsureStaffTeams(client, org, shortName)
 	if err != nil {

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -233,6 +233,13 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	// mirroring the web.
 	dropCreatorFromNonTeacherTeams(client, errOut, org, login, team.Slug, staffTeams)
 
+	// Grant staff-team config-repo access AFTER the creator drop above (the order
+	// is load-bearing — see GrantStaffTeamsConfigRepoAccess). Best-effort,
+	// mirroring the web: a failure warns but doesn't fail creation.
+	if err := configrepo.GrantStaffTeamsConfigRepoAccess(client, org, staffTeams); err != nil {
+		_, _ = fmt.Fprintf(errOut, "Warning: couldn't grant staff teams config-repo access (%v); staff may lack write until re-affirmed.\n", err)
+	}
+
 	files, err := classroomScaffold(org, shortName, name, term, secret, nil, nil, &team, staffTeams)
 	if err != nil {
 		return err
@@ -284,13 +291,16 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	return nil
 }
 
-// seedStaffTeams creates (or adopts) the staff teams (teacher, hta, ta), grants
-// each its config-repo access (teacher/hta write, ta read-only), and adds the
-// acting teacher as teacher-team maintainer — shared by `classroom add` and
-// `classroom migrate`. Returns the resolved acting login (empty when it couldn't
-// be read) so the caller can drop that same user from the non-teacher teams. The
-// maintainer add is best-effort: a CurrentUser/membership failure warns but
-// doesn't fail creation (the teacher can self-add via the web).
+// seedStaffTeams creates (or adopts) the staff teams (teacher, hta, ta) and
+// adds the acting teacher as teacher-team maintainer — shared by `classroom
+// add` and `classroom migrate`. It deliberately does NOT grant config-repo
+// access; the caller does that via GrantStaffTeamsConfigRepoAccess AFTER
+// dropping the auto-added creator from the non-teacher teams, so the drop
+// doesn't email the owner (see EnsureStaffTeams). Returns the resolved acting
+// login (empty when it couldn't be read) so the caller can drop that same user
+// from the non-teacher teams. The maintainer add is best-effort: a
+// CurrentUser/membership failure warns but doesn't fail creation (the teacher
+// can self-add via the web).
 func seedStaffTeams(client githubapi.Client, errOut io.Writer, org, shortName string) (*configrepo.StaffTeamsRef, string, error) {
 	staffTeams, err := configrepo.EnsureStaffTeams(client, org, shortName)
 	if err != nil {

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -251,6 +251,13 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// teacher — mixed roles aren't allowed, same as `classroom add`.
 	dropCreatorFromNonTeacherTeams(client, errOut, plan.TargetOrg, login, team.Slug, staffTeams)
 
+	// Grant staff teams their config-repo access AFTER the drop (granting before
+	// the owner removal emails them a "removed from team" alert — see
+	// EnsureStaffTeams). Same order as `classroom add`. Best-effort.
+	if err := configrepo.GrantStaffTeamsConfigRepoAccess(client, plan.TargetOrg, staffTeams); err != nil {
+		_, _ = fmt.Fprintf(errOut, "Warning: couldn't grant staff teams config-repo access (%v); staff may lack write until re-affirmed.\n", err)
+	}
+
 	build := func(parentSHA string) (map[string]string, error) {
 		exists, err := configrepo.ContentsExists(client, plan.TargetOrg, configrepo.ConfigRepoName, plan.ShortName, parentSHA)
 		if err != nil {

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -251,9 +251,8 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// teacher — mixed roles aren't allowed, same as `classroom add`.
 	dropCreatorFromNonTeacherTeams(client, errOut, plan.TargetOrg, login, team.Slug, staffTeams)
 
-	// Grant staff teams their config-repo access AFTER the drop (granting before
-	// the owner removal emails them a "removed from team" alert — see
-	// EnsureStaffTeams). Same order as `classroom add`. Best-effort.
+	// Grant staff-team config-repo access AFTER the drop (order is load-bearing —
+	// see EnsureStaffTeams), same as `classroom add`. Best-effort.
 	if err := configrepo.GrantStaffTeamsConfigRepoAccess(client, plan.TargetOrg, staffTeams); err != nil {
 		_, _ = fmt.Fprintf(errOut, "Warning: couldn't grant staff teams config-repo access (%v); staff may lack write until re-affirmed.\n", err)
 	}

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -217,6 +217,11 @@ func EnsureClassroomTeam(client githubapi.Client, org, shortName, description st
 // EnsureClassroomStaffTeam creates (or adopts) the per-classroom STAFF team for
 // `role` — a `secret` team `classroom50-<short>-<role>`. Mirrors the web's
 // ensureClassroomRoleTeam. Idempotent; safe as a preflight before any staff op.
+//
+// Staff teams create `notificationsEnabled` so @mentions reach TAs/teachers
+// (#335). This is independent of the create-time removal-email fix, which is an
+// ordering concern handled by GrantStaffTeamsConfigRepoAccess, not a
+// notification one.
 func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, role StaffRole) (TeamRef, error) {
 	if !CanonicalTeamSlugShortName(shortName) {
 		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking staff membership and config-repo grants)", shortName)
@@ -227,20 +232,22 @@ func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, ro
 }
 
 // EnsureStaffTeams creates (or adopts) all staff teams (teacher, hta, ta) and
-// grants each its config-repo permission — `push` for teacher/hta so staff can
-// author assignments, `pull` for ta (read-only). The grant is permission-aware,
-// so re-affirming an existing TA team that holds `push` downgrades it to `pull`.
-// Returns the refs to record under classroom.json `teams`. Mirrors the web's
+// returns the refs to record under classroom.json `teams`. Mirrors the web's
 // ensureStaffTeams.
+//
+// This does NOT grant config-repo access — callers must invoke
+// GrantStaffTeamsConfigRepoAccess separately, AFTER dropping the auto-added
+// creator from the non-teacher teams. GitHub auto-adds the team creator as a
+// maintainer, and removing a member from a team that HOLDS repo access emails
+// them a "removed from team" alert; granting only once the owner is gone keeps
+// that drop silent (the notification_setting toggle can't — it governs only
+// @mentions).
 func EnsureStaffTeams(client githubapi.Client, org, shortName string) (*StaffTeamsRef, error) {
 	refs := &StaffTeamsRef{}
 	for _, role := range StaffRoles {
 		team, err := EnsureClassroomStaffTeam(client, org, shortName, role)
 		if err != nil {
 			return nil, fmt.Errorf("ensure %s staff team: %w", role, err)
-		}
-		if _, err := GrantTeamConfigRepoAccess(client, org, team.Slug, role); err != nil {
-			return nil, fmt.Errorf("grant %s staff team config-repo access: %w", role, err)
 		}
 		switch role {
 		case RoleTeacher:
@@ -252,6 +259,29 @@ func EnsureStaffTeams(client githubapi.Client, org, shortName string) (*StaffTea
 		}
 	}
 	return refs, nil
+}
+
+// GrantStaffTeamsConfigRepoAccess grants each recorded staff team its role's
+// config-repo permission — `push` for teacher/hta so staff can author
+// assignments, `pull` for ta (read-only). Split from EnsureStaffTeams so
+// callers can sequence it AFTER the creator drop (see EnsureStaffTeams for why
+// the order matters). Permission-aware, so re-affirming an existing TA team
+// that holds `push` downgrades it to `pull`. A nil refs pointer or empty slug
+// is skipped. Mirrors the web's grantStaffTeamsConfigRepoAccess.
+func GrantStaffTeamsConfigRepoAccess(client githubapi.Client, org string, refs *StaffTeamsRef) error {
+	if refs == nil {
+		return nil
+	}
+	for _, role := range StaffRoles {
+		ref := refs.RefForRole(role)
+		if ref == nil || ref.Slug == "" {
+			continue
+		}
+		if _, err := GrantTeamConfigRepoAccess(client, org, ref.Slug, role); err != nil {
+			return fmt.Errorf("grant %s staff team config-repo access: %w", role, err)
+		}
+	}
+	return nil
 }
 
 // ReconcileClassroomTeamDescription re-derives the classroom50/team/v1 bootstrap

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -217,11 +217,8 @@ func EnsureClassroomTeam(client githubapi.Client, org, shortName, description st
 // EnsureClassroomStaffTeam creates (or adopts) the per-classroom STAFF team for
 // `role` — a `secret` team `classroom50-<short>-<role>`. Mirrors the web's
 // ensureClassroomRoleTeam. Idempotent; safe as a preflight before any staff op.
-//
 // Staff teams create `notificationsEnabled` so @mentions reach TAs/teachers
-// (#335). This is independent of the create-time removal-email fix, which is an
-// ordering concern handled by GrantStaffTeamsConfigRepoAccess, not a
-// notification one.
+// (#335).
 func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, role StaffRole) (TeamRef, error) {
 	if !CanonicalTeamSlugShortName(shortName) {
 		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking staff membership and config-repo grants)", shortName)
@@ -262,12 +259,11 @@ func EnsureStaffTeams(client githubapi.Client, org, shortName string) (*StaffTea
 }
 
 // GrantStaffTeamsConfigRepoAccess grants each recorded staff team its role's
-// config-repo permission — `push` for teacher/hta so staff can author
-// assignments, `pull` for ta (read-only). Split from EnsureStaffTeams so
-// callers can sequence it AFTER the creator drop (see EnsureStaffTeams for why
-// the order matters). Permission-aware, so re-affirming an existing TA team
-// that holds `push` downgrades it to `pull`. A nil refs pointer or empty slug
-// is skipped. Mirrors the web's grantStaffTeamsConfigRepoAccess.
+// config-repo permission — `push` for teacher/hta (author assignments), `pull`
+// for ta (read-only). Permission-aware, so re-affirming a TA team that holds
+// `push` downgrades it to `pull`. Split from EnsureStaffTeams so callers run it
+// AFTER the creator drop (see EnsureStaffTeams). Nil refs or empty slug skipped.
+// Mirrors the web's grantStaffTeamsConfigRepoAccess.
 func GrantStaffTeamsConfigRepoAccess(client githubapi.Client, org string, refs *StaffTeamsRef) error {
 	if refs == nil {
 		return nil

--- a/cli/gh-teacher/internal/configrepo/team_http_test.go
+++ b/cli/gh-teacher/internal/configrepo/team_http_test.go
@@ -249,12 +249,13 @@ func TestStaffTeamRepoPermissions(t *testing.T) {
 	}
 }
 
-// TestEnsureStaffTeams verifies both staff teams are created and each is
-// granted push (write) on the config repo, and that the returned refs
-// carry the created ids/slugs.
+// TestEnsureStaffTeams verifies all three staff teams are created as `secret`
+// with notifications_enabled (#335), the returned refs carry the created
+// ids/slugs, and NO config-repo grant is issued — the grant is now a separate
+// step (GrantStaffTeamsConfigRepoAccess) callers run AFTER the creator drop so
+// the drop stays silent.
 func TestEnsureStaffTeams(t *testing.T) {
 	var createdNames []string
-	grantPerms := map[string]string{} // slug -> permission
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -274,19 +275,9 @@ func TestEnsureStaffTeams(t *testing.T) {
 			createdNames = append(createdNames, body.Name)
 			// slug == name (canonical short-name).
 			_ = json.NewEncoder(w).Encode(map[string]any{"id": int64(len(createdNames)), "slug": body.Name})
-		case strings.HasPrefix(r.URL.Path, "/orgs/o/teams/") && strings.Contains(r.URL.Path, "/repos/") && r.Method == http.MethodGet:
-			// No access yet.
-			w.WriteHeader(http.StatusNotFound)
-		case strings.HasPrefix(r.URL.Path, "/orgs/o/teams/") && strings.Contains(r.URL.Path, "/repos/") && r.Method == http.MethodPut:
-			var body struct {
-				Permission string `json:"permission"`
-			}
-			_ = json.NewDecoder(r.Body).Decode(&body)
-			// slug is the segment between /teams/ and /repos/.
-			slug := strings.TrimPrefix(r.URL.Path, "/orgs/o/teams/")
-			slug = strings.SplitN(slug, "/repos/", 2)[0]
-			grantPerms[slug] = body.Permission
-			w.WriteHeader(http.StatusNoContent)
+		case strings.Contains(r.URL.Path, "/repos/"):
+			t.Errorf("EnsureStaffTeams must not grant config-repo access (that moved to GrantStaffTeamsConfigRepoAccess): %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
@@ -311,6 +302,44 @@ func TestEnsureStaffTeams(t *testing.T) {
 	if len(createdNames) != 3 {
 		t.Fatalf("created %d teams, want 3: %v", len(createdNames), createdNames)
 	}
+}
+
+// TestGrantStaffTeamsConfigRepoAccess pins that each recorded staff team is
+// granted its role's config-repo permission (teacher/hta push, ta pull) — the
+// grant split out of EnsureStaffTeams so callers run it AFTER the silent
+// creator drop. A nil ref/empty slug is skipped.
+func TestGrantStaffTeamsConfigRepoAccess(t *testing.T) {
+	grantPerms := map[string]string{} // slug -> permission
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/repos/") && r.Method == http.MethodGet:
+			// No access yet, so each role issues its PUT.
+			w.WriteHeader(http.StatusNotFound)
+		case strings.Contains(r.URL.Path, "/repos/") && r.Method == http.MethodPut:
+			var body struct {
+				Permission string `json:"permission"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			slug := strings.TrimPrefix(r.URL.Path, "/orgs/o/teams/")
+			slug = strings.SplitN(slug, "/repos/", 2)[0]
+			grantPerms[slug] = body.Permission
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	refs := &StaffTeamsRef{
+		Teacher: &TeamRef{ID: 1, Slug: "classroom50-cs-principles-teacher"},
+		HeadTA:  &TeamRef{ID: 2, Slug: "classroom50-cs-principles-hta"},
+		TA:      &TeamRef{ID: 3, Slug: "classroom50-cs-principles-ta"},
+	}
+	if err := GrantStaffTeamsConfigRepoAccess(client, "o", refs); err != nil {
+		t.Fatalf("GrantStaffTeamsConfigRepoAccess: %v", err)
+	}
 	// Teacher and head-TA get config-repo write; a plain TA gets read-only.
 	for _, slug := range []string{"classroom50-cs-principles-teacher", "classroom50-cs-principles-hta"} {
 		if grantPerms[slug] != "push" {
@@ -319,6 +348,49 @@ func TestEnsureStaffTeams(t *testing.T) {
 	}
 	if grantPerms["classroom50-cs-principles-ta"] != "pull" {
 		t.Errorf("ta team granted %q on config repo, want pull", grantPerms["classroom50-cs-principles-ta"])
+	}
+}
+
+// TestGrantStaffTeamsConfigRepoAccess_SkipsAbsentAndNil pins the guards: a nil
+// refs pointer is a no-op, and a role with no recorded ref is skipped.
+func TestGrantStaffTeamsConfigRepoAccess_SkipsAbsentAndNil(t *testing.T) {
+	var touchedSlugs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/repos/") {
+			slug := strings.TrimPrefix(r.URL.Path, "/orgs/o/teams/")
+			slug = strings.SplitN(slug, "/repos/", 2)[0]
+			touchedSlugs = append(touchedSlugs, slug)
+		}
+		// GET probe returns 404 (no access) so a recorded team would PUT.
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	if err := GrantStaffTeamsConfigRepoAccess(client, "o", nil); err != nil {
+		t.Fatalf("nil refs: %v", err)
+	}
+	if len(touchedSlugs) != 0 {
+		t.Errorf("nil refs touched teams: %v", touchedSlugs)
+	}
+
+	// Only teacher recorded; hta/ta absent must be skipped.
+	if err := GrantStaffTeamsConfigRepoAccess(client, "o", &StaffTeamsRef{
+		Teacher: &TeamRef{ID: 1, Slug: "classroom50-cs101-teacher"},
+	}); err != nil {
+		t.Fatalf("partial refs: %v", err)
+	}
+	for _, s := range touchedSlugs {
+		if s != "classroom50-cs101-teacher" {
+			t.Errorf("partial refs touched unexpected team %q, want only classroom50-cs101-teacher", s)
+		}
+	}
+	if len(touchedSlugs) == 0 {
+		t.Error("partial refs: expected the teacher team to be granted")
 	}
 }
 

--- a/web/src/domain/classrooms.ts
+++ b/web/src/domain/classrooms.ts
@@ -17,6 +17,7 @@ import {
   editClassroom,
   ensureClassroomTeam,
   ensureStaffTeams,
+  grantStaffTeamsConfigRepoAccess,
   addUserToTeam,
   removeUserFromTeam,
   isDeletableClassroomTeamRef,
@@ -116,6 +117,23 @@ export async function createClassroomFiles(
         // Non-fatal; the classroom still scaffolds.
       }
     }
+  }
+
+  // Grant staff-team config-repo access AFTER the creator drop above (the order
+  // is load-bearing — see grantStaffTeamsConfigRepoAccess). Best-effort: a grant
+  // hiccup leaves staff without config-repo write until the next reconcile
+  // re-affirms it, but must not fail the scaffold.
+  try {
+    await grantStaffTeamsConfigRepoAccess(client, input.org, teams)
+  } catch (err) {
+    log.warn(
+      "create classroom: granting staff-team config-repo access failed",
+      {
+        org: input.org,
+        classroom: input.classroom,
+        err,
+      },
+    )
   }
 
   // If scaffolding fails after the teams exist, any team we CREATED would be

--- a/web/src/domain/reconcileClassroom.test.ts
+++ b/web/src/domain/reconcileClassroom.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest"
 const getClassroomJson = vi.fn()
 const ensureClassroomTeam = vi.fn()
 const ensureStaffTeams = vi.fn()
+const grantStaffTeamsConfigRepoAccess = vi.fn()
 const reconcileDescription = vi.fn()
 const removeUserFromTeam = vi.fn()
 
@@ -12,6 +13,8 @@ vi.mock("@/github-core/configRepoReads", () => ({
 vi.mock("@/github-core/mutations", () => ({
   ensureClassroomTeam: (...a: unknown[]) => ensureClassroomTeam(...a),
   ensureStaffTeams: (...a: unknown[]) => ensureStaffTeams(...a),
+  grantStaffTeamsConfigRepoAccess: (...a: unknown[]) =>
+    grantStaffTeamsConfigRepoAccess(...a),
   reconcileStudentTeamDescription: (...a: unknown[]) =>
     reconcileDescription(...a),
   removeUserFromTeam: (...a: unknown[]) => removeUserFromTeam(...a),
@@ -44,6 +47,7 @@ beforeEach(() => {
   getClassroomJson.mockReset()
   ensureClassroomTeam.mockReset()
   ensureStaffTeams.mockReset()
+  grantStaffTeamsConfigRepoAccess.mockReset()
   reconcileDescription.mockReset()
   removeUserFromTeam.mockReset()
   // Healthy defaults: active classroom, everything already converged.
@@ -63,6 +67,7 @@ beforeEach(() => {
   })
   reconcileDescription.mockResolvedValue({ changed: false })
   removeUserFromTeam.mockResolvedValue(undefined)
+  grantStaffTeamsConfigRepoAccess.mockResolvedValue(undefined)
 })
 
 describe("reconcileClassroom", () => {

--- a/web/src/domain/reconcileClassroom.ts
+++ b/web/src/domain/reconcileClassroom.ts
@@ -81,10 +81,9 @@ export async function reconcileClassroom(
     staffTeams.ta?.slug,
   ])
 
-  // Grant staff teams their config-repo access AFTER the drop (see
-  // ensureStaffTeams / createClassroomFiles: granting before removal is what
-  // emails the owner). Also re-affirms the TA read-only downgrade. Best-effort:
-  // a failure leaves config-repo access unset until the next pass, never aborts
+  // Grant staff-team config-repo access AFTER the drop (order is load-bearing —
+  // see ensureStaffTeams); also re-affirms the TA read-only downgrade.
+  // Best-effort: a failure leaves access unset until the next pass, never aborts
   // the heal.
   try {
     await grantStaffTeamsConfigRepoAccess(client, org, staffTeams)

--- a/web/src/domain/reconcileClassroom.ts
+++ b/web/src/domain/reconcileClassroom.ts
@@ -5,6 +5,7 @@ import { isClassroomArchived, type StaffRole } from "@/types/classroom"
 import {
   ensureClassroomTeam,
   ensureStaffTeams,
+  grantStaffTeamsConfigRepoAccess,
   reconcileStudentTeamDescription,
   removeUserFromTeam,
   type TeamDescriptionReconcileResult,
@@ -79,6 +80,24 @@ export async function reconcileClassroom(
     staffTeams.hta?.slug,
     staffTeams.ta?.slug,
   ])
+
+  // Grant staff teams their config-repo access AFTER the drop (see
+  // ensureStaffTeams / createClassroomFiles: granting before removal is what
+  // emails the owner). Also re-affirms the TA read-only downgrade. Best-effort:
+  // a failure leaves config-repo access unset until the next pass, never aborts
+  // the heal.
+  try {
+    await grantStaffTeamsConfigRepoAccess(client, org, staffTeams)
+  } catch (err) {
+    log.warn(
+      "classroom reconcile: granting staff-team config-repo access failed",
+      {
+        org,
+        classroom,
+        err,
+      },
+    )
+  }
 
   // A 404 from the student-team read is permanent (a wrong derived slug never
   // converges) UNLESS we just created that team this pass: then it's a

--- a/web/src/github-core/mutations.teamNotifications.test.ts
+++ b/web/src/github-core/mutations.teamNotifications.test.ts
@@ -7,8 +7,11 @@ import type { GitHubRequestOptions } from "./client"
 
 // Pins the team-level notification policy (#335): student teams create with
 // notifications_disabled (assignment-repo churn would spam the class), staff
-// teams with notifications_enabled (so @mentions reach TAs/teachers). tsc keeps
-// the arg well-typed but cannot catch a wrong literal — these do.
+// teams with notifications_enabled (so @mentions reach TAs/teachers). The
+// create-time owner-drop is kept silent by ORDERING (drop before granting the
+// team config-repo access — see grantStaffTeamsConfigRepoAccess), not by muting
+// notifications, which govern only @mentions. tsc keeps the arg well-typed but
+// cannot catch a wrong literal — these do.
 
 type Call = { path: string; options?: GitHubRequestOptions }
 

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -33,6 +33,7 @@ export {
   grantTeamConfigRepoWrite,
   grantTeamConfigRepoAccess,
   ensureStaffTeams,
+  grantStaffTeamsConfigRepoAccess,
   deleteClassroomTeam,
   addRepositoryToTeam,
   removeRepositoryFromTeam,

--- a/web/src/github-core/mutations/teams.test.ts
+++ b/web/src/github-core/mutations/teams.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from "vitest"
-import { grantTeamConfigRepoAccess } from "./teams"
+import {
+  grantTeamConfigRepoAccess,
+  grantStaffTeamsConfigRepoAccess,
+} from "./teams"
 import type { GitHubClient } from "@/github-core/client"
 
 // grantTeamConfigRepoAccess routes each staff role to its config-repo
@@ -48,5 +51,44 @@ describe("grantTeamConfigRepoAccess", () => {
       "student" as never,
     )
     expect(request).not.toHaveBeenCalled()
+  })
+})
+
+// grantStaffTeamsConfigRepoAccess grants each recorded staff team its role's
+// config-repo permission (teacher/hta push, ta pull). Split from
+// ensureStaffTeams so callers sequence it AFTER the creator drop (granting a
+// team repo access before removing a member emails that member). Skips absent
+// slugs. The web grantTeamConfigRepoAccess PUTs unconditionally.
+describe("grantStaffTeamsConfigRepoAccess", () => {
+  it("PUTs each role's permission for every recorded staff team", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    const client = { request } as unknown as GitHubClient
+    await grantStaffTeamsConfigRepoAccess(client, "acme", {
+      teacher: { id: 1, slug: "classroom50-cs101-teacher" },
+      hta: { id: 2, slug: "classroom50-cs101-hta" },
+      ta: { id: 3, slug: "classroom50-cs101-ta" },
+    })
+    // teacher -> push, hta -> push, ta -> pull; one PUT each.
+    expect(request).toHaveBeenCalledTimes(3)
+    const bodies = request.mock.calls.map(
+      ([, o]) => (o as { body?: unknown }).body,
+    )
+    expect(bodies).toEqual([
+      { permission: "push" },
+      { permission: "push" },
+      { permission: "pull" },
+    ])
+  })
+
+  it("skips a role whose team ref is absent", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    const client = { request } as unknown as GitHubClient
+    await grantStaffTeamsConfigRepoAccess(client, "acme", {
+      teacher: { id: 1, slug: "classroom50-cs101-teacher" },
+    })
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request.mock.calls[0][0] as string).toContain(
+      "classroom50-cs101-teacher",
+    )
   })
 })

--- a/web/src/github-core/mutations/teams.ts
+++ b/web/src/github-core/mutations/teams.ts
@@ -156,9 +156,7 @@ export async function ensureClassroomRoleTeam(
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   assertCanonicalTeamShortName(classroom)
   // Staff enable notifications so @mentions reach TAs/teachers (#335); the
-  // student team stays disabled (see TeamNotificationSetting). This is
-  // independent of the create-time removal-email fix, which is an ordering
-  // concern handled by grantStaffTeamsConfigRepoAccess, not a notification one.
+  // student team stays disabled (see TeamNotificationSetting).
   return ensureSecretTeamByName(
     client,
     org,
@@ -235,10 +233,10 @@ export async function ensureStaffTeams(
 }
 
 // Grant each staff team its role's config-repo access (teacher/hta write, ta
-// read-only). Split from ensureStaffTeams so callers can sequence it AFTER the
-// creator drop (see ensureStaffTeams for why the order matters). Idempotent and
-// permission-aware — a TA team that still holds write is downgraded to read on
-// re-affirm — so this is safe at create AND as a reconcile preflight.
+// read-only). Permission-aware — a TA team that still holds write is downgraded
+// to read on re-affirm. Split from ensureStaffTeams so callers run it AFTER the
+// creator drop (see ensureStaffTeams). Safe at create AND as a reconcile
+// preflight.
 export async function grantStaffTeamsConfigRepoAccess(
   client: GitHubClient,
   org: string,

--- a/web/src/github-core/mutations/teams.ts
+++ b/web/src/github-core/mutations/teams.ts
@@ -155,8 +155,10 @@ export async function ensureClassroomRoleTeam(
   role: StaffRole,
 ): Promise<ClassroomTeamRef & { created: boolean }> {
   assertCanonicalTeamShortName(classroom)
-  // Staff enable notifications (student team stays disabled); see
-  // TeamNotificationSetting.
+  // Staff enable notifications so @mentions reach TAs/teachers (#335); the
+  // student team stays disabled (see TeamNotificationSetting). This is
+  // independent of the create-time removal-email fix, which is an ordering
+  // concern handled by grantStaffTeamsConfigRepoAccess, not a notification one.
   return ensureSecretTeamByName(
     client,
     org,
@@ -205,12 +207,18 @@ export async function grantTeamConfigRepoAccess(
   })
 }
 
-// Ensure every staff team exists and holds its role's config-repo access
-// (teacher/hta write, ta read-only), returning their refs for classroom.json.
+// Ensure every staff team exists, returning their refs for classroom.json.
 // Idempotent — used at create AND as a preflight, so a classroom missing a
-// staff team self-heals on next touch, and a TA team that still holds write is
-// downgraded to read on re-affirm. `created` lists the roles this call newly
-// created (for create-failure rollback).
+// staff team self-heals on next touch. `created` lists the roles this call
+// newly created (for create-failure rollback).
+//
+// This does NOT grant config-repo access — callers must invoke
+// grantStaffTeamsConfigRepoAccess separately, AFTER dropping the auto-added
+// creator from the non-teacher teams. GitHub auto-adds the team creator as a
+// maintainer, and removing a member from a team that HOLDS repo access emails
+// them a "removed from team" alert; doing the grant only once the owner is gone
+// keeps that drop silent (the notification_setting toggle can't — it governs
+// only @mentions).
 export async function ensureStaffTeams(
   client: GitHubClient,
   org: string,
@@ -222,9 +230,25 @@ export async function ensureStaffTeams(
     const team = await ensureClassroomRoleTeam(client, org, classroom, role)
     teams[role] = { id: team.id, slug: team.slug }
     if (team.created) created.push(role)
-    await grantTeamConfigRepoAccess(client, org, team.slug, role)
   }
   return { teams, created }
+}
+
+// Grant each staff team its role's config-repo access (teacher/hta write, ta
+// read-only). Split from ensureStaffTeams so callers can sequence it AFTER the
+// creator drop (see ensureStaffTeams for why the order matters). Idempotent and
+// permission-aware — a TA team that still holds write is downgraded to read on
+// re-affirm — so this is safe at create AND as a reconcile preflight.
+export async function grantStaffTeamsConfigRepoAccess(
+  client: GitHubClient,
+  org: string,
+  teams: StaffTeamRefs,
+): Promise<void> {
+  for (const role of STAFF_ROLES) {
+    const slug = teams[role]?.slug
+    if (!slug) continue
+    await grantTeamConfigRepoAccess(client, org, slug, role)
+  }
 }
 
 // Thrown by deleteClassroomTeam when the live team's id no longer matches the

--- a/web/src/migration/migrate.ts
+++ b/web/src/migration/migrate.ts
@@ -20,6 +20,7 @@ import {
   createBlob,
   ensureClassroomTeam,
   ensureStaffTeams,
+  grantStaffTeamsConfigRepoAccess,
   removeUserFromTeam,
   updateRef,
 } from "@/github-core/mutations"
@@ -107,6 +108,19 @@ export async function migrateClassroom(
         // Non-fatal.
       }
     }
+  }
+
+  // Grant staff teams their config-repo access AFTER the drop (granting before
+  // the owner removal emails them a "removed from team" alert — see
+  // ensureStaffTeams). Same order as `classroom add`.
+  try {
+    await grantStaffTeamsConfigRepoAccess(client, targetOrg, teams)
+  } catch (err) {
+    log.warn("migrate: granting staff-team config-repo access failed", {
+      targetOrg,
+      shortName,
+      err,
+    })
   }
 
   // --- Phase B: copy templates (best-effort per item) ---

--- a/web/src/migration/migrate.ts
+++ b/web/src/migration/migrate.ts
@@ -110,9 +110,8 @@ export async function migrateClassroom(
     }
   }
 
-  // Grant staff teams their config-repo access AFTER the drop (granting before
-  // the owner removal emails them a "removed from team" alert — see
-  // ensureStaffTeams). Same order as `classroom add`.
+  // Grant staff-team config-repo access AFTER the drop (order is load-bearing —
+  // see ensureStaffTeams), same as `classroom add`.
   try {
     await grantStaffTeamsConfigRepoAccess(client, targetOrg, teams)
   } catch (err) {


### PR DESCRIPTION
## What

Classroom creation was emailing the acting owner a confusing "You've been removed from the `<classroom>-hta`/`<classroom>-ta` team" notification on every classroom create.

## Root cause

When a classroom is created, GitHub auto-adds the acting owner as a maintainer of every team the create POST makes. To keep the owner's only role `teacher` (mixed roles aren't allowed, and the team-driven roster would otherwise miscount the owner), the create flow drops the owner from the student/hta/ta teams. That drop is what emails the owner — but only for the staff teams, because the flow granted those teams config-repo access **before** the drop. GitHub sends the "removed from team" email when a member is removed from a team that **holds repo access**; the student team is silent only because it never gets a config-repo grant.

The team-level `notification_setting` does **not** gate this email — [GitHub's docs](https://docs.github.com/en/organizations/organizing-members-into-teams/configuring-team-notifications) confirm it governs only team @mentions, not membership/access-change notifications. I verified all of this empirically against a real org (created teams disabled vs enabled, with and without a repo grant, and removing the owner before vs after the grant): the email fires only when the team holds repo access at removal time, and is silent when the owner is removed before the grant — regardless of `notification_setting`.

## Fix

Reorder so the owner is dropped **before** the staff teams are granted config-repo access. Split the config-repo grant out of `ensureStaffTeams` / `EnsureStaffTeams` into a dedicated `grantStaffTeamsConfigRepoAccess` / `GrantStaffTeamsConfigRepoAccess`, so create, reconcile, and migrate all run the grant only after the creator drop. Removing the owner while the team holds no repo access is silent, so no email is sent. Staff teams keep `notifications_enabled` (the existing behavior for team @mentions).

Mirrored 1:1 across the web app and the `gh-teacher` CLI, per the repo's hand-mirrored cross-tool contract.

## Verification

- Empirically confirmed against a real org that the reorder eliminates the email.
- CLI: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (0 issues), and `golangci-lint fmt --diff` all clean.
- Web: `tsc`, `eslint`, `prettier`, `arch:validate` (0 violations), and the full unit suite (3277 tests) all pass.
