### PR TITLE
fix(cli): record a submission when no autograder is configured

### DIFF
--- a/cli/gh-teacher/autograders_tests/test_inline_validator.py
+++ b/cli/gh-teacher/autograders_tests/test_inline_validator.py
@@ -751,8 +751,9 @@ class TestReleaseAssetsValidation:
 
 
 # ---------------------------------------------------------------------------
-# No-autograder detection — emits no-autograder so grade/set-latest skip
-# when no autograder is configured.
+# No-autograder detection — emits no-autograder so the grade job can skip
+# language-toolchain setup (the submission is still recorded via runner.py's
+# vacuous pass; the grade job no longer skips outright).
 # ---------------------------------------------------------------------------
 
 

--- a/cli/gh-teacher/init_skeleton_test.go
+++ b/cli/gh-teacher/init_skeleton_test.go
@@ -217,9 +217,11 @@ func TestSkeletonFiles_AutogradeRunner(t *testing.T) {
 		// a dropped output would make every gate below read empty and
 		// re-grade the acceptance commit.
 		"is-acceptance",
-		// no-autograder gates the skip-when-nothing-configured path; a
-		// dropped output would read empty and grade every submission,
-		// re-spending Actions minutes on assignments with no autograder.
+		// no-autograder no longer skips the grade job (the submission is
+		// still recorded via runner.py's vacuous pass); the output is retained
+		// so the toolchain-setup steps can skip provisioning a toolchain the
+		// recording path won't use. A dropped output would read empty and
+		// re-provision toolchains on every no-autograder submission.
 		"no-autograder",
 	} {
 		if _, ok := outputsMap[out]; !ok {
@@ -236,14 +238,15 @@ func TestSkeletonFiles_AutogradeRunner(t *testing.T) {
 	// every acceptance commit and republish the spurious 0/0 release —
 	// exactly what this guard exists to prevent.
 	//
-	// grade is gated at the job level (set-latest needs grade, so it skips
-	// transitively). The gate also carries the no-autograder skip: an
-	// assignment with no declarative tests, no per-assignment bundle, and no
-	// classroom-default autograder.py has nothing to grade, so setup emits
-	// no-autograder=true and the grade job skips (fail-open — any probe error
-	// emits false and grades).
-	if got, _ := nested(doc, "jobs", "grade", "if"); got != "needs.setup.outputs.is-acceptance != 'true' && needs.setup.outputs.no-autograder != 'true'" {
-		t.Errorf("grade.if = %v, want the acceptance-commit + no-autograder skip gate", got)
+	// grade is gated at the job level ONLY on the acceptance commit. The
+	// no-autograder case still runs the grade job so the submission is
+	// recorded: runner.py synthesizes a vacuous-pass (0/0 success) result and
+	// the Release step publishes it, keeping the submission visible on the
+	// teacher dashboard (which reads submit/* releases). Toolchain setup is
+	// separately gated off no-autograder so the recording path spends no
+	// minutes provisioning unused toolchains.
+	if got, _ := nested(doc, "jobs", "grade", "if"); got != "needs.setup.outputs.is-acceptance != 'true'" {
+		t.Errorf("grade.if = %v, want the acceptance-commit skip gate", got)
 	}
 	// The setup checkout must use full history: _baseline_scan walks back
 	// to the commit that added .classroom50.yaml, and a shallow clone
@@ -338,20 +341,22 @@ func TestSkeletonFiles_AutogradeRunner(t *testing.T) {
 		}
 	}
 
-	// Toolchain steps gated on matching setup outputs AND a hosted runner
-	// (`runner.environment != 'self-hosted'`); see the workflow comment / #369.
+	// Toolchain steps gated on matching setup outputs, NOT the no-autograder
+	// recording path, AND a hosted runner (`runner.environment !=
+	// 'self-hosted'`); see the workflow comment / #369. The no-autograder
+	// clause keeps the recording path from provisioning unused toolchains.
 	for _, want := range []string{
-		"if: needs.setup.outputs.python != '' && runner.environment != 'self-hosted'",
+		"if: needs.setup.outputs.python != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'",
 		"actions/setup-python@v7",
-		"if: needs.setup.outputs.node != '' && runner.environment != 'self-hosted'",
+		"if: needs.setup.outputs.node != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'",
 		"actions/setup-node@v7",
-		"if: needs.setup.outputs.java != '' && runner.environment != 'self-hosted'",
+		"if: needs.setup.outputs.java != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'",
 		"actions/setup-java@v5",
-		"if: needs.setup.outputs.go != '' && runner.environment != 'self-hosted'",
+		"if: needs.setup.outputs.go != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'",
 		"actions/setup-go@v7",
-		"if: needs.setup.outputs.rust != '' && runner.environment != 'self-hosted'",
+		"if: needs.setup.outputs.rust != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'",
 		"dtolnay/rust-toolchain@master",
-		"if: needs.setup.outputs.apt != '' && runner.os == 'Linux' && runner.environment != 'self-hosted'",
+		"if: needs.setup.outputs.apt != '' && needs.setup.outputs.no-autograder != 'true' && runner.os == 'Linux' && runner.environment != 'self-hosted'",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("autograde-runner.yaml missing toolchain dispatch %q", want)

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -624,29 +624,15 @@ jobs:
           emit("release-assets", release_assets_json)
           emit("no-autograder", "true" if no_autograder else "false")
 
-      # === Autograde-skipped commit status ===
-      # Parallel to the acceptance-skip status: post an explicit
-      # classroom50/autograde success so a status-polling client can tell
-      # "skipped — no autograder configured" from "hasn't run yet".
-      # Best-effort; never fails the job.
-      - name: Autograde-skipped commit status
-        if: steps.read.outputs.no-autograder == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-            -f state="success" \
-            -f context="classroom50/autograde" \
-            -f description="no autograder configured — autograding skipped" \
-            -f target_url="$RUN_URL" >/dev/null 2>&1 || true
-
   grade:
     needs: setup
-    # Skip the acceptance commit and the no-autograder case (set-latest needs
-    # grade, so it skips too).
-    if: needs.setup.outputs.is-acceptance != 'true' && needs.setup.outputs.no-autograder != 'true'
+    # Skip only the acceptance commit. The no-autograder case still runs so the
+    # submission is RECORDED: runner.py synthesizes a vacuous-pass (0/0 success)
+    # result and the Release step publishes it, keeping the submission visible on
+    # the teacher dashboard (which reads submit/* releases). Language-toolchain
+    # setup is separately gated off no-autograder below, so this cheap path spends
+    # no minutes installing toolchains it won't use.
+    if: needs.setup.outputs.is-acceptance != 'true'
     runs-on:   ${{ fromJSON(needs.setup.outputs.runs-on) }}
     container: ${{ fromJSON(needs.setup.outputs.container) }}
     timeout-minutes: 15
@@ -698,27 +684,32 @@ jobs:
       # packages (see issue #369). Keyed on the runner itself — not the
       # `runs-on` label — so it also covers self-hosted runners registered
       # with --no-default-labels or selected by a runner group.
+      #
+      # Also gated off no-autograder: when nothing is configured to grade, the
+      # job still runs to RECORD the submission (runner.py's vacuous-pass), but
+      # it needs only system python3 — so skip every toolchain install and spend
+      # no minutes provisioning a toolchain the recording path won't use.
       - name: Set up Python
-        if: needs.setup.outputs.python != '' && runner.environment != 'self-hosted'
+        if: needs.setup.outputs.python != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'
         uses: actions/setup-python@v7
         with:
           python-version: ${{ needs.setup.outputs.python }}
 
       - name: Set up Node
-        if: needs.setup.outputs.node != '' && runner.environment != 'self-hosted'
+        if: needs.setup.outputs.node != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'
         uses: actions/setup-node@v7
         with:
           node-version: ${{ needs.setup.outputs.node }}
 
       - name: Set up Java
-        if: needs.setup.outputs.java != '' && runner.environment != 'self-hosted'
+        if: needs.setup.outputs.java != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ needs.setup.outputs.java }}
 
       - name: Set up Go
-        if: needs.setup.outputs.go != '' && runner.environment != 'self-hosted'
+        if: needs.setup.outputs.go != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'
         uses: actions/setup-go@v7
         with:
           go-version: ${{ needs.setup.outputs.go }}
@@ -727,13 +718,13 @@ jobs:
       # standard. Pinned to @master with an explicit `toolchain:` input
       # (its @rev-derived default can't read a version from a SHA pin).
       - name: Set up Rust
-        if: needs.setup.outputs.rust != '' && runner.environment != 'self-hosted'
+        if: needs.setup.outputs.rust != '' && needs.setup.outputs.no-autograder != 'true' && runner.environment != 'self-hosted'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ needs.setup.outputs.rust }}
 
       - name: Install apt packages
-        if: needs.setup.outputs.apt != '' && runner.os == 'Linux' && runner.environment != 'self-hosted'
+        if: needs.setup.outputs.apt != '' && needs.setup.outputs.no-autograder != 'true' && runner.os == 'Linux' && runner.environment != 'self-hosted'
         run: |
           set -euo pipefail
           sudo apt-get update -qq
@@ -921,9 +912,10 @@ jobs:
   # reclaiming latest.
   set-latest:
     needs: [setup, grade]
-    # Explicit no-autograder guard, defensive against a future change to
-    # grade's result semantics.
-    if: needs.setup.outputs.no-autograder != 'true' && needs.grade.result == 'success' && (needs.grade.outputs.status == 'success' || needs.grade.outputs.status == 'failure')
+    # Advance latest for any recorded submission — including the no-autograder
+    # vacuous pass (status 'success'), so its release becomes the latest the
+    # dashboard surfaces. Gated only on a clean grade result with a real status.
+    if: needs.grade.result == 'success' && (needs.grade.outputs.status == 'success' || needs.grade.outputs.status == 'failure')
     runs-on: ubuntu-latest
     concurrency:
       group: classroom50-set-latest-${{ github.repository }}


### PR DESCRIPTION
## Summary

PR #458 made the autograde workflow's `grade` and `set-latest` jobs skip entirely when an assignment has no autograder configured (no declarative tests, no per-assignment bundle, no classroom-default `autograder.py`). That correctly stopped spending Actions minutes, but it also stopped the side effect that *records* a submission: the `submit/*` GitHub Release. The `submit/*` tag was still minted in the `setup` job, but the teacher submissions dashboard reads Releases (via `latestSubmitReleaseAndCount`), not tags — so a student who pushed to a no-autograder assignment silently vanished from the teacher's view and it read like a bug.

This restores the "records" half while keeping #458's cost win. The `grade` job now runs for the no-autograder case so `runner.py`'s existing vacuous-pass path (`Finalizer.no_autograder()`) synthesizes a `result.json` scoring 0/0 with `status=success`, which the existing "Publish submission release" step publishes as the `submit/*` release. Language-toolchain setup (Python/Node/Java/Go/Rust + apt) is gated off `no-autograder`, so the recording path provisions no toolchain it won't use — it needs only system `python3`.

This is forward-compatible with the "milestone tags trigger; `submit/*` records" invariant reaffirmed in the draft PR #531: `submit/*` stays the canonical record channel.

## Changes

- `grade.if` now gates only on the acceptance commit; the no-autograder clause is dropped so the job runs and records the submission.
- The five toolchain setup steps and the apt step now also carry `&& needs.setup.outputs.no-autograder != 'true'`, preserving the #458 minute savings.
- Removed the setup-job "Autograde-skipped commit status" step — the grade job's `always()` "Post commit status" step already posts `classroom50/autograde=success` with the runner's "no autograder configured" summary, so the status-polling channel is at parity with no double-post.
- `set-latest` drops its `no-autograder` guard so the recorded submission advances the latest pointer.
- Updated the `init_skeleton_test.go` parity assertions (the pinned `grade.if` string and the six toolchain `if:` strings) and a stale comment in `test_inline_validator.py`. No `runner.py` logic change — its no-autograder synthesis was already correct and covered.

## Verification

- `go test ./...` in `cli/gh-teacher` passes, including `TestSkeletonFiles_AutogradeRunner`; `go vet` and `gofmt` clean.
- `python3 -m pytest cli/gh-teacher/autograders_tests` — 358 pass, including `test_no_bundle_and_no_default_synthesizes_vacuous_pass`, which pins the end-to-end 0/0-success recording (result.json, release body, `status=success`).
- Workflow YAML parses; jobs remain `setup/grade/set-latest` (no job added).
- No web changes needed: the dashboard surfaces the release automatically once it exists again.