### PR TITLE
fix: exempt forks from the empty-template size-0 guard

### DIFF
--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1028,7 +1028,9 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 		Fork          bool   `json:"fork"`
 		// Repo size in KB. 0 means no commits — an empty template can't be
 		// generated from (POST /generate 422s "is empty"), and GitHub reports a
-		// phantom default_branch for it, so size is the reliable emptiness signal.
+		// phantom default_branch for it, so size is the reliable emptiness signal
+		// for a non-fork. Forks report size 0 while sharing parent objects, so the
+		// emptiness guard exempts them.
 		Size   int `json:"size"`
 		Parent struct {
 			FullName string `json:"full_name"`
@@ -1041,7 +1043,7 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 		}
 		return assignment.TemplateRef{}, false, "", fmt.Errorf("GET %s: %w", path, err)
 	}
-	ref, err = resolveTemplateBranch(t, resp.IsTemplate, resp.DefaultBranch, resp.Size)
+	ref, err = resolveTemplateBranch(t, resp.IsTemplate, resp.Fork, resp.DefaultBranch, resp.Size)
 	if err != nil {
 		return assignment.TemplateRef{}, false, "", err
 	}
@@ -1067,15 +1069,17 @@ func templateInOrg(templateOwner, org string) bool {
 // resolveTemplateBranch picks the final assignment.TemplateRef from
 // --template + repo fields: not-a-template, empty (commitless), explicit
 // @branch, default_branch fallback, or empty-default_branch guard.
-func resolveTemplateBranch(t templateArg, isTemplate bool, defaultBranch string, size int) (assignment.TemplateRef, error) {
+func resolveTemplateBranch(t templateArg, isTemplate, isFork bool, defaultBranch string, size int) (assignment.TemplateRef, error) {
 	if !isTemplate {
 		return assignment.TemplateRef{}, fmt.Errorf("`%s/%s` is not a template repository — toggle Settings → \"Template repository\" on the repo, then re-run", t.Owner, t.Repo)
 	}
 	// Caught before the empty-branch guard below (which a commitless repo's
 	// phantom default_branch would slip past). Fail closed on an absent size —
 	// Go's zero value — the deliberate opposite of the web verify path's
-	// fail-open === 0, since `add` is the last gate before write.
-	if size == 0 {
+	// fail-open === 0, since `add` is the last gate before write. Forks are
+	// exempt: GitHub reports size 0 for a fork sharing objects with its parent
+	// even when it has commits, and a fork can only exist from a non-empty parent.
+	if size == 0 && !isFork {
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run", t.Owner, t.Repo)
 	}
 	branch := t.Branch

--- a/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
@@ -169,12 +169,14 @@ func TestNormalizeDueDate_UnresolvableTZ(t *testing.T) {
 func TestResolveTemplateBranch(t *testing.T) {
 	// Each row covers one branch of the post-HTTP decision tree so a
 	// change to validateTemplateRepo's response handling can't
-	// silently drop a guard: not-a-template, explicit-@branch
-	// retention, default_branch fallback, empty-default_branch error.
+	// silently drop a guard: not-a-template, empty-template (with the
+	// fork exemption), explicit-@branch retention, default_branch
+	// fallback, empty-default_branch error.
 	cases := []struct {
 		name        string
 		arg         templateArg
 		isTemplate  bool
+		isFork      bool
 		defaultBr   string
 		size        int
 		wantRef     assignment.TemplateRef
@@ -195,6 +197,17 @@ func TestResolveTemplateBranch(t *testing.T) {
 			defaultBr:   "main", // GitHub reports a phantom default_branch for a commitless repo
 			size:        0,
 			wantErrPart: "has no commits",
+		},
+		{
+			// A fork reports size 0 while sharing objects with its parent even when
+			// it has commits, so the emptiness guard must exempt it (regression #528).
+			name:       "fork with reported size 0 is not treated as empty",
+			arg:        templateArg{Owner: "cs50", Repo: "cross-org-fork-template"},
+			isTemplate: true,
+			isFork:     true,
+			defaultBr:  "main",
+			size:       0,
+			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "cross-org-fork-template", Branch: "main"},
 		},
 		{
 			name:       "explicit @branch retained even when default_branch differs",
@@ -231,7 +244,7 @@ func TestResolveTemplateBranch(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveTemplateBranch(tc.arg, tc.isTemplate, tc.defaultBr, tc.size)
+			got, err := resolveTemplateBranch(tc.arg, tc.isTemplate, tc.isFork, tc.defaultBr, tc.size)
 			if tc.wantErrPart != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil (returned %#v)", tc.wantErrPart, got)

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1828,6 +1828,28 @@ describe("verifyTemplateAccess", () => {
     expect(result.kind).toBe("empty-template")
   })
 
+  it("does not flag a fork as empty-template despite size 0 (regression #528)", async () => {
+    // GitHub reports size 0 for a fork sharing objects with its parent even when
+    // the fork has commits, so a fork must never be treated as commitless.
+    const client = clientReturning({
+      name: "cross-org-fork-template",
+      full_name: `${ORG}/cross-org-fork-template`,
+      private: false,
+      is_template: true,
+      fork: true,
+      default_branch: "main",
+      size: 0,
+    })
+
+    const result = await verifyTemplateAccess(
+      client,
+      ORG,
+      "cross-org-fork-template",
+    )
+
+    expect(result.kind).not.toBe("empty-template")
+  })
+
   it("prefers not-template over empty-template when both apply (ordering)", async () => {
     const client = clientReturning({
       name: "tmpl",
@@ -2068,6 +2090,32 @@ describe("resolveTemplate (create/edit blocking path)", () => {
     await expect(
       resolveTemplate(client, ORG, ref(ORG, "tmpl")),
     ).rejects.toThrow(/has no commits/)
+  })
+
+  it("does not reject a fork with reported size 0 as commitless (regression #528)", async () => {
+    // GitHub reports size 0 for a fork sharing objects with its parent even when
+    // the fork has commits, so a fork must resolve normally rather than throw.
+    const client = clientReturning({
+      name: "cross-org-fork-template",
+      full_name: `${ORG}/cross-org-fork-template`,
+      private: false,
+      is_template: true,
+      fork: true,
+      default_branch: "main",
+      size: 0,
+    })
+
+    const result = await resolveTemplate(
+      client,
+      ORG,
+      ref(ORG, "cross-org-fork-template"),
+    )
+
+    expect(result.template).toEqual({
+      owner: ORG,
+      repo: "cross-org-fork-template",
+      branch: "main",
+    })
   })
 
   it("resolves a template with commits (size > 0)", async () => {

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -204,7 +204,9 @@ export type TemplateAccessVerification =
   | { kind: "not-template"; owner: string; repo: string }
   // Template with no commits (size 0): GitHub's generate 422s "is empty" at
   // accept. A commitless repo reports a phantom default_branch, so `no-branch`
-  // never catches it — size is the reliable signal. resolveTemplate rejects it.
+  // never catches it — size is the reliable signal for a NON-fork. Forks report
+  // size 0 while sharing objects with the parent, so they're exempt (a fork can
+  // only exist from a non-empty parent). resolveTemplate rejects it.
   | { kind: "empty-template"; owner: string; repo: string }
   // No usable branch: no @branch given and the repo has no default branch
   // (e.g., a commitless template). resolveTemplate rejects this too.
@@ -358,8 +360,11 @@ export async function verifyTemplateAccess(
     return { kind: "not-template", owner: parsed.owner, repo: parsed.repo }
   }
   // Caught before no-branch: a commitless repo reports a phantom default_branch
-  // (see the empty-template verdict). Fail open on an absent size.
-  if (repo.size === 0) {
+  // (see the empty-template verdict). Fail open on an absent size. Skip forks:
+  // GitHub reports size 0 for a fork that shares objects with its parent even
+  // when the fork has commits, so size is not a valid emptiness signal there —
+  // and a fork can only exist from a parent that already had commits.
+  if (repo.size === 0 && !repo.fork) {
     return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
   }
 
@@ -447,8 +452,10 @@ export async function resolveTemplate(
   }
 
   // Fail closed: never write an assignment pointing at a commitless template
-  // (see the empty-template verdict for why size, not default_branch).
-  if (repo.size === 0) {
+  // (see the empty-template verdict for why size, not default_branch). Skip
+  // forks — GitHub reports size 0 for a fork sharing objects with its parent
+  // even when it has commits, and a fork can only exist from a non-empty parent.
+  if (repo.size === 0 && !repo.fork) {
     throw new Error(
       `Template "${parsed.owner}/${parsed.repo}" has no commits — add at least one commit (e.g. a README) so students can generate from it, then retry.`,
     )

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -88,7 +88,9 @@ export type GitHubRepo = {
   // Repo size in KB (GET /repos). 0 means the repo has no commits — a
   // commitless template can't be generated from (GitHub's POST /generate 422s
   // "is empty"), so the template pre-flight rejects it. GitHub reports a phantom
-  // default_branch for such a repo, so size is the reliable emptiness signal.
+  // default_branch for such a repo, so size is the reliable emptiness signal —
+  // except for a fork, which GitHub reports as size 0 while it shares objects
+  // with its parent, so the emptiness guard exempts forks.
   size?: number
   visibility?: "public" | "private" | "internal"
   archived?: boolean


### PR DESCRIPTION
## What & why

Assignment creation from a cross-org **forked** template regressed: the teacher app and CLI rejected a valid fork template with `"<owner>/<repo> is a template but has no commits. Add at least one commit (e.g. a README), then retry."`

The cause is [#528](https://github.com/foundation50/classroom50/pull/528), which added a guard treating `repo.size === 0` as "commitless". That assumption is false for forks: a fork shares its Git objects with its parent, so the GitHub REST API commonly reports `size: 0` even when the fork has commits and branches. GitHub's docs describe `size` only as a bare integer with no documented emptiness semantics, so relying on it is an undocumented heuristic — and forks are exactly where it breaks.

Verified live against the demo org: `classroom50-summer-dev/cross-org-fork-template` returns `is_template: true`, `fork: true`, `default_branch: "main"`, **`size: 0`**, yet has a `main` branch with two real commits.

## Fix

Exempt forks from the size-0 emptiness guard on both sides, keeping the documented, reliable signals (`is_template` plus `fork`/`parent`, and the branch check):

- `web/src/domain/assignments/accessPrimitives.ts` — `verifyTemplateAccess` (pre-flight verdict) and `resolveTemplate` (save-time gate) now guard on `repo.size === 0 && !repo.fork`.

- `cli/gh-teacher/internal/assignmentcmd/assignment.go` — `resolveTemplateBranch` takes an `isFork` param and applies `size == 0 && !isFork`; the caller passes `resp.Fork`.

- `web/src/github-core/types.ts` plus the verdict-type and CLI struct comments document the fork caveat, keeping the web/CLI parity intended by #528.

A genuinely commitless **non-fork** template is still rejected, and a fork with no usable branch is still caught by the existing no-branch guard.

## Tests

Added regression coverage on both sides: CLI `TestResolveTemplateBranch` gets a "fork with reported size 0 is not treated as empty" row; web adds fork + `size: 0` cases to both `verifyTemplateAccess` (no longer `empty-template`) and `resolveTemplate` (resolves instead of throwing).

`go build ./... && go test ./...` and the web `npm run check` (tsc, eslint, prettier, arch:validate, vitest) both pass.

## Notes / follow-ups (non-blocking)

A self-review surfaced two low-priority items left out of scope: the fork-path branch-resolution case (fork + `size: 0` + empty `default_branch`) could use an explicit test, and the `size === 0` heuristic depends on GitHub's undocumented fork behavior. A separate pre-existing observation — the accept handler treats every `422` from `generate` as "already accepted" (`repoCreation.ts`) — is worth a later ticket but is untouched here.
