### PR TITLE
feat(cli): reuse/refresh gh auth instead of clobbering it on login

### DIFF
--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
 )
 
 // ShortNamePattern: classroom short-names and assignment slugs both flow into
@@ -77,29 +79,18 @@ func ScopeListContains(scopes, want string) bool {
 	return false
 }
 
-// scopeImpliedBy maps an OAuth scope to broader scopes that include it. GitHub
-// normalizes granted scopes, dropping any implied by a broader one, so a token
-// with `admin:org` reports only that and a whole-token match for `read:org`
-// would wrongly report it missing. Only the org hierarchy is listed (the only
-// implication in gh-teacher's scopes); extend if a new required scope has
-// implied parents.
-var scopeImpliedBy = map[string][]string{
-	"read:org":  {"admin:org", "write:org"},
-	"write:org": {"admin:org"},
-}
+// scopeImpliedBy lives in the shared contract package (the single source of the
+// OAuth scope hierarchy across both CLIs); ScopeListSatisfies delegates to it.
 
 // ScopeListSatisfies reports whether the X-OAuth-Scopes list satisfies want,
 // treating a broader granted scope as covering the narrower one it implies. Use
 // this (not ScopeListContains) when checking whether a token can perform an
-// operation.
+// operation. Resolves through contract.ScopeSatisfiedBy so the auto-login probe
+// (shared ghauth) and this preflight check share one scope hierarchy.
 func ScopeListSatisfies(scopes, want string) bool {
-	if ScopeListContains(scopes, want) {
-		return true
+	granted := make(map[string]bool)
+	for _, s := range strings.Split(scopes, ",") {
+		granted[strings.TrimSpace(s)] = true
 	}
-	for _, broader := range scopeImpliedBy[want] {
-		if ScopeListContains(scopes, broader) {
-			return true
-		}
-	}
-	return false
+	return contract.ScopeSatisfiedBy(granted, want)
 }

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -71,8 +71,8 @@ func OrgClassroom(args []string) (org, classroom string, err error) {
 // ScopeListContains reports whether the comma-separated OAuth scope
 // list (an X-OAuth-Scopes header value) includes want.
 func ScopeListContains(scopes, want string) bool {
-	for _, s := range strings.Split(scopes, ",") {
-		if strings.TrimSpace(s) == want {
+	for _, s := range contract.ParseScopeList(scopes) {
+		if s == want {
 			return true
 		}
 	}

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -79,9 +79,6 @@ func ScopeListContains(scopes, want string) bool {
 	return false
 }
 
-// scopeImpliedBy lives in the shared contract package (the single source of the
-// OAuth scope hierarchy across both CLIs); ScopeListSatisfies delegates to it.
-
 // ScopeListSatisfies reports whether the X-OAuth-Scopes list satisfies want,
 // treating a broader granted scope as covering the narrower one it implies. Use
 // this (not ScopeListContains) when checking whether a token can perform an
@@ -89,8 +86,8 @@ func ScopeListContains(scopes, want string) bool {
 // (shared ghauth) and this preflight check share one scope hierarchy.
 func ScopeListSatisfies(scopes, want string) bool {
 	granted := make(map[string]bool)
-	for _, s := range strings.Split(scopes, ",") {
-		granted[strings.TrimSpace(s)] = true
+	for _, s := range contract.ParseScopeList(scopes) {
+		granted[s] = true
 	}
 	return contract.ScopeSatisfiedBy(granted, want)
 }

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -185,6 +185,19 @@ var scopeImpliedBy = map[string][]string{
 	"write:org": {"admin:org"},
 }
 
+// ParseScopeList splits an X-OAuth-Scopes header value (a comma-separated OAuth
+// scope list) into trimmed, non-empty scopes. Single source of the scope-list
+// parse shared by both CLIs' scope checks. Returns nil for an empty list.
+func ParseScopeList(list string) []string {
+	var scopes []string
+	for _, s := range strings.Split(list, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			scopes = append(scopes, s)
+		}
+	}
+	return scopes
+}
+
 // ScopeSatisfiedBy reports whether a token whose granted OAuth scopes are keyed
 // true in have satisfies the single scope want, honoring the scope hierarchy (a
 // broader granted scope covers the narrower one it implies).

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -171,6 +171,51 @@ func RequiredOAuthScopes() []string {
 	return append([]string(nil), requiredOAuthScopes...)
 }
 
+// scopeImpliedBy maps an OAuth scope to the broader scopes that include it.
+// GitHub normalizes granted scopes, dropping any implied by a broader one, so a
+// token with `admin:org` reports only that; a whole-token match for `read:org`
+// would then wrongly report it missing. Single source of the OAuth scope
+// hierarchy for both CLIs — the shared auto-login scope probe (ghauth) and
+// gh-teacher's init preflight / validate both resolve through it, so a
+// required-scope change can't make two paths disagree. Kept in contract (a pure
+// package, no go-gh client dependency) so the pure validators can share it.
+// Extend when a new required scope has implied parents.
+var scopeImpliedBy = map[string][]string{
+	"read:org":  {"admin:org", "write:org"},
+	"write:org": {"admin:org"},
+}
+
+// ScopeSatisfiedBy reports whether a token whose granted OAuth scopes are keyed
+// true in have satisfies the single scope want, honoring the scope hierarchy (a
+// broader granted scope covers the narrower one it implies).
+func ScopeSatisfiedBy(have map[string]bool, want string) bool {
+	if have[want] {
+		return true
+	}
+	for _, broader := range scopeImpliedBy[want] {
+		if have[broader] {
+			return true
+		}
+	}
+	return false
+}
+
+// ScopesSatisfy reports whether granted covers every scope in required,
+// honoring the OAuth scope hierarchy (e.g. admin:org implies read:org and
+// write:org). Elements are trimmed; empty required is vacuously satisfied.
+func ScopesSatisfy(granted, required []string) bool {
+	have := make(map[string]bool, len(granted))
+	for _, g := range granted {
+		have[strings.TrimSpace(g)] = true
+	}
+	for _, r := range required {
+		if !ScopeSatisfiedBy(have, strings.TrimSpace(r)) {
+			return false
+		}
+	}
+	return true
+}
+
 // PrefixCommit prepends CommitPrefix, producing the canonical "[Classroom 50]
 // <message>" form. Any trailing "(gh ... )" provenance hint inside message is
 // preserved verbatim.

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -288,3 +288,35 @@ func TestFeedbackPRBody(t *testing.T) {
 // feedbackPRBodyGoldenPath locates the rendered-body golden, also consumed by
 // the Python (skeleton_tests) and TypeScript (web) mirror tests.
 const feedbackPRBodyGoldenPath = "testdata/feedback_pr_body.golden"
+
+// TestScopesSatisfy pins the single OAuth scope-hierarchy source both CLIs
+// share (the shared auto-login probe and gh-teacher's init preflight): a
+// superset satisfies, and GitHub's org implications (admin:org ⊇ write:org ⊇
+// read:org) are honored so a normalized grant isn't wrongly reported missing.
+func TestScopesSatisfy(t *testing.T) {
+	cases := []struct {
+		name     string
+		granted  []string
+		required []string
+		want     bool
+	}{
+		{"exact match", []string{"repo", "workflow"}, []string{"repo", "workflow"}, true},
+		{"superset satisfies", []string{"repo", "workflow", "gist"}, []string{"repo"}, true},
+		{"unified grant satisfies unified required", []string{"admin:org", "repo", "workflow"}, RequiredOAuthScopes(), true},
+		{"admin:org implies read:org", []string{"admin:org"}, []string{"read:org"}, true},
+		{"admin:org implies write:org", []string{"admin:org"}, []string{"write:org"}, true},
+		{"write:org implies read:org", []string{"write:org"}, []string{"read:org"}, true},
+		{"write:org does not imply admin:org", []string{"write:org"}, []string{"admin:org"}, false},
+		{"read:org does not imply admin:org", []string{"read:org"}, []string{"admin:org"}, false},
+		{"missing workflow", []string{"admin:org", "repo"}, []string{"admin:org", "repo", "workflow"}, false},
+		{"empty required is satisfied", []string{"repo"}, nil, true},
+		{"whitespace tolerated", []string{" repo ", "workflow"}, []string{"repo", "workflow"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ScopesSatisfy(tc.granted, tc.required); got != tc.want {
+				t.Errorf("ScopesSatisfy(%v, %v) = %v, want %v", tc.granted, tc.required, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -320,3 +320,31 @@ func TestScopesSatisfy(t *testing.T) {
 		})
 	}
 }
+
+// TestParseScopeList pins the shared X-OAuth-Scopes parse: GitHub returns a
+// comma-space-separated list, possibly empty, possibly with stray spaces.
+func TestParseScopeList(t *testing.T) {
+	cases := []struct {
+		name string
+		list string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "repo", []string{"repo"}},
+		{"comma-space separated", "admin:org, read:org, repo, workflow", []string{"admin:org", "read:org", "repo", "workflow"}},
+		{"stray spaces and empties", " repo ,, workflow ", []string{"repo", "workflow"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseScopeList(tc.list)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ParseScopeList(%q) = %v, want %v", tc.list, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("ParseScopeList(%q) = %v, want %v", tc.list, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -1,19 +1,26 @@
 // Package ghauth holds the auth scaffolding shared by the gh-teacher and
 // gh-student CLIs: resolving an authenticated go-gh REST client (auto-running
-// `gh auth login` when no token is present), the interactive-TTY guard, and the
-// `gh auth login` shell-out used by both the auto-login path and the explicit
-// `login` command. The two CLIs differ only in required OAuth scopes and
-// command name ("gh teacher" vs "gh student"), passed in via Options.
+// `gh auth login` when no token is present, OR when a gh-managed token lacks a
+// required scope — reusing an already-sufficient token so a working `gh` auth
+// config is never rewritten just to re-request scopes it already has, issue
+// #534), the interactive-TTY guard, and the `gh auth login` shell-out used by
+// both the auto-login path and the explicit `login` command. The two CLIs
+// differ only in required OAuth scopes and command name ("gh teacher" vs
+// "gh student"), passed in via Options.
 package ghauth
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/cli/go-gh/v2/pkg/auth"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
 )
 
 // Options carries the per-CLI auth configuration.
@@ -38,22 +45,107 @@ func defaultHost() string {
 	return host
 }
 
-// RequireClient returns an authenticated REST client, auto-running
-// `gh auth login` (with opts.RequiredScopes) when no token is set for the
-// default host, turning the cryptic "token not found" failure into a guided
-// login. Non-interactive shells get a clear error instead.
+// RequireClient returns an authenticated REST client. It auto-runs
+// `gh auth login` (with opts.RequiredScopes) only when the host has no token,
+// OR when the existing token is a `gh`-managed OAuth token that lacks a
+// required scope — reusing an already-sufficient token so we never rewrite a
+// user's working `gh` auth config just to re-request scopes it already has
+// (issue #534). A token from a non-`gh` source (env var / keyring) that is
+// insufficient is not silently re-authed: `gh auth login` can't rewrite an
+// env token and clobbering a keyring token is surprising, so we point the user
+// at manual remediation instead. Non-interactive shells get a clear error.
 func RequireClient(out, errOut writer, opts Options) (*api.RESTClient, error) {
 	host := defaultHost()
-	if token, _ := auth.TokenForHost(host); token == "" {
+	token, source := auth.TokenForHost(host)
+
+	if token == "" {
 		if err := autoLogin(out, errOut, host, opts); err != nil {
 			return nil, err
 		}
+		return newDefaultClient()
 	}
+
+	client, err := newDefaultClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// A present token might still lack a scope we need. Probe it; on an
+	// inconclusive probe (network/transport error) proceed with the token
+	// rather than forcing a disruptive re-login on a transient failure.
+	ok, probeErr := tokenHasScopes(client, opts.RequiredScopes)
+	if probeErr != nil || ok {
+		return client, nil
+	}
+
+	// Insufficient. Only a `gh`-managed token is safe to fix with
+	// `gh auth login`; env/keyring tokens must be fixed by the user.
+	if !isGhManagedToken(source) {
+		return nil, fmt.Errorf(
+			"your %s token (source: %s) is missing scopes %s needs (%s); it wasn't set by `gh auth login`, so re-run won't fix it — re-issue the token with those scopes, or unset it and run `%s login`",
+			host, source, opts.CommandName, strings.Join(opts.RequiredScopes, ", "), opts.CommandName)
+	}
+	_, _ = fmt.Fprintf(errOut, "Your %s login is missing scopes %s needs (%s); running `%s login` to add them...\n", host, opts.CommandName, strings.Join(opts.RequiredScopes, ", "), opts.CommandName)
+	if err := autoLogin(out, errOut, host, opts); err != nil {
+		return nil, err
+	}
+	return newDefaultClient()
+}
+
+// newDefaultClient builds go-gh's default REST client (reads the ambient gh
+// auth/host config), wrapping the error for callers.
+func newDefaultClient() (*api.RESTClient, error) {
 	client, err := api.DefaultRESTClient()
 	if err != nil {
 		return nil, fmt.Errorf("REST client: %w", err)
 	}
 	return client, nil
+}
+
+// isGhManagedToken reports whether TokenForHost's source string denotes a token
+// `gh auth login` owns — the hosts.yml `oauth_token` (config-file storage) or
+// `gh` (the default OS-keyring / secure-storage path, which go-gh reports by
+// shelling out to `gh auth token`). These are the only cases where re-running
+// `gh auth login` can add scopes without clobbering something the user set by
+// hand. An env-var source (GH_TOKEN / GITHUB_TOKEN) is user-managed → false.
+func isGhManagedToken(source string) bool {
+	s := strings.ToLower(strings.TrimSpace(source))
+	return s == "oauth_token" || s == "gh"
+}
+
+// parseScopesHeader splits GitHub's X-OAuth-Scopes header (a comma-space list)
+// into a trimmed, non-empty scope slice. Returns nil for an empty header.
+func parseScopesHeader(header string) []string {
+	var scopes []string
+	for _, s := range strings.Split(header, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			scopes = append(scopes, s)
+		}
+	}
+	return scopes
+}
+
+// scopesSatisfy reports whether the granted scopes cover every required scope.
+// Delegates to the shared contract scope-hierarchy source (honoring GitHub's
+// admin:org ⊇ read:org/write:org implications) so this auto-login probe and
+// gh-teacher's init preflight can never disagree on what a token satisfies.
+func scopesSatisfy(granted, required []string) bool {
+	return contract.ScopesSatisfy(granted, required)
+}
+
+// tokenHasScopes probes the client's token via a cheap authenticated request
+// (GET /, the API root) and reports whether its granted OAuth scopes — read
+// from the X-OAuth-Scopes response header — satisfy required. A transport
+// error is returned so callers can treat the probe as inconclusive.
+func tokenHasScopes(client *api.RESTClient, required []string) (bool, error) {
+	resp, err := client.Request(http.MethodGet, "", nil)
+	if err != nil {
+		return false, fmt.Errorf("probe token scopes: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	granted := parseScopesHeader(resp.Header.Get("X-OAuth-Scopes"))
+	return scopesSatisfy(granted, required), nil
 }
 
 // autoLogin shells out to `gh auth login` with the CLI's scopes against the
@@ -69,8 +161,10 @@ func autoLogin(out, errOut writer, host string, opts Options) error {
 
 // RunLogin execs `gh auth login --hostname <host>` with the required scopes
 // plus any extra scopes, wiring stdio through. Shared by autoLogin and the
-// explicit `login` command.
+// explicit `login` command. Warns first that it hands control to `gh`, which
+// rewrites the stored auth for this host in `gh`'s config (issue #534).
 func RunLogin(out, errOut writer, host string, requiredScopes, extraScopes []string) error {
+	_, _ = fmt.Fprintf(errOut, "Note: this runs `gh auth login`, which will update %s's stored authentication in your gh config (e.g. ~/.config/gh/hosts.yml) — replacing the token gh has for %s.\n", host, host)
 	args := []string{"auth", "login", "--hostname", host}
 	for _, s := range requiredScopes {
 		args = append(args, "-s", s)

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -47,15 +47,19 @@ func defaultHost() string {
 	return host
 }
 
-// RequireClient returns an authenticated REST client. It auto-runs
-// `gh auth login` (with opts.RequiredScopes) only when the host has no token,
-// OR when the existing token is a `gh`-managed OAuth token that lacks a
-// required scope — reusing an already-sufficient token so we never rewrite a
-// user's working `gh` auth config just to re-request scopes it already has
-// (issue #534). A token from a non-`gh` source (env var / keyring) that is
-// insufficient is not silently re-authed: `gh auth login` can't rewrite an
-// env token and clobbering a keyring token is surprising, so we point the user
-// at manual remediation instead. Non-interactive shells get a clear error.
+// RequireClient returns an authenticated REST client. It reuses an
+// already-sufficient token untouched so a working `gh` auth config is never
+// disturbed just to re-request scopes it already has (issue #534). Only when
+// the token is missing or under-scoped does it hand off to `gh`:
+//   - no token: `gh auth login` (a fresh sign-in; warns that it rewrites gh's
+//     stored auth).
+//   - `gh`-managed token missing a scope: `gh auth refresh -s <scopes>`, which
+//     ADDS the scopes to the existing credential without replacing its token or
+//     other hosts.yml settings — the non-clobbering path.
+//   - non-`gh` token (env var / PAT) missing a scope: not auto-fixed (`gh` can't
+//     widen an env/PAT token); returns an error pointing at manual remediation.
+//
+// Non-interactive shells get a clear error instead of a hung browser flow.
 func RequireClient(out, errOut writer, opts Options) (*api.RESTClient, error) {
 	host := defaultHost()
 	token, source := auth.TokenForHost(host)
@@ -80,15 +84,19 @@ func RequireClient(out, errOut writer, opts Options) (*api.RESTClient, error) {
 		return client, nil
 	}
 
-	// Insufficient. Only a `gh`-managed token is safe to fix with
-	// `gh auth login`; env/keyring tokens must be fixed by the user.
+	// Insufficient. Only a `gh`-managed token can be widened with
+	// `gh auth refresh`; env/PAT tokens must be fixed by the user.
 	if !isGhManagedToken(source) {
 		return nil, fmt.Errorf(
 			"your %s token (source: %s) is missing scopes %s needs (%s); it wasn't set by `gh auth login`, so re-run won't fix it — re-issue the token with those scopes, or unset it and run `%s login`",
 			host, source, opts.CommandName, strings.Join(opts.RequiredScopes, ", "), opts.CommandName)
 	}
-	_, _ = fmt.Fprintf(errOut, "Your %s login is missing scopes %s needs (%s); running `%s login` to add them...\n", host, opts.CommandName, strings.Join(opts.RequiredScopes, ", "), opts.CommandName)
-	if err := autoLogin(out, errOut, host, opts); err != nil {
+	if !IsInteractiveTTY() {
+		return nil, fmt.Errorf("your %s login is missing scopes %s needs (%s); run `gh auth refresh -h %s -s %s` (or `%s login`) from an interactive terminal to add them", host, opts.CommandName, strings.Join(opts.RequiredScopes, ", "), host, strings.Join(opts.RequiredScopes, ","), opts.CommandName)
+	}
+	// Widen the existing login in place — no fresh token, no config clobber.
+	_, _ = fmt.Fprintf(errOut, "Your %s login is missing scopes %s needs (%s); running `gh auth refresh` to add them (your existing token is kept, not replaced)...\n", host, opts.CommandName, strings.Join(opts.RequiredScopes, ", "))
+	if err := RunRefresh(out, errOut, host, opts.RequiredScopes, nil); err != nil {
 		return nil, err
 	}
 	return newDefaultClient()
@@ -156,25 +164,50 @@ func autoLogin(out, errOut writer, host string, opts Options) error {
 // RunLogin execs `gh auth login --hostname <host>` with the required scopes
 // plus any extra scopes, wiring stdio through. Shared by autoLogin and the
 // explicit `login` command. Warns first, prominently, that it hands control to
-// `gh`, which rewrites the stored auth for this host in `gh`'s config (issue
-// #534).
+// `gh`, which mints a fresh token and rewrites the stored auth for this host in
+// `gh`'s config (issue #534). Use this only for a FRESH sign-in (no token yet)
+// or an explicit user `login`; to widen an existing login's scopes without
+// replacing its token, prefer RunRefresh.
 func RunLogin(out, errOut writer, host string, requiredScopes, extraScopes []string) error {
 	printConfigRewriteWarning(errOut, host)
-	args := []string{"auth", "login", "--hostname", host}
+	return runGh(out, errOut, ghScopeArgs([]string{"auth", "login", "--hostname", host}, requiredScopes, extraScopes)...)
+}
+
+// RunRefresh execs `gh auth refresh --hostname <host> -s <scopes>` to ADD
+// scopes to the host's existing stored credential, rather than minting a fresh
+// token the way `gh auth login` does. This is the non-clobbering path: it
+// preserves the user's token identity, git-protocol, and other hosts.yml
+// settings, re-running only the OAuth consent to widen the grant (issue #534).
+// It only works for a `gh`-managed OAuth credential (not a PAT / env token),
+// which is why callers gate it behind isGhManagedToken.
+func RunRefresh(out, errOut writer, host string, requiredScopes, extraScopes []string) error {
+	return runGh(out, errOut, ghScopeArgs([]string{"auth", "refresh", "--hostname", host}, requiredScopes, extraScopes)...)
+}
+
+// ghScopeArgs appends `-s <scope>` for each required scope, then each non-empty
+// trimmed extra scope, to base. Shared by the login and refresh invocations so
+// both request scopes identically.
+func ghScopeArgs(base, requiredScopes, extraScopes []string) []string {
 	for _, s := range requiredScopes {
-		args = append(args, "-s", s)
+		base = append(base, "-s", s)
 	}
 	for _, s := range extraScopes {
 		if s = strings.TrimSpace(s); s != "" {
-			args = append(args, "-s", s)
+			base = append(base, "-s", s)
 		}
 	}
+	return base
+}
+
+// runGh execs `gh <args...>` with stdio wired through: stdin from the process
+// (the OAuth flow reads it), stdout/stderr to the caller's writers.
+func runGh(out, errOut writer, args ...string) error {
 	sub := exec.Command("gh", args...)
 	sub.Stdin = os.Stdin
 	sub.Stdout = out
 	sub.Stderr = errOut
 	if err := sub.Run(); err != nil {
-		return fmt.Errorf("gh auth login: %w", err)
+		return fmt.Errorf("gh %s: %w", strings.Join(args[:2], " "), err)
 	}
 	return nil
 }

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -257,7 +257,13 @@ func runGh(out, errOut writer, args ...string) error {
 	sub.Stdout = out
 	sub.Stderr = errOut
 	if err := sub.Run(); err != nil {
-		return fmt.Errorf("gh %s: %w", strings.Join(args[:2], " "), err)
+		// Name the subcommand (e.g. "gh auth login") in the error; guard the
+		// slice so a short arg list degrades to "gh" instead of panicking.
+		label := "gh"
+		if len(args) >= 2 {
+			label = "gh " + strings.Join(args[:2], " ")
+		}
+		return fmt.Errorf("%s: %w", label, err)
 	}
 	return nil
 }
@@ -345,7 +351,10 @@ func renderWarningBox(errOut writer, color bool, lines []string) {
 // stderrWantsColor reports whether to emit color/box drawing to w: w must be
 // the real stderr and a TTY, with neither NO_COLOR nor CLASSROOM50_NO_COLOR
 // set. Mirrors ghui.UseColor (duplicated to avoid an import cycle — ghui
-// imports ghauth); keep the two in lockstep.
+// imports ghauth); keep the two in lockstep. A future cleanup could instead
+// move these color/TTY/width primitives DOWN into ghauth (the layer ghui and
+// both ui packages already import) and have them re-use it, collapsing the
+// copies — a cross-package change left out of this fix's scope.
 func stderrWantsColor(w writer) bool {
 	if os.Getenv("NO_COLOR") != "" || os.Getenv("CLASSROOM50_NO_COLOR") != "" {
 		return false

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -15,10 +15,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/cli/go-gh/v2/pkg/auth"
+	"github.com/cli/go-gh/v2/pkg/config"
 
 	"github.com/foundation50/classroom50-cli-shared/contract"
 )
@@ -153,10 +155,11 @@ func autoLogin(out, errOut writer, host string, opts Options) error {
 
 // RunLogin execs `gh auth login --hostname <host>` with the required scopes
 // plus any extra scopes, wiring stdio through. Shared by autoLogin and the
-// explicit `login` command. Warns first that it hands control to `gh`, which
-// rewrites the stored auth for this host in `gh`'s config (issue #534).
+// explicit `login` command. Warns first, prominently, that it hands control to
+// `gh`, which rewrites the stored auth for this host in `gh`'s config (issue
+// #534).
 func RunLogin(out, errOut writer, host string, requiredScopes, extraScopes []string) error {
-	_, _ = fmt.Fprintf(errOut, "Note: this runs `gh auth login`, which will update %s's stored authentication in your gh config (e.g. ~/.config/gh/hosts.yml) — replacing the token gh has for %s.\n", host, host)
+	printConfigRewriteWarning(errOut, host)
 	args := []string{"auth", "login", "--hostname", host}
 	for _, s := range requiredScopes {
 		args = append(args, "-s", s)
@@ -174,6 +177,116 @@ func RunLogin(out, errOut writer, host string, requiredScopes, extraScopes []str
 		return fmt.Errorf("gh auth login: %w", err)
 	}
 	return nil
+}
+
+// Minimal SGR codes + rounded box-drawing runes for the config-rewrite warning.
+// Hand-rolled (not the shared ghui renderer) because ghui imports ghauth for
+// the TTY guard, so ghauth can't import ghui back without an import cycle.
+const (
+	warnAnsiReset  = "\x1b[0m"
+	warnAnsiBold   = "\x1b[1m"
+	warnAnsiYellow = "\x1b[33m"
+
+	boxTopLeft     = "╭"
+	boxTopRight    = "╮"
+	boxBottomLeft  = "╰"
+	boxBottomRight = "╯"
+	boxHorizontal  = "─"
+	boxVertical    = "│"
+)
+
+// printConfigRewriteWarning warns, prominently, that `gh auth login` is about
+// to rewrite gh's stored auth for host (issue #534). On a color TTY it renders
+// a yellow box; on a non-TTY / NO_COLOR it prints plain lines. Either way the
+// literal "Warning:" prefix is present so log scrapers and tests keep matching.
+func printConfigRewriteWarning(errOut writer, host string) {
+	lines := []string{
+		"Warning: this runs `gh auth login`, which rewrites gh's stored",
+		fmt.Sprintf("authentication for %s in your gh config", host),
+		fmt.Sprintf("(%s), replacing the token gh currently has.", hostsConfigPath()),
+	}
+	renderWarningBox(errOut, stderrWantsColor(errOut), lines)
+}
+
+// hostsConfigPath returns the platform-correct path to gh's hosts file — the
+// file `gh auth login` rewrites — resolved the same way gh does (GH_CONFIG_DIR,
+// then XDG_CONFIG_HOME, then Windows AppData, else ~/.config/gh). Never
+// hardcode ~/.config/gh/hosts.yml: it's wrong on Windows and whenever
+// GH_CONFIG_DIR / XDG_CONFIG_HOME is set.
+func hostsConfigPath() string {
+	return filepath.Join(config.ConfigDir(), "hosts.yml")
+}
+
+// renderWarningBox draws lines inside a yellow rounded box when color is true,
+// or prints them as plain left-aligned lines otherwise. Box width fits the
+// widest line; line widths ignore ANSI escapes so the border stays aligned.
+// color is a parameter (not read inline) so tests can exercise both paths.
+func renderWarningBox(errOut writer, color bool, lines []string) {
+	if !color {
+		for _, ln := range lines {
+			_, _ = fmt.Fprintf(errOut, "%s\n", ln)
+		}
+		return
+	}
+
+	width := 0
+	for _, ln := range lines {
+		if w := displayWidth(ln); w > width {
+			width = w
+		}
+	}
+	const pad = 1 // one space of horizontal padding inside the border
+	inner := width + pad*2
+
+	yellow := func(s string) string { return warnAnsiYellow + s + warnAnsiReset }
+
+	top := yellow(boxTopLeft + strings.Repeat(boxHorizontal, inner) + boxTopRight)
+	bottom := yellow(boxBottomLeft + strings.Repeat(boxHorizontal, inner) + boxBottomRight)
+	bar := yellow(boxVertical)
+
+	_, _ = fmt.Fprintf(errOut, "%s\n", top)
+	for _, ln := range lines {
+		// Bold the leading "Warning:" so it stands out; right-pad to the box
+		// interior using the ANSI-free display width.
+		display := ln
+		if rest, ok := strings.CutPrefix(ln, "Warning:"); ok {
+			display = warnAnsiBold + "Warning:" + warnAnsiReset + rest
+		}
+		gap := width - displayWidth(ln)
+		_, _ = fmt.Fprintf(errOut, "%s %s%s %s\n",
+			bar, display, strings.Repeat(" ", gap), bar)
+	}
+	_, _ = fmt.Fprintf(errOut, "%s\n", bottom)
+}
+
+// stderrWantsColor reports whether to emit color/box drawing to w: w must be
+// the real stderr and a TTY, with neither NO_COLOR nor CLASSROOM50_NO_COLOR
+// set. Mirrors ghui.UseColor (duplicated to avoid an import cycle — ghui
+// imports ghauth); keep the two in lockstep.
+func stderrWantsColor(w writer) bool {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("CLASSROOM50_NO_COLOR") != "" {
+		return false
+	}
+	return w == writer(os.Stderr) && IsCharDevice(os.Stderr)
+}
+
+// displayWidth counts the printed width of s as its rune count, skipping ANSI
+// SGR escapes so a colored string still measures by its visible glyphs.
+func displayWidth(s string) int {
+	n, inEscape := 0, false
+	for _, r := range s {
+		switch {
+		case inEscape:
+			if r == 'm' {
+				inEscape = false
+			}
+		case r == '\x1b':
+			inEscape = true
+		default:
+			n++
+		}
+	}
+	return n
 }
 
 // DefaultHost is exported for the `login` command, which needs the host to

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -163,13 +163,16 @@ func autoLogin(out, errOut writer, host string, opts Options) error {
 
 // RunLogin execs `gh auth login --hostname <host>` with the required scopes
 // plus any extra scopes, wiring stdio through. Shared by autoLogin and the
-// explicit `login` command. Warns first, prominently, that it hands control to
-// `gh`, which mints a fresh token and rewrites the stored auth for this host in
-// `gh`'s config (issue #534). Use this only for a FRESH sign-in (no token yet)
-// or an explicit user `login`; to widen an existing login's scopes without
-// replacing its token, prefer RunRefresh.
+// explicit `login` command. Prints the prominent config-rewrite box ONLY when
+// the host already has a stored token — that's the case where `gh auth login`
+// mints a fresh token and overwrites the user's existing auth in `gh`'s config
+// (issue #534). A first-time login (no token yet) has nothing to clobber, so it
+// skips the box. To widen an existing login's scopes without replacing its
+// token, prefer RunRefresh.
 func RunLogin(out, errOut writer, host string, requiredScopes, extraScopes []string) error {
-	printConfigRewriteWarning(errOut, host)
+	if token, _ := auth.TokenForHost(host); token != "" {
+		printConfigRewriteWarning(errOut, host)
+	}
 	return runGh(out, errOut, ghScopeArgs([]string{"auth", "login", "--hostname", host}, requiredScopes, extraScopes)...)
 }
 

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -113,18 +113,6 @@ func isGhManagedToken(source string) bool {
 	return s == "oauth_token" || s == "gh"
 }
 
-// parseScopesHeader splits GitHub's X-OAuth-Scopes header (a comma-space list)
-// into a trimmed, non-empty scope slice. Returns nil for an empty header.
-func parseScopesHeader(header string) []string {
-	var scopes []string
-	for _, s := range strings.Split(header, ",") {
-		if s = strings.TrimSpace(s); s != "" {
-			scopes = append(scopes, s)
-		}
-	}
-	return scopes
-}
-
 // scopesSatisfy reports whether the granted scopes cover every required scope.
 // Delegates to the shared contract scope-hierarchy source (honoring GitHub's
 // admin:org ⊇ read:org/write:org implications) so this auto-login probe and
@@ -136,15 +124,19 @@ func scopesSatisfy(granted, required []string) bool {
 // tokenHasScopes probes the client's token via a cheap authenticated request
 // (GET /, the API root) and reports whether its granted OAuth scopes — read
 // from the X-OAuth-Scopes response header — satisfy required. A transport
-// error is returned so callers can treat the probe as inconclusive.
+// error is returned so callers can treat the probe as inconclusive. An empty
+// required set is vacuously satisfied and skips the request.
 func tokenHasScopes(client *api.RESTClient, required []string) (bool, error) {
+	if len(required) == 0 {
+		return true, nil
+	}
 	resp, err := client.Request(http.MethodGet, "", nil)
 	if err != nil {
 		return false, fmt.Errorf("probe token scopes: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	granted := parseScopesHeader(resp.Header.Get("X-OAuth-Scopes"))
+	granted := contract.ParseScopeList(resp.Header.Get("X-OAuth-Scopes"))
 	return scopesSatisfy(granted, required), nil
 }
 

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -10,6 +10,8 @@
 package ghauth
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -163,17 +165,62 @@ func autoLogin(out, errOut writer, host string, opts Options) error {
 
 // RunLogin execs `gh auth login --hostname <host>` with the required scopes
 // plus any extra scopes, wiring stdio through. Shared by autoLogin and the
-// explicit `login` command. Prints the prominent config-rewrite box ONLY when
-// the host already has a stored token — that's the case where `gh auth login`
-// mints a fresh token and overwrites the user's existing auth in `gh`'s config
-// (issue #534). A first-time login (no token yet) has nothing to clobber, so it
-// skips the box. To widen an existing login's scopes without replacing its
-// token, prefer RunRefresh.
+// explicit `login` command.
+//
+// When the host already has a stored token, `gh auth login` mints a fresh token
+// and overwrites the user's existing auth in `gh`'s config (issue #534), so
+// RunLogin first prints the config-rewrite box and — on an interactive
+// terminal — asks the user to confirm. Declining aborts with manual
+// alternatives and returns ErrLoginDeclined. A first-time login (no token yet)
+// has nothing to clobber, so it skips both the box and the prompt. To widen an
+// existing login's scopes without replacing its token, prefer RunRefresh.
 func RunLogin(out, errOut writer, host string, requiredScopes, extraScopes []string) error {
 	if token, _ := auth.TokenForHost(host); token != "" {
 		printConfigRewriteWarning(errOut, host)
+		// Only gate on a real interactive terminal; a non-TTY (CI, piped)
+		// can't answer, so proceed as before rather than blocking.
+		if IsInteractiveTTY() && !confirmProceed(errOut, os.Stdin) {
+			printLoginDeclinedHelp(errOut, host, requiredScopes)
+			return ErrLoginDeclined
+		}
 	}
 	return runGh(out, errOut, ghScopeArgs([]string{"auth", "login", "--hostname", host}, requiredScopes, extraScopes)...)
+}
+
+// ErrLoginDeclined is returned by RunLogin when the user answers No to the
+// config-rewrite confirmation. Callers can treat it as a clean, user-chosen
+// abort (the guidance was already printed) rather than an unexpected failure.
+var ErrLoginDeclined = errors.New("login declined: existing gh authentication left unchanged")
+
+// confirmProceed prompts on errOut and reads a line from in, returning true
+// only on an explicit yes. Defaults to No (empty/anything-else), so the safe
+// choice — leaving the existing auth untouched — is the one a bare Enter makes.
+func confirmProceed(errOut writer, in io.Reader) bool {
+	_, _ = fmt.Fprint(errOut, "Proceed and let `gh auth login` replace it? [y/N] ")
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// printLoginDeclinedHelp explains, after a declined re-login, the non-clobbering
+// ways to get the scopes the CLI needs without a full `gh auth login`: widen the
+// existing credential with `gh auth refresh`, or supply your own token via
+// GH_TOKEN. Keeps the reporter's "let me set it up manually" path first-class
+// (issue #534).
+func printLoginDeclinedHelp(errOut writer, host string, requiredScopes []string) {
+	scopeCSV := strings.Join(requiredScopes, ",")
+	_, _ = fmt.Fprintf(errOut,
+		"Aborted — your existing %s authentication is unchanged. To get the scopes without replacing your token, either:\n"+
+			"  • widen your current login in place:  gh auth refresh -h %s -s %s\n"+
+			"  • or use your own token:               export GH_TOKEN=<a PAT with %s>\n",
+		host, host, scopeCSV, strings.Join(requiredScopes, ", "))
 }
 
 // RunRefresh execs `gh auth refresh --hostname <host> -s <scopes>` to ADD

--- a/cli/shared/ghauth/ghauth_test.go
+++ b/cli/shared/ghauth/ghauth_test.go
@@ -43,6 +43,58 @@ func TestScopesSatisfy(t *testing.T) {
 	}
 }
 
+// TestConfirmProceed pins the re-login confirmation: only an explicit yes
+// proceeds; empty (bare Enter), no, and EOF all default to No so the safe
+// choice — leaving the existing auth untouched — is the effortless one.
+func TestConfirmProceed(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"y proceeds", "y\n", true},
+		{"yes proceeds", "yes\n", true},
+		{"uppercase Y proceeds", "Y\n", true},
+		{"padded yes proceeds", "  yes  \n", true},
+		{"bare enter declines", "\n", false},
+		{"n declines", "n\n", false},
+		{"no declines", "no\n", false},
+		{"garbage declines", "maybe\n", false},
+		{"EOF declines", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var errOut bytes.Buffer
+			got := confirmProceed(&errOut, strings.NewReader(tc.in))
+			if got != tc.want {
+				t.Errorf("confirmProceed(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+			if !strings.Contains(errOut.String(), "Proceed") {
+				t.Errorf("confirmProceed must print a prompt; got %q", errOut.String())
+			}
+		})
+	}
+}
+
+// TestPrintLoginDeclinedHelp pins the post-decline guidance: it must name the
+// two no-clobber alternatives the reporter asked for (issue #534) — refreshing
+// the existing login and supplying your own token via GH_TOKEN — with the
+// required scopes filled in.
+func TestPrintLoginDeclinedHelp(t *testing.T) {
+	var buf bytes.Buffer
+	printLoginDeclinedHelp(&buf, "github.com", []string{"admin:org", "workflow"})
+	got := buf.String()
+	for _, want := range []string{
+		"gh auth refresh -h github.com -s admin:org,workflow",
+		"GH_TOKEN",
+		"unchanged",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("decline help missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGhScopeArgs pins the `gh auth login`/`refresh` argument builder shared by
 // the login and refresh paths: each required scope and each non-empty trimmed
 // extra scope becomes a `-s <scope>` pair appended to the base command.

--- a/cli/shared/ghauth/ghauth_test.go
+++ b/cli/shared/ghauth/ghauth_test.go
@@ -43,6 +43,25 @@ func TestScopesSatisfy(t *testing.T) {
 	}
 }
 
+// TestGhScopeArgs pins the `gh auth login`/`refresh` argument builder shared by
+// the login and refresh paths: each required scope and each non-empty trimmed
+// extra scope becomes a `-s <scope>` pair appended to the base command.
+func TestGhScopeArgs(t *testing.T) {
+	got := ghScopeArgs(
+		[]string{"auth", "refresh", "--hostname", "github.com"},
+		[]string{"admin:org", "workflow"},
+		[]string{" gist ", "", "read:user"},
+	)
+	want := []string{
+		"auth", "refresh", "--hostname", "github.com",
+		"-s", "admin:org", "-s", "workflow",
+		"-s", "gist", "-s", "read:user",
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("ghScopeArgs = %v, want %v", got, want)
+	}
+}
+
 // TestHostsConfigPath verifies the warning points at gh's real hosts file
 // resolved per-platform (via go-gh's config.ConfigDir), not a hardcoded
 // ~/.config/gh path: setting GH_CONFIG_DIR must move it, proving it isn't

--- a/cli/shared/ghauth/ghauth_test.go
+++ b/cli/shared/ghauth/ghauth_test.go
@@ -1,9 +1,12 @@
 package ghauth
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cli/go-gh/v2/pkg/api"
@@ -37,6 +40,93 @@ func TestScopesSatisfy(t *testing.T) {
 				t.Errorf("scopesSatisfy(%v, %v) = %v, want %v", tc.granted, tc.required, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestHostsConfigPath verifies the warning points at gh's real hosts file
+// resolved per-platform (via go-gh's config.ConfigDir), not a hardcoded
+// ~/.config/gh path: setting GH_CONFIG_DIR must move it, proving it isn't
+// macOS/Linux-only and honors gh's own precedence.
+func TestHostsConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", dir)
+
+	got := hostsConfigPath()
+	want := filepath.Join(dir, "hosts.yml")
+	if got != want {
+		t.Errorf("hostsConfigPath() = %q, want %q (should honor GH_CONFIG_DIR)", got, want)
+	}
+}
+
+// TestRenderWarningBox pins the config-rewrite warning renderer (issue #534):
+// the plain path stays ANSI-free and keeps the literal "Warning:" prefix so
+// log scrapers/tests match; the color path draws an aligned yellow box whose
+// borders line up regardless of the widest line.
+func TestRenderWarningBox(t *testing.T) {
+	lines := []string{
+		"Warning: this runs `gh auth login`, which rewrites gh's stored",
+		"authentication for github.com in your gh config",
+		"(e.g. ~/.config/gh/hosts.yml), replacing the token gh currently has.",
+	}
+
+	t.Run("plain path is ANSI-free and keeps Warning prefix", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderWarningBox(&buf, false, lines)
+		got := buf.String()
+		if strings.Contains(got, "\x1b[") {
+			t.Errorf("plain path must not emit ANSI escapes:\n%q", got)
+		}
+		if strings.ContainsAny(got, boxTopLeft+boxVertical+boxBottomRight) {
+			t.Errorf("plain path must not draw box-drawing runes:\n%q", got)
+		}
+		if !strings.Contains(got, "Warning:") {
+			t.Errorf("plain path must keep the literal Warning: prefix:\n%q", got)
+		}
+		for _, ln := range lines {
+			if !strings.Contains(got, ln) {
+				t.Errorf("plain path dropped a line %q:\n%q", ln, got)
+			}
+		}
+	})
+
+	t.Run("color path draws an aligned yellow box", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderWarningBox(&buf, true, lines)
+		out := buf.String()
+		if !strings.Contains(out, warnAnsiYellow) {
+			t.Errorf("color path must emit the yellow SGR code:\n%q", out)
+		}
+		if !strings.Contains(out, boxTopLeft) || !strings.Contains(out, boxBottomRight) {
+			t.Errorf("color path must draw the box corners:\n%q", out)
+		}
+		// Every rendered row must have the same visible width, so the right
+		// border lines up under the top border.
+		rows := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		for i, row := range rows {
+			if w := displayWidth(row); w != displayWidth(rows[0]) {
+				t.Errorf("row %d visible width %d != top border width %d; box misaligned:\n%q",
+					i, w, displayWidth(rows[0]), out)
+			}
+		}
+	})
+}
+
+// TestDisplayWidth pins the ANSI-aware width used to align the box border: it
+// counts visible runes and skips SGR escapes.
+func TestDisplayWidth(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"\x1b[33mabc\x1b[0m", 3},
+		{"\x1b[1mWarning:\x1b[0m x", 10},
+	}
+	for _, tc := range cases {
+		if got := displayWidth(tc.in); got != tc.want {
+			t.Errorf("displayWidth(%q) = %d, want %d", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/cli/shared/ghauth/ghauth_test.go
+++ b/cli/shared/ghauth/ghauth_test.go
@@ -40,34 +40,6 @@ func TestScopesSatisfy(t *testing.T) {
 	}
 }
 
-// TestParseScopesHeader pins the X-OAuth-Scopes parse: GitHub returns a
-// comma-space-separated list, possibly empty, possibly with stray spaces.
-func TestParseScopesHeader(t *testing.T) {
-	cases := []struct {
-		name   string
-		header string
-		want   []string
-	}{
-		{"empty", "", nil},
-		{"single", "repo", []string{"repo"}},
-		{"comma-space separated", "admin:org, read:org, repo, workflow", []string{"admin:org", "read:org", "repo", "workflow"}},
-		{"stray spaces and empties", " repo ,, workflow ", []string{"repo", "workflow"}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := parseScopesHeader(tc.header)
-			if len(got) != len(tc.want) {
-				t.Fatalf("parseScopesHeader(%q) = %v, want %v", tc.header, got, tc.want)
-			}
-			for i := range got {
-				if got[i] != tc.want[i] {
-					t.Fatalf("parseScopesHeader(%q) = %v, want %v", tc.header, got, tc.want)
-				}
-			}
-		})
-	}
-}
-
 // TestIsGhManagedToken pins which TokenForHost sources count as gh-managed —
 // the cases where re-running `gh auth login` can add scopes safely. go-gh
 // returns "gh" for a keyring/secure-storage token and "oauth_token" for the

--- a/cli/shared/ghauth/ghauth_test.go
+++ b/cli/shared/ghauth/ghauth_test.go
@@ -12,34 +12,17 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 )
 
-// TestScopesSatisfy pins the granted-vs-required decision that lets an
-// already-sufficient token skip a re-login (issue #534): a superset satisfies,
-// admin:org covers read:org (GitHub's implication), and a genuine gap does not.
+// TestScopesSatisfy is a smoke check that ghauth's wrapper delegates to the
+// shared scope-hierarchy source: the two cases that matter for the reuse
+// decision — a satisfied set (incl. GitHub's admin:org ⊇ read:org implication)
+// and a genuine gap. The exhaustive hierarchy matrix is owned by
+// contract.TestScopesSatisfy; this only pins that the seam is wired through.
 func TestScopesSatisfy(t *testing.T) {
-	cases := []struct {
-		name     string
-		granted  []string
-		required []string
-		want     bool
-	}{
-		{"exact match", []string{"repo", "workflow"}, []string{"repo", "workflow"}, true},
-		{"granted superset", []string{"repo", "workflow", "gist"}, []string{"repo"}, true},
-		{"admin:org implies read:org", []string{"admin:org", "repo", "workflow"}, []string{"admin:org", "read:org", "repo", "workflow"}, true},
-		{"admin:org implies write:org", []string{"admin:org"}, []string{"write:org"}, true},
-		{"write:org implies read:org but not admin:org", []string{"write:org"}, []string{"read:org"}, true},
-		{"unified set satisfied by unified grant", []string{"admin:org", "repo", "workflow"}, []string{"admin:org", "read:org", "repo", "workflow"}, true},
-		{"missing workflow", []string{"admin:org", "read:org", "repo"}, []string{"admin:org", "read:org", "repo", "workflow"}, false},
-		{"read:org alone does not imply admin:org", []string{"read:org", "repo", "workflow"}, []string{"admin:org", "read:org", "repo", "workflow"}, false},
-		{"empty granted, non-empty required", nil, []string{"repo"}, false},
-		{"empty required is always satisfied", []string{"repo"}, nil, true},
-		{"whitespace in granted list tolerated", []string{" repo ", "workflow"}, []string{"repo", "workflow"}, true},
+	if !scopesSatisfy([]string{"admin:org", "repo", "workflow"}, []string{"admin:org", "read:org", "repo", "workflow"}) {
+		t.Error("want satisfied: admin:org should imply read:org for the unified set")
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := scopesSatisfy(tc.granted, tc.required); got != tc.want {
-				t.Errorf("scopesSatisfy(%v, %v) = %v, want %v", tc.granted, tc.required, got, tc.want)
-			}
-		})
+	if scopesSatisfy([]string{"admin:org", "read:org", "repo"}, []string{"admin:org", "read:org", "repo", "workflow"}) {
+		t.Error("want unsatisfied: workflow is missing")
 	}
 }
 

--- a/cli/shared/ghauth/ghauth_test.go
+++ b/cli/shared/ghauth/ghauth_test.go
@@ -1,0 +1,174 @@
+package ghauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+// TestScopesSatisfy pins the granted-vs-required decision that lets an
+// already-sufficient token skip a re-login (issue #534): a superset satisfies,
+// admin:org covers read:org (GitHub's implication), and a genuine gap does not.
+func TestScopesSatisfy(t *testing.T) {
+	cases := []struct {
+		name     string
+		granted  []string
+		required []string
+		want     bool
+	}{
+		{"exact match", []string{"repo", "workflow"}, []string{"repo", "workflow"}, true},
+		{"granted superset", []string{"repo", "workflow", "gist"}, []string{"repo"}, true},
+		{"admin:org implies read:org", []string{"admin:org", "repo", "workflow"}, []string{"admin:org", "read:org", "repo", "workflow"}, true},
+		{"admin:org implies write:org", []string{"admin:org"}, []string{"write:org"}, true},
+		{"write:org implies read:org but not admin:org", []string{"write:org"}, []string{"read:org"}, true},
+		{"unified set satisfied by unified grant", []string{"admin:org", "repo", "workflow"}, []string{"admin:org", "read:org", "repo", "workflow"}, true},
+		{"missing workflow", []string{"admin:org", "read:org", "repo"}, []string{"admin:org", "read:org", "repo", "workflow"}, false},
+		{"read:org alone does not imply admin:org", []string{"read:org", "repo", "workflow"}, []string{"admin:org", "read:org", "repo", "workflow"}, false},
+		{"empty granted, non-empty required", nil, []string{"repo"}, false},
+		{"empty required is always satisfied", []string{"repo"}, nil, true},
+		{"whitespace in granted list tolerated", []string{" repo ", "workflow"}, []string{"repo", "workflow"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := scopesSatisfy(tc.granted, tc.required); got != tc.want {
+				t.Errorf("scopesSatisfy(%v, %v) = %v, want %v", tc.granted, tc.required, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseScopesHeader pins the X-OAuth-Scopes parse: GitHub returns a
+// comma-space-separated list, possibly empty, possibly with stray spaces.
+func TestParseScopesHeader(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   []string
+	}{
+		{"empty", "", nil},
+		{"single", "repo", []string{"repo"}},
+		{"comma-space separated", "admin:org, read:org, repo, workflow", []string{"admin:org", "read:org", "repo", "workflow"}},
+		{"stray spaces and empties", " repo ,, workflow ", []string{"repo", "workflow"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseScopesHeader(tc.header)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseScopesHeader(%q) = %v, want %v", tc.header, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("parseScopesHeader(%q) = %v, want %v", tc.header, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestIsGhManagedToken pins which TokenForHost sources count as gh-managed —
+// the cases where re-running `gh auth login` can add scopes safely. go-gh
+// returns "gh" for a keyring/secure-storage token and "oauth_token" for the
+// config-file token; env sources (GH_TOKEN / GITHUB_TOKEN) are user-managed.
+// A miss here (issue #534 review) misclassifies the default keyring token and
+// wrongly hard-errors instead of auto-fixing it.
+func TestIsGhManagedToken(t *testing.T) {
+	cases := []struct {
+		source string
+		want   bool
+	}{
+		{"gh", true},          // keyring / secure storage (go-gh default)
+		{"oauth_token", true}, // hosts.yml config file
+		{"GH_TOKEN", false},   // env var — user-managed
+		{"GITHUB_TOKEN", false},
+		{"default", false}, // no token found
+		{"", false},
+		{" GH ", true}, // case/space tolerant
+	}
+	for _, tc := range cases {
+		t.Run(tc.source, func(t *testing.T) {
+			if got := isGhManagedToken(tc.source); got != tc.want {
+				t.Errorf("isGhManagedToken(%q) = %v, want %v", tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+type hostRewriteTransport struct{ target *url.URL }
+
+func (h *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = h.target.Scheme
+	req.URL.Host = h.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func newTestRESTClient(t *testing.T, server *httptest.Server) *api.RESTClient {
+	t.Helper()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client, err := api.NewRESTClient(api.ClientOptions{
+		Host:         "github.com",
+		AuthToken:    "test-token",
+		Transport:    &hostRewriteTransport{target: u},
+		LogIgnoreEnv: true,
+	})
+	if err != nil {
+		t.Fatalf("api.NewRESTClient: %v", err)
+	}
+	return client
+}
+
+// TestTokenHasScopes pins the live-probe half: it reads the X-OAuth-Scopes
+// header off a cheap authenticated request and reports whether the granted set
+// satisfies the required set. This is what lets RequireClient skip login for an
+// already-sufficient token (#534).
+func TestTokenHasScopes(t *testing.T) {
+	t.Run("sufficient token reports true", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("X-OAuth-Scopes", "admin:org, read:org, repo, workflow")
+			w.WriteHeader(http.StatusOK)
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		ok, err := tokenHasScopes(newTestRESTClient(t, server), []string{"admin:org", "read:org", "repo", "workflow"})
+		if err != nil {
+			t.Fatalf("tokenHasScopes: %v", err)
+		}
+		if !ok {
+			t.Error("want true for a token whose granted scopes cover the required set")
+		}
+	})
+
+	t.Run("insufficient token reports false", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("X-OAuth-Scopes", "repo")
+			w.WriteHeader(http.StatusOK)
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		ok, err := tokenHasScopes(newTestRESTClient(t, server), []string{"admin:org", "read:org", "repo", "workflow"})
+		if err != nil {
+			t.Fatalf("tokenHasScopes: %v", err)
+		}
+		if ok {
+			t.Error("want false when workflow/admin:org/read:org are not granted")
+		}
+	})
+
+	t.Run("transport error surfaces", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		server.Close() // force a connection failure
+
+		if _, err := tokenHasScopes(newTestRESTClient(t, server), []string{"repo"}); err == nil {
+			t.Error("want a transport error when the request cannot complete")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #534.

## Problem

`gh teacher login` / `gh student login` — and the implicit auto-login that fires inside commands like `gh teacher init` — shelled out to `gh auth login` unconditionally. `gh auth login` mints a fresh OAuth token and rewrites the user's `gh` hosts file, so it replaced a pre-existing PAT or keyring configuration even when the token already had every scope Classroom 50 needs. The reporter lost the tokens they had configured and their keyring token source. We never touched the config ourselves, but our wrapper triggered the `gh` write, sometimes without the user explicitly asking to log in.

## What this does

The fix lives in the shared `cli/shared/ghauth` package, so both CLIs get it. The behavior is now, in order:

- **Reuse a sufficient token untouched.** `RequireClient` probes the existing token's granted scopes via the `X-OAuth-Scopes` header on a cheap `GET /`, and if it already satisfies the required set it is left completely alone — no login, no refresh, no prompt. This is the reporter's core ask: "if the current auth setup is fine, nothing should be changed." The probe fails open — any inconclusive result (transport error, transient 401/403) proceeds with the existing token rather than forcing a disruptive re-login.
- **Widen an under-scoped `gh`-managed token in place, don't replace it.** When the token is missing a scope, we run `gh auth refresh -s <scopes>` instead of a full `gh auth login`. `refresh` expands the existing credential's grant while keeping the user's token, git-protocol, and other hosts.yml settings intact. (This matches the manual guidance the repo already gives elsewhere for the `workflow` scope.)
- **Never silently re-auth an env/PAT token.** A token from `GH_TOKEN` / `GITHUB_TOKEN` or another user-managed source can't be widened by `gh`, so an under-scoped one returns an actionable error pointing at manual remediation rather than clobbering anything.
- **Only warn when a rewrite would actually happen, and confirm first.** A genuine fresh `gh auth login` (or an explicit `gh teacher|student login` while a token already exists) shows a prominent yellow boxed warning and — on an interactive terminal — asks the user to confirm before replacing the stored token. Declining aborts (non-zero exit) and prints the no-clobber alternatives the reporter asked for: `gh auth refresh` to widen the current login, or `GH_TOKEN` to supply their own token. A first-time login has nothing to clobber, so it skips both the box and the prompt; non-interactive shells skip the prompt and proceed unchanged.

The config-rewrite warning resolves `gh`'s hosts-file path via go-gh's `config.ConfigDir()` (honoring `GH_CONFIG_DIR` / `XDG_CONFIG_HOME` / Windows `AppData`) rather than hardcoding `~/.config/gh/hosts.yml`, which was wrong on Windows and under those env vars.

## Notes

Single-sourced the OAuth scope hierarchy (`admin:org ⊇ write:org ⊇ read:org`) and the scope-list parse in the pure `contract` package. The auto-login scope probe and gh-teacher's existing `init` preflight now both resolve through `contract.ScopeSatisfiedBy` / `ScopesSatisfy` / `ParseScopeList`, per the repo's "one recipe, one source" rule, so a future required-scope change can't make the two paths disagree. No new dependencies (`go-gh`'s `config` package was already transitively present).

## Testing

Added Go unit tests for the scope-satisfaction logic and its hierarchy, the `X-OAuth-Scopes` parse, the live scope probe against an `httptest` server, `isGhManagedToken` source classification (`gh` / `oauth_token` vs env sources), the platform-correct hosts path (honors `GH_CONFIG_DIR`), the warning-box renderer (ANSI-free plain path keeps the literal `Warning:`; color path draws an aligned box), the confirmation prompt (only an explicit yes proceeds; empty/no/EOF decline), and the decline-help text.

Also exercised both built CLIs locally against the live API:

- With a real keyring token (`admin:org` present, `read:org` absent), `gh teacher whoami` and `gh student whoami` reused the token silently and printed the user — proving the `admin:org ⊇ read:org` reuse path with no login/refresh/box/prompt.
- With no token and non-interactive stdin, both errored cleanly (`run gh teacher|student login from an interactive terminal`) with exit 1 and no hung browser flow.
- With an invalid `GH_TOKEN`, the probe's 401 was treated as inconclusive (fail-open): the CLI proceeded with the token rather than forcing a re-login, surfacing an honest `GET /user: HTTP 401`.

`go build`, `go test`, `go vet`, `gofmt`, and `golangci-lint run` / `fmt --diff` all pass clean across `shared`, `gh-teacher`, and `gh-student`.

## Post-Deploy Monitoring & Validation

No runtime/service impact — this is a client-side CLI change. The one new behavior is an extra `GET https://api.github.com/` on commands run with a present token, to read its scopes; it is skipped when no scopes are required and kept non-fatal (fail-open on any probe error), so an API outage or a transient 401/403 never blocks a command. Validation: with a token that already has the unified scopes, confirm `gh teacher whoami` runs without triggering `gh auth login`/`refresh` and leaves the gh config unmodified; with an under-scoped `gh`-managed login, confirm it runs `gh auth refresh` (not `login`); with a fresh (no-token) setup, confirm the login flow still runs and skips the box; with an existing token, confirm `gh teacher login` shows the box and confirmation prompt and that declining leaves auth unchanged.
