### PR TITLE
ci(web): make Playwright install-deps resilient to apt hangs

### DIFF
--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -120,10 +120,24 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
 
-      # On a cache hit the browser binary is present but its OS deps may not be;
-      # `install-deps` is cheap and idempotent. On a miss, install the browser too.
+      # On a cache hit the browser binary is present but its OS deps may not be.
+      # `install-deps` shells out to apt, so it can hang on a transient
+      # mirror/network blip — give it its own short timeout and a couple of
+      # retries so one flaky apt call fails fast and self-heals instead of
+      # burning the whole job budget and cancelling the lane (a hung apt here
+      # once ate all 10 minutes and failed the release CI).
       - name: Install Playwright browser deps
-        run: npx playwright install-deps chromium
+        timeout-minutes: 4
+        run: |
+          for attempt in 1 2 3; do
+            if npx playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "playwright install-deps failed (attempt $attempt); retrying..." >&2
+            sleep $((attempt * 10))
+          done
+          echo "playwright install-deps failed after 3 attempts" >&2
+          exit 1
       - name: Install Playwright Chromium
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium


### PR DESCRIPTION
## Problem

The **A11y layout guards (Chromium)** lane in `web-ci.yaml` failed on the `chore: release main` PR ([run 31206074320](https://github.com/foundation50/classroom50/actions/runs/31206074320/job/92957604019)), taking down the CI gate. It was not a test failure — the `Install Playwright browser deps` step (`npx playwright install-deps chromium`, which shells out to `apt`) hung for ~9m53s while unpacking Ubuntu font packages and was killed by the job-level 10-minute timeout ("The operation was canceled"). The actual browser tests never ran.

The step had no timeout or retry of its own, so a single transient apt/mirror hang consumed the entire job budget and cancelled the release lane.

## Fix

Contain and self-heal the flaky step without changing what's tested:

- Give `Install Playwright browser deps` its own `timeout-minutes: 4`, so a hung apt fails that step fast instead of eating the whole 10-minute job budget.
- Retry it up to 3 times with a short backoff, so a transient apt/network blip recovers instead of failing the lane.

Browser *binaries* are already cached (`Cache Playwright browsers`); only the OS-level `install-deps` apt step was unbounded, and that's what this hardens.

## Post-Deploy Monitoring & Validation

CI-only change; no runtime/product impact. Validation: the A11y layout guards lane should pass normally; on a transient apt hang it now retries and, worst case, fails the single step at ~4 minutes with a clear "failed after 3 attempts" message rather than cancelling the whole job at 10 minutes.
