### PR TITLE
fix(web): use branches probe, not repo size, to detect empty templates

### DIFF
--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1044,12 +1044,14 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 		}
 		return assignment.TemplateRef{}, false, "", fmt.Errorf("GET %s: %w", path, err)
 	}
-	// hasCommits resolves the ambiguous non-fork size-0 case with an
-	// authoritative branches probe; forks and size > 0 short-circuit with no
-	// extra request.
-	hasCommits, err := templateHasCommits(client, t, resp.Fork, resp.Size)
-	if err != nil {
-		return assignment.TemplateRef{}, false, "", err
+	// Resolve emptiness only for an actual template (mirrors the web path, which
+	// returns not-template before probing): a non-template short-circuits in
+	// resolveTemplateBranch below, so a non-template size-0 repo issues no probe.
+	// For a template, hasCommits resolves the ambiguous non-fork size-0 case with
+	// an authoritative branches probe; forks and size > 0 issue no extra request.
+	hasCommits := true
+	if resp.IsTemplate {
+		hasCommits = templateHasCommits(client, t, resp.Fork, resp.Size)
 	}
 	ref, err = resolveTemplateBranch(t, resp.IsTemplate, hasCommits, resp.DefaultBranch)
 	if err != nil {
@@ -1109,26 +1111,29 @@ func resolveTemplateBranch(t templateArg, isTemplate, hasCommits bool, defaultBr
 // #528; fast path). Only the ambiguous non-fork size-0 case issues an
 // authoritative branches probe (GET /branches?per_page=1): a non-empty array
 // means the repo has commits, an empty array means it is genuinely commitless
-// (issue #544 — size lags a fresh repo's real commits). A probe that cannot
-// confirm emptiness (transient error) fails toward "has commits" rather than
-// manufacturing a false "has no commits"; `add`'s real emptiness gate is
-// GitHub's generate at accept, and the fresh-repo 409 is already tolerated
-// there.
-func templateHasCommits(client githubapi.Client, t templateArg, isFork bool, size int) (bool, error) {
+// (verified: a truly-empty repo returns 200 [] — issue #544, where size lags a
+// fresh repo's real commits). Only a 404 (repo gone) is a definite empty; any
+// other error — including a 409 "Git Repository is empty." (the fresh-repo
+// warmup window this codebase treats as transient, see gh-student's
+// isFreshRepoRetryable) — fails toward has-commits rather than manufacturing a
+// false "has no commits". `add`'s real emptiness gate is GitHub's generate at
+// accept, and the fresh-repo 409 is already tolerated there.
+func templateHasCommits(client githubapi.Client, t templateArg, isFork bool, size int) bool {
 	if isFork || size > 0 {
-		return true, nil
+		return true
 	}
 	path := fmt.Sprintf("repos/%s/%s/branches?per_page=1", url.PathEscape(t.Owner), url.PathEscape(t.Repo))
 	var branches []struct {
 		Name string `json:"name"`
 	}
 	if err := client.Get(path, &branches); err != nil {
-		// 404 (gone) or 409 ("Git Repository is empty.") is a definite empty; any
-		// other error is inconclusive, so fail toward has-commits (don't block).
-		if cliutil.IsHTTPStatus(err, http.StatusNotFound) || cliutil.IsHTTPStatus(err, http.StatusConflict) {
-			return false, nil
+		// 404 (gone) is a definite empty; any other error (incl. a transient
+		// fresh-repo 409, rate-limit 403, or 5xx) is inconclusive, so fail toward
+		// has-commits and let generate-at-accept be the real gate.
+		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
+			return false
 		}
-		return true, nil
+		return true
 	}
-	return len(branches) > 0, nil
+	return len(branches) > 0
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1026,11 +1026,12 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 		DefaultBranch string `json:"default_branch"`
 		Private       bool   `json:"private"`
 		Fork          bool   `json:"fork"`
-		// Repo size in KB. 0 means no commits — an empty template can't be
-		// generated from (POST /generate 422s "is empty"), and GitHub reports a
-		// phantom default_branch for it, so size is the reliable emptiness signal
-		// for a non-fork. Forks report size 0 while sharing parent objects, so the
-		// emptiness guard exempts them.
+		// Repo size in KB. size is populated by an async background job, so a
+		// freshly-created/pushed repo with real commits reads 0 for minutes
+		// (issue #544) — size alone is NOT a reliable emptiness signal. A non-fork
+		// size 0 is only a suspicion, confirmed by an authoritative branches probe
+		// below. Forks report size 0 while sharing parent objects (regression
+		// #528), so they're never probed and never treated as empty.
 		Size   int `json:"size"`
 		Parent struct {
 			FullName string `json:"full_name"`
@@ -1043,7 +1044,14 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 		}
 		return assignment.TemplateRef{}, false, "", fmt.Errorf("GET %s: %w", path, err)
 	}
-	ref, err = resolveTemplateBranch(t, resp.IsTemplate, resp.Fork, resp.DefaultBranch, resp.Size)
+	// hasCommits resolves the ambiguous non-fork size-0 case with an
+	// authoritative branches probe; forks and size > 0 short-circuit with no
+	// extra request.
+	hasCommits, err := templateHasCommits(client, t, resp.Fork, resp.Size)
+	if err != nil {
+		return assignment.TemplateRef{}, false, "", err
+	}
+	ref, err = resolveTemplateBranch(t, resp.IsTemplate, hasCommits, resp.DefaultBranch)
 	if err != nil {
 		return assignment.TemplateRef{}, false, "", err
 	}
@@ -1068,18 +1076,20 @@ func templateInOrg(templateOwner, org string) bool {
 
 // resolveTemplateBranch picks the final assignment.TemplateRef from
 // --template + repo fields: not-a-template, empty (commitless), explicit
-// @branch, default_branch fallback, or empty-default_branch guard.
-func resolveTemplateBranch(t templateArg, isTemplate, isFork bool, defaultBranch string, size int) (assignment.TemplateRef, error) {
+// @branch, default_branch fallback, or empty-default_branch guard. Emptiness is
+// passed in as a resolved `hasCommits` (the HTTP-aware caller owns the branches
+// probe) so this stays a pure, unit-testable function.
+func resolveTemplateBranch(t templateArg, isTemplate, hasCommits bool, defaultBranch string) (assignment.TemplateRef, error) {
 	if !isTemplate {
 		return assignment.TemplateRef{}, fmt.Errorf("`%s/%s` is not a template repository — toggle Settings → \"Template repository\" on the repo, then re-run", t.Owner, t.Repo)
 	}
 	// Caught before the empty-branch guard below (which a commitless repo's
-	// phantom default_branch would slip past). Fail closed on an absent size —
-	// Go's zero value — the deliberate opposite of the web verify path's
-	// fail-open === 0, since `add` is the last gate before write. Forks are
-	// exempt: GitHub reports size 0 for a fork sharing objects with its parent
-	// even when it has commits, and a fork can only exist from a non-empty parent.
-	if size == 0 && !isFork {
+	// phantom default_branch would slip past). `hasCommits` is resolved by the
+	// caller: size > 0, or a fork (regression #528 — GitHub reports size 0 for a
+	// fork sharing objects with its parent), or an authoritative branches probe
+	// when size is 0 (size is async and lags a fresh repo's real commits —
+	// issue #544).
+	if !hasCommits {
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run", t.Owner, t.Repo)
 	}
 	branch := t.Branch
@@ -1092,4 +1102,33 @@ func resolveTemplateBranch(t templateArg, isTemplate, isFork bool, defaultBranch
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch — pass --template %s/%s@<branch> explicitly", t.Owner, t.Repo, t.Owner, t.Repo)
 	}
 	return assignment.TemplateRef{Owner: t.Owner, Repo: t.Repo, Branch: branch}, nil
+}
+
+// templateHasCommits resolves whether a template has any commits. Forks and a
+// reported size > 0 short-circuit to true with no extra request (regression
+// #528; fast path). Only the ambiguous non-fork size-0 case issues an
+// authoritative branches probe (GET /branches?per_page=1): a non-empty array
+// means the repo has commits, an empty array means it is genuinely commitless
+// (issue #544 — size lags a fresh repo's real commits). A probe that cannot
+// confirm emptiness (transient error) fails toward "has commits" rather than
+// manufacturing a false "has no commits"; `add`'s real emptiness gate is
+// GitHub's generate at accept, and the fresh-repo 409 is already tolerated
+// there.
+func templateHasCommits(client githubapi.Client, t templateArg, isFork bool, size int) (bool, error) {
+	if isFork || size > 0 {
+		return true, nil
+	}
+	path := fmt.Sprintf("repos/%s/%s/branches?per_page=1", url.PathEscape(t.Owner), url.PathEscape(t.Repo))
+	var branches []struct {
+		Name string `json:"name"`
+	}
+	if err := client.Get(path, &branches); err != nil {
+		// 404 (gone) or 409 ("Git Repository is empty.") is a definite empty; any
+		// other error is inconclusive, so fail toward has-commits (don't block).
+		if cliutil.IsHTTPStatus(err, http.StatusNotFound) || cliutil.IsHTTPStatus(err, http.StatusConflict) {
+			return false, nil
+		}
+		return true, nil
+	}
+	return len(branches) > 0, nil
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
@@ -169,16 +169,17 @@ func TestNormalizeDueDate_UnresolvableTZ(t *testing.T) {
 func TestResolveTemplateBranch(t *testing.T) {
 	// Each row covers one branch of the post-HTTP decision tree so a
 	// change to validateTemplateRepo's response handling can't
-	// silently drop a guard: not-a-template, empty-template (with the
-	// fork exemption), explicit-@branch retention, default_branch
-	// fallback, empty-default_branch error.
+	// silently drop a guard: not-a-template, empty-template,
+	// explicit-@branch retention, default_branch fallback,
+	// empty-default_branch error. Emptiness is now an input (hasCommits);
+	// the fork exemption (#528) and the size-0 branches probe (#544) are
+	// resolved by templateHasCommits and covered by TestTemplateHasCommits.
 	cases := []struct {
 		name        string
 		arg         templateArg
 		isTemplate  bool
-		isFork      bool
+		hasCommits  bool
 		defaultBr   string
-		size        int
 		wantRef     assignment.TemplateRef
 		wantErrPart string // empty → expect success
 	}{
@@ -186,65 +187,64 @@ func TestResolveTemplateBranch(t *testing.T) {
 			name:        "not a template",
 			arg:         templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate:  false,
+			hasCommits:  true,
 			defaultBr:   "main",
-			size:        0,
 			wantErrPart: "not a template repository",
 		},
 		{
 			name:        "empty template (no commits) rejected before branch resolution",
 			arg:         templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate:  true,
+			hasCommits:  false,
 			defaultBr:   "main", // GitHub reports a phantom default_branch for a commitless repo
-			size:        0,
 			wantErrPart: "has no commits",
 		},
 		{
-			// A fork reports size 0 while sharing objects with its parent even when
-			// it has commits, so the emptiness guard must exempt it (regression #528).
-			name:       "fork with reported size 0 is not treated as empty",
+			// The fork exemption (#528) is resolved by templateHasCommits before
+			// this pure function; here it arrives as hasCommits: true.
+			name:       "template with commits resolves to default_branch",
 			arg:        templateArg{Owner: "cs50", Repo: "cross-org-fork-template"},
 			isTemplate: true,
-			isFork:     true,
+			hasCommits: true,
 			defaultBr:  "main",
-			size:       0,
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "cross-org-fork-template", Branch: "main"},
 		},
 		{
 			name:       "explicit @branch retained even when default_branch differs",
 			arg:        templateArg{Owner: "cs50", Repo: "hello-template", Branch: "feature/foo"},
 			isTemplate: true,
+			hasCommits: true,
 			defaultBr:  "main",
-			size:       1,
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "feature/foo"},
 		},
 		{
 			name:       "no @branch falls back to default_branch (master)",
 			arg:        templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate: true,
+			hasCommits: true,
 			defaultBr:  "master",
-			size:       1,
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "master"},
 		},
 		{
 			name:       "no @branch falls back to default_branch (main)",
 			arg:        templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate: true,
+			hasCommits: true,
 			defaultBr:  "main",
-			size:       1,
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "main"},
 		},
 		{
 			name:        "no @branch and empty default_branch → defensive error",
 			arg:         templateArg{Owner: "cs50", Repo: "hello-template"},
 			isTemplate:  true,
+			hasCommits:  true,
 			defaultBr:   "",
-			size:        1,
 			wantErrPart: "has no default branch",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveTemplateBranch(tc.arg, tc.isTemplate, tc.isFork, tc.defaultBr, tc.size)
+			got, err := resolveTemplateBranch(tc.arg, tc.isTemplate, tc.hasCommits, tc.defaultBr)
 			if tc.wantErrPart != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil (returned %#v)", tc.wantErrPart, got)
@@ -546,6 +546,122 @@ func TestValidateTemplateRepo_CrossOrgFork(t *testing.T) {
 		}
 		if parent != "" {
 			t.Errorf("crossOrgForkParent = %q, want empty for a non-fork", parent)
+		}
+	})
+}
+
+func TestTemplateHasCommits(t *testing.T) {
+	// newClient serves an optional /branches endpoint and records whether it was
+	// hit, so the fork / size>0 fast paths can assert "no probe issued".
+	newClient := func(t *testing.T, branches []map[string]any, branchErr int) (githubapi.Client, *bool) {
+		t.Helper()
+		probed := false
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/o/tmpl/branches", func(w http.ResponseWriter, _ *http.Request) {
+			probed = true
+			if branchErr != 0 {
+				w.WriteHeader(branchErr)
+				_, _ = w.Write([]byte(`{"message":"boom"}`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(branches)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+		return githubtest.NewTestClient(t, server), &probed
+	}
+	arg := templateArg{Owner: "o", Repo: "tmpl"}
+
+	t.Run("fork short-circuits to has-commits without probing (regression #528)", func(t *testing.T) {
+		client, probed := newClient(t, nil, 0)
+		got, err := templateHasCommits(client, arg, true /*fork*/, 0)
+		if err != nil || !got {
+			t.Fatalf("got (%v, %v), want (true, nil)", got, err)
+		}
+		if *probed {
+			t.Error("branches endpoint was probed for a fork; want no probe")
+		}
+	})
+
+	t.Run("size > 0 short-circuits to has-commits without probing (fast path)", func(t *testing.T) {
+		client, probed := newClient(t, nil, 0)
+		got, err := templateHasCommits(client, arg, false, 12)
+		if err != nil || !got {
+			t.Fatalf("got (%v, %v), want (true, nil)", got, err)
+		}
+		if *probed {
+			t.Error("branches endpoint was probed when size > 0; want no probe")
+		}
+	})
+
+	t.Run("size 0 with a branch resolves to has-commits (regression #544)", func(t *testing.T) {
+		client, probed := newClient(t, []map[string]any{{"name": "main"}}, 0)
+		got, err := templateHasCommits(client, arg, false, 0)
+		if err != nil || !got {
+			t.Fatalf("got (%v, %v), want (true, nil)", got, err)
+		}
+		if !*probed {
+			t.Error("branches endpoint was not probed for a non-fork size-0 repo")
+		}
+	})
+
+	t.Run("size 0 with no branches resolves to empty", func(t *testing.T) {
+		client, _ := newClient(t, []map[string]any{}, 0)
+		got, err := templateHasCommits(client, arg, false, 0)
+		if err != nil || got {
+			t.Fatalf("got (%v, %v), want (false, nil)", got, err)
+		}
+	})
+
+	t.Run("size 0 with an inconclusive probe fails toward has-commits", func(t *testing.T) {
+		client, _ := newClient(t, nil, http.StatusInternalServerError)
+		got, err := templateHasCommits(client, arg, false, 0)
+		if err != nil || !got {
+			t.Fatalf("got (%v, %v), want (true, nil) on a transient probe error", got, err)
+		}
+	})
+}
+
+func TestValidateTemplateRepo_Emptiness(t *testing.T) {
+	// End-to-end through validateTemplateRepo: a fresh non-fork template with
+	// size 0 but a real branch must resolve (not error "has no commits").
+	newClient := func(t *testing.T, repo map[string]any, branches []map[string]any) githubapi.Client {
+		t.Helper()
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/o/tmpl/branches", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(branches)
+		})
+		mux.HandleFunc("/repos/o/tmpl", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(repo)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+		return githubtest.NewTestClient(t, server)
+	}
+
+	t.Run("fresh size-0 template with a branch resolves (regression #544)", func(t *testing.T) {
+		client := newClient(t,
+			map[string]any{"is_template": true, "size": 0, "default_branch": "main", "private": true},
+			[]map[string]any{{"name": "main"}},
+		)
+		ref, _, _, err := validateTemplateRepo(client, templateArg{Owner: "o", Repo: "tmpl"}, "o")
+		if err != nil {
+			t.Fatalf("validateTemplateRepo: %v", err)
+		}
+		want := assignment.TemplateRef{Owner: "o", Repo: "tmpl", Branch: "main"}
+		if ref != want {
+			t.Errorf("ref = %#v, want %#v", ref, want)
+		}
+	})
+
+	t.Run("size-0 template with no branches errors has-no-commits", func(t *testing.T) {
+		client := newClient(t,
+			map[string]any{"is_template": true, "size": 0, "default_branch": "main", "private": true},
+			[]map[string]any{},
+		)
+		_, _, _, err := validateTemplateRepo(client, templateArg{Owner: "o", Repo: "tmpl"}, "o")
+		if err == nil || !strings.Contains(err.Error(), "has no commits") {
+			t.Fatalf("err = %v, want it to contain %q", err, "has no commits")
 		}
 	})
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
@@ -574,9 +574,8 @@ func TestTemplateHasCommits(t *testing.T) {
 
 	t.Run("fork short-circuits to has-commits without probing (regression #528)", func(t *testing.T) {
 		client, probed := newClient(t, nil, 0)
-		got, err := templateHasCommits(client, arg, true /*fork*/, 0)
-		if err != nil || !got {
-			t.Fatalf("got (%v, %v), want (true, nil)", got, err)
+		if got := templateHasCommits(client, arg, true /*fork*/, 0); !got {
+			t.Fatalf("got %v, want true", got)
 		}
 		if *probed {
 			t.Error("branches endpoint was probed for a fork; want no probe")
@@ -585,9 +584,8 @@ func TestTemplateHasCommits(t *testing.T) {
 
 	t.Run("size > 0 short-circuits to has-commits without probing (fast path)", func(t *testing.T) {
 		client, probed := newClient(t, nil, 0)
-		got, err := templateHasCommits(client, arg, false, 12)
-		if err != nil || !got {
-			t.Fatalf("got (%v, %v), want (true, nil)", got, err)
+		if got := templateHasCommits(client, arg, false, 12); !got {
+			t.Fatalf("got %v, want true", got)
 		}
 		if *probed {
 			t.Error("branches endpoint was probed when size > 0; want no probe")
@@ -596,9 +594,8 @@ func TestTemplateHasCommits(t *testing.T) {
 
 	t.Run("size 0 with a branch resolves to has-commits (regression #544)", func(t *testing.T) {
 		client, probed := newClient(t, []map[string]any{{"name": "main"}}, 0)
-		got, err := templateHasCommits(client, arg, false, 0)
-		if err != nil || !got {
-			t.Fatalf("got (%v, %v), want (true, nil)", got, err)
+		if got := templateHasCommits(client, arg, false, 0); !got {
+			t.Fatalf("got %v, want true", got)
 		}
 		if !*probed {
 			t.Error("branches endpoint was not probed for a non-fork size-0 repo")
@@ -607,17 +604,38 @@ func TestTemplateHasCommits(t *testing.T) {
 
 	t.Run("size 0 with no branches resolves to empty", func(t *testing.T) {
 		client, _ := newClient(t, []map[string]any{}, 0)
-		got, err := templateHasCommits(client, arg, false, 0)
-		if err != nil || got {
-			t.Fatalf("got (%v, %v), want (false, nil)", got, err)
+		if got := templateHasCommits(client, arg, false, 0); got {
+			t.Fatalf("got %v, want false", got)
 		}
 	})
 
-	t.Run("size 0 with an inconclusive probe fails toward has-commits", func(t *testing.T) {
+	t.Run("size 0 with a 404 (repo gone) resolves to empty", func(t *testing.T) {
+		client, _ := newClient(t, nil, http.StatusNotFound)
+		if got := templateHasCommits(client, arg, false, 0); got {
+			t.Fatalf("got %v, want false", got)
+		}
+	})
+
+	t.Run("size 0 with a 409 (fresh-repo warmup) fails toward has-commits", func(t *testing.T) {
+		// A 409 is the transient fresh-repo window, not a definite empty (a
+		// settled empty repo returns 200 []). Must not manufacture a rejection.
+		client, _ := newClient(t, nil, http.StatusConflict)
+		if got := templateHasCommits(client, arg, false, 0); !got {
+			t.Fatalf("got %v, want true (409 is inconclusive, fail toward has-commits)", got)
+		}
+	})
+
+	t.Run("size 0 with a 403 (rate limit / restriction) fails toward has-commits", func(t *testing.T) {
+		client, _ := newClient(t, nil, http.StatusForbidden)
+		if got := templateHasCommits(client, arg, false, 0); !got {
+			t.Fatalf("got %v, want true (403 is inconclusive, never empty)", got)
+		}
+	})
+
+	t.Run("size 0 with an inconclusive 5xx fails toward has-commits", func(t *testing.T) {
 		client, _ := newClient(t, nil, http.StatusInternalServerError)
-		got, err := templateHasCommits(client, arg, false, 0)
-		if err != nil || !got {
-			t.Fatalf("got (%v, %v), want (true, nil) on a transient probe error", got, err)
+		if got := templateHasCommits(client, arg, false, 0); !got {
+			t.Fatalf("got %v, want true on a transient probe error", got)
 		}
 	})
 }
@@ -625,10 +643,14 @@ func TestTemplateHasCommits(t *testing.T) {
 func TestValidateTemplateRepo_Emptiness(t *testing.T) {
 	// End-to-end through validateTemplateRepo: a fresh non-fork template with
 	// size 0 but a real branch must resolve (not error "has no commits").
-	newClient := func(t *testing.T, repo map[string]any, branches []map[string]any) githubapi.Client {
+	// probed reports whether the branches endpoint was hit, so the fork /
+	// size>0 fast paths can assert no probe end-to-end.
+	newClient := func(t *testing.T, repo map[string]any, branches []map[string]any) (githubapi.Client, *bool) {
 		t.Helper()
+		probed := false
 		mux := http.NewServeMux()
 		mux.HandleFunc("/repos/o/tmpl/branches", func(w http.ResponseWriter, _ *http.Request) {
+			probed = true
 			_ = json.NewEncoder(w).Encode(branches)
 		})
 		mux.HandleFunc("/repos/o/tmpl", func(w http.ResponseWriter, _ *http.Request) {
@@ -636,11 +658,11 @@ func TestValidateTemplateRepo_Emptiness(t *testing.T) {
 		})
 		server := httptest.NewServer(mux)
 		t.Cleanup(server.Close)
-		return githubtest.NewTestClient(t, server)
+		return githubtest.NewTestClient(t, server), &probed
 	}
 
 	t.Run("fresh size-0 template with a branch resolves (regression #544)", func(t *testing.T) {
-		client := newClient(t,
+		client, _ := newClient(t,
 			map[string]any{"is_template": true, "size": 0, "default_branch": "main", "private": true},
 			[]map[string]any{{"name": "main"}},
 		)
@@ -655,13 +677,43 @@ func TestValidateTemplateRepo_Emptiness(t *testing.T) {
 	})
 
 	t.Run("size-0 template with no branches errors has-no-commits", func(t *testing.T) {
-		client := newClient(t,
+		client, _ := newClient(t,
 			map[string]any{"is_template": true, "size": 0, "default_branch": "main", "private": true},
 			[]map[string]any{},
 		)
 		_, _, _, err := validateTemplateRepo(client, templateArg{Owner: "o", Repo: "tmpl"}, "o")
 		if err == nil || !strings.Contains(err.Error(), "has no commits") {
 			t.Fatalf("err = %v, want it to contain %q", err, "has no commits")
+		}
+	})
+
+	t.Run("fork with size 0 resolves without probing branches (regression #528)", func(t *testing.T) {
+		client, probed := newClient(t,
+			map[string]any{"is_template": true, "size": 0, "default_branch": "main", "private": true, "fork": true},
+			nil,
+		)
+		ref, _, _, err := validateTemplateRepo(client, templateArg{Owner: "o", Repo: "tmpl"}, "o")
+		if err != nil {
+			t.Fatalf("validateTemplateRepo: %v", err)
+		}
+		if ref.Branch != "main" {
+			t.Errorf("ref.Branch = %q, want %q", ref.Branch, "main")
+		}
+		if *probed {
+			t.Error("branches endpoint was probed for a fork; want no probe")
+		}
+	})
+
+	t.Run("non-fork size > 0 resolves without probing branches (fast path)", func(t *testing.T) {
+		client, probed := newClient(t,
+			map[string]any{"is_template": true, "size": 12, "default_branch": "main", "private": true},
+			nil,
+		)
+		if _, _, _, err := validateTemplateRepo(client, templateArg{Owner: "o", Repo: "tmpl"}, "o"); err != nil {
+			t.Fatalf("validateTemplateRepo: %v", err)
+		}
+		if *probed {
+			t.Error("branches endpoint was probed when size > 0; want no probe")
 		}
 	})
 }

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1752,8 +1752,16 @@ describe("verifyTemplateAccess", () => {
 
   // A GitHubClient whose only method that matters here is `request`, which
   // returns the given repo object or throws the given error for the repo read.
-  function clientReturning(result: unknown | (() => never)): GitHubClient {
-    const request = vi.fn(async () => {
+  // When `branches` is supplied, a `/branches` request returns that array
+  // (the size-0 emptiness tiebreaker) while every other path returns the repo.
+  function clientReturning(
+    result: unknown | (() => never),
+    branches?: unknown[],
+  ): GitHubClient {
+    const request = vi.fn(async (path: string) => {
+      if (branches !== undefined && path.includes("/branches")) {
+        return branches
+      }
       if (typeof result === "function") {
         ;(result as () => never)()
       }
@@ -1811,41 +1819,128 @@ describe("verifyTemplateAccess", () => {
     expect(result.kind).toBe("not-template")
   })
 
-  it("returns empty-template when the template has no commits (size 0)", async () => {
-    const client = clientReturning({
-      name: "tmpl",
-      full_name: `${ORG}/tmpl`,
-      private: false,
-      is_template: true,
-      // GitHub reports a phantom default_branch for a commitless repo, so the
-      // signal is size, not the branch.
-      default_branch: "main",
-      size: 0,
-    })
+  it("returns empty-template when size 0 and the branches probe confirms no commits", async () => {
+    const client = clientReturning(
+      {
+        name: "tmpl",
+        full_name: `${ORG}/tmpl`,
+        private: false,
+        is_template: true,
+        // GitHub reports a phantom default_branch for a commitless repo; the
+        // authoritative signal is the empty branches array, not size alone.
+        default_branch: "main",
+        size: 0,
+      },
+      [], // no branches -> genuinely commitless
+    )
 
     const result = await verifyTemplateAccess(client, ORG, "tmpl")
 
     expect(result.kind).toBe("empty-template")
   })
 
-  it("does not flag a fork as empty-template despite size 0 (regression #528)", async () => {
-    // GitHub reports size 0 for a fork sharing objects with its parent even when
-    // the fork has commits, so a fork must never be treated as commitless.
-    const client = clientReturning({
-      name: "cross-org-fork-template",
-      full_name: `${ORG}/cross-org-fork-template`,
-      private: false,
-      is_template: true,
-      fork: true,
-      default_branch: "main",
-      size: 0,
+  it("does NOT flag a fresh repo with commits as empty despite size 0 (regression #544)", async () => {
+    // A freshly-pushed repo reports size 0 for minutes even with real commits.
+    // The branches probe (non-empty) proves it has commits, so it must resolve.
+    const client = clientReturning(
+      {
+        name: "tmpl",
+        full_name: `${ORG}/tmpl`,
+        private: true,
+        is_template: true,
+        default_branch: "main",
+        size: 0,
+      },
+      [{ name: "main" }], // has a branch -> has commits
+    )
+
+    const result = await verifyTemplateAccess(client, ORG, "tmpl")
+
+    expect(result.kind).not.toBe("empty-template")
+    expect(result.kind).toBe("ok")
+  })
+
+  it("fails open (not empty-template) when the size-0 branches probe is inconclusive", async () => {
+    // A transient error on the probe must not manufacture a false empty verdict
+    // on this advisory path.
+    const request = vi.fn(async (path: string) => {
+      if (path.includes("/branches")) {
+        throw new GitHubAPIError({
+          status: 500,
+          url: path,
+          message: "Server Error",
+          body: {},
+          rateLimit: emptyRateLimit,
+        })
+      }
+      return {
+        name: "tmpl",
+        full_name: `${ORG}/tmpl`,
+        private: true,
+        is_template: true,
+        default_branch: "main",
+        size: 0,
+      }
     })
+    const client = { request } as unknown as GitHubClient
+
+    const result = await verifyTemplateAccess(client, ORG, "tmpl")
+
+    expect(result.kind).not.toBe("empty-template")
+  })
+
+  it("does not probe branches when size > 0 (fast path)", async () => {
+    const requestedPaths: string[] = []
+    const request = vi.fn(async (path: string) => {
+      requestedPaths.push(path)
+      return {
+        name: "tmpl",
+        full_name: `${ORG}/tmpl`,
+        private: false,
+        is_template: true,
+        default_branch: "main",
+        size: 12,
+      }
+    })
+    const client = { request } as unknown as GitHubClient
+
+    await verifyTemplateAccess(client, ORG, "tmpl")
+
+    const requestedBranches = requestedPaths.some((p) =>
+      p.includes("/branches"),
+    )
+    expect(requestedBranches).toBe(false)
+  })
+
+  it("does not flag a fork as empty-template despite size 0, and never probes branches (regression #528)", async () => {
+    // GitHub reports size 0 for a fork sharing objects with its parent even when
+    // the fork has commits, so a fork must never be treated as commitless and
+    // must never trigger the branches probe.
+    const requestedPaths: string[] = []
+    const request = vi.fn(async (path: string) => {
+      requestedPaths.push(path)
+      return {
+        name: "cross-org-fork-template",
+        full_name: `${ORG}/cross-org-fork-template`,
+        private: false,
+        is_template: true,
+        fork: true,
+        default_branch: "main",
+        size: 0,
+      }
+    })
+    const client = { request } as unknown as GitHubClient
 
     const result = await verifyTemplateAccess(
       client,
       ORG,
       "cross-org-fork-template",
     )
+
+    const requestedBranches = requestedPaths.some((p) =>
+      p.includes("/branches"),
+    )
+    expect(requestedBranches).toBe(false)
 
     expect(result.kind).not.toBe("empty-template")
   })
@@ -2072,24 +2167,98 @@ describe("resolveTemplate (create/edit blocking path)", () => {
   const ORG = "cs50"
   const ref = (owner: string, repo: string) => ({ owner, repo })
 
-  function clientReturning(result: unknown): GitHubClient {
-    const request = vi.fn(async () => result)
+  function clientReturning(
+    result: unknown,
+    branches?: unknown[],
+  ): GitHubClient {
+    const request = vi.fn(async (path: string) => {
+      if (branches !== undefined && path.includes("/branches")) {
+        return branches
+      }
+      return result
+    })
     return { request } as unknown as GitHubClient
   }
 
-  it("throws for an empty template (no commits, size 0)", async () => {
-    const client = clientReturning({
-      name: "tmpl",
-      full_name: `${ORG}/tmpl`,
-      private: false,
-      is_template: true,
-      default_branch: "main",
-      size: 0,
-    })
+  it("throws for an empty template (size 0 and branches probe confirms no commits)", async () => {
+    const client = clientReturning(
+      {
+        name: "tmpl",
+        full_name: `${ORG}/tmpl`,
+        private: false,
+        is_template: true,
+        default_branch: "main",
+        size: 0,
+      },
+      [], // no branches -> genuinely commitless
+    )
 
     await expect(
       resolveTemplate(client, ORG, ref(ORG, "tmpl")),
     ).rejects.toThrow(/has no commits/)
+  })
+
+  it("resolves a fresh template with commits despite size 0 (regression #544)", async () => {
+    // A freshly-pushed repo reports size 0 for minutes even with real commits;
+    // the branches probe (non-empty) proves it has commits, so it must resolve
+    // rather than throw "has no commits".
+    const client = clientReturning(
+      {
+        name: "tmpl",
+        full_name: `${ORG}/tmpl`,
+        private: true,
+        is_template: true,
+        default_branch: "main",
+        size: 0,
+      },
+      [{ name: "main" }],
+    )
+
+    const result = await resolveTemplate(client, ORG, ref(ORG, "tmpl"))
+
+    expect(result.template).toEqual({
+      owner: ORG,
+      repo: "tmpl",
+      branch: "main",
+    })
+  })
+
+  it("does not throw when the size-0 branches probe is inconclusive", async () => {
+    const request = vi.fn(async (path: string) => {
+      if (path.includes("/branches")) {
+        throw new GitHubAPIError({
+          status: 500,
+          url: path,
+          message: "Server Error",
+          body: {},
+          rateLimit: {
+            limit: null,
+            remaining: null,
+            used: null,
+            reset: null,
+            resource: null,
+            retryAfter: null,
+          },
+        })
+      }
+      return {
+        name: "tmpl",
+        full_name: `${ORG}/tmpl`,
+        private: true,
+        is_template: true,
+        default_branch: "main",
+        size: 0,
+      }
+    })
+    const client = { request } as unknown as GitHubClient
+
+    const result = await resolveTemplate(client, ORG, ref(ORG, "tmpl"))
+
+    expect(result.template).toEqual({
+      owner: ORG,
+      repo: "tmpl",
+      branch: "main",
+    })
   })
 
   it("does not reject a fork with reported size 0 as commitless (regression #528)", async () => {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1887,6 +1887,7 @@ describe("verifyTemplateAccess", () => {
     const result = await verifyTemplateAccess(client, ORG, "tmpl")
 
     expect(result.kind).not.toBe("empty-template")
+    expect(result.kind).toBe("ok")
   })
 
   it("does not probe branches when size > 0 (fast path)", async () => {

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -203,11 +203,8 @@ export type TemplateAccessVerification =
   | { kind: "not-visible"; owner: string; repo: string }
   | { kind: "not-template"; owner: string; repo: string }
   // Template with no commits: GitHub's generate 422s "is empty" at accept.
-  // Detected by an authoritative branches probe (GET /branches?per_page=1 →
-  // empty array) when GET /repos reports size 0 — size alone is unreliable
-  // because it's computed asynchronously and lags a fresh repo's real commits
-  // (issue #544). Forks report size 0 while sharing objects with the parent, so
-  // they're never probed and never treated as empty (regression #528).
+  // Detected via hasAnyCommits when GET /repos reports size 0 (see its comment
+  // for why size alone is unreliable — #544; forks exempt — #528).
   // resolveTemplate rejects a confirmed-empty template.
   | { kind: "empty-template"; owner: string; repo: string }
   // No usable branch: no @branch given and the repo has no default branch
@@ -361,15 +358,11 @@ export async function verifyTemplateAccess(
   if (!repo.is_template) {
     return { kind: "not-template", owner: parsed.owner, repo: parsed.repo }
   }
-  // Caught before no-branch: a commitless repo reports a phantom default_branch.
-  // size is an async, lagging value (a freshly-pushed repo with commits reads
-  // size 0 for minutes — issue #544), so a non-fork size 0 is only a *suspicion*
-  // of emptiness; confirm it with an authoritative branches probe. Skip forks:
-  // GitHub reports size 0 for a fork that shares objects with its parent even
-  // when the fork has commits (regression #528), and a fork can only exist from
-  // a parent that already had commits. Fail OPEN: a null (inconclusive) probe
-  // never returns empty-template — this advisory path must never be harder than
-  // the real accept-time gate.
+  // Caught before no-branch (a commitless repo reports a phantom default_branch).
+  // A non-fork size 0 is only a suspicion; confirm via hasAnyCommits (#544).
+  // Forks are never probed and never treated as empty (#528). Fail OPEN: a null
+  // (inconclusive) probe never returns empty-template — this advisory path must
+  // never be harder than the real accept-time gate.
   if (repo.size === 0 && !repo.fork) {
     const commits = await hasAnyCommits(client, parsed.owner, parsed.repo)
     if (commits === false) {
@@ -460,15 +453,11 @@ export async function resolveTemplate(
     )
   }
 
-  // Never write an assignment pointing at a commitless template. size is an
-  // async, lagging value (a freshly-pushed repo with commits reads size 0 for
-  // minutes — issue #544), so a non-fork size 0 is only a suspicion; confirm it
-  // with an authoritative branches probe and throw only when it's definitely
-  // commitless. Skip forks — GitHub reports size 0 for a fork sharing objects
-  // with its parent even when it has commits (regression #528), and a fork can
-  // only exist from a non-empty parent. An inconclusive probe does NOT throw:
-  // this pre-flight is advisory (accept is the real gate), so a transient blip
-  // must not manufacture a false "has no commits".
+  // Never write an assignment pointing at a commitless template. A non-fork
+  // size 0 is only a suspicion; confirm via hasAnyCommits (#544). Forks are
+  // never probed (#528). An inconclusive probe does NOT throw: this pre-flight
+  // is advisory (accept is the real gate), so a transient blip must not
+  // manufacture a false "has no commits".
   if (repo.size === 0 && !repo.fork) {
     const commits = await hasAnyCommits(client, parsed.owner, parsed.repo)
     if (commits === false) {

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -293,6 +293,24 @@ export function classifyPrivateFork(
   }
 }
 
+// Confirmed-commitless: a non-fork whose size-0 emptiness *suspicion* (size is
+// an async, lagging value — issue #544) is corroborated by the authoritative
+// branches probe. Forks (size 0 while sharing parent objects — regression #528)
+// and an inconclusive/null probe are never treated as empty, so both the
+// advisory verify path and the blocking resolve path fail open on uncertainty.
+// The size-0 gate is checked before no-branch because a commitless repo reports
+// a phantom default_branch. Mirrors the CLI's templateHasCommits factoring:
+// this owns the probe decision; each caller owns the terminal action.
+async function isConfirmedEmptyTemplate(
+  client: GitHubClient,
+  repo: GitHubRepo,
+  owner: string,
+  name: string,
+): Promise<boolean> {
+  if (repo.size !== 0 || repo.fork) return false
+  return (await hasAnyCommits(client, owner, name)) === false
+}
+
 export async function verifyTemplateAccess(
   client: GitHubClient,
   org: string,
@@ -359,15 +377,10 @@ export async function verifyTemplateAccess(
     return { kind: "not-template", owner: parsed.owner, repo: parsed.repo }
   }
   // Caught before no-branch (a commitless repo reports a phantom default_branch).
-  // A non-fork size 0 is only a suspicion; confirm via hasAnyCommits (#544).
-  // Forks are never probed and never treated as empty (#528). Fail OPEN: a null
-  // (inconclusive) probe never returns empty-template — this advisory path must
-  // never be harder than the real accept-time gate.
-  if (repo.size === 0 && !repo.fork) {
-    const commits = await hasAnyCommits(client, parsed.owner, parsed.repo)
-    if (commits === false) {
-      return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
-    }
+  // Fail open: isConfirmedEmptyTemplate only returns true on a corroborated
+  // empty — this advisory path must never be stricter than accept.
+  if (await isConfirmedEmptyTemplate(client, repo, parsed.owner, parsed.repo)) {
+    return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
   }
 
   const inOrg = parsed.owner.toLowerCase() === org.toLowerCase()
@@ -453,18 +466,13 @@ export async function resolveTemplate(
     )
   }
 
-  // Never write an assignment pointing at a commitless template. A non-fork
-  // size 0 is only a suspicion; confirm via hasAnyCommits (#544). Forks are
-  // never probed (#528). An inconclusive probe does NOT throw: this pre-flight
-  // is advisory (accept is the real gate), so a transient blip must not
-  // manufacture a false "has no commits".
-  if (repo.size === 0 && !repo.fork) {
-    const commits = await hasAnyCommits(client, parsed.owner, parsed.repo)
-    if (commits === false) {
-      throw new Error(
-        `Template "${parsed.owner}/${parsed.repo}" has no commits — add at least one commit (e.g. a README) so students can generate from it, then retry.`,
-      )
-    }
+  // Never write an assignment pointing at a commitless template. Same
+  // corroborated-empty decision as the verify path (see isConfirmedEmptyTemplate);
+  // an inconclusive probe does NOT throw — accept is the real gate.
+  if (await isConfirmedEmptyTemplate(client, repo, parsed.owner, parsed.repo)) {
+    throw new Error(
+      `Template "${parsed.owner}/${parsed.repo}" has no commits — add at least one commit (e.g. a README) so students can generate from it, then retry.`,
+    )
   }
 
   const branch = parsed.branch || repo.default_branch

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -1,6 +1,6 @@
 import type { GitHubClient } from "@/github-core/client"
 import type { Assignment } from "@/types/classroom"
-import { getRepo } from "@/github-core/repoReads"
+import { getRepo, hasAnyCommits } from "@/github-core/repoReads"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { GitHubAPIError } from "@/github-core/errors"
 import { isDefiniteOutageError } from "@/lib/githubHealth/githubHealthStore"
@@ -202,11 +202,13 @@ export type TemplateAccessVerification =
   | { kind: "invalid"; message: string }
   | { kind: "not-visible"; owner: string; repo: string }
   | { kind: "not-template"; owner: string; repo: string }
-  // Template with no commits (size 0): GitHub's generate 422s "is empty" at
-  // accept. A commitless repo reports a phantom default_branch, so `no-branch`
-  // never catches it — size is the reliable signal for a NON-fork. Forks report
-  // size 0 while sharing objects with the parent, so they're exempt (a fork can
-  // only exist from a non-empty parent). resolveTemplate rejects it.
+  // Template with no commits: GitHub's generate 422s "is empty" at accept.
+  // Detected by an authoritative branches probe (GET /branches?per_page=1 →
+  // empty array) when GET /repos reports size 0 — size alone is unreliable
+  // because it's computed asynchronously and lags a fresh repo's real commits
+  // (issue #544). Forks report size 0 while sharing objects with the parent, so
+  // they're never probed and never treated as empty (regression #528).
+  // resolveTemplate rejects a confirmed-empty template.
   | { kind: "empty-template"; owner: string; repo: string }
   // No usable branch: no @branch given and the repo has no default branch
   // (e.g., a commitless template). resolveTemplate rejects this too.
@@ -359,13 +361,20 @@ export async function verifyTemplateAccess(
   if (!repo.is_template) {
     return { kind: "not-template", owner: parsed.owner, repo: parsed.repo }
   }
-  // Caught before no-branch: a commitless repo reports a phantom default_branch
-  // (see the empty-template verdict). Fail open on an absent size. Skip forks:
+  // Caught before no-branch: a commitless repo reports a phantom default_branch.
+  // size is an async, lagging value (a freshly-pushed repo with commits reads
+  // size 0 for minutes — issue #544), so a non-fork size 0 is only a *suspicion*
+  // of emptiness; confirm it with an authoritative branches probe. Skip forks:
   // GitHub reports size 0 for a fork that shares objects with its parent even
-  // when the fork has commits, so size is not a valid emptiness signal there —
-  // and a fork can only exist from a parent that already had commits.
+  // when the fork has commits (regression #528), and a fork can only exist from
+  // a parent that already had commits. Fail OPEN: a null (inconclusive) probe
+  // never returns empty-template — this advisory path must never be harder than
+  // the real accept-time gate.
   if (repo.size === 0 && !repo.fork) {
-    return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
+    const commits = await hasAnyCommits(client, parsed.owner, parsed.repo)
+    if (commits === false) {
+      return { kind: "empty-template", owner: parsed.owner, repo: parsed.repo }
+    }
   }
 
   const inOrg = parsed.owner.toLowerCase() === org.toLowerCase()
@@ -451,14 +460,22 @@ export async function resolveTemplate(
     )
   }
 
-  // Fail closed: never write an assignment pointing at a commitless template
-  // (see the empty-template verdict for why size, not default_branch). Skip
-  // forks — GitHub reports size 0 for a fork sharing objects with its parent
-  // even when it has commits, and a fork can only exist from a non-empty parent.
+  // Never write an assignment pointing at a commitless template. size is an
+  // async, lagging value (a freshly-pushed repo with commits reads size 0 for
+  // minutes — issue #544), so a non-fork size 0 is only a suspicion; confirm it
+  // with an authoritative branches probe and throw only when it's definitely
+  // commitless. Skip forks — GitHub reports size 0 for a fork sharing objects
+  // with its parent even when it has commits (regression #528), and a fork can
+  // only exist from a non-empty parent. An inconclusive probe does NOT throw:
+  // this pre-flight is advisory (accept is the real gate), so a transient blip
+  // must not manufacture a false "has no commits".
   if (repo.size === 0 && !repo.fork) {
-    throw new Error(
-      `Template "${parsed.owner}/${parsed.repo}" has no commits — add at least one commit (e.g. a README) so students can generate from it, then retry.`,
-    )
+    const commits = await hasAnyCommits(client, parsed.owner, parsed.repo)
+    if (commits === false) {
+      throw new Error(
+        `Template "${parsed.owner}/${parsed.repo}" has no commits — add at least one commit (e.g. a README) so students can generate from it, then retry.`,
+      )
+    }
   }
 
   const branch = parsed.branch || repo.default_branch

--- a/web/src/github-core/repoReads.test.ts
+++ b/web/src/github-core/repoReads.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest"
+import type { GitHubClient } from "./client"
+import { GitHubAPIError } from "./errors"
+import { hasAnyCommits } from "./repoReads"
+
+const rateLimit = {
+  limit: 0,
+  remaining: 0,
+  reset: 0,
+  used: 0,
+  resource: null,
+  retryAfter: null,
+}
+
+function apiError(status: number, message = ""): GitHubAPIError {
+  return new GitHubAPIError({
+    status,
+    url: "/repos/o/r/branches",
+    message,
+    body: {},
+    rateLimit,
+  })
+}
+
+function clientReturning(impl: (path: string) => Promise<unknown>): {
+  client: GitHubClient
+  paths: string[]
+} {
+  const paths: string[] = []
+  const request = vi.fn(async (path: string) => {
+    paths.push(path)
+    return impl(path)
+  })
+  return { client: { request } as unknown as GitHubClient, paths }
+}
+
+describe("hasAnyCommits", () => {
+  it("returns true when the repo has at least one branch", async () => {
+    const { client } = clientReturning(async () => [{ name: "main" }])
+    expect(await hasAnyCommits(client, "o", "r")).toBe(true)
+  })
+
+  it("returns false for a commitless repo (empty branch array)", async () => {
+    const { client } = clientReturning(async () => [])
+    expect(await hasAnyCommits(client, "o", "r")).toBe(false)
+  })
+
+  it("probes exactly the paginated branches endpoint (one cheap request)", async () => {
+    const { client, paths } = clientReturning(async () => [{ name: "main" }])
+    await hasAnyCommits(client, "o", "r")
+    expect(paths).toEqual(["/repos/o/r/branches?per_page=1"])
+  })
+
+  it("treats a 409 'Git Repository is empty.' as definitely empty", async () => {
+    const { client } = clientReturning(async () => {
+      throw apiError(409, "Git Repository is empty.")
+    })
+    expect(await hasAnyCommits(client, "o", "r")).toBe(false)
+  })
+
+  it("treats a 404 (repo gone) as definitely empty", async () => {
+    const { client } = clientReturning(async () => {
+      throw apiError(404, "Not Found")
+    })
+    expect(await hasAnyCommits(client, "o", "r")).toBe(false)
+  })
+
+  it("returns null (inconclusive) on a transient server error", async () => {
+    const { client } = clientReturning(async () => {
+      throw apiError(500, "Server Error")
+    })
+    expect(await hasAnyCommits(client, "o", "r")).toBeNull()
+  })
+
+  it("returns null (inconclusive) on a non-GitHub error", async () => {
+    const { client } = clientReturning(async () => {
+      throw new Error("network down")
+    })
+    expect(await hasAnyCommits(client, "o", "r")).toBeNull()
+  })
+})

--- a/web/src/github-core/repoReads.test.ts
+++ b/web/src/github-core/repoReads.test.ts
@@ -51,11 +51,11 @@ describe("hasAnyCommits", () => {
     expect(paths).toEqual(["/repos/o/r/branches?per_page=1"])
   })
 
-  it("treats a 409 'Git Repository is empty.' as definitely empty", async () => {
+  it("treats a 409 'Git Repository is empty.' as inconclusive (fresh-repo warmup)", async () => {
     const { client } = clientReturning(async () => {
       throw apiError(409, "Git Repository is empty.")
     })
-    expect(await hasAnyCommits(client, "o", "r")).toBe(false)
+    expect(await hasAnyCommits(client, "o", "r")).toBeNull()
   })
 
   it("treats a 404 (repo gone) as definitely empty", async () => {
@@ -63,6 +63,11 @@ describe("hasAnyCommits", () => {
       throw apiError(404, "Not Found")
     })
     expect(await hasAnyCommits(client, "o", "r")).toBe(false)
+  })
+
+  it("returns null (inconclusive) on a malformed non-array 200 body", async () => {
+    const { client } = clientReturning(async () => ({ message: "nope" }))
+    expect(await hasAnyCommits(client, "o", "r")).toBeNull()
   })
 
   it("returns null (inconclusive) on a transient server error", async () => {

--- a/web/src/github-core/repoReads.ts
+++ b/web/src/github-core/repoReads.ts
@@ -16,17 +16,18 @@ export async function getRepo(
 // Authoritative "does this repo have any commits?" probe, used as the tiebreaker
 // when GET /repos reports size 0 (an async, lagging value: a freshly-pushed repo
 // with real commits reads size 0 for minutes — issue #544). List-branches is the
-// robust signal because it returns a well-formed 200 array in every state: a
-// non-empty array iff the repo has at least one commit, an empty array iff it is
-// commitless. Unlike list-commits / git-refs (which 409 on an empty repo — a
-// status this codebase already reads as a transient fresh-repo lag to retry, see
-// gh-student's isFreshRepoRetryable), branches has no such overlap, and it needs
+// robust signal because a settled repo returns a well-formed 200 array in every
+// state: a non-empty array iff the repo has at least one commit, an empty array
+// iff it is commitless (verified: a truly-empty repo returns 200 []). It needs
 // no default_branch (phantom on a commitless repo).
 //
 // Tri-state: true = has commits, false = definitely commitless, null =
 // inconclusive (transient/unknown error) so the caller applies its own
-// fail-direction rather than manufacturing a false "empty" verdict. A 404 (repo
-// gone) or a 409 "Git Repository is empty." both mean definitely-empty.
+// fail-direction rather than manufacturing a false "empty" verdict. Only a 404
+// (repo gone) is a definite empty. A 409 "Git Repository is empty." is NOT
+// treated as empty: it's the fresh-repo warmup window (the same #544 scenario)
+// that this codebase treats as transient/retryable elsewhere (see gh-student's
+// isFreshRepoRetryable), so it's inconclusive and fails open.
 export async function hasAnyCommits(
   client: GitHubClient,
   owner: string,
@@ -36,12 +37,10 @@ export async function hasAnyCommits(
     const branches = await client.request<unknown[]>(
       `/repos/${owner}/${repo}/branches?per_page=1`,
     )
-    return branches.length > 0
+    // A malformed non-array 200 body is inconclusive, not "has commits".
+    return Array.isArray(branches) ? branches.length > 0 : null
   } catch (err) {
-    if (
-      err instanceof GitHubAPIError &&
-      (err.status === 404 || err.status === 409)
-    ) {
+    if (err instanceof GitHubAPIError && err.status === 404) {
       return false
     }
     return null

--- a/web/src/github-core/repoReads.ts
+++ b/web/src/github-core/repoReads.ts
@@ -1,6 +1,6 @@
 import type { GitHubClient } from "./client"
 import type { GitHubRepo } from "./types"
-import { tolerateGitHubError } from "./errors"
+import { GitHubAPIError, tolerateGitHubError } from "./errors"
 
 export async function getRepo(
   client: GitHubClient,
@@ -11,4 +11,39 @@ export async function getRepo(
     () => client.request<GitHubRepo>(`/repos/${owner}/${repo}`),
     null,
   )
+}
+
+// Authoritative "does this repo have any commits?" probe, used as the tiebreaker
+// when GET /repos reports size 0 (an async, lagging value: a freshly-pushed repo
+// with real commits reads size 0 for minutes — issue #544). List-branches is the
+// robust signal because it returns a well-formed 200 array in every state: a
+// non-empty array iff the repo has at least one commit, an empty array iff it is
+// commitless. Unlike list-commits / git-refs (which 409 on an empty repo — a
+// status this codebase already reads as a transient fresh-repo lag to retry, see
+// gh-student's isFreshRepoRetryable), branches has no such overlap, and it needs
+// no default_branch (phantom on a commitless repo).
+//
+// Tri-state: true = has commits, false = definitely commitless, null =
+// inconclusive (transient/unknown error) so the caller applies its own
+// fail-direction rather than manufacturing a false "empty" verdict. A 404 (repo
+// gone) or a 409 "Git Repository is empty." both mean definitely-empty.
+export async function hasAnyCommits(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+): Promise<boolean | null> {
+  try {
+    const branches = await client.request<unknown[]>(
+      `/repos/${owner}/${repo}/branches?per_page=1`,
+    )
+    return branches.length > 0
+  } catch (err) {
+    if (
+      err instanceof GitHubAPIError &&
+      (err.status === 404 || err.status === 409)
+    ) {
+      return false
+    }
+    return null
+  }
 }

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -85,14 +85,10 @@ export type GitHubRepo = {
     private: boolean
   }
   default_branch: string
-  // Repo size in KB (GET /repos). Populated by an async background job, so a
-  // freshly-created/pushed repo with real commits reads 0 for minutes (issue
-  // #544) — size is NOT a reliable emptiness signal on its own. A commitless
-  // template can't be generated from (GitHub's POST /generate 422s "is empty"),
-  // so the pre-flight treats a non-fork size 0 as a *suspicion* and confirms it
-  // with an authoritative branches probe (see hasAnyCommits). Forks report
-  // size 0 while sharing objects with their parent, so they're never probed
-  // and never treated as empty (regression #528).
+  // Repo size in KB (GET /repos). Populated by an async background job, so it
+  // lags a fresh repo's real commits (issue #544) — a non-fork size 0 is only a
+  // suspicion of emptiness, confirmed via hasAnyCommits (see its comment); forks
+  // (size 0 while sharing parent objects, #528) are never probed.
   size?: number
   visibility?: "public" | "private" | "internal"
   archived?: boolean

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -85,12 +85,14 @@ export type GitHubRepo = {
     private: boolean
   }
   default_branch: string
-  // Repo size in KB (GET /repos). 0 means the repo has no commits — a
-  // commitless template can't be generated from (GitHub's POST /generate 422s
-  // "is empty"), so the template pre-flight rejects it. GitHub reports a phantom
-  // default_branch for such a repo, so size is the reliable emptiness signal —
-  // except for a fork, which GitHub reports as size 0 while it shares objects
-  // with its parent, so the emptiness guard exempts forks.
+  // Repo size in KB (GET /repos). Populated by an async background job, so a
+  // freshly-created/pushed repo with real commits reads 0 for minutes (issue
+  // #544) — size is NOT a reliable emptiness signal on its own. A commitless
+  // template can't be generated from (GitHub's POST /generate 422s "is empty"),
+  // so the pre-flight treats a non-fork size 0 as a *suspicion* and confirms it
+  // with an authoritative branches probe (see hasAnyCommits). Forks report
+  // size 0 while sharing objects with their parent, so they're never probed
+  // and never treated as empty (regression #528).
   size?: number
   visibility?: "public" | "private" | "internal"
   archived?: boolean


### PR DESCRIPTION
## What & why

The template pre-flight (web verify, web create/edit block, and CLI `assignment add`) rejected valid templates as "has no commits" whenever GitHub reported `size: 0`. GitHub computes a repo's `size` via an asynchronous background job, so a freshly-created or freshly-pushed template with real commits reads `size: 0` for minutes (longer for private repos) — and the pre-flight treated that as commitless. This is [#544](https://github.com/foundation50/classroom50/issues/544).

Verified live against a private, non-fork template with one commit: `GET /repos` reported `size: 0` three minutes after creation, yet `POST /generate` succeeded — so the pre-flight was blocking an operation that actually works.

## The fix

Stop trusting `size` as an emptiness oracle. When `size` is `0` on a **non-fork** template, confirm emptiness with an authoritative `GET /branches?per_page=1` probe: a non-empty array means the repo has commits (proceed), an empty array means it is genuinely commitless (reject). Chosen over `GET /commits` / `GET /git/refs` because those return `409 "Git Repository is empty."` on an empty repo — a status this codebase already treats as a *transient fresh-repo lag to retry* (`gh-student`'s `isFreshRepoRetryable`) — whereas list-branches returns an unambiguous `200` array in every settled state (a truly-empty repo returns `200 []`, verified live).

Invariants preserved:

- **#544 fixed** — a non-fork template with `size: 0` and at least one branch now resolves instead of being rejected.
- **Truly-empty still rejected** — a non-fork `size: 0` template with no branches keeps the existing "has no commits" error.
- **#528 fork exemption intact** — forks report `size: 0` while sharing objects with their parent, so they are never probed and never treated as empty.
- **Fast path unchanged** — `size > 0` and fork cases issue zero extra API calls.
- **Fail-safe on an inconclusive probe** — only a `404` (repo gone) is a definite empty; a `409` (fresh-repo warmup), `403` (rate limit / restriction), or `5xx` is inconclusive, so web fails open and CLI fails toward has-commits. A transient blip never manufactures a false rejection; `POST /generate` at accept remains the real gate.

Web and CLI hand-mirror the same accept/reject/exempt decision, per the synchronized-release contract.

## Changes

`web/`: new `hasAnyCommits` probe in `github-core/repoReads.ts`; `verifyTemplateAccess` and `resolveTemplate` in `domain/assignments/accessPrimitives.ts` now confirm via the probe; `GitHubRepo.size` comment corrected.

`cli/gh-teacher/`: new `templateHasCommits` probe in `assignmentcmd/assignment.go`; `resolveTemplateBranch` takes a resolved `hasCommits` bool (stays pure/unit-testable) instead of raw `size`.

No schema changes (the emptiness rule lives in code, not the stored `assignments.json` contract).

## Testing

- `web/`: `npm run check` green (tsc, eslint, prettier, arch:validate, vitest — 3317 tests). New unit tests for `hasAnyCommits` (true / empty-array / 404 / 409 / 403·5xx-inconclusive / malformed body) and regression tests for #544 (fresh size-0 accepts) and #528 (fork never probed) in both the verify and block paths, including fast-path "no `/branches` request" assertions.
- `cli/gh-teacher/`: `go build ./...`, `go test ./...`, `golangci-lint run` (0 issues), `golangci-lint fmt --diff` all green. New `TestTemplateHasCommits` (fork / size>0 / branch-present / empty / 404 / 409 / 403 / 5xx) and end-to-end `TestValidateTemplateRepo_Emptiness` (fresh-accept, empty-reject, fork no-probe, size>0 no-probe).
- A multi-reviewer code-review pass (correctness, reliability, API-contract, testing, adversarial, standards) caught a latent re-introduction of #544 — an early draft treated a branches-probe `409` as definite-empty; corrected to inconclusive before this PR.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a create/edit pre-flight change with no new persistent state and no runtime/background component. Healthy signal: teachers can create an assignment from a recently-created in-org template without the spurious "has no commits" error; a genuinely empty template still shows it. If a regression appears, it would surface as either a false "has no commits" on a valid template (fix regressed) or a template with no commits slipping to accept and failing at `POST /generate` (probe too lenient) — revert to mitigate.
