### PR TITLE
fix(web): bump nanoid to 3.3.18 to fix zero-size infinite loop (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9078,9 +9078,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves Dependabot alert [#20](https://github.com/foundation50/classroom50/security/dependabot/20) (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, high).

`nanoid` before 3.3.17 has an infinite loop in `customAlphabet`/`customRandom` when called with `size: 0`, enabling a denial-of-service. The vulnerable version was a transitive dependency of `postcss` (pinned via the `^3.3.16` range).

This bumps the transitive `nanoid` from 3.3.16 to 3.3.18 (above the patched 3.3.17) via `npm update nanoid`. Only `web/package-lock.json` changes; `package.json` is untouched since the existing range already permits the patched release.

`npm run check` passes locally (tsc, eslint, prettier, arch:validate, and all 3299 vitest tests); `npm audit` reports 0 vulnerabilities.