### PR TITLE
feat: add autograding tri-state selector to the assignment form

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1146,6 +1146,7 @@
       "autograding": {
         "label": "Autograding",
         "emptyExplain": "Autograding is unavailable for empty repositories. Change the repository source in Repository Setup to use a template if you want autograding.",
+        "lockedHelp": "The autograding mode can't be changed after creation: repositories students already accepted are not retrofitted with (or stripped of) the autograding workflow.",
         "choices": {
           "built-in": {
             "label": "Built-in autograder",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1143,6 +1143,20 @@
           "admin": "Admin"
         }
       },
+      "autograding": {
+        "label": "Autograding",
+        "emptyExplain": "Autograding is unavailable for empty repositories. Change the repository source in Repository Setup to use a template if you want autograding.",
+        "choices": {
+          "built-in": {
+            "label": "Built-in autograder",
+            "help": "Classroom 50 adds its autograding workflow to each repo. Configure triggers, runtime, and tests below."
+          },
+          "none": {
+            "label": "No built-in autograder (teacher-supplied CI)",
+            "help": "Classroom 50 adds no autograding workflow. Your template supplies its own GitHub Actions CI. Scores are not collected."
+          }
+        }
+      },
       "submissionMode": {
         "label": "Autograding trigger",
         "help": "When the autograder runs. \"Every push\" grades each push to the default branch. \"On submit only\" grades only when a student submits (with gh student submit) or pushes a submit/* tag — regular pushes cost no Actions minutes, which matters for large classes.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1161,7 +1161,6 @@
       "submissionMode": {
         "label": "Autograding trigger",
         "help": "When the autograder runs. \"Every push\" grades each push to the default branch. \"On submit only\" grades only when a student submits (with gh student submit) or pushes a submit/* tag — regular pushes cost no Actions minutes, which matters for large classes.",
-        "emptyRepoHelp": "Unavailable for empty repositories — they carry no autograding workflow.",
         "editWarning": "Changing the trigger only affects repositories created from now on. Repositories students already accepted keep the old trigger until you update them — use \"Update autograding triggers\" on the submissions page or gh teacher assignment submission-mode. Students must pull after the update.",
         "choices": {
           "everyPush": "Every push (default)",

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -129,6 +129,7 @@ const CreateAssignmentPage = () => {
                 max_group_size: values.max_group_size,
                 feedback_pr: values.feedback_pr,
                 empty_repo: values.empty_repo,
+                no_autograder: values.autograding_state === "none",
                 runs_on: values.runs_on,
                 container_image: values.container_image,
                 container_user: values.container_user,

--- a/web/src/pages/assignments/AdvancedSection.tsx
+++ b/web/src/pages/assignments/AdvancedSection.tsx
@@ -140,11 +140,17 @@ export const AdvancedSection = ({
       </form.Subscribe>
 
       {/* Grading-only settings: a bare repo never autogrades, so the setup
-          command, allowed-files allowlist, and passing threshold are hidden
-          while empty_repo is on (submit clears them). */}
-      <form.Subscribe selector={(state) => state.values.empty_repo}>
-        {(emptyRepo) =>
-          emptyRepo ? null : (
+          command, allowed-files allowlist, and passing threshold belong to the
+          built-in autograder only, so they are hidden unless the autograding
+          tri-state is "built-in" (submit clears them otherwise). */}
+      <form.Subscribe
+        selector={(state) =>
+          !state.values.empty_repo &&
+          state.values.autograding_state === "built-in"
+        }
+      >
+        {(showsBuiltIn) =>
+          !showsBuiltIn ? null : (
             <>
               <div className="mt-4 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-[minmax(0,1fr)_12rem]">
                 <form.Field name="setup_command">

--- a/web/src/pages/assignments/AdvancedSection.tsx
+++ b/web/src/pages/assignments/AdvancedSection.tsx
@@ -139,10 +139,11 @@ export const AdvancedSection = ({
         }}
       </form.Subscribe>
 
-      {/* Grading-only settings: a bare repo never autogrades, so the setup
-          command, allowed-files allowlist, and passing threshold belong to the
-          built-in autograder only, so they are hidden unless the autograding
-          tri-state is "built-in" (submit clears them otherwise). */}
+      {/* Grading-only settings: the setup command, allowed-files allowlist, and
+          passing threshold belong to the built-in autograder only, so they are
+          hidden unless the autograding tri-state is "built-in" — a bare repo or
+          teacher-supplied CI ("none") commits no shim to run them. Submit clears
+          them for both no-shim states (empty_repo and "none"). */}
       <form.Subscribe
         selector={(state) =>
           !state.values.empty_repo &&

--- a/web/src/pages/assignments/AutogradingSection.tsx
+++ b/web/src/pages/assignments/AutogradingSection.tsx
@@ -15,9 +15,20 @@ import type { AutogradingState } from "@/domain/assignments/autogradingState"
 //                 (gated by the caller on autograding_state === "built-in").
 // Wired to the form's UI-only autograding_state; the submit mapping in
 // toSubmitValues translates it to the wire fields (no_autograder + clears).
+//
+// Immutable after creation: the "none" ↔ "built-in" choice maps to no_autograder,
+// which the domain layer rejects changing on edit (already-accepted repos aren't
+// retrofitted). So on edit the radios render locked, mirroring the empty_repo
+// field — the form must not offer a change the save path will reject.
 const SELECTABLE: readonly AutogradingState[] = ["built-in", "none"]
 
-export function AutogradingSection({ form }: { form: AssignmentForm }) {
+export function AutogradingSection({
+  form,
+  edit,
+}: {
+  form: AssignmentForm
+  edit: boolean
+}) {
   const { t } = useTranslation()
 
   return (
@@ -39,39 +50,55 @@ export function AutogradingSection({ form }: { form: AssignmentForm }) {
                     </span>
                   </Alert>
                 ) : (
-                  <fieldset className="flex flex-col gap-2">
-                    <legend className="sr-only">
-                      {t("assignments.form.autograding.label")}
-                    </legend>
-                    {SELECTABLE.map((option) => (
-                      <label
-                        key={option}
-                        htmlFor={`${field.name}-${option}`}
-                        className="label cursor-pointer items-start justify-start gap-3 p-0"
-                      >
-                        <input
-                          id={`${field.name}-${option}`}
-                          type="radio"
-                          className="radio mt-1"
-                          name={field.name}
-                          value={option}
-                          checked={field.state.value === option}
-                          onBlur={field.handleBlur}
-                          onChange={() => field.handleChange(option)}
-                        />
-                        <span className="font-bold">
-                          {t(
-                            `assignments.form.autograding.choices.${option}.label`,
-                          )}
-                          <span className="mt-0.5 block font-normal text-sm text-base-content/70">
+                  <>
+                    <fieldset
+                      className={
+                        edit
+                          ? "flex flex-col gap-2 pointer-events-none opacity-50"
+                          : "flex flex-col gap-2"
+                      }
+                      disabled={edit}
+                      aria-disabled={edit}
+                    >
+                      <legend className="sr-only">
+                        {t("assignments.form.autograding.label")}
+                      </legend>
+                      {SELECTABLE.map((option) => (
+                        <label
+                          key={option}
+                          htmlFor={`${field.name}-${option}`}
+                          className="label cursor-pointer items-start justify-start gap-3 p-0"
+                        >
+                          <input
+                            id={`${field.name}-${option}`}
+                            type="radio"
+                            className="radio mt-1"
+                            name={field.name}
+                            value={option}
+                            checked={field.state.value === option}
+                            disabled={edit}
+                            onBlur={field.handleBlur}
+                            onChange={() => field.handleChange(option)}
+                          />
+                          <span className="font-bold">
                             {t(
-                              `assignments.form.autograding.choices.${option}.help`,
+                              `assignments.form.autograding.choices.${option}.label`,
                             )}
+                            <span className="mt-0.5 block font-normal text-sm text-base-content/70">
+                              {t(
+                                `assignments.form.autograding.choices.${option}.help`,
+                              )}
+                            </span>
                           </span>
-                        </span>
-                      </label>
-                    ))}
-                  </fieldset>
+                        </label>
+                      ))}
+                    </fieldset>
+                    {edit ? (
+                      <p className="mt-1.5 text-sm text-base-content/70">
+                        {t("assignments.form.autograding.lockedHelp")}
+                      </p>
+                    ) : null}
+                  </>
                 )}
               </div>
             )}

--- a/web/src/pages/assignments/AutogradingSection.tsx
+++ b/web/src/pages/assignments/AutogradingSection.tsx
@@ -1,0 +1,85 @@
+import { useTranslation } from "react-i18next"
+import { Alert, FormField } from "@/components/ui"
+import type { AssignmentForm } from "./assignmentFormModel"
+import type { AutogradingState } from "@/domain/assignments/autogradingState"
+
+// The autograding tri-state selector (assignment-form IA overhaul U3/U7).
+// A single radio group over the three states:
+//   - empty     : bare repo, no shim — driven by the repository source choice,
+//                 so it renders read-only here with an inline explanation that
+//                 points back to Repository Setup (a teacher changes it there,
+//                 not here).
+//   - none      : templated, teacher-supplied CI — no built-in shim; the
+//                 teacher's own .github/ runs. Maps to no_autograder on the wire.
+//   - built-in  : the default-shim path; reveals triggers / advanced / tests
+//                 (gated by the caller on autograding_state === "built-in").
+// Wired to the form's UI-only autograding_state; the submit mapping in
+// toSubmitValues translates it to the wire fields (no_autograder + clears).
+const SELECTABLE: readonly AutogradingState[] = ["built-in", "none"]
+
+export function AutogradingSection({ form }: { form: AssignmentForm }) {
+  const { t } = useTranslation()
+
+  return (
+    <form.Field name="autograding_state">
+      {(field) => {
+        const isEmpty = field.state.value === "empty"
+        return (
+          <FormField
+            htmlFor={field.name}
+            label={t("assignments.form.autograding.label")}
+          >
+            {({ describedById }) => (
+              <div aria-describedby={describedById}>
+                {isEmpty ? (
+                  // Driven by the empty-repo source choice; not editable here.
+                  <Alert tone="info" role="status" className="text-sm">
+                    <span>
+                      {t("assignments.form.autograding.emptyExplain")}
+                    </span>
+                  </Alert>
+                ) : (
+                  <fieldset className="flex flex-col gap-2">
+                    <legend className="sr-only">
+                      {t("assignments.form.autograding.label")}
+                    </legend>
+                    {SELECTABLE.map((option) => (
+                      <label
+                        key={option}
+                        htmlFor={`${field.name}-${option}`}
+                        className="label cursor-pointer items-start justify-start gap-3 p-0"
+                      >
+                        <input
+                          id={`${field.name}-${option}`}
+                          type="radio"
+                          className="radio mt-1"
+                          name={field.name}
+                          value={option}
+                          checked={field.state.value === option}
+                          onBlur={field.handleBlur}
+                          onChange={() => field.handleChange(option)}
+                        />
+                        <span className="font-bold">
+                          {t(
+                            `assignments.form.autograding.choices.${option}.label`,
+                          )}
+                          <span className="mt-0.5 block font-normal text-sm text-base-content/70">
+                            {t(
+                              `assignments.form.autograding.choices.${option}.help`,
+                            )}
+                          </span>
+                        </span>
+                      </label>
+                    ))}
+                  </fieldset>
+                )}
+              </div>
+            )}
+          </FormField>
+        )
+      }}
+    </form.Field>
+  )
+}
+
+export default AutogradingSection

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -449,3 +449,84 @@ describe("self-hosted disables built-in runtime options", () => {
     ).not.toBeNull()
   })
 })
+
+// The autograding tri-state selector: interactive on create, but the built-in
+// vs teacher-supplied choice maps to no_autograder — immutable after creation —
+// so it must render locked on edit (mirroring empty_repo). See AutogradingSection.
+describe("autograding tri-state selector", () => {
+  const renderForm = (
+    props: {
+      edit?: boolean
+      defaultValues?: Partial<CreateAssignmentFormValues>
+    } = {},
+  ) =>
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <CreateAssignmentForm
+          edit={props.edit}
+          defaultValues={props.defaultValues}
+          onSubmit={() => {}}
+        />
+      </QueryClientProvider>,
+    )
+
+  const radios = (container: HTMLElement) => ({
+    builtIn: container.querySelector<HTMLInputElement>(
+      "#autograding_state-built-in",
+    ),
+    none: container.querySelector<HTMLInputElement>("#autograding_state-none"),
+  })
+
+  it("create: renders both choices enabled with no locked note", () => {
+    const { container } = renderForm()
+    const { builtIn, none } = radios(container)
+    expect(builtIn?.disabled).toBe(false)
+    expect(none?.disabled).toBe(false)
+    expect(
+      screen.queryByText("assignments.form.autograding.lockedHelp"),
+    ).toBeNull()
+  })
+
+  it("edit: locks both choices and shows the immutability note", () => {
+    const { container } = renderForm({
+      edit: true,
+      defaultValues: assignmentToFormValues(baseAssignment),
+    })
+    const { builtIn, none } = radios(container)
+    expect(builtIn?.disabled).toBe(true)
+    expect(none?.disabled).toBe(true)
+    expect(
+      screen.getByText("assignments.form.autograding.lockedHelp"),
+    ).not.toBeNull()
+  })
+
+  it("edit: a stored no_autograder assignment opens on the 'none' choice, locked", () => {
+    const { container } = renderForm({
+      edit: true,
+      defaultValues: assignmentToFormValues({
+        ...baseAssignment,
+        template: { owner: "acme", repo: "starter", branch: "main" },
+        no_autograder: true,
+      }),
+    })
+    const { builtIn, none } = radios(container)
+    expect(none?.checked).toBe(true)
+    expect(builtIn?.checked).toBe(false)
+    expect(none?.disabled).toBe(true)
+  })
+
+  it("empty_repo: shows the read-only explanation and no radios", () => {
+    const { container } = renderForm({
+      defaultValues: assignmentToFormValues({
+        ...baseAssignment,
+        empty_repo: true,
+      }),
+    })
+    const { builtIn, none } = radios(container)
+    expect(builtIn).toBeNull()
+    expect(none).toBeNull()
+    expect(
+      screen.getByText("assignments.form.autograding.emptyExplain"),
+    ).not.toBeNull()
+  })
+})

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Button, Card } from "@/components/ui"
 import { DetailsSection } from "./DetailsSection"
 import { AdvancedSection } from "./AdvancedSection"
+import { AutogradingSection } from "./AutogradingSection"
 import AutogradingTestsPane from "./AutogradingTestsPane"
 import {
   useAssignmentForm,
@@ -99,15 +100,27 @@ const CreateAssignmentForm = ({
 
         <Card bordered={false} className="w-full mb-6">
           <Card.Body>
+            <AutogradingSection form={form} />
+          </Card.Body>
+        </Card>
+
+        <Card bordered={false} className="w-full mb-6">
+          <Card.Body>
             <AdvancedSection form={form} org={org} />
           </Card.Body>
         </Card>
 
-        {/* Declarative tests can never run in a bare repo (no autograde
-            workflow), so the whole pane is hidden while empty_repo is on. */}
-        <form.Subscribe selector={(state) => state.values.empty_repo}>
-          {(emptyRepo) =>
-            emptyRepo ? null : <AutogradingTestsPane form={form} />
+        {/* Declarative tests belong to the built-in autograder only: hidden for
+            a bare repo (no shim) and for teacher-supplied CI (no built-in
+            grading). empty_repo always wins over a stale tri-state value. */}
+        <form.Subscribe
+          selector={(state) =>
+            !state.values.empty_repo &&
+            state.values.autograding_state === "built-in"
+          }
+        >
+          {(showsBuiltIn) =>
+            showsBuiltIn ? <AutogradingTestsPane form={form} /> : null
           }
         </form.Subscribe>
       </fieldset>

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -100,7 +100,7 @@ const CreateAssignmentForm = ({
 
         <Card bordered={false} className="w-full mb-6">
           <Card.Body>
-            <AutogradingSection form={form} />
+            <AutogradingSection form={form} edit={edit} />
           </Card.Body>
         </Card>
 

--- a/web/src/pages/assignments/DetailsSection.tsx
+++ b/web/src/pages/assignments/DetailsSection.tsx
@@ -395,77 +395,77 @@ export const DetailsSection = ({
                 repo has no shim, so the picker locks to the default. On
                 EDIT, a change only affects new accepts: warn that existing
                 repos need the retrofit action. */}
-            <form.Subscribe selector={(state) => state.values.empty_repo}>
-              {(emptyRepo) => (
-                <form.Field name="submission_mode">
-                  {(field) => (
-                    <div
-                      className={
-                        emptyRepo ? "pointer-events-none opacity-50" : ""
-                      }
-                      aria-disabled={emptyRepo}
-                    >
-                      <FormField
-                        htmlFor={field.name}
-                        label={t("assignments.form.submissionMode.label")}
-                        help={
-                          emptyRepo
-                            ? t("assignments.form.submissionMode.emptyRepoHelp")
-                            : t("assignments.form.submissionMode.help")
-                        }
-                      >
-                        {({ id, describedById }) => (
-                          <Select
-                            id={id}
-                            name={field.name}
-                            className="w-full sm:max-w-xs"
-                            aria-describedby={describedById}
-                            value={emptyRepo ? "every-push" : field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) =>
-                              field.handleChange(
-                                e.target.value as typeof field.state.value,
-                              )
-                            }
-                          >
-                            <option value="every-push">
-                              {t(
-                                "assignments.form.submissionMode.choices.everyPush",
-                              )}
-                            </option>
-                            <option value="tag">
-                              {t("assignments.form.submissionMode.choices.tag")}
-                            </option>
-                          </Select>
-                        )}
-                      </FormField>
-                      {edit ? (
-                        <form.Subscribe
-                          selector={(state) => state.values.submission_mode}
+            <form.Subscribe
+              selector={(state) =>
+                !state.values.empty_repo &&
+                state.values.autograding_state === "built-in"
+              }
+            >
+              {(showsBuiltIn) =>
+                !showsBuiltIn ? null : (
+                  <form.Field name="submission_mode">
+                    {(field) => (
+                      <div>
+                        <FormField
+                          htmlFor={field.name}
+                          label={t("assignments.form.submissionMode.label")}
+                          help={t("assignments.form.submissionMode.help")}
                         >
-                          {(mode) =>
-                            mode !==
-                            (form.options.defaultValues?.submission_mode ??
-                              "every-push") ? (
-                              <Alert
-                                tone="warning"
-                                role="status"
-                                className="mt-2 text-sm"
-                              >
-                                <span>
-                                  {t(
-                                    "assignments.form.submissionMode.editWarning",
-                                  )}
-                                </span>
-                              </Alert>
-                            ) : null
-                          }
-                        </form.Subscribe>
-                      ) : null}
-                    </div>
-                  )}
-                </form.Field>
-              )}
+                          {({ id, describedById }) => (
+                            <Select
+                              id={id}
+                              name={field.name}
+                              className="w-full sm:max-w-xs"
+                              aria-describedby={describedById}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                field.handleChange(
+                                  e.target.value as typeof field.state.value,
+                                )
+                              }
+                            >
+                              <option value="every-push">
+                                {t(
+                                  "assignments.form.submissionMode.choices.everyPush",
+                                )}
+                              </option>
+                              <option value="tag">
+                                {t(
+                                  "assignments.form.submissionMode.choices.tag",
+                                )}
+                              </option>
+                            </Select>
+                          )}
+                        </FormField>
+                        {edit ? (
+                          <form.Subscribe
+                            selector={(state) => state.values.submission_mode}
+                          >
+                            {(mode) =>
+                              mode !==
+                              (form.options.defaultValues?.submission_mode ??
+                                "every-push") ? (
+                                <Alert
+                                  tone="warning"
+                                  role="status"
+                                  className="mt-2 text-sm"
+                                >
+                                  <span>
+                                    {t(
+                                      "assignments.form.submissionMode.editWarning",
+                                    )}
+                                  </span>
+                                </Alert>
+                              ) : null
+                            }
+                          </form.Subscribe>
+                        ) : null}
+                      </div>
+                    )}
+                  </form.Field>
+                )
+              }
             </form.Subscribe>
 
             {/* Milestone submission tags: teacher-named tag patterns (e.g.
@@ -475,117 +475,117 @@ export const DetailsSection = ({
                 runner mints. Union with submit/* in the shim, orthogonal to
                 the mode picker above; the same shim-retrofit warning applies
                 on edit. Locked like the mode picker for a bare repo. */}
-            <form.Subscribe selector={(state) => state.values.empty_repo}>
-              {(emptyRepo) => (
-                <form.Field name="submission_tags">
-                  {(field) => {
-                    const error = field.state.meta.errors[0] as
-                      string | undefined
-                    return (
-                      <div
-                        className={
-                          emptyRepo ? "pointer-events-none opacity-50" : ""
-                        }
-                        aria-disabled={emptyRepo}
-                      >
-                        <FormField
-                          htmlFor={field.name}
-                          label={t("assignments.form.submissionTags.label")}
-                          help={
-                            emptyRepo
-                              ? t(
-                                  "assignments.form.submissionMode.emptyRepoHelp",
-                                )
-                              : t("assignments.form.submissionTags.help")
-                          }
-                        >
-                          {({ id, describedById }) => (
-                            <Textarea
-                              id={id}
-                              name={field.name}
-                              className="font-mono w-full sm:max-w-xs"
-                              rows={3}
-                              spellCheck={false}
-                              placeholder={"phase1\nphase2\ncomplete"}
-                              aria-describedby={describedById}
-                              value={emptyRepo ? "" : field.state.value}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                field.handleChange(e.target.value)
-                              }
-                            />
-                          )}
-                        </FormField>
-                        {error ? (
-                          <p role="alert" className="mt-1.5 text-sm text-error">
-                            {error}
-                          </p>
-                        ) : null}
-                        <form.Subscribe
-                          selector={(state) => state.values.submission_tags}
-                        >
-                          {(tags) => {
-                            // Surface the same problems the save-time validator
-                            // catches, live and ahead of save (the form only
-                            // validates onSubmit). Priority, most to least
-                            // actionable:
-                            //   1. comma — the obvious wrong guess for a
-                            //      one-per-line field; its own friendly hint
-                            //      since the generic charset error wouldn't
-                            //      explain the real fix.
-                            //   2. a hard validation error (bad charset,
-                            //      duplicate, stacked quantifier) — the exact
-                            //      message the save path would show.
-                            //   3. broad-glob caution / edit-retrofit warning —
-                            //      advisory, not errors.
-                            const parsed = parseSubmissionTags(tags)
-                            const hasComma = (tags ?? "").includes(",")
-                            const validationError =
-                              validateSubmissionTags(parsed)
-                            const broad = parsed.some(
-                              (p) => p.includes("*") || p.includes("+"),
-                            )
-                            const changed =
-                              edit &&
-                              tags !==
-                                (form.options.defaultValues?.submission_tags ??
-                                  "")
-                            if (
-                              !hasComma &&
-                              !validationError &&
-                              !broad &&
-                              !changed
-                            )
-                              return null
-                            const message = hasComma
-                              ? t("assignments.form.submissionTags.commaHint")
-                              : (validationError ??
-                                (broad
-                                  ? t(
-                                      "assignments.form.submissionTags.wildcardCaution",
-                                    )
-                                  : t(
-                                      "assignments.form.submissionMode.editWarning",
-                                    )))
-                            // Errors read as errors; the advisory cautions stay
-                            // warning-toned.
-                            const isError = hasComma || Boolean(validationError)
-                            return (
-                              <Alert
-                                tone={isError ? "error" : "warning"}
-                                role="status"
-                                className="mt-2 text-sm"
-                              >
-                                <span>{message}</span>
-                              </Alert>
-                            )
-                          }}
-                        </form.Subscribe>
-                      </div>
-                    )
-                  }}
-                </form.Field>
-              )}
+            <form.Subscribe
+              selector={(state) =>
+                !state.values.empty_repo &&
+                state.values.autograding_state === "built-in"
+              }
+            >
+              {(showsBuiltIn) =>
+                !showsBuiltIn ? null : (
+                  <form.Field name="submission_tags">
+                    {(field) => {
+                      const error = field.state.meta.errors[0] as
+                        string | undefined
+                      return (
+                        <div>
+                          <FormField
+                            htmlFor={field.name}
+                            label={t("assignments.form.submissionTags.label")}
+                            help={t("assignments.form.submissionTags.help")}
+                          >
+                            {({ id, describedById }) => (
+                              <Textarea
+                                id={id}
+                                name={field.name}
+                                className="font-mono w-full sm:max-w-xs"
+                                rows={3}
+                                spellCheck={false}
+                                placeholder={"phase1\nphase2\ncomplete"}
+                                aria-describedby={describedById}
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(e) =>
+                                  field.handleChange(e.target.value)
+                                }
+                              />
+                            )}
+                          </FormField>
+                          {error ? (
+                            <p
+                              role="alert"
+                              className="mt-1.5 text-sm text-error"
+                            >
+                              {error}
+                            </p>
+                          ) : null}
+                          <form.Subscribe
+                            selector={(state) => state.values.submission_tags}
+                          >
+                            {(tags) => {
+                              // Surface the same problems the save-time validator
+                              // catches, live and ahead of save (the form only
+                              // validates onSubmit). Priority, most to least
+                              // actionable:
+                              //   1. comma — the obvious wrong guess for a
+                              //      one-per-line field; its own friendly hint
+                              //      since the generic charset error wouldn't
+                              //      explain the real fix.
+                              //   2. a hard validation error (bad charset,
+                              //      duplicate, stacked quantifier) — the exact
+                              //      message the save path would show.
+                              //   3. broad-glob caution / edit-retrofit warning —
+                              //      advisory, not errors.
+                              const parsed = parseSubmissionTags(tags)
+                              const hasComma = (tags ?? "").includes(",")
+                              const validationError =
+                                validateSubmissionTags(parsed)
+                              const broad = parsed.some(
+                                (p) => p.includes("*") || p.includes("+"),
+                              )
+                              const changed =
+                                edit &&
+                                tags !==
+                                  (form.options.defaultValues
+                                    ?.submission_tags ?? "")
+                              if (
+                                !hasComma &&
+                                !validationError &&
+                                !broad &&
+                                !changed
+                              )
+                                return null
+                              const message = hasComma
+                                ? t("assignments.form.submissionTags.commaHint")
+                                : (validationError ??
+                                  (broad
+                                    ? t(
+                                        "assignments.form.submissionTags.wildcardCaution",
+                                      )
+                                    : t(
+                                        "assignments.form.submissionMode.editWarning",
+                                      )))
+                              // Errors read as errors; the advisory cautions stay
+                              // warning-toned.
+                              const isError =
+                                hasComma || Boolean(validationError)
+                              return (
+                                <Alert
+                                  tone={isError ? "error" : "warning"}
+                                  role="status"
+                                  className="mt-2 text-sm"
+                                >
+                                  <span>{message}</span>
+                                </Alert>
+                              )
+                            }}
+                          </form.Subscribe>
+                        </div>
+                      )
+                    }}
+                  </form.Field>
+                )
+              }
             </form.Subscribe>
           </div>
 

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -79,6 +79,7 @@ const EditAssignmentForm = ({
                 max_group_size: values.max_group_size,
                 feedback_pr: values.feedback_pr,
                 empty_repo: values.empty_repo,
+                no_autograder: values.autograding_state === "none",
                 runs_on: values.runs_on,
                 container_image: values.container_image,
                 container_user: values.container_user,

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -43,6 +43,7 @@ const base: CreateAssignmentFormValues = {
   max_group_size: 2,
   feedback_pr: true,
   empty_repo: false,
+  autograding_state: "built-in",
   runtime_env: "hosted",
   runs_on: "",
   container_image: "",
@@ -431,6 +432,78 @@ describe("toSubmitValues — runtime field clearing", () => {
     expect(out.student_permission).toBe("admin")
     expect(out.submission_mode).toBe("tag")
     expect(out.submission_tags).toBe("phase1\nphase2")
+  })
+
+  it("clears built-in-only fields for the 'none' autograding state but keeps template + feedback_pr", () => {
+    // "none" (teacher-supplied CI) commits no shim, so the grading-adjacent
+    // fields clear like empty_repo — but unlike empty_repo it PERMITS a
+    // template and the Feedback PR (a templated repo has a baseline commit).
+    const out = toSubmitValues({
+      ...base,
+      autograding_state: "none",
+      template_repo: "acme/starter",
+      feedback_pr: true,
+      setup_command: "make",
+      allowed_files: "*\n!hello.py",
+      release_assets: "report.pdf",
+      pass_threshold_enabled: true,
+      submission_mode: "tag",
+      submission_tags: "phase1",
+    })
+    // Permitted (the asymmetry vs empty_repo):
+    expect(out.template_repo).toBe("acme/starter")
+    expect(out.feedback_pr).toBe(true)
+    // Cleared (no shim to run/trigger):
+    expect(out.setup_command).toBe("")
+    expect(out.allowed_files).toBe("")
+    expect(out.release_assets).toBe("")
+    expect(out.pass_threshold_enabled).toBe(false)
+    expect(out.submission_mode).toBe("every-push")
+    expect(out.submission_tags).toBe("")
+    expect(out.autograding_state).toBe("none")
+  })
+
+  it("empty_repo forces the autograding state to 'empty' regardless of the picked value", () => {
+    const out = toSubmitValues({
+      ...base,
+      empty_repo: true,
+      autograding_state: "built-in",
+    })
+    expect(out.autograding_state).toBe("empty")
+  })
+})
+
+describe("assignmentToFormValues — autograding tri-state", () => {
+  it("derives 'built-in' for a default-autograder assignment", () => {
+    const values = assignmentToFormValues({
+      slug: "hw1",
+      name: "Homework",
+      mode: "individual",
+      autograder: "default",
+    })
+    expect(values.autograding_state).toBe("built-in")
+  })
+
+  it("derives 'none' for a no_autograder assignment", () => {
+    const values = assignmentToFormValues({
+      slug: "hw1",
+      name: "Homework",
+      mode: "individual",
+      autograder: "default",
+      no_autograder: true,
+    })
+    expect(values.autograding_state).toBe("none")
+  })
+
+  it("derives 'empty' for an empty_repo assignment", () => {
+    const values = assignmentToFormValues({
+      slug: "hw1",
+      name: "Homework",
+      mode: "individual",
+      autograder: "default",
+      empty_repo: true,
+    })
+    expect(values.autograding_state).toBe("empty")
   })
 })
 

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -288,6 +288,50 @@ describe("validateAssignmentForm — runtime env", () => {
   })
 })
 
+describe("validateAssignmentForm — submission mode + milestone tags", () => {
+  it("accepts the two valid submission modes", () => {
+    expect(
+      validateAssignmentForm({ ...base, submission_mode: "tag" }, t)
+        .submission_mode,
+    ).toBeUndefined()
+    expect(
+      validateAssignmentForm({ ...base, submission_mode: "every-push" }, t)
+        .submission_mode,
+    ).toBeUndefined()
+  })
+
+  it("flags a hand-tampered submission mode", () => {
+    expect(
+      validateAssignmentForm(
+        { ...base, submission_mode: "on-demand" as never },
+        t,
+      ).submission_mode,
+    ).toBe("assignments.form.validation.submissionModeInvalid")
+  })
+
+  it("accepts valid milestone tag patterns", () => {
+    expect(
+      validateAssignmentForm(
+        { ...base, submission_tags: "phase1\nphase2\nv*" },
+        t,
+      ).submission_tags,
+    ).toBeUndefined()
+  })
+
+  it.each([
+    ["exclude pattern", "!v*"],
+    ["charset violation (quote)", 'ta"g'],
+    ["whitespace", "has space"],
+    ["stacked quantifier", "v*+"],
+    ["duplicate", "phase1\nphase1"],
+  ])("flags an invalid milestone tag: %s", (_label, raw) => {
+    expect(
+      validateAssignmentForm({ ...base, submission_tags: raw }, t)
+        .submission_tags,
+    ).toBeDefined()
+  })
+})
+
 // The validator delegates to two shared helpers and folds their results into
 // the same error map — these prove the parse-then-merge wiring, which the
 // per-field cases above don't touch.
@@ -350,6 +394,9 @@ describe("toSubmitValues — runtime field clearing", () => {
       setup_timeout: 600,
       allowed_files: "*\n!hello.py",
       pass_threshold_enabled: true,
+      submission_mode: "tag",
+      submission_tags: "phase1\nphase2",
+      release_assets: "report.pdf",
       tests: [{ name: "t", run: "pytest", points: 1 } as never],
     })
     expect(out.empty_repo).toBe(true)
@@ -360,6 +407,30 @@ describe("toSubmitValues — runtime field clearing", () => {
     expect(out.allowed_files).toBe("")
     expect(out.pass_threshold_enabled).toBe(false)
     expect(out.tests).toEqual([])
+    // The two newest grading-trigger fields must also clear for a bare repo
+    // (no shim to trigger) — pins the empty-repo clear set the autograding
+    // restructure reproduces.
+    expect(out.submission_mode).toBe("every-push")
+    expect(out.submission_tags).toBe("")
+    expect(out.release_assets).toBe("")
+  })
+
+  it("passes group provisioning and submission fields through for a non-empty repo", () => {
+    // The complement of the empty-repo clear: a normal assignment keeps its
+    // group size, submission mode, and milestone tags. Pins the fields the
+    // restructure must NOT clear when the repo is non-empty.
+    const out = toSubmitValues({
+      ...base,
+      mode: "group",
+      max_group_size: 4,
+      student_permission: "admin",
+      submission_mode: "tag",
+      submission_tags: "phase1\nphase2",
+    })
+    expect(out.max_group_size).toBe(4)
+    expect(out.student_permission).toBe("admin")
+    expect(out.submission_mode).toBe("tag")
+    expect(out.submission_tags).toBe("phase1\nphase2")
   })
 })
 

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -38,6 +38,10 @@ import {
   validateLanguageVersion,
 } from "@/util/runtime"
 import { utcIsoToDatetimeLocalValue } from "./formFieldHelpers"
+import {
+  deriveAutogradingState,
+  type AutogradingState,
+} from "@/domain/assignments/autogradingState"
 import type {
   Assignment,
   RepoPermission,
@@ -80,6 +84,14 @@ export type CreateAssignmentFormValues = {
   // are hidden and their values cleared on submit, mirroring runtime_env's
   // conditional-clear idiom.
   empty_repo: boolean
+  // UI-only autograding tri-state (never sent verbatim; mapped to wire fields
+  // on submit): "empty" (bare repo — driven by empty_repo), "none" (templated,
+  // teacher-supplied CI — maps to no_autograder: true, no shim), "built-in"
+  // (the default-shim path with triggers/advanced/tests). Read from the stored
+  // entry via deriveAutogradingState; on submit "none" writes no_autograder and
+  // clears the built-in-only fields, "built-in" clears no_autograder. Mirrors
+  // the runtime_env UI-only-discriminator idiom.
+  autograding_state: AutogradingState
   // UI-only: which runtime environment the teacher is configuring. Selects
   // which fields render and get written; never sent to the wire. "hosted" uses
   // a GitHub Actions runner (runs-on + apt); "container" grades inside a Docker
@@ -410,6 +422,15 @@ export function toSubmitValues(
   // value from before toggling must not reach the wire (the mutation layer
   // rejects the combination).
   const isEmptyRepo = value.empty_repo
+  // "none" (teacher-supplied CI) also commits no shim, so it clears the same
+  // built-in-only grading fields as empty_repo — but it PERMITS template and
+  // feedback_pr (a templated repo has a baseline commit), so those clear only
+  // for empty_repo. Both no-shim states collapse the autograding-state to a
+  // value the wire mapping reads; empty_repo forces "empty" regardless.
+  const autogradingState: AutogradingState = isEmptyRepo
+    ? "empty"
+    : value.autograding_state
+  const noBuiltIn = isEmptyRepo || autogradingState === "none"
   return {
     name: value.name.trim(),
     slug: slugify(value.slug),
@@ -421,6 +442,7 @@ export function toSubmitValues(
     max_group_size: value.max_group_size,
     feedback_pr: isEmptyRepo ? false : value.feedback_pr,
     empty_repo: isEmptyRepo,
+    autograding_state: autogradingState,
     runtime_env: value.runtime_env,
     runs_on: value.runs_on.trim(),
     container_image: isContainer ? value.container_image.trim() : "",
@@ -431,17 +453,17 @@ export function toSubmitValues(
     runtime_go: value.runtime_go.trim(),
     runtime_rust: value.runtime_rust.trim(),
     runtime_apt: isContainer ? "" : value.runtime_apt.trim(),
-    setup_command: isEmptyRepo ? "" : value.setup_command.trim(),
-    setup_timeout: isEmptyRepo ? 0 : value.setup_timeout,
-    allowed_files: isEmptyRepo ? "" : value.allowed_files,
-    release_assets: isEmptyRepo ? "" : value.release_assets,
-    pass_threshold_enabled: isEmptyRepo ? false : value.pass_threshold_enabled,
+    setup_command: noBuiltIn ? "" : value.setup_command.trim(),
+    setup_timeout: noBuiltIn ? 0 : value.setup_timeout,
+    allowed_files: noBuiltIn ? "" : value.allowed_files,
+    release_assets: noBuiltIn ? "" : value.release_assets,
+    pass_threshold_enabled: noBuiltIn ? false : value.pass_threshold_enabled,
     pass_threshold: Number(value.pass_threshold),
     student_permission: value.student_permission,
-    // A bare repo has no shim to trigger; clear a stale pick on submit
-    // (mirrors the other grading-adjacent clears above).
-    submission_mode: isEmptyRepo ? "every-push" : value.submission_mode,
-    submission_tags: isEmptyRepo ? "" : value.submission_tags,
+    // No shim (bare repo OR teacher-supplied CI) means no trigger to configure;
+    // clear a stale pick on submit (mirrors the other grading-adjacent clears).
+    submission_mode: noBuiltIn ? "every-push" : value.submission_mode,
+    submission_tags: noBuiltIn ? "" : value.submission_tags,
     // Uniform tri-state controls; "inherit" is the default and resolves to the
     // template's feature (templated) or GitHub's own create default (template-
     // less) at accept time, so no template-dependent default-flip is needed here.
@@ -473,6 +495,7 @@ export const useAssignmentForm = (
       max_group_size: defaultValues?.max_group_size || 2,
       feedback_pr: defaultValues?.feedback_pr ?? true,
       empty_repo: defaultValues?.empty_repo ?? false,
+      autograding_state: defaultValues?.autograding_state ?? "built-in",
       runtime_env: defaultValues?.runtime_env || "hosted",
       runs_on: defaultValues?.runs_on || "",
       container_image: defaultValues?.container_image || "",
@@ -555,6 +578,10 @@ export const assignmentToFormValues = (
     max_group_size: assignment.max_group_size ?? 2,
     feedback_pr: assignment.feedback_pr ?? true,
     empty_repo: assignment.empty_repo ?? false,
+    // Derive the tri-state from the stored wire fields (empty_repo /
+    // no_autograder / default), so an edit opens on the right autograding
+    // option and a round-trip preserves it. Uses the #554 domain helper.
+    autograding_state: deriveAutogradingState(assignment),
     // A stored container block means the assignment was configured in container
     // mode; otherwise it's the hosted runner (the default).
     runtime_env: assignment.runtime?.container ? "container" : "hosted",


### PR DESCRIPTION
## Summary

First slice of the assignment create/edit form IA overhaul: the **autograding tri-state selector**. A teacher now picks, in the form, between **Built-in autograder** and **No built-in autograder (teacher-supplied CI)**; the **Empty repo** state shows as a read-only explanation that points back to the repository-source choice.

This is the visible half of the tri-state that PR #554 wired underneath (the `no_autograder` contract, the `deriveAutogradingState` domain helper, and the accept path). Selecting "No built-in autograder" sets `no_autograder: true`, which #554's accept path already honors — so this PR closes the loop from the form to the wire.

## What changed

- **Form model** (`assignmentFormModel.ts`): a UI-only `autograding_state` field (`empty | none | built-in`, same idiom as `runtime_env`). Read: derived from the stored entry via `deriveAutogradingState`. Submit: `"none"` maps to `no_autograder: true` and clears the built-in-only grading fields, while **preserving template + Feedback PR** (the asymmetry vs empty_repo); `empty_repo` forces `"empty"`.
- **Selector UI** (`AutogradingSection.tsx`): a radio group with the two selectable states plus the read-only empty explanation.
- **Sub-control gating**: the submission-mode/milestone-tags controls (`DetailsSection`), the Advanced grading fields (`AdvancedSection`), and the declarative-tests pane (`CreateAssignmentForm`) now render only when the effective state is built-in (`!empty_repo && autograding_state === "built-in"` — empty always wins over a stale value).
- **Mutation wiring**: create and edit send `no_autograder` from the tri-state.

## Scope boundary

This PR is intentionally just the autograding tri-state. The rest of the IA overhaul — the five-section restructure (Assignment Details / Repository Setup / Autograding / Repository Features / Schedule), the Feedback-PR relocation, section status, and the deferred fork-mirror/Extensions affordances — is separate follow-up work on the same plan. The submission-mode/tags controls still physically live in the Details section here; they move to the Autograding section during the restructure.

## Type of change

- [x] New feature

## Checklist

- [x] `cd web && npm run check` green (tsc / eslint / prettier / arch:validate / i18n audit / 3,415 vitest).
- [x] New tri-state model tests (read-derivation for all three states, the "none"-clears-but-keeps-template mapping, empty-forces-empty).
- [x] Behavior-preserving for existing configs (the U1 characterization suite still passes).
- [x] Commits follow Conventional Commits.