### PR TITLE
refactor(web): add deriveFormShape section model for the assignment form

### DIFF
--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -42,6 +42,7 @@ import {
   deriveAutogradingState,
   type AutogradingState,
 } from "@/domain/assignments/autogradingState"
+import { deriveFormShape } from "./formShape"
 import type {
   Assignment,
   RepoPermission,
@@ -416,21 +417,16 @@ export function validateAssignmentForm(
 export function toSubmitValues(
   value: CreateAssignmentFormValues,
 ): CreateAssignmentFormValues {
-  const isContainer = value.runtime_env === "container"
-  // An empty repo never autogrades, so every grading-adjacent field is cleared
-  // on submit — the sections are hidden while the toggle is on, and a stale
-  // value from before toggling must not reach the wire (the mutation layer
-  // rejects the combination).
-  const isEmptyRepo = value.empty_repo
-  // "none" (teacher-supplied CI) also commits no shim, so it clears the same
-  // built-in-only grading fields as empty_repo — but it PERMITS template and
-  // feedback_pr (a templated repo has a baseline commit), so those clear only
-  // for empty_repo. Both no-shim states collapse the autograding-state to a
-  // value the wire mapping reads; empty_repo forces "empty" regardless.
-  const autogradingState: AutogradingState = isEmptyRepo
-    ? "empty"
-    : value.autograding_state
-  const noBuiltIn = isEmptyRepo || autogradingState === "none"
+  // One derived shape drives every clear below, so the render gates (which read
+  // the same deriveFormShape) and the submit clears can't drift. empty_repo
+  // forces autogradingState "empty" inside deriveFormShape; a bare repo and
+  // teacher-supplied CI ("none") both commit no shim, so both clear the built-
+  // in-only grading fields — but only empty_repo also clears template and
+  // feedback_pr (a templated repo has a baseline commit).
+  const shape = deriveFormShape(value)
+  const isContainer = shape.showContainerFields
+  const isEmptyRepo = shape.repositorySource === "empty"
+  const noBuiltIn = !shape.showBuiltInConfig
   return {
     name: value.name.trim(),
     slug: slugify(value.slug),
@@ -442,7 +438,7 @@ export function toSubmitValues(
     max_group_size: value.max_group_size,
     feedback_pr: isEmptyRepo ? false : value.feedback_pr,
     empty_repo: isEmptyRepo,
-    autograding_state: autogradingState,
+    autograding_state: shape.autogradingState,
     runtime_env: value.runtime_env,
     runs_on: value.runs_on.trim(),
     container_image: isContainer ? value.container_image.trim() : "",

--- a/web/src/pages/assignments/formShape.test.ts
+++ b/web/src/pages/assignments/formShape.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { deriveFormShape } from "./formShape"
+import type { CreateAssignmentFormValues } from "./assignmentFormModel"
+
+// Minimal valid form values; each test overrides only the fields under test.
+const base: CreateAssignmentFormValues = {
+  name: "Homework 1",
+  slug: "hw1",
+  description: "",
+  mode: "individual",
+  template_repo: "",
+  due_date: "",
+  available_from_date: "",
+  max_group_size: 2,
+  feedback_pr: true,
+  empty_repo: false,
+  autograding_state: "built-in",
+  runtime_env: "hosted",
+  runs_on: "",
+  container_image: "",
+  container_user: "",
+  runtime_python: "",
+  runtime_node: "",
+  runtime_java: "",
+  runtime_go: "",
+  runtime_rust: "",
+  runtime_apt: "",
+  setup_command: "",
+  setup_timeout: 120,
+  allowed_files: "",
+  release_assets: "",
+  pass_threshold_enabled: false,
+  pass_threshold: 80,
+  student_permission: "",
+  submission_mode: "every-push",
+  submission_tags: "",
+  repo_feature_issues: "inherit",
+  repo_feature_wiki: "inherit",
+  repo_feature_projects: "inherit",
+  repo_feature_pull_requests: "inherit",
+  tests: [],
+}
+
+describe("deriveFormShape", () => {
+  it("empty_repo forces the empty source and empty autograding, disabling grading + feedback + template", () => {
+    // empty_repo wins even over a stale "built-in" pick on the radios.
+    const shape = deriveFormShape({
+      ...base,
+      empty_repo: true,
+      autograding_state: "built-in",
+    })
+    expect(shape.repositorySource).toBe("empty")
+    expect(shape.autogradingState).toBe("empty")
+    expect(shape.showTemplateFields).toBe(false)
+    expect(shape.feedbackPrEnabled).toBe(false)
+    expect(shape.showBuiltInConfig).toBe(false)
+  })
+
+  it("a templated default-autograder assignment is built-in with template + feedback available", () => {
+    const shape = deriveFormShape({
+      ...base,
+      empty_repo: false,
+      autograding_state: "built-in",
+    })
+    expect(shape.repositorySource).toBe("template-or-blank")
+    expect(shape.autogradingState).toBe("built-in")
+    expect(shape.showTemplateFields).toBe(true)
+    expect(shape.feedbackPrEnabled).toBe(true)
+    expect(shape.showBuiltInConfig).toBe(true)
+  })
+
+  it("a teacher-supplied-CI assignment is 'none': no built-in config, but template + feedback stay available", () => {
+    const shape = deriveFormShape({
+      ...base,
+      empty_repo: false,
+      autograding_state: "none",
+    })
+    expect(shape.autogradingState).toBe("none")
+    expect(shape.showBuiltInConfig).toBe(false)
+    // The asymmetry vs empty_repo: "none" keeps the template + Feedback PR.
+    expect(shape.showTemplateFields).toBe(true)
+    expect(shape.feedbackPrEnabled).toBe(true)
+  })
+
+  it("showGroupSize is true only for a group assignment", () => {
+    expect(deriveFormShape({ ...base, mode: "group" }).showGroupSize).toBe(true)
+    expect(deriveFormShape({ ...base, mode: "individual" }).showGroupSize).toBe(
+      false,
+    )
+  })
+
+  it("assignmentType mirrors mode", () => {
+    expect(deriveFormShape({ ...base, mode: "group" }).assignmentType).toBe(
+      "group",
+    )
+    expect(
+      deriveFormShape({ ...base, mode: "individual" }).assignmentType,
+    ).toBe("individual")
+  })
+
+  it("showContainerFields is true only in container runtime mode", () => {
+    expect(
+      deriveFormShape({ ...base, runtime_env: "container" })
+        .showContainerFields,
+    ).toBe(true)
+    expect(
+      deriveFormShape({ ...base, runtime_env: "hosted" }).showContainerFields,
+    ).toBe(false)
+  })
+})

--- a/web/src/pages/assignments/formShape.ts
+++ b/web/src/pages/assignments/formShape.ts
@@ -1,0 +1,65 @@
+import type { AutogradingState } from "@/domain/assignments/autogradingState"
+import type { CreateAssignmentFormValues } from "./assignmentFormModel"
+
+// The single derived "form shape" (KTD3): every section's visibility, disabled
+// state, and on-submit clearing is computed from form values here, rather than
+// the form's older scattered per-field form.Subscribe show/hide/clear blocks
+// for empty_repo, runtime_env, and mode. One source keeps the five-section IA
+// consistent and lets a new capability add a gate here instead of another
+// bespoke conditional.
+//
+// This is a pure view over the form values: it reads nothing and writes
+// nothing, so both the render gates and toSubmitValues can share it without a
+// second copy of the rules drifting.
+export type RepositorySource = "empty" | "template-or-blank"
+export type AssignmentType = "individual" | "group"
+
+export type FormShape = {
+  // The repository source is the primary Repository Setup choice; empty_repo
+  // is its wire representation. Everything template- and grading-related keys
+  // off it.
+  repositorySource: RepositorySource
+  // The autograding tri-state as it applies to THIS form's values: empty_repo
+  // forces "empty" (a bare repo can never autograde) regardless of the picked
+  // radio; otherwise it's the teacher's autograding_state choice. Mirrors the
+  // collapse toSubmitValues performs before writing the wire fields.
+  autogradingState: AutogradingState
+  assignmentType: AssignmentType
+  // Max group size only applies to a group assignment.
+  showGroupSize: boolean
+  // Template ref + creation method only when the source isn't a bare repo.
+  showTemplateFields: boolean
+  // The Feedback PR needs a baseline commit, so it's offered for any non-empty
+  // repo — decoupled from autograding (KTD5). Only empty_repo disables it.
+  feedbackPrEnabled: boolean
+  // Built-in autograder sub-controls (triggers, advanced, tests) render only
+  // for the "built-in" state; "empty" and "none" commit no shim.
+  showBuiltInConfig: boolean
+  // Container mode reveals image/user and hides apt (hosted-only); the two are
+  // mutually exclusive on the wire.
+  showContainerFields: boolean
+}
+
+// Derive the section-shape from form values. empty_repo wins over a stale
+// autograding_state pick (the radios can hold "built-in" while empty_repo is
+// on); the collapse here is the single definition toSubmitValues and the render
+// gates both consume.
+export function deriveFormShape(value: CreateAssignmentFormValues): FormShape {
+  const repositorySource: RepositorySource = value.empty_repo
+    ? "empty"
+    : "template-or-blank"
+  const autogradingState: AutogradingState =
+    repositorySource === "empty" ? "empty" : value.autograding_state
+  const nonEmpty = repositorySource !== "empty"
+
+  return {
+    repositorySource,
+    autogradingState,
+    assignmentType: value.mode === "group" ? "group" : "individual",
+    showGroupSize: value.mode === "group",
+    showTemplateFields: nonEmpty,
+    feedbackPrEnabled: nonEmpty,
+    showBuiltInConfig: autogradingState === "built-in",
+    showContainerFields: value.runtime_env === "container",
+  }
+}


### PR DESCRIPTION
Introduces a single pure `deriveFormShape(values)` that computes the assignment form's repository source, autograding tri-state, assignment type, and the section visibility/disable gates (`showGroupSize`, `showTemplateFields`, `feedbackPrEnabled`, `showBuiltInConfig`, `showContainerFields`) from form values. This replaces the three ad-hoc conditional mechanisms (`empty_repo`, `runtime_env`, group `mode`) that were scattered as independent `form.Subscribe` show/hide/clear blocks, and is the structural prerequisite (KTD3 / U2) for the five-section IA restructure that follows.

`toSubmitValues` now expresses its on-submit clears in terms of the derived shape rather than recomputing the same predicates inline, so the render gates and the submit-time clears share one definition and can't drift. The change is behavior-preserving for the wire contract: the existing characterization suite pins every `toSubmitValues` outcome unchanged (empty-repo clears, the teacher-supplied-CI "none" clears, container/hosted clears), and `deriveFormShape` adds focused branch coverage in `formShape.test.ts`.

No JSX moved and no `assignments.json` field changed in this PR — the section extractions (U4-U10) land in a follow-up. Part of the assignment create/edit flow IA overhaul.

Verification: `cd web && npm run check` (tsc, eslint incl. boundaries, prettier, arch:validate, vitest, i18n audit). Focused: `npx vitest run src/pages/assignments` -> 91 passed; arch:validate -> no dependency violations.