### PR TITLE
feat: add include_all_branches for template assignments

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -482,7 +482,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	createSp.Start()
 	if hasTemplate {
 		var genBranch string
-		htmlURL, fullName, genBranch, alreadyExisted, err = createTemplatedPrivateAssignmentRepoInOrg(client, u, verbose, username, classroom, assignment, org, *entry.Template, entry.RepoFeatures)
+		htmlURL, fullName, genBranch, alreadyExisted, err = createTemplatedPrivateAssignmentRepoInOrg(client, u, verbose, username, classroom, assignment, org, *entry.Template, entry.RepoFeatures, entry.IncludeAllBranches)
 		// The generated repo's own default branch — not the template's branch —
 		// is where control files land and what the shim must trigger on.
 		commitBranch = genBranch
@@ -1170,12 +1170,13 @@ func patchRepoFeatures(client githubapi.Client, u *ui.UI, verbose bool, org, rep
 // cross-org visibility message (template not readable by the student).
 // 422-already-exists → alreadyExisted=true and the PATCH is skipped so
 // re-runs don't disturb an existing repo.
-func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, verbose bool, username, classroom, assignment, org string, tmpl assignments.TemplateRef, features *assignments.RepoFeatures) (htmlURL, fullName, defaultBranch string, alreadyExisted bool, err error) {
+func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, verbose bool, username, classroom, assignment, org string, tmpl assignments.TemplateRef, features *assignments.RepoFeatures, includeAllBranches bool) (htmlURL, fullName, defaultBranch string, alreadyExisted bool, err error) {
 	newRepoName := reponame.Name(classroom, assignment, username)
 	createBody, err := json.Marshal(map[string]any{
-		"owner":   org,
-		"name":    newRepoName,
-		"private": true,
+		"owner":                org,
+		"name":                 newRepoName,
+		"private":              true,
+		"include_all_branches": includeAllBranches,
 	})
 	if err != nil {
 		return "", "", "", false, fmt.Errorf("error encoding json for template: %w", err)

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -33,6 +33,39 @@ func writePermissionReadback(w http.ResponseWriter, set string) {
 func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 	tmpl := assignments.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "main"}
 
+	// The generate body carries include_all_branches as passed — false by
+	// default, true when the assignment opts in (copies all template branches).
+	t.Run("generate body carries include_all_branches", func(t *testing.T) {
+		for _, want := range []bool{false, true} {
+			var body map[string]any
+			mux := http.NewServeMux()
+			mux.HandleFunc("/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"full_name":      "o/cs-principles-hello-alice",
+					"html_url":       "https://github.com/o/cs-principles-hello-alice",
+					"default_branch": "main",
+				})
+			})
+			mux.HandleFunc("/repos/o/cs-principles-hello-alice", func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "main"})
+			})
+			mux.HandleFunc("/repos/o/cs-principles-hello-alice/branches", func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "main"}})
+			})
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+			var out bytes.Buffer
+			_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(newTestRESTClient(t, server), ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil, want)
+			if err != nil {
+				t.Fatalf("include_all_branches=%v: unexpected error: %v", want, err)
+			}
+			if body["include_all_branches"] != want {
+				t.Errorf("include_all_branches=%v: generate body = %v, want include_all_branches:%v", want, body, want)
+			}
+		}
+	})
+
 	t.Run("success: generate then patch, returns new repo", func(t *testing.T) {
 		var generated, patched bool
 		mux := http.NewServeMux()
@@ -65,7 +98,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		allOff := &assignments.RepoFeatures{
 			Issues: boolPtr(false), Wiki: boolPtr(false), Projects: boolPtr(false),
 		}
-		htmlURL, fullName, branch, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, allOff)
+		htmlURL, fullName, branch, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, allOff, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -106,7 +139,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		t.Cleanup(server.Close)
 
 		var out bytes.Buffer
-		_, _, branch, _, err := createTemplatedPrivateAssignmentRepoInOrg(newTestRESTClient(t, server), ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil)
+		_, _, branch, _, err := createTemplatedPrivateAssignmentRepoInOrg(newTestRESTClient(t, server), ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -146,7 +179,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		t.Cleanup(server.Close)
 
 		var out bytes.Buffer
-		_, _, branch, _, err := createTemplatedPrivateAssignmentRepoInOrg(newTestRESTClient(t, server), ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil)
+		_, _, branch, _, err := createTemplatedPrivateAssignmentRepoInOrg(newTestRESTClient(t, server), ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -180,7 +213,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		client := newTestRESTClient(t, server)
 
 		var out bytes.Buffer
-		_, fullName, _, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil)
+		_, fullName, _, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -205,7 +238,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		client := newTestRESTClient(t, server)
 
 		var out bytes.Buffer
-		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil)
+		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil, false)
 		if err == nil || !strings.Contains(err.Error(), "not accessible to you") {
 			t.Fatalf("err = %v, want the cross-org 'not accessible' message", err)
 		}
@@ -234,7 +267,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		client := newTestRESTClient(t, server)
 
 		var out bytes.Buffer
-		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", inOrgTmpl, nil)
+		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", inOrgTmpl, nil, false)
 		if err == nil || !strings.Contains(err.Error(), "`upstream-org`") || !strings.Contains(err.Error(), "fork") {
 			t.Fatalf("err = %v, want a fork-upstream message naming `upstream-org`", err)
 		}
@@ -260,7 +293,7 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		client := newTestRESTClient(t, server)
 
 		var out bytes.Buffer
-		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", inOrgTmpl, nil)
+		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", inOrgTmpl, nil, false)
 		if err == nil || !strings.Contains(err.Error(), "`upstream-org`") {
 			t.Fatalf("err = %v, want a fork-upstream message naming `upstream-org`", err)
 		}
@@ -1128,7 +1161,7 @@ func TestOrgRepoCreationDenied(t *testing.T) {
 
 	templated := func(client githubapi.Client) error {
 		var out bytes.Buffer
-		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil)
+		_, _, _, _, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil, false)
 		return err
 	}
 	templateless := func(client githubapi.Client, autoInit bool) error {

--- a/cli/gh-student/internal/assignments/assignments.go
+++ b/cli/gh-student/internal/assignments/assignments.go
@@ -107,6 +107,13 @@ type Entry struct {
 	// produces submit/* releases. Mutually exclusive with EmptyRepo, a template,
 	// and NoAutograder. Absent reads as false (teacher CLI omits it when false).
 	InitShim bool `json:"init_shim,omitempty"`
+
+	// IncludeAllBranches opts a TEMPLATED assignment into copying ALL of the
+	// template's branches (not just the default) when the student repo is
+	// generated: accept passes include_all_branches to POST /generate. Only
+	// affects the templated path; the bare/template-less paths never generate.
+	// Absent reads as false (teacher CLI omits it when false).
+	IncludeAllBranches bool `json:"include_all_branches,omitempty"`
 }
 
 // IsTagSubmissionMode reports whether the entry grades only on submit/* tag

--- a/cli/gh-student/internal/assignments/assignments_test.go
+++ b/cli/gh-student/internal/assignments/assignments_test.go
@@ -353,6 +353,27 @@ func TestEntryDecodesInitShim(t *testing.T) {
 	}
 }
 
+func TestEntryDecodesIncludeAllBranches(t *testing.T) {
+	// include_all_branches decodes when present and defaults to false when
+	// absent. accept passes it into the templated /generate body.
+	var file assignmentsFile
+	if err := json.Unmarshal([]byte(`{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    {"slug": "mirror", "name": "Mirror", "mode": "individual", "autograder": "default", "template": {"owner": "o", "repo": "t", "branch": "main"}, "include_all_branches": true},
+    {"slug": "hello", "name": "Hello", "mode": "individual", "autograder": "default", "template": {"owner": "o", "repo": "t", "branch": "main"}}
+  ]
+}`), &file); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !file.Assignments[0].IncludeAllBranches {
+		t.Error("mirror.IncludeAllBranches = false, want true")
+	}
+	if file.Assignments[1].IncludeAllBranches {
+		t.Error("hello.IncludeAllBranches = true, want false (field absent — back-compat)")
+	}
+}
+
 func TestEntryCommitsShim(t *testing.T) {
 	// CommitsShim is the accept-time gate: both no-shim states (empty_repo,
 	// no_autograder) suppress the shim; everything else commits it. This pins

--- a/cli/gh-student/repo_features_test.go
+++ b/cli/gh-student/repo_features_test.go
@@ -184,7 +184,7 @@ func TestTemplatedInheritAppliesTemplateFeatures(t *testing.T) {
 	var out bytes.Buffer
 	_, _, branch, _, err := createTemplatedPrivateAssignmentRepoInOrg(
 		newTestRESTClient(t, server), ui.NewForced(&out, false), false,
-		"alice", "cs-principles", "hello", "o", tmpl, nil, /* inherit */
+		"alice", "cs-principles", "hello", "o", tmpl, nil /* inherit */, false,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -250,6 +250,7 @@ func TestTemplatedExplicitOverridePatchesSetKeys(t *testing.T) {
 		newTestRESTClient(t, server), ui.NewForced(&out, false), false,
 		"alice", "cs-principles", "hello", "o", tmpl,
 		&assignments.RepoFeatures{Issues: boolPtr(false)},
+		false,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -304,6 +305,7 @@ func TestTemplatedFeaturePatchFailsOpen(t *testing.T) {
 		newTestRESTClient(t, server), ui.NewForced(&out, false), false,
 		"alice", "cs-principles", "hello", "o", tmpl,
 		&assignments.RepoFeatures{Projects: boolPtr(true)}, // forces a PATCH that 422s
+		false,
 	)
 	if err != nil {
 		t.Fatalf("accept must not fail when the feature PATCH is rejected (fail-open): %v", err)
@@ -372,6 +374,7 @@ func TestTemplatedFeaturePatchRetriesWithForcedKeysOnly(t *testing.T) {
 		newTestRESTClient(t, server), ui.NewForced(&out, false), false,
 		"alice", "cs-principles", "hello", "o", tmpl,
 		&assignments.RepoFeatures{Issues: boolPtr(false)}, // forced OFF; projects inherited ON
+		false,
 	)
 	if err != nil {
 		t.Fatalf("accept must not fail: %v", err)

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -141,32 +141,33 @@ type AssignmentsJSON struct {
 // changing it later requires retrofitting existing repos' shims (`gh teacher
 // assignment submission-mode`). Mutually exclusive with EmptyRepo (no shim).
 type AssignmentEntry struct {
-	Slug              string           `json:"slug"`
-	Name              string           `json:"name"`
-	Description       string           `json:"description,omitempty"`
-	Template          *TemplateRef     `json:"template,omitempty"`
-	Due               string           `json:"due,omitempty"`
-	DueMeta           *DueMeta         `json:"due_meta,omitempty"`
-	AvailableFrom     string           `json:"available_from,omitempty"`
-	AvailableFromMeta *DueMeta         `json:"available_from_meta,omitempty"`
-	Mode              string           `json:"mode"`
-	Autograder        string           `json:"autograder"`
-	MaxGroupSize      int              `json:"max_group_size,omitempty"`
-	Runtime           *RuntimeRef      `json:"runtime,omitempty"`
-	Tests             []TestSpec       `json:"tests,omitempty"`
-	FeedbackPR        bool             `json:"feedback_pr,omitempty"`
-	EmptyRepo         bool             `json:"empty_repo,omitempty"`
-	NoAutograder      bool             `json:"no_autograder,omitempty"`
-	InitShim          bool             `json:"init_shim,omitempty"`
-	Locked            bool             `json:"locked,omitempty"`
-	AllowedFiles      []string         `json:"allowed_files,omitempty"`
-	ReleaseAssets     []string         `json:"release_assets,omitempty"`
-	PassThreshold     *int             `json:"pass_threshold,omitempty"`
-	StudentPermission string           `json:"student_permission,omitempty"`
-	SubmissionMode    string           `json:"submission_mode,omitempty"`
-	SubmissionTags    []string         `json:"submission_tags,omitempty"`
-	RepoFeatures      *RepoFeatures    `json:"repo_features,omitempty"`
-	MigratedFrom      *MigratedFromRef `json:"migrated_from,omitempty"`
+	Slug               string           `json:"slug"`
+	Name               string           `json:"name"`
+	Description        string           `json:"description,omitempty"`
+	Template           *TemplateRef     `json:"template,omitempty"`
+	Due                string           `json:"due,omitempty"`
+	DueMeta            *DueMeta         `json:"due_meta,omitempty"`
+	AvailableFrom      string           `json:"available_from,omitempty"`
+	AvailableFromMeta  *DueMeta         `json:"available_from_meta,omitempty"`
+	Mode               string           `json:"mode"`
+	Autograder         string           `json:"autograder"`
+	MaxGroupSize       int              `json:"max_group_size,omitempty"`
+	Runtime            *RuntimeRef      `json:"runtime,omitempty"`
+	Tests              []TestSpec       `json:"tests,omitempty"`
+	FeedbackPR         bool             `json:"feedback_pr,omitempty"`
+	EmptyRepo          bool             `json:"empty_repo,omitempty"`
+	NoAutograder       bool             `json:"no_autograder,omitempty"`
+	InitShim           bool             `json:"init_shim,omitempty"`
+	IncludeAllBranches bool             `json:"include_all_branches,omitempty"`
+	Locked             bool             `json:"locked,omitempty"`
+	AllowedFiles       []string         `json:"allowed_files,omitempty"`
+	ReleaseAssets      []string         `json:"release_assets,omitempty"`
+	PassThreshold      *int             `json:"pass_threshold,omitempty"`
+	StudentPermission  string           `json:"student_permission,omitempty"`
+	SubmissionMode     string           `json:"submission_mode,omitempty"`
+	SubmissionTags     []string         `json:"submission_tags,omitempty"`
+	RepoFeatures       *RepoFeatures    `json:"repo_features,omitempty"`
+	MigratedFrom       *MigratedFromRef `json:"migrated_from,omitempty"`
 
 	// Extra holds unknown top-level entry keys, re-emitted verbatim so a
 	// read-modify-write never drops a field a newer binary/GUI added.
@@ -183,9 +184,10 @@ var knownEntryKeys = map[string]struct{}{
 	"locked": {}, "allowed_files": {}, "release_assets": {}, "pass_threshold": {},
 	"migrated_from": {}, "available_from": {}, "available_from_meta": {},
 	"student_permission": {}, "submission_mode": {}, "submission_tags": {},
-	"no_autograder": {},
-	"init_shim":     {},
-	"repo_features": {},
+	"no_autograder":        {},
+	"init_shim":            {},
+	"include_all_branches": {},
+	"repo_features":        {},
 }
 
 // UnmarshalJSON captures unknown top-level keys into Extra, then strictly
@@ -884,6 +886,11 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 			return err
 		}
 	}
+	if entry.IncludeAllBranches {
+		if err := validateIncludeAllBranchesExclusions(entry); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -983,6 +990,28 @@ func validateInitShimExclusions(entry AssignmentEntry) error {
 	}
 	if entry.Autograder != "" && entry.Autograder != contract.DefaultAutograderName {
 		return fmt.Errorf("init_shim is mutually exclusive with a non-default autograder (%q): init_shim commits the universal default shim, a custom autograder fetches a teacher-authored workflow instead", entry.Autograder)
+	}
+	return nil
+}
+
+// validateIncludeAllBranchesExclusions rejects the combinations
+// include_all_branches rules out. It only affects the templated generate call
+// (POST /generate include_all_branches), so it REQUIRES a template and is
+// mutually exclusive with the template-less states empty_repo and init_shim
+// (neither is ever generated). It is compatible with everything else, including
+// no_autograder and the grading-adjacent fields (branches do not affect
+// grading). Unlike empty_repo/no_autograder/init_shim it is NOT immutable —
+// changing it affects only repos generated from now on (no retrofit), so there
+// is no ValidateIncludeAllBranchesUnchanged.
+func validateIncludeAllBranchesExclusions(entry AssignmentEntry) error {
+	if entry.Template == nil {
+		return errors.New("include_all_branches requires a template: it only affects the template generate call; a template-less repo is never generated")
+	}
+	if entry.EmptyRepo {
+		return errors.New("include_all_branches is mutually exclusive with empty_repo: a bare repo is never generated from a template")
+	}
+	if entry.InitShim {
+		return errors.New("include_all_branches is mutually exclusive with init_shim: an init_shim repo is template-less and never generated")
 	}
 	return nil
 }
@@ -1124,6 +1153,11 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 	}
 	if entry.InitShim {
 		if err := validateInitShimExclusions(entry); err != nil {
+			return fmt.Errorf("entry %q: %w", entry.Slug, err)
+		}
+	}
+	if entry.IncludeAllBranches {
+		if err := validateIncludeAllBranchesExclusions(entry); err != nil {
 			return fmt.Errorf("entry %q: %w", entry.Slug, err)
 		}
 	}

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -1831,6 +1831,57 @@ func TestParseAssignments_InitShimRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAssignments_IncludeAllBranchesRoundTrip(t *testing.T) {
+	in := []byte(`{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    {
+      "slug": "mirror",
+      "name": "Mirror",
+      "template": { "owner": "cs50", "repo": "multi-branch", "branch": "main" },
+      "mode": "individual",
+      "autograder": "default",
+      "include_all_branches": true
+    },
+    {
+      "slug": "world",
+      "name": "World",
+      "template": { "owner": "cs50", "repo": "world-template", "branch": "main" },
+      "mode": "individual",
+      "autograder": "default"
+    }
+  ]
+}`)
+	file, err := ParseAssignments(in)
+	if err != nil {
+		t.Fatalf("ParseAssignments: %v", err)
+	}
+	if !file.Assignments[0].IncludeAllBranches {
+		t.Errorf("mirror.IncludeAllBranches = false, want true")
+	}
+	if file.Assignments[1].IncludeAllBranches {
+		t.Errorf("world.IncludeAllBranches = true, want false (field absent — back-compat)")
+	}
+
+	encoded, err := EncodeAssignments(file)
+	if err != nil {
+		t.Fatalf("EncodeAssignments: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"include_all_branches": true`) {
+		t.Errorf("encoded missing include_all_branches:\n%s", encoded)
+	}
+	if strings.Contains(string(encoded), `"include_all_branches": false`) {
+		t.Errorf("include_all_branches:false should omit, not serialize:\n%s", encoded)
+	}
+	again, err := ParseAssignments(encoded)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if !again.Assignments[0].IncludeAllBranches || again.Assignments[1].IncludeAllBranches {
+		t.Errorf("include_all_branches not stable across round-trip: %#v", again.Assignments)
+	}
+}
+
 // TestValidateAssignmentEntry_EmptyRepoHappyPath: a bare empty_repo entry
 // (no template, no grading fields) passes both validators.
 func TestValidateAssignmentEntry_EmptyRepoHappyPath(t *testing.T) {
@@ -2062,5 +2113,52 @@ func TestValidateInitShimUnchanged(t *testing.T) {
 	}
 	if err := ValidateInitShimUnchanged(off, on); err == nil || !strings.Contains(err.Error(), "init_shim cannot be changed") {
 		t.Errorf("flip false->true: got %v, want the immutability error", err)
+	}
+}
+
+func TestValidateIncludeAllBranchesExclusions(t *testing.T) {
+	// include_all_branches only affects the templated generate call, so it
+	// REQUIRES a template and is mutually exclusive with the template-less
+	// states empty_repo/init_shim; it is compatible with everything else.
+	base := AssignmentEntry{
+		Slug: "hw", Name: "HW", Mode: "individual", Autograder: "default",
+		IncludeAllBranches: true,
+		Template:           &TemplateRef{Owner: "o", Repo: "t", Branch: "main"},
+	}
+	// Permitted: no_autograder + grading fields alongside include_all_branches.
+	ok := base
+	ok.NoAutograder = true
+	if err := validateIncludeAllBranchesExclusions(ok); err != nil {
+		t.Errorf("no_autograder should be permitted with include_all_branches: %v", err)
+	}
+	ok2 := base
+	ok2.Tests = []TestSpec{{Name: "t", Type: "run", Run: "true", Points: 1}}
+	ok2.SubmissionMode = "tag"
+	if err := validateIncludeAllBranchesExclusions(ok2); err != nil {
+		t.Errorf("grading fields should be permitted with include_all_branches: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*AssignmentEntry)
+		want   string
+	}{
+		{"no template", func(e *AssignmentEntry) { e.Template = nil }, "requires a template"},
+		{"empty_repo", func(e *AssignmentEntry) {
+			e.EmptyRepo = true
+		}, "mutually exclusive with empty_repo"},
+		{"init_shim", func(e *AssignmentEntry) {
+			e.InitShim = true
+		}, "mutually exclusive with init_shim"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := base
+			tc.mutate(&e)
+			err := validateIncludeAllBranchesExclusions(e)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("got %v, want an error containing %q", err, tc.want)
+			}
+		})
 	}
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -765,6 +765,14 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			entry.InitShim = file.Assignments[prevIdx].InitShim
 			attemptEntry.InitShim = entry.InitShim
 		}
+		// include_all_branches is likewise GUI/manifest-owned (no flag), so carry
+		// it forward so a same-slug CLI re-add doesn't silently reset it. Unlike
+		// the above it is MUTABLE (no immutability check) — a teacher may change
+		// it; it only affects repos generated from now on.
+		if hasPrev {
+			entry.IncludeAllBranches = file.Assignments[prevIdx].IncludeAllBranches
+			attemptEntry.IncludeAllBranches = entry.IncludeAllBranches
+		}
 		// empty_repo is immutable: student repos were provisioned (or left
 		// bare) at accept time and are never retrofitted. Checked at parentSHA
 		// inside the build so a concurrent add/remove is observed on retry.

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -768,8 +768,12 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		// include_all_branches is likewise GUI/manifest-owned (no flag), so carry
 		// it forward so a same-slug CLI re-add doesn't silently reset it. Unlike
 		// the above it is MUTABLE (no immutability check) — a teacher may change
-		// it; it only affects repos generated from now on.
-		if hasPrev {
+		// it; it only affects repos generated from now on. Gate on the current
+		// template: a re-add that drops --template turns the entry template-less,
+		// and include_all_branches only affects the generate call — carrying it
+		// onto a template-less entry would write a combination
+		// ValidateExistingEntry rejects, wedging every future read of the file.
+		if hasPrev && attemptEntry.Template != nil {
 			entry.IncludeAllBranches = file.Assignments[prevIdx].IncludeAllBranches
 			attemptEntry.IncludeAllBranches = entry.IncludeAllBranches
 		}
@@ -848,6 +852,16 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			}
 		}
 		committedLocked = attemptEntry.Locked
+		// Re-validate the fully assembled entry after every carry-forward: the
+		// initial ValidateAssignmentEntry ran on the flag-built `entry` before
+		// GUI/manifest-owned fields (include_all_branches, submission_mode, …)
+		// were carried forward, so a carry-forward that reconstructs an invalid
+		// combination (e.g. include_all_branches on a now-template-less entry)
+		// would otherwise be caught only on the next read — by which point the
+		// bad entry is already committed and wedges the file. Fail here instead.
+		if err := assignment.ValidateAssignmentEntry(attemptEntry); err != nil {
+			return nil, err
+		}
 		updated, replaced := assignment.UpsertAssignment(file.Assignments, attemptEntry)
 		if replaced {
 			action = "updated"

--- a/cli/gh-teacher/internal/assignmentcmd/lock_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock_test.go
@@ -543,10 +543,10 @@ func TestRunAssignmentAdd_TemplateDropClearsIncludeAllBranches(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
-		Org:        "o",
-		Classroom:  "dst",
-		Slug:       "hello",
-		Name:       "Hello",
+		Org:       "o",
+		Classroom: "dst",
+		Slug:      "hello",
+		Name:      "Hello",
 		// --template omitted: the entry becomes template-less, so the mutable
 		// include_all_branches must be dropped rather than carried forward.
 		Mode:       assignment.ModeIndividual,

--- a/cli/gh-teacher/internal/assignmentcmd/lock_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock_test.go
@@ -479,3 +479,89 @@ func TestRunAssignmentAdd_PreservesSubmissionTags(t *testing.T) {
 		t.Errorf("explicit --submission-tag must replace the set, got %v", got)
 	}
 }
+
+func includeAllBranchesAssignmentsBody() string {
+	return `{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    {
+      "slug": "hello",
+      "name": "Hello",
+      "template": { "owner": "o", "repo": "hello-template", "branch": "main" },
+      "mode": "individual",
+      "autograder": "default",
+      "include_all_branches": true,
+      "feedback_pr": true
+    }
+  ]
+}`
+}
+
+// TestRunAssignmentAdd_PreservesIncludeAllBranches is the carry-forward guard
+// for the mutable include_all_branches: a same-slug re-add that KEEPS the
+// template (the field has no --flag, so it's GUI/manifest-owned) must not
+// silently reset a prior true. Mirrors TestRunAssignmentAdd_PreservesSubmissionMode.
+func TestRunAssignmentAdd_PreservesIncludeAllBranches(t *testing.T) {
+	server, fix := newLockServer(t, lockServerConfig{
+		assignments: includeAllBranchesAssignmentsBody(),
+		classroom:   lockClassroomBody(),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
+		Org:        "o",
+		Classroom:  "dst",
+		Slug:       "hello",
+		Name:       "Hello",
+		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Mode:       assignment.ModeIndividual,
+		Autograder: "default",
+	})
+	if err != nil {
+		t.Fatalf("runAssignmentAdd(re-add templated): %v", err)
+	}
+	if !decodeLock(t, fix).Assignments[0].IncludeAllBranches {
+		t.Errorf("re-adding a templated entry must keep include_all_branches=true")
+	}
+}
+
+// TestRunAssignmentAdd_TemplateDropClearsIncludeAllBranches is the regression
+// guard for the wedge bug: a same-slug re-add that DROPS --template must NOT
+// carry include_all_branches:true onto the now-template-less entry. That combo
+// is rejected by ParseAssignments/ValidateExistingEntry, so committing it would
+// wedge every subsequent read of the file. The carry-forward is gated on the
+// current template, and a post-carry-forward ValidateAssignmentEntry backstops
+// it — so the committed entry is template-less, has no include_all_branches,
+// and re-parses cleanly (decodeLock parses, proving no wedge).
+func TestRunAssignmentAdd_TemplateDropClearsIncludeAllBranches(t *testing.T) {
+	server, fix := newLockServer(t, lockServerConfig{
+		assignments: includeAllBranchesAssignmentsBody(),
+		classroom:   lockClassroomBody(),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
+		Org:        "o",
+		Classroom:  "dst",
+		Slug:       "hello",
+		Name:       "Hello",
+		// --template omitted: the entry becomes template-less, so the mutable
+		// include_all_branches must be dropped rather than carried forward.
+		Mode:       assignment.ModeIndividual,
+		Autograder: "default",
+	})
+	if err != nil {
+		t.Fatalf("runAssignmentAdd(re-add dropping --template): %v", err)
+	}
+	// decodeLock re-parses the committed file through ParseAssignments; a
+	// template-less include_all_branches:true would fail that parse (the wedge).
+	got := decodeLock(t, fix).Assignments[0]
+	if got.Template != nil {
+		t.Errorf("dropping --template must produce a template-less entry, got template %+v", got.Template)
+	}
+	if got.IncludeAllBranches {
+		t.Errorf("include_all_branches must not carry forward onto a template-less entry (would wedge the file)")
+	}
+}

--- a/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
+++ b/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
@@ -571,6 +571,56 @@ class TestInitShim:
         assert _errors(_manifest(self._entry(autograder="io-suite"))) != []
 
 
+class TestIncludeAllBranches:
+    # include_all_branches only affects the templated generate call, so it
+    # REQUIRES a template and is mutually exclusive with the template-less states
+    # empty_repo/init_shim; compatible with everything else. Mirrors Go's
+    # validateIncludeAllBranchesExclusions.
+    def _entry(self, **overrides):
+        # Keeps the default template (include_all_branches requires one).
+        return _entry(**{"include_all_branches": True, **overrides})
+
+    def test_include_all_branches_accepted_with_template(self):
+        assert _errors(_manifest(self._entry())) == []
+
+    def test_include_all_branches_permits_no_autograder_and_grading_fields(self):
+        assert _errors(_manifest(self._entry(no_autograder=True))) == []
+        assert (
+            _errors(
+                _manifest(
+                    self._entry(
+                        submission_mode="tag",
+                        tests=[
+                            {"name": "t", "type": "run", "run": "true", "points": 1}
+                        ],
+                    )
+                )
+            )
+            == []
+        )
+
+    def test_include_all_branches_false_accepted(self):
+        assert _errors(_manifest(_entry(include_all_branches=False))) == []
+
+    def test_include_all_branches_must_be_boolean(self):
+        assert _errors(_manifest(self._entry(include_all_branches="yes"))) != []
+
+    def test_include_all_branches_requires_template(self):
+        entry = self._entry()
+        del entry["template"]
+        assert _errors(_manifest(entry)) != []
+
+    def test_include_all_branches_rejects_empty_repo(self):
+        entry = self._entry(empty_repo=True)
+        del entry["template"]  # empty_repo also forbids a template
+        assert _errors(_manifest(entry)) != []
+
+    def test_include_all_branches_rejects_init_shim(self):
+        entry = self._entry(init_shim=True)
+        del entry["template"]  # init_shim also forbids a template
+        assert _errors(_manifest(entry)) != []
+
+
 def _release_assets_errors(value):
     return _errors(_manifest(_entry(release_assets=value)))
 

--- a/schemas/assignments-v1.schema.json
+++ b/schemas/assignments-v1.schema.json
@@ -134,6 +134,10 @@
           "type": "boolean",
           "description": "Opt a TEMPLATE-LESS assignment into an initialized-but-README-less repo that carries ONLY the control files: accept creates the repo with an initial commit and commits the .classroom50.yaml marker + the universal default autograde shim (.github/workflows/autograde.yaml) — but NO README and no other starter content. UNLIKE empty_repo (which is a bare repo with zero commits and no shim, and which NEVER autogrades), an init_shim repo DOES autograde: it commits the default shim, produces submit/* releases, and is collected/regraded exactly like any built-in-autograder assignment — so the grading pipeline (collect_scores.py / regrade_repos.py / autograde-runner.yaml) treats it as a normal grading assignment and does NOT skip it. It is the 'built-in autograder on an otherwise-empty repo' state. REQUIRES the default autograder and NO template (a template provides its own starter content — use a plain templated assignment for that). Mutually exclusive with empty_repo (bare, no shim), template (starter content comes from the template), no_autograder (the no-shim state), and a non-default autograder (which fetches a teacher-authored workflow from Pages). PERMITS the grading-adjacent fields (tests/allowed_files/release_assets/pass_threshold/submission_mode/submission_tags/feedback_pr) because it autogrades. See the conditional at the assignment level. IMMUTABLE after creation like empty_repo/no_autograder: student repos are provisioned at accept time and never retrofitted, so writers must reject an edit that changes it. On the wire it is collapsed like empty_repo/no_autograder/feedback_pr: the CLI omits the field when false (omitempty), so readers must treat an absent field as `false`; accept an explicit `false` too."
         },
+        "include_all_branches": {
+          "type": "boolean",
+          "description": "Opt a TEMPLATED assignment into copying ALL of the template's branches (not just the default branch) when each student repo is generated: accept passes include_all_branches to GitHub's POST /repos/{template}/generate. REQUIRES a template (it only affects the generate call — a template-less repo is never generated). Mutually exclusive with empty_repo and init_shim (both template-less, never generated). COMPATIBLE with everything else, including no_autograder (a templated teacher-supplied-CI assignment may still want all branches) and the grading-adjacent fields (branches do not affect grading — the grading pipeline never reads this field). ACCEPT-TIME ONLY and NOT immutable: it governs what NEW student repos get; changing it affects only repos generated from now on (like submission_mode, not like empty_repo — already-accepted repos are never re-generated). On the wire it is collapsed like feedback_pr: the CLI omits the field when false (omitempty), so readers must treat an absent field as `false`; accept an explicit `false` too."
+        },
         "locked": {
           "type": "boolean",
           "description": "Lock the assignment against student access. The web accept page, the student assignments list, the student submission view, and `gh student accept` all refuse a locked assignment for EVERY student, including one who already accepted. UNLIKE available_from (which is listing-advisory only), this is intended as access control — but because assignments.json is published publicly to GitHub Pages, the client gates are still best-effort UX; a determined student can read the raw file. The ENFORCEABLE boundary applies only to a PRIVATE, in-org template: locking also removes the classroom STUDENT team's read on that template repo (teacher/head-TA/TA teams are left untouched), so no new student can generate a repo from it while locked; unlocking re-grants that read. Public-template and template-less assignments can only be UX-gated, never hard-blocked. Existing student repos are not deleted. On the wire it is collapsed like feedback_pr/empty_repo: the CLI omits the field when false (omitempty), so readers must treat an absent field as `false`; accept an explicit `false` too."
@@ -255,6 +259,16 @@
               { "not": { "properties": { "empty_repo": { "const": true } }, "required": ["empty_repo"] } },
               { "not": { "properties": { "no_autograder": { "const": true } }, "required": ["no_autograder"] } },
               { "properties": { "autograder": { "const": "default" } } }
+            ]
+          }
+        },
+        {
+          "if": { "properties": { "include_all_branches": { "const": true } }, "required": ["include_all_branches"] },
+          "then": {
+            "allOf": [
+              { "required": ["template"] },
+              { "not": { "properties": { "empty_repo": { "const": true } }, "required": ["empty_repo"] } },
+              { "not": { "properties": { "init_shim": { "const": true } }, "required": ["init_shim"] } }
             ]
           }
         }

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -2972,6 +2972,38 @@ describe("createAssignmentRepo (bare / empty_repo)", () => {
 
     expect(getCreateBody()).toMatchObject({ auto_init: true })
   })
+
+  it("templated: passes include_all_branches to /generate (false and true)", async () => {
+    for (const want of [false, true]) {
+      let generateBody: Record<string, unknown> | undefined
+      const request = vi.fn(async (url: string, init?: unknown) => {
+        const method = (init as { method?: string })?.method ?? "GET"
+        if (method === "POST" && url.endsWith("/generate")) {
+          generateBody = (init as { body?: Record<string, unknown> }).body
+          return {
+            name: "cs101-actions-lab-alice",
+            full_name: "cs50/cs101-actions-lab-alice",
+            html_url: "https://github.com/cs50/cs101-actions-lab-alice",
+            default_branch: "main",
+          }
+        }
+        // Later provisioning requests are irrelevant to the generate-body check.
+        throw new Error(`unexpected request: ${method} ${url}`)
+      })
+      await createAssignmentRepo({
+        client: { request } as unknown as GitHubClient,
+        templateOwner: "acme",
+        templateRepo: "starter",
+        owner: "cs50",
+        name: "cs101-actions-lab-alice",
+        fallbackBranch: "main",
+        includeAllBranches: want,
+      }).catch(() => {
+        // Full templated flow makes further requests this minimal mock omits.
+      })
+      expect(generateBody).toMatchObject({ include_all_branches: want })
+    }
+  })
 })
 
 // Issue #413: GitHub refuses the create because the *destination* org doesn't let

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -747,6 +747,7 @@ export async function acceptAssignment(params: {
         name: studentRepoNameValue,
         fallbackBranch: sourceBranch || "main",
         bare: isEmptyRepo,
+        includeAllBranches: assignment.include_all_branches === true,
       }),
   )
 

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -111,6 +111,7 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   empty_repo: "classroom50-owned",
   no_autograder: "classroom50-owned",
   init_shim: "classroom50-owned",
+  include_all_branches: "classroom50-owned",
   // Rebuilt AND a closed object: the CLI decodes runtime strictly (RuntimeRef
   // has no Extra, DisallowUnknownFields; schema additionalProperties false), so
   // the rebuilt runtime must win and any unknown sub-key drops rather than
@@ -477,6 +478,28 @@ async function buildAssignmentEntry(
     }
   }
 
+  // include_all_branches only affects the templated generate call, so it
+  // requires a template and excludes the template-less states empty_repo /
+  // init_shim. Compatible with everything else (branches don't affect grading).
+  // Mirrors the CLI's validateIncludeAllBranchesExclusions.
+  if (input.include_all_branches) {
+    if (!input.template_repo.trim()) {
+      throw new Error(
+        "include_all_branches: requires a template — it only affects the template generate call.",
+      )
+    }
+    if (input.empty_repo) {
+      throw new Error(
+        "include_all_branches: mutually exclusive with empty_repo — a bare repo is never generated from a template.",
+      )
+    }
+    if (input.init_shim) {
+      throw new Error(
+        "include_all_branches: mutually exclusive with init_shim — an init_shim repo is template-less and never generated.",
+      )
+    }
+  }
+
   if (tests.length > 0) {
     await ensureDeclarativeTestsWritable(
       client,
@@ -535,6 +558,11 @@ async function buildAssignmentEntry(
   // otherwise-empty, template-less repo (marker + default shim, no README).
   if (input.init_shim) {
     entry.init_shim = true
+  }
+  // Written only when true (CLI omitempty). Copy all template branches at
+  // generate. No immutability check — it's mutable (only affects new accepts).
+  if (input.include_all_branches) {
+    entry.include_all_branches = true
   }
   // Omit the template block entirely for a template-less assignment, matching
   // the CLI's nil TemplateRef.

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -85,6 +85,9 @@ export async function createAssignmentRepo(params: {
   // mutual exclusion with template is enforced at write time, so template
   // params are never set alongside this.
   bare?: boolean
+  // Templated only: copy ALL of the template's branches (not just the default)
+  // on POST /generate. Ignored for the bare/template-less paths (no generate).
+  includeAllBranches?: boolean
 }): Promise<AcceptRepoCreationResult> {
   const {
     client,
@@ -94,6 +97,7 @@ export async function createAssignmentRepo(params: {
     name,
     fallbackBranch,
     bare,
+    includeAllBranches = false,
   } = params
 
   const cleanTemplateRepo = templateRepo
@@ -110,7 +114,7 @@ export async function createAssignmentRepo(params: {
             owner,
             name,
             private: true,
-            include_all_branches: false,
+            include_all_branches: includeAllBranches,
           },
         },
       )
@@ -348,6 +352,10 @@ export type CreateAssignmentInput = {
   // autogrades. Mutually exclusive with empty_repo, a template, and
   // no_autograder. Immutable after creation. Mirrors the CLI's init_shim field.
   init_shim?: boolean
+  // Copy all template branches at generate (POST /generate include_all_branches).
+  // Requires a template; mutually exclusive with empty_repo/init_shim. Mutable.
+  // Mirrors the CLI's include_all_branches field.
+  include_all_branches?: boolean
   runs_on?: string
   container_image?: string
   container_user?: string

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1153,8 +1153,8 @@
         "helpOff": "Create an empty repository with no initial commit. Autograding and the Feedback PR are unavailable until the student's first commit."
       },
       "includeAllBranches": {
-        "label": "Include all branches (coming soon)",
-        "help": "Copy every branch and its history from the template, not just the default branch. Not yet available."
+        "label": "Include all branches",
+        "help": "Copy every branch and its history from the template, not just the default branch."
       },
       "feedbackPr": "Feedback pull request",
       "feedbackPrHelp": "Open a pull request per repo for inline review of each submission.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1154,7 +1154,7 @@
       },
       "includeAllBranches": {
         "label": "Include all branches",
-        "help": "Copy every branch and its history from the template, not just the default branch."
+        "help": "Copy every branch and its history from the template, not just the default branch. This applies to students who accept from now on; repositories already created are not changed."
       },
       "feedbackPr": "Feedback pull request",
       "feedbackPrHelp": "Open a pull request per repo for inline review of each submission.",

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -132,6 +132,7 @@ const CreateAssignmentPage = () => {
                 empty_repo: values.empty_repo,
                 no_autograder: values.autograding_state === "none",
                 init_shim: deriveFormShape(values).initShim,
+                include_all_branches: values.include_all_branches,
                 runs_on: values.runs_on,
                 container_image: values.container_image,
                 container_user: values.container_user,

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -629,29 +629,27 @@ describe("assignment form five-section IA", () => {
     ).toBeGreaterThan(0)
   })
 
-  it("shows Add-a-README for the no-template source and reserves include-all-branches for a template", () => {
+  it("shows Add-a-README for the no-template source and an enabled include-all-branches toggle for a template", () => {
     // No template (the default): the Add-a-README toggle shows, no
-    // include-all-branches affordance.
+    // include-all-branches toggle.
     const noTemplate = renderForm({ defaultValues: { repo_source: "none" } })
     expect(noTemplate.container.querySelector("#add_readme")).not.toBeNull()
     expect(
-      noTemplate.container.querySelector("#include-all-branches-deferred"),
+      noTemplate.container.querySelector("#include_all_branches"),
     ).toBeNull()
     cleanup()
 
-    // Template source: the README toggle is hidden and the deferred
-    // include-all-branches toggle renders disabled.
+    // Template source: the README toggle is hidden and the include-all-branches
+    // toggle renders enabled (no longer a disabled "coming soon" affordance).
     const templated = renderForm({
       defaultValues: { repo_source: "template", template_repo: "acme/starter" },
     })
     expect(templated.container.querySelector("#add_readme")).toBeNull()
-    // The include-all-branches affordance is present but inert (wrapped in an
-    // aria-disabled container, mirroring the Extensions affordance).
-    const mirror = templated.container.querySelector<HTMLInputElement>(
-      "#include-all-branches-deferred",
+    const branches = templated.container.querySelector<HTMLInputElement>(
+      "#include_all_branches",
     )
-    expect(mirror).not.toBeNull()
-    expect(mirror?.closest("[aria-disabled='true']")).not.toBeNull()
+    expect(branches).not.toBeNull()
+    expect(branches?.disabled).toBe(false)
   })
 
   it("reserves the schedule Extensions affordance as disabled", () => {

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -82,6 +82,7 @@ const EditAssignmentForm = ({
                 empty_repo: values.empty_repo,
                 no_autograder: values.autograding_state === "none",
                 init_shim: deriveFormShape(values).initShim,
+                include_all_branches: values.include_all_branches,
                 runs_on: values.runs_on,
                 container_image: values.container_image,
                 container_user: values.container_user,

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -46,6 +46,7 @@ const base: CreateAssignmentFormValues = {
   empty_repo: false,
   repo_source: "none",
   add_readme: true,
+  include_all_branches: false,
   autograding_state: "built-in",
   runtime_env: "hosted",
   runs_on: "",
@@ -518,6 +519,24 @@ describe("toSubmitValues — runtime field clearing", () => {
     })
     expect(out.empty_repo).toBe(false)
     expect(out.template_repo).toBe("acme/starter")
+  })
+
+  it("include_all_branches passes through for a template source, clears otherwise", () => {
+    const templated = toSubmitValues({
+      ...base,
+      repo_source: "template",
+      template_repo: "acme/starter",
+      include_all_branches: true,
+    })
+    expect(templated.include_all_branches).toBe(true)
+    // No template -> cleared (a stale toggle can't reach the wire).
+    const noTemplate = toSubmitValues({
+      ...base,
+      repo_source: "none",
+      add_readme: true,
+      include_all_branches: true,
+    })
+    expect(noTemplate.include_all_branches).toBe(false)
   })
 
   it("round-trips a stored init_shim assignment without flipping the flag", () => {

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -101,6 +101,11 @@ export type CreateAssignmentFormValues = {
   // README off maps to empty_repo: true (a bare repo, no commit). Hidden when a
   // template is chosen (the template provides the initial commit).
   add_readme: boolean
+  // UI-only, only meaningful for a template source: copy ALL of the template's
+  // branches (not just the default) when each student repo is generated. Maps
+  // to the wire include_all_branches; cleared on submit when the source isn't a
+  // template. Default off.
+  include_all_branches: boolean
   // UI-only autograding tri-state (never sent verbatim; mapped to wire fields
   // on submit): "empty" (bare repo — driven by empty_repo), "none" (templated,
   // teacher-supplied CI — maps to no_autograder: true, no shim), "built-in"
@@ -459,6 +464,9 @@ export function toSubmitValues(
     empty_repo: isEmptyRepo,
     repo_source: value.repo_source,
     add_readme: value.add_readme,
+    // Only meaningful for a template source; clear it otherwise so a stale
+    // toggle can't reach the wire (buildAssignmentEntry also rejects the combo).
+    include_all_branches: isTemplate ? value.include_all_branches : false,
     autograding_state: shape.autogradingState,
     runtime_env: value.runtime_env,
     runs_on: value.runs_on.trim(),
@@ -517,6 +525,7 @@ export const useAssignmentForm = (
       // the stored wire fields on edit via assignmentToFormValues.
       repo_source: defaultValues?.repo_source ?? "none",
       add_readme: defaultValues?.add_readme ?? false,
+      include_all_branches: defaultValues?.include_all_branches ?? false,
       autograding_state: defaultValues?.autograding_state ?? "none",
       runtime_env: defaultValues?.runtime_env || "hosted",
       runs_on: defaultValues?.runs_on || "",
@@ -609,6 +618,7 @@ export const assignmentToFormValues = (
     repo_source: assignment.template ? "template" : "none",
     add_readme:
       !(assignment.empty_repo ?? false) && !(assignment.init_shim ?? false),
+    include_all_branches: assignment.include_all_branches ?? false,
     // Derive the tri-state from the stored wire fields (empty_repo /
     // no_autograder / default), so an edit opens on the right autograding
     // option and a round-trip preserves it. Uses the #554 domain helper.

--- a/web/src/pages/assignments/formShape.test.ts
+++ b/web/src/pages/assignments/formShape.test.ts
@@ -16,6 +16,7 @@ const base: CreateAssignmentFormValues = {
   empty_repo: false,
   repo_source: "none",
   add_readme: true,
+  include_all_branches: false,
   autograding_state: "built-in",
   runtime_env: "hosted",
   runs_on: "",

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -21,7 +21,7 @@ const REPO_ROLES_DOCS_URL =
 //     toggle picks between an initialized repo (auto_init, README on) and a
 //     bare repo (README off). A template hides the README toggle (the template
 //     provides the initial commit) and shows an "Include all branches" toggle
-//     (deferred/coming-soon).
+//     (copy every branch at generate, default off).
 //   - Student repo access, and the Feedback PR (decoupled from autograding —
 //     available for any non-empty repo).
 // The source choice folds into empty_repo + template on submit via
@@ -102,7 +102,7 @@ export function RepositorySetupSection({
           </form.Field>
 
           {/* No-template branch: "Add a README" picks initialized vs bare.
-              Template branch: the template picker + a deferred "Include all
+              Template branch: the template picker + an "Include all
               branches" toggle. deriveFormShape decides which shows. */}
           <form.Subscribe selector={(state) => deriveFormShape(state.values)}>
             {(shape) =>

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -119,22 +119,22 @@ export function RepositorySetupSection({
                     )}
                   </form.Field>
 
-                  {/* Deferred (R6/U9): include-all-branches mirror. Reserved as
-                      an inert, disabled toggle (off) — the accept path doesn't
-                      send include_all_branches yet, and there's no wire field
-                      to carry it, so it writes nothing. */}
-                  <div
-                    className="pointer-events-none opacity-50"
-                    aria-disabled="true"
-                  >
-                    <ToggleRow
-                      id="include-all-branches-deferred"
-                      checked={false}
-                      onChange={() => {}}
-                      label={t("assignments.form.includeAllBranches.label")}
-                      help={t("assignments.form.includeAllBranches.help")}
-                    />
-                  </div>
+                  {/* Copy all template branches at generate (include_all_branches).
+                      Only shown for a template source; default off. */}
+                  <form.Field name="include_all_branches">
+                    {(branchesField) => (
+                      <ToggleRow
+                        id={branchesField.name}
+                        checked={branchesField.state.value}
+                        onChange={(checked) =>
+                          branchesField.handleChange(checked)
+                        }
+                        onBlur={branchesField.handleBlur}
+                        label={t("assignments.form.includeAllBranches.label")}
+                        help={t("assignments.form.includeAllBranches.help")}
+                      />
+                    )}
+                  </form.Field>
                 </>
               ) : shape.showAddReadme ? (
                 <form.Field name="add_readme">

--- a/web/src/pages/assignments/sections/sectionStatus.test.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.test.ts
@@ -17,6 +17,7 @@ const defaults: CreateAssignmentFormValues = {
   empty_repo: false,
   repo_source: "none",
   add_readme: true,
+  include_all_branches: false,
   autograding_state: "built-in",
   runtime_env: "hosted",
   runs_on: "",

--- a/web/src/pages/assignments/sections/sectionStatus.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.ts
@@ -25,6 +25,7 @@ const SECTION_FIELDS: Record<
   repository: [
     "repo_source",
     "add_readme",
+    "include_all_branches",
     "empty_repo",
     "template_repo",
     "student_permission",

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -166,6 +166,14 @@ export type Assignment = {
   // Omitted when false (CLI omitempty); absent reads as false. In lockstep with
   // the CLI's assignments-v1 schema (`init_shim`).
   init_shim?: boolean
+  // Copy ALL of the template's branches (not just the default) when each student
+  // repo is generated: accept passes include_all_branches to GitHub's POST
+  // /generate. Requires a template; mutually exclusive with empty_repo/init_shim
+  // (template-less, never generated); compatible with everything else (branches
+  // don't affect grading). Accept-time only and MUTABLE (not immutable — only
+  // affects repos generated from now on). Omitted when false; absent reads as
+  // false. In lockstep with the CLI's assignments-v1 schema (`include_all_branches`).
+  include_all_branches?: boolean
   // Lock the assignment against student access. Every student surface (accept
   // page, assignments list, submission view, and `gh student accept`) refuses
   // a locked assignment for EVERY student, including one who already accepted.

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -451,6 +451,19 @@ grading-adjacent fields (it autogrades). It is immutable after creation. Like
 `assignments.json` (via the gradebook's edit path); there is no `assignment add`
 flag.
 
+**Include all branches (`include_all_branches`).** A **templated** assignment can
+carry `include_all_branches: true` in `assignments.json` to copy **all** of the
+template's branches (not just the default) when each student repo is generated:
+accept passes `include_all_branches` to GitHub's `POST /repos/{template}/generate`.
+It **requires** a template (it only affects the generate call) and is mutually
+exclusive with `empty_repo` and `init_shim` (both template-less, never
+generated); it is **compatible** with everything else, including `no_autograder`
+and the grading-adjacent fields (branches don't affect grading). Unlike the
+immutable no-shim states it is **accept-time only and mutable**: changing it
+affects only repos generated from now on (already-accepted repos are never
+re-generated). Like `no_autograder`/`init_shim` it is currently set via the
+gradebook edit path; there is no `assignment add` flag.
+
 <details>
 <summary>Errors</summary>
 


### PR DESCRIPTION
Adds a new additive `assignments.json` boolean, `include_all_branches`, so a teacher can opt a **templated** assignment into copying **all** of the template's branches (not just the default) when each student repo is generated. Accept passes it to GitHub's `POST /repos/{template}/generate`. This activates the "Include all branches" form toggle that previously rendered as a disabled "coming soon" affordance.

The field is strictly additive and template-gated. It **requires** a template (it only affects the generate call) and is mutually exclusive with `empty_repo` and `init_shim` (both template-less, never generated); it is **compatible** with everything else, including `no_autograder` and the grading-adjacent fields — branches don't affect grading, so the grading pipeline never reads it. Unlike the immutable no-shim states (`empty_repo`/`no_autograder`/`init_shim`), `include_all_branches` is **accept-time only and mutable**: changing it affects only repos generated from now on (already-accepted repos are never re-generated), so there is no immutability guard — just a carry-forward on CLI re-add so an unrelated edit can't silently drop it. That carry-forward is **gated on the current template**: a same-slug re-add that drops `--template` turns the entry template-less and correctly clears the flag rather than carrying `include_all_branches: true` onto a template-less entry (a combination the parse-path validator rejects, which would otherwise wedge every future read of the file). As a backstop, the CLI re-validates the fully assembled entry after all carry-forwards.

Shipped in four-tool lockstep, mirroring the `init_shim` and `no_autograder` rollouts: the `assignments-v1` schema (property + `allOf` conditional), the Go teacher validators (`validateIncludeAllBranchesExclusions` + template-gated carry-forward + a post-carry-forward `ValidateAssignmentEntry`, no immutability check), the Go student accept path (threaded into `createTemplatedPrivateAssignmentRepoInOrg`'s generate body — previously always absent), the web type + `buildAssignmentEntry` (exclusions + write) + accept path (`repoCreation.ts` un-pinned from its hardcoded `include_all_branches: false`, plumbed from `accept.ts`), and the web form (the toggle is now an enabled `form.Field`, shown for the template source, default off; help text notes it applies to accepts from now on). The teacher-side template migration (`migrate_template.go`) already used `include_all_branches: true`; this brings the student accept path to parity.

## Verification

`cd web && npm run check` (tsc, eslint incl. boundaries, prettier, arch:validate, vitest, i18n audit) -> green; `cd cli/gh-teacher && go test ./... && golangci-lint run`; `cd cli/gh-student && go test ./...`; `python3 -m pytest cli/gh-teacher/skeleton_tests -q`. Focused: both accept clients have a test asserting the `/generate` body carries the flag for false and true; the schema/Go/web exclusions + round-trip are covered; the CLI carry-forward has a preserve test plus a `--template`-drop test proving the re-add clears the flag and the committed file re-parses (no wedge); web 504 node tests, Python schema 173.