### PR TITLE
feat(web): add grading mode and manual score override

### DIFF
--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -163,6 +163,7 @@ type AssignmentEntry struct {
 	AllowedFiles       []string         `json:"allowed_files,omitempty"`
 	ReleaseAssets      []string         `json:"release_assets,omitempty"`
 	PassThreshold      *int             `json:"pass_threshold,omitempty"`
+	Grading            *Grading         `json:"grading,omitempty"`
 	StudentPermission  string           `json:"student_permission,omitempty"`
 	SubmissionMode     string           `json:"submission_mode,omitempty"`
 	SubmissionTags     []string         `json:"submission_tags,omitempty"`
@@ -188,6 +189,7 @@ var knownEntryKeys = map[string]struct{}{
 	"init_shim":            {},
 	"include_all_branches": {},
 	"repo_features":        {},
+	"grading":              {},
 }
 
 // UnmarshalJSON captures unknown top-level keys into Extra, then strictly
@@ -321,6 +323,49 @@ func ValidatePassThreshold(n *int) error {
 	}
 	if *n < PassThresholdMin || *n > PassThresholdMax {
 		return fmt.Errorf("pass_threshold %d out of range (%d..%d)", *n, PassThresholdMin, PassThresholdMax)
+	}
+	return nil
+}
+
+// Grading records the teacher's grading intent as a first-class choice the GUI
+// surfaces: `auto` (autograded — the default; an absent block reads as auto),
+// `manual` (the teacher records scores by hand on the submissions page), or
+// `off` (not graded). ORTHOGONAL to the autograding tri-state
+// (empty_repo/no_autograder/init_shim) and to collection: nothing in the
+// grading pipeline reads it, so the two axes never need to agree and are not
+// coupled by any exclusion. MaxPoints is a pointer so absent stays distinct
+// from a would-be 0; it is required (and >= 1) for manual, forbidden otherwise.
+type Grading struct {
+	Mode      string `json:"mode"`
+	MaxPoints *int   `json:"max_points,omitempty"`
+}
+
+// GradingMaxPointsMin is the smallest legal manual max_points. Not 0: a
+// gradebook client divides score by max to show passing/failing and to tally
+// stats, and treats a 0 max as the "ungraded" sentinel — so a configured
+// manual max must be at least 1.
+const GradingMaxPointsMin = 1
+
+// ValidateGrading checks an optional grading block, mirroring the schema's
+// grading conditionals. A nil pointer (absent) is valid and means auto. When
+// present: mode must be a valid GradingMode; manual requires max_points >= 1;
+// off/auto must omit max_points.
+func ValidateGrading(g *Grading) error {
+	if g == nil {
+		return nil
+	}
+	if !contract.IsValidGradingMode(g.Mode) {
+		return fmt.Errorf("invalid grading.mode %q: must be one of %v", g.Mode, contract.GradingModes)
+	}
+	if g.Mode == contract.GradingModeManual {
+		if g.MaxPoints == nil {
+			return errors.New("grading.mode manual requires grading.max_points")
+		}
+		if *g.MaxPoints < GradingMaxPointsMin {
+			return fmt.Errorf("grading.max_points %d out of range (must be >= %d)", *g.MaxPoints, GradingMaxPointsMin)
+		}
+	} else if g.MaxPoints != nil {
+		return fmt.Errorf("grading.max_points is only valid for manual grading (mode is %q)", g.Mode)
 	}
 	return nil
 }
@@ -862,6 +907,9 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 	if err := ValidatePassThreshold(entry.PassThreshold); err != nil {
 		return err
 	}
+	if err := ValidateGrading(entry.Grading); err != nil {
+		return err
+	}
 	if err := ValidateStudentPermission(entry.StudentPermission); err != nil {
 		return err
 	}
@@ -1130,6 +1178,9 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 		return fmt.Errorf("entry %q: %w", entry.Slug, err)
 	}
 	if err := ValidatePassThreshold(entry.PassThreshold); err != nil {
+		return fmt.Errorf("entry %q: %w", entry.Slug, err)
+	}
+	if err := ValidateGrading(entry.Grading); err != nil {
 		return fmt.Errorf("entry %q: %w", entry.Slug, err)
 	}
 	if err := ValidateStudentPermission(entry.StudentPermission); err != nil {

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -89,6 +89,105 @@ func TestSubmissionModeEnumParity(t *testing.T) {
 	}
 }
 
+// TestGradingModeEnumParity pins the grading.mode allow-list across its
+// hand-mirrored sources: the JSON schema enum (declared source of truth) and
+// the Go contract.GradingModes (what ValidateGrading enforces). The web mirror
+// (GRADING_MODES) is pinned against the same schema enum by a vitest.
+func TestGradingModeEnumParity(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "schemas", "assignments-v1.schema.json"))
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		Defs struct {
+			Assignment struct {
+				Properties struct {
+					Grading struct {
+						Properties struct {
+							Mode struct {
+								Enum []string `json:"enum"`
+							} `json:"mode"`
+						} `json:"properties"`
+					} `json:"grading"`
+				} `json:"properties"`
+			} `json:"assignment"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	schemaEnum := schema.Defs.Assignment.Properties.Grading.Properties.Mode.Enum
+	if len(schemaEnum) == 0 {
+		t.Fatalf("schema grading.mode.enum not found; did the $defs shape change?")
+	}
+	if !reflect.DeepEqual(schemaEnum, contract.GradingModes) {
+		t.Errorf("grading.mode drift: schema enum %v != contract.GradingModes %v — update every mirror in lockstep (schema, Go contract, web GRADING_MODES)",
+			schemaEnum, contract.GradingModes)
+	}
+}
+
+// TestValidateGrading pins the grading validator against the same shapes the
+// schema conditionals enforce: absent is valid (auto); off/auto forbid
+// max_points; manual requires max_points >= 1.
+func TestValidateGrading(t *testing.T) {
+	ptr := func(n int) *int { return &n }
+	cases := []struct {
+		name    string
+		grading *Grading
+		wantErr bool
+	}{
+		{"absent", nil, false},
+		{"off", &Grading{Mode: "off"}, false},
+		{"auto", &Grading{Mode: "auto"}, false},
+		{"manual with max", &Grading{Mode: "manual", MaxPoints: ptr(100)}, false},
+		{"manual min max", &Grading{Mode: "manual", MaxPoints: ptr(1)}, false},
+		{"manual missing max", &Grading{Mode: "manual"}, true},
+		{"manual zero max", &Grading{Mode: "manual", MaxPoints: ptr(0)}, true},
+		{"manual negative max", &Grading{Mode: "manual", MaxPoints: ptr(-5)}, true},
+		{"auto with max", &Grading{Mode: "auto", MaxPoints: ptr(10)}, true},
+		{"off with max", &Grading{Mode: "off", MaxPoints: ptr(10)}, true},
+		{"bad mode", &Grading{Mode: "none"}, true},
+		{"empty mode", &Grading{Mode: ""}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGrading(tc.grading)
+			if tc.wantErr && err == nil {
+				t.Errorf("ValidateGrading(%+v) = nil, want error", tc.grading)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("ValidateGrading(%+v) = %v, want nil", tc.grading, err)
+			}
+		})
+	}
+}
+
+// TestGradingRoundTrips confirms a grading block survives parse->encode
+// (manual grading coexists with any autograding state; here alongside a
+// template, i.e. an auto assignment the teacher chose to grade manually).
+func TestGradingRoundTrips(t *testing.T) {
+	src := `{"schema":"classroom50/assignments/v1","assignments":[{"slug":"hw1","name":"HW1","template":{"owner":"o","repo":"t","branch":"main"},"mode":"individual","autograder":"default","grading":{"mode":"manual","max_points":50}}]}`
+	file, err := ParseAssignments([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseAssignments: %v", err)
+	}
+	g := file.Assignments[0].Grading
+	if g == nil || g.Mode != "manual" || g.MaxPoints == nil || *g.MaxPoints != 50 {
+		t.Fatalf("grading not parsed: %+v", g)
+	}
+	out, err := EncodeAssignments(file)
+	if err != nil {
+		t.Fatalf("EncodeAssignments: %v", err)
+	}
+	if !strings.Contains(string(out), `"grading"`) || !strings.Contains(string(out), `"max_points": 50`) {
+		t.Errorf("grading dropped on re-encode: %s", out)
+	}
+}
+
 // TestValidateSubmissionMode pins the read/write validator: absent (empty) and
 // both enum values pass; anything else is a hard error. An explicit
 // "every-push" is legal on read even though this CLI normalizes it to absent

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -835,6 +835,20 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			attemptEntry.ReleaseAssets = append([]string(nil), previous.ReleaseAssets...)
 			attemptEntry.Extra = previous.Extra
 			attemptEntry.Locked = previous.Locked
+			// grading is a GUI/manifest-owned field with no `assignment add`
+			// flag; since it was promoted to a known key it no longer rides
+			// through Extra, so a same-slug re-add would silently drop a
+			// GUI-authored grading block (its mode is immutable, and the manual
+			// max_points feeds the gradebook). Deep-copy the *Grading + *int so
+			// the carried value doesn't alias the previous entry.
+			if attemptEntry.Grading == nil && previous.Grading != nil {
+				carried := *previous.Grading
+				if previous.Grading.MaxPoints != nil {
+					maxPoints := *previous.Grading.MaxPoints
+					carried.MaxPoints = &maxPoints
+				}
+				attemptEntry.Grading = &carried
+			}
 			// submission_mode is carried forward when --submission-mode was
 			// omitted: deployed shims were rendered under the prior mode, so a
 			// silent reset to every-push would strand a tag-mode assignment

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
@@ -798,6 +798,39 @@ func TestRunAssignmentAdd_PreservesReleaseAssets(t *testing.T) {
 	}
 }
 
+// TestRunAssignmentAdd_PreservesGrading guards the grading carry-forward: a
+// same-slug re-add WITHOUT a grading flag (the CLI has none) must keep a prior
+// GUI-authored grading block. grading was promoted to a known key, so it no
+// longer rides through Extra; without the carry-forward the upsert would drop a
+// manual-grading assignment back to auto and lose its max_points.
+func TestRunAssignmentAdd_PreservesGrading(t *testing.T) {
+	seeded := `{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [{
+    "slug": "hello",
+    "name": "Hello",
+    "template": {"owner":"cs50","repo":"hello-template","branch":"main"},
+    "mode": "individual",
+    "autograder": "default",
+    "grading": {"mode": "manual", "max_points": 50}
+  }]
+}`
+	server, fix := newTestCmdServer(t, seeded, false)
+	client := githubtest.NewTestClient(t, server)
+
+	var stdout, stderr bytes.Buffer
+	if err := runAssignmentAdd(client, &stdout, &stderr, helloAddParams()); err != nil {
+		t.Fatalf("runAssignmentAdd: %v", err)
+	}
+	got := decodeCommitted(t, fix).Assignments[0].Grading
+	if got == nil {
+		t.Fatalf("grading block dropped on re-add")
+	}
+	if got.Mode != "manual" || got.MaxPoints == nil || *got.MaxPoints != 50 {
+		t.Fatalf("grading = %+v (max_points %v), want mode manual / max_points 50", got, got.MaxPoints)
+	}
+}
+
 func TestRunAssignmentAdd_RetryDoesNotResurrectPreservedFieldsAfterConcurrentDelete(t *testing.T) {
 	seeded := `{
   "schema": "classroom50/assignments/v1",

--- a/cli/gh-teacher/internal/download/download_test.go
+++ b/cli/gh-teacher/internal/download/download_test.go
@@ -468,6 +468,54 @@ func TestWriteScoresCSV(t *testing.T) {
 	}
 }
 
+func TestWriteScoresCSV_ManualOverride(t *testing.T) {
+	// A web-authored manual/override grade is an ordinary entry with
+	// override:true whose submissions[0] is a synthesized submit/manual-* record
+	// in the existing shape. The CSV renders it exactly like any other row (the
+	// score/max/datetime are real; the sentinel tag flows through verbatim), so
+	// no download-side branch is needed — this pins that.
+	scores := scoresschema.File{
+		Schema: scoresschema.SchemaV1,
+		Assignments: map[string]scoresschema.AssignmentBucket{
+			"hello": {
+				Type: "individual",
+				Entries: []map[string]any{
+					{
+						"owner":    "alice",
+						"override": true,
+						"submissions": []any{
+							map[string]any{
+								"score":      float64(42),
+								"max-score":  float64(50),
+								"datetime":   "2026-06-02T09:00:00Z",
+								"submission": "submit/manual-2026-06-02T09-00-00Z",
+								"review":     "submit/manual-2026-06-02T09-00-00Z",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scores.csv")
+	if err := writeScoresCSV(path, scores, "hello", []string{"alice"}, nil); err != nil {
+		t.Fatalf("writeScoresCSV: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	want := strings.Join([]string{
+		"username,first_name,last_name,email,section,score,max_score,datetime,submission_tag,submitted_by,review_url,late,override",
+		"alice,,,,,42,50,2026-06-02T09:00:00Z,submit/manual-2026-06-02T09-00-00Z,,submit/manual-2026-06-02T09-00-00Z,,true",
+		"",
+	}, "\n")
+	if string(got) != want {
+		t.Fatalf("scores.csv mismatch:\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func TestWriteScoresCSV_GroupFanOut(t *testing.T) {
 	// A group submission is one multi-username row. writeScoresCSV must
 	// credit every member with the group's submissions, including a

--- a/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
+++ b/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
@@ -621,6 +621,73 @@ class TestIncludeAllBranches:
         assert _errors(_manifest(entry)) != []
 
 
+class TestGrading:
+    # `grading` records the teacher's grading intent (off / auto / manual) as a
+    # first-class GUI choice. ABSENT reads as auto (today's behavior). manual
+    # requires max_points (>= 1, since a 0 max is the ungraded sentinel a
+    # gradebook divides by); off/auto forbid max_points. The field is orthogonal
+    # to the autograding tri-state and to collection, so it is intentionally NOT
+    # coupled to empty_repo/no_autograder by any conditional.
+    def test_grading_absent_accepted(self):
+        # Covered by test_minimal_manifest, pinned here for intent.
+        assert _errors(_manifest(_entry())) == []
+
+    def test_grading_off_accepted(self):
+        assert _errors(_manifest(_entry(grading={"mode": "off"}))) == []
+
+    def test_grading_auto_accepted(self):
+        assert _errors(_manifest(_entry(grading={"mode": "auto"}))) == []
+
+    def test_grading_manual_with_max_points_accepted(self):
+        assert (
+            _errors(_manifest(_entry(grading={"mode": "manual", "max_points": 100})))
+            == []
+        )
+
+    def test_grading_manual_min_max_points_accepted(self):
+        assert (
+            _errors(_manifest(_entry(grading={"mode": "manual", "max_points": 1})))
+            == []
+        )
+
+    def test_grading_manual_requires_max_points(self):
+        assert _errors(_manifest(_entry(grading={"mode": "manual"}))) != []
+
+    def test_grading_manual_rejects_zero_max_points(self):
+        # 0 is the ungraded sentinel the submissions UI divides by; a configured
+        # manual max must be >= 1.
+        assert (
+            _errors(_manifest(_entry(grading={"mode": "manual", "max_points": 0})))
+            != []
+        )
+
+    @pytest.mark.parametrize("mode", ["off", "auto"])
+    def test_grading_non_manual_forbids_max_points(self, mode):
+        assert (
+            _errors(_manifest(_entry(grading={"mode": mode, "max_points": 50}))) != []
+        )
+
+    def test_grading_requires_mode(self):
+        assert _errors(_manifest(_entry(grading={}))) != []
+
+    @pytest.mark.parametrize("mode", ["Manual", "none", "", None, True])
+    def test_grading_bad_mode_rejected(self, mode):
+        assert _errors(_manifest(_entry(grading={"mode": mode}))) != []
+
+    def test_grading_unknown_key_rejected(self):
+        # The grading object is additionalProperties:false.
+        assert (
+            _errors(_manifest(_entry(grading={"mode": "auto", "weight": 2}))) != []
+        )
+
+    def test_grading_manual_coexists_with_no_autograder(self):
+        # grading is orthogonal to the autograding tri-state: a teacher-supplied
+        # CI (no_autograder) assignment graded manually is a legal combination —
+        # no conditional couples the two.
+        entry = _entry(no_autograder=True, grading={"mode": "manual", "max_points": 10})
+        assert _errors(_manifest(entry)) == []
+
+
 def _release_assets_errors(value):
     return _errors(_manifest(_entry(release_assets=value)))
 

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -54,6 +54,18 @@ const (
 	SubmissionModeEveryPush = "every-push"
 	SubmissionModeTag       = "tag"
 
+	// GradingModeOff, GradingModeAuto, and GradingModeManual are the assignment
+	// grading.mode values — the teacher's grading intent as a first-class GUI
+	// choice. auto = autograded (ABSENT reads as auto, so existing files are
+	// unchanged); manual = the teacher records scores by hand (requires
+	// max_points); off = not graded. Orthogonal to the autograding tri-state and
+	// to collection (nothing in the grading pipeline reads grading). Mirrored in
+	// the assignments-v1 schema enum and the web GRADING_MODES; pinned by the
+	// schema-parity tests.
+	GradingModeOff    = "off"
+	GradingModeAuto   = "auto"
+	GradingModeManual = "manual"
+
 	// SubmitTagPrefix is the tag namespace that marks a grading submission:
 	// only submit/* tag Releases count as submissions everywhere (runner,
 	// collect_scores.py SUBMIT_TAG_PREFIX, regrade_repos.py, the web
@@ -306,6 +318,21 @@ var SubmissionModes = []string{SubmissionModeEveryPush, SubmissionModeTag}
 // IsValidSubmissionMode reports whether m is one of the SubmissionModes.
 func IsValidSubmissionMode(m string) bool {
 	for _, allowed := range SubmissionModes {
+		if m == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// GradingModes is every valid assignments.json grading.mode value.
+// Single-sources the allow-list; the schema enum in assignments-v1.schema.json
+// and the web GRADING_MODES mirror it (parity-tested on both sides).
+var GradingModes = []string{GradingModeOff, GradingModeAuto, GradingModeManual}
+
+// IsValidGradingMode reports whether m is one of the GradingModes.
+func IsValidGradingMode(m string) bool {
+	for _, allowed := range GradingModes {
 		if m == allowed {
 			return true
 		}

--- a/schemas/assignments-v1.schema.json
+++ b/schemas/assignments-v1.schema.json
@@ -169,6 +169,22 @@
           "maximum": 100,
           "description": "Opt-in, advisory passing bar: the integer percentage of max score (0–100) at/above which a gradebook client (e.g., the GUI) shows a submission as passing, plus passing/failing rollups, badges, and filters. ABSENT means the feature is OFF — no passing concept — which is distinct from a 0% threshold; clients must not treat absent as a default. CLI-unenforced like max_group_size: the autograder and score collection never read it; it changes no student's actual score. Written only when a teacher enables it."
         },
+        "grading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode"],
+          "properties": {
+            "mode": {
+              "enum": ["off", "auto", "manual"],
+              "description": "How the teacher intends this assignment to be graded, as a first-class choice the GUI surfaces. `auto` = autograded (the default meaning; ABSENT reads as `auto` so existing files are unchanged). `manual` = the teacher records scores by hand on the submissions page. `off` = not graded. ORTHOGONAL to the autograding tri-state (empty_repo/no_autograder/init_shim) and to collection: this field records intent only and is NOT read by collect_scores.py/regrade_repos.py (which key off the tri-state), so the two never need to agree and must not be coupled by a conditional here. A manual (or overridden) score is stored in scores.json as an ordinary entry with `override: true` — there is no separate manual scores shape."
+            },
+            "max_points": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Total points available for a MANUAL assignment. Required when mode is `manual`; forbidden otherwise. Minimum 1 (not 0) because a gradebook client divides score by max to show passing/failing and to tally stats — a 0 max is the 'ungraded' sentinel, so it must not be a legal configured max."
+            }
+          }
+        },
         "migrated_from": {
           "type": "object",
           "additionalProperties": false,
@@ -271,6 +287,14 @@
               { "not": { "properties": { "init_shim": { "const": true } }, "required": ["init_shim"] } }
             ]
           }
+        },
+        {
+          "if": {
+            "properties": { "grading": { "properties": { "mode": { "const": "manual" } }, "required": ["mode"] } },
+            "required": ["grading"]
+          },
+          "then": { "properties": { "grading": { "required": ["max_points"] } } },
+          "else": { "properties": { "grading": { "not": { "required": ["max_points"] } } } }
         }
       ]
     },

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -927,6 +927,93 @@ describe("editAssignment (preserved-entry integration)", () => {
     ).rejects.toThrow(/init_shim cannot be changed after creation/)
   })
 
+  it("rejects changing grading.mode after creation (auto -> manual, immutable)", async () => {
+    // existingEntry has no grading (resolves to auto); the edit sets manual.
+    // Scores already recorded under the old mode would be misread.
+    const { client } = makeClient()
+    await expect(
+      editAssignment(
+        client,
+        editInput({ grading: { mode: "manual", max_points: 50 } }),
+      ),
+    ).rejects.toThrow(/grading mode cannot be changed after creation/)
+  })
+
+  it("rejects changing grading.mode after creation (manual -> auto, immutable)", async () => {
+    const manualEntry: Assignment = {
+      slug: SLUG,
+      name: "Homework 1",
+      mode: "individual",
+      autograder: "default",
+      template: { owner: "cs50", repo: "hello-template", branch: "main" },
+      feedback_pr: true,
+      grading: { mode: "manual", max_points: 50 },
+    }
+    const { client } = makeBareClient(manualEntry)
+    await expect(
+      editAssignment(client, editInput({ grading: { mode: "auto" } })),
+    ).rejects.toThrow(/grading mode cannot be changed after creation/)
+  })
+
+  it("writes grading:{mode,max_points} on a same-mode manual edit", async () => {
+    // A manual assignment edited without changing the mode: the immutability
+    // guard passes and buildAssignmentEntry emits the grading block. max_points
+    // is mutable, so a bumped value lands.
+    const manualEntry: Assignment = {
+      slug: SLUG,
+      name: "Homework 1",
+      mode: "individual",
+      autograder: "default",
+      template: { owner: "cs50", repo: "hello-template", branch: "main" },
+      feedback_pr: true,
+      grading: { mode: "manual", max_points: 50 },
+    }
+    const { client, committedContent } = makeBareClient(manualEntry)
+    await editAssignment(
+      client,
+      editInput({ grading: { mode: "manual", max_points: 80 } }),
+    )
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    expect(edited.grading).toEqual({ mode: "manual", max_points: 80 })
+  })
+
+  it("rejects a manual grading edit with an out-of-range max_points", async () => {
+    // Same-mode manual edit (immutability guard passes) with max_points 0 must
+    // hit buildAssignmentEntry's grading validation throw (min 1).
+    const manualEntry: Assignment = {
+      slug: SLUG,
+      name: "Homework 1",
+      mode: "individual",
+      autograder: "default",
+      template: { owner: "cs50", repo: "hello-template", branch: "main" },
+      feedback_pr: true,
+      grading: { mode: "manual", max_points: 50 },
+    }
+    const { client } = makeBareClient(manualEntry)
+    await expect(
+      editAssignment(
+        client,
+        editInput({ grading: { mode: "manual", max_points: 0 } }),
+      ),
+    ).rejects.toThrow(/grading\.max_points/)
+  })
+
+  it("rejects a grading edit carrying max_points on a non-manual mode", async () => {
+    // An auto assignment edited with grading:{mode:auto, max_points} must hit
+    // the defensive "max_points only valid for manual" throw. Mode stays auto,
+    // so the immutability guard passes first.
+    const { client } = makeClient()
+    await expect(
+      editAssignment(
+        client,
+        editInput({ grading: { mode: "auto", max_points: 10 } }),
+      ),
+    ).rejects.toThrow(/grading\.max_points/)
+  })
+
   it("rejects flipping empty_repo off after creation (immutable)", async () => {
     const bareEntry: Assignment = {
       slug: SLUG,

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -243,7 +243,8 @@ export async function editAssignment(
   // existing scores. Absent reads as "auto", so compare the resolved modes.
   // max_points is NOT immutable — it's only a display max, safe to adjust.
   if (
-    (input.grading?.mode ?? "auto") !== (targetAssignment.grading?.mode ?? "auto")
+    (input.grading?.mode ?? "auto") !==
+    (targetAssignment.grading?.mode ?? "auto")
   ) {
     throw new Error(
       `grading mode cannot be changed after creation (assignment "${slug}"): scores already recorded under the old grading mode would be misread. Create a new assignment under a different slug instead.`,
@@ -849,9 +850,7 @@ async function buildAssignmentEntry(
     }
   } else if (input.grading?.max_points !== undefined) {
     // Defensive: an auto/absent grading must not carry max_points.
-    throw new Error(
-      "grading.max_points: only valid for manual grading.",
-    )
+    throw new Error("grading.max_points: only valid for manual grading.")
   }
 
   // repo_features: write only the keys the teacher set (undefined = inherit),

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -7,6 +7,8 @@ import {
   PASS_THRESHOLD_MIN,
   REPO_PERMISSIONS,
   SUBMISSION_MODES,
+  GRADING_MODES,
+  GRADING_MAX_POINTS_MIN,
   assertAssignmentMode,
   defaultStudentPermission,
 } from "@/types/classroom"
@@ -123,6 +125,11 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   student_permission: "classroom50-owned",
   submission_mode: "classroom50-owned",
   submission_tags: "classroom50-owned",
+  // Rebuilt from input but IMMUTABLE: editAssignment rejects an edit whose
+  // grading.mode differs from the stored entry (a manual<->auto flip would
+  // change how already-graded repos are read), so the rebuild only ever
+  // re-writes the same mode. The edit form shows the choice read-only.
+  grading: "classroom50-owned",
   repo_features: "classroom50-owned",
   tests: "classroom50-owned",
   // Written only by the CLI's `migrate`; the form never rebuilds it, so it must
@@ -227,6 +234,19 @@ export async function editAssignment(
   if (Boolean(input.init_shim) !== Boolean(targetAssignment.init_shim)) {
     throw new Error(
       `init_shim cannot be changed after creation (assignment "${slug}"): repositories students already accepted are not retrofitted. Create a new assignment under a different slug instead — reusing this slug (even after removing it) would leave already-accepted repos on the old setting.`,
+    )
+  }
+
+  // grading.mode is immutable: flipping manual<->auto (or off) changes how
+  // already-graded repos are read and scored (an override-backed manual grade
+  // vs a collected autograded one), so a mid-course flip would misrepresent
+  // existing scores. Absent reads as "auto", so compare the resolved modes.
+  // max_points is NOT immutable — it's only a display max, safe to adjust.
+  if (
+    (input.grading?.mode ?? "auto") !== (targetAssignment.grading?.mode ?? "auto")
+  ) {
+    throw new Error(
+      `grading mode cannot be changed after creation (assignment "${slug}"): scores already recorded under the old grading mode would be misread. Create a new assignment under a different slug instead.`,
     )
   }
 
@@ -798,6 +818,40 @@ async function buildAssignmentEntry(
       )
     }
     entry.submission_tags = [...input.submission_tags]
+  }
+
+  // grading: omit when it resolves to plain auto with no max (today's behavior),
+  // mirroring the CLI's omitempty. Validate mode against the enum and require a
+  // whole-number max >= 1 for manual (a 0 max is the ungraded sentinel); reject
+  // max_points for off/auto. Orthogonal to the autograding tri-state, so no
+  // empty_repo/no_autograder cross-check here.
+  if (input.grading && input.grading.mode !== "auto") {
+    if (!GRADING_MODES.includes(input.grading.mode)) {
+      throw new Error(
+        `grading.mode: must be one of ${GRADING_MODES.join(", ")} (got "${input.grading.mode}").`,
+      )
+    }
+    if (input.grading.mode === "manual") {
+      const max = input.grading.max_points
+      if (
+        typeof max !== "number" ||
+        !Number.isInteger(max) ||
+        max < GRADING_MAX_POINTS_MIN
+      ) {
+        throw new Error(
+          `grading.max_points: must be a whole number >= ${GRADING_MAX_POINTS_MIN} for manual grading (got ${String(max)}).`,
+        )
+      }
+      entry.grading = { mode: "manual", max_points: max }
+    } else {
+      // "off" — no max_points.
+      entry.grading = { mode: input.grading.mode }
+    }
+  } else if (input.grading?.max_points !== undefined) {
+    // Defensive: an auto/absent grading must not carry max_points.
+    throw new Error(
+      "grading.max_points: only valid for manual grading.",
+    )
   }
 
   // repo_features: write only the keys the teacher set (undefined = inherit),

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -4,6 +4,7 @@ import type {
   RepoPermission,
   RepoFeatures,
   SubmissionMode,
+  Grading,
 } from "@/types/classroom"
 import { GitHubAPIError } from "@/github-core/errors"
 import { getRepo } from "@/github-core/repoReads"
@@ -387,6 +388,12 @@ export type CreateAssignmentInput = {
   // none (buildAssignmentEntry omits the key). Mutually exclusive with
   // empty_repo. Mirrors the CLI's --submission-tag.
   submission_tags?: string[]
+  // The teacher's grading intent (off/auto/manual) with a manual max_points.
+  // Undefined reads as "auto" (today's behavior). Orthogonal to the autograding
+  // tri-state; buildAssignmentEntry omits the block when it resolves to plain
+  // auto with no max. The mode is immutable after creation (edit rejects a
+  // change). Mirrors the CLI's grading object.
+  grading?: Grading
   // Per-assignment repo feature overrides (tri-state per key: undefined =
   // inherit, true = force on, false = force off). buildAssignmentEntry omits
   // the block when no key is set; accept resolves + applies it at fresh create.

--- a/web/src/domain/assignments/scoreOverride.test.ts
+++ b/web/src/domain/assignments/scoreOverride.test.ts
@@ -91,6 +91,7 @@ type WrittenScores = {
           score: number
           "max-score": number
           schema: string
+          datetime: string
         }[]
       }[]
     }
@@ -237,13 +238,19 @@ describe("editScoreOverride", () => {
       "max-score": 100,
       tests: [],
     }
-    const manual = { ...real, submission: "submit/manual-2026-02-02T00-00-00Z", score: 90 }
+    const manual = {
+      ...real,
+      submission: "submit/manual-2026-02-02T00-00-00Z",
+      score: 90,
+    }
     const scores = {
       schema: "classroom50/scores/v1",
       assignments: {
         [ASSIGNMENT]: {
           type: "individual",
-          entries: [{ owner: "alice", override: true, submissions: [manual, real] }],
+          entries: [
+            { owner: "alice", override: true, submissions: [manual, real] },
+          ],
         },
       },
     }
@@ -262,6 +269,109 @@ describe("editScoreOverride", () => {
     expect(entry.submissions).toHaveLength(1)
     expect(entry.submissions[0].submission).toBe(
       "submit/2026-01-01T00-00-00Z-abc1234",
+    )
+  })
+
+  it("throws (never commits) when the scores.json read fails with a non-404", async () => {
+    // A transient 5xx/429/network read failure must NOT be treated as an absent
+    // file: committing the empty scaffold would overwrite the whole gradebook.
+    let committed = ""
+    const request = vi.fn(async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? "GET"
+      if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(url)) {
+        return { default_branch: "main" }
+      }
+      if (method === "GET" && url.includes("/git/ref/heads/main")) {
+        return { object: { sha: "refsha" } }
+      }
+      if (method === "GET" && url.includes("/git/commits/refsha")) {
+        return { tree: { sha: "basetree" } }
+      }
+      if (method === "GET" && url.includes("/contents/cs50/scores.json")) {
+        throw new GitHubAPIError({
+          status: 500,
+          url,
+          message: "Server Error",
+          body: null,
+          rateLimit: {
+            limit: null,
+            remaining: null,
+            used: null,
+            reset: null,
+            resource: null,
+            retryAfter: null,
+          },
+        })
+      }
+      if (method === "POST") {
+        committed = "SHOULD-NOT-COMMIT"
+        return { sha: "x" }
+      }
+      throw new Error(`unexpected request: ${method} ${url}`)
+    })
+    const requestRaw = vi.fn(async () => {
+      throw notFound("classroom.json")
+    })
+    const client = { request, requestRaw } as unknown as GitHubClient
+    await expect(
+      editScoreOverride(client, {
+        org: ORG,
+        classroom: CLASSROOM,
+        assignment: ASSIGNMENT,
+        owner: "alice",
+        assignmentType: "individual",
+        score: 10,
+        maxPoints: 50,
+      }),
+    ).rejects.toThrow()
+    expect(committed).toBe("")
+  })
+
+  it("clamps the override datetime above a future-dated real submission", async () => {
+    // A real autograded submission's datetime is the student-controllable
+    // committer date and can be in the future; the override record must still
+    // sort as the newest submission so the displayed grade is the override.
+    const future = {
+      schema: "classroom50/result/v1",
+      classroom: CLASSROOM,
+      assignment_type: "individual",
+      owner: "alice",
+      submission: "submit/2099-01-01T00-00-00Z-abc1234",
+      commit: "c",
+      release: "r",
+      review: "v",
+      datetime: "2099-01-01T00:00:00Z",
+      score: 10,
+      "max-score": 100,
+      tests: [],
+    }
+    const scores = {
+      schema: "classroom50/scores/v1",
+      assignments: {
+        [ASSIGNMENT]: {
+          type: "individual",
+          entries: [{ owner: "alice", submissions: [future] }],
+        },
+      },
+    }
+    const { client, committed } = makeClient(scores)
+    await editScoreOverride(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+      assignment: ASSIGNMENT,
+      owner: "alice",
+      assignmentType: "individual",
+      score: 95,
+      maxPoints: 100,
+    })
+    const written = JSON.parse(committed()) as WrittenScores
+    const entry = written.assignments[ASSIGNMENT].entries[0]
+    const overrideRec = entry.submissions[0]
+    expect(overrideRec.submission.startsWith("submit/manual-")).toBe(true)
+    // The override's datetime must be strictly later than the future-dated
+    // real submission so a datetime-desc sort puts the override first.
+    expect(new Date(overrideRec.datetime).getTime()).toBeGreaterThan(
+      new Date("2099-01-01T00:00:00Z").getTime(),
     )
   })
 })

--- a/web/src/domain/assignments/scoreOverride.test.ts
+++ b/web/src/domain/assignments/scoreOverride.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { GitHubClient } from "@/github-core/client"
+import { GitHubAPIError } from "@/github-core/errors"
+import { editScoreOverride } from "./scoreOverride"
+
+const ORG = "acme"
+const CLASSROOM = "cs50"
+const ASSIGNMENT = "hw1"
+
+const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64")
+
+function notFound(url: string): GitHubAPIError {
+  return new GitHubAPIError({
+    status: 404,
+    url,
+    message: "Not Found",
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
+// A minimal config-repo write mock: branch/ref/commit reads, the scores.json
+// contents read (absent -> 404 unless `scores` supplied), and tree/commit/ref
+// writes. Captures the committed scores.json content.
+function makeClient(scores?: unknown): {
+  client: GitHubClient
+  committed: () => string
+} {
+  let committed = ""
+  const request = vi.fn(async (url: string, init?: { method?: string }) => {
+    const method = init?.method ?? "GET"
+    if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(url)) {
+      return { default_branch: "main" }
+    }
+    if (method === "GET" && url.includes("/git/ref/heads/main")) {
+      return { object: { sha: "refsha" } }
+    }
+    if (method === "GET" && url.includes("/git/commits/refsha")) {
+      return { tree: { sha: "basetree" } }
+    }
+    if (method === "GET" && url.includes("/contents/cs50/scores.json")) {
+      if (scores === undefined) throw notFound(url)
+      return {
+        type: "file",
+        encoding: "base64",
+        content: b64(JSON.stringify(scores)),
+      }
+    }
+    if (method === "POST" && url.endsWith("/git/trees")) {
+      const body = (init as { body?: { tree: { content: string }[] } }).body
+      committed = body!.tree[0].content
+      return { sha: "newtree" }
+    }
+    if (method === "POST" && url.endsWith("/git/commits")) {
+      return { sha: "newcommit" }
+    }
+    if (method === "PATCH" && url.includes("/git/refs/heads/main")) {
+      return { object: { sha: "newcommit" } }
+    }
+    throw new Error(`unexpected request: ${method} ${url}`)
+  })
+  // classroom.json archive guard: 404 -> active.
+  const requestRaw = vi.fn(async () => {
+    throw notFound("classroom.json")
+  })
+  return {
+    client: { request, requestRaw } as unknown as GitHubClient,
+    committed: () => committed,
+  }
+}
+
+type WrittenScores = {
+  schema: string
+  assignments: Record<
+    string,
+    {
+      type: string
+      entries: {
+        owner: string
+        override?: boolean
+        submissions: {
+          submission: string
+          score: number
+          "max-score": number
+          schema: string
+        }[]
+      }[]
+    }
+  >
+}
+
+describe("editScoreOverride", () => {
+  it("seeds an override entry with a valid synthesized record when scores.json is absent", async () => {
+    const { client, committed } = makeClient(undefined)
+    const result = await editScoreOverride(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+      assignment: ASSIGNMENT,
+      owner: "alice",
+      assignmentType: "individual",
+      score: 42,
+      maxPoints: 50,
+    })
+    expect(result.newCommitSha).toBe("newcommit")
+
+    const written = JSON.parse(committed()) as WrittenScores
+    const entry = written.assignments[ASSIGNMENT].entries[0]
+    expect(entry.owner).toBe("alice")
+    expect(entry.override).toBe(true)
+    const rec = entry.submissions[0]
+    expect(rec.score).toBe(42)
+    expect(rec["max-score"]).toBe(50)
+    // The synthesized record satisfies scores-v1: submission matches ^submit/,
+    // and it carries the result sentinel.
+    expect(rec.submission.startsWith("submit/")).toBe(true)
+    expect(rec.schema).toBe("classroom50/result/v1")
+  })
+
+  it("overrides an autograded entry in place, preserving the real submission beneath", async () => {
+    const scores = {
+      schema: "classroom50/scores/v1",
+      assignments: {
+        [ASSIGNMENT]: {
+          type: "individual",
+          entries: [
+            {
+              owner: "alice",
+              submissions: [
+                {
+                  schema: "classroom50/result/v1",
+                  classroom: CLASSROOM,
+                  assignment_type: "individual",
+                  owner: "alice",
+                  submission: "submit/2026-01-01T00-00-00Z-abc1234",
+                  commit: "c",
+                  release: "r",
+                  review: "v",
+                  datetime: "2026-01-01T00:00:00Z",
+                  score: 10,
+                  "max-score": 100,
+                  tests: [],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }
+    const { client, committed } = makeClient(scores)
+    await editScoreOverride(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+      assignment: ASSIGNMENT,
+      owner: "alice",
+      assignmentType: "individual",
+      score: 95,
+      maxPoints: 100,
+    })
+    const written = JSON.parse(committed()) as WrittenScores
+    const entry = written.assignments[ASSIGNMENT].entries[0]
+    expect(entry.override).toBe(true)
+    // Override record leads; the real autograded submission is retained beneath.
+    expect(entry.submissions[0].score).toBe(95)
+    expect(entry.submissions[0].submission.startsWith("submit/manual-")).toBe(
+      true,
+    )
+    expect(entry.submissions[1].submission).toBe(
+      "submit/2026-01-01T00-00-00Z-abc1234",
+    )
+  })
+
+  it("clearing an override-only entry removes it entirely", async () => {
+    const scores = {
+      schema: "classroom50/scores/v1",
+      assignments: {
+        [ASSIGNMENT]: {
+          type: "individual",
+          entries: [
+            {
+              owner: "alice",
+              override: true,
+              submissions: [
+                {
+                  schema: "classroom50/result/v1",
+                  classroom: CLASSROOM,
+                  assignment_type: "individual",
+                  owner: "alice",
+                  submission: "submit/manual-2026-01-01T00-00-00Z",
+                  commit: "submit/manual-2026-01-01T00-00-00Z",
+                  release: "submit/manual-2026-01-01T00-00-00Z",
+                  review: "submit/manual-2026-01-01T00-00-00Z",
+                  datetime: "2026-01-01T00:00:00Z",
+                  score: 5,
+                  "max-score": 10,
+                  tests: [],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }
+    const { client, committed } = makeClient(scores)
+    await editScoreOverride(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+      assignment: ASSIGNMENT,
+      owner: "alice",
+      assignmentType: "individual",
+      clear: true,
+    })
+    const written = JSON.parse(committed()) as WrittenScores
+    // The emptied bucket is dropped.
+    expect(written.assignments[ASSIGNMENT]).toBeUndefined()
+  })
+
+  it("clearing an override over a real submission strips override and restores it", async () => {
+    const real = {
+      schema: "classroom50/result/v1",
+      classroom: CLASSROOM,
+      assignment_type: "individual",
+      owner: "alice",
+      submission: "submit/2026-01-01T00-00-00Z-abc1234",
+      commit: "c",
+      release: "r",
+      review: "v",
+      datetime: "2026-01-01T00:00:00Z",
+      score: 10,
+      "max-score": 100,
+      tests: [],
+    }
+    const manual = { ...real, submission: "submit/manual-2026-02-02T00-00-00Z", score: 90 }
+    const scores = {
+      schema: "classroom50/scores/v1",
+      assignments: {
+        [ASSIGNMENT]: {
+          type: "individual",
+          entries: [{ owner: "alice", override: true, submissions: [manual, real] }],
+        },
+      },
+    }
+    const { client, committed } = makeClient(scores)
+    await editScoreOverride(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+      assignment: ASSIGNMENT,
+      owner: "alice",
+      assignmentType: "individual",
+      clear: true,
+    })
+    const written = JSON.parse(committed()) as WrittenScores
+    const entry = written.assignments[ASSIGNMENT].entries[0]
+    expect(entry.override).toBeUndefined()
+    expect(entry.submissions).toHaveLength(1)
+    expect(entry.submissions[0].submission).toBe(
+      "submit/2026-01-01T00-00-00Z-abc1234",
+    )
+  })
+})

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -11,6 +11,7 @@ import {
 } from "@/github-core/mutations"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { decodeBase64Utf8 } from "@/util/github"
+import { GitHubAPIError } from "@/github-core/errors"
 import { prefixCommit } from "@/util/commit"
 import { withGitConflictRetry, assertClassroomNotArchived } from "../classrooms"
 
@@ -90,11 +91,18 @@ export type SetScoreOverrideResult = {
 // the rest are non-empty). Readers key off score/max-score/datetime, which are
 // real. `graded_by` is deliberately NOT stored — the config-repo commit author
 // is the authoritative, GitHub-authenticated "who".
+//
+// `sentinelIso` is the wall-clock stamp used only for the placeholder tag;
+// `datetimeIso` is the record's sort key, clamped by the caller so the override
+// always sorts as the newest submission (a real autograded submission's
+// datetime is the student-controllable committer date and could otherwise be
+// future-dated above the override — see editScoreOverride).
 function synthesizeOverrideRecord(
   input: SetScoreOverrideInput,
-  nowIso: string,
+  sentinelIso: string,
+  datetimeIso: string,
 ): SubmissionRecord {
-  const sentinel = `submit/manual-${nowIso.replace(/[:.]/g, "-")}`
+  const sentinel = `submit/manual-${sentinelIso.replace(/[:.]/g, "-")}`
   return {
     schema: RESULT_SCHEMA,
     classroom: input.classroom,
@@ -104,7 +112,7 @@ function synthesizeOverrideRecord(
     commit: sentinel,
     release: sentinel,
     review: sentinel,
-    datetime: nowIso,
+    datetime: datetimeIso,
     score: input.score ?? 0,
     "max-score": input.maxPoints ?? 0,
     tests: [],
@@ -128,8 +136,9 @@ async function readScoresFile(
   classroom: string,
   ref: string,
 ): Promise<ScoresFile> {
+  let file: { type: "file"; encoding: "base64"; content: string }
   try {
-    const file = await client.request<{
+    file = await client.request<{
       type: "file"
       encoding: "base64"
       content: string
@@ -138,13 +147,23 @@ async function readScoresFile(
         classroom,
       )}?ref=${encodeURIComponent(ref)}`,
     )
-    const parsed = JSON.parse(decodeBase64Utf8(file.content)) as ScoresFile
-    if (!parsed.assignments) parsed.assignments = {}
-    return parsed
-  } catch {
-    // Absent scores.json (never collected): scaffold so an override can seed it.
-    return { schema: SCORES_SCHEMA, assignments: {} }
+  } catch (err) {
+    // ONLY a genuine 404 means the file is absent (never collected) — scaffold
+    // so an override can seed it. Any other error (5xx / rate-limit / network)
+    // is NOT proof of absence: swallowing it here would let the caller commit a
+    // full-content blob that replaces the whole gradebook with this scaffold.
+    // Rethrow so the write fails loudly and the caller can retry, mirroring
+    // assertClassroomNotArchived's non-404 rethrow.
+    if (err instanceof GitHubAPIError && err.isNotFound) {
+      return { schema: SCORES_SCHEMA, assignments: {} }
+    }
+    throw err
   }
+  // Decode/parse OUTSIDE the 404-tolerated region: a truncated or malformed
+  // body must fail the save, not scaffold an empty gradebook over real scores.
+  const parsed = JSON.parse(decodeBase64Utf8(file.content)) as ScoresFile
+  if (!parsed.assignments) parsed.assignments = {}
+  return parsed
 }
 
 // Upsert (or clear) a teacher score override for one repo owner in scores.json,
@@ -200,17 +219,34 @@ export async function editScoreOverride(
         }
       }
     } else {
-      const record = synthesizeOverrideRecord(input, nowIso)
-      if (idx >= 0) {
-        const entry = bucket.entries[idx]
-        const realSubmissions = (entry.submissions ?? []).filter(
-          (s) => !isSynthesizedManual(s),
-        )
+      const existingEntry = idx >= 0 ? bucket.entries[idx] : undefined
+      const realSubmissions = (existingEntry?.submissions ?? []).filter(
+        (s) => !isSynthesizedManual(s),
+      )
+      // Clamp the override datetime to strictly after the newest existing
+      // submission so the override always sorts as the latest row. A real
+      // autograded submission's datetime is the student-controllable committer
+      // date and can be future-dated; without this clamp bucketToRows (which
+      // sorts by datetime desc) would show that autograded score under the
+      // "Manual" badge. max(now, newest+1s).
+      const newestExistingMs = realSubmissions.reduce((max, s) => {
+        const ms = new Date(s.datetime).getTime()
+        return Number.isFinite(ms) && ms > max ? ms : max
+      }, 0)
+      const overrideMs = Math.max(
+        new Date(nowIso).getTime(),
+        newestExistingMs + 1000,
+      )
+      const overrideIso = new Date(overrideMs)
+        .toISOString()
+        .replace(/\.\d+Z$/, "Z")
+      const record = synthesizeOverrideRecord(input, nowIso, overrideIso)
+      if (existingEntry) {
         // The override record leads (newest first); real history is retained
         // beneath it so clearing can restore it.
         bucket.entries[idx] = {
-          ...entry,
-          owner: entry.owner ?? owner,
+          ...existingEntry,
+          owner: existingEntry.owner ?? owner,
           override: true,
           submissions: [record, ...realSubmissions],
         }

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -114,8 +114,10 @@ function synthesizeOverrideRecord(
 // A submission record is a real autograder result (not our synthesized manual
 // one) when its submission tag isn't the manual sentinel.
 function isSynthesizedManual(record: SubmissionRecord): boolean {
-  return typeof record.submission === "string" &&
+  return (
+    typeof record.submission === "string" &&
     record.submission.startsWith("submit/manual-")
+  )
 }
 
 // Read scores.json at a ref, returning a normalized file (a scaffold when the
@@ -189,8 +191,9 @@ export async function editScoreOverride(
         if (realSubmissions.length > 0) {
           // Keep the real autograder history; drop the override so the next
           // collect refreshes it.
-          const { override: _override, ...rest } = entry
-          bucket.entries[idx] = { ...rest, submissions: realSubmissions }
+          const rest: ScoreEntry = { ...entry, submissions: realSubmissions }
+          delete rest.override
+          bucket.entries[idx] = rest
         } else {
           // No real submissions — the entry existed only for the override.
           bucket.entries.splice(idx, 1)

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -1,0 +1,263 @@
+import type { GitHubClient } from "@/github-core/client"
+import {
+  getBranchRef,
+  getCommit,
+  getConfigRepoBranch,
+} from "@/github-core/configRepoReads"
+import {
+  createGitCommit,
+  createGitTree,
+  updateRef,
+} from "@/github-core/mutations"
+import { CONFIG_REPO } from "@/util/configRepo"
+import { decodeBase64Utf8 } from "@/util/github"
+import { prefixCommit } from "@/util/commit"
+import { withGitConflictRetry, assertClassroomNotArchived } from "../classrooms"
+
+// A stored submission record inside scores.json (classroom50/result/v1 payload
+// minus the bucket-key `assignment`). We only type the fields the override path
+// reads or writes; unknown fields are preserved verbatim on read-modify-write.
+type SubmissionRecord = {
+  schema: string
+  classroom: string
+  assignment_type: "individual" | "group"
+  owner: string
+  submission: string
+  commit: string
+  release: string
+  review: string
+  datetime: string
+  score: number
+  "max-score": number
+  tests: unknown[]
+  [key: string]: unknown
+}
+
+type ScoreEntry = {
+  owner: string
+  member_usernames?: string[]
+  submissions: SubmissionRecord[]
+  override?: boolean
+  [key: string]: unknown
+}
+
+type AssignmentBucket = {
+  type: "individual" | "group"
+  entries: ScoreEntry[]
+}
+
+type ScoresFile = {
+  schema: "classroom50/scores/v1"
+  assignments: Record<string, AssignmentBucket>
+}
+
+const SCORES_SCHEMA = "classroom50/scores/v1"
+const RESULT_SCHEMA = "classroom50/result/v1"
+
+// scores.json is the classroom gradebook (written by the CLI collector). The
+// web is otherwise a pure reader; this is the one write path.
+function scoresFilePath(classroom: string): string {
+  return `${classroom}/scores.json`
+}
+
+export type SetScoreOverrideInput = {
+  org: string
+  classroom: string
+  assignment: string
+  // Repo owner login — the stable per-bucket key (individual student, or group
+  // founder). Case-insensitive on match; stored as given for a new entry.
+  owner: string
+  // Group crediting for a new entry (individual entries omit it and are
+  // credited to `owner`). Ignored when clearing.
+  memberUsernames?: string[]
+  assignmentType: "individual" | "group"
+  // The teacher-entered score and its max (max >= 1). Ignored when clearing.
+  score?: number
+  maxPoints?: number
+  // When true, remove the teacher override for this owner: drop the entry if it
+  // has no real (autograder-collected) submissions, else strip `override` and
+  // the synthesized record so the next collect refreshes it.
+  clear?: boolean
+}
+
+export type SetScoreOverrideResult = {
+  newCommitSha: string
+}
+
+// A synthesized submission record for a hand-entered/overridden score. It has no
+// real submit/* release, so `submission`/`commit`/`release`/`review` carry
+// stable placeholders that still satisfy scores-v1 (submission matches ^submit/;
+// the rest are non-empty). Readers key off score/max-score/datetime, which are
+// real. `graded_by` is deliberately NOT stored — the config-repo commit author
+// is the authoritative, GitHub-authenticated "who".
+function synthesizeOverrideRecord(
+  input: SetScoreOverrideInput,
+  nowIso: string,
+): SubmissionRecord {
+  const sentinel = `submit/manual-${nowIso.replace(/[:.]/g, "-")}`
+  return {
+    schema: RESULT_SCHEMA,
+    classroom: input.classroom,
+    assignment_type: input.assignmentType,
+    owner: input.owner,
+    submission: sentinel,
+    commit: sentinel,
+    release: sentinel,
+    review: sentinel,
+    datetime: nowIso,
+    score: input.score ?? 0,
+    "max-score": input.maxPoints ?? 0,
+    tests: [],
+  }
+}
+
+// A submission record is a real autograder result (not our synthesized manual
+// one) when its submission tag isn't the manual sentinel.
+function isSynthesizedManual(record: SubmissionRecord): boolean {
+  return typeof record.submission === "string" &&
+    record.submission.startsWith("submit/manual-")
+}
+
+// Read scores.json at a ref, returning a normalized file (a scaffold when the
+// file is absent — a fresh classroom may not have run collection yet).
+async function readScoresFile(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  ref: string,
+): Promise<ScoresFile> {
+  try {
+    const file = await client.request<{
+      type: "file"
+      encoding: "base64"
+      content: string
+    }>(
+      `/repos/${org}/${CONFIG_REPO}/contents/${scoresFilePath(
+        classroom,
+      )}?ref=${encodeURIComponent(ref)}`,
+    )
+    const parsed = JSON.parse(decodeBase64Utf8(file.content)) as ScoresFile
+    if (!parsed.assignments) parsed.assignments = {}
+    return parsed
+  } catch {
+    // Absent scores.json (never collected): scaffold so an override can seed it.
+    return { schema: SCORES_SCHEMA, assignments: {} }
+  }
+}
+
+// Upsert (or clear) a teacher score override for one repo owner in scores.json,
+// then commit it to the config repo. The entry is written with `override: true`
+// so the CLI collector preserves it verbatim (collect_scores.py apply_updates
+// skips override:true entries), which is what makes a manual grade — and an
+// override of an autograded score — survive re-collection. The whole thing is
+// wrapped in withGitConflictRetry so a race with the nightly collect run (or
+// another teacher) re-reads and retries transparently.
+export async function editScoreOverride(
+  client: GitHubClient,
+  input: SetScoreOverrideInput,
+): Promise<SetScoreOverrideResult> {
+  const { org, classroom, assignment, owner } = input
+
+  return withGitConflictRetry(async () => {
+    const [, configBranch] = await Promise.all([
+      assertClassroomNotArchived(client, org, classroom),
+      getConfigRepoBranch(client, org),
+    ])
+    const ref = await getBranchRef(client, org, configBranch)
+    const commit = await getCommit(client, org, ref.object.sha)
+
+    const scores = await readScoresFile(client, org, classroom, ref.object.sha)
+    const bucket: AssignmentBucket = scores.assignments[assignment] ?? {
+      type: input.assignmentType,
+      entries: [],
+    }
+    // Keep the bucket type in sync with the assignment mode.
+    bucket.type = input.assignmentType
+
+    const ownerKey = owner.trim().toLowerCase()
+    const idx = bucket.entries.findIndex(
+      (e) => (e.owner ?? "").trim().toLowerCase() === ownerKey,
+    )
+    const nowIso = new Date().toISOString().replace(/\.\d+Z$/, "Z")
+
+    if (input.clear) {
+      if (idx >= 0) {
+        const entry = bucket.entries[idx]
+        const realSubmissions = (entry.submissions ?? []).filter(
+          (s) => !isSynthesizedManual(s),
+        )
+        if (realSubmissions.length > 0) {
+          // Keep the real autograder history; drop the override so the next
+          // collect refreshes it.
+          const { override: _override, ...rest } = entry
+          bucket.entries[idx] = { ...rest, submissions: realSubmissions }
+        } else {
+          // No real submissions — the entry existed only for the override.
+          bucket.entries.splice(idx, 1)
+        }
+      }
+    } else {
+      const record = synthesizeOverrideRecord(input, nowIso)
+      if (idx >= 0) {
+        const entry = bucket.entries[idx]
+        const realSubmissions = (entry.submissions ?? []).filter(
+          (s) => !isSynthesizedManual(s),
+        )
+        // The override record leads (newest first); real history is retained
+        // beneath it so clearing can restore it.
+        bucket.entries[idx] = {
+          ...entry,
+          owner: entry.owner ?? owner,
+          override: true,
+          submissions: [record, ...realSubmissions],
+        }
+      } else {
+        const entry: ScoreEntry = {
+          owner,
+          override: true,
+          submissions: [record],
+        }
+        if (
+          input.assignmentType === "group" &&
+          input.memberUsernames &&
+          input.memberUsernames.length > 0
+        ) {
+          entry.member_usernames = input.memberUsernames
+        }
+        bucket.entries.push(entry)
+      }
+    }
+
+    // Drop an emptied bucket so the file stays clean.
+    if (bucket.entries.length === 0) {
+      delete scores.assignments[assignment]
+    } else {
+      scores.assignments[assignment] = bucket
+    }
+
+    const tree = await createGitTree(client, {
+      org,
+      base_tree: commit.tree.sha,
+      tree: [
+        {
+          path: scoresFilePath(classroom),
+          mode: "100644",
+          type: "blob",
+          content: JSON.stringify(scores, null, 2) + "\n",
+        },
+      ],
+    })
+    const message = input.clear
+      ? `Clear score override: ${classroom}/${assignment} (${owner})`
+      : `Set score override: ${classroom}/${assignment} (${owner})`
+    const newCommit = await createGitCommit(client, {
+      org,
+      message: prefixCommit(message),
+      tree_sha: tree.sha,
+      parents: [ref.object.sha],
+    })
+    await updateRef(client, org, newCommit.sha, configBranch)
+
+    return { newCommitSha: newCommit.sha }
+  })
+}

--- a/web/src/hooks/mutations/useSetScoreOverride.ts
+++ b/web/src/hooks/mutations/useSetScoreOverride.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { githubKeys } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
+import { CONFIG_REPO } from "@/util/configRepo"
+import {
+  editScoreOverride,
+  type SetScoreOverrideInput,
+  type SetScoreOverrideResult,
+} from "@/domain/assignments/scoreOverride"
+
+// Set or clear a teacher score override for one repo owner, writing the
+// classroom's scores.json in the config repo (the web's only scores write).
+// Invalidates the scores.json read so the submissions page reflects it. The
+// domain helper wraps the read-modify-write in withGitConflictRetry, so a race
+// with the nightly collect run retries transparently.
+export function useSetScoreOverride(opts?: {
+  onWrite?: (
+    result: SetScoreOverrideResult,
+    input: SetScoreOverrideInput,
+  ) => void
+}) {
+  const { onWrite } = opts ?? {}
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    SetScoreOverrideResult,
+    GitHubAPIError,
+    SetScoreOverrideInput
+  >({
+    mutationFn: (input) => editScoreOverride(client, input),
+    onSuccess: (result, input) => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(
+          input.org,
+          CONFIG_REPO,
+          `${input.classroom}/scores.json`,
+        ),
+      })
+      onWrite?.(result, input)
+    },
+  })
+}
+
+export default useSetScoreOverride

--- a/web/src/hooks/useGetScores.test.ts
+++ b/web/src/hooks/useGetScores.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeScores } from "./useGetScores"
+
+// A scores.json shape with one assignment bucket. Kept minimal to the fields
+// bucketToRows reads.
+function scoresWith(entries: unknown[]) {
+  return {
+    schema: "classroom50/scores/v1",
+    assignments: {
+      hw1: { type: "individual", entries },
+    },
+  }
+}
+
+const overrideRecord = {
+  schema: "classroom50/result/v1",
+  classroom: "cs50",
+  assignment_type: "individual",
+  owner: "alice",
+  submission: "submit/manual-2026-02-02T00-00-00Z",
+  commit: "submit/manual-2026-02-02T00-00-00Z",
+  release: "submit/manual-2026-02-02T00-00-00Z",
+  review: "submit/manual-2026-02-02T00-00-00Z",
+  datetime: "2026-02-02T00:00:00Z",
+  score: 42,
+  "max-score": 50,
+  tests: [],
+}
+
+describe("normalizeScores — manual override entries", () => {
+  it("renders a synthesized override entry as a normal graded row", () => {
+    // A manual/override entry carries a real submissions[0] in the existing
+    // shape, so the reader surfaces its score/max-score with no special branch.
+    const normalized = normalizeScores(
+      scoresWith([
+        { owner: "alice", override: true, submissions: [overrideRecord] },
+      ]) as never,
+    )
+    const rows = normalized?.submissions.hw1 ?? []
+    expect(rows).toHaveLength(1)
+    expect(rows[0].owner).toBe("alice")
+    expect(rows[0].score).toBe(42)
+    expect(rows[0]["max-score"]).toBe(50)
+    // The override flag is surfaced so the table can mark it.
+    expect(rows[0].overridden).toBe(true)
+  })
+
+  it("leaves overridden false for a plain autograded entry", () => {
+    const normalized = normalizeScores(
+      scoresWith([
+        {
+          owner: "bob",
+          submissions: [
+            {
+              ...overrideRecord,
+              owner: "bob",
+              submission: "submit/2026-01-01T00-00-00Z-abc1234",
+            },
+          ],
+        },
+      ]) as never,
+    )
+    const rows = normalized?.submissions.hw1 ?? []
+    expect(rows[0].overridden).toBe(false)
+  })
+})

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -136,7 +136,18 @@ function bucketToRows(bucket: AssignmentBucket): SubmissionRow[] {
           (a, b) =>
             new Date(b.datetime).getTime() - new Date(a.datetime).getTime(),
         )
-      const latest = sorted[0]
+      // For a teacher-overridden entry, the displayed grade must be the manual
+      // override record, not whichever submission sorts newest by datetime — a
+      // real autograded submission's datetime is the student-controllable
+      // committer date and could be future-dated above the override. Prefer the
+      // synthesized manual record (submission tag `submit/manual-*`) when the
+      // entry is overridden; the writer also clamps its datetime to sort first,
+      // so this is defense-in-depth for entries written before that clamp.
+      const overrideRecord =
+        entry.override === true
+          ? sorted.find((s) => s.submission.startsWith("submit/manual-"))
+          : undefined
+      const latest = overrideRecord ?? sorted[0]
 
       const usernames =
         entry.member_usernames && entry.member_usernames.length > 0

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -70,6 +70,11 @@ export type SubmissionRow = {
   late?: boolean
   // Last (re-)graded instant of the latest submission (mirrors submissions[0]).
   gradedAt?: string
+  // The entry carries a teacher override (`override: true` in scores.json): the
+  // latest score was set/frozen by hand rather than (only) autograded. The
+  // table marks it so a hand-entered grade is distinguishable from an
+  // autograded one. Mirrors the collector's per-entry override flag.
+  overridden?: boolean
   // A row with a submission the collector recorded as present but not graded
   // (no score yet) — rendered as "submitted, not yet collected" rather than a
   // 0/0 score. Excluded from graded stats/average and the CSV score column.
@@ -150,6 +155,7 @@ function bucketToRows(bucket: AssignmentBucket): SubmissionRow[] {
         submissionCount: entry.submissions.length,
         late: latest.late,
         gradedAt: latest.graded_at,
+        overridden: entry.override === true,
         submissions: sorted.map((s) => ({
           datetime: s.datetime,
           commit: s.commit,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1301,6 +1301,8 @@
         "passThresholdRange": "Pass threshold must be a whole number between {{min}} and {{max}}.",
         "studentPermissionInvalid": "Student repo access must be one of pull, triage, push, maintain, or admin.",
         "submissionModeInvalid": "Autograding trigger must be \"every-push\" or \"tag\".",
+        "gradingModeInvalid": "Grading must be \"off\", \"auto\", or \"manual\".",
+        "gradingMaxPointsInvalid": "Max points must be a whole number of at least {{min}}.",
         "releaseAssetsTooMany": "Choose at most {{max}} submission release files (currently {{count}}).",
         "releaseAssetsTooLarge": "Submission release file paths may total at most {{max}} UTF-8 bytes (8 KiB); currently {{bytes}}.",
         "releaseAssetsInvalidPath": "{{path}} is not an exact workspace-relative file path.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2459,6 +2459,8 @@
       "loading": "Loading submissions…",
       "pendingGrade": "Pending",
       "pendingGradeTitle": "Submitted — grade not yet collected. Run \"Sync submissions now\" or wait for the nightly collection.",
+      "overridden": "Manual",
+      "overriddenTitle": "This score was set by hand and won't be changed by autograding until the override is cleared.",
       "notSubmitted": "Not submitted",
       "acceptedAwaiting": "Accepted · awaiting submission",
       "notAccepted": "Not accepted",
@@ -2468,6 +2470,17 @@
       "review": "Review",
       "reviewAria": "Open feedback pull request",
       "fullHistory": "Open the <repoLink>repository</repoLink> for the full commit history."
+    },
+    "manualGrade": {
+      "notGraded": "Not graded",
+      "add": "Add grade",
+      "edit": "Edit grade",
+      "addLabel": "Add grade for {{name}}",
+      "editLabel": "Edit grade for {{name}}",
+      "inputLabel": "Score for {{name}}",
+      "required": "Enter a score to save.",
+      "range": "Score must be a whole number from 0 to {{max}}.",
+      "saveError": "Couldn't save the grade. Check your connection and try again."
     },
     "reviewModal": {
       "errorTitle": "Couldn't check for a feedback PR",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1189,6 +1189,21 @@
           }
         }
       },
+      "grading": {
+        "label": "Grading",
+        "help": "How this assignment is graded. \"Autograded\" runs the autograder you configure below. \"Manual\" lets you enter each student's score by hand on the submissions page. \"Not graded\" records no score. Can't be changed after the assignment is created.",
+        "editWarning": "The grading mode can't be changed after creation: scores already recorded under the old mode would be misread. Create a new assignment under a different slug instead.",
+        "autoNote": "This assignment is autograded. Configure the autograder in the Autograding section above. Whether you use the built-in autograder or supply your own workflow, it must publish a result.json asset on the submission release — that file is what the app reads to show scores.",
+        "choices": {
+          "off": "Not graded",
+          "auto": "Autograded",
+          "manual": "Manual (enter scores by hand)"
+        },
+        "maxPoints": {
+          "label": "Max points",
+          "help": "Total points available for this manual assignment. Used to show each student's score out of the maximum."
+        }
+      },
       "submissionMode": {
         "label": "Autograding trigger",
         "help": "When the autograder runs. \"Every push\" grades each push to the default branch. \"On submit only\" grades only when a student submits (with gh student submit) or pushes a submit/* tag — regular pushes cost no Actions minutes, which matters for large classes.",

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -152,6 +152,13 @@ const CreateAssignmentPage = () => {
                 student_permission: values.student_permission || undefined,
                 submission_mode: values.submission_mode,
                 submission_tags: parseSubmissionTags(values.submission_tags),
+                grading:
+                  values.grading_choice === "manual"
+                    ? {
+                        mode: "manual",
+                        max_points: values.grading_max_points,
+                      }
+                    : { mode: values.grading_choice },
                 repo_features: formValuesToRepoFeatures(values),
                 classroom,
                 tests: values.tests,

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -1160,6 +1160,21 @@ const SubmissionsPageContent = () => {
             : undefined
         }
         submissionTags={assignmentInfo?.submission_tags}
+        // Manual grading: staff may enter/edit scores inline. Gated on a
+        // resolved manual-mode assignment with a valid max_points. Group
+        // manual entry keys on the founder (row owner).
+        manualGrade={
+          assignmentInfo?.grading?.mode === "manual" &&
+          typeof assignmentInfo.grading.max_points === "number"
+            ? {
+                org,
+                classroom,
+                assignment,
+                assignmentType: isGroupAssignment ? "group" : "individual",
+                maxPoints: assignmentInfo.grading.max_points,
+              }
+            : undefined
+        }
         // Per-row Pause/Resume autograding: same gate as the bulk pause/resume
         // (owner + individual + resolved default-autograder). Kept separate from
         // submissionMode so the row action doesn't inherit the trigger action's

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -591,12 +591,12 @@ describe("assignment form section IA", () => {
       </QueryClientProvider>,
     )
 
-  // The default create form leaves the autograder off, so the Submission and
-  // Grading section (gated on a built-in shim) is absent; these are the
-  // always-present sections, in order.
+  // The Submission and Grading section now always renders (grading applies to
+  // any assignment), between Repository Setup and Autograding.
   const baseSectionTitleKeys = [
     "assignments.form.detailsSection",
     "assignments.form.repositorySetupSection",
+    "assignments.form.submissionSection",
     "assignments.form.autograding.label",
     "assignments.form.repositoryFeaturesSection",
     "assignments.form.scheduleSection",
@@ -608,51 +608,44 @@ describe("assignment form section IA", () => {
       .getAllByRole("heading", { level: 3 })
       .map((h) => h.textContent)
     // The section headings appear in the required order (other h3s may exist
-    // inside sections, so assert the titles are a subsequence). The Submission
-    // and Grading section is absent here (no built-in autograder by default).
+    // inside sections, so assert the titles are a subsequence).
     const indices = baseSectionTitleKeys.map((key) => headings.indexOf(key))
     expect(indices.every((i) => i >= 0)).toBe(true)
     expect([...indices]).toEqual([...indices].sort((a, b) => a - b))
-    expect(headings).not.toContain("assignments.form.submissionSection")
   })
 
   it("renders the sections in order for edit", () => {
-    // baseAssignment uses the default (built-in) autograder, so the Submission
-    // and Grading section renders between Repository Setup and Autograding.
     renderForm({
       edit: true,
       defaultValues: assignmentToFormValues(baseAssignment),
     })
-    const editSectionTitleKeys = [
-      "assignments.form.detailsSection",
-      "assignments.form.repositorySetupSection",
-      "assignments.form.submissionSection",
-      "assignments.form.autograding.label",
-      "assignments.form.repositoryFeaturesSection",
-      "assignments.form.scheduleSection",
-    ]
     const headings = screen
       .getAllByRole("heading", { level: 3 })
       .map((h) => h.textContent)
-    const indices = editSectionTitleKeys.map((key) => headings.indexOf(key))
+    const indices = baseSectionTitleKeys.map((key) => headings.indexOf(key))
     expect(indices.every((i) => i >= 0)).toBe(true)
     expect([...indices]).toEqual([...indices].sort((a, b) => a - b))
   })
 
-  it("shows the Submission and Grading section when built-in is on", () => {
-    // The built-in autograder means a shim exists to trigger, so the
-    // submission-trigger section renders.
-    renderForm({ defaultValues: { autograding_state: "built-in" } })
+  it("shows the grading choice regardless of the autograder state", () => {
+    // Grading applies to any assignment, so the section + grading control
+    // render even with no built-in autograder.
+    renderForm({ defaultValues: { autograding_state: "none" } })
     expect(
       screen.getByText("assignments.form.submissionSection"),
     ).not.toBeNull()
+    expect(screen.getByText("assignments.form.grading.label")).not.toBeNull()
+    // The submission trigger needs a shim, so it stays hidden here.
+    expect(
+      screen.queryByText("assignments.form.submissionMode.label"),
+    ).toBeNull()
   })
 
-  it("hides the Submission and Grading section when there is no built-in autograder", () => {
-    // "No built-in autograder" means no shim exists to trigger, so the whole
-    // submission-trigger section drops out (matching showBuiltInConfig).
-    renderForm({ defaultValues: { autograding_state: "none" } })
-    expect(screen.queryByText("assignments.form.submissionSection")).toBeNull()
+  it("shows the submission trigger controls only when built-in is on", () => {
+    renderForm({ defaultValues: { autograding_state: "built-in" } })
+    expect(
+      screen.getByText("assignments.form.submissionMode.label"),
+    ).not.toBeNull()
   })
 
   it("shows a per-section status badge (default on a fresh create form)", () => {

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -102,6 +102,13 @@ const EditAssignmentForm = ({
                 student_permission: values.student_permission || undefined,
                 submission_mode: values.submission_mode,
                 submission_tags: parseSubmissionTags(values.submission_tags),
+                grading:
+                  values.grading_choice === "manual"
+                    ? {
+                        mode: "manual",
+                        max_points: values.grading_max_points,
+                      }
+                    : { mode: values.grading_choice },
                 repo_features: formValuesToRepoFeatures(values),
                 classroom,
                 tests: values.tests,

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -363,10 +363,8 @@ describe("validateAssignmentForm — grading", () => {
 
   it("flags a hand-tampered grading choice", () => {
     expect(
-      validateAssignmentForm(
-        { ...base, grading_choice: "partial" as never },
-        t,
-      ).grading_choice,
+      validateAssignmentForm({ ...base, grading_choice: "partial" as never }, t)
+        .grading_choice,
     ).toBe("assignments.form.validation.gradingModeInvalid")
   })
 

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -67,6 +67,8 @@ const base: CreateAssignmentFormValues = {
   student_permission: "",
   submission_mode: "every-push",
   submission_tags: "",
+  grading_choice: "auto",
+  grading_max_points: 100,
   repo_feature_issues: "inherit",
   repo_feature_wiki: "inherit",
   repo_feature_projects: "inherit",
@@ -334,6 +336,132 @@ describe("validateAssignmentForm — submission mode + milestone tags", () => {
       validateAssignmentForm({ ...base, submission_tags: raw }, t)
         .submission_tags,
     ).toBeDefined()
+  })
+})
+
+describe("validateAssignmentForm — grading", () => {
+  it("accepts off/auto without a max, and manual with a max >= 1", () => {
+    for (const choice of ["off", "auto"] as const) {
+      expect(
+        validateAssignmentForm({ ...base, grading_choice: choice }, t)
+          .grading_max_points,
+      ).toBeUndefined()
+    }
+    expect(
+      validateAssignmentForm(
+        { ...base, grading_choice: "manual", grading_max_points: 1 },
+        t,
+      ).grading_max_points,
+    ).toBeUndefined()
+    expect(
+      validateAssignmentForm(
+        { ...base, grading_choice: "manual", grading_max_points: 100 },
+        t,
+      ).grading_max_points,
+    ).toBeUndefined()
+  })
+
+  it("flags a hand-tampered grading choice", () => {
+    expect(
+      validateAssignmentForm(
+        { ...base, grading_choice: "partial" as never },
+        t,
+      ).grading_choice,
+    ).toBe("assignments.form.validation.gradingModeInvalid")
+  })
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["non-integer", 2.5],
+  ])("flags a manual max of %s", (_label, max) => {
+    expect(
+      validateAssignmentForm(
+        { ...base, grading_choice: "manual", grading_max_points: max },
+        t,
+      ).grading_max_points,
+    ).toBe("assignments.form.validation.gradingMaxPointsInvalid")
+  })
+
+  it("ignores the max when the choice is not manual", () => {
+    // A stale/invalid max is not validated unless manual is selected.
+    expect(
+      validateAssignmentForm(
+        { ...base, grading_choice: "auto", grading_max_points: 0 },
+        t,
+      ).grading_max_points,
+    ).toBeUndefined()
+  })
+})
+
+describe("toSubmitValues — grading", () => {
+  it("passes the choice through and keeps the manual max", () => {
+    const out = toSubmitValues({
+      ...base,
+      grading_choice: "manual",
+      grading_max_points: 50,
+    })
+    expect(out.grading_choice).toBe("manual")
+    expect(out.grading_max_points).toBe(50)
+  })
+
+  it("resets the max when the choice is not manual", () => {
+    const out = toSubmitValues({
+      ...base,
+      grading_choice: "auto",
+      grading_max_points: 37,
+    })
+    expect(out.grading_choice).toBe("auto")
+    expect(out.grading_max_points).toBe(100)
+  })
+
+  it("does not clear grading for a teacher-CI (no built-in) assignment", () => {
+    // grading is orthogonal to the autograding tri-state: a no-built-in repo
+    // can still be graded manually, unlike submission_mode which is cleared.
+    const out = toSubmitValues({
+      ...base,
+      autograding_state: "none",
+      grading_choice: "manual",
+      grading_max_points: 20,
+    })
+    expect(out.grading_choice).toBe("manual")
+    expect(out.grading_max_points).toBe(20)
+    expect(out.submission_mode).toBe("every-push")
+  })
+})
+
+describe("assignmentToFormValues — grading", () => {
+  it("defaults to auto when grading is absent", () => {
+    const values = assignmentToFormValues({
+      slug: "hw1",
+      name: "Homework",
+      mode: "individual",
+      autograder: "default",
+    })
+    expect(values.grading_choice).toBe("auto")
+  })
+
+  it("reads a stored manual grading with its max", () => {
+    const values = assignmentToFormValues({
+      slug: "hw1",
+      name: "Homework",
+      mode: "individual",
+      autograder: "default",
+      grading: { mode: "manual", max_points: 25 },
+    })
+    expect(values.grading_choice).toBe("manual")
+    expect(values.grading_max_points).toBe(25)
+  })
+
+  it("reads a stored off grading", () => {
+    const values = assignmentToFormValues({
+      slug: "hw1",
+      name: "Homework",
+      mode: "individual",
+      autograder: "default",
+      grading: { mode: "off" },
+    })
+    expect(values.grading_choice).toBe("off")
   })
 })
 

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -48,6 +48,7 @@ import type {
   RepoPermission,
   RepoFeatures,
   SubmissionMode,
+  GradingMode,
 } from "@/types/classroom"
 import {
   GROUP_SIZE_MAX,
@@ -57,7 +58,12 @@ import {
   PASS_THRESHOLD_MIN,
   REPO_PERMISSIONS,
   SUBMISSION_MODES,
+  GRADING_MODES,
+  GRADING_MAX_POINTS_MIN,
 } from "@/types/classroom"
+
+// Default manual max-points shown when a teacher first picks manual grading.
+const DEFAULT_GRADING_MAX_POINTS = 100
 
 // Which runtime environment the Advanced Settings form is configuring. A UI-
 // only discriminator (not a wire field): "hosted" = a GitHub Actions runner
@@ -154,6 +160,16 @@ export type CreateAssignmentFormValues = {
   // Raw textarea text (one milestone tag pattern per line); parsed to
   // string[] on save, joined back on read. Empty = no milestone tags.
   submission_tags: string
+  // The teacher's grading intent: "off" (not graded), "auto" (autograded — the
+  // default), or "manual" (teacher enters scores on the submissions page).
+  // Maps to the wire grading.mode; ABSENT on the wire reads as "auto". Shown
+  // regardless of the autograding tri-state (a bare/teacher-CI repo can still
+  // be graded manually).
+  grading_choice: GradingMode
+  // Total points for a manual assignment; only meaningful when
+  // grading_choice === "manual" (cleared on submit otherwise). Maps to the wire
+  // grading.max_points (>= 1).
+  grading_max_points: number
   // Per-feature repo override, tri-state (one control shape regardless of
   // template): "inherit" writes no key (absent = inherit the template when
   // templated, else GitHub's own create default), "on"/"off" force the feature.
@@ -425,6 +441,21 @@ export function validateAssignmentForm(
     errors.submission_tags = submissionTagsError
   }
 
+  // Guard the grading picker against a hand-tampered value.
+  if (!GRADING_MODES.includes(value.grading_choice)) {
+    errors.grading_choice = t("assignments.form.validation.gradingModeInvalid")
+  } else if (value.grading_choice === "manual") {
+    // Manual grading needs a whole-number max >= 1 (a 0 max is the ungraded
+    // sentinel the submissions UI divides by). Mirrors the CLI ValidateGrading.
+    const max = Number(value.grading_max_points)
+    if (!Number.isInteger(max) || max < GRADING_MAX_POINTS_MIN) {
+      errors.grading_max_points = t(
+        "assignments.form.validation.gradingMaxPointsInvalid",
+        { min: GRADING_MAX_POINTS_MIN },
+      )
+    }
+  }
+
   return errors
 }
 
@@ -489,6 +520,15 @@ export function toSubmitValues(
     // clear a stale pick on submit (mirrors the other grading-adjacent clears).
     submission_mode: noBuiltIn ? "every-push" : value.submission_mode,
     submission_tags: noBuiltIn ? "" : value.submission_tags,
+    // Grading intent is orthogonal to the autograding tri-state (a bare or
+    // teacher-CI repo can still be graded manually), so it is NOT cleared by
+    // noBuiltIn. Only the manual max-points is normalized: kept when manual,
+    // reset otherwise so a stale value can't reach the wire.
+    grading_choice: value.grading_choice,
+    grading_max_points:
+      value.grading_choice === "manual"
+        ? Number(value.grading_max_points)
+        : DEFAULT_GRADING_MAX_POINTS,
     // Uniform tri-state controls; "inherit" is the default and resolves to the
     // template's feature (templated) or GitHub's own create default (template-
     // less) at accept time, so no template-dependent default-flip is needed here.
@@ -547,6 +587,9 @@ export const useAssignmentForm = (
       student_permission: defaultValues?.student_permission ?? "",
       submission_mode: defaultValues?.submission_mode ?? "every-push",
       submission_tags: defaultValues?.submission_tags || "",
+      grading_choice: defaultValues?.grading_choice ?? "auto",
+      grading_max_points:
+        defaultValues?.grading_max_points ?? DEFAULT_GRADING_MAX_POINTS,
       repo_feature_issues: defaultValues?.repo_feature_issues ?? "inherit",
       repo_feature_wiki: defaultValues?.repo_feature_wiki ?? "inherit",
       repo_feature_projects: defaultValues?.repo_feature_projects ?? "inherit",
@@ -653,6 +696,11 @@ export const assignmentToFormValues = (
     submission_mode: assignment.submission_mode ?? "every-push",
     // Milestone tag patterns, joined one-per-line for the textarea.
     submission_tags: submissionTagsToText(assignment.submission_tags),
+    // Grading intent; absent reads as "auto" (today's behavior). A stored
+    // manual max seeds the input, else the default (only used once manual).
+    grading_choice: assignment.grading?.mode ?? "auto",
+    grading_max_points:
+      assignment.grading?.max_points ?? DEFAULT_GRADING_MAX_POINTS,
     // Read mapping: absent object/key -> "inherit", true -> "on", false ->
     // "off", per key, so a stored "off" round-trips instead of reverting.
     repo_feature_issues: repoFeatureChoice(assignment.repo_features?.issues),

--- a/web/src/pages/assignments/formShape.test.ts
+++ b/web/src/pages/assignments/formShape.test.ts
@@ -37,6 +37,8 @@ const base: CreateAssignmentFormValues = {
   student_permission: "",
   submission_mode: "every-push",
   submission_tags: "",
+  grading_choice: "auto",
+  grading_max_points: 100,
   repo_feature_issues: "inherit",
   repo_feature_wiki: "inherit",
   repo_feature_projects: "inherit",

--- a/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
+++ b/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
@@ -1,22 +1,25 @@
 import { useTranslation } from "react-i18next"
-import { Alert, FormField, Select, Textarea } from "@/components/ui"
+import { Alert, FormField, Input, Select, Textarea } from "@/components/ui"
 import {
   parseSubmissionTags,
   validateSubmissionTags,
 } from "@/util/submissionTags"
+import { GRADING_MAX_POINTS_MIN } from "@/types/classroom"
 import type { AssignmentForm } from "../assignmentFormModel"
 import { deriveFormShape } from "../formShape"
 import type { SectionStatus } from "./sectionStatus"
 import { SectionCard } from "./SectionCard"
 
-// Submission and Grading: what counts as a submission for the assignment — the
-// submission trigger (every push vs. on submit only) and optional milestone
-// tags. Split out of Autograding so "what counts as a submission" has its own
-// home. Both controls only matter when a built-in shim exists (they are
-// mutually exclusive with empty_repo / no_autograder on the wire), so the whole
-// section hides for a bare repo or teacher-supplied CI, mirroring
-// showBuiltInConfig. On a hidden section the fields keep their (default) values,
-// so the wire stays correct.
+// Submission and Grading: how the assignment is graded (off / auto / manual,
+// with a manual max-points) and — when a built-in shim exists — what triggers
+// the autograder (every push vs. on submit only, plus milestone tags).
+//
+// The grading controls apply to ANY assignment (a bare or teacher-CI repo can
+// still be graded by hand), so the section always renders. The submission
+// trigger + milestone tags only matter with a built-in shim (they are mutually
+// exclusive with empty_repo / no_autograder on the wire), so those sub-controls
+// stay gated on showBuiltInConfig. Hidden fields keep their (default) values, so
+// the wire stays correct.
 export function SubmissionGradingSection({
   form,
   edit,
@@ -29,24 +32,149 @@ export function SubmissionGradingSection({
   const { t } = useTranslation()
 
   return (
-    <form.Subscribe
-      selector={(state) => deriveFormShape(state.values).showBuiltInConfig}
+    <SectionCard
+      title={t("assignments.form.submissionSection")}
+      status={status}
+      description={t("assignments.form.submissionSectionHelp")}
     >
-      {(showBuiltInConfig) =>
-        showBuiltInConfig ? (
-          <SectionCard
-            title={t("assignments.form.submissionSection")}
-            status={status}
-            description={t("assignments.form.submissionSectionHelp")}
-          >
-            <div className="flex flex-col gap-4">
-              <SubmissionModeField form={form} edit={edit} />
-              <SubmissionTagsField form={form} edit={edit} />
-            </div>
-          </SectionCard>
-        ) : null
-      }
-    </form.Subscribe>
+      <div className="flex flex-col gap-4">
+        <GradingChoiceField form={form} edit={edit} />
+        {/* Submission trigger + milestone tags need a built-in shim; hidden for
+            a bare repo or teacher-supplied CI. */}
+        <form.Subscribe
+          selector={(state) => deriveFormShape(state.values).showBuiltInConfig}
+        >
+          {(showBuiltInConfig) =>
+            showBuiltInConfig ? (
+              <>
+                <div className="divider my-0" />
+                <SubmissionModeField form={form} edit={edit} />
+                <SubmissionTagsField form={form} edit={edit} />
+              </>
+            ) : null
+          }
+        </form.Subscribe>
+      </div>
+    </SectionCard>
+  )
+}
+
+// Grading choice (off / auto / manual). manual reveals a max-points input; auto
+// shows a pointer to the Autograding section + the result.json requirement.
+// The mode is immutable after creation, so on edit a change warns.
+function GradingChoiceField({
+  form,
+  edit,
+}: {
+  form: AssignmentForm
+  edit: boolean
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col gap-3">
+      <form.Field name="grading_choice">
+        {(field) => (
+          <div>
+            <FormField
+              htmlFor={field.name}
+              label={t("assignments.form.grading.label")}
+              help={t("assignments.form.grading.help")}
+            >
+              {({ id, describedById }) => (
+                <Select
+                  id={id}
+                  name={field.name}
+                  className="w-full sm:max-w-xs"
+                  aria-describedby={describedById}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) =>
+                    field.handleChange(e.target.value as typeof field.state.value)
+                  }
+                >
+                  <option value="off">
+                    {t("assignments.form.grading.choices.off")}
+                  </option>
+                  <option value="auto">
+                    {t("assignments.form.grading.choices.auto")}
+                  </option>
+                  <option value="manual">
+                    {t("assignments.form.grading.choices.manual")}
+                  </option>
+                </Select>
+              )}
+            </FormField>
+            {edit ? (
+              <form.Subscribe selector={(state) => state.values.grading_choice}>
+                {(choice) =>
+                  choice !==
+                  (form.options.defaultValues?.grading_choice ?? "auto") ? (
+                    <Alert tone="warning" role="status" className="mt-2 text-sm">
+                      <span>{t("assignments.form.grading.editWarning")}</span>
+                    </Alert>
+                  ) : null
+                }
+              </form.Subscribe>
+            ) : null}
+          </div>
+        )}
+      </form.Field>
+
+      {/* manual -> max points; auto -> result.json pointer. Keyed off the live
+          choice so switching modes reveals the right affordance. */}
+      <form.Subscribe selector={(state) => state.values.grading_choice}>
+        {(choice) =>
+          choice === "manual" ? (
+            <ManualMaxPointsField form={form} />
+          ) : choice === "auto" ? (
+            <Alert tone="info" role="note" className="text-sm">
+              <span>{t("assignments.form.grading.autoNote")}</span>
+            </Alert>
+          ) : null
+        }
+      </form.Subscribe>
+    </div>
+  )
+}
+
+function ManualMaxPointsField({ form }: { form: AssignmentForm }) {
+  const { t } = useTranslation()
+  return (
+    <form.Field name="grading_max_points">
+      {(field) => {
+        const error = field.state.meta.errors[0] as string | undefined
+        return (
+          <div>
+            <FormField
+              htmlFor={field.name}
+              label={t("assignments.form.grading.maxPoints.label")}
+              help={t("assignments.form.grading.maxPoints.help")}
+            >
+              {({ id, describedById }) => (
+                <Input
+                  id={id}
+                  name={field.name}
+                  type="number"
+                  inputMode="numeric"
+                  min={GRADING_MAX_POINTS_MIN}
+                  step={1}
+                  className="w-28"
+                  aria-describedby={describedById}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(Number(e.target.value))}
+                />
+              )}
+            </FormField>
+            {error ? (
+              <p role="alert" className="mt-1.5 text-sm text-error">
+                {error}
+              </p>
+            ) : null}
+          </div>
+        )
+      }}
+    </form.Field>
   )
 }
 

--- a/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
+++ b/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
@@ -89,7 +89,9 @@ function GradingChoiceField({
                   value={field.state.value}
                   onBlur={field.handleBlur}
                   onChange={(e) =>
-                    field.handleChange(e.target.value as typeof field.state.value)
+                    field.handleChange(
+                      e.target.value as typeof field.state.value,
+                    )
                   }
                 >
                   <option value="off">
@@ -109,7 +111,11 @@ function GradingChoiceField({
                 {(choice) =>
                   choice !==
                   (form.options.defaultValues?.grading_choice ?? "auto") ? (
-                    <Alert tone="warning" role="status" className="mt-2 text-sm">
+                    <Alert
+                      tone="warning"
+                      role="status"
+                      className="mt-2 text-sm"
+                    >
                       <span>{t("assignments.form.grading.editWarning")}</span>
                     </Alert>
                   ) : null

--- a/web/src/pages/assignments/sections/sectionStatus.test.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.test.ts
@@ -130,6 +130,23 @@ describe("deriveSectionStatus", () => {
     )
   })
 
+  it("attributes the grading choice + max points to the submission section", () => {
+    const manual = { ...defaults, grading_choice: "manual" as const }
+    expect(deriveSectionStatus("submission", manual, defaults, {})).toBe(
+      "configured",
+    )
+    const maxChanged = { ...defaults, grading_max_points: 42 }
+    expect(deriveSectionStatus("submission", maxChanged, defaults, {})).toBe(
+      "configured",
+    )
+    // A grading validation error routes to the submission section.
+    expect(
+      deriveSectionStatus("submission", defaults, defaults, {
+        grading_max_points: "bad",
+      }),
+    ).toBe("error")
+  })
+
   it("routes a submission_tags validation error to the submission section", () => {
     const errors = { submission_tags: "bad" }
     expect(deriveSectionStatus("submission", defaults, defaults, errors)).toBe(

--- a/web/src/pages/assignments/sections/sectionStatus.test.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.test.ts
@@ -38,6 +38,8 @@ const defaults: CreateAssignmentFormValues = {
   student_permission: "",
   submission_mode: "every-push",
   submission_tags: "",
+  grading_choice: "auto",
+  grading_max_points: 100,
   repo_feature_issues: "inherit",
   repo_feature_wiki: "inherit",
   repo_feature_projects: "inherit",

--- a/web/src/pages/assignments/sections/sectionStatus.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.ts
@@ -58,7 +58,12 @@ const SECTION_FIELDS: Record<
     "pass_threshold",
     "tests",
   ],
-  submission: ["submission_mode", "submission_tags", "grading_choice", "grading_max_points"],
+  submission: [
+    "submission_mode",
+    "submission_tags",
+    "grading_choice",
+    "grading_max_points",
+  ],
   features: [
     "repo_feature_issues",
     "repo_feature_wiki",

--- a/web/src/pages/assignments/sections/sectionStatus.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.ts
@@ -58,7 +58,7 @@ const SECTION_FIELDS: Record<
     "pass_threshold",
     "tests",
   ],
-  submission: ["submission_mode", "submission_tags"],
+  submission: ["submission_mode", "submission_tags", "grading_choice", "grading_max_points"],
   features: [
     "repo_feature_issues",
     "repo_feature_wiki",

--- a/web/src/pages/submissions/ManualGradeCell.test.tsx
+++ b/web/src/pages/submissions/ManualGradeCell.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) =>
+        opts && "max" in opts
+          ? `${key}:${String(opts.max)}`
+          : opts && "name" in opts
+            ? `${key}:${String(opts.name)}`
+            : key,
+    }),
+  }
+})
+
+const mutate = vi.fn()
+let isPending = false
+let isError = false
+const reset = vi.fn()
+
+vi.mock("@/hooks/mutations/useSetScoreOverride", () => ({
+  useSetScoreOverride: () => ({ mutate, isPending, isError, reset }),
+}))
+
+import { ManualGradeCell } from "./ManualGradeCell"
+
+const ctx = {
+  org: "acme",
+  classroom: "cs50",
+  assignment: "hw1",
+  assignmentType: "individual" as const,
+  maxPoints: 50,
+}
+
+beforeEach(() => {
+  mutate.mockReset()
+  reset.mockReset()
+  isPending = false
+  isError = false
+})
+afterEach(cleanup)
+
+function renderCell(props?: Partial<Parameters<typeof ManualGradeCell>[0]>) {
+  return render(
+    <ManualGradeCell
+      owner="alice"
+      score={0}
+      max={50}
+      hasGrade={false}
+      thresholdFraction={null}
+      ctx={ctx}
+      {...props}
+    />,
+  )
+}
+
+describe("ManualGradeCell", () => {
+  it("shows the ungraded empty state (not a 0) when no grade exists", () => {
+    renderCell({ hasGrade: false })
+    expect(screen.getByText("submissions.manualGrade.notGraded")).toBeTruthy()
+    // No score badge (which would read 0/50) in the ungraded state.
+    expect(screen.queryByText("0/50")).toBeNull()
+  })
+
+  it("shows the current score badge when a grade exists", () => {
+    renderCell({ hasGrade: true, score: 42, max: 50 })
+    expect(screen.getByText("42/50")).toBeTruthy()
+  })
+
+  it("enters edit mode, validates the range, and blocks save until valid", async () => {
+    const user = userEvent.setup()
+    renderCell({ hasGrade: false })
+    await user.click(
+      screen.getByRole("button", {
+        name: "submissions.manualGrade.addLabel:alice",
+      }),
+    )
+    const input = screen.getByRole("spinbutton", {
+      name: "submissions.manualGrade.inputLabel:alice",
+    })
+    // Over the max -> range error, save disabled, mutate not called.
+    await user.type(input, "99")
+    expect(screen.getByRole("alert").textContent).toBe(
+      "submissions.manualGrade.range:50",
+    )
+    const save = screen.getByRole("button", { name: "common.save" })
+    expect(save.hasAttribute("disabled")).toBe(true)
+    await user.click(save)
+    expect(mutate).not.toHaveBeenCalled()
+  })
+
+  it("saves a valid score with override context", async () => {
+    const user = userEvent.setup()
+    renderCell({ hasGrade: false })
+    await user.click(
+      screen.getByRole("button", {
+        name: "submissions.manualGrade.addLabel:alice",
+      }),
+    )
+    const input = screen.getByRole("spinbutton", {
+      name: "submissions.manualGrade.inputLabel:alice",
+    })
+    await user.type(input, "40")
+    await user.click(screen.getByRole("button", { name: "common.save" }))
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(mutate.mock.calls[0][0]).toMatchObject({
+      org: "acme",
+      classroom: "cs50",
+      assignment: "hw1",
+      owner: "alice",
+      score: 40,
+      maxPoints: 50,
+    })
+  })
+
+  it("cancels back to idle without saving", async () => {
+    const user = userEvent.setup()
+    renderCell({ hasGrade: true, score: 10, max: 50 })
+    await user.click(
+      screen.getByRole("button", {
+        name: "submissions.manualGrade.editLabel:alice",
+      }),
+    )
+    await user.click(screen.getByRole("button", { name: "common.cancel" }))
+    expect(mutate).not.toHaveBeenCalled()
+    // Back to the idle badge.
+    expect(screen.getByText("10/50")).toBeTruthy()
+  })
+})

--- a/web/src/pages/submissions/ManualGradeCell.tsx
+++ b/web/src/pages/submissions/ManualGradeCell.tsx
@@ -1,0 +1,222 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Check, Pencil, X } from "lucide-react"
+
+import { Badge, Button, Input, Spinner } from "@/components/ui"
+import { scoreTone } from "@/pages/submissions/dashboard"
+import { useSetScoreOverride } from "@/hooks/mutations/useSetScoreOverride"
+
+export type ManualGradeContext = {
+  org: string
+  classroom: string
+  assignment: string
+  assignmentType: "individual" | "group"
+  // The assignment's configured max points (>= 1) for a manual assignment.
+  maxPoints: number
+  // Group crediting for a new entry (the credited members of the group repo).
+  memberUsernames?: string[]
+}
+
+// The inline score editor for a MANUAL-mode assignment (or a teacher override).
+// A small state machine in the score cell:
+//   idle    -> shows the current score badge (or an "Add grade" affordance) with
+//              an edit button
+//   editing -> a number input with Save / Cancel; Enter saves, Esc cancels
+//   saving  -> input disabled + spinner
+//   error   -> inline role="alert" message + the value kept for a retry
+// Validation mirrors the form: integer, 0..maxPoints, non-empty to save. An
+// un-scored row renders empty (never a defaulted 0) and stays "ungraded".
+export function ManualGradeCell({
+  owner,
+  score,
+  max,
+  hasGrade,
+  thresholdFraction,
+  ctx,
+}: {
+  owner: string
+  // Current score / max (from the collected/override row). Ignored for display
+  // when hasGrade is false.
+  score: number
+  max: number
+  // Whether a grade has actually been recorded for this owner. False = the
+  // ungraded empty state (show "Add grade", not 0).
+  hasGrade: boolean
+  thresholdFraction: number | null
+  ctx: ManualGradeContext
+}) {
+  const { t } = useTranslation()
+  const [editing, setEditing] = useState(false)
+  // The draft value while editing, as a string so an empty field is
+  // representable (distinct from 0).
+  const [draft, setDraft] = useState("")
+  const mutation = useSetScoreOverride()
+
+  const startEditing = () => {
+    setDraft(hasGrade ? String(score) : "")
+    mutation.reset()
+    setEditing(true)
+  }
+
+  const cancel = () => {
+    setEditing(false)
+    setDraft("")
+    mutation.reset()
+  }
+
+  const parsed = Number(draft)
+  const validationError =
+    draft.trim() === ""
+      ? t("submissions.manualGrade.required")
+      : !Number.isInteger(parsed) || parsed < 0 || parsed > ctx.maxPoints
+        ? t("submissions.manualGrade.range", { max: ctx.maxPoints })
+        : null
+
+  const save = () => {
+    if (validationError) return
+    mutation.mutate(
+      {
+        org: ctx.org,
+        classroom: ctx.classroom,
+        assignment: ctx.assignment,
+        owner,
+        assignmentType: ctx.assignmentType,
+        memberUsernames: ctx.memberUsernames,
+        score: parsed,
+        maxPoints: ctx.maxPoints,
+      },
+      {
+        onSuccess: () => {
+          setEditing(false)
+          setDraft("")
+        },
+      },
+    )
+  }
+
+  if (editing) {
+    const saving = mutation.isPending
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-1.5">
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={ctx.maxPoints}
+            step={1}
+            className="w-20"
+            autoFocus
+            disabled={saving}
+            aria-label={t("submissions.manualGrade.inputLabel", {
+              name: owner,
+            })}
+            aria-describedby={
+              validationError ? `manual-grade-error-${owner}` : undefined
+            }
+            aria-invalid={validationError ? true : undefined}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault()
+                save()
+              } else if (e.key === "Escape") {
+                e.preventDefault()
+                cancel()
+              }
+            }}
+          />
+          <span className="text-sm text-base-content/60 whitespace-nowrap">
+            / {ctx.maxPoints}
+          </span>
+          {saving ? (
+            <Spinner size="xs" />
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                shape="square"
+                aria-label={t("common.save")}
+                disabled={Boolean(validationError)}
+                onClick={save}
+              >
+                <Check className="size-4" aria-hidden="true" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                shape="square"
+                aria-label={t("common.cancel")}
+                onClick={cancel}
+              >
+                <X className="size-4" aria-hidden="true" />
+              </Button>
+            </>
+          )}
+        </div>
+        {validationError && !saving ? (
+          <p
+            id={`manual-grade-error-${owner}`}
+            role="alert"
+            className="text-xs text-error"
+          >
+            {validationError}
+          </p>
+        ) : null}
+        {mutation.isError ? (
+          <p role="alert" className="text-xs text-error">
+            {t("submissions.manualGrade.saveError")}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  // Idle: the current grade (or an "Add grade" ghost for an ungraded row), plus
+  // an edit affordance.
+  const tone = scoreTone(score, max, thresholdFraction)
+  return (
+    <div className="flex items-center gap-1.5">
+      {hasGrade ? (
+        tone.ghost ? (
+          <Badge ghost>
+            {score}/{max}
+          </Badge>
+        ) : (
+          <Badge tone={tone.tone}>
+            {score}/{max}
+          </Badge>
+        )
+      ) : (
+        <span className="text-sm text-base-content/50">
+          {t("submissions.manualGrade.notGraded")}
+        </span>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        shape="square"
+        aria-label={
+          hasGrade
+            ? t("submissions.manualGrade.editLabel", { name: owner })
+            : t("submissions.manualGrade.addLabel", { name: owner })
+        }
+        title={
+          hasGrade
+            ? t("submissions.manualGrade.edit")
+            : t("submissions.manualGrade.add")
+        }
+        onClick={startEditing}
+      >
+        <Pencil className="size-3.5" aria-hidden="true" />
+      </Button>
+    </div>
+  )
+}
+
+export default ManualGradeCell

--- a/web/src/pages/submissions/ManualGradeCell.tsx
+++ b/web/src/pages/submissions/ManualGradeCell.tsx
@@ -2,8 +2,8 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Check, Pencil, X } from "lucide-react"
 
-import { Badge, Button, Input, Spinner } from "@/components/ui"
-import { scoreTone } from "@/pages/submissions/dashboard"
+import { Button, Input, Spinner } from "@/components/ui"
+import { ScoreBadge } from "@/pages/submissions/ScoreBadge"
 import { useSetScoreOverride } from "@/hooks/mutations/useSetScoreOverride"
 
 export type ManualGradeContext = {
@@ -177,20 +177,15 @@ export function ManualGradeCell({
   }
 
   // Idle: the current grade (or an "Add grade" ghost for an ungraded row), plus
-  // an edit affordance.
-  const tone = scoreTone(score, max, thresholdFraction)
+  // an edit affordance. Reuses the shared ScoreBadge (one recipe, one source).
   return (
     <div className="flex items-center gap-1.5">
       {hasGrade ? (
-        tone.ghost ? (
-          <Badge ghost>
-            {score}/{max}
-          </Badge>
-        ) : (
-          <Badge tone={tone.tone}>
-            {score}/{max}
-          </Badge>
-        )
+        <ScoreBadge
+          score={score}
+          max={max}
+          thresholdFraction={thresholdFraction}
+        />
       ) : (
         <span className="text-sm text-base-content/50">
           {t("submissions.manualGrade.notGraded")}

--- a/web/src/pages/submissions/ScoreBadge.tsx
+++ b/web/src/pages/submissions/ScoreBadge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from "@/components/ui"
+import { scoreTone } from "@/pages/submissions/dashboard"
+
+// Score chip via the shared scoreTone recipe — the single source for the
+// score→tone→Badge mapping (AGENTS.md "one recipe, one source"). Used by the
+// submissions table, the per-attempt history timeline, and the manual-grade
+// cell. success/error tone for graded rows, neutral ghost for ungraded (no
+// threshold or zero/NaN max).
+export const ScoreBadge = ({
+  score,
+  max,
+  thresholdFraction,
+  size,
+}: {
+  score: number
+  max: number
+  thresholdFraction: number | null
+  size?: "xs" | "sm" | "md"
+}) => {
+  const t = scoreTone(score, max, thresholdFraction)
+  return (
+    <Badge
+      size={size}
+      ghost={"ghost" in t && t.ghost}
+      tone={"tone" in t ? t.tone : "neutral"}
+    >
+      {score}/{max}
+    </Badge>
+  )
+}
+
+export default ScoreBadge

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -6,6 +6,8 @@ import { studentRepoUrl } from "@/util/studentRepo"
 import Avatar from "@/components/avatar"
 import { Badge, Button } from "@/components/ui"
 import { nonSubmitterStatus } from "@/pages/submissions/dashboard"
+import { ManualGradeCell } from "@/pages/submissions/ManualGradeCell"
+import type { ManualGradeContext } from "@/pages/submissions/ManualGradeCell"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import type { Student } from "@/types/classroom"
 
@@ -233,6 +235,7 @@ export const NonSubmitterRow = ({
   acceptedUsernames,
   onProfile,
   actions,
+  manualGrade,
 }: {
   student: Student
   students: Student[]
@@ -240,6 +243,10 @@ export const NonSubmitterRow = ({
   acceptedUsernames?: Set<string>
   onProfile: (username: string) => void
   actions?: React.ReactNode
+  // When set (individual manual-grade assignment, writable viewer), the score
+  // cell offers inline grade entry for this not-yet-graded student instead of
+  // an em-dash.
+  manualGrade?: ManualGradeContext
 }) => {
   return (
     <tr>
@@ -265,7 +272,20 @@ export const NonSubmitterRow = ({
           acceptedUsernames={acceptedUsernames}
         />
       </td>
-      <td>—</td>
+      <td>
+        {manualGrade && !isGroup && student.username ? (
+          <ManualGradeCell
+            owner={student.username}
+            score={0}
+            max={manualGrade.maxPoints}
+            hasGrade={false}
+            thresholdFraction={null}
+            ctx={manualGrade}
+          />
+        ) : (
+          "—"
+        )}
+      </td>
       <td>—</td>
       <td>
         {actions ? (

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -50,6 +50,8 @@ import {
   RepoRowActions,
 } from "@/pages/submissions/SubmissionsRowActions"
 import { ManageSubmissionModal } from "@/pages/submissions/ManageSubmissionModal"
+import { ManualGradeCell } from "@/pages/submissions/ManualGradeCell"
+import type { ManualGradeContext } from "@/pages/submissions/ManualGradeCell"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
 import { RepoAccessModal } from "@/components/modals/RepoAccessModal"
 import { StudentProfileModal } from "@/components/modals/StudentProfileModal"
@@ -230,6 +232,7 @@ const SubmissionsTable = ({
   emptyRepo = false,
   submissionMode,
   submissionTags,
+  manualGrade,
   canPauseAutograding = false,
   initialLoading = false,
   nonSubmittersLoading = false,
@@ -274,6 +277,10 @@ const SubmissionsTable = ({
   submissionMode?: SubmissionMode
   // The assignment's milestone submission_tags for the same action.
   submissionTags?: string[]
+  // When set, the assignment is graded MANUALLY and the viewer may enter/edit
+  // scores inline. Carries the write context (org/classroom/assignment/type/
+  // max points). Omitted for autograded assignments or a viewer who can't write.
+  manualGrade?: ManualGradeContext
   // Whether the per-row Pause/Resume-autograding action applies. Gated by the
   // page (owner + individual + resolved default-autograder), matching the bulk
   // pause/resume gate so the row and menu entry points stay in lockstep — the
@@ -460,16 +467,36 @@ const SubmissionsTable = ({
               >
                 —
               </span>
+            ) : manualGrade ? (
+              <ManualGradeCell
+                owner={rest.owner}
+                score={score}
+                max={rest["max-score"]}
+                hasGrade={!rest.pending}
+                thresholdFraction={passBar}
+                ctx={{ ...manualGrade, memberUsernames: usernames }}
+              />
             ) : rest.pending ? (
               <Badge ghost title={t("submissions.table.pendingGradeTitle")}>
                 {t("submissions.table.pendingGrade")}
               </Badge>
             ) : (
-              <ScoreBadge
-                score={score}
-                max={rest["max-score"]}
-                thresholdFraction={passBar}
-              />
+              <div className="flex items-center gap-1.5">
+                <ScoreBadge
+                  score={score}
+                  max={rest["max-score"]}
+                  thresholdFraction={passBar}
+                />
+                {rest.overridden ? (
+                  <Badge
+                    ghost
+                    size="sm"
+                    title={t("submissions.table.overriddenTitle")}
+                  >
+                    {t("submissions.table.overridden")}
+                  </Badge>
+                ) : null}
+              </div>
             )}
           </td>
           <td>
@@ -737,6 +764,7 @@ const SubmissionsTable = ({
                     acceptedUsernames={acceptedUsernames}
                     onProfile={setProfileUsername}
                     actions={actions}
+                    manualGrade={manualGrade}
                   />
                 )
               }

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -24,7 +24,6 @@ import {
   TablePagination,
   rtlFlip,
 } from "@/components/ui"
-import { scoreTone } from "@/pages/submissions/dashboard"
 import type { GroupRepo } from "@/pages/submissions/dashboard"
 import type { SubmissionSort } from "@/pages/submissions/dashboard"
 import {
@@ -50,6 +49,7 @@ import {
   RepoRowActions,
 } from "@/pages/submissions/SubmissionsRowActions"
 import { ManageSubmissionModal } from "@/pages/submissions/ManageSubmissionModal"
+import { ScoreBadge as SharedScoreBadge } from "@/pages/submissions/ScoreBadge"
 import { ManualGradeCell } from "@/pages/submissions/ManualGradeCell"
 import type { ManualGradeContext } from "@/pages/submissions/ManualGradeCell"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
@@ -65,30 +65,10 @@ const formatDateTime = (datetime: string) =>
     timeStyle: "short",
   })
 
-// Score chip via the shared scoreTone recipe (one mapping for table + history):
-// success/error tone for graded rows, neutral ghost for ungraded.
-const ScoreBadge = ({
-  score,
-  max,
-  thresholdFraction,
-  size,
-}: {
-  score: number
-  max: number
-  thresholdFraction: number | null
-  size?: "xs" | "sm" | "md"
-}) => {
-  const t = scoreTone(score, max, thresholdFraction)
-  return (
-    <Badge
-      size={size}
-      ghost={"ghost" in t && t.ghost}
-      tone={"tone" in t ? t.tone : "neutral"}
-    >
-      {score}/{max}
-    </Badge>
-  )
-}
+// Score chip: the shared ScoreBadge (one recipe, one source — see
+// ./ScoreBadge). Imported rather than re-implemented so the manual-grade cell
+// and this table can't drift.
+const ScoreBadge = SharedScoreBadge
 
 type IconComponent = React.ComponentType<{ className?: string }>
 

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -100,6 +100,28 @@ export function defaultStudentPermission(mode: AssignmentMode): RepoPermission {
 export const SUBMISSION_MODES = ["every-push", "tag"] as const
 export type SubmissionMode = (typeof SUBMISSION_MODES)[number]
 
+// The teacher's grading intent. Absent reads as "auto" (today's behavior). In
+// lockstep with the CLI's assignments-v1 schema enum and contract.GradingModes
+// (parity-tested by a vitest). Orthogonal to the autograding tri-state and to
+// collection — nothing in the grading pipeline reads it.
+export const GRADING_MODES = ["off", "auto", "manual"] as const
+export type GradingMode = (typeof GRADING_MODES)[number]
+
+// Smallest legal manual max_points. Not 0: a gradebook client divides score by
+// max and treats a 0 max as the "ungraded" sentinel, so a configured manual max
+// must be >= 1. In lockstep with the CLI schema (grading.max_points minimum) and
+// contract.GradingMaxPointsMin.
+export const GRADING_MAX_POINTS_MIN = 1
+
+// A first-class grading choice: off (not graded), auto (autograded), or manual
+// (teacher-entered, requires max_points). In lockstep with the CLI's
+// assignments-v1 `grading` object and the Go Grading struct.
+export type Grading = {
+  mode: GradingMode
+  max_points?: number
+}
+
+
 // Per-assignment repo feature overrides (tri-state per key: absent = inherit,
 // true = force on, false = force off). The `repo_features` block on Assignment,
 // and the value the create/edit form round-trips. In lockstep with the CLI's
@@ -243,6 +265,12 @@ export type Assignment = {
   // In lockstep with the CLI's assignments-v1 schema (`submission_tags`);
   // validation in @/util/submissionTags.
   submission_tags?: string[]
+  // The teacher's grading intent (off / auto / manual), a first-class GUI
+  // choice. Absent reads as "auto" (today's behavior). Manual carries
+  // max_points (>= 1). Orthogonal to the autograding tri-state and to
+  // collection. In lockstep with the CLI's assignments-v1 schema (`grading`
+  // object) and the Go Grading struct.
+  grading?: Grading
   // Per-assignment repo feature overrides applied to each student repo at
   // accept time, on fresh create only. Each key is tri-state: absent = inherit
   // (a templated assignment carries the template's setting through GitHub's

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -121,7 +121,6 @@ export type Grading = {
   max_points?: number
 }
 
-
 // Per-assignment repo feature overrides (tri-state per key: absent = inherit,
 // true = force on, false = force off). The `repo_features` block on Assignment,
 // and the value the create/edit form round-trips. In lockstep with the CLI's


### PR DESCRIPTION
## Summary

Adds a first-class **grading choice** to assignments and a **manual score entry / override** flow. Stacked on top of #`feat/submission-and-grading-section` — this PR should merge after that base branch lands. Review the grading diff here; the earlier "Submission and Grading section split" is its own base PR.

Teachers can now set an assignment's grading to **off / auto / manual** on the create/edit form, give a **manual assignment a max-points value**, and enter or override a per-student score inline on the Assignment Submissions page — including overriding an autograded score. A manual/overridden grade reuses the existing `scores.json` `override` mechanism (written as an ordinary `override: true` entry carrying a synthesized `submit/manual-*` record), so it survives re-collection and renders through every existing reader with no new `scores.json` variant.

## What changed

- **Contract (additive, all mirrors in lockstep):** new `grading { mode: off|auto|manual, max_points>=1 }` on `assignments-v1.schema.json`, mirrored in the Go `contract.GradingModes` + `Grading` struct/`ValidateGrading`, and the web TS types/form model, with schema-parity and round-trip tests. No `scores-v1` change.
- **Assignment form:** the Submission and Grading section leads with the grading choice; manual reveals a max-points input, auto shows the `result.json` requirement note. `grading.mode` is immutable after creation.
- **Score override write path:** new `editScoreOverride` domain helper does a config-repo read-modify-write of `scores.json` wrapped in `withGitConflictRetry`, plus a `useSetScoreOverride` mutation. Provenance is the git commit author (no self-reported `graded_by`).
- **Submissions page:** an inline score editor (`ManualGradeCell`) with a full idle/editing/saving/error state machine, `0..max` integer validation, an ungraded-vs-0 empty state, keyboard + ARIA, and an "Overridden" marker on hand-set scores.

## Review + fixes

Ran a full multi-agent code review (correctness, security, api-contract, testing, maintainability, reliability, adversarial, project-standards). All findings were fixed in the final commit:

- **P1** — narrowed the `readScoresFile` catch to 404-only so a transient/parse read failure can't overwrite the whole gradebook.
- **P1** — carry a GUI-authored `grading` block forward on a same-slug `gh teacher assignment add`.
- **P1** — clamp the override `datetime` above existing submissions (and prefer the manual record in `bucketToRows`) so a future-dated autograded push can't out-rank a teacher override.
- **P2** — shared `ScoreBadge` instead of duplicating the score→tone recipe; added immutability/validation/no-clobber/carry-forward tests.

## Test plan

- [ ] `cd web && npm run check` (tsc, eslint, prettier, arch:validate, vitest) — green locally (3501 tests).
- [ ] CLI: `go build ./... && go test ./...`, `golangci-lint run`; `python3 -m pytest cli/gh-teacher/skeleton_tests -q` — green locally.
- [ ] Manually: create a manual assignment, enter a score on the Submissions page, confirm it renders as Overridden and survives a Collect run; confirm clearing it restores collector refresh.
- [ ] Confirm grading mode can't be flipped on edit.