### PR TITLE
docs: fix inaccurate and superfluous comments from 1.28.0

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -77,9 +77,8 @@ const shimTagsTriggerLine = "    tags: [\"submit/*\"]\n"
 //
 // submissionMode contract.SubmissionModeTag drops the branch-push trigger line
 // so only submission-tag pushes grade (`gh student submit` creates the tag; a
-// hand-pushed submit/* tag works too). Every other value — including "" and an
-// explicit "every-push" — takes the identical code path as before the field
-// existed, keeping the default shim byte-identical.
+// hand-pushed submit/* tag works too). Any other value (incl. "" and
+// "every-push") keeps the default every-push shim byte-identical.
 //
 // submissionTags (teacher-named milestone patterns, e.g. phase1) widen the
 // tags trigger to their union with the always-on submit/* namespace; empty

--- a/cli/gh-student/internal/assignments/assignments.go
+++ b/cli/gh-student/internal/assignments/assignments.go
@@ -123,8 +123,8 @@ type Entry struct {
 }
 
 // IsTagSubmissionMode reports whether the entry grades only on submit/* tag
-// pushes. Centralized so accept (shim rendering) and submit (tag push) can't
-// drift on the absent-means-every-push default.
+// pushes. Centralized so submit's tag-push branch (and tests) share the
+// absent-means-every-push default.
 func (e Entry) IsTagSubmissionMode() bool {
 	return e.SubmissionMode == contract.SubmissionModeTag
 }
@@ -132,9 +132,7 @@ func (e Entry) IsTagSubmissionMode() bool {
 // CommitsShim reports whether accept commits an autograde shim for this entry.
 // Both no-shim states suppress it: EmptyRepo (a bare repo commits nothing) and
 // NoAutograder (teacher-supplied CI). Centralized so the two accept-time shim
-// branches can't drift on the predicate — the Go analogue of the Python
-// skips_grading() family (the inverse: skips_grading is "does not autograde",
-// this is "does the shim get committed").
+// branches can't drift on the predicate.
 func (e Entry) CommitsShim() bool {
 	return !e.EmptyRepo && !e.NoAutograder
 }

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -356,11 +356,9 @@ func pushSubmitTag(gitDir, sha string) (string, error) {
 	if err == nil && existing != "" {
 		return existing, nil
 	}
-	// A failed reuse probe falls through to pushing a fresh tag. The fresh
-	// tag's timestamped name never collides with an existing one, so the
-	// worst case is a second submit/* tag at the same SHA (one extra graded
-	// run of identical work) — preferred over failing the submission when
-	// the probe hiccups but the push would succeed.
+	// Probe failure falls through to a fresh tag: worst case is a duplicate
+	// submit/* tag at the same SHA (one extra identical graded run), preferred
+	// over failing a submission whose push would succeed.
 	tag := contract.BuildSubmitTag(timeNow(), sha)
 	if _, err := gitOutputWithGitDir(gitDir, "push", "origin", sha+":refs/tags/"+tag); err != nil {
 		return "", err

--- a/cli/gh-teacher/internal/assignment/submission_tags_test.go
+++ b/cli/gh-teacher/internal/assignment/submission_tags_test.go
@@ -34,7 +34,7 @@ func TestValidateSubmissionTags(t *testing.T) {
 		{[]string{""}, "only letters"},
 		// Stacked/leading quantifiers: possessive in Python, compile error
 		// in Go/JS — the one construct where the four matcher copies would
-		// diverge, so the writer refuses it (see contract.stackedQuantifierRE).
+		// diverge, so the writer refuses it (see IsSafeSubmissionTagPattern).
 		{[]string{"v*+"}, "follow another glob quantifier"},
 		{[]string{"a++"}, "follow another glob quantifier"},
 		{[]string{"x?+"}, "follow another glob quantifier"},
@@ -58,7 +58,7 @@ func TestValidateSubmissionTags(t *testing.T) {
 
 // TestSubmissionTagsSchemaParity pins the hand-mirrored constants against the
 // schema (declared source of truth): maxItems vs SubmissionTagsCap and
-// items.pattern vs submissionTagPatternRE. The web mirror
+// items.pattern vs contract.SubmissionTagCharsetRE. The web mirror
 // (SUBMISSION_TAGS_CAP / SUBMISSION_TAG_PATTERN_RE) is pinned by its own
 // vitest against the same schema.
 func TestSubmissionTagsSchemaParity(t *testing.T) {

--- a/cli/shared/contract/submissiontags.go
+++ b/cli/shared/contract/submissiontags.go
@@ -134,8 +134,6 @@ func compileTagPattern(pattern string) (*regexp.Regexp, error) {
 				b.WriteString("[^/]*") // * stops at /
 			}
 		case '?':
-			// Zero-or-one of the preceding element: regexp `?` after the
-			// previous literal/class already emitted.
 			b.WriteString("?")
 		case '+':
 			b.WriteString("+")

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -380,13 +380,12 @@ export type CreateAssignmentInput = {
   student_permission?: RepoPermission
   // When the autograder fires. Undefined or "every-push" = the wire default
   // (buildAssignmentEntry omits it); "tag" = the shim grades only submit/* tag
-  // pushes. Mutually exclusive with empty_repo. Mirrors the CLI's
-  // --submission-mode.
+  // pushes. Mirrors the CLI's --submission-mode.
   submission_mode?: SubmissionMode
   // Teacher-named milestone tag patterns that also trigger grading (union
   // with the always-on submit/* namespace in the shim). Empty/undefined =
-  // none (buildAssignmentEntry omits the key). Mutually exclusive with
-  // empty_repo. Mirrors the CLI's --submission-tag.
+  // none (buildAssignmentEntry omits the key). Mirrors the CLI's
+  // --submission-tag.
   submission_tags?: string[]
   // The teacher's grading intent (off/auto/manual) with a manual max_points.
   // Undefined reads as "auto" (today's behavior). Orthogonal to the autograding

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -119,8 +119,8 @@ function synthesizeOverrideRecord(
   }
 }
 
-// A submission record is a real autograder result (not our synthesized manual
-// one) when its submission tag isn't the manual sentinel.
+// True when this record is our synthesized manual override (its submission tag
+// starts with the manual sentinel), not a real autograder result.
 function isSynthesizedManual(record: SubmissionRecord): boolean {
   return (
     typeof record.submission === "string" &&

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -174,9 +174,9 @@ export const githubKeys = {
   orgActionsUsage: (owner: string) =>
     [...githubKeys.all, "orgActionsUsage", owner] as const,
 
-  // The autograde workflow's Actions state for one student repo (active /
-  // disabled_manually / …), mapped to enabled|paused. Invalidated after a
-  // per-repo or bulk pause/resume so the row's action label flips.
+  // The autograde workflow's Actions state for one student repo, mapped to an
+  // AutogradeState. Invalidated after a per-repo or bulk pause/resume so the
+  // row's action label flips.
   autogradeState: (owner: string, repo: string) =>
     [...githubKeys.all, "autogradeState", owner, repo] as const,
 

--- a/web/src/pages/assignments/formShape.ts
+++ b/web/src/pages/assignments/formShape.ts
@@ -32,19 +32,15 @@ export type FormShape = {
   // The repository source, folded from the UI's repo_source + add_readme.
   // Everything template- and grading-related keys off it.
   repositorySource: RepositorySource
-  // The wire empty_repo boolean this shape resolves to: a no-template no-README
-  // repo where the teacher did NOT pick built-in autograding (a truly bare
-  // repo). If they picked built-in on that same source, it's init_shim instead
-  // (see below) and this is false.
+  // The wire empty_repo boolean this shape resolves to (a truly bare repo).
+  // See the header three-way: "empty" source without built-in autograding.
   emptyRepo: boolean
   // The wire init_shim boolean: a no-template no-README repo that is Autograded
   // — initialized with the marker + default shim, and it autogrades.
   initShim: boolean
-  // The wire no_autograder boolean: a TEMPLATED assignment the teacher marked
-  // as teacher-supplied CI (grading is Autograded but the built-in shim is
-  // off). Only a template source can be no_autograder — a README/empty repo
-  // with the built-in autograder off is simply "no autograder", NOT the
-  // teacher-supplied-CI wire state (which requires a template).
+  // The wire no_autograder boolean: a TEMPLATED teacher-supplied-CI assignment
+  // (grading Autograded, built-in shim off). Only a template can be
+  // no_autograder — see deriveFormShape.
   noAutograder: boolean
   // The autograding tri-state as it applies to THIS form's values. A bare
   // (empty_repo) repo forces "empty"; otherwise it's derived from the grading

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -188,10 +188,7 @@ export function mergeDetectedSubmissions(
   const merged = rows.map((row) => {
     const d = detectedByOwner.get(row.owner.trim().toLowerCase())
     if (!d || d.count <= row.submissionCount) return row
-    // A teacher-overridden (manual) grade is frozen by hand and never
-    // auto-collected, so the "newest push isn't graded yet — re-collect" hint
-    // (staleCount) doesn't apply: bump the visible count but leave the row
-    // unflagged. Autograded rows still get the stale hint.
+    // staleCount off for overrides — see mergeLiveRows.
     return { ...row, submissionCount: d.count, staleCount: !row.overridden }
   })
 


### PR DESCRIPTION
Cross-checked every code comment shipped in the 1.28.0 release diff (`web-v1.27.2`/`cli-v1.27.2` → `7897d9a1`) for accuracy, then fixed the defects. Comment-only changes — no logic touched (24 insertions, 39 deletions across 10 files). All three Go modules build, `gofmt` is clean, affected Go tests pass, and web has no lint errors.

## Accuracy fixes

`web/src/domain/assignments/repoCreation.ts` — removed the false "Mutually exclusive with empty_repo" claim on both `submission_mode` and `submission_tags`. The canonical `Assignment` type (`web/src/types/classroom.ts`) and the write path (`createEdit.ts`) both explicitly permit these on every repo shape, including `empty_repo`/`no_autograder`, and nothing in code enforces any exclusion.

`cli/gh-student/internal/assignments/assignments.go` — `IsTagSubmissionMode`'s doc no longer claims accept routes through it. Only `submit` (and tests) call it; `accept.go` compares `submissionMode == contract.SubmissionModeTag` inline, so the old "can't drift" guarantee for accept was false.

`cli/gh-teacher/internal/assignment/submission_tags_test.go` — `TestSubmissionTagsSchemaParity`'s doc referenced a nonexistent `submissionTagPatternRE`; the assertion actually pins against `contract.SubmissionTagCharsetRE`. Also repointed a "see" reference from the unexported `contract.stackedQuantifierRE` (unreferenceable across packages) to the exported `IsSafeSubmissionTagPattern`.

`web/src/github-core/queries/keys.ts` — `autogradeState` said "mapped to enabled|paused" but `AutogradeState` has four values; changed to "mapped to an AutogradeState".

`web/src/domain/assignments/scoreOverride.ts` — `isSynthesizedManual`'s comment described the complement of what it returns; reworded to describe the actual return (true when the record is the manual sentinel).

## Simplification / superfluous

Trimmed duplicated rationale (`dashboard.ts` `staleCount` note now points to `mergeLiveRows`; `formShape.ts` no longer restates the empty/`init_shim`/`no_autograder` three-way at type, field, and inline), condensed verbose trade-off comments (`accept.go`, `submit.go`), dropped a tangential Python cross-language aside on `CommitsShim`, and removed a superfluous inline `?` comment in `submissiontags.go` already covered by the file header.

## Test plan

- [x] `go build ./...` in `cli/gh-teacher`, `cli/gh-student`, `cli/shared`
- [x] `gofmt -l` clean on all touched Go files
- [x] `go test` passes for the touched `assignment` and `contract` packages
- [x] web: no new lint errors on touched files