### PR TITLE
feat(web): remove inert per-student extensions affordance

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1131,10 +1131,6 @@
       "typeGroup": "Group project",
       "maxGroupSize": "Max group size",
       "maxGroupSizeTitle": "Must be a whole number between {{min}} and {{max}}",
-      "extensions": {
-        "label": "Per-student extensions (coming soon)",
-        "help": "Grant individual students or groups a later due date. Not yet available."
-      },
       "repoSource": {
         "label": "Start with a template",
         "lockedHelp": "The repository source can't be changed after creation: repositories students already accepted are not re-provisioned.",

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -733,9 +733,4 @@ describe("assignment form section IA", () => {
     expect(branches).not.toBeNull()
     expect(branches?.disabled).toBe(false)
   })
-
-  it("reserves the schedule Extensions affordance as disabled", () => {
-    renderForm({})
-    expect(screen.getByText("assignments.form.extensions.label")).not.toBeNull()
-  })
 })

--- a/web/src/pages/assignments/sections/ScheduleSection.tsx
+++ b/web/src/pages/assignments/sections/ScheduleSection.tsx
@@ -5,10 +5,9 @@ import type { AssignmentForm } from "../assignmentFormModel"
 import type { SectionStatus } from "./sectionStatus"
 import { SectionCard } from "./SectionCard"
 
-// Schedule (IA overhaul U8): the opt-in release-date and due-date pickers, plus
-// the deferred per-student/group Extensions affordance (U9, inert). The toggle
-// state lives in the orchestrator so the pickers stay controlled across the
-// section split.
+// Schedule (IA overhaul U8): the opt-in release-date and due-date pickers. The
+// toggle state lives in the orchestrator so the pickers stay controlled across
+// the section split.
 export function ScheduleSection({
   form,
   status,
@@ -113,19 +112,6 @@ export function ScheduleSection({
             </div>
           )}
         </form.Field>
-
-        {/* Deferred (R14/U9): per-student/group due-date extensions. Reserved
-            as an inert, disabled affordance — there is no due-override data
-            model yet, so it writes nothing to assignments.json. */}
-        <div className="pointer-events-none opacity-50" aria-disabled="true">
-          <ToggleRow
-            id="extensions-deferred"
-            checked={false}
-            onChange={() => {}}
-            label={t("assignments.form.extensions.label")}
-            help={t("assignments.form.extensions.help")}
-          />
-        </div>
       </div>
     </SectionCard>
   )


### PR DESCRIPTION
## Summary

The assignment creation form's Schedule section showed a **"Per-student extensions (coming soon)"** toggle. It was an inert, disabled affordance — `checked={false}`, `onChange={() => {}}` — with no data model behind it and, as its own comment stated, it wrote nothing to `assignments.json`. Since there is no wiring, this removes it.

Changes:

- `web/src/pages/assignments/sections/ScheduleSection.tsx` — remove the disabled `ToggleRow` and drop the affordance from the section header comment.
- `web/src/pages/assignments/CreateAssignmentForm.test.tsx` — remove the now-obsolete "reserves the schedule Extensions affordance as disabled" test.
- `web/src/locales/en.json` — remove the unused `assignments.form.extensions` `label`/`help` keys.

## Test plan

- [x] `npm run check` passes (tsc, eslint, prettier, arch:validate, and all 3569 vitest tests).
- [x] i18n audit stays balanced — both the keys and their only usages were removed together.
- [ ] Confirm the Schedule section renders without the removed toggle in the running app.