### PR TITLE
feat(web): opt-in assignments.json schema migration with legacy gate

### DIFF
--- a/web/src/components/ClassroomMigrationBanner.tsx
+++ b/web/src/components/ClassroomMigrationBanner.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { AlertTriangle } from "lucide-react"
+
+import { Alert, Button } from "@/components/ui"
+import { MigrateSubmissionTrackingModal } from "@/components/modals/MigrateSubmissionTrackingModal"
+import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
+import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
+import { can } from "@/authz"
+
+type ClassroomMigrationBannerProps = {
+  org: string | undefined
+  classroom: string | undefined
+}
+
+// MIGRATION(v1.28): the classroom-level schema-migration banner. Safe to remove
+// in a future version once no legacy (submission_mode-absent) files remain.
+// Greppable tag: MIGRATION(v1.28).
+// A classroom-level, persist-across-subviews prompt to migrate a pre-1.28
+// assignments.json to explicit submission-tracking semantics. Rendered once in
+// the classroom layout so it stays visible on every subview (submissions,
+// roster, settings, …) until the teacher migrates — a legacy file (any entry
+// with no explicit submission_mode) keeps the detection overlay off, so this is
+// the single opt-in surface. Owner + authoring-tier only, and it self-hides the
+// moment every assignment carries an explicit submission_mode.
+export function ClassroomMigrationBanner({
+  org,
+  classroom,
+}: ClassroomMigrationBannerProps) {
+  const { t } = useTranslation()
+  const { role: classroomRole } = useClassroomRoleContext()
+  const { isOwner } = useIsOrgOwner()
+  const { data: assignmentData } = useGetClassroomAssignments(org, classroom)
+  const [open, setOpen] = useState(false)
+
+  const canAuthor = can("authorAssignments", { classroomRole })
+  const hasLegacy = (assignmentData?.assignments ?? []).some(
+    (a) => a.submission_mode === undefined,
+  )
+
+  if (!org || !classroom || !isOwner || !canAuthor || !hasLegacy) return null
+
+  return (
+    <>
+      <Alert
+        tone="error"
+        soft={false}
+        role="status"
+        className="rounded-none border-x-0"
+      >
+        <AlertTriangle className="size-5 shrink-0" aria-hidden="true" />
+        <span className="flex-1">
+          {t("submissions.migrateTracking.bannerText")}
+        </span>
+        <Button variant="neutral" size="sm" onClick={() => setOpen(true)}>
+          {t("submissions.migrateTracking.bannerAction")}
+        </Button>
+      </Alert>
+      <MigrateSubmissionTrackingModal
+        open={open}
+        onClose={() => setOpen(false)}
+        org={org}
+        classroom={classroom}
+      />
+    </>
+  )
+}
+
+export default ClassroomMigrationBanner

--- a/web/src/components/modals/MigrateSubmissionTrackingModal.tsx
+++ b/web/src/components/modals/MigrateSubmissionTrackingModal.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useId, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { RefreshCw } from "lucide-react"
+
+import { Alert, Button, Modal } from "@/components/ui"
+import { Spinner } from "@/components/Spinner"
+import useMigrateClassroomAssignments from "@/hooks/mutations/useMigrateClassroomAssignments"
+
+type MigrateSubmissionTrackingModalProps = {
+  open: boolean
+  onClose: () => void
+  org: string
+  classroom: string
+}
+
+type Phase = "idle" | "working" | "complete" | "error"
+
+// MIGRATION(v1.28): the schema-migration modal for pre-1.28 assignments.json
+// files. Safe to remove in a future version once no legacy files remain.
+// Greppable tag: MIGRATION(v1.28).
+// Explicit, teacher-triggered migration of a classroom's assignments.json to
+// the new submission-tracking semantics: one confirm writes an explicit
+// submission_mode (+ grading:auto) onto every legacy assignment, opting the
+// submissions-page detection overlay in without changing any grade. Nothing
+// runs until the teacher clicks Migrate. A content normalization within v1 —
+// no schema version bump.
+export function MigrateSubmissionTrackingModal({
+  open,
+  onClose,
+  org,
+  classroom,
+}: MigrateSubmissionTrackingModalProps) {
+  const titleId = useId()
+  const { t } = useTranslation()
+  const migrate = useMigrateClassroomAssignments(org, classroom)
+  const runningRef = useRef(false)
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      runningRef.current = false
+    }
+  }, [])
+
+  const [phase, setPhase] = useState<Phase>("idle")
+  const [migratedCount, setMigratedCount] = useState(0)
+
+  useEffect(() => {
+    if (!open) {
+      runningRef.current = false
+      setPhase("idle")
+      setMigratedCount(0)
+    }
+  }, [open])
+
+  const run = async () => {
+    if (runningRef.current) return
+    runningRef.current = true
+    setPhase("working")
+    try {
+      const result = await migrate.mutateAsync({ org, classroom })
+      if (mountedRef.current) {
+        setMigratedCount(result.migratedCount)
+        setPhase("complete")
+      }
+    } catch {
+      if (mountedRef.current) setPhase("error")
+    } finally {
+      runningRef.current = false
+    }
+  }
+
+  const busy = phase === "working"
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      closeDisabled={busy}
+      size="lg"
+      aria-labelledby={titleId}
+    >
+      <div className="flex items-start gap-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <RefreshCw className="size-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("submissions.migrateTracking.title")}
+          </h3>
+          <p className="mt-1 text-sm text-base-content/70">
+            {t("submissions.migrateTracking.subtitle")}
+          </p>
+        </div>
+      </div>
+
+      {phase === "idle" && (
+        <div className="mt-4 flex flex-col gap-4">
+          <Alert tone="info" className="text-sm">
+            {t("submissions.migrateTracking.warning")}
+          </Alert>
+        </div>
+      )}
+
+      {busy && (
+        <div className="mt-6 flex flex-col items-center gap-3 py-6">
+          <Spinner label={t("submissions.migrateTracking.working")} />
+        </div>
+      )}
+
+      {phase === "error" && (
+        <div className="mt-4">
+          <Alert tone="error" className="text-sm">
+            {t("submissions.migrateTracking.error")}
+          </Alert>
+        </div>
+      )}
+
+      {phase === "complete" && (
+        <div className="mt-4">
+          <Alert tone="success" className="text-sm">
+            {t("submissions.migrateTracking.resultHeadline", {
+              count: migratedCount,
+            })}
+          </Alert>
+        </div>
+      )}
+
+      <div className="modal-action">
+        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+          {phase === "complete" || phase === "error"
+            ? t("common.close")
+            : t("common.cancel")}
+        </Button>
+        {phase === "idle" && (
+          <Button variant="primary" onClick={() => void run()}>
+            {t("submissions.migrateTracking.apply")}
+          </Button>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+export default MigrateSubmissionTrackingModal

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -19,6 +19,7 @@ import {
   resolveTemplateGrant,
   setAssignmentLock,
   setAssignmentClosed,
+  migrateClassroomAssignments,
   TEMPLATE_READ_STAFF_ROLES,
   verifyTemplateAccess,
 } from "./assignments"
@@ -3954,6 +3955,163 @@ describe("setAssignmentClosed", () => {
     // Already closed: the commit is skipped, so no tree content was captured.
     expect(committed()).toBeUndefined()
     expect(result.updatedRef).toBeUndefined()
+  })
+})
+
+describe("migrateClassroomAssignments", () => {
+  const ORG = "cs50"
+  const CLASSROOM = "cs50"
+  const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64")
+
+  afterEach(() => vi.restoreAllMocks())
+
+  // A fake config repo serving the classroom-wide migration read-modify-commit
+  // flow. `assignments` is the raw entry array the served assignments.json
+  // carries.
+  function makeMigrateClient(assignments: Record<string, unknown>[]): {
+    client: GitHubClient
+    committed: () => string | undefined
+  } {
+    let committed: string | undefined
+    const assignmentsFile = {
+      schema: "classroom50/assignments/v1",
+      assignments,
+    }
+    const classroomJson = {
+      schema: "classroom50/classroom/v1",
+      short_name: CLASSROOM,
+    }
+
+    const request = vi.fn(
+      async (url: string, init?: { method?: string; body?: unknown }) => {
+        const method = init?.method ?? "GET"
+        if (url.endsWith("/git/trees") && init?.body) {
+          const body = init.body as { tree?: { content?: string }[] }
+          committed = body.tree?.[0]?.content
+        }
+        if (/\/repos\/[^/]+\/classroom50$/.test(url))
+          return { default_branch: "main" }
+        if (url.includes("/git/ref/heads/main")) return { object: { sha: "s" } }
+        if (url.includes("/git/commits/s")) return { tree: { sha: "t" } }
+        if (url.includes(`/contents/${CLASSROOM}/classroom.json`)) {
+          return {
+            type: "file",
+            encoding: "base64",
+            content: b64(JSON.stringify(classroomJson)),
+          }
+        }
+        if (url.includes(`/contents/${CLASSROOM}/assignments.json`)) {
+          return {
+            type: "file",
+            encoding: "base64",
+            content: b64(JSON.stringify(assignmentsFile)),
+          }
+        }
+        if (url.endsWith("/git/trees")) return { sha: "newtree" }
+        if (url.endsWith("/git/commits")) return { sha: "newcommit" }
+        if (method === "PATCH" && url.includes("/git/refs/heads/main")) {
+          return { object: { sha: "newcommit" } }
+        }
+        throw new Error(`unexpected request: ${method} ${url}`)
+      },
+    )
+    const requestRaw = vi.fn(async () => JSON.stringify(classroomJson))
+
+    return {
+      client: {
+        request,
+        requestRaw,
+      } as unknown as GitHubClient,
+      committed: () => committed,
+    }
+  }
+
+  const legacyEntry = (slug: string, extra: Record<string, unknown> = {}) => ({
+    slug,
+    name: slug,
+    mode: "individual",
+    autograder: "default",
+    template: { owner: ORG, repo: "tmpl", branch: "main" },
+    ...extra,
+  })
+
+  it("writes explicit submission_mode + grading:auto onto every legacy entry in one commit", async () => {
+    const { client, committed } = makeMigrateClient([
+      legacyEntry("hw1"),
+      legacyEntry("hw2"),
+      legacyEntry("hw3"),
+    ])
+    const result = await migrateClassroomAssignments(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+    })
+    expect(result.migratedCount).toBe(3)
+    expect(result.alreadyMigratedCount).toBe(0)
+    const written = committed()!
+    // Every entry now carries an explicit every-push mode and auto grading.
+    expect(written.match(/"submission_mode": "every-push"/g)).toHaveLength(3)
+    expect(written.match(/"mode": "auto"/g)).toHaveLength(3)
+  })
+
+  it("no-ops when every entry is already migrated (no commit)", async () => {
+    const { client, committed } = makeMigrateClient([
+      legacyEntry("hw1", { submission_mode: "every-push" }),
+      legacyEntry("hw2", { submission_mode: "tag" }),
+    ])
+    const result = await migrateClassroomAssignments(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+    })
+    expect(result.migratedCount).toBe(0)
+    expect(result.alreadyMigratedCount).toBe(2)
+    expect(committed()).toBeUndefined()
+    expect(result.updatedRef).toBeUndefined()
+  })
+
+  it("migrates only the legacy entries, leaving already-migrated ones untouched", async () => {
+    const { client, committed } = makeMigrateClient([
+      legacyEntry("hw1", { submission_mode: "tag" }),
+      legacyEntry("hw2"),
+    ])
+    const result = await migrateClassroomAssignments(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+    })
+    expect(result.migratedCount).toBe(1)
+    expect(result.alreadyMigratedCount).toBe(1)
+    const written = committed()!
+    // The pre-migrated tag entry keeps its mode; only the legacy one gains one.
+    expect(written).toContain(`"submission_mode": "tag"`)
+    expect(written.match(/"submission_mode": "every-push"/g)).toHaveLength(1)
+  })
+
+  it("preserves an entry's grading and unknown fields verbatim", async () => {
+    const { client, committed } = makeMigrateClient([
+      legacyEntry("hw1", {
+        grading: { mode: "manual", max_points: 10 },
+        future_field: "v2-only",
+      }),
+    ])
+    const result = await migrateClassroomAssignments(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+    })
+    expect(result.migratedCount).toBe(1)
+    const written = committed()!
+    // Existing grading is not overwritten with auto; unknown keys round-trip.
+    expect(written).toContain(`"mode": "manual"`)
+    expect(written).toContain(`"max_points": 10`)
+    expect(written).toContain(`"future_field": "v2-only"`)
+    expect(written).not.toContain(`"mode": "auto"`)
+  })
+
+  it("does not bump the schema sentinel", async () => {
+    const { client, committed } = makeMigrateClient([legacyEntry("hw1")])
+    await migrateClassroomAssignments(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+    })
+    expect(committed()).toContain(`"schema": "classroom50/assignments/v1"`)
   })
 })
 

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -4048,8 +4048,9 @@ describe("migrateClassroomAssignments", () => {
     expect(result.migratedCount).toBe(3)
     expect(result.alreadyMigratedCount).toBe(0)
     const written = committed()!
-    // Every entry now carries an explicit every-push mode and auto grading.
-    expect(written.match(/"submission_mode": "every-push"/g)).toHaveLength(3)
+    // Every entry now carries an explicit tag mode (preserving pre-1.28
+    // submit/*-release counting) and auto grading.
+    expect(written.match(/"submission_mode": "tag"/g)).toHaveLength(3)
     expect(written.match(/"mode": "auto"/g)).toHaveLength(3)
   })
 
@@ -4070,7 +4071,7 @@ describe("migrateClassroomAssignments", () => {
 
   it("migrates only the legacy entries, leaving already-migrated ones untouched", async () => {
     const { client, committed } = makeMigrateClient([
-      legacyEntry("hw1", { submission_mode: "tag" }),
+      legacyEntry("hw1", { submission_mode: "every-push" }),
       legacyEntry("hw2"),
     ])
     const result = await migrateClassroomAssignments(client, {
@@ -4080,9 +4081,10 @@ describe("migrateClassroomAssignments", () => {
     expect(result.migratedCount).toBe(1)
     expect(result.alreadyMigratedCount).toBe(1)
     const written = committed()!
-    // The pre-migrated tag entry keeps its mode; only the legacy one gains one.
-    expect(written).toContain(`"submission_mode": "tag"`)
-    expect(written.match(/"submission_mode": "every-push"/g)).toHaveLength(1)
+    // The pre-migrated every-push entry keeps its mode; the legacy one gains
+    // tag mode (the pre-1.28-preserving default), so both survive distinctly.
+    expect(written).toContain(`"submission_mode": "every-push"`)
+    expect(written.match(/"submission_mode": "tag"/g)).toHaveLength(1)
   })
 
   it("preserves an entry's grading and unknown fields verbatim", async () => {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1129,14 +1129,15 @@ describe("editAssignment (preserved-entry integration)", () => {
 
   // The write path's submission_mode branches (buildAssignmentEntry is not
   // exported — assert through editAssignment, like the sibling tests above):
-  // "tag" lands in the entry; the wire default (explicit or absent) is
-  // omitted, mirroring the CLI's omitempty collapse; junk is rejected before
-  // a file the CLI would refuse to parse can be written.
-  it("writes submission_mode tag and omits the every-push wire default", async () => {
+  // 1.28+ ALWAYS writes submission_mode explicitly (the migration signal), so
+  // "tag" and "every-push" both land verbatim and an absent input defaults to
+  // an explicit "every-push"; junk is rejected before a file the CLI would
+  // refuse to parse can be written.
+  it("always writes submission_mode explicitly (the 1.28 migration signal)", async () => {
     for (const [input, want] of [
       ["tag", "tag"],
-      ["every-push", undefined],
-      [undefined, undefined],
+      ["every-push", "every-push"],
+      [undefined, "every-push"],
     ] as const) {
       const { client, committedContent } = makeClient()
       await editAssignment(client, editInput({ submission_mode: input }))

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -23,6 +23,9 @@ export {
   setAssignmentLockWithConflictRetry,
   setAssignmentClosed,
   setAssignmentClosedWithConflictRetry,
+  // MIGRATION(v1.28): remove with the schema-migration flow in createEdit.ts.
+  migrateClassroomAssignments,
+  migrateClassroomAssignmentsWithConflictRetry,
   preserveUnmanagedAssignmentKeys,
   tryGrantTeamTemplateRead,
   resolveTemplateGrant,
@@ -32,6 +35,9 @@ export {
   type SetAssignmentLockResult,
   type SetAssignmentClosedInput,
   type SetAssignmentClosedResult,
+  // MIGRATION(v1.28): remove with the schema-migration flow in createEdit.ts.
+  type MigrateClassroomAssignmentsInput,
+  type MigrateClassroomAssignmentsResult,
 } from "./assignments/createEdit"
 export {
   createAssignmentRepo,

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -1500,17 +1500,20 @@ function isSubmissionTrackingMigrated(entry: Assignment): boolean {
 }
 
 // Normalize an unmigrated entry into the new canonical shape by writing the
-// fields that pre-1.28 left absent: submission_mode = "every-push" (the wire
-// default, so behavior is unchanged) and, when grading is absent, an explicit
-// grading: { mode: "auto" } so the file self-documents. Immutable provisioning
-// flags (empty_repo/no_autograder/init_shim), locked/closed, and every other
-// field are left exactly as-is. Returns the entry unchanged when already
-// migrated.
+// fields that pre-1.28 left absent: submission_mode = "tag" and, when grading
+// is absent, an explicit grading: { mode: "auto" } so the file self-documents.
+// "tag" (NOT "every-push") is what preserves pre-1.28 counting: before 1.28 a
+// submission was a submit/* release, and tag-mode detection counts exactly the
+// always-unioned submit/* namespace — every-push would instead start counting
+// every default-branch push, inflating the count for an untouched file.
+// Immutable provisioning flags (empty_repo/no_autograder/init_shim),
+// locked/closed, and every other field are left exactly as-is. Returns the
+// entry unchanged when already migrated.
 function normalizeEntryForMigration(entry: Assignment): Assignment {
   if (isSubmissionTrackingMigrated(entry)) return entry
   const migrated: Assignment = {
     ...entry,
-    submission_mode: SUBMISSION_MODES[0],
+    submission_mode: "tag",
   }
   if (migrated.grading === undefined) {
     migrated.grading = { mode: "auto" }
@@ -1520,12 +1523,13 @@ function normalizeEntryForMigration(entry: Assignment): Assignment {
 
 // Migrate every eligible assignment in a classroom's assignments.json to the
 // new submission-configuration semantics in ONE commit: write an explicit
-// submission_mode (and grading: auto) onto each legacy entry so the detection
-// overlay opts in, while preserving pre-1.28 behavior byte-for-byte (every-push
-// is the wire default). This is a content normalization WITHIN v1 — the schema
-// sentinel is untouched and no version bump occurs. Unknown fields round-trip
-// via the whole-entry spread. Mirrors setAssignmentClosed's no-op short-circuit:
-// an all-migrated file skips the commit.
+// submission_mode: "tag" (and grading: auto) onto each legacy entry so the
+// detection overlay opts in while PRESERVING pre-1.28 counting — a submission
+// was a submit/* release before 1.28, and tag mode counts exactly the
+// always-unioned submit/* namespace. This is a content normalization WITHIN v1
+// — the schema sentinel is untouched and no version bump occurs. Unknown fields
+// round-trip via the whole-entry spread. Mirrors setAssignmentClosed's no-op
+// short-circuit: an all-migrated file skips the commit.
 export async function migrateClassroomAssignments(
   client: GitHubClient,
   input: MigrateClassroomAssignmentsInput,

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -781,20 +781,25 @@ async function buildAssignmentEntry(
     }
   }
 
-  // submission_mode: omit the wire default (every-push) so an untouched
-  // assignment stays byte-identical, mirroring the CLI's omitempty collapse.
-  // Validate against the enum so a bad value can't produce a file the CLI
-  // refuses to parse. Permitted for every repo shape (including empty_repo /
-  // no_autograder): with no shim it carries no trigger, but it still defines
-  // what the submissions page counts as a submission.
-  if (input.submission_mode && input.submission_mode !== "every-push") {
-    if (!SUBMISSION_MODES.includes(input.submission_mode)) {
-      throw new Error(
-        `submission_mode: must be one of ${SUBMISSION_MODES.join(", ")} (got "${input.submission_mode}").`,
-      )
-    }
-    entry.submission_mode = input.submission_mode
+  // submission_mode: ALWAYS write it explicitly (default every-push when
+  // unset), NOT collapsed to the wire default. This is the migration signal:
+  // an assignment written by 1.28+ code always carries an explicit
+  // submission_mode, so a legacy pre-1.28 file (which omits it) is
+  // distinguishable and the classroom migration banner can target only genuine
+  // legacy files (see MIGRATION(v1.28) in SubmissionsPage / ClassroomMigrationBanner).
+  // An explicit "every-push" is legal on the wire — the Go reader accepts it
+  // ("other writers may emit it", ValidateSubmissionMode) and the schema
+  // permits it. Validate against the enum so a bad value can't produce a file
+  // the CLI refuses to parse. Permitted for every repo shape (including
+  // empty_repo / no_autograder): with no shim it carries no trigger, but it
+  // still defines what the submissions page counts as a submission.
+  const resolvedSubmissionMode = input.submission_mode ?? "every-push"
+  if (!SUBMISSION_MODES.includes(resolvedSubmissionMode)) {
+    throw new Error(
+      `submission_mode: must be one of ${SUBMISSION_MODES.join(", ")} (got "${resolvedSubmissionMode}").`,
+    )
   }
+  entry.submission_mode = resolvedSubmissionMode
 
   // submission_tags: omit when empty (no milestone tags — today's behavior),
   // mirroring the CLI's omitempty. Validate so a bad pattern can't produce a

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -1467,3 +1467,145 @@ export async function setAssignmentClosedWithConflictRetry(
 ) {
   return withGitConflictRetry(() => setAssignmentClosed(client, input))
 }
+
+// MIGRATION(v1.28): the whole assignments.json schema-migration flow below
+// (types, helpers, and the writer) is a one-time normalization of pre-1.28
+// files to the current schema. Safe to remove in a future version once no
+// legacy (submission_mode-absent) files remain in the wild. Greppable tag:
+// MIGRATION(v1.28).
+export type MigrateClassroomAssignmentsInput = {
+  org: string
+  classroom: string
+}
+
+export type MigrateClassroomAssignmentsResult = Omit<
+  CreateClassroomResult,
+  "updatedRef"
+> & {
+  // Present only when at least one entry was normalized; an all-migrated file
+  // (or an empty classroom) skips the commit and leaves this undefined.
+  updatedRef?: CreateClassroomResult["updatedRef"]
+  // Entries this run wrote explicit fields onto.
+  migratedCount: number
+  // Entries already carrying an explicit submission_mode (left untouched).
+  alreadyMigratedCount: number
+}
+
+// An entry is "migrated" once it carries an explicit submission_mode. That
+// presence is the opt-in signal SubmissionsPage reads to enable the detection
+// overlay, so a legacy file (no submission_mode) keeps its pre-1.28
+// submit/*-only counts until a teacher runs this classroom-wide normalization.
+function isSubmissionTrackingMigrated(entry: Assignment): boolean {
+  return entry.submission_mode !== undefined
+}
+
+// Normalize an unmigrated entry into the new canonical shape by writing the
+// fields that pre-1.28 left absent: submission_mode = "every-push" (the wire
+// default, so behavior is unchanged) and, when grading is absent, an explicit
+// grading: { mode: "auto" } so the file self-documents. Immutable provisioning
+// flags (empty_repo/no_autograder/init_shim), locked/closed, and every other
+// field are left exactly as-is. Returns the entry unchanged when already
+// migrated.
+function normalizeEntryForMigration(entry: Assignment): Assignment {
+  if (isSubmissionTrackingMigrated(entry)) return entry
+  const migrated: Assignment = {
+    ...entry,
+    submission_mode: SUBMISSION_MODES[0],
+  }
+  if (migrated.grading === undefined) {
+    migrated.grading = { mode: "auto" }
+  }
+  return migrated
+}
+
+// Migrate every eligible assignment in a classroom's assignments.json to the
+// new submission-configuration semantics in ONE commit: write an explicit
+// submission_mode (and grading: auto) onto each legacy entry so the detection
+// overlay opts in, while preserving pre-1.28 behavior byte-for-byte (every-push
+// is the wire default). This is a content normalization WITHIN v1 — the schema
+// sentinel is untouched and no version bump occurs. Unknown fields round-trip
+// via the whole-entry spread. Mirrors setAssignmentClosed's no-op short-circuit:
+// an all-migrated file skips the commit.
+export async function migrateClassroomAssignments(
+  client: GitHubClient,
+  input: MigrateClassroomAssignmentsInput,
+): Promise<MigrateClassroomAssignmentsResult> {
+  const { org, classroom } = input
+  log.info("migrate classroom assignments: started", { org, classroom })
+
+  const [, configBranch] = await Promise.all([
+    assertClassroomNotArchived(client, org, classroom),
+    getConfigRepoBranch(client, org),
+  ])
+  const ref = await getBranchRef(client, org, configBranch)
+  const commit = await getCommit(client, org, ref.object.sha)
+
+  const assignmentsFilePath = `${classroom}/assignments.json`
+  const currentAssignments = await getAssignmentsFile(client, {
+    org,
+    path: assignmentsFilePath,
+    ref: ref.object.sha,
+  })
+
+  const alreadyMigratedCount = currentAssignments.assignments.filter(
+    isSubmissionTrackingMigrated,
+  ).length
+  const migratedCount =
+    currentAssignments.assignments.length - alreadyMigratedCount
+
+  let newCommitSha = ref.object.sha
+  let newTreeSha = commit.tree.sha
+  let updatedRef: CreateClassroomResult["updatedRef"] | undefined
+
+  if (migratedCount > 0) {
+    const nextAssignments: AssignmentsFile = {
+      ...currentAssignments,
+      assignments: currentAssignments.assignments.map(
+        normalizeEntryForMigration,
+      ),
+    }
+
+    const tree = await createGitTree(client, {
+      org,
+      base_tree: commit.tree.sha,
+      tree: [
+        {
+          path: assignmentsFilePath,
+          mode: "100644",
+          type: "blob",
+          content: JSON.stringify(nextAssignments, null, 2) + "\n",
+        },
+      ],
+    })
+    const newCommit = await createGitCommit(client, {
+      org,
+      message: prefixCommit(
+        `Migrate submission tracking: ${classroom} (${migratedCount} assignment${migratedCount === 1 ? "" : "s"})`,
+      ),
+      tree_sha: tree.sha,
+      parents: [ref.object.sha],
+    })
+    updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
+    newCommitSha = newCommit.sha
+    newTreeSha = tree.sha
+  }
+
+  return {
+    previousCommitSha: ref.object.sha,
+    baseTreeSha: commit.tree.sha,
+    newTreeSha,
+    newCommitSha,
+    updatedRef,
+    migratedCount,
+    alreadyMigratedCount,
+  }
+}
+
+// Same concurrency story as the other assignments.json writers: retry on a
+// concurrent-write 409, each attempt re-reading the ref and file.
+export async function migrateClassroomAssignmentsWithConflictRetry(
+  client: GitHubClient,
+  input: MigrateClassroomAssignmentsInput,
+) {
+  return withGitConflictRetry(() => migrateClassroomAssignments(client, input))
+}

--- a/web/src/hooks/mutations/useMigrateClassroomAssignments.ts
+++ b/web/src/hooks/mutations/useMigrateClassroomAssignments.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import {
+  migrateClassroomAssignmentsWithConflictRetry,
+  type MigrateClassroomAssignmentsInput,
+  type MigrateClassroomAssignmentsResult,
+} from "@/domain/assignments"
+import { githubKeys } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// MIGRATION(v1.28): schema-migration hook for one-time normalization of
+// pre-1.28 assignments.json files. Safe to remove in a future version once no
+// legacy files remain. Greppable tag: MIGRATION(v1.28).
+// Migrate a classroom's assignments.json to the new submission-tracking
+// semantics (write an explicit submission_mode + grading:auto onto every legacy
+// entry, opting the detection overlay in without changing behavior). The hook
+// owns the assignments.json listing invalidate (unmount-safe — the migrate
+// banner must clear even if the teacher navigates away). A content
+// normalization within v1, so there is no schema-version side effect.
+export function useMigrateClassroomAssignments(
+  org: string,
+  classroom: string,
+  onWrite?: (
+    result: MigrateClassroomAssignmentsResult,
+    input: MigrateClassroomAssignmentsInput,
+  ) => void,
+) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    MigrateClassroomAssignmentsResult,
+    GitHubAPIError,
+    MigrateClassroomAssignmentsInput
+  >({
+    mutationFn: (input) =>
+      migrateClassroomAssignmentsWithConflictRetry(client, input),
+    onSuccess: (result, input) => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.jsonFile(
+          org,
+          CONFIG_REPO,
+          `${classroom}/assignments.json`,
+        ),
+      })
+      onWrite?.(result, input)
+    },
+  })
+}
+
+export default useMigrateClassroomAssignments

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2621,6 +2621,18 @@
         "closed": "Closed"
       }
     },
+    "migrateTracking": {
+      "bannerText": "This classroom's configuration uses an older format. Migrate it to the latest schema to enable the newest assignment and submissions features.",
+      "bannerAction": "Migrate configuration",
+      "title": "Migrate classroom configuration",
+      "subtitle": "Update this classroom's assignments to the latest configuration schema.",
+      "warning": "This records each assignment's settings explicitly so every tool reads them the same way and the newest features (such as live submission tracking) are enabled. It does not change any grade, deadline, or student's access, and you can keep working as before.",
+      "apply": "Migrate configuration",
+      "working": "Updating assignments",
+      "resultHeadline_one": "Migrated {{count}} assignment.",
+      "resultHeadline_other": "Migrated {{count}} assignments.",
+      "error": "The assignments could not be updated. Try again."
+    },
     "bulkFeatures": {
       "menuLabel": "Update repository features",
       "menuTitle": "Turn Issues, Wiki, Projects, or Pull requests on or off across every student repository",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -432,6 +432,19 @@ const SubmissionsPageContent = () => {
     enabled: liveCapable,
   })
 
+  // MIGRATION(v1.28): legacy-preserving gate. Safe to simplify (drop the
+  // submissionTrackingMigrated term, always enable) in a future version once no
+  // legacy (submission_mode-absent) files remain. Greppable tag: MIGRATION(v1.28).
+  // The detection overlay is a submission-configuration feature that did not
+  // exist pre-1.28, so a file written before it (no submission_mode field) must
+  // keep its pre-1.28 submit/*-only counts until a teacher explicitly migrates.
+  // The presence of an explicit submission_mode is the opt-in signal the
+  // classroom-wide migration writes; absent = legacy = overlay off. The live
+  // submit/* overlay (useLiveSubmissions) stays on either way, so a legacy
+  // file's owner experience is byte-identical to pre-1.28.
+  const submissionTrackingMigrated =
+    assignmentInfo?.submission_mode !== undefined
+
   // Detection overlay (submission-configuration hybrid model): the same
   // page-scoped owners as the live fan-out, reading each repo's default-branch
   // pushes (branch mode) or git tags (tag mode) so a submission shows even
@@ -444,7 +457,7 @@ const SubmissionsPageContent = () => {
       mode: assignmentInfo?.submission_mode,
       submissionTags: assignmentInfo?.submission_tags,
       repoOwners: livePageOwners,
-      enabled: liveCapable,
+      enabled: liveCapable && submissionTrackingMigrated,
     })
 
   // Overlay live presence over the snapshot for a live-capable viewer (snapshot

--- a/web/src/routes/_authed/$org/$classroom/route.tsx
+++ b/web/src/routes/_authed/$org/$classroom/route.tsx
@@ -1,5 +1,7 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useParams } from "@tanstack/react-router"
 import { PermissionErrorBoundary } from "@/components/PermissionErrorBoundary"
+// MIGRATION(v1.28): remove with the schema-migration banner component.
+import { ClassroomMigrationBanner } from "@/components/ClassroomMigrationBanner"
 
 export const Route = createFileRoute("/_authed/$org/$classroom")({
   component: ClassroomLayout,
@@ -7,10 +9,15 @@ export const Route = createFileRoute("/_authed/$org/$classroom")({
 
 // The effective classroom role is now resolved once at the `_authed` shell
 // (ClassroomRoleProvider wraps the persistent sidebar + Outlet there), so this
-// boundary only keeps the classroom-scoped permission error surface.
+// boundary only keeps the classroom-scoped permission error surface. The
+// migration banner sits above the Outlet so it persists across every classroom
+// subview until the teacher migrates assignments.json (it self-hides otherwise).
 function ClassroomLayout() {
+  const { org, classroom } = useParams({ strict: false })
   return (
     <PermissionErrorBoundary>
+      {/* MIGRATION(v1.28): remove with the schema-migration banner. */}
+      <ClassroomMigrationBanner org={org} classroom={classroom} />
       <Outlet />
     </PermissionErrorBoundary>
   )


### PR DESCRIPTION
## Summary

The 1.28 release added new `assignments.json` fields (submission configuration, grading modes, etc.). The schema is backward-compatible, but one new behavior is not opt-in: the submissions-page **detection overlay** counts every default-branch push for an every-push assignment, so an untouched pre-1.28 file's submission count silently rises (pre-1.28 counted only `submit/*` releases).

This PR makes the new behavior strictly opt-in and gives teachers an explicit, one-click way to migrate.

- **Legacy-preserving gate:** the detection overlay is now gated on an explicit `submission_mode`. A pre-1.28 file (no `submission_mode`) keeps its exact pre-1.28 `submit/*`-only counts until migrated. The live `submit/*` overlay stays on regardless, so a legacy file's owner experience is byte-identical to before.
- **Classroom-wide migration:** a persistent, classroom-level banner (red, shown across every subview to owner + authoring-tier until migrated) opens a confirmation modal that normalizes the classroom's `assignments.json` in one commit — writing an explicit `submission_mode: "tag"` (plus `grading: {mode: "auto"}`) onto each legacy entry. Nothing runs until the teacher explicitly confirms.
- **`tag`, not `every-push`:** migration writes `submission_mode: "tag"` because pre-1.28 a submission was a `submit/*` release, and tag-mode detection counts exactly the always-unioned `submit/*` namespace. `every-push` would inflate counts for an untouched file.
- **No schema version bump:** this is a content normalization within `v1`; the schema sentinel is untouched.
- All v1.28-only migration code is tagged `MIGRATION(v1.28)` for safe future removal (`rg "MIGRATION\(v1\.28\)"`).

## Test plan

- [x] `npm run check` — tsc, eslint, prettier, `arch:validate` (no boundary violations), and the full node vitest suite (3574 tests) pass.
- [x] Strict i18n audit (`audit_i18n.py --strict`) passes — no missing/dead/hardcoded keys.
- [x] New domain-writer tests cover: all-legacy migration writes `tag` + `grading:auto` in one commit; already-migrated no-op (no commit); mixed (only legacy entries change); grading/unknown fields preserved verbatim; schema sentinel unchanged.
- [ ] Manual smoke: open a classroom with a pre-1.28 `assignments.json` → red migrate banner shows on every subview; submissions page shows legacy `submit/*`-only counts; click Migrate → banner clears, file gains explicit `submission_mode: "tag"`, detection overlay behaves as tag mode.
- Note: the `browser` vitest project (Playwright/Chromium) was not run in the sandbox (missing browser binary); it is unrelated to these changes.