### PR TITLE
feat(web): add per-row autograder-details shortcut and unify 1.28 terminology

### DIFF
--- a/web/src/domain/assignments/autogradingState.ts
+++ b/web/src/domain/assignments/autogradingState.ts
@@ -37,6 +37,8 @@ export function assignmentSkipsGrading(assignment: Assignment): boolean {
 // on (empty repo / no built-in autograding / built-in autograding). Derived
 // from the wire fields so the form and every read surface agree; no_autograder
 // is the wire representation of the "none" state.
+// NOTE: distinct from github-core's `AutogradeWorkflowState` (enabled/paused/…),
+// which is the runtime workflow pause/resume state, not this form choice.
 export type AutogradingState = "empty" | "none" | "built-in"
 
 /**

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -116,7 +116,7 @@ export {
   getAutogradeState,
   setAutogradeState,
   AUTOGRADE_WORKFLOW_FILE,
-  type AutogradeState,
+  type AutogradeWorkflowState,
 } from "./mutations/autogradeState"
 export {
   createPullRequest,

--- a/web/src/github-core/mutations/autogradeState.ts
+++ b/web/src/github-core/mutations/autogradeState.ts
@@ -17,17 +17,20 @@ import { GitHubAPIError } from "../errors"
 export const AUTOGRADE_WORKFLOW_FILE = "autograde.yaml"
 
 // The teacher-facing autograding state, derived from the workflow's GitHub state.
+// NOTE: distinct from domain/assignments/autogradingState.ts's `AutogradingState`
+// ("empty" | "none" | "built-in"), which is the assignment-form repo-source
+// choice. This one is the runtime workflow pause/resume state.
 //  - enabled       → workflow active, grading runs (offer Pause)
 //  - paused        → teacher-disabled (disabled_manually) (offer Resume)
 //  - pausedByGitHub → disabled_fork/_inactivity: GitHub disabled it, not the
 //    teacher; Resume (enable) is still the correct remediation
 //  - notGradable   → no autograde workflow (empty_repo/no_autograder/custom, or
 //    repo not accepted yet) — a first-class non-error state, not a failure
-export type AutogradeState =
+export type AutogradeWorkflowState =
   "enabled" | "paused" | "pausedByGitHub" | "notGradable"
 
 // Map GitHub's workflow `state` enum onto the teacher-facing state.
-function toAutogradeState(githubState: string): AutogradeState {
+function toAutogradeState(githubState: string): AutogradeWorkflowState {
   switch (githubState) {
     case "active":
       return "enabled"
@@ -49,7 +52,7 @@ export async function getAutogradeState(params: {
   client: GitHubClient
   org: string
   repo: string
-}): Promise<AutogradeState> {
+}): Promise<AutogradeWorkflowState> {
   const { client, org, repo } = params
   try {
     const wf = await client.request<{ state?: string }>(

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -175,8 +175,8 @@ export const githubKeys = {
     [...githubKeys.all, "orgActionsUsage", owner] as const,
 
   // The autograde workflow's Actions state for one student repo, mapped to an
-  // AutogradeState. Invalidated after a per-repo or bulk pause/resume so the
-  // row's action label flips.
+  // AutogradeWorkflowState. Invalidated after a per-repo or bulk pause/resume so
+  // the row's action label flips.
   autogradeState: (owner: string, repo: string) =>
     [...githubKeys.all, "autogradeState", owner, repo] as const,
 

--- a/web/src/hooks/useGetAutogradeState.ts
+++ b/web/src/hooks/useGetAutogradeState.ts
@@ -2,7 +2,10 @@ import { useQuery } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { githubKeys } from "@/github-core/queries"
-import { getAutogradeState, type AutogradeState } from "@/github-core/mutations"
+import {
+  getAutogradeState,
+  type AutogradeWorkflowState,
+} from "@/github-core/mutations"
 
 // The autograde workflow's live state for one repo, so a row action can show
 // Pause (enabled) vs Resume (paused). Read lazily — the manage hub enables it
@@ -17,7 +20,7 @@ export function useGetAutogradeState(
 ) {
   const client = useGitHubClient()
 
-  return useQuery<AutogradeState>({
+  return useQuery<AutogradeWorkflowState>({
     queryKey: githubKeys.autogradeState(org ?? "", repo ?? ""),
     queryFn: () =>
       getAutogradeState({ client, org: org ?? "", repo: repo ?? "" }),

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1100,8 +1100,8 @@
     "goToAssignments": "Go to assignments",
     "form": {
       "detailsSection": "Details",
-      "repositorySetupSection": "Repository Setup",
-      "submissionSection": "Submission and Grading",
+      "repositorySetupSection": "Repository setup",
+      "submissionSection": "Submission and grading",
       "submissionSectionHelp": "Define what counts as a submission for this assignment — when the autograder runs and which tags a student can push to submit.",
       "scheduleSection": "Schedule",
       "sectionStatus": {
@@ -1171,7 +1171,7 @@
       },
       "autograding": {
         "label": "Autograding",
-        "notAutogradedNote": "Autograding options apply only when this assignment is set to \"Autograded\" in the Submission and Grading section above. Change the grading choice to Autograded to configure the autograder.",
+        "notAutogradedNote": "Autograding options apply only when this assignment is set to \"Autograded\" in the Submission and grading section above. Change the grading choice to Autograded to configure the autograder.",
         "modeLabel": "Built-in autograder",
         "lockedHelp": "Whether the built-in autograder is used can't be changed after creation: repositories students already accepted are not re-provisioned.",
         "choices": {
@@ -1205,7 +1205,7 @@
         "help": "How the submissions page detects and counts each student's work. The autograder uses the same definition."
       },
       "submissionMode": {
-        "label": "Submission type",
+        "label": "Autograding trigger",
         "help": "\"Every push to the default branch\" counts each push (other than the starting commit). \"A tagged commit\" counts only tagged commits — a student submits with gh student submit or by pushing a tag, so ordinary pushes cost no Actions minutes.",
         "editWarning": "Changing this only affects repositories created from now on. Repositories students already accepted keep the old setting until you update them — use \"Update autograding triggers\" on the submissions page or gh teacher assignment submission-mode. Students must pull after the update.",
         "choices": {
@@ -1412,7 +1412,7 @@
       "unlockAria": "Unlock {{name}}",
       "lockTitleModal": "Lock assignment?",
       "unlockTitleModal": "Unlock assignment?",
-      "lockDescription": "This closes <assignment>{{assignment}}</assignment> to every student — including those who already accepted — on the accept page, the assignments list, the submission view, and the CLI. If it uses a private template, the student team's read on that template is removed too (staff access is unaffected). Existing student repositories are not deleted.",
+      "lockDescription": "This locks <assignment>{{assignment}}</assignment> to every student — including those who already accepted — on the accept page, the assignments list, the submission view, and the CLI. If it uses a private template, the student team's read on that template is removed too (staff access is unaffected). Existing student repositories are not deleted.",
       "unlockDescription": "This reopens <assignment>{{assignment}}</assignment> to students. If it uses a private template, the student team's read on that template is restored so students can accept again.",
       "lockConfirm": "Lock assignment",
       "unlockConfirm": "Unlock assignment",
@@ -2292,11 +2292,11 @@
     "lock": {
       "lockLabel": "Lock assignment",
       "unlockLabel": "Unlock assignment",
-      "lockTitle": "Close this assignment to students and, for a private template, remove the student team's read on it",
+      "lockTitle": "Lock this assignment so students can't access or accept it, and, for a private template, remove the student team's read on it",
       "unlockTitle": "Reopen this assignment to students and restore private-template access",
       "lockTitleModal": "Lock assignment?",
       "unlockTitleModal": "Unlock assignment?",
-      "lockDescription": "This closes <assignment>{{assignment}}</assignment> to every student — including those who already accepted — on the accept page, the assignments list, the submission view, and the CLI. If it uses a private template, the student team's read on that template is removed too (staff access is unaffected). Existing student repositories are not deleted.",
+      "lockDescription": "This locks <assignment>{{assignment}}</assignment> to every student — including those who already accepted — on the accept page, the assignments list, the submission view, and the CLI. If it uses a private template, the student team's read on that template is removed too (staff access is unaffected). Existing student repositories are not deleted.",
       "unlockDescription": "This reopens <assignment>{{assignment}}</assignment> to students. If it uses a private template, the student team's read on that template is restored so students can accept again.",
       "lockSuccess": "Assignment locked.",
       "unlockSuccess": "Assignment unlocked."

--- a/web/src/pages/assignments/sections/sectionStatus.test.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.test.ts
@@ -3,7 +3,9 @@ import { deriveSectionStatus } from "./sectionStatus"
 import type { CreateAssignmentFormValues } from "../assignmentFormModel"
 
 // The create-form baseline defaults; deriveSectionStatus compares against these
-// to tell "configured" from "default". Mirrors useAssignmentForm's defaults.
+// to tell "configured" from "default". These MUST match useAssignmentForm's
+// create defaults (assignmentFormModel.ts): a fresh create form is an
+// uninitialized repo with no README, no built-in autograding, and grading off.
 const defaults: CreateAssignmentFormValues = {
   name: "",
   slug: "",
@@ -16,9 +18,9 @@ const defaults: CreateAssignmentFormValues = {
   feedback_pr: true,
   empty_repo: false,
   repo_source: "none",
-  add_readme: true,
+  add_readme: false,
   include_all_branches: false,
-  autograding_state: "built-in",
+  autograding_state: "none",
   runtime_env: "hosted",
   runs_on: "",
   container_image: "",
@@ -38,7 +40,7 @@ const defaults: CreateAssignmentFormValues = {
   student_permission: "",
   submission_mode: "every-push",
   submission_tags: "",
-  grading_choice: "auto",
+  grading_choice: "off",
   grading_max_points: 100,
   repo_feature_issues: "inherit",
   repo_feature_wiki: "inherit",

--- a/web/src/pages/submissions/DataFreshness.tsx
+++ b/web/src/pages/submissions/DataFreshness.tsx
@@ -27,7 +27,8 @@ export type DataFreshnessProps = {
   // Repos the live fan-out couldn't read (owner only); > 0 shows a warning so
   // an incomplete live status doesn't look authoritative.
   errorCount?: number
-  // empty_repo assignments never autograde; show that instead of freshness.
+  // The assignment skips built-in grading (empty_repo OR no_autograder — fed
+  // skipsGrading); show a note instead of freshness. noAutograder picks the note.
   emptyRepo?: boolean
   // no_autograder assignments also never autograde, but keep the Feedback PR —
   // pick the accurate note (only meaningful when emptyRepo is true).

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -272,8 +272,9 @@ export const RepoRowActions = ({
 //
 // Gating mirrors the old cluster: repo-only actions (Review, access, regrade,
 // download) disable only when no repo exists; submission-only links
-// (commit, details) dim until an attempt lands; `emptyRepo` assignments omit
-// the PR/access/details/regrade actions entirely.
+// (commit, details) dim until an attempt lands; assignments that skip built-in
+// grading (empty_repo OR no_autograder — this receives skipsGrading) omit the
+// PR/access/details/regrade actions entirely.
 export type SubmissionActionListProps = {
   mode: AssignmentMode
   org: string

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -227,28 +227,51 @@ export const DownloadButton = ({
 }
 
 // The per-repo Actions cell, shared by every row family (submitted,
-// non-submitter, group). It now holds just two affordances: the leading
-// Open-repo shortcut (`header`) and a single Manage trigger that opens the
-// submission hub (ManageSubmissionModal), where every other action —
-// commit, Review, access, details, regrade, download — lives as a labeled row.
-// Consolidating keeps the dense table to one GitHub-repo shortcut plus one
-// entry point that scales as we add actions, instead of a growing icon cluster.
+// non-submitter, group). It now holds a small set of shortcuts: the leading
+// Open-repo link (`header`), a direct "View autograder details" link to the
+// latest submission release (a teacher's most common jump, so it skips the hub),
+// and a single Manage trigger that opens the submission hub
+// (ManageSubmissionModal), where every other action — commit, Review, access,
+// regrade, download — lives as a labeled row. Keeping the dense table to these
+// few shortcuts plus one entry point scales as we add actions, instead of a
+// growing icon cluster.
 export const RepoRowActions = ({
   owner,
   header,
+  release,
+  skipsGrading = false,
   onManage,
 }: {
   owner: string
   // The leading affordance for this row family (Open-repo link for individuals,
   // repo link for groups).
   header: React.ReactNode
+  // The submission's latest release page (autograder result). When present, a
+  // direct "View autograder details" shortcut links it (skipping the hub). The
+  // shortcut is hidden when there's no result to view — before a submission
+  // lands, or for assignments that skip built-in grading (see skipsGrading).
+  release?: string | null
+  // The assignment skips built-in grading (empty_repo OR no_autograder): there's
+  // no autograder result, so the details shortcut is hidden entirely.
+  skipsGrading?: boolean
   // Opens the submission hub for this row.
   onManage: () => void
 }) => {
   const { t } = useTranslation()
+  const releaseHref = skipsGrading ? null : safeHttpUrl(release)
   return (
     <>
       {header}
+      {releaseHref && (
+        <ActionIconLink
+          href={releaseHref}
+          icon={ScrollText}
+          label={t("submissions.table.viewDetails")}
+          title={t("submissions.table.viewDetails")}
+          emptyLabel={t("submissions.table.viewDetails")}
+          emptyTitle={t("submissions.table.viewDetails")}
+        />
+      )}
       <Button
         variant="ghost"
         size="sm"

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -248,8 +248,10 @@ const SubmissionsTable = ({
   filtered?: boolean
   // Clears the active search + filters (wired to the controls' clearAll).
   onClearFilters?: () => void
-  // empty_repo assignment: never autogrades, so score badges and the
-  // Feedback-PR/regrade actions are hidden (repos + accept state stay useful).
+  // The assignment skips built-in grading (empty_repo OR no_autograder): score
+  // badges and the regrade action are hidden. Fed skipsGrading by the page. Note
+  // no_autograder repos are templated and keep the Feedback PR — the wire flag
+  // this receives is skipsGrading, not empty_repo alone.
   emptyRepo?: boolean
   // The assignment's submission_mode, enabling the per-repo "Update
   // autograding trigger" action in the manage hub. Omitted (action hidden)

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -531,6 +531,8 @@ const SubmissionsTable = ({
               {isGroup ? (
                 <RepoRowActions
                   owner={rest.owner}
+                  release={rest.release}
+                  skipsGrading={emptyRepo}
                   header={
                     <GroupActionControls repo={repo} repoHref={repoHref} />
                   }
@@ -550,6 +552,8 @@ const SubmissionsTable = ({
               ) : (
                 <RepoRowActions
                   owner={rest.owner}
+                  release={rest.release}
+                  skipsGrading={emptyRepo}
                   header={
                     <IndividualRowHeader
                       repo={repo}
@@ -716,6 +720,7 @@ const SubmissionsTable = ({
                   actions = (
                     <RepoRowActions
                       owner={student.username}
+                      skipsGrading={emptyRepo}
                       header={
                         <IndividualRowHeader
                           repo={repoName}
@@ -777,6 +782,7 @@ const SubmissionsTable = ({
                   actions={
                     <RepoRowActions
                       owner={owner}
+                      skipsGrading={emptyRepo}
                       header={
                         <GroupActionControls
                           repo={repoName}

--- a/wiki/CLI-Student-Guide.md
+++ b/wiki/CLI-Student-Guide.md
@@ -153,7 +153,7 @@ When submit finishes, it prints two URLs:
   assignment, only `gh student submit` (or a hand-pushed `submit/*` tag)
   grades; regular pushes save your work without grading it.
 - **Pull after teacher-side workflow updates.** If your teacher changes the
-  assignment's grading trigger, a small commit lands in your repo. Run
+  assignment's autograding trigger, a small commit lands in your repo. Run
   `git pull` before your next push, or git will report a conflict.
 - **History is preserved.** Submissions stack as commits; prior commits stay
   reachable for review.


### PR DESCRIPTION
## Summary

Follow-ups from a review of the v1.27.2 → v1.28.0 diff, plus a small submissions-page usability addition. Two logical changes:

**Add a per-row "View autograder details" shortcut on the submissions page.** The action already lived inside the Manage hub; this surfaces it as a direct per-row link to the latest submission release (the autograder result) so a teacher can open a result without opening the hub first. It renders only when there's a result to view — hidden before a submission lands and for assignments that skip built-in grading (`empty_repo` / `no_autograder`). The hub action is unchanged.

**Correct terminology and comment findings from the 1.28 review.** Standardize the user-facing name for `submission_mode` on "Autograding trigger" (the form label previously said "Submission type", mismatching its own validation error and the bulk action), and stop the Lock copy from saying it "closes" the assignment now that Close submission is a distinct feature. Correct the `emptyRepo` prop comments left stale by the `skipsGrading` (`empty_repo || no_autograder`) generalization, rename the workflow-runtime `AutogradeState` type to `AutogradeWorkflowState` to disambiguate it from the form's `AutogradingState`, fix the `sectionStatus` test baseline fixture to match the real create-form defaults, and sentence-case the assignment settings section headings ("Repository setup", "Submission and grading").

No wire/schema/enum changes — these are UI strings, comments, a test fixture, an internal type rename, and one additive UI shortcut.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest) — passes (one unrelated environmental flake: `contrastSource.test.ts` temp-file race + missing Playwright browser in sandbox; passes in isolation)
- [x] i18n strict audit (`audit_i18n.py --strict`) — PASS, 0 missing/dead/hardcoded
- [x] Submissions test suite — 212/212
- [ ] Manual: confirm the details shortcut links the release and is hidden for empty_repo/no_autograder rows