### PR TITLE
feat(web): show explicit "Copied" feedback in the share link modal

### DIFF
--- a/web/src/components/ui/CopyableCode.test.tsx
+++ b/web/src/components/ui/CopyableCode.test.tsx
@@ -36,4 +36,34 @@ describe("CopyableCode", () => {
     const btn = screen.getByRole("button", { name: "Copy" })
     expect(btn.className).toContain("btn-success")
   })
+
+  it("stays icon-only (no visible text) without copiedLabel", () => {
+    render(<CopyableCode value="x" copied onCopy={() => {}} label="Copy" />)
+    expect(screen.queryByText("Copy")).toBeNull()
+  })
+
+  it("spells out the state and announces it when copiedLabel is set", () => {
+    const { rerender } = render(
+      <CopyableCode
+        value="x"
+        copied={false}
+        onCopy={() => {}}
+        label="Copy"
+        copiedLabel="Copied"
+      />,
+    )
+    expect(screen.getByText("Copy")).not.toBeNull()
+
+    rerender(
+      <CopyableCode
+        value="x"
+        copied
+        onCopy={() => {}}
+        label="Copy"
+        copiedLabel="Copied"
+      />,
+    )
+    // The button text and the aria-live region both read "Copied".
+    expect(screen.getAllByText("Copied").length).toBeGreaterThanOrEqual(2)
+  })
 })

--- a/web/src/components/ui/CopyableCode.tsx
+++ b/web/src/components/ui/CopyableCode.tsx
@@ -9,12 +9,18 @@ import { cx } from "./cx"
 // stays caller-owned (via useCopyToClipboard) so each instance tracks its own
 // copy and its own revert timing — the primitive is stateless. Replaces the
 // hand-rolled copy blocks scattered across the app.
+//
+// `copiedLabel` opts into a text button (icon + label, plus an aria-live
+// announcement) over the compact icon-only default — use it where the copy is
+// the primary action so success reads clearly, not just as a color swap.
 
 export type CopyableCodeProps = {
   value: string
   copied: boolean
   onCopy: (e: MouseEvent<HTMLButtonElement>) => void
   label: string
+  // Resting label is `label`; while copied the button reads `copiedLabel`.
+  copiedLabel?: string
   className?: string
   children?: ReactNode
 }
@@ -24,9 +30,11 @@ export function CopyableCode({
   copied,
   onCopy,
   label,
+  copiedLabel,
   className,
   children,
 }: CopyableCodeProps) {
+  const withText = copiedLabel !== undefined
   return (
     <div
       className={cx(
@@ -40,7 +48,7 @@ export function CopyableCode({
       <Button
         variant={copied ? "success" : "ghost"}
         size="sm"
-        shape="square"
+        shape={withText ? undefined : "square"}
         className="me-2 shrink-0"
         onClick={onCopy}
         aria-label={label}
@@ -51,7 +59,13 @@ export function CopyableCode({
         ) : (
           <Copy aria-hidden="true" className="size-4" />
         )}
+        {withText ? (copied ? copiedLabel : label) : null}
       </Button>
+      {withText ? (
+        <span aria-live="polite" className="sr-only">
+          {copied ? copiedLabel : ""}
+        </span>
+      ) : null}
     </div>
   )
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2374,6 +2374,7 @@
       "unlistedNote": "This classroom uses an unlisted URL, so the link includes the access key — treat it like a shared password and send the full link as-is.",
       "copyLink": "Copy accept link",
       "copyCli": "Copy CLI command",
+      "copied": "Copied",
       "preferCli": "Prefer the command line?",
       "warnNoStudents": "No students can accept this link in <classroom>{{classroom}}</classroom> yet. Add students to the roster and invite them to the organization first.",
       "shareWithCount_one": "Sharing with <count>{{count}} student</count> who can accept this assignment.",

--- a/web/src/pages/submissions/AcceptLinkModal.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.tsx
@@ -90,6 +90,7 @@ export function AcceptLinkModal({
           copied={copiedUrl}
           onCopy={copyUrl}
           label={t("submissions.accept.copyLink")}
+          copiedLabel={t("submissions.accept.copied")}
         />
 
         <details className="group/cli">
@@ -106,6 +107,7 @@ export function AcceptLinkModal({
             copied={copiedCli}
             onCopy={copyCli}
             label={t("submissions.accept.copyCli")}
+            copiedLabel={t("submissions.accept.copied")}
           />
         </details>
       </div>


### PR DESCRIPTION
## Summary

The accept-link share modal (`AcceptLinkModal`) only signaled a successful copy by swapping the button icon and color — an icon-only square button with no text and no screen-reader announcement, so the feedback was easy to miss.

This adds an explicit "Copied" state to match the device-flow login prompt (`GitHubDevicePrompt`):

- `CopyableCode` gains an opt-in `copiedLabel` prop. When set, the button spells out its state next to the icon ("Copy" → green check + "Copied") and announces the change via an `aria-live="polite"` region. Omitting the prop keeps the compact icon-only button, so other callers (e.g. `SubmitGuidance`) are unchanged.
- `AcceptLinkModal` passes `copiedLabel` to both the accept-link and CLI-command copy buttons.
- New `submissions.accept.copied` key in `en.json` (target packs are machine-translated from `en.json`).

## Test plan

- [ ] `npm run check` passes (tsc, eslint, prettier, arch:validate, vitest) — new `CopyableCode` tests cover the icon-only default staying text-free and the labelled variant reading "Copy"/"Copied" with the aria-live announcement.
- [ ] Manually: open an assignment's Share modal, click Copy — button turns green, shows "Copied", and reverts after ~1.5s.