### PR TITLE
feat(web): copy template About and topics to student repos

### DIFF
--- a/schemas/assignments-v1.schema.json
+++ b/schemas/assignments-v1.schema.json
@@ -138,6 +138,14 @@
           "type": "boolean",
           "description": "Opt a TEMPLATED assignment into copying ALL of the template's branches (not just the default branch) when each student repo is generated: accept passes include_all_branches to GitHub's POST /repos/{template}/generate. REQUIRES a template (it only affects the generate call — a template-less repo is never generated). Mutually exclusive with empty_repo and init_shim (both template-less, never generated). COMPATIBLE with everything else, including no_autograder (a templated teacher-supplied-CI assignment may still want all branches) and the grading-adjacent fields (branches do not affect grading — the grading pipeline never reads this field). ACCEPT-TIME ONLY and NOT immutable: it governs what NEW student repos get; changing it affects only repos generated from now on (like submission_mode, not like empty_repo — already-accepted repos are never re-generated). On the wire it is collapsed like feedback_pr: the CLI omits the field when false (omitempty), so readers must treat an absent field as `false`; accept an explicit `false` too."
         },
+        "copy_about": {
+          "type": "boolean",
+          "description": "Opt a TEMPLATED assignment into copying the TEMPLATE repo's About (its `description`) onto each student repo at ACCEPT TIME, on FRESH CREATE only — because GitHub's POST /repos/{template}/generate does NOT copy the template's description (a generated repo starts blank). Accept reads the template repo's current description and applies it via PATCH /repos/{org}/{repo}. REQUIRES a template (a template-less/empty_repo assignment has no source to copy from). Best-effort/fail-open: a rejected PATCH is logged and does not fail accept, and an empty template description is skipped (never blanks an existing value). ACCEPT-TIME ONLY and NOT immutable: it governs what NEW student repos get and is NOT retrofitted to already-accepted repos, nor re-asserted on re-accept (a student's own later edit survives). On the wire it is collapsed like feedback_pr: writers omit the field when false (omitempty), so readers must treat an absent field as `false`; accept an explicit `false` too."
+        },
+        "copy_topics": {
+          "type": "boolean",
+          "description": "Opt a TEMPLATED assignment into copying the TEMPLATE repo's Topics onto each student repo at ACCEPT TIME, on FRESH CREATE only — because GitHub's POST /repos/{template}/generate does NOT copy the template's topics (a generated repo starts with none). Accept reads the template repo's current topics and applies them via PUT /repos/{org}/{repo}/topics. REQUIRES a template (a template-less/empty_repo assignment has no source to copy from). Best-effort/fail-open: a rejected request is logged and does not fail accept, and an empty template topic list is skipped (never clears an existing set). ACCEPT-TIME ONLY and NOT immutable: it governs what NEW student repos get and is NOT retrofitted to already-accepted repos, nor re-asserted on re-accept. On the wire it is collapsed like feedback_pr: writers omit the field when false (omitempty), so readers must treat an absent field as `false`; accept an explicit `false` too."
+        },
         "locked": {
           "type": "boolean",
           "description": "Lock the assignment against student access. The web accept page, the student assignments list, the student submission view, and `gh student accept` all refuse a locked assignment for EVERY student, including one who already accepted. UNLIKE available_from (which is listing-advisory only), this is intended as access control — but because assignments.json is published publicly to GitHub Pages, the client gates are still best-effort UX; a determined student can read the raw file. The ENFORCEABLE boundary applies only to a PRIVATE, in-org template: locking also removes the classroom STUDENT team's read on that template repo (teacher/head-TA/TA teams are left untouched), so no new student can generate a repo from it while locked; unlocking re-grants that read. Public-template and template-less assignments can only be UX-gated, never hard-blocked. Existing student repos are not deleted. On the wire it is collapsed like feedback_pr/empty_repo: the CLI omits the field when false (omitempty), so readers must treat an absent field as `false`; accept an explicit `false` too."
@@ -287,6 +295,14 @@
               { "not": { "properties": { "init_shim": { "const": true } }, "required": ["init_shim"] } }
             ]
           }
+        },
+        {
+          "if": { "properties": { "copy_about": { "const": true } }, "required": ["copy_about"] },
+          "then": { "required": ["template"] }
+        },
+        {
+          "if": { "properties": { "copy_topics": { "const": true } }, "required": ["copy_topics"] },
+          "then": { "required": ["template"] }
         },
         {
           "if": {

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1156,6 +1156,28 @@ describe("editAssignment (preserved-entry integration)", () => {
     ).rejects.toThrow(/submission_mode: must be one of every-push, tag/)
   })
 
+  // copy_about / copy_topics (issue #569): template-required guard + omitempty.
+  it("rejects copy_about / copy_topics without a template", async () => {
+    const { client } = makeClient()
+    await expect(
+      editAssignment(client, editInput({ copy_about: true })),
+    ).rejects.toThrow(/copy_about: requires a template/)
+    await expect(
+      editAssignment(client, editInput({ copy_topics: true })),
+    ).rejects.toThrow(/copy_topics: requires a template/)
+  })
+
+  it("omits copy_about / copy_topics when false (template-less)", async () => {
+    const { client, committedContent } = makeClient()
+    await editAssignment(client, editInput())
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    expect(edited.copy_about).toBeUndefined()
+    expect(edited.copy_topics).toBeUndefined()
+  })
+
   // Route-table client like makeClient(), but seeded with a caller-supplied
   // existing entry (the empty_repo tests need a bare one).
   function makeBareClient(entry: Assignment): {

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -45,8 +45,10 @@ import {
   founderPermission,
   assertAssignmentModeCoherent,
   patchRepoSurface,
+  applyRepoAboutTopics,
   resolveRepoFeaturesPatch,
   explicitRepoFeaturesPatch,
+  type RepoAboutTopics,
 } from "./permissions"
 import type { RepoFeaturePatch } from "@/github-core/mutations"
 import { createAssignmentRepo } from "./repoCreation"
@@ -169,6 +171,9 @@ function grantFounderAccessStep(params: {
   // fail-open retry body. Empty `full` ({}) skips the request (templated +
   // all-inherit); best-effort/fail-open.
   repoFeatures: RepoFeatureApply
+  // Template About/Topics to copy onto the repo (issue #569), applied after the
+  // feature PATCH, best-effort/fail-open. `{}` = nothing to copy.
+  repoAboutTopics: RepoAboutTopics
   onStepUpdate?: OnAcceptStepUpdate
 }) {
   const {
@@ -179,6 +184,7 @@ function grantFounderAccessStep(params: {
     mode,
     studentPermission,
     repoFeatures,
+    repoAboutTopics,
     onStepUpdate,
   } = params
   return withAcceptStep(
@@ -200,6 +206,7 @@ function grantFounderAccessStep(params: {
         repoFeatures.full,
         repoFeatures.explicit,
       )
+      await applyRepoAboutTopics(client, org, repo, repoAboutTopics)
       await addFounderCollaborator({
         client,
         owner: org,
@@ -223,6 +230,8 @@ async function provisionAcceptedRepo(params: {
   studentPermission?: RepoPermission
   // Resolved repo-feature PATCH, forwarded to the founder-access step.
   repoFeatures: RepoFeatureApply
+  // Template About/Topics to copy, forwarded to the founder-access step.
+  repoAboutTopics: RepoAboutTopics
   branch: string
   metadataYaml: string
   autogradeYaml: string
@@ -239,6 +248,7 @@ async function provisionAcceptedRepo(params: {
     mode,
     studentPermission,
     repoFeatures,
+    repoAboutTopics,
     branch,
     metadataYaml,
     autogradeYaml,
@@ -306,6 +316,7 @@ async function provisionAcceptedRepo(params: {
     mode,
     studentPermission,
     repoFeatures,
+    repoAboutTopics,
     onStepUpdate,
   })
 }
@@ -562,20 +573,36 @@ export async function acceptAssignment(params: {
     rf.wiki === undefined ||
     rf.projects === undefined ||
     rf.pull_requests === undefined
+  // Also read the template when copy_about / copy_topics is set: like the
+  // feature flags, GitHub's POST /generate drops the template's About and
+  // Topics, so an opted-in assignment must re-read and re-apply them (#569).
+  const wantsAbout = assignment.copy_about === true
+  const wantsTopics = assignment.copy_topics === true
+  const needsTemplateRead = anyInherit || wantsAbout || wantsTopics
   let templateFeatures: RepoFeaturePatch | null = null
-  if (assignment.template && sourceOwner && sourceRepo && anyInherit) {
+  let repoAboutTopics: RepoAboutTopics = {}
+  if (assignment.template && sourceOwner && sourceRepo && needsTemplateRead) {
     try {
       const tmpl = await getRepo(client, sourceOwner, sourceRepo)
       if (tmpl) {
-        templateFeatures = {
-          has_issues: tmpl.has_issues,
-          has_wiki: tmpl.has_wiki,
-          has_projects: tmpl.has_projects,
-          has_pull_requests: tmpl.has_pull_requests,
+        if (anyInherit) {
+          templateFeatures = {
+            has_issues: tmpl.has_issues,
+            has_wiki: tmpl.has_wiki,
+            has_projects: tmpl.has_projects,
+            has_pull_requests: tmpl.has_pull_requests,
+          }
+        }
+        // Drop empty values: never blank a repo's About or clear its topics.
+        const description = wantsAbout ? tmpl.description?.trim() : undefined
+        const topics = wantsTopics ? tmpl.topics : undefined
+        repoAboutTopics = {
+          ...(description ? { description } : {}),
+          ...(topics && topics.length > 0 ? { topics } : {}),
         }
       }
     } catch (err) {
-      log.debug("accept: template feature read failed (non-fatal)", {
+      log.debug("accept: template read failed (non-fatal)", {
         sourceOwner,
         sourceRepo,
         err,
@@ -826,6 +853,7 @@ export async function acceptAssignment(params: {
         mode: assignment.mode,
         studentPermission: assignment.student_permission,
         repoFeatures,
+        repoAboutTopics,
         onStepUpdate,
       })
     }
@@ -993,6 +1021,10 @@ export async function acceptAssignment(params: {
       // the healthy already-accepted branch and both CLIs (which skip the PATCH
       // on 422-already-exists).
       repoFeatures: { full: {}, explicit: {} },
+      // Same reasoning: About/Topics are copied on FRESH create only, never
+      // re-applied when repairing an already-existing repo (a re-accept), so a
+      // student's own later edit survives. Nothing to copy on this path.
+      repoAboutTopics: {},
       branch: created.repo.default_branch || sourceBranch,
       metadataYaml,
       autogradeYaml,
@@ -1031,6 +1063,7 @@ export async function acceptAssignment(params: {
     mode: assignment.mode,
     studentPermission: assignment.student_permission,
     repoFeatures,
+    repoAboutTopics,
     branch: targetBranch,
     metadataYaml,
     autogradeYaml,

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -114,6 +114,8 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   no_autograder: "classroom50-owned",
   init_shim: "classroom50-owned",
   include_all_branches: "classroom50-owned",
+  copy_about: "classroom50-owned",
+  copy_topics: "classroom50-owned",
   // Rebuilt AND a closed object: the CLI decodes runtime strictly (RuntimeRef
   // has no Extra, DisallowUnknownFields; schema additionalProperties false), so
   // the rebuilt runtime must win and any unknown sub-key drops rather than
@@ -515,6 +517,21 @@ async function buildAssignmentEntry(
     }
   }
 
+  // copy_about / copy_topics copy the template's About/Topics onto each student
+  // repo at accept time, so both require a template (there is nothing to copy
+  // from otherwise). Compatible with everything else. Mirrors the schema's
+  // copy_about/copy_topics template-required rules. Issue #569.
+  if (input.copy_about && !input.template_repo.trim()) {
+    throw new Error(
+      "copy_about: requires a template — it copies the template repo's About onto each student repo.",
+    )
+  }
+  if (input.copy_topics && !input.template_repo.trim()) {
+    throw new Error(
+      "copy_topics: requires a template — it copies the template repo's Topics onto each student repo.",
+    )
+  }
+
   if (tests.length > 0) {
     await ensureDeclarativeTestsWritable(
       client,
@@ -578,6 +595,16 @@ async function buildAssignmentEntry(
   // generate. No immutability check — it's mutable (only affects new accepts).
   if (input.include_all_branches) {
     entry.include_all_branches = true
+  }
+  // Written only when true (omitempty). Copy the template's About/Topics onto
+  // each student repo at accept time (issue #569). Mutable (only affects new
+  // accepts). The template-required guard above already rejected them without
+  // a template, so no extra check here.
+  if (input.copy_about) {
+    entry.copy_about = true
+  }
+  if (input.copy_topics) {
+    entry.copy_topics = true
   }
   // Omit the template block entirely for a template-less assignment, matching
   // the CLI's nil TemplateRef.

--- a/web/src/domain/assignments/permissions.test.ts
+++ b/web/src/domain/assignments/permissions.test.ts
@@ -4,6 +4,7 @@ import {
   resolveRepoFeaturesPatch,
   explicitRepoFeaturesPatch,
   patchRepoSurface,
+  applyRepoAboutTopics,
 } from "./permissions"
 
 describe("resolveRepoFeaturesPatch", () => {
@@ -147,5 +148,77 @@ describe("explicitRepoFeaturesPatch", () => {
 
   it("returns an empty patch when nothing is forced", () => {
     expect(explicitRepoFeaturesPatch(undefined)).toEqual({})
+  })
+})
+
+describe("applyRepoAboutTopics (issue #569)", () => {
+  it("sends no request when nothing is set", async () => {
+    const request = vi.fn()
+    const client = { request } as unknown as GitHubClient
+    await applyRepoAboutTopics(client, "org", "repo", {})
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it("PATCHes the description for About", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    const client = { request } as unknown as GitHubClient
+    await applyRepoAboutTopics(client, "org", "repo", {
+      description: "A nice starter",
+    })
+    expect(request).toHaveBeenCalledWith("/repos/org/repo", {
+      method: "PATCH",
+      body: { description: "A nice starter" },
+    })
+  })
+
+  it("PUTs the topics as { names }", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    const client = { request } as unknown as GitHubClient
+    await applyRepoAboutTopics(client, "org", "repo", {
+      topics: ["python", "hw"],
+    })
+    expect(request).toHaveBeenCalledWith("/repos/org/repo/topics", {
+      method: "PUT",
+      body: { names: ["python", "hw"] },
+    })
+  })
+
+  it("applies both independently in one call", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    const client = { request } as unknown as GitHubClient
+    await applyRepoAboutTopics(client, "org", "repo", {
+      description: "d",
+      topics: ["t"],
+    })
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it("fails open: an About PATCH rejection is swallowed and does not block topics", async () => {
+    // The description PATCH 422s; the topics PUT still runs and the call
+    // resolves (accept must never be stranded by a best-effort copy).
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("422"))
+      .mockResolvedValueOnce({})
+    const client = { request } as unknown as GitHubClient
+    await expect(
+      applyRepoAboutTopics(client, "org", "repo", {
+        description: "d",
+        topics: ["t"],
+      }),
+    ).resolves.toBeUndefined()
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(request).toHaveBeenLastCalledWith("/repos/org/repo/topics", {
+      method: "PUT",
+      body: { names: ["t"] },
+    })
+  })
+
+  it("fails open: a topics PUT rejection is swallowed", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("403 topics blocked"))
+    const client = { request } as unknown as GitHubClient
+    await expect(
+      applyRepoAboutTopics(client, "org", "repo", { topics: ["t"] }),
+    ).resolves.toBeUndefined()
   })
 })

--- a/web/src/domain/assignments/permissions.ts
+++ b/web/src/domain/assignments/permissions.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/types/classroom"
 import type { GitHubRepo } from "@/github-core/types"
 import type { RepoFeaturePatch } from "@/github-core/mutations"
+import { replaceRepoTopics } from "@/github-core/mutations"
 import { defaultStudentPermission } from "@/types/classroom"
 import { localizedError } from "@/types/localizedMessage"
 import { log } from "./accessPrimitives"
@@ -243,5 +244,58 @@ export async function patchRepoSurface(
       patch,
       err: finalErr,
     })
+  }
+}
+
+// The template's About/Topics resolved for copy at accept time (issue #569).
+// A key is present only when the assignment opted in (copy_about / copy_topics)
+// AND the template actually had a non-empty value — an empty template value is
+// dropped at resolve time so we never blank a student repo's existing About or
+// clear its topics. `{}` means "nothing to copy" (no template, opted out, or
+// the template read failed / was empty).
+export type RepoAboutTopics = { description?: string; topics?: string[] }
+
+// Copy the template's About/Topics onto a just-created student repo,
+// best-effort/fail-open — same contract as patchRepoSurface: this runs inside
+// the throwing accept "access" step, so a rejected write (e.g. an org that
+// blocks topics) is logged and swallowed rather than stranding the student.
+// About rides PATCH /repos/{owner}/{repo} (description); Topics use the
+// separate PUT /repos/{owner}/{repo}/topics. Each is applied independently so a
+// topics rejection can't drop a successful About copy. Nothing set = no request.
+export async function applyRepoAboutTopics(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  about: RepoAboutTopics,
+) {
+  if (about.description !== undefined) {
+    try {
+      await client.request<GitHubRepo>(`/repos/${owner}/${repo}`, {
+        method: "PATCH",
+        body: { description: about.description },
+      })
+    } catch (err) {
+      log.warn("accept: copy-About PATCH failed (non-fatal)", {
+        owner,
+        repo,
+        err,
+      })
+    }
+  }
+  if (about.topics !== undefined) {
+    try {
+      await replaceRepoTopics({
+        client,
+        org: owner,
+        repo,
+        topics: about.topics,
+      })
+    } catch (err) {
+      log.warn("accept: copy-Topics PUT failed (non-fatal)", {
+        owner,
+        repo,
+        err,
+      })
+    }
   }
 }

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -357,6 +357,11 @@ export type CreateAssignmentInput = {
   // Requires a template; mutually exclusive with empty_repo/init_shim. Mutable.
   // Mirrors the CLI's include_all_branches field.
   include_all_branches?: boolean
+  // Copy the template's About (description) / Topics onto each student repo at
+  // accept time (issue #569). Require a template; mutable. buildAssignmentEntry
+  // omits each when false. Mirror the assignments-v1 copy_about / copy_topics.
+  copy_about?: boolean
+  copy_topics?: boolean
   runs_on?: string
   container_image?: string
   container_user?: string

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -110,6 +110,7 @@ export {
   addRepoCollaborator,
   removeRepoCollaborator,
   setRepoFeatures,
+  replaceRepoTopics,
   type RepoFeaturePatch,
 } from "./mutations/collaborators"
 export {

--- a/web/src/github-core/mutations/collaborators.ts
+++ b/web/src/github-core/mutations/collaborators.ts
@@ -104,12 +104,15 @@ export async function removeRepoCollaborator(params: {
 }
 
 // The GitHub repo-feature toggles PATCH /repos accepts. Only the keys present
-// are changed. Shared with the accept path's RepoFeaturePatch shape.
+// are changed. Shared with the accept path's RepoFeaturePatch shape. The About
+// (`description`) rides the same PATCH — accept copies the template's About
+// onto a student repo through this body (issue #569).
 export type RepoFeaturePatch = {
   has_issues?: boolean
   has_wiki?: boolean
   has_projects?: boolean
   has_pull_requests?: boolean
+  description?: string
 }
 
 // Set a repo's feature toggles (Issues/Wiki/Projects/Pull requests) via
@@ -128,6 +131,27 @@ export async function setRepoFeatures(params: {
     {
       method: "PATCH",
       body: features,
+    },
+  )
+}
+
+// Replace a repo's Topics via PUT /repos/{org}/{repo}/topics (the modern
+// endpoint — no preview media type needed; the body is { names }). Used by
+// accept to copy the template's Topics onto a student repo (issue #569).
+// Throws on failure so the accept path's own fail-open wrapper decides whether
+// to swallow it (topics are best-effort, never a reason to fail accept).
+export async function replaceRepoTopics(params: {
+  client: GitHubClient
+  org: string
+  repo: string
+  topics: string[]
+}): Promise<void> {
+  const { client, org, repo, topics } = params
+  await client.request(
+    `/repos/${encodeURIComponent(org)}/${encodeURIComponent(repo)}/topics`,
+    {
+      method: "PUT",
+      body: { names: topics },
     },
   )
 }

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -109,6 +109,10 @@ export type GitHubRepo = {
   // rely on it.
   created_at?: string
   description?: string | null
+  // Repository topics (GET /repos returns them). Used by accept to copy the
+  // template's Topics onto a student repo (issue #569). Optional — most callers
+  // ignore them.
+  topics?: string[]
   owner?: {
     login: string
     id: number

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1152,6 +1152,14 @@
         "label": "Include all branches",
         "help": "Copy every branch and its history from the template, not just the default branch. This applies to students who accept from now on; repositories already created are not changed."
       },
+      "copyAbout": {
+        "label": "Copy About from template",
+        "help": "Copy the template's About (its description) onto each student repository. GitHub does not copy it automatically. This applies to students who accept from now on; repositories already created are not changed."
+      },
+      "copyTopics": {
+        "label": "Copy topics from template",
+        "help": "Copy the template's topics onto each student repository. GitHub does not copy them automatically. This applies to students who accept from now on; repositories already created are not changed."
+      },
       "feedbackPr": "Feedback pull request",
       "feedbackPrHelp": "Open a pull request per repo for inline review of each submission.",
       "feedbackPrEmptyRepoHelp": "Unavailable for empty repositories. There is no starter commit to diff against.",

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -133,6 +133,8 @@ const CreateAssignmentPage = () => {
                 no_autograder: deriveFormShape(values).noAutograder,
                 init_shim: deriveFormShape(values).initShim,
                 include_all_branches: values.include_all_branches,
+                copy_about: values.copy_about,
+                copy_topics: values.copy_topics,
                 runs_on: values.runs_on,
                 container_image: values.container_image,
                 container_user: values.container_user,

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -83,6 +83,8 @@ const EditAssignmentForm = ({
                 no_autograder: deriveFormShape(values).noAutograder,
                 init_shim: deriveFormShape(values).initShim,
                 include_all_branches: values.include_all_branches,
+                copy_about: values.copy_about,
+                copy_topics: values.copy_topics,
                 runs_on: values.runs_on,
                 container_image: values.container_image,
                 container_user: values.container_user,

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -47,6 +47,8 @@ const base: CreateAssignmentFormValues = {
   repo_source: "none",
   add_readme: true,
   include_all_branches: false,
+  copy_about: false,
+  copy_topics: false,
   autograding_state: "built-in",
   runtime_env: "hosted",
   runs_on: "",
@@ -731,6 +733,53 @@ describe("toSubmitValues — runtime field clearing", () => {
       include_all_branches: true,
     })
     expect(noTemplate.include_all_branches).toBe(false)
+  })
+
+  it("copy_about/copy_topics pass through for a template source, clear otherwise", () => {
+    const templated = toSubmitValues({
+      ...base,
+      repo_source: "template",
+      template_repo: "acme/starter",
+      copy_about: true,
+      copy_topics: true,
+    })
+    expect(templated.copy_about).toBe(true)
+    expect(templated.copy_topics).toBe(true)
+    // No template -> cleared (nothing to copy from; a stale toggle can't reach
+    // the wire).
+    const noTemplate = toSubmitValues({
+      ...base,
+      repo_source: "none",
+      add_readme: true,
+      copy_about: true,
+      copy_topics: true,
+    })
+    expect(noTemplate.copy_about).toBe(false)
+    expect(noTemplate.copy_topics).toBe(false)
+  })
+
+  it("round-trips stored copy_about/copy_topics flags", () => {
+    const values = assignmentToFormValues({
+      slug: "hw",
+      name: "HW",
+      mode: "individual",
+      autograder: "default",
+      template: { owner: "acme", repo: "starter", branch: "main" },
+      copy_about: true,
+      copy_topics: true,
+    })
+    expect(values.copy_about).toBe(true)
+    expect(values.copy_topics).toBe(true)
+    // Absent flags read back as false.
+    const bare = assignmentToFormValues({
+      slug: "hw2",
+      name: "HW2",
+      mode: "individual",
+      autograder: "default",
+      template: { owner: "acme", repo: "starter", branch: "main" },
+    })
+    expect(bare.copy_about).toBe(false)
+    expect(bare.copy_topics).toBe(false)
   })
 
   it("round-trips a stored init_shim assignment without flipping the flag", () => {

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -112,6 +112,12 @@ export type CreateAssignmentFormValues = {
   // to the wire include_all_branches; cleared on submit when the source isn't a
   // template. Default off.
   include_all_branches: boolean
+  // Copy the template's About (description) / Topics onto each student repo at
+  // accept time. Only meaningful for a template source (nothing to copy from
+  // otherwise); cleared on submit when the source isn't a template. Map to the
+  // wire copy_about / copy_topics. Default off. See issue #569.
+  copy_about: boolean
+  copy_topics: boolean
   // UI-only autograding tri-state (never sent verbatim; mapped to wire fields
   // on submit): "empty" (bare repo — driven by empty_repo), "none" (no built-in
   // autograder — teacher-supplied CI on a template maps to no_autograder: true,
@@ -505,6 +511,11 @@ export function toSubmitValues(
     // Only meaningful for a template source; clear it otherwise so a stale
     // toggle can't reach the wire (buildAssignmentEntry also rejects the combo).
     include_all_branches: isTemplate ? value.include_all_branches : false,
+    // Copy About/Topics only make sense with a template to copy from; clear
+    // them for a non-template source so a stale toggle can't reach the wire
+    // (buildAssignmentEntry also rejects the combo). Issue #569.
+    copy_about: isTemplate ? value.copy_about : false,
+    copy_topics: isTemplate ? value.copy_topics : false,
     autograding_state: shape.autogradingState,
     runtime_env: value.runtime_env,
     runs_on: value.runs_on.trim(),
@@ -578,6 +589,13 @@ export const useAssignmentForm = (
       repo_source: defaultValues?.repo_source ?? "none",
       add_readme: defaultValues?.add_readme ?? false,
       include_all_branches: defaultValues?.include_all_branches ?? false,
+      // Default ON for a new assignment: copying the template's About/Topics is
+      // the expected behavior (GitHub's generate drops both). Edit round-trips
+      // the stored value via assignmentToFormValues (absent reads as false, the
+      // wire's omitempty shape), so this create-only default never silently
+      // re-enables a flag a teacher turned off.
+      copy_about: defaultValues?.copy_about ?? true,
+      copy_topics: defaultValues?.copy_topics ?? true,
       autograding_state: defaultValues?.autograding_state ?? "none",
       runtime_env: defaultValues?.runtime_env || "hosted",
       runs_on: defaultValues?.runs_on || "",
@@ -677,6 +695,8 @@ export const assignmentToFormValues = (
     add_readme:
       !(assignment.empty_repo ?? false) && !(assignment.init_shim ?? false),
     include_all_branches: assignment.include_all_branches ?? false,
+    copy_about: assignment.copy_about ?? false,
+    copy_topics: assignment.copy_topics ?? false,
     // Derive the tri-state from the stored wire fields (empty_repo /
     // no_autograder / default), so an edit opens on the right autograding
     // option and a round-trip preserves it. Uses the #554 domain helper.

--- a/web/src/pages/assignments/formShape.test.ts
+++ b/web/src/pages/assignments/formShape.test.ts
@@ -17,6 +17,8 @@ const base: CreateAssignmentFormValues = {
   repo_source: "none",
   add_readme: true,
   include_all_branches: false,
+  copy_about: false,
+  copy_topics: false,
   autograding_state: "built-in",
   runtime_env: "hosted",
   runs_on: "",

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -143,6 +143,39 @@ export function RepositorySetupSection({
                         />
                       )}
                     </form.Field>
+
+                    {/* Copy the template's About + Topics onto each student
+                        repo at accept time (issue #569). Template-only; default
+                        off. GitHub's generate drops both, so accept re-applies. */}
+                    <form.Field name="copy_about">
+                      {(aboutField) => (
+                        <ToggleRow
+                          id={aboutField.name}
+                          checked={aboutField.state.value}
+                          onChange={(checked) =>
+                            aboutField.handleChange(checked)
+                          }
+                          onBlur={aboutField.handleBlur}
+                          label={t("assignments.form.copyAbout.label")}
+                          help={t("assignments.form.copyAbout.help")}
+                        />
+                      )}
+                    </form.Field>
+
+                    <form.Field name="copy_topics">
+                      {(topicsField) => (
+                        <ToggleRow
+                          id={topicsField.name}
+                          checked={topicsField.state.value}
+                          onChange={(checked) =>
+                            topicsField.handleChange(checked)
+                          }
+                          onBlur={topicsField.handleBlur}
+                          label={t("assignments.form.copyTopics.label")}
+                          help={t("assignments.form.copyTopics.help")}
+                        />
+                      )}
+                    </form.Field>
                   </>
                 ) : shape.showAddReadme ? (
                   <form.Field name="add_readme">

--- a/web/src/pages/assignments/sections/sectionStatus.test.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.test.ts
@@ -20,6 +20,8 @@ const defaults: CreateAssignmentFormValues = {
   repo_source: "none",
   add_readme: false,
   include_all_branches: false,
+  copy_about: false,
+  copy_topics: false,
   autograding_state: "none",
   runtime_env: "hosted",
   runs_on: "",

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -195,6 +195,18 @@ export type Assignment = {
   // affects repos generated from now on). Omitted when false; absent reads as
   // false. In lockstep with the CLI's assignments-v1 schema (`include_all_branches`).
   include_all_branches?: boolean
+  // Copy the TEMPLATE repo's About (description) onto each student repo at
+  // accept time, on fresh create only (GitHub's POST /generate drops it).
+  // Requires a template; best-effort/fail-open; not retrofitted or re-asserted
+  // on re-accept. Omitted when false; absent reads as false. In lockstep with
+  // the CLI's assignments-v1 schema (`copy_about`).
+  copy_about?: boolean
+  // Copy the TEMPLATE repo's Topics onto each student repo at accept time, on
+  // fresh create only (applied via PUT /repos/{o}/{r}/topics). Requires a
+  // template; best-effort/fail-open; not retrofitted or re-asserted on
+  // re-accept. Omitted when false; absent reads as false. In lockstep with the
+  // CLI's assignments-v1 schema (`copy_topics`).
+  copy_topics?: boolean
   // Lock the assignment against student access. Every student surface (accept
   // page, assignments list, submission view, and `gh student accept`) refuses
   // a locked assignment for EVERY student, including one who already accepted.


### PR DESCRIPTION
## Summary

Adds two opt-in Repository Setup toggles — **Copy About from template** and **Copy topics from template** — that copy the template repo's About (description) and topics onto each student repo at accept time. GitHub's `POST /generate` does not copy either, so a student repo generated from a well-described template otherwise starts blank (see #569). This mirrors the existing `repo_features` "inherit from template" pattern end-to-end.

Both toggles default **on** for new assignments (copying is the expected behavior); editing an existing assignment round-trips the stored value, so a flag a teacher turned off stays off.

The apply is best-effort and fail-open (a rejected write is logged, never blocks accept), template-only, and not retrofitted to already-accepted repos (new accepts only, same policy as `repo_features`). Empty template values are skipped so a student repo's existing About or topics are never blanked.

## Changes

- **Schema** (`schemas/assignments-v1.schema.json`): additive `copy_about` / `copy_topics` booleans plus template-required conditional rules.
- **Type** (`web/src/types/classroom.ts`): `copy_about?` / `copy_topics?` on `Assignment`, in lockstep with the schema.
- **GitHub plumbing** (`github-core/mutations`): `description` added to `RepoFeaturePatch`; new `replaceRepoTopics` (`PUT /repos/{o}/{r}/topics`); `topics` typed on `GitHubRepo`.
- **Accept flow** (`accept.ts`, `permissions.ts`): the single template `getRepo` read now also fetches description/topics; new `applyRepoAboutTopics` helper applies both independently, fail-open, after the feature PATCH. The already-accepted repair path passes `{}` so a student's own later edits are never clobbered.
- **Teacher form**: two `ToggleRow`s in `RepositorySetupSection` (template branch), form-model wiring (default on for create, clear when not a template), omitempty write + template-required guard in `buildAssignmentEntry`, and `ASSIGNMENT_KEY_OWNERSHIP` entries.
- **i18n**: four `en.json` keys.
- **Tests**: `applyRepoAboutTopics` (apply + fail-open), form round-trip/clear, and `buildAssignmentEntry` guard/omitempty coverage.

Web app only; no Go CLI change (the schema evolves additively so CLI readers tolerate the new keys).

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 3586 tests) passes
- [x] `audit_i18n.py --strict` passes (0 missing / dead keys)
- [ ] Accept a templated assignment with the toggles on and confirm the student repo's About and topics match the template
- [ ] Accept with a toggle off and confirm that field is left as GitHub's default
- [ ] Confirm an org that blocks topics does not fail accept (fail-open)

Closes #569.