### PR TITLE
feat(web): rename autograding trigger field to Submission type

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1213,7 +1213,7 @@
         "help": "How the submissions page detects and counts each student's work. The autograder uses the same definition."
       },
       "submissionMode": {
-        "label": "Autograding trigger",
+        "label": "Submission type",
         "help": "\"Every push to the default branch\" counts each push (other than the starting commit). \"A tagged commit\" counts only tagged commits — a student submits with gh student submit or by pushing a tag, so ordinary pushes cost no Actions minutes.",
         "editWarning": "Changing this only affects repositories created from now on. Repositories students already accepted keep the old setting until you update them — use \"Update autograding triggers\" on the submissions page or gh teacher assignment submission-mode. Students must pull after the update.",
         "choices": {


### PR DESCRIPTION
## Summary

Renames the assignment form field label from "Autograding trigger" to "Submission type" in the Submission and grading section of the assignment creation/edit page.

Only the field label in `web/src/locales/en.json` (`assignments.form.submissionMode.label`) changes. The related help text, validation error, and the submissions-page bulk/row action strings keep their existing "Autograding trigger" wording, since those refer to a distinct feature on a different page. The label renders via `t("assignments.form.submissionMode.label")`, so no component change is needed. Only `en.json` is edited; the machine-translation workflow regenerates the other locale packs.

## Test plan

- [ ] `npm run check` passes in `web/` (tsc, eslint, prettier, arch:validate, vitest)
- [ ] The assignment create/edit page shows the field labeled "Submission type"