### PR TITLE
chore: pin next release to 1.28.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": true,
       "include-v-in-tag": true,
-      "tag-separator": "-"
+      "tag-separator": "-",
+      "release-as": "1.28.1"
     },
     "cli": {
       "release-type": "go",
@@ -15,7 +16,8 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": true,
       "include-v-in-tag": true,
-      "tag-separator": "-"
+      "tag-separator": "-",
+      "release-as": "1.28.1"
     }
   },
   "plugins": [


### PR DESCRIPTION
Pin the next release to 1.28.1 instead of the computed 1.29.0.

#582 tried to do this via a `Release-As:` footer, but the squash-merge dropped the footer from the commit body, so release-please still produced 1.29.0 in #579. Setting `release-as` directly in the config is a real file change that survives squash and pins the version deterministically for both web and cli (kept in lockstep by `linked-versions`).

Once #579 is regenerated as 1.28.1 and merged, remove the `release-as` keys so subsequent releases resume normal computed bumps.