### PR TITLE
chore: remove release-as pin after 1.28.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": true,
       "include-v-in-tag": true,
-      "tag-separator": "-",
-      "release-as": "1.28.1"
+      "tag-separator": "-"
     },
     "cli": {
       "release-type": "go",
@@ -16,8 +15,7 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": true,
       "include-v-in-tag": true,
-      "tag-separator": "-",
-      "release-as": "1.28.1"
+      "tag-separator": "-"
     }
   },
   "plugins": [


### PR DESCRIPTION
Remove the temporary `release-as: 1.28.1` pin from both packages now that #579 has cut `web-v1.28.1` and `cli-v1.28.1`.

Leaving the pin in place would freeze every future release at 1.28.1, so this restores normal release-please version computation. No functional change beyond release tooling.