### PR TITLE
feat(web): reset controls, inline field errors, and auto-unique slug in assignment form

### DIFF
--- a/web/src/components/ui/FormField.test.tsx
+++ b/web/src/components/ui/FormField.test.tsx
@@ -58,6 +58,11 @@ describe("FormField", () => {
     const input = screen.getByLabelText("Name")
     expect(input.getAttribute("aria-describedby")).toBe(alert.id)
     expect(input.getAttribute("aria-invalid")).toBe("true")
+    // The invalid field renders a decorative error marker (lucide svg) in the
+    // label row; the alert text carries the accessible announcement.
+    expect(
+      document.querySelector("svg.text-error[aria-hidden='true']"),
+    ).not.toBeNull()
   })
 
   it("shows helper text (not an alert) when there is no error", () => {

--- a/web/src/components/ui/FormField.tsx
+++ b/web/src/components/ui/FormField.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle } from "lucide-react"
+import { HelpCircle, TriangleAlert } from "lucide-react"
 import { useId, type ReactNode } from "react"
 
 import { Button } from "./Button"
@@ -107,6 +107,12 @@ export function FormField({
             </span>
           ) : null}
         </label>
+        {/* An invalid field gets an exclamation marker next to its label so the
+            error is visible at a glance; the role="alert" message below carries
+            the accessible announcement, so the icon is decorative. */}
+        {invalid ? (
+          <TriangleAlert aria-hidden="true" className="size-4 text-error" />
+        ) : null}
         {help ? <HelpTooltip help={help} /> : null}
         {labelExtra}
       </div>

--- a/web/src/domain/assignments/copyReuse.ts
+++ b/web/src/domain/assignments/copyReuse.ts
@@ -6,6 +6,7 @@ import {
   getConfigRepoBranch,
 } from "@/github-core/configRepoReads"
 import { prefixCommit } from "@/util/commit"
+import { nextAvailableSlug } from "@/util/slug"
 import { validateReleaseAssets } from "@/util/releaseAssets"
 import {
   createGitCommit,
@@ -36,33 +37,10 @@ export type CopyAssignmentInput = {
   canGrantTemplateAccess?: boolean
 }
 
-// First slug not in `taken`, suffixing `-2`, `-3`, … A base ending in `-<n>`
-// continues from n+1 ("hw1-2" -> "hw1-3", not "hw1-2-2"). Case-insensitive, to
-// match GitHub repo naming and the server-side check. Pure; prefills the reuse
-// modals — the write path re-checks authoritatively.
-export function nextAvailableSlug(
-  base: string,
-  taken: Iterable<string>,
-): string {
-  const takenSet = new Set(Array.from(taken, (s) => s.trim().toLowerCase()))
-  const isFree = (candidate: string) => !takenSet.has(candidate.toLowerCase())
-
-  if (isFree(base)) return base
-
-  // Split off a trailing "-<n>" so we increment it rather than append again.
-  const match = /^(.*?)-(\d+)$/.exec(base)
-  const stem = match ? match[1] : base
-  let n = match ? Number(match[2]) + 1 : 2
-
-  // Bounded defensively; a classroom never has thousands of same-stem slugs.
-  for (let i = 0; i < 10000; i++) {
-    const candidate = `${stem}-${n}`
-    if (isFree(candidate)) return candidate
-    n++
-  }
-  // Unreachable in practice, but never silently return a taken slug.
-  return `${stem}-${Date.now()}`
-}
+// First slug not in `taken`; the shared generator lives in @/util/slug so the
+// create form and the reuse modals share one implementation. Re-exported for
+// the existing @/domain/assignments barrel and reuse-flow call sites.
+export { nextAvailableSlug }
 
 // Build the target classroom's record, overriding slug/name. Pure: deep-copies
 // (no shared mutable structure) and drops undefined keys to stay omitempty-clean

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1104,11 +1104,9 @@
       "submissionSection": "Submission and grading",
       "submissionSectionHelp": "Define what counts as a submission for this assignment — when the autograder runs and which tags a student can push to submit.",
       "scheduleSection": "Schedule",
-      "sectionStatus": {
-        "error": "Needs attention",
-        "configured": "Configured",
-        "default": "Default"
-      },
+      "reset": "Reset",
+      "resetSection": "Reset this section to its default settings",
+      "discardChanges": "Discard changes",
       "optional": "optional",
       "name": "Assignment name",
       "namePlaceholder": "e.g., Loops Assignment",

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -887,4 +887,3 @@ describe("validation error highlighting and scroll-to-first-error", () => {
     vi.restoreAllMocks()
   })
 })
-

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -443,6 +443,31 @@ describe("edit form re-disables Save after a successful save", () => {
     // A rejected write must not re-baseline, so Save stays enabled.
     await vi.waitFor(() => expect(saveButton().disabled).toBe(false))
   })
+
+  it("Discard changes reverts edits and hides once pristine", async () => {
+    const user = userEvent.setup()
+    renderForm(vi.fn())
+
+    const discardButton = () =>
+      screen.queryByRole("button", {
+        name: "assignments.form.discardChanges",
+      })
+    const name = screen.getByRole("textbox", {
+      name: "assignments.form.name",
+    }) as HTMLInputElement
+
+    // Pristine: no Discard affordance.
+    expect(discardButton()).toBeNull()
+
+    await user.type(name, " updated")
+    expect(discardButton()).not.toBeNull()
+
+    await user.click(discardButton()!)
+    // Reverts to the stored name and the affordance disappears again.
+    expect(name.value).toBe(baseAssignment.name)
+    expect(discardButton()).toBeNull()
+    expect(saveButton().disabled).toBe(true)
+  })
 })
 // Built-in runtime options (language versions + apt) are disabled when the
 // runner targets self-hosted: the grade job skips managed setup there
@@ -724,12 +749,46 @@ describe("assignment form section IA", () => {
     ).not.toBeNull()
   })
 
-  it("shows a per-section status badge (default on a fresh create form)", () => {
+  it("shows no per-section Reset control on a fresh create form", () => {
     renderForm({})
-    // Details is untouched on a fresh form -> "default" badge present.
+    // Nothing is configured yet, so no section offers a reset.
     expect(
-      screen.getAllByText("assignments.form.sectionStatus.default").length,
-    ).toBeGreaterThan(0)
+      screen.queryAllByRole("button", {
+        name: "assignments.form.resetSection",
+      }).length,
+    ).toBe(0)
+  })
+
+  it("create: a configured section shows a Reset that restores its defaults", async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm({})
+    const nameInput = container.querySelector<HTMLInputElement>("#name")!
+    await user.type(nameInput, "Homework 1")
+    // Details is now configured -> a Reset control appears.
+    const reset = screen.getAllByRole("button", {
+      name: "assignments.form.resetSection",
+    })
+    expect(reset.length).toBeGreaterThan(0)
+    await user.click(reset[0])
+    // The name is back to its default and the reset control is gone again.
+    expect(nameInput.value).toBe("")
+    expect(
+      screen.queryAllByRole("button", {
+        name: "assignments.form.resetSection",
+      }).length,
+    ).toBe(0)
+  })
+
+  it("edit: never renders a per-section Reset control", () => {
+    renderForm({
+      edit: true,
+      defaultValues: assignmentToFormValues(baseAssignment),
+    })
+    expect(
+      screen.queryAllByRole("button", {
+        name: "assignments.form.resetSection",
+      }).length,
+    ).toBe(0)
   })
 
   it("shows Add-a-README for the no-template source and an enabled include-all-branches toggle for a template", () => {

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -468,6 +468,40 @@ describe("edit form re-disables Save after a successful save", () => {
     expect(discardButton()).toBeNull()
     expect(saveButton().disabled).toBe(true)
   })
+
+  it("Discard changes re-syncs the schedule pickers with the restored dates", async () => {
+    const user = userEvent.setup()
+    const withDue: Assignment = {
+      ...baseAssignment,
+      due: "2026-09-01T23:59:00Z",
+    }
+    const { container } = render(
+      <QueryClientProvider client={new QueryClient()}>
+        <CreateAssignmentForm
+          edit
+          defaultValues={assignmentToFormValues(withDue)}
+          onSubmit={vi.fn()}
+        />
+      </QueryClientProvider>,
+    )
+    const dueToggle = () =>
+      container.querySelector<HTMLInputElement>("#due_date-enabled")!
+    // Stored due date -> picker starts shown.
+    expect(dueToggle().checked).toBe(true)
+
+    // Turn the picker off (clears due_date), making the form dirty.
+    await user.click(dueToggle())
+    expect(dueToggle().checked).toBe(false)
+
+    // Discard restores the stored due date AND re-shows its picker.
+    await user.click(
+      screen.getByRole("button", {
+        name: "assignments.form.discardChanges",
+      }),
+    )
+    expect(dueToggle().checked).toBe(true)
+    expect(screen.getByLabelText("assignments.form.dueDate")).not.toBeNull()
+  })
 })
 // Built-in runtime options (language versions + apt) are disabled when the
 // runner targets self-hosted: the grade job skips managed setup there

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -814,3 +814,77 @@ describe("assignment form section IA", () => {
     expect(branches?.disabled).toBe(false)
   })
 })
+
+describe("validation error highlighting and scroll-to-first-error", () => {
+  const renderForm = (ui: ReactElement) =>
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        {ui}
+      </QueryClientProvider>,
+    )
+
+  it("submitting with an empty required name marks the field invalid", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    const { container } = renderForm(
+      <CreateAssignmentForm onSubmit={onSubmit} />,
+    )
+    // Name is required and empty on a fresh create form.
+    await user.click(
+      screen.getByRole("button", { name: "assignments.form.createButton" }),
+    )
+    expect(onSubmit).not.toHaveBeenCalled()
+    // The role="alert" message renders once validation runs.
+    expect(
+      await screen.findByText("assignments.form.validation.nameRequired"),
+    ).not.toBeNull()
+    const nameInput = container.querySelector<HTMLInputElement>("#name")!
+    expect(nameInput.getAttribute("aria-invalid")).toBe("true")
+  })
+
+  it("scrolls the first invalid field into view on a failed submit", async () => {
+    const user = userEvent.setup()
+    const scrollIntoView = vi.fn()
+    const focus = vi.fn()
+    // happy-dom doesn't implement scrollIntoView; stub it on the prototype.
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(
+      scrollIntoView,
+    )
+    vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(focus)
+
+    renderForm(<CreateAssignmentForm onSubmit={vi.fn()} />)
+    await user.click(
+      screen.getByRole("button", { name: "assignments.form.createButton" }),
+    )
+    await vi.waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
+    expect(focus).toHaveBeenCalled()
+
+    vi.restoreAllMocks()
+  })
+
+  it("does not scroll when the form is valid", async () => {
+    const user = userEvent.setup()
+    const scrollIntoView = vi.fn()
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(
+      scrollIntoView,
+    )
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { container } = renderForm(
+      <CreateAssignmentForm
+        takenSlugs={[]}
+        defaultValues={{ name: "Homework 1", slug: "homework-1" }}
+        onSubmit={onSubmit}
+      />,
+    )
+    // Sanity: no validation alert on a filled valid form.
+    expect(container.querySelector('[aria-invalid="true"]')).toBeNull()
+    await user.click(
+      screen.getByRole("button", { name: "assignments.form.createButton" }),
+    )
+    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(scrollIntoView).not.toHaveBeenCalled()
+
+    vi.restoreAllMocks()
+  })
+})
+

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -183,6 +183,27 @@ describe("assignment slug field", () => {
     expect(slugInput(container).value).toBe("loops-assignment")
   })
 
+  it("create: auto-fills a unique slug when the name's slug is taken", async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm(
+      <CreateAssignmentForm takenSlugs={["loops"]} onSubmit={() => {}} />,
+    )
+    await user.type(nameInput(container), "Loops")
+    // The plain slug "loops" collides, so the auto-fill suffixes it.
+    expect(slugInput(container).value).toBe("loops-2")
+  })
+
+  it("create: blurring an emptied slug restores a unique name-derived default", async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm(
+      <CreateAssignmentForm takenSlugs={["loops"]} onSubmit={() => {}} />,
+    )
+    await user.type(nameInput(container), "Loops")
+    await user.clear(slugInput(container))
+    await user.tab()
+    expect(slugInput(container).value).toBe("loops-2")
+  })
+
   it("create: editing the slug stops auto-fill from the name", async () => {
     const user = userEvent.setup()
     const { container } = renderForm(

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -9,8 +9,9 @@ import { ScheduleSection } from "./sections/ScheduleSection"
 import {
   SECTION_FIELDS,
   sectionIsConfigured,
+  errorKeyMatchesField,
   type SectionId,
-} from "./sections/sectionStatus"
+} from "./sections/sectionFields"
 import {
   useAssignmentForm,
   validateAssignmentForm,
@@ -144,18 +145,15 @@ const CreateAssignmentForm = ({
         // it here to avoid an unhandled rejection.
         void form.handleSubmit().catch(() => {})
         if (Object.keys(errors).length === 0) return
-        // The first errored field in section render order. Error keys may be
-        // indexed (e.g. "tests[0].name"), so match the owning field by prefix.
+        // Error keys may be indexed (e.g. "tests[0].name"), so match the owning
+        // field by prefix — in section render order, first errored field wins.
         const orderedFields = (
           Object.keys(SECTION_FIELDS) as SectionId[]
         ).flatMap((section) => SECTION_FIELDS[section])
         const firstErroredField = orderedFields.find((field) =>
-          Object.keys(errors).some(
-            (key) => key === field || key.startsWith(`${field}[`),
-          ),
+          Object.keys(errors).some((key) => errorKeyMatchesField(key, field)),
         )
         if (!firstErroredField) return
-        // The field element is already in the DOM, so scroll immediately.
         const target = document.getElementById(firstErroredField)
         if (!target) return
         target.scrollIntoView({ behavior: "smooth", block: "center" })

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "./sections/sectionStatus"
 import {
   useAssignmentForm,
+  validateAssignmentForm,
   type AssignmentForm,
   type CreateAssignmentFormValues,
 } from "./assignmentFormModel"
@@ -120,10 +121,34 @@ const CreateAssignmentForm = ({
       onSubmit={(e) => {
         e.preventDefault()
         e.stopPropagation()
+        // Validate up front so we can point the teacher at the first problem
+        // regardless of how (or whether) the form library propagates the
+        // submit-validator errors onto individual field DOM nodes.
+        const errors = validateAssignmentForm(form.state.values, t, {
+          takenSlugs,
+          edit,
+        })
         // handleSubmit re-throws an onSubmit rejection (an edit-mode mutateAsync
         // failure); the caller's onError banner already surfaces it, so swallow
         // it here to avoid an unhandled rejection.
         void form.handleSubmit().catch(() => {})
+        if (Object.keys(errors).length === 0) return
+        // The first errored field in section render order. Error keys may be
+        // indexed (e.g. "tests[0].name"), so match the owning field by prefix.
+        const orderedFields = (
+          Object.keys(SECTION_FIELDS) as SectionId[]
+        ).flatMap((section) => SECTION_FIELDS[section])
+        const firstErroredField = orderedFields.find((field) =>
+          Object.keys(errors).some(
+            (key) => key === field || key.startsWith(`${field}[`),
+          ),
+        )
+        if (!firstErroredField) return
+        // The field element is already in the DOM, so scroll immediately.
+        const target = document.getElementById(firstErroredField)
+        if (!target) return
+        target.scrollIntoView({ behavior: "smooth", block: "center" })
+        target.focus({ preventScroll: true })
       }}
     >
       {/* readOnly disables every descendant control. */}

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -6,10 +6,13 @@ import { RepositorySetupSection } from "./sections/RepositorySetupSection"
 import { AutogradingSection } from "./sections/AutogradingSection"
 import { SubmissionGradingSection } from "./sections/SubmissionGradingSection"
 import { ScheduleSection } from "./sections/ScheduleSection"
-import { deriveSectionStatus } from "./sections/sectionStatus"
+import {
+  SECTION_FIELDS,
+  sectionIsConfigured,
+  type SectionId,
+} from "./sections/sectionStatus"
 import {
   useAssignmentForm,
-  validateAssignmentForm,
   type AssignmentForm,
   type CreateAssignmentFormValues,
 } from "./assignmentFormModel"
@@ -91,6 +94,27 @@ const CreateAssignmentForm = ({
     Boolean(form.state.values.available_from_date),
   )
 
+  // Restore one section's fields to their create defaults. Because
+  // deriveFormShape is a pure view over values, resetting the owned fields also
+  // restores that section's derived visibility (e.g. Repository's template
+  // fields hide again). Offered on create only; edit mode uses Discard changes.
+  const resetSection = (section: SectionId) => {
+    const defaults = form.options.defaultValues as CreateAssignmentFormValues
+    for (const field of SECTION_FIELDS[section]) {
+      form.setFieldValue(field, defaults[field])
+    }
+    if (section === "details") {
+      // Re-arm the name->slug auto-fill; the slug is back at its default.
+      setSlugTouched(false)
+    }
+    if (section === "schedule") {
+      // The date pickers are opt-in; a reset clears the dates, so collapse the
+      // pickers to match (they seed from a present value otherwise).
+      setDueDateEnabled(false)
+      setAvailableFromEnabled(false)
+    }
+  }
+
   return (
     <form
       onSubmit={(e) => {
@@ -104,30 +128,25 @@ const CreateAssignmentForm = ({
     >
       {/* readOnly disables every descendant control. */}
       <fieldset disabled={readOnly} className="m-0 min-w-0 border-0 p-0">
-        {/* Per-section status (R2): derived from the live form values against
-            the baseline defaults and the same validator the save path uses, so
-            each section header reflects error / configured / default. */}
-        <form.Subscribe
-          selector={(state) => [state.values, state.errorMap.onSubmit] as const}
-        >
-          {([values]) => {
+        {/* Per-section Reset (create only): shown when a section differs from
+            its create defaults, restoring just that section in one click. Edit
+            mode offers a single Discard changes affordance instead. */}
+        <form.Subscribe selector={(state) => state.values}>
+          {(values) => {
             const defaults = form.options
               .defaultValues as CreateAssignmentFormValues
-            const errors = validateAssignmentForm(values, t, {
-              takenSlugs,
-              edit,
-            })
+            // Only create mode offers per-section reset; in edit mode the
+            // baseline is the stored assignment and Discard changes reverts all.
+            const onReset = (section: SectionId) =>
+              !edit && sectionIsConfigured(section, values, defaults)
+                ? () => resetSection(section)
+                : undefined
             return (
               <>
                 <DetailsSection
                   form={form}
                   edit={edit}
-                  status={deriveSectionStatus(
-                    "details",
-                    values,
-                    defaults,
-                    errors,
-                  )}
+                  onReset={onReset("details")}
                   slugTouched={slugTouched}
                   setSlugTouched={setSlugTouched}
                   takenSlugs={takenSlugs}
@@ -135,12 +154,7 @@ const CreateAssignmentForm = ({
                 <RepositorySetupSection
                   form={form}
                   edit={edit}
-                  status={deriveSectionStatus(
-                    "repository",
-                    values,
-                    defaults,
-                    errors,
-                  )}
+                  onReset={onReset("repository")}
                   org={org}
                   classroom={classroom}
                   slug={slug}
@@ -148,32 +162,17 @@ const CreateAssignmentForm = ({
                 <SubmissionGradingSection
                   form={form}
                   edit={edit}
-                  status={deriveSectionStatus(
-                    "submission",
-                    values,
-                    defaults,
-                    errors,
-                  )}
+                  onReset={onReset("submission")}
                 />
                 <AutogradingSection
                   form={form}
                   edit={edit}
-                  status={deriveSectionStatus(
-                    "autograding",
-                    values,
-                    defaults,
-                    errors,
-                  )}
+                  onReset={onReset("autograding")}
                   org={org}
                 />
                 <ScheduleSection
                   form={form}
-                  status={deriveSectionStatus(
-                    "schedule",
-                    values,
-                    defaults,
-                    errors,
-                  )}
+                  onReset={onReset("schedule")}
                   dueDateEnabled={dueDateEnabled}
                   setDueDateEnabled={setDueDateEnabled}
                   availableFromEnabled={availableFromEnabled}
@@ -206,23 +205,37 @@ const CreateAssignmentForm = ({
             ]}
           >
             {([canSubmit, isSubmitting, isDefaultValue]) => (
-              <Button
-                variant="primary"
-                type="submit"
-                loading={isSubmitting || loading}
-                disabled={
-                  !canSubmit ||
-                  isSubmitting ||
-                  loading ||
-                  (edit && isDefaultValue)
-                }
-              >
-                {isSubmitting || loading
-                  ? null
-                  : edit
-                    ? t("assignments.form.saveChanges")
-                    : t("assignments.form.createButton")}
-              </Button>
+              <>
+                {/* Edit mode: revert all unsaved edits back to the stored
+                    assignment. Shown only while the form is dirty. */}
+                {edit && !isDefaultValue ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => form.reset()}
+                    disabled={isSubmitting || loading}
+                  >
+                    {t("assignments.form.discardChanges")}
+                  </Button>
+                ) : null}
+                <Button
+                  variant="primary"
+                  type="submit"
+                  loading={isSubmitting || loading}
+                  disabled={
+                    !canSubmit ||
+                    isSubmitting ||
+                    loading ||
+                    (edit && isDefaultValue)
+                  }
+                >
+                  {isSubmitting || loading
+                    ? null
+                    : edit
+                      ? t("assignments.form.saveChanges")
+                      : t("assignments.form.createButton")}
+                </Button>
+              </>
             )}
           </form.Subscribe>
         )}

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -116,6 +116,17 @@ const CreateAssignmentForm = ({
     }
   }
 
+  // Edit-mode discard: revert all unsaved edits to the stored assignment. The
+  // schedule pickers' shown/hidden state lives in local state (seeded on mount),
+  // so re-sync it from the restored values or a discard would leave a stored
+  // date hidden behind a collapsed, out-of-sync picker.
+  const discardChanges = () => {
+    form.reset()
+    const restored = form.options.defaultValues as CreateAssignmentFormValues
+    setDueDateEnabled(Boolean(restored.due_date))
+    setAvailableFromEnabled(Boolean(restored.available_from_date))
+  }
+
   return (
     <form
       onSubmit={(e) => {
@@ -237,7 +248,7 @@ const CreateAssignmentForm = ({
                   <Button
                     type="button"
                     variant="ghost"
-                    onClick={() => form.reset()}
+                    onClick={discardChanges}
                     disabled={isSubmitting || loading}
                   >
                     {t("assignments.form.discardChanges")}

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -130,6 +130,7 @@ const CreateAssignmentForm = ({
                   )}
                   slugTouched={slugTouched}
                   setSlugTouched={setSlugTouched}
+                  takenSlugs={takenSlugs}
                 />
                 <RepositorySetupSection
                   form={form}

--- a/web/src/pages/assignments/sections/AutogradingSection.tsx
+++ b/web/src/pages/assignments/sections/AutogradingSection.tsx
@@ -31,7 +31,10 @@ export function AutogradingSection({
   const { t } = useTranslation()
 
   return (
-    <SectionCard title={t("assignments.form.autograding.label")} onReset={onReset}>
+    <SectionCard
+      title={t("assignments.form.autograding.label")}
+      onReset={onReset}
+    >
       <form.Subscribe selector={(state) => deriveFormShape(state.values)}>
         {(shape) =>
           !shape.showAutogradingConfig ? (

--- a/web/src/pages/assignments/sections/AutogradingSection.tsx
+++ b/web/src/pages/assignments/sections/AutogradingSection.tsx
@@ -5,7 +5,6 @@ import { AdvancedSection } from "../AdvancedSection"
 import AutogradingTestsPane from "../AutogradingTestsPane"
 import { AutogradingStateField } from "./AutogradingStateField"
 import { Alert } from "@/components/ui"
-import type { SectionStatus } from "./sectionStatus"
 import { SectionCard } from "./SectionCard"
 
 // Autograding: the built-in-autograder toggle plus the runtime/setup/allowed-
@@ -18,12 +17,12 @@ import { SectionCard } from "./SectionCard"
 // (showBuiltInConfig).
 export function AutogradingSection({
   form,
-  status,
+  onReset,
   org,
   edit = false,
 }: {
   form: AssignmentForm
-  status: SectionStatus
+  onReset?: () => void
   org?: string
   // On edit the built-in choice is locked (it maps to no_autograder/init_shim,
   // which the domain layer refuses to change after creation).
@@ -32,10 +31,7 @@ export function AutogradingSection({
   const { t } = useTranslation()
 
   return (
-    <SectionCard
-      title={t("assignments.form.autograding.label")}
-      status={status}
-    >
+    <SectionCard title={t("assignments.form.autograding.label")} onReset={onReset}>
       <form.Subscribe selector={(state) => deriveFormShape(state.values)}>
         {(shape) =>
           !shape.showAutogradingConfig ? (

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -34,36 +34,47 @@ export function DetailsSection({
     <SectionCard title={t("assignments.form.detailsSection")} onReset={onReset}>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <form.Field name="name">
-          {(field) => (
-            <FormField
-              htmlFor={field.name}
-              required
-              label={t("assignments.form.name")}
-            >
-              {({ id }) => (
-                <Input
-                  id={id}
-                  name={field.name}
-                  required
-                  aria-required="true"
-                  placeholder={t("assignments.form.namePlaceholder")}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => {
-                    field.handleChange(e.target.value)
-                    if (!edit && !slugTouched) {
-                      // Auto-fill a slug that's already unique in this
-                      // classroom, so a collision doesn't wait until submit.
-                      form.setFieldValue(
-                        "slug",
-                        nextAvailableSlug(slugify(e.target.value), takenSlugs ?? []),
-                      )
-                    }
-                  }}
-                />
-              )}
-            </FormField>
-          )}
+          {(field) => {
+            const nameError =
+              field.state.meta.errors.length > 0
+                ? String(field.state.meta.errors[0])
+                : undefined
+            return (
+              <FormField
+                htmlFor={field.name}
+                required
+                label={t("assignments.form.name")}
+                error={nameError}
+              >
+                {({ id, describedById, invalid }) => (
+                  <Input
+                    id={id}
+                    name={field.name}
+                    aria-required="true"
+                    invalid={invalid}
+                    aria-describedby={describedById}
+                    placeholder={t("assignments.form.namePlaceholder")}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => {
+                      field.handleChange(e.target.value)
+                      if (!edit && !slugTouched) {
+                        // Auto-fill a slug that's already unique in this
+                        // classroom, so a collision doesn't wait until submit.
+                        form.setFieldValue(
+                          "slug",
+                          nextAvailableSlug(
+                            slugify(e.target.value),
+                            takenSlugs ?? [],
+                          ),
+                        )
+                      }
+                    }}
+                  />
+                )}
+              </FormField>
+            )
+          }}
         </form.Field>
 
         <form.Field name="slug">
@@ -88,7 +99,6 @@ export function DetailsSection({
                   <Input
                     id={id}
                     name={field.name}
-                    required={!edit}
                     aria-required={!edit}
                     // The slug is the assignment's repo-path identity; renaming
                     // isn't supported, so it's read-only on edit.

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { slugify } from "@/util/slug"
+import { nextAvailableSlug, slugify } from "@/util/slug"
 import { FormField, Input, Textarea } from "@/components/ui"
 import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
 import { FieldLabel } from "../AdvancedRuntimeFields"
@@ -18,12 +18,16 @@ export function DetailsSection({
   status,
   slugTouched,
   setSlugTouched,
+  takenSlugs,
 }: {
   form: AssignmentForm
   edit: boolean
   status: SectionStatus
   slugTouched: boolean
   setSlugTouched: (touched: boolean) => void
+  // Existing assignment slugs, so the create-mode auto-fill can pick a slug
+  // that's already unique instead of surfacing a conflict only at submit.
+  takenSlugs?: string[]
 }) {
   const { t } = useTranslation()
 
@@ -49,7 +53,12 @@ export function DetailsSection({
                   onChange={(e) => {
                     field.handleChange(e.target.value)
                     if (!edit && !slugTouched) {
-                      form.setFieldValue("slug", slugify(e.target.value))
+                      // Auto-fill a slug that's already unique in this
+                      // classroom, so a collision doesn't wait until submit.
+                      form.setFieldValue(
+                        "slug",
+                        nextAvailableSlug(slugify(e.target.value), takenSlugs ?? []),
+                      )
                     }
                   }}
                 />
@@ -92,11 +101,15 @@ export function DetailsSection({
                     onBlur={(e) => {
                       // Normalize on blur so what the teacher sees is what's
                       // saved (the repo path segment). An emptied slug falls
-                      // back to the name-derived default, so leaving it blank
-                      // restores the auto slug.
+                      // back to a unique name-derived default, so leaving it
+                      // blank restores the auto slug.
                       const normalized = slugify(e.target.value)
                       field.handleChange(
-                        normalized || slugify(form.state.values.name),
+                        normalized ||
+                          nextAvailableSlug(
+                            slugify(form.state.values.name),
+                            takenSlugs ?? [],
+                          ),
                       )
                       field.handleBlur()
                     }}

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -5,7 +5,6 @@ import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
 import { FieldLabel } from "../AdvancedRuntimeFields"
 import type { AssignmentForm } from "../assignmentFormModel"
 import { deriveFormShape } from "../formShape"
-import type { SectionStatus } from "./sectionStatus"
 import { SectionCard } from "./SectionCard"
 
 // Assignment Details (IA overhaul U4): the assignment's identity — name, slug,
@@ -15,14 +14,14 @@ import { SectionCard } from "./SectionCard"
 export function DetailsSection({
   form,
   edit,
-  status,
+  onReset,
   slugTouched,
   setSlugTouched,
   takenSlugs,
 }: {
   form: AssignmentForm
   edit: boolean
-  status: SectionStatus
+  onReset?: () => void
   slugTouched: boolean
   setSlugTouched: (touched: boolean) => void
   // Existing assignment slugs, so the create-mode auto-fill can pick a slug
@@ -32,7 +31,7 @@ export function DetailsSection({
   const { t } = useTranslation()
 
   return (
-    <SectionCard title={t("assignments.form.detailsSection")} status={status}>
+    <SectionCard title={t("assignments.form.detailsSection")} onReset={onReset}>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <form.Field name="name">
           {(field) => (

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -10,7 +10,6 @@ import { TemplateField } from "../TemplateField"
 import { ToggleRow } from "../AdvancedRuntimeFields"
 import type { AssignmentForm, RepoSource } from "../assignmentFormModel"
 import { deriveFormShape } from "../formShape"
-import type { SectionStatus } from "./sectionStatus"
 import { SectionCard } from "./SectionCard"
 
 // GitHub's own reference for the repo role ladder (read/triage/write/maintain/
@@ -34,14 +33,14 @@ const REPO_ROLES_DOCS_URL =
 export function RepositorySetupSection({
   form,
   edit,
-  status,
+  onReset,
   org,
   classroom,
   slug,
 }: {
   form: AssignmentForm
   edit: boolean
-  status: SectionStatus
+  onReset?: () => void
   org?: string
   classroom?: string
   slug?: string
@@ -51,7 +50,7 @@ export function RepositorySetupSection({
   return (
     <SectionCard
       title={t("assignments.form.repositorySetupSection")}
-      status={status}
+      onReset={onReset}
     >
       <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2 sm:items-start">
         <div className="flex flex-col gap-4">

--- a/web/src/pages/assignments/sections/ScheduleSection.tsx
+++ b/web/src/pages/assignments/sections/ScheduleSection.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next"
 import { Input } from "@/components/ui"
 import { ToggleRow } from "../AdvancedRuntimeFields"
 import type { AssignmentForm } from "../assignmentFormModel"
-import type { SectionStatus } from "./sectionStatus"
 import { SectionCard } from "./SectionCard"
 
 // Schedule (IA overhaul U8): the opt-in release-date and due-date pickers. The
@@ -10,14 +9,14 @@ import { SectionCard } from "./SectionCard"
 // the section split.
 export function ScheduleSection({
   form,
-  status,
+  onReset,
   dueDateEnabled,
   setDueDateEnabled,
   availableFromEnabled,
   setAvailableFromEnabled,
 }: {
   form: AssignmentForm
-  status: SectionStatus
+  onReset?: () => void
   dueDateEnabled: boolean
   setDueDateEnabled: (enabled: boolean) => void
   availableFromEnabled: boolean
@@ -31,7 +30,7 @@ export function ScheduleSection({
     .find((part) => part.type === "timeZoneName")?.value
 
   return (
-    <SectionCard title={t("assignments.form.scheduleSection")} status={status}>
+    <SectionCard title={t("assignments.form.scheduleSection")} onReset={onReset}>
       <div className="flex flex-col gap-4">
         <form.Field name="available_from_date">
           {(field) => (

--- a/web/src/pages/assignments/sections/ScheduleSection.tsx
+++ b/web/src/pages/assignments/sections/ScheduleSection.tsx
@@ -30,7 +30,10 @@ export function ScheduleSection({
     .find((part) => part.type === "timeZoneName")?.value
 
   return (
-    <SectionCard title={t("assignments.form.scheduleSection")} onReset={onReset}>
+    <SectionCard
+      title={t("assignments.form.scheduleSection")}
+      onReset={onReset}
+    >
       <div className="flex flex-col gap-4">
         <form.Field name="available_from_date">
           {(field) => (

--- a/web/src/pages/assignments/sections/SectionCard.tsx
+++ b/web/src/pages/assignments/sections/SectionCard.tsx
@@ -1,30 +1,24 @@
 import type { ReactNode } from "react"
+import { RotateCcw } from "lucide-react"
 import { useTranslation } from "react-i18next"
-import { Badge, Card } from "@/components/ui"
-import type { BadgeTone } from "@/types/badgeTone"
-import type { SectionStatus } from "./sectionStatus"
+import { Button, Card } from "@/components/ui"
 
-// The per-section status badge (R2): a teacher scans the header to see whether a
-// section needs attention, holds custom config, or is untouched. "default" is
-// intentionally quiet (a ghost badge) so only error/configured draw the eye.
-const STATUS_TONE: Record<SectionStatus, BadgeTone> = {
-  error: "error",
-  configured: "info",
-  default: "neutral",
-}
-
-// One card wrapper for every top-level section: a bold heading, the status
-// badge, an optional description, and the section body. Keeps the five sections
-// visually uniform and their status in one place.
+// One card wrapper for every top-level section: a bold heading, an optional
+// per-section Reset control, an optional description, and the section body.
+// Keeps the five sections visually uniform. The Reset control appears only when
+// the caller passes `onReset` (create mode, and the section differs from its
+// defaults); clicking it restores that section to its default settings.
 export function SectionCard({
   title,
-  status,
   description,
+  onReset,
   children,
 }: {
   title: string
-  status: SectionStatus
   description?: string
+  // When provided, render a Reset control in the header. Omitted (undefined)
+  // means the section is unchanged or resetting isn't offered (edit mode).
+  onReset?: () => void
   children: ReactNode
 }) {
   const { t } = useTranslation()
@@ -33,13 +27,19 @@ export function SectionCard({
       <Card.Body>
         <div className="flex items-center justify-between gap-3 pb-1">
           <h3 className="text-lg font-bold">{title}</h3>
-          <Badge
-            tone={STATUS_TONE[status]}
-            ghost={status === "default"}
-            className="shrink-0"
-          >
-            {t(`assignments.form.sectionStatus.${status}`)}
-          </Badge>
+          {onReset ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onReset}
+              aria-label={t("assignments.form.resetSection")}
+              title={t("assignments.form.resetSection")}
+              className="shrink-0 gap-1.5 text-base-content/60 hover:text-base-content"
+            >
+              <RotateCcw aria-hidden="true" className="size-4" />
+              {t("assignments.form.reset")}
+            </Button>
+          ) : null}
         </div>
         {description ? (
           <p className="mb-3 text-sm text-base-content/70">{description}</p>

--- a/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
+++ b/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
@@ -3,7 +3,6 @@ import { Alert, FormField, Input, Select } from "@/components/ui"
 import { GRADING_MAX_POINTS_MIN } from "@/types/classroom"
 import type { AssignmentForm } from "../assignmentFormModel"
 import { deriveFormShape } from "../formShape"
-import type { SectionStatus } from "./sectionStatus"
 import { SectionCard } from "./SectionCard"
 import { SubmissionsSubsection } from "./SubmissionsSubsection"
 
@@ -20,18 +19,18 @@ import { SubmissionsSubsection } from "./SubmissionsSubsection"
 export function SubmissionGradingSection({
   form,
   edit,
-  status,
+  onReset,
 }: {
   form: AssignmentForm
   edit: boolean
-  status: SectionStatus
+  onReset?: () => void
 }) {
   const { t } = useTranslation()
 
   return (
     <SectionCard
       title={t("assignments.form.submissionSection")}
-      status={status}
+      onReset={onReset}
       description={t("assignments.form.submissionSectionHelp")}
     >
       <div className="flex flex-col gap-4">

--- a/web/src/pages/assignments/sections/sectionFields.test.ts
+++ b/web/src/pages/assignments/sections/sectionFields.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { sectionIsConfigured } from "./sectionStatus"
+import { errorKeyMatchesField, sectionIsConfigured } from "./sectionFields"
 import type { CreateAssignmentFormValues } from "../assignmentFormModel"
 
 // The create-form baseline defaults; sectionIsConfigured compares against these
@@ -97,5 +97,24 @@ describe("sectionIsConfigured", () => {
     expect(sectionIsConfigured("submission", manual, defaults)).toBe(true)
     const maxChanged = { ...defaults, grading_max_points: 42 }
     expect(sectionIsConfigured("submission", maxChanged, defaults)).toBe(true)
+  })
+})
+
+describe("errorKeyMatchesField", () => {
+  it("matches an exact field key", () => {
+    expect(errorKeyMatchesField("name", "name")).toBe(true)
+    expect(errorKeyMatchesField("name", "slug")).toBe(false)
+  })
+
+  it("matches an indexed sub-key of the field", () => {
+    // validateAssignmentForm keys per-test errors as "tests[0].name".
+    expect(errorKeyMatchesField("tests[0].name", "tests")).toBe(true)
+    expect(errorKeyMatchesField("tests[2].run", "tests")).toBe(true)
+  })
+
+  it("does not match a different field with a shared prefix", () => {
+    expect(errorKeyMatchesField("submission_tags", "submission_mode")).toBe(
+      false,
+    )
   })
 })

--- a/web/src/pages/assignments/sections/sectionFields.ts
+++ b/web/src/pages/assignments/sections/sectionFields.ts
@@ -74,3 +74,14 @@ export function sectionIsConfigured(
     return value !== defaults[field]
   })
 }
+
+// Whether a validateAssignmentForm error key belongs to a field, matching the
+// field itself or an indexed sub-key of it (e.g. "tests[0].name" -> "tests").
+// The single source of truth for that keying convention, so a caller mapping
+// errors back to fields can't drift from validateAssignmentForm.
+export function errorKeyMatchesField(
+  errorKey: string,
+  field: keyof CreateAssignmentFormValues,
+): boolean {
+  return errorKey === field || errorKey.startsWith(`${field}[`)
+}

--- a/web/src/pages/assignments/sections/sectionStatus.test.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest"
-import { deriveSectionStatus } from "./sectionStatus"
+import { sectionIsConfigured } from "./sectionStatus"
 import type { CreateAssignmentFormValues } from "../assignmentFormModel"
 
-// The create-form baseline defaults; deriveSectionStatus compares against these
-// to tell "configured" from "default". These MUST match useAssignmentForm's
-// create defaults (assignmentFormModel.ts): a fresh create form is an
-// uninitialized repo with no README, no built-in autograding, and grading off.
+// The create-form baseline defaults; sectionIsConfigured compares against these
+// to decide whether a section differs from its defaults (so a Reset control
+// appears). These MUST match useAssignmentForm's create defaults
+// (assignmentFormModel.ts): a fresh create form is an uninitialized repo with
+// no README, no built-in autograding, and grading off.
 const defaults: CreateAssignmentFormValues = {
   name: "",
   slug: "",
@@ -51,74 +52,27 @@ const defaults: CreateAssignmentFormValues = {
   tests: [],
 }
 
-describe("deriveSectionStatus", () => {
-  it("reports 'default' for an untouched section", () => {
-    expect(deriveSectionStatus("details", defaults, defaults, {})).toBe(
-      "default",
-    )
-    expect(deriveSectionStatus("schedule", defaults, defaults, {})).toBe(
-      "default",
-    )
+describe("sectionIsConfigured", () => {
+  it("is false for an untouched section", () => {
+    expect(sectionIsConfigured("details", defaults, defaults)).toBe(false)
+    expect(sectionIsConfigured("schedule", defaults, defaults)).toBe(false)
   })
 
-  it("reports 'configured' once the section holds a non-default value", () => {
+  it("is true once the section holds a non-default value", () => {
     const values = { ...defaults, name: "Homework 1" }
-    expect(deriveSectionStatus("details", values, defaults, {})).toBe(
-      "configured",
-    )
+    expect(sectionIsConfigured("details", values, defaults)).toBe(true)
     // A field another section owns doesn't flip Details.
     const withDue = { ...defaults, due_date: "2026-09-01T23:59" }
-    expect(deriveSectionStatus("details", withDue, defaults, {})).toBe(
-      "default",
-    )
-    expect(deriveSectionStatus("schedule", withDue, defaults, {})).toBe(
-      "configured",
-    )
+    expect(sectionIsConfigured("details", withDue, defaults)).toBe(false)
+    expect(sectionIsConfigured("schedule", withDue, defaults)).toBe(true)
   })
 
   it("attributes the folded repo-feature choices to the repository section", () => {
     const wikiOff = { ...defaults, repo_feature_wiki: "off" as const }
-    expect(deriveSectionStatus("repository", wikiOff, defaults, {})).toBe(
-      "configured",
-    )
+    expect(sectionIsConfigured("repository", wikiOff, defaults)).toBe(true)
     // All features left at "inherit" (and no other repo field changed) reads
-    // default — the four repo_feature_* fields fold into this one badge.
-    expect(deriveSectionStatus("repository", defaults, defaults, {})).toBe(
-      "default",
-    )
-  })
-
-  it("reports 'error' when a validation error names one of the section's fields", () => {
-    expect(
-      deriveSectionStatus("details", defaults, defaults, {
-        name: "assignments.form.validation.nameRequired",
-      }),
-    ).toBe("error")
-    // The error belongs to Details, not Repository Setup.
-    expect(
-      deriveSectionStatus("repository", defaults, defaults, {
-        name: "assignments.form.validation.nameRequired",
-      }),
-    ).toBe("default")
-  })
-
-  it("routes an indexed test error to the autograding section", () => {
-    // validateAssignmentForm keys per-test errors as "tests[0].name" etc.; the
-    // status must attribute those to the section that owns "tests".
-    expect(
-      deriveSectionStatus("autograding", defaults, defaults, {
-        "tests[0].name": "bad",
-      }),
-    ).toBe("error")
-  })
-
-  it("error wins over configured", () => {
-    const values = { ...defaults, name: "Homework 1" }
-    expect(
-      deriveSectionStatus("details", values, defaults, {
-        name: "assignments.form.validation.nameRequired",
-      }),
-    ).toBe("error")
+    // unconfigured — the four repo_feature_* fields fold into this one section.
+    expect(sectionIsConfigured("repository", defaults, defaults)).toBe(false)
   })
 
   it("treats any declarative test as configured autograding", () => {
@@ -126,50 +80,22 @@ describe("deriveSectionStatus", () => {
       ...defaults,
       tests: [{ name: "t", run: "pytest", points: 1 } as never],
     }
-    expect(deriveSectionStatus("autograding", values, defaults, {})).toBe(
-      "configured",
-    )
+    expect(sectionIsConfigured("autograding", values, defaults)).toBe(true)
   })
 
   it("attributes the submission trigger + tags to the submission section", () => {
     const tagMode = { ...defaults, submission_mode: "tag" as const }
-    expect(deriveSectionStatus("submission", tagMode, defaults, {})).toBe(
-      "configured",
-    )
-    // Those fields no longer flip Autograding — they moved to their own section.
-    expect(deriveSectionStatus("autograding", tagMode, defaults, {})).toBe(
-      "default",
-    )
+    expect(sectionIsConfigured("submission", tagMode, defaults)).toBe(true)
+    // Those fields belong to submission, not autograding.
+    expect(sectionIsConfigured("autograding", tagMode, defaults)).toBe(false)
     const withTags = { ...defaults, submission_tags: "phase1" }
-    expect(deriveSectionStatus("submission", withTags, defaults, {})).toBe(
-      "configured",
-    )
+    expect(sectionIsConfigured("submission", withTags, defaults)).toBe(true)
   })
 
   it("attributes the grading choice + max points to the submission section", () => {
     const manual = { ...defaults, grading_choice: "manual" as const }
-    expect(deriveSectionStatus("submission", manual, defaults, {})).toBe(
-      "configured",
-    )
+    expect(sectionIsConfigured("submission", manual, defaults)).toBe(true)
     const maxChanged = { ...defaults, grading_max_points: 42 }
-    expect(deriveSectionStatus("submission", maxChanged, defaults, {})).toBe(
-      "configured",
-    )
-    // A grading validation error routes to the submission section.
-    expect(
-      deriveSectionStatus("submission", defaults, defaults, {
-        grading_max_points: "bad",
-      }),
-    ).toBe("error")
-  })
-
-  it("routes a submission_tags validation error to the submission section", () => {
-    const errors = { submission_tags: "bad" }
-    expect(deriveSectionStatus("submission", defaults, defaults, errors)).toBe(
-      "error",
-    )
-    expect(deriveSectionStatus("autograding", defaults, defaults, errors)).toBe(
-      "default",
-    )
+    expect(sectionIsConfigured("submission", maxChanged, defaults)).toBe(true)
   })
 })

--- a/web/src/pages/assignments/sections/sectionStatus.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.ts
@@ -1,26 +1,22 @@
 import type { CreateAssignmentFormValues } from "../assignmentFormModel"
 
-// Per-section status (R2): a teacher scans the section headers to see progress
-// without reading each section's contents.
-//   - "error"      : a field the section owns has a validation error.
-//   - "configured" : no error, and the section holds a non-default value.
-//   - "default"    : no error and every owned field is still at its default.
-export type SectionStatus = "error" | "configured" | "default"
-
-// The sections, in render order. Each owns a disjoint slice of the form fields;
-// the status derivation keys off these lists so a field belongs to exactly one
-// section's badge. "submission" (the Submission and Grading section, whose
-// Submissions subsection is the single source of truth for what counts as a
-// submission) owns the submission definition + milestone tags and the grading
-// choice, right after Repository Setup.
+// The form's sections, in render order. Each owns a disjoint slice of the form
+// fields; the reset control keys off these lists so a field belongs to exactly
+// one section. "submission" (the Submission and Grading section) owns the
+// submission definition + milestone tags and the grading choice, right after
+// Repository Setup.
 export type SectionId =
-  "details" | "repository" | "submission" | "autograding" | "schedule"
+  | "details"
+  | "repository"
+  | "submission"
+  | "autograding"
+  | "schedule"
 
-// The fields each section owns, for both the error scan (which validation keys
-// map to this section) and the configured scan (which values to compare against
-// their default). Kept here as the single ownership map so a moved field
-// updates its badge in one place.
-const SECTION_FIELDS: Record<
+// The fields each section owns. Used to decide whether a section differs from
+// its create defaults (so a Reset control appears) and to restore just that
+// section's fields on reset. Kept here as the single ownership map so a moved
+// field updates its section in one place.
+export const SECTION_FIELDS: Record<
   SectionId,
   ReadonlyArray<keyof CreateAssignmentFormValues>
 > = {
@@ -67,21 +63,10 @@ const SECTION_FIELDS: Record<
   schedule: ["available_from_date", "due_date"],
 }
 
-// A validation error key belongs to a section when it names one of that
-// section's fields, or is an indexed sub-key of one (e.g. "tests[0].name"
-// belongs to autograding's "tests"). This mirrors validateAssignmentForm's
-// keying so the badge and the field-level error stay in agreement.
-function errorBelongsToSection(errorKey: string, section: SectionId): boolean {
-  return SECTION_FIELDS[section].some(
-    (field) => errorKey === field || errorKey.startsWith(`${field}[`),
-  )
-}
-
-// Whether the section holds any non-default value. Compared against the form's
-// baseline defaults (the create-form initial state), so an untouched section
-// reads "default" and a filled one reads "configured". Fields the section
-// doesn't own are ignored.
-function sectionIsConfigured(
+// Whether the section holds any non-default value, compared against the form's
+// baseline (create) defaults. An untouched section reads false (no Reset shown);
+// a changed one reads true. Fields the section doesn't own are ignored.
+export function sectionIsConfigured(
   section: SectionId,
   values: CreateAssignmentFormValues,
   defaults: CreateAssignmentFormValues,
@@ -92,19 +77,4 @@ function sectionIsConfigured(
     if (field === "tests") return Array.isArray(value) && value.length > 0
     return value !== defaults[field]
   })
-}
-
-export function deriveSectionStatus(
-  section: SectionId,
-  values: CreateAssignmentFormValues,
-  defaults: CreateAssignmentFormValues,
-  errors: Record<string, string>,
-): SectionStatus {
-  const hasError = Object.keys(errors).some((key) =>
-    errorBelongsToSection(key, section),
-  )
-  if (hasError) return "error"
-  return sectionIsConfigured(section, values, defaults)
-    ? "configured"
-    : "default"
 }

--- a/web/src/pages/assignments/sections/sectionStatus.ts
+++ b/web/src/pages/assignments/sections/sectionStatus.ts
@@ -6,11 +6,7 @@ import type { CreateAssignmentFormValues } from "../assignmentFormModel"
 // submission definition + milestone tags and the grading choice, right after
 // Repository Setup.
 export type SectionId =
-  | "details"
-  | "repository"
-  | "submission"
-  | "autograding"
-  | "schedule"
+  "details" | "repository" | "submission" | "autograding" | "schedule"
 
 // The fields each section owns. Used to decide whether a section differs from
 // its create defaults (so a Reset control appears) and to restore just that

--- a/web/src/util/slug.test.ts
+++ b/web/src/util/slug.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { nextAvailableSlug, slugify } from "./slug"
+
+describe("slugify", () => {
+  it("normalizes free text to a repo-safe slug", () => {
+    expect(slugify("Loops Assignment")).toBe("loops-assignment")
+    expect(slugify("  Hello, World!  ")).toBe("hello-world")
+  })
+
+  it("is idempotent on an already-slugified value", () => {
+    expect(slugify("loops-assignment")).toBe("loops-assignment")
+  })
+})
+
+describe("nextAvailableSlug", () => {
+  it("returns the base when it is free", () => {
+    expect(nextAvailableSlug("hw1", [])).toBe("hw1")
+    expect(nextAvailableSlug("hw1", ["hw2"])).toBe("hw1")
+  })
+
+  it("suffixes -2, -3 when the base and its suffixes are taken", () => {
+    expect(nextAvailableSlug("hw1", ["hw1"])).toBe("hw1-2")
+    expect(nextAvailableSlug("hw1", ["hw1", "hw1-2"])).toBe("hw1-3")
+  })
+
+  it("continues from a trailing -<n> rather than re-appending", () => {
+    expect(nextAvailableSlug("hw1-2", ["hw1-2"])).toBe("hw1-3")
+  })
+
+  it("matches case-insensitively (slugs are repo path segments)", () => {
+    expect(nextAvailableSlug("hw1", ["HW1"])).toBe("hw1-2")
+  })
+})

--- a/web/src/util/slug.ts
+++ b/web/src/util/slug.ts
@@ -11,3 +11,32 @@ export function slugify(value: string) {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
 }
+
+// First slug not in `taken`, suffixing `-2`, `-3`, … A base ending in `-<n>`
+// continues from n+1 ("hw1-2" -> "hw1-3", not "hw1-2-2"). Case-insensitive, to
+// match GitHub repo naming and the server-side check. Pure; prefills both the
+// reuse modals and the create-form auto-slug — the write path re-checks
+// authoritatively.
+export function nextAvailableSlug(
+  base: string,
+  taken: Iterable<string>,
+): string {
+  const takenSet = new Set(Array.from(taken, (s) => s.trim().toLowerCase()))
+  const isFree = (candidate: string) => !takenSet.has(candidate.toLowerCase())
+
+  if (isFree(base)) return base
+
+  // Split off a trailing "-<n>" so we increment it rather than append again.
+  const match = /^(.*?)-(\d+)$/.exec(base)
+  const stem = match ? match[1] : base
+  let n = match ? Number(match[2]) + 1 : 2
+
+  // Bounded defensively; a classroom never has thousands of same-stem slugs.
+  for (let i = 0; i < 10000; i++) {
+    const candidate = `${stem}-${n}`
+    if (isFree(candidate)) return candidate
+    n++
+  }
+  // Unreachable in practice, but never silently return a taken slug.
+  return `${stem}-${Date.now()}`
+}


### PR DESCRIPTION
## Summary

Reworks the assignment create/edit form's feedback UX and slug handling for a clearer, more action-oriented experience.

- **Per-section Reset (create)**: removes the `Default` / `Configured` / `Needs attention` section badges. Each create-mode section now shows a **Reset** control only when it differs from its defaults, restoring just that section in one click.
- **Discard changes (edit)**: edit mode gains a single **Discard changes** button that reverts all unsaved edits back to the stored assignment, re-syncing the opt-in schedule date pickers with the restored values.
- **Inline validation**: invalid fields now show a red border and an exclamation marker next to the label (replacing the `Needs attention` badge), and a failed submit scrolls to and focuses the first errored field. Native `required` on name/slug is dropped in favor of our own validation so it owns the invalid UX consistently; `aria-required` is retained.
- **Auto-unique slug**: the name→slug auto-fill now uses `nextAvailableSlug` (extracted into `@/util/slug`, shared with the reuse flow) so a generated slug never collides — conflicts are resolved up front instead of surfacing only at save. The slug stays editable and a manually typed conflict still errors inline.

## Notes

- `nextAvailableSlug` moved from `domain/assignments/copyReuse.ts` to `util/slug.ts` and is re-exported, so the reuse flow and its call sites are unchanged.
- `sections/sectionStatus.ts` was renamed to `sections/sectionFields.ts` (it no longer computes status), and the error-key→field matching convention is centralized in `errorKeyMatchesField`.

## Test plan

- [ ] `cd web && npm run check` is green (tsc, eslint, prettier, arch:validate, vitest).
- [ ] Create form: badges gone; a configured section shows Reset that restores its defaults; typing a name whose slug is taken auto-fills a unique slug; submitting with an invalid field highlights it and scrolls to it.
- [ ] Edit form: no per-section Reset; Discard changes appears after edits and reverts them (including re-showing a schedule picker for a restored date).