### PR TITLE
feat(web): split submission badge into type and grading badges

### DIFF
--- a/web/src/components/submissions/SubmissionRowCells.tsx
+++ b/web/src/components/submissions/SubmissionRowCells.tsx
@@ -65,7 +65,8 @@ const autogradingBadgeContent: Record<
 
 // The "how is it graded" badge, paired with SubmissionModeBadge on the teacher
 // heading and the student page. Keyed off the autograding tri-state so the
-// 2-mode x 3-grading combinations stay two independent badges.
+// 2-mode x 3-grading combinations stay two independent badges. The detail is
+// hover text for sighted users and sr-only text for screen readers.
 export const AutogradingBadge = ({
   state,
   size,
@@ -85,6 +86,7 @@ export const AutogradingBadge = ({
     >
       <Icon aria-hidden="true" className="size-3.5" />
       {t(label)}
+      {title && <span className="sr-only">{t(title)}</span>}
     </Badge>
   )
 }

--- a/web/src/components/submissions/SubmissionRowCells.tsx
+++ b/web/src/components/submissions/SubmissionRowCells.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from "react-i18next"
-import { GitCommitHorizontal, Tag } from "lucide-react"
+import { Bot, CircleOff, GitCommitHorizontal, Tag } from "lucide-react"
 
 import { Badge, type BadgeSize } from "@/components/ui"
 import {
   submissionModeBadgeKey,
   submissionModeCountKey,
 } from "@/domain/assignments/submissionDetection"
+import type { AutogradingState } from "@/domain/assignments/autogradingState"
 import { formatSubmissionDateTime } from "@/util/formatDate"
 import type { SubmissionMode } from "@/types/classroom"
 
@@ -26,22 +27,64 @@ export const SubmissionModeIcon = ({
   )
 
 // The "what counts as a submission" mode badge, shared by the teacher heading
-// and the student page so their wording can't drift. `skipsGrading` drops the
-// "is graded" claim for assignments that never autograde.
+// and the student page so their wording can't drift. Grading is described by
+// the separate AutogradingBadge, so this badge never claims a grade.
 export const SubmissionModeBadge = ({
   mode,
-  skipsGrading = false,
   size,
 }: {
   mode: SubmissionMode | undefined
-  skipsGrading?: boolean
   size?: BadgeSize
 }) => {
   const { t } = useTranslation()
   return (
     <Badge ghost size={size} className="gap-1">
       <SubmissionModeIcon mode={mode} />
-      {t(submissionModeBadgeKey(mode, skipsGrading))}
+      {t(submissionModeBadgeKey(mode))}
+    </Badge>
+  )
+}
+
+// Label + hover detail per autograding tri-state. Built-in autograding needs
+// no elaboration; the two no-grading states carry the "what's disabled / what
+// still works" detail that used to be a full-width dashboard note.
+const autogradingBadgeContent: Record<
+  AutogradingState,
+  { label: string; title?: string }
+> = {
+  "built-in": { label: "submissions.grading.badgeBuiltIn" },
+  none: {
+    label: "submissions.grading.badgeNoAutograder",
+    title: "submissions.grading.titleNoAutograder",
+  },
+  empty: {
+    label: "submissions.grading.badgeEmptyRepo",
+    title: "submissions.grading.titleEmptyRepo",
+  },
+}
+
+// The "how is it graded" badge, paired with SubmissionModeBadge on the teacher
+// heading and the student page. Keyed off the autograding tri-state so the
+// 2-mode x 3-grading combinations stay two independent badges.
+export const AutogradingBadge = ({
+  state,
+  size,
+}: {
+  state: AutogradingState
+  size?: BadgeSize
+}) => {
+  const { t } = useTranslation()
+  const { label, title } = autogradingBadgeContent[state]
+  const Icon = state === "built-in" ? Bot : CircleOff
+  return (
+    <Badge
+      ghost
+      size={size}
+      className="gap-1"
+      title={title ? t(title) : undefined}
+    >
+      <Icon aria-hidden="true" className="size-3.5" />
+      {t(label)}
     </Badge>
   )
 }

--- a/web/src/domain/assignments/submissionDetection.test.ts
+++ b/web/src/domain/assignments/submissionDetection.test.ts
@@ -193,17 +193,4 @@ describe("submissionModeBadgeKey / submissionModeCountKey", () => {
       "submissions.type.countEveryPush",
     )
   })
-
-  it("drops the 'is graded' claim when the assignment skips grading", () => {
-    expect(submissionModeBadgeKey("every-push", true)).toBe(
-      "submissions.type.badgeEveryPushNoGrade",
-    )
-    expect(submissionModeBadgeKey("tag", true)).toBe(
-      "submissions.type.badgeTagNoGrade",
-    )
-    // Grading enabled keeps the graded wording.
-    expect(submissionModeBadgeKey("every-push", false)).toBe(
-      "submissions.type.badgeEveryPush",
-    )
-  })
 })

--- a/web/src/domain/assignments/submissionDetection.ts
+++ b/web/src/domain/assignments/submissionDetection.ts
@@ -132,22 +132,14 @@ export function resolveSubmissionMode(
 }
 
 // The i18n key for the "what counts as a submission" heading badge, keyed by
-// mode. Single source so the teacher heading and the student page agree.
-// `skipsGrading` (empty_repo or no_autograder — the assignment never
-// autogrades) drops the "is graded" claim: for those assignments a push/tag is
-// still the submission unit, but nothing is graded, so the badge describes what
-// counts without promising a grade.
+// mode. Single source so the teacher heading and the student page agree. The
+// badge only describes what counts; whether it is graded is the separate
+// autograding badge's job (see AutogradingBadge).
 export function submissionModeBadgeKey(
   mode: SubmissionMode | undefined,
-  skipsGrading = false,
 ): string {
-  if (resolveSubmissionMode(mode) === "tag") {
-    return skipsGrading
-      ? "submissions.type.badgeTagNoGrade"
-      : "submissions.type.badgeTag"
-  }
-  return skipsGrading
-    ? "submissions.type.badgeEveryPushNoGrade"
+  return resolveSubmissionMode(mode) === "tag"
+    ? "submissions.type.badgeTag"
     : "submissions.type.badgeEveryPush"
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2288,16 +2288,21 @@
     "dueDate": "Due {{date}}",
     "noDueDate": "No due date",
     "type": {
-      "badgeEveryPush": "Every push to the default branch is graded",
-      "badgeEveryPushNoGrade": "Every push to the default branch counts",
-      "badgeTag": "Graded on submission tags",
-      "badgeTagNoGrade": "Submitted by tag",
+      "badgeEveryPush": "Every push to the default branch counts",
+      "badgeTag": "Submitted by tag",
       "countEveryPush_one": "{{count}} push to the default branch",
       "countEveryPush_other": "{{count}} pushes to the default branch",
       "countTag_one": "{{count}} tagged submission",
       "countTag_other": "{{count}} tagged submissions",
       "tagGroupCount_one": "{{pattern}} · {{count}} tag",
       "tagGroupCount_other": "{{pattern}} · {{count}} tags"
+    },
+    "grading": {
+      "badgeBuiltIn": "Autograded",
+      "badgeNoAutograder": "No built-in autograding",
+      "titleNoAutograder": "The teacher supplies their own CI in the template. Built-in scores and regrading are disabled; the feedback pull request still works when enabled.",
+      "badgeEmptyRepo": "No autograding",
+      "titleEmptyRepo": "This assignment uses empty repositories — autograding, scores, and the feedback pull request are disabled. The table shows who has accepted."
     },
     "details": {
       "viewRepository": "View repository",
@@ -2317,8 +2322,6 @@
     "lateBadge_other": "{{count}} late",
     "downloadCsv": "Download scores (CSV)",
     "viewSourceRepo": "View template",
-    "emptyRepoNote": "This assignment uses empty repositories — autograding, scores, and the feedback pull request are disabled. Students create and push their own work; the table below shows who has accepted.",
-    "noAutograderNote": "This assignment has no built-in autograding — the teacher supplies their own CI in the template. Built-in scores and regrading are disabled; the table below shows who has accepted. The feedback pull request still works when enabled.",
     "lockedNotice": "This assignment is locked. Students can't accept or open it, and if it uses a private template the student team's access to that template has been removed. Existing repositories and their submissions are unaffected. Unlock it from the Actions menu (or the assignments list) to reopen it.",
     "closedNotice": "Submissions are closed. New students can't accept this assignment. When you close from here, accepted students' repositories are set to read-only; existing work is preserved. Reopen it from the Actions menu to allow submissions again.",
     "lock": {

--- a/web/src/pages/StudentSubmissionPage.test.tsx
+++ b/web/src/pages/StudentSubmissionPage.test.tsx
@@ -117,6 +117,27 @@ beforeEach(() => {
 
 afterEach(cleanup)
 
+describe("StudentSubmissionPage grading badge", () => {
+  it("shows the autograded badge for built-in autograding", () => {
+    render(<StudentSubmissionPage />)
+    expect(screen.getByText("submissions.grading.badgeBuiltIn")).toBeTruthy()
+  })
+
+  it("shows the teacher-CI badge for no_autograder assignments", () => {
+    assignmentData = assignment({ no_autograder: true })
+    render(<StudentSubmissionPage />)
+    expect(
+      screen.getByText("submissions.grading.badgeNoAutograder"),
+    ).toBeTruthy()
+  })
+
+  it("shows the no-autograding badge for empty_repo assignments", () => {
+    assignmentData = assignment({ empty_repo: true })
+    render(<StudentSubmissionPage />)
+    expect(screen.getByText("submissions.grading.badgeEmptyRepo")).toBeTruthy()
+  })
+})
+
 describe("StudentSubmissionPage submission type", () => {
   it("shows the every-push type badge and the push-count chip by default", () => {
     assignmentData = assignment({ submission_mode: "every-push" })

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -21,7 +21,7 @@ import { safeHttpUrl } from "@/util/url"
 import type { GitHubCommit, GitHubRelease } from "@/github-core/types"
 import { SUBMISSION_TAG_PREFIX } from "@/github-core/queries/releaseRunReads"
 import { submissionModeCountKey } from "@/domain/assignments/submissionDetection"
-import { assignmentSkipsGrading } from "@/domain/assignments/autogradingState"
+import { deriveAutogradingState } from "@/domain/assignments/autogradingState"
 import type { Assignment, SubmissionMode } from "@/types/classroom"
 import { assignmentDescription } from "@/types/classroom"
 import { EnterDiv } from "@/lib/motionComponents"
@@ -37,6 +37,7 @@ import {
   type PushSubmission,
 } from "@/components/submissions/submissionDetailItems"
 import {
+  AutogradingBadge,
   LastSubmittedCell,
   SubmissionCountCell,
   SubmissionModeBadge,
@@ -108,10 +109,8 @@ const AssignmentMeta = ({
           {t("submissions.student.modeIndividual")}
         </Badge>
       ) : null}
-      <SubmissionModeBadge
-        mode={submissionMode}
-        skipsGrading={assignmentSkipsGrading(assignment)}
-      />
+      <SubmissionModeBadge mode={submissionMode} />
+      <AutogradingBadge state={deriveAutogradingState(assignment)} />
       <Badge
         tone={overdue ? "error" : "neutral"}
         ghost={!overdue}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -172,9 +172,9 @@ const SubmissionsPageContent = () => {
   // Assignments that never autograde (empty_repo bare repos, or no_autograder
   // teacher-supplied CI) produce no submit/* releases. Grading UI (Regrade all,
   // per-row regrade, scores, live polling, the trigger retrofit) is hidden and
-  // a notice explains why. Collect stays enabled — it's org-wide and
-  // collect_scores.py skips these assignments itself. Mirrors the Python
-  // skips_grading() predicate family.
+  // the header's grading badge explains why. Collect stays enabled — it's
+  // org-wide and collect_scores.py skips these assignments itself. Mirrors the
+  // Python skips_grading() predicate family.
   const skipsGrading = assignmentInfo
     ? assignmentSkipsGrading(assignmentInfo)
     : false

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -24,10 +24,13 @@ import { BulkRepoFeaturesModal } from "@/components/modals/BulkRepoFeaturesModal
 import { BulkAutogradeStateModal } from "@/components/modals/BulkAutogradeStateModal"
 import { BulkSubmissionTriggerModal } from "@/components/modals/BulkSubmissionTriggerModal"
 import { isDefaultAutograder } from "@/domain/assignments/autograderYaml"
-import { SubmissionModeBadge } from "@/components/submissions/SubmissionRowCells"
+import {
+  AutogradingBadge,
+  SubmissionModeBadge,
+} from "@/components/submissions/SubmissionRowCells"
 import {
   assignmentSkipsGrading,
-  isNoAutograderAssignment,
+  deriveAutogradingState,
 } from "@/domain/assignments/autogradingState"
 import { DataFreshness } from "@/pages/submissions/DataFreshness"
 import { ConfirmModal } from "@/components/modals"
@@ -179,11 +182,6 @@ const SubmissionsPageContent = () => {
   // repo-management bulk actions (access/features) key off this — a
   // no_autograder repo is templated and DOES have repos to manage.
   const isEmptyRepoAssignment = assignmentInfo?.empty_repo === true
-  // Distinguishes the two skips-grading states for the freshness note wording
-  // (no_autograder keeps the Feedback PR; empty_repo does not).
-  const isNoAutograder = assignmentInfo
-    ? isNoAutograderAssignment(assignmentInfo)
-    : false
   // Locked assignments are closed to students (accept + submission surfaces
   // refuse them); the gradebook stays fully functional for staff, so this is a
   // heads-up banner, not a gate.
@@ -947,11 +945,16 @@ const SubmissionsPageContent = () => {
               </Badge>
             )}
             {assignmentInfo && (
-              <SubmissionModeBadge
-                mode={assignmentInfo.submission_mode}
-                skipsGrading={skipsGrading}
-                size="md"
-              />
+              <>
+                <SubmissionModeBadge
+                  mode={assignmentInfo.submission_mode}
+                  size="md"
+                />
+                <AutogradingBadge
+                  state={deriveAutogradingState(assignmentInfo)}
+                  size="md"
+                />
+              </>
             )}
             {assignmentInfo?.template && (
               <GitHubLink
@@ -1074,33 +1077,35 @@ const SubmissionsPageContent = () => {
         // name-ordered, unfiltered view, so hide Sort + Status while live.
         hideSortAndStatus={liveCapable}
         onShare={() => setAcceptOpen(true)}
+        // No collect/freshness exists for assignments that skip built-in
+        // grading — the header's grading badge explains why.
         leading={
-          <DataFreshness
-            lastCollectedLabel={lastCollectedLabel}
-            stale={snapshotStale}
-            collecting={collecting}
-            errorCount={liveErrorCount}
-            emptyRepo={skipsGrading}
-            noAutograder={isNoAutograder}
-            onRefresh={
-              collecting || emptyRoster.show
-                ? undefined
-                : () => {
-                    // Sync = re-collect (rebuild scores.json). Re-read the org
-                    // repo list too so the staleness line re-derives against the
-                    // newest pushes (latestPush would otherwise stay frozen at
-                    // page load), and re-run the live fan-out for a live-capable
-                    // viewer so presence refreshes alongside the dispatched
-                    // collect.
-                    collectScores.collect()
-                    refetchOrgRepos()
-                    if (liveCapable) {
-                      refetchLive()
-                      refetchDetected()
+          skipsGrading ? undefined : (
+            <DataFreshness
+              lastCollectedLabel={lastCollectedLabel}
+              stale={snapshotStale}
+              collecting={collecting}
+              errorCount={liveErrorCount}
+              onRefresh={
+                collecting || emptyRoster.show
+                  ? undefined
+                  : () => {
+                      // Sync = re-collect (rebuild scores.json). Re-read the org
+                      // repo list too so the staleness line re-derives against the
+                      // newest pushes (latestPush would otherwise stay frozen at
+                      // page load), and re-run the live fan-out for a live-capable
+                      // viewer so presence refreshes alongside the dispatched
+                      // collect.
+                      collectScores.collect()
+                      refetchOrgRepos()
+                      if (liveCapable) {
+                        refetchLive()
+                        refetchDetected()
+                      }
                     }
-                  }
-            }
-          />
+              }
+            />
+          )
         }
         trailing={
           <SubmissionsActionsMenu

--- a/web/src/pages/submissions/DataFreshness.test.tsx
+++ b/web/src/pages/submissions/DataFreshness.test.tsx
@@ -28,14 +28,6 @@ const base = {
 }
 
 describe("DataFreshness", () => {
-  it("shows the empty-repo note instead of freshness for empty_repo assignments", () => {
-    render(<DataFreshness {...base} emptyRepo />)
-    expect(screen.getByText("submissions.emptyRepoNote")).not.toBeNull()
-    expect(
-      screen.queryByText("submissions.freshness.collected:18 hours ago"),
-    ).toBeNull()
-  })
-
   it("leads with 'Collected {when}' (the true data age, not the fetch time)", () => {
     render(<DataFreshness {...base} />)
     expect(

--- a/web/src/pages/submissions/DataFreshness.tsx
+++ b/web/src/pages/submissions/DataFreshness.tsx
@@ -1,4 +1,4 @@
-import { Info, RefreshCw } from "lucide-react"
+import { RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Alert, Button, cx } from "@/components/ui"
@@ -12,6 +12,8 @@ import { Alert, Button, cx } from "@/components/ui"
 // to flag that the snapshot is out of date; otherwise it's a quiet "Refresh
 // submissions". Following data-freshness UX guidance: never let
 // stale data look authoritative, and give the user a direct way to refresh it.
+// Assignments that skip built-in grading have no collect/freshness at all —
+// the page omits this component and the header's grading badge explains why.
 export type DataFreshnessProps = {
   // Relative "x ago" of the last completed collect run — when the submission
   // data was produced org-wide. Null when never collected.
@@ -27,12 +29,6 @@ export type DataFreshnessProps = {
   // Repos the live fan-out couldn't read (owner only); > 0 shows a warning so
   // an incomplete live status doesn't look authoritative.
   errorCount?: number
-  // The assignment skips built-in grading (empty_repo OR no_autograder — fed
-  // skipsGrading); show a note instead of freshness. noAutograder picks the note.
-  emptyRepo?: boolean
-  // no_autograder assignments also never autograde, but keep the Feedback PR —
-  // pick the accurate note (only meaningful when emptyRepo is true).
-  noAutograder?: boolean
 }
 
 export function DataFreshness({
@@ -41,25 +37,8 @@ export function DataFreshness({
   collecting,
   onRefresh,
   errorCount = 0,
-  emptyRepo = false,
-  noAutograder = false,
 }: DataFreshnessProps) {
   const { t } = useTranslation()
-
-  if (emptyRepo) {
-    return (
-      <div className="flex items-start gap-2 text-sm text-base-content/70">
-        <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-        <p>
-          {t(
-            noAutograder
-              ? "submissions.noAutograderNote"
-              : "submissions.emptyRepoNote",
-          )}
-        </p>
-      </div>
-    )
-  }
 
   const collectedLine = lastCollectedLabel
     ? t("submissions.freshness.collected", { when: lastCollectedLabel })


### PR DESCRIPTION
## Summary

- The submissions header previously combined submission mode and grading into one badge with 4 wordings, plus two long paragraph notes (`emptyRepoNote` / `noAutograderNote`) that took a full line of the dashboard whenever an assignment skips built-in grading. This splits the 2 x 3 combinations into two independent badges: a **type badge** ("Every push to the default branch counts" / "Submitted by tag") and a new **grading badge** ("Autograded" / "No built-in autograding" / "No autograding") keyed off the existing `deriveAutogradingState` tri-state.
- The long notes are gone; their detail (what's disabled, whether the feedback PR still works) survives as the grading badge's hover tooltip and equivalent screen-reader-only text. `DataFreshness` lost its note branch, and the page omits it entirely for skips-grading assignments since they have no collect/freshness.
- Both the teacher submissions page and the student submission page share the same two badge components, so wording can't drift.

## Test plan

- [x] Proof-first: 3 new grading-badge tests on `StudentSubmissionPage` observed failing before implementation
- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 3690 tests) passes
- [x] `audit_i18n.py --strict` passes (no dead/missing keys after the locale changes)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — pure client-side UI/i18n change with no data, API, or workflow impact.