### PR TITLE
feat: assignment-scoped score collection and accurate submission status

### DIFF
--- a/cli/gh-teacher/internal/scores/scores.go
+++ b/cli/gh-teacher/internal/scores/scores.go
@@ -18,8 +18,10 @@ type File struct {
 
 // AssignmentBucket is one assignment's gradebook — its mode (`type`) plus
 // per-repo entries. Each entry decodes as a tolerant map[string]any (download
-// reads only a few well-known keys).
+// reads only a few well-known keys). CollectedAt is the optional per-bucket
+// freshness stamp written by collect_scores.py; empty when absent.
 type AssignmentBucket struct {
-	Type    string           `json:"type"`
-	Entries []map[string]any `json:"entries"`
+	Type        string           `json:"type"`
+	Entries     []map[string]any `json:"entries"`
+	CollectedAt string           `json:"collected_at,omitempty"`
 }

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -126,6 +126,7 @@ FULL_ROSTER_HEADER = ",".join(ROSTER_REQUIRED_COLUMNS)
 def main() -> int:
     base_dir = pathlib.Path(os.environ.get("GITHUB_WORKSPACE") or ".").resolve()
     classroom_filter = (os.environ.get("CLASSROOM_FILTER") or "").strip()
+    assignment_filter = (os.environ.get("ASSIGNMENT_FILTER") or "").strip()
 
     org = (os.environ.get("GITHUB_REPOSITORY_OWNER") or "").strip()
     if not org:
@@ -159,7 +160,17 @@ def main() -> int:
 
     total_changes = 0
     failed_classrooms: list[str] = []
+    # Whether ASSIGNMENT_FILTER named a slug that exists in at least one
+    # collected classroom's manifest — a no-match scoped run fails like a
+    # no-match classroom filter.
+    assignment_filter_matched = not assignment_filter
     for classroom_short, classroom_meta, assignments in classroom_dirs:
+        if assignment_filter and any(
+            entry.get("slug") == assignment_filter
+            for entry in assignments.get("assignments") or []
+            if isinstance(entry, dict)
+        ):
+            assignment_filter_matched = True
         scores_path = base_dir / classroom_short / "scores.json"
         try:
             scores = load_scores(scores_path)
@@ -210,6 +221,7 @@ def main() -> int:
                 assignments=assignments,
                 service_token=service_token,
                 roster_meta=load_roster_metadata(base_dir / classroom_short),
+                assignment_filter=assignment_filter,
             )
         except urllib.error.HTTPError as exc:
             # Auth (401/403) and synthetic-network (599) failures on COLLECTION
@@ -245,7 +257,14 @@ def main() -> int:
         # Suppress this when collect_classroom already attributed the empty
         # result to a mode flip (releases present but all rejected): that has
         # its own loud warning, and blaming the token here would misdirect.
-        assignment_count = len(valid_assignment_slugs(assignments))
+        # An assignment-scoped run only polls the filtered slug, so only that
+        # slug counts toward the heuristic's denominator.
+        collectable_slugs = [
+            s
+            for s in valid_assignment_slugs(assignments)
+            if not assignment_filter or s == assignment_filter
+        ]
+        assignment_count = len(collectable_slugs)
         if assignment_count and not updates and not mode_flip_assignments:
             emit_warning(
                 f"{classroom_short}: collected 0 submissions across "
@@ -273,6 +292,15 @@ def main() -> int:
         f"collect: {total_changes} total submission(s) updated across "
         f"{len(classroom_dirs)} classroom(s)"
     )
+    if not assignment_filter_matched:
+        # Same contract as the classroom-filter no-match above: a scoped run
+        # naming an assignment no collected classroom has must fail loudly.
+        emit_error(
+            f"no assignment matches ASSIGNMENT_FILTER={assignment_filter!r} in "
+            f"the collected classroom(s) — check the slug, or pull the latest "
+            f"config repo"
+        )
+        return 1
     if failed_classrooms:
         # Dedup (preserve order): a classroom can be recorded once for a
         # non-fatal staff-grant failure and again for a scores write failure.
@@ -492,6 +520,7 @@ def collect_classroom(
     assignments: dict[str, Any],
     service_token: str,
     roster_meta: dict[str, dict[str, str]] | None = None,
+    assignment_filter: str = "",
 ) -> tuple[list[dict[str, Any]], int]:
     """Return (validated result payloads for every (student, assignment) pair,
     count of assignments whose only submissions were rejected by validation).
@@ -504,6 +533,10 @@ def collect_classroom(
     see load_roster_metadata); when a collected owner has a matching row its
     name/section/email are attached to the entry. Absent/blank is fine — the
     join never gates collection.
+
+    `assignment_filter` (an assignment slug, empty for all) narrows the walk to
+    one assignment — the web app's per-assignment "Sync now" scope. Sibling
+    assignments' buckets in scores.json are untouched (apply_updates upserts).
     """
     roster_meta = roster_meta or {}
     results: list[dict[str, Any]] = []
@@ -561,6 +594,8 @@ def collect_classroom(
     for entry in assignments.get("assignments") or []:
         slug = entry.get("slug")
         if not isinstance(slug, str) or not slug:
+            continue
+        if assignment_filter and slug != assignment_filter:
             continue
         # Assignments that never autograde (empty_repo or no_autograder) —
         # same predicate as valid_assignment_slugs, kept in lockstep.

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -213,7 +213,7 @@ def main() -> int:
             failed_classrooms.append(classroom_short)
 
         try:
-            updates, mode_flip_assignments = collect_classroom(
+            updates, mode_flip_assignments, collected = collect_classroom(
                 api_url=api_url,
                 org=org,
                 classroom_short=classroom_short,
@@ -277,6 +277,16 @@ def main() -> int:
             )
 
         n_changes = apply_updates(scores, updates)
+        # Stamp the buckets this run actually walked (even when nothing changed)
+        # so per-assignment freshness is knowable — an org-wide run timestamp
+        # can't say whether a scoped run touched a given assignment. A bucket
+        # with no submissions yet is created empty so the stamp has a home.
+        collected_at = utc_now_iso()
+        for slug, atype in collected.items():
+            bucket = scores["assignments"].setdefault(
+                slug, {"type": atype, "entries": []}
+            )
+            bucket["collected_at"] = collected_at
         try:
             save_scores(scores_path, scores)
         except ScoresFileError as exc:
@@ -521,13 +531,17 @@ def collect_classroom(
     service_token: str,
     roster_meta: dict[str, dict[str, str]] | None = None,
     assignment_filter: str = "",
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, dict[str, str]]:
     """Return (validated result payloads for every (student, assignment) pair,
-    count of assignments whose only submissions were rejected by validation).
+    count of assignments whose only submissions were rejected by validation,
+    slug -> mode map of the assignments actually walked).
     Per-repo failures warn and skip; hard failures (auth 401/403; network 599)
     propagate and main() converts them to exit 1. The second tuple element lets
     main() distinguish a mode-flip-induced empty result (which has its own loud
-    warning) from a token-access problem.
+    warning) from a token-access problem. The third records which buckets this
+    run refreshed — main() stamps their `collected_at` — and stays empty when
+    collection was skipped wholesale (team unreadable/empty), so a skipped
+    classroom never reads as freshly collected.
 
     `roster_meta` is the best-effort roster join (username -> display metadata,
     see load_roster_metadata); when a collected owner has a matching row its
@@ -541,6 +555,9 @@ def collect_classroom(
     roster_meta = roster_meta or {}
     results: list[dict[str, Any]] = []
     group_attribution_degraded = 0
+    # Assignments this run actually walked (slug -> mode), for `collected_at`
+    # stamping. Populated only past the team-read gate below.
+    collected: dict[str, str] = {}
     # (assignment) buckets where every present submission was rejected by
     # validation (the mode-flip symptom). Returned so main() can suppress its
     # "rotate token" heuristic, which would otherwise misread this as a
@@ -572,20 +589,20 @@ def collect_classroom(
             f"Members: Read (a fine-grained PAT permission) — rotate it with "
             f"`gh teacher rotate-service-token {org}`."
         )
-        return results, mode_flip_assignments
+        return results, mode_flip_assignments, collected
     except (json.JSONDecodeError, ValueError) as exc:
         emit_warning(
             f"{classroom_short}: team {team_slug!r} member listing malformed "
             f"({exc}); skipping collection for this classroom."
         )
-        return results, mode_flip_assignments
+        return results, mode_flip_assignments, collected
 
     if not team_usernames:
         emit_warning(
             f"{classroom_short}: teams {team_slug!r} (and staff teams) have no "
             f"members — no (username, assignment) pairs to poll; skipping."
         )
-        return results, mode_flip_assignments
+        return results, mode_flip_assignments, collected
 
     # Group attribution credits a collaborator only if on a classroom team
     # (owner always credited) — same trust model, team-sourced set. Staff are in
@@ -629,6 +646,7 @@ def collect_classroom(
                 f"expected 'individual' or 'group'; collecting as individual"
             )
         assignment_type = "group" if is_group else "individual"
+        collected[slug] = assignment_type
 
         submitted = 0
         # Staff (non-student-team) members who actually submitted this
@@ -823,7 +841,7 @@ def collect_classroom(
             f"lacks the collaborator-read permission — rotate it with `gh teacher rotate-service-token`."
         )
 
-    return results, mode_flip_assignments
+    return results, mode_flip_assignments, collected
 
 
 def assignment_repo_name(classroom: str, assignment: str, username: str) -> str:
@@ -1030,6 +1048,13 @@ def _dedupe_logins(logins: list[str]) -> list[str]:
 # Due-date / lateness ---------------------------------------------------------
 
 
+def utc_now_iso() -> str:
+    """Now in the schema's timestamp shape (UTC, seconds, trailing Z)."""
+    return datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
 def parse_rfc3339(value: Any) -> datetime.datetime | None:
     """Parse an RFC 3339 timestamp into an aware datetime, or None when it
     isn't one (non-string, unparseable, or missing a timezone offset). Naive
@@ -1155,7 +1180,10 @@ def normalize_assignments(assignments: Any) -> dict[str, dict[str, Any]]:
             raise ValueError(
                 f"assignments[{slug!r}].entries must be a list, got {type(entries).__name__}"
             )
-        normalized[slug] = {"type": atype, "entries": entries}
+        # Spread the whole bucket so unknown fields (e.g. `collected_at`, or
+        # anything a newer writer added) survive this read-modify-write instead
+        # of being silently dropped on the next save.
+        normalized[slug] = {**bucket, "type": atype, "entries": entries}
     return normalized
 
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -145,10 +145,16 @@ def main() -> int:
 
     classroom_dirs = list(iter_classrooms(base_dir, classroom_filter))
     if not classroom_dirs:
-        msg = f"no classrooms found in {base_dir}"
         if classroom_filter:
-            msg += f" matching CLASSROOM_FILTER={classroom_filter!r}"
-        print(msg)
+            # An explicit filter matching nothing is a FAILED run (typo, or a
+            # stale checkout) — a green run that collected nothing would read
+            # as "collected" to the web app's freshness tracking.
+            emit_error(
+                f"no classroom in {base_dir} matches "
+                f"CLASSROOM_FILTER={classroom_filter!r}"
+            )
+            return 1
+        print(f"no classrooms found in {base_dir}")
         return 0
 
     total_changes = 0
@@ -574,7 +580,19 @@ def collect_classroom(
                 f"timestamp with timezone; skipping late-marking for this assignment"
             )
 
-        is_group = (entry.get("mode") or "").lower() == "group"
+        raw_mode = entry.get("mode")
+        is_group = (raw_mode or "").lower() == "group"
+        if isinstance(raw_mode, str) and raw_mode and raw_mode.lower() not in (
+            "individual",
+            "group",
+        ):
+            # A typo'd mode would silently collect as individual and reject
+            # every group submission via the owner-identity check (reading as
+            # a mode flip) — name the real cause up front.
+            emit_warning(
+                f"{classroom_short}/{slug}: unknown mode {raw_mode!r} — "
+                f"expected 'individual' or 'group'; collecting as individual"
+            )
         assignment_type = "group" if is_group else "individual"
 
         submitted = 0
@@ -1017,7 +1035,7 @@ class ScoresFileError(Exception):
 
 
 class AssetMissingError(Exception):
-    """Raised when the latest submit release has no result.json asset."""
+    """Raised when a submit release has no result.json asset."""
 
 
 def strict_json_loads(raw: str) -> Any:
@@ -1453,6 +1471,11 @@ def all_submit_releases(
                     f"GET {url}: expected release object at index {i}, got {type(release).__name__}"
                 )
             if (release.get("tag_name") or "").startswith(SUBMIT_TAG_PREFIX):
+                # A read-write token also lists draft releases. The runner
+                # never publishes drafts, so a draft submit/* tag is hand-made
+                # noise whose assets aren't downloadable anyway — skip it.
+                if release.get("draft") is True:
+                    continue
                 releases.append(release)
         link_header = headers.get("Link") if headers else None
         next_url = _next_page_link(link_header)
@@ -1712,10 +1735,16 @@ def download_result_asset(
         c for c in (release.get("assets") or [])
         if (c.get("name") or "").lower() == RESULT_ASSET_NAME
     ]
+    # Runs once per release in the history walk, so errors name THIS release.
+    release_label = release.get("tag_name") or release.get("url") or "release"
     if not matches:
-        raise AssetMissingError(f"{RESULT_ASSET_NAME} asset missing from latest submit release")
+        raise AssetMissingError(
+            f"{RESULT_ASSET_NAME} asset missing from {release_label}"
+        )
     if len(matches) > 1:
-        raise ValueError(f"latest submit release has {len(matches)} {RESULT_ASSET_NAME} assets")
+        raise ValueError(
+            f"{release_label} has {len(matches)} {RESULT_ASSET_NAME} assets"
+        )
 
     asset_url = matches[0].get("url")
     if not asset_url:

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
@@ -19,6 +19,9 @@ on:
       classroom:
         description: "Classroom short-name (leave blank to collect all)"
         required: false
+      assignment:
+        description: "Assignment slug (leave blank to collect the whole classroom; requires classroom to be meaningful)"
+        required: false
   schedule:
     # Nightly autopilot. Comment out the next line if you only want
     # manual triggers.
@@ -27,8 +30,10 @@ on:
 permissions:
   contents: write       # write scores.json + commit
 
+# Serialize same-scope runs; different scopes may overlap (each writes only its
+# own classroom's scores.json, and the push step rebases on a mid-run advance).
 concurrency:
-  group: collect-${{ github.event.inputs.classroom || 'all' }}
+  group: collect-${{ github.event.inputs.classroom || 'all' }}-${{ github.event.inputs.assignment || 'all' }}
   cancel-in-progress: false
 
 jobs:
@@ -58,6 +63,9 @@ jobs:
           # Optional restriction to a single classroom; empty
           # means "collect all classrooms in this config repo".
           CLASSROOM_FILTER: ${{ github.event.inputs.classroom || '' }}
+          # Optional further restriction to one assignment slug (the web app's
+          # per-assignment "Sync now"); empty means every assignment.
+          ASSIGNMENT_FILTER: ${{ github.event.inputs.assignment || '' }}
         run: python3 .github/scripts/collect_scores.py
 
       - name: Commit and push

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
@@ -67,6 +67,18 @@ jobs:
             git add '*/scores.json'
             git -c user.name=classroom50-bot -c user.email=bot@classroom50 \
                 commit -m "[Classroom 50] collect: refresh scores.json"
+            # The branch can advance mid-run (a teacher edit, or a collect
+            # scoped to another classroom — the concurrency group only
+            # serializes same-scope runs). Rebase our scores.json commit onto
+            # the new tip and retry instead of failing the whole collection.
+            for attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              echo "push rejected (attempt ${attempt}); rebasing onto the remote tip"
+              git -c user.name=classroom50-bot -c user.email=bot@classroom50 \
+                  pull --rebase
+            done
             git push
           else
             echo "no scores.json changes to commit"

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
@@ -30,10 +30,12 @@ on:
 permissions:
   contents: write       # write scores.json + commit
 
-# Serialize same-scope runs; different scopes may overlap (each writes only its
-# own classroom's scores.json, and the push step rebases on a mid-run advance).
+# Serialize same-classroom runs (scoped or not); only runs for DIFFERENT
+# classrooms may overlap. The org-wide nightly ('all') still overlaps a scoped
+# run on the same scores.json, so the push step below rebases with -X theirs to
+# self-resolve the same-line collected_at/entry conflicts that overlap creates.
 concurrency:
-  group: collect-${{ github.event.inputs.classroom || 'all' }}-${{ github.event.inputs.assignment || 'all' }}
+  group: collect-${{ github.event.inputs.classroom || 'all' }}
   cancel-in-progress: false
 
 jobs:
@@ -75,17 +77,26 @@ jobs:
             git add '*/scores.json'
             git -c user.name=classroom50-bot -c user.email=bot@classroom50 \
                 commit -m "[Classroom 50] collect: refresh scores.json"
-            # The branch can advance mid-run (a teacher edit, or a collect
-            # scoped to another classroom — the concurrency group only
-            # serializes same-scope runs). Rebase our scores.json commit onto
-            # the new tip and retry instead of failing the whole collection.
+            # The branch can advance mid-run: a teacher edit, a collect for
+            # another classroom, or the org-wide nightly overlapping a scoped
+            # run on the SAME scores.json (the concurrency group only
+            # serializes same-classroom runs). Rebase our commit onto the new
+            # tip and retry instead of failing the whole collection. -X theirs
+            # self-resolves same-line conflicts (e.g. both runs re-stamped a
+            # bucket's collected_at) in favor of OUR replayed commit — "theirs"
+            # during a rebase is the commit being replayed — so an overlapping
+            # nightly can't abort a teacher's scoped sync. Set -e would kill
+            # the step on a failed pull, so guard it and abort the half-done
+            # rebase before retrying.
             for attempt in 1 2 3; do
               if git push; then
                 exit 0
               fi
               echo "push rejected (attempt ${attempt}); rebasing onto the remote tip"
-              git -c user.name=classroom50-bot -c user.email=bot@classroom50 \
-                  pull --rebase
+              if ! git -c user.name=classroom50-bot -c user.email=bot@classroom50 \
+                  pull --rebase -X theirs; then
+                git rebase --abort || true
+              fi
             done
             git push
           else

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml
@@ -32,8 +32,10 @@ permissions:
 
 # Serialize same-classroom runs (scoped or not); only runs for DIFFERENT
 # classrooms may overlap. The org-wide nightly ('all') still overlaps a scoped
-# run on the same scores.json, so the push step below rebases with -X theirs to
-# self-resolve the same-line collected_at/entry conflicts that overlap creates.
+# run on the same scores.json, so on a push race the step below re-runs the
+# collector against the freshly-pulled tree (re-applying this run's per-owner
+# upserts onto the other run's already-committed entries) instead of a blind
+# text merge that could drop them.
 concurrency:
   group: collect-${{ github.event.inputs.classroom || 'all' }}
   cancel-in-progress: false
@@ -41,6 +43,11 @@ concurrency:
 jobs:
   collect:
     runs-on: ubuntu-latest
+    # Bound the job: the commit/push retry below can loop, and with
+    # cancel-in-progress: false a wedged git operation would otherwise hold the
+    # same-classroom concurrency slot until GitHub's ~6h default, stalling every
+    # queued scoped/nightly run behind it. Fail loudly instead.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -71,34 +78,53 @@ jobs:
         run: python3 .github/scripts/collect_scores.py
 
       - name: Commit and push
+        env:
+          # Re-collection on a push race needs the same inputs as the step above.
+          CLASSROOM50_SERVICE_TOKEN: ${{ secrets.CLASSROOM50_SERVICE_TOKEN }}
+          CLASSROOM_FILTER: ${{ github.event.inputs.classroom || '' }}
+          ASSIGNMENT_FILTER: ${{ github.event.inputs.assignment || '' }}
         run: |
           set -euo pipefail
-          if [ -n "$(git status --porcelain '*/scores.json' 2>/dev/null)" ]; then
+          commit_scores() {
+            if [ -z "$(git status --porcelain '*/scores.json' 2>/dev/null)" ]; then
+              return 1  # nothing to commit
+            fi
             git add '*/scores.json'
             git -c user.name=classroom50-bot -c user.email=bot@classroom50 \
                 commit -m "[Classroom 50] collect: refresh scores.json"
-            # The branch can advance mid-run: a teacher edit, a collect for
-            # another classroom, or the org-wide nightly overlapping a scoped
-            # run on the SAME scores.json (the concurrency group only
-            # serializes same-classroom runs). Rebase our commit onto the new
-            # tip and retry instead of failing the whole collection. -X theirs
-            # self-resolves same-line conflicts (e.g. both runs re-stamped a
-            # bucket's collected_at) in favor of OUR replayed commit — "theirs"
-            # during a rebase is the commit being replayed — so an overlapping
-            # nightly can't abort a teacher's scoped sync. Set -e would kill
-            # the step on a failed pull, so guard it and abort the half-done
-            # rebase before retrying.
-            for attempt in 1 2 3; do
-              if git push; then
-                exit 0
-              fi
-              echo "push rejected (attempt ${attempt}); rebasing onto the remote tip"
-              if ! git -c user.name=classroom50-bot -c user.email=bot@classroom50 \
-                  pull --rebase -X theirs; then
-                git rebase --abort || true
-              fi
-            done
-            git push
-          else
+            return 0
+          }
+
+          if ! commit_scores; then
             echo "no scores.json changes to commit"
+            exit 0
           fi
+
+          # The branch can advance mid-run: a teacher edit, a collect for
+          # another classroom, or the org-wide nightly overlapping a scoped run
+          # on the SAME scores.json (the concurrency group only serializes
+          # same-classroom runs). On a push race, fast-forward to the remote tip
+          # and RE-RUN the collector: apply_updates upserts this run's entries
+          # per repo-owner onto whatever the other run already committed, so no
+          # entry is lost (unlike a text-level `-X theirs` merge, which favored
+          # our replayed commit and could discard the other run's newer entry).
+          # Re-collection is idempotent; the extra API cost is bounded to the
+          # rare contention case and the 3 attempts below.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}); re-collecting onto the remote tip"
+            # Drop our local commit, fast-forward to the remote, and re-run the
+            # collector against the now-current tree.
+            git reset --hard HEAD~1
+            git pull --ff-only
+            python3 .github/scripts/collect_scores.py
+            if ! commit_scores; then
+              # An idempotent re-collect produced no diff — the remote already
+              # carries equivalent data, so there is nothing left to push.
+              echo "re-collect produced no changes; remote already current"
+              exit 0
+            fi
+          done
+          git push

--- a/cli/gh-teacher/skeleton_tests/test_artifact_schemas.py
+++ b/cli/gh-teacher/skeleton_tests/test_artifact_schemas.py
@@ -418,6 +418,24 @@ class TestScoresSchema:
         doc = _scores({"hello": _individual_bucket([_entry(submissions=[bad_record])])})
         assert _errs(SCORES_V, doc) != []
 
+    def test_bucket_collected_at_accepted(self):
+        # The per-bucket freshness stamp, on a populated bucket and on an
+        # empty just-scaffolded one.
+        doc = _scores({
+            "hello": {**_individual_bucket([_entry()]), "collected_at": "2026-06-01T15:00:00Z"},
+            "empty": {"type": "individual", "entries": [], "collected_at": "2026-06-01T15:00:00Z"},
+        })
+        assert _errs(SCORES_V, doc) == []
+
+    def test_bucket_collected_at_malformed_rejected(self):
+        # Must be the schema's UTC-Z timestamp shape, not a bare date or an
+        # offset form.
+        for bad in ("2026-06-01", "2026-06-01T15:00:00+02:00", ""):
+            doc = _scores({
+                "hello": {**_individual_bucket([_entry()]), "collected_at": bad},
+            })
+            assert _errs(SCORES_V, doc) != []
+
     @pytest.mark.parametrize("doc", [
         {"schema": "classroom50/scores/v2", "assignments": {}},        # bad sentinel
         {"schema": "classroom50/scores/v1", "assignments": []},        # array, not an object map

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -853,7 +853,7 @@ class TestGroupCollectClassroom:
         )
         stub_team_members(monkeypatch, ["alice", "bob", "carol"])
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -881,7 +881,7 @@ class TestGroupCollectClassroom:
         )
         stub_team_members(monkeypatch, ["alice", "bob"])
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -911,7 +911,7 @@ class TestGroupCollectClassroom:
         monkeypatch.setattr(cs, "list_repo_collaborator_logins", boom)
         stub_team_members(monkeypatch, ["alice"])
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -942,7 +942,7 @@ class TestGroupCollectClassroom:
         monkeypatch.setattr(cs, "list_repo_collaborator_logins", malformed)
         stub_team_members(monkeypatch, ["alice"])
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -968,7 +968,7 @@ class TestGroupCollectClassroom:
         )
         stub_team_members(monkeypatch, ["alice", "bob"])
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -1004,7 +1004,7 @@ class TestGroupCollectClassroom:
         monkeypatch.setattr(cs, "list_repo_collaborator_logins", lambda *a, **k: ["alice"])
         stub_team_members(monkeypatch, ["alice"])
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -1193,7 +1193,7 @@ class TestCollectClassroomTeamDriven:
             cs, "download_result_asset",
             lambda *a, **k: make_result(username="alice"),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta={}, assignments=self._assignments(), service_token="token",
         )
@@ -1202,7 +1202,7 @@ class TestCollectClassroomTeamDriven:
 
     def test_empty_team_warns_and_collects_nothing(self, monkeypatch, capsys):
         stub_team_members(monkeypatch, [])
-        results, mode_flip = cs.collect_classroom(
+        results, mode_flip, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta={}, assignments=self._assignments(), service_token="token",
         )
@@ -1238,7 +1238,7 @@ class TestCollectClassroomTeamDriven:
             raise urllib.error.HTTPError("u", 404, "Not Found", None, None)
 
         monkeypatch.setattr(cs, "list_team_member_logins", boom)
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta={}, assignments=self._assignments(), service_token="token",
         )
@@ -1308,7 +1308,7 @@ class TestCollectClassroomTeamDriven:
             raise ValueError("expected JSON array, got dict")
 
         monkeypatch.setattr(cs, "list_team_member_logins", boom)
-        results, mode_flip = cs.collect_classroom(
+        results, mode_flip, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta={}, assignments=self._assignments(), service_token="token",
         )
@@ -1397,7 +1397,7 @@ class TestCollectClassroomTeamDriven:
         monkeypatch.setattr(
             cs, "download_result_asset", lambda *a, **k: make_result(username="ta1"),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta=meta, assignments=self._assignments(), service_token="token",
         )
@@ -1425,7 +1425,7 @@ class TestCollectClassroomTeamDriven:
         monkeypatch.setattr(
             cs, "download_result_asset", lambda *a, **k: make_result(username="alice"),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta=meta, assignments=self._assignments(), service_token="token",
         )
@@ -1453,7 +1453,7 @@ class TestCollectClassroomTeamDriven:
         monkeypatch.setattr(
             cs, "download_result_asset", lambda *a, **k: make_result(username="alice"),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta=meta, assignments=self._assignments(), service_token="token",
         )
@@ -1512,7 +1512,7 @@ class TestCollectClassroomTeamDriven:
             cs, "download_result_asset",
             lambda *a, **k: make_result(username=seen["owner"]),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta=meta, assignments=self._assignments(), service_token="token",
         )
@@ -1577,7 +1577,7 @@ class TestLateness:
         monkeypatch.setattr(cs, "download_result_asset", fake_download)
         stub_team_members(monkeypatch, ["alice"])
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -1631,7 +1631,7 @@ class TestRosterMetadataJoin:
             cs, "download_result_asset",
             lambda *a, **k: make_result(username="alice"),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta={}, assignments=self._assignments(), service_token="token",
             roster_meta=cs.load_roster_metadata(tmp_path),
@@ -1965,7 +1965,7 @@ class TestReleaseLookup:
 
         monkeypatch.setattr(cs, "all_submit_releases", malformed_listing)
         stub_team_members(monkeypatch, ["alice"])
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -2050,7 +2050,7 @@ class TestCollectAllSubmissions:
 
         monkeypatch.setattr(cs, "download_result_asset", fake_download)
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -2088,7 +2088,7 @@ class TestCollectAllSubmissions:
 
         monkeypatch.setattr(cs, "download_result_asset", fake_download)
 
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -2107,7 +2107,7 @@ class TestCollectAllSubmissions:
         monkeypatch.setattr(
             cs, "download_result_asset", lambda *a, **k: (_ for _ in ()).throw(ValueError("bad"))
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -2127,7 +2127,7 @@ class TestCollectAllSubmissions:
             cs, "download_result_asset",
             lambda *a, **k: make_result(username="alice", score=7, max_score=10),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -2149,7 +2149,7 @@ class TestCollectAllSubmissions:
             cs, "download_result_asset",
             lambda *a, **k: make_result(username="alice", score=7, max_score=10),
         )
-        results, _ = cs.collect_classroom(
+        results, _, _ = cs.collect_classroom(
             api_url="https://api.github.com",
             org="cs50",
             classroom_short="cs-principles",
@@ -2248,7 +2248,7 @@ class TestMain:
 
         def fake_collect(**kwargs):
             seen.append(kwargs["api_url"])
-            return [], 0
+            return [], 0, {}
 
         monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
@@ -2298,7 +2298,7 @@ class TestMain:
 
         def fake_collect(**kwargs):
             seen.append(kwargs.get("assignment_filter"))
-            return [], 0
+            return [], 0, {}
 
         monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
@@ -2320,7 +2320,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
         monkeypatch.setenv("ASSIGNMENT_FILTER", "no-such-assignment")
-        monkeypatch.setattr(cs, "collect_classroom", lambda **k: ([], 0))
+        monkeypatch.setattr(cs, "collect_classroom", lambda **k: ([], 0, {}))
 
         assert cs.main() == 1
         assert "no-such-assignment" in capsys.readouterr().err
@@ -2382,7 +2382,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
-        monkeypatch.setattr(cs, "collect_classroom", lambda **kwargs: ([], 0))
+        monkeypatch.setattr(cs, "collect_classroom", lambda **kwargs: ([], 0, {}))
 
         assert cs.main() == 0
         err = capsys.readouterr().err
@@ -2401,7 +2401,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
         monkeypatch.setattr(
-            cs, "collect_classroom", lambda **kwargs: ([make_update(username="alice")], 0)
+            cs, "collect_classroom", lambda **kwargs: ([make_update(username="alice")], 0, {"hello": "individual"})
         )
 
         assert cs.main() == 0
@@ -2419,7 +2419,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
-        monkeypatch.setattr(cs, "collect_classroom", lambda **kwargs: ([], 0))
+        monkeypatch.setattr(cs, "collect_classroom", lambda **kwargs: ([], 0, {}))
 
         assert cs.main() == 0
         assert "collected 0 submissions" in capsys.readouterr().err
@@ -2435,7 +2435,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
-        monkeypatch.setattr(cs, "collect_classroom", lambda **kwargs: ([], 0))
+        monkeypatch.setattr(cs, "collect_classroom", lambda **kwargs: ([], 0, {}))
 
         assert cs.main() == 0
         assert "collected 0 submissions" not in capsys.readouterr().err
@@ -2473,7 +2473,7 @@ class TestMain:
 
         def fake_collect(**kwargs):
             collected["called"] = True
-            return [make_update(username="alice")], 0
+            return [make_update(username="alice")], 0, {"hello": "individual"}
 
         monkeypatch.setattr(cs, "grant_classroom_team_access", grant_403)
         monkeypatch.setattr(cs, "collect_classroom", fake_collect)
@@ -2533,7 +2533,7 @@ class TestMain:
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
         monkeypatch.setattr(
             cs, "collect_classroom",
-            lambda **kwargs: ([make_update(username="alice")], 0) if kwargs["classroom_short"] == "z-good" else ([], 0),
+            lambda **kwargs: ([make_update(username="alice")], 0, {"hello": "individual"}) if kwargs["classroom_short"] == "z-good" else ([], 0, {}),
         )
 
         # Run fails (a classroom was bad) but the good classroom is collected.
@@ -2544,6 +2544,109 @@ class TestMain:
         assert "hello" in good_scores["assignments"], (
             "z-good must still be collected even though a-bad failed first"
         )
+
+
+class TestCollectedAtStamp:
+    """Per-bucket `collected_at`: main() stamps every bucket the run actually
+    walked (even unchanged/empty), a skipped bucket keeps its old stamp, and
+    the load path preserves the field across read-modify-write."""
+
+    def _env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+
+    def test_walked_bucket_is_stamped(self, tmp_path, monkeypatch):
+        write_minimal_classroom(tmp_path)
+        self._env(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            cs, "collect_classroom",
+            lambda **kwargs: ([make_update(username="alice")], 0, {"hello": "individual"}),
+        )
+
+        assert cs.main() == 0
+        scores = json.loads((tmp_path / "cs-principles" / "scores.json").read_text())
+        stamp = scores["assignments"]["hello"]["collected_at"]
+        assert cs.RFC3339_RE.fullmatch(stamp), stamp
+
+    def test_walked_bucket_with_no_submissions_is_created_empty_and_stamped(
+        self, tmp_path, monkeypatch
+    ):
+        # Zero submissions is still a completed walk — "checked at T, nothing
+        # found" must be distinguishable from "never collected".
+        write_minimal_classroom(tmp_path)
+        self._env(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            cs, "collect_classroom", lambda **kwargs: ([], 0, {"hello": "individual"})
+        )
+
+        assert cs.main() == 0
+        scores = json.loads((tmp_path / "cs-principles" / "scores.json").read_text())
+        bucket = scores["assignments"]["hello"]
+        assert bucket["type"] == "individual"
+        assert bucket["entries"] == []
+        assert cs.RFC3339_RE.fullmatch(bucket["collected_at"])
+
+    def test_unwalked_bucket_keeps_its_old_stamp(self, tmp_path, monkeypatch):
+        # A scoped run must not refresh (or drop) a sibling bucket's stamp —
+        # this also exercises load_scores preserving unknown bucket fields.
+        classroom = write_minimal_classroom(tmp_path)
+        (classroom / "scores.json").write_text(
+            json.dumps(
+                {
+                    "schema": cs.SCORES_SCHEMA_V1,
+                    "assignments": {
+                        "sibling": {
+                            "type": "individual",
+                            "entries": [],
+                            "collected_at": "2026-01-01T00:00:00Z",
+                        }
+                    },
+                }
+            )
+        )
+        self._env(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            cs, "collect_classroom", lambda **kwargs: ([], 0, {"hello": "individual"})
+        )
+
+        assert cs.main() == 0
+        scores = json.loads((classroom / "scores.json").read_text())
+        assert scores["assignments"]["sibling"]["collected_at"] == "2026-01-01T00:00:00Z"
+        assert "collected_at" in scores["assignments"]["hello"]
+
+    def test_skipped_classroom_returns_no_walked_slugs(self, monkeypatch):
+        # Team unreadable -> collection skipped wholesale; nothing may be
+        # stamped, or a skipped classroom would read as freshly collected.
+        stub_team_members(monkeypatch, [])
+        _, _, collected = cs.collect_classroom(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
+            classroom_meta={},
+            assignments={"assignments": [{"slug": "hello", "name": "H", "mode": "individual", "tests": []}]},
+            service_token="token",
+        )
+        assert collected == {}
+
+    def test_collect_classroom_reports_only_walked_slugs(self, monkeypatch):
+        # The filtered-out sibling and the never-grading assignment are not
+        # walked, so neither may be stamped; the group assignment reports its
+        # mode so an absent bucket can be scaffolded with the right type.
+        stub_team_members(monkeypatch, ["alice"])
+        monkeypatch.setattr(cs, "all_submit_releases", lambda *a, **k: [])
+        _, _, collected = cs.collect_classroom(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
+            classroom_meta={},
+            assignments={
+                "assignments": [
+                    {"slug": "hello", "name": "H", "mode": "group", "tests": []},
+                    {"slug": "other", "name": "O", "mode": "individual", "tests": []},
+                    {"slug": "reading", "name": "R", "mode": "individual", "empty_repo": True, "tests": []},
+                ]
+            },
+            service_token="token",
+            assignment_filter="hello",
+        )
+        assert collected == {"hello": "group"}
 
 
 class TestCollectClassroomModeFlip:
@@ -2569,7 +2672,7 @@ class TestCollectClassroomModeFlip:
         )
         # Manifest now says group.
         stub_team_members(monkeypatch, ["alice"])
-        results, mode_flip = cs.collect_classroom(
+        results, mode_flip, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta={},
             assignments=self._assignments("group"),
@@ -2598,7 +2701,7 @@ class TestCollectClassroomModeFlip:
 
         monkeypatch.setattr(cs, "download_result_asset", _no_asset)
         stub_team_members(monkeypatch, ["alice"])
-        results, mode_flip = cs.collect_classroom(
+        results, mode_flip, _ = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
             classroom_meta={},
             assignments=self._assignments("individual"),
@@ -2739,7 +2842,7 @@ def test_collect_classroom_skips_no_autograder_assignment(monkeypatch, capsys):
     monkeypatch.setattr(cs, "all_submit_releases", fail_releases)
     stub_team_members(monkeypatch, ["alice"])
 
-    results, _ = cs.collect_classroom(
+    results, _, _ = cs.collect_classroom(
         api_url="https://api.github.com",
         org="cs50",
         classroom_short="cs-principles",
@@ -2761,7 +2864,7 @@ def test_collect_classroom_skips_empty_repo_assignment(monkeypatch, capsys):
     monkeypatch.setattr(cs, "all_submit_releases", fail_releases)
     stub_team_members(monkeypatch, ["alice"])
 
-    results, _ = cs.collect_classroom(
+    results, _, _ = cs.collect_classroom(
         api_url="https://api.github.com",
         org="cs50",
         classroom_short="cs-principles",

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1258,6 +1258,30 @@ class TestCollectClassroomTeamDriven:
                 classroom_meta={}, assignments=self._assignments(), service_token="token",
             )
 
+    def test_assignment_filter_polls_only_that_assignment(self, monkeypatch):
+        # The per-assignment scoped collect must not touch sibling assignments'
+        # repos (that's the whole point — a classroom-wide walk is slow and
+        # rate-limit hungry).
+        stub_team_members(monkeypatch, ["alice"])
+        seen_repos = []
+
+        def fake_all(api_url, org, repo, token):
+            seen_repos.append(repo)
+            return []
+
+        monkeypatch.setattr(cs, "all_submit_releases", fake_all)
+        cs.collect_classroom(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
+            classroom_meta={},
+            assignments={"assignments": [
+                {"slug": "hello", "name": "H", "mode": "individual", "tests": []},
+                {"slug": "world", "name": "W", "mode": "individual", "tests": []},
+            ]},
+            service_token="token",
+            assignment_filter="world",
+        )
+        assert seen_repos == ["cs-principles-world-alice"]
+
     def test_dedupes_team_members_case_insensitively(self, monkeypatch):
         stub_team_members(monkeypatch, ["Alice", "alice", "BOB"])
         seen_repos = []
@@ -2265,6 +2289,41 @@ class TestMain:
         monkeypatch.delenv("CLASSROOM_FILTER", raising=False)
 
         assert cs.main() == 0
+
+    def test_assignment_filter_threads_into_collect_classroom(self, tmp_path, monkeypatch):
+        # ASSIGNMENT_FILTER narrows collection to one assignment (the web app's
+        # per-assignment "Sync now"); main() must hand it to collect_classroom.
+        write_minimal_classroom(tmp_path)
+        seen = []
+
+        def fake_collect(**kwargs):
+            seen.append(kwargs.get("assignment_filter"))
+            return [], 0
+
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        monkeypatch.setenv("ASSIGNMENT_FILTER", "hello")
+        monkeypatch.setattr(cs, "collect_classroom", fake_collect)
+
+        assert cs.main() == 0
+        assert seen == ["hello"]
+
+    def test_assignment_filter_matching_nothing_exits_nonzero(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # Same contract as the classroom filter: a scoped dispatch naming an
+        # assignment that exists in NO collected classroom is a failed run, not
+        # a green no-op the web app would read as "collected".
+        write_minimal_classroom(tmp_path)
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        monkeypatch.setenv("ASSIGNMENT_FILTER", "no-such-assignment")
+        monkeypatch.setattr(cs, "collect_classroom", lambda **k: ([], 0))
+
+        assert cs.main() == 1
+        assert "no-such-assignment" in capsys.readouterr().err
 
     def test_hard_http_error_prints_actionable_message(self, tmp_path, monkeypatch, capsys):
         # Hard HTTP failures must surface a clean workflow error,

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -12,10 +12,20 @@ import csv
 import json
 import os
 import pathlib
+import re
 
 import pytest
 
 from conftest import collect_scores as cs
+
+
+# The exact `collected_at` shape the scores-v1 schema (and every reader —
+# Go/TS) enforces: UTC only, seconds precision, trailing `Z`. Stricter than
+# cs.RFC3339_RE, which also accepts offsets and fractional seconds — so a drift
+# of utc_now_iso() to an isoformat()-style output would satisfy RFC3339_RE yet
+# write a document the schema and the other tools reject. Assert the writer's
+# output against THIS pattern, matching the schema's collected_at pattern.
+SCHEMA_UTC_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T([01]\d|2[0-3]):[0-5]\d:[0-5]\dZ$")
 
 
 # Helpers ---------------------------------------------------------------------
@@ -2556,6 +2566,12 @@ class TestCollectedAtStamp:
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
 
+    def test_utc_now_iso_matches_schema_shape(self):
+        # The writer's stamp source must emit the schema's UTC-Z shape directly
+        # (no offset, no fractional seconds) — the direct guard on the helper so
+        # a drift is caught even if the end-to-end stamping tests change.
+        assert SCHEMA_UTC_Z_RE.fullmatch(cs.utc_now_iso())
+
     def test_walked_bucket_is_stamped(self, tmp_path, monkeypatch):
         write_minimal_classroom(tmp_path)
         self._env(tmp_path, monkeypatch)
@@ -2567,7 +2583,10 @@ class TestCollectedAtStamp:
         assert cs.main() == 0
         scores = json.loads((tmp_path / "cs-principles" / "scores.json").read_text())
         stamp = scores["assignments"]["hello"]["collected_at"]
-        assert cs.RFC3339_RE.fullmatch(stamp), stamp
+        # Strict UTC-Z shape, not just cs.RFC3339_RE (which also accepts offsets
+        # / fractional seconds): the schema and the Go/TS readers require this
+        # exact form, so a drift of utc_now_iso() must fail here.
+        assert SCHEMA_UTC_Z_RE.fullmatch(stamp), stamp
 
     def test_walked_bucket_with_no_submissions_is_created_empty_and_stamped(
         self, tmp_path, monkeypatch
@@ -2585,7 +2604,7 @@ class TestCollectedAtStamp:
         bucket = scores["assignments"]["hello"]
         assert bucket["type"] == "individual"
         assert bucket["entries"] == []
-        assert cs.RFC3339_RE.fullmatch(bucket["collected_at"])
+        assert SCHEMA_UTC_Z_RE.fullmatch(bucket["collected_at"])
 
     def test_unwalked_bucket_keeps_its_old_stamp(self, tmp_path, monkeypatch):
         # A scoped run must not refresh (or drop) a sibling bucket's stamp —

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1210,6 +1210,27 @@ class TestCollectClassroomTeamDriven:
         assert mode_flip == 0
         assert "have no members" in capsys.readouterr().err
 
+    def test_unknown_assignment_mode_warns_and_collects_as_individual(
+        self, monkeypatch, capsys
+    ):
+        # A typo'd mode (e.g. "grupo") must not silently collect as an
+        # individual assignment: every submission would be rejected by the
+        # owner-identity check and read as a mode flip. Warn loudly, then
+        # proceed with the individual default (today's fallback behavior).
+        stub_team_members(monkeypatch, ["alice"])
+        monkeypatch.setattr(cs, "all_submit_releases", lambda *a, **k: [])
+        cs.collect_classroom(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs-principles",
+            classroom_meta={},
+            assignments={"assignments": [
+                {"slug": "hello", "name": "H", "mode": "grupo", "tests": []}
+            ]},
+            service_token="token",
+        )
+        err = capsys.readouterr().err
+        assert "grupo" in err
+        assert "individual" in err
+
     def test_team_read_404_warns_and_skips(self, monkeypatch, capsys):
         import urllib.error
 
@@ -1861,6 +1882,17 @@ class TestErrorClassification:
                 "token",
             )
 
+    def test_missing_asset_error_names_the_release_not_latest(self):
+        # download_result_asset runs once PER release (the full history walk),
+        # so its error must name the release it inspected — "latest submit
+        # release" would misdirect debugging toward the wrong release.
+        with pytest.raises(cs.AssetMissingError, match="submit/2026-06-01T10-00-00Z"):
+            cs.download_result_asset(
+                "https://api.github.com",
+                {"tag_name": "submit/2026-06-01T10-00-00Z", "assets": []},
+                "token",
+            )
+
     def test_duplicate_result_assets_are_rejected(self):
         # Normal releases have a single result.json (library uses
         # --clobber). Duplicates make grading ambiguous, so reject.
@@ -2136,6 +2168,28 @@ class TestAllSubmitReleases:
         monkeypatch.setattr(cs, "_http_get_with_headers", boom)
         assert cs.all_submit_releases("https://api.github.com", "o", "r", "token") == []
 
+    def test_skips_draft_releases(self, monkeypatch):
+        # A read-write token also sees draft releases. The runner never
+        # publishes drafts, so a draft submit/* tag is hand-made noise — a
+        # draft's assets aren't downloadable via the public asset URL either,
+        # so ingesting it would fail downstream. Skip drafts entirely.
+        body = json.dumps([
+            {"tag_name": "submit/2026-06-03T10-00-00Z", "draft": True},
+            {"tag_name": "submit/2026-06-01T10-00-00Z", "draft": False},
+            {"tag_name": "submit/2026-05-01T10-00-00Z"},
+        ]).encode("utf-8")
+
+        class NoHeaders:
+            def get(self, name):
+                return None
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", lambda *a, **k: (body, NoHeaders()))
+        releases = cs.all_submit_releases("https://api.github.com", "o", "r", "token")
+        assert [r["tag_name"] for r in releases] == [
+            "submit/2026-06-01T10-00-00Z",
+            "submit/2026-05-01T10-00-00Z",
+        ]
+
     def test_paginates_via_link_header(self, monkeypatch):
         page1 = json.dumps([{"tag_name": f"submit/p1-{i}"} for i in range(100)]).encode("utf-8")
         page2 = json.dumps([{"tag_name": "submit/last"}]).encode("utf-8")
@@ -2185,6 +2239,32 @@ class TestMain:
         monkeypatch.setenv("GH_API_URL", "http://127.0.0.1:9999")
         assert cs.main() == 0
         assert seen == ["http://127.0.0.1:9999"]
+
+    def test_filter_matching_no_classroom_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        # A dispatch scoped to a classroom that doesn't exist in the config
+        # repo (typo, or the repo checkout predates the classroom) must FAIL,
+        # not report a successful run that collected nothing — the web app's
+        # freshness tracking treats a green run as "collected".
+        write_minimal_classroom(tmp_path)
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        monkeypatch.setenv("CLASSROOM_FILTER", "no-such-classroom")
+
+        assert cs.main() == 1
+        err = capsys.readouterr().err
+        assert "no-such-classroom" in err
+
+    def test_no_classrooms_without_filter_still_exits_zero(self, tmp_path, monkeypatch):
+        # An empty config repo with the nightly cron enabled legitimately has
+        # nothing to collect — that stays a clean no-op, unlike a no-match
+        # explicit filter.
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        monkeypatch.delenv("CLASSROOM_FILTER", raising=False)
+
+        assert cs.main() == 0
 
     def test_hard_http_error_prints_actionable_message(self, tmp_path, monkeypatch, capsys):
         # Hard HTTP failures must surface a clean workflow error,

--- a/schemas/scores-v1.schema.json
+++ b/schemas/scores-v1.schema.json
@@ -34,6 +34,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/entry" },
           "description": "One entry per student repo (keyed by owner). `[]` when nothing collected yet."
+        },
+        "collected_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\dZ$",
+          "description": "Optional. The wall-clock UTC instant collection last walked THIS assignment (stamped even when nothing changed, so per-assignment freshness is knowable — an org-wide run timestamp can't say whether a scoped run touched this bucket). Absent on files written before this field existed and on buckets a scoped run skipped."
         }
       }
     },

--- a/web/src/components/submissions/SubmissionRowCells.tsx
+++ b/web/src/components/submissions/SubmissionRowCells.tsx
@@ -137,10 +137,11 @@ export const SubmissionCountCell = ({
 // only sub-lines (late badge, graded-at, live-latest). The student view passes
 // only `datetime`, so the sub-lines collapse away.
 //
-// A detection-only / not-yet-collected teacher row carries no graded submission
-// time (empty `datetime`), so the primary line shows a neutral "not yet
-// collected" placeholder instead of a formatted "Invalid Date". A real latest-
-// push time, when known, still surfaces on the `liveLatestAt` sub-line.
+// A not-yet-collected teacher row without any detectable time (e.g. a
+// milestone tag whose commit lookup failed) carries an empty `datetime`, so
+// the primary line shows a neutral "not yet collected" placeholder instead of
+// a formatted "Invalid Date". Branch-mode commits, canonical submit/* tags,
+// and dated milestone tags all render a real timestamp.
 export const LastSubmittedCell = ({
   datetime,
   late = false,

--- a/web/src/components/submissions/submissionDetailItems.ts
+++ b/web/src/components/submissions/submissionDetailItems.ts
@@ -62,6 +62,9 @@ export function tagDetailItems(
             count: entry.count,
           })
         : detectedTagLabel(entry.label),
+    sublabel: entry.datetime
+      ? formatSubmissionDateTime(entry.datetime)
+      : undefined,
     href: detectedTagHref(entry, org, repo),
     count: entry.count,
   }))

--- a/web/src/domain/assignments/scoreOverride.test.ts
+++ b/web/src/domain/assignments/scoreOverride.test.ts
@@ -223,6 +223,60 @@ describe("editScoreOverride", () => {
     expect(written.assignments[ASSIGNMENT]).toBeUndefined()
   })
 
+  it("clearing the last entry keeps a collector-stamped bucket (collected_at)", async () => {
+    // An empty {type, entries: [], collected_at} bucket is the collector's
+    // "checked at T, nothing found" freshness marker — clearing a manual grade
+    // must not delete it and regress the page to the run-based fallback.
+    const scores = {
+      schema: "classroom50/scores/v1",
+      assignments: {
+        [ASSIGNMENT]: {
+          type: "individual",
+          collected_at: "2026-06-01T15:00:00Z",
+          entries: [
+            {
+              owner: "alice",
+              override: true,
+              submissions: [
+                {
+                  schema: "classroom50/result/v1",
+                  classroom: CLASSROOM,
+                  assignment_type: "individual",
+                  owner: "alice",
+                  submission: "submit/manual-2026-01-01T00-00-00Z",
+                  commit: "submit/manual-2026-01-01T00-00-00Z",
+                  release: "submit/manual-2026-01-01T00-00-00Z",
+                  review: "submit/manual-2026-01-01T00-00-00Z",
+                  datetime: "2026-01-01T00:00:00Z",
+                  score: 5,
+                  "max-score": 10,
+                  tests: [],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }
+    const { client, committed } = makeClient(scores)
+    await editScoreOverride(client, {
+      org: ORG,
+      classroom: CLASSROOM,
+      assignment: ASSIGNMENT,
+      owner: "alice",
+      assignmentType: "individual",
+      clear: true,
+    })
+    const written = JSON.parse(committed()) as WrittenScores
+    const bucket = written.assignments[ASSIGNMENT] as unknown as {
+      entries: unknown[]
+      collected_at?: string
+    }
+    expect(bucket).toBeDefined()
+    expect(bucket.entries).toEqual([])
+    expect(bucket.collected_at).toBe("2026-06-01T15:00:00Z")
+  })
+
   it("clearing an override over a real submission strips override and restores it", async () => {
     const real = {
       schema: "classroom50/result/v1",

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -45,6 +45,8 @@ type ScoreEntry = {
 type AssignmentBucket = {
   type: "individual" | "group"
   entries: ScoreEntry[]
+  // e.g. the collector's `collected_at` — preserved verbatim on RMW.
+  [key: string]: unknown
 }
 
 type ScoresFile = {

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -269,8 +269,11 @@ export async function editScoreOverride(
       }
     }
 
-    // Drop an emptied bucket so the file stays clean.
-    if (bucket.entries.length === 0) {
+    // Drop an emptied bucket so the file stays clean — unless the collector
+    // stamped it: an empty `{type, entries: [], collected_at}` bucket is the
+    // deliberate "checked at T, nothing found" freshness marker, and deleting
+    // it would regress the page to the org-wide run fallback.
+    if (bucket.entries.length === 0 && !("collected_at" in bucket)) {
       delete scores.assignments[assignment]
     } else {
       scores.assignments[assignment] = bucket

--- a/web/src/domain/assignments/submissionDetection.test.ts
+++ b/web/src/domain/assignments/submissionDetection.test.ts
@@ -8,18 +8,23 @@ import {
   detectedTagLabel,
   detectedTagRef,
   jumpableTagEntries,
+  latestDetectedAt,
   resolveSubmissionMode,
   submissionModeBadgeKey,
   submissionModeCountKey,
+  submitTagDatetime,
 } from "./submissionDetection"
 import type { GitHubCommit, GitHubTag } from "@/github-core/types"
 import type { DetectedSubmission } from "./submissionDetection"
 
-function commit(sha: string): GitHubCommit {
+function commit(sha: string, date?: string): GitHubCommit {
   return {
     sha,
     html_url: `https://x/commit/${sha}`,
-    commit: { message: sha },
+    commit: {
+      message: sha,
+      committer: date ? { date } : undefined,
+    },
     author: null,
   }
 }
@@ -46,6 +51,56 @@ describe("detectBranchSubmissions", () => {
     const commits = [commit("c2"), commit("c1")]
     const detected = detectBranchSubmissions(commits, null)
     expect(detectedSubmissionCount(detected)).toBe(2)
+  })
+
+  it("carries each commit's time (committer date, else author date)", () => {
+    const authored: GitHubCommit = {
+      sha: "c1",
+      html_url: "https://x/commit/c1",
+      commit: { message: "c1", author: { date: "2026-06-01T00:00:00Z" } },
+      author: null,
+    }
+    const detected = detectBranchSubmissions(
+      [commit("c2", "2026-06-02T00:00:00Z"), authored],
+      null,
+    )
+    expect(detected.map((d) => d.datetime)).toEqual([
+      "2026-06-02T00:00:00Z",
+      "2026-06-01T00:00:00Z",
+    ])
+  })
+})
+
+describe("latestDetectedAt", () => {
+  it("returns the newest entry time regardless of order", () => {
+    const detected = detectBranchSubmissions(
+      [
+        commit("c1", "2026-06-01T00:00:00Z"),
+        commit("c2", "2026-06-03T00:00:00Z"),
+      ],
+      null,
+    )
+    expect(latestDetectedAt(detected)).toBe("2026-06-03T00:00:00Z")
+  })
+
+  it("returns null when no entry carries a time (tag detection)", () => {
+    const detected = detectTagSubmissions([tag("phase1")], ["phase1"])
+    expect(latestDetectedAt(detected)).toBeNull()
+    expect(latestDetectedAt(undefined)).toBeNull()
+  })
+
+  it("ignores unparseable datetimes", () => {
+    expect(
+      latestDetectedAt([
+        { kind: "commit", label: "bad", count: 1, datetime: "not-a-date" },
+        {
+          kind: "commit",
+          label: "ok",
+          count: 1,
+          datetime: "2026-06-02T00:00:00Z",
+        },
+      ]),
+    ).toBe("2026-06-02T00:00:00Z")
   })
 })
 
@@ -91,6 +146,51 @@ describe("detectTagSubmissions", () => {
     expect(detectedSubmissionCount(detected)).toBe(3)
     expect(detected[0]).toMatchObject({ kind: "tag", label: "v1" })
     expect(detected[1]).toMatchObject({ kind: "tag-group", count: 2 })
+  })
+
+  it("decodes a canonical submit/* tag's time from its name", () => {
+    const detected = detectTagSubmissions(
+      [tag("submit/2026-06-20T10-30-00Z-abc1234")],
+      ["submit/*"],
+    )
+    expect(detected[0].datetime).toBe("2026-06-20T10:30:00Z")
+  })
+
+  it("dates a submit/* group by its newest member and uses that member's sha", () => {
+    const older = tag("submit/2026-06-19T08-00-00Z-abc1234", "sha-old")
+    const newer = tag("submit/2026-06-21T09-00-00Z-def5678", "sha-new")
+    const detected = detectTagSubmissions([older, newer], ["submit/*"])
+    expect(detected[0]).toMatchObject({
+      kind: "tag-group",
+      count: 2,
+      sha: "sha-new",
+      datetime: "2026-06-21T09:00:00Z",
+    })
+  })
+
+  it("leaves a milestone tag/group dateless (its time comes from a commit lookup)", () => {
+    const detected = detectTagSubmissions(
+      [tag("phase1"), tag("v1"), tag("v2")],
+      ["phase1", "v*"],
+    )
+    expect(detected[0].datetime).toBeUndefined()
+    expect(detected[1].datetime).toBeUndefined()
+    // Without an encoded time the group keeps the list's first match as sha.
+    expect(detected[1].sha).toBe("sha-v1")
+  })
+})
+
+describe("submitTagDatetime", () => {
+  it("parses the buildSubmitTag format back to ISO", () => {
+    expect(submitTagDatetime("submit/2026-06-20T10-30-05Z-abc1234")).toBe(
+      "2026-06-20T10:30:05Z",
+    )
+  })
+
+  it("returns undefined for milestone and malformed names", () => {
+    expect(submitTagDatetime("phase1")).toBeUndefined()
+    expect(submitTagDatetime("submit/not-a-timestamp")).toBeUndefined()
+    expect(submitTagDatetime("submit/2026-06-20T10-30-05Z")).toBeUndefined()
   })
 })
 

--- a/web/src/domain/assignments/submissionDetection.ts
+++ b/web/src/domain/assignments/submissionDetection.ts
@@ -13,12 +13,16 @@ import type { SubmissionMode } from "@/types/classroom"
 // One detected submission (or grouped set, for a glob). `count` is the number of
 // underlying commits/tags it represents (1 for a single commit or exact tag; N
 // for a glob group). `label` names it for the UI (a tag name, a glob pattern, or
-// a commit sha); `sha` points at the underlying commit when known.
+// a commit sha); `sha` points at the underlying commit when known. `datetime`
+// is the submission's ISO time when the source carries one: branch-mode
+// commits always do, canonical submit/* tags encode it in the name, and
+// milestone tags get it filled by a per-commit lookup in the fan-out.
 export type DetectedSubmission = {
   kind: "commit" | "tag" | "tag-group"
   label: string
   count: number
   sha?: string
+  datetime?: string
 }
 
 // A glob pattern uses any Actions tag-filter metacharacter; an exact pattern is
@@ -42,7 +46,22 @@ export function detectBranchSubmissions(
       label: c.sha.slice(0, 7),
       count: 1,
       sha: c.sha,
+      datetime: c.commit.committer?.date ?? c.commit.author?.date,
     }))
+}
+
+// The submission time encoded in a canonical submit/<UTC-ts>-<short-sha> tag
+// name (buildSubmitTag replaces the timestamp's colons with dashes to keep the
+// ref valid). The one tag-mode time that costs no extra API call — the
+// lightweight tags list carries no dates. Undefined for milestone/malformed
+// names; those fall back to a per-commit date lookup in the fan-out.
+export function submitTagDatetime(tagName: string): string | undefined {
+  const m = /^submit\/(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})Z-/.exec(
+    tagName,
+  )
+  if (!m) return undefined
+  const iso = `${m[1]}T${m[2]}:${m[3]}:${m[4]}Z`
+  return Number.isFinite(new Date(iso).getTime()) ? iso : undefined
 }
 
 // Tag mode: for each configured pattern, an EXACT pattern yields one submission
@@ -64,11 +83,17 @@ export function detectTagSubmissions(
     for (const t of matches) claimed.add(t.name)
 
     if (isGlobPattern(pattern)) {
+      // A group's time and representative sha come from its newest member by
+      // encoded submit/* timestamp; without any parseable name (a milestone
+      // glob) keep the list's first match and leave the time for the
+      // per-commit lookup.
+      const newest = newestByEncodedTime(matches)
       detected.push({
         kind: "tag-group",
         label: pattern,
         count: matches.length,
-        sha: matches[0].commit.sha,
+        sha: (newest ?? matches[0]).commit.sha,
+        datetime: newest ? submitTagDatetime(newest.name) : undefined,
       })
     } else {
       for (const t of matches) {
@@ -77,12 +102,30 @@ export function detectTagSubmissions(
           label: t.name,
           count: 1,
           sha: t.commit.sha,
+          datetime: submitTagDatetime(t.name),
         })
       }
     }
   }
 
   return detected
+}
+
+// The tag with the newest submit/*-encoded timestamp, or null when none of the
+// names encode one.
+function newestByEncodedTime(tags: GitHubTag[]): GitHubTag | null {
+  let best: GitHubTag | null = null
+  let bestMs = -Infinity
+  for (const t of tags) {
+    const iso = submitTagDatetime(t.name)
+    if (!iso) continue
+    const ms = new Date(iso).getTime()
+    if (ms > bestMs) {
+      best = t
+      bestMs = ms
+    }
+  }
+  return best
 }
 
 // The total number of submissions a detected set represents — the sum of each
@@ -92,6 +135,25 @@ export function detectedSubmissionCount(
   detected: DetectedSubmission[],
 ): number {
   return detected.reduce((sum, d) => sum + d.count, 0)
+}
+
+// The newest detected submission time, or null when no entry carries one.
+// Robust against callers that don't preserve newest-first order; unparseable
+// datetimes are ignored.
+export function latestDetectedAt(
+  detected: DetectedSubmission[] | undefined,
+): string | null {
+  let best: string | null = null
+  let bestMs = -Infinity
+  for (const d of detected ?? []) {
+    if (!d.datetime) continue
+    const ms = new Date(d.datetime).getTime()
+    if (Number.isFinite(ms) && ms > bestMs) {
+      best = d.datetime
+      bestMs = ms
+    }
+  }
+  return best
 }
 
 // The entries that can be "jumped to" as a tag: branch-mode `commit` entries

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -285,6 +285,13 @@ export function is422NoCommitsBetween(err: unknown): boolean {
   return is422Mentioning(err, "no commits between")
 }
 
+// The workflow_dispatch 422 for inputs the workflow file doesn't declare
+// ("Unexpected inputs provided") — the signal that the org's config repo
+// carries an older workflow than this app expects.
+export function is422UnexpectedInputs(err: unknown): boolean {
+  return is422Mentioning(err, "unexpected inputs")
+}
+
 function is422Mentioning(err: unknown, needle: string): boolean {
   if (!(err instanceof GitHubAPIError) || err.status !== 422) return false
   if (err.message.toLowerCase().includes(needle)) return true

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -105,6 +105,7 @@ export {
   triggerScoreCollection,
   triggerRegrade,
   rerunFailedRun,
+  CollectInputsUnsupportedError,
 } from "./mutations/workflowDispatch"
 export {
   addRepoCollaborator,

--- a/web/src/github-core/mutations/workflowDispatch.test.ts
+++ b/web/src/github-core/mutations/workflowDispatch.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import {
+  CollectInputsUnsupportedError,
+  triggerScoreCollection,
+} from "./workflowDispatch"
+import type { GitHubClient } from "../client"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const unexpectedInputs422 = () =>
+  new GitHubAPIError({
+    status: 422,
+    url: "https://api.github.com/x",
+    message: "Unexpected inputs provided",
+    body: { message: "Unexpected inputs provided" },
+    rateLimit: noRateLimit,
+  })
+
+// A client stub for the three calls triggerScoreCollection makes: getRepo,
+// the baseline runs read, and the dispatch POST (whose behavior varies per
+// test via `onDispatch`).
+const makeClient = (onDispatch: () => unknown) => {
+  const request = vi.fn((url: string) => {
+    if (url.endsWith("/repos/acme/classroom50")) {
+      return Promise.resolve({ default_branch: "main" })
+    }
+    if (url.includes("/runs?")) {
+      return Promise.resolve({ workflow_runs: [{ id: 41 }] })
+    }
+    try {
+      return Promise.resolve(onDispatch())
+    } catch (err) {
+      return Promise.reject(err as Error)
+    }
+  })
+  return { client: { request } as unknown as GitHubClient, request }
+}
+
+describe("triggerScoreCollection", () => {
+  it("dispatches with empty inputs when unscoped", async () => {
+    const { client, request } = makeClient(() => ({}))
+
+    const result = await triggerScoreCollection(client, "acme")
+
+    expect(result.sinceRunId).toBe(41)
+    const dispatchCall = request.mock.calls.find(([url]) =>
+      (url as string).endsWith("/dispatches"),
+    )
+    expect(dispatchCall?.[1]).toMatchObject({
+      method: "POST",
+      body: { ref: "main", inputs: {} },
+    })
+  })
+
+  it("sends classroom + assignment inputs when scoped", async () => {
+    const { client, request } = makeClient(() => ({}))
+
+    await triggerScoreCollection(client, "acme", {
+      classroom: "cs50",
+      assignment: "hello",
+    })
+
+    const dispatchCall = request.mock.calls.find(([url]) =>
+      (url as string).endsWith("/dispatches"),
+    )
+    expect(dispatchCall?.[1]).toMatchObject({
+      body: { inputs: { classroom: "cs50", assignment: "hello" } },
+    })
+  })
+
+  it("maps a scoped 422 'unexpected inputs' to CollectInputsUnsupportedError", async () => {
+    const { client } = makeClient(() => {
+      throw unexpectedInputs422()
+    })
+
+    await expect(
+      triggerScoreCollection(client, "acme", {
+        classroom: "cs50",
+        assignment: "hello",
+      }),
+    ).rejects.toBeInstanceOf(CollectInputsUnsupportedError)
+  })
+
+  it("rethrows an unscoped 422 unchanged (not an outdated-workflow signal)", async () => {
+    const { client } = makeClient(() => {
+      throw unexpectedInputs422()
+    })
+
+    await expect(
+      triggerScoreCollection(client, "acme"),
+    ).rejects.toBeInstanceOf(GitHubAPIError)
+  })
+
+  it("rethrows other scoped dispatch errors unchanged", async () => {
+    const { client } = makeClient(() => {
+      throw new GitHubAPIError({
+        status: 403,
+        url: "https://api.github.com/x",
+        message: "Forbidden",
+        body: null,
+        rateLimit: noRateLimit,
+      })
+    })
+
+    await expect(
+      triggerScoreCollection(client, "acme", {
+        classroom: "cs50",
+        assignment: "hello",
+      }),
+    ).rejects.toBeInstanceOf(GitHubAPIError)
+  })
+})

--- a/web/src/github-core/mutations/workflowDispatch.test.ts
+++ b/web/src/github-core/mutations/workflowDispatch.test.ts
@@ -29,7 +29,7 @@ const unexpectedInputs422 = () =>
 // the baseline runs read, and the dispatch POST (whose behavior varies per
 // test via `onDispatch`).
 const makeClient = (onDispatch: () => unknown) => {
-  const request = vi.fn((url: string) => {
+  const request = vi.fn((url: string, _options?: unknown) => {
     if (url.endsWith("/repos/acme/classroom50")) {
       return Promise.resolve({ default_branch: "main" })
     }

--- a/web/src/github-core/mutations/workflowDispatch.test.ts
+++ b/web/src/github-core/mutations/workflowDispatch.test.ts
@@ -29,19 +29,21 @@ const unexpectedInputs422 = () =>
 // the baseline runs read, and the dispatch POST (whose behavior varies per
 // test via `onDispatch`).
 const makeClient = (onDispatch: () => unknown) => {
-  const request = vi.fn((url: string, _options?: unknown) => {
-    if (url.endsWith("/repos/acme/classroom50")) {
-      return Promise.resolve({ default_branch: "main" })
-    }
-    if (url.includes("/runs?")) {
-      return Promise.resolve({ workflow_runs: [{ id: 41 }] })
-    }
-    try {
-      return Promise.resolve(onDispatch())
-    } catch (err) {
-      return Promise.reject(err as Error)
-    }
-  })
+  const request = vi.fn<(url: string, options?: unknown) => Promise<unknown>>(
+    (url) => {
+      if (url.endsWith("/repos/acme/classroom50")) {
+        return Promise.resolve({ default_branch: "main" })
+      }
+      if (url.includes("/runs?")) {
+        return Promise.resolve({ workflow_runs: [{ id: 41 }] })
+      }
+      try {
+        return Promise.resolve(onDispatch())
+      } catch (err) {
+        return Promise.reject(err as Error)
+      }
+    },
+  )
   return { client: { request } as unknown as GitHubClient, request }
 }
 
@@ -95,9 +97,9 @@ describe("triggerScoreCollection", () => {
       throw unexpectedInputs422()
     })
 
-    await expect(
-      triggerScoreCollection(client, "acme"),
-    ).rejects.toBeInstanceOf(GitHubAPIError)
+    await expect(triggerScoreCollection(client, "acme")).rejects.toBeInstanceOf(
+      GitHubAPIError,
+    )
   })
 
   it("rethrows other scoped dispatch errors unchanged", async () => {

--- a/web/src/github-core/mutations/workflowDispatch.ts
+++ b/web/src/github-core/mutations/workflowDispatch.ts
@@ -1,10 +1,25 @@
 import type { GitHubClient } from "../client"
+import { is422UnexpectedInputs } from "../errors"
 import { getRepo } from "../repoReads"
 import { COLLECT_SCORES_WORKFLOW, REGRADE_WORKFLOW } from "../workflows"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { logger } from "@/lib/logger"
 
 const logWorkflows = logger.scope("github:workflows")
+
+// The org's collect-scores.yaml predates the `assignment` dispatch input, so
+// GitHub rejected the scoped dispatch with a 422 ("Unexpected inputs"). The
+// message is developer-facing (logs); the view layer maps this class to a
+// translated "update your config repo" explanation.
+export class CollectInputsUnsupportedError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "collect-scores.yaml does not declare the `assignment` input; the config repo's workflows are out of date",
+    )
+    this.name = "CollectInputsUnsupportedError"
+    this.cause = cause
+  }
+}
 
 /**
  * Dispatches the classroom50 repo's `collect-scores.yaml` workflow (the same
@@ -16,13 +31,15 @@ const logWorkflows = logger.scope("github:workflows")
  * triggered run as the oldest dispatch run with a larger id — monotonic, so no
  * clock comparison and unambiguous when dispatches race.
  *
- * @param classroom optional dispatch input to scope collection to one classroom;
- *   callers currently omit it to collect org-wide.
+ * @param scope optional dispatch inputs narrowing the collection to one
+ *   classroom, or one assignment within it; omitted collects org-wide.
+ *   Sending `assignment` against a config repo whose workflow predates the
+ *   input throws CollectInputsUnsupportedError.
  */
 export async function triggerScoreCollection(
   client: GitHubClient,
   org: string | undefined,
-  classroom?: string,
+  scope?: { classroom: string; assignment?: string },
 ): Promise<{ sinceRunId: number | null }> {
   if (!org) throw new Error("org must be specified to collect scores")
 
@@ -41,18 +58,36 @@ export async function triggerScoreCollection(
   )
   const sinceRunId = baseline.workflow_runs?.[0]?.id ?? null
 
-  await client.request(
-    `/repos/${org}/${CONFIG_REPO}/actions/workflows/${COLLECT_SCORES_WORKFLOW}/dispatches`,
-    {
-      method: "POST",
-      body: {
-        ref,
-        inputs: classroom ? { classroom } : {},
-      },
-    },
-  )
+  const inputs: Record<string, string> = {}
+  if (scope) {
+    inputs.classroom = scope.classroom
+    if (scope.assignment) inputs.assignment = scope.assignment
+  }
 
-  logWorkflows.info("dispatched collect-scores", { org, classroom, sinceRunId })
+  try {
+    await client.request(
+      `/repos/${org}/${CONFIG_REPO}/actions/workflows/${COLLECT_SCORES_WORKFLOW}/dispatches`,
+      {
+        method: "POST",
+        body: { ref, inputs },
+      },
+    )
+  } catch (err) {
+    // Only the `assignment` input is newer than the long-standing `classroom`
+    // one, so a 422 "unexpected inputs" on a scoped dispatch means the config
+    // repo's workflow predates per-assignment collection.
+    if (scope?.assignment && is422UnexpectedInputs(err)) {
+      throw new CollectInputsUnsupportedError(err)
+    }
+    throw err
+  }
+
+  logWorkflows.info("dispatched collect-scores", {
+    org,
+    classroom: scope?.classroom ?? "(all)",
+    assignment: scope?.assignment ?? "(all)",
+    sinceRunId,
+  })
   return { sinceRunId }
 }
 

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -53,6 +53,7 @@ export {
 export {
   listDefaultBranchCommits,
   listRepoTags,
+  getCommitDatetime,
   defaultBranchCommitsQuery,
   repoTagsQuery,
 } from "./queries/repoDetectionReads"

--- a/web/src/github-core/queries/releaseRunReads.test.ts
+++ b/web/src/github-core/queries/releaseRunReads.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from "vitest"
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 import {
   classifyServiceTokenExpiry,
+  getCollectScoresRunAfterId,
+  getLastCollectScoresRun,
   getServiceTokenStatus,
   latestSubmitReleaseAndCount,
   latestSubmitReleaseWithAssets,
@@ -276,5 +278,54 @@ describe("latestSubmitReleaseAndCount", () => {
     await expect(
       latestSubmitReleaseAndCount(clientThrowing(apiError(403)), "o", "r"),
     ).rejects.toThrow()
+  })
+})
+
+// A paging-aware client mock for the workflow-runs endpoint: serves per_page
+// slices of `allRuns` (newest-first) keyed by the request's `page` param.
+const runsClient = (allRuns: { id: number }[]) => {
+  const request = vi.fn().mockImplementation((url: string) => {
+    const params = new URL(`https://api.github.com${url}`).searchParams
+    const perPage = Number(params.get("per_page") ?? "1")
+    const page = Number(params.get("page") ?? "1")
+    const start = (page - 1) * perPage
+    return Promise.resolve({
+      workflow_runs: allRuns.slice(start, start + perPage),
+    })
+  })
+  return { client: { request } as unknown as GitHubClient, request }
+}
+
+describe("getCollectScoresRunAfterId", () => {
+  it("binds to the oldest run newer than the baseline", async () => {
+    const { client } = runsClient([{ id: 30 }, { id: 20 }, { id: 10 }])
+    const run = await getCollectScoresRunAfterId(client, "acme", 10)
+    expect(run?.id).toBe(20)
+  })
+
+  it("returns null while our run has not registered yet", async () => {
+    const { client } = runsClient([{ id: 10 }])
+    expect(await getCollectScoresRunAfterId(client, "acme", 10)).toBeNull()
+  })
+
+  it("pages past the first page when many dispatches piled up", async () => {
+    // 35 runs newer than the baseline (ids 45..11 newest-first) push our own
+    // run (id 11) off a single 30-run page; the reader must keep paging until
+    // it sees the baseline, not bind to a later dispatch on page 1.
+    const newer = Array.from({ length: 35 }, (_, i) => ({ id: 45 - i }))
+    const { client, request } = runsClient([...newer, { id: 10 }])
+    const run = await getCollectScoresRunAfterId(client, "acme", 10)
+    expect(run?.id).toBe(11)
+    expect(request.mock.calls.length).toBeGreaterThan(1)
+  })
+})
+
+describe("getLastCollectScoresRun", () => {
+  it("asks for the last SUCCESSFUL run, so a failed collection never reads as fresh", async () => {
+    const { client, request } = runsClient([{ id: 5 }])
+    const run = await getLastCollectScoresRun(client, "acme")
+    expect(run?.id).toBe(5)
+    const url = String(request.mock.calls[0][0])
+    expect(url).toContain("status=success")
   })
 })

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -287,45 +287,23 @@ async function listLatestWorkflowRun(
 // POST). Binding to our own run avoids mistaking a concurrent dispatch for ours
 // and needs no clock. Null until our run registers; `sinceRunId === null` means
 // no prior runs, so the oldest run on the first page is ours.
-export async function getCollectScoresRunAfterId(
-  client: GitHubClient,
-  org: string,
-  sinceRunId: number | null,
-  signal?: AbortSignal,
-): Promise<GitHubWorkflowRun | null> {
-  const runs = await listLatestWorkflowRun(
-    client,
-    org,
-    { event: "workflow_dispatch", perPage: 20 },
-    signal,
-  )
-
-  // runs come newest-first; the run we triggered is the oldest one newer than
-  // the pre-dispatch baseline.
-  const newer =
-    sinceRunId === null ? runs : runs.filter((r) => r.id > sinceRunId)
-  return newer.length > 0 ? newer[newer.length - 1] : null
-}
-
-// Finds the regrade run we dispatched, by the same monotonic-id binding as
-// getCollectScoresRunAfterId but against regrade.yaml. Null until our run
-// registers.
 //
-// Unlike collect (one org-wide dispatcher), regrade can fan out one dispatch per
-// student via the per-row buttons, so far more than a page of dispatch runs can
-// pile up between our snapshot and this poll. A fixed first page would let our
-// own run scroll off and bind us to a later student's run. So we page
-// newest-first, accumulating only runs with id > sinceRunId, and stop once a
-// page contains a run at/below the baseline (everything older is irrelevant) or
-// we hit the page cap. The bound run is the oldest such run.
-const REGRADE_RUNS_PER_PAGE = 30
-const REGRADE_MAX_PAGES = 10
+// Both dispatch trackers (collect-scores and regrade) share this: more than a
+// page of dispatch runs can pile up between the snapshot and this poll (regrade
+// fans out per-student; collect can race concurrent viewers), and a fixed first
+// page would let our own run scroll off and bind us to a later dispatch. So we
+// page newest-first, accumulating only runs with id > sinceRunId, and stop once
+// a page contains a run at/below the baseline (everything older is irrelevant)
+// or we hit the page cap. The bound run is the oldest such run.
+const DISPATCH_RUNS_PER_PAGE = 30
+const DISPATCH_RUNS_MAX_PAGES = 10
 
-export async function getRegradeRunAfterId(
+async function getDispatchRunAfterId(
   client: GitHubClient,
   org: string,
   sinceRunId: number | null,
-  signal?: AbortSignal,
+  signal: AbortSignal | undefined,
+  workflow: string,
 ): Promise<GitHubWorkflowRun | null> {
   // No prior runs: our run is the oldest dispatch run that exists, so a single
   // newest-first page is enough — the last entry is the earliest run.
@@ -333,9 +311,9 @@ export async function getRegradeRunAfterId(
     const runs = await listLatestWorkflowRun(
       client,
       org,
-      { event: "workflow_dispatch", perPage: REGRADE_RUNS_PER_PAGE },
+      { event: "workflow_dispatch", perPage: DISPATCH_RUNS_PER_PAGE },
       signal,
-      REGRADE_WORKFLOW,
+      workflow,
     )
     return runs.length > 0 ? runs[runs.length - 1] : null
   }
@@ -343,13 +321,13 @@ export async function getRegradeRunAfterId(
   // Page through dispatch runs (newest-first) collecting those newer than the
   // baseline. Stop once a page reaches the baseline or yields nothing.
   const newer: GitHubWorkflowRun[] = []
-  for (let page = 1; page <= REGRADE_MAX_PAGES; page++) {
+  for (let page = 1; page <= DISPATCH_RUNS_MAX_PAGES; page++) {
     const runs = await listLatestWorkflowRun(
       client,
       org,
-      { event: "workflow_dispatch", perPage: REGRADE_RUNS_PER_PAGE, page },
+      { event: "workflow_dispatch", perPage: DISPATCH_RUNS_PER_PAGE, page },
       signal,
-      REGRADE_WORKFLOW,
+      workflow,
     )
     if (runs.length === 0) break
 
@@ -366,9 +344,40 @@ export async function getRegradeRunAfterId(
   return newer.length > 0 ? newer[newer.length - 1] : null
 }
 
-// The most recent *completed* collect-scores run (cron or manual), or null if
-// the workflow has never completed. Used for the "last collected" timestamp;
-// status=completed stops an in-flight newer run from hiding the prior one.
+export async function getCollectScoresRunAfterId(
+  client: GitHubClient,
+  org: string,
+  sinceRunId: number | null,
+  signal?: AbortSignal,
+): Promise<GitHubWorkflowRun | null> {
+  return getDispatchRunAfterId(
+    client,
+    org,
+    sinceRunId,
+    signal,
+    COLLECT_SCORES_WORKFLOW,
+  )
+}
+
+export async function getRegradeRunAfterId(
+  client: GitHubClient,
+  org: string,
+  sinceRunId: number | null,
+  signal?: AbortSignal,
+): Promise<GitHubWorkflowRun | null> {
+  return getDispatchRunAfterId(
+    client,
+    org,
+    sinceRunId,
+    signal,
+    REGRADE_WORKFLOW,
+  )
+}
+
+// The most recent *successful* collect-scores run (cron or manual), or null if
+// the workflow has never succeeded. Used for the "last collected" timestamp;
+// a completed-but-FAILED run committed nothing, so counting it would make a
+// stale snapshot read as fresh and hide the "Sync now" prompt.
 export async function getLastCollectScoresRun(
   client: GitHubClient,
   org: string,
@@ -377,7 +386,7 @@ export async function getLastCollectScoresRun(
   const runs = await listLatestWorkflowRun(
     client,
     org,
-    { status: "completed" },
+    { status: "success" },
     signal,
   )
   return runs[0] ?? null

--- a/web/src/github-core/queries/repoDetectionReads.ts
+++ b/web/src/github-core/queries/repoDetectionReads.ts
@@ -53,6 +53,27 @@ export async function listRepoTags(
   )
 }
 
+// One commit's ISO time (committer date, else author date), or null when the
+// commit can't be read or carries no date. Used to date a milestone tag —
+// the tags list is dateless and only canonical submit/* names encode a time.
+export async function getCommitDatetime(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  sha: string,
+): Promise<string | null> {
+  const commit = await tolerateGitHubError(
+    () =>
+      client.request<GitHubCommit>(
+        `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+          repo,
+        )}/commits/${encodeURIComponent(sha)}`,
+      ),
+    null,
+  )
+  return commit?.commit.committer?.date ?? commit?.commit.author?.date ?? null
+}
+
 export function defaultBranchCommitsQuery(
   client: GitHubClient,
   owner: string,

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -295,6 +295,12 @@ export type GitHubCommit = {
       name?: string
       date?: string
     }
+    // Committer date is when the commit object was (re)created — the better
+    // "when was this pushed" proxy, since author date survives rebases.
+    committer?: {
+      name?: string
+      date?: string
+    }
   }
   // The GitHub account, when the commit author is a known user (null for a
   // workflow/bot-authored commit that isn't linked to an account).

--- a/web/src/hooks/useDetectedSubmissions.test.tsx
+++ b/web/src/hooks/useDetectedSubmissions.test.tsx
@@ -48,6 +48,8 @@ const base = {
 
 // A URL router for the branch-mode reads: repo object (default_branch),
 // the marker commit list (baseline), and the default-branch commit log.
+// Branch commits get a representative `commit` payload (the real list-commits
+// response always carries one) so detection can read the commit time.
 function branchClient(opts: {
   defaultBranch?: string | null
   baselineCommits?: Array<{ sha: string }>
@@ -63,7 +65,15 @@ function branchClient(opts: {
       return Promise.resolve(opts.baselineCommits ?? [])
     }
     if (url.includes("/commits?sha=")) {
-      return Promise.resolve(opts.branchCommits ?? [])
+      return Promise.resolve(
+        (opts.branchCommits ?? []).map((c) => ({
+          ...c,
+          commit: {
+            message: c.sha,
+            committer: { date: "2026-06-20T10:00:00Z" },
+          },
+        })),
+      )
     }
     return Promise.resolve([])
   }
@@ -147,15 +157,20 @@ describe("useDetectedSubmissions — branch mode", () => {
 
 describe("useDetectedSubmissions — tag mode", () => {
   it("groups glob-matching tags into one submission set", async () => {
-    request.mockImplementation((url: string) =>
-      url.includes("/tags")
-        ? Promise.resolve([
-            { name: "v1", commit: { sha: "a" } },
-            { name: "v2", commit: { sha: "b" } },
-            { name: "other", commit: { sha: "c" } },
-          ])
-        : Promise.resolve([]),
-    )
+    request.mockImplementation((url: string) => {
+      if (url.includes("/tags"))
+        return Promise.resolve([
+          { name: "v1", commit: { sha: "a" } },
+          { name: "v2", commit: { sha: "b" } },
+          { name: "other", commit: { sha: "c" } },
+        ])
+      if (url.includes("/commits/"))
+        return Promise.resolve({
+          sha: "a",
+          commit: { message: "m", committer: { date: "2026-06-20T10:00:00Z" } },
+        })
+      return Promise.resolve([])
+    })
     const { result } = renderHook(
       () =>
         useDetectedSubmissions({
@@ -172,7 +187,35 @@ describe("useDetectedSubmissions — tag mode", () => {
     expect(result.current.detected[0].entries[0]).toMatchObject({
       kind: "tag-group",
       label: "v*",
+      // A milestone group's time comes from its representative commit lookup.
+      datetime: "2026-06-20T10:00:00Z",
     })
+  })
+
+  it("leaves a milestone tag dateless when its commit lookup 404s, without erroring", async () => {
+    request.mockImplementation((url: string) => {
+      if (url.includes("/tags"))
+        return Promise.resolve([{ name: "phase1", commit: { sha: "a" } }])
+      if (url.includes("/commits/")) return Promise.reject(apiError(404))
+      return Promise.resolve([])
+    })
+    const { result } = renderHook(
+      () =>
+        useDetectedSubmissions({
+          ...base,
+          mode: "tag",
+          submissionTags: ["phase1"],
+          repoOwners: ["a"],
+        }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+    expect(result.current.errorCount).toBe(0)
+    expect(result.current.detected[0].entries[0]).toMatchObject({
+      kind: "tag",
+      label: "phase1",
+    })
+    expect(result.current.detected[0].entries[0].datetime).toBeUndefined()
   })
 
   it("counts submit/* tags even with no milestone patterns configured", async () => {
@@ -208,6 +251,13 @@ describe("useDetectedSubmissions — tag mode", () => {
     expect(result.current.detected).toHaveLength(1)
     // The two submit/* tags group under the submit/* glob; "random" is ignored.
     expect(result.current.detected[0].count).toBe(2)
+    // Their time is decoded from the newest name — no commit lookup fired.
+    expect(result.current.detected[0].entries[0].datetime).toBe(
+      "2026-01-02T00:00:00Z",
+    )
+    expect(
+      request.mock.calls.some(([url]) => String(url).includes("/commits/")),
+    ).toBe(false)
   })
 })
 
@@ -217,6 +267,11 @@ describe("useDetectedSubmissions — fan-out contract", () => {
       if (url.includes("cs101-hw1-bad")) return Promise.reject(apiError(500))
       if (url.includes("/tags"))
         return Promise.resolve([{ name: "phase1", commit: { sha: "a" } }])
+      if (url.includes("/commits/"))
+        return Promise.resolve({
+          sha: "a",
+          commit: { message: "m", committer: { date: "2026-06-20T10:00:00Z" } },
+        })
       return Promise.resolve([])
     })
     const { result } = renderHook(

--- a/web/src/hooks/useDetectedSubmissions.ts
+++ b/web/src/hooks/useDetectedSubmissions.ts
@@ -2,9 +2,11 @@ import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import type { GitHubClient } from "@/github-core/client"
 import {
   REPO_READ_CONCURRENCY,
   githubKeys,
+  getCommitDatetime,
   getOldestCommitShaForPath,
   listDefaultBranchCommits,
   listRepoTags,
@@ -127,10 +129,11 @@ export function useDetectedSubmissions({
                   // assignment with no milestone patterns — the common case,
                   // where students push submit/* tags via `gh student submit` —
                   // would detect nothing. submit/* is a glob, so it groups.
-                  return detectTagSubmissions(tags, [
+                  const entries = detectTagSubmissions(tags, [
                     ...(submissionTags ?? []),
                     `${SUBMISSION_TAG_PREFIX}*`,
                   ])
+                  return dateMilestoneTagEntries(client, org!, repo, entries)
                 }
                 // Branch mode: resolve the default branch, its baseline, and the
                 // commit log, then exclude the baseline commit.
@@ -192,6 +195,51 @@ export function useDetectedSubmissions({
       void refetch()
     },
   }
+}
+
+// At most this many per-commit date lookups per repo. Milestone patterns are
+// capped at 20 and repos typically carry 1-3, so the cap only bites on a
+// pathological tag set — where the newest submit/* time (free, from the tag
+// name) usually covers the row anyway.
+const MILESTONE_DATE_LOOKUP_CAP = 10
+
+// Fill the datetime of milestone tag entries by reading their tagged commit:
+// canonical submit/* names encode their time (already parsed by detection),
+// but a milestone tag's only time source is its commit. Lookups are deduped
+// by sha; a failed read leaves the entry dateless rather than voiding the
+// batch. Runs inside the caller's read slot, so the extra requests stay
+// within the fan-out's aggregate bound.
+async function dateMilestoneTagEntries(
+  client: GitHubClient,
+  org: string,
+  repo: string,
+  entries: DetectedSubmission[],
+): Promise<DetectedSubmission[]> {
+  const dateless = entries.filter((e) => !e.datetime && e.sha)
+  if (dateless.length === 0) return entries
+
+  const shas = [...new Set(dateless.map((e) => e.sha!))].slice(
+    0,
+    MILESTONE_DATE_LOOKUP_CAP,
+  )
+  const dateBySha = new Map<string, string>()
+  for (const sha of shas) {
+    try {
+      const date = await getCommitDatetime(client, org, repo, sha)
+      if (date) dateBySha.set(sha, date)
+    } catch (err) {
+      // Best-effort enrichment: a failed lookup must not void the detection
+      // entries we already have. Cancellation still propagates.
+      if ((err as Error)?.name === "AbortError") throw err
+    }
+  }
+  if (dateBySha.size === 0) return entries
+
+  return entries.map((e) => {
+    if (e.datetime || !e.sha) return e
+    const date = dateBySha.get(e.sha)
+    return date ? { ...e, datetime: date } : e
+  })
 }
 
 export default useDetectedSubmissions

--- a/web/src/hooks/useGetScores.test.ts
+++ b/web/src/hooks/useGetScores.test.ts
@@ -65,3 +65,33 @@ describe("normalizeScores — manual override entries", () => {
     expect(rows[0].overridden).toBe(false)
   })
 })
+
+describe("normalizeScores — per-bucket collected_at", () => {
+  it("surfaces a bucket's collected_at and omits unstamped buckets", () => {
+    const normalized = normalizeScores({
+      schema: "classroom50/scores/v1",
+      assignments: {
+        stamped: {
+          type: "individual",
+          entries: [],
+          collected_at: "2026-06-01T15:00:00Z",
+        },
+        legacy: { type: "individual", entries: [] },
+      },
+    } as never)
+    expect(normalized?.collectedAt).toEqual({
+      stamped: "2026-06-01T15:00:00Z",
+    })
+  })
+
+  it("ignores a non-string or empty collected_at", () => {
+    const normalized = normalizeScores({
+      schema: "classroom50/scores/v1",
+      assignments: {
+        bad: { type: "individual", entries: [], collected_at: 12345 },
+        blank: { type: "individual", entries: [], collected_at: "" },
+      },
+    } as never)
+    expect(normalized?.collectedAt).toEqual({})
+  })
+})

--- a/web/src/hooks/useGetScores.ts
+++ b/web/src/hooks/useGetScores.ts
@@ -48,6 +48,10 @@ type ScoreEntry = {
 type AssignmentBucket = {
   type: "individual" | "group"
   entries: ScoreEntry[]
+  // Per-bucket freshness stamp written by collect_scores.py: the UTC instant
+  // collection last walked THIS assignment (absent on files written before the
+  // field existed).
+  collected_at?: string
 }
 
 type ScoresSchema = {
@@ -111,6 +115,10 @@ export type SubmissionAttempt = {
 export type NormalizedScores = {
   schema: string
   submissions: Record<string, SubmissionRow[]>
+  // Slug -> per-bucket `collected_at` stamp, where present. More precise than
+  // the org-wide workflow-run timestamp: a scoped collect refreshes only its
+  // own bucket, so only that bucket's stamp moves.
+  collectedAt: Record<string, string>
 }
 
 // Collapse a bucket's entries to one row each (latest submission first).
@@ -192,11 +200,15 @@ export function normalizeScores(
   if (!data) return undefined
 
   const submissions: Record<string, SubmissionRow[]> = {}
+  const collectedAt: Record<string, string> = {}
   for (const [slug, bucket] of Object.entries(data.assignments ?? {})) {
     submissions[slug] = bucketToRows(bucket)
+    if (typeof bucket?.collected_at === "string" && bucket.collected_at) {
+      collectedAt[slug] = bucket.collected_at
+    }
   }
 
-  return { schema: data.schema, submissions }
+  return { schema: data.schema, submissions, collectedAt }
 }
 
 const useGetScores = (

--- a/web/src/hooks/useTriggerScoreCollection.ts
+++ b/web/src/hooks/useTriggerScoreCollection.ts
@@ -8,23 +8,32 @@ import { useGitHubOperation, type OperationPhase } from "./useGitHubOperation"
 
 export type CollectScoresPhase = OperationPhase
 
+// Narrows a dispatched collection to one assignment (the assignment
+// submissions page); omitted collects org-wide.
+export type CollectScoresScope = { classroom: string; assignment: string }
+
 /**
  * Triggers collect-scores and tracks the run via useGitHubOperation; also
- * registers the dispatch with the activity banner.
+ * registers the dispatch with the activity banner. Pass `scope` to collect a
+ * single assignment instead of the whole org.
  */
-const useTriggerScoreCollection = (org: string | undefined) => {
+const useTriggerScoreCollection = (
+  org: string | undefined,
+  scope?: CollectScoresScope,
+) => {
   const client = useGitHubClient()
   const { register } = useActionActivityRegistry()
   const { t } = useTranslation()
 
+  // Scope-suffixed keys so an assignment page's tracked run never bleeds into
+  // another page's (or the org-wide) collect tracker across remounts.
+  const scopeSuffix = scope ? `:${scope.classroom}:${scope.assignment}` : ""
   const { trigger, phase, run, error } = useGitHubOperation({
-    storageKey: org ? `cl50:collect-scores:${org}` : null,
+    storageKey: org ? `cl50:collect-scores:${org}${scopeSuffix}` : null,
     queryKey: (sinceRunId) =>
       githubKeys.collectScoresRun(org ?? "", sinceRunId),
-    resetKey: org ?? "",
-    // Org-wide collection, matching the "Last collected" timestamp. Pass a
-    // classroom slug to triggerScoreCollection to scope it.
-    dispatch: () => triggerScoreCollection(client, org ?? ""),
+    resetKey: `${org ?? ""}${scopeSuffix}`,
+    dispatch: () => triggerScoreCollection(client, org ?? "", scope),
     findRun: (sinceRunId, signal) =>
       getCollectScoresRunAfterId(client, org ?? "", sinceRunId, signal),
     onDispatched: (result) => {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2383,6 +2383,7 @@
       "statusFailed": "The collection run did not complete successfully.",
       "statusFailedWithReason": "Could not start collection: {{reason}}",
       "statusFailedHint": "You can check or trigger it manually on GitHub.",
+      "workflowOutdated": "Could not collect this assignment: the Collect Scores workflow in this organization's classroom50 config repo is out of date. Update the org's workflows (an update banner appears when a newer version is available), then try again.",
       "statusTimeout": "Still running after a while. Check its progress on GitHub, or refresh this page once it finishes."
     },
     "regradeAll": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2820,6 +2820,7 @@
       "detailsTitle": "Your submissions",
       "tableCaption": "Your submission for this assignment",
       "notSubmittedYet": "Not submitted yet",
+      "submittedAwaitingGrading": "Submitted — awaiting grading",
       "loadError": "Could not load your submissions.",
       "notAccepted": "You haven't accepted this assignment yet. <acceptLink>Accept it</acceptLink> to get your repository, then push your work to be graded.",
       "locked": "This assignment is locked by your teacher and isn't available right now. Check back later or ask your teacher to unlock it.",

--- a/web/src/pages/StudentSubmissionPage.test.tsx
+++ b/web/src/pages/StudentSubmissionPage.test.tsx
@@ -204,9 +204,7 @@ describe("StudentSubmissionPage submission type", () => {
     expect(
       screen.getByText("submissions.student.submittedAwaitingGrading"),
     ).toBeTruthy()
-    expect(
-      screen.queryByText("submissions.student.notSubmittedYet"),
-    ).toBeNull()
+    expect(screen.queryByText("submissions.student.notSubmittedYet")).toBeNull()
   })
 
   it("still shows 'not submitted yet' in tag mode with no tags and no releases", () => {
@@ -215,9 +213,7 @@ describe("StudentSubmissionPage submission type", () => {
       submission_tags: ["phase1"],
     })
     render(<StudentSubmissionPage />)
-    expect(
-      screen.getByText("submissions.student.notSubmittedYet"),
-    ).toBeTruthy()
+    expect(screen.getByText("submissions.student.notSubmittedYet")).toBeTruthy()
   })
 
   it("renders as a one-row table with the student column set", () => {

--- a/web/src/pages/StudentSubmissionPage.test.tsx
+++ b/web/src/pages/StudentSubmissionPage.test.tsx
@@ -189,6 +189,37 @@ describe("StudentSubmissionPage submission type", () => {
     )
   })
 
+  it("shows awaiting-grading (not 'not submitted') for an ungraded pushed tag", () => {
+    // Tag mode: a pushed milestone tag counts in the chip, but no submit/*
+    // release exists yet (grading pending or teacher-supplied CI). "Not
+    // submitted yet" beside a positive count contradicts itself — the cell
+    // must say the submission exists and is awaiting grading.
+    assignmentData = assignment({
+      submission_mode: "tag",
+      submission_tags: ["phase1"],
+    })
+    taggedData = [{ kind: "tag", label: "phase1", count: 1, sha: "aaa1111" }]
+    releasesData = []
+    render(<StudentSubmissionPage />)
+    expect(
+      screen.getByText("submissions.student.submittedAwaitingGrading"),
+    ).toBeTruthy()
+    expect(
+      screen.queryByText("submissions.student.notSubmittedYet"),
+    ).toBeNull()
+  })
+
+  it("still shows 'not submitted yet' in tag mode with no tags and no releases", () => {
+    assignmentData = assignment({
+      submission_mode: "tag",
+      submission_tags: ["phase1"],
+    })
+    render(<StudentSubmissionPage />)
+    expect(
+      screen.getByText("submissions.student.notSubmittedYet"),
+    ).toBeTruthy()
+  })
+
   it("renders as a one-row table with the student column set", () => {
     assignmentData = assignment({ submission_mode: "every-push" })
     pushData = [commit("aaa", "2026-06-20T10:00:00Z")]

--- a/web/src/pages/StudentSubmissionPage.test.tsx
+++ b/web/src/pages/StudentSubmissionPage.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event"
 import type { DetectedSubmission } from "@/domain/assignments/submissionDetection"
 import type { GitHubCommit, GitHubRelease } from "@/github-core/types"
 import type { Assignment } from "@/types/classroom"
+import { formatSubmissionDateTime } from "@/util/formatDate"
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -99,11 +100,19 @@ const assignment = (over: Partial<Assignment> = {}): Assignment =>
     ...over,
   }) as Assignment
 
-const commit = (sha: string, date: string): GitHubCommit =>
+const commit = (
+  sha: string,
+  date: string,
+  committerDate?: string,
+): GitHubCommit =>
   ({
     sha,
     html_url: `https://github.com/acme/cs101-hw1-alice/commit/${sha}`,
-    commit: { message: sha, author: { date } },
+    commit: {
+      message: sha,
+      author: { date },
+      ...(committerDate ? { committer: { date: committerDate } } : {}),
+    },
     author: null,
   }) as GitHubCommit
 
@@ -214,6 +223,22 @@ describe("StudentSubmissionPage submission type", () => {
     })
     render(<StudentSubmissionPage />)
     expect(screen.getByText("submissions.student.notSubmittedYet")).toBeTruthy()
+  })
+
+  it("prefers the committer date over the author date for the last-submitted time", () => {
+    // Every-push mode: the newest push's time drives the "last submitted"
+    // cell. Author date survives a rebase, so committer date is the truer
+    // "when was this pushed" — assert the cell shows the committer date, not
+    // the (older) author date, when the two differ.
+    assignmentData = assignment({ submission_mode: "every-push" })
+    const authorDate = "2026-06-20T10:00:00Z"
+    const committerDate = "2027-01-15T12:00:00Z"
+    pushData = [commit("abc1234", authorDate, committerDate)]
+    render(<StudentSubmissionPage />)
+    expect(
+      screen.getByText(formatSubmissionDateTime(committerDate)),
+    ).toBeTruthy()
+    expect(screen.queryByText(formatSubmissionDateTime(authorDate))).toBeNull()
   })
 
   it("renders as a one-row table with the student column set", () => {

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -300,6 +300,15 @@ const SubmissionBody = ({
               <td>
                 {latestSubmittedAt ? (
                   <LastSubmittedCell datetime={latestSubmittedAt} />
+                ) : submissionCount > 0 ? (
+                  // Submissions exist (e.g. a pushed milestone tag) but none
+                  // has a graded release yet, so there's no timestamp to show.
+                  // "Not submitted yet" beside a positive count would
+                  // contradict itself — say the work is in and awaiting
+                  // grading instead.
+                  <span className="text-base-content/50">
+                    {t("submissions.student.submittedAwaitingGrading")}
+                  </span>
                 ) : (
                   <span className="text-base-content/50">
                     {t("submissions.student.notSubmittedYet")}

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -20,7 +20,10 @@ import { formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { safeHttpUrl } from "@/util/url"
 import type { GitHubCommit, GitHubRelease } from "@/github-core/types"
 import { SUBMISSION_TAG_PREFIX } from "@/github-core/queries/releaseRunReads"
-import { submissionModeCountKey } from "@/domain/assignments/submissionDetection"
+import {
+  submissionModeCountKey,
+  latestDetectedAt,
+} from "@/domain/assignments/submissionDetection"
 import { deriveAutogradingState } from "@/domain/assignments/autogradingState"
 import type { Assignment, SubmissionMode } from "@/types/classroom"
 import { assignmentDescription } from "@/types/classroom"
@@ -79,7 +82,7 @@ const toPushSubmissions = (
   return (commits ?? []).map((commit, i) => ({
     key: `${commit.sha}-${i}`,
     commitHref: commit.html_url,
-    datetime: commit.commit.author?.date,
+    datetime: commit.commit.committer?.date ?? commit.commit.author?.date,
     releaseHref: releaseHrefBySha.get(commit.sha.slice(0, 7)),
   }))
 }
@@ -191,12 +194,17 @@ const SubmissionBody = ({
   const submissionCount = detailItemsCount(detailItems)
 
   // The newest submission's time for the "last submitted" cell: the newest
-  // push's commit date in every-push mode, else the newest graded release's
-  // publish time (a tag submission's time isn't carried by detection). Absent
-  // until the first submission lands.
+  // push's commit date in every-push mode; in tag mode the newest detected
+  // tag's time (a canonical submit/* name encodes it) — the actual submission
+  // instant — falling back to the newest graded release's publish time for a
+  // dateless milestone tag. Absent until the first submission lands.
   const latestSubmittedAt = isTagMode
-    ? (releases?.[0]?.published_at ?? releases?.[0]?.created_at ?? undefined)
-    : pushSubmissions?.[0]?.commit.author?.date
+    ? (latestDetectedAt(taggedSubmissions) ??
+      releases?.[0]?.published_at ??
+      releases?.[0]?.created_at ??
+      undefined)
+    : (pushSubmissions?.[0]?.commit.committer?.date ??
+      pushSubmissions?.[0]?.commit.author?.date)
 
   if (releasesLoading || repoLoading) {
     return (

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -51,7 +51,7 @@ import {
   filterNonSubmitters,
   hasAccepted,
   latestAssignmentPush,
-  latestCollectedAt,
+  effectiveCollectedAt,
   mergeDetectedSubmissions,
   mergeLiveRows,
   reconcileNonSubmitters,
@@ -173,9 +173,10 @@ const SubmissionsPageContent = () => {
   // Assignments that never autograde (empty_repo bare repos, or no_autograder
   // teacher-supplied CI) produce no submit/* releases. Grading UI (Regrade all,
   // per-row regrade, scores, live polling, the trigger retrofit) is hidden and
-  // the header's grading badge explains why. Collect stays enabled — it's
-  // org-wide and collect_scores.py skips these assignments itself. Mirrors the
-  // Python skips_grading() predicate family.
+  // the header's grading badge explains why — including collect/freshness,
+  // since a collect scoped to this assignment would be skipped by
+  // collect_scores.py anyway. Mirrors the Python skips_grading() predicate
+  // family.
   const skipsGrading = assignmentInfo
     ? assignmentSkipsGrading(assignmentInfo)
     : false
@@ -811,29 +812,24 @@ const SubmissionsPageContent = () => {
     [orgRepos, classroom, assignment, siblingSlugs],
   )
 
-  // Effective "last collected" prefers the run we just dispatched and know
-  // finished over the status=completed query, which can still report the prior
-  // run while GitHub's Actions list catches up. Gating on phase "completed"
-  // means conclusion === "success" (see useGitHubOperation), so a failed/timed
-  // -out run never relaxes the button. Both the freshness label and the
-  // staleness color read this one value so they can't disagree.
+  // Gating trackedCompletedAt on phase "completed" means conclusion ===
+  // "success" (see useGitHubOperation), so a failed/timed-out run never
+  // relaxes the button. Both the freshness label and the staleness color read
+  // the one effectiveCollectedAt value so they can't disagree; that helper
+  // owns the bucket-stamp vs run-timestamp precedence.
   const lastRunCompletedAt =
     lastRun?.status === "completed" ? lastRun.created_at : null
   const trackedCompletedAt =
     collectScores.phase === "completed"
       ? (collectScores.run?.created_at ?? null)
       : null
-  // When the bucket carries its own `collected_at` stamp, it is authoritative
-  // for THIS assignment: an org-wide run timestamp can't tell whether a scoped
-  // run (another assignment's "Sync now") touched this bucket, so trusting it
-  // would overstate freshness. The tracked run still participates — it's a
-  // collect we dispatched for this very assignment and completes before the
-  // scores.json refetch lands. Buckets from an older collector (no stamp) fall
-  // back to the run-based derivation.
-  const bucketCollectedAt = scoresData?.collectedAt?.[assignment ?? ""] ?? null
-  const effectiveLastCollectedAt = bucketCollectedAt
-    ? latestCollectedAt(bucketCollectedAt, trackedCompletedAt)
-    : latestCollectedAt(lastRunCompletedAt, trackedCompletedAt)
+  const effectiveLastCollectedAt = effectiveCollectedAt({
+    bucketCollectedAt: scoresData?.collectedAt?.[assignment ?? ""] ?? null,
+    collectorStampsBuckets:
+      Object.keys(scoresData?.collectedAt ?? {}).length > 0,
+    lastRunCompletedAt,
+    trackedCompletedAt,
+  })
 
   const lastCollectedLabel = effectiveLastCollectedAt
     ? formatRelativeToNow(new Date(effectiveLastCollectedAt))

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -482,6 +482,7 @@ const SubmissionsPageContent = () => {
         release: s.releaseUrl,
         submissionCount: s.submissionCount,
       })),
+      assignmentInfo?.due,
     )
     const merged = mergeDetectedSubmissions(
       withLive,
@@ -499,6 +500,7 @@ const SubmissionsPageContent = () => {
     detectedSubmissions,
     rosterReady,
     students,
+    assignmentInfo?.due,
   ])
 
   // Repos whose latest submission landed after the deadline. `late` is computed

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -98,6 +98,7 @@ import {
   REGRADE_WORKFLOW,
 } from "@/github-core/workflows"
 import { githubKeys } from "@/github-core/queries"
+import { CollectInputsUnsupportedError } from "@/github-core/mutations"
 import {
   formatDueDateTime,
   formatRelativeToNow,
@@ -735,7 +736,13 @@ const SubmissionsPageContent = () => {
     })
   }, [effectiveFilters, query, unsubmittedGroupRepos, students])
 
-  const collectScores = useTriggerScoreCollection(org)
+  // Scope the manual collect to this assignment: the workflow serializes runs
+  // per scope and the Python side collects only the matching slug, so "Sync
+  // now" here doesn't rebuild every classroom's gradebook.
+  const collectScores = useTriggerScoreCollection(
+    org,
+    classroom && assignment ? { classroom, assignment } : undefined,
+  )
   const regradeAll = useTriggerRegrade({ org, classroom, assignment })
   const { notify } = useToast()
   // Lock/unlock this assignment. The page owns the mutation (like Regrade all)
@@ -1008,12 +1015,18 @@ const SubmissionsPageContent = () => {
           )}
           {collectScores.phase === "failed" && (
             <Alert tone="error" role="status">
-              {collectScores.error instanceof Error
-                ? t("submissions.collect.statusFailedWithReason", {
-                    reason: collectScores.error.message,
-                  })
-                : t("submissions.collect.statusFailed")}{" "}
-              {t("submissions.collect.statusFailedHint")}
+              {collectScores.error instanceof CollectInputsUnsupportedError ? (
+                t("submissions.collect.workflowOutdated")
+              ) : (
+                <>
+                  {collectScores.error instanceof Error
+                    ? t("submissions.collect.statusFailedWithReason", {
+                        reason: collectScores.error.message,
+                      })
+                    : t("submissions.collect.statusFailed")}{" "}
+                  {t("submissions.collect.statusFailedHint")}
+                </>
+              )}
             </Alert>
           )}
           {collectScores.phase === "timeout" && (

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -823,10 +823,17 @@ const SubmissionsPageContent = () => {
     collectScores.phase === "completed"
       ? (collectScores.run?.created_at ?? null)
       : null
-  const effectiveLastCollectedAt = latestCollectedAt(
-    lastRunCompletedAt,
-    trackedCompletedAt,
-  )
+  // When the bucket carries its own `collected_at` stamp, it is authoritative
+  // for THIS assignment: an org-wide run timestamp can't tell whether a scoped
+  // run (another assignment's "Sync now") touched this bucket, so trusting it
+  // would overstate freshness. The tracked run still participates — it's a
+  // collect we dispatched for this very assignment and completes before the
+  // scores.json refetch lands. Buckets from an older collector (no stamp) fall
+  // back to the run-based derivation.
+  const bucketCollectedAt = scoresData?.collectedAt?.[assignment ?? ""] ?? null
+  const effectiveLastCollectedAt = bucketCollectedAt
+    ? latestCollectedAt(bucketCollectedAt, trackedCompletedAt)
+    : latestCollectedAt(lastRunCompletedAt, trackedCompletedAt)
 
   const lastCollectedLabel = effectiveLastCollectedAt
     ? formatRelativeToNow(new Date(effectiveLastCollectedAt))

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -493,6 +493,7 @@ const SubmissionsPageContent = () => {
         count: d.count,
         entries: d.entries,
       })),
+      assignmentInfo?.due,
     )
     return rosterReady ? rosterScopedRows(merged, students) : merged
   }, [

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -236,6 +236,7 @@ export const NonSubmitterRow = ({
   onProfile,
   actions,
   manualGrade,
+  thresholdFraction = null,
 }: {
   student: Student
   students: Student[]
@@ -247,6 +248,9 @@ export const NonSubmitterRow = ({
   // cell offers inline grade entry for this not-yet-graded student instead of
   // an em-dash.
   manualGrade?: ManualGradeContext
+  // The assignment's pass threshold, so the first saved grade renders with the
+  // same tone the submitter row would give it.
+  thresholdFraction?: number | null
 }) => {
   return (
     <tr>
@@ -279,7 +283,7 @@ export const NonSubmitterRow = ({
             score={0}
             max={manualGrade.maxPoints}
             hasGrade={false}
-            thresholdFraction={null}
+            thresholdFraction={thresholdFraction}
             ctx={manualGrade}
           />
         ) : (

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -32,6 +32,14 @@ vi.mock("@/hooks/useGetFeedbackPr", () => ({
 vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
   default: () => ({ mutate: vi.fn(), isPending: false }),
 }))
+vi.mock("@/hooks/mutations/useSetScoreOverride", () => ({
+  useSetScoreOverride: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    reset: vi.fn(),
+  }),
+}))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
   useToast: () => ({ notify: vi.fn() }),
 }))
@@ -206,6 +214,67 @@ describe("SubmissionsTable empty_repo score cell", () => {
       />,
     )
     expect(screen.queryByTitle("submissions.table.noGradingTitle")).toBeNull()
+  })
+})
+
+describe("SubmissionsTable manual grading on a no-autograder assignment", () => {
+  // A templated manual-graded assignment is written as no_autograder (the
+  // emptyRepo prop here), so manual grading must win over the no-grading
+  // em-dash — otherwise a grade entered via the non-submitter row becomes
+  // invisible once the student turns into a submitter row.
+  const manualGrade = {
+    org: "acme",
+    classroom: "cs101",
+    assignment: "hw1",
+    assignmentType: "individual" as const,
+    maxPoints: 10,
+  }
+
+  it("offers the inline manual editor on a submitter row despite emptyRepo", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+        emptyRepo
+        manualGrade={manualGrade}
+      />,
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "submissions.manualGrade.editLabel",
+      }),
+    ).toBeTruthy()
+    expect(screen.queryByTitle("submissions.table.noGradingTitle")).toBeNull()
+  })
+
+  it("still shows the no-grading em-dash without manualGrade", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+        emptyRepo
+      />,
+    )
+    expect(screen.getByTitle("submissions.table.noGradingTitle")).toBeTruthy()
+  })
+
+  it("matches the non-submitter row's Add-grade affordance under emptyRepo", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set(["alice"])}
+        emptyRepo
+        manualGrade={manualGrade}
+      />,
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "submissions.manualGrade.addLabel",
+      }),
+    ).toBeTruthy()
   })
 })
 

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -128,9 +128,7 @@ function buildDetailItems(
       ? detectedCommits.map((e) => ({
           key: `commit-${e.sha ?? e.label}`,
           commitHref: e.sha ? repoCommitUrl(org, repo, e.sha) : undefined,
-          // Detection doesn't carry a per-commit time; the collected attempt
-          // (when present) does, matched by sha below.
-          datetime: undefined,
+          datetime: e.datetime,
           releaseHref: e.sha
             ? (releaseByCommit.get(e.sha) ??
               releaseByCommit.get(e.sha.slice(0, 7)))

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -403,22 +403,20 @@ const SubmissionsTable = ({
           />
         </td>
         <td>
-          {emptyRepo ? (
-            <span
-              className="text-base-content/50"
-              title={t("submissions.table.noGradingTitle")}
-            >
-              —
-            </span>
-          ) : manualGrade && !(isGroup && rest.pending) ? (
-            // A pending GROUP row comes from the live/detection overlay before
-            // collection, so its `usernames` is just the founder ([owner]) —
-            // the real members aren't known yet. Grading it here would write
+          {manualGrade && !(isGroup && rest.pending) ? (
+            // Manual grading wins over the no-grading em-dash: a manual-graded
+            // assignment is typically written as no_autograder (emptyRepo
+            // here), and the non-submitter row offers "Add grade" under the
+            // same flags — hiding the editor here would make an entered grade
+            // invisible. A pending GROUP row still falls through: it comes
+            // from the live/detection overlay before collection, so its
+            // `usernames` is just the founder ([owner]) — the real members
+            // aren't known yet. Grading it here would write
             // member_usernames:[founder] and mis-credit the group (the other
             // members would read as non-submitters and never see the grade),
-            // so fall through to the pending badge until collection resolves
-            // the member list. Individual pending rows and any collected group
-            // row are safe to grade inline.
+            // so show the pending badge until collection resolves the member
+            // list. Individual pending rows and any collected group row are
+            // safe to grade inline.
             <ManualGradeCell
               owner={rest.owner}
               score={score}
@@ -427,6 +425,13 @@ const SubmissionsTable = ({
               thresholdFraction={passBar}
               ctx={{ ...manualGrade, memberUsernames: usernames }}
             />
+          ) : emptyRepo ? (
+            <span
+              className="text-base-content/50"
+              title={t("submissions.table.noGradingTitle")}
+            >
+              —
+            </span>
           ) : rest.pending ? (
             <Badge ghost title={t("submissions.table.pendingGradeTitle")}>
               {t("submissions.table.pendingGrade")}
@@ -676,6 +681,7 @@ const SubmissionsTable = ({
                     onProfile={setProfileUsername}
                     actions={actions}
                     manualGrade={manualGrade}
+                    thresholdFraction={passBar}
                   />
                 )
               }

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -857,6 +857,17 @@ describe("buildScoresCsvRows", () => {
       release: "",
     })
   })
+
+  it("exports a blank submitted_at (not a crash) for a dateless pending row", () => {
+    // A detection-only row can still be dateless; toISOString on an
+    // Invalid Date would throw and break the whole export.
+    const out = buildScoresCsvRows(
+      [row({ usernames: ["bob"], datetime: "", pending: true })],
+      [],
+    )
+    expect(out[0].submitted_at).toBe("")
+    expect(out[0].score).toBe("")
+  })
 })
 
 describe("selectActiveWorkflowAction", () => {
@@ -1422,6 +1433,97 @@ describe("mergeDetectedSubmissions", () => {
     const bob = merged.find((r) => r.owner === "bob")
     expect(bob?.pending).toBe(true)
     expect(bob?.detectedEntries).toEqual(entries)
+  })
+
+  it("gives a detection-only row the newest detected push time and lateness", () => {
+    // Branch-mode detection carries commit times; the pending row's "last
+    // submitted" must show WHEN the push landed, not "not yet collected".
+    const entries = [
+      {
+        kind: "commit" as const,
+        label: "bbb2222",
+        count: 1,
+        sha: "bbb2222",
+        datetime: "2026-06-22T10:00:00Z",
+      },
+      {
+        kind: "commit" as const,
+        label: "aaa1111",
+        count: 1,
+        sha: "aaa1111",
+        datetime: "2026-06-20T10:00:00Z",
+      },
+    ]
+    const merged = mergeDetectedSubmissions(
+      [],
+      [{ owner: "bob", count: 2, entries }],
+      "2026-06-21T00:00:00Z",
+    )
+    expect(merged[0].datetime).toBe("2026-06-22T10:00:00Z")
+    expect(merged[0].late).toBe(true)
+  })
+
+  it("leaves a dateless detection-only row's time empty and lateness unknown", () => {
+    // A tag entry can stay dateless (milestone tag whose commit lookup
+    // failed); never guess lateness.
+    const entries = [
+      { kind: "tag" as const, label: "phase1", count: 1, sha: "aaa1111" },
+    ]
+    const merged = mergeDetectedSubmissions(
+      [],
+      [{ owner: "bob", count: 1, entries }],
+      "2026-06-21T00:00:00Z",
+    )
+    expect(merged[0].datetime).toBe("")
+    expect(merged[0].late).toBeUndefined()
+  })
+
+  it("surfaces a newer detected push time on a count-raising row", () => {
+    const rows = [
+      row({
+        owner: "alice",
+        submissionCount: 1,
+        datetime: "2026-06-20T10:00:00Z",
+      }),
+    ]
+    const entries = [
+      {
+        kind: "commit" as const,
+        label: "bbb2222",
+        count: 1,
+        sha: "bbb2222",
+        datetime: "2026-06-25T10:00:00Z",
+      },
+    ]
+    const merged = mergeDetectedSubmissions(rows, [
+      { owner: "alice", count: 2, entries },
+    ])
+    expect(merged[0].liveLatestAt).toBe("2026-06-25T10:00:00Z")
+  })
+
+  it("never lets an older detection displace the row time or a newer live latest", () => {
+    const rows = [
+      row({
+        owner: "alice",
+        submissionCount: 1,
+        datetime: "2026-06-20T10:00:00Z",
+        liveLatestAt: "2026-06-26T10:00:00Z",
+      }),
+    ]
+    const entries = [
+      {
+        kind: "commit" as const,
+        label: "bbb2222",
+        count: 1,
+        sha: "bbb2222",
+        datetime: "2026-06-25T10:00:00Z",
+      },
+    ]
+    const merged = mergeDetectedSubmissions(rows, [
+      { owner: "alice", count: 2, entries },
+    ])
+    expect(merged[0].liveLatestAt).toBe("2026-06-26T10:00:00Z")
+    expect(merged[0].datetime).toBe("2026-06-20T10:00:00Z")
   })
 })
 

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -868,6 +868,26 @@ describe("buildScoresCsvRows", () => {
     expect(out[0].submitted_at).toBe("")
     expect(out[0].score).toBe("")
   })
+
+  it("neutralizes CSV formula injection in free-text columns", () => {
+    // A commit/release/review URL (or a group's joined logins) can carry a
+    // leading formula trigger; guard it so a spreadsheet renders it as text.
+    const out = buildScoresCsvRows(
+      [
+        row({
+          usernames: ["=cmd()"],
+          commit: "=HYPERLINK(1)",
+          review: "+evil",
+          release: "@x",
+        }),
+      ],
+      [],
+    )
+    expect(out[0].usernames).toBe("'=cmd()")
+    expect(out[0].commit).toBe("'=HYPERLINK(1)")
+    expect(out[0].review).toBe("'+evil")
+    expect(out[0].release).toBe("'@x")
+  })
 })
 
 describe("selectActiveWorkflowAction", () => {
@@ -1476,6 +1496,57 @@ describe("mergeDetectedSubmissions", () => {
     )
     expect(merged[0].datetime).toBe("")
     expect(merged[0].late).toBeUndefined()
+  })
+
+  it("never derives lateness from a tag entry's decoded time (student-controllable)", () => {
+    // A submit/* tag's time is decoded from the tag NAME, which a student can
+    // backdate — so even a dated tag entry must NOT set `late`. The row still
+    // SHOWS the tag time on the last-submitted cell; only the late flag is
+    // withheld (the collector marks it later from the release datetime).
+    const entries = [
+      {
+        kind: "tag" as const,
+        label: "submit/2026-06-01T09-00-00Z-abc1234",
+        count: 1,
+        sha: "abc1234",
+        datetime: "2026-06-01T09:00:00Z",
+      },
+    ]
+    const merged = mergeDetectedSubmissions(
+      [],
+      [{ owner: "bob", count: 1, entries }],
+      "2026-06-21T00:00:00Z",
+    )
+    // Time is shown (a pre-due tag), but late is withheld rather than false.
+    expect(merged[0].datetime).toBe("2026-06-01T09:00:00Z")
+    expect(merged[0].late).toBeUndefined()
+  })
+
+  it("derives lateness from a commit entry even when a dated tag entry is also present", () => {
+    // A mixed detection set (a commit plus a tag) still trusts only the
+    // commit's committer date for `late`.
+    const entries = [
+      {
+        kind: "commit" as const,
+        label: "ddd4444",
+        count: 1,
+        sha: "ddd4444",
+        datetime: "2026-06-25T10:00:00Z",
+      },
+      {
+        kind: "tag" as const,
+        label: "submit/2026-06-01T09-00-00Z-ddd4444",
+        count: 1,
+        sha: "ddd4444",
+        datetime: "2026-06-01T09:00:00Z",
+      },
+    ]
+    const merged = mergeDetectedSubmissions(
+      [],
+      [{ owner: "bob", count: 2, entries }],
+      "2026-06-21T00:00:00Z",
+    )
+    expect(merged[0].late).toBe(true)
   })
 
   it("surfaces a newer detected push time on a count-raising row", () => {

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -1175,6 +1175,49 @@ describe("mergeLiveRows", () => {
     expect(merged[0].submissionCount).toBe(1)
   })
 
+  it("marks a pending live row late when it landed after the due date", () => {
+    const merged = mergeLiveRows(
+      [],
+      [live("bob", "2026-06-21T10:00:00Z")],
+      "2026-06-20T23:59:00Z",
+    )
+    expect(merged[0].pending).toBe(true)
+    expect(merged[0].late).toBe(true)
+  })
+
+  it("marks a pending live row on-time when it landed before the due date", () => {
+    const merged = mergeLiveRows(
+      [],
+      [live("bob", "2026-06-19T10:00:00Z")],
+      "2026-06-20T23:59:00Z",
+    )
+    expect(merged[0].late).toBe(false)
+  })
+
+  it("leaves lateness undefined without a due date or with unparseable inputs", () => {
+    expect(
+      mergeLiveRows([], [live("bob", "2026-06-19T10:00:00Z")])[0].late,
+    ).toBeUndefined()
+    expect(
+      mergeLiveRows([], [live("bob", "2026-06-19T10:00:00Z")], null)[0].late,
+    ).toBeUndefined()
+    expect(
+      mergeLiveRows([], [live("bob", "not-a-date")], "2026-06-20T23:59:00Z")[0]
+        .late,
+    ).toBeUndefined()
+  })
+
+  it("never rewrites a snapshot row's collected lateness", () => {
+    const merged = mergeLiveRows(
+      [row({ owner: "alice", late: false, submissionCount: 1 })],
+      [live("alice", "2026-06-25T10:00:00Z", 3)],
+      "2026-06-20T23:59:00Z",
+    )
+    // The collected `late` is the source of record for graded submissions —
+    // the live overlay only bumps count/staleness.
+    expect(merged[0].late).toBe(false)
+  })
+
   it("raises a snapshot row's count to the live count and flags it stale", () => {
     const merged = mergeLiveRows(
       [row({ owner: "alice", score: 9, submissionCount: 1 })],

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest"
-
 import type { SubmissionRow } from "@/hooks/useGetScores"
 import type { GitHubRepo } from "@/github-core/types"
 import type { Student } from "@/types/classroom"
@@ -21,6 +20,7 @@ import {
   displayItemOwner,
   displayPageOwners,
   distinctSections,
+  effectiveCollectedAt,
   existingGroupRepos,
   filterAndSortRows,
   filterNonSubmitters,
@@ -1112,6 +1112,71 @@ describe("latestCollectedAt", () => {
       "2026-06-20T10:00:00Z",
     )
     expect(latestCollectedAt("not-a-date", null)).toBeNull()
+  })
+})
+
+describe("effectiveCollectedAt", () => {
+  const stamp = "2026-06-24T10:00:00Z"
+  const lastRun = "2026-06-25T10:00:00Z"
+  const tracked = "2026-06-26T10:00:00Z"
+
+  it("prefers the bucket stamp over the org-wide run timestamp", () => {
+    // The newer lastRun may have been a scoped sync of another assignment, so
+    // the older bucket stamp must win.
+    expect(
+      effectiveCollectedAt({
+        bucketCollectedAt: stamp,
+        collectorStampsBuckets: true,
+        lastRunCompletedAt: lastRun,
+        trackedCompletedAt: null,
+      }),
+    ).toBe(stamp)
+  })
+
+  it("lets our own tracked run beat an older bucket stamp", () => {
+    expect(
+      effectiveCollectedAt({
+        bucketCollectedAt: stamp,
+        collectorStampsBuckets: true,
+        lastRunCompletedAt: null,
+        trackedCompletedAt: tracked,
+      }),
+    ).toBe(tracked)
+  })
+
+  it("ignores the run fallback for an unstamped bucket under a stamp-aware collector", () => {
+    // A successful scoped run of ANOTHER assignment must not make this
+    // never-collected bucket read as fresh.
+    expect(
+      effectiveCollectedAt({
+        bucketCollectedAt: null,
+        collectorStampsBuckets: true,
+        lastRunCompletedAt: lastRun,
+        trackedCompletedAt: null,
+      }),
+    ).toBeNull()
+  })
+
+  it("still counts our own tracked run for an unstamped bucket", () => {
+    expect(
+      effectiveCollectedAt({
+        bucketCollectedAt: null,
+        collectorStampsBuckets: true,
+        lastRunCompletedAt: lastRun,
+        trackedCompletedAt: tracked,
+      }),
+    ).toBe(tracked)
+  })
+
+  it("falls back to run timestamps for a wholly unstamped (pre-stamp) file", () => {
+    expect(
+      effectiveCollectedAt({
+        bucketCollectedAt: null,
+        collectorStampsBuckets: false,
+        lastRunCompletedAt: lastRun,
+        trackedCompletedAt: null,
+      }),
+    ).toBe(lastRun)
   })
 })
 

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -13,6 +13,7 @@ import { rowToStudent } from "@/util/teamRoster"
 import { hasStudentEnrollment } from "@/util/classroomRoleUI"
 import { getName, nameFromParts } from "@/util/students"
 import { studentRepoName } from "@/util/studentRepo"
+import { escapeCsvFormulaInjection } from "@/util/csv"
 
 // Whether a row's grade still belongs to a current roster member. A row is
 // credited to `usernames` (group members, else [owner]); keep it when ANY
@@ -260,7 +261,13 @@ export function mergeDetectedSubmissions(
         "max-score": 0,
         submissionCount: Math.max(1, d.count),
         pending: true,
-        late: liveLateness(detectedAt, dueDate),
+        // Derive `late` only from a trustworthy time. A commit's committer
+        // date is server-recorded on push; a tag entry's time is decoded from
+        // the student-authored `submit/<ts>` tag NAME, which a student can
+        // backdate to read on-time. So only branch-mode commit entries feed
+        // lateness here; a tag-mode pending row leaves `late` undefined until
+        // the collector marks it from the authoritative release datetime.
+        late: liveLateness(latestCommitDetectedAt(d.entries), dueDate),
         detectedEntries: d.entries,
         submissions: [],
       }
@@ -287,6 +294,20 @@ function newerDetectedAt(
     if (Number.isFinite(referenceMs) && detectedMs <= referenceMs) return null
   }
   return detectedAt
+}
+
+// The newest time among branch-mode COMMIT detections only, or "" when none
+// carry one. Used to derive `late` for a pending row: a commit's committer
+// date is server-recorded on push, whereas a tag entry's time is decoded from
+// the student-authored `submit/<ts>` tag name and can be backdated to dodge a
+// late flag — so tag times must never feed lateness (the collector marks tag
+// lateness later from the authoritative release datetime).
+function latestCommitDetectedAt(
+  entries: DetectedSubmission[] | undefined,
+): string {
+  return (
+    latestDetectedAt((entries ?? []).filter((e) => e.kind === "commit")) ?? ""
+  )
 }
 
 // The most recent push time across this assignment's repos, or null when none
@@ -936,7 +957,12 @@ export function buildScoresCsvRows(
       (a, b) => new Date(b.datetime).getTime() - new Date(a.datetime).getTime(),
     )
     .map(({ usernames, score, datetime, submissionCount, late, ...rest }) => ({
-      usernames: usernames.join(", "),
+      // Free-text columns can carry student-influenceable content (a repo/
+      // commit/release/review URL, a group's joined logins), so neutralize
+      // spreadsheet formula injection on them. The numeric/enum/timestamp
+      // columns below are our own generated values and must round-trip
+      // byte-exact, so they are NOT escaped.
+      usernames: escapeCsvFormulaInjection(usernames.join(", ")),
       // A pending live row (submitted, not yet collected) has no real grade —
       // export a blank score, not a 0, so importing the CSV can't record a
       // graded zero for a student who actually submitted.
@@ -948,13 +974,13 @@ export function buildScoresCsvRows(
       // Invalid Date.
       submitted_at: isoOrBlank(datetime),
       late: late ? "yes" : "no",
-      commit: rest.commit,
-      review: rest.review,
-      release: rest.release,
+      commit: escapeCsvFormulaInjection(rest.commit),
+      review: escapeCsvFormulaInjection(rest.review),
+      release: escapeCsvFormulaInjection(rest.release),
     }))
 
   const nonSubmittedRows: ScoresCsvRow[] = nonSubmitters.map((student) => ({
-    usernames: student.username,
+    usernames: escapeCsvFormulaInjection(student.username),
     score: 0,
     max_score: "",
     submissions: 0,

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -4,6 +4,7 @@
 
 import type { SubmissionRow } from "@/hooks/useGetScores"
 import type { GitHubRepo } from "@/github-core/types"
+import { latestDetectedAt } from "@/domain/assignments/submissionDetection"
 import type { DetectedSubmission } from "@/domain/assignments/submissionDetection"
 import type { Student } from "@/types/classroom"
 import type { BadgeTone } from "@/components/ui"
@@ -196,10 +197,17 @@ export type DetectedPresence = {
 // mergeLiveRows: detection can only REVEAL more submissions than are already
 // counted (max wins), never fewer, and never sets a score. A detection-only
 // owner (pushes/tags but no submit/* release and no snapshot entry) becomes a
-// pending row so the teacher sees the work exists, ungraded.
+// pending row so the teacher sees the work exists, ungraded — carrying the
+// newest detected submission time (commit dates in branch mode; encoded
+// submit/* timestamps or milestone commit lookups in tag mode) so the "last
+// submitted" cell shows when the work landed instead of a bare "not yet
+// collected".
 export function mergeDetectedSubmissions(
   rows: SubmissionRow[],
   detected: DetectedPresence[],
+  // The assignment's due date (ISO), used only to derive `late` for PENDING
+  // detection-only rows — mirrors the mergeLiveRows parameter.
+  dueDate?: string | null,
 ): SubmissionRow[] {
   const detectedByOwner = new Map<string, DetectedPresence>()
   for (const d of detected) {
@@ -224,6 +232,12 @@ export function mergeDetectedSubmissions(
       ...withEntries,
       submissionCount: d.count,
       staleCount: !row.overridden,
+      // Surface the newest detected push on the live sub-line when it beats
+      // both the row's recorded time and any release-based live latest, so a
+      // stale-count row says WHEN the newer work landed, not just that it did.
+      liveLatestAt:
+        newerDetectedAt(d.entries, row.datetime, row.liveLatestAt) ??
+        row.liveLatestAt,
     }
   })
 
@@ -233,22 +247,46 @@ export function mergeDetectedSubmissions(
     .filter(
       (d) => d.count > 0 && !knownOwners.has(d.owner.trim().toLowerCase()),
     )
-    .map<SubmissionRow>((d) => ({
-      usernames: [d.owner],
-      owner: d.owner,
-      datetime: "",
-      commit: "",
-      release: "",
-      review: "",
-      score: 0,
-      "max-score": 0,
-      submissionCount: Math.max(1, d.count),
-      pending: true,
-      detectedEntries: d.entries,
-      submissions: [],
-    }))
+    .map<SubmissionRow>((d) => {
+      const detectedAt = latestDetectedAt(d.entries) ?? ""
+      return {
+        usernames: [d.owner],
+        owner: d.owner,
+        datetime: detectedAt,
+        commit: "",
+        release: "",
+        review: "",
+        score: 0,
+        "max-score": 0,
+        submissionCount: Math.max(1, d.count),
+        pending: true,
+        late: liveLateness(detectedAt, dueDate),
+        detectedEntries: d.entries,
+        submissions: [],
+      }
+    })
 
   return [...merged, ...detectedOnly]
+}
+
+// The newest detected time when it's strictly newer than BOTH reference
+// instants (the row's recorded submission and any already-set live latest);
+// null otherwise, so an older/equal detection never displaces either.
+function newerDetectedAt(
+  entries: DetectedSubmission[] | undefined,
+  rowDatetime: string,
+  currentLiveLatestAt: string | undefined,
+): string | null {
+  const detectedAt = latestDetectedAt(entries)
+  if (!detectedAt) return null
+  const detectedMs = new Date(detectedAt).getTime()
+  if (!Number.isFinite(detectedMs)) return null
+  for (const reference of [rowDatetime, currentLiveLatestAt]) {
+    if (!reference) continue
+    const referenceMs = new Date(reference).getTime()
+    if (Number.isFinite(referenceMs) && detectedMs <= referenceMs) return null
+  }
+  return detectedAt
 }
 
 // The most recent push time across this assignment's repos, or null when none
@@ -905,7 +943,10 @@ export function buildScoresCsvRows(
       score: rest.pending ? "" : score,
       max_score: rest.pending ? "" : rest["max-score"],
       submissions: submissionCount,
-      submitted_at: new Date(datetime).toISOString(),
+      // A detection-only row can still be dateless (e.g. a milestone tag
+      // whose commit lookup failed) — export a blank rather than crashing on
+      // Invalid Date.
+      submitted_at: isoOrBlank(datetime),
       late: late ? "yes" : "no",
       commit: rest.commit,
       review: rest.review,
@@ -925,6 +966,12 @@ export function buildScoresCsvRows(
   }))
 
   return [...submittedRows, ...nonSubmittedRows]
+}
+
+// The ISO form of a row's submission time, or "" for an absent/unparseable one.
+function isoOrBlank(datetime: string): string {
+  const ms = new Date(datetime).getTime()
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : ""
 }
 
 // Which workflow action a single contextual "View …" link points at, and which

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -108,6 +108,9 @@ export type LiveSubmissionPresence = {
 export function mergeLiveRows(
   snapshotRows: SubmissionRow[],
   liveRows: LiveSubmissionPresence[],
+  // The assignment's due date (ISO), used only to derive `late` for PENDING
+  // live-only rows — collected rows keep the collector-computed `late`.
+  dueDate?: string | null,
 ): SubmissionRow[] {
   const liveByOwner = new Map<string, LiveSubmissionPresence>()
   for (const live of liveRows) {
@@ -153,10 +156,28 @@ export function mergeLiveRows(
       // At least 1 (the release we just saw); use the live count when higher.
       submissionCount: Math.max(1, live.submissionCount),
       pending: true,
+      // The collector isn't here to compute `late` for this not-yet-collected
+      // row, so derive it from the live submission time vs the due date —
+      // otherwise a pending late submission reads as on-time until the next
+      // collect. Left undefined (never guessed) without a parseable pair.
+      late: liveLateness(live.datetime, dueDate),
       submissions: [],
     }))
 
   return [...merged, ...liveOnly]
+}
+
+// `late` for a pending live row: submission time strictly after the due date.
+// Undefined (unknown, not "on time") when either side is missing/unparseable.
+function liveLateness(
+  submittedAt: string,
+  dueDate: string | null | undefined,
+): boolean | undefined {
+  if (!dueDate) return undefined
+  const submittedMs = new Date(submittedAt).getTime()
+  const dueMs = new Date(dueDate).getTime()
+  if (!Number.isFinite(submittedMs) || !Number.isFinite(dueMs)) return undefined
+  return submittedMs > dueMs
 }
 
 // Detected-submission presence for one repo, from the detection subsystem

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -327,6 +327,39 @@ export function latestCollectedAt(
   return aMs >= bMs ? (a ?? null) : (b ?? null)
 }
 
+/**
+ * The assignment page's "last collected" instant. Precedence:
+ *
+ * 1. Bucket stamp (`collected_at`) — authoritative for THIS assignment; the
+ *    tracked run we just dispatched still participates (it's scoped to this
+ *    very assignment and finishes before the scores.json refetch lands).
+ * 2. No stamp but the collector is stamp-aware (another bucket carries one):
+ *    the latest successful run may have been a scoped sync of a DIFFERENT
+ *    assignment (the runs API can't see dispatch inputs), so borrowing the
+ *    org-wide run timestamp would read "just collected" for a bucket no run
+ *    walked. Only our own tracked dispatch counts.
+ * 3. Wholly unstamped file — a pre-stamp collector, where every run was
+ *    org-wide, so the run-based fallback stays sound.
+ */
+export function effectiveCollectedAt(params: {
+  bucketCollectedAt: string | null
+  collectorStampsBuckets: boolean
+  lastRunCompletedAt: string | null
+  trackedCompletedAt: string | null
+}): string | null {
+  const {
+    bucketCollectedAt,
+    collectorStampsBuckets,
+    lastRunCompletedAt,
+    trackedCompletedAt,
+  } = params
+  if (bucketCollectedAt) {
+    return latestCollectedAt(bucketCollectedAt, trackedCompletedAt)
+  }
+  if (collectorStampsBuckets) return trackedCompletedAt
+  return latestCollectedAt(lastRunCompletedAt, trackedCompletedAt)
+}
+
 // Whether a row passes the threshold. Ungraded when the assignment sets no
 // threshold, or the row has no/zero/NaN max score.
 export type PassState = "passing" | "failing" | "ungraded"


### PR DESCRIPTION
## Summary

Audit of the assignment submissions page (teacher + student): grade collection is now assignment-aware, and both views report live repo state accurately instead of stale placeholders.

- **Assignment-scoped collection** — "Sync submissions now" on an assignment page dispatches Collect Scores for just that classroom + assignment (new `assignment` workflow input, `ASSIGNMENT_FILTER` in `collect_scores.py`). Because the Actions runs API can't see dispatch inputs, each walked bucket in `scores.json` now carries a `collected_at` stamp (schema + Go + Python + TypeScript mirrors, evolved additively) so per-assignment freshness stays truthful; wholly unstamped files keep the org-wide run fallback. Dispatching a scoped collect against an outdated config-repo workflow (422 "unexpected inputs") surfaces a clear "update the org's workflows" message instead of a raw API error.
- **Collector hardening** — a filter that matches nothing fails the run instead of silently succeeding; draft releases are skipped; an unknown assignment `mode` warns instead of being mis-bucketed. Clearing a manual override no longer deletes a bucket's freshness stamp.
- **Concurrent-collect safety** — a scoped "Sync now" and the nightly org-wide run can touch the same `scores.json` in different concurrency groups. On a push race the workflow now fast-forwards to the remote tip and re-runs the collector (an idempotent per-repo-owner upsert onto whatever the other run already committed) rather than a blind `git pull --rebase -X theirs`, which favored the replayed commit and could silently drop the nightly's newer entry. The job is also bounded with `timeout-minutes` so a wedged git operation can't hold the concurrency slot.
- **Live submission times** — a pushed-but-not-yet-collected row used to read "Not yet collected" even when the submission time was knowable. Detection now carries real times everywhere: branch-mode commit dates, timestamps decoded from canonical `submit/*` tag names (zero extra API calls), and bounded per-commit lookups for milestone tags. Pending rows show when the work landed; the details modal dates each push/tag; the student page shows the actual submission instant (or "awaiting grading") instead of a contradictory "not submitted yet". A pending row's late badge is derived only from a server-recorded commit date, never a `submit/*` tag's name-encoded time (which a student could backdate to read on-time before collection marks it authoritatively).
- **Smaller fixes** — the manual grade editor no longer hides on no-autograder assignments; "Last collected" counts only successful runs and pages past interleaved runs when binding a tracked dispatch; pending live rows derive lateness from the due date; the gradebook CSV export no longer crashes on a dateless pending row and neutralizes spreadsheet formula injection on its free-text columns.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). *(n/a — no CLI command or flag changes)*
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
