### PR TITLE
docs(wiki): catch up to 1.28 and answer recurring support questions

### DIFF
--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -73,6 +73,51 @@ template.
 > access, so accept would 404). Enterprise Cloud's "internal" visibility also
 > works.
 
+## Template requirements and gotchas
+
+- **The template must have at least one commit.** A freshly created, commitless
+  repository is rejected when you register the assignment — GitHub can't
+  generate a copy of nothing. (A brand-new template with real commits can
+  briefly be misreported by GitHub right after a push; if a just-pushed
+  template is rejected, wait a minute and retry.)
+- **Forked templates can trip other orgs' OAuth restrictions.** With a
+  template that is a **fork of a repository in a different organization**,
+  GitHub evaluates OAuth-app access restrictions against the fork's *parent*
+  organization too — accept can fail with an HTTP 403 naming OAuth App access
+  restrictions even though your own org has approved Classroom 50. Either have
+  the upstream organization approve Classroom 50 as well, or (simpler) copy
+  the content into a fresh, fork-free repository in your organization and flag
+  that as the template.
+- **Only the default branch is copied** unless the assignment enables
+  **Include all branches** (`include_all_branches`), which passes every branch
+  through to each generated student repo.
+- **GitHub's template-generate copies files, not settings.** Classroom 50
+  compensates at accept time:
+  - The **About description and topics** are copied when the assignment's
+    **Copy About from template** / **Copy topics from template** toggles are on
+    (the default).
+  - **Repository features** (Issues, Wiki, Projects, Pull requests) follow the
+    assignment's Repository features settings — by default each **inherits the
+    template's current setting**; you can force any of them on or off per
+    assignment. Repos accepted before a change can be reconciled with the
+    submissions page's **Update repository features** action.
+
+## Reusing one template across assignments
+
+The same repository can be the template for any number of assignments — each
+accept generates an independent copy of the template **as it exists at that
+moment**. That makes an evolving course repository workable: register
+assignment A, keep committing, register assignment B later from the same repo.
+Two things to keep in mind:
+
+- Students who accept the *same* assignment at different times can start from
+  different template states — late accepters get the newer content. Freeze the
+  template (or cut a dedicated template repo per assignment) if identical
+  starting points matter.
+- `.gitignore` and `.github/` are re-fetched from the template on every
+  submit (see below), so changes to those files propagate to **every**
+  assignment that shares the template.
+
 ## Why `.gitignore` and `.github/` re-sync
 
 On every submission, `gh student submit` re-fetches `.gitignore` and `.github/`

--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -95,12 +95,15 @@ template.
   compensates at accept time:
   - The **About description and topics** are copied when the assignment's
     **Copy About from template** / **Copy topics from template** toggles are on
-    (the default).
+    (the default for new assignments). This runs on the web accept path; a
+    student who accepts with `gh student accept` gets the repository without
+    them.
   - **Repository features** (Issues, Wiki, Projects, Pull requests) follow the
     assignment's Repository features settings — by default each **inherits the
     template's current setting**; you can force any of them on or off per
-    assignment. Repos accepted before a change can be reconciled with the
-    submissions page's **Update repository features** action.
+    assignment. This applies on both the web and CLI accept paths. Repos
+    accepted before a change can be reconciled with the submissions page's
+    **Update repository features** action.
 
 ## Reusing one template across assignments
 

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -49,10 +49,11 @@ large cohorts. Submissions become an explicit act:
   required.
 
 **Milestone submission tags** — with either mode, the assignment can also
-name **milestone tags** (`submission_tags` in assignments.json, e.g.
-`["phase1", "phase2", "complete"]`, settable at creation or from the
-assignment settings / `gh teacher assignment add --submission-tag`). Pushing
-a matching tag grades that commit — plain git, no CLI required:
+name **milestone tags** (`submission_tags` in assignments.json, the web form's
+**Submission tags** field, e.g. `["phase1", "phase2", "complete"]`, settable at
+creation or from the assignment settings / `gh teacher assignment add
+--submission-tag`). Pushing a matching tag grades that commit — plain git, no
+CLI required:
 
 ```sh
 git tag phase1
@@ -151,9 +152,10 @@ Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
 - **Per assignment, temporarily** — **Pause autograding** in the submissions
   page's **Actions** menu disables the `autograde.yaml` workflow in every
   student repo via GitHub's workflow-disable API. No files change, students'
-  other workflows keep running, and **Resume autograding** re-enables it. (A
-  student with admin on their repo can technically re-enable the workflow — a
-  known limitation.)
+  other workflows keep running, and **Resume autograding** re-enables it.
+  Available on individual assignments using the built-in autograder (a single
+  repo can also be paused from its row). A student with admin on their own
+  repo can technically re-enable the workflow — a known limitation.
 - **Org-wide** — the organization settings' **Pause autograding for all
   student repositories** toggle narrows the org's Actions policy to the config
   repo. **This stops all workflows in student repositories**, including any

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -139,6 +139,28 @@ yourself and use `--update-shims=false` to flip only the field.
 After a retrofit, students must `git pull` — clones made before the change
 will conflict on their next push.
 
+## Turning autograding off or pausing it
+
+Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
+
+- **Per assignment, at creation** — pick **Do not use the built-in
+  autograder** (`no_autograder` in assignments.json). Accept installs no shim
+  at all; a templated assignment's own CI workflows run instead, and score
+  collection skips the assignment. Immutable after creation. See
+  [`gh teacher` reference](gh-teacher#assignment-add).
+- **Per assignment, temporarily** — **Pause autograding** in the submissions
+  page's **Actions** menu disables the `autograde.yaml` workflow in every
+  student repo via GitHub's workflow-disable API. No files change, students'
+  other workflows keep running, and **Resume autograding** re-enables it. (A
+  student with admin on their repo can technically re-enable the workflow — a
+  known limitation.)
+- **Org-wide** — the organization settings' **Pause autograding for all
+  student repositories** toggle narrows the org's Actions policy to the config
+  repo. **This stops all workflows in student repositories**, including any
+  course CI — prefer the per-assignment pause unless that's what you want.
+
+See also the [FAQ on reducing Actions usage](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage).
+
 ## The `result.json` contract
 
 This is the **only** contract every autograder must satisfy — whatever produces
@@ -190,7 +212,10 @@ payload can't land in another student's gradebook.
 The gradebook is keyed by assignment slug under a root `assignments` object;
 each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is
 one repo's record: `owner` (the stable key), `submissions` (full history, newest
-first), and — for a group — `member_usernames` (credited members).
+first), and — for a group — `member_usernames` (credited members). Each bucket
+also carries a `collected_at` UTC timestamp stamped whenever a collection run
+walks that assignment (even if nothing changed), so per-assignment freshness is
+knowable — the web app's "Submission data synced" strip reads it.
 
 </details>
 

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -226,7 +226,7 @@ Create a classroom:
 
 ```sh
 gh teacher classroom add <org> <short-name> --name "<full name>" --term <term>
-gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Spring-2026
+gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Fall-2026
 ```
 
 The `<short-name>` must match `^[a-z0-9][a-z0-9-]{1,38}$` (2–39 characters,

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -432,11 +432,19 @@ Run it from the Actions tab on `<org>/classroom50`, or from your shell:
 ```sh
 gh workflow run collect-scores.yaml --repo <org>/classroom50
 gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=cs-principles   # one classroom
+gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=cs-principles -f assignment=hello   # one assignment
 ```
 
-The workflow also runs nightly (`17 4 * * *` UTC), so scores land daily even if
-you never trigger it. To disable that, comment out the `schedule:` block in
-`.github/workflows/collect-scores.yaml`.
+An `assignment=` run walks only that assignment's repos — much faster and
+lighter on API rate limits for a large classroom — and is exactly what the web
+app's per-assignment **Sync now** button dispatches. Each collected
+assignment's bucket in `scores.json` gets a `collected_at` UTC timestamp, so
+you (and the web app's freshness strip) can tell when each assignment was last
+walked; a scoped run leaves sibling assignments' buckets untouched.
+
+The workflow also runs nightly (`17 4 * * *` UTC) across **every** classroom,
+so scores land daily even if you never trigger it. To disable that, comment out
+the `schedule:` block in `.github/workflows/collect-scores.yaml`.
 
 <details>
 <summary>What each collection run does</summary>

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -420,12 +420,14 @@ gh teacher member list <org>/<repo>  # repo collaborators
 ## 9. Collect scores
 
 Every submission publishes a GitHub Release carrying a `result.json`. The
-`collect-scores` workflow walks every `(member, assignment)` pair, collects each
-repo's submissions, and aggregates them into `<classroom>/scores.json` — the
-class's authoritative gradebook. Members are the union of the student team and
-the staff teams (teacher/hta/ta), so a staff member who accepted an assignment
-to test the autograde flow is collected like a student; staff who never accepted
-have no repo and produce no entry.
+`collect-scores` workflow walks each `(member, assignment)` pair in scope,
+collects each repo's submissions, and aggregates them into
+`<classroom>/scores.json` — the class's authoritative gradebook. By default the
+scope is every classroom and every assignment; you can narrow it to one
+classroom, or to a single assignment (see below). Members are the union of the
+student team and the staff teams (teacher/hta/ta), so a staff member who
+accepted an assignment to test the autograde flow is collected like a student;
+staff who never accepted have no repo and produce no entry.
 
 Run it from the Actions tab on `<org>/classroom50`, or from your shell:
 
@@ -451,7 +453,8 @@ the `schedule:` block in `.github/workflows/collect-scores.yaml`.
 
 1. Iterates each classroom (or just the one you passed).
 2. For each `(member, assignment)` pair — every student team member plus every
-   staff team member — computes the repo name
+   staff team member, narrowed to one assignment when you passed
+   `assignment=` — computes the repo name
    `<classroom>-<assignment>-<username>` and walks its `submit/*` releases. No
    releases means the member hasn't accepted or submitted yet (a staff member
    who never accepted simply drops out here).

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -196,8 +196,8 @@ Yes, several levers, from least to most drastic:
 - **Pause autograding org-wide** from the organization's Actions settings in
   the web app. **Caution:** this stops **all** workflows in student
   repositories, not just autograding — any CI your students run stops too.
-  Setup also applies a **$0 Actions spending cap** by default so a runaway
-  workflow can't run up a bill.
+  Setup also creates a **$0 Actions spending cap** (only when the organization
+  has none) so a runaway workflow can't run up a bill.
 
 ### Can I use my own (self-hosted) runners?
 
@@ -253,15 +253,17 @@ results.
 
 Yes, two ways:
 
-- **In the web app** — on the submissions page, each row has an **Add grade**
-  / **Edit grade** button. A hand-entered score shows a **Manual** badge and
-  is stored as an override; autograding won't change it until the override is
-  cleared. (An assignment can also be created in **Manual** grading mode, with
-  a **Max points** field, when it's graded exclusively by hand.)
-- **In the config repo** — edit the classroom's `scores.json`: change the
-  submission's `score` and add `"override": true` to that entry, then commit.
-  Collection leaves overridden entries untouched on future runs. See
-  [Collect scores](CLI-Teacher-Guide#9-collect-scores).
+- **In the web app, on a manual assignment.** Create the assignment with
+  **Grading → Manual (enter scores by hand)** and a **Max points** value; each
+  row on the submissions page then gets an **Add grade** / **Edit grade**
+  button. Hand-entered scores show a **Manual** badge and are stored as
+  overrides. (This editor appears only for manual-mode assignments, and only
+  for organization owners — writing scores means writing the config repo. The
+  grading mode can't be changed after an assignment is created.)
+- **In the config repo, for any assignment.** Edit the classroom's
+  `scores.json`: change the submission's `score` and add `"override": true` to
+  that entry, then commit. Collection leaves overridden entries untouched on
+  future runs. See [Collect scores](CLI-Teacher-Guide#9-collect-scores).
 
 ### How do I export grades, or download student work in bulk?
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -50,10 +50,14 @@ course, section, or term. Add each with **Create classroom** in the web app or
 
 ### Should I create one organization per course, like GitHub Classroom?
 
-You don't have to. Because one organization holds many classrooms, most teachers
-use a single organization and add a classroom per course or term. You can still
-use separate organizations if you prefer — each just needs its own one-time
-setup.
+You don't have to. Because one organization holds many classrooms, a single,
+stable teaching team running one course (across terms or sections) works well
+with **one organization** and a classroom per term or section. Prefer
+**separate organizations** when many teachers run very different classes (e.g.
+school-wide adoption) — each teacher then manages their own org — or when a
+large course would otherwise accumulate hundreds of assignment repositories
+per year; in that case, one org per academic year keeps things tidy. Each
+organization needs its own one-time setup.
 
 ### Can a classroom have multiple teachers or TAs?
 
@@ -119,16 +123,27 @@ Yes. Deadlines support a date **and** time (down to the second, in your
 timezone). Submissions after the deadline are **marked late**; nothing is
 blocked automatically.
 
+### Does the deadline cut off student access?
+
+No — the due date only marks later submissions late. To actually end an
+assignment, use **Close submission** in the submissions page's **Actions**
+menu: it blocks new accepts and sets every student's repository to read-only
+(work is preserved). **Reopen submission** restores write access — useful when
+a project continues in a follow-up course. **Update student repo access** in
+the same menu gives finer control over the role students hold on their repos.
+
 ### What's the difference between "template-less" and "empty repository"?
 
-- **Template-less** (no template chosen): students get a repo containing only
-  the autograder setup — good for write-from-scratch or short-answer work.
-- **Empty repository**: a completely bare repo — no starter files **and** no
-  autograding or feedback pull request. Use it when students build everything
-  themselves, including their own GitHub Actions.
+- **Template-less** (no template chosen, **Add a README** on): students get a
+  repo containing only the autograder setup — good for write-from-scratch or
+  short-answer work.
+- **Empty repository** (no template, **Add a README** off): a completely bare
+  repo with no initial commit — no starter files **and** no autograding or
+  feedback pull request. Use it when students build everything themselves,
+  including their own GitHub Actions.
 
-**Empty repository is permanent** for an assignment — you can't switch it on or
-off after creating the assignment.
+**The empty-repository choice is permanent** for an assignment — you can't
+switch it on or off after creating the assignment.
 
 ### How do group assignments work?
 
@@ -155,22 +170,34 @@ write an `autograder.py`. See [Autograders](Autograders).
 
 ### Can I turn autograding off, or reduce Actions usage?
 
-Yes, several levers:
+Yes, several levers, from least to most drastic:
 
-- **Grade on submit only** — set the assignment's autograding trigger to
-  **On submit only** (`--submission-mode tag` in the CLI). Students' regular
+- **Grade on submit only** — set the assignment's **Submission type** to **A
+  tagged commit** (`--submission-mode tag` in the CLI). Students' regular
   pushes then run nothing at all; grading happens only when they submit
   (`gh student submit` or a hand-pushed `submit/*` tag). This is the biggest
   saver for large classes, where every work-in-progress push would otherwise
   grade. You can also name **milestone tags** (`--submission-tag phase1`) so
   students grade specific checkpoints with plain git. See
   [Autograders → Which commits grade](Autograders#which-commits-grade).
+- **Don't use the built-in autograder at all** — when creating an assignment,
+  pick **Do not use the built-in autograder**. Accept then installs no
+  autograding workflow: a templated assignment runs only your template's own
+  CI (if any), and score collection skips the assignment. The right choice for
+  project-shaped assignments graded by hand or by your own CI.
 - Create an assignment with **no autograding tests**, and no grading runs
   (Classroom 50 still uses a lightweight workflow to tag submissions and
   support written feedback, which uses far fewer Actions minutes).
+- **Pause autograding for one assignment** — **Pause autograding** in the
+  submissions page's **Actions** menu disables the built-in `autograde.yaml`
+  workflow in every student repository (via GitHub's workflow-disable API — no
+  files change). Students' other workflows keep running, and **Resume
+  autograding** re-enables it anytime.
 - **Pause autograding org-wide** from the organization's Actions settings in
-  the web app; setup also applies a **$0 Actions spending cap** by default so
-  a runaway workflow can't run up a bill.
+  the web app. **Caution:** this stops **all** workflows in student
+  repositories, not just autograding — any CI your students run stops too.
+  Setup also applies a **$0 Actions spending cap** by default so a runaway
+  workflow can't run up a bill.
 
 ### Can I use my own (self-hosted) runners?
 
@@ -200,7 +227,9 @@ GitHub's side.
 A few common reasons:
 
 - **Scores haven't been collected yet.** Collection runs nightly; click
-  **Collect now** on the submissions page to pull the latest immediately.
+  **Sync now** on the submissions page to pull this assignment's latest
+  results immediately (the sync is scoped to the assignment you're viewing, so
+  it's fast even in a big classroom).
 - **GitHub Pages is still deploying.** Right after a config change, published
   files can take a few minutes to go live.
 - **The student's repo predates a workflow update.** If you updated Classroom 50
@@ -209,20 +238,41 @@ A few common reasons:
 
 See [Troubleshooting](Troubleshooting) for specific error messages.
 
+### Can students see their grades in the web app?
+
+Not yet. Grades live in each student's repository: every graded submission
+publishes a **Release** with the score and a per-test breakdown, which is what
+the student-facing **View grade** link opens. Showing grades inside the app is
+blocked by a technical limitation — Classroom 50 has no server, and the
+browser can't read Release assets cross-origin — but it's on the wish list
+(see [#567](https://github.com/foundation50/classroom50/issues/567)). Point
+students at their repository's Releases page (or the Feedback PR) for
+results.
+
 ### Can I manually override or adjust a grade?
 
-Yes. Edit the classroom's `scores.json` in the config repo: change the
-submission's `score` and add `"override": true` to that entry, then commit.
-Collection leaves overridden entries untouched on future runs. See
-[Collect scores](CLI-Teacher-Guide#9-collect-scores).
+Yes, two ways:
 
-### How do I export grades?
+- **In the web app** — on the submissions page, each row has an **Add grade**
+  / **Edit grade** button. A hand-entered score shows a **Manual** badge and
+  is stored as an override; autograding won't change it until the override is
+  cleared. (An assignment can also be created in **Manual** grading mode, with
+  a **Max points** field, when it's graded exclusively by hand.)
+- **In the config repo** — edit the classroom's `scores.json`: change the
+  submission's `score` and add `"override": true` to that entry, then commit.
+  Collection leaves overridden entries untouched on future runs. See
+  [Collect scores](CLI-Teacher-Guide#9-collect-scores).
+
+### How do I export grades, or download student work in bulk?
 
 Download scores as a CSV from the submissions page
-(**Download scores (CSV)**). The `gh teacher download` command clones every
-submission repo and also writes a `scores.csv` summary at the destination root.
-The raw score data also lives in `scores.json` in your config repo, so you can
-build your own automations against it.
+(**Download scores (CSV)**). For the work itself, **Download all submissions**
+in the same **Actions** menu bundles every repository's latest submission into
+a single zip (built in your browser). For real clones — e.g. to run your own
+tooling locally — `gh teacher download` clones every submission repo and also
+writes a `scores.csv` summary at the destination root. The raw score data also
+lives in `scores.json` in your config repo, so you can build your own
+automations against it.
 
 ### As a teacher, can I test an assignment as a student?
 
@@ -265,6 +315,27 @@ Classroom 50 authenticates the same way the GitHub CLI does, using GitHub's
 to a single organization's repositories — so the grant covers your repos even
 though Classroom 50 only acts on classroom ones. This matches the CLI's behavior.
 
+### Why does signing in ask for permission to "Delete repositories"?
+
+One feature uses it: **Tear down organization** (org settings → Danger zone),
+which resets an organization by deleting the repositories Classroom 50 manages
+— and only after you type an explicit confirmation. Nothing else ever deletes
+a repository. Classroom 50 has no server, so the token never leaves your
+browser and nobody else can act on your organization with it. If you'd rather
+not grant it at all, the CLIs never request `delete_repo` unless you opt in
+(`gh teacher login -s delete_repo`). See
+[GitHub Integration](GitHub-Integration#2-teacher-authentication).
+
+### Can I edit the config files in the `classroom50` repo by hand?
+
+It's not recommended. Some state is derived from both the config files and the
+live state on GitHub.com, and the app's reconciliation process updates the
+files automatically to keep them in sync — a hand-edit can create a state the
+tools don't know how to handle (and makes problems much harder to
+troubleshoot). Manage the classroom through the web app or the `gh teacher`
+CLI instead; the one documented exception is a `scores.json` grade override
+(see above).
+
 ### What is the service token, and is it the same one the web app set up?
 
 The **service token** is a fine-grained personal access token stored as a secret
@@ -276,6 +347,8 @@ need one per organization. See
 ## Roadmap
 
 Some capabilities from GitHub Classroom aren't available today, including
-**LTI / LMS grade passback** and a built-in **manual-grading UI**. Classroom 50
-is open source and actively developed — share ideas or track direction in
+**LTI / LMS grade passback**, in-app **grade visibility for students**, and
+**roster self-selection** (students picking their own roster entry when
+accepting). Classroom 50 is open source and actively developed — share ideas
+or track direction in
 [Discussions](https://github.com/foundation50/classroom50/discussions).

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -134,16 +134,22 @@ the same menu gives finer control over the role students hold on their repos.
 
 ### What's the difference between "template-less" and "empty repository"?
 
-- **Template-less** (no template chosen, **Add a README** on): students get a
-  repo containing only the autograder setup — good for write-from-scratch or
-  short-answer work.
-- **Empty repository** (no template, **Add a README** off): a completely bare
-  repo with no initial commit — no starter files **and** no autograding or
-  feedback pull request. Use it when students build everything themselves,
-  including their own GitHub Actions.
+Both start from no template; the difference is what (if anything) is committed:
 
-**The empty-repository choice is permanent** for an assignment — you can't
-switch it on or off after creating the assignment.
+- **Template-less with a README** (**Add a README** on): students get a repo
+  with an initial commit and the autograder setup — good for write-from-scratch
+  or short-answer work.
+- **Empty repository** (**Add a README** off, built-in autograder off): a
+  completely bare repo with no commit at all — no starter files **and** no
+  autograding or feedback pull request, ever. Use it when students build
+  everything themselves, including their own GitHub Actions.
+- (**Add a README** off with the built-in autograder **on** is a third,
+  in-between shape: an initialized repo carrying only the control files, no
+  README, which grades normally.)
+
+**These repository-shape choices are permanent** for an assignment — you can't
+switch them after creating it, because repositories students already accepted
+can't be retrofitted.
 
 ### How do group assignments work?
 
@@ -170,7 +176,7 @@ write an `autograder.py`. See [Autograders](Autograders).
 
 ### Can I turn autograding off, or reduce Actions usage?
 
-Yes, several levers, from least to most drastic:
+Yes, several levers:
 
 - **Grade on submit only** — set the assignment's **Submission type** to **A
   tagged commit** (`--submission-mode tag` in the CLI). Students' regular
@@ -180,24 +186,26 @@ Yes, several levers, from least to most drastic:
   grade. You can also name **milestone tags** (`--submission-tag phase1`) so
   students grade specific checkpoints with plain git. See
   [Autograders → Which commits grade](Autograders#which-commits-grade).
-- **Don't use the built-in autograder at all** — when creating an assignment,
-  pick **Do not use the built-in autograder**. Accept then installs no
-  autograding workflow: a templated assignment runs only your template's own
-  CI (if any), and score collection skips the assignment. The right choice for
-  project-shaped assignments graded by hand or by your own CI.
+- **Pause autograding for one assignment** (reversible) — **Pause autograding**
+  in the submissions page's **Actions** menu disables the built-in
+  `autograde.yaml` workflow in every student repository (via GitHub's
+  workflow-disable API — no files change). Students' other workflows keep
+  running, and **Resume autograding** re-enables it. Offered on individual
+  assignments that use the built-in autograder, once students have accepted.
 - Create an assignment with **no autograding tests**, and no grading runs
   (Classroom 50 still uses a lightweight workflow to tag submissions and
   support written feedback, which uses far fewer Actions minutes).
-- **Pause autograding for one assignment** — **Pause autograding** in the
-  submissions page's **Actions** menu disables the built-in `autograde.yaml`
-  workflow in every student repository (via GitHub's workflow-disable API — no
-  files change). Students' other workflows keep running, and **Resume
-  autograding** re-enables it anytime.
-- **Pause autograding org-wide** from the organization's Actions settings in
-  the web app. **Caution:** this stops **all** workflows in student
-  repositories, not just autograding — any CI your students run stops too.
-  Setup also creates a **$0 Actions spending cap** (only when the organization
-  has none) so a runaway workflow can't run up a bill.
+- **Don't use the built-in autograder at all** (permanent) — when creating an
+  assignment, pick **Do not use the built-in autograder**. Accept then installs
+  no autograding workflow: a templated assignment runs only your template's own
+  CI (if any), and score collection skips the assignment. The right choice for
+  project-shaped assignments graded by hand or by your own CI. Can't be changed
+  after the assignment is created.
+- **Pause autograding org-wide** — the organization's Actions settings in the
+  web app. **Caution:** this stops **all** workflows in student repositories,
+  not just autograding — any CI your students run stops too. Setup also creates
+  a **$0 Actions spending cap** (only when the organization has none) so a
+  runaway workflow can't run up a bill.
 
 ### Can I use my own (self-hosted) runners?
 
@@ -321,11 +329,10 @@ though Classroom 50 only acts on classroom ones. This matches the CLI's behavior
 
 One feature uses it: **Tear down organization** (org settings → Danger zone),
 which resets an organization by deleting the repositories Classroom 50 manages
-— and only after you type an explicit confirmation. Nothing else ever deletes
-a repository. Classroom 50 has no server, so the token never leaves your
-browser and nobody else can act on your organization with it. If you'd rather
-not grant it at all, the CLIs never request `delete_repo` unless you opt in
-(`gh teacher login -s delete_repo`). See
+— and only after you type an explicit confirmation. Nothing else ever deletes a
+repository, and because there's no Classroom 50 server, the token stays in your
+browser. The CLIs don't request it at all unless you opt in
+(`gh teacher login -s delete_repo`). Details:
 [GitHub Integration](GitHub-Integration#2-teacher-authentication).
 
 ### Can I edit the config files in the `classroom50` repo by hand?

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -59,11 +59,16 @@ Run once per machine, or after a token rotation:
 gh teacher login
 ```
 
-This runs `gh auth login -s admin:org -s read:org -s repo -s workflow` and opens
-a browser. It's the unified Classroom 50 scope set — `gh teacher login` and
-`gh student login` request the same scopes, so authenticating one CLI covers the
-other. (`delete_repo` is not included — opt in with `gh teacher login -s
-delete_repo` for teardown.)
+This checks your existing `gh` credentials first: a token that already carries
+the required scopes is **reused untouched** (no re-auth, no rewrite of your `gh`
+configuration). Only an absent or under-scoped gh-managed token triggers
+`gh auth login -s admin:org -s read:org -s repo -s workflow` — with a warning
+first, since that rewrites your stored `gh` auth. An under-scoped token supplied
+via `GH_TOKEN` or your keyring can't be refreshed by `gh`, so the CLI errors
+with remediation instead. It's the unified Classroom 50 scope set —
+`gh teacher login` and `gh student login` request the same scopes, so
+authenticating one CLI covers the other. (`delete_repo` is not included — opt
+in with `gh teacher login -s delete_repo` for teardown.)
 
 | Scope | Required for |
 |---|---|
@@ -71,6 +76,17 @@ delete_repo` for teardown.)
 | `read:org` | Checking org membership. |
 | `repo` | Repo creation, contents writes, collaborators. |
 | `workflow` | Committing the config repo's workflow files during `init` (GitHub 404s the write without it). |
+
+> [!NOTE]
+> **Why the web app's sign-in asks for "Delete repositories".** Signing in at
+> classroom50.org requests `delete_repo` in addition to the set above. It is
+> used by exactly one feature: **Tear down organization** (org settings →
+> Danger zone), which resets an org by deleting the repositories Classroom 50
+> manages — and it only runs when you type an explicit confirmation. Nothing
+> else deletes repositories. Classroom 50 has no server: the token stays in
+> your browser, so nobody but you can act on your org with it. If you prefer,
+> the CLIs never request `delete_repo` unless you opt in with
+> `gh teacher login -s delete_repo`.
 
 ### 3. Student authentication
 
@@ -142,13 +158,20 @@ gh api -X PUT /repos/<org>/classroom50/actions/permissions/access \
 
 ### 6. Score collection
 
-The `collect-scores.yaml` workflow runs nightly (`17 4 * * *` UTC). Trigger it
-manually:
+The `collect-scores.yaml` workflow runs nightly (`17 4 * * *` UTC) across every
+classroom. Trigger it manually, optionally scoped to one classroom or a single
+assignment (the same scoped run the web app's per-assignment **Sync now**
+button dispatches):
 
 ```sh
 gh workflow run collect-scores.yaml --repo <org>/classroom50
 gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=<short-name>
+gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=<short-name> -f assignment=<slug>
 ```
+
+A scoped run walks only the matching assignment's repos (faster and cheaper on
+API rate limits for a large classroom) and stamps that assignment's
+`collected_at` in `scores.json`; sibling assignments' buckets are untouched.
 
 ### 7. Verify the service token
 
@@ -207,13 +230,16 @@ Some networks can't allow `workers.dev`. When the proxy is unreachable:
   and assignments is unaffected.
 - **What breaks:** the normal "Sign in with GitHub" button (its token exchange
   goes through the proxy) and in-app repo downloads.
-- **Signing in anyway:** paste a **classic** personal access token instead. On
-  the sign-in card, open **Other sign-in methods → Use a personal access token**.
-  This validates the token directly against `api.github.com`, so it never touches
-  the proxy. The prompt links to a token page with the required scopes
-  pre-checked. Fine-grained tokens aren't accepted here — use a classic token.
-  (This sign-in token is a **classic** token you paste into the web app; it is
-  separate from the fine-grained `CLASSROOM50_SERVICE_TOKEN` used for
+- **Signing in anyway:** paste a personal access token instead. On the sign-in
+  card, open **Other sign-in methods** and pick **Use a personal access token
+  (classic)** or **Use a personal access token (fine-grained)**. Both validate
+  the token directly against `api.github.com`, so they never touch the proxy,
+  and both link to a token-creation page with the required scopes/permissions
+  pre-filled. A fine-grained token works with **one organization only** — you
+  name the org (it becomes the token's resource owner) and must set Repository
+  access to **All repositories**.
+  (This sign-in token is one you paste into the web app; it is separate from
+  the fine-grained `CLASSROOM50_SERVICE_TOKEN` used for
   [score collection](#4-fine-grained-pat-for-score-collection).)
 - **A fuller fix:** host the proxy yourself on a domain your network already
   allows and point `VITE_GITHUB_PROXY_BASE` at it. This restores both the normal
@@ -261,7 +287,7 @@ The CLIs call GitHub through [`go-gh`](https://github.com/cli/go-gh);
 | GET / PATCH | `/user/memberships/orgs/{org}` | Check / accept a pending org invite. |
 | POST | `/repos/{template_owner}/{template_repo}/generate` | Generate the repo from a template. |
 | POST | `/orgs/{org}/repos` | Create an empty repo (template-less). |
-| GET / PATCH | `/repos/{owner}/{repo}` | Recover from "already exists"; disable issues/projects/wiki. |
+| GET / PATCH | `/repos/{owner}/{repo}` | Recover from "already exists"; read the template's features and apply the assignment's repository-feature settings (inherit/on/off). |
 | PUT | `/repos/{owner}/{repo}/collaborators/{username}` | Set the founder role: `push` (individual) or `admin` (group); also backs `gh student invite`. |
 | GET / POST / PATCH | `/repos/{owner}/{repo}/git/{refs,commits,blobs,trees}` + `/branches/{branch}` | Commit the setup files. |
 | GET | `/repos/{owner}/{repo}/contents/{path}` | Fetch `.gitignore`/`.github/` from the template (`submit`). |

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -59,16 +59,18 @@ Run once per machine, or after a token rotation:
 gh teacher login
 ```
 
-This checks your existing `gh` credentials first: a token that already carries
-the required scopes is **reused untouched** (no re-auth, no rewrite of your `gh`
-configuration). Only an absent or under-scoped gh-managed token triggers
-`gh auth login -s admin:org -s read:org -s repo -s workflow` — with a warning
-first, since that rewrites your stored `gh` auth. An under-scoped token supplied
-via `GH_TOKEN` or your keyring can't be refreshed by `gh`, so the CLI errors
-with remediation instead. It's the unified Classroom 50 scope set —
-`gh teacher login` and `gh student login` request the same scopes, so
+This wraps `gh auth login -s admin:org -s read:org -s repo -s workflow` — the
+unified Classroom 50 scope set, shared with `gh student login`, so
 authenticating one CLI covers the other. (`delete_repo` is not included — opt
 in with `gh teacher login -s delete_repo` for teardown.)
+
+You often don't need to run it. Every other command checks your existing `gh`
+credentials first: a sufficiently-scoped token is reused untouched, and an
+under-scoped token that `gh` manages is widened in place with `gh auth refresh`
+(your token is kept). `login` itself always re-runs `gh auth login`, which
+**replaces** your stored github.com token — so when one already exists, the CLI
+warns and asks for confirmation before proceeding. See
+[Will `gh teacher login` disturb my existing `gh` setup?](Troubleshooting#will-gh-teacher-login-disturb-my-existing-gh-setup).
 
 | Scope | Required for |
 |---|---|

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,13 +8,16 @@ Use it as a web app at [classroom50.org](https://classroom50.org/) or as the
 `gh teacher` and `gh student` command-line tools.
 
 > [!NOTE]
-> The Fifty Foundation hosts occasional live online training sessions on
-> Classroom 50. The next one is
-> [Friday, August 14, 1pm-2pm EDT](https://time.cs50.io/20260814T1300-0400/PT1H?title=Classroom+50+Training+Session)
-> — [register here](https://docs.google.com/forms/d/e/1FAIpQLSdSZzOUOtSExmldFOsdlePWGZkJELHnZBpH3NPhXAJMDG9eXA/viewform?usp=dialog).
-> Materials from the July 24 session are available:
-> [slides](images/classroom_50_training_session.pdf) and
-> [video](https://youtu.be/gpIz6XEVlEE).
+> The Fifty Foundation will host two online training sessions to teach you how
+> to use Classroom 50 and to answer your questions live. The sessions will take
+> place at the following times:
+>
+> - [Friday, July 24, 1pm-2pm EDT](https://time.cs50.io/20260724T1300-0400/PT1H?title=Classroom+50+Training+Session)
+>   - [Slides](images/classroom_50_training_session.pdf)
+>   - [Video](https://youtu.be/gpIz6XEVlEE)
+> - [Friday, August 14, 1pm-2pm EDT](https://time.cs50.io/20260814T1300-0400/PT1H?title=Classroom+50+Training+Session)
+>
+> To sign up to attend one of the training sessions, [complete the registration form here](https://docs.google.com/forms/d/e/1FAIpQLSdSZzOUOtSExmldFOsdlePWGZkJELHnZBpH3NPhXAJMDG9eXA/viewform?usp=dialog).
 
 ## How it works, in brief
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,16 +8,13 @@ Use it as a web app at [classroom50.org](https://classroom50.org/) or as the
 `gh teacher` and `gh student` command-line tools.
 
 > [!NOTE]
-> The Fifty Foundation will host two online training sessions to teach you how
-> to use Classroom 50 and to answer your questions live. The sessions will take
-> place at the following times:
->
-> - [Friday, July 24, 1pm-2pm EDT](https://time.cs50.io/20260724T1300-0400/PT1H?title=Classroom+50+Training+Session)
->   - [Slides](images/classroom_50_training_session.pdf)
->   - [Video](https://youtu.be/gpIz6XEVlEE)
-> - [Friday, August 14, 1pm-2pm EDT](https://time.cs50.io/20260814T1300-0400/PT1H?title=Classroom+50+Training+Session)
->
-> To sign up to attend one of the training sessions, [complete the registration form here](https://docs.google.com/forms/d/e/1FAIpQLSdSZzOUOtSExmldFOsdlePWGZkJELHnZBpH3NPhXAJMDG9eXA/viewform?usp=dialog).
+> The Fifty Foundation hosts occasional live online training sessions on
+> Classroom 50. The next one is
+> [Friday, August 14, 1pm-2pm EDT](https://time.cs50.io/20260814T1300-0400/PT1H?title=Classroom+50+Training+Session)
+> — [register here](https://docs.google.com/forms/d/e/1FAIpQLSdSZzOUOtSExmldFOsdlePWGZkJELHnZBpH3NPhXAJMDG9eXA/viewform?usp=dialog).
+> Materials from the July 24 session are available:
+> [slides](images/classroom_50_training_session.pdf) and
+> [video](https://youtu.be/gpIz6XEVlEE).
 
 ## How it works, in brief
 

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -49,6 +49,26 @@ hosted service can. As a result:
   GitHub Actions on a schedule, but only after you provision the
   [service token](#the-service-token) that lets them act while you are offline.
 
+### When state refreshes
+
+Because state lives on GitHub, "what you see" depends on when something last
+read it:
+
+- **Web app** — loading a page reads the current GitHub state (so opening
+  classroom50.org effectively refreshes the roster, teams, and config), and
+  signing in as an owner can additionally run reconciliation upkeep. One
+  exception: the **organization list** is cached for ten minutes — use
+  **Refresh list** to force it.
+- **CLI reads** (`roster list`, `classroom list`, `member list`, …) report
+  what's committed and on GitHub **at that moment**; they never write or
+  reconcile. If the web app shows a newer roster than `roster list` did a
+  minute earlier, someone (or a sign-in reconciliation) committed in between.
+- **CLI writes** (`roster add`, `staff add`, `assignment add`, …) update the
+  config repo and GitHub teams immediately, but only for the thing they
+  change — they don't run the web app's broader reconciliation.
+- **Grades** refresh only when collection runs: nightly, or on demand via
+  **Sync now** / `collect-scores.yaml`.
+
 For teachers, this means administering Classroom 50 is closer to administering
 your own GitHub organization than to using a hosted service. If a view looks out
 of date, signing in and reopening the page often updates it.
@@ -203,7 +223,7 @@ organization. See [the service-token setup](CLI-Teacher-Guide#create-the-service
 | Backend | Hosted service | None (GitHub repos + Actions) |
 | Classroom ↔ org | One classroom per org | Many classrooms per org |
 | Grading | Hosted autograder | GitHub Actions in each repo |
-| Feedback PR | Opened at accept | Opened at accept |
+| Joining | Students self-select their roster entry from an invite link | The owner invites students; accept links work once they've joined the org |
 | Group naming | Team names | Founder's username |
 | Data | In the service | In your `classroom50` config repo (yours to keep) |
 

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -49,6 +49,9 @@ hosted service can. As a result:
   GitHub Actions on a schedule, but only after you provision the
   [service token](#the-service-token) that lets them act while you are offline.
 
+For teachers, this means administering Classroom 50 is closer to administering
+your own GitHub organization than to using a hosted service.
+
 ### When state refreshes
 
 Because state lives on GitHub, "what you see" depends on when something last
@@ -58,7 +61,8 @@ read it:
   classroom50.org effectively refreshes the roster, teams, and config), and
   signing in as an owner can additionally run reconciliation upkeep. One
   exception: the **organization list** is cached for ten minutes — use
-  **Refresh list** to force it.
+  **Refresh list** to force it. If a view looks out of date, reopening the page
+  usually updates it.
 - **CLI reads** (`roster list`, `classroom list`, `member list`, …) report
   what's committed and on GitHub **at that moment**; they never write or
   reconcile. If the web app shows a newer roster than `roster list` did a
@@ -68,10 +72,6 @@ read it:
   change — they don't run the web app's broader reconciliation.
 - **Grades** refresh only when collection runs: nightly, or on demand via
   **Sync now** / `collect-scores.yaml`.
-
-For teachers, this means administering Classroom 50 is closer to administering
-your own GitHub organization than to using a hosted service. If a view looks out
-of date, signing in and reopening the page often updates it.
 
 ## Interactive vs. background work
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -39,12 +39,17 @@ Workarounds:
 
 ## "Couldn't verify the Actions spending cap"
 
-Setup applies a **$0 Actions spending cap** so a runaway workflow can't run up
-a bill, then verifies it. On **GitHub Enterprise** (and some other setups)
-billing is managed above the organization, so your OAuth token can't read it
-and the verification fails with an advisory warning (e.g. `read failed
-(400)`). This is expected and **doesn't block anything** — confirm your
-Actions spending limits with your Enterprise administrator instead.
+Setup creates a **$0 GitHub Actions spending cap** so a runaway workflow can't
+run up a bill — but only when your organization has no Actions cap yet; a cap
+you set yourself is never modified. It then verifies the cap, and that
+verification can fail with an advisory warning (e.g. `read failed (400)`) when
+billing isn't readable by your token — typically **enterprise-managed
+billing**, a plan that doesn't expose organization budgets, or a token without
+Organization Administration read.
+
+This is expected and **doesn't block anything** — Classroom 50 keeps working.
+Confirm your Actions spending limits in the organization's billing settings, or
+with your Enterprise/billing administrator.
 
 ## My organization doesn't appear
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -19,6 +19,33 @@ GH_DEBUG=api gh teacher invite <org> <username>
 
 Commands with informational output also accept `--quiet` / `-q`.
 
+## classroom50.org won't load, or is flagged as unsafe
+
+A few ISPs and school web filters have blocked `classroom50.org` (a relatively
+new domain) as a suspected phishing site — the symptom is a timeout, a
+DNS failure, or an ISP warning page (Safari may just time out without showing
+the warning). Classroom 50 is not compromised; we file unblock requests with
+ISPs and security vendors as reports come in.
+
+Workarounds:
+
+- **Add an exception.** On a home connection, add `classroom50.org` to the
+  ISP's security-feature exception list (e.g. AT&T ActiveArmor) or switch the
+  device's DNS resolver (e.g. `1.1.1.1` or `8.8.8.8`).
+- **School/district filters:** ask IT to allow the domains in
+  [Network and allowed domains](GitHub-Integration#network-and-allowed-domains).
+- Please still [report it](https://github.com/foundation50/classroom50/issues)
+  with the ISP's name so we can request an unblock.
+
+## "Couldn't verify the Actions spending cap"
+
+Setup applies a **$0 Actions spending cap** so a runaway workflow can't run up
+a bill, then verifies it. On **GitHub Enterprise** (and some other setups)
+billing is managed above the organization, so your OAuth token can't read it
+and the verification fails with an advisory warning (e.g. `read failed
+(400)`). This is expected and **doesn't block anything** — confirm your
+Actions spending limits with your Enterprise administrator instead.
+
 ## My organization doesn't appear
 
 GitHub only reports organizations you've granted Classroom 50 access to. A
@@ -81,6 +108,29 @@ gh auth refresh -s admin:org,workflow
 
 Whether a plain `gh auth login` already granted `workflow` depends on unrelated
 prompt choices, which is why this appears on some machines and not others.
+
+## Will `gh teacher login` disturb my existing `gh` setup?
+
+The Classroom 50 CLIs share the GitHub CLI's credential store (`hosts.yml`), so
+this is worth knowing if you already use `gh` for other work:
+
+- A stored token that **already carries** the required scopes (`admin:org`,
+  `read:org`, `repo`, `workflow`) is **reused untouched** — `login` changes
+  nothing.
+- An absent or under-scoped **gh-managed** token triggers `gh auth login`,
+  which mints a new token and **rewrites your stored `gh` auth for
+  github.com**; the CLI warns before doing so. If you'd rather add scopes to
+  your existing token in place, run `gh auth refresh -s admin:org,workflow`
+  yourself first.
+- A token supplied via **`GH_TOKEN`** (or your keyring) can't be refreshed by
+  `gh`, so an under-scoped one produces an error with remediation rather than
+  a silent rewrite.
+- With **multiple `gh` accounts**, the CLIs use whichever account is active
+  for github.com (`gh auth status`); switch with `gh auth switch` before
+  running teacher/student commands.
+
+Not sure whether you need to log in at all? `gh teacher audit <org>` is
+read-only and a good first probe of your existing credentials.
 
 ## "Not an admin" on `gh teacher invite`
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -116,26 +116,40 @@ prompt choices, which is why this appears on some machines and not others.
 
 ## Will `gh teacher login` disturb my existing `gh` setup?
 
-The Classroom 50 CLIs share the GitHub CLI's credential store (`hosts.yml`), so
-this is worth knowing if you already use `gh` for other work:
+The Classroom 50 CLIs share the GitHub CLI's credential store, so this is worth
+knowing if you already use `gh` for other work.
 
-- A stored token that **already carries** the required scopes (`admin:org`,
-  `read:org`, `repo`, `workflow`) is **reused untouched** — `login` changes
-  nothing.
-- An absent or under-scoped **gh-managed** token triggers `gh auth login`,
-  which mints a new token and **rewrites your stored `gh` auth for
-  github.com**; the CLI warns before doing so. If you'd rather add scopes to
-  your existing token in place, run `gh auth refresh -s admin:org,workflow`
-  yourself first.
-- A token supplied via **`GH_TOKEN`** (or your keyring) can't be refreshed by
-  `gh`, so an under-scoped one produces an error with remediation rather than
-  a silent rewrite.
-- With **multiple `gh` accounts**, the CLIs use whichever account is active
-  for github.com (`gh auth status`); switch with `gh auth switch` before
-  running teacher/student commands.
+**Running any teacher/student command** (not `login`) never disturbs a working
+setup unnecessarily:
 
-Not sure whether you need to log in at all? `gh teacher audit <org>` is
-read-only and a good first probe of your existing credentials.
+- A stored token that already carries the required scopes (`admin:org`,
+  `read:org`, `repo`, `workflow`) is **reused untouched**.
+- An under-scoped token that `gh` manages (its config file or OS keyring) is
+  widened in place with `gh auth refresh` — your existing token is kept, not
+  replaced, and no other `gh` settings change.
+- An under-scoped token from **`GH_TOKEN` / `GITHUB_TOKEN`** can't be widened by
+  `gh`, so you get an error naming the missing scopes: re-issue that token with
+  them, or unset the variable and sign in.
+- With no stored token at all, the command starts a sign-in for you.
+
+**Running `login` explicitly is the one clobbering path.** `gh teacher login`
+wraps `gh auth login`, which mints a **new** token and replaces your stored
+github.com auth. When a token already exists, the CLI warns and asks
+`Proceed and let gh auth login replace it? [y/N]` — the default is **No**, and
+declining leaves your auth untouched and prints the alternatives:
+
+```sh
+gh auth refresh -h github.com -s admin:org,read:org,repo,workflow   # widen in place
+export GH_TOKEN=<a PAT with those scopes>                           # or bring your own
+```
+
+So if `gh` is already set up, you usually don't need `login` at all — just run
+the command you want and let it add any missing scope in place.
+
+With **multiple `gh` accounts**, the CLIs use whichever account is active for
+github.com (`gh auth status`); switch with `gh auth switch` first. Not sure
+whether anything needs fixing? `gh teacher audit <org>` is read-only and a good
+first probe.
 
 ## "Not an admin" on `gh teacher invite`
 

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -109,3 +109,10 @@ If your teacher configured autograding, click **View grade** to see your results
 on GitHub:
 
 ![Submission on GitHub](images/web_assignment_github_release_student.png)
+
+> [!NOTE]
+> Grades live on your repository's GitHub **Releases** — each graded submission
+> publishes a Release with the score and a per-test breakdown. Classroom 50
+> can't yet display the score inside the app itself, so **View grade** takes
+> you to the Release. Your teacher may also leave comments on your feedback
+> pull request.

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -385,8 +385,10 @@ assignment:
   preserved). This is the enforcement mechanism for deadlines — the due date
   itself only marks submissions late. **Reopen submission** restores write
   access.
-- **Lock assignment** / **Unlock assignment** — prevent further accepts of the
-  assignment.
+- **Lock assignment** / **Unlock assignment** — lock the assignment so
+  students can't access or accept it (and, for a private template, remove the
+  student team's read on it); unlock reopens it and restores template access.
+  Useful for staging an assignment before release.
 - **Download scores (CSV)** — export all submissions as a CSV.
 - **Download all submissions** — download each repository's latest submission
   bundled into a single zip (built in the browser, one repository at a time;

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -156,10 +156,11 @@ How each student's repository is created:
   [Assignment Templates](Assignment-Templates) for requirements.
 - **Add a README** (no-template assignments) — whether the repository starts
   with an initial commit. With it **off**, what students get depends on the
-  built-in autograder choice below:
-  - autograder **off** → a **truly bare repository**: no commit, no
-    autograding, and no feedback pull request (permanently — not just until the
-    student's first commit). Use it when students build everything from
+  built-in autograder choice under [Grading and
+  submissions](#grading-and-submissions):
+  - autograder **off** (the default) → a **truly bare repository**: no commit,
+    no autograding, and no feedback pull request (permanently — not just until
+    the student's first commit). Use it when students build everything from
     scratch, including their own GitHub Actions.
   - autograder **on** → an initialized repository carrying only the control
     files (no README, no starter content) that grades normally.
@@ -182,21 +183,24 @@ How each student's repository is created:
 - **Student repo access** — the role students get on their own repository.
 
 > [!WARNING]
-> **The empty-repository choice is permanent** — you can't change it after
-> creating the assignment, because repositories students already accepted
-> can't be retrofitted.
+> **These repository-shape choices are permanent** — the template/README/bare
+> and built-in-autograder choices can't be changed after you create the
+> assignment, because repositories students already accepted can't be
+> retrofitted.
 
 ### Grading and submissions
 
-- **Built-in autograder** — **Use the built-in autograder** (the default) or
-  **Do not use the built-in autograder**. Opting out means accept installs no
-  autograding workflow at all: on a templated assignment your template's own
-  CI workflows run instead, and Classroom 50's score collection skips the
-  assignment. Immutable after creation.
-- **Grading** — **Not graded**, **Autograded**, or **Manual (enter scores by
-  hand)**. Manual assignments get a **Max points** field, and you enter each
-  student's score directly on the submissions page (see below). Immutable
+- **Grading** — **Not graded** (the default), **Autograded**, or **Manual
+  (enter scores by hand)**. The autograding options below are offered only
+  under **Autograded**; **Manual** assignments get a **Max points** field and
+  you enter each student's score on the submissions page (see below). Immutable
   after creation.
+- **Built-in autograder** — under **Autograded**, choose **Use the built-in
+  autograder** or **Do not use the built-in autograder** (the default on a new
+  assignment). Opting out means accept installs no autograding workflow at all:
+  on a templated assignment your template's own CI workflows run instead, and
+  Classroom 50's score collection skips the assignment. Immutable after
+  creation.
 - **Submission type** — when the autograder runs. **Every push to the default
   branch** (the default) grades each push. **A tagged commit** grades only
   when a student submits (`gh student submit`) or pushes a `submit/*` tag —

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -165,7 +165,7 @@ How each student's repository is created:
 - **Copy About from template** / **Copy topics from template** (templated, both
   on by default) — carry the template's About description and topics over to
   each student repository (GitHub's template-generate doesn't copy them on its
-  own).
+  own). Applies when students accept in the web app.
 - **Repository features** — per-feature settings for **Issues**, **Wiki**,
   **Projects**, and **Pull requests** on student repositories. The default,
   **Inherit from template**, re-applies the template's current setting at
@@ -350,11 +350,16 @@ and links to the repository, the commit, the feedback pull request
 
 ### Manual grades
 
-On a **Manual** grading-mode assignment (and as an override elsewhere), each
-row has an **Add grade** / **Edit grade** button for entering a score by hand.
-A hand-entered score is stored as an override in the classroom's `scores.json`
-and shows a **Manual** badge — autograding won't change it until the override
-is cleared.
+On an assignment created with **Grading → Manual (enter scores by hand)**, each
+row gets an **Add grade** / **Edit grade** button for entering a score out of
+the assignment's **Max points**. A hand-entered score is stored as an override
+in the classroom's `scores.json` and shows a **Manual** badge — autograding
+won't change it until the override is cleared.
+
+The inline editor appears only on manual-mode assignments, and only for
+organization owners (entering a score writes the config repo). To adjust a
+score on an **autograded** assignment, edit `scores.json` directly — see the
+[FAQ](FAQ#can-i-manually-override-or-adjust-a-grade).
 
 ### Bulk actions
 
@@ -380,6 +385,8 @@ assignment:
   workflow-disable API. No files are changed, and you can resume anytime;
   other workflows in student repositories keep running. Use it to stop
   autograding for one assignment without touching the rest of the org.
+  (Available on individual assignments that use the built-in autograder, once
+  students have accepted; a single repository can also be paused from its row.)
 - **Close submission** / **Reopen submission** — close the submission window:
   block new accepts and set every student's repository to read-only (work is
   preserved). This is the enforcement mechanism for deadlines — the due date

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -155,10 +155,14 @@ How each student's repository is created:
   `<repo>` if it's in this organization. See
   [Assignment Templates](Assignment-Templates) for requirements.
 - **Add a README** (no-template assignments) — whether the repository starts
-  with an initial commit. Leaving it **off** creates a completely **empty
-  repository**: no initial commit, and autograding and the feedback pull
-  request are unavailable until the student's first commit. Use it when
-  students build everything from scratch.
+  with an initial commit. With it **off**, what students get depends on the
+  built-in autograder choice below:
+  - autograder **off** → a **truly bare repository**: no commit, no
+    autograding, and no feedback pull request (permanently — not just until the
+    student's first commit). Use it when students build everything from
+    scratch, including their own GitHub Actions.
+  - autograder **on** → an initialized repository carrying only the control
+    files (no README, no starter content) that grades normally.
 - **Include all branches** (templated) — copy **all** of the template's
   branches into each student repository, not just the default branch. Useful
   for multi-branch starter repos.

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -75,10 +75,15 @@ When step 1 is complete, continue to step 2 to add your service token.
 
 ### Add a service token
 
-The **service token** is a fine-grained personal access token (PAT) with read
-access to your organization's repositories. Classroom 50 stores it as the
-`CLASSROOM50_SERVICE_TOKEN` secret in your config repo, where the daily
-score-collection workflow uses it.
+The **service token** is a fine-grained personal access token (PAT) scoped to
+your organization, used by the score-collection and regrade workflows to read
+student repositories (and push regrade tags) across the org. It needs
+**Contents**, **Actions**, and **Administration** read/write plus
+**Organization → Members** read — the form and the pre-filled GitHub page set
+these up for you; the full permission table is in
+[GitHub Integration](GitHub-Integration#4-fine-grained-pat-for-score-collection).
+Classroom 50 stores it as the `CLASSROOM50_SERVICE_TOKEN` secret in your config
+repo, where the daily score-collection workflow uses it.
 
 ![Service token setup](images/web_pat.png)
 
@@ -133,33 +138,71 @@ On the classroom page, click **+ Assignment**. Fill in:
 
 - **Name** — the assignment's name.
 - **Description** (optional) — details for students.
-- **Template repository** (optional) — a [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)
-  used as each student's starting point. Enter `<owner>/<repo>`, or just
-  `<repo>` if it's in this organization. Leave blank for an empty starter repo.
-- **Due date** (optional) — a date and time in your local timezone.
+- **Due date** (optional) — a date and time in your local timezone. A deadline
+  marks later submissions **late** in the gradebook; it does not block pushes
+  or revoke access. To actually close an assignment, use the **Close
+  submission** action (see below).
 - **Assignment type** — **Individual** (one repository per student) or **Group
   project** (students share a repository and submit together).
+
+### Repository setup
+
+How each student's repository is created:
+
+- **Start with a template** — **No template** or **Template repository**: a
+  [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)
+  used as each student's starting point. Enter `<owner>/<repo>`, or just
+  `<repo>` if it's in this organization. See
+  [Assignment Templates](Assignment-Templates) for requirements.
+- **Add a README** (no-template assignments) — whether the repository starts
+  with an initial commit. Leaving it **off** creates a completely **empty
+  repository**: no initial commit, and autograding and the feedback pull
+  request are unavailable until the student's first commit. Use it when
+  students build everything from scratch.
+- **Include all branches** (templated) — copy **all** of the template's
+  branches into each student repository, not just the default branch. Useful
+  for multi-branch starter repos.
+- **Copy About from template** / **Copy topics from template** (templated, both
+  on by default) — carry the template's About description and topics over to
+  each student repository (GitHub's template-generate doesn't copy them on its
+  own).
+- **Repository features** — per-feature settings for **Issues**, **Wiki**,
+  **Projects**, and **Pull requests** on student repositories. The default,
+  **Inherit from template**, re-applies the template's current setting at
+  accept time (again, GitHub's generate doesn't copy these); you can force any
+  feature **On** or **Off** instead. Template-less assignments default to
+  GitHub's own defaults. To reconcile repositories that already exist, use the
+  **Update repository features** action on the submissions page.
 - **Feedback pull request** — automatically opens a pull request per student so
   you can review changes and leave inline feedback.
-- **Autograding trigger** — when the autograder runs. **Every push** (the
-  default) grades each push to the default branch. **On submit only** grades
-  only when a student submits (`gh student submit`) or pushes a `submit/*`
-  tag — regular pushes cost no Actions minutes, which matters at scale.
-- **Milestone submission tags** (optional) — tag names (e.g. `phase1`,
-  `phase2`, `complete`) that also trigger grading. A student pushes the tag
-  with plain git (`git tag phase1 && git push origin phase1`) and that commit
-  grades; the result appears as a normal `submit/*` release titled "via
-  phase1". Prefer exact names — a broad glob like `v*` grades every matching
-  tag. Changing them later requires the same trigger update as the mode (see
-  below).
-- **Empty repository** — creates each student's repository completely empty: no
-  starter files, no autograding, no feedback pull request. Use it when students
-  build everything from scratch, including their own GitHub Actions.
+- **Student repo access** — the role students get on their own repository.
 
 > [!WARNING]
-> **Empty repository is permanent** — you can't change it after creating the
-> assignment, because repositories students already accepted can't be
-> retrofitted. Enabling it hides the template and grading fields.
+> **The empty-repository choice is permanent** — you can't change it after
+> creating the assignment, because repositories students already accepted
+> can't be retrofitted.
+
+### Grading and submissions
+
+- **Built-in autograder** — **Use the built-in autograder** (the default) or
+  **Do not use the built-in autograder**. Opting out means accept installs no
+  autograding workflow at all: on a templated assignment your template's own
+  CI workflows run instead, and Classroom 50's score collection skips the
+  assignment. Immutable after creation.
+- **Grading** — **Not graded**, **Autograded**, or **Manual (enter scores by
+  hand)**. Manual assignments get a **Max points** field, and you enter each
+  student's score directly on the submissions page (see below). Immutable
+  after creation.
+- **Submission type** — when the autograder runs. **Every push to the default
+  branch** (the default) grades each push. **A tagged commit** grades only
+  when a student submits (`gh student submit`) or pushes a `submit/*` tag —
+  regular pushes cost no Actions minutes, which matters at scale.
+- **Submission tags** (optional) — tag names (e.g. `phase1`, `phase2`,
+  `complete`) that also trigger grading. A student pushes the tag with plain
+  git (`git tag phase1 && git push origin phase1`) and that commit grades; the
+  result appears as a normal `submit/*` release titled "via phase1". Prefer
+  exact names — a broad glob like `v*` grades every matching tag. Changing
+  them later requires the same trigger update as the mode (see below).
 
 ### Advanced settings
 
@@ -193,8 +236,8 @@ for dependency installation and environment-variable guidance.
 
 ### Autograding tests
 
-Autograding tests run every time a student pushes. Click **Add test** to add
-one.
+Autograding tests run whenever a submission grades (per the assignment's
+submission type). Click **Add test** to add one.
 
 ![Autograding tests](images/web_create_assignment_tests.png)
 
@@ -280,8 +323,14 @@ demand) aggregates those results into the classroom's gradebook.
 
 ![Assignment with submissions](images/web_viewing_assignment_submissions.png)
 
-Collect scores by letting the nightly workflow run, or click **Collect now** at
-the top of the submissions page. Click **View workflow** to see the Actions run.
+Scores flow into the gradebook when collection runs: the nightly workflow
+covers every classroom, or click **Sync now** in the freshness strip at the top
+of the submissions page (also **Collect now** in the **Actions** menu). Both
+are **scoped to the current assignment** — they walk only this assignment's
+repositories, so a sync is fast even in a large classroom and doesn't rebuild
+other assignments' gradebooks. The strip shows when this assignment's data was
+last synced (a per-assignment `collected_at` stamp in `scores.json`). Click
+**View workflow** to see the Actions run.
 
 The top of the page shows:
 
@@ -299,10 +348,56 @@ Each row shows a student's (or group's) latest submission plus its full history
 and links to the repository, the commit, the feedback pull request
 (**Review**), and the Release (**Details**).
 
+### Manual grades
+
+On a **Manual** grading-mode assignment (and as an override elsewhere), each
+row has an **Add grade** / **Edit grade** button for entering a score by hand.
+A hand-entered score is stored as an override in the classroom's `scores.json`
+and shows a **Manual** badge — autograding won't change it until the override
+is cleared.
+
+### Bulk actions
+
+The **Actions** menu at the top of the submissions page operates on the whole
+assignment:
+
+- **Metrics** — summary statistics for the assignment.
+- **Open all Feedback PRs** — review each student's feedback pull request in
+  turn.
+- **Collect now** — trigger a score collection scoped to this assignment.
+- **Regrade all** — re-run the autograder on every collected submission.
+- **Update student repo access** — bulk-set every student's role on their
+  repository (e.g. drop everyone to read-only for grading, restore write
+  afterwards).
+- **Update repository features** — re-apply the assignment's Issues / Wiki /
+  Projects / Pull-requests settings to every existing student repository
+  (repositories created before a settings change, or before features were
+  inherited from the template).
+- **Update autograding triggers** — retrofit existing repositories after a
+  submission-type change (see below).
+- **Pause autograding** / **Resume autograding** — disable or re-enable the
+  built-in `autograde.yaml` workflow in every student repository via GitHub's
+  workflow-disable API. No files are changed, and you can resume anytime;
+  other workflows in student repositories keep running. Use it to stop
+  autograding for one assignment without touching the rest of the org.
+- **Close submission** / **Reopen submission** — close the submission window:
+  block new accepts and set every student's repository to read-only (work is
+  preserved). This is the enforcement mechanism for deadlines — the due date
+  itself only marks submissions late. **Reopen submission** restores write
+  access.
+- **Lock assignment** / **Unlock assignment** — prevent further accepts of the
+  assignment.
+- **Download scores (CSV)** — export all submissions as a CSV.
+- **Download all submissions** — download each repository's latest submission
+  bundled into a single zip (built in the browser, one repository at a time;
+  for very large classes prefer `gh teacher download`, which clones every repo
+  and writes a `scores.csv` — see the
+  [CLI Teacher Guide](CLI-Teacher-Guide#10-download-submissions)).
+
 ### Download scores
 
-Click **Download Scores (CSV)** at the top right to export all submissions as a
-CSV for a spreadsheet or external tool.
+Click **Download scores (CSV)** to export all submissions as a CSV for a
+spreadsheet or external tool.
 
 ## Edit assignments and classrooms
 
@@ -311,12 +406,12 @@ CSV for a spreadsheet or external tool.
 - **Edit a classroom** — open the classroom, then **Settings**. Same form as
   creating one, pre-filled.
 
-### Changing the autograding trigger later
+### Changing the submission type later
 
 The trigger is baked into each student repository's autograding workflow when
-the student accepts, so changing it in **Assignment settings** only affects
-repositories created from then on. To update repositories students already
-accepted:
+the student accepts, so changing the submission type in **Assignment settings**
+only affects repositories created from then on. To update repositories students
+already accepted:
 
 1. Change the trigger in **Assignment settings** and save.
 2. On the submissions page, open the actions menu and click **Update

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -130,13 +130,13 @@ commit** is skipped (nothing to grade); your first real submit always grades.
 ## `whoami` / `login` / `logout`
 
 - `whoami` — prints the authenticated GitHub user.
-- `login` — checks your existing `gh` credentials first and **reuses them if
-  they already carry the required scopes** (`admin:org`, `read:org`, `repo`,
-  `workflow` — the unified set shared with `gh teacher login`). Only an absent
-  or under-scoped gh-managed token triggers `gh auth login`, with a warning
-  before your stored gh auth is rewritten; an under-scoped token supplied via
-  `GH_TOKEN` or your keyring errors with remediation instead. Add scopes with
-  `-s`.
+- `login` — wraps `gh auth login` with the unified scope set (`admin:org`,
+  `read:org`, `repo`, `workflow`, shared with `gh teacher login`); add scopes
+  with `-s`. It replaces your stored github.com token, so when one already
+  exists it warns and asks for confirmation. `accept` and `submit` don't need
+  it: they reuse a sufficiently-scoped token untouched and widen an
+  under-scoped gh-managed one in place. See
+  [Will `gh teacher login` disturb my existing `gh` setup?](Troubleshooting#will-gh-teacher-login-disturb-my-existing-gh-setup).
 - `logout` — runs `gh auth logout`.
 
 ## Contributing

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -39,7 +39,13 @@ a `git clone` command.
    *before* creating the repo, so a fetch failure leaves no half-baked repo).
 4. Creates the repo — from the template, an empty `auto_init` repo, or (for an
    `empty_repo` assignment) a truly bare repo with steps 3 and 7 skipped.
-5. Disables issues, projects, and wiki.
+5. Applies the assignment's repository features (Issues, Wiki, Projects, Pull
+   requests). By default each feature **inherits the template's setting**
+   (GitHub's template-generate doesn't copy them, so accept reads the template
+   and re-applies them); the teacher can force any feature on or off per
+   assignment. A template-less assignment keeps GitHub's own defaults unless
+   the teacher forced a feature. Best-effort — a rejected feature update never
+   fails accept.
 6. Sets your repo role: `push` for an individual assignment, or `admin` for a
    group assignment (so a group founder can invite teammates).
 7. Commits `.classroom50.yaml` and `.github/workflows/autograde.yaml` in one
@@ -124,8 +130,13 @@ commit** is skipped (nothing to grade); your first real submit always grades.
 ## `whoami` / `login` / `logout`
 
 - `whoami` — prints the authenticated GitHub user.
-- `login` — runs `gh auth login -s admin:org -s read:org -s repo -s workflow`
-  (the unified scope set, shared with `gh teacher login`); add scopes with `-s`.
+- `login` — checks your existing `gh` credentials first and **reuses them if
+  they already carry the required scopes** (`admin:org`, `read:org`, `repo`,
+  `workflow` — the unified set shared with `gh teacher login`). Only an absent
+  or under-scoped gh-managed token triggers `gh auth login`, with a warning
+  before your stored gh auth is rewritten; an under-scoped token supplied via
+  `GH_TOKEN` or your keyring errors with remediation instead. Add scopes with
+  `-s`.
 - `logout` — runs `gh auth logout`.
 
 ## Contributing

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -147,13 +147,18 @@ Classrooms are root-level directories in `<org>/classroom50`, each with a
 ### `classroom add`
 
 ```sh
-gh teacher classroom add <org> <short-name> [--name "<full name>"] [--term <term>]
-gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Spring-2026
+gh teacher classroom add <org> <short-name> [--name "<full name>"] [--term <term>] [--unlisted] [--key <key>]
+gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Fall-2026
 ```
 
 **Short-name rules:** `^[a-z0-9][a-z0-9-]{1,38}$` — 2–39 characters, lowercase
 letters/digits/hyphens, starting with a letter or digit. It becomes part of
 student repo names (`<short-name>-<assignment>-<username>`).
+
+`--unlisted` publishes the classroom's resources at an unguessable URL path
+segment (the web app's "Use an unlisted link" option — obscurity, not access
+control; it prompts to accept a generated key). `--key <key>` supplies a
+specific access key instead of the generated one (implies `--unlisted`).
 
 Scaffolds four files in one commit — `classroom.json`, `assignments.json`,
 `roster.csv`, `scores.json` — and creates the `classroom50-<short-name>` GitHub
@@ -429,10 +434,10 @@ templated repo has a baseline commit); it is mutually exclusive with
 `empty_repo`, a non-default `--autograder`, and the grading-adjacent fields
 (tests/allowed-files/release-assets/pass-threshold/submission-mode/
 submission-tag), and it is immutable after creation. Score collection and
-regrade skip it (no `submit/*` releases are produced). It is currently set by
-writing `no_autograder: true` into `assignments.json` (via the gradebook's
-edit path); there is no `assignment add` flag and no dedicated form control for
-it yet.
+regrade skip it (no `submit/*` releases are produced). Set it in the web app's
+assignment form — choose **"Do not use the built-in autograder"** under
+**Built-in autograder** — or by writing `no_autograder: true` into
+`assignments.json`; there is no `assignment add` flag.
 
 **Built-in autograder on an otherwise-empty repo (`init_shim`).** A
 **template-less** assignment can carry `init_shim: true` in `assignments.json`
@@ -446,10 +451,10 @@ assignment (the grading pipeline does **not** skip it). It **requires** the
 default autograder and **no** template (a template provides its own starter
 content); it is mutually exclusive with `empty_repo`, `template`,
 `no_autograder`, and a non-default `--autograder`, and it **permits** the
-grading-adjacent fields (it autogrades). It is immutable after creation. Like
-`no_autograder`, it is currently set by writing `init_shim: true` into
-`assignments.json` (via the gradebook's edit path); there is no `assignment add`
-flag.
+grading-adjacent fields (it autogrades). It is immutable after creation. Set it
+in the web app's assignment form — pick **"No template"**, leave **"Add a
+README"** off, and keep **"Use the built-in autograder"** — or by writing
+`init_shim: true` into `assignments.json`; there is no `assignment add` flag.
 
 **Include all branches (`include_all_branches`).** A **templated** assignment can
 carry `include_all_branches: true` in `assignments.json` to copy **all** of the
@@ -461,8 +466,8 @@ generated); it is **compatible** with everything else, including `no_autograder`
 and the grading-adjacent fields (branches don't affect grading). Unlike the
 immutable no-shim states it is **accept-time only and mutable**: changing it
 affects only repos generated from now on (already-accepted repos are never
-re-generated). Like `no_autograder`/`init_shim` it is currently set via the
-gradebook edit path; there is no `assignment add` flag.
+re-generated). Set it with the web assignment form's **"Include all branches"**
+toggle or via `assignments.json`; there is no `assignment add` flag.
 
 <details>
 <summary>Errors</summary>
@@ -678,8 +683,10 @@ interrupted run stays safe to re-run).
 ## `whoami` / `login` / `logout`
 
 - `whoami` — prints the authenticated GitHub user.
-- `login` — runs `gh auth login -s admin:org -s read:org -s repo -s workflow`;
-  add scopes with `-s`.
+- `login` — reuses your existing `gh` credentials when they already carry the
+  required scopes (`admin:org`, `read:org`, `repo`, `workflow`); only an absent
+  or under-scoped gh-managed token triggers `gh auth login`, with a warning
+  before your stored `gh` auth is rewritten. Add scopes with `-s`.
 - `logout` — runs `gh auth logout`.
 
 ## Contributing

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -237,7 +237,7 @@ Import an existing GitHub Classroom into `<target>/classroom50`.
 
 ```sh
 gh teacher classroom migrate --source <id-or-org> --target <org> [--dry-run]
-gh teacher classroom migrate --source 95884 --target cs50-fall-2026 --short-name cs-principles --term Spring-2026
+gh teacher classroom migrate --source 95884 --target cs50-fall-2026 --short-name cs-principles --term Fall-2026
 ```
 
 For each assignment, it copies the source starter repo into the target

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -683,10 +683,13 @@ interrupted run stays safe to re-run).
 ## `whoami` / `login` / `logout`
 
 - `whoami` — prints the authenticated GitHub user.
-- `login` — reuses your existing `gh` credentials when they already carry the
-  required scopes (`admin:org`, `read:org`, `repo`, `workflow`); only an absent
-  or under-scoped gh-managed token triggers `gh auth login`, with a warning
-  before your stored `gh` auth is rewritten. Add scopes with `-s`.
+- `login` — wraps `gh auth login` with the required scopes (`admin:org`,
+  `read:org`, `repo`, `workflow`); add more with `-s`. It always mints a new
+  token and **replaces** your stored github.com auth, so when one already
+  exists it warns and asks for confirmation first. Other commands don't: they
+  reuse a sufficiently-scoped token untouched, and widen an under-scoped
+  gh-managed one in place with `gh auth refresh`. See
+  [Will `gh teacher login` disturb my existing `gh` setup?](Troubleshooting#will-gh-teacher-login-disturb-my-existing-gh-setup).
 - `logout` — runs `gh auth logout`.
 
 ## Contributing


### PR DESCRIPTION
Audits the wiki against the shipped code, the issues opened or closed in the past two weeks, and the active discussion threads. The wiki tracked features well through #531 (submission triggers), but most of the 1.28.x wave (#554–#593) shipped without wiki updates, and several support threads pointed at pre-existing holes.

Every claim here was checked against the code rather than the issue or PR prose — exact labels come from `web/src/locales/en.json`, behavior from the components, CLI, and workflow scripts. That surfaced four places where the intended fix and the shipped behavior differ, called out under "Corrections" below.

## Stale content corrected

- **Student repo features.** `gh-student.md` and `GitHub-Integration.md` said accept *disables* issues/projects/wiki. Since #479 each feature **inherits the template's setting** (GitHub's generate doesn't copy them, so accept reads the template and re-applies), with per-assignment on/off overrides and the **Update repository features** bulk action.
- **`no_autograder` / `init_shim` / `include_all_branches`** were documented as JSON-only with "no dedicated form control yet"; all three now have controls, so each entry names the form path.
- **Manual grading.** The FAQ roadmap still listed a manual-grading UI as missing (#565 shipped grading modes and manual scoring), and the override answer only described hand-editing `scores.json`.
- **Fine-grained token sign-in.** `GitHub-Integration.md` said fine-grained tokens aren't accepted on the proxy-blocked path; #532 added that flow with a pre-filled creation URL.
- **Terminology and scopes.** `Web-Teacher-Guide.md` still used "Autograding trigger" (renamed to **Submission type** in #581) and understated the service token as needing only repository read.

## Recurring questions now answered

- **Why sign-in asks for "Delete repositories"** (#592) — used only by **Tear down organization**, behind a typed confirmation, and readable without signing in. The wiki previously framed `delete_repo` as CLI-opt-in only, without noting the web OAuth grant requests it.
- **Turning autograding off** (#553, #453, Discussion #577) — documents the per-assignment **Pause autograding** action and the org-wide toggle's side effect (it stops *all* student workflows, including course CI), which #553 explicitly asked for.
- **Template requirements** (#544, #468) — a template needs at least one commit, and a fork of a repo in another org can 403 on the *parent* org's OAuth restrictions (the actual #468 resolution: approve Classroom 50 upstream, or use a fork-free copy).
- **About/topics copying** (#569, shipped in #580), **pre-existing `gh` auth** (#534), **ISP-blocked domain** (#525), **the spending-cap advisory on Enterprise** (#463), and **why students can't see grades in-app** (#567, with the CORS reason).
- From discussions: what triggers reconciliation (#548), what a deadline actually does versus **Close submission** (#543), per-assignment collection scope and `collected_at` (#542), reusing one template across assignments (#557), bulk-downloading student work (#555), hand-editing config files (#587), and one-org-versus-many guidance (#461).

## Corrections where docs and code disagreed

Four claims I had written from the issue threads turned out not to match the code, and are documented as the code actually behaves:

- **`login` is the clobbering path, not the smart one.** The scope-probe-and-reuse logic (#537) lives in the *implicit* auth path every other command uses; `gh teacher login` itself always re-runs `gh auth login` and replaces the stored token, warning and prompting `[y/N]` first. An under-scoped **gh-managed** token (config *or* keyring) is widened in place with `gh auth refresh` — only `GH_TOKEN`/`GITHUB_TOKEN` sources error out.
- **An `empty_repo` never autogrades**, not "until the student's first commit". Relatedly, **Add a README** off means a bare repo only when the built-in autograder is *also* off; with it on you get an initialized shim-only repo that grades normally.
- **The assignment form's autograder default is "Do not use the built-in autograder"** (and Grading defaults to **Not graded**), so "the default" needed reversing.
- **The inline grade editor is gated** to manual-mode assignments and org owners; it is not a general override affordance.

## Notes

Documentation-only; no release or changelog impact. Merging triggers `publish-wiki.yaml`, which overwrites the live GitHub wiki, so this lands publicly on merge.

All intra-wiki links and heading anchors were validated mechanically across the 16 pages (0 unresolved). `Home.md` is intentionally untouched — its training-session note is current.

## Post-Deploy Monitoring & Validation

No runtime or production impact. After merge, confirm the `publish-wiki` workflow run succeeds and spot-check rendering on the most-restructured pages ([Web Teacher Guide](https://github.com/foundation50/classroom50/wiki/Web-Teacher-Guide), [FAQ](https://github.com/foundation50/classroom50/wiki/FAQ), [Troubleshooting](https://github.com/foundation50/classroom50/wiki/Troubleshooting)) — nested list items and the new bulk-actions list are the parts most likely to render differently on the wiki than in the repo preview.