### PR TITLE
feat: allow editing provisioning settings after assignment creation

### DIFF
--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -1070,24 +1070,14 @@ func validateIncludeAllBranchesExclusions(entry AssignmentEntry) error {
 // left bare) at accept time and never retrofitted, so a change only affects
 // repos accepted from now on — callers warn (they do not block) when this is
 // true. Kept as a single-sourced helper so the command and its tests agree.
+//
+// There is deliberately no NoAutograderChanged/InitShimChanged sibling: those
+// flags have no `assignment add` flag and are carried forward from the prior
+// entry before any comparison, so `add` can never change them — a detector
+// would be dead code. They stay mutable via the web GUI, which owns its own
+// edit-time confirmation.
 func EmptyRepoChanged(existing, updated AssignmentEntry) bool {
 	return existing.EmptyRepo != updated.EmptyRepo
-}
-
-// NoAutograderChanged reports whether an upsert flips no_autograder relative to
-// the existing entry, mirroring EmptyRepoChanged: the shim (or its absence) is
-// baked into each student repo at accept time and never retrofitted, so a
-// change only affects future accepts — callers warn, not block.
-func NoAutograderChanged(existing, updated AssignmentEntry) bool {
-	return existing.NoAutograder != updated.NoAutograder
-}
-
-// InitShimChanged reports whether an upsert flips init_shim relative to the
-// existing entry, mirroring EmptyRepoChanged/NoAutograderChanged: the shim (or
-// its absence) is baked in at accept time and never retrofitted, so a change
-// only affects future accepts — callers warn, not block.
-func InitShimChanged(existing, updated AssignmentEntry) bool {
-	return existing.InitShim != updated.InitShim
 }
 
 // ValidateExistingEntry is the parse-path twin of ValidateAssignmentEntry.

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -116,9 +116,11 @@ type AssignmentsJSON struct {
 // no initial commit and lands NO control files (no README, no
 // .classroom50.yaml marker, no autograde shim), so autograding and the
 // Feedback PR never run. Mutually exclusive with Template, Tests, FeedbackPR,
-// AllowedFiles, ReleaseAssets, and PassThreshold, and IMMUTABLE once the entry
-// exists — flipping it later would mean retrofitting every already-accepted repo.
-// Mirrors FeedbackPR's wire shape: omitempty, absent reads as false.
+// AllowedFiles, ReleaseAssets, and PassThreshold. MUTABLE after creation, but
+// student repos are provisioned at accept time and never retrofitted, so a
+// change only affects repos accepted from now on — `assignment add` warns
+// (EmptyRepoChanged) rather than blocking. Mirrors FeedbackPR's wire shape:
+// omitempty, absent reads as false.
 //
 // Locked hard-blocks student access: every accept surface (web + `gh student
 // accept`) refuses a locked assignment for all students, including ones who
@@ -1063,38 +1065,29 @@ func validateIncludeAllBranchesExclusions(entry AssignmentEntry) error {
 	return nil
 }
 
-// ValidateEmptyRepoUnchanged enforces empty_repo's immutability on upsert:
-// student repos are provisioned (or not) at accept time, so flipping the flag
-// after creation would strand every already-accepted repo on the old
-// behavior. Callers run it before UpsertAssignment when replacing an entry.
-func ValidateEmptyRepoUnchanged(existing, updated AssignmentEntry) error {
-	if existing.EmptyRepo != updated.EmptyRepo {
-		return fmt.Errorf("empty_repo cannot be changed after creation (assignment %q): student repos already accepted under the old setting are not retrofitted — remove the assignment and add it under a new slug instead", existing.Slug)
-	}
-	return nil
+// EmptyRepoChanged reports whether an upsert flips empty_repo relative to the
+// existing entry. empty_repo is MUTABLE, but student repos are provisioned (or
+// left bare) at accept time and never retrofitted, so a change only affects
+// repos accepted from now on — callers warn (they do not block) when this is
+// true. Kept as a single-sourced helper so the command and its tests agree.
+func EmptyRepoChanged(existing, updated AssignmentEntry) bool {
+	return existing.EmptyRepo != updated.EmptyRepo
 }
 
-// ValidateNoAutograderUnchanged enforces no_autograder's immutability on
-// upsert, mirroring ValidateEmptyRepoUnchanged: the shim (or its absence) is
-// baked into each student repo at accept time and never retrofitted, so
-// flipping the flag would strand every already-accepted repo. Callers run it
-// alongside ValidateEmptyRepoUnchanged before UpsertAssignment.
-func ValidateNoAutograderUnchanged(existing, updated AssignmentEntry) error {
-	if existing.NoAutograder != updated.NoAutograder {
-		return fmt.Errorf("no_autograder cannot be changed after creation (assignment %q): student repos already accepted under the old setting are not retrofitted — remove the assignment and add it under a new slug instead", existing.Slug)
-	}
-	return nil
+// NoAutograderChanged reports whether an upsert flips no_autograder relative to
+// the existing entry, mirroring EmptyRepoChanged: the shim (or its absence) is
+// baked into each student repo at accept time and never retrofitted, so a
+// change only affects future accepts — callers warn, not block.
+func NoAutograderChanged(existing, updated AssignmentEntry) bool {
+	return existing.NoAutograder != updated.NoAutograder
 }
 
-// ValidateInitShimUnchanged enforces init_shim's immutability on upsert,
-// mirroring ValidateEmptyRepoUnchanged/ValidateNoAutograderUnchanged: the shim
-// (or its absence) is baked into each student repo at accept time and never
-// retrofitted, so flipping the flag would strand every already-accepted repo.
-func ValidateInitShimUnchanged(existing, updated AssignmentEntry) error {
-	if existing.InitShim != updated.InitShim {
-		return fmt.Errorf("init_shim cannot be changed after creation (assignment %q): student repos already accepted under the old setting are not retrofitted — remove the assignment and add it under a new slug instead", existing.Slug)
-	}
-	return nil
+// InitShimChanged reports whether an upsert flips init_shim relative to the
+// existing entry, mirroring EmptyRepoChanged/NoAutograderChanged: the shim (or
+// its absence) is baked in at accept time and never retrofitted, so a change
+// only affects future accepts — callers warn, not block.
+func InitShimChanged(existing, updated AssignmentEntry) bool {
+	return existing.InitShim != updated.InitShim
 }
 
 // ValidateExistingEntry is the parse-path twin of ValidateAssignmentEntry.

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -2125,23 +2125,23 @@ func TestValidateAssignmentEntry_EmptyRepoExclusions(t *testing.T) {
 	}
 }
 
-// TestValidateEmptyRepoUnchanged: empty_repo is immutable on upsert — a flip
-// in either direction errors; same-value replacement is fine.
-func TestValidateEmptyRepoUnchanged(t *testing.T) {
+// TestEmptyRepoChanged: empty_repo is mutable — a flip in either direction is
+// detected (so callers can warn); same-value replacement is not a change.
+func TestEmptyRepoChanged(t *testing.T) {
 	bare := AssignmentEntry{Slug: "hw", EmptyRepo: true}
 	normal := AssignmentEntry{Slug: "hw", EmptyRepo: false}
 
-	if err := ValidateEmptyRepoUnchanged(bare, bare); err != nil {
-		t.Errorf("same value (true): %v", err)
+	if EmptyRepoChanged(bare, bare) {
+		t.Error("same value (true): reported changed")
 	}
-	if err := ValidateEmptyRepoUnchanged(normal, normal); err != nil {
-		t.Errorf("same value (false): %v", err)
+	if EmptyRepoChanged(normal, normal) {
+		t.Error("same value (false): reported changed")
 	}
-	if err := ValidateEmptyRepoUnchanged(bare, normal); err == nil || !strings.Contains(err.Error(), "empty_repo cannot be changed") {
-		t.Errorf("flip true->false: got %v, want the immutability error", err)
+	if !EmptyRepoChanged(bare, normal) {
+		t.Error("flip true->false: not detected")
 	}
-	if err := ValidateEmptyRepoUnchanged(normal, bare); err == nil || !strings.Contains(err.Error(), "empty_repo cannot be changed") {
-		t.Errorf("flip false->true: got %v, want the immutability error", err)
+	if !EmptyRepoChanged(normal, bare) {
+		t.Error("flip false->true: not detected")
 	}
 }
 
@@ -2198,23 +2198,23 @@ func TestValidateNoAutograderExclusions(t *testing.T) {
 	}
 }
 
-// TestValidateNoAutograderUnchanged: no_autograder is immutable on upsert, like
-// empty_repo — the shim (or its absence) is baked at accept time.
-func TestValidateNoAutograderUnchanged(t *testing.T) {
+// TestNoAutograderChanged: no_autograder is mutable, like empty_repo — a flip
+// is detected so callers can warn.
+func TestNoAutograderChanged(t *testing.T) {
 	on := AssignmentEntry{Slug: "hw", NoAutograder: true}
 	off := AssignmentEntry{Slug: "hw", NoAutograder: false}
 
-	if err := ValidateNoAutograderUnchanged(on, on); err != nil {
-		t.Errorf("same value (true): %v", err)
+	if NoAutograderChanged(on, on) {
+		t.Error("same value (true): reported changed")
 	}
-	if err := ValidateNoAutograderUnchanged(off, off); err != nil {
-		t.Errorf("same value (false): %v", err)
+	if NoAutograderChanged(off, off) {
+		t.Error("same value (false): reported changed")
 	}
-	if err := ValidateNoAutograderUnchanged(on, off); err == nil || !strings.Contains(err.Error(), "no_autograder cannot be changed") {
-		t.Errorf("flip true->false: got %v, want the immutability error", err)
+	if !NoAutograderChanged(on, off) {
+		t.Error("flip true->false: not detected")
 	}
-	if err := ValidateNoAutograderUnchanged(off, on); err == nil || !strings.Contains(err.Error(), "no_autograder cannot be changed") {
-		t.Errorf("flip false->true: got %v, want the immutability error", err)
+	if !NoAutograderChanged(off, on) {
+		t.Error("flip false->true: not detected")
 	}
 }
 
@@ -2266,23 +2266,23 @@ func TestValidateInitShimExclusions(t *testing.T) {
 	}
 }
 
-// TestValidateInitShimUnchanged: init_shim is immutable on upsert, like
-// empty_repo/no_autograder — the shim is committed at accept time.
-func TestValidateInitShimUnchanged(t *testing.T) {
+// TestInitShimChanged: init_shim is mutable, like empty_repo/no_autograder — a
+// flip is detected so callers can warn.
+func TestInitShimChanged(t *testing.T) {
 	on := AssignmentEntry{Slug: "hw", InitShim: true}
 	off := AssignmentEntry{Slug: "hw", InitShim: false}
 
-	if err := ValidateInitShimUnchanged(on, on); err != nil {
-		t.Errorf("same value (true): %v", err)
+	if InitShimChanged(on, on) {
+		t.Error("same value (true): reported changed")
 	}
-	if err := ValidateInitShimUnchanged(off, off); err != nil {
-		t.Errorf("same value (false): %v", err)
+	if InitShimChanged(off, off) {
+		t.Error("same value (false): reported changed")
 	}
-	if err := ValidateInitShimUnchanged(on, off); err == nil || !strings.Contains(err.Error(), "init_shim cannot be changed") {
-		t.Errorf("flip true->false: got %v, want the immutability error", err)
+	if !InitShimChanged(on, off) {
+		t.Error("flip true->false: not detected")
 	}
-	if err := ValidateInitShimUnchanged(off, on); err == nil || !strings.Contains(err.Error(), "init_shim cannot be changed") {
-		t.Errorf("flip false->true: got %v, want the immutability error", err)
+	if !InitShimChanged(off, on) {
+		t.Error("flip false->true: not detected")
 	}
 }
 

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -2198,25 +2198,11 @@ func TestValidateNoAutograderExclusions(t *testing.T) {
 	}
 }
 
-// TestNoAutograderChanged: no_autograder is mutable, like empty_repo — a flip
-// is detected so callers can warn.
-func TestNoAutograderChanged(t *testing.T) {
-	on := AssignmentEntry{Slug: "hw", NoAutograder: true}
-	off := AssignmentEntry{Slug: "hw", NoAutograder: false}
-
-	if NoAutograderChanged(on, on) {
-		t.Error("same value (true): reported changed")
-	}
-	if NoAutograderChanged(off, off) {
-		t.Error("same value (false): reported changed")
-	}
-	if !NoAutograderChanged(on, off) {
-		t.Error("flip true->false: not detected")
-	}
-	if !NoAutograderChanged(off, on) {
-		t.Error("flip false->true: not detected")
-	}
-}
+// TestNoAutograderChanged / TestInitShimChanged were removed with their
+// helpers: no_autograder / init_shim have no `assignment add` flag and are
+// carried forward before any comparison, so `add` can never change them and a
+// detector would be dead code. Only empty_repo is detectable on the CLI path
+// (see TestEmptyRepoChanged).
 
 func TestValidateInitShimExclusions(t *testing.T) {
 	// init_shim is the built-in-autograder-on-an-empty-repo state: template-less,
@@ -2266,25 +2252,9 @@ func TestValidateInitShimExclusions(t *testing.T) {
 	}
 }
 
-// TestInitShimChanged: init_shim is mutable, like empty_repo/no_autograder — a
-// flip is detected so callers can warn.
-func TestInitShimChanged(t *testing.T) {
-	on := AssignmentEntry{Slug: "hw", InitShim: true}
-	off := AssignmentEntry{Slug: "hw", InitShim: false}
-
-	if InitShimChanged(on, on) {
-		t.Error("same value (true): reported changed")
-	}
-	if InitShimChanged(off, off) {
-		t.Error("same value (false): reported changed")
-	}
-	if !InitShimChanged(on, off) {
-		t.Error("flip true->false: not detected")
-	}
-	if !InitShimChanged(off, on) {
-		t.Error("flip false->true: not detected")
-	}
-}
+// TestInitShimChanged was removed with its helper (see the note above
+// TestEmptyRepoChanged's siblings): init_shim has no `assignment add` flag and
+// is carried forward before any comparison, so `add` can never change it.
 
 func TestValidateIncludeAllBranchesExclusions(t *testing.T) {
 	// include_all_branches only affects the templated generate call, so it

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -692,13 +692,13 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		droppedAllowedCnt    int
 		droppedPassThreshold *int
 		droppedStudentPerm   string
-		// Provisioning-class settings changed on a same-slug re-add. These are
-		// no longer blocked — the change only affects repos accepted from now
-		// on (already-accepted repos aren't retrofitted), so warn instead of
-		// erroring. Mirrors the web app's edit-time confirmation.
-		changedEmptyRepo    bool
-		changedNoAutograder bool
-		changedInitShim     bool
+		// empty_repo changed on a same-slug re-add. No longer blocked — the
+		// change only affects repos accepted from now on (already-accepted repos
+		// aren't retrofitted), so warn instead of erroring. Mirrors the web app's
+		// edit-time confirmation. (no_autograder / init_shim have no `add` flag
+		// and are carried forward from the prior entry below, so `add` can never
+		// change them — only empty_repo is detectable here.)
+		changedEmptyRepo bool
 		// The locked state that actually landed (carried forward from a prior
 		// same-slug entry). Read after the commit to decide the template grant,
 		// since `entry` (rebuilt from flags) never carries Locked.
@@ -711,8 +711,6 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		droppedPassThreshold = nil
 		droppedStudentPerm = ""
 		changedEmptyRepo = false
-		changedNoAutograder = false
-		changedInitShim = false
 		attemptEntry := entry
 		// Refuse on an archived classroom (active:false), mirroring the web.
 		// Checked at parentSHA so a concurrent unarchive is observed on retry.
@@ -787,17 +785,16 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			entry.IncludeAllBranches = file.Assignments[prevIdx].IncludeAllBranches
 			attemptEntry.IncludeAllBranches = entry.IncludeAllBranches
 		}
-		// Provisioning-class settings (empty_repo, no_autograder, init_shim) are
-		// now MUTABLE on a same-slug re-add: student repos are provisioned at
-		// accept time and never retrofitted, so a change only affects repos
-		// accepted from now on. Detect a change and warn after the commit rather
-		// than blocking it (mirrors the web app, which confirms the same change
-		// when students have already accepted). Checked at parentSHA inside the
-		// build so a concurrent add/remove is observed on retry.
+		// empty_repo is MUTABLE on a same-slug re-add: student repos are
+		// provisioned at accept time and never retrofitted, so a change only
+		// affects repos accepted from now on. Detect a change and warn after the
+		// commit rather than blocking it (mirrors the web app, which confirms the
+		// same change when students have already accepted). Checked at parentSHA
+		// inside the build so a concurrent add/remove is observed on retry.
+		// no_autograder / init_shim are carried forward above (no `add` flag), so
+		// they can't change here — only empty_repo is detectable.
 		if hasPrev {
 			changedEmptyRepo = assignment.EmptyRepoChanged(file.Assignments[prevIdx], entry)
-			changedNoAutograder = assignment.NoAutograderChanged(file.Assignments[prevIdx], entry)
-			changedInitShim = assignment.InitShimChanged(file.Assignments[prevIdx], entry)
 		}
 		// Upsert replaces the whole entry, so re-running add without --tests
 		// drops tests authored via `assignment test add`. Count them for the
@@ -851,8 +848,9 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			// grading is a GUI/manifest-owned field with no `assignment add`
 			// flag; since it was promoted to a known key it no longer rides
 			// through Extra, so a same-slug re-add would silently drop a
-			// GUI-authored grading block (its mode is immutable, and the manual
-			// max_points feeds the gradebook). Deep-copy the *Grading + *int so
+			// GUI-authored grading block (its max_points feeds the gradebook).
+			// The mode is mutable via the GUI; `add` carries it forward only
+			// because it has no --grading flag. Deep-copy the *Grading + *int so
 			// the carried value doesn't alias the previous entry.
 			if attemptEntry.Grading == nil && previous.Grading != nil {
 				carried := *previous.Grading
@@ -974,17 +972,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	// reconciling any resulting inconsistency (mirrors the web app's confirm).
 	if changedEmptyRepo {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q changed its empty_repo setting. Repositories students already accepted are not retrofitted — they keep their original setup. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
-			slug)
-	}
-	if changedNoAutograder {
-		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q changed its no_autograder setting. Repositories students already accepted are not retrofitted — they keep their original setup. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
-			slug)
-	}
-	if changedInitShim {
-		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q changed its init_shim setting. Repositories students already accepted are not retrofitted — they keep their original setup. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
+			"Warning: replacing %q changed its empty_repo setting. Repositories students already accepted are not retrofitted — they keep their original setup, and if autograding is now off their autograde runs start failing and drop out of the gradebook. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
 			slug)
 	}
 	// Heads-up if the encoded file nears GitHub's ~1 MiB contents-API limit

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -101,9 +101,9 @@ func assignmentAddCmd() *cobra.Command {
 			".classroom50.yaml marker, no autograde workflow — for assignments\n" +
 			"where students build everything (including their own GitHub\n" +
 			"Actions) from scratch. Autograding and the Feedback PR are\n" +
-			"disabled, and the setting is immutable after creation: enabling\n" +
-			"autograding later would require retrofitting control files into\n" +
-			"every already-accepted repo, which classroom50 does not do.\n" +
+			"disabled. The setting can be changed on a same-slug re-add, but\n" +
+			"repositories students already accepted are not retrofitted, so the\n" +
+			"change applies only to accepts from now on (a warning is printed).\n" +
 			"Mutually exclusive with --template, --tests, --feedback-pr,\n" +
 			"--allowed-files, --pass-threshold, --submission-mode, and\n" +
 			"--submission-tag.\n\n" +
@@ -303,7 +303,7 @@ func assignmentAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&runtimeFile, "runtime", "", "Path to a JSON file describing the runtime environment (runs-on as a single label or an array of labels for self-hosted runners, python/node/java/go/rust versions, apt packages, or container image), or `-` to read from stdin. Omit for ubuntu-latest + Python 3.14.")
 	cmd.Flags().StringVar(&testsFile, "tests", "", "Path to a JSON file with a bare array of declarative test specs (io/run/python), or `-` to read from stdin. Sets the assignment's `tests` block; mutually exclusive with a per-assignment autograder.py. See `gh teacher assignment test --help`.")
 	cmd.Flags().BoolVar(&feedbackPR, "feedback-pr", true, "Open one long-lived Feedback pull request per student repo so you can leave inline review comments on the full starter→submission diff. Accept freezes a base branch at the baseline commit and opens the PR right away, so it exists even with GitHub Actions disabled; the autograde runner then adopts and maintains it (and opens it on the first submission if accept could not). Default on; pass --feedback-pr=false to disable. Requires `gh teacher init` to have set up the org prerequisites.")
-	cmd.Flags().BoolVar(&emptyRepo, "empty-repo", false, "Create truly bare student repos: no README/initial commit, no .classroom50.yaml marker, no autograde workflow — for assignments where students build the repo (including their own GitHub Actions) from scratch. Autograding and the Feedback PR are disabled and cannot be enabled later (the setting is immutable after creation). Mutually exclusive with --template, --tests, --feedback-pr, --allowed-files, --pass-threshold, --submission-mode, and --submission-tag.")
+	cmd.Flags().BoolVar(&emptyRepo, "empty-repo", false, "Create truly bare student repos: no README/initial commit, no .classroom50.yaml marker, no autograde workflow — for assignments where students build the repo (including their own GitHub Actions) from scratch. Autograding and the Feedback PR are disabled. Changing this on a same-slug re-add applies only to accepts from now on (repositories students already accepted are not retrofitted; a warning is printed). Mutually exclusive with --template, --tests, --feedback-pr, --allowed-files, --pass-threshold, --submission-mode, and --submission-tag.")
 	cmd.Flags().StringArrayVar(&allowedFiles, "allowed-files", nil, "Ordered .gitignore-style pattern (repeatable, order preserved) defining which files belong to the submission. Last match wins; `!` re-includes. Pass `--allowed-files '*' --allowed-files '!hello.py'` to allow only hello.py. The autograde runner removes disallowed files before grading (control files are always kept); `gh student submit` filters them too. Omit to allow every file.")
 	cmd.Flags().IntVar(&passThreshold, "pass-threshold", 0, "Opt-in passing bar as a percentage of max score (0–100): at/above it a gradebook client shows a submission as passing. Advisory/display-only — it does not change a student's score. Omit to leave it off (no passing concept); pass --pass-threshold 0 for an explicit 0%.")
 	cmd.Flags().StringVar(&studentPerm, "student-permission", "", "Optional collaborator role each student gets on their OWN assignment repo at accept time: one of pull, triage, push, maintain, admin. Omit for the default (push for individual, admin for group). Choose admin to let students manage repo settings and enable GitHub Pages. Applies to students who accept from now on; existing repos are unchanged. Caution: admin on a private repo also lets the student change its visibility.")
@@ -328,9 +328,9 @@ func assignmentRemoveCmd() *cobra.Command {
 			"stop finding the slug.\n\n" +
 			"Because the repos survive, re-adding the SAME slug is not a\n" +
 			"clean reset: an --empty-repo flag that differs from the removed\n" +
-			"entry would leave already-accepted repos on the old behavior\n" +
-			"(the immutability guard only fires on an in-place edit, which a\n" +
-			"remove+add bypasses). To change empty_repo, add under a NEW slug.",
+			"entry leaves already-accepted repos on the old behavior — the\n" +
+			"change applies only to accepts from now on (a warning is printed;\n" +
+			"reconcile existing repositories yourself).",
 		Example: "  gh teacher assignment remove cs50-fall-2026 cs-principles hello",
 		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -692,6 +692,13 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		droppedAllowedCnt    int
 		droppedPassThreshold *int
 		droppedStudentPerm   string
+		// Provisioning-class settings changed on a same-slug re-add. These are
+		// no longer blocked — the change only affects repos accepted from now
+		// on (already-accepted repos aren't retrofitted), so warn instead of
+		// erroring. Mirrors the web app's edit-time confirmation.
+		changedEmptyRepo    bool
+		changedNoAutograder bool
+		changedInitShim     bool
 		// The locked state that actually landed (carried forward from a prior
 		// same-slug entry). Read after the commit to decide the template grant,
 		// since `entry` (rebuilt from flags) never carries Locked.
@@ -703,6 +710,9 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		droppedAllowedCnt = 0
 		droppedPassThreshold = nil
 		droppedStudentPerm = ""
+		changedEmptyRepo = false
+		changedNoAutograder = false
+		changedInitShim = false
 		attemptEntry := entry
 		// Refuse on an archived classroom (active:false), mirroring the web.
 		// Checked at parentSHA so a concurrent unarchive is observed on retry.
@@ -749,47 +759,45 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		// no_autograder is owned by the gradebook GUI, not `assignment add`
 		// (there is no --no-autograder flag), so `entry`/`attemptEntry` rebuilt
 		// from flags never carry it. Carry it forward from the prior entry
-		// BEFORE the immutability check below — otherwise a same-slug re-add
+		// BEFORE the change detection below — otherwise a same-slug re-add
 		// (e.g. editing the due date) would compare the flag-default false
-		// against a stored true and wrongly trip ValidateNoAutograderUnchanged,
-		// making a GUI-created no_autograder assignment impossible to update.
-		// Mirrors the Locked carry-forward (also GUI/other-command-owned).
+		// against a stored true and spuriously warn that no_autograder changed,
+		// even though the CLI can't change it. Mirrors the Locked carry-forward
+		// (also GUI/other-command-owned).
 		if hasPrev {
 			entry.NoAutograder = file.Assignments[prevIdx].NoAutograder
 			attemptEntry.NoAutograder = entry.NoAutograder
 		}
 		// init_shim is likewise GUI/manifest-owned (no --init-shim flag), so
-		// carry it forward before the immutability check for the same reason as
+		// carry it forward before the change detection for the same reason as
 		// no_autograder above.
 		if hasPrev {
 			entry.InitShim = file.Assignments[prevIdx].InitShim
 			attemptEntry.InitShim = entry.InitShim
 		}
 		// include_all_branches is likewise GUI/manifest-owned (no flag), so carry
-		// it forward so a same-slug CLI re-add doesn't silently reset it. Unlike
-		// the above it is MUTABLE (no immutability check) — a teacher may change
-		// it; it only affects repos generated from now on. Gate on the current
-		// template: a re-add that drops --template turns the entry template-less,
-		// and include_all_branches only affects the generate call — carrying it
-		// onto a template-less entry would write a combination
-		// ValidateExistingEntry rejects, wedging every future read of the file.
+		// it forward so a same-slug CLI re-add doesn't silently reset it. Like
+		// the above it is MUTABLE — a teacher may change it; it only affects
+		// repos generated from now on. Gate on the current template: a re-add
+		// that drops --template turns the entry template-less, and
+		// include_all_branches only affects the generate call — carrying it onto
+		// a template-less entry would write a combination ValidateExistingEntry
+		// rejects, wedging every future read of the file.
 		if hasPrev && attemptEntry.Template != nil {
 			entry.IncludeAllBranches = file.Assignments[prevIdx].IncludeAllBranches
 			attemptEntry.IncludeAllBranches = entry.IncludeAllBranches
 		}
-		// empty_repo is immutable: student repos were provisioned (or left
-		// bare) at accept time and are never retrofitted. Checked at parentSHA
-		// inside the build so a concurrent add/remove is observed on retry.
+		// Provisioning-class settings (empty_repo, no_autograder, init_shim) are
+		// now MUTABLE on a same-slug re-add: student repos are provisioned at
+		// accept time and never retrofitted, so a change only affects repos
+		// accepted from now on. Detect a change and warn after the commit rather
+		// than blocking it (mirrors the web app, which confirms the same change
+		// when students have already accepted). Checked at parentSHA inside the
+		// build so a concurrent add/remove is observed on retry.
 		if hasPrev {
-			if err := assignment.ValidateEmptyRepoUnchanged(file.Assignments[prevIdx], entry); err != nil {
-				return nil, err
-			}
-			if err := assignment.ValidateNoAutograderUnchanged(file.Assignments[prevIdx], entry); err != nil {
-				return nil, err
-			}
-			if err := assignment.ValidateInitShimUnchanged(file.Assignments[prevIdx], entry); err != nil {
-				return nil, err
-			}
+			changedEmptyRepo = assignment.EmptyRepoChanged(file.Assignments[prevIdx], entry)
+			changedNoAutograder = assignment.NoAutograderChanged(file.Assignments[prevIdx], entry)
+			changedInitShim = assignment.InitShimChanged(file.Assignments[prevIdx], entry)
 		}
 		// Upsert replaces the whole entry, so re-running add without --tests
 		// drops tests authored via `assignment test add`. Count them for the
@@ -959,6 +967,25 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		_, _ = fmt.Fprintf(errOut,
 			"Warning: replacing %q dropped its student_permission (%s) — `assignment add` rewrites the whole entry, and you re-ran it without --student-permission. New accepters revert to the mode default. Pass --student-permission %s to keep it.\n",
 			slug, droppedStudentPerm, droppedStudentPerm)
+	}
+	// Provisioning-class changes only affect repos accepted from now on;
+	// already-accepted repos keep their original starter content/shim, which
+	// this CLI does not retrofit. Warn (not block) so the teacher knows they own
+	// reconciling any resulting inconsistency (mirrors the web app's confirm).
+	if changedEmptyRepo {
+		_, _ = fmt.Fprintf(errOut,
+			"Warning: replacing %q changed its empty_repo setting. Repositories students already accepted are not retrofitted — they keep their original setup. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
+			slug)
+	}
+	if changedNoAutograder {
+		_, _ = fmt.Fprintf(errOut,
+			"Warning: replacing %q changed its no_autograder setting. Repositories students already accepted are not retrofitted — they keep their original setup. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
+			slug)
+	}
+	if changedInitShim {
+		_, _ = fmt.Fprintf(errOut,
+			"Warning: replacing %q changed its init_shim setting. Repositories students already accepted are not retrofitted — they keep their original setup. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
+			slug)
 	}
 	// Heads-up if the encoded file nears GitHub's ~1 MiB contents-API limit
 	// (past which encoding flips to "none", wedging future reads/writes).

--- a/web/src/components/modals/ProvisioningChangeConfirmModal.tsx
+++ b/web/src/components/modals/ProvisioningChangeConfirmModal.tsx
@@ -1,0 +1,74 @@
+import { useId } from "react"
+import { useTranslation } from "react-i18next"
+import { TriangleAlert } from "lucide-react"
+
+import { Alert, Button, Modal } from "@/components/ui"
+
+type ProvisioningChangeConfirmModalProps = {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+  // How many student repositories already exist for this assignment. Drives the
+  // pluralized warning copy; the modal is only opened when this is > 0.
+  acceptedCount: number
+  saving?: boolean
+}
+
+// Confirm changing a provisioning-class setting (repository source, built-in
+// autograder, or grading mode) after students have already accepted. The
+// setting is editable now, but existing repos are never retrofitted, so the
+// teacher must acknowledge that the change only affects future accepts and that
+// reconciling the existing repos is on them. Mirrors the CLI's non-blocking
+// warning; here it's a blocking confirm because the web edit is a single click.
+export function ProvisioningChangeConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+  acceptedCount,
+  saving = false,
+}: ProvisioningChangeConfirmModalProps) {
+  const titleId = useId()
+  const { t } = useTranslation()
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      closeDisabled={saving}
+      size="lg"
+      aria-labelledby={titleId}
+    >
+      <div className="flex items-start gap-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-warning/10 text-warning">
+          <TriangleAlert className="size-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 id={titleId} className="text-lg font-bold">
+            {t("assignmentSettings.provisioningConfirm.title")}
+          </h3>
+          <Alert tone="warning" className="mt-3 text-sm">
+            {t("assignmentSettings.provisioningConfirm.body", {
+              count: acceptedCount,
+            })}
+          </Alert>
+        </div>
+      </div>
+
+      <div className="modal-action">
+        <Button variant="ghost" disabled={saving} onClick={onClose}>
+          {t("assignmentSettings.provisioningConfirm.cancel")}
+        </Button>
+        <Button
+          variant="warning"
+          loading={saving}
+          disabled={saving}
+          onClick={onConfirm}
+        >
+          {t("assignmentSettings.provisioningConfirm.confirm")}
+        </Button>
+      </div>
+    </Modal>
+  )
+}
+
+export default ProvisioningChangeConfirmModal

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -887,24 +887,20 @@ describe("editAssignment (preserved-entry integration)", () => {
     ).rejects.toThrow(/runtime\.runs-on/i)
   })
 
-  it("rejects flipping empty_repo on after creation (immutable)", async () => {
-    // existingEntry has no empty_repo (false); the edit tries to enable it.
-    const { client } = makeClient()
-    await expect(
-      editAssignment(client, editInput({ empty_repo: true })),
-    ).rejects.toThrow(/empty_repo cannot be changed after creation/)
+  it("allows flipping empty_repo on after creation (mutable, UI warns)", async () => {
+    // existingEntry has no empty_repo (false); the edit enables it. The domain
+    // layer no longer blocks this — the UI warns when students already
+    // accepted, since existing repos aren't retrofitted.
+    const { client, committedContent } = makeClient()
+    await editAssignment(client, editInput({ empty_repo: true }))
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    expect(edited.empty_repo).toBe(true)
   })
 
-  it("rejects flipping no_autograder on after creation (immutable)", async () => {
-    // existingEntry has no no_autograder (false); the edit tries to enable it.
-    // The shim (or its absence) is baked at accept time and never retrofitted.
-    const { client } = makeClient()
-    await expect(
-      editAssignment(client, editInput({ no_autograder: true })),
-    ).rejects.toThrow(/no_autograder cannot be changed after creation/)
-  })
-
-  it("rejects flipping no_autograder off after creation (immutable)", async () => {
+  it("allows flipping no_autograder off after creation (mutable, UI warns)", async () => {
     const ciEntry: Assignment = {
       slug: SLUG,
       name: "CI Lab",
@@ -914,22 +910,28 @@ describe("editAssignment (preserved-entry integration)", () => {
       feedback_pr: true,
       no_autograder: true,
     }
-    const { client } = makeBareClient(ciEntry)
-    await expect(
-      editAssignment(client, editInput({ no_autograder: false })),
-    ).rejects.toThrow(/no_autograder cannot be changed after creation/)
+    const { client, committedContent } = makeBareClient(ciEntry)
+    await editAssignment(client, editInput({ no_autograder: false }))
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    // Collapsed to the wire's absent-is-false shape.
+    expect(edited.no_autograder).toBeUndefined()
   })
 
-  it("rejects flipping init_shim on after creation (immutable)", async () => {
-    // existingEntry has no init_shim (false); the edit tries to enable it. The
-    // shim is committed at accept time and never retrofitted.
-    const { client } = makeClient()
-    await expect(
-      editAssignment(client, editInput({ init_shim: true })),
-    ).rejects.toThrow(/init_shim cannot be changed after creation/)
+  it("allows flipping init_shim on after creation (mutable, UI warns)", async () => {
+    // existingEntry has no init_shim; the edit enables it. No longer blocked.
+    const { client, committedContent } = makeClient()
+    await editAssignment(client, editInput({ init_shim: true }))
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    expect(edited.init_shim).toBe(true)
   })
 
-  it("rejects flipping init_shim off after creation (immutable)", async () => {
+  it("allows flipping init_shim off after creation (mutable, UI warns)", async () => {
     const shimEntry: Assignment = {
       slug: SLUG,
       name: "Scratch",
@@ -938,25 +940,31 @@ describe("editAssignment (preserved-entry integration)", () => {
       feedback_pr: true,
       init_shim: true,
     }
-    const { client } = makeBareClient(shimEntry)
-    await expect(
-      editAssignment(client, editInput({ init_shim: false })),
-    ).rejects.toThrow(/init_shim cannot be changed after creation/)
+    const { client, committedContent } = makeBareClient(shimEntry)
+    await editAssignment(client, editInput({ init_shim: false }))
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    expect(edited.init_shim).toBeUndefined()
   })
 
-  it("rejects changing grading.mode after creation (auto -> manual, immutable)", async () => {
-    // existingEntry has no grading (resolves to auto); the edit sets manual.
-    // Scores already recorded under the old mode would be misread.
-    const { client } = makeClient()
-    await expect(
-      editAssignment(
-        client,
-        editInput({ grading: { mode: "manual", max_points: 50 } }),
-      ),
-    ).rejects.toThrow(/grading mode cannot be changed after creation/)
+  it("allows changing grading.mode after creation (auto -> manual, UI warns)", async () => {
+    // existingEntry has no grading (resolves to auto); the edit sets manual. No
+    // longer blocked — the UI warns that scores under the old mode may misread.
+    const { client, committedContent } = makeClient()
+    await editAssignment(
+      client,
+      editInput({ grading: { mode: "manual", max_points: 50 } }),
+    )
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    expect(edited.grading).toEqual({ mode: "manual", max_points: 50 })
   })
 
-  it("rejects changing grading.mode after creation (manual -> auto, immutable)", async () => {
+  it("allows changing grading.mode after creation (manual -> auto, UI warns)", async () => {
     const manualEntry: Assignment = {
       slug: SLUG,
       name: "Homework 1",
@@ -966,16 +974,19 @@ describe("editAssignment (preserved-entry integration)", () => {
       feedback_pr: true,
       grading: { mode: "manual", max_points: 50 },
     }
-    const { client } = makeBareClient(manualEntry)
-    await expect(
-      editAssignment(client, editInput({ grading: { mode: "auto" } })),
-    ).rejects.toThrow(/grading mode cannot be changed after creation/)
+    const { client, committedContent } = makeBareClient(manualEntry)
+    await editAssignment(client, editInput({ grading: { mode: "auto" } }))
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    // auto collapses to omitted (today's wire default).
+    expect(edited.grading).toBeUndefined()
   })
 
   it("writes grading:{mode,max_points} on a same-mode manual edit", async () => {
-    // A manual assignment edited without changing the mode: the immutability
-    // guard passes and buildAssignmentEntry emits the grading block. max_points
-    // is mutable, so a bumped value lands.
+    // A manual assignment edited without changing the mode: buildAssignmentEntry
+    // emits the grading block. max_points is mutable, so a bumped value lands.
     const manualEntry: Assignment = {
       slug: SLUG,
       name: "Homework 1",
@@ -998,8 +1009,8 @@ describe("editAssignment (preserved-entry integration)", () => {
   })
 
   it("rejects a manual grading edit with an out-of-range max_points", async () => {
-    // Same-mode manual edit (immutability guard passes) with max_points 0 must
-    // hit buildAssignmentEntry's grading validation throw (min 1).
+    // Manual edit with max_points 0 must hit buildAssignmentEntry's grading
+    // validation throw (min 1).
     const manualEntry: Assignment = {
       slug: SLUG,
       name: "Homework 1",
@@ -1020,8 +1031,7 @@ describe("editAssignment (preserved-entry integration)", () => {
 
   it("rejects a grading edit carrying max_points on a non-manual mode", async () => {
     // An auto assignment edited with grading:{mode:auto, max_points} must hit
-    // the defensive "max_points only valid for manual" throw. Mode stays auto,
-    // so the immutability guard passes first.
+    // the defensive "max_points only valid for manual" throw.
     const { client } = makeClient()
     await expect(
       editAssignment(
@@ -1031,7 +1041,7 @@ describe("editAssignment (preserved-entry integration)", () => {
     ).rejects.toThrow(/grading\.max_points/)
   })
 
-  it("rejects flipping empty_repo off after creation (immutable)", async () => {
+  it("allows flipping empty_repo off after creation (mutable, UI warns)", async () => {
     const bareEntry: Assignment = {
       slug: SLUG,
       name: "Homework 1",
@@ -1040,11 +1050,14 @@ describe("editAssignment (preserved-entry integration)", () => {
       feedback_pr: false,
       empty_repo: true,
     }
-    const { client } = makeBareClient(bareEntry)
-    // Form sends empty_repo: false (or omits it) — either way it's a flip.
-    await expect(
-      editAssignment(client, editInput({ empty_repo: false })),
-    ).rejects.toThrow(/empty_repo cannot be changed after creation/)
+    const { client, committedContent } = makeBareClient(bareEntry)
+    // Form sends empty_repo: false — a flip that now lands.
+    await editAssignment(client, editInput({ empty_repo: false }))
+    const written = JSON.parse(committedContent()) as {
+      assignments: Assignment[]
+    }
+    const edited = written.assignments.find((a) => a.slug === SLUG)!
+    expect(edited.empty_repo).toBeUndefined()
   })
 
   it("preserves empty_repo and forces feedback_pr off on a same-value edit", async () => {

--- a/web/src/domain/assignments.ts
+++ b/web/src/domain/assignments.ts
@@ -67,6 +67,11 @@ export {
 } from "./assignments/permissions"
 export { acceptAssignment } from "./assignments/accept"
 export {
+  provisioningSettingsChanged,
+  provisioningFieldsFromAssignment,
+  type ProvisioningFields,
+} from "./assignments/provisioningChange"
+export {
   repairFeedbackPullRequest,
   openAllFeedbackPullRequests,
   type RepairFeedbackPrResult,

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -107,9 +107,9 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   autograder: "classroom50-owned",
   max_group_size: "classroom50-owned",
   feedback_pr: "classroom50-owned",
-  // Rebuilt from input but IMMUTABLE: editAssignment rejects an edit whose
-  // empty_repo differs from the stored entry, so the rebuild can only ever
-  // re-write the same value. The edit form shows it read-only.
+  // Rebuilt from input and MUTABLE: an edit may flip empty_repo now (the UI
+  // warns when students already accepted, since existing repos aren't
+  // retrofitted). A clearing edit must win over the stale stored value.
   empty_repo: "classroom50-owned",
   no_autograder: "classroom50-owned",
   init_shim: "classroom50-owned",
@@ -127,10 +127,9 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   student_permission: "classroom50-owned",
   submission_mode: "classroom50-owned",
   submission_tags: "classroom50-owned",
-  // Rebuilt from input but IMMUTABLE: editAssignment rejects an edit whose
-  // grading.mode differs from the stored entry (a manual<->auto flip would
-  // change how already-graded repos are read), so the rebuild only ever
-  // re-writes the same mode. The edit form shows the choice read-only.
+  // Rebuilt from input and MUTABLE: an edit may change grading.mode now (the UI
+  // warns when students already accepted — scores recorded under the old mode
+  // may be misread, so the teacher reconciles them).
   grading: "classroom50-owned",
   repo_features: "classroom50-owned",
   tests: "classroom50-owned",
@@ -212,50 +211,14 @@ export async function editAssignment(
     throw new Error(`Existing assignment matching ${slug} was not found.`)
   }
 
-  // empty_repo is immutable: student repos were provisioned (or left bare) at
-  // accept time and are never retrofitted, so flipping the flag would strand
-  // every already-accepted repo on the old behavior. Mirrors the CLI's
-  // ValidateEmptyRepoUnchanged. Checked before the build so the error names
-  // the real constraint rather than a mutual-exclusion side effect.
-  if (Boolean(input.empty_repo) !== Boolean(targetAssignment.empty_repo)) {
-    throw new Error(
-      `empty_repo cannot be changed after creation (assignment "${slug}"): repositories students already accepted are not retrofitted. Create a new assignment under a different slug instead — reusing this slug (even after removing it) would leave already-accepted repos on the old setting.`,
-    )
-  }
-
-  // no_autograder is immutable for the same reason: the shim (or its absence)
-  // is baked into each student repo at accept time and never retrofitted, so
-  // flipping it strands every already-accepted repo. Mirrors the CLI's
-  // ValidateNoAutograderUnchanged.
-  if (
-    Boolean(input.no_autograder) !== Boolean(targetAssignment.no_autograder)
-  ) {
-    throw new Error(
-      `no_autograder cannot be changed after creation (assignment "${slug}"): repositories students already accepted are not retrofitted. Create a new assignment under a different slug instead — reusing this slug (even after removing it) would leave already-accepted repos on the old setting.`,
-    )
-  }
-
-  // init_shim is immutable for the same reason: the shim is committed at accept
-  // time and never retrofitted. Mirrors the CLI's ValidateInitShimUnchanged.
-  if (Boolean(input.init_shim) !== Boolean(targetAssignment.init_shim)) {
-    throw new Error(
-      `init_shim cannot be changed after creation (assignment "${slug}"): repositories students already accepted are not retrofitted. Create a new assignment under a different slug instead — reusing this slug (even after removing it) would leave already-accepted repos on the old setting.`,
-    )
-  }
-
-  // grading.mode is immutable: flipping manual<->auto (or off) changes how
-  // already-graded repos are read and scored (an override-backed manual grade
-  // vs a collected autograded one), so a mid-course flip would misrepresent
-  // existing scores. Absent reads as "auto", so compare the resolved modes.
-  // max_points is NOT immutable — it's only a display max, safe to adjust.
-  if (
-    (input.grading?.mode ?? "auto") !==
-    (targetAssignment.grading?.mode ?? "auto")
-  ) {
-    throw new Error(
-      `grading mode cannot be changed after creation (assignment "${slug}"): scores already recorded under the old grading mode would be misread. Create a new assignment under a different slug instead.`,
-    )
-  }
+  // Provisioning-class settings (empty_repo, no_autograder, init_shim) and the
+  // grading.mode are no longer blocked on edit: student repos are provisioned
+  // at accept time and never retrofitted, so a change only takes effect for
+  // repos accepted from now on. The UI computes whether any student has already
+  // accepted and, if so, confirms with a warning that existing repos keep the
+  // old starter code / grading and that the teacher reconciles the difference
+  // themselves (mirrors the CLI's non-blocking warning). The write path stays
+  // permissive because it can't cheaply know the acceptance count.
 
   // Normalize the edit like create so it never leaves stray non-schema keys
   // the CLI rejects. Pass the stored template so an unchanged ref is reused

--- a/web/src/domain/assignments/provisioningChange.test.ts
+++ b/web/src/domain/assignments/provisioningChange.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import type { Assignment } from "@/types/classroom"
+import {
+  provisioningFieldsFromAssignment,
+  provisioningSettingsChanged,
+} from "./provisioningChange"
+
+const base: Assignment = {
+  slug: "hw1",
+  name: "Homework 1",
+  mode: "individual",
+  autograder: "default",
+}
+
+describe("provisioningFieldsFromAssignment", () => {
+  it("normalizes absent flags to false and absent grading to auto", () => {
+    expect(provisioningFieldsFromAssignment(base)).toEqual({
+      empty_repo: false,
+      no_autograder: false,
+      init_shim: false,
+      gradingMode: "auto",
+    })
+  })
+
+  it("reads explicit values", () => {
+    expect(
+      provisioningFieldsFromAssignment({
+        ...base,
+        empty_repo: true,
+        grading: { mode: "manual", max_points: 20 },
+      }),
+    ).toEqual({
+      empty_repo: true,
+      no_autograder: false,
+      init_shim: false,
+      gradingMode: "manual",
+    })
+  })
+})
+
+describe("provisioningSettingsChanged", () => {
+  it("is false when nothing provisioning-class changed", () => {
+    expect(
+      provisioningSettingsChanged(base, {
+        empty_repo: false,
+        no_autograder: false,
+        init_shim: false,
+        gradingMode: "auto",
+      }),
+    ).toBe(false)
+  })
+
+  it("treats absent-vs-false and absent-vs-auto as unchanged", () => {
+    // A no-op edit that expresses the same state differently must not gate.
+    expect(provisioningSettingsChanged(base, {})).toBe(false)
+  })
+
+  it("detects an empty_repo flip", () => {
+    expect(provisioningSettingsChanged(base, { empty_repo: true })).toBe(true)
+  })
+
+  it("detects a no_autograder flip", () => {
+    expect(provisioningSettingsChanged(base, { no_autograder: true })).toBe(
+      true,
+    )
+  })
+
+  it("detects an init_shim flip", () => {
+    expect(provisioningSettingsChanged(base, { init_shim: true })).toBe(true)
+  })
+
+  it("detects a grading-mode change (auto -> manual)", () => {
+    expect(provisioningSettingsChanged(base, { gradingMode: "manual" })).toBe(
+      true,
+    )
+  })
+
+  it("detects a grading-mode change (manual -> auto)", () => {
+    const manual: Assignment = {
+      ...base,
+      grading: { mode: "manual", max_points: 50 },
+    }
+    expect(provisioningSettingsChanged(manual, { gradingMode: "auto" })).toBe(
+      true,
+    )
+    // Same manual mode is not a change even if max_points differs (display-only).
+    expect(provisioningSettingsChanged(manual, { gradingMode: "manual" })).toBe(
+      false,
+    )
+  })
+})

--- a/web/src/domain/assignments/provisioningChange.ts
+++ b/web/src/domain/assignments/provisioningChange.ts
@@ -1,0 +1,49 @@
+import type { Assignment } from "@/types/classroom"
+
+// The provisioning-class settings that, once changed, only take effect for
+// repositories accepted from now on — already-accepted repos are never
+// retrofitted. The edit form is now permissive about changing them, but warns
+// (and confirms) when students have already accepted so the teacher knows they
+// own reconciling the difference.
+//
+// This mirrors exactly the four transitions the domain layer used to reject in
+// editAssignment: empty_repo, no_autograder, init_shim, and grading.mode.
+// max_points is deliberately excluded — it's only a display max, safe to adjust.
+export type ProvisioningFields = {
+  empty_repo?: boolean
+  no_autograder?: boolean
+  init_shim?: boolean
+  // Resolved grading mode; absent reads as "auto" everywhere downstream.
+  gradingMode?: string
+}
+
+// Normalize a stored assignment to the comparable provisioning shape. Absent
+// booleans read as false and an absent grading block reads as "auto", matching
+// the wire's omitempty semantics so an unchanged edit never looks like a flip.
+export function provisioningFieldsFromAssignment(
+  assignment: Assignment,
+): Required<ProvisioningFields> {
+  return {
+    empty_repo: Boolean(assignment.empty_repo),
+    no_autograder: Boolean(assignment.no_autograder),
+    init_shim: Boolean(assignment.init_shim),
+    gradingMode: assignment.grading?.mode ?? "auto",
+  }
+}
+
+// Whether an edit changes any provisioning-class setting relative to the stored
+// assignment. Both sides are normalized the same way so an edit that leaves a
+// field at its stored value (even expressed differently, e.g. absent vs false)
+// is not counted as a change.
+export function provisioningSettingsChanged(
+  stored: Assignment,
+  next: ProvisioningFields,
+): boolean {
+  const before = provisioningFieldsFromAssignment(stored)
+  return (
+    before.empty_repo !== Boolean(next.empty_repo) ||
+    before.no_autograder !== Boolean(next.no_autograder) ||
+    before.init_shim !== Boolean(next.init_shim) ||
+    before.gradingMode !== (next.gradingMode ?? "auto")
+  )
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1193,8 +1193,7 @@
       },
       "grading": {
         "label": "Grading",
-        "help": "How this assignment is graded. \"Autograded\" runs the autograder you configure below. \"Manual\" lets you enter each student's score by hand on the submissions page. \"Not graded\" records no score. Can't be changed after the assignment is created.",
-        "editWarning": "The grading mode can't be changed after creation: scores already recorded under the old mode would be misread. Create a new assignment under a different slug instead.",
+        "help": "How this assignment is graded. \"Autograded\" runs the autograder you configure below. \"Manual\" lets you enter each student's score by hand on the submissions page. \"Not graded\" records no score.",
         "autoNote": "This assignment is autograded. Configure the autograder in the Autograding section below. Whether you use the built-in autograder or supply your own workflow, it must publish a result.json asset on the submission release — that file is what the app reads to show scores.",
         "choices": {
           "off": "Not graded",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1127,6 +1127,7 @@
       "type": "Assignment type",
       "typeIndividual": "Individual",
       "typeGroup": "Group project",
+      "typeLockedHelp": "Can't be changed after creation — switching it would invalidate existing submissions.",
       "maxGroupSize": "Max group size",
       "maxGroupSizeTitle": "Must be a whole number between {{min}} and {{max}}",
       "repoSource": {
@@ -1662,8 +1663,8 @@
     "manageCollaborators": "Manage collaborators",
     "provisioningConfirm": {
       "title": "Change provisioning settings after students accepted?",
-      "body_one": "{{count}} student has already accepted this assignment. Changing the repository source, built-in autograder, or grading mode only affects repositories accepted from now on. The {{count}} existing repository keeps its original starter code and setup, and scores recorded under the old grading mode may be read differently — you'll need to reconcile any inconsistency yourself.",
-      "body_other": "{{count}} students have already accepted this assignment. Changing the repository source, built-in autograder, or grading mode only affects repositories accepted from now on. The {{count}} existing repositories keep their original starter code and setup, and scores recorded under the old grading mode may be read differently — you'll need to reconcile any inconsistency yourself.",
+      "body_one": "{{count}} student has already accepted this assignment. This change only affects repositories accepted from now on — the {{count}} existing repository keeps its original starter code and setup. If you turn off autograding, those repositories' autograde runs start failing and drop out of the gradebook; if you change the grading mode, scores recorded under the old mode may read differently. You'll need to reconcile any inconsistency yourself.",
+      "body_other": "{{count}} students have already accepted this assignment. This change only affects repositories accepted from now on — the {{count}} existing repositories keep their original starter code and setup. If you turn off autograding, those repositories' autograde runs start failing and drop out of the gradebook; if you change the grading mode, scores recorded under the old mode may read differently. You'll need to reconcile any inconsistency yourself.",
       "confirm": "Save changes anyway",
       "cancel": "Cancel"
     }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1131,7 +1131,7 @@
       "maxGroupSizeTitle": "Must be a whole number between {{min}} and {{max}}",
       "repoSource": {
         "label": "Start with a template",
-        "lockedHelp": "The repository source can't be changed after creation: repositories students already accepted are not re-provisioned.",
+        "editHelp": "Changing the repository source only affects repositories students accept from now on. Repositories already accepted keep their original starter content — you'll need to reconcile any difference yourself.",
         "none": {
           "label": "No template",
           "help": "Create a fresh repository for each student."
@@ -1179,7 +1179,7 @@
         "label": "Autograding",
         "notAutogradedNote": "Autograding options apply only when this assignment is set to \"Autograded\" in the Submission and grading section above. Change the grading choice to Autograded to configure the autograder.",
         "modeLabel": "Built-in autograder",
-        "lockedHelp": "Whether the built-in autograder is used can't be changed after creation: repositories students already accepted are not re-provisioned.",
+        "editHelp": "Changing the built-in autograder only affects repositories students accept from now on. Repositories already accepted keep their original setup — you'll need to reconcile any difference yourself.",
         "choices": {
           "none": {
             "label": "Do not use the built-in autograder",
@@ -1660,7 +1660,14 @@
     "viewRepository": "View repository",
     "collaboratorsHint_one": "Add or remove collaborators for this assignment repository. This assignment allows up to <count>{{count}}</count> student in addition to the group owner.",
     "collaboratorsHint_other": "Add or remove collaborators for this assignment repository. This assignment allows up to <count>{{count}}</count> students in addition to the group owner.",
-    "manageCollaborators": "Manage collaborators"
+    "manageCollaborators": "Manage collaborators",
+    "provisioningConfirm": {
+      "title": "Change provisioning settings after students accepted?",
+      "body_one": "{{count}} student has already accepted this assignment. Changing the repository source, built-in autograder, or grading mode only affects repositories accepted from now on. The {{count}} existing repository keeps its original starter code and setup, and scores recorded under the old grading mode may be read differently — you'll need to reconcile any inconsistency yourself.",
+      "body_other": "{{count}} students have already accepted this assignment. Changing the repository source, built-in autograder, or grading mode only affects repositories accepted from now on. The {{count}} existing repositories keep their original starter code and setup, and scores recorded under the old grading mode may be read differently — you'll need to reconcile any inconsistency yourself.",
+      "confirm": "Save changes anyway",
+      "cancel": "Cancel"
+    }
   },
   "serviceTokenHealth": {
     "summary_one": "{{count}} organization needs a service-token check.",

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -557,6 +557,7 @@ describe("grading drives the autograding config", () => {
     props: {
       edit?: boolean
       defaultValues?: Partial<CreateAssignmentFormValues>
+      hasAcceptedStudents?: boolean
     } = {},
   ) =>
     render(
@@ -564,6 +565,7 @@ describe("grading drives the autograding config", () => {
         <CreateAssignmentForm
           edit={props.edit}
           defaultValues={props.defaultValues}
+          hasAcceptedStudents={props.hasAcceptedStudents}
           onSubmit={() => {}}
         />
       </QueryClientProvider>,
@@ -638,10 +640,10 @@ describe("grading drives the autograding config", () => {
     ).toBeNull()
   })
 
-  it("keeps the built-in autograder radios editable on edit (with a caveat)", () => {
+  it("keeps the built-in autograder radios editable on edit", () => {
     // On edit the built-in choice maps to no_autograder/init_shim. It's now
-    // mutable — the radios render enabled with an edit caveat, and the edit form
-    // confirms before saving when students have already accepted.
+    // mutable — the radios render enabled (the caveat is conditional; see the
+    // dedicated caveat tests below).
     const { container } = renderForm({
       edit: true,
       defaultValues: {
@@ -656,9 +658,102 @@ describe("grading drives the autograding config", () => {
     )
     expect(radios.length).toBe(2)
     radios.forEach((radio) => expect(radio.disabled).toBe(false))
+  })
+
+  it("hides the built-in-autograder caveat until the choice changes, even with accepters", async () => {
+    const user = userEvent.setup()
+    renderForm({
+      edit: true,
+      hasAcceptedStudents: true,
+      defaultValues: {
+        repo_source: "none",
+        add_readme: true,
+        grading_choice: "auto",
+        autograding_state: "none",
+      },
+    })
+    // Unchanged: no caveat, even though students have accepted.
+    expect(
+      screen.queryByText("assignments.form.autograding.editHelp"),
+    ).toBeNull()
+    // Flipping the choice surfaces the caveat.
+    await user.click(
+      screen.getByRole("radio", {
+        name: /assignments\.form\.autograding\.choices\.built-in\.label/,
+      }),
+    )
     expect(
       screen.getByText("assignments.form.autograding.editHelp"),
     ).not.toBeNull()
+  })
+
+  it("hides the built-in-autograder caveat on a change when no students have accepted", async () => {
+    const user = userEvent.setup()
+    renderForm({
+      edit: true,
+      hasAcceptedStudents: false,
+      defaultValues: {
+        repo_source: "none",
+        add_readme: true,
+        grading_choice: "auto",
+        autograding_state: "none",
+      },
+    })
+    await user.click(
+      screen.getByRole("radio", {
+        name: /assignments\.form\.autograding\.choices\.built-in\.label/,
+      }),
+    )
+    expect(
+      screen.queryByText("assignments.form.autograding.editHelp"),
+    ).toBeNull()
+  })
+
+  it("shows the repo-source caveat only after a change when students have accepted", async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm({
+      edit: true,
+      hasAcceptedStudents: true,
+      defaultValues: {
+        repo_source: "none",
+        add_readme: true,
+        grading_choice: "auto",
+        autograding_state: "none",
+      },
+    })
+    // Unchanged: no caveat despite accepters.
+    expect(
+      screen.queryByText("assignments.form.repoSource.editHelp"),
+    ).toBeNull()
+    // Flipping the source to template surfaces the caveat.
+    const templateRadio = container.querySelector<HTMLInputElement>(
+      "#repo_source-template",
+    )!
+    await user.click(templateRadio)
+    expect(
+      screen.getByText("assignments.form.repoSource.editHelp"),
+    ).not.toBeNull()
+  })
+
+  it("hides the repo-source caveat on a change when no students have accepted", async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm({
+      edit: true,
+      hasAcceptedStudents: false,
+      defaultValues: {
+        repo_source: "none",
+        add_readme: true,
+        grading_choice: "auto",
+        autograding_state: "none",
+      },
+    })
+    const templateRadio = container.querySelector<HTMLInputElement>(
+      "#repo_source-template",
+    )!
+    await user.click(templateRadio)
+    expect(
+      screen.queryByText("assignments.form.repoSource.editHelp"),
+    ).toBeNull()
   })
 })
 

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -253,6 +253,32 @@ describe("assignment slug field", () => {
     expect(slug.value).toBe("hw1")
     expect(slug.disabled).toBe(true)
   })
+
+  it("edit: locks the assignment-type radios (switching invalidates submissions)", () => {
+    const { container } = renderForm(
+      <CreateAssignmentForm
+        edit
+        defaultValues={assignmentToFormValues(baseAssignment)}
+        onSubmit={() => {}}
+      />,
+    )
+    const modeRadios =
+      container.querySelectorAll<HTMLInputElement>('input[name="mode"]')
+    expect(modeRadios.length).toBe(2)
+    modeRadios.forEach((radio) => expect(radio.disabled).toBe(true))
+    expect(screen.getByText("assignments.form.typeLockedHelp")).not.toBeNull()
+  })
+
+  it("create: leaves the assignment-type radios editable", () => {
+    const { container } = renderForm(
+      <CreateAssignmentForm onSubmit={() => {}} />,
+    )
+    const modeRadios =
+      container.querySelectorAll<HTMLInputElement>('input[name="mode"]')
+    expect(modeRadios.length).toBe(2)
+    modeRadios.forEach((radio) => expect(radio.disabled).toBe(false))
+    expect(screen.queryByText("assignments.form.typeLockedHelp")).toBeNull()
+  })
 })
 
 describe("submission release files visibility", () => {

--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -550,7 +550,8 @@ describe("self-hosted disables built-in runtime options", () => {
 
 // The autograding selector: "No built-in autograder" first + default; built-in
 // requires an initialized repo (README or template) and is disabled while the
-// repo is uninitialized; the none<->built-in choice is immutable on edit.
+// repo is uninitialized; the none<->built-in choice is editable on edit
+// (with a caveat), so the built-in autograder radios stay enabled.
 describe("grading drives the autograding config", () => {
   const renderForm = (
     props: {
@@ -637,10 +638,10 @@ describe("grading drives the autograding config", () => {
     ).toBeNull()
   })
 
-  it("locks the built-in autograder radios on edit (the choice is immutable)", () => {
-    // On edit the built-in choice maps to no_autograder/init_shim, which the
-    // domain layer refuses to change after creation, so the radios render
-    // disabled with the locked-help note.
+  it("keeps the built-in autograder radios editable on edit (with a caveat)", () => {
+    // On edit the built-in choice maps to no_autograder/init_shim. It's now
+    // mutable — the radios render enabled with an edit caveat, and the edit form
+    // confirms before saving when students have already accepted.
     const { container } = renderForm({
       edit: true,
       defaultValues: {
@@ -654,9 +655,9 @@ describe("grading drives the autograding config", () => {
       'input[name="autograding_state"]',
     )
     expect(radios.length).toBe(2)
-    radios.forEach((radio) => expect(radio.disabled).toBe(true))
+    radios.forEach((radio) => expect(radio.disabled).toBe(false))
     expect(
-      screen.getByText("assignments.form.autograding.lockedHelp"),
+      screen.getByText("assignments.form.autograding.editHelp"),
     ).not.toBeNull()
   })
 })

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -61,6 +61,11 @@ type CreateAssignmentFormProps = {
   slug?: string
   // Existing assignment slugs, for the create-mode uniqueness check.
   takenSlugs?: string[]
+  // Edit mode: whether any student has already accepted this assignment. Gates
+  // the provisioning-change caveats (repo source, built-in autograder) so they
+  // only show when a change would actually strand existing repos. Absent/false
+  // on create and when nobody has accepted.
+  hasAcceptedStudents?: boolean
 }
 
 const CreateAssignmentForm = ({
@@ -74,6 +79,7 @@ const CreateAssignmentForm = ({
   classroom,
   slug,
   takenSlugs,
+  hasAcceptedStudents = false,
 }: CreateAssignmentFormProps) => {
   const { t } = useTranslation()
   const form = useAssignmentForm(defaultValues, onSubmit, t, {
@@ -192,6 +198,7 @@ const CreateAssignmentForm = ({
                   org={org}
                   classroom={classroom}
                   slug={slug}
+                  hasAcceptedStudents={hasAcceptedStudents}
                 />
                 <SubmissionGradingSection
                   form={form}
@@ -203,6 +210,7 @@ const CreateAssignmentForm = ({
                   edit={edit}
                   onReset={onReset("autograding")}
                   org={org}
+                  hasAcceptedStudents={hasAcceptedStudents}
                 />
                 <ScheduleSection
                   form={form}

--- a/web/src/pages/assignments/EditAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
-import { fireEvent, render, screen } from "@testing-library/react"
-import { beforeEach, expect, it, vi } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
 
 const mutateAsync = vi.fn().mockResolvedValue({})
 vi.mock("@/hooks/mutations/useEditAssignment", () => ({
@@ -8,6 +14,19 @@ vi.mock("@/hooks/mutations/useEditAssignment", () => ({
 }))
 vi.mock("@/hooks/useTrackPublishDeploy", () => ({
   useTrackPublishDeploy: () => vi.fn(),
+}))
+// Acceptance is derived from the org repo list + roster; the count of existing
+// repos gates the provisioning-change confirmation. `acceptedRepoNames` lets a
+// test set that count without wiring GitHub reads.
+let acceptedRepoNames: string[] = []
+vi.mock("@/hooks/useGetMyOrgRepos", () => ({
+  default: () => ({ data: [] }),
+}))
+vi.mock("@/hooks/useGetStudents", () => ({
+  default: () => ({ students: [] }),
+}))
+vi.mock("@/pages/submissions/dashboard", () => ({
+  assignmentRepoNames: () => acceptedRepoNames,
 }))
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -26,34 +45,43 @@ vi.mock("./CreateAssignmentForm", () => ({
   }) => (
     <button
       type="button"
-      onClick={() =>
-        onSubmit({
-          name: "Homework",
-          mode: "individual",
-          template_repo: "",
-          description: "",
-          due_date: "",
-          max_group_size: 2,
-          feedback_pr: true,
-          empty_repo: false,
-          runs_on: "",
-          container_image: "",
-          container_user: "",
-          runtime_python: "",
-          runtime_node: "",
-          runtime_java: "",
-          runtime_go: "",
-          runtime_rust: "",
-          runtime_apt: "",
-          setup_command: "make",
-          setup_timeout: 300,
-          allowed_files: "",
-          release_assets: "plots/chart.png",
-          pass_threshold_enabled: false,
-          pass_threshold: 0,
-          tests: [],
-        })
-      }
+      onClick={() => {
+        // The real CreateAssignmentForm swallows an onSubmit rejection (a
+        // cancelled confirm leaves the form dirty); mirror that here so the
+        // cancel path doesn't surface as an unhandled rejection in the test.
+        void Promise.resolve(
+          onSubmit({
+            name: "Homework",
+            mode: "individual",
+            template_repo: "",
+            description: "",
+            due_date: "",
+            max_group_size: 2,
+            feedback_pr: true,
+            empty_repo: false,
+            repo_source: "none",
+            add_readme: true,
+            autograding_state: "none",
+            grading_choice: "auto",
+            runs_on: "",
+            container_image: "",
+            container_user: "",
+            runtime_python: "",
+            runtime_node: "",
+            runtime_java: "",
+            runtime_go: "",
+            runtime_rust: "",
+            runtime_apt: "",
+            setup_command: "make",
+            setup_timeout: 300,
+            allowed_files: "",
+            release_assets: "plots/chart.png",
+            pass_threshold_enabled: false,
+            pass_threshold: 0,
+            tests: [],
+          }),
+        ).catch(() => {})
+      }}
     >
       submit
     </button>
@@ -62,7 +90,11 @@ vi.mock("./CreateAssignmentForm", () => ({
 
 import EditAssignmentForm from "./EditAssignmentForm"
 
-beforeEach(() => mutateAsync.mockClear())
+beforeEach(() => {
+  mutateAsync.mockClear()
+  acceptedRepoNames = []
+})
+afterEach(cleanup)
 
 it("passes grading form fields through the edit boundary", () => {
   render(
@@ -87,4 +119,111 @@ it("passes grading form fields through the edit boundary", () => {
     }),
     expect.any(Object),
   )
+})
+
+it("saves a provisioning change directly when no students have accepted", () => {
+  // Stored auto assignment; the submit flips grading to manual. With zero
+  // accepted repos, no confirmation gates the write.
+  acceptedRepoNames = []
+  render(
+    <EditAssignmentForm
+      org="acme"
+      classroom="cs101"
+      assignment="hw1"
+      defaultData={{
+        slug: "hw1",
+        name: "Homework",
+        mode: "individual",
+        autograder: "default",
+      }}
+      onSuccess={vi.fn()}
+    />,
+  )
+  fireEvent.click(screen.getByRole("button", { name: "submit" }))
+  expect(mutateAsync).toHaveBeenCalledTimes(1)
+  // The confirmation dialog was never opened (no showModal()).
+  expect(document.querySelector("dialog[open]")).toBeNull()
+})
+
+it("confirms before saving a provisioning change when students have accepted", async () => {
+  // Two existing repos; the stored assignment is manual-graded but the submit
+  // sends the default auto grading — a provisioning-class change that must
+  // prompt first, and the write only fires after the teacher confirms.
+  acceptedRepoNames = ["cs101-hw1-alice", "cs101-hw1-bob"]
+  render(
+    <EditAssignmentForm
+      org="acme"
+      classroom="cs101"
+      assignment="hw1"
+      defaultData={{
+        slug: "hw1",
+        name: "Homework",
+        mode: "individual",
+        autograder: "default",
+        grading: { mode: "manual", max_points: 50 },
+      }}
+      onSuccess={vi.fn()}
+    />,
+  )
+  fireEvent.click(screen.getByRole("button", { name: "submit" }))
+  // The write is deferred behind the confirmation modal (now open).
+  expect(mutateAsync).not.toHaveBeenCalled()
+  expect(document.querySelector("dialog[open]")).not.toBeNull()
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: "assignmentSettings.provisioningConfirm.confirm",
+    }),
+  )
+  await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1))
+})
+
+it("does not write when the provisioning-change confirmation is cancelled", () => {
+  acceptedRepoNames = ["cs101-hw1-alice"]
+  render(
+    <EditAssignmentForm
+      org="acme"
+      classroom="cs101"
+      assignment="hw1"
+      defaultData={{
+        slug: "hw1",
+        name: "Homework",
+        mode: "individual",
+        autograder: "default",
+        grading: { mode: "manual", max_points: 50 },
+      }}
+      onSuccess={vi.fn()}
+    />,
+  )
+  fireEvent.click(screen.getByRole("button", { name: "submit" }))
+  expect(document.querySelector("dialog[open]")).not.toBeNull()
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: "assignmentSettings.provisioningConfirm.cancel",
+    }),
+  )
+  expect(mutateAsync).not.toHaveBeenCalled()
+})
+
+it("saves directly (no confirm) when accepted but no provisioning setting changed", () => {
+  // Two accepted repos, but the edit changes nothing provisioning-class (stored
+  // auto, submit stays auto), so the write proceeds without a prompt.
+  acceptedRepoNames = ["cs101-hw1-alice", "cs101-hw1-bob"]
+  render(
+    <EditAssignmentForm
+      org="acme"
+      classroom="cs101"
+      assignment="hw1"
+      defaultData={{
+        slug: "hw1",
+        name: "Homework",
+        mode: "individual",
+        autograder: "default",
+      }}
+      onSuccess={vi.fn()}
+    />,
+  )
+  fireEvent.click(screen.getByRole("button", { name: "submit" }))
+  expect(mutateAsync).toHaveBeenCalledTimes(1)
+  // No provisioning-class change, so the dialog was never opened.
+  expect(document.querySelector("dialog[open]")).toBeNull()
 })

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -1,13 +1,22 @@
+import { useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import CreateAssignmentForm, {
   assignmentToFormValues,
   formValuesToRepoFeatures,
 } from "./CreateAssignmentForm"
 import { deriveFormShape } from "./formShape"
-import { type CreateAssignmentResult } from "@/domain/assignments"
+import {
+  provisioningSettingsChanged,
+  type CreateAssignmentResult,
+} from "@/domain/assignments"
+import type { Assignment } from "@/types/classroom"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useTrackPublishDeploy } from "@/hooks/useTrackPublishDeploy"
 import { useEditAssignment } from "@/hooks/mutations/useEditAssignment"
+import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
+import useGetStudents from "@/hooks/useGetStudents"
+import { assignmentRepoNames } from "@/pages/submissions/dashboard"
+import { ProvisioningChangeConfirmModal } from "@/components/modals/ProvisioningChangeConfirmModal"
 import { LoadingSwap } from "@/lib/LoadingSwap"
 import { Spinner } from "@/components/Spinner"
 import { parseSubmissionTags } from "@/util/submissionTags"
@@ -26,7 +35,7 @@ const EditAssignmentForm = ({
   org: string
   classroom: string
   assignment: string
-  defaultData: Parameters<typeof assignmentToFormValues>[0] | undefined
+  defaultData: Assignment | undefined
   onSuccess: (result: CreateAssignmentResult) => void
   onError?: (error: GitHubAPIError) => void
   onMutate?: () => void
@@ -48,6 +57,61 @@ const EditAssignmentForm = ({
     onMutate,
   })
 
+  // Deterministic acceptance count for this assignment, derived from the org
+  // repo list + roster the same way the submissions page does (no per-student
+  // fetch). Gates the provisioning-change confirmation: zero accepted → the
+  // edit saves silently; one or more → confirm with a warning first. Both reads
+  // are cached and shared with other views, so this adds no dedicated request
+  // beyond what a staff member already loads.
+  const { data: orgRepos } = useGetOrgRepos(org)
+  const { students } = useGetStudents(org, classroom)
+  const isGroup = defaultData?.mode === "group"
+  const acceptedCount = useMemo(
+    () =>
+      assignmentRepoNames({
+        isGroup,
+        repos: orgRepos,
+        classroom,
+        assignment,
+        students,
+      }).length,
+    [isGroup, orgRepos, classroom, assignment, students],
+  )
+
+  // A change to a provisioning-class setting is confirmed before it writes when
+  // students have already accepted. The submit is deferred through a promise the
+  // modal resolves (confirm) or rejects-as-cancel (so the form stays dirty and
+  // re-submittable, matching a failed write).
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const pendingSubmit = useRef<{
+    run: () => Promise<void>
+    resolve: () => void
+    reject: (reason?: unknown) => void
+  } | null>(null)
+
+  const closeConfirm = () => {
+    setConfirmOpen(false)
+    // Treat a dismissal as a cancel: reject the deferred submit so the form's
+    // onSubmit rejects and the form is left dirty (no reset), never written.
+    const pending = pendingSubmit.current
+    pendingSubmit.current = null
+    pending?.reject(new Error("provisioning-change-cancelled"))
+  }
+
+  const confirmSubmit = async () => {
+    const pending = pendingSubmit.current
+    if (!pending) return
+    try {
+      await pending.run()
+      pending.resolve()
+    } catch (err) {
+      pending.reject(err)
+    } finally {
+      pendingSubmit.current = null
+      setConfirmOpen(false)
+    }
+  }
+
   return (
     <LoadingSwap
       loading={!defaultData}
@@ -58,18 +122,19 @@ const EditAssignmentForm = ({
       }
     >
       {defaultData ? (
-        <CreateAssignmentForm
-          edit
-          readOnly={readOnly}
-          loading={editAssignmentMutation.isPending}
-          org={org}
-          classroom={classroom}
-          slug={assignment}
-          onCancel={onCancel}
-          defaultValues={assignmentToFormValues(defaultData)}
-          onSubmit={async (values) => {
-            await editAssignmentMutation.mutateAsync(
-              {
+        <>
+          <CreateAssignmentForm
+            edit
+            readOnly={readOnly}
+            loading={editAssignmentMutation.isPending}
+            org={org}
+            classroom={classroom}
+            slug={assignment}
+            onCancel={onCancel}
+            defaultValues={assignmentToFormValues(defaultData)}
+            onSubmit={async (values) => {
+              const shape = deriveFormShape(values)
+              const input = {
                 name: values.name,
                 mode: values.mode,
                 org,
@@ -80,8 +145,8 @@ const EditAssignmentForm = ({
                 max_group_size: values.max_group_size,
                 feedback_pr: values.feedback_pr,
                 empty_repo: values.empty_repo,
-                no_autograder: deriveFormShape(values).noAutograder,
-                init_shim: deriveFormShape(values).initShim,
+                no_autograder: shape.noAutograder,
+                init_shim: shape.initShim,
                 include_all_branches: values.include_all_branches,
                 copy_about: values.copy_about,
                 copy_topics: values.copy_topics,
@@ -107,7 +172,7 @@ const EditAssignmentForm = ({
                 grading:
                   values.grading_choice === "manual"
                     ? {
-                        mode: "manual",
+                        mode: "manual" as const,
                         max_points: values.grading_max_points,
                       }
                     : { mode: values.grading_choice },
@@ -115,14 +180,47 @@ const EditAssignmentForm = ({
                 classroom,
                 tests: values.tests,
                 slug: assignment,
-              },
-              {
-                onSuccess: (result) => onSuccess(result),
-                onError,
-              },
-            )
-          }}
-        />
+              }
+
+              const run = () =>
+                editAssignmentMutation.mutateAsync(input, {
+                  onSuccess: (result) => onSuccess(result),
+                  onError,
+                })
+
+              // Confirm only when a provisioning-class setting changed AND
+              // students already accepted (their repos keep the old setup).
+              const changed = provisioningSettingsChanged(defaultData, {
+                empty_repo: values.empty_repo,
+                no_autograder: shape.noAutograder,
+                init_shim: shape.initShim,
+                gradingMode: values.grading_choice,
+              })
+              if (changed && acceptedCount > 0) {
+                await new Promise<void>((resolve, reject) => {
+                  pendingSubmit.current = {
+                    run: async () => {
+                      await run()
+                    },
+                    resolve,
+                    reject,
+                  }
+                  setConfirmOpen(true)
+                })
+                return
+              }
+
+              await run()
+            }}
+          />
+          <ProvisioningChangeConfirmModal
+            open={confirmOpen}
+            onClose={closeConfirm}
+            onConfirm={() => void confirmSubmit()}
+            acceptedCount={acceptedCount}
+            saving={editAssignmentMutation.isPending}
+          />
+        </>
       ) : null}
     </LoadingSwap>
   )

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -130,6 +130,7 @@ const EditAssignmentForm = ({
             org={org}
             classroom={classroom}
             slug={assignment}
+            hasAcceptedStudents={acceptedCount > 0}
             onCancel={onCancel}
             defaultValues={assignmentToFormValues(defaultData)}
             onSubmit={async (values) => {

--- a/web/src/pages/assignments/sections/AutogradingSection.tsx
+++ b/web/src/pages/assignments/sections/AutogradingSection.tsx
@@ -20,13 +20,16 @@ export function AutogradingSection({
   onReset,
   org,
   edit = false,
+  hasAcceptedStudents = false,
 }: {
   form: AssignmentForm
   onReset?: () => void
   org?: string
-  // On edit the built-in choice is locked (it maps to no_autograder/init_shim,
-  // which the domain layer refuses to change after creation).
+  // On edit the built-in choice maps to no_autograder/init_shim. It's editable,
+  // but changing it only affects future accepts, so the caveat shows when
+  // students have already accepted.
   edit?: boolean
+  hasAcceptedStudents?: boolean
 }) {
   const { t } = useTranslation()
 
@@ -43,7 +46,11 @@ export function AutogradingSection({
             </Alert>
           ) : (
             <div className="flex flex-col gap-6">
-              <AutogradingStateField form={form} edit={edit} />
+              <AutogradingStateField
+                form={form}
+                edit={edit}
+                hasAcceptedStudents={hasAcceptedStudents}
+              />
               {shape.showBuiltInConfig ? (
                 <>
                   <div className="divider my-0" />

--- a/web/src/pages/assignments/sections/AutogradingStateField.tsx
+++ b/web/src/pages/assignments/sections/AutogradingStateField.tsx
@@ -19,10 +19,10 @@ import type { AutogradingState } from "@/domain/assignments/autogradingState"
 // wire mapping (deriveFormShape + toSubmitValues) folds it to init_shim /
 // no_autograder accordingly.
 //
-// Immutable after creation: the none<->built-in choice maps to no_autograder /
-// init_shim, which the domain layer rejects changing on edit (already-accepted
-// repos aren't retrofitted). So on edit the radios render locked, mirroring the
-// repository-source field.
+// Editable after creation: the none<->built-in choice maps to no_autograder /
+// init_shim. The domain layer allows changing it; the edit form warns before
+// saving when students have already accepted (already-accepted repos aren't
+// retrofitted). The radios stay interactive in edit mode with an inline caveat.
 const SELECTABLE: readonly AutogradingState[] = ["none", "built-in"]
 
 export function AutogradingStateField({
@@ -37,7 +37,6 @@ export function AutogradingStateField({
   return (
     <form.Field name="autograding_state">
       {(field) => {
-        const locked = edit
         // A stored bare repo has autograding_state "empty"; show it as "none"
         // (no built-in autograder) since the two radios are none/built-in.
         const selected: AutogradingState =
@@ -49,15 +48,7 @@ export function AutogradingStateField({
           >
             {({ describedById }) => (
               <div aria-describedby={describedById}>
-                <fieldset
-                  className={
-                    locked
-                      ? "flex flex-col gap-2 pointer-events-none opacity-50"
-                      : "flex flex-col gap-2"
-                  }
-                  disabled={locked}
-                  aria-disabled={locked}
-                >
+                <fieldset className="flex flex-col gap-2">
                   <legend className="sr-only">
                     {t("assignments.form.autograding.modeLabel")}
                   </legend>
@@ -74,7 +65,6 @@ export function AutogradingStateField({
                         name={field.name}
                         value={option}
                         checked={selected === option}
-                        disabled={locked}
                         onBlur={field.handleBlur}
                         onChange={() => field.handleChange(option)}
                       />
@@ -91,9 +81,9 @@ export function AutogradingStateField({
                     </label>
                   ))}
                 </fieldset>
-                {locked ? (
+                {edit ? (
                   <p className="mt-1.5 text-sm text-base-content/70">
-                    {t("assignments.form.autograding.lockedHelp")}
+                    {t("assignments.form.autograding.editHelp")}
                   </p>
                 ) : null}
               </div>

--- a/web/src/pages/assignments/sections/AutogradingStateField.tsx
+++ b/web/src/pages/assignments/sections/AutogradingStateField.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { FormField } from "@/components/ui"
+import { Alert, FormField } from "@/components/ui"
 import type { AssignmentForm } from "../assignmentFormModel"
 import type { AutogradingState } from "@/domain/assignments/autogradingState"
 
@@ -28,9 +28,14 @@ const SELECTABLE: readonly AutogradingState[] = ["none", "built-in"]
 export function AutogradingStateField({
   form,
   edit,
+  hasAcceptedStudents = false,
 }: {
   form: AssignmentForm
   edit: boolean
+  // Edit mode: whether any student has already accepted. Gates the
+  // built-in-autograder change caveat so it shows only when a change would
+  // strand existing repos.
+  hasAcceptedStudents?: boolean
 }) {
   const { t } = useTranslation()
 
@@ -41,6 +46,14 @@ export function AutogradingStateField({
         // (no built-in autograder) since the two radios are none/built-in.
         const selected: AutogradingState =
           field.state.value === "built-in" ? "built-in" : "none"
+        // The stored choice mapped the same way, so a change is only real when
+        // the none/built-in selection actually flips (a stored "empty" that
+        // stays "none" is not a change).
+        const defaultSelected: AutogradingState =
+          form.options.defaultValues?.autograding_state === "built-in"
+            ? "built-in"
+            : "none"
+        const changed = selected !== defaultSelected
         return (
           <FormField
             htmlFor={field.name}
@@ -81,10 +94,10 @@ export function AutogradingStateField({
                     </label>
                   ))}
                 </fieldset>
-                {edit ? (
-                  <p className="mt-1.5 text-sm text-base-content/70">
-                    {t("assignments.form.autograding.editHelp")}
-                  </p>
+                {edit && hasAcceptedStudents && changed ? (
+                  <Alert tone="warning" role="status" className="mt-2 text-sm">
+                    <span>{t("assignments.form.autograding.editHelp")}</span>
+                  </Alert>
                 ) : null}
               </div>
             )}

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -165,6 +165,11 @@ export function DetailsSection({
         )}
       </form.Field>
 
+      {/* Assignment type is the repo-shape identity (individual = one repo per
+          student; group = a shared repo). Immutable on edit: switching it after
+          students accept invalidates every existing submission at collection
+          (the assignment_type check rejects them), so the radios lock like the
+          slug and a caveat says so up-front. */}
       <form.Field name="mode">
         {(field) => (
           <fieldset className="mt-4">
@@ -185,6 +190,7 @@ export function DetailsSection({
                     name={field.name}
                     value={value}
                     checked={field.state.value === value}
+                    disabled={edit}
                     onBlur={field.handleBlur}
                     onChange={() => field.handleChange(value)}
                   />
@@ -196,6 +202,11 @@ export function DetailsSection({
                 </label>
               ))}
             </div>
+            {edit ? (
+              <p className="mt-1.5 text-sm text-base-content/70">
+                {t("assignments.form.typeLockedHelp")}
+              </p>
+            ) : null}
           </fieldset>
         )}
       </form.Field>

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -54,16 +54,13 @@ export function RepositorySetupSection({
     >
       <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2 sm:items-start">
         <div className="flex flex-col gap-4">
-          {/* Repository source: template vs no template (default No). Immutable
-              after creation (locked on edit): already-accepted repos can't be
-              retrofitted from one source to the other. */}
+          {/* Repository source: template vs no template (default No). Editable
+              after creation, but changing it only re-provisions repositories
+              accepted from now on — the edit form warns before saving when
+              students have already accepted (see AssignmentSettingsPage). */}
           <form.Field name="repo_source">
             {(field) => (
-              <fieldset
-                className={edit ? "pointer-events-none opacity-50" : ""}
-                disabled={edit}
-                aria-disabled={edit}
-              >
+              <fieldset>
                 <legend className="label font-bold mb-2">
                   {t("assignments.form.repoSource.label")}
                 </legend>
@@ -81,7 +78,6 @@ export function RepositorySetupSection({
                         name={field.name}
                         value={option}
                         checked={field.state.value === option}
-                        disabled={edit}
                         onBlur={field.handleBlur}
                         onChange={() =>
                           field.handleChange(option as RepoSource)
@@ -98,7 +94,7 @@ export function RepositorySetupSection({
                 </div>
                 {edit ? (
                   <p className="mt-1.5 text-sm text-base-content/70">
-                    {t("assignments.form.repoSource.lockedHelp")}
+                    {t("assignments.form.repoSource.editHelp")}
                   </p>
                 ) : null}
               </fieldset>

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -37,6 +37,7 @@ export function RepositorySetupSection({
   org,
   classroom,
   slug,
+  hasAcceptedStudents = false,
 }: {
   form: AssignmentForm
   edit: boolean
@@ -44,6 +45,10 @@ export function RepositorySetupSection({
   org?: string
   classroom?: string
   slug?: string
+  // Edit mode: whether any student has already accepted. Gates the
+  // repo-source change caveat so it shows only when a change would strand
+  // existing repos.
+  hasAcceptedStudents?: boolean
 }) {
   const { t } = useTranslation()
 
@@ -92,10 +97,13 @@ export function RepositorySetupSection({
                     </label>
                   ))}
                 </div>
-                {edit ? (
-                  <p className="mt-1.5 text-sm text-base-content/70">
-                    {t("assignments.form.repoSource.editHelp")}
-                  </p>
+                {edit &&
+                hasAcceptedStudents &&
+                field.state.value !==
+                  (form.options.defaultValues?.repo_source ?? "none") ? (
+                  <Alert tone="warning" role="status" className="mt-2 text-sm">
+                    <span>{t("assignments.form.repoSource.editHelp")}</span>
+                  </Alert>
                 ) : null}
               </fieldset>
             )}

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -29,7 +29,9 @@ const REPO_ROLES_DOCS_URL =
 //     the tri-state controls folded in from the former standalone section so
 //     all repo config lives in one card.
 // The source choice folds into empty_repo + template on submit via
-// deriveFormShape; the choice is immutable after creation (locked on edit).
+// deriveFormShape; it stays editable on edit, but changing it only re-provisions
+// repos accepted from now on (already-accepted repos aren't retrofitted), so the
+// edit form warns when students have already accepted.
 export function RepositorySetupSection({
   form,
   edit,

--- a/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
+++ b/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
@@ -64,7 +64,9 @@ export function SubmissionGradingSection({
 
 // Grading choice (off / auto / manual). manual reveals a max-points input; auto
 // shows a pointer to the Autograding section + the result.json requirement.
-// The mode is immutable after creation, so on edit a change warns.
+// Editable after creation; on edit a change shows an inline warning, and the
+// edit form also confirms before saving when students have already accepted
+// (scores recorded under the old mode may be read differently).
 function GradingChoiceField({
   form,
   edit,

--- a/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
+++ b/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
@@ -56,7 +56,7 @@ export function SubmissionGradingSection({
           </form.Subscribe>
         </div>
         <div className="divider my-0" />
-        <GradingChoiceField form={form} edit={edit} />
+        <GradingChoiceField form={form} />
       </div>
     </SectionCard>
   )
@@ -64,16 +64,10 @@ export function SubmissionGradingSection({
 
 // Grading choice (off / auto / manual). manual reveals a max-points input; auto
 // shows a pointer to the Autograding section + the result.json requirement.
-// Editable after creation; on edit a change shows an inline warning, and the
-// edit form also confirms before saving when students have already accepted
-// (scores recorded under the old mode may be read differently).
-function GradingChoiceField({
-  form,
-  edit,
-}: {
-  form: AssignmentForm
-  edit: boolean
-}) {
+// Editable after creation; the edit form confirms before saving when students
+// have already accepted (scores recorded under the old mode may be read
+// differently), so no inline edit warning is needed here.
+function GradingChoiceField({ form }: { form: AssignmentForm }) {
   const { t } = useTranslation()
   return (
     <div className="flex flex-col gap-3">
@@ -111,22 +105,6 @@ function GradingChoiceField({
                 </Select>
               )}
             </FormField>
-            {edit ? (
-              <form.Subscribe selector={(state) => state.values.grading_choice}>
-                {(choice) =>
-                  choice !==
-                  (form.options.defaultValues?.grading_choice ?? "auto") ? (
-                    <Alert
-                      tone="warning"
-                      role="status"
-                      className="mt-2 text-sm"
-                    >
-                      <span>{t("assignments.form.grading.editWarning")}</span>
-                    </Alert>
-                  ) : null
-                }
-              </form.Subscribe>
-            ) : null}
           </div>
         )}
       </form.Field>


### PR DESCRIPTION
## Summary

Lifts the post-creation lock on the assignment settings that were previously immutable — repository source (`empty_repo`), the built-in autograder choice (`no_autograder` / `init_shim`), and `grading.mode` — in both the web app and the `gh-teacher` CLI. Student repositories are provisioned at accept time and never retrofitted, so a change only takes effect for repos accepted from now on; the teacher reconciles any existing inconsistency.

- **Web (`web/`)**: `editAssignment` no longer throws on these transitions. The edit form's repository-source and built-in-autograder controls are editable, and the form derives the accepted-repo count client-side (org repo list + roster). When a provisioning-class setting changed **and** at least one student has accepted, a warning-toned confirmation modal blocks the save until the teacher confirms; with zero accepters the edit saves silently. Inline repo-source / autograder caveats render as warning alerts only when a change would strand existing repos.
- **CLI (`cli/gh-teacher/`)**: the `Validate*Unchanged` hard errors became a single-sourced `EmptyRepoChanged` boolean helper; a same-slug re-add that flips `empty_repo` prints a non-blocking `Warning:` instead of failing.
- **Assignment type stays locked on edit.** Switching individual↔group after students accept invalidates every existing submission at collection (the `assignment_type` check rejects them), so the type radios lock like the slug, with an up-front caveat.
- The confirm modal and CLI warning name the concrete consequence of turning autograding off after accept: existing repos' autograde runs start failing and drop out of the gradebook.

## Review

Ran a multi-reviewer code review (correctness, standards, testing, maintainability, performance, reliability, adversarial). Resolved findings: dead CLI warning branches removed, stale "immutable" comments corrected, and the assignment-type flip locked (the one un-gated destructive transition).

**Known follow-up (out of scope):** flipping `empty_repo`/`no_autograder` **on** after students accepted makes the shared autograde runner hard-fail those repos' next push and makes score collection silently skip the slug. This is pre-existing autograde-pipeline behavior (the flip was previously blocked entirely); this PR makes the flip reachable and warns about it. Softening the runner/collector to skip-with-status for a mismatched already-accepted repo is tracked as a separate change.

## Test plan

- [x] `web/`: `tsc -b`, `eslint`, `prettier --check`, `arch:validate`, strict i18n audit, and the node vitest suite (3735 passing, incl. new tests for change detection, confirm gating, conditional caveats, and the assignment-type edit lock) all pass.
- [x] `cli/gh-teacher`: `go build ./...`, `go test ./...`, `go vet`, `gofmt`, and `golangci-lint run` + `fmt --diff` all pass.
- [x] Verified against a live org (`classroom50-summer-dev`): manifests exercise auto/manual/off grading, empty_repo, no_autograder, init_shim, and group modes; confirmed the collection pipeline does not read `grading.mode`.
- [ ] Browser-project vitest tests run in CI (missing Playwright browser binary locally).