### PR TITLE
docs(wiki): assignment provisioning settings are editable after creation

### DIFF
--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -147,7 +147,8 @@ Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
 - **Per assignment, at creation** — pick **Do not use the built-in
   autograder** (`no_autograder` in assignments.json). Accept installs no shim
   at all; a templated assignment's own CI workflows run instead, and score
-  collection skips the assignment. Immutable after creation. See
+  collection skips the assignment. Changeable later, but only affects
+  repositories accepted from then on (existing ones keep their setup). See
   [`gh teacher` reference](gh-teacher#assignment-add).
 - **Per assignment, temporarily** — **Pause autograding** in the submissions
   page's **Actions** menu disables the `autograde.yaml` workflow in every

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -147,9 +147,12 @@ Both start from no template; the difference is what (if anything) is committed:
   in-between shape: an initialized repo carrying only the control files, no
   README, which grades normally.)
 
-**These repository-shape choices are permanent** for an assignment — you can't
-switch them after creating it, because repositories students already accepted
-can't be retrofitted.
+**These repository-shape choices can be changed after creation, but a change
+only affects repositories accepted from then on** — repositories students
+already accepted aren't retrofitted, so they keep their original shape. The web
+edit form asks you to confirm when students have already accepted. (**Assignment
+type** — Individual vs. Group — is the exception and stays locked, since
+switching it would invalidate existing submissions.)
 
 ### How do group assignments work?
 
@@ -195,12 +198,13 @@ Yes, several levers:
 - Create an assignment with **no autograding tests**, and no grading runs
   (Classroom 50 still uses a lightweight workflow to tag submissions and
   support written feedback, which uses far fewer Actions minutes).
-- **Don't use the built-in autograder at all** (permanent) — when creating an
+- **Don't use the built-in autograder at all** — when creating an
   assignment, pick **Do not use the built-in autograder**. Accept then installs
   no autograding workflow: a templated assignment runs only your template's own
   CI (if any), and score collection skips the assignment. The right choice for
-  project-shaped assignments graded by hand or by your own CI. Can't be changed
-  after the assignment is created.
+  project-shaped assignments graded by hand or by your own CI. Can be changed
+  after creation, but only affects repositories accepted from then on (existing
+  ones keep their original setup).
 - **Pause autograding org-wide** — the organization's Actions settings in the
   web app. **Caution:** this stops **all** workflows in student repositories,
   not just autograding — any CI your students run stops too. Setup also creates
@@ -267,7 +271,8 @@ Yes, two ways:
   button. Hand-entered scores show a **Manual** badge and are stored as
   overrides. (This editor appears only for manual-mode assignments, and only
   for organization owners — writing scores means writing the config repo. The
-  grading mode can't be changed after an assignment is created.)
+  grading mode can be changed later from the edit form, though a change only
+  affects how repositories accepted from then on are read.)
 - **In the config repo, for any assignment.** Edit the classroom's
   `scores.json`: change the submission's `score` and add `"override": true` to
   that entry, then commit. Collection leaves overridden entries untouched on

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -182,25 +182,30 @@ How each student's repository is created:
   you can review changes and leave inline feedback.
 - **Student repo access** — the role students get on their own repository.
 
-> [!WARNING]
-> **These repository-shape choices are permanent** — the template/README/bare
-> and built-in-autograder choices can't be changed after you create the
-> assignment, because repositories students already accepted can't be
-> retrofitted.
+> [!NOTE]
+> **These settings can be changed after creation, but only affect repositories
+> accepted from now on** — repositories students already accepted aren't
+> retrofitted, so they keep their original starter code and setup. When at least
+> one student has already accepted, the edit form asks you to confirm and warns
+> that you'll need to reconcile the existing repositories yourself. (**Assignment
+> type** — Individual vs. Group — is the exception: it stays locked on edit,
+> because switching it would invalidate every existing submission.)
 
 ### Grading and submissions
 
 - **Grading** — **Not graded** (the default), **Autograded**, or **Manual
   (enter scores by hand)**. The autograding options below are offered only
   under **Autograded**; **Manual** assignments get a **Max points** field and
-  you enter each student's score on the submissions page (see below). Immutable
-  after creation.
+  you enter each student's score on the submissions page (see below). Can be
+  changed after creation (edits only affect repositories accepted from now on).
 - **Built-in autograder** — under **Autograded**, choose **Use the built-in
   autograder** or **Do not use the built-in autograder** (the default on a new
   assignment). Opting out means accept installs no autograding workflow at all:
   on a templated assignment your template's own CI workflows run instead, and
-  Classroom 50's score collection skips the assignment. Immutable after
-  creation.
+  Classroom 50's score collection skips the assignment. Can be changed after
+  creation (edits only affect repositories accepted from now on; turning
+  autograding off later makes already-accepted repositories' autograde runs
+  fail and drop out of the gradebook).
 - **Submission type** — when the autograder runs. **Every push to the default
   branch** (the default) grades each push. **A tagged commit** grades only
   when a student submits (`gh student submit`) or pushes a `submit/*` tag —
@@ -419,7 +424,11 @@ spreadsheet or external tool.
 ## Edit assignments and classrooms
 
 - **Edit an assignment** — open the assignment, then **Assignment settings**.
-  Same form as creating one, pre-filled.
+  Same form as creating one, pre-filled. Provisioning settings (repository
+  source, built-in autograder, grading mode) are editable; a change only affects
+  repositories accepted from then on, so the form asks you to confirm when
+  students have already accepted. **Assignment type** (Individual vs. Group)
+  stays locked, since switching it would invalidate existing submissions.
 - **Edit a classroom** — open the classroom, then **Settings**. Same form as
   creating one, pre-filled.
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -414,7 +414,7 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | `--tests <path>` | JSON array of declarative tests. Mutually exclusive with a per-assignment `autograder.py`. |
 | `--autograder <name>` | Swap the reusable workflow (rare). Default `default`. |
 | `--feedback-pr` | One review PR per student repo. **On by default**; `--feedback-pr=false` disables. |
-| `--empty-repo` | Truly bare repos (no README/marker/shim); autograding and feedback PR disabled; immutable; mutually exclusive with template/tests/feedback-pr/allowed-files/pass-threshold/submission-mode/submission-tag/no-autograder/init-shim. |
+| `--empty-repo` | Truly bare repos (no README/marker/shim); autograding and feedback PR disabled; changeable on a same-slug re-add (warns; only affects future accepts); mutually exclusive with template/tests/feedback-pr/allowed-files/pass-threshold/submission-mode/submission-tag/no-autograder/init-shim. |
 | `--pass-threshold <0–100>` | Advisory passing bar shown by gradebook clients. Off when omitted (distinct from `0`). |
 | `--submission-mode every-push\|tag` | When the autograder fires: `every-push` (default) grades every push; `tag` grades only `submit/*` tag pushes (the submit clients push the tag — plain `git push` costs no Actions minutes). Change it later with `assignment submission-mode`. |
 | `--submission-tag <pattern>` | Milestone tag (repeatable) that also triggers grading: `git tag phase1 && git push origin phase1` grades that commit. Simple globs (`v*`) work; exact names are safer. The record still lives at the canonical `submit/*` tag. Mutually exclusive with `--empty-repo`. |
@@ -433,7 +433,8 @@ CI). Unlike `--empty-repo` it keeps the template and the Feedback PR (a
 templated repo has a baseline commit); it is mutually exclusive with
 `empty_repo`, a non-default `--autograder`, and the grading-adjacent fields
 (tests/allowed-files/release-assets/pass-threshold/submission-mode/
-submission-tag), and it is immutable after creation. Score collection and
+submission-tag). It can be changed later, but only affects repositories accepted
+from then on (already-accepted repos aren't retrofitted). Score collection and
 regrade skip it (no `submit/*` releases are produced). Set it in the web app's
 assignment form — choose **"Do not use the built-in autograder"** under
 **Built-in autograder** — or by writing `no_autograder: true` into
@@ -451,10 +452,12 @@ assignment (the grading pipeline does **not** skip it). It **requires** the
 default autograder and **no** template (a template provides its own starter
 content); it is mutually exclusive with `empty_repo`, `template`,
 `no_autograder`, and a non-default `--autograder`, and it **permits** the
-grading-adjacent fields (it autogrades). It is immutable after creation. Set it
-in the web app's assignment form — pick **"No template"**, leave **"Add a
-README"** off, and keep **"Use the built-in autograder"** — or by writing
-`init_shim: true` into `assignments.json`; there is no `assignment add` flag.
+grading-adjacent fields (it autogrades). It can be changed later, but only
+affects repositories accepted from then on (already-accepted repos aren't
+retrofitted). Set it in the web app's assignment form — pick **"No template"**,
+leave **"Add a README"** off, and keep **"Use the built-in autograder"** — or by
+writing `init_shim: true` into `assignments.json`; there is no `assignment add`
+flag.
 
 **Include all branches (`include_all_branches`).** A **templated** assignment can
 carry `include_all_branches: true` in `assignments.json` to copy **all** of the
@@ -463,8 +466,8 @@ accept passes `include_all_branches` to GitHub's `POST /repos/{template}/generat
 It **requires** a template (it only affects the generate call) and is mutually
 exclusive with `empty_repo` and `init_shim` (both template-less, never
 generated); it is **compatible** with everything else, including `no_autograder`
-and the grading-adjacent fields (branches don't affect grading). Unlike the
-immutable no-shim states it is **accept-time only and mutable**: changing it
+and the grading-adjacent fields (branches don't affect grading). Like the other
+provisioning settings it is **mutable**, and being **accept-time only** it
 affects only repos generated from now on (already-accepted repos are never
 re-generated). Set it with the web assignment form's **"Include all branches"**
 toggle or via `assignments.json`; there is no `assignment add` flag.


### PR DESCRIPTION
## Summary

Follow-up to #597, which lifted the post-creation lock on assignment provisioning settings. Updates the wiki so the docs match the shipped behavior.

- **Web-Teacher-Guide** — the repository-shape / grading / built-in-autograder settings are now described as editable (a change only affects repos accepted from then on; the edit form confirms when students have already accepted), and the "Edit an assignment" section spells this out. The assignment **type** (Individual vs. Group) is called out as the one setting that stays locked.
- **FAQ** — the "repository-shape choices are permanent" and "grading mode can't be changed" answers are corrected.
- **gh-teacher / Autograders reference** — the `empty_repo` / `no_autograder` / `init_shim` "immutable after creation" notes are corrected (CLI: `--empty-repo` is changeable on a same-slug re-add with a warning; the shim states are GUI-owned and mutable), and the `include_all_branches` "unlike the immutable no-shim states" contrast is fixed.

Docs-only; no code changes.

## Test plan

- [x] Grepped the wiki for remaining "immutable / can't be changed after creation / permanent" claims about these settings — none remain (the legitimately-immutable ones — classroom short-name, roster github_id, submit releases — are untouched).