### PR TITLE
feat(web): sort rosters by last name and add student names to grade CSV

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -618,6 +618,11 @@
     "filterAllSections": "All sections",
     "filterByRoleLabel": "Filter by role",
     "filterAllRoles": "All roles",
+    "sortBy": {
+      "label": "Sort by name",
+      "firstName": "First name",
+      "lastName": "Last name"
+    },
     "roleTeacher": "Teacher",
     "roleTa": "TA",
     "roleHeadTa": "Head TA",
@@ -2472,8 +2477,8 @@
       "sortAria": "Sort submissions",
       "sortRecent": "Newest first",
       "sortOldest": "Oldest first",
-      "sortNameAsc": "Name A–Z",
-      "sortNameDesc": "Name Z–A"
+      "sortNameFirst": "By first name",
+      "sortNameLast": "By last name"
     },
     "table": {
       "captionGroup": "Group submissions",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -60,6 +60,7 @@ import {
   selectActiveWorkflowAction,
   showsNonSubmitters,
   snapshotIsStale,
+  sortNameMode,
   studentInSection,
   submissionRosterStudents,
   type SubmissionFilters,
@@ -246,6 +247,11 @@ const SubmissionsPageContent = () => {
     }
     return set
   }, [teamRows, orgRepos, isGroupAssignment, classroom, assignment])
+  const [sort, setSort] = useState<SubmissionSort>("name-first")
+  // The roster spine's name order. When live, the view is pinned to the plain
+  // name-ordered fan-out (see effectiveSort below), so the spine follows the
+  // user's first/last choice only off-live; live always uses first-name order.
+  const rosterSortMode = isOwner && !skipsGrading ? "first" : sortNameMode(sort)
   const students: Student[] = useMemo(
     () =>
       sortStudentsByName(
@@ -253,8 +259,9 @@ const SubmissionsPageContent = () => {
           acceptedStaffLogins,
           groupRepoMembers: groupRepoFounders,
         }),
+        rosterSortMode,
       ),
-    [teamRows, acceptedStaffLogins, groupRepoFounders],
+    [teamRows, acceptedStaffLogins, groupRepoFounders, rosterSortMode],
   )
   // Gate Regrade all / Collect now on an empty roster: dispatching with no
   // students is wasted effort. `show` is loading-aware (won't flash before the
@@ -306,7 +313,6 @@ const SubmissionsPageContent = () => {
   // the page/size/filters must be known before it runs.
   const [query, setQuery] = useState("")
   const [filters, setFilters] = useState<SubmissionFilters>(DEFAULT_FILTERS)
-  const [sort, setSort] = useState<SubmissionSort>("name-asc")
   // Client-side table pagination over the display list. `page` is 0-based;
   // clamped at render (pageBounds) so a filter that shrinks the list can't
   // strand the view on an empty page.
@@ -355,7 +361,7 @@ const SubmissionsPageContent = () => {
   // plain name-ordered, unfiltered view the fan-out aligns to — even if a prior
   // session left non-default state. Search + section still apply (they don't
   // reorder the spine). Non-live viewers keep full sort/status.
-  const effectiveSort: SubmissionSort = liveCapable ? "name-asc" : sort
+  const effectiveSort: SubmissionSort = liveCapable ? "name-first" : sort
   const effectiveStatusFilters: SubmissionFilters = useMemo(
     () =>
       liveCapable
@@ -870,7 +876,7 @@ const SubmissionsPageContent = () => {
     // make the file's counts depend on the last-viewed page. `snapshotScoped`
     // (the roster-scoped snapshot, already memoized for the fan-out spine) always
     // matches scores.json regardless of paging.
-    const rows = buildScoresCsvRows(snapshotScoped, csvNonSubmitters)
+    const rows = buildScoresCsvRows(snapshotScoped, csvNonSubmitters, students)
 
     const csv = Papa.unparse(rows, {
       header: true,

--- a/web/src/pages/students/CsvRosterView.test.tsx
+++ b/web/src/pages/students/CsvRosterView.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  within,
+} from "@testing-library/react"
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -98,5 +104,35 @@ describe("CsvRosterView", () => {
   it("renders no mutating controls (read-only)", () => {
     const { container } = render(<CsvRosterView students={[student()]} />)
     expect(container.querySelectorAll("button")).toHaveLength(0)
+  })
+
+  it("re-sorts by first name vs last name when the toggle changes", () => {
+    // Zed Adams vs Amy Brown: first-name order is Amy, Zed; last-name order is
+    // Adams (Zed), Brown (Amy) — so flipping the toggle must reorder the rows.
+    render(
+      <CsvRosterView
+        students={[
+          student({ username: "zed", first_name: "Zed", last_name: "Adams" }),
+          student({ username: "amy", first_name: "Amy", last_name: "Brown" }),
+        ]}
+      />,
+    )
+
+    const names = () =>
+      screen
+        .getAllByRole("row")
+        // Skip the header row (no data cell); read the bold display-name cell.
+        .map((r) => within(r).queryByText(/Zed Adams|Amy Brown/)?.textContent)
+        .filter(Boolean)
+
+    // Defaults to first-name order.
+    expect(names()).toEqual(["Amy Brown", "Zed Adams"])
+
+    fireEvent.change(screen.getByLabelText("students.sortBy.label"), {
+      target: { value: "last" },
+    })
+
+    // Last-name order: Adams (Zed) before Brown (Amy).
+    expect(names()).toEqual(["Zed Adams", "Amy Brown"])
   })
 })

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -4,6 +4,7 @@ import { Info } from "lucide-react"
 
 import { Alert, Toolbar } from "@/components/ui"
 import { RoleBadges } from "./RoleBadges"
+import { StudentSortSelect } from "./StudentSortSelect"
 import { coerceImportRole } from "./rosterImportParse"
 import type { Student } from "@/types/classroom"
 import {
@@ -41,16 +42,7 @@ const CsvRosterView = ({ students }: { students: Student[] }) => {
 
       {students.length > 0 ? (
         <Toolbar>
-          <Toolbar.FilterSelect
-            selectSize="md"
-            className="w-full sm:w-auto"
-            aria-label={t("students.sortBy.label")}
-            value={sortMode}
-            onChange={(e) => setSortMode(e.target.value as StudentSortMode)}
-          >
-            <option value="first">{t("students.sortBy.firstName")}</option>
-            <option value="last">{t("students.sortBy.lastName")}</option>
-          </Toolbar.FilterSelect>
+          <StudentSortSelect value={sortMode} onChange={setSortMode} />
         </Toolbar>
       ) : null}
 

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -1,11 +1,16 @@
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Info } from "lucide-react"
 
-import { Alert } from "@/components/ui"
+import { Alert, Toolbar } from "@/components/ui"
 import { RoleBadges } from "./RoleBadges"
 import { coerceImportRole } from "./rosterImportParse"
 import type { Student } from "@/types/classroom"
+import {
+  DEFAULT_STUDENT_SORT,
+  sortStudentsByName,
+  type StudentSortMode,
+} from "@/util/students"
 
 function displayName(student: Student): string {
   const full = `${student.first_name} ${student.last_name}`.trim()
@@ -19,11 +24,12 @@ function displayName(student: Student): string {
 // teacher-maintained, not live, no invites or management actions.
 const CsvRosterView = ({ students }: { students: Student[] }) => {
   const { t } = useTranslation()
+  const [sortMode, setSortMode] =
+    useState<StudentSortMode>(DEFAULT_STUDENT_SORT)
 
   const rows = useMemo(
-    () =>
-      students.toSorted((a, b) => displayName(a).localeCompare(displayName(b))),
-    [students],
+    () => sortStudentsByName(students, sortMode),
+    [students, sortMode],
   )
 
   return (
@@ -32,6 +38,21 @@ const CsvRosterView = ({ students }: { students: Student[] }) => {
         <Info aria-hidden="true" className="size-5" />
         <span>{t("students.csvRoster.notice")}</span>
       </Alert>
+
+      {students.length > 0 ? (
+        <Toolbar>
+          <Toolbar.FilterSelect
+            selectSize="md"
+            className="w-full sm:w-auto"
+            aria-label={t("students.sortBy.label")}
+            value={sortMode}
+            onChange={(e) => setSortMode(e.target.value as StudentSortMode)}
+          >
+            <option value="first">{t("students.sortBy.firstName")}</option>
+            <option value="last">{t("students.sortBy.lastName")}</option>
+          </Toolbar.FilterSelect>
+        </Toolbar>
+      ) : null}
 
       <div className="overflow-x-auto rounded-box border border-base-content/5 bg-base-100">
         <table className="table">

--- a/web/src/pages/students/EnrolledStudents.smoke.test.tsx
+++ b/web/src/pages/students/EnrolledStudents.smoke.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
 import type { ReactElement } from "react"
 
 // A rendered smoke test locking the component's phase views (loading / empty /
@@ -234,5 +234,57 @@ describe("EnrolledStudents — rendered phase views", () => {
     useTeamRoster.mockReturnValue(populatedRoster)
     render(renderView())
     expect(capturedCanManage).toBe(false)
+  })
+
+  // The sort toggle re-orders the rendered roster by first vs last name. Two
+  // enrolled rows whose first/last order disagree pin the wiring.
+  it("re-sorts the roster by first vs last name via the sort toggle", () => {
+    useTeamRoster.mockReturnValue({
+      ...emptyRoster,
+      isEmpty: false,
+      counts: { enrolled: 2, pending: 0 },
+      rows: [
+        {
+          key: "amy",
+          username: "amy",
+          first_name: "Amy",
+          last_name: "Brown",
+          email: "",
+          section: "",
+          github_id: "1",
+          roles: ["student"],
+          state: "enrolled",
+        },
+        {
+          key: "zed",
+          username: "zed",
+          first_name: "Zed",
+          last_name: "Adams",
+          email: "",
+          section: "",
+          github_id: "2",
+          roles: ["student"],
+          state: "enrolled",
+        },
+      ],
+    })
+    render(renderView())
+
+    const order = () => {
+      const text = document.body.textContent ?? ""
+      return text.indexOf("amy") < text.indexOf("zed")
+        ? "amy-first"
+        : "zed-first"
+    }
+
+    // Defaults to first-name order: Amy before Zed.
+    expect(order()).toBe("amy-first")
+
+    fireEvent.change(screen.getByLabelText("students.sortBy.label"), {
+      target: { value: "last" },
+    })
+
+    // Last-name order: Adams (Zed) before Brown (Amy).
+    expect(order()).toBe("zed-first")
   })
 })

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -26,6 +26,7 @@ import { useSyncRoster } from "@/hooks/mutations/useSyncRoster"
 import { useReinviteFailedInvite } from "@/hooks/mutations/useReinviteFailedInvite"
 import type { SuppressedLogins } from "@/hooks/useSuppressedLogins"
 import type { TeamRosterRow, ClassroomRole } from "@/util/teamRoster"
+import { sortTeamRosterRows } from "@/util/teamRoster"
 import { STAFF_ROLES } from "@/types/classroom"
 import { ROLE_LABEL_KEY, hasStudentEnrollment } from "@/util/classroomRoleUI"
 import {
@@ -35,7 +36,11 @@ import {
   type StatusFilter,
 } from "@/pages/students/rosterFilter"
 import { studentKey, toStudent } from "@/util/roster"
-import { isSameGitHubUser } from "@/util/students"
+import {
+  DEFAULT_STUDENT_SORT,
+  isSameGitHubUser,
+  type StudentSortMode,
+} from "@/util/students"
 import {
   resolveSelectedRows,
   selectableRows,
@@ -110,6 +115,8 @@ const EnrolledStudents = ({
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all")
   const [sectionFilter, setSectionFilter] = useState<string>("all")
+  const [sortMode, setSortMode] =
+    useState<StudentSortMode>(DEFAULT_STUDENT_SORT)
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
   // Session-only banner dismissal — a page refresh re-derives roster state and
@@ -234,15 +241,20 @@ const EnrolledStudents = ({
 
   // Text search over username/name/email + the status, role, and section
   // filters (see filterRosterRows — extracted so the facets are unit-tested).
+  // Re-sorted by the chosen name direction (first vs last name); the underlying
+  // rows already arrive first-name sorted, so `first` is a no-op reorder.
   const filtered = useMemo(
     () =>
-      filterRosterRows(rows, {
-        query,
-        statusFilter,
-        roleFilter: effectiveRole,
-        sectionFilter: effectiveSection,
-      }),
-    [rows, query, statusFilter, effectiveRole, effectiveSection],
+      sortTeamRosterRows(
+        filterRosterRows(rows, {
+          query,
+          statusFilter,
+          roleFilter: effectiveRole,
+          sectionFilter: effectiveSection,
+        }),
+        sortMode,
+      ),
+    [rows, query, statusFilter, effectiveRole, effectiveSection, sortMode],
   )
 
   const hasSectionsInFiltered = useMemo(
@@ -576,6 +588,16 @@ const EnrolledStudents = ({
               ))}
             </Toolbar.FilterSelect>
           ) : null}
+          <Toolbar.FilterSelect
+            selectSize="md"
+            className="w-full sm:w-auto"
+            aria-label={t("students.sortBy.label")}
+            value={sortMode}
+            onChange={(e) => setSortMode(e.target.value as StudentSortMode)}
+          >
+            <option value="first">{t("students.sortBy.firstName")}</option>
+            <option value="last">{t("students.sortBy.lastName")}</option>
+          </Toolbar.FilterSelect>
           {syncMutation.isPending || csvMissingCount > 0 ? (
             <Button
               variant="ghost"

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -35,6 +35,7 @@ import {
   type RoleFilter,
   type StatusFilter,
 } from "@/pages/students/rosterFilter"
+import { StudentSortSelect } from "@/pages/students/StudentSortSelect"
 import { studentKey, toStudent } from "@/util/roster"
 import {
   DEFAULT_STUDENT_SORT,
@@ -241,8 +242,7 @@ const EnrolledStudents = ({
 
   // Text search over username/name/email + the status, role, and section
   // filters (see filterRosterRows — extracted so the facets are unit-tested).
-  // Re-sorted by the chosen name direction (first vs last name); the underlying
-  // rows already arrive first-name sorted, so `first` is a no-op reorder.
+  // The rows already arrive first-name sorted, so mode "first" is a no-op reorder.
   const filtered = useMemo(
     () =>
       sortTeamRosterRows(
@@ -588,16 +588,7 @@ const EnrolledStudents = ({
               ))}
             </Toolbar.FilterSelect>
           ) : null}
-          <Toolbar.FilterSelect
-            selectSize="md"
-            className="w-full sm:w-auto"
-            aria-label={t("students.sortBy.label")}
-            value={sortMode}
-            onChange={(e) => setSortMode(e.target.value as StudentSortMode)}
-          >
-            <option value="first">{t("students.sortBy.firstName")}</option>
-            <option value="last">{t("students.sortBy.lastName")}</option>
-          </Toolbar.FilterSelect>
+          <StudentSortSelect value={sortMode} onChange={setSortMode} />
           {syncMutation.isPending || csvMissingCount > 0 ? (
             <Button
               variant="ghost"

--- a/web/src/pages/students/StudentSortSelect.tsx
+++ b/web/src/pages/students/StudentSortSelect.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from "react-i18next"
+
+import { Toolbar } from "@/components/ui"
+import type { StudentSortMode } from "@/util/students"
+
+// The by-name sort toggle shared across roster views (enrolled + CSV) and any
+// other surface that orders students by first vs last name, so the label,
+// options, and StudentSortMode cast live in one place.
+export function StudentSortSelect({
+  value,
+  onChange,
+}: {
+  value: StudentSortMode
+  onChange: (mode: StudentSortMode) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <Toolbar.FilterSelect
+      selectSize="md"
+      className="w-full sm:w-auto"
+      aria-label={t("students.sortBy.label")}
+      value={value}
+      onChange={(e) => onChange(e.target.value as StudentSortMode)}
+    >
+      <option value="first">{t("students.sortBy.firstName")}</option>
+      <option value="last">{t("students.sortBy.lastName")}</option>
+    </Toolbar.FilterSelect>
+  )
+}

--- a/web/src/pages/submissions/SubmissionsControls.tsx
+++ b/web/src/pages/submissions/SubmissionsControls.tsx
@@ -207,11 +207,11 @@ const SubmissionsControls = ({
             <option value="oldest">
               {t("submissions.filters.sortOldest")}
             </option>
-            <option value="name-asc">
-              {t("submissions.filters.sortNameAsc")}
+            <option value="name-first">
+              {t("submissions.filters.sortNameFirst")}
             </option>
-            <option value="name-desc">
-              {t("submissions.filters.sortNameDesc")}
+            <option value="name-last">
+              {t("submissions.filters.sortNameLast")}
             </option>
           </Toolbar.FilterSelect>
         )}

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -20,9 +20,11 @@ import {
   buildGroupRosterDisplayItems,
   buildSortedDisplayItems,
   hasAccepted,
+  isNameSort,
   pageBounds,
   paginateDisplayItems,
   paginationRange,
+  sortNameMode,
   PAGE_SIZE_OPTIONS,
 } from "@/pages/submissions/dashboard"
 import {
@@ -243,7 +245,7 @@ const SubmissionsTable = ({
   pageSize = Number.MAX_SAFE_INTEGER,
   onPageChange = () => {},
   onPageSizeChange = () => {},
-  sort = "name-asc",
+  sort = "name-first",
 }: {
   scores: SubmissionRow[]
   students: Student[]
@@ -314,7 +316,7 @@ const SubmissionsTable = ({
   onPageChange?: (page: number) => void
   onPageSizeChange?: (pageSize: number) => void
   // The active sort. Individual assignments render one row per roster student in
-  // name order under "name-asc" (the live-eligible view); any other sort renders
+  // name order under a name sort (the live-eligible view); a time sort renders
   // the sorted submitted rows then non-submitters (a static snapshot view).
   sort?: SubmissionSort
 }) => {
@@ -363,18 +365,23 @@ const SubmissionsTable = ({
 
   // The display list rendered as one paginated sequence. For a group assignment
   // it's submitted group rows then unsubmitted group repos. For an individual
-  // assignment in the default name order it's one row per roster student
-  // (submitters and non-submitters interleaved by roster name) — the same
-  // ordering the live fan-out pages over. Under any other sort (a static
+  // assignment in a name order it's one row per roster student (submitters and
+  // non-submitters interleaved by roster name, in the active first/last mode) —
+  // the same ordering the live fan-out pages over. Under a time sort (a static
   // snapshot view; live is off then) fall back to sorted submitters first, then
   // non-submitters, preserving the chosen order.
   const displayItems = useMemo(() => {
     if (isGroup) {
-      return sort === "name-asc"
-        ? buildGroupRosterDisplayItems(scores, unsubmittedGroupRepos, students)
+      return isNameSort(sort)
+        ? buildGroupRosterDisplayItems(
+            scores,
+            unsubmittedGroupRepos,
+            students,
+            sortNameMode(sort),
+          )
         : buildGroupDisplayItems(scores, unsubmittedGroupRepos)
     }
-    if (sort === "name-asc") {
+    if (isNameSort(sort)) {
       return buildRosterDisplayItems(students, scores, nonSubmitters)
     }
     return buildSortedDisplayItems(scores, nonSubmitters)

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -356,17 +356,31 @@ describe("filterAndSortRows", () => {
     expect(out.map((r) => r.owner)).toEqual(["bob", "alice"])
   })
 
-  it("sorts by name A-Z and Z-A using the roster display name", () => {
+  it("sorts by first name and by last name using the roster display name", () => {
+    // Zed Adams vs Amy Brown: first-name order is Amy, Zed; last-name order is
+    // Adams (Zed), Brown (Amy) — so the two modes disagree, proving the key.
+    const nameStudents = [
+      student({ username: "zed", first_name: "Zed", last_name: "Adams" }),
+      student({ username: "amy", first_name: "Amy", last_name: "Brown" }),
+    ]
+    const nameRows = [
+      row({ owner: "zed", usernames: ["zed"] }),
+      row({ owner: "amy", usernames: ["amy"] }),
+    ]
     expect(
-      filterAndSortRows(rows, { ...base, sort: "name-asc" }).map(
-        (r) => r.owner,
-      ),
-    ).toEqual(["alice", "bob"])
+      filterAndSortRows(nameRows, {
+        ...base,
+        students: nameStudents,
+        sort: "name-first",
+      }).map((r) => r.owner),
+    ).toEqual(["amy", "zed"])
     expect(
-      filterAndSortRows(rows, { ...base, sort: "name-desc" }).map(
-        (r) => r.owner,
-      ),
-    ).toEqual(["bob", "alice"])
+      filterAndSortRows(nameRows, {
+        ...base,
+        students: nameStudents,
+        sort: "name-last",
+      }).map((r) => r.owner),
+    ).toEqual(["zed", "amy"])
   })
 
   it("filters to late only", () => {
@@ -801,8 +815,8 @@ describe("scoreTone", () => {
 })
 
 describe("buildScoresCsvRows", () => {
-  it("orders submitters newest-first, then non-submitters, preserving the column contract", () => {
-    const older = row({
+  it("resolves names from the roster and orders the whole file by last name", () => {
+    const alice = row({
       usernames: ["alice"],
       datetime: "2026-06-20T10:00:00Z",
       score: 8,
@@ -813,7 +827,9 @@ describe("buildScoresCsvRows", () => {
       review: "r1",
       release: "rel1",
     })
-    const newer = row({
+    // A group row is credited to all members; names come from the first
+    // (owner/founder) login.
+    const group = row({
       usernames: ["bob", "carol"],
       datetime: "2026-06-21T10:00:00Z",
       score: 9,
@@ -824,28 +840,45 @@ describe("buildScoresCsvRows", () => {
       review: "r2",
       release: "rel2",
     })
+    const roster = [
+      student({ username: "alice", first_name: "Alice", last_name: "Adams" }),
+      student({ username: "bob", first_name: "Bob", last_name: "Brown" }),
+      student({ username: "dave", first_name: "Dave", last_name: "Clark" }),
+    ]
     const out = buildScoresCsvRows(
-      [older, newer],
-      [student({ username: "dave" })],
+      [alice, group],
+      [student({ username: "dave", first_name: "Dave", last_name: "Clark" })],
+      roster,
     )
 
     expect(out).toHaveLength(3)
-    // Newest submission first.
+    // Ordered by last name across submitters + non-submitters: Adams, Brown,
+    // Clark — not by submission time.
+    expect(out.map((r) => r.last_name)).toEqual(["Adams", "Brown", "Clark"])
+
+    // The Adams submitter row carries names + the full column contract.
     expect(out[0]).toEqual({
-      usernames: "bob, carol",
-      score: 9,
+      name: "Alice Adams",
+      first_name: "Alice",
+      last_name: "Adams",
+      usernames: "alice",
+      score: 8,
       max_score: 10,
-      submissions: 1,
-      submitted_at: new Date("2026-06-21T10:00:00Z").toISOString(),
-      late: "no",
-      commit: "c2",
-      review: "r2",
-      release: "rel2",
+      submissions: 2,
+      submitted_at: new Date("2026-06-20T10:00:00Z").toISOString(),
+      late: "yes",
+      commit: "c1",
+      review: "r1",
+      release: "rel1",
     })
-    expect(out[1].usernames).toBe("alice")
-    expect(out[1].late).toBe("yes")
-    // Non-submitter pinned last with a 0 score and blank fields.
+    // The group row keeps all credited logins but takes the owner's name.
+    expect(out[1].usernames).toBe("bob, carol")
+    expect(out[1].name).toBe("Bob Brown")
+    // Non-submitter carries a name too, with a 0 score and blank fields.
     expect(out[2]).toEqual({
+      name: "Dave Clark",
+      first_name: "Dave",
+      last_name: "Clark",
       usernames: "dave",
       score: 0,
       max_score: "",
@@ -858,20 +891,36 @@ describe("buildScoresCsvRows", () => {
     })
   })
 
+  it("leaves name columns blank (falling back to login order) for an off-roster login", () => {
+    // A submitter whose login isn't on the roster still exports, just without
+    // names — resolveStudent returns a placeholder.
+    const out = buildScoresCsvRows(
+      [row({ usernames: ["ghost"], datetime: "2026-06-20T10:00:00Z" })],
+      [],
+      [],
+    )
+    expect(out[0].name).toBe("")
+    expect(out[0].first_name).toBe("")
+    expect(out[0].last_name).toBe("")
+    expect(out[0].usernames).toBe("ghost")
+  })
+
   it("exports a blank submitted_at (not a crash) for a dateless pending row", () => {
     // A detection-only row can still be dateless; toISOString on an
     // Invalid Date would throw and break the whole export.
     const out = buildScoresCsvRows(
       [row({ usernames: ["bob"], datetime: "", pending: true })],
       [],
+      [],
     )
     expect(out[0].submitted_at).toBe("")
     expect(out[0].score).toBe("")
   })
 
-  it("neutralizes CSV formula injection in free-text columns", () => {
+  it("neutralizes CSV formula injection in free-text columns, including names", () => {
     // A commit/release/review URL (or a group's joined logins) can carry a
     // leading formula trigger; guard it so a spreadsheet renders it as text.
+    // Self-reported names are equally untrusted, so they're escaped too.
     const out = buildScoresCsvRows(
       [
         row({
@@ -882,11 +931,96 @@ describe("buildScoresCsvRows", () => {
         }),
       ],
       [],
+      [
+        student({
+          username: "=cmd()",
+          first_name: "=evilFirst",
+          last_name: "=evilLast",
+        }),
+      ],
     )
     expect(out[0].usernames).toBe("'=cmd()")
     expect(out[0].commit).toBe("'=HYPERLINK(1)")
     expect(out[0].review).toBe("'+evil")
     expect(out[0].release).toBe("'@x")
+    expect(out[0].first_name).toBe("'=evilFirst")
+    expect(out[0].last_name).toBe("'=evilLast")
+    expect(out[0].name).toBe("'=evilFirst =evilLast")
+  })
+
+  it("orders partial-name and login-fallback rows by their last-name key", () => {
+    // Realistic partial roster: one last-only, one first-only, one login-only.
+    // Keys: "brown" (last-only), "amy" (first-only sorts on the first name),
+    // "zzz-login" (no name -> username). Expected asc: amy, brown, zzz-login.
+    const roster = [
+      student({ username: "lastonly", first_name: "", last_name: "Brown" }),
+      student({ username: "firstonly", first_name: "Amy", last_name: "" }),
+      student({ username: "zzz-login", first_name: "", last_name: "" }),
+    ]
+    const out = buildScoresCsvRows(
+      [
+        row({ usernames: ["zzz-login"] }),
+        row({ usernames: ["lastonly"] }),
+        row({ usernames: ["firstonly"] }),
+      ],
+      [],
+      roster,
+    )
+    expect(out.map((r) => r.usernames)).toEqual([
+      "firstonly",
+      "lastonly",
+      "zzz-login",
+    ])
+  })
+
+  it("uses natural (numeric) collation for digit-bearing names", () => {
+    // student2 must sort before student10, not lexicographically after it.
+    const roster = [
+      student({ username: "s10", first_name: "", last_name: "Team10" }),
+      student({ username: "s2", first_name: "", last_name: "Team2" }),
+    ]
+    const out = buildScoresCsvRows(
+      [row({ usernames: ["s10"] }), row({ usernames: ["s2"] })],
+      [],
+      roster,
+    )
+    expect(out.map((r) => r.last_name)).toEqual(["Team2", "Team10"])
+  })
+
+  it("breaks last+first name ties on username so the order is deterministic", () => {
+    // Two distinct "Sam Smith"s (a submitter and a non-submitter) share a name
+    // key; the username tie-break pins their order regardless of input side.
+    const smithA = student({
+      username: "smith-a",
+      first_name: "Sam",
+      last_name: "Smith",
+    })
+    const smithB = student({
+      username: "smith-b",
+      first_name: "Sam",
+      last_name: "Smith",
+    })
+    const out = buildScoresCsvRows(
+      [row({ usernames: ["smith-b"] })],
+      [smithA],
+      [smithA, smithB],
+    )
+    // smith-a (non-submitter) precedes smith-b (submitter) by username, even
+    // though the submitter was passed first.
+    expect(out.map((r) => r.usernames)).toEqual(["smith-a", "smith-b"])
+  })
+
+  it("resolves a group's name from the first credited (owner) login even when off-roster", () => {
+    // Group credited to [ghost, carol]; the owner (ghost) is off-roster while a
+    // teammate (carol) is on it. Names follow the owner convention -> blank, and
+    // the row sorts by the owner login fallback.
+    const out = buildScoresCsvRows(
+      [row({ usernames: ["ghost", "carol"] })],
+      [],
+      [student({ username: "carol", first_name: "Carol", last_name: "Ng" })],
+    )
+    expect(out[0].name).toBe("")
+    expect(out[0].usernames).toBe("ghost, carol")
   })
 })
 
@@ -1035,7 +1169,7 @@ describe("pending rows (collector-emitted, not graded)", () => {
         pending: true,
       }),
     ]
-    const [csv] = buildScoresCsvRows(rows, [])
+    const [csv] = buildScoresCsvRows(rows, [], [])
     expect(csv.score).toBe("")
     expect(csv.max_score).toBe("")
     expect(csv.usernames).toBe("bob")
@@ -1605,11 +1739,11 @@ describe("displayPageOwners", () => {
     student({ username: "cara", first_name: "Cara", last_name: "Cole" }),
   ]
 
-  it("returns the current page's owners in name order (name-asc)", () => {
+  it("returns the current page's owners in name order (name-first)", () => {
     const rows = [row({ owner: "bob", usernames: ["bob"] })]
     const owners = displayPageOwners({
       isGroup: false,
-      sort: "name-asc",
+      sort: "name-first",
       students,
       rows,
       nonSubmitters: students, // alice + cara have no row
@@ -1628,7 +1762,7 @@ describe("displayPageOwners", () => {
     const rows = [row({ owner: "bob", usernames: ["bob"] })]
     const owners = displayPageOwners({
       isGroup: false,
-      sort: "name-asc",
+      sort: "name-first",
       students,
       rows,
       // Search narrowed non-submitters to just "cara" (alice filtered out).
@@ -1761,6 +1895,22 @@ describe("pagination helpers", () => {
         "row",
         "groupRepo",
       ])
+    })
+
+    it("orders founders by last name when mode is 'last'", () => {
+      // Founders: team-a (Zed Adams), team-b (Amy Brown). First-name order is
+      // Amy, Zed; last-name order is Adams (team-a), Brown (team-b).
+      const roster = [
+        student({ username: "team-a", first_name: "Zed", last_name: "Adams" }),
+        student({ username: "team-b", first_name: "Amy", last_name: "Brown" }),
+      ]
+      const items = buildGroupRosterDisplayItems(
+        [row({ owner: "team-b" })],
+        [groupRepo("team-a")],
+        roster,
+        "last",
+      )
+      expect(items.map(displayItemOwner)).toEqual(["team-a", "team-b"])
     })
   })
 

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -16,9 +16,9 @@ import {
   getName,
   nameFromParts,
   NAME_COLLATION,
+  placeholderStudent,
   resolveStudent,
-  studentSortKey,
-  studentSortKeyByLastName,
+  studentSortKeyFor,
   type StudentSortMode,
 } from "@/util/students"
 import { studentRepoName } from "@/util/studentRepo"
@@ -877,11 +877,10 @@ export function filterAndSortRows(
   // rows order by the same key the roster spine does. Falls back to the login.
   const nameKey = (row: SubmissionRow) => {
     const login = row.usernames[0] ?? ""
-    const student = resolveStudent(login, students)
-    const key =
-      sort === "name-last"
-        ? studentSortKeyByLastName(student)
-        : studentSortKey(student)
+    const key = studentSortKeyFor(
+      resolveStudent(login, students),
+      sortNameMode(sort),
+    )
     return key || login.toLowerCase()
   }
 
@@ -999,12 +998,23 @@ export function buildScoresCsvRows(
     last_name: escapeCsvFormulaInjection(student.last_name.trim()),
   })
 
+  // Resolve each row's names from the roster in one pass: a login→Student map
+  // keyed like findByUsername (trimmed + lowercased), so building the export
+  // doesn't rescan the whole roster once per submitted row.
+  const byLogin = new Map<string, Student>()
+  for (const student of students) {
+    const login = student.username.trim().toLowerCase()
+    if (login && !byLogin.has(login)) byLogin.set(login, student)
+  }
+  const studentFor = (login: string): Student =>
+    byLogin.get(login.trim().toLowerCase()) ?? placeholderStudent(login)
+
   const submittedRows: Keyed[] = scoresInfo.map(
     ({ usernames, score, datetime, submissionCount, late, ...rest }) => {
       // Names come from the roster, keyed on the primary credited login (group
       // rows are credited to all members; the first is the owner/founder, which
       // is how the dashboard already derives a group's display name).
-      const student = resolveStudent(usernames[0] ?? "", students)
+      const student = studentFor(usernames[0] ?? "")
       return {
         row: {
           ...nameColumns(student),

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -11,7 +11,16 @@ import type { BadgeTone } from "@/components/ui"
 import type { TeamRosterRow } from "@/util/teamRoster"
 import { rowToStudent } from "@/util/teamRoster"
 import { hasStudentEnrollment } from "@/util/classroomRoleUI"
-import { getName, nameFromParts } from "@/util/students"
+import {
+  compareStudentsByName,
+  getName,
+  nameFromParts,
+  NAME_COLLATION,
+  resolveStudent,
+  studentSortKey,
+  studentSortKeyByLastName,
+  type StudentSortMode,
+} from "@/util/students"
 import { studentRepoName } from "@/util/studentRepo"
 import { escapeCsvFormulaInjection } from "@/util/csv"
 
@@ -578,7 +587,20 @@ export function studentInSection(student: Student, section: string): boolean {
   return (student.section?.trim() ?? "") === section
 }
 
-export type SubmissionSort = "recent" | "oldest" | "name-asc" | "name-desc"
+export type SubmissionSort = "recent" | "oldest" | "name-first" | "name-last"
+
+// Whether a sort orders by student name (either direction) — the roster-spine
+// view that interleaves non-submitters — vs a time sort. Centralized so the
+// table, pagination, and page-owner fan-out all agree on what "a name sort" is.
+export function isNameSort(sort: SubmissionSort): boolean {
+  return sort === "name-first" || sort === "name-last"
+}
+
+// The roster sort mode a name sort maps to; time sorts default to first-name
+// (used only when a caller needs a mode regardless of the sort).
+export function sortNameMode(sort: SubmissionSort): StudentSortMode {
+  return sort === "name-last" ? "last" : "first"
+}
 
 // Who has accepted an INDIVIDUAL assignment, derived from the org repo list: a
 // student accepted iff `<classroom>-<assignment>-<username>` exists. Independent
@@ -850,18 +872,24 @@ export function filterAndSortRows(
     return true
   })
 
-  const byName = (row: SubmissionRow) =>
-    (
-      getName(row.usernames[0], students) ||
-      row.usernames[0] ||
-      ""
-    ).toLowerCase()
+  // Name sort key for a row, in the active mode: resolve the primary credited
+  // login to its roster student and reuse the shared first/last sort keys, so
+  // rows order by the same key the roster spine does. Falls back to the login.
+  const nameKey = (row: SubmissionRow) => {
+    const login = row.usernames[0] ?? ""
+    const student = resolveStudent(login, students)
+    const key =
+      sort === "name-last"
+        ? studentSortKeyByLastName(student)
+        : studentSortKey(student)
+    return key || login.toLowerCase()
+  }
 
-  // Key each row's name + time once before sorting: byName scans the roster
+  // Key each row's name + time once before sorting: nameKey scans the roster
   // linearly, so calling it in the comparator would repeat it O(rows·log rows).
   const keyed = filtered.map((row) => ({
     row,
-    name: byName(row),
+    name: nameKey(row),
     time: new Date(row.datetime).getTime(),
   }))
 
@@ -869,10 +897,9 @@ export function filterAndSortRows(
     switch (sort) {
       case "oldest":
         return a.time - b.time
-      case "name-asc":
-        return a.name.localeCompare(b.name)
-      case "name-desc":
-        return b.name.localeCompare(a.name)
+      case "name-first":
+      case "name-last":
+        return a.name.localeCompare(b.name, undefined, NAME_COLLATION)
       case "recent":
       default:
         return b.time - a.time
@@ -931,12 +958,15 @@ export function filterNonSubmitters(
   })
 }
 
-// Rows for the exported gradebook CSV, in the order the file writes them.
-// Submitters come first (newest submission first), then non-submitters pinned
-// after with a 0 score and blank submission fields, so the export covers the
-// whole roster. Column order and the empty-string-vs-literal typing are the
-// contract downstream sheets rely on — keep them stable.
+// Rows for the exported gradebook CSV. Every row carries the student's names
+// (resolved from the roster) alongside their login(s), and the whole set is
+// ordered by last name — matching a gradebook so a teacher can transcribe
+// grades top-to-bottom. Column order and the empty-string-vs-literal typing are
+// the contract downstream sheets rely on — keep them stable.
 export type ScoresCsvRow = {
+  name: string
+  first_name: string
+  last_name: string
   usernames: string
   score: number | string
   max_score: number | string
@@ -951,47 +981,79 @@ export type ScoresCsvRow = {
 export function buildScoresCsvRows(
   scoresInfo: SubmissionRow[],
   nonSubmitters: Student[],
+  students: Student[],
 ): ScoresCsvRow[] {
-  const submittedRows: ScoresCsvRow[] = scoresInfo
-    .toSorted(
-      (a, b) => new Date(b.datetime).getTime() - new Date(a.datetime).getTime(),
-    )
-    .map(({ usernames, score, datetime, submissionCount, late, ...rest }) => ({
-      // Free-text columns can carry student-influenceable content (a repo/
-      // commit/release/review URL, a group's joined logins), so neutralize
-      // spreadsheet formula injection on them. The numeric/enum/timestamp
-      // columns below are our own generated values and must round-trip
-      // byte-exact, so they are NOT escaped.
-      usernames: escapeCsvFormulaInjection(usernames.join(", ")),
-      // A pending live row (submitted, not yet collected) has no real grade —
-      // export a blank score, not a 0, so importing the CSV can't record a
-      // graded zero for a student who actually submitted.
-      score: rest.pending ? "" : score,
-      max_score: rest.pending ? "" : rest["max-score"],
-      submissions: submissionCount,
-      // A detection-only row can still be dateless (e.g. a milestone tag
-      // whose commit lookup failed) — export a blank rather than crashing on
-      // Invalid Date.
-      submitted_at: isoOrBlank(datetime),
-      late: late ? "yes" : "no",
-      commit: escapeCsvFormulaInjection(rest.commit),
-      review: escapeCsvFormulaInjection(rest.review),
-      release: escapeCsvFormulaInjection(rest.release),
-    }))
+  // Carry the resolved student alongside each row so the final ordering can use
+  // the shared name comparator (last name, then first, then username) — the
+  // same collation and identity tie-break every other roster view uses, so two
+  // same-named students order deterministically rather than by input order.
+  type Keyed = { row: ScoresCsvRow; student: Student }
 
-  const nonSubmittedRows: ScoresCsvRow[] = nonSubmitters.map((student) => ({
-    usernames: escapeCsvFormulaInjection(student.username),
-    score: 0,
-    max_score: "",
-    submissions: 0,
-    submitted_at: "",
-    late: "",
-    commit: "",
-    review: "",
-    release: "",
+  // The name columns, escaped against spreadsheet formula injection: self-
+  // reported names are as untrusted as the login/URL columns.
+  const nameColumns = (student: Student) => ({
+    name: escapeCsvFormulaInjection(
+      nameFromParts(student.first_name, student.last_name),
+    ),
+    first_name: escapeCsvFormulaInjection(student.first_name.trim()),
+    last_name: escapeCsvFormulaInjection(student.last_name.trim()),
+  })
+
+  const submittedRows: Keyed[] = scoresInfo.map(
+    ({ usernames, score, datetime, submissionCount, late, ...rest }) => {
+      // Names come from the roster, keyed on the primary credited login (group
+      // rows are credited to all members; the first is the owner/founder, which
+      // is how the dashboard already derives a group's display name).
+      const student = resolveStudent(usernames[0] ?? "", students)
+      return {
+        row: {
+          ...nameColumns(student),
+          // Free-text columns can carry student-influenceable content (a repo/
+          // commit/release/review URL, a group's joined logins), so neutralize
+          // spreadsheet formula injection on them. The numeric/enum/timestamp
+          // columns below are our own generated values and must round-trip
+          // byte-exact, so they are NOT escaped.
+          usernames: escapeCsvFormulaInjection(usernames.join(", ")),
+          // A pending live row (submitted, not yet collected) has no real grade
+          // — export a blank score, not a 0, so importing the CSV can't record
+          // a graded zero for a student who actually submitted.
+          score: rest.pending ? "" : score,
+          max_score: rest.pending ? "" : rest["max-score"],
+          submissions: submissionCount,
+          // A detection-only row can still be dateless (e.g. a milestone tag
+          // whose commit lookup failed) — export a blank rather than crashing
+          // on Invalid Date.
+          submitted_at: isoOrBlank(datetime),
+          late: late ? "yes" : "no",
+          commit: escapeCsvFormulaInjection(rest.commit),
+          review: escapeCsvFormulaInjection(rest.review),
+          release: escapeCsvFormulaInjection(rest.release),
+        },
+        student,
+      }
+    },
+  )
+
+  const nonSubmittedRows: Keyed[] = nonSubmitters.map((student) => ({
+    row: {
+      ...nameColumns(student),
+      usernames: escapeCsvFormulaInjection(student.username),
+      score: 0,
+      max_score: "",
+      submissions: 0,
+      submitted_at: "",
+      late: "",
+      commit: "",
+      review: "",
+      release: "",
+    },
+    student,
   }))
 
+  const byLastName = compareStudentsByName("last")
   return [...submittedRows, ...nonSubmittedRows]
+    .sort((a, b) => byLastName(a.student, b.student))
+    .map((keyed) => keyed.row)
 }
 
 // The ISO form of a row's submission time, or "" for an absent/unparseable one.
@@ -1077,15 +1139,17 @@ export function buildRosterDisplayItems(
   return items
 }
 
-// Build the display list for a GROUP assignment in the default name order: one
-// item per group founder, name-sorted, resolved to the founder's submitted row
-// when one exists (owner match) else an unsubmitted group-repo row. The group
-// analog of buildRosterDisplayItems. `rows` are the (filtered) submitted group
-// rows; `groupRepos` the unsubmitted group repos.
+// Build the display list for a GROUP assignment in name order: one item per
+// group founder, name-sorted in the given mode (first- or last-name), resolved
+// to the founder's submitted row when one exists (owner match) else an
+// unsubmitted group-repo row. The group analog of buildRosterDisplayItems.
+// `rows` are the (filtered) submitted group rows; `groupRepos` the unsubmitted
+// group repos.
 export function buildGroupRosterDisplayItems(
   rows: SubmissionRow[],
   groupRepos: GroupRepo[],
   students: Student[],
+  mode: StudentSortMode = "first",
 ): DisplayItem[] {
   const submitted = rows.map<DisplayItem>((row) => ({ kind: "row", row }))
   const unsubmitted = groupRepos.map<DisplayItem>((repo) => ({
@@ -1094,10 +1158,12 @@ export function buildGroupRosterDisplayItems(
   }))
   // Precompute the name map once so the comparator is O(1) per compare (getName
   // would re-scan the roster each call).
-  const names = buildNameKeyLookup(students)
+  const names = buildNameKeyLookup(students, mode)
   return [...submitted, ...unsubmitted].sort((a, b) =>
     ownerSortKey(displayItemOwner(a), names).localeCompare(
       ownerSortKey(displayItemOwner(b), names),
+      undefined,
+      NAME_COLLATION,
     ),
   )
 }
@@ -1191,15 +1257,19 @@ export function displayItemOwner(item: DisplayItem): string {
 // inside a comparator — which turns an O(n log n) sort into O(n^2). The value
 // mirrors getName exactly: the display name, or "" when the login isn't on the
 // roster or the row has no name.
-export function buildNameKeyLookup(students: Student[]): Map<string, string> {
+export function buildNameKeyLookup(
+  students: Student[],
+  mode: StudentSortMode = "first",
+): Map<string, string> {
   const map = new Map<string, string>()
   for (const student of students) {
     const login = student.username.trim().toLowerCase()
     if (!login) continue
-    map.set(
-      login,
-      nameFromParts(student.first_name, student.last_name).toLowerCase(),
-    )
+    const name =
+      mode === "last"
+        ? nameFromParts(student.last_name, student.first_name)
+        : nameFromParts(student.first_name, student.last_name)
+    map.set(login, name.toLowerCase())
   }
   return map
 }
@@ -1237,10 +1307,15 @@ export function displayPageOwners({
   pageSize: number
 }): string[] {
   const items = isGroup
-    ? sort === "name-asc"
-      ? buildGroupRosterDisplayItems(rows, groupRepos, students)
+    ? isNameSort(sort)
+      ? buildGroupRosterDisplayItems(
+          rows,
+          groupRepos,
+          students,
+          sortNameMode(sort),
+        )
       : buildGroupDisplayItems(rows, groupRepos)
-    : sort === "name-asc"
+    : isNameSort(sort)
       ? buildRosterDisplayItems(students, rows, nonSubmitters)
       : buildSortedDisplayItems(rows, nonSubmitters)
   const seen = new Set<string>()

--- a/web/src/util/students.test.ts
+++ b/web/src/util/students.test.ts
@@ -4,6 +4,7 @@ import {
   initialsFromParts,
   nameFromParts,
   sortStudentsByName,
+  studentSortKeyByLastName,
 } from "@/util/students"
 import type { Student } from "@/types/classroom"
 
@@ -98,5 +99,58 @@ describe("sortStudentsByName — deterministic name-ascending roster order", () 
     const copy = [...input]
     sortStudentsByName(input)
     expect(input).toEqual(copy)
+  })
+
+  it("defaults to first-name order (mode omitted)", () => {
+    const sorted = sortStudentsByName([
+      mkStudent({ username: "z", first_name: "Zed", last_name: "Adams" }),
+      mkStudent({ username: "a", first_name: "Amy", last_name: "Zephyr" }),
+    ])
+    // Amy Zephyr < Zed Adams by first name, even though Zephyr > Adams by last.
+    expect(sorted.map((s) => s.username)).toEqual(["a", "z"])
+  })
+
+  it("orders by last name when mode is 'last'", () => {
+    const sorted = sortStudentsByName(
+      [
+        mkStudent({ username: "z", first_name: "Zed", last_name: "Adams" }),
+        mkStudent({ username: "a", first_name: "Amy", last_name: "Zephyr" }),
+      ],
+      "last",
+    )
+    // Adams < Zephyr, so Zed Adams sorts first in last-name mode.
+    expect(sorted.map((s) => s.username)).toEqual(["z", "a"])
+  })
+
+  it("breaks last-name ties on first name, then username", () => {
+    const sorted = sortStudentsByName(
+      [
+        mkStudent({ username: "b", first_name: "Sam", last_name: "Smith" }),
+        mkStudent({ username: "a", first_name: "Amy", last_name: "Smith" }),
+        mkStudent({ username: "c", first_name: "Amy", last_name: "Smith" }),
+      ],
+      "last",
+    )
+    // Same last name: Amy < Sam; the two Amys tie on name and break on username.
+    expect(sorted.map((s) => s.username)).toEqual(["a", "c", "b"])
+  })
+})
+
+describe("studentSortKeyByLastName — last-name-first ordering key", () => {
+  it("builds a lowercased 'last first' key", () => {
+    expect(
+      studentSortKeyByLastName(
+        mkStudent({ first_name: "Rongxin", last_name: "Liu" }),
+      ),
+    ).toBe("liu rongxin")
+  })
+
+  it("falls back to username, then email, when no name is recorded", () => {
+    expect(studentSortKeyByLastName(mkStudent({ username: "Zed" }))).toBe("zed")
+    expect(
+      studentSortKeyByLastName(
+        mkStudent({ username: "", email: "A@example.edu" }),
+      ),
+    ).toBe("a@example.edu")
   })
 })

--- a/web/src/util/students.ts
+++ b/web/src/util/students.ts
@@ -90,6 +90,19 @@ export const initialsFromParts = (
 export const getSection = (key: string, students: Student[]): string =>
   findByUsername(key, students)?.section?.trim() ?? ""
 
+// Whether a roster is ordered by first name ("First Last") or by last name
+// ("Last First"). Gradebooks are usually last-name first, so a teacher can pick
+// that order to transcribe grades without re-reading each row.
+export type StudentSortMode = "first" | "last"
+
+export const DEFAULT_STUDENT_SORT: StudentSortMode = "first"
+
+// One collation regime for every "by name" ordering in the app (roster views,
+// team roster, and the exported gradebook CSV), so the same students never sort
+// differently across surfaces. `numeric: true` keeps digit-bearing names in
+// natural order (student2 before student10).
+export const NAME_COLLATION: Intl.CollatorOptions = { numeric: true }
+
 // Case-insensitive sort key for ordering a roster by display name: full name
 // when known, else username, else email. Mirrors the team-roster sortKey so the
 // dashboard's deterministic order matches other roster views.
@@ -98,15 +111,41 @@ export const studentSortKey = (student: Student): string => {
   return (name || student.username || student.email || "").toLowerCase()
 }
 
-// Roster sorted by display name (ascending), stable and case-insensitive. Ties
-// break on the lowercased username so the order is fully deterministic — the
-// spine the submissions dashboard pages over and targets repos by.
-export const sortStudentsByName = (students: Student[]): Student[] =>
-  students.toSorted((a, b) => {
-    const byName = studentSortKey(a).localeCompare(studentSortKey(b))
+// Last-name-first sort key ("Last First"), same fallback chain as
+// studentSortKey (username, then email) when no name is recorded, so a
+// nameless row still sorts deterministically in either mode.
+export const studentSortKeyByLastName = (student: Student): string => {
+  const name = nameFromParts(student.last_name, student.first_name)
+  return (name || student.username || student.email || "").toLowerCase()
+}
+
+const studentSortKeyFor = (student: Student, mode: StudentSortMode): string =>
+  mode === "last" ? studentSortKeyByLastName(student) : studentSortKey(student)
+
+// Shared comparator for a roster ordered by name in the given mode, with the
+// lowercased username as a deterministic tie-break so two students who share a
+// name (or resolve to the same key) always keep a stable, identity-based order
+// — not one that depends on input/collection order. Every by-name sort routes
+// through this so collation and tie-break can't drift between surfaces.
+export const compareStudentsByName =
+  (mode: StudentSortMode = DEFAULT_STUDENT_SORT) =>
+  (a: Student, b: Student): number => {
+    const byName = studentSortKeyFor(a, mode).localeCompare(
+      studentSortKeyFor(b, mode),
+      undefined,
+      NAME_COLLATION,
+    )
     if (byName !== 0) return byName
     return a.username
       .trim()
       .toLowerCase()
-      .localeCompare(b.username.trim().toLowerCase())
-  })
+      .localeCompare(b.username.trim().toLowerCase(), undefined, NAME_COLLATION)
+  }
+
+// Roster sorted by display name, stable and case-insensitive (see
+// compareStudentsByName). `mode` defaults to first-name so existing call sites
+// keep their order.
+export const sortStudentsByName = (
+  students: Student[],
+  mode: StudentSortMode = DEFAULT_STUDENT_SORT,
+): Student[] => students.toSorted(compareStudentsByName(mode))

--- a/web/src/util/students.ts
+++ b/web/src/util/students.ts
@@ -119,7 +119,13 @@ export const studentSortKeyByLastName = (student: Student): string => {
   return (name || student.username || student.email || "").toLowerCase()
 }
 
-const studentSortKeyFor = (student: Student, mode: StudentSortMode): string =>
+// Name sort key for a student in the given mode — first-name ("First Last") or
+// last-name ("Last First") order. Single dispatch so callers that sort loose
+// rows (not full Student arrays) use the same keys as compareStudentsByName.
+export const studentSortKeyFor = (
+  student: Student,
+  mode: StudentSortMode,
+): string =>
   mode === "last" ? studentSortKeyByLastName(student) : studentSortKey(student)
 
 // Shared comparator for a roster ordered by name in the given mode, with the

--- a/web/src/util/teamRoster.test.ts
+++ b/web/src/util/teamRoster.test.ts
@@ -5,8 +5,10 @@ import {
   githubOrgRoleForRole,
   roleForGitHubOrgRole,
   rowToStudent,
+  sortTeamRosterRows,
   teamMembersMissingFromCsv,
   rowsNeedingBackfill,
+  type TeamRosterRow,
 } from "./teamRoster"
 import { isOwnerGitHubOrgRole } from "@/authz"
 import { enrolledCountsByRole } from "./classroomRoleUI"
@@ -687,5 +689,74 @@ describe("isOwnerGitHubOrgRole — wire org-role owner test", () => {
     expect(isOwnerGitHubOrgRole("member")).toBe(false)
     expect(isOwnerGitHubOrgRole("")).toBe(false)
     expect(isOwnerGitHubOrgRole("direct_member")).toBe(false)
+  })
+})
+
+describe("sortTeamRosterRows — first- vs last-name ordering", () => {
+  const enrolledRow = (over: Partial<TeamRosterRow>): TeamRosterRow => ({
+    key: over.username ?? "u",
+    state: "enrolled",
+    roles: ["student"],
+    username: "u",
+    github_id: "",
+    first_name: "",
+    last_name: "",
+    section: "",
+    email: "",
+    avatar_url: "",
+    ...over,
+  })
+
+  it("defaults to first-name order within a bucket", () => {
+    const sorted = sortTeamRosterRows([
+      enrolledRow({ username: "z", first_name: "Zed", last_name: "Adams" }),
+      enrolledRow({ username: "a", first_name: "Amy", last_name: "Zephyr" }),
+    ])
+    expect(sorted.map((r) => r.username)).toEqual(["a", "z"])
+  })
+
+  it("orders by last name within a bucket when mode is 'last'", () => {
+    const sorted = sortTeamRosterRows(
+      [
+        enrolledRow({ username: "z", first_name: "Zed", last_name: "Adams" }),
+        enrolledRow({ username: "a", first_name: "Amy", last_name: "Zephyr" }),
+      ],
+      "last",
+    )
+    expect(sorted.map((r) => r.username)).toEqual(["z", "a"])
+  })
+
+  it("keeps the enrolled -> pending -> needs-attention bucket order regardless of mode", () => {
+    const sorted = sortTeamRosterRows(
+      [
+        {
+          ...enrolledRow({ username: "z", last_name: "Zzz" }),
+          state: "pending",
+        },
+        enrolledRow({ username: "a", last_name: "Aaa" }),
+      ],
+      "last",
+    )
+    // Enrolled (Aaa) still precedes pending (Zzz) — the bucket wins over name.
+    expect(sorted.map((r) => r.state)).toEqual(["enrolled", "pending"])
+  })
+
+  it("uses natural (numeric) collation within a bucket", () => {
+    const sorted = sortTeamRosterRows([
+      enrolledRow({ username: "s10", first_name: "Team", last_name: "10" }),
+      enrolledRow({ username: "s2", first_name: "Team", last_name: "2" }),
+    ])
+    // Team 2 before Team 10 (numeric), not lexicographic ("10" < "2").
+    expect(sorted.map((r) => r.username)).toEqual(["s2", "s10"])
+  })
+
+  it("does not mutate the input array", () => {
+    const input = [
+      enrolledRow({ username: "b", first_name: "Bob" }),
+      enrolledRow({ username: "a", first_name: "Amy" }),
+    ]
+    const copy = [...input]
+    sortTeamRosterRows(input)
+    expect(input).toEqual(copy)
   })
 })

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -3,6 +3,11 @@ import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
 import type { GitHubUser, GitHubOrgInvitation } from "@/github-core/types"
 import { parseGitHubId, rosterClaimSet } from "@/util/identity"
 import {
+  DEFAULT_STUDENT_SORT,
+  NAME_COLLATION,
+  type StudentSortMode,
+} from "@/util/students"
+import {
   type ClassroomRole,
   ROLE_RANK,
   sortRolesByRank,
@@ -367,26 +372,48 @@ function addRole(row: TeamRosterRow, role: ClassroomRole): void {
   row.roles = sortRolesByRank([...row.roles, role])
 }
 
-// Display name for sorting: "Last, First" folded to a comparable string, else
-// username, else email.
-function sortName(row: TeamRosterRow): string {
-  const name = [row.first_name, row.last_name].filter(Boolean).join(" ")
+// Display name for sorting: full name folded to a comparable string, else
+// username, else email. `mode` selects first-name ("First Last") vs last-name
+// ("Last First") ordering; the fallback chain is identical so a nameless row
+// still sorts deterministically in either mode.
+function sortName(
+  row: TeamRosterRow,
+  mode: StudentSortMode = DEFAULT_STUDENT_SORT,
+): string {
+  const parts =
+    mode === "last"
+      ? [row.last_name, row.first_name]
+      : [row.first_name, row.last_name]
+  const name = parts.filter(Boolean).join(" ")
   return (name || row.username || row.email).toLowerCase()
 }
 
 // Enrolled first, then pending, then needs-attention; alphabetical within each.
-function sortRows(rows: TeamRosterRow[]): TeamRosterRow[] {
+// The bucket order is independent of `mode` — only the within-bucket name
+// direction changes. Returns a new array (never mutates the input).
+export function sortTeamRosterRows(
+  rows: TeamRosterRow[],
+  mode: StudentSortMode = DEFAULT_STUDENT_SORT,
+): TeamRosterRow[] {
   const order: Record<TeamRosterRowState, number> = {
     enrolled: 0,
     pending: 1,
     needs_attention_in_org: 2,
     needs_attention_not_in_org: 3,
   }
-  return rows.sort((a, b) => {
+  return rows.toSorted((a, b) => {
     const byState = order[a.state] - order[b.state]
     if (byState !== 0) return byState
-    return sortName(a).localeCompare(sortName(b), undefined, { numeric: true })
+    return sortName(a, mode).localeCompare(
+      sortName(b, mode),
+      undefined,
+      NAME_COLLATION,
+    )
   })
+}
+
+function sortRows(rows: TeamRosterRow[]): TeamRosterRow[] {
+  return sortTeamRosterRows(rows)
 }
 
 // Project a roster row back to the display-metadata Student shape the grade

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -363,7 +363,7 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
     }
   }
 
-  return sortRows(rows)
+  return sortTeamRosterRows(rows)
 }
 
 // Add a role to a row's set (idempotent), keeping ROLE_RANK order.
@@ -410,10 +410,6 @@ export function sortTeamRosterRows(
       NAME_COLLATION,
     )
   })
-}
-
-function sortRows(rows: TeamRosterRow[]): TeamRosterRow[] {
-  return sortTeamRosterRows(rows)
 }
 
 // Project a roster row back to the display-metadata Student shape the grade


### PR DESCRIPTION
Resolves [#601](https://github.com/foundation50/classroom50/discussions/601). Two teacher-facing improvements to how student rosters are ordered and exported.

## Sorting by first vs last name

Teachers can now order student lists by **first name** or **last name** (gradebooks are usually last-name-first). Added a sort toggle to the enrolled roster, the read-only CSV roster, and the submissions view. Default stays first-name so existing behavior is unchanged.

- New `StudentSortMode` (`"first" | "last"`) and a single shared `compareStudentsByName(mode)` comparator in `web/src/util/students.ts`, so every by-name surface uses one collation (`numeric: true`, natural digit ordering) and one identity tie-break (lowercased username). This keeps the enrolled roster, CSV roster, submissions list, and the exported gradebook all in agreement.
- The submissions view's old "Name A–Z / Name Z–A" is replaced with "By first name / By last name"; both are the roster-spine (non-submitter-interleaved, live-eligible) view, keyed by the chosen mode. The assignment-list "Name (A–Z)/(Z–A)" sort is untouched — that orders assignment names, not students.

## Names in the grade CSV

The grade download now includes `name`, `first_name`, and `last_name` (resolved from the roster), and the whole file is ordered by last name (then first, then username) so a teacher can transcribe grades top-to-bottom.

Note: the CSV now leads with `name, first_name, last_name` before `usernames`, so the **column order changes**. `usernames` remains the join key; the new columns are additive, but any downstream importer that reads by column position will need to adjust.

## Tests

Added coverage for the last-name sort key, both sort modes, numeric collation and tie-break determinism, the enriched/last-name-ordered CSV (including partial names and an off-roster group founder), and toggle-interaction tests for the roster views.

## Test plan

- [ ] Toggle first/last on the enrolled roster, CSV roster, and submissions list — rows reorder as expected.
- [ ] Download the grade CSV — it includes name columns and is ordered by last name.
- [ ] `npm run check` passes in `web/`.