### PR TITLE
fix(web): distinguish student view-submissions icon from autograder details

### DIFF
--- a/web/src/pages/submissions/StudentRowActions.tsx
+++ b/web/src/pages/submissions/StudentRowActions.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { ScrollText } from "lucide-react"
+import { History, ScrollText } from "lucide-react"
 
 import { Button } from "@/components/ui"
 import { ActionIconLink } from "@/pages/submissions/SubmissionsRows"
@@ -47,7 +47,7 @@ export const StudentRowActions = ({
         aria-label={t("submissions.details.viewSubmissions")}
         title={t("submissions.details.viewSubmissions")}
       >
-        <ScrollText aria-hidden="true" className="size-4" />
+        <History aria-hidden="true" className="size-4" />
       </Button>
     </div>
   )


### PR DESCRIPTION
## Summary

On the student assignment submission view, the Actions cell rendered both "View autograder details" and "View submissions" with the identical `ScrollText` icon, making the two actions visually indistinguishable.

This swaps the "View submissions" trigger to the `History` icon (submission history), keeping `ScrollText` for the graded-release "View autograder details" link. The three actions now read as distinct icons: GitHub octocat (open repo), `ScrollText` (autograder details), and `History` (view submissions).

Icon-only change in `web/src/pages/submissions/StudentRowActions.tsx` — no i18n keys, labels, titles, or shared primitives touched.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest) passes; the only failure is a sandbox Playwright-binary issue unrelated to this change
- [ ] Visually confirm the student Actions cell shows three distinct icons