### PR TITLE
fix(web): stop long help text overflowing in the assignment form

### DIFF
--- a/web/src/pages/assignments/AdvancedSection.tsx
+++ b/web/src/pages/assignments/AdvancedSection.tsx
@@ -40,7 +40,9 @@ export const AdvancedSection = ({
         {t("assignments.form.advanced")}
       </summary>
 
-      <p className="label pt-2 pb-4">{t("assignments.form.advancedHelp")}</p>
+      <p className="pt-2 pb-4 text-sm text-base-content/70">
+        {t("assignments.form.advancedHelp")}
+      </p>
 
       <form.Field name="runtime_env">
         {(field) => (

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -159,7 +159,7 @@ const AutogradingTestModal = ({
               />
             ))}
           </div>
-          <p className="label text-sm pt-1">
+          <p className="text-sm pt-1 text-base-content/70">
             {(() => {
               const hintKey = TYPE_OPTIONS.find(
                 (o) => o.value === draft.type,
@@ -288,7 +288,7 @@ const AutogradingTestModal = ({
                 errors.exitCode ? `${field("exitCode")}-error` : undefined
               }
             />
-            <p className="label text-sm pt-1">
+            <p className="text-sm pt-1 text-base-content/70">
               {t("assignments.autograder.exitCodeHint")}
             </p>
             <FieldError
@@ -331,7 +331,7 @@ const AutogradingTestModal = ({
                 errors.timeout ? `${field("timeout")}-error` : undefined
               }
             />
-            <p className="label text-sm pt-1">
+            <p className="text-sm pt-1 text-base-content/70">
               {t("assignments.autograder.timeoutHint")}
             </p>
             <FieldError

--- a/web/src/pages/assignments/sections/AutogradingStateField.tsx
+++ b/web/src/pages/assignments/sections/AutogradingStateField.tsx
@@ -69,7 +69,7 @@ export function AutogradingStateField({
                     <label
                       key={option}
                       htmlFor={`${field.name}-${option}`}
-                      className="label cursor-pointer items-start justify-start gap-3 p-0"
+                      className="flex cursor-pointer items-start justify-start gap-3"
                     >
                       <input
                         id={`${field.name}-${option}`}

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -77,7 +77,7 @@ export function RepositorySetupSection({
                     <label
                       key={option}
                       htmlFor={`${field.name}-${option}`}
-                      className="label cursor-pointer items-start justify-start gap-3 p-0"
+                      className="flex cursor-pointer items-start justify-start gap-3"
                     >
                       <input
                         id={`${field.name}-${option}`}


### PR DESCRIPTION
## Summary

DaisyUI 5's `.label` class sets `white-space: nowrap` (it is designed for short inline labels beside inputs). The `.label` override in `web/src/index.css` only re-tunes the color, so `nowrap` stayed active. Wherever sentence-length help text lived inside a `.label` element, it could not wrap and overflowed horizontally — most visibly the "Do not use the built-in autograder" help in the Autograding section.

The fix follows the pattern already used by the canonical `FormField`: keep `.label` for the short bold label, and render wrapping helper text as a plain paragraph / flex label instead.

Audited the whole assignment creation form and adjacent components for the same misuse and fixed every sentence-length case; short single-line `.label` uses (legends, the individual/group and runtime radios, accept-page labels, `FormField`'s own label) were left as-is because `nowrap` is correct there.

Changed:

- `sections/AutogradingStateField.tsx` — the reported bug: the built-in-autograder radio option label.
- `sections/RepositorySetupSection.tsx` — the repo-source radio option label (same recipe, same `*.help` text).
- `AdvancedSection.tsx` — the `advancedHelp` paragraph.
- `AutogradingTestsPane.tsx` — the test-type / exit-code / timeout hint paragraphs.

Side benefit: these elements no longer inherit `.label`'s 60%-muted color, so bold option labels render at full contrast.

## Test plan

- [x] `npm run check` in `web/` — tsc, eslint (0 errors), prettier, arch:validate, and 3766 unit tests pass.
- [x] Browser layout suite (reflow / target-size / text-spacing a11y) passes 18/18 after `npx playwright install chromium`.
- [ ] Manual: with grading = Autograded, confirm the "Do not use the built-in autograder" help wraps within the card; spot-check the repo-source radios and the Advanced / autograder-test hints.