### PR TITLE
docs(wiki): document roster CSV format and enrolling existing org members

### DIFF
--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -88,6 +88,34 @@ The organization should be listed `active` (and `admin` if you're setting it
 up). The CLI token and the web app's token are separate, so a passing check here
 still leaves the browser grant to do.
 
+## Already an org member, but not on the roster
+
+Adding a student who is **already in your organization** (commonly someone from
+a previous course) doesn't put them on the classroom roster, and re-inviting
+them does nothing. GitHub won't send a fresh invitation to an existing member,
+so the web app reports **"Already a member or already invited — no new
+invitation sent"** (and the CLI prints "Already a member" and exits 0). This is
+expected: **organization membership and classroom enrollment are separate.** An
+invite only covers membership; enrolling an existing member is a different
+action.
+
+To enroll students who are already org members:
+
+1. In Classroom 50, open the organization's **Members** page (the People view,
+   not a classroom's **Students** page).
+2. Find each student. They show as a member with no classroom, or you can filter
+   by "no classroom".
+3. Use **Add to classroom** to place them on a classroom's roster and team. To
+   do several at once, select the rows and use the bulk **Add to {classroom}**
+   action.
+
+Uploading a **username** list or **roster CSV** on the Students page also enrolls
+existing members: the invite is skipped, but they're still added to the roster
+and team. Only an **email** upload can't, because an email invite writes nothing
+to the roster until the student onboards, so an already-member email is simply
+skipped. From the CLI, `gh teacher roster add <org> <classroom> <username>` (or
+`roster import`) enrolls an existing member the same way.
+
 ## "Missing scope" / 403 on `gh teacher invite`
 
 Org invitations need the `admin:org` scope, which a plain `gh auth login`

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -323,8 +323,74 @@ GitHub organization.
 optional). You can enter an email instead of a username; that student then
 completes a separate onboarding process (see below).
 
-**Upload roster** — bulk-add students from a CSV or text file of GitHub
-usernames.
+**Upload roster** — bulk-add students from a file. The upload accepts three
+formats and auto-detects which one you uploaded (you can override the guess):
+
+- **A username list**: one GitHub username per line, no header. Simplest when
+  you already know everyone's handle.
+- **A roster CSV**: a header row plus one student per line. See the fields and
+  example below.
+- **An email list**: one email address per line. Use this when you don't know
+  students' GitHub usernames. Each becomes an email invitation the student
+  completes by onboarding (see below).
+
+### Roster CSV fields
+
+Only `username` is required. Every other column is optional and can be left out.
+Headers are matched case-insensitively, and any unrecognized column is ignored,
+so a CSV exported from another gradebook usually works unchanged. (A `github_id`
+column, if present, is ignored and re-resolved from GitHub.)
+
+| Column | Required | Description |
+| --- | --- | --- |
+| `username` | **Yes** | The student's GitHub username, e.g. `octocat`. |
+| `first_name` | No | Given name, for display and score exports. |
+| `last_name` | No | Family name, for display and score exports. |
+| `name` | No | Full name in one column, split into first/last. Use instead of `first_name`/`last_name`. |
+| `email` | No | Contact email. This does not send an email invite; the `username` invites them. |
+| `section` | No | A section or group label you can filter by. |
+| `role` | No | `student` (default), `ta`, `hta`, or `teacher`. Leave blank for students. |
+
+A complete roster CSV looks like this:
+
+| username | first_name | last_name | email | section |
+| --- | --- | --- | --- | --- |
+| octocat | Mona | Octocat | octocat@example.edu | A |
+| hubot | Hu | Bot | hubot@example.com | A |
+| octofez | Octo | Fez | | B |
+
+As a plain text file:
+
+```csv
+username,first_name,last_name,email,section
+octocat,Mona,Octocat,octocat@example.edu,A
+hubot,Hu,Bot,hubot@example.com,A
+octofez,Octo,Fez,,B
+```
+
+A single `username` column is also valid:
+
+```csv
+username
+octocat
+hubot
+octofez
+```
+
+> [!NOTE]
+> A username list or roster CSV both invites students **and** adds them to the
+> roster. An email list only sends invitations. An email carries no GitHub
+> identity until the student onboards, so those students appear under **pending
+> invitations**, not on the roster, until they accept.
+
+> [!TIP]
+> Adding students who are **already in your organization** (for example, from a
+> previous course) is a different action. Inviting them again does nothing:
+> GitHub reports "Already a member," and it won't put them on this classroom's
+> roster. To enroll an existing member, open the organization's **Members** page
+> in Classroom 50 and use **Add to classroom** (per member, or select several
+> for the bulk action). See
+> [Already an org member, but not on the roster](Troubleshooting#already-an-org-member-but-not-on-the-roster).
 
 **Enrolled students** — the students already in this classroom. Classroom 50
 gives you two shareable links: one to accept the organization invite, and one to


### PR DESCRIPTION
Prompted by [Discussion #610](https://github.com/foundation50/classroom50/discussions/610), where a teacher couldn't tell what format the roster upload expects and hit "Already a member" when adding students who were already in the org from a previous course. Both facts were only discoverable in the source, so this documents them.

## Web Teacher Guide

Expanded the "Upload roster" section to cover the three accepted upload formats (username list, roster CSV, email list), plus a **Roster CSV fields** subsection that spells out which columns are required. `username` is the only required column; everything else is optional. Includes a fields table, a worked example rendered both as a table and as a copy-paste `.csv`, and a minimal `username`-only example. A NOTE clarifies that username/CSV uploads enroll students while an email upload only invites, and a TIP points at the existing-member case below.

## Troubleshooting

New section **"Already an org member, but not on the roster"** explaining that organization membership and classroom enrollment are separate, why re-inviting an existing member does nothing, and the **Add to classroom** flow on the org Members page (with the CLI equivalent).

## Test plan

- [ ] Preview both wiki pages and confirm the tables and code blocks render.
- [ ] Confirm the `Troubleshooting#already-an-org-member-but-not-on-the-roster` anchor link resolves from the Web Teacher Guide.