### PR TITLE
docs(wiki): rewrite autograders page and standardize terminology

### DIFF
--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -202,6 +202,24 @@ workflow at submission setup, and by `runner.py` before executing.
 
 </details>
 
+<details>
+<summary>Writing a valid assignments.json from another client (e.g., a GUI)</summary>
+
+Anything that writes a valid `assignments.json` gets the whole pipeline for
+free. A non-CLI client should:
+
+1. Validate against
+   [`schemas/assignments-v1.schema.json`](https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json)
+   (two rules it can't express: unique test names, and name length ≤ 100 UTF-8
+   *bytes*).
+2. Probe before writing tests: `<classroom>/autograders/<slug>/autograder.py`
+   must NOT exist, and `.github/scripts/materialize_tests.py` MUST exist.
+3. Write via the git-data API and retry on a non-fast-forward rejection.
+
+The CLI parses strictly (unknown fields rejected), so persist only schema fields.
+
+</details>
+
 ### Writing an `autograder.py`
 
 When declarative tests aren't enough, write the grading logic yourself: the

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -1,257 +1,81 @@
 # Autograders
 
-How Classroom 50 grades submissions, and how to customize grading.
+How Classroom 50 grades submissions, how to read the results, and how to
+customize grading. If you only remember one thing: **define tests on the
+assignment, and every submission gets a score you can read on the submissions
+page and export as CSV.**
 
 ## How grading works
 
-Every push to a student's default branch triggers a small shim at
-`.github/workflows/autograde.yaml`, which calls the reusable **autograde-runner**
-workflow in `<org>/classroom50`. On each submission the runner:
+The whole pipeline, end to end:
 
-1. Creates (or reuses) the `submit/<UTC-timestamp>-<short-sha>` tag.
-2. Fetches `runner.py` and the assignment's autograder from Pages.
-3. Runs the autograder against the graded commit.
-4. Publishes a GitHub Release with the score, and maintains the Feedback PR.
+1. **You describe the grading** on the assignment — usually
+   [declarative tests](#declarative-tests) (input/output checks, run commands,
+   or pytest), written in the web form or with `gh teacher assignment test add`.
+2. **A student submits** — by pushing to their repository, or explicitly with
+   `gh student submit`, depending on the assignment's
+   [submission type](#which-commits-grade).
+3. **GitHub Actions grades the submission** in the student's own repository:
+   a small workflow calls the shared **autograde runner**, which fetches your
+   grading config and runs the tests against the submitted commit.
+4. **The result is published on the student's repository** as a GitHub
+   **Release** on a `submit/<UTC-timestamp>-<short-sha>` tag — the score, a
+   per-test PASS/FAIL table, and a machine-readable `result.json`. The graded
+   commit also gets a `classroom50/autograde` commit status, and the student's
+   **View grade** link opens the Release.
+5. **Scores are collected into the gradebook** (`scores.json` in your config
+   repo) by the **score-collection** workflow — nightly, or on demand via
+   **Sync now** on the submissions page. That's what the web app's submissions
+   page and both CSV exports read. See [Reading results](#reading-results).
 
-Later, `collect-scores.yaml` aggregates each Release's `result.json` into
-`<classroom>/scores.json`.
+Steps 3–5 run with no per-repo maintenance: everything substantive (the runner
+workflow, `runner.py`, autograders, runtime config) lives in the config repo
+and is fetched at run time, so a grading edit reaches every existing student
+repo on the next submission.
 
-Everything substantive (the runner workflow, `runner.py`, autograders, runtime
-config) lives in the config repo and is fetched at run time, so teacher edits
-reach every existing student repo on the next submission with no per-repo
-maintenance.
+Both surfaces drive the same pipeline: the web assignment form and
+`gh teacher assignment` write the same `assignments.json`, and the submissions
+page and `gh teacher download` read the same results.
 
 > [!NOTE]
 > Grading and publishing share one job and runner, so the workflow is **not** a
 > credential or hostile-workflow isolation boundary between them.
 
-## Which commits grade
+## Setting up grading
 
-What triggers grading is a **per-assignment choice** (`submission_mode` in
-assignments.json, settable at creation or later from the assignment settings /
-`gh teacher assignment add --submission-mode` / `gh teacher assignment
-submission-mode`):
+### Grading modes
 
-**`every-push` (the default)** — the shim triggers on two events:
+Each assignment has a **Grading** choice (the web form's Grading field; the
+`grading` block in `assignments.json`):
 
-- **Push to the default branch** — every commit grades, **except the acceptance
-  commit** (the one that introduced `.classroom50.yaml`, with nothing on top).
-- **Push of a `submit/*` tag** — manual tag pushes work too.
+- **Not graded** — no scores; submissions still tag and publish Releases, and
+  the Feedback PR still works.
+- **Autograded** — the default meaning of grading here: tests or an
+  `autograder.py` score each submission automatically. The rest of this page
+  is about this mode.
+- **Manual** — you enter each score by hand on the submissions page, out of
+  the assignment's **Max points**. No autograding runs on your behalf.
 
-**`tag`** — the shim triggers **only** on `submit/*` tag pushes. A plain
-`git push` runs nothing and costs no Actions minutes — the cost lever for
-large cohorts. Submissions become an explicit act:
+Two related, optional settings:
 
-- `gh student submit` pushes a `submit/<UTC-timestamp>-<short-sha>` tag after
-  the branch commit — that tag push is what grades.
-- A hand-pushed tag works exactly the same: `git tag submit/anything && git
-  push origin submit/anything`. Any tag under `submit/` grades; no CLI
-  required.
+- **Pass threshold** — an advisory percentage of the max score (0–100) at or
+  above which the submissions page shows a submission as *passing* (badges,
+  passing/failing rollups, and filters). It never changes a student's actual
+  score, and leaving it unset simply turns the passing concept off.
+- **Built-in autograder off** (`no_autograder`) — accept installs no
+  autograding workflow at all; a templated assignment's own CI runs instead,
+  and score collection skips the assignment. See
+  [Turning autograding off or pausing it](#turning-autograding-off-or-pausing-it).
 
-**Milestone submission tags** — with either mode, the assignment can also
-name **milestone tags** (`submission_tags` in assignments.json, the web form's
-**Submission tags** field, e.g. `["phase1", "phase2", "complete"]`, settable at
-creation or from the assignment settings / `gh teacher assignment add
---submission-tag`). Pushing a matching tag grades that commit — plain git, no
-CLI required:
-
-```sh
-git tag phase1
-git push origin phase1
-```
-
-Simple globs work too (`v*`), though exact milestone names are safer — a
-broad glob grades every matching tag a student pushes. The milestone tag
-**triggers** grading; the graded **record** still lives at the canonical
-`submit/<UTC-timestamp>-<short-sha>` tag the runner mints at that commit (its
-Release title notes *"via phase1"*), so history stays one-immutable-release-
-per-submission and collection, regrade, and the gradebook are unaffected. The
-`submit/*` namespace always keeps working alongside milestone tags.
-
-Because the trigger lives in each student repo's shim (GitHub evaluates a
-workflow's `on:` block before any job runs), **changing the mode or the
-milestone patterns after repos exist requires retrofitting each repo's
-shim** — see
-[Changing the trigger on existing repos](#changing-the-trigger-on-existing-repos).
-
-<details>
-<summary>Why the acceptance commit is skipped</summary>
-
-Accepting lands `.classroom50.yaml` + the shim in one commit, which fires the
-workflow — but that's *accepting*, not *submitting*. The runner detects it and
-skips tagging, grading, and the Release (the run still appears in the Actions
-tab with a `notice`). Detection is **fail-open**: any uncertainty grades rather
-than risk dropping a real submission. Your first `gh student submit` always
-stacks a fresh commit, so it's never mistaken for the acceptance.
-
-</details>
-
-<details>
-<summary>Tag-mode defenses in the runner</summary>
-
-Two guards keep tag mode honest even when a repo's shim is stale:
-
-- **Stale-shim suppression** — a repo accepted before the mode flipped to
-  `tag` (or whose retrofit failed) still carries the every-push trigger. The
-  runner reads `submission_mode` from the published assignments.json at setup
-  time and, when the assignment is tag-mode but the run was branch-triggered,
-  skips tagging and grading, posting a `classroom50/autograde-skipped`
-  success status: *"tag-mode assignment — push not graded; run gh student
-  submit"*.
-- **Retrofit-commit skip** — the teacher-side shim update commits with
-  `[skip ci]`, so it fires no workflow. As a backstop (e.g., a client that
-  dropped the marker), the runner also recognizes a tip commit touching ONLY
-  `.github/workflows/autograde.yaml` and skips it with the status
-  *"autograder trigger updated — nothing to grade"*.
-- **Foreign-tag suppression** — a pushed tag matching neither `submit/*` nor
-  any configured milestone pattern (possible only with a stale or hand-edited
-  shim) is skipped gracefully with the `classroom50/autograde-skipped` status
-  *"tag is not a submission trigger — not graded"*, never a failed run.
-
-The two suppression statuses use the separate `classroom50/autograde-skipped`
-context deliberately: in both cases the student's real work exists but was
-**not** graded, and a green `classroom50/autograde` would read as "graded
-successfully". Graded commits alone report under `classroom50/autograde`.
-(The nothing-to-grade skips — acceptance commit, shim-update commit, no
-autograder configured — stay on the main context: there is no work there to
-mistake for graded.)
-
-</details>
-
-## Changing the trigger on existing repos
-
-The shim is written at accept time and otherwise never changes, so flipping
-`submission_mode` on an assignment with accepted repos needs a retrofit:
-
-- **CLI**: `gh teacher assignment submission-mode <org> <classroom> <slug>
-  --tag` (or `--every-push`) flips the field AND rewrites the shim across
-  every student repo (add `--user <login>` for one repo, `--dry-run` to
-  preview). Requires the `workflow` OAuth scope
-  (`gh auth refresh -s workflow`).
-- **Web**: change the trigger on the assignment settings page, then run
-  **Update autograding triggers** from the submissions page's actions menu
-  (or per-repo from a row's manage dialog).
-
-The rewrite is surgical — only the trigger lines change; a shim a student
-hand-edited is reported and left untouched. **Custom (non-default)
-autograders are never rewritten**: you own their `on:` block; edit it
-yourself and use `--update-shims=false` to flip only the field.
-
-After a retrofit, students must `git pull` — clones made before the change
-will conflict on their next push.
-
-## Turning autograding off or pausing it
-
-Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
-
-- **Per assignment, at creation** — pick **Do not use the built-in
-  autograder** (`no_autograder` in assignments.json). Accept installs no shim
-  at all; a templated assignment's own CI workflows run instead, and score
-  collection skips the assignment. Changeable later, but only affects
-  repositories accepted from then on (existing ones keep their setup). See
-  [`gh teacher` reference](gh-teacher#assignment-add).
-- **Per assignment, temporarily** — **Pause autograding** in the submissions
-  page's **Actions** menu disables the `autograde.yaml` workflow in every
-  student repo via GitHub's workflow-disable API. No files change, students'
-  other workflows keep running, and **Resume autograding** re-enables it.
-  Available on individual assignments using the built-in autograder (a single
-  repo can also be paused from its row). A student with admin on their own
-  repo can technically re-enable the workflow — a known limitation.
-- **Org-wide** — the organization settings' **Pause autograding for all
-  student repositories** toggle narrows the org's Actions policy to the config
-  repo. **This stops all workflows in student repositories**, including any
-  course CI — prefer the per-assignment pause unless that's what you want.
-
-See also the [FAQ on reducing Actions usage](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage).
-
-## The `result.json` contract
-
-This is the **only** contract every autograder must satisfy — whatever produces
-it (pytest, check50, a shell script, a Rust binary) is up to you. The runner
-reads `result.json` from the workspace after the autograder exits.
-
-```json
-{
-  "schema":          "classroom50/result/v1",
-  "classroom":       "cs-principles",
-  "assignment":      "hello",
-  "assignment_type": "individual",
-  "owner":           "alice",
-  "submission":      "submit/2026-06-01T14-32-05Z-a1b2c3d",
-  "commit":          "https://github.com/.../commit/<sha>",
-  "release":         "https://github.com/.../releases/tag/submit%2F...",
-  "review":          "https://github.com/.../compare/<baseline-sha>...<sha>",
-  "datetime":        "2026-06-01T14:33:11Z",
-  "score":           4,
-  "max-score":       5,
-  "tests": [
-    { "test-name": "compiles",        "passed": true,  "score": 4, "max-score": 4 },
-    { "test-name": "outputs_correct", "passed": false, "score": 0, "max-score": 1 }
-  ]
-}
-```
-
-| Field | Type | Notes |
-|---|---|---|
-| `schema` | string | Exactly `classroom50/result/v1`. |
-| `classroom` / `assignment` | string | Must match the source repo's identity (checked in code alongside `owner`). |
-| `assignment_type` | string | `individual` or `group`, stamped by the runner. |
-| `owner` | string | The repo owner login — the identity anchor. |
-| `submission` | string | The submit-tag name. |
-| `commit` / `release` / `review` | string | URLs. `review` is the full diff from starter code to the graded commit. |
-| `datetime` | string | UTC ISO 8601. |
-| `score` / `max-score` | int | Sum of test scores / max-scores. |
-| `tests` | array | Per-test breakdown (`[]` is valid for a vacuous pass). |
-| `submitted_by` | object | Optional. Who pushed: `username`, and `id` (which may be null or absent). |
-
-`collect-scores` validates this before merging into `scores.json`. A payload
-whose identity (classroom/assignment/`owner`) doesn't match the source repo is
-rejected, and a mismatched `assignment_type` is warned-and-skipped, so a hostile
-payload can't land in another student's gradebook.
-
-<details>
-<summary>scores.json shape</summary>
-
-The gradebook is keyed by assignment slug under a root `assignments` object;
-each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is
-one repo's record: `owner` (the stable key), `submissions` (full history, newest
-first), and — for a group — `member_usernames` (credited members). Each bucket
-also carries a `collected_at` UTC timestamp stamped whenever a collection run
-walks that assignment (even if nothing changed), so per-assignment freshness is
-knowable — the web app's "Submission data synced" strip reads it.
-
-</details>
-
-### Group attribution model
-
-A group assignment is graded once, in the founder's repo. `collect-scores`
-credits the shared score to every collaborator **on the classroom team** (the
-owner is always included), recorded as the entry's `member_usernames`.
-
-- **Crediting is by team membership, not permission level.** A teammate is
-  credited whether they hold `push` or `admin`. Teachers and TAs are excluded
-  automatically because they aren't on the student team.
-- **Classmates on the team are mutually trusted.** Collection can't tell how a
-  collaborator was added, so a student could credit a teammate who's on the team.
-  The team intersection bounds this to classmates — an account off the team is
-  never credited. Review each group repo's collaborators if you need stricter
-  control.
-- **Owner-only submissions warn.** If a group submission resolves to just the
-  owner, collection emits a `::warning::` so the "team submission scored as solo"
-  case is visible.
-- **`submitted_by` records the pusher**, so you can see who did the work even
-  though the grade is shared.
-- **Rows are keyed by the repo owner**, so re-collecting a group repo whose
-  members changed updates the same row in place.
-
-## Declarative tests
+### Declarative tests
 
 The lowest-friction way to grade: describe io/run/pytest checks directly on the
 assignment, and the runner grades them with a built-in interpreter — no grading
 code to write. The three types map onto GitHub Classroom's legacy autograder
 presets.
 
-Author tests one at a time:
+In the web app, add tests in the assignment form's **Autograding tests**
+section. From the CLI, author them one at a time:
 
 ```sh
 gh teacher assignment test add cs50-fall-2026 cs-principles hello \
@@ -279,7 +103,7 @@ shape `assignment test list --json` emits:
 ]
 ```
 
-### Test types
+#### Test types
 
 | Type | Passes when | Type-specific fields |
 |---|---|---|
@@ -291,7 +115,7 @@ shape `assignment test list --json` emits:
 > The runner auto-installs `pytest` and `pytest-json-report` for `python` tests.
 > Add a `setup` install line only to pin a version.
 
-### Fields
+#### Fields
 
 | Field | Notes |
 |---|---|
@@ -378,7 +202,22 @@ workflow at submission setup, and by `runner.py` before executing.
 
 </details>
 
-### Precedence
+### Writing an `autograder.py`
+
+When declarative tests aren't enough, write the grading logic yourself: the
+autograder is a Python script the runner invokes once per submission. There are
+two scopes:
+
+| Path | Scope | Used when |
+|---|---|---|
+| `<classroom>/autograders/<slug>/autograder.py` | One assignment | Present in the bundle. |
+| `<classroom>/autograders/<slug>/tests.json` | One assignment | [Declarative tests](#declarative-tests); no per-assignment `autograder.py`. |
+| `<classroom>/autograder.py` | One classroom | Neither of the above exists. |
+
+If none exist, the runner emits a vacuous pass (score 0/0) and the submission
+still lands as a tagged Release — a valid mid-setup state.
+
+#### Precedence
 
 `runner.py` resolves the grading entrypoint in this order:
 
@@ -391,39 +230,7 @@ workflow at submission setup, and by `runner.py` before executing.
 To keep precedence from silently swallowing tests, the CLI refuses `assignment
 test add` / `--tests` while a per-assignment `autograder.py` exists.
 
-<details>
-<summary>Writing a valid assignments.json from another client (e.g., a GUI)</summary>
-
-Anything that writes a valid `assignments.json` gets the whole pipeline for
-free. A non-CLI client should:
-
-1. Validate against
-   [`schemas/assignments-v1.schema.json`](https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json)
-   (two rules it can't express: unique test names, and name length ≤ 100 UTF-8
-   *bytes*).
-2. Probe before writing tests: `<classroom>/autograders/<slug>/autograder.py`
-   must NOT exist, and `.github/scripts/materialize_tests.py` MUST exist.
-3. Write via the git-data API and retry on a non-fast-forward rejection.
-
-The CLI parses strictly (unknown fields rejected), so persist only schema fields.
-
-</details>
-
-## Writing an `autograder.py`
-
-The autograder is a Python script the runner invokes once per submission. There
-are two scopes:
-
-| Path | Scope | Used when |
-|---|---|---|
-| `<classroom>/autograders/<slug>/autograder.py` | One assignment | Present in the bundle. |
-| `<classroom>/autograders/<slug>/tests.json` | One assignment | [Declarative tests](#declarative-tests); no per-assignment `autograder.py`. |
-| `<classroom>/autograder.py` | One classroom | Neither of the above exists. |
-
-If none exist, the runner emits a vacuous pass (score 0/0) and the submission
-still lands as a tagged Release — a valid mid-setup state.
-
-### Contract
+#### Contract
 
 The runner provides:
 
@@ -435,7 +242,8 @@ The runner provides:
 - **Sibling files:** anything else under `<classroom>/autograders/<slug>/` is
   bundled and lives at `Path(__file__).parent`.
 
-The autograder must produce **`./result.json`** (required). Optionally
+The autograder must produce **`./result.json`** (required — see
+[the `result.json` contract](#the-resultjson-contract)). Optionally
 `./release-body.md` and `status=`/`summary=` in `$GITHUB_OUTPUT`; the runner
 synthesizes them from `result.json` if absent. Exit **0** if it ran end-to-end
 (pass/fail is in `result.json`); a **non-zero** exit is an infrastructure error
@@ -545,7 +353,7 @@ Path("result.json").write_text(json.dumps(result, indent=2))
 
 </details>
 
-### Classroom default
+#### Classroom default
 
 `gh teacher autograder set-default <org> <classroom> --from <path>` installs a
 default that grades every assignment without its own autograder or tests. With no
@@ -553,12 +361,13 @@ default that grades every assignment without its own autograder or tests. With n
 pass) — useful for verifying the pipeline. Inspect it with `autograder show`, and
 delete it outright with `autograder remove`.
 
-## The `runtime` block
+### The `runtime` block
 
 Per-assignment environment (runner OS, language toolchains, packages, container
-image) lives as an optional `runtime` field on each `assignments.json` entry. The
-runner reads it on every submission, so changes propagate with no student-repo
-edit. Pass a JSON file to `gh teacher assignment add --runtime`:
+image) lives as an optional `runtime` field on each `assignments.json` entry, or
+under **Advanced settings** in the web assignment form. The runner reads it on
+every submission, so changes propagate with no student-repo edit. Pass a JSON
+file to `gh teacher assignment add --runtime`:
 
 ```json
 {
@@ -616,6 +425,353 @@ is required and injection-checked; `user` accepts `docker run --user` syntax.
 > `runtime` values are teacher-authored (from your config repo), never student
 > input, so a permissive `runs-on` doesn't widen what a student repo can request.
 
+## Which commits grade
+
+What triggers grading is a **per-assignment choice** (the web form's
+**Submission type**; `submission_mode` in assignments.json; `gh teacher
+assignment add --submission-mode` / `gh teacher assignment submission-mode`):
+
+**`every-push` (the default)** — grading triggers on two events:
+
+- **Push to the default branch** — every commit grades, **except the acceptance
+  commit** (the one that introduced `.classroom50.yaml`, with nothing on top).
+- **Push of a `submit/*` tag** — manual tag pushes work too.
+
+**`tag`** — grading triggers **only** on `submit/*` tag pushes. A plain
+`git push` runs nothing and costs no Actions minutes — the cost lever for
+large cohorts. Submissions become an explicit act:
+
+- `gh student submit` pushes a `submit/<UTC-timestamp>-<short-sha>` tag after
+  the branch commit — that tag push is what grades.
+- A hand-pushed tag works exactly the same: `git tag submit/anything && git
+  push origin submit/anything`. Any tag under `submit/` grades; no CLI
+  required.
+
+**Milestone submission tags** — with either mode, the assignment can also
+name **milestone tags** (`submission_tags` in assignments.json, the web form's
+**Submission tags** field, e.g. `["phase1", "phase2", "complete"]`, settable at
+creation or from the assignment settings / `gh teacher assignment add
+--submission-tag`). Pushing a matching tag grades that commit — plain git, no
+CLI required:
+
+```sh
+git tag phase1
+git push origin phase1
+```
+
+Simple globs work too (`v*`), though exact milestone names are safer — a
+broad glob grades every matching tag a student pushes. The milestone tag
+**triggers** grading; the graded **record** still lives at the canonical
+`submit/<UTC-timestamp>-<short-sha>` tag the runner mints at that commit (its
+Release title notes *"via phase1"*), so history stays one-immutable-release-
+per-submission and collection, regrade, and the gradebook are unaffected. The
+`submit/*` namespace always keeps working alongside milestone tags.
+
+Because the trigger lives in each student repo's workflow (GitHub evaluates a
+workflow's `on:` block before any job runs), **changing the mode or the
+milestone patterns after repos exist requires retrofitting each repo's
+workflow** — see
+[Changing the trigger on existing repos](#changing-the-trigger-on-existing-repos).
+
+<details>
+<summary>Why the acceptance commit is skipped</summary>
+
+Accepting lands `.classroom50.yaml` + the workflow in one commit, which fires
+the workflow — but that's *accepting*, not *submitting*. The runner detects it
+and skips tagging, grading, and the Release (the run still appears in the
+Actions tab with a `notice`). Detection is **fail-open**: any uncertainty grades
+rather than risk dropping a real submission. Your first `gh student submit`
+always stacks a fresh commit, so it's never mistaken for the acceptance.
+
+</details>
+
+<details>
+<summary>Tag-mode defenses in the runner</summary>
+
+Two guards keep tag mode honest even when a repo's workflow trigger is stale:
+
+- **Stale-trigger suppression** — a repo accepted before the mode flipped to
+  `tag` (or whose retrofit failed) still carries the every-push trigger. The
+  runner reads `submission_mode` from the published assignments.json at setup
+  time and, when the assignment is tag-mode but the run was branch-triggered,
+  skips tagging and grading, posting a `classroom50/autograde-skipped`
+  success status: *"tag-mode assignment — push not graded; run gh student
+  submit"*.
+- **Retrofit-commit skip** — the teacher-side trigger update commits with
+  `[skip ci]`, so it fires no workflow. As a backstop (e.g., a client that
+  dropped the marker), the runner also recognizes a tip commit touching ONLY
+  `.github/workflows/autograde.yaml` and skips it with the status
+  *"autograder trigger updated — nothing to grade"*.
+- **Foreign-tag suppression** — a pushed tag matching neither `submit/*` nor
+  any configured milestone pattern (possible only with a stale or hand-edited
+  workflow) is skipped gracefully with the `classroom50/autograde-skipped`
+  status *"tag is not a submission trigger — not graded"*, never a failed run.
+
+The two suppression statuses use the separate `classroom50/autograde-skipped`
+context deliberately: in both cases the student's real work exists but was
+**not** graded, and a green `classroom50/autograde` would read as "graded
+successfully". Graded commits alone report under `classroom50/autograde`.
+(The nothing-to-grade skips — acceptance commit, trigger-update commit, no
+autograder configured — stay on the main context: there is no work there to
+mistake for graded.)
+
+</details>
+
+### Changing the trigger on existing repos
+
+The autograding workflow is written into each student repo at accept time and
+otherwise never changes, so flipping `submission_mode` on an assignment with
+accepted repos needs a retrofit:
+
+- **CLI**: `gh teacher assignment submission-mode <org> <classroom> <slug>
+  --tag` (or `--every-push`) flips the field AND rewrites the workflow across
+  every student repo (add `--user <login>` for one repo, `--dry-run` to
+  preview). Requires the `workflow` OAuth scope
+  (`gh auth refresh -s workflow`).
+- **Web**: change the trigger on the assignment settings page, then run
+  **Update autograding triggers** from the submissions page's actions menu
+  (or per-repo from a row's manage dialog).
+
+The rewrite is surgical — only the trigger lines change; a workflow a student
+hand-edited is reported and left untouched. **Custom (non-default)
+autograders are never rewritten**: you own their `on:` block; edit it
+yourself and use `--update-shims=false` to flip only the field.
+
+After a retrofit, students must `git pull` — clones made before the change
+will conflict on their next push.
+
+### Turning autograding off or pausing it
+
+Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
+
+- **Per assignment, at creation** — pick **Do not use the built-in
+  autograder** (`no_autograder` in assignments.json). Accept installs no
+  autograding workflow at all; a templated assignment's own CI workflows run
+  instead, and score collection skips the assignment. Changeable later, but
+  only affects repositories accepted from then on (existing ones keep their
+  setup). See [`gh teacher` reference](gh-teacher#assignment-add).
+- **Per assignment, temporarily** — **Pause autograding** in the submissions
+  page's **Actions** menu disables the `autograde.yaml` workflow in every
+  student repo via GitHub's workflow-disable API. No files change, students'
+  other workflows keep running, and **Resume autograding** re-enables it.
+  Available on individual assignments using the built-in autograder (a single
+  repo can also be paused from its row). A student with admin on their own
+  repo can technically re-enable the workflow — a known limitation.
+- **Org-wide** — the organization settings' **Pause autograding for all
+  student repositories** toggle narrows the org's Actions policy to the config
+  repo. **This stops all workflows in student repositories**, including any
+  course CI — prefer the per-assignment pause unless that's what you want.
+
+See also the [FAQ on reducing Actions usage](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage).
+
+## Reading results
+
+Where to find scores, per-test breakdowns, past attempts, and who submitted —
+and what each export contains.
+
+### Where results live
+
+Every graded submission produces the same three records:
+
+| Record | Where | What it shows |
+|---|---|---|
+| **Release** | The student repo, on the `submit/<UTC-timestamp>-<short-sha>` tag | The score, a **per-test PASS/FAIL table**, and the machine-readable `result.json`. This is what **View grade** / **View autograder details** links open — and the only place with the per-test breakdown. |
+| **Commit status** | The graded commit (`classroom50/autograde`) | success / failure / error at a glance, right on the commit. |
+| **Gradebook row** | `scores.json` in the config repo, after collection | What the submissions page and the CSV exports read: score, submission time, links, late flag, and full attempt history. |
+
+Releases and statuses appear the moment grading finishes. The gradebook lags
+until **collection** runs — nightly, or on demand with **Sync now** on the
+submissions page (`gh workflow run collect-scores.yaml` from the shell). If a
+student says "I submitted" and you see no score, sync first.
+
+On the submissions page, each row shows the student's (or group's) current
+score with links to the repository, the graded **commit**, the Release
+(**View autograder details**), the full **review** diff (starter code → graded
+commit), and the Feedback PR (**Review**).
+
+### Latest score vs. history
+
+The score on a row — and in both CSV exports' summary columns — is the
+**latest submission's** (or a teacher override). "Latest" follows the
+*submission*, not the commit: if a student deliberately submits an older
+commit (a milestone tag pointing at earlier work, or a regrade), that
+submission's Release becomes the latest. The badge and the gradebook always
+agree because they use the same rule.
+
+The full history is kept everywhere:
+
+- **Web** — click a row's submission count to open its details: every attempt,
+  newest first, each with its commit link and a per-attempt **View grade**
+  Release link.
+- **Student repo** — one immutable Release per attempt, under the repo's
+  Releases tab (each `submit/*` tag is one graded attempt).
+- **`scores.json`** — each entry's `submissions` array holds every collected
+  attempt, newest first.
+- **`gh teacher download`** — writes each repo's `results.json` (all attempts)
+  next to `result.json` (latest), and one CSV line per attempt (see below).
+
+### Grading a specific commit
+
+Students sometimes ask you to grade a particular commit, not their latest:
+
+- **Every attempt already has its own frozen result** — find that commit's
+  `submit/*` Release in the history; its score and per-test table are exactly
+  as graded.
+- **To grade an arbitrary commit**, have the student push a `submit/*` tag (or
+  a configured milestone tag) pointing at it: `git tag submit/regrade-me
+  <sha> && git push origin submit/regrade-me`. That mints a normal graded
+  submission at that commit.
+- **Regrade** (per-row, or **Regrade all** in the Actions menu) re-runs the
+  autograder on each already-collected submission **at its original commit** —
+  useful after fixing a broken test. `datetime` (the submission instant) stays
+  fixed so late-marking never changes; `graded_at` records the re-run.
+
+### Who submitted
+
+- `owner` — the repo owner (the `<username>` in the repo name); the identity
+  scores are keyed by.
+- `submitted_by` — the GitHub account that actually pushed that submission.
+  For group work this is how you see who did the pushing even though the score
+  is shared.
+- Group scores are credited to every teammate on the classroom team, recorded
+  as the entry's `member_usernames` — see
+  [Group attribution model](#group-attribution-model).
+
+### Group attribution model
+
+A group assignment is graded once, in the founder's repo. `collect-scores`
+credits the shared score to every collaborator **on the classroom team** (the
+owner is always included), recorded as the entry's `member_usernames`.
+
+- **Crediting is by team membership, not permission level.** A teammate is
+  credited whether they hold `push` or `admin`. Teachers and TAs are excluded
+  automatically because they aren't on the student team.
+- **Classmates on the team are mutually trusted.** Collection can't tell how a
+  collaborator was added, so a student could credit a teammate who's on the team.
+  The team intersection bounds this to classmates — an account off the team is
+  never credited. Review each group repo's collaborators if you need stricter
+  control.
+- **Owner-only submissions warn.** If a group submission resolves to just the
+  owner, collection emits a `::warning::` so the "team submission scored as solo"
+  case is visible.
+- **`submitted_by` records the pusher**, so you can see who did the work even
+  though the score is shared.
+- **Rows are keyed by the repo owner**, so re-collecting a group repo whose
+  members changed updates the same row in place.
+
+### Score exports
+
+Two CSV exports cover most gradebook needs; the raw JSON is always there for
+anything custom.
+
+#### Web: Download scores (CSV)
+
+**Download scores (CSV)** on the submissions page saves
+`<classroom>-<assignment>-scores.csv` — **one row per student (or group)**,
+sorted by last name, with the latest submission's data:
+
+| Column | Description |
+|---|---|
+| `name` / `first_name` / `last_name` | From the roster (blank if the login isn't on it). |
+| `usernames` | The credited GitHub username(s) — one for individual work, all members (founder first) for a group. |
+| `score` / `max_score` | The latest submission's score. Blank if submitted but not yet collected; `0` with blanks for a non-submitter. |
+| `submissions` | How many attempts were collected. |
+| `submitted_at` | The latest submission instant (ISO 8601 UTC). |
+| `late` | `yes` / `no` against the due date; blank for non-submitters. |
+| `commit` / `review` / `release` | Links: the graded commit, the full starter→graded diff, and the Release. |
+
+#### CLI: `gh teacher download`
+
+`gh teacher download <org> <classroom> <assignment>` clones every student
+repo and writes a `scores.csv` at the destination root — **one line per
+submission** (a student with several attempts contributes several lines,
+newest first), plus one blank-score line per non-submitter:
+
+| Column | Description |
+|---|---|
+| `username` | The team member (repo owner for groups). |
+| `first_name` / `last_name` / `email` / `section` | Joined from `roster.csv` when present. |
+| `score` / `max_score` | This attempt's score. Blank for non-submitters. |
+| `datetime` | This attempt's submission instant (ISO 8601 UTC). |
+| `submission_tag` | The `submit/…` tag identifying the attempt. |
+| `submitted_by` | Who pushed this attempt. |
+| `review_url` | The starter→graded diff for this attempt. |
+| `late` | `true` / `false` against the due date; blank when unknown. |
+| `override` | `true` when a teacher override is in effect for the entry. |
+
+Per-test breakdowns aren't in either CSV — they're in each attempt's Release
+(and in the per-repo `result.json` / `results.json` files the download also
+refreshes).
+
+#### Raw JSON
+
+- `<classroom>/scores.json` in your config repo is the authoritative gradebook
+  (see [scores.json shape](#the-resultjson-contract) below) — build any custom
+  report from it.
+- `gh teacher download` leaves `result.json` (latest attempt) and
+  `results.json` (all attempts, newest first) in each cloned repo, including
+  the per-test arrays.
+
+## The `result.json` contract
+
+This is the **only** contract every autograder must satisfy — whatever produces
+it (pytest, check50, a shell script, a Rust binary) is up to you. The runner
+reads `result.json` from the workspace after the autograder exits.
+
+```json
+{
+  "schema":          "classroom50/result/v1",
+  "classroom":       "cs-principles",
+  "assignment":      "hello",
+  "assignment_type": "individual",
+  "owner":           "alice",
+  "submission":      "submit/2026-06-01T14-32-05Z-a1b2c3d",
+  "commit":          "https://github.com/.../commit/<sha>",
+  "release":         "https://github.com/.../releases/tag/submit%2F...",
+  "review":          "https://github.com/.../compare/<baseline-sha>...<sha>",
+  "datetime":        "2026-06-01T14:32:01Z",
+  "graded_at":       "2026-06-01T14:33:11Z",
+  "score":           4,
+  "max-score":       5,
+  "tests": [
+    { "test-name": "compiles",        "passed": true,  "score": 4, "max-score": 4 },
+    { "test-name": "outputs_correct", "passed": false, "score": 0, "max-score": 1 }
+  ]
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema` | string | Exactly `classroom50/result/v1`. |
+| `classroom` / `assignment` | string | Must match the source repo's identity (checked in code alongside `owner`). |
+| `assignment_type` | string | `individual` or `group`, stamped by the runner. |
+| `owner` | string | The repo owner login — the identity anchor. |
+| `submission` | string | The submit-tag name. |
+| `commit` / `release` / `review` | string | URLs. `review` is the full diff from starter code to the graded commit. |
+| `datetime` | string | The **submission instant**: the graded commit's committer date (UTC ISO 8601). Invariant across regrades, so late-marking never changes on a re-run. |
+| `graded_at` | string | Optional. When this grading run produced the result — moves on every regrade. |
+| `score` / `max-score` | int | Sum of test scores / max-scores. |
+| `tests` | array | Per-test breakdown (`[]` is valid for a vacuous pass). Extra diagnostic fields on a test are preserved verbatim. |
+| `submitted_by` | object | Optional. Who pushed: `username`, and `id` (which may be null or absent). |
+
+`collect-scores` validates this before merging into `scores.json`. A payload
+whose identity (classroom/assignment/`owner`) doesn't match the source repo is
+rejected, and a mismatched `assignment_type` is warned-and-skipped, so a hostile
+payload can't land in another student's gradebook.
+
+<details>
+<summary>scores.json shape</summary>
+
+The gradebook is keyed by assignment slug under a root `assignments` object;
+each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is
+one repo's record: `owner` (the stable key), `submissions` (full history, newest
+first), and — for a group — `member_usernames` (credited members). Each bucket
+also carries a `collected_at` UTC timestamp stamped whenever a collection run
+walks that assignment (even if nothing changed), so per-assignment freshness is
+knowable — the web app's "Submission data synced" strip reads it.
+
+</details>
+
 ## Feedback pull requests
 
 The Feedback PR is **on by default** for assignments created with `gh teacher
@@ -667,8 +823,8 @@ Actions to create and approve pull requests" must be on, and two org rulesets
 protect submission history and the frozen `feedback` branch. If you enable
 feedback on an org set up before this feature, **re-run `gh teacher init`**.
 
-**Student repos accepted before this feature** use an older shim and must be
-re-created (delete + re-accept) to pick up the new one.
+**Student repos accepted before this feature** use an older workflow and must
+be re-created (delete + re-accept) to pick up the new one.
 
 </details>
 
@@ -723,7 +879,8 @@ uploads warn without changing the grade.
 > [!NOTE]
 > Submission publishing doesn't support GitHub Immutable Releases (reruns edit
 > the Release in place). To roll this out to an existing org, run `gh teacher
-> init`, approve the skeleton refresh, and wait for `publish-pages` to finish.
+> init`, approve the workflow-files refresh, and wait for `publish-pages` to
+> finish.
 
 ## Where to customize
 
@@ -741,8 +898,8 @@ or to replace the runner bootstrap.
 
 ## Failure paths
 
-Classroom 50 separates an ordinary pass/fail grade from an infrastructure error.
-Passing and failing grades publish the Release; an `error` posts an error status
+Classroom 50 separates an ordinary pass/fail score from an infrastructure error.
+Passing and failing scores publish the Release; an `error` posts an error status
 and leaves the Release unchanged.
 
 | What failed | What surfaces |
@@ -770,13 +927,8 @@ configured by `init`). The only PAT in the system is the teacher-side
 - **The grade job stops after 15 minutes.** This includes managed runtime setup,
   the assignment Setup command, every test, and submission Release publishing.
   Per-command timeouts do not extend the job limit.
-- **Every push grades, every push gets a Release.** Five pushes in ten minutes
-  produce five graded runs and five Releases.
-- **"Latest" follows the submission, not the commit.** Each graded
-  submission's Release becomes the latest — also when the student submits an
-  OLDER commit on purpose (a milestone tag pointed at earlier work, or a
-  regrade). The gradebook and the web pages use the same rule, so the badge
-  and the score always agree.
+- **Every push grades, every push gets a Release** (in `every-push` mode). Five
+  pushes in ten minutes produce five graded runs and five Releases.
 - **Immutable-release rulesets freeze regrade Releases.** Orgs enforcing
   immutable releases (a GitHub ruleset) cannot refresh a submission's Release
   on regrade; the regraded score appears in the commit status and the Actions
@@ -791,15 +943,15 @@ configured by `init`). The only PAT in the system is the teacher-side
 Every earlier layer changes *what* grading does while keeping the built-in
 runner. When you need a different grading *pipeline* entirely — a
 [reusable workflow](https://docs.github.com/actions/using-workflows/reusing-workflows)
-you author yourself — `--autograder <name>` swaps the caller shim instead of the
-autograder script. Most teachers never need this.
+you author yourself — `--autograder <name>` swaps the caller workflow instead of
+the autograder script. Most teachers never need this.
 
-**How the swap works.** By default `gh student accept` writes a shim to
-`.github/workflows/autograde.yaml` whose `uses:` points at the built-in
-`autograde-runner.yaml`. With `--autograder <name>`, accept instead fetches your
-shim from `<classroom>/autograders/<name>.yaml` and writes it verbatim. Your
-shim owns its own `on:` triggers and `uses:` a reusable workflow you control, so
-your grading logic runs in place of the runner.
+**How the swap works.** By default `gh student accept` writes a small caller
+workflow to `.github/workflows/autograde.yaml` whose `uses:` points at the
+built-in `autograde-runner.yaml`. With `--autograder <name>`, accept instead
+fetches your caller from `<classroom>/autograders/<name>.yaml` and writes it
+verbatim. Your caller owns its own `on:` triggers and `uses:` a reusable
+workflow you control, so your grading logic runs in place of the runner.
 
 **Set one up:**
 
@@ -807,16 +959,17 @@ your grading logic runs in place of the runner.
    with a name other than the reserved `autograde-runner.yaml`. It must be
    [callable](https://docs.github.com/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow)
    (`on: workflow_call`). Non-reserved names are never touched by Classroom 50.
-2. **Add a caller shim** at `<classroom>/autograders/<name>.yaml`. Give it your
-   trigger events and a `jobs.<id>.uses:` pointing at the workflow from step 1.
-   Because it's written verbatim, template `<org>`/branch refs to your own
-   values rather than relying on the built-in shim's substitution.
+2. **Add a caller workflow** at `<classroom>/autograders/<name>.yaml`. Give it
+   your trigger events and a `jobs.<id>.uses:` pointing at the workflow from
+   step 1. Because it's written verbatim, template `<org>`/branch refs to your
+   own values rather than relying on the built-in caller's substitution.
 3. **Register the assignment** with `gh teacher assignment add <org> <classroom>
    <slug> --autograder <name>`.
 
 > [!NOTE]
 > Once an assignment uses a custom autograder, `gh teacher assignment
-> submission-mode` never rewrites its shim — trigger changes are yours to make.
+> submission-mode` never rewrites its caller workflow — trigger changes are
+> yours to make.
 
 ### Bringing a GitHub Classroom autograder along
 
@@ -829,13 +982,13 @@ you keep your existing format:
 1. Put your grading action's workflow in the config repo's `.github/workflows/`
    (any non-reserved name). Have it read `autograding.json` from the student
    repo as before.
-2. Point a caller shim at it as above, and register assignments with
+2. Point a caller workflow at it as above, and register assignments with
    `--autograder <name>`.
 3. Ship `autograding.json` (and any fixtures) in the **assignment template**, not
    the config repo — it travels with each student's starter code.
 
 > [!WARNING]
-> The template must **not** contain `.github/workflows/autograde.yaml`; that name
-> is reserved for the shim and would be clobbered on accept and submit (see
-> [Assignment Templates](Assignment-Templates#structure)). Use any other filename
-> for template-side workflows.
+> The template must **not** contain `.github/workflows/autograde.yaml`; that
+> name is reserved for the autograding caller and would be clobbered on accept
+> and submit (see [Assignment Templates](Assignment-Templates#structure)). Use
+> any other filename for template-side workflows.

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -54,7 +54,9 @@ Each assignment has a **Grading** choice (the web form's Grading field; the
   `autograder.py` score each submission automatically. The rest of this page
   is about this mode.
 - **Manual** — you enter each score by hand on the submissions page, out of
-  the assignment's **Max points**. No autograding runs on your behalf.
+  the assignment's **Max points**. No autograder score is used — though the
+  built-in workflow still runs on submissions unless you also turn the
+  built-in autograder off.
 
 Two related, optional settings:
 
@@ -609,8 +611,9 @@ commit), and the Feedback PR (**Review**).
 
 ### Latest score vs. history
 
-The score on a row — and in both CSV exports' summary columns — is the
-**latest submission's** (or a teacher override). "Latest" follows the
+The score on a row — and in the web CSV's summary columns — is the
+**latest submission's** (or a teacher override); in the CLI CSV the latest is
+simply the first line per member. "Latest" follows the
 *submission*, not the commit: if a student deliberately submits an older
 commit (a milestone tag pointing at earlier work, or a regrade), that
 submission's Release becomes the latest. The badge and the gradebook always
@@ -639,10 +642,12 @@ Students sometimes ask you to grade a particular commit, not their latest:
   a configured milestone tag) pointing at it: `git tag submit/regrade-me
   <sha> && git push origin submit/regrade-me`. That mints a normal graded
   submission at that commit.
-- **Regrade** (per-row, or **Regrade all** in the Actions menu) re-runs the
-  autograder on each already-collected submission **at its original commit** —
-  useful after fixing a broken test. `datetime` (the submission instant) stays
-  fixed so late-marking never changes; `graded_at` records the re-run.
+- **Regrade** (per-row, or **Regrade all** in the Actions menu) re-runs each
+  repo's **latest** submission **at its original commit** — useful after
+  fixing a broken test. A never-graded repo is first-graded at its current
+  HEAD instead (a new submission). On a re-run, `datetime` (the submission
+  instant) stays fixed so late-marking never changes; `graded_at` records the
+  re-run.
 
 ### Who submitted
 
@@ -691,7 +696,7 @@ sorted by last name, with the latest submission's data:
 | Column | Description |
 |---|---|
 | `name` / `first_name` / `last_name` | From the roster (blank if the login isn't on it). |
-| `usernames` | The credited GitHub username(s) — one for individual work, all members (founder first) for a group. |
+| `usernames` | The credited GitHub username(s) — one for individual work, every credited member (alphabetical) for a group. |
 | `score` / `max_score` | The latest submission's score. Blank if submitted but not yet collected; `0` with blanks for a non-submitter. |
 | `submissions` | How many attempts were collected. |
 | `submitted_at` | The latest submission instant (ISO 8601 UTC). |
@@ -707,7 +712,7 @@ newest first), plus one blank-score line per non-submitter:
 
 | Column | Description |
 |---|---|
-| `username` | The team member (repo owner for groups). |
+| `username` | The team member. For a group, every credited member repeats the shared submission's lines under their own username. |
 | `first_name` / `last_name` / `email` / `section` | Joined from `roster.csv` when present. |
 | `score` / `max_score` | This attempt's score. Blank for non-submitters. |
 | `datetime` | This attempt's submission instant (ISO 8601 UTC). |
@@ -892,7 +897,7 @@ them) and uploads them under their basenames.
 Release-safe (ASCII letters/digits/`.`/`_`/`-`, no leading/trailing dot, no `..`,
 not `result.json` or `release-body.md`), and relative. A separate 100 MiB
 file-content budget applies at runtime. Missing, unsafe, oversized, or failed
-uploads warn without changing the grade.
+uploads warn without changing the score.
 
 > [!NOTE]
 > Submission publishing doesn't support GitHub Immutable Releases (reruns edit

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -24,14 +24,14 @@ The whole pipeline, end to end:
    commit also gets a `classroom50/autograde` commit status, and the student's
    **View grade** link opens the Release.
 5. **Scores are collected into the gradebook** (`scores.json` in your config
-   repo) by the **score-collection** workflow — nightly, or on demand via
+   repository) by the **score-collection** workflow — nightly, or on demand with
    **Sync now** on the submissions page. That's what the web app's submissions
    page and both CSV exports read. See [Reading results](#reading-results).
 
-Steps 3–5 run with no per-repo maintenance: everything substantive (the runner
-workflow, `runner.py`, autograders, runtime config) lives in the config repo
+Steps 3–5 run with no per-repository maintenance: everything substantive (the runner
+workflow, `runner.py`, autograders, runtime config) lives in the config repository
 and is fetched at run time, so a grading edit reaches every existing student
-repo on the next submission.
+repository on the next submission.
 
 Both surfaces drive the same pipeline: the web assignment form and
 `gh teacher assignment` write the same `assignments.json`, and the submissions
@@ -63,7 +63,7 @@ Two related, optional settings:
 - **Pass threshold** — an advisory percentage of the max score (0–100) at or
   above which the submissions page shows a submission as *passing* (badges,
   passing/failing rollups, and filters). It never changes a student's actual
-  score, and leaving it unset simply turns the passing concept off.
+  score, and leaving it unset turns the passing concept off.
 - **Built-in autograder off** (`no_autograder`) — accept installs no
   autograding workflow at all; a templated assignment's own CI runs instead,
   and score collection skips the assignment. See
@@ -124,7 +124,7 @@ shape `assignment test list --json` emits:
 | `name` | Required. Unique within the assignment; ≤ 100 UTF-8 bytes; no control characters. |
 | `type` | Required. `io`, `run`, or `python`. |
 | `run` | Required. Shell command, run in the student checkout. |
-| `setup` | Optional pre-command (e.g., compile). Non-zero exit fails the test. |
+| `setup` | Optional pre-command (for example, compile). Non-zero exit fails the test. |
 | `input` / `input-file` | `io` only, mutually exclusive. Inline stdin or a bundled fixture. |
 | `expected` / `expected-file` | `io` only, mutually exclusive. Must be non-empty for `included`/`regex`. |
 | `comparison` | `io` only. `included` (substring), `exact` (trimmed equality), or `regex` (Python `re.search`, multiline). |
@@ -192,7 +192,7 @@ cannot change the runner process or the environment of later tests.
 <details>
 <summary>How tests flow, and where failures surface</summary>
 
-Tests live inline in `assignments.json`. On the next config-repo push,
+Tests live inline in `assignments.json`. On the next config-repository push,
 publish-pages **materializes** them into the assignment's Pages bundle as
 `tests.json`. At grade time, `runner.py` runs each spec in the student checkout:
 one row per test in `result.json`, plus a failure breakdown in three places — the
@@ -205,7 +205,7 @@ workflow at submission setup, and by `runner.py` before executing.
 </details>
 
 <details>
-<summary>Writing a valid assignments.json from another client (e.g., a GUI)</summary>
+<summary>Writing a valid assignments.json from another client (such as a GUI)</summary>
 
 Anything that writes a valid `assignments.json` gets the whole pipeline for
 free. A non-CLI client should:
@@ -216,7 +216,7 @@ free. A non-CLI client should:
    *bytes*).
 2. Probe before writing tests: `<classroom>/autograders/<slug>/autograder.py`
    must NOT exist, and `.github/scripts/materialize_tests.py` MUST exist.
-3. Write via the git-data API and retry on a non-fast-forward rejection.
+3. Write with the git-data API and retry on a non-fast-forward rejection.
 
 The CLI parses strictly (unknown fields rejected), so persist only schema fields.
 
@@ -386,7 +386,7 @@ delete it outright with `autograder remove`.
 Per-assignment environment (runner OS, language toolchains, packages, container
 image) lives as an optional `runtime` field on each `assignments.json` entry, or
 under **Advanced settings** in the web assignment form. The runner reads it on
-every submission, so changes propagate with no student-repo edit. Pass a JSON
+every submission, so changes propagate with no student-repository edit. Pass a JSON
 file to `gh teacher assignment add --runtime`:
 
 ```json
@@ -407,7 +407,7 @@ the image owns the toolchain unless you set `python` explicitly.
 |---|---|
 | `runs-on` | A single runner label (`"ubuntu-latest"`) or an array (`["self-hosted", "gpu"]`). No allow-list — you own the label; each is anti-injection-checked (1–10 labels). |
 | `python` / `node` / `java` / `go` | Version passed to the matching `setup-*` action. Skipped when unset (`python` defaults to 3.14 on the host path). |
-| `rust` | Rustup toolchain (`stable`, `1.79`, …) via `dtolnay/rust-toolchain`. |
+| `rust` | Rustup toolchain (`stable`, `1.79`, …) through `dtolnay/rust-toolchain`. |
 | `apt` | Debian/Ubuntu package names. Linux runners only. Mutually exclusive with `container`. |
 | `container` | Escape hatch — see below. |
 
@@ -415,7 +415,7 @@ the image owns the toolchain unless you set `python` explicitly.
 <summary>Custom and self-hosted runners</summary>
 
 `runs-on` works exactly as in any Actions workflow. Multiple labels are AND-ed; a
-misspelled label just won't match a runner. A `container` needs a Linux
+misspelled label won't match a runner. A `container` needs a Linux
 `runs-on`.
 
 **Self-hosted runners keep their own toolchains.** On a self-hosted runner the
@@ -435,15 +435,15 @@ runner agent (v2.294.0+) up to date.
 ```
 
 The image must be **publicly pullable** (private-registry pull secrets can't be
-delivered safely in a student repo). Set `user` for any image that doesn't run
+delivered safely in a student repository). Set `user` for any image that doesn't run
 as root by default, or `actions/checkout` fails with a permission error. `image`
 is required and injection-checked; `user` accepts `docker run --user` syntax.
 
 </details>
 
 > [!NOTE]
-> `runtime` values are teacher-authored (from your config repo), never student
-> input, so a permissive `runs-on` doesn't widen what a student repo can request.
+> `runtime` values are teacher-authored (from your config repository), never student
+> input, so a permissive `runs-on` doesn't widen what a student repository can request.
 
 ## Which commits grade
 
@@ -469,7 +469,7 @@ large cohorts. Submissions become an explicit act:
 
 **Milestone submission tags** — with either mode, the assignment can also
 name **milestone tags** (`submission_tags` in assignments.json, the web form's
-**Submission tags** field, e.g. `["phase1", "phase2", "complete"]`, settable at
+**Submission tags** field, for example `["phase1", "phase2", "complete"]`, settable at
 creation or from the assignment settings / `gh teacher assignment add
 --submission-tag`). Pushing a matching tag grades that commit — plain git, no
 CLI required:
@@ -487,11 +487,11 @@ Release title notes *"via phase1"*), so history stays one-immutable-release-
 per-submission and collection, regrade, and the gradebook are unaffected. The
 `submit/*` namespace always keeps working alongside milestone tags.
 
-Because the trigger lives in each student repo's workflow (GitHub evaluates a
+Because the trigger lives in each student repository's workflow (GitHub evaluates a
 workflow's `on:` block before any job runs), **changing the mode or the
-milestone patterns after repos exist requires retrofitting each repo's
+milestone patterns after repositories exist requires retrofitting each repository's
 workflow** — see
-[Changing the trigger on existing repos](#changing-the-trigger-on-existing-repos).
+[Changing the trigger on existing repositories](#changing-the-trigger-on-existing-repositories).
 
 <details>
 <summary>Why the acceptance commit is skipped</summary>
@@ -508,9 +508,9 @@ always stacks a fresh commit, so it's never mistaken for the acceptance.
 <details>
 <summary>Tag-mode defenses in the runner</summary>
 
-Two guards keep tag mode honest even when a repo's workflow trigger is stale:
+Two guards keep tag mode honest even when a repository's workflow trigger is stale:
 
-- **Stale-trigger suppression** — a repo accepted before the mode flipped to
+- **Stale-trigger suppression** — a repository accepted before the mode flipped to
   `tag` (or whose retrofit failed) still carries the every-push trigger. The
   runner reads `submission_mode` from the published assignments.json at setup
   time and, when the assignment is tag-mode but the run was branch-triggered,
@@ -518,7 +518,7 @@ Two guards keep tag mode honest even when a repo's workflow trigger is stale:
   success status: *"tag-mode assignment — push not graded; run gh student
   submit"*.
 - **Retrofit-commit skip** — the teacher-side trigger update commits with
-  `[skip ci]`, so it fires no workflow. As a backstop (e.g., a client that
+  `[skip ci]`, so it fires no workflow. As a backstop (for example, a client that
   dropped the marker), the runner also recognizes a tip commit touching ONLY
   `.github/workflows/autograde.yaml` and skips it with the status
   *"autograder trigger updated — nothing to grade"*.
@@ -537,20 +537,20 @@ mistake for graded.)
 
 </details>
 
-### Changing the trigger on existing repos
+### Changing the trigger on existing repositories
 
-The autograding workflow is written into each student repo at accept time and
+The autograding workflow is written into each student repository at accept time and
 otherwise never changes, so flipping `submission_mode` on an assignment with
-accepted repos needs a retrofit:
+accepted repositories needs a retrofit:
 
 - **CLI**: `gh teacher assignment submission-mode <org> <classroom> <slug>
   --tag` (or `--every-push`) flips the field AND rewrites the workflow across
-  every student repo (add `--user <login>` for one repo, `--dry-run` to
+  every student repository (add `--user <login>` for one repository, `--dry-run` to
   preview). Requires the `workflow` OAuth scope
   (`gh auth refresh -s workflow`).
 - **Web**: change the trigger on the assignment settings page, then run
   **Update autograding triggers** from the submissions page's actions menu
-  (or per-repo from a row's manage dialog).
+  (or per-repository from a row's manage dialog).
 
 The rewrite is surgical — only the trigger lines change; a workflow a student
 hand-edited is reported and left untouched. **Custom (non-default)
@@ -572,14 +572,14 @@ Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
   setup). See [`gh teacher` reference](gh-teacher#assignment-add).
 - **Per assignment, temporarily** — **Pause autograding** in the submissions
   page's **Actions** menu disables the `autograde.yaml` workflow in every
-  student repo via GitHub's workflow-disable API. No files change, students'
+  student repository through GitHub's workflow-disable API. No files change, students'
   other workflows keep running, and **Resume autograding** re-enables it.
   Available on individual assignments using the built-in autograder (a single
-  repo can also be paused from its row). A student with admin on their own
-  repo can technically re-enable the workflow — a known limitation.
+  repository can also be paused from its row). A student with admin on their own
+  repository can technically re-enable the workflow — a known limitation.
 - **Org-wide** — the organization settings' **Pause autograding for all
   student repositories** toggle narrows the org's Actions policy to the config
-  repo. **This stops all workflows in student repositories**, including any
+  repository. **This stops all workflows in student repositories**, including any
   course CI — prefer the per-assignment pause unless that's what you want.
 
 See also the [FAQ on reducing Actions usage](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage).
@@ -595,9 +595,9 @@ Every graded submission produces the same three records:
 
 | Record | Where | What it shows |
 |---|---|---|
-| **Release** | The student repo, on the `submit/<UTC-timestamp>-<short-sha>` tag | The score, a **per-test PASS/FAIL table**, and the machine-readable `result.json`. This is what **View grade** / **View autograder details** links open — and the only place with the per-test breakdown. |
+| **Release** | The student repository, on the `submit/<UTC-timestamp>-<short-sha>` tag | The score, a **per-test PASS/FAIL table**, and the machine-readable `result.json`. This is what **View grade** / **View autograder details** links open — and the only place with the per-test breakdown. |
 | **Commit status** | The graded commit (`classroom50/autograde`) | success / failure / error at a glance, right on the commit. |
-| **Gradebook row** | `scores.json` in the config repo, after collection | What the submissions page and the CSV exports read: score, submission time, links, late flag, and full attempt history. |
+| **Gradebook row** | `scores.json` in the config repository, after collection | What the submissions page and the CSV exports read: score, submission time, links, late flag, and full attempt history. |
 
 Releases and statuses appear the moment grading finishes. The gradebook lags
 until **collection** runs — nightly, or on demand with **Sync now** on the
@@ -609,12 +609,12 @@ score with links to the repository, the graded **commit**, the Release
 (**View autograder details**), the full **review** diff (starter code → graded
 commit), and the Feedback PR (**Review**).
 
-### Latest score vs. history
+### Latest score versus history
 
 The score on a row — and in the web CSV's summary columns — is the
 **latest submission's** (or a teacher override); in the CLI CSV the latest is
-simply the first line per member. "Latest" follows the
-*submission*, not the commit: if a student deliberately submits an older
+the first line per member. "Latest" follows the *submission*, not the commit:
+if a student deliberately submits an older
 commit (a milestone tag pointing at earlier work, or a regrade), that
 submission's Release becomes the latest. The badge and the gradebook always
 agree because they use the same rule.
@@ -624,11 +624,11 @@ The full history is kept everywhere:
 - **Web** — click a row's submission count to open its details: every attempt,
   newest first, each with its commit link and a per-attempt **View grade**
   Release link.
-- **Student repo** — one immutable Release per attempt, under the repo's
+- **Student repository** — one immutable Release per attempt, under the repository's
   Releases tab (each `submit/*` tag is one graded attempt).
 - **`scores.json`** — each entry's `submissions` array holds every collected
   attempt, newest first.
-- **`gh teacher download`** — writes each repo's `results.json` (all attempts)
+- **`gh teacher download`** — writes each repository's `results.json` (all attempts)
   next to `result.json` (latest), and one CSV line per attempt (see below).
 
 ### Grading a specific commit
@@ -643,15 +643,15 @@ Students sometimes ask you to grade a particular commit, not their latest:
   <sha> && git push origin submit/regrade-me`. That mints a normal graded
   submission at that commit.
 - **Regrade** (per-row, or **Regrade all** in the Actions menu) re-runs each
-  repo's **latest** submission **at its original commit** — useful after
-  fixing a broken test. A never-graded repo is first-graded at its current
+  repository's **latest** submission **at its original commit** — useful after
+  fixing a broken test. A never-graded repository is first-graded at its current
   HEAD instead (a new submission). On a re-run, `datetime` (the submission
   instant) stays fixed so late-marking never changes; `graded_at` records the
   re-run.
 
 ### Who submitted
 
-- `owner` — the repo owner (the `<username>` in the repo name); the identity
+- `owner` — the repository owner (the `<username>` in the repository name); the identity
   scores are keyed by.
 - `submitted_by` — the GitHub account that actually pushed that submission.
   For group work this is how you see who did the pushing even though the score
@@ -662,7 +662,7 @@ Students sometimes ask you to grade a particular commit, not their latest:
 
 ### Group attribution model
 
-A group assignment is graded once, in the founder's repo. `collect-scores`
+A group assignment is graded once, in the founder's repository. `collect-scores`
 credits the shared score to every collaborator **on the classroom team** (the
 owner is always included), recorded as the entry's `member_usernames`.
 
@@ -672,14 +672,14 @@ owner is always included), recorded as the entry's `member_usernames`.
 - **Classmates on the team are mutually trusted.** Collection can't tell how a
   collaborator was added, so a student could credit a teammate who's on the team.
   The team intersection bounds this to classmates — an account off the team is
-  never credited. Review each group repo's collaborators if you need stricter
+  never credited. Review each group repository's collaborators if you need stricter
   control.
-- **Owner-only submissions warn.** If a group submission resolves to just the
+- **Owner-only submissions warn.** If a group submission resolves to only the
   owner, collection emits a `::warning::` so the "team submission scored as solo"
   case is visible.
 - **`submitted_by` records the pusher**, so you can see who did the work even
   though the score is shared.
-- **Rows are keyed by the repo owner**, so re-collecting a group repo whose
+- **Rows are keyed by the repository owner**, so re-collecting a group repository whose
   members changed updates the same row in place.
 
 ### Score exports
@@ -706,7 +706,7 @@ sorted by last name, with the latest submission's data:
 #### CLI: `gh teacher download`
 
 `gh teacher download <org> <classroom> <assignment>` clones every student
-repo and writes a `scores.csv` at the destination root — **one line per
+repository and writes a `scores.csv` at the destination root — **one line per
 submission** (a student with several attempts contributes several lines,
 newest first), plus one blank-score line per non-submitter:
 
@@ -723,16 +723,16 @@ newest first), plus one blank-score line per non-submitter:
 | `override` | `true` when a teacher override is in effect for the entry. |
 
 Per-test breakdowns aren't in either CSV — they're in each attempt's Release
-(and in the per-repo `result.json` / `results.json` files the download also
+(and in the per-repository `result.json` / `results.json` files the download also
 refreshes).
 
 #### Raw JSON
 
-- `<classroom>/scores.json` in your config repo is the authoritative gradebook
+- `<classroom>/scores.json` in your config repository is the authoritative gradebook
   (see [scores.json shape](#the-resultjson-contract) below) — build any custom
   report from it.
 - `gh teacher download` leaves `result.json` (latest attempt) and
-  `results.json` (all attempts, newest first) in each cloned repo, including
+  `results.json` (all attempts, newest first) in each cloned repository, including
   the per-test arrays.
 
 ## The `result.json` contract
@@ -766,9 +766,9 @@ reads `result.json` from the workspace after the autograder exits.
 | Field | Type | Notes |
 |---|---|---|
 | `schema` | string | Exactly `classroom50/result/v1`. |
-| `classroom` / `assignment` | string | Must match the source repo's identity (checked in code alongside `owner`). |
+| `classroom` / `assignment` | string | Must match the source repository's identity (checked in code alongside `owner`). |
 | `assignment_type` | string | `individual` or `group`, stamped by the runner. |
-| `owner` | string | The repo owner login — the identity anchor. |
+| `owner` | string | The repository owner login — the identity anchor. |
 | `submission` | string | The submit-tag name. |
 | `commit` / `release` / `review` | string | URLs. `review` is the full diff from starter code to the graded commit. |
 | `datetime` | string | The **submission instant**: the graded commit's committer date (UTC ISO 8601). Invariant across regrades, so late-marking never changes on a re-run. |
@@ -778,7 +778,7 @@ reads `result.json` from the workspace after the autograder exits.
 | `submitted_by` | object | Optional. Who pushed: `username`, and `id` (which may be null or absent). |
 
 `collect-scores` validates this before merging into `scores.json`. A payload
-whose identity (classroom/assignment/`owner`) doesn't match the source repo is
+whose identity (classroom/assignment/`owner`) doesn't match the source repository is
 rejected, and a mismatched `assignment_type` is warned-and-skipped, so a hostile
 payload can't land in another student's gradebook.
 
@@ -787,7 +787,7 @@ payload can't land in another student's gradebook.
 
 The gradebook is keyed by assignment slug under a root `assignments` object;
 each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is
-one repo's record: `owner` (the stable key), `submissions` (full history, newest
+one repository's record: `owner` (the stable key), `submissions` (full history, newest
 first), and — for a group — `member_usernames` (credited members). Each bucket
 also carries a `collected_at` UTC timestamp stamped whenever a collection run
 walks that assignment (even if nothing changed), so per-assignment freshness is
@@ -799,7 +799,7 @@ knowable — the web app's "Submission data synced" strip reads it.
 
 The Feedback PR is **on by default** for assignments created with `gh teacher
 assignment add` (`--feedback-pr=false` to disable). When on, there is
-**one long-lived "Feedback" pull request per student repo** so you review
+**one long-lived "Feedback" pull request per student repository** so you review
 cumulative work with inline comments alongside the scored Release.
 
 - **Base = a frozen branch.** Accept creates a `feedback` branch at the
@@ -807,7 +807,7 @@ cumulative work with inline comments alongside the scored Release.
   `base = feedback`, `head = default branch`, so it always shows the full
   starter→latest diff.
 - **Opens at accept**, so it is there before the first submission and exists even
-  when GitHub Actions is disabled for student repos. The diff still starts at the
+  when GitHub Actions is disabled for student repositories. The diff still starts at the
   baseline, so the setup files never appear in it.
 - **One PR, reused** across submissions, labeled **Individual Assignment** or
   **Group Assignment**. A student closing it reopens it; a teacher merge is left
@@ -822,7 +822,7 @@ cumulative work with inline comments alongside the scored Release.
   missing, empty, oversized, or unreadable file falls back to the built-in body
   and never blocks the PR. Keeping the template's contents correct is up to you.
 - **The runner adopts it** by base+head and maintains it from then on. If accept
-  could not open it (a permissions oddity, or a repo accepted before this
+  could not open it (a permissions oddity, or a repository accepted before this
   feature), the runner opens it on the first submission instead, and
   re-accepting also retries, which is the only route with Actions off. On that
   fallback open the runner honors the template too, best-effort: its Actions
@@ -846,7 +846,7 @@ Actions to create and approve pull requests" must be on, and two org rulesets
 protect submission history and the frozen `feedback` branch. If you enable
 feedback on an org set up before this feature, **re-run `gh teacher init`**.
 
-**Student repos accepted before this feature** use an older workflow and must
+**Student repositories accepted before this feature** use an older workflow and must
 be re-created (delete + re-accept) to pick up the new one.
 
 </details>
@@ -877,13 +877,14 @@ gh teacher assignment add cs50-fall-2026 cs-principles hello \
 > Control files (`.classroom50.yaml`, `.github/`) are always kept.
 >
 > **It fails open** and is a grading-scope/hygiene tool, **not** a security
-> boundary: a student who forces a git failure (or just `git push`es) gets the
+> boundary: a student who forces a git failure (or pushes directly with
+> `git push`) gets the
 > unfiltered tree graded. Never use it to hide an answer key. Removals are logged
 > in the release body ("Removed N file(s)").
 
 ## Attaching files to submission Releases
 
-Attach generated PDFs, plots, or logs to each submission's Release via the web
+Attach generated PDFs, plots, or logs to each submission's Release with the web
 form's **Submission release files**, or the `release_assets` field:
 
 ```json
@@ -913,9 +914,9 @@ uploads warn without changing the score.
 | Grading logic for one assignment | `<classroom>/autograders/<slug>/autograder.py` | Next submission |
 | Grading logic for a classroom | `<classroom>/autograder.py` (`autograder set-default`) | Next submission |
 | Runtime for one assignment | `runtime` block on the entry | Next submission |
-| Files attached to Releases | `release_assets` (usually via the web form) | Next submission or regrade |
+| Files attached to Releases | `release_assets` (usually in the web form) | Next submission or regrade |
 
-All layers live in the config repo; none require a student-repo change. Edit
+All layers live in the config repository; none require a student-repository change. Edit
 `autograde-runner.yaml` only to add a toolchain GitHub has no setup action for,
 or to replace the runner bootstrap.
 
@@ -941,7 +942,7 @@ A failure that stops the reusable workflow from loading doesn't appear in
 
 Students never configure tokens or secrets. Grading runs on the job-scoped
 `GITHUB_TOKEN`, unauthenticated Pages fetches, and reusable-workflow access
-between the student repo and the config repo (both in the teacher's org,
+between the student repository and the config repository (both in the teacher's org,
 configured by `init`). The only PAT in the system is the teacher-side
 `CLASSROOM50_SERVICE_TOKEN`, used only by `collect-scores.yaml`.
 
@@ -978,7 +979,7 @@ workflow you control, so your grading logic runs in place of the runner.
 
 **Set one up:**
 
-1. **Add the reusable workflow** to your config repo under `.github/workflows/`,
+1. **Add the reusable workflow** to your config repository under `.github/workflows/`,
    with a name other than the reserved `autograde-runner.yaml`. It must be
    [callable](https://docs.github.com/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow)
    (`on: workflow_call`). Non-reserved names are never touched by Classroom 50.
@@ -1002,13 +1003,13 @@ This is the intended path for keeping an `autograding.json`-driven workflow afte
 [`tests` block](#declarative-tests) instead — but a custom runner workflow lets
 you keep your existing format:
 
-1. Put your grading action's workflow in the config repo's `.github/workflows/`
+1. Put your grading action's workflow in the config repository's `.github/workflows/`
    (any non-reserved name). Have it read `autograding.json` from the student
-   repo as before.
+   repository as before.
 2. Point a caller workflow at it as above, and register assignments with
    `--autograder <name>`.
 3. Ship `autograding.json` (and any fixtures) in the **assignment template**, not
-   the config repo — it travels with each student's starter code.
+   the config repository — it travels with each student's starter code.
 
 > [!WARNING]
 > The template must **not** contain `.github/workflows/autograde.yaml`; that

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -133,8 +133,9 @@ shape `assignment test list --json` emits:
 | `points` | Required, 0–1000. A 0-point test does not affect the numeric score; a failure still sets the autograde status to `failure`. |
 
 At most 100 tests per assignment. Put large fixtures in files
-(`input-file` / `expected-file`) under `<classroom>/autograders/<slug>/`, not
-inline.
+(`input-file` / `expected-file`) under `CLASSROOM/autograders/ASSIGNMENT/`, not
+inline. In paths and commands on this page, replace `CLASSROOM` with the
+classroom's short name and `ASSIGNMENT` with the assignment slug.
 
 ### Setup commands, dependencies, and environment variables
 
@@ -208,13 +209,13 @@ workflow at submission setup, and by `runner.py` before executing.
 <summary>Writing a valid assignments.json from another client (such as a GUI)</summary>
 
 Anything that writes a valid `assignments.json` gets the whole pipeline for
-free. A non-CLI client should:
+free. A non-CLI client must:
 
 1. Validate against
    [`schemas/assignments-v1.schema.json`](https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json)
    (two rules it can't express: unique test names, and name length ≤ 100 UTF-8
    *bytes*).
-2. Probe before writing tests: `<classroom>/autograders/<slug>/autograder.py`
+2. Probe before writing tests: `CLASSROOM/autograders/ASSIGNMENT/autograder.py`
    must NOT exist, and `.github/scripts/materialize_tests.py` MUST exist.
 3. Write with the git-data API and retry on a non-fast-forward rejection.
 
@@ -230,9 +231,9 @@ two scopes:
 
 | Path | Scope | Used when |
 |---|---|---|
-| `<classroom>/autograders/<slug>/autograder.py` | One assignment | Present in the bundle. |
-| `<classroom>/autograders/<slug>/tests.json` | One assignment | [Declarative tests](#declarative-tests); no per-assignment `autograder.py`. |
-| `<classroom>/autograder.py` | One classroom | Neither of the above exists. |
+| `CLASSROOM/autograders/ASSIGNMENT/autograder.py` | One assignment | Present in the bundle. |
+| `CLASSROOM/autograders/ASSIGNMENT/tests.json` | One assignment | [Declarative tests](#declarative-tests); no per-assignment `autograder.py`. |
+| `CLASSROOM/autograder.py` | One classroom | Neither of the above exists. |
 
 If none exist, the runner emits a vacuous pass (score 0/0) and the submission
 still lands as a tagged Release — a valid mid-setup state.
@@ -241,10 +242,10 @@ still lands as a tagged Release — a valid mid-setup state.
 
 `runner.py` resolves the grading entrypoint in this order:
 
-1. Per-assignment `<classroom>/autograders/<slug>/autograder.py` (an override
+1. Per-assignment `CLASSROOM/autograders/ASSIGNMENT/autograder.py` (an override
    always wins).
 2. Per-assignment `tests.json` (declarative tests).
-3. Classroom default `<classroom>/autograder.py`.
+3. Classroom default `CLASSROOM/autograder.py`.
 4. None of the above → vacuous pass.
 
 To keep precedence from silently swallowing tests, the CLI refuses `assignment
@@ -259,7 +260,7 @@ The runner provides:
   `RELEASE_URL`, `REVIEW_URL`, and all standard `GITHUB_*`.
 - **Working directory:** the student's checkout (relative paths resolve to
   student code).
-- **Sibling files:** anything else under `<classroom>/autograders/<slug>/` is
+- **Sibling files:** anything else under `CLASSROOM/autograders/ASSIGNMENT/` is
   bundled and lives at `Path(__file__).parent`.
 
 The autograder must produce **`./result.json`** (required — see
@@ -272,7 +273,7 @@ and the runner synthesizes a `status=error` result.
 <details>
 <summary>Template: pytest</summary>
 
-Drop at `<classroom>/autograders/<slug>/autograder.py` alongside your `test_*.py`
+Drop at `CLASSROOM/autograders/ASSIGNMENT/autograder.py` alongside your `test_*.py`
 files:
 
 ```python
@@ -375,7 +376,7 @@ Path("result.json").write_text(json.dumps(result, indent=2))
 
 #### Classroom default
 
-`gh teacher autograder set-default <org> <classroom> --from <path>` installs a
+`gh teacher autograder set-default ORG CLASSROOM --from PATH` installs a
 default that grades every assignment without its own autograder or tests. With no
 `--from`, it installs a diagnostic stub (echoes the environment, emits a vacuous
 pass) — useful for verifying the pipeline. Inspect it with `autograder show`, and
@@ -414,7 +415,7 @@ the image owns the toolchain unless you set `python` explicitly.
 <details>
 <summary>Custom and self-hosted runners</summary>
 
-`runs-on` works exactly as in any Actions workflow. Multiple labels are AND-ed; a
+`runs-on` works exactly as in any GitHub Actions workflow. Multiple labels are AND-ed; a
 misspelled label won't match a runner. A `container` needs a Linux
 `runs-on`.
 
@@ -458,7 +459,7 @@ assignment add --submission-mode` / `gh teacher assignment submission-mode`):
 - **Push of a `submit/*` tag** — manual tag pushes work too.
 
 **`tag`** — grading triggers **only** on `submit/*` tag pushes. A plain
-`git push` runs nothing and costs no Actions minutes — the cost lever for
+`git push` runs nothing and costs no GitHub Actions minutes — the cost lever for
 large cohorts. Submissions become an explicit act:
 
 - `gh student submit` pushes a `submit/<UTC-timestamp>-<short-sha>` tag after
@@ -543,9 +544,9 @@ The autograding workflow is written into each student repository at accept time 
 otherwise never changes, so flipping `submission_mode` on an assignment with
 accepted repositories needs a retrofit:
 
-- **CLI**: `gh teacher assignment submission-mode <org> <classroom> <slug>
+- **CLI**: `gh teacher assignment submission-mode ORG CLASSROOM ASSIGNMENT
   --tag` (or `--every-push`) flips the field AND rewrites the workflow across
-  every student repository (add `--user <login>` for one repository, `--dry-run` to
+  every student repository (add `--user USERNAME` for one repository, `--dry-run` to
   preview). Requires the `workflow` OAuth scope
   (`gh auth refresh -s workflow`).
 - **Web**: change the trigger on the assignment settings page, then run
@@ -558,7 +559,7 @@ autograders are never rewritten**: you own their `on:` block; edit it
 yourself and use `--update-shims=false` to flip only the field.
 
 After a retrofit, students must `git pull` — clones made before the change
-will conflict on their next push.
+conflict on their next push.
 
 ### Turning autograding off or pausing it
 
@@ -578,11 +579,11 @@ Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
   repository can also be paused from its row). A student with admin on their own
   repository can technically re-enable the workflow — a known limitation.
 - **Org-wide** — the organization settings' **Pause autograding for all
-  student repositories** toggle narrows the org's Actions policy to the config
+  student repositories** toggle narrows the organization's GitHub Actions policy to the config
   repository. **This stops all workflows in student repositories**, including any
   course CI — prefer the per-assignment pause unless that's what you want.
 
-See also the [FAQ on reducing Actions usage](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage).
+See also the [FAQ on reducing GitHub Actions usage](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage).
 
 ## Reading results
 
@@ -640,9 +641,9 @@ Students sometimes ask you to grade a particular commit, not their latest:
   as graded.
 - **To grade an arbitrary commit**, have the student push a `submit/*` tag (or
   a configured milestone tag) pointing at it: `git tag submit/regrade-me
-  <sha> && git push origin submit/regrade-me`. That mints a normal graded
+  SHA && git push origin submit/regrade-me`. That mints a normal graded
   submission at that commit.
-- **Regrade** (per-row, or **Regrade all** in the Actions menu) re-runs each
+- **Regrade** (per-row, or **Regrade all** in the **Actions** menu) re-runs each
   repository's **latest** submission **at its original commit** — useful after
   fixing a broken test. A never-graded repository is first-graded at its current
   HEAD instead (a new submission). On a re-run, `datetime` (the submission
@@ -651,7 +652,7 @@ Students sometimes ask you to grade a particular commit, not their latest:
 
 ### Who submitted
 
-- `owner` — the repository owner (the `<username>` in the repository name); the identity
+- `owner` — the repository owner (the `USERNAME` in the repository name); the identity
   scores are keyed by.
 - `submitted_by` — the GitHub account that actually pushed that submission.
   For group work this is how you see who did the pushing even though the score
@@ -690,7 +691,7 @@ anything custom.
 #### Web: Download scores (CSV)
 
 **Download scores (CSV)** on the submissions page saves
-`<classroom>-<assignment>-scores.csv` — **one row per student (or group)**,
+`CLASSROOM-ASSIGNMENT-scores.csv` — **one row per student (or group)**,
 sorted by last name, with the latest submission's data:
 
 | Column | Description |
@@ -705,7 +706,7 @@ sorted by last name, with the latest submission's data:
 
 #### CLI: `gh teacher download`
 
-`gh teacher download <org> <classroom> <assignment>` clones every student
+`gh teacher download ORG CLASSROOM ASSIGNMENT` clones every student
 repository and writes a `scores.csv` at the destination root — **one line per
 submission** (a student with several attempts contributes several lines,
 newest first), plus one blank-score line per non-submitter:
@@ -728,7 +729,7 @@ refreshes).
 
 #### Raw JSON
 
-- `<classroom>/scores.json` in your config repository is the authoritative gradebook
+- `CLASSROOM/scores.json` in your config repository is the authoritative gradebook
   (see [scores.json shape](#the-resultjson-contract) below) — build any custom
   report from it.
 - `gh teacher download` leaves `result.json` (latest attempt) and
@@ -749,9 +750,9 @@ reads `result.json` from the workspace after the autograder exits.
   "assignment_type": "individual",
   "owner":           "alice",
   "submission":      "submit/2026-06-01T14-32-05Z-a1b2c3d",
-  "commit":          "https://github.com/.../commit/<sha>",
+  "commit":          "https://github.com/.../commit/SHA",
   "release":         "https://github.com/.../releases/tag/submit%2F...",
-  "review":          "https://github.com/.../compare/<baseline-sha>...<sha>",
+  "review":          "https://github.com/.../compare/BASELINE-SHA...SHA",
   "datetime":        "2026-06-01T14:32:01Z",
   "graded_at":       "2026-06-01T14:33:11Z",
   "score":           4,
@@ -824,8 +825,8 @@ cumulative work with inline comments alongside the scored Release.
 - **The runner adopts it** by base+head and maintains it from then on. If accept
   could not open it (a permissions oddity, or a repository accepted before this
   feature), the runner opens it on the first submission instead, and
-  re-accepting also retries, which is the only route with Actions off. On that
-  fallback open the runner honors the template too, best-effort: its Actions
+  re-accepting also retries, which is the only route with GitHub Actions off. On that
+  fallback open the runner honors the template too, best-effort: its GitHub Actions
   token cannot always read a private or external template, so it uses the
   built-in body and logs a warning when it has to.
 
@@ -836,15 +837,15 @@ Both accept and the runner resolve the baseline as **the commit that introduced
 `.classroom50.yaml`** (a structural marker, not a commit subject) so they agree
 on where the base is frozen. The runner refuses to open or update the PR when
 the `feedback` branch sits at any other commit, since a student can create that
-branch themselves; an org admin deleting it lets the next submission re-freeze
+branch themselves; an organization administrator deleting it lets the next submission re-freeze
 it correctly. If no marker commit is found, the runner opens the PR against the
 root commit and **warns** that the baseline is untrusted; if no baseline resolves
 at all, it **skips** with a warning.
 
-**Prerequisites (handled by `gh teacher init`):** the org setting "Allow GitHub
-Actions to create and approve pull requests" must be on, and two org rulesets
+**Prerequisites (handled by `gh teacher init`):** the organization setting "Allow GitHub
+Actions to create and approve pull requests" must be on, and two organization rulesets
 protect submission history and the frozen `feedback` branch. If you enable
-feedback on an org set up before this feature, **re-run `gh teacher init`**.
+feedback on an organization set up before this feature, **re-run `gh teacher init`**.
 
 **Student repositories accepted before this feature** use an older workflow and must
 be re-created (delete + re-accept) to pick up the new one.
@@ -902,7 +903,7 @@ uploads warn without changing the score.
 
 > [!NOTE]
 > Submission publishing doesn't support GitHub Immutable Releases (reruns edit
-> the Release in place). To roll this out to an existing org, run `gh teacher
+> the Release in place). To roll this out to an existing organization, run `gh teacher
 > init`, approve the workflow-files refresh, and wait for `publish-pages` to
 > finish.
 
@@ -911,8 +912,8 @@ uploads warn without changing the score.
 | To change… | Edit… | Propagates on… |
 |---|---|---|
 | Simple checks, no code | `tests` block (`assignment test add` / `--tests`) | Next Pages publish, then next submission |
-| Grading logic for one assignment | `<classroom>/autograders/<slug>/autograder.py` | Next submission |
-| Grading logic for a classroom | `<classroom>/autograder.py` (`autograder set-default`) | Next submission |
+| Grading logic for one assignment | `CLASSROOM/autograders/ASSIGNMENT/autograder.py` | Next submission |
+| Grading logic for a classroom | `CLASSROOM/autograder.py` (`autograder set-default`) | Next submission |
 | Runtime for one assignment | `runtime` block on the entry | Next submission |
 | Files attached to Releases | `release_assets` (usually in the web form) | Next submission or regrade |
 
@@ -942,7 +943,7 @@ A failure that stops the reusable workflow from loading doesn't appear in
 
 Students never configure tokens or secrets. Grading runs on the job-scoped
 `GITHUB_TOKEN`, unauthenticated Pages fetches, and reusable-workflow access
-between the student repository and the config repository (both in the teacher's org,
+between the student repository and the config repository (both in the teacher's organization,
 configured by `init`). The only PAT in the system is the teacher-side
 `CLASSROOM50_SERVICE_TOKEN`, used only by `collect-scores.yaml`.
 
@@ -955,7 +956,7 @@ configured by `init`). The only PAT in the system is the teacher-side
   pushes in ten minutes produce five graded runs and five Releases.
 - **Immutable-release rulesets freeze regrade Releases.** Orgs enforcing
   immutable releases (a GitHub ruleset) cannot refresh a submission's Release
-  on regrade; the regraded score appears in the commit status and the Actions
+  on regrade; the regraded score appears in the commit status and the GitHub Actions
   job summary, but the Release — and thus the collected gradebook score for
   that submission — keeps the pre-regrade result.
 - **Pages CDN lag:** updated content can take ~10 minutes to serve, so a
@@ -967,13 +968,13 @@ configured by `init`). The only PAT in the system is the teacher-side
 Every earlier layer changes *what* grading does while keeping the built-in
 runner. When you need a different grading *pipeline* entirely — a
 [reusable workflow](https://docs.github.com/actions/using-workflows/reusing-workflows)
-you author yourself — `--autograder <name>` swaps the caller workflow instead of
+you author yourself — `--autograder NAME` swaps the caller workflow instead of
 the autograder script. Most teachers never need this.
 
 **How the swap works.** By default `gh student accept` writes a small caller
 workflow to `.github/workflows/autograde.yaml` whose `uses:` points at the
-built-in `autograde-runner.yaml`. With `--autograder <name>`, accept instead
-fetches your caller from `<classroom>/autograders/<name>.yaml` and writes it
+built-in `autograde-runner.yaml`. With `--autograder NAME`, accept instead
+fetches your caller from `CLASSROOM/autograders/NAME.yaml` and writes it
 verbatim. Your caller owns its own `on:` triggers and `uses:` a reusable
 workflow you control, so your grading logic runs in place of the runner.
 
@@ -983,12 +984,12 @@ workflow you control, so your grading logic runs in place of the runner.
    with a name other than the reserved `autograde-runner.yaml`. It must be
    [callable](https://docs.github.com/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow)
    (`on: workflow_call`). Non-reserved names are never touched by Classroom 50.
-2. **Add a caller workflow** at `<classroom>/autograders/<name>.yaml`. Give it
+2. **Add a caller workflow** at `CLASSROOM/autograders/NAME.yaml`. Give it
    your trigger events and a `jobs.<id>.uses:` pointing at the workflow from
-   step 1. Because it's written verbatim, template `<org>`/branch refs to your
+   step 1. Because it's written verbatim, template `ORG`/branch refs to your
    own values rather than relying on the built-in caller's substitution.
-3. **Register the assignment** with `gh teacher assignment add <org> <classroom>
-   <slug> --autograder <name>`.
+3. **Register the assignment** with `gh teacher assignment add ORG CLASSROOM
+   ASSIGNMENT --autograder NAME`.
 
 > [!NOTE]
 > Once an assignment uses a custom autograder, `gh teacher assignment
@@ -1007,7 +1008,7 @@ you keep your existing format:
    (any non-reserved name). Have it read `autograding.json` from the student
    repository as before.
 2. Point a caller workflow at it as above, and register assignments with
-   `--autograder <name>`.
+   `--autograder NAME`.
 3. Ship `autograding.json` (and any fixtures) in the **assignment template**, not
    the config repository — it travels with each student's starter code.
 

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -9,22 +9,22 @@ page and export as CSV.**
 
 The whole pipeline, end to end:
 
-1. **You describe the grading** on the assignment — usually
+1. You define tests on the assignment — usually
    [declarative tests](#declarative-tests) (input/output checks, run commands,
    or pytest), written in the web form or with `gh teacher assignment test add`.
-2. **A student submits** — by pushing to their repository, or explicitly with
+2. A student submits by pushing to their repository, or explicitly with
    `gh student submit`, depending on the assignment's
    [submission type](#which-commits-grade).
-3. **GitHub Actions grades the submission** in the student's own repository:
+3. GitHub Actions grades the submission in the student's own repository:
    a small workflow calls the shared **autograde runner**, which fetches your
    grading config and runs the tests against the submitted commit.
-4. **The result is published on the student's repository** as a GitHub
+4. The runner publishes the result on the student's repository as a GitHub
    **Release** on a `submit/<UTC-timestamp>-<short-sha>` tag — the score, a
    per-test PASS/FAIL table, and a machine-readable `result.json`. The graded
    commit also gets a `classroom50/autograde` commit status, and the student's
    **View grade** link opens the Release.
-5. **Scores are collected into the gradebook** (`scores.json` in your config
-   repository) by the **score-collection** workflow — nightly, or on demand with
+5. The **score-collection** workflow collects scores into the gradebook
+   (`scores.json` in your config repository) — nightly, or on demand with
    **Sync now** on the submissions page. That's what the web app's submissions
    page and both CSV exports read. See [Reading results](#reading-results).
 
@@ -803,17 +803,17 @@ assignment add` (`--feedback-pr=false` to disable). When on, there is
 **one long-lived "Feedback" pull request per student repository** so you review
 cumulative work with inline comments alongside the scored Release.
 
-- **Base = a frozen branch.** Accept creates a `feedback` branch at the
-  student's baseline commit (the accept commit) and never advances it. The PR is
-  `base = feedback`, `head = default branch`, so it always shows the full
-  starter→latest diff.
-- **Opens at accept**, so it is there before the first submission and exists even
+- **Frozen base branch.** Accept creates a `feedback` branch at the
+  student's baseline commit (the accept commit) and never advances it. The PR's
+  base is `feedback` and its head is the default branch, so it always shows the
+  full starter→latest diff.
+- **Opened at accept.** The PR is there before the first submission and exists even
   when GitHub Actions is disabled for student repositories. The diff still starts at the
   baseline, so the setup files never appear in it.
 - **One PR, reused** across submissions, labeled **Individual Assignment** or
   **Group Assignment**. A student closing it reopens it; a teacher merge is left
   alone.
-- **The body** is Classroom 50's built-in "here is where your teacher leaves
+- **Default body.** The PR opens with Classroom 50's built-in "here is where your teacher leaves
   feedback" text by default. Set `feedback_pr_template: true` (or check the box
   on the web form) to use the template repository's own pull request template as
   the body instead. Accept reads the first existing of
@@ -822,7 +822,8 @@ cumulative work with inline comments alongside the scored Release.
   requires a template and the Feedback PR itself. The read is best-effort: a
   missing, empty, oversized, or unreadable file falls back to the built-in body
   and never blocks the PR. Keeping the template's contents correct is up to you.
-- **The runner adopts it** by base+head and maintains it from then on. If accept
+- **Maintained by the runner.** The runner adopts the PR by base and head and
+  maintains it from then on. If accept
   could not open it (a permissions oddity, or a repository accepted before this
   feature), the runner opens it on the first submission instead, and
   re-accepting also retries, which is the only route with GitHub Actions off. On that

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -485,7 +485,7 @@ the `schedule:` block in `.github/workflows/collect-scores.yaml`.
 that repo's collaborators, keeps those on the classroom team, and credits each
 with the same score. See [Autograders](Autograders#group-attribution-model) for
 the full attribution model — and
-[Autograders → Reading results](Autograders#reading-results) for where every
+[Reading results](Autograders#reading-results) in Autograders for where every
 result lives, per-test breakdowns, and past attempts.
 
 ## 10. Download submissions
@@ -508,7 +508,7 @@ submission** (a student with several pushes contributes several lines), plus a
 blank-score line for each non-submitter, so you can sort by
 score to see who hasn't submitted. The column-by-column reference for
 `scores.csv` (and the per-repository `result.json` / `results.json` files) is in
-[Autograders → Score exports](Autograders#score-exports).
+[Score exports](Autograders#score-exports) in Autograders.
 
 Each run creates a fresh timestamped folder. Override the destination with `-d`:
 

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -359,7 +359,7 @@ shim). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | `--max-group-size <N>` | Max collaborators on a group repo (2–100). Advisory, not hard-enforced. |
 | `--runtime <path>` | JSON describing the autograde environment (`runs-on`, language versions, `apt`, or a `container`). Omit for ubuntu-latest + Python 3.14. See [Autograders](Autograders). |
 | `--autograder <name>` | Reserved for swapping the whole reusable workflow (rare). Use `--runtime` for language toolchains. |
-| `--submission-mode every-push\|tag` | When the autograder fires. `every-push` (default) grades every push; `tag` grades only on explicit submits (`gh student submit`, or a hand-pushed `submit/*` tag) — regular pushes cost no Actions minutes, the cost lever for large classes. |
+| `--submission-mode every-push\|tag` | When the autograder fires. `every-push` (default) grades every push; `tag` grades only on explicit submits (`gh student submit`, or a hand-pushed `submit/*` tag) — regular pushes cost no Actions minutes, the cost lever for large classrooms. |
 | `--submission-tag <pattern>` | Milestone tag (repeatable) that also triggers grading — e.g. `--submission-tag phase1 --submission-tag phase2`. Students grade a milestone with plain git: `git tag phase1 && git push origin phase1`. Works with either mode; the graded record still appears as a `submit/*` release. |
 
 > [!NOTE]
@@ -423,7 +423,7 @@ gh teacher member list <org>/<repo>  # repo collaborators
 Every submission publishes a GitHub Release carrying a `result.json`. The
 `collect-scores` workflow walks each `(member, assignment)` pair in scope,
 collects each repo's submissions, and aggregates them into
-`<classroom>/scores.json` — the class's authoritative gradebook. By default the
+`<classroom>/scores.json` — the classroom's authoritative gradebook. By default the
 scope is every classroom and every assignment; you can narrow it to one
 classroom, or to a single assignment (see below). Members are the union of the
 student team and the staff teams (teacher/hta/ta), so a staff member who

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -72,9 +72,10 @@ gh teacher init <org>
 ```
 
 `init` is **idempotent** — re-running picks up where a prior run left off. It
-also offers to refresh skeleton files when the CLI ships newer versions (this is
-how an existing organization gains new features); it asks before overwriting, so
-your edits are safe. Use `--yes` to skip the prompt in scripts.
+also offers to refresh the **skeleton files** — the workflow and script files
+Classroom 50 commits to the config repo — when the CLI ships newer versions
+(this is how an existing organization gains new features); it asks before
+overwriting, so your edits are safe. Use `--yes` to skip the prompt in scripts.
 
 **Useful flags:**
 
@@ -483,7 +484,9 @@ the `schedule:` block in `.github/workflows/collect-scores.yaml`.
 **Group assignments** are graded once, in the founder's repo. Collection reads
 that repo's collaborators, keeps those on the classroom team, and credits each
 with the same score. See [Autograders](Autograders#group-attribution-model) for
-the full attribution model.
+the full attribution model — and
+[Autograders → Reading results](Autograders#reading-results) for where every
+result lives, per-test breakdowns, and past attempts.
 
 ## 10. Download submissions
 
@@ -503,7 +506,9 @@ for each one probes for the expected repo, clones it (or reports `Missing:
 It then writes a `scores.csv` at the destination root, **one line per
 submission** (a student with several pushes contributes several lines), plus a
 blank-score line for each non-submitter, so you can sort by
-score to see who hasn't submitted.
+score to see who hasn't submitted. The column-by-column reference for
+`scores.csv` (and the per-repo `result.json` / `results.json` files) is in
+[Autograders → Score exports](Autograders#score-exports).
 
 Each run creates a fresh timestamped folder. Override the destination with `-d`:
 

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -73,7 +73,7 @@ gh teacher init <org>
 
 `init` is **idempotent** — re-running picks up where a prior run left off. It
 also offers to refresh the **skeleton files** — the workflow and script files
-Classroom 50 commits to the config repo — when the CLI ships newer versions
+Classroom 50 commits to the config repository — when the CLI ships newer versions
 (this is how an existing organization gains new features); it asks before
 overwriting, so your edits are safe. Use `--yes` to skip the prompt in scripts.
 
@@ -507,7 +507,7 @@ It then writes a `scores.csv` at the destination root, **one line per
 submission** (a student with several pushes contributes several lines), plus a
 blank-score line for each non-submitter, so you can sort by
 score to see who hasn't submitted. The column-by-column reference for
-`scores.csv` (and the per-repo `result.json` / `results.json` files) is in
+`scores.csv` (and the per-repository `result.json` / `results.json` files) is in
 [Autograders → Score exports](Autograders#score-exports).
 
 Each run creates a fresh timestamped folder. Override the destination with `-d`:

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -333,7 +333,10 @@ Yes. `gh teacher classroom migrate` imports a GitHub Classroom into your
 `classroom50` config repo — it copies each starter repo into your organization
 as a fresh template and recreates the assignments. Rosters, scores, and past
 student repositories are **not** migrated; you re-onboard students for the new
-term. See [`gh teacher classroom migrate`](gh-teacher#classroom-migrate).
+term. See [`gh teacher classroom migrate`](gh-teacher#classroom-migrate), and
+[Coming from GitHub Classroom?](Glossary#coming-from-github-classroom) for how
+GitHub Classroom's vocabulary (cutoff date, Download grades, roster
+identifiers, teams) maps onto Classroom 50's.
 
 ### Will my existing scripts that manipulate student repos still work?
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -133,20 +133,21 @@ file in alone does nothing until you enable this option. If the file is missing
 or can't be read, the built-in body is used. It's set in the web app; there is
 no `gh teacher` flag for it.
 
-### Can I set a deadline with a specific time, not just a date?
+### Can I set a due date with a specific time, not just a date?
 
-Yes. Deadlines support a date **and** time (down to the second, in your
-timezone). Submissions after the deadline are **marked late**; nothing is
+Yes. Due dates support a date **and** time (down to the second, in your
+timezone). Submissions after the due date are **marked late**; nothing is
 blocked automatically.
 
-### Does the deadline cut off student access?
+### Does the due date cut off student access?
 
-No — the due date only marks later submissions late. To actually end an
-assignment, use **Close submission** in the submissions page's **Actions**
-menu: it blocks new accepts and sets every student's repository to read-only
-(work is preserved). **Reopen submission** restores write access — useful when
-a project continues in a follow-up course. **Update student repo access** in
-the same menu gives finer control over the role students hold on their repos.
+No — there is no cutoff date; the due date only marks later submissions late.
+To actually end an assignment, use **Close submission** in the submissions
+page's **Actions** menu: it blocks new accepts and sets every student's
+repository to read-only (work is preserved). **Reopen submission** restores
+write access — useful when a project continues in a follow-up course. **Update
+student repo access** in the same menu gives finer control over the role
+students hold on their repos.
 
 ### What's the difference between "template-less" and "empty repository"?
 
@@ -248,9 +249,9 @@ assignment repository in Codespaces like any other repo. Classroom 50 doesn't
 manage Codespaces itself — any education Codespaces benefit is handled on
 GitHub's side.
 
-## Grades and submissions
+## Scores and submissions
 
-### A student submitted, but I don't see a grade. Why?
+### A student submitted, but I don't see a score. Why?
 
 A few common reasons:
 
@@ -266,18 +267,18 @@ A few common reasons:
 
 See [Troubleshooting](Troubleshooting) for specific error messages.
 
-### Can students see their grades in the web app?
+### Can students see their scores in the web app?
 
-Not yet. Grades live in each student's repository: every graded submission
+Not yet. Scores live in each student's repository: every graded submission
 publishes a **Release** with the score and a per-test breakdown, which is what
-the student-facing **View grade** link opens. Showing grades inside the app is
+the student-facing **View grade** link opens. Showing scores inside the app is
 blocked by a technical limitation — Classroom 50 has no server, and the
 browser can't read Release assets cross-origin — but it's on the wish list
 (see [#567](https://github.com/foundation50/classroom50/issues/567)). Point
 students at their repository's Releases page (or the Feedback PR) for
 results.
 
-### Can I manually override or adjust a grade?
+### Can I manually override or adjust a score?
 
 Yes, right in the web app — for both **manual** and **autograded** assignments.
 On the submissions page, each row's score cell has an edit button that opens a
@@ -298,7 +299,7 @@ config repo). Under the hood, an override is just an entry in the classroom's
 future runs — so you can still edit it by hand if you prefer (see
 [Collect scores](CLI-Teacher-Guide#9-collect-scores)).
 
-### How do I export grades, or download student work in bulk?
+### How do I export scores, or download student work in bulk?
 
 Download scores as a CSV from the submissions page
 (**Download scores (CSV)**). For the work itself, **Download all submissions**
@@ -307,7 +308,8 @@ a single zip (built in your browser). For real clones — e.g. to run your own
 tooling locally — `gh teacher download` clones every submission repo and also
 writes a `scores.csv` summary at the destination root. The raw score data also
 lives in `scores.json` in your config repo, so you can build your own
-automations against it.
+automations against it. The column-by-column reference for both CSVs is in
+[Autograders → Score exports](Autograders#score-exports).
 
 ### As a teacher, can I test an assignment as a student?
 
@@ -370,7 +372,7 @@ live state on GitHub.com, and the app's reconciliation process updates the
 files automatically to keep them in sync — a hand-edit can create a state the
 tools don't know how to handle (and makes problems much harder to
 troubleshoot). Manage the classroom through the web app or the `gh teacher`
-CLI instead; the one documented exception is a `scores.json` grade override
+CLI instead; the one documented exception is a `scores.json` score override
 (see above).
 
 ### What is the service token, and is it the same one the web app set up?

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -133,7 +133,7 @@ file in alone does nothing until you enable this option. If the file is missing
 or can't be read, the built-in body is used. It's set in the web app; there is
 no `gh teacher` flag for it.
 
-### Can I set a due date with a specific time, not just a date?
+### Can I set a due date with a specific time of day?
 
 Yes. Due dates support a date **and** time (down to the second, in your
 timezone). Submissions after the due date are **marked late**; nothing is
@@ -147,7 +147,7 @@ page's **Actions** menu: it blocks new accepts and sets every student's
 repository to read-only (work is preserved). **Reopen submission** restores
 write access — useful when a project continues in a follow-up course. **Update
 student repo access** in the same menu gives finer control over the role
-students hold on their repos.
+students hold on their repositories.
 
 ### What's the difference between "template-less" and "empty repository"?
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -202,7 +202,7 @@ Yes, several levers:
   tagged commit** (`--submission-mode tag` in the CLI). Students' regular
   pushes then run nothing at all; grading happens only when they submit
   (`gh student submit` or a hand-pushed `submit/*` tag). This is the biggest
-  saver for large classes, where every work-in-progress push would otherwise
+  saver for large classrooms, where every work-in-progress push would otherwise
   grade. You can also name **milestone tags** (`--submission-tag phase1`) so
   students grade specific checkpoints with plain git. See
   [Autograders → Which commits grade](Autograders#which-commits-grade).

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -205,7 +205,7 @@ Yes, several levers:
   saver for large classrooms, where every work-in-progress push would otherwise
   grade. You can also name **milestone tags** (`--submission-tag phase1`) so
   students grade specific checkpoints with plain git. See
-  [Autograders → Which commits grade](Autograders#which-commits-grade).
+  [Which commits grade](Autograders#which-commits-grade) in Autograders.
 - **Pause autograding for one assignment** (reversible) — **Pause autograding**
   in the submissions page's **Actions** menu disables the built-in
   `autograde.yaml` workflow in every student repository (via GitHub's
@@ -309,7 +309,7 @@ tooling locally — `gh teacher download` clones every submission repo and also
 writes a `scores.csv` summary at the destination root. The raw score data also
 lives in `scores.json` in your config repo, so you can build your own
 automations against it. The column-by-column reference for both CSVs is in
-[Autograders → Score exports](Autograders#score-exports).
+[Score exports](Autograders#score-exports) in Autograders.
 
 ### As a teacher, can I test an assignment as a student?
 

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -49,8 +49,9 @@ supplies an assignment's **starter code**. Each student who accepts gets a copy.
 Assignments can also be template-less, in which case a student's repository
 contains only the autograder setup.
 
-**Deadline (due date)** — An optional date and time for an assignment.
-Submissions after it are marked *late*; nothing is blocked.
+**Due date** — An optional date and time for an assignment. Submissions after
+it are marked *late*; nothing is blocked. To actually stop submissions, use
+**Close submission** on the submissions page.
 
 **Autograder** — The grading logic that runs on each submission. Can be
 declarative tests (defined in the assignment) or a Python script you write.
@@ -67,8 +68,11 @@ is tagged, graded, and published as a GitHub Release.
 **Feedback pull request** — An optional, long-lived pull request per student
 repository for inline review of a student's work.
 
-**Score / gradebook** — Collected results. The gradebook (`scores.json`) is
-built by the score-collection workflow; teachers can download it as CSV.
+**Score / gradebook** — A **score** is the number a submission earned
+(`score` out of `max-score`); the **gradebook** (`scores.json`) is the
+collected record of every submission, built by the score-collection workflow.
+Teachers can download it as CSV. See
+[Autograders → Reading results](Autograders#reading-results).
 
 **Score override** — A teacher-set score entered on the submissions page,
 stored in the gradebook and left untouched by autograding until cleared. Used
@@ -100,3 +104,23 @@ Assignment repositories are named:
 
 For a group assignment, `<username>` is the founder who created the shared
 repository.
+
+## Coming from GitHub Classroom?
+
+Most vocabulary carries over unchanged: classroom, roster, assignment,
+individual and group assignments, template repository, starter code, accept.
+Where the words — or the behavior behind them — differ:
+
+| GitHub Classroom | Classroom 50 |
+| --- | --- |
+| **Deadline / cutoff date** | **Due date**. It only marks later submissions *late* — nothing is blocked. The enforcement tools are **Close submission** (block new accepts, set repositories read-only) and **Lock assignment**. |
+| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The underlying gradebook is `scores.json` in your config repo. See [Autograders → Reading results](Autograders#reading-results). |
+| **Roster identifier** and student self-linking | Doesn't exist — there's nothing to link. The roster is keyed by **GitHub username** (the numeric `github_id` is resolved automatically); you invite students, and accept links work once they've joined the organization. |
+| **Teams** (group assignments) | **Groups.** The first student to accept (the **founder**) creates the shared repository and invites teammates as collaborators — there is no separate team-creation step. |
+| **Autograding presets** (`.github/classroom/autograding.json`) | **Declarative tests**, stored on the assignment itself (Input/Output, Run command, Python/pytest). An existing `autograding.json` workflow can be kept via a [custom runner workflow](Autograders#custom-runner-workflow-rare). |
+| One classroom per organization | **Many classrooms per organization** — for example, one per term or section. |
+| Hosted service stores your data | Everything lives in **your GitHub organization** (config repo, student repos, Actions). |
+
+To bring an existing classroom over, see
+[`gh teacher classroom migrate`](gh-teacher#classroom-migrate) and the
+[migration FAQ](FAQ#migrating-from-github-classroom).

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -118,7 +118,6 @@ Where the words — or the behavior behind them — differ:
 | **Roster identifier** and student self-linking | Doesn't exist — there's nothing to link. The roster is keyed by **GitHub username** (the numeric `github_id` is resolved automatically); you invite students, and accept links work once they've joined the organization. |
 | **Teams** (group assignments) | **Groups.** The first student to accept (the **founder**) creates the shared repository and invites teammates as collaborators — there is no separate team-creation step. |
 | **Autograding presets** (`.github/classroom/autograding.json`) | **Declarative tests**, stored on the assignment itself (Input/Output, Run command, Python/pytest). An existing `autograding.json` workflow can be kept via a [custom runner workflow](Autograders#custom-runner-workflow-rare). |
-| One classroom per organization | **Many classrooms per organization** — for example, one per term or section. |
 | Hosted service stores your data | Everything lives in **your GitHub organization** (config repo, student repos, Actions). |
 
 To bring an existing classroom over, see

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -72,7 +72,7 @@ repository for inline review of a student's work.
 (`score` out of `max-score`); the **gradebook** (`scores.json`) is the
 collected record of every submission, built by the score-collection workflow.
 Teachers can download it as CSV. See
-[Autograders → Reading results](Autograders#reading-results).
+[Reading results](Autograders#reading-results) in Autograders.
 
 **Score override** — A teacher-set score entered on the submissions page,
 stored in the gradebook and left untouched by autograding until cleared. Used
@@ -114,7 +114,7 @@ Where the words — or the behavior behind them — differ:
 | GitHub Classroom | Classroom 50 |
 | --- | --- |
 | **Deadline / cutoff date** | **Due date**. It only marks later submissions *late* — nothing is blocked. The enforcement tools are **Close submission** (block new accepts, set repositories read-only) and **Lock assignment**. |
-| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The underlying gradebook is `scores.json` in your config repository. See [Autograders → Reading results](Autograders#reading-results). |
+| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The underlying gradebook is `scores.json` in your config repository. See [Reading results](Autograders#reading-results) in Autograders. |
 | **Roster identifier** and student self-linking | Doesn't exist — there's nothing to link. The roster is keyed by **GitHub username** (the numeric `github_id` is resolved automatically); you invite students, and accept links work once they've joined the organization. |
 | **Teams** (group assignments) | **Groups.** The first student to accept (the **founder**) creates the shared repository and invites teammates as collaborators — there is no separate team-creation step. |
 | **Autograding presets** (`.github/classroom/autograding.json`) | **Declarative tests**, stored on the assignment itself (Input/Output, Run command, Python/pytest). An existing `autograding.json` workflow can be kept with a [custom runner workflow](Autograders#custom-runner-workflow-rare). |

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -24,18 +24,18 @@ enrolled.
 **Organization (org)** — The GitHub organization that hosts a Classroom 50
 setup. Requires the Team or Enterprise plan.
 
-**Config repo** — The private `classroom50` repository in your organization.
+**Config repository** — The private `classroom50` repository in your organization.
 It holds every classroom's settings, roster, assignments, autograders, and
 scores. Classroom 50 has no other backend.
 
 ## Roles
 
 **Teacher** — Full control of a classroom. Granted organization owner and write
-access to the config repo.
+access to the config repository.
 
-**Head TA** — Write access to the config repo, but not organization owner.
+**Head TA** — Write access to the config repository, but not organization owner.
 
-**TA** — Read-only access to the config repo.
+**TA** — Read-only access to the config repository.
 
 **Student** — A member of the classroom who accepts and submits assignments.
 
@@ -82,7 +82,7 @@ and restored when the override is cleared).
 ## Access and setup
 
 **Service token** — A fine-grained personal access token (PAT) stored as a
-secret in the config repo. The score-collection and regrade workflows use it to
+secret in the config repository. The score-collection and regrade workflows use it to
 read and update student repositories.
 
 **Accept** — The student action that creates their assignment repository from
@@ -114,11 +114,11 @@ Where the words — or the behavior behind them — differ:
 | GitHub Classroom | Classroom 50 |
 | --- | --- |
 | **Deadline / cutoff date** | **Due date**. It only marks later submissions *late* — nothing is blocked. The enforcement tools are **Close submission** (block new accepts, set repositories read-only) and **Lock assignment**. |
-| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The underlying gradebook is `scores.json` in your config repo. See [Autograders → Reading results](Autograders#reading-results). |
+| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The underlying gradebook is `scores.json` in your config repository. See [Autograders → Reading results](Autograders#reading-results). |
 | **Roster identifier** and student self-linking | Doesn't exist — there's nothing to link. The roster is keyed by **GitHub username** (the numeric `github_id` is resolved automatically); you invite students, and accept links work once they've joined the organization. |
 | **Teams** (group assignments) | **Groups.** The first student to accept (the **founder**) creates the shared repository and invites teammates as collaborators — there is no separate team-creation step. |
-| **Autograding presets** (`.github/classroom/autograding.json`) | **Declarative tests**, stored on the assignment itself (Input/Output, Run command, Python/pytest). An existing `autograding.json` workflow can be kept via a [custom runner workflow](Autograders#custom-runner-workflow-rare). |
-| Hosted service stores your data | Everything lives in **your GitHub organization** (config repo, student repos, Actions). |
+| **Autograding presets** (`.github/classroom/autograding.json`) | **Declarative tests**, stored on the assignment itself (Input/Output, Run command, Python/pytest). An existing `autograding.json` workflow can be kept with a [custom runner workflow](Autograders#custom-runner-workflow-rare). |
+| Hosted service stores your data | Everything lives in **your GitHub organization** (config repository, student repositories, Actions). |
 
 To bring an existing classroom over, see
 [`gh teacher classroom migrate`](gh-teacher#classroom-migrate) and the

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -10,7 +10,7 @@ and an organization can hold several classrooms (for example, one per term or
 section).
 
 **Assignment** — A piece of coursework in a classroom. May be individual or
-group, may include starter code, and may have a deadline and autograding.
+group, may include starter code, and may have a due date and autograding.
 
 **Individual assignment** — Each student gets their own repository.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -24,7 +24,7 @@ Use it as a web app at [classroom50.org](https://classroom50.org/) or as the
 Classroom 50 has no server or database of its own. The web app is a static site
 hosted on GitHub Pages and the CLI runs on your machine; the app keeps only a
 small amount of local state in your browser (your GitHub access token and
-interface preferences). Your classrooms, roster, assignments, and grades are not
+interface preferences). Your classrooms, roster, assignments, and scores are not
 kept in a Classroom 50 account; they are stored in GitHub, as organization and
 team membership, repositories, commit history, permissions, and a few config
 files in your organization.

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -221,7 +221,7 @@ organization. See [the service-token setup](CLI-Teacher-Guide#create-the-service
 | | GitHub Classroom | Classroom 50 |
 | --- | --- | --- |
 | Backend | Hosted service | None (GitHub repos + Actions) |
-| Classroom ↔ org | One classroom per org | Many classrooms per org |
+| Classroom ↔ org | Classrooms managed in the hosted dashboard | A folder in your org's config repo, plus GitHub teams |
 | Grading | Hosted autograder | GitHub Actions in each repo |
 | Joining | Students self-select their roster entry from an invite link | The owner invites students; accept links work once they've joined the org |
 | Group naming | Team names | Founder's username |

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -70,7 +70,7 @@ read it:
 - **CLI writes** (`roster add`, `staff add`, `assignment add`, …) update the
   config repo and GitHub teams immediately, but only for the thing they
   change — they don't run the web app's broader reconciliation.
-- **Scores** refresh only when collection runs: nightly, or on demand via
+- **Scores** refresh only when collection runs: nightly, or on demand with
   **Sync now** / `collect-scores.yaml`.
 
 ## Interactive vs. background work
@@ -221,7 +221,7 @@ organization. See [the service-token setup](CLI-Teacher-Guide#create-the-service
 | | GitHub Classroom | Classroom 50 |
 | --- | --- | --- |
 | Backend | Hosted service | None (GitHub repos + Actions) |
-| Classroom ↔ org | Classrooms managed in the hosted dashboard | A folder in your org's config repo, plus GitHub teams |
+| Classroom ↔ org | Classrooms managed in the hosted dashboard | A folder in your organization's config repository, plus GitHub teams |
 | Grading | Hosted autograder | GitHub Actions in each repo |
 | Joining | Students self-select their roster entry from an invite link | The owner invites students; accept links work once they've joined the org |
 | Group naming | Team names | Founder's username |

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -227,5 +227,10 @@ organization. See [the service-token setup](CLI-Teacher-Guide#create-the-service
 | Group naming | Team names | Founder's username |
 | Data | In the service | In your `classroom50` config repo (yours to keep) |
 
+For a term-by-term mapping of GitHub Classroom vocabulary (cutoff date,
+Download grades, roster identifiers, teams) to Classroom 50's, see
+[Coming from GitHub Classroom?](Glossary#coming-from-github-classroom) in the
+Glossary.
+
 For a term-by-term reference, see the [Glossary](Glossary); for common questions,
 see the [FAQ](FAQ).

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -70,7 +70,7 @@ read it:
 - **CLI writes** (`roster add`, `staff add`, `assignment add`, …) update the
   config repo and GitHub teams immediately, but only for the thing they
   change — they don't run the web app's broader reconciliation.
-- **Grades** refresh only when collection runs: nightly, or on demand via
+- **Scores** refresh only when collection runs: nightly, or on demand via
   **Sync now** / `collect-scores.yaml`.
 
 ## Interactive vs. background work

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -111,7 +111,7 @@ on GitHub:
 ![Submission on GitHub](images/web_assignment_github_release_student.png)
 
 > [!NOTE]
-> Grades live on your repository's GitHub **Releases** — each graded submission
+> Scores live on your repository's GitHub **Releases** — each graded submission
 > publishes a Release with the score and a per-test breakdown. Classroom 50
 > can't yet display the score inside the app itself, so **View grade** takes
 > you to the Release. Your teacher may also leave comments on your feedback

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -138,7 +138,7 @@ On the classroom page, click **+ Assignment**. Fill in:
 
 - **Name** — the assignment's name.
 - **Description** (optional) — details for students.
-- **Due date** (optional) — a date and time in your local timezone. A deadline
+- **Due date** (optional) — a date and time in your local timezone. A due date
   marks later submissions **late** in the gradebook; it does not block pushes
   or revoke access. To actually close an assignment, use the **Close
   submission** action (see below).
@@ -252,9 +252,10 @@ form, holds optional settings for customizing the autograding environment:
   skipped with a warning.
 
 > [!NOTE]
-> Existing organizations must refresh the shared skeleton before using
-> submission release files. Submission publishing doesn't support GitHub
-> Immutable Releases. See [Autograders](Autograders#attaching-files-to-submission-releases)
+> Existing organizations must refresh the shared workflow files (re-run
+> setup) before using submission release files. Submission publishing doesn't
+> support GitHub Immutable Releases. See
+> [Autograders](Autograders#attaching-files-to-submission-releases)
 > for path rules and limits.
 
 Commands run in separate shell processes. See
@@ -441,9 +442,11 @@ The top of the page shows:
 Each row shows a student's (or group's) latest submission plus its full history
 (newest first). For each submission you can view the score, the submission date,
 and links to the repository, the commit, the feedback pull request
-(**Review**), and the Release (**Details**).
+(**Review**), and the Release (**Details**). For where every result lives —
+per-test breakdowns, past attempts, grading a specific commit, and who
+submitted — see [Autograders → Reading results](Autograders#reading-results).
 
-### Grades and score overrides
+### Scores and overrides
 
 Each row's score cell has an edit button (pencil) that opens a score dialog.
 It works for both grading modes:
@@ -487,7 +490,7 @@ assignment:
   students have accepted; a single repository can also be paused from its row.)
 - **Close submission** / **Reopen submission** — close the submission window:
   block new accepts and set every student's repository to read-only (work is
-  preserved). This is the enforcement mechanism for deadlines — the due date
+  preserved). This is the enforcement mechanism for due dates — the due date
   itself only marks submissions late. **Reopen submission** restores write
   access.
 - **Lock assignment** / **Unlock assignment** — lock the assignment so
@@ -504,7 +507,8 @@ assignment:
 ### Download scores
 
 Click **Download scores (CSV)** to export all submissions as a CSV for a
-spreadsheet or external tool.
+spreadsheet or external tool. The column-by-column reference is in
+[Autograders → Score exports](Autograders#score-exports).
 
 ## Edit assignments and classrooms
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -501,7 +501,7 @@ assignment:
 - **Download scores (CSV)** — export all submissions as a CSV.
 - **Download all submissions** — download each repository's latest submission
   bundled into a single zip (built in the browser, one repository at a time;
-  for very large classrooms prefer `gh teacher download`, which clones every repo
+  for very large classrooms prefer `gh teacher download`, which clones every repository
   and writes a `scores.csv` — see the
   [CLI Teacher Guide](CLI-Teacher-Guide#10-download-submissions)).
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -445,7 +445,7 @@ and links to the repository, the commit, the feedback pull request
 (**Review**), and the Release (**View autograder details**). For where every
 result lives — per-test breakdowns, past attempts, grading a specific commit,
 and who submitted — see
-[Autograders → Reading results](Autograders#reading-results).
+[Reading results](Autograders#reading-results) in Autograders.
 
 ### Scores and overrides
 
@@ -509,7 +509,7 @@ assignment:
 
 Click **Download scores (CSV)** to export all submissions as a CSV for a
 spreadsheet or external tool. The column-by-column reference is in
-[Autograders → Score exports](Autograders#score-exports).
+[Score exports](Autograders#score-exports) in Autograders.
 
 ## Edit assignments and classrooms
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -431,20 +431,21 @@ last synced (a per-assignment `collected_at` stamp in `scores.json`). Click
 The top of the page shows:
 
 - **Submitted** — submissions vs. students enrolled.
-- **Classroom average** — average grade among students who submitted.
+- **Classroom average** — average score among students who submitted.
 - **Passing** — how many students are passing vs. failing.
 - **Accepted** — how many students accepted (one per student).
 
 > [!TIP]
-> For larger classes, use the search box, filters ("Submitted", "On time",
+> For larger classrooms, use the search box, filters ("Submitted", "On time",
 > passing/failing, "Accepted"), and sorting (by name or submission date).
 
 Each row shows a student's (or group's) latest submission plus its full history
 (newest first). For each submission you can view the score, the submission date,
 and links to the repository, the commit, the feedback pull request
-(**Review**), and the Release (**Details**). For where every result lives —
-per-test breakdowns, past attempts, grading a specific commit, and who
-submitted — see [Autograders → Reading results](Autograders#reading-results).
+(**Review**), and the Release (**View autograder details**). For where every
+result lives — per-test breakdowns, past attempts, grading a specific commit,
+and who submitted — see
+[Autograders → Reading results](Autograders#reading-results).
 
 ### Scores and overrides
 
@@ -500,7 +501,7 @@ assignment:
 - **Download scores (CSV)** — export all submissions as a CSV.
 - **Download all submissions** — download each repository's latest submission
   bundled into a single zip (built in the browser, one repository at a time;
-  for very large classes prefer `gh teacher download`, which clones every repo
+  for very large classrooms prefer `gh teacher download`, which clones every repo
   and writes a `scores.csv` — see the
   [CLI Teacher Guide](CLI-Teacher-Guide#10-download-submissions)).
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -370,7 +370,7 @@ The classroom's GitHub teams are the authority for enrollment and role; the
   automatic sync refreshes it, so you may see a commit rewrite an empty/`""`
   role to `teacher` shortly after `roster add`. That's the snapshot updating,
   not a change to enrollment — nothing reads this column to decide access.
-- **Grades & submissions** — an account with a student enrollment is always
+- **Scores & submissions** — an account with a student enrollment is always
   listed as a student. (A pure-staff account only appears in submissions once it
   has actually accepted an assignment repo.)
 - **Unenroll** — drops only the student side (the roster row and student-team


### PR DESCRIPTION
## Summary

- Rewrites `wiki/Autograders.md` around the common teacher path: a short end-to-end "How grading works" overview, then setup (grading modes, declarative tests, `autograder.py`, runtime), then when commits grade, with pipeline internals folded into collapsibles.
- Adds a new **Reading results** section: where every result lives (Release, commit status, gradebook), latest score versus history, grading a specific commit, who submitted, and column-by-column tables for both CSV exports — all verified against `dashboard.ts`, `download.go`, and `result-v1.schema.json`.
- Adds a **Coming from GitHub Classroom?** mapping table to the Glossary (cutoff date, Download grades, roster identifier, teams, autograding presets) and standardizes vocabulary across the wiki: *score* (not grades-as-noun), *due date* (not deadline), *classroom* (not class).
- Repoints the FAQ and both teacher guides at the new results reference; every wiki-internal anchor is validated by script.
- Conforms the rewritten pages to the [GitHub docs style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide): repository/organization spelled out, no Latin abbreviations or filler words, present tense, ALL-CAPS placeholders (`CLASSROOM/autograders/ASSIGNMENT/`), full product names, and GitHub-style cross-reference phrasing. Verbatim product copy (CLI usage strings, UI labels, generated tag formats) is reproduced exactly.

## Notes

- Factual fixes along the way: regrade re-runs each repo's latest submission at its original commit (`datetime` fixed, `graded_at` moves); group CSV usernames are alphabetical; the CLI CSV writes one line per submission per credited member.
- A follow-up PR will sweep the remaining wiki pages onto the same style.