### PR TITLE
fix(cli): correct scores.csv shape in download help text

### DIFF
--- a/cli/gh-teacher/internal/download/download.go
+++ b/cli/gh-teacher/internal/download/download.go
@@ -106,8 +106,10 @@ func NewCmd() *cobra.Command {
 			"the latest. Team members\n" +
 			"with no repo on the org are reported as `not yet accepted` and don't\n" +
 			"fail the run. A scores.csv summary is written at the destination root\n" +
-			"with one row per team member — submitters carry their score columns,\n" +
-			"non-submitters get blanks. roster.csv (if present) supplies optional\n" +
+			"with one line per submission (newest first) for each team member —\n" +
+			"group members repeat the shared submission's lines under their own\n" +
+			"username, and non-submitters get one line with blank score columns.\n" +
+			"roster.csv (if present) supplies optional\n" +
 			"name/section/email metadata for that summary; it never decides who is\n" +
 			"cloned.\n\n" +
 			"Pass --by-pattern to skip the team lookup and clone every <org> repo\n" +


### PR DESCRIPTION
## Summary

- `gh teacher download --help` claimed `scores.csv` has one row per team member; it actually writes one line per submission (newest first) for each credited member — group members repeat the shared submission's lines under their own username, and non-submitters get one blank-score line. The help text now matches `writeScoresCSV` and the wiki's export reference (#614).

## Test plan

- [x] `go build ./...`, `go test ./...`, `golangci-lint run`, `golangci-lint fmt --diff` — all clean.