### PR TITLE
docs(wiki): establish canonical terminology in the glossary

### DIFF
--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -3,10 +3,10 @@
 Terms used throughout Classroom 50, in the web app, the CLI, and this wiki.
 
 One concept, one term: when writing about Classroom 50, use the terms
-defined here and avoid mixing in synonyms (an "instructor" next to a
-"teacher" leaves readers wondering whether those are two roles). Occasional
-slips are understandable, but this page is the reference. If you find copy
-that disagrees with it,
+defined here and avoid mixing in synonyms, so readers never have to wonder
+whether two words mean two different things. Occasional slips are
+understandable, but this page is the reference. If you find copy that
+disagrees with it,
 [file an issue](https://github.com/foundation50/classroom50/issues).
 
 ## Core concepts

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -35,11 +35,13 @@ group, may include starter code, and may have a due date and autograding.
 **Individual assignment** — Each student gets their own repository.
 
 **Group assignment** — Teammates share one repository. The first student to
-accept creates it and invites the others.
+accept creates it and invites the others. Groups replace GitHub Classroom's
+teams: there is no separate team-creation step and no group names.
 
 **Roster** — The list of students in a classroom. Backed by a `roster.csv`
 file, but the classroom's GitHub team is the source of truth for who is
-enrolled.
+enrolled. The roster is keyed by GitHub username; there is no equivalent of
+GitHub Classroom's roster identifier or student self-linking.
 
 **Organization (org)** — The GitHub organization that hosts a Classroom 50
 setup. Requires the Team or Enterprise plan.
@@ -71,14 +73,18 @@ Assignments can also be template-less, in which case a student's repository
 contains only the autograder setup.
 
 **Due date** — An optional date and time for an assignment. Submissions after
-it are marked *late*; nothing is blocked. To actually stop submissions, use
-**Close submission** on the submissions page.
+it are marked *late*; nothing is blocked, unlike GitHub Classroom's cutoff
+date. To actually stop submissions, use **Close submission** on the
+submissions page.
 
 **Autograder** — The grading logic that runs on each submission. Can be
 declarative tests (defined in the assignment) or a Python script you write.
 
 **Declarative tests** — Input/output, run-command, and pytest checks defined
-directly on an assignment, graded with no code to write.
+directly on an assignment, graded with no code to write. They fill the role
+of GitHub Classroom's `autograding.json` presets; an existing
+`autograding.json` workflow can be kept with a
+[custom runner workflow](Autograders#custom-runner-workflow-rare).
 
 **Runner** — The shared grading engine that runs in GitHub Actions on every
 submission.
@@ -130,17 +136,7 @@ repository.
 
 Most vocabulary carries over unchanged: classroom, roster, assignment,
 individual and group assignments, template repository, starter code, accept.
-Where the words — or the behavior behind them — differ:
-
-| GitHub Classroom | Classroom 50 |
-| --- | --- |
-| **Deadline / cutoff date** | **Due date**. It only marks later submissions *late* — nothing is blocked. The enforcement tools are **Close submission** (block new accepts, set repositories read-only) and **Lock assignment**. |
-| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The collected scores live in `scores.json` in your `classroom50` repository. See [Reading results](Autograders#reading-results) in Autograders. |
-| **Roster identifier** and student self-linking | Doesn't exist — there's nothing to link. The roster is keyed by **GitHub username** (the numeric `github_id` is resolved automatically); you invite students, and accept links work once they've joined the organization. |
-| **Teams** (group assignments) | **Groups.** The first student to accept (the **founder**) creates the shared repository and invites teammates as collaborators — there is no separate team-creation step. |
-| **Autograding presets** (`.github/classroom/autograding.json`) | **Declarative tests**, stored on the assignment itself (Input/Output, Run command, Python/pytest). An existing `autograding.json` workflow can be kept with a [custom runner workflow](Autograders#custom-runner-workflow-rare). |
-| Hosted service stores your data | Everything lives in **your GitHub organization** (the `classroom50` repository, student repositories, Actions). |
-
-To bring an existing classroom over, see
+Where a term or the behavior behind it differs, the entry above says so. To
+bring an existing classroom over, see
 [`gh teacher classroom migrate`](gh-teacher#classroom-migrate) and the
 [migration FAQ](FAQ#migrating-from-github-classroom).

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -2,6 +2,26 @@
 
 Terms used throughout Classroom 50, in the web app, the CLI, and this wiki.
 
+## One term per concept
+
+Classroom 50 uses one canonical term per concept across the web app, the
+CLI, and this wiki. Where GitHub Classroom or GitHub's documentation has a
+term for the same concept, Classroom 50 uses it. If you see copy that uses
+a different word for something defined here, that copy is out of date —
+[file an issue](https://github.com/foundation50/classroom50/issues).
+
+| Use | Not |
+| --- | --- |
+| classroom | class, course |
+| teacher | instructor |
+| due date | deadline, cutoff date |
+| score | grade (as a noun) |
+| the `classroom50` repository | config repo, config repository |
+| workflow files | skeleton |
+| template repository | starter repository |
+| group, founder | team (for group assignments) |
+| repository | repo (except in command output and UI labels) |
+
 ## Core concepts
 
 **Classroom** — The basic unit of Classroom 50: one course's students,
@@ -24,18 +44,19 @@ enrolled.
 **Organization (org)** — The GitHub organization that hosts a Classroom 50
 setup. Requires the Team or Enterprise plan.
 
-**Config repository** — The private `classroom50` repository in your organization.
-It holds every classroom's settings, roster, assignments, autograders, and
-scores. Classroom 50 has no other backend.
+**The `classroom50` repository** — The private repository named `classroom50`
+in your organization. It holds every classroom's settings, roster,
+assignments, autograders, and scores. Classroom 50 has no other backend.
 
 ## Roles
 
 **Teacher** — Full control of a classroom. Granted organization owner and write
-access to the config repository.
+access to the `classroom50` repository.
 
-**Head TA** — Write access to the config repository, but not organization owner.
+**Head TA** — Write access to the `classroom50` repository, but not
+organization owner.
 
-**TA** — Read-only access to the config repository.
+**TA** — Read-only access to the `classroom50` repository.
 
 **Student** — A member of the classroom who accepts and submits assignments.
 
@@ -68,22 +89,22 @@ is tagged, graded, and published as a GitHub Release.
 **Feedback pull request** — An optional, long-lived pull request per student
 repository for inline review of a student's work.
 
-**Score / gradebook** — A **score** is the number a submission earned
-(`score` out of `max-score`); the **gradebook** (`scores.json`) is the
-collected record of every submission, built by the score-collection workflow.
-Teachers can download it as CSV. See
+**Score / collected scores** — A **score** is the number a submission earned
+(`score` out of `max-score`). The **collected scores** (`scores.json` in the
+`classroom50` repository) are the record of every submission, built by the
+score-collection workflow. Teachers can download them as CSV. See
 [Reading results](Autograders#reading-results) in Autograders.
 
 **Score override** — A teacher-set score entered on the submissions page,
-stored in the gradebook and left untouched by autograding until cleared. Used
-for manual grading and for overriding an autograded result (which is preserved
-and restored when the override is cleared).
+stored with the collected scores and left untouched by autograding until
+cleared. Used for manual grading and for overriding an autograded result
+(which is preserved and restored when the override is cleared).
 
 ## Access and setup
 
 **Service token** — A fine-grained personal access token (PAT) stored as a
-secret in the config repository. The score-collection and regrade workflows use it to
-read and update student repositories.
+secret in the `classroom50` repository. The score-collection and regrade
+workflows use it to read and update student repositories.
 
 **Accept** — The student action that creates their assignment repository from
 the template.
@@ -114,11 +135,11 @@ Where the words — or the behavior behind them — differ:
 | GitHub Classroom | Classroom 50 |
 | --- | --- |
 | **Deadline / cutoff date** | **Due date**. It only marks later submissions *late* — nothing is blocked. The enforcement tools are **Close submission** (block new accepts, set repositories read-only) and **Lock assignment**. |
-| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The underlying gradebook is `scores.json` in your config repository. See [Reading results](Autograders#reading-results) in Autograders. |
+| **Download grades** (CSV) | **Download scores (CSV)** on an assignment's submissions page. The collected scores live in `scores.json` in your `classroom50` repository. See [Reading results](Autograders#reading-results) in Autograders. |
 | **Roster identifier** and student self-linking | Doesn't exist — there's nothing to link. The roster is keyed by **GitHub username** (the numeric `github_id` is resolved automatically); you invite students, and accept links work once they've joined the organization. |
 | **Teams** (group assignments) | **Groups.** The first student to accept (the **founder**) creates the shared repository and invites teammates as collaborators — there is no separate team-creation step. |
 | **Autograding presets** (`.github/classroom/autograding.json`) | **Declarative tests**, stored on the assignment itself (Input/Output, Run command, Python/pytest). An existing `autograding.json` workflow can be kept with a [custom runner workflow](Autograders#custom-runner-workflow-rare). |
-| Hosted service stores your data | Everything lives in **your GitHub organization** (config repository, student repositories, Actions). |
+| Hosted service stores your data | Everything lives in **your GitHub organization** (the `classroom50` repository, student repositories, Actions). |
 
 To bring an existing classroom over, see
 [`gh teacher classroom migrate`](gh-teacher#classroom-migrate) and the

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -2,32 +2,19 @@
 
 Terms used throughout Classroom 50, in the web app, the CLI, and this wiki.
 
-## One term per concept
-
-Classroom 50 uses one canonical term per concept across the web app, the
-CLI, and this wiki. Where GitHub Classroom or GitHub's documentation has a
-term for the same concept, Classroom 50 uses it. If you see copy that uses
-a different word for something defined here, that copy is out of date —
+Classroom 50 uses one term for each concept, matching GitHub Classroom and
+GitHub documentation where they have a word for the same thing. Each entry
+below defines the canonical term; where an older or alternative word is
+still in circulation, the entry says so. If you find copy that disagrees
+with this page,
 [file an issue](https://github.com/foundation50/classroom50/issues).
-
-| Use | Not |
-| --- | --- |
-| classroom | class, course |
-| teacher | instructor |
-| due date | deadline, cutoff date |
-| score | grade (as a noun) |
-| the `classroom50` repository | config repo, config repository |
-| workflow files | skeleton |
-| template repository | starter repository |
-| group, founder | team (for group assignments) |
-| repository | repo (except in command output and UI labels) |
 
 ## Core concepts
 
 **Classroom** — The basic unit of Classroom 50: one course's students,
 assignments, roster, and scores. A classroom belongs to a GitHub organization,
 and an organization can hold several classrooms (for example, one per term or
-section).
+section). Always "classroom", not "class" or "course".
 
 **Assignment** — A piece of coursework in a classroom. May be individual or
 group, may include starter code, and may have a due date and autograding.
@@ -49,11 +36,12 @@ setup. Requires the Team or Enterprise plan.
 **The `classroom50` repository** — The private repository named `classroom50`
 in your organization. It holds every classroom's settings, roster,
 assignments, autograders, and scores. Classroom 50 has no other backend.
+Earlier copy called this the "config repository".
 
 ## Roles
 
 **Teacher** — Full control of a classroom. Granted organization owner and write
-access to the `classroom50` repository.
+access to the `classroom50` repository. Always "teacher", not "instructor".
 
 **Head TA** — Write access to the `classroom50` repository, but not
 organization owner.
@@ -70,12 +58,13 @@ the shared repository and invite the other teammates as collaborators.
 **Template repository** — A GitHub repository, flagged as a template, that
 supplies an assignment's **starter code**. Each student who accepts gets a copy.
 Assignments can also be template-less, in which case a student's repository
-contains only the autograder setup.
+contains only the autograder setup. "Template repository", not "starter
+repository".
 
 **Due date** — An optional date and time for an assignment. Submissions after
 it are marked *late*; nothing is blocked, unlike GitHub Classroom's cutoff
 date. To actually stop submissions, use **Close submission** on the
-submissions page.
+submissions page. Always "due date", not "deadline".
 
 **Autograder** — The grading logic that runs on each submission. Can be
 declarative tests (defined in the assignment) or a Python script you write.
@@ -96,9 +85,10 @@ is tagged, graded, and published as a GitHub Release.
 repository for inline review of a student's work.
 
 **Score / collected scores** — A **score** is the number a submission earned
-(`score` out of `max-score`). The **collected scores** (`scores.json` in the
-`classroom50` repository) are the record of every submission, built by the
-score-collection workflow. Teachers can download them as CSV. See
+(`score` out of `max-score`); Classroom 50 says "score", not "grade". The
+**collected scores** (`scores.json` in the `classroom50` repository) are the
+record of every submission, built by the score-collection workflow. Teachers
+can download them as CSV. See
 [Reading results](Autograders#reading-results) in Autograders.
 
 **Score override** — A teacher-set score entered on the submissions page,
@@ -111,6 +101,11 @@ cleared. Used for manual grading and for overriding an autograded result
 **Service token** — A fine-grained personal access token (PAT) stored as a
 secret in the `classroom50` repository. The score-collection and regrade
 workflows use it to read and update student repositories.
+
+**Workflow files** — The GitHub Actions files Classroom 50 places in the
+`classroom50` repository and in each assignment repository (such as
+`autograde.yaml`) to run grading, collection, and publishing. Some CLI
+output still calls these the "skeleton".
 
 **Accept** — The student action that creates their assignment repository from
 the template.

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -2,11 +2,11 @@
 
 Terms used throughout Classroom 50, in the web app, the CLI, and this wiki.
 
-Classroom 50 uses one term for each concept, matching GitHub Classroom and
-GitHub documentation where they have a word for the same thing. Each entry
-below defines the canonical term; where an older or alternative word is
-still in circulation, the entry says so. If you find copy that disagrees
-with this page,
+One concept, one term: when writing about Classroom 50, use the terms
+defined here and avoid mixing in synonyms (an "instructor" next to a
+"teacher" leaves readers wondering whether those are two roles). Occasional
+slips are understandable, but this page is the reference. If you find copy
+that disagrees with it,
 [file an issue](https://github.com/foundation50/classroom50/issues).
 
 ## Core concepts
@@ -14,7 +14,7 @@ with this page,
 **Classroom** — The basic unit of Classroom 50: one course's students,
 assignments, roster, and scores. A classroom belongs to a GitHub organization,
 and an organization can hold several classrooms (for example, one per term or
-section). Always "classroom", not "class" or "course".
+section).
 
 **Assignment** — A piece of coursework in a classroom. May be individual or
 group, may include starter code, and may have a due date and autograding.
@@ -36,12 +36,11 @@ setup. Requires the Team or Enterprise plan.
 **The `classroom50` repository** — The private repository named `classroom50`
 in your organization. It holds every classroom's settings, roster,
 assignments, autograders, and scores. Classroom 50 has no other backend.
-Earlier copy called this the "config repository".
 
 ## Roles
 
 **Teacher** — Full control of a classroom. Granted organization owner and write
-access to the `classroom50` repository. Always "teacher", not "instructor".
+access to the `classroom50` repository.
 
 **Head TA** — Write access to the `classroom50` repository, but not
 organization owner.
@@ -58,13 +57,12 @@ the shared repository and invite the other teammates as collaborators.
 **Template repository** — A GitHub repository, flagged as a template, that
 supplies an assignment's **starter code**. Each student who accepts gets a copy.
 Assignments can also be template-less, in which case a student's repository
-contains only the autograder setup. "Template repository", not "starter
-repository".
+contains only the autograder setup.
 
 **Due date** — An optional date and time for an assignment. Submissions after
 it are marked *late*; nothing is blocked, unlike GitHub Classroom's cutoff
 date. To actually stop submissions, use **Close submission** on the
-submissions page. Always "due date", not "deadline".
+submissions page.
 
 **Autograder** — The grading logic that runs on each submission. Can be
 declarative tests (defined in the assignment) or a Python script you write.
@@ -85,10 +83,9 @@ is tagged, graded, and published as a GitHub Release.
 repository for inline review of a student's work.
 
 **Score / collected scores** — A **score** is the number a submission earned
-(`score` out of `max-score`); Classroom 50 says "score", not "grade". The
-**collected scores** (`scores.json` in the `classroom50` repository) are the
-record of every submission, built by the score-collection workflow. Teachers
-can download them as CSV. See
+(`score` out of `max-score`). The **collected scores** (`scores.json` in the
+`classroom50` repository) are the record of every submission, built by the
+score-collection workflow. Teachers can download them as CSV. See
 [Reading results](Autograders#reading-results) in Autograders.
 
 **Score override** — A teacher-set score entered on the submissions page,
@@ -104,8 +101,7 @@ workflows use it to read and update student repositories.
 
 **Workflow files** — The GitHub Actions files Classroom 50 places in the
 `classroom50` repository and in each assignment repository (such as
-`autograde.yaml`) to run grading, collection, and publishing. Some CLI
-output still calls these the "skeleton".
+`autograde.yaml`) to run grading, collection, and publishing.
 
 **Accept** — The student action that creates their assignment repository from
 the template.
@@ -131,7 +127,7 @@ repository.
 
 Most vocabulary carries over unchanged: classroom, roster, assignment,
 individual and group assignments, template repository, starter code, accept.
-Where a term or the behavior behind it differs, the entry above says so. To
+Where the behavior behind a term differs, the entry above says so. To
 bring an existing classroom over, see
 [`gh teacher classroom migrate`](gh-teacher#classroom-migrate) and the
 [migration FAQ](FAQ#migrating-from-github-classroom).


### PR DESCRIPTION
## Summary

- Establishes the Glossary as the canonical vocabulary for the web app, the CLI, and the wiki. A short guidance paragraph up top asks writers to stick to the terms defined here and avoid mixing in synonyms (occasional slips are understandable); the entries themselves are plain definitions with no per-entry "not X" notes.
- Settles two naming decisions: `<org>/classroom50` is called **the `classroom50` repository** in user-facing copy (replacing "config repo/repository"), and **"gradebook" is removed from current copy** ("collected scores" describes `scores.json`) since a gradebook is a possible future feature of its own, not a current concept.
- Keeps GitHub Classroom mentions only where they clarify behavior (due date vs cutoff date, groups vs teams, roster identifiers, `autograding.json`), adds a **Workflow files** entry, and keeps the "Coming from GitHub Classroom?" heading so existing links keep resolving.

This is the first PR of the wiki reorganization: it lands the vocabulary so subsequent copy sweeps (web `en.json`, CLI strings, remaining wiki pages) and new pages are written against one canon. Externally cited anchors are unaffected; "declarative tests" and "built-in autograder" stay as established terms.

## Test plan

- [ ] Review the guidance paragraph and each entry's definition
- [ ] Confirm the `classroom50` repository naming and the gradebook removal read well
- [ ] `wiki/` publish workflow mirrors the page after merge