### PR TITLE
docs(wiki): add five teacher onboarding guide pages

### DIFF
--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -1,0 +1,144 @@
+# Course lifecycle and end of term
+
+The moments in a course that aren't covered by day-to-day assignment work:
+staging an assignment before release, ending one at the due date, updating
+starter code mid-flight, and cleaning up when the term is over.
+
+## Staging an assignment before release
+
+Assignments are hidden from the student assignments page by default; until an
+assignment is listed, students can accept it only through its invite link.
+Two controls build on that:
+
+- **Release date** lists the assignment for everyone once the date passes.
+  It controls listing only, not access: a student with the invite link can
+  still accept early, and students who already accepted always see the
+  assignment.
+- **Lock assignment** (in the submissions page's **Actions** menu) blocks
+  access entirely: students can't accept it, and for a private template the
+  student team's read access is removed. **Unlock assignment** reopens it and
+  restores template access. Use it to prepare an assignment (or its capstone
+  solution review) without any chance of early accepts.
+
+To try the assignment before students do, accept it yourself from a separate
+student account, or add yourself to the roster; see
+[Testing an assignment as a student](FAQ#as-a-teacher-can-i-test-an-assignment-as-a-student).
+
+## Due dates mark late; closing enforces
+
+A due date is a label: submissions after it are marked **late**, and nothing
+is blocked. Autograding also keeps running after the due date, so a late
+submission still gets a score (marked late). When you want an actual cutoff:
+
+- **Close submission** (in the **Actions** menu) blocks new accepts and sets
+  every student's repository to read-only. Work is preserved, and students
+  keep read access. **Reopen submission** restores write access, useful when
+  a project continues in a follow-up course.
+- **Update student repo access** in the same menu gives finer control, such
+  as dropping everyone to read-only while you grade and restoring write
+  afterward.
+
+Closing doesn't grade anything by itself; collect scores first if you want
+the final state in your export (see
+[Collect submissions](Web-Teacher-Guide#collect-submissions)).
+
+## Updating starter code after students accept
+
+A student repository is a copy of the template as it existed at accept time,
+not a fork; there is no upstream link to pull new template commits through.
+What that means in practice:
+
+- **Template edits reach future accepts only.** Students who already
+  accepted keep their original starter code. Late accepters get the newer
+  content, so freeze the template if identical starting points matter.
+- **Two files do propagate:** `.gitignore` and `.github/` are re-fetched
+  from the template on every `gh student submit`. Fixing a broken ignore
+  rule or a CI workflow there reaches every student's next submission. See
+  [Why `.gitignore` and `.github/` re-sync](Assignment-Templates#why-gitignore-and-github-re-sync).
+- **Grading changes propagate on their own.** Autograder logic and
+  declarative tests live in your `classroom50` repository, not in student
+  repositories, so you can fix tests any time and regrade.
+- **For everything else, reach repositories directly.** Announce the change
+  and let students apply it, or script it: clone each repository
+  (`gh teacher download`) and push a fix or open a pull request per student.
+
+## End of term
+
+In rough order:
+
+1. **Close or lock the assignments.** **Close submission** per assignment
+   freezes student work (read-only, no new accepts).
+2. **Collect and export.** Run a final collection, then **Download scores
+   (CSV)**. For the work itself, **Download all submissions** bundles the
+   latest submissions into a zip, or `gh teacher download` clones every
+   repository and writes a `scores.csv`. See
+   [Download submissions](CLI-Teacher-Guide#10-download-submissions).
+3. **Archive the classroom.**
+
+   ```sh
+   gh teacher classroom archive cs50-fall-2026 cs-principles
+   ```
+
+   Archiving hides the classroom from the default list, blocks new accepts
+   (after the next publish run), and refuses new assignments; student
+   repositories are untouched, and `unarchive` reverses it. See
+   [`gh teacher classroom archive`](gh-teacher#classroom-archive--unarchive).
+4. **Optionally archive the student repositories on GitHub.** Archiving a
+   repository makes it read-only for everyone while preserving it. Classroom
+   50 has no bulk action for this yet, but the GitHub CLI handles it. List
+   the candidates first:
+
+   ```sh
+   gh repo list YOUR-ORGANIZATION --visibility private --no-archived --limit 1000 \
+     --json name,isTemplate \
+     -q '.[] | select(.isTemplate == false) | .name' \
+     | grep -vE '^(classroom50|KEEP-THIS-REPO)$'
+   ```
+
+   Replace `YOUR-ORGANIZATION` with your organization and extend the `grep`
+   pattern with any repository to keep (it already excludes the `classroom50`
+   repository; templates are excluded by the filter). When the list looks
+   right, append the archiving step:
+
+   ```sh
+   ... | xargs -I {} gh repo archive YOUR-ORGANIZATION/{} --yes
+   ```
+
+5. **Tidy membership if you need to.** Unenrolling a student removes them
+   from the roster and classroom team but not from the organization, and
+   never deletes repositories; removing them from the organization revokes
+   access but still deletes nothing. See
+   [Enroll, unenroll, and remove are separate](How-Classroom-50-Works#lifecycle-enroll-unenroll-and-remove-are-separate).
+
+## Reusing assignments next term
+
+Create the new term's classroom, then copy assignments into it:
+
+```sh
+gh teacher assignment reuse cs50-fall-2026 hello --from cs-principles --to cs-principles-spring
+```
+
+Every field is copied (template, tests, runtime, due date included; update
+the due date after copying). Student repositories and scores are not copied,
+and the target classroom's team is re-granted read on a private in-org
+template. The web app offers the same action on an assignment. See
+[`gh teacher assignment reuse`](gh-teacher#assignment-reuse).
+
+## Resetting an organization (destructive)
+
+**Tear down organization** (web app: organization settings, Danger zone; CLI:
+`gh teacher teardown`) deletes every repository Classroom 50 manages in the
+organization, after you type an explicit confirmation. It exists for
+development resets and complete decommissioning.
+
+> [!WARNING]
+> Teardown deletes student work permanently. Export scores and download
+> submissions first. It requires the `delete_repo` scope, which the CLI only
+> requests when you opt in (`gh teacher login -s delete_repo`).
+
+## Further reading
+
+- [Can I turn autograding off, or reduce Actions usage?](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage)
+  for pausing grading over a break.
+- [Which commits grade](Autograders#which-commits-grade) for submission modes
+  and milestone tags.

--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -2,7 +2,7 @@
 
 The moments in a course that aren't covered by day-to-day assignment work:
 staging an assignment before release, ending one at the due date, updating
-starter code mid-flight, and cleaning up when the term is over.
+starter code mid-course, and cleaning up when the term is over.
 
 ## Staging an assignment before release
 
@@ -17,8 +17,8 @@ Two controls build on that:
 - **Lock assignment** (in the submissions page's **Actions** menu) blocks
   access entirely: students can't accept it, and for a private template the
   student team's read access is removed. **Unlock assignment** reopens it and
-  restores template access. Use it to prepare an assignment (or its capstone
-  solution review) without any chance of early accepts.
+  restores template access. Use it to prepare an assignment with no chance
+  of early accepts.
 
 To try the assignment before students do, accept it yourself from a separate
 student account, or add yourself to the roster; see
@@ -64,16 +64,16 @@ What that means in practice:
 
 ## End of term
 
-In rough order:
+Wrap up a finished course in this order:
 
-1. **Close or lock the assignments.** **Close submission** per assignment
+1. Close or lock the assignments. **Close submission** per assignment
    freezes student work (read-only, no new accepts).
-2. **Collect and export.** Run a final collection, then **Download scores
+2. Collect and export. Run a final collection, then **Download scores
    (CSV)**. For the work itself, **Download all submissions** bundles the
    latest submissions into a zip, or `gh teacher download` clones every
    repository and writes a `scores.csv`. See
    [Download submissions](CLI-Teacher-Guide#10-download-submissions).
-3. **Archive the classroom.**
+3. Archive the classroom.
 
    ```sh
    gh teacher classroom archive cs50-fall-2026 cs-principles
@@ -83,7 +83,7 @@ In rough order:
    (after the next publish run), and refuses new assignments; student
    repositories are untouched, and `unarchive` reverses it. See
    [`gh teacher classroom archive`](gh-teacher#classroom-archive--unarchive).
-4. **Optionally archive the student repositories on GitHub.** Archiving a
+4. Optionally, archive the student repositories on GitHub. Archiving a
    repository makes it read-only for everyone while preserving it. Classroom
    50 has no bulk action for this yet, but the GitHub CLI handles it. List
    the candidates first:
@@ -95,16 +95,16 @@ In rough order:
      | grep -vE '^(classroom50|KEEP-THIS-REPO)$'
    ```
 
-   Replace `YOUR-ORGANIZATION` with your organization and extend the `grep`
-   pattern with any repository to keep (it already excludes the `classroom50`
-   repository; templates are excluded by the filter). When the list looks
-   right, append the archiving step:
+   Replace `YOUR-ORGANIZATION` with your organization and `KEEP-THIS-REPO`
+   with any repository to keep; the command already skips the `classroom50`
+   repository and your templates. When the list looks right, append the
+   archiving step:
 
    ```sh
    ... | xargs -I {} gh repo archive YOUR-ORGANIZATION/{} --yes
    ```
 
-5. **Tidy membership if you need to.** Unenrolling a student removes them
+5. Remove students if you need to. Unenrolling a student removes them
    from the roster and classroom team but not from the organization, and
    never deletes repositories; removing them from the organization revokes
    access but still deletes nothing. See
@@ -120,8 +120,9 @@ gh teacher assignment reuse cs50-fall-2026 hello --from cs-principles --to cs-pr
 
 Every field is copied (template, tests, runtime, due date included; update
 the due date after copying). Student repositories and scores are not copied,
-and the target classroom's team is re-granted read on a private in-org
-template. The web app offers the same action on an assignment. See
+and the target classroom's team is re-granted read access to a private
+template inside the organization. The web app offers the same action on an
+assignment. See
 [`gh teacher assignment reuse`](gh-teacher#assignment-reuse).
 
 ## Resetting an organization (destructive)

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -1,0 +1,108 @@
+# Known limitations
+
+Classroom 50 has no server: state lives in GitHub, work runs as you or as
+GitHub Actions in your organization. That design keeps your data yours, but
+it also rules some features out and makes others behave unexpectedly. This
+page lists those limits candidly, each with the reason and the workaround
+where one exists, so you don't have to rediscover them as bugs.
+
+## Roster and enrollment
+
+**You can't add students by email alone.** GitHub's API provides no way to
+look up an account from an email address, so a roster is keyed by GitHub
+username. Workarounds: collect usernames up front (a signup form works
+well), or use the email-invitation path, where each student completes a
+short onboarding step that links their account. See
+[Add students](Web-Teacher-Guide#add-students).
+
+**Students can't join through a link alone.** GitHub requires an
+organization owner to invite members, so there's no self-service join link.
+Adding a student to the roster sends the invitation; once they've accepted
+it, assignment accept links work with no further action from you.
+
+**There's no roster self-identification at accept time.** GitHub Classroom
+lets a student claim "I am this roster entry" when accepting. That step
+requires a server to mediate identities, so Classroom 50 identifies students
+by their GitHub account instead. Rows in the roster are usernames, not
+names to be claimed.
+
+## Visibility and feedback
+
+**Students can't see scores inside the app.** Grading results are published
+as a Release on each student's repository, and the browser can't read
+Release assets across origins (GitHub redirects them to storage that lacks
+CORS headers). Point students at their repository's Releases page or the
+feedback pull request; the student view's **View grade** link opens the
+right Release. In-app scores are on the wish list; see
+[#567](https://github.com/foundation50/classroom50/issues/567).
+
+**There are no notifications or webhooks.** Nothing runs while no one is
+signed in, so Classroom 50 can't email you when a student accepts or a
+grading run fails. GitHub's own notifications still work (for example,
+watching activity on the `classroom50` repository or on feedback pull
+requests).
+
+**What you see refreshes when a page loads.** With no server polling in the
+background, the app reads GitHub's current state when you open or reload a
+page, and scores update only when collection runs (nightly, or **Sync now**).
+If a view looks stale, reload it. See
+[When state refreshes](How-Classroom-50-Works#when-state-refreshes).
+
+## Templates and student repositories
+
+**Students can read private in-org templates.** Accept works by giving the
+classroom's team read access to the template, so a curious student can
+browse it, including its history. Never commit solutions (or their history)
+to a template: develop privately and copy or squash the clean state into the
+template repository you register.
+
+**Student repositories are not forks.** Accept generates a copy of the
+template; there is no upstream link, so template updates can't be pushed or
+pulled into accepted repositories. `.gitignore` and `.github/` are the
+exception, re-fetched on every submit. See
+[Updating starter code after students accept](Course-Lifecycle-and-End-of-Term#updating-starter-code-after-students-accept).
+
+**Renaming a repository breaks tracking.** Classroom 50 finds student work
+by the repository name (`<classroom>-<assignment>-<username>`). A renamed
+repository disappears from the submissions view. Tell students not to rename
+their repositories; if one already did, rename it back.
+
+**Students can re-enable paused workflows.** Students have write access to
+their repositories, which includes the Actions tab, so **Pause autograding**
+(and any Actions policy) is housekeeping, not enforcement: a student can
+re-enable the workflow. Treat grading controls as cost management, and use
+**Close submission** when you need actual enforcement.
+
+**Group repositories have no names.** A group repository is named after the
+founder (the first student to accept); there's no group-name concept and no
+pre-assigned teams. See
+[How group assignments work](FAQ#how-do-group-assignments-work).
+
+## Timing
+
+**Published changes take a moment to go live.** Classroom data that students
+read (the assignment list an accept link resolves against) is published
+through GitHub Pages, and a deploy takes from about 20 seconds to a few
+minutes. Right after you create or change an assignment, an accept link can
+briefly fail or show stale data; wait a minute and retry before debugging
+anything else.
+
+## Requested, but architecturally hard
+
+- **LTI / LMS grade passback** needs a server-to-server integration, which
+  the serverless design doesn't currently accommodate. Exports (score CSVs
+  and `scores.json`) are the supported path into an LMS today.
+- **Live in-app grades for students** are blocked by the cross-origin limit
+  above ([#567](https://github.com/foundation50/classroom50/issues/567)).
+- **Roster self-selection** would need a server to arbitrate identity
+  claims.
+
+Classroom 50 is open source and actively developed; if one of these matters
+to your course, weigh in on
+[Discussions](https://github.com/foundation50/classroom50/discussions).
+
+## Further reading
+
+- [How Classroom 50 Works](How-Classroom-50-Works) for the design these
+  limits fall out of.
+- [Troubleshooting](Troubleshooting) for error messages with fixes.

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -1,14 +1,14 @@
 # Known limitations
 
-Classroom 50 has no server: state lives in GitHub, work runs as you or as
-GitHub Actions in your organization. That design keeps your data yours, but
-it also rules some features out and makes others behave unexpectedly. This
-page lists those limits candidly, each with the reason and the workaround
-where one exists, so you don't have to rediscover them as bugs.
+Classroom 50 has no server: state lives in GitHub, and work runs as you or
+as GitHub Actions in your organization. That design keeps your data in your
+organization, but it also rules some features out and makes others behave
+unexpectedly. This page lists those limits, each with the reason and the
+workaround where one exists.
 
 ## Roster and enrollment
 
-**You can't add students by email alone.** GitHub's API provides no way to
+**Students can't be added by email alone.** GitHub's API provides no way to
 look up an account from an email address, so a roster is keyed by GitHub
 username. Workarounds: collect usernames up front (a signup form works
 well), or use the email-invitation path, where each student completes a
@@ -42,7 +42,7 @@ grading run fails. GitHub's own notifications still work (for example,
 watching activity on the `classroom50` repository or on feedback pull
 requests).
 
-**What you see refreshes when a page loads.** With no server polling in the
+**State refreshes only when a page loads.** With no server polling in the
 background, the app reads GitHub's current state when you open or reload a
 page, and scores update only when collection runs (nightly, or **Sync now**).
 If a view looks stale, reload it. See
@@ -50,11 +50,11 @@ If a view looks stale, reload it. See
 
 ## Templates and student repositories
 
-**Students can read private in-org templates.** Accept works by giving the
-classroom's team read access to the template, so a curious student can
-browse it, including its history. Never commit solutions (or their history)
-to a template: develop privately and copy or squash the clean state into the
-template repository you register.
+**Students can read private templates in your organization.** Accept works
+by giving the classroom's team read access to the template, so a curious
+student can browse it, including its history. Never commit solutions (or
+their history) to a template: develop privately and copy or squash the clean
+state into the template repository you register.
 
 **Student repositories are not forks.** Accept generates a copy of the
 template; there is no upstream link, so template updates can't be pushed or
@@ -84,8 +84,7 @@ pre-assigned teams. See
 read (the assignment list an accept link resolves against) is published
 through GitHub Pages, and a deploy takes from about 20 seconds to a few
 minutes. Right after you create or change an assignment, an accept link can
-briefly fail or show stale data; wait a minute and retry before debugging
-anything else.
+briefly fail or show stale data; wait a minute and retry.
 
 ## Requested, but architecturally hard
 
@@ -98,11 +97,11 @@ anything else.
   claims.
 
 Classroom 50 is open source and actively developed; if one of these matters
-to your course, weigh in on
+to your course, share your use case in
 [Discussions](https://github.com/foundation50/classroom50/discussions).
 
 ## Further reading
 
-- [How Classroom 50 Works](How-Classroom-50-Works) for the design these
-  limits fall out of.
+- [How Classroom 50 Works](How-Classroom-50-Works) for the design behind
+  these limits.
 - [Troubleshooting](Troubleshooting) for error messages with fixes.

--- a/wiki/Migrating-from-GitHub-Classroom.md
+++ b/wiki/Migrating-from-GitHub-Classroom.md
@@ -1,0 +1,112 @@
+# Migrating from GitHub Classroom
+
+How to bring an existing GitHub Classroom into Classroom 50: what the import
+carries over, what you rebuild, what behaves differently, and how to avoid
+conflicts while both tools touch the same organization.
+
+## The migration path
+
+The import copies each assignment's starter repository into your organization
+as a fresh template repository and recreates the assignments in a new
+classroom. GitHub Classroom ties one classroom to one organization; you can
+migrate several legacy classrooms into a single Classroom 50 organization by
+importing each one.
+
+**Prerequisite:** the target organization is set up for Classroom 50 (the
+one-time setup in the [Web Teacher Guide](Web-Teacher-Guide#set-up-an-organization-one-time)
+or [CLI Teacher Guide](CLI-Teacher-Guide#3-set-up-the-organization)).
+
+**Web app:** open your organization at
+`https://classroom50.org/YOUR-ORGANIZATION` and click
+**Import from GitHub Classroom**. Pick the classroom from the list of GitHub
+Classrooms your account administers, review the plan, and confirm; nothing is
+created until you do.
+
+**CLI:**
+
+```sh
+gh teacher classroom migrate --source cs50-legacy --target cs50-fall-2026
+```
+
+`--dry-run` previews without changes. See
+[`gh teacher classroom migrate`](gh-teacher#classroom-migrate) for source
+resolution, naming flags, and the failure model.
+
+## What carries over, and what doesn't
+
+**Imported:** the classroom (as a new Classroom 50 classroom), its
+assignments (individual and group, with group sizes), and a copy of each
+starter repository as a template in your organization.
+
+**Not imported:**
+
+- **Rosters.** You re-onboard students for the new term; see
+  [Add students](Web-Teacher-Guide#add-students).
+- **Scores and past student repositories.** They stay where they are, in the
+  old organization, and remain yours to keep.
+- **Autograding configuration.** GitHub Classroom's autograding setup doesn't
+  translate 1:1; the next section covers your options.
+
+## Reusing your autograders
+
+Classroom 50's [declarative tests](Autograders#declarative-tests) fill the
+role of GitHub Classroom's autograding presets: input/output, run-command,
+and pytest checks defined on the assignment, no grading script required. For
+most assignments, re-entering the tests on the imported assignment is the
+whole job.
+
+If you've invested in a working `autograding.json` workflow, you can keep it
+and skip Classroom 50's grading pipeline for that assignment; see
+[Bringing a GitHub Classroom autograder along](Autograders#bringing-a-github-classroom-autograder-along).
+
+## What behaves differently
+
+Most concepts carry over unchanged. The differences you'll hit, roughly in
+the order you'll hit them:
+
+- **Students don't self-select from a roster.** GitHub Classroom lets a
+  student pick their roster entry from an invite link. In Classroom 50 you
+  add students by GitHub username (individually or by CSV), which sends the
+  organization invitation; the accept link works once they've joined. There
+  are no roster identifiers. See
+  [Add students](Web-Teacher-Guide#add-students).
+- **Due dates don't cut anything off.** A due date only marks later
+  submissions late; there is no cutoff date. To end an assignment, use
+  **Close submission**, which blocks new accepts and sets student
+  repositories to read-only. See
+  [Course lifecycle and end of term](Course-Lifecycle-and-End-of-Term).
+- **Groups replace teams.** There's no team-creation step and no group
+  names: the first student to accept (the founder) creates the shared
+  repository and invites teammates, and the repository is named after the
+  founder. See [How group assignments work](FAQ#how-do-group-assignments-work).
+- **Scores live in your organization, not a dashboard.** Every graded
+  submission publishes a Release on the student's repository, and collection
+  gathers results into `scores.json` in your `classroom50` repository. You
+  download scores as CSV from the submissions page; students read their
+  results from their repository's Releases, not inside the app.
+
+For honest gaps rather than differences (features GitHub Classroom has and
+Classroom 50 doesn't), see [Known limitations](Known-Limitations).
+
+## Running both in the same organization
+
+Don't leave active GitHub Classroom classrooms in an organization you use
+with Classroom 50. The two tools disagree about the private-repository
+forking policy and each flips the setting back, an endless tug-of-war that
+shows up as settings warnings. Archive the old GitHub Classroom classrooms
+once you've migrated. See
+[Why org policies sometimes "drift"](How-Classroom-50-Works#why-org-policies-sometimes-drift).
+
+## Your existing scripts still work
+
+Each student gets a normal GitHub repository named
+`<classroom>-<assignment>-<username>`, as with GitHub Classroom, so scripts
+that automate git operations against student repositories generally carry
+over unchanged.
+
+## Further reading
+
+- [Coming from GitHub Classroom?](Glossary#coming-from-github-classroom) in
+  the Glossary, for vocabulary.
+- [How Classroom 50 Works](How-Classroom-50-Works#how-this-differs-from-github-classroom)
+  for the architectural comparison.

--- a/wiki/Migrating-from-GitHub-Classroom.md
+++ b/wiki/Migrating-from-GitHub-Classroom.md
@@ -19,8 +19,8 @@ or [CLI Teacher Guide](CLI-Teacher-Guide#3-set-up-the-organization)).
 **Web app:** open your organization at
 `https://classroom50.org/YOUR-ORGANIZATION` and click
 **Import from GitHub Classroom**. Pick the classroom from the list of GitHub
-Classrooms your account administers, review the plan, and confirm; nothing is
-created until you do.
+Classrooms your account administers, review the import summary, and confirm;
+nothing is created until you do.
 
 **CLI:**
 
@@ -51,9 +51,9 @@ starter repository as a template in your organization.
 
 Classroom 50's [declarative tests](Autograders#declarative-tests) fill the
 role of GitHub Classroom's autograding presets: input/output, run-command,
-and pytest checks defined on the assignment, no grading script required. For
-most assignments, re-entering the tests on the imported assignment is the
-whole job.
+and pytest checks defined on the assignment, with no grading script to
+write. For most assignments, migrating the autograder means re-entering
+those tests on the imported assignment.
 
 If you've invested in a working `autograding.json` workflow, you can keep it
 and skip Classroom 50's grading pipeline for that assignment; see
@@ -61,8 +61,8 @@ and skip Classroom 50's grading pipeline for that assignment; see
 
 ## What behaves differently
 
-Most concepts carry over unchanged. The differences you'll hit, roughly in
-the order you'll hit them:
+Most concepts carry over unchanged. The differences, roughly in the order
+you'll meet them:
 
 - **Students don't self-select from a roster.** GitHub Classroom lets a
   student pick their roster entry from an invite link. In Classroom 50 you
@@ -85,15 +85,15 @@ the order you'll hit them:
   download scores as CSV from the submissions page; students read their
   results from their repository's Releases, not inside the app.
 
-For honest gaps rather than differences (features GitHub Classroom has and
-Classroom 50 doesn't), see [Known limitations](Known-Limitations).
+For features GitHub Classroom has and Classroom 50 doesn't, see
+[Known limitations](Known-Limitations).
 
 ## Running both in the same organization
 
 Don't leave active GitHub Classroom classrooms in an organization you use
 with Classroom 50. The two tools disagree about the private-repository
-forking policy and each flips the setting back, an endless tug-of-war that
-shows up as settings warnings. Archive the old GitHub Classroom classrooms
+forking policy, and each keeps flipping the setting back, which shows up as
+recurring settings warnings. Archive the old GitHub Classroom classrooms
 once you've migrated. See
 [Why org policies sometimes "drift"](How-Classroom-50-Works#why-org-policies-sometimes-drift).
 

--- a/wiki/Prerequisites-and-GitHub-Education.md
+++ b/wiki/Prerequisites-and-GitHub-Education.md
@@ -1,0 +1,87 @@
+# Prerequisites and GitHub Education
+
+What you need before your first classroom: a GitHub organization on the right
+plan, a free upgrade through GitHub Education, and a network that can reach
+GitHub. Work through this page once and the setup guides go smoothly.
+
+## What you need
+
+- **A GitHub account** for you. Students each need their own free account;
+  no student pays for anything.
+- **A GitHub organization on the Team or Enterprise plan.** Classroom 50
+  stores everything in an organization and relies on Team-plan features,
+  most importantly GitHub Pages from a private repository.
+
+Create the organization at
+[github.com/account/organizations/new](https://github.com/account/organizations/new)
+if you don't have one. The Free plan is enough to create it; the next two
+sections cover the upgrade.
+
+## The organization's plan is separate from your account
+
+This is the most common setup surprise: organizations have their own plans,
+separate from any plan or benefit on your personal account. A teacher benefit
+on your account does not upgrade your organization by itself. You apply for
+the benefit first, then use it to upgrade the specific organization your
+classroom will live in.
+
+## Get the Team plan free through GitHub Education
+
+Verified teachers get GitHub Team free for their organizations:
+
+1. [Apply to GitHub Education as a teacher](https://docs.github.com/en/education/about-github-education/github-education-for-teachers/apply-to-github-education-as-a-teacher).
+   Verification goes fastest with a school-issued email address and clear
+   proof of your role, such as a photo of a valid faculty ID or an employment
+   letter. Blurry or expired documents are the usual reason applications
+   bounce.
+2. Wait for approval. Many applications clear in a few days, but allow up to
+   one or two weeks; apply before the term starts, not the week of.
+3. Once approved, upgrade your organization to GitHub Team at no cost
+   through your [GitHub Education](https://github.com/education/teachers)
+   benefits.
+
+If your school already runs GitHub Enterprise, your organization may already
+be covered; see the next section.
+
+## Enterprise organizations
+
+Enterprise-managed organizations work, but two setup warnings look like
+failures and aren't:
+
+- **"Couldn't verify the Actions spending cap"** (a `read failed (400)`
+  warning). Billing is managed at the enterprise level, so Classroom 50 can't
+  read it. The warning is advisory; setup continues. See
+  [Couldn't verify the Actions spending cap](Troubleshooting#couldnt-verify-the-actions-spending-cap).
+- **Branch protection can't be applied.** An enterprise policy can pin
+  branch-protection settings so that neither you nor Classroom 50 can change
+  them from the organization side. Ask your enterprise administrator to
+  adjust the policy, or note the warning and continue.
+
+Enterprise policies can also restrict which OAuth apps an organization may
+use. If Classroom 50 doesn't appear or can't be granted, an owner or
+enterprise administrator needs to approve it; see
+[My organization doesn't appear](Troubleshooting#my-organization-doesnt-appear).
+
+## School and district networks
+
+Classroom 50 runs in the browser, so the browser itself must reach GitHub and
+the app's domains. On a filtered network, ask IT to allow the short domain
+list in
+[Network and allowed domains](GitHub-Integration#network-and-allowed-domains).
+
+Two related problems have known workarounds:
+
+- **classroom50.org is blocked or flagged.** A few ISPs and school filters
+  have flagged the domain; add an exception or switch DNS resolvers. See
+  [classroom50.org won't load, or is flagged as unsafe](Troubleshooting#classroom50org-wont-load-or-is-flagged-as-unsafe).
+- **The sign-in proxy is blocked.** Some networks block `workers.dev`, which
+  breaks the normal **Sign in with GitHub** button. Sign in with a personal
+  access token instead; see
+  [If the proxy domain is blocked](GitHub-Integration#if-the-proxy-domain-is-blocked).
+
+## Next steps
+
+With the organization on the Team plan, follow the
+[Web Teacher Guide](Web-Teacher-Guide) or the
+[CLI Teacher Guide](CLI-Teacher-Guide) to run the one-time setup and create
+your first classroom.

--- a/wiki/Prerequisites-and-GitHub-Education.md
+++ b/wiki/Prerequisites-and-GitHub-Education.md
@@ -2,12 +2,12 @@
 
 What you need before your first classroom: a GitHub organization on the right
 plan, a free upgrade through GitHub Education, and a network that can reach
-GitHub. Work through this page once and the setup guides go smoothly.
+GitHub.
 
 ## What you need
 
-- **A GitHub account** for you. Students each need their own free account;
-  no student pays for anything.
+- **A GitHub account** for you. Students each need their own account; the
+  free plan is enough for students.
 - **A GitHub organization on the Team or Enterprise plan.** Classroom 50
   stores everything in an organization and relies on Team-plan features,
   most importantly GitHub Pages from a private repository.
@@ -19,23 +19,22 @@ sections cover the upgrade.
 
 ## The organization's plan is separate from your account
 
-This is the most common setup surprise: organizations have their own plans,
-separate from any plan or benefit on your personal account. A teacher benefit
-on your account does not upgrade your organization by itself. You apply for
-the benefit first, then use it to upgrade the specific organization your
-classroom will live in.
+Organizations have their own plans, separate from any plan or benefit on
+your personal account. A teacher benefit on your account does not upgrade
+your organization by itself: you apply for the benefit first, then use it to
+upgrade the specific organization your classroom will live in.
 
-## Get the Team plan free through GitHub Education
+## Getting the Team plan free through GitHub Education
 
 Verified teachers get GitHub Team free for their organizations:
 
 1. [Apply to GitHub Education as a teacher](https://docs.github.com/en/education/about-github-education/github-education-for-teachers/apply-to-github-education-as-a-teacher).
    Verification goes fastest with a school-issued email address and clear
    proof of your role, such as a photo of a valid faculty ID or an employment
-   letter. Blurry or expired documents are the usual reason applications
-   bounce.
+   letter. Blurry or expired documents are the most common reason
+   applications are rejected.
 2. Wait for approval. Many applications clear in a few days, but allow up to
-   one or two weeks; apply before the term starts, not the week of.
+   one or two weeks; apply well before the term starts.
 3. Once approved, upgrade your organization to GitHub Team at no cost
    through your [GitHub Education](https://github.com/education/teachers)
    benefits.
@@ -57,7 +56,7 @@ failures and aren't:
   them from the organization side. Ask your enterprise administrator to
   adjust the policy, or note the warning and continue.
 
-Enterprise policies can also restrict which OAuth apps an organization may
+Enterprise policies can also restrict which OAuth apps an organization can
 use. If Classroom 50 doesn't appear or can't be granted, an owner or
 enterprise administrator needs to approve it; see
 [My organization doesn't appear](Troubleshooting#my-organization-doesnt-appear).

--- a/wiki/Staff-TAs-and-Multiple-Teachers.md
+++ b/wiki/Staff-TAs-and-Multiple-Teachers.md
@@ -18,10 +18,9 @@ no separate role database, so staff you add show up as GitHub team
 invitations. For the underlying model, see
 [Roles are GitHub organization roles and teams](How-Classroom-50-Works#roles-are-github-organization-roles-and-teams).
 
-The head TA role exists for exactly the situation where a trusted grader
-needs to manage the classroom (edit assignments, run collection) without
-holding organization-owner power. TAs who only grade need the read-only TA
-role.
+The head TA role covers a trusted grader who manages the classroom (edits
+assignments, runs collection) without holding organization-owner power. TAs
+who only grade need the read-only TA role.
 
 ## Adding staff
 
@@ -73,8 +72,8 @@ With read access, TAs can open each student's work and leave reviews on the
 automatic reviewer assignment yet; TAs pick up repositories from the
 submissions page (**Open all Feedback PRs** steps through them).
 
-Because TAs and head TAs are ordinary organization members, graders no longer
-need owner rights to do their job. If your institution's privacy rules (such
+Because TAs and head TAs are ordinary organization members, graders don't
+need owner rights to do their work. If your institution's privacy rules (such
 as FERPA) require limiting who holds administrative access to student data,
 keep the teacher role small and use head TA and TA for everyone else.
 
@@ -109,8 +108,8 @@ student. See
 
 ## One organization or several?
 
-A single organization can hold many classrooms, so the question is really
-about people, not courses:
+A single organization can hold many classrooms, so the question is about
+people, not courses:
 
 - **One organization** works well for a stable teaching team running one
   course across terms or sections: create a classroom per term or section and

--- a/wiki/Staff-TAs-and-Multiple-Teachers.md
+++ b/wiki/Staff-TAs-and-Multiple-Teachers.md
@@ -1,0 +1,136 @@
+# Staff, TAs, and multiple teachers
+
+How to run a classroom with more than one person on staff: the four roles,
+how to grant them, what each role can see, and how to structure organizations
+when several teachers are involved.
+
+## The four roles
+
+| Role | On GitHub | Can |
+| --- | --- | --- |
+| **Teacher** | Organization **owner**, on the classroom's teacher team | Everything, including organization and classroom settings |
+| **Head TA** | Organization member, on the head-TA team | Write the `classroom50` repository; manage the classroom; not an owner |
+| **TA** | Organization member, on the TA team | Read the `classroom50` repository; view submissions and scores |
+| **Student** | Organization member, on the classroom team | Accept and submit assignments |
+
+A role is membership in one of the classroom's `secret` GitHub teams; there is
+no separate role database, so staff you add show up as GitHub team
+invitations. For the underlying model, see
+[Roles are GitHub organization roles and teams](How-Classroom-50-Works#roles-are-github-organization-roles-and-teams).
+
+The head TA role exists for exactly the situation where a trusted grader
+needs to manage the classroom (edit assignments, run collection) without
+holding organization-owner power. TAs who only grade need the read-only TA
+role.
+
+## Adding staff
+
+Adding a staff member sends them a GitHub invitation, which they must accept
+before the role takes effect. The web app and the CLI manage the same teams,
+so staff added in one show up in the other.
+
+**Web app:** open the classroom, click **Settings**, and use the
+**Staff and roles** section. Enter a GitHub username, pick a role, and click
+**Add**. The section also links each role's GitHub team and shows pending
+invitations.
+
+**CLI:**
+
+```sh
+gh teacher staff add cs50-fall-2026 cs-principles octocat --role ta
+```
+
+`--role` accepts `teacher`, `hta`, or `ta` and defaults to `teacher`. See
+[`gh teacher staff`](gh-teacher#staff) for details. Removing a staff member
+(`gh teacher staff remove`, or the web app's staff list) takes away the role
+but doesn't touch their organization membership.
+
+> [!NOTE]
+> Granting the **teacher** role makes that person an organization owner, with
+> full control over the whole organization, not only the classroom. Grant it
+> to co-teachers you'd trust with the organization itself; give everyone else
+> head TA or TA.
+
+## What TAs can and can't see
+
+TAs and head TAs see the same classroom content as teachers: the roster,
+assignments, submissions, and scores. The differences:
+
+- **Organization and classroom settings are teacher-only.** Only organization
+  owners can run setup, change organization policy, or write scores from the
+  web app.
+- **Pending invitations are owner-only.** GitHub lets only organization
+  owners read pending invitations, so a TA's roster view can't show who has
+  been invited but hasn't joined yet; the app notes this instead of showing
+  an incomplete list.
+- **Access to student repositories arrives with collection.** The
+  score-collection workflow grants the staff teams read access to student
+  repositories as it runs. A freshly accepted repository has no staff access
+  yet, which is expected; it appears after the next collection run.
+
+With read access, TAs can open each student's work and leave reviews on the
+[feedback pull request](Autograders#feedback-pull-requests). There is no
+automatic reviewer assignment yet; TAs pick up repositories from the
+submissions page (**Open all Feedback PRs** steps through them).
+
+Because TAs and head TAs are ordinary organization members, graders no longer
+need owner rights to do their job. If your institution's privacy rules (such
+as FERPA) require limiting who holds administrative access to student data,
+keep the teacher role small and use head TA and TA for everyone else.
+
+## Staff who are also students (dual roles)
+
+Classroom 50 doesn't stop one account from holding a staff role and a student
+enrollment in the same classroom. The common case is a teacher or TA who adds
+themselves to the roster to preview the student experience. The classroom's
+GitHub teams are the authority for enrollment and role; the `role` column in
+`roster.csv` is only a display snapshot. With that in mind:
+
+- **Roster view** shows all of the account's role badges, and the account
+  appears under each role's filter.
+- **In-app access** follows the highest role (`teacher > hta > ta >
+  student`), so a teacher-who-is-also-a-student keeps teacher-level access.
+  "View as" only changes the preview locally; it never grants access.
+- **`roster list` and the `role` column** record the single highest role. An
+  automatic sync may rewrite the column shortly after `roster add`; that's
+  the snapshot updating, not a change to enrollment.
+- **Submissions** list any account with a student enrollment as a student. A
+  pure-staff account appears in submissions only once it has accepted an
+  assignment repository.
+- **Unenroll** drops only the student side (the roster row and student-team
+  membership); the staff role stays.
+
+One caveat when testing as yourself: an organization owner keeps `admin` on
+their own assignment repository (GitHub won't let an owner reduce their own
+access), so it won't match a real student's `write`-level setup. For the
+exact student experience, use a separate GitHub account enrolled as a
+student. See
+[Testing an assignment as a student](FAQ#as-a-teacher-can-i-test-an-assignment-as-a-student).
+
+## One organization or several?
+
+A single organization can hold many classrooms, so the question is really
+about people, not courses:
+
+- **One organization** works well for a stable teaching team running one
+  course across terms or sections: create a classroom per term or section and
+  keep the same staff.
+- **Separate organizations per teacher** fit school-wide adoption, where many
+  teachers run unrelated classes; each teacher manages their own organization
+  and its staff.
+- **One organization per academic year** keeps a very large course tidy:
+  hundreds of assignment repositories per year stay grouped, and old years
+  can be archived wholesale.
+
+Each organization needs its own one-time setup (plan upgrade, setup run, and
+service token). See
+[Should I create one organization per course?](FAQ#should-i-create-one-organization-per-course-like-github-classroom)
+for the short version.
+
+## Further reading
+
+- [How Classroom 50 Works](How-Classroom-50-Works) for the permission model
+  behind roles.
+- [`gh teacher staff`](gh-teacher#staff) for command syntax.
+- [Course lifecycle and end of term](Course-Lifecycle-and-End-of-Term) for
+  end-of-term staff housekeeping.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,4 +1,5 @@
 - [Home](Home)
+- [Prerequisites and GitHub Education](Prerequisites-and-GitHub-Education)
 - [How Classroom 50 Works](How-Classroom-50-Works)
 - [Glossary](Glossary)
 - [FAQ](FAQ)
@@ -11,8 +12,13 @@
   - [CLI Student Guide](CLI-Student-Guide)
   - [gh teacher](gh-teacher)
   - [gh student](gh-student)
+- **Guides**
+  - [Staff, TAs, and Multiple Teachers](Staff-TAs-and-Multiple-Teachers)
+  - [Migrating from GitHub Classroom](Migrating-from-GitHub-Classroom)
+  - [Course Lifecycle and End of Term](Course-Lifecycle-and-End-of-Term)
 - **Reference**
   - [Assignment Templates](Assignment-Templates)
   - [Autograders](Autograders)
   - [GitHub Integration](GitHub-Integration)
+  - [Known Limitations](Known-Limitations)
   - [Troubleshooting](Troubleshooting)


### PR DESCRIPTION
## Summary

PR 1 of the wiki reorganization (follows #619): five new standalone pages, plus sidebar entries under the current structure. No existing content moves yet, so nothing breaks; content moves and de-duplication follow in a later PR.

- **Prerequisites and GitHub Education** — the onboarding gate: the org-plan-vs-personal-plan confusion, getting Team free through GitHub Education (timeline and verification gotchas), enterprise-org advisory warnings (spending cap 400, pinned branch protection), and school/district network guidance with the PAT sign-in fallback.
- **Staff, TAs, and multiple teachers** — the biggest current gap: the four roles and their GitHub mapping, adding staff (web and CLI), what TAs can and can't see (owner-only pending invitations, collection-granted repo access), FERPA-relevant boundaries, dual roles (duplicated from gh-teacher for now, per the plan; slimmed in the moves PR), and one-org-or-many guidance.
- **Migrating from GitHub Classroom** — consolidates fragments from six pages: the import path (web and CLI), what carries over and what doesn't, reusing autograding.json, the behavior differences in migration order, and the coexistence (private-forking tug-of-war) warning.
- **Course lifecycle and end of term** — release dates and locking, due dates vs Close submission, updating starter code after acceptance, and the end-of-term sequence (export, archive classroom, bulk-archive repositories with a GitHub CLI recipe, teardown).
- **Known limitations** — a candid serverless-limitations page (no email-to-username mapping, no join links, no in-app student scores, template visibility, repository renames, non-fork repositories, Pages latency, and so on), each with the why and the workaround, so teachers stop rediscovering these as bugs.

All prose follows `docs/github-docs-writing-style.md` and the Glossary canon (the `classroom50` repository, workflow files, score, due date). Every intra-wiki link and anchor is script-checked; no existing anchors changed.

## Test plan

- [ ] Review each page for factual accuracy against current app/CLI behavior
- [ ] Confirm the sidebar grouping (new **Guides** section; Known Limitations under Reference) reads well until the PR 4 restructure
- [ ] `wiki/` publish workflow mirrors the pages after merge