### PR TITLE
docs(wiki): split Autograders into four task-focused pages

### DIFF
--- a/wiki/Advanced-Autograding.md
+++ b/wiki/Advanced-Autograding.md
@@ -1,0 +1,475 @@
+# Advanced Autograding
+
+Custom grading beyond [declarative tests](Autograding-Basics#declarative-tests):
+writing your own `autograder.py`, the `result.json` contract every autograder
+must satisfy, the `runtime` block (toolchains, containers, self-hosted
+runners), and swapping the grading pipeline entirely. For the grading model
+and day-to-day results, see [Autograding Basics](Autograding-Basics).
+
+In paths and commands on this page, replace `CLASSROOM` with the classroom's
+short name and `ASSIGNMENT` with the assignment slug.
+
+## Writing an `autograder.py`
+
+When declarative tests aren't enough, write the grading logic yourself: the
+autograder is a Python script the runner invokes once per submission. There are
+two scopes:
+
+| Path | Scope | Used when |
+|---|---|---|
+| `CLASSROOM/autograders/ASSIGNMENT/autograder.py` | One assignment | Present in the bundle. |
+| `CLASSROOM/autograders/ASSIGNMENT/tests.json` | One assignment | [Declarative tests](Autograding-Basics#declarative-tests); no per-assignment `autograder.py`. |
+| `CLASSROOM/autograder.py` | One classroom | Neither of the above exists. |
+
+If none exist, the runner emits a vacuous pass (score 0/0) and the submission
+still lands as a tagged Release — a valid mid-setup state.
+
+### Precedence
+
+`runner.py` resolves the grading entrypoint in this order:
+
+1. Per-assignment `CLASSROOM/autograders/ASSIGNMENT/autograder.py` (an override
+   always wins).
+2. Per-assignment `tests.json` (declarative tests).
+3. Classroom default `CLASSROOM/autograder.py`.
+4. None of the above → vacuous pass.
+
+To keep precedence from silently swallowing tests, the CLI refuses `assignment
+test add` / `--tests` while a per-assignment `autograder.py` exists.
+
+### Contract
+
+The runner provides:
+
+- **Environment variables:** `CLASSROOM`, `ASSIGNMENT`, `SUBMISSION_TAG`,
+  `PAGES_BASE_URL`, `USERNAME`/`OWNER`, `ASSIGNMENT_TYPE`, `COMMIT_URL`,
+  `RELEASE_URL`, `REVIEW_URL`, and all standard `GITHUB_*`.
+- **Working directory:** the student's checkout (relative paths resolve to
+  student code).
+- **Sibling files:** anything else under `CLASSROOM/autograders/ASSIGNMENT/` is
+  bundled and lives at `Path(__file__).parent`.
+
+The autograder must produce **`./result.json`** (required — see
+[the `result.json` contract](#the-resultjson-contract)). Optionally
+`./release-body.md` and `status=`/`summary=` in `$GITHUB_OUTPUT`; the runner
+synthesizes them from `result.json` if absent. Exit **0** if it ran end-to-end
+(pass/fail is in `result.json`); a **non-zero** exit is an infrastructure error
+and the runner synthesizes a `status=error` result.
+
+<details>
+<summary>Template: pytest</summary>
+
+Drop at `CLASSROOM/autograders/ASSIGNMENT/autograder.py` alongside your `test_*.py`
+files:
+
+```python
+"""Pytest-based autograder. Runs sibling test_*.py files against
+the student's code, parses pytest's JSON report, emits result.json."""
+
+import datetime, json, os, subprocess, sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+REPORT = HERE / "pytest-report.json"
+
+WEIGHTS = {}          # per-test overrides; anything else gets DEFAULT_WEIGHT
+DEFAULT_WEIGHT = 1
+
+subprocess.run(
+    [sys.executable, "-m", "pip", "install", "--quiet", "--user",
+     "pytest", "pytest-json-report"],
+    check=True,
+)
+subprocess.run(
+    [sys.executable, "-m", "pytest", str(HERE),
+     "--json-report", f"--json-report-file={REPORT}", "-q", "--no-header"],
+    cwd=os.getcwd(),
+    check=False,
+)
+
+if not REPORT.is_file():
+    print("::error::pytest did not produce a JSON report", file=sys.stderr)
+    sys.exit(1)
+
+data = json.loads(REPORT.read_text())
+tests = []
+for t in data.get("tests", []):
+    nodeid = t.get("nodeid", "")
+    passed = t.get("outcome") == "passed"
+    max_score = WEIGHTS.get(nodeid.split("::")[-1], DEFAULT_WEIGHT)
+    tests.append({
+        "test-name": nodeid,
+        "passed": passed,
+        "score": max_score if passed else 0,
+        "max-score": max_score,
+    })
+
+result = {
+    "schema":     "classroom50/result/v1",
+    "classroom":  os.environ["CLASSROOM"],
+    "assignment": os.environ["ASSIGNMENT"],
+    # owner + assignment_type are stamped authoritatively by the runner.
+    "submission": os.environ["SUBMISSION_TAG"],
+    "commit":     os.environ["COMMIT_URL"],
+    "release":    os.environ["RELEASE_URL"],
+    "review":     os.environ.get("REVIEW_URL") or os.environ["COMMIT_URL"],
+    "datetime":   datetime.datetime.now(datetime.timezone.utc)
+                  .strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "score":      sum(t["score"] for t in tests),
+    "max-score":  sum(t["max-score"] for t in tests),
+    "tests":      tests,
+}
+Path("result.json").write_text(json.dumps(result, indent=2))
+```
+
+</details>
+
+<details>
+<summary>Template: minimal custom</summary>
+
+Anything that produces `result.json` works — compile-and-diff, image scoring,
+scraping a deployed app:
+
+```python
+import datetime, json, os, subprocess
+from pathlib import Path
+
+subprocess.run(["gcc", "-o", "hello", "hello.c"], check=True)
+proc = subprocess.run(["./hello"], capture_output=True, text=True, check=False)
+passed = proc.stdout.strip() == "Hello, world!"
+
+result = {
+    "schema":     "classroom50/result/v1",
+    "classroom":  os.environ["CLASSROOM"],
+    "assignment": os.environ["ASSIGNMENT"],
+    "submission": os.environ["SUBMISSION_TAG"],
+    "commit":     os.environ["COMMIT_URL"],
+    "release":    os.environ["RELEASE_URL"],
+    "review":     os.environ.get("REVIEW_URL") or os.environ["COMMIT_URL"],
+    "datetime":   datetime.datetime.now(datetime.timezone.utc)
+                  .strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "score":      1 if passed else 0,
+    "max-score":  1,
+    "tests": [
+        {"test-name": "prints_hello_world", "passed": passed,
+         "score": 1 if passed else 0, "max-score": 1},
+    ],
+}
+Path("result.json").write_text(json.dumps(result, indent=2))
+```
+
+</details>
+
+### Classroom default
+
+`gh teacher autograder set-default ORG CLASSROOM --from PATH` installs a
+default that grades every assignment without its own autograder or tests. With no
+`--from`, it installs a diagnostic stub (echoes the environment, emits a vacuous
+pass) — useful for verifying the pipeline. Inspect it with `autograder show`, and
+delete it outright with `autograder remove`.
+
+## The `result.json` contract
+
+This is the **only** contract every autograder must satisfy — whatever produces
+it (pytest, check50, a shell script, a Rust binary) is up to you. The runner
+reads `result.json` from the workspace after the autograder exits.
+
+```json
+{
+  "schema":          "classroom50/result/v1",
+  "classroom":       "cs-principles",
+  "assignment":      "hello",
+  "assignment_type": "individual",
+  "owner":           "alice",
+  "submission":      "submit/2026-06-01T14-32-05Z-a1b2c3d",
+  "commit":          "https://github.com/.../commit/SHA",
+  "release":         "https://github.com/.../releases/tag/submit%2F...",
+  "review":          "https://github.com/.../compare/BASELINE-SHA...SHA",
+  "datetime":        "2026-06-01T14:32:01Z",
+  "graded_at":       "2026-06-01T14:33:11Z",
+  "score":           4,
+  "max-score":       5,
+  "tests": [
+    { "test-name": "compiles",        "passed": true,  "score": 4, "max-score": 4 },
+    { "test-name": "outputs_correct", "passed": false, "score": 0, "max-score": 1 }
+  ]
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema` | string | Exactly `classroom50/result/v1`. |
+| `classroom` / `assignment` | string | Must match the source repository's identity (checked in code alongside `owner`). |
+| `assignment_type` | string | `individual` or `group`, stamped by the runner. |
+| `owner` | string | The repository owner login — the identity anchor. |
+| `submission` | string | The submit-tag name. |
+| `commit` / `release` / `review` | string | URLs. `review` is the full diff from starter code to the graded commit. |
+| `datetime` | string | The **submission instant**: the graded commit's committer date (UTC ISO 8601). Invariant across regrades, so late-marking never changes on a re-run. |
+| `graded_at` | string | Optional. When this grading run produced the result — moves on every regrade. |
+| `score` / `max-score` | int | Sum of test scores / max-scores. |
+| `tests` | array | Per-test breakdown (`[]` is valid for a vacuous pass). Extra diagnostic fields on a test are preserved verbatim. |
+| `submitted_by` | object | Optional. Who pushed: `username`, and `id` (which may be null or absent). |
+
+`collect-scores` validates this before merging into `scores.json`. A payload
+whose identity (classroom/assignment/`owner`) doesn't match the source repository is
+rejected, and a mismatched `assignment_type` is warned-and-skipped, so a hostile
+payload can't land in another student's collected scores.
+
+<details>
+<summary>scores.json shape</summary>
+
+`scores.json` is keyed by assignment slug under a root `assignments` object;
+each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is
+one repository's record: `owner` (the stable key), `submissions` (full history, newest
+first), and — for a group — `member_usernames` (credited members). Each bucket
+also carries a `collected_at` UTC timestamp stamped whenever a collection run
+walks that assignment (even if nothing changed), so per-assignment freshness is
+knowable — the web app's "Submission data synced" strip reads it.
+
+</details>
+
+## The `runtime` block
+
+Per-assignment environment (runner OS, language toolchains, packages, container
+image) lives as an optional `runtime` field on each `assignments.json` entry, or
+under **Advanced settings** in the web assignment form. The runner reads it on
+every submission, so changes propagate with no student-repository edit. Pass a JSON
+file to `gh teacher assignment add --runtime`:
+
+```json
+{
+  "runs-on": "ubuntu-latest",
+  "python":  "3.14",
+  "node":    "20",
+  "java":    "21",
+  "go":      "1.23",
+  "apt":     ["build-essential", "valgrind"]
+}
+```
+
+When omitted, the default is `ubuntu-latest` + Python 3.14. Inside a `container`,
+the image owns the toolchain unless you set `python` explicitly.
+
+| Field | Notes |
+|---|---|
+| `runs-on` | A single runner label (`"ubuntu-latest"`) or an array (`["self-hosted", "gpu"]`). No allow-list — you own the label; each is anti-injection-checked (1–10 labels). |
+| `python` / `node` / `java` / `go` | Version passed to the matching `setup-*` action. Skipped when unset (`python` defaults to 3.14 on the host path). |
+| `rust` | Rustup toolchain (`stable`, `1.79`, …) through `dtolnay/rust-toolchain`. |
+| `apt` | Debian/Ubuntu package names. Linux runners only. Mutually exclusive with `container`. |
+| `container` | Escape hatch — see below. |
+
+<details>
+<summary>Custom and self-hosted runners</summary>
+
+`runs-on` works exactly as in any GitHub Actions workflow. Multiple labels are AND-ed; a
+misspelled label won't match a runner. A `container` needs a Linux
+`runs-on`.
+
+**Self-hosted runners keep their own toolchains.** On a self-hosted runner the
+grade job skips *all* managed toolchain/apt setup (even the default Python), so
+the autograder runs against the interpreter and packages your image ships. Bake
+those into the runner image; `runner.py` still installs `pytest` /
+`pytest-json-report` on demand. Detection uses `runner.environment`, so keep the
+runner agent (v2.294.0+) up to date.
+
+</details>
+
+<details>
+<summary>Custom container</summary>
+
+```json
+{ "container": { "image": "cs50/cli:latest", "user": "root" } }
+```
+
+The image must be **publicly pullable** (private-registry pull secrets can't be
+delivered safely in a student repository). Set `user` for any image that doesn't run
+as root by default, or `actions/checkout` fails with a permission error. `image`
+is required and injection-checked; `user` accepts `docker run --user` syntax.
+
+</details>
+
+> [!NOTE]
+> `runtime` values are teacher-authored (from your `classroom50` repository), never student
+> input, so a permissive `runs-on` doesn't widen what a student repository can request.
+
+## Restricting submission files (`allowed_files`)
+
+An assignment can declare `allowed_files` — an ordered list of `.gitignore`-style
+patterns defining which files belong to the submission. It's an allowlist in
+gitignore syntax: `*` ignores everything, then `!hello.py` re-includes it.
+
+```sh
+gh teacher assignment add cs50-fall-2026 cs-principles hello \
+    --name "Hello" --template cs50/hello-template \
+    --allowed-files '*' --allowed-files '!hello.py'
+```
+
+- **Git's own syntax:** order matters, last match wins, `!` re-includes. Pass
+  `--allowed-files` once per pattern (don't comma-join). Omit it (or pass empty)
+  to allow every file.
+- **Re-running `add` rewrites the whole entry**, so re-pass `--allowed-files` to
+  keep it (the CLI warns when it's dropped).
+
+> [!WARNING]
+> **`allowed_files` gates what the autograder reads.** Files are removed before
+> setup and grading, so every student-checkout file they read must be
+> allowlisted. This includes dependency manifests (`requirements.txt`,
+> `pyproject.toml`), package source, setup scripts, and starter scaffolding.
+> Control files (`.classroom50.yaml`, `.github/`) are always kept.
+>
+> **It fails open** and is a grading-scope/hygiene tool, **not** a security
+> boundary: a student who forces a git failure (or pushes directly with
+> `git push`) gets the
+> unfiltered tree graded. Never use it to hide an answer key. Removals are logged
+> in the release body ("Removed N file(s)").
+
+## Attaching files to submission Releases
+
+Attach generated PDFs, plots, or logs to each submission's Release with the web
+form's **Submission release files**, or the `release_assets` field:
+
+```json
+"release_assets": ["report.pdf", "plots/chart.png"]
+```
+
+The runner resolves these paths **after grading** (so an autograder can generate
+them) and uploads them under their basenames.
+
+**Limits:** at most 50 paths totaling ≤ 8 KiB; each basename must be unique,
+Release-safe (ASCII letters/digits/`.`/`_`/`-`, no leading/trailing dot, no `..`,
+not `result.json` or `release-body.md`), and relative. A separate 100 MiB
+file-content budget applies at runtime. Missing, unsafe, oversized, or failed
+uploads warn without changing the score.
+
+> [!NOTE]
+> Submission publishing doesn't support GitHub Immutable Releases (reruns edit
+> the Release in place). To roll this out to an existing organization, run `gh teacher
+> init`, approve the workflow-files refresh, and wait for `publish-pages` to
+> finish.
+
+## Custom runner workflow (rare)
+
+Every earlier layer changes *what* grading does while keeping the built-in
+runner. When you need a different grading *pipeline* entirely — a
+[reusable workflow](https://docs.github.com/actions/using-workflows/reusing-workflows)
+you author yourself — `--autograder NAME` swaps the caller workflow instead of
+the autograder script. Most teachers never need this.
+
+**How the swap works.** By default `gh student accept` writes a small caller
+workflow to `.github/workflows/autograde.yaml` whose `uses:` points at the
+built-in `autograde-runner.yaml`. With `--autograder NAME`, accept instead
+fetches your caller from `CLASSROOM/autograders/NAME.yaml` and writes it
+verbatim. Your caller owns its own `on:` triggers and `uses:` a reusable
+workflow you control, so your grading logic runs in place of the runner.
+
+**Set one up:**
+
+1. **Add the reusable workflow** to your `classroom50` repository under `.github/workflows/`,
+   with a name other than the reserved `autograde-runner.yaml`. It must be
+   [callable](https://docs.github.com/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow)
+   (`on: workflow_call`). Non-reserved names are never touched by Classroom 50.
+2. **Add a caller workflow** at `CLASSROOM/autograders/NAME.yaml`. Give it
+   your trigger events and a `jobs.<id>.uses:` pointing at the workflow from
+   step 1. Because it's written verbatim, template `ORG`/branch refs to your
+   own values rather than relying on the built-in caller's substitution.
+3. **Register the assignment** with `gh teacher assignment add ORG CLASSROOM
+   ASSIGNMENT --autograder NAME`.
+
+> [!NOTE]
+> Once an assignment uses a custom autograder, `gh teacher assignment
+> submission-mode` never rewrites its caller workflow — trigger changes are
+> yours to make.
+
+### Bringing a GitHub Classroom autograder along
+
+This is the intended path for keeping an `autograding.json`-driven workflow after
+[migrating](FAQ#migrating-from-github-classroom). Classroom 50 has no
+`.github/classroom/autograding.json` of its own — the built-in runner reads a
+[`tests` block](Autograding-Basics#declarative-tests) instead — but a custom runner workflow lets
+you keep your existing format:
+
+1. Put your grading action's workflow in the `classroom50` repository's `.github/workflows/`
+   (any non-reserved name). Have it read `autograding.json` from the student
+   repository as before.
+2. Point a caller workflow at it as above, and register assignments with
+   `--autograder NAME`.
+3. Ship `autograding.json` (and any fixtures) in the **assignment template**, not
+   the `classroom50` repository — it travels with each student's starter code.
+
+> [!WARNING]
+> The template must **not** contain `.github/workflows/autograde.yaml`; that
+> name is reserved for the autograding caller and would be clobbered on accept
+> and submit (see [Assignment Templates](Assignment-Templates#structure)). Use
+> any other filename for template-side workflows.
+
+## Writing `assignments.json` from another client
+
+Anything that writes a valid `assignments.json` gets the whole pipeline for
+free. A non-CLI client (such as a GUI) must:
+
+1. Validate against
+   [`schemas/assignments-v1.schema.json`](https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json)
+   (two rules it can't express: unique test names, and name length ≤ 100 UTF-8
+   *bytes*).
+2. Probe before writing tests: `CLASSROOM/autograders/ASSIGNMENT/autograder.py`
+   must NOT exist, and `.github/scripts/materialize_tests.py` MUST exist.
+3. Write with the git-data API and retry on a non-fast-forward rejection.
+
+The CLI parses strictly (unknown fields rejected), so persist only schema fields.
+
+## Where to customize
+
+| To change… | Edit… | Propagates on… |
+|---|---|---|
+| Simple checks, no code | `tests` block (`assignment test add` / `--tests`) | Next Pages publish, then next submission |
+| Grading logic for one assignment | `CLASSROOM/autograders/ASSIGNMENT/autograder.py` | Next submission |
+| Grading logic for a classroom | `CLASSROOM/autograder.py` (`autograder set-default`) | Next submission |
+| Runtime for one assignment | `runtime` block on the entry | Next submission |
+| Files attached to Releases | `release_assets` (usually in the web form) | Next submission or regrade |
+
+All layers live in the `classroom50` repository; none require a
+student-repository change. Edit
+`autograde-runner.yaml` only to add a toolchain GitHub has no setup action for,
+or to replace the runner bootstrap.
+
+## Failure paths
+
+Classroom 50 separates an ordinary pass/fail score from an infrastructure error.
+Passing and failing scores publish the Release; an `error` posts an error status
+and leaves the Release unchanged.
+
+| What failed | What surfaces |
+|---|---|
+| Invalid hand-edited `release_assets` config | Setup exits with a field-specific `::error::`; no Release update |
+| Autograder produces `status=error` | Grade posts `error`; no Release update |
+| A configured extra is missing/unsafe/over budget | Warning; core and other extras continue |
+| Core Release or `result.json` upload fails | Grade job fails; latest pointer doesn't move |
+| Some tests fail | `status=failure`; Release publishes; details in the log and Summary |
+| All tests pass | `status=success`; Release publishes |
+
+A failure that stops the reusable workflow from loading doesn't appear in
+`scores.json`; collect counts the student as not-yet-submitted.
+
+## No credentials required
+
+Students never configure tokens or secrets. Grading runs on the job-scoped
+`GITHUB_TOKEN`, unauthenticated Pages fetches, and reusable-workflow access
+between the student repository and the `classroom50` repository (both in the teacher's organization,
+configured by `init`). The only PAT in the system is the teacher-side
+`CLASSROOM50_SERVICE_TOKEN`, used only by `collect-scores.yaml`.
+
+## Operational notes
+
+- **The grade job stops after 15 minutes.** This includes managed runtime setup,
+  the assignment Setup command, every test, and submission Release publishing.
+  Per-command timeouts do not extend the job limit.
+- **Every push grades, every push gets a Release** (in `every-push` mode). Five
+  pushes in ten minutes produce five graded runs and five Releases.
+- **Immutable-release rulesets freeze regrade Releases.** Orgs enforcing
+  immutable releases (a GitHub ruleset) cannot refresh a submission's Release
+  on regrade; the regraded score appears in the commit status and the GitHub Actions
+  job summary, but the Release — and thus the collected score for
+  that submission — keeps the pre-regrade result.
+- **Pages CDN lag:** updated content can take ~10 minutes to serve, so a
+  submission in that window may fetch the previous `runner.py` or bundle.
+- **Don't force-push or delete submit tags** — collection keys on them.

--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -38,7 +38,7 @@ A worked example lives at
   assignment enables **Use the template's pull request template as the Feedback
   PR body**, Classroom 50 uses this file's contents as each student's Feedback
   PR body instead of the built-in text. See
-  [Autograders](Autograders#feedback-pull-requests).
+  [Autograders](Autograding-Basics#feedback-pull-requests).
 - **Starter code** — any files the student starts from, from a single file to a
   full project.
 
@@ -47,7 +47,7 @@ A worked example lives at
 > shim is written by `gh student accept` (it's embedded in `gh-student`) and
 > never changes after accept. A copy in the template would be clobbered by
 > submit's `.github/` re-fetch and double-grade or break grading. Autograding
-> logic lives in your config repo, not the template — see [Autograders](Autograders).
+> logic lives in your config repo, not the template — see [Autograding Basics](Autograding-Basics).
 
 ## Set it up
 

--- a/wiki/Autograder-Recipes.md
+++ b/wiki/Autograder-Recipes.md
@@ -1,0 +1,197 @@
+# Autograder Recipes
+
+Working setups for grading common languages with
+[declarative tests](Autograding-Basics#declarative-tests): what to put in the
+template repository, the tests to define, and the failures teachers hit
+first. Each recipe works in the web assignment form or as a `--tests` JSON
+file; adjust names, commands, and points to your assignment.
+
+Two conventions apply throughout:
+
+- **Timeouts are per command** (`setup` and `run` separately), 1–600
+  seconds, default 10. Builds and dependency installs usually need more than
+  the default; the assignment's **Setup command** starts at 120 seconds.
+- **Every command starts in a fresh shell** in the student checkout. Files
+  and installed packages persist between commands; `cd`, `export`, and
+  virtual-environment activation don't. See
+  [Setup commands, dependencies, and environment variables](Autograding-Basics#setup-commands-dependencies-and-environment-variables).
+
+## Python
+
+The default runtime already provides Python; pin a version with a `runtime`
+of `{ "python": "3.14" }` if you need one.
+
+- **Template:** starter code, `requirements.txt` if the assignment has
+  dependencies, and your `test_*.py` files.
+- **Setup command:** `python3 -m pip install -r requirements.txt` (only when
+  there are dependencies). Raise its timeout for heavy installs, up to 600
+  seconds.
+- **Tests:** one `python` test runs pytest and splits its points across the
+  test cases. The runner auto-installs `pytest` and `pytest-json-report`;
+  add an install line only to pin versions.
+
+```json
+[
+  { "name": "pytest suite", "type": "python", "run": "python -m pytest -q", "timeout": 120, "points": 10 }
+]
+```
+
+Common failures:
+
+- `ModuleNotFoundError` — a dependency wasn't installed; add the
+  requirements install to the Setup command.
+- Imports work locally but not in grading — pytest can't see a `src/`
+  layout. Set `pythonpath` in `pyproject.toml` or `pytest.ini`, or prefix
+  the run command: `PYTHONPATH=src python -m pytest -q`.
+- Environment variables vanish between tests — expected; writes to
+  `$GITHUB_ENV` don't reach later tests. Set variables inline per command.
+
+## Java
+
+Pin a JDK with the `runtime` block, and commit the Gradle wrapper to the
+template so grading uses your build's exact Gradle version:
+
+```json
+{ "java": "21" }
+```
+
+- **Template:** a standard Gradle (or Maven) project with the wrapper
+  committed (`gradlew`, `gradle/wrapper/`), starter sources under
+  `src/main/java`, and your test classes under `src/test/java`.
+- **Tests:** a `run` test that passes when the build's tests pass. The first
+  run downloads Gradle and dependencies, so give it a generous timeout.
+
+```json
+[
+  { "name": "unit tests", "type": "run", "run": "sh ./gradlew test --console=plain", "timeout": 300, "points": 10 }
+]
+```
+
+For partial credit, add one `run` test per test class:
+`sh ./gradlew test --tests "CalculatorTest"` with its own points.
+
+Common failures:
+
+- `Permission denied: ./gradlew` — the wrapper lost its executable bit; run
+  it as `sh ./gradlew` (as above) or restore the bit in the template.
+- Timeouts on the first test — dependency downloads exceeded the limit;
+  raise the test's timeout rather than splitting the build.
+
+## C\#
+
+GitHub-hosted Ubuntu runners ship recent .NET SDKs, so most assignments need
+no runtime block. To pin an exact SDK, grade in a container:
+
+```json
+{ "container": { "image": "mcr.microsoft.com/dotnet/sdk:8.0" } }
+```
+
+- **Template:** a solution or project with the student code and an
+  `xunit`/`NUnit`/`MSTest` test project.
+- **Setup command:** `dotnet restore` with a raised timeout.
+- **Tests:** a `run` test on `dotnet test`.
+
+```json
+[
+  { "name": "unit tests", "type": "run", "run": "dotnet test --nologo", "timeout": 300, "points": 10 }
+]
+```
+
+For partial credit, filter per test group:
+`dotnet test --filter "FullyQualifiedName~AddTests"`.
+
+Common failures:
+
+- Timeouts — the first restore and build dominate; put `dotnet restore` in
+  the Setup command so test timeouts only cover the tests.
+
+## C and C++
+
+Compilers and `make` are preinstalled on Ubuntu runners; add packages with
+the runtime's `apt` list when you need more (for example
+`{ "apt": ["valgrind"] }`).
+
+- **Template:** starter sources plus your test program. For
+  [Catch2](https://github.com/catchorg/Catch2), commit the amalgamated
+  header and source with the template so nothing needs installing.
+- **Tests:** compile in a `setup` (or the Setup command), then run. Plain
+  input/output tests on the student's binary also work well and need no test
+  framework.
+
+```json
+[
+  { "name": "compiles", "type": "run", "run": "make", "timeout": 60, "points": 1 },
+  { "name": "unit tests", "type": "run", "setup": "g++ -std=c++17 -o tests tests.cpp student.cpp",
+    "run": "./tests", "timeout": 120, "points": 8 },
+  { "name": "prints usage", "type": "io", "run": "./student", "input": "\n",
+    "expected": "Usage:", "comparison": "included", "points": 1 }
+]
+```
+
+For partial credit with Catch2, run tagged subsets:
+`./tests "[part1]"` as one test, `./tests "[part2]"` as another.
+
+Common failures:
+
+- Compile errors surface as a failed `setup`; the captured compiler output
+  is in the Release body and the run's Grade details log.
+- A crashing binary fails an `io` test with the captured stderr; a hanging
+  one hits the test's timeout.
+
+## Rust
+
+Request a toolchain with the runtime block:
+
+```json
+{ "rust": "stable" }
+```
+
+- **Template:** a Cargo project with starter code and `#[test]` functions
+  (or a `tests/` directory). Commit `Cargo.lock` so grading builds the same
+  dependency versions students used.
+- **Tests:** `cargo test` as a `run` test. The first build compiles all
+  dependencies; give it the largest timeout.
+
+```json
+[
+  { "name": "builds", "type": "run", "run": "cargo build", "timeout": 300, "points": 1 },
+  { "name": "test suite", "type": "run", "run": "cargo test", "timeout": 120, "points": 9 }
+]
+```
+
+For partial credit, run one named test per declarative test:
+`cargo test test_add -- --exact` passes only when that test passes, so each
+carries its own points.
+
+Common failures:
+
+- Timeouts on `cargo test` — the build happened inside the test; add the
+  `cargo build` test first (as above) so compilation and testing budget
+  separately.
+
+## Bring your own CI
+
+If your grading already lives in workflows you maintain, you don't have to
+adopt the built-in autograder:
+
+- **Grade entirely outside Classroom 50.** Create the assignment with **Do
+  not use the built-in autograder**; each accept then installs no grading
+  workflow, your template's own CI runs instead, and score collection skips
+  the assignment. See
+  [Turning autograding off or pausing it](Managing-Actions-Cost#turning-autograding-off-or-pausing-it).
+- **Keep a GitHub Classroom `autograding.json`.** A custom runner workflow
+  lets your existing grading action keep reading `autograding.json` from
+  each student repository. See
+  [Bringing a GitHub Classroom autograder along](Advanced-Autograding#bringing-a-github-classroom-autograder-along).
+
+The one reserved filename is `.github/workflows/autograde.yaml`; template
+workflows under any other name are left alone.
+
+## Further reading
+
+- [Declarative tests](Autograding-Basics#declarative-tests) for every test
+  type and field.
+- [Writing an `autograder.py`](Advanced-Autograding#writing-an-autograderpy)
+  when a recipe outgrows declarative tests.
+- [The `runtime` block](Advanced-Autograding#the-runtime-block) for
+  toolchains, `apt` packages, containers, and self-hosted runners.

--- a/wiki/Autograders.md
+++ b/wiki/Autograders.md
@@ -1,1020 +1,167 @@
 # Autograders
 
-How Classroom 50 grades submissions, how to read the results, and how to
-customize grading. If you only remember one thing: **define tests on the
-assignment, and every submission gets a score you can read on the submissions
-page and export as CSV.**
+This page was split into four focused pages. Start from the one that matches
+your task:
+
+- **[Autograding Basics](Autograding-Basics)** — how grading works, grading
+  modes, declarative tests, which commits grade, reading results, and score
+  exports.
+- **[Autograder Recipes](Autograder-Recipes)** — working setups for Python,
+  Java, C#, C and C++, Rust, and bring-your-own-CI.
+- **[Advanced Autograding](Advanced-Autograding)** — writing an
+  `autograder.py`, the `result.json` contract, the `runtime` block, and
+  custom runner workflows.
+- **[Managing Actions cost](Managing-Actions-Cost)** — the cost playbook:
+  submission types, pausing, self-hosted runners, and the spending cap.
+
+The headings below preserve links to this page's former sections; each
+points to the section's new home.
 
 ## How grading works
 
-The whole pipeline, end to end:
-
-1. You define tests on the assignment — usually
-   [declarative tests](#declarative-tests) (input/output checks, run commands,
-   or pytest), written in the web form or with `gh teacher assignment test add`.
-2. A student submits by pushing to their repository, or explicitly with
-   `gh student submit`, depending on the assignment's
-   [submission type](#which-commits-grade).
-3. GitHub Actions grades the submission in the student's own repository:
-   a small workflow calls the shared **autograde runner**, which fetches your
-   grading config and runs the tests against the submitted commit.
-4. The runner publishes the result on the student's repository as a GitHub
-   **Release** on a `submit/<UTC-timestamp>-<short-sha>` tag — the score, a
-   per-test PASS/FAIL table, and a machine-readable `result.json`. The graded
-   commit also gets a `classroom50/autograde` commit status, and the student's
-   **View grade** link opens the Release.
-5. The **score-collection** workflow collects scores into the gradebook
-   (`scores.json` in your config repository) — nightly, or on demand with
-   **Sync now** on the submissions page. That's what the web app's submissions
-   page and both CSV exports read. See [Reading results](#reading-results).
-
-Steps 3–5 run with no per-repository maintenance: everything substantive (the runner
-workflow, `runner.py`, autograders, runtime config) lives in the config repository
-and is fetched at run time, so a grading edit reaches every existing student
-repository on the next submission.
-
-Both surfaces drive the same pipeline: the web assignment form and
-`gh teacher assignment` write the same `assignments.json`, and the submissions
-page and `gh teacher download` read the same results.
-
-> [!NOTE]
-> Grading and publishing share one job and runner, so the workflow is **not** a
-> credential or hostile-workflow isolation boundary between them.
+Moved to [How grading works](Autograding-Basics#how-grading-works) in
+Autograding Basics.
 
 ## Setting up grading
 
+Moved to [Setting up grading](Autograding-Basics#setting-up-grading) in
+Autograding Basics.
+
 ### Grading modes
 
-Each assignment has a **Grading** choice (the web form's Grading field; the
-`grading` block in `assignments.json`):
-
-- **Not graded** — no scores; submissions still tag and publish Releases, and
-  the Feedback PR still works.
-- **Autograded** — the default meaning of grading here: tests or an
-  `autograder.py` score each submission automatically. The rest of this page
-  is about this mode.
-- **Manual** — you enter each score by hand on the submissions page, out of
-  the assignment's **Max points**. No autograder score is used — though the
-  built-in workflow still runs on submissions unless you also turn the
-  built-in autograder off.
-
-Two related, optional settings:
-
-- **Pass threshold** — an advisory percentage of the max score (0–100) at or
-  above which the submissions page shows a submission as *passing* (badges,
-  passing/failing rollups, and filters). It never changes a student's actual
-  score, and leaving it unset turns the passing concept off.
-- **Built-in autograder off** (`no_autograder`) — accept installs no
-  autograding workflow at all; a templated assignment's own CI runs instead,
-  and score collection skips the assignment. See
-  [Turning autograding off or pausing it](#turning-autograding-off-or-pausing-it).
+Moved to [Grading modes](Autograding-Basics#grading-modes) in Autograding
+Basics.
 
 ### Declarative tests
 
-The lowest-friction way to grade: describe io/run/pytest checks directly on the
-assignment, and the runner grades them with a built-in interpreter — no grading
-code to write. The three types map onto GitHub Classroom's legacy autograder
-presets.
-
-In the web app, add tests in the assignment form's **Autograding tests**
-section. From the CLI, author them one at a time:
-
-```sh
-gh teacher assignment test add cs50-fall-2026 cs-principles hello \
-    --name compiles --type run --run "gcc -o hello hello.c" --points 1
-gh teacher assignment test add cs50-fall-2026 cs-principles hello \
-    --name "prints hello" --type io --setup "gcc -o hello hello.c" \
-    --run ./hello --expected "Hello, world!" --comparison included --points 2
-gh teacher assignment test list cs50-fall-2026 cs-principles hello
-gh teacher assignment test remove cs50-fall-2026 cs-principles hello compiles
-```
-
-Or set the whole array at once with `gh teacher assignment add ... --tests
-<file.json>` (`--tests -` reads stdin). The file is a bare JSON array — the same
-shape `assignment test list --json` emits:
-
-```json
-[
-  { "name": "compiles", "type": "run", "run": "gcc -o hello hello.c", "timeout": 30, "points": 1 },
-  { "name": "prints Hello, world!", "type": "io", "setup": "gcc -o hello hello.c",
-    "run": "./hello", "expected": "Hello, world!", "comparison": "included", "points": 2 },
-  { "name": "greets by name", "type": "io", "setup": "gcc -o hello hello.c",
-    "run": "./hello", "input": "Alice\n", "expected": "^hello,\\s+Alice\\b",
-    "comparison": "regex", "points": 2 },
-  { "name": "pytest suite", "type": "python", "run": "python -m pytest -q", "timeout": 120, "points": 10 }
-]
-```
-
-#### Test types
-
-| Type | Passes when | Type-specific fields |
-|---|---|---|
-| `io` | stdout of `run` matches `expected` per `comparison` | `input` / `input-file`, `expected` / `expected-file`, `comparison` |
-| `run` | exit code of `run` equals `exit-code` (default 0) | `exit-code` |
-| `python` | pytest passes; points split across cases | — |
-
-> [!NOTE]
-> The runner auto-installs `pytest` and `pytest-json-report` for `python` tests.
-> Add a `setup` install line only to pin a version.
-
-#### Fields
-
-| Field | Notes |
-|---|---|
-| `name` | Required. Unique within the assignment; ≤ 100 UTF-8 bytes; no control characters. |
-| `type` | Required. `io`, `run`, or `python`. |
-| `run` | Required. Shell command, run in the student checkout. |
-| `setup` | Optional pre-command (for example, compile). Non-zero exit fails the test. |
-| `input` / `input-file` | `io` only, mutually exclusive. Inline stdin or a bundled fixture. |
-| `expected` / `expected-file` | `io` only, mutually exclusive. Must be non-empty for `included`/`regex`. |
-| `comparison` | `io` only. `included` (substring), `exact` (trimmed equality), or `regex` (Python `re.search`, multiline). |
-| `timeout` | Seconds, 1–600. Omit or 0 for the default of 10s. Applies to `setup` and `run` separately. |
-| `exit-code` | `run` only, 0–255. Omit to require 0. |
-| `points` | Required, 0–1000. A 0-point test does not affect the numeric score; a failure still sets the autograde status to `failure`. |
-
-At most 100 tests per assignment. Put large fixtures in files
-(`input-file` / `expected-file`) under `CLASSROOM/autograders/ASSIGNMENT/`, not
-inline. In paths and commands on this page, replace `CLASSROOM` with the
-classroom's short name and `ASSIGNMENT` with the assignment slug.
+Moved to [Declarative tests](Autograding-Basics#declarative-tests) in
+Autograding Basics.
 
 ### Setup commands, dependencies, and environment variables
 
-The web assignment's **Setup command** is stored as the leading zero-point
-`run` test named `setup`. New setup commands start with a 120-second timeout.
-Set the timeout to 0 for the runner's 10-second default, or choose a whole
-number from 1 through 600. A failure or timeout sets the autograde status to
-`failure` without changing the numeric score; later tests still run.
-
-Use the command for filesystem changes that later tests need. Install a
-requirements file with:
-
-```sh
-python3 -m pip install -r requirements.txt
-```
-
-For a packaged project, including one with a `src/` layout, install the package
-in editable mode:
-
-```sh
-python3 -m pip install -e .
-```
-
-Choose the command that matches the project. An editable package install reads
-the project's package metadata; a separate requirements install is needed only
-when the project uses that file.
-
-Every assignment setup, per-test `setup`, and `run` command starts in a separate
-shell process in the student checkout. Files, virtual-environment directories,
-and installed packages persist between commands. Shell state does not: `cd`,
-`export`, aliases, and virtual-environment activation end when their command
-exits. Invoke a virtual environment's interpreter by path in later commands,
-for example `.venv/bin/python -m pytest -q` on Linux or macOS and
-`.venv\Scripts\python.exe -m pytest -q` on Windows.
-
-For pytest-only import paths, set `pythonpath` in `pyproject.toml` or
-`pytest.ini`. A command that needs one environment value can set it inline on
-Linux or macOS:
-
-```sh
-PYTHONPATH=src python3 -m pytest -q
-```
-
-On Windows:
-
-```bat
-set "PYTHONPATH=src" && python -m pytest -q
-```
-
-Do not write grading environment variables to `$GITHUB_ENV`. All declarative
-commands run as child processes inside the single Grade details workflow step,
-and GitHub Actions reads `$GITHUB_ENV` only after that step finishes. A write
-cannot change the runner process or the environment of later tests.
-
-<details>
-<summary>How tests flow, and where failures surface</summary>
-
-Tests live inline in `assignments.json`. On the next config-repository push,
-publish-pages **materializes** them into the assignment's Pages bundle as
-`tests.json`. At grade time, `runner.py` runs each spec in the student checkout:
-one row per test in `result.json`, plus a failure breakdown in three places — the
-**Release body**, the **grade job log** ("Grade details"), and the **run Summary
-page**. Captured output is truncated at 2000 characters.
-
-Specs are validated three times: by the CLI at write time, by the runner
-workflow at submission setup, and by `runner.py` before executing.
-
-</details>
-
-<details>
-<summary>Writing a valid assignments.json from another client (such as a GUI)</summary>
-
-Anything that writes a valid `assignments.json` gets the whole pipeline for
-free. A non-CLI client must:
-
-1. Validate against
-   [`schemas/assignments-v1.schema.json`](https://github.com/foundation50/classroom50/blob/main/schemas/assignments-v1.schema.json)
-   (two rules it can't express: unique test names, and name length ≤ 100 UTF-8
-   *bytes*).
-2. Probe before writing tests: `CLASSROOM/autograders/ASSIGNMENT/autograder.py`
-   must NOT exist, and `.github/scripts/materialize_tests.py` MUST exist.
-3. Write with the git-data API and retry on a non-fast-forward rejection.
-
-The CLI parses strictly (unknown fields rejected), so persist only schema fields.
-
-</details>
+Moved to
+[Setup commands, dependencies, and environment variables](Autograding-Basics#setup-commands-dependencies-and-environment-variables)
+in Autograding Basics.
 
 ### Writing an `autograder.py`
 
-When declarative tests aren't enough, write the grading logic yourself: the
-autograder is a Python script the runner invokes once per submission. There are
-two scopes:
-
-| Path | Scope | Used when |
-|---|---|---|
-| `CLASSROOM/autograders/ASSIGNMENT/autograder.py` | One assignment | Present in the bundle. |
-| `CLASSROOM/autograders/ASSIGNMENT/tests.json` | One assignment | [Declarative tests](#declarative-tests); no per-assignment `autograder.py`. |
-| `CLASSROOM/autograder.py` | One classroom | Neither of the above exists. |
-
-If none exist, the runner emits a vacuous pass (score 0/0) and the submission
-still lands as a tagged Release — a valid mid-setup state.
-
-#### Precedence
-
-`runner.py` resolves the grading entrypoint in this order:
-
-1. Per-assignment `CLASSROOM/autograders/ASSIGNMENT/autograder.py` (an override
-   always wins).
-2. Per-assignment `tests.json` (declarative tests).
-3. Classroom default `CLASSROOM/autograder.py`.
-4. None of the above → vacuous pass.
-
-To keep precedence from silently swallowing tests, the CLI refuses `assignment
-test add` / `--tests` while a per-assignment `autograder.py` exists.
-
-#### Contract
-
-The runner provides:
-
-- **Environment variables:** `CLASSROOM`, `ASSIGNMENT`, `SUBMISSION_TAG`,
-  `PAGES_BASE_URL`, `USERNAME`/`OWNER`, `ASSIGNMENT_TYPE`, `COMMIT_URL`,
-  `RELEASE_URL`, `REVIEW_URL`, and all standard `GITHUB_*`.
-- **Working directory:** the student's checkout (relative paths resolve to
-  student code).
-- **Sibling files:** anything else under `CLASSROOM/autograders/ASSIGNMENT/` is
-  bundled and lives at `Path(__file__).parent`.
-
-The autograder must produce **`./result.json`** (required — see
-[the `result.json` contract](#the-resultjson-contract)). Optionally
-`./release-body.md` and `status=`/`summary=` in `$GITHUB_OUTPUT`; the runner
-synthesizes them from `result.json` if absent. Exit **0** if it ran end-to-end
-(pass/fail is in `result.json`); a **non-zero** exit is an infrastructure error
-and the runner synthesizes a `status=error` result.
-
-<details>
-<summary>Template: pytest</summary>
-
-Drop at `CLASSROOM/autograders/ASSIGNMENT/autograder.py` alongside your `test_*.py`
-files:
-
-```python
-"""Pytest-based autograder. Runs sibling test_*.py files against
-the student's code, parses pytest's JSON report, emits result.json."""
-
-import datetime, json, os, subprocess, sys
-from pathlib import Path
-
-HERE = Path(__file__).parent
-REPORT = HERE / "pytest-report.json"
-
-WEIGHTS = {}          # per-test overrides; anything else gets DEFAULT_WEIGHT
-DEFAULT_WEIGHT = 1
-
-subprocess.run(
-    [sys.executable, "-m", "pip", "install", "--quiet", "--user",
-     "pytest", "pytest-json-report"],
-    check=True,
-)
-subprocess.run(
-    [sys.executable, "-m", "pytest", str(HERE),
-     "--json-report", f"--json-report-file={REPORT}", "-q", "--no-header"],
-    cwd=os.getcwd(),
-    check=False,
-)
-
-if not REPORT.is_file():
-    print("::error::pytest did not produce a JSON report", file=sys.stderr)
-    sys.exit(1)
-
-data = json.loads(REPORT.read_text())
-tests = []
-for t in data.get("tests", []):
-    nodeid = t.get("nodeid", "")
-    passed = t.get("outcome") == "passed"
-    max_score = WEIGHTS.get(nodeid.split("::")[-1], DEFAULT_WEIGHT)
-    tests.append({
-        "test-name": nodeid,
-        "passed": passed,
-        "score": max_score if passed else 0,
-        "max-score": max_score,
-    })
-
-result = {
-    "schema":     "classroom50/result/v1",
-    "classroom":  os.environ["CLASSROOM"],
-    "assignment": os.environ["ASSIGNMENT"],
-    # owner + assignment_type are stamped authoritatively by the runner.
-    "submission": os.environ["SUBMISSION_TAG"],
-    "commit":     os.environ["COMMIT_URL"],
-    "release":    os.environ["RELEASE_URL"],
-    "review":     os.environ.get("REVIEW_URL") or os.environ["COMMIT_URL"],
-    "datetime":   datetime.datetime.now(datetime.timezone.utc)
-                  .strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "score":      sum(t["score"] for t in tests),
-    "max-score":  sum(t["max-score"] for t in tests),
-    "tests":      tests,
-}
-Path("result.json").write_text(json.dumps(result, indent=2))
-```
-
-</details>
-
-<details>
-<summary>Template: minimal custom</summary>
-
-Anything that produces `result.json` works — compile-and-diff, image scoring,
-scraping a deployed app:
-
-```python
-import datetime, json, os, subprocess
-from pathlib import Path
-
-subprocess.run(["gcc", "-o", "hello", "hello.c"], check=True)
-proc = subprocess.run(["./hello"], capture_output=True, text=True, check=False)
-passed = proc.stdout.strip() == "Hello, world!"
-
-result = {
-    "schema":     "classroom50/result/v1",
-    "classroom":  os.environ["CLASSROOM"],
-    "assignment": os.environ["ASSIGNMENT"],
-    "submission": os.environ["SUBMISSION_TAG"],
-    "commit":     os.environ["COMMIT_URL"],
-    "release":    os.environ["RELEASE_URL"],
-    "review":     os.environ.get("REVIEW_URL") or os.environ["COMMIT_URL"],
-    "datetime":   datetime.datetime.now(datetime.timezone.utc)
-                  .strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "score":      1 if passed else 0,
-    "max-score":  1,
-    "tests": [
-        {"test-name": "prints_hello_world", "passed": passed,
-         "score": 1 if passed else 0, "max-score": 1},
-    ],
-}
-Path("result.json").write_text(json.dumps(result, indent=2))
-```
-
-</details>
-
-#### Classroom default
-
-`gh teacher autograder set-default ORG CLASSROOM --from PATH` installs a
-default that grades every assignment without its own autograder or tests. With no
-`--from`, it installs a diagnostic stub (echoes the environment, emits a vacuous
-pass) — useful for verifying the pipeline. Inspect it with `autograder show`, and
-delete it outright with `autograder remove`.
+Moved to
+[Writing an `autograder.py`](Advanced-Autograding#writing-an-autograderpy)
+in Advanced Autograding.
 
 ### The `runtime` block
 
-Per-assignment environment (runner OS, language toolchains, packages, container
-image) lives as an optional `runtime` field on each `assignments.json` entry, or
-under **Advanced settings** in the web assignment form. The runner reads it on
-every submission, so changes propagate with no student-repository edit. Pass a JSON
-file to `gh teacher assignment add --runtime`:
-
-```json
-{
-  "runs-on": "ubuntu-latest",
-  "python":  "3.14",
-  "node":    "20",
-  "java":    "21",
-  "go":      "1.23",
-  "apt":     ["build-essential", "valgrind"]
-}
-```
-
-When omitted, the default is `ubuntu-latest` + Python 3.14. Inside a `container`,
-the image owns the toolchain unless you set `python` explicitly.
-
-| Field | Notes |
-|---|---|
-| `runs-on` | A single runner label (`"ubuntu-latest"`) or an array (`["self-hosted", "gpu"]`). No allow-list — you own the label; each is anti-injection-checked (1–10 labels). |
-| `python` / `node` / `java` / `go` | Version passed to the matching `setup-*` action. Skipped when unset (`python` defaults to 3.14 on the host path). |
-| `rust` | Rustup toolchain (`stable`, `1.79`, …) through `dtolnay/rust-toolchain`. |
-| `apt` | Debian/Ubuntu package names. Linux runners only. Mutually exclusive with `container`. |
-| `container` | Escape hatch — see below. |
-
-<details>
-<summary>Custom and self-hosted runners</summary>
-
-`runs-on` works exactly as in any GitHub Actions workflow. Multiple labels are AND-ed; a
-misspelled label won't match a runner. A `container` needs a Linux
-`runs-on`.
-
-**Self-hosted runners keep their own toolchains.** On a self-hosted runner the
-grade job skips *all* managed toolchain/apt setup (even the default Python), so
-the autograder runs against the interpreter and packages your image ships. Bake
-those into the runner image; `runner.py` still installs `pytest` /
-`pytest-json-report` on demand. Detection uses `runner.environment`, so keep the
-runner agent (v2.294.0+) up to date.
-
-</details>
-
-<details>
-<summary>Custom container</summary>
-
-```json
-{ "container": { "image": "cs50/cli:latest", "user": "root" } }
-```
-
-The image must be **publicly pullable** (private-registry pull secrets can't be
-delivered safely in a student repository). Set `user` for any image that doesn't run
-as root by default, or `actions/checkout` fails with a permission error. `image`
-is required and injection-checked; `user` accepts `docker run --user` syntax.
-
-</details>
-
-> [!NOTE]
-> `runtime` values are teacher-authored (from your config repository), never student
-> input, so a permissive `runs-on` doesn't widen what a student repository can request.
+Moved to [The `runtime` block](Advanced-Autograding#the-runtime-block) in
+Advanced Autograding.
 
 ## Which commits grade
 
-What triggers grading is a **per-assignment choice** (the web form's
-**Submission type**; `submission_mode` in assignments.json; `gh teacher
-assignment add --submission-mode` / `gh teacher assignment submission-mode`):
-
-**`every-push` (the default)** — grading triggers on two events:
-
-- **Push to the default branch** — every commit grades, **except the acceptance
-  commit** (the one that introduced `.classroom50.yaml`, with nothing on top).
-- **Push of a `submit/*` tag** — manual tag pushes work too.
-
-**`tag`** — grading triggers **only** on `submit/*` tag pushes. A plain
-`git push` runs nothing and costs no GitHub Actions minutes — the cost lever for
-large cohorts. Submissions become an explicit act:
-
-- `gh student submit` pushes a `submit/<UTC-timestamp>-<short-sha>` tag after
-  the branch commit — that tag push is what grades.
-- A hand-pushed tag works exactly the same: `git tag submit/anything && git
-  push origin submit/anything`. Any tag under `submit/` grades; no CLI
-  required.
-
-**Milestone submission tags** — with either mode, the assignment can also
-name **milestone tags** (`submission_tags` in assignments.json, the web form's
-**Submission tags** field, for example `["phase1", "phase2", "complete"]`, settable at
-creation or from the assignment settings / `gh teacher assignment add
---submission-tag`). Pushing a matching tag grades that commit — plain git, no
-CLI required:
-
-```sh
-git tag phase1
-git push origin phase1
-```
-
-Simple globs work too (`v*`), though exact milestone names are safer — a
-broad glob grades every matching tag a student pushes. The milestone tag
-**triggers** grading; the graded **record** still lives at the canonical
-`submit/<UTC-timestamp>-<short-sha>` tag the runner mints at that commit (its
-Release title notes *"via phase1"*), so history stays one-immutable-release-
-per-submission and collection, regrade, and the gradebook are unaffected. The
-`submit/*` namespace always keeps working alongside milestone tags.
-
-Because the trigger lives in each student repository's workflow (GitHub evaluates a
-workflow's `on:` block before any job runs), **changing the mode or the
-milestone patterns after repositories exist requires retrofitting each repository's
-workflow** — see
-[Changing the trigger on existing repositories](#changing-the-trigger-on-existing-repositories).
-
-<details>
-<summary>Why the acceptance commit is skipped</summary>
-
-Accepting lands `.classroom50.yaml` + the workflow in one commit, which fires
-the workflow — but that's *accepting*, not *submitting*. The runner detects it
-and skips tagging, grading, and the Release (the run still appears in the
-Actions tab with a `notice`). Detection is **fail-open**: any uncertainty grades
-rather than risk dropping a real submission. Your first `gh student submit`
-always stacks a fresh commit, so it's never mistaken for the acceptance.
-
-</details>
-
-<details>
-<summary>Tag-mode defenses in the runner</summary>
-
-Two guards keep tag mode honest even when a repository's workflow trigger is stale:
-
-- **Stale-trigger suppression** — a repository accepted before the mode flipped to
-  `tag` (or whose retrofit failed) still carries the every-push trigger. The
-  runner reads `submission_mode` from the published assignments.json at setup
-  time and, when the assignment is tag-mode but the run was branch-triggered,
-  skips tagging and grading, posting a `classroom50/autograde-skipped`
-  success status: *"tag-mode assignment — push not graded; run gh student
-  submit"*.
-- **Retrofit-commit skip** — the teacher-side trigger update commits with
-  `[skip ci]`, so it fires no workflow. As a backstop (for example, a client that
-  dropped the marker), the runner also recognizes a tip commit touching ONLY
-  `.github/workflows/autograde.yaml` and skips it with the status
-  *"autograder trigger updated — nothing to grade"*.
-- **Foreign-tag suppression** — a pushed tag matching neither `submit/*` nor
-  any configured milestone pattern (possible only with a stale or hand-edited
-  workflow) is skipped gracefully with the `classroom50/autograde-skipped`
-  status *"tag is not a submission trigger — not graded"*, never a failed run.
-
-The two suppression statuses use the separate `classroom50/autograde-skipped`
-context deliberately: in both cases the student's real work exists but was
-**not** graded, and a green `classroom50/autograde` would read as "graded
-successfully". Graded commits alone report under `classroom50/autograde`.
-(The nothing-to-grade skips — acceptance commit, trigger-update commit, no
-autograder configured — stay on the main context: there is no work there to
-mistake for graded.)
-
-</details>
+Moved to [Which commits grade](Autograding-Basics#which-commits-grade) in
+Autograding Basics.
 
 ### Changing the trigger on existing repositories
 
-The autograding workflow is written into each student repository at accept time and
-otherwise never changes, so flipping `submission_mode` on an assignment with
-accepted repositories needs a retrofit:
-
-- **CLI**: `gh teacher assignment submission-mode ORG CLASSROOM ASSIGNMENT
-  --tag` (or `--every-push`) flips the field AND rewrites the workflow across
-  every student repository (add `--user USERNAME` for one repository, `--dry-run` to
-  preview). Requires the `workflow` OAuth scope
-  (`gh auth refresh -s workflow`).
-- **Web**: change the trigger on the assignment settings page, then run
-  **Update autograding triggers** from the submissions page's actions menu
-  (or per-repository from a row's manage dialog).
-
-The rewrite is surgical — only the trigger lines change; a workflow a student
-hand-edited is reported and left untouched. **Custom (non-default)
-autograders are never rewritten**: you own their `on:` block; edit it
-yourself and use `--update-shims=false` to flip only the field.
-
-After a retrofit, students must `git pull` — clones made before the change
-conflict on their next push.
+Moved to
+[Changing the trigger on existing repositories](Autograding-Basics#changing-the-trigger-on-existing-repositories)
+in Autograding Basics.
 
 ### Turning autograding off or pausing it
 
-Beyond choosing *when* commits grade, you can turn the pipeline off entirely:
-
-- **Per assignment, at creation** — pick **Do not use the built-in
-  autograder** (`no_autograder` in assignments.json). Accept installs no
-  autograding workflow at all; a templated assignment's own CI workflows run
-  instead, and score collection skips the assignment. Changeable later, but
-  only affects repositories accepted from then on (existing ones keep their
-  setup). See [`gh teacher` reference](gh-teacher#assignment-add).
-- **Per assignment, temporarily** — **Pause autograding** in the submissions
-  page's **Actions** menu disables the `autograde.yaml` workflow in every
-  student repository through GitHub's workflow-disable API. No files change, students'
-  other workflows keep running, and **Resume autograding** re-enables it.
-  Available on individual assignments using the built-in autograder (a single
-  repository can also be paused from its row). A student with admin on their own
-  repository can technically re-enable the workflow — a known limitation.
-- **Org-wide** — the organization settings' **Pause autograding for all
-  student repositories** toggle narrows the organization's GitHub Actions policy to the config
-  repository. **This stops all workflows in student repositories**, including any
-  course CI — prefer the per-assignment pause unless that's what you want.
-
-See also the [FAQ on reducing GitHub Actions usage](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage).
+Moved to
+[Turning autograding off or pausing it](Managing-Actions-Cost#turning-autograding-off-or-pausing-it)
+in Managing Actions cost.
 
 ## Reading results
 
-Where to find scores, per-test breakdowns, past attempts, and who submitted —
-and what each export contains.
+Moved to [Reading results](Autograding-Basics#reading-results) in
+Autograding Basics.
 
 ### Where results live
 
-Every graded submission produces the same three records:
-
-| Record | Where | What it shows |
-|---|---|---|
-| **Release** | The student repository, on the `submit/<UTC-timestamp>-<short-sha>` tag | The score, a **per-test PASS/FAIL table**, and the machine-readable `result.json`. This is what **View grade** / **View autograder details** links open — and the only place with the per-test breakdown. |
-| **Commit status** | The graded commit (`classroom50/autograde`) | success / failure / error at a glance, right on the commit. |
-| **Gradebook row** | `scores.json` in the config repository, after collection | What the submissions page and the CSV exports read: score, submission time, links, late flag, and full attempt history. |
-
-Releases and statuses appear the moment grading finishes. The gradebook lags
-until **collection** runs — nightly, or on demand with **Sync now** on the
-submissions page (`gh workflow run collect-scores.yaml` from the shell). If a
-student says "I submitted" and you see no score, sync first.
-
-On the submissions page, each row shows the student's (or group's) current
-score with links to the repository, the graded **commit**, the Release
-(**View autograder details**), the full **review** diff (starter code → graded
-commit), and the Feedback PR (**Review**).
+Moved to [Where results live](Autograding-Basics#where-results-live) in
+Autograding Basics.
 
 ### Latest score versus history
 
-The score on a row — and in the web CSV's summary columns — is the
-**latest submission's** (or a teacher override); in the CLI CSV the latest is
-the first line per member. "Latest" follows the *submission*, not the commit:
-if a student deliberately submits an older
-commit (a milestone tag pointing at earlier work, or a regrade), that
-submission's Release becomes the latest. The badge and the gradebook always
-agree because they use the same rule.
-
-The full history is kept everywhere:
-
-- **Web** — click a row's submission count to open its details: every attempt,
-  newest first, each with its commit link and a per-attempt **View grade**
-  Release link.
-- **Student repository** — one immutable Release per attempt, under the repository's
-  Releases tab (each `submit/*` tag is one graded attempt).
-- **`scores.json`** — each entry's `submissions` array holds every collected
-  attempt, newest first.
-- **`gh teacher download`** — writes each repository's `results.json` (all attempts)
-  next to `result.json` (latest), and one CSV line per attempt (see below).
+Moved to
+[Latest score versus history](Autograding-Basics#latest-score-versus-history)
+in Autograding Basics.
 
 ### Grading a specific commit
 
-Students sometimes ask you to grade a particular commit, not their latest:
-
-- **Every attempt already has its own frozen result** — find that commit's
-  `submit/*` Release in the history; its score and per-test table are exactly
-  as graded.
-- **To grade an arbitrary commit**, have the student push a `submit/*` tag (or
-  a configured milestone tag) pointing at it: `git tag submit/regrade-me
-  SHA && git push origin submit/regrade-me`. That mints a normal graded
-  submission at that commit.
-- **Regrade** (per-row, or **Regrade all** in the **Actions** menu) re-runs each
-  repository's **latest** submission **at its original commit** — useful after
-  fixing a broken test. A never-graded repository is first-graded at its current
-  HEAD instead (a new submission). On a re-run, `datetime` (the submission
-  instant) stays fixed so late-marking never changes; `graded_at` records the
-  re-run.
+Moved to
+[Grading a specific commit](Autograding-Basics#grading-a-specific-commit)
+in Autograding Basics.
 
 ### Who submitted
 
-- `owner` — the repository owner (the `USERNAME` in the repository name); the identity
-  scores are keyed by.
-- `submitted_by` — the GitHub account that actually pushed that submission.
-  For group work this is how you see who did the pushing even though the score
-  is shared.
-- Group scores are credited to every teammate on the classroom team, recorded
-  as the entry's `member_usernames` — see
-  [Group attribution model](#group-attribution-model).
+Moved to [Who submitted](Autograding-Basics#who-submitted) in Autograding
+Basics.
 
 ### Group attribution model
 
-A group assignment is graded once, in the founder's repository. `collect-scores`
-credits the shared score to every collaborator **on the classroom team** (the
-owner is always included), recorded as the entry's `member_usernames`.
-
-- **Crediting is by team membership, not permission level.** A teammate is
-  credited whether they hold `push` or `admin`. Teachers and TAs are excluded
-  automatically because they aren't on the student team.
-- **Classmates on the team are mutually trusted.** Collection can't tell how a
-  collaborator was added, so a student could credit a teammate who's on the team.
-  The team intersection bounds this to classmates — an account off the team is
-  never credited. Review each group repository's collaborators if you need stricter
-  control.
-- **Owner-only submissions warn.** If a group submission resolves to only the
-  owner, collection emits a `::warning::` so the "team submission scored as solo"
-  case is visible.
-- **`submitted_by` records the pusher**, so you can see who did the work even
-  though the score is shared.
-- **Rows are keyed by the repository owner**, so re-collecting a group repository whose
-  members changed updates the same row in place.
+Moved to
+[Group attribution model](Autograding-Basics#group-attribution-model) in
+Autograding Basics.
 
 ### Score exports
 
-Two CSV exports cover most gradebook needs; the raw JSON is always there for
-anything custom.
-
-#### Web: Download scores (CSV)
-
-**Download scores (CSV)** on the submissions page saves
-`CLASSROOM-ASSIGNMENT-scores.csv` — **one row per student (or group)**,
-sorted by last name, with the latest submission's data:
-
-| Column | Description |
-|---|---|
-| `name` / `first_name` / `last_name` | From the roster (blank if the login isn't on it). |
-| `usernames` | The credited GitHub username(s) — one for individual work, every credited member (alphabetical) for a group. |
-| `score` / `max_score` | The latest submission's score. Blank if submitted but not yet collected; `0` with blanks for a non-submitter. |
-| `submissions` | How many attempts were collected. |
-| `submitted_at` | The latest submission instant (ISO 8601 UTC). |
-| `late` | `yes` / `no` against the due date; blank for non-submitters. |
-| `commit` / `review` / `release` | Links: the graded commit, the full starter→graded diff, and the Release. |
-
-#### CLI: `gh teacher download`
-
-`gh teacher download ORG CLASSROOM ASSIGNMENT` clones every student
-repository and writes a `scores.csv` at the destination root — **one line per
-submission** (a student with several attempts contributes several lines,
-newest first), plus one blank-score line per non-submitter:
-
-| Column | Description |
-|---|---|
-| `username` | The team member. For a group, every credited member repeats the shared submission's lines under their own username. |
-| `first_name` / `last_name` / `email` / `section` | Joined from `roster.csv` when present. |
-| `score` / `max_score` | This attempt's score. Blank for non-submitters. |
-| `datetime` | This attempt's submission instant (ISO 8601 UTC). |
-| `submission_tag` | The `submit/…` tag identifying the attempt. |
-| `submitted_by` | Who pushed this attempt. |
-| `review_url` | The starter→graded diff for this attempt. |
-| `late` | `true` / `false` against the due date; blank when unknown. |
-| `override` | `true` when a teacher override is in effect for the entry. |
-
-Per-test breakdowns aren't in either CSV — they're in each attempt's Release
-(and in the per-repository `result.json` / `results.json` files the download also
-refreshes).
-
-#### Raw JSON
-
-- `CLASSROOM/scores.json` in your config repository is the authoritative gradebook
-  (see [scores.json shape](#the-resultjson-contract) below) — build any custom
-  report from it.
-- `gh teacher download` leaves `result.json` (latest attempt) and
-  `results.json` (all attempts, newest first) in each cloned repository, including
-  the per-test arrays.
+Moved to [Score exports](Autograding-Basics#score-exports) in Autograding
+Basics.
 
 ## The `result.json` contract
 
-This is the **only** contract every autograder must satisfy — whatever produces
-it (pytest, check50, a shell script, a Rust binary) is up to you. The runner
-reads `result.json` from the workspace after the autograder exits.
-
-```json
-{
-  "schema":          "classroom50/result/v1",
-  "classroom":       "cs-principles",
-  "assignment":      "hello",
-  "assignment_type": "individual",
-  "owner":           "alice",
-  "submission":      "submit/2026-06-01T14-32-05Z-a1b2c3d",
-  "commit":          "https://github.com/.../commit/SHA",
-  "release":         "https://github.com/.../releases/tag/submit%2F...",
-  "review":          "https://github.com/.../compare/BASELINE-SHA...SHA",
-  "datetime":        "2026-06-01T14:32:01Z",
-  "graded_at":       "2026-06-01T14:33:11Z",
-  "score":           4,
-  "max-score":       5,
-  "tests": [
-    { "test-name": "compiles",        "passed": true,  "score": 4, "max-score": 4 },
-    { "test-name": "outputs_correct", "passed": false, "score": 0, "max-score": 1 }
-  ]
-}
-```
-
-| Field | Type | Notes |
-|---|---|---|
-| `schema` | string | Exactly `classroom50/result/v1`. |
-| `classroom` / `assignment` | string | Must match the source repository's identity (checked in code alongside `owner`). |
-| `assignment_type` | string | `individual` or `group`, stamped by the runner. |
-| `owner` | string | The repository owner login — the identity anchor. |
-| `submission` | string | The submit-tag name. |
-| `commit` / `release` / `review` | string | URLs. `review` is the full diff from starter code to the graded commit. |
-| `datetime` | string | The **submission instant**: the graded commit's committer date (UTC ISO 8601). Invariant across regrades, so late-marking never changes on a re-run. |
-| `graded_at` | string | Optional. When this grading run produced the result — moves on every regrade. |
-| `score` / `max-score` | int | Sum of test scores / max-scores. |
-| `tests` | array | Per-test breakdown (`[]` is valid for a vacuous pass). Extra diagnostic fields on a test are preserved verbatim. |
-| `submitted_by` | object | Optional. Who pushed: `username`, and `id` (which may be null or absent). |
-
-`collect-scores` validates this before merging into `scores.json`. A payload
-whose identity (classroom/assignment/`owner`) doesn't match the source repository is
-rejected, and a mismatched `assignment_type` is warned-and-skipped, so a hostile
-payload can't land in another student's gradebook.
-
-<details>
-<summary>scores.json shape</summary>
-
-The gradebook is keyed by assignment slug under a root `assignments` object;
-each value is `{ "type": "individual"|"group", "entries": [...] }`. An `entry` is
-one repository's record: `owner` (the stable key), `submissions` (full history, newest
-first), and — for a group — `member_usernames` (credited members). Each bucket
-also carries a `collected_at` UTC timestamp stamped whenever a collection run
-walks that assignment (even if nothing changed), so per-assignment freshness is
-knowable — the web app's "Submission data synced" strip reads it.
-
-</details>
+Moved to
+[The `result.json` contract](Advanced-Autograding#the-resultjson-contract)
+in Advanced Autograding.
 
 ## Feedback pull requests
 
-The Feedback PR is **on by default** for assignments created with `gh teacher
-assignment add` (`--feedback-pr=false` to disable). When on, there is
-**one long-lived "Feedback" pull request per student repository** so you review
-cumulative work with inline comments alongside the scored Release.
-
-- **Frozen base branch.** Accept creates a `feedback` branch at the
-  student's baseline commit (the accept commit) and never advances it. The PR's
-  base is `feedback` and its head is the default branch, so it always shows the
-  full starter→latest diff.
-- **Opened at accept.** The PR is there before the first submission and exists even
-  when GitHub Actions is disabled for student repositories. The diff still starts at the
-  baseline, so the setup files never appear in it.
-- **One PR, reused** across submissions, labeled **Individual Assignment** or
-  **Group Assignment**. A student closing it reopens it; a teacher merge is left
-  alone.
-- **Default body.** The PR opens with Classroom 50's built-in "here is where your teacher leaves
-  feedback" text by default. Set `feedback_pr_template: true` (or check the box
-  on the web form) to use the template repository's own pull request template as
-  the body instead. Accept reads the first existing of
-  `.github/pull_request_template.md`, `pull_request_template.md`, or
-  `docs/pull_request_template.md` from the template and uses it verbatim. It
-  requires a template and the Feedback PR itself. The read is best-effort: a
-  missing, empty, oversized, or unreadable file falls back to the built-in body
-  and never blocks the PR. Keeping the template's contents correct is up to you.
-- **Maintained by the runner.** The runner adopts the PR by base and head and
-  maintains it from then on. If accept
-  could not open it (a permissions oddity, or a repository accepted before this
-  feature), the runner opens it on the first submission instead, and
-  re-accepting also retries, which is the only route with GitHub Actions off. On that
-  fallback open the runner honors the template too, best-effort: its GitHub Actions
-  token cannot always read a private or external template, so it uses the
-  built-in body and logs a warning when it has to.
-
-<details>
-<summary>Baseline resolution and prerequisites</summary>
-
-Both accept and the runner resolve the baseline as **the commit that introduced
-`.classroom50.yaml`** (a structural marker, not a commit subject) so they agree
-on where the base is frozen. The runner refuses to open or update the PR when
-the `feedback` branch sits at any other commit, since a student can create that
-branch themselves; an organization administrator deleting it lets the next submission re-freeze
-it correctly. If no marker commit is found, the runner opens the PR against the
-root commit and **warns** that the baseline is untrusted; if no baseline resolves
-at all, it **skips** with a warning.
-
-**Prerequisites (handled by `gh teacher init`):** the organization setting "Allow GitHub
-Actions to create and approve pull requests" must be on, and two organization rulesets
-protect submission history and the frozen `feedback` branch. If you enable
-feedback on an organization set up before this feature, **re-run `gh teacher init`**.
-
-**Student repositories accepted before this feature** use an older workflow and must
-be re-created (delete + re-accept) to pick up the new one.
-
-</details>
+Moved to
+[Feedback pull requests](Autograding-Basics#feedback-pull-requests) in
+Autograding Basics.
 
 ## Restricting submission files (`allowed_files`)
 
-An assignment can declare `allowed_files` — an ordered list of `.gitignore`-style
-patterns defining which files belong to the submission. It's an allowlist in
-gitignore syntax: `*` ignores everything, then `!hello.py` re-includes it.
-
-```sh
-gh teacher assignment add cs50-fall-2026 cs-principles hello \
-    --name "Hello" --template cs50/hello-template \
-    --allowed-files '*' --allowed-files '!hello.py'
-```
-
-- **Git's own syntax:** order matters, last match wins, `!` re-includes. Pass
-  `--allowed-files` once per pattern (don't comma-join). Omit it (or pass empty)
-  to allow every file.
-- **Re-running `add` rewrites the whole entry**, so re-pass `--allowed-files` to
-  keep it (the CLI warns when it's dropped).
-
-> [!WARNING]
-> **`allowed_files` gates what the autograder reads.** Files are removed before
-> setup and grading, so every student-checkout file they read must be
-> allowlisted. This includes dependency manifests (`requirements.txt`,
-> `pyproject.toml`), package source, setup scripts, and starter scaffolding.
-> Control files (`.classroom50.yaml`, `.github/`) are always kept.
->
-> **It fails open** and is a grading-scope/hygiene tool, **not** a security
-> boundary: a student who forces a git failure (or pushes directly with
-> `git push`) gets the
-> unfiltered tree graded. Never use it to hide an answer key. Removals are logged
-> in the release body ("Removed N file(s)").
+Moved to
+[Restricting submission files](Advanced-Autograding#restricting-submission-files-allowed_files)
+in Advanced Autograding.
 
 ## Attaching files to submission Releases
 
-Attach generated PDFs, plots, or logs to each submission's Release with the web
-form's **Submission release files**, or the `release_assets` field:
-
-```json
-"release_assets": ["report.pdf", "plots/chart.png"]
-```
-
-The runner resolves these paths **after grading** (so an autograder can generate
-them) and uploads them under their basenames.
-
-**Limits:** at most 50 paths totaling ≤ 8 KiB; each basename must be unique,
-Release-safe (ASCII letters/digits/`.`/`_`/`-`, no leading/trailing dot, no `..`,
-not `result.json` or `release-body.md`), and relative. A separate 100 MiB
-file-content budget applies at runtime. Missing, unsafe, oversized, or failed
-uploads warn without changing the score.
-
-> [!NOTE]
-> Submission publishing doesn't support GitHub Immutable Releases (reruns edit
-> the Release in place). To roll this out to an existing organization, run `gh teacher
-> init`, approve the workflow-files refresh, and wait for `publish-pages` to
-> finish.
+Moved to
+[Attaching files to submission Releases](Advanced-Autograding#attaching-files-to-submission-releases)
+in Advanced Autograding.
 
 ## Where to customize
 
-| To change… | Edit… | Propagates on… |
-|---|---|---|
-| Simple checks, no code | `tests` block (`assignment test add` / `--tests`) | Next Pages publish, then next submission |
-| Grading logic for one assignment | `CLASSROOM/autograders/ASSIGNMENT/autograder.py` | Next submission |
-| Grading logic for a classroom | `CLASSROOM/autograder.py` (`autograder set-default`) | Next submission |
-| Runtime for one assignment | `runtime` block on the entry | Next submission |
-| Files attached to Releases | `release_assets` (usually in the web form) | Next submission or regrade |
-
-All layers live in the config repository; none require a student-repository change. Edit
-`autograde-runner.yaml` only to add a toolchain GitHub has no setup action for,
-or to replace the runner bootstrap.
+Moved to [Where to customize](Advanced-Autograding#where-to-customize) in
+Advanced Autograding.
 
 ## Failure paths
 
-Classroom 50 separates an ordinary pass/fail score from an infrastructure error.
-Passing and failing scores publish the Release; an `error` posts an error status
-and leaves the Release unchanged.
-
-| What failed | What surfaces |
-|---|---|
-| Invalid hand-edited `release_assets` config | Setup exits with a field-specific `::error::`; no Release update |
-| Autograder produces `status=error` | Grade posts `error`; no Release update |
-| A configured extra is missing/unsafe/over budget | Warning; core and other extras continue |
-| Core Release or `result.json` upload fails | Grade job fails; latest pointer doesn't move |
-| Some tests fail | `status=failure`; Release publishes; details in the log and Summary |
-| All tests pass | `status=success`; Release publishes |
-
-A failure that stops the reusable workflow from loading doesn't appear in
-`scores.json`; collect counts the student as not-yet-submitted.
+Moved to [Failure paths](Advanced-Autograding#failure-paths) in Advanced
+Autograding.
 
 ## No credentials required
 
-Students never configure tokens or secrets. Grading runs on the job-scoped
-`GITHUB_TOKEN`, unauthenticated Pages fetches, and reusable-workflow access
-between the student repository and the config repository (both in the teacher's organization,
-configured by `init`). The only PAT in the system is the teacher-side
-`CLASSROOM50_SERVICE_TOKEN`, used only by `collect-scores.yaml`.
+Moved to
+[No credentials required](Advanced-Autograding#no-credentials-required) in
+Advanced Autograding.
 
 ## Operational notes
 
-- **The grade job stops after 15 minutes.** This includes managed runtime setup,
-  the assignment Setup command, every test, and submission Release publishing.
-  Per-command timeouts do not extend the job limit.
-- **Every push grades, every push gets a Release** (in `every-push` mode). Five
-  pushes in ten minutes produce five graded runs and five Releases.
-- **Immutable-release rulesets freeze regrade Releases.** Orgs enforcing
-  immutable releases (a GitHub ruleset) cannot refresh a submission's Release
-  on regrade; the regraded score appears in the commit status and the GitHub Actions
-  job summary, but the Release — and thus the collected gradebook score for
-  that submission — keeps the pre-regrade result.
-- **Pages CDN lag:** updated content can take ~10 minutes to serve, so a
-  submission in that window may fetch the previous `runner.py` or bundle.
-- **Don't force-push or delete submit tags** — collection keys on them.
+Moved to [Operational notes](Advanced-Autograding#operational-notes) in
+Advanced Autograding.
 
 ## Custom runner workflow (rare)
 
-Every earlier layer changes *what* grading does while keeping the built-in
-runner. When you need a different grading *pipeline* entirely — a
-[reusable workflow](https://docs.github.com/actions/using-workflows/reusing-workflows)
-you author yourself — `--autograder NAME` swaps the caller workflow instead of
-the autograder script. Most teachers never need this.
-
-**How the swap works.** By default `gh student accept` writes a small caller
-workflow to `.github/workflows/autograde.yaml` whose `uses:` points at the
-built-in `autograde-runner.yaml`. With `--autograder NAME`, accept instead
-fetches your caller from `CLASSROOM/autograders/NAME.yaml` and writes it
-verbatim. Your caller owns its own `on:` triggers and `uses:` a reusable
-workflow you control, so your grading logic runs in place of the runner.
-
-**Set one up:**
-
-1. **Add the reusable workflow** to your config repository under `.github/workflows/`,
-   with a name other than the reserved `autograde-runner.yaml`. It must be
-   [callable](https://docs.github.com/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow)
-   (`on: workflow_call`). Non-reserved names are never touched by Classroom 50.
-2. **Add a caller workflow** at `CLASSROOM/autograders/NAME.yaml`. Give it
-   your trigger events and a `jobs.<id>.uses:` pointing at the workflow from
-   step 1. Because it's written verbatim, template `ORG`/branch refs to your
-   own values rather than relying on the built-in caller's substitution.
-3. **Register the assignment** with `gh teacher assignment add ORG CLASSROOM
-   ASSIGNMENT --autograder NAME`.
-
-> [!NOTE]
-> Once an assignment uses a custom autograder, `gh teacher assignment
-> submission-mode` never rewrites its caller workflow — trigger changes are
-> yours to make.
+Moved to
+[Custom runner workflow](Advanced-Autograding#custom-runner-workflow-rare)
+in Advanced Autograding.
 
 ### Bringing a GitHub Classroom autograder along
 
-This is the intended path for keeping an `autograding.json`-driven workflow after
-[migrating](FAQ#migrating-from-github-classroom). Classroom 50 has no
-`.github/classroom/autograding.json` of its own — the built-in runner reads a
-[`tests` block](#declarative-tests) instead — but a custom runner workflow lets
-you keep your existing format:
-
-1. Put your grading action's workflow in the config repository's `.github/workflows/`
-   (any non-reserved name). Have it read `autograding.json` from the student
-   repository as before.
-2. Point a caller workflow at it as above, and register assignments with
-   `--autograder NAME`.
-3. Ship `autograding.json` (and any fixtures) in the **assignment template**, not
-   the config repository — it travels with each student's starter code.
-
-> [!WARNING]
-> The template must **not** contain `.github/workflows/autograde.yaml`; that
-> name is reserved for the autograding caller and would be clobbered on accept
-> and submit (see [Assignment Templates](Assignment-Templates#structure)). Use
-> any other filename for template-side workflows.
+Moved to
+[Bringing a GitHub Classroom autograder along](Advanced-Autograding#bringing-a-github-classroom-autograder-along)
+in Advanced Autograding.

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -1,0 +1,544 @@
+# Autograding Basics
+
+How Classroom 50 grades submissions and how to read the results: define
+tests on the assignment, and every submission gets a score you can read on
+the submissions page and export as CSV. For custom grading scripts and
+environments, see [Advanced Autograding](Advanced-Autograding); for
+ready-made per-language setups, see
+[Autograder Recipes](Autograder-Recipes); for reducing what grading costs,
+see [Managing Actions cost](Managing-Actions-Cost).
+
+## How grading works
+
+The whole pipeline, end to end:
+
+1. You define tests on the assignment — usually
+   [declarative tests](#declarative-tests) (input/output checks, run commands,
+   or pytest), written in the web form or with `gh teacher assignment test add`.
+2. A student submits by pushing to their repository, or explicitly with
+   `gh student submit`, depending on the assignment's
+   [submission type](#which-commits-grade).
+3. GitHub Actions grades the submission in the student's own repository:
+   a small workflow calls the shared **autograde runner**, which fetches your
+   grading config and runs the tests against the submitted commit.
+4. The runner publishes the result on the student's repository as a GitHub
+   **Release** on a `submit/<UTC-timestamp>-<short-sha>` tag — the score, a
+   per-test PASS/FAIL table, and a machine-readable `result.json`. The graded
+   commit also gets a `classroom50/autograde` commit status, and the student's
+   **View grade** link opens the Release.
+5. The **score-collection** workflow gathers the **collected scores**
+   (`scores.json` in your `classroom50` repository) — nightly, or on demand with
+   **Sync now** on the submissions page. That's what the web app's submissions
+   page and both CSV exports read. See [Reading results](#reading-results).
+
+Steps 3–5 run with no per-repository maintenance: everything substantive (the runner
+workflow, `runner.py`, autograders, runtime config) lives in the `classroom50` repository
+and is fetched at run time, so a grading edit reaches every existing student
+repository on the next submission.
+
+Both surfaces drive the same pipeline: the web assignment form and
+`gh teacher assignment` write the same `assignments.json`, and the submissions
+page and `gh teacher download` read the same results.
+
+> [!NOTE]
+> Grading and publishing share one job and runner, so the workflow is **not** a
+> credential or hostile-workflow isolation boundary between them.
+
+## Setting up grading
+
+### Grading modes
+
+Each assignment has a **Grading** choice (the web form's Grading field; the
+`grading` block in `assignments.json`):
+
+- **Not graded** — no scores; submissions still tag and publish Releases, and
+  the Feedback PR still works.
+- **Autograded** — the default meaning of grading here: tests or an
+  `autograder.py` score each submission automatically. The rest of this page
+  is about this mode.
+- **Manual** — you enter each score by hand on the submissions page, out of
+  the assignment's **Max points**. No autograder score is used — though the
+  built-in workflow still runs on submissions unless you also turn the
+  built-in autograder off.
+
+Two related, optional settings:
+
+- **Pass threshold** — an advisory percentage of the max score (0–100) at or
+  above which the submissions page shows a submission as *passing* (badges,
+  passing/failing rollups, and filters). It never changes a student's actual
+  score, and leaving it unset turns the passing concept off.
+- **Built-in autograder off** (`no_autograder`) — accept installs no
+  autograding workflow at all; a templated assignment's own CI runs instead,
+  and score collection skips the assignment. See
+  [Turning autograding off or pausing it](Managing-Actions-Cost#turning-autograding-off-or-pausing-it).
+
+### Declarative tests
+
+The lowest-friction way to grade: describe io/run/pytest checks directly on the
+assignment, and the runner grades them with a built-in interpreter — no grading
+code to write. The three types map onto GitHub Classroom's legacy autograder
+presets.
+
+In the web app, add tests in the assignment form's **Autograding tests**
+section. From the CLI, author them one at a time:
+
+```sh
+gh teacher assignment test add cs50-fall-2026 cs-principles hello \
+    --name compiles --type run --run "gcc -o hello hello.c" --points 1
+gh teacher assignment test add cs50-fall-2026 cs-principles hello \
+    --name "prints hello" --type io --setup "gcc -o hello hello.c" \
+    --run ./hello --expected "Hello, world!" --comparison included --points 2
+gh teacher assignment test list cs50-fall-2026 cs-principles hello
+gh teacher assignment test remove cs50-fall-2026 cs-principles hello compiles
+```
+
+Or set the whole array at once with `gh teacher assignment add ... --tests
+<file.json>` (`--tests -` reads stdin). The file is a bare JSON array — the same
+shape `assignment test list --json` emits:
+
+```json
+[
+  { "name": "compiles", "type": "run", "run": "gcc -o hello hello.c", "timeout": 30, "points": 1 },
+  { "name": "prints Hello, world!", "type": "io", "setup": "gcc -o hello hello.c",
+    "run": "./hello", "expected": "Hello, world!", "comparison": "included", "points": 2 },
+  { "name": "greets by name", "type": "io", "setup": "gcc -o hello hello.c",
+    "run": "./hello", "input": "Alice\n", "expected": "^hello,\\s+Alice\\b",
+    "comparison": "regex", "points": 2 },
+  { "name": "pytest suite", "type": "python", "run": "python -m pytest -q", "timeout": 120, "points": 10 }
+]
+```
+
+#### Test types
+
+| Type | Passes when | Type-specific fields |
+|---|---|---|
+| `io` | stdout of `run` matches `expected` per `comparison` | `input` / `input-file`, `expected` / `expected-file`, `comparison` |
+| `run` | exit code of `run` equals `exit-code` (default 0) | `exit-code` |
+| `python` | pytest passes; points split across cases | — |
+
+> [!NOTE]
+> The runner auto-installs `pytest` and `pytest-json-report` for `python` tests.
+> Add a `setup` install line only to pin a version.
+
+#### Fields
+
+| Field | Notes |
+|---|---|
+| `name` | Required. Unique within the assignment; ≤ 100 UTF-8 bytes; no control characters. |
+| `type` | Required. `io`, `run`, or `python`. |
+| `run` | Required. Shell command, run in the student checkout. |
+| `setup` | Optional pre-command (for example, compile). Non-zero exit fails the test. |
+| `input` / `input-file` | `io` only, mutually exclusive. Inline stdin or a bundled fixture. |
+| `expected` / `expected-file` | `io` only, mutually exclusive. Must be non-empty for `included`/`regex`. |
+| `comparison` | `io` only. `included` (substring), `exact` (trimmed equality), or `regex` (Python `re.search`, multiline). |
+| `timeout` | Seconds, 1–600. Omit or 0 for the default of 10s. Applies to `setup` and `run` separately. |
+| `exit-code` | `run` only, 0–255. Omit to require 0. |
+| `points` | Required, 0–1000. A 0-point test does not affect the numeric score; a failure still sets the autograde status to `failure`. |
+
+At most 100 tests per assignment. Put large fixtures in files
+(`input-file` / `expected-file`) under `CLASSROOM/autograders/ASSIGNMENT/`, not
+inline. In paths and commands on this page, replace `CLASSROOM` with the
+classroom's short name and `ASSIGNMENT` with the assignment slug.
+
+### Setup commands, dependencies, and environment variables
+
+The web assignment's **Setup command** is stored as the leading zero-point
+`run` test named `setup`. New setup commands start with a 120-second timeout.
+Set the timeout to 0 for the runner's 10-second default, or choose a whole
+number from 1 through 600. A failure or timeout sets the autograde status to
+`failure` without changing the numeric score; later tests still run.
+
+Use the command for filesystem changes that later tests need. Install a
+requirements file with:
+
+```sh
+python3 -m pip install -r requirements.txt
+```
+
+For a packaged project, including one with a `src/` layout, install the package
+in editable mode:
+
+```sh
+python3 -m pip install -e .
+```
+
+Choose the command that matches the project. An editable package install reads
+the project's package metadata; a separate requirements install is needed only
+when the project uses that file.
+
+Every assignment setup, per-test `setup`, and `run` command starts in a separate
+shell process in the student checkout. Files, virtual-environment directories,
+and installed packages persist between commands. Shell state does not: `cd`,
+`export`, aliases, and virtual-environment activation end when their command
+exits. Invoke a virtual environment's interpreter by path in later commands,
+for example `.venv/bin/python -m pytest -q` on Linux or macOS and
+`.venv\Scripts\python.exe -m pytest -q` on Windows.
+
+For pytest-only import paths, set `pythonpath` in `pyproject.toml` or
+`pytest.ini`. A command that needs one environment value can set it inline on
+Linux or macOS:
+
+```sh
+PYTHONPATH=src python3 -m pytest -q
+```
+
+On Windows:
+
+```bat
+set "PYTHONPATH=src" && python -m pytest -q
+```
+
+Do not write grading environment variables to `$GITHUB_ENV`. All declarative
+commands run as child processes inside the single Grade details workflow step,
+and GitHub Actions reads `$GITHUB_ENV` only after that step finishes. A write
+cannot change the runner process or the environment of later tests.
+
+<details>
+<summary>How tests flow, and where failures surface</summary>
+
+Tests live inline in `assignments.json`. On the next config-repository push,
+publish-pages **materializes** them into the assignment's Pages bundle as
+`tests.json`. At grade time, `runner.py` runs each spec in the student checkout:
+one row per test in `result.json`, plus a failure breakdown in three places — the
+**Release body**, the **grade job log** ("Grade details"), and the **run Summary
+page**. Captured output is truncated at 2000 characters.
+
+Specs are validated three times: by the CLI at write time, by the runner
+workflow at submission setup, and by `runner.py` before executing.
+
+</details>
+
+### Beyond declarative tests
+
+When declarative tests aren't enough, write the grading logic yourself as an
+`autograder.py`, customize the grading environment with the `runtime` block,
+or swap the grading pipeline entirely. All three live in
+[Advanced Autograding](Advanced-Autograding). For worked per-language
+setups, see [Autograder Recipes](Autograder-Recipes).
+
+## Which commits grade
+
+What triggers grading is a **per-assignment choice** (the web form's
+**Submission type**; `submission_mode` in assignments.json; `gh teacher
+assignment add --submission-mode` / `gh teacher assignment submission-mode`):
+
+**`every-push` (the default)** — grading triggers on two events:
+
+- **Push to the default branch** — every commit grades, **except the acceptance
+  commit** (the one that introduced `.classroom50.yaml`, with nothing on top).
+- **Push of a `submit/*` tag** — manual tag pushes work too.
+
+**`tag`** — grading triggers **only** on `submit/*` tag pushes. A plain
+`git push` runs nothing and costs no GitHub Actions minutes — the cost lever for
+large cohorts. Submissions become an explicit act:
+
+- `gh student submit` pushes a `submit/<UTC-timestamp>-<short-sha>` tag after
+  the branch commit — that tag push is what grades.
+- A hand-pushed tag works exactly the same: `git tag submit/anything && git
+  push origin submit/anything`. Any tag under `submit/` grades; no CLI
+  required.
+
+**Milestone submission tags** — with either mode, the assignment can also
+name **milestone tags** (`submission_tags` in assignments.json, the web form's
+**Submission tags** field, for example `["phase1", "phase2", "complete"]`, settable at
+creation or from the assignment settings / `gh teacher assignment add
+--submission-tag`). Pushing a matching tag grades that commit — plain git, no
+CLI required:
+
+```sh
+git tag phase1
+git push origin phase1
+```
+
+Simple globs work too (`v*`), though exact milestone names are safer — a
+broad glob grades every matching tag a student pushes. The milestone tag
+**triggers** grading; the graded **record** still lives at the canonical
+`submit/<UTC-timestamp>-<short-sha>` tag the runner mints at that commit (its
+Release title notes *"via phase1"*), so history stays one-immutable-release-
+per-submission and collection, regrade, and the collected scores are unaffected. The
+`submit/*` namespace always keeps working alongside milestone tags.
+
+Because the trigger lives in each student repository's workflow (GitHub evaluates a
+workflow's `on:` block before any job runs), **changing the mode or the
+milestone patterns after repositories exist requires retrofitting each repository's
+workflow** — see
+[Changing the trigger on existing repositories](#changing-the-trigger-on-existing-repositories).
+
+<details>
+<summary>Why the acceptance commit is skipped</summary>
+
+Accepting lands `.classroom50.yaml` + the workflow in one commit, which fires
+the workflow — but that's *accepting*, not *submitting*. The runner detects it
+and skips tagging, grading, and the Release (the run still appears in the
+Actions tab with a `notice`). Detection is **fail-open**: any uncertainty grades
+rather than risk dropping a real submission. Your first `gh student submit`
+always stacks a fresh commit, so it's never mistaken for the acceptance.
+
+</details>
+
+<details>
+<summary>Tag-mode defenses in the runner</summary>
+
+Two guards keep tag mode honest even when a repository's workflow trigger is stale:
+
+- **Stale-trigger suppression** — a repository accepted before the mode flipped to
+  `tag` (or whose retrofit failed) still carries the every-push trigger. The
+  runner reads `submission_mode` from the published assignments.json at setup
+  time and, when the assignment is tag-mode but the run was branch-triggered,
+  skips tagging and grading, posting a `classroom50/autograde-skipped`
+  success status: *"tag-mode assignment — push not graded; run gh student
+  submit"*.
+- **Retrofit-commit skip** — the teacher-side trigger update commits with
+  `[skip ci]`, so it fires no workflow. As a backstop (for example, a client that
+  dropped the marker), the runner also recognizes a tip commit touching ONLY
+  `.github/workflows/autograde.yaml` and skips it with the status
+  *"autograder trigger updated — nothing to grade"*.
+- **Foreign-tag suppression** — a pushed tag matching neither `submit/*` nor
+  any configured milestone pattern (possible only with a stale or hand-edited
+  workflow) is skipped gracefully with the `classroom50/autograde-skipped`
+  status *"tag is not a submission trigger — not graded"*, never a failed run.
+
+The two suppression statuses use the separate `classroom50/autograde-skipped`
+context deliberately: in both cases the student's real work exists but was
+**not** graded, and a green `classroom50/autograde` would read as "graded
+successfully". Graded commits alone report under `classroom50/autograde`.
+(The nothing-to-grade skips — acceptance commit, trigger-update commit, no
+autograder configured — stay on the main context: there is no work there to
+mistake for graded.)
+
+</details>
+
+### Changing the trigger on existing repositories
+
+The autograding workflow is written into each student repository at accept time and
+otherwise never changes, so flipping `submission_mode` on an assignment with
+accepted repositories needs a retrofit:
+
+- **CLI**: `gh teacher assignment submission-mode ORG CLASSROOM ASSIGNMENT
+  --tag` (or `--every-push`) flips the field AND rewrites the workflow across
+  every student repository (add `--user USERNAME` for one repository, `--dry-run` to
+  preview). Requires the `workflow` OAuth scope
+  (`gh auth refresh -s workflow`).
+- **Web**: change the trigger on the assignment settings page, then run
+  **Update autograding triggers** from the submissions page's actions menu
+  (or per-repository from a row's manage dialog).
+
+The rewrite is surgical — only the trigger lines change; a workflow a student
+hand-edited is reported and left untouched. **Custom (non-default)
+autograders are never rewritten**: you own their `on:` block; edit it
+yourself and use `--update-shims=false` to flip only the field.
+
+After a retrofit, students must `git pull` — clones made before the change
+conflict on their next push.
+
+To turn autograding off for an assignment, pause it over a break, or reduce
+what grading costs, see [Managing Actions cost](Managing-Actions-Cost).
+
+## Reading results
+
+Where to find scores, per-test breakdowns, past attempts, and who submitted —
+and what each export contains.
+
+### Where results live
+
+Every graded submission produces the same three records:
+
+| Record | Where | What it shows |
+|---|---|---|
+| **Release** | The student repository, on the `submit/<UTC-timestamp>-<short-sha>` tag | The score, a **per-test PASS/FAIL table**, and the machine-readable `result.json`. This is what **View grade** / **View autograder details** links open — and the only place with the per-test breakdown. |
+| **Commit status** | The graded commit (`classroom50/autograde`) | success / failure / error at a glance, right on the commit. |
+| **Collected score** | `scores.json` in the `classroom50` repository, after collection | What the submissions page and the CSV exports read: score, submission time, links, late flag, and full attempt history. |
+
+Releases and statuses appear the moment grading finishes. The collected scores
+lag until **collection** runs — nightly, or on demand with **Sync now** on the
+submissions page (`gh workflow run collect-scores.yaml` from the shell). If a
+student says "I submitted" and you see no score, sync first.
+
+On the submissions page, each row shows the student's (or group's) current
+score with links to the repository, the graded **commit**, the Release
+(**View autograder details**), the full **review** diff (starter code → graded
+commit), and the Feedback PR (**Review**).
+
+### Latest score versus history
+
+The score on a row — and in the web CSV's summary columns — is the
+**latest submission's** (or a teacher override); in the CLI CSV the latest is
+the first line per member. "Latest" follows the *submission*, not the commit:
+if a student deliberately submits an older
+commit (a milestone tag pointing at earlier work, or a regrade), that
+submission's Release becomes the latest. The badge and the collected scores
+always agree because they use the same rule.
+
+The full history is kept everywhere:
+
+- **Web** — click a row's submission count to open its details: every attempt,
+  newest first, each with its commit link and a per-attempt **View grade**
+  Release link.
+- **Student repository** — one immutable Release per attempt, under the repository's
+  Releases tab (each `submit/*` tag is one graded attempt).
+- **`scores.json`** — each entry's `submissions` array holds every collected
+  attempt, newest first.
+- **`gh teacher download`** — writes each repository's `results.json` (all attempts)
+  next to `result.json` (latest), and one CSV line per attempt (see below).
+
+### Grading a specific commit
+
+Students sometimes ask you to grade a particular commit, not their latest:
+
+- **Every attempt already has its own frozen result** — find that commit's
+  `submit/*` Release in the history; its score and per-test table are exactly
+  as graded.
+- **To grade an arbitrary commit**, have the student push a `submit/*` tag (or
+  a configured milestone tag) pointing at it: `git tag submit/regrade-me
+  SHA && git push origin submit/regrade-me`. That mints a normal graded
+  submission at that commit.
+- **Regrade** (per-row, or **Regrade all** in the **Actions** menu) re-runs each
+  repository's **latest** submission **at its original commit** — useful after
+  fixing a broken test. A never-graded repository is first-graded at its current
+  HEAD instead (a new submission). On a re-run, `datetime` (the submission
+  instant) stays fixed so late-marking never changes; `graded_at` records the
+  re-run.
+
+### Who submitted
+
+- `owner` — the repository owner (the `USERNAME` in the repository name); the identity
+  scores are keyed by.
+- `submitted_by` — the GitHub account that actually pushed that submission.
+  For group work this is how you see who did the pushing even though the score
+  is shared.
+- Group scores are credited to every teammate on the classroom team, recorded
+  as the entry's `member_usernames` — see
+  [Group attribution model](#group-attribution-model).
+
+### Group attribution model
+
+A group assignment is graded once, in the founder's repository. `collect-scores`
+credits the shared score to every collaborator **on the classroom team** (the
+owner is always included), recorded as the entry's `member_usernames`.
+
+- **Crediting is by team membership, not permission level.** A teammate is
+  credited whether they hold `push` or `admin`. Teachers and TAs are excluded
+  automatically because they aren't on the student team.
+- **Classmates on the team are mutually trusted.** Collection can't tell how a
+  collaborator was added, so a student could credit a teammate who's on the team.
+  The team intersection bounds this to classmates — an account off the team is
+  never credited. Review each group repository's collaborators if you need stricter
+  control.
+- **Owner-only submissions warn.** If a group submission resolves to only the
+  owner, collection emits a `::warning::` so the "team submission scored as solo"
+  case is visible.
+- **`submitted_by` records the pusher**, so you can see who did the work even
+  though the score is shared.
+- **Rows are keyed by the repository owner**, so re-collecting a group repository whose
+  members changed updates the same row in place.
+
+### Score exports
+
+Two CSV exports cover most needs; the raw JSON is always there for anything
+custom.
+
+#### Web: Download scores (CSV)
+
+**Download scores (CSV)** on the submissions page saves
+`CLASSROOM-ASSIGNMENT-scores.csv` — **one row per student (or group)**,
+sorted by last name, with the latest submission's data:
+
+| Column | Description |
+|---|---|
+| `name` / `first_name` / `last_name` | From the roster (blank if the login isn't on it). |
+| `usernames` | The credited GitHub username(s) — one for individual work, every credited member (alphabetical) for a group. |
+| `score` / `max_score` | The latest submission's score. Blank if submitted but not yet collected; `0` with blanks for a non-submitter. |
+| `submissions` | How many attempts were collected. |
+| `submitted_at` | The latest submission instant (ISO 8601 UTC). |
+| `late` | `yes` / `no` against the due date; blank for non-submitters. |
+| `commit` / `review` / `release` | Links: the graded commit, the full starter→graded diff, and the Release. |
+
+#### CLI: `gh teacher download`
+
+`gh teacher download ORG CLASSROOM ASSIGNMENT` clones every student
+repository and writes a `scores.csv` at the destination root — **one line per
+submission** (a student with several attempts contributes several lines,
+newest first), plus one blank-score line per non-submitter:
+
+| Column | Description |
+|---|---|
+| `username` | The team member. For a group, every credited member repeats the shared submission's lines under their own username. |
+| `first_name` / `last_name` / `email` / `section` | Joined from `roster.csv` when present. |
+| `score` / `max_score` | This attempt's score. Blank for non-submitters. |
+| `datetime` | This attempt's submission instant (ISO 8601 UTC). |
+| `submission_tag` | The `submit/…` tag identifying the attempt. |
+| `submitted_by` | Who pushed this attempt. |
+| `review_url` | The starter→graded diff for this attempt. |
+| `late` | `true` / `false` against the due date; blank when unknown. |
+| `override` | `true` when a teacher override is in effect for the entry. |
+
+Per-test breakdowns aren't in either CSV — they're in each attempt's Release
+(and in the per-repository `result.json` / `results.json` files the download also
+refreshes).
+
+#### Raw JSON
+
+- `CLASSROOM/scores.json` in your `classroom50` repository is the
+  authoritative record (see
+  [scores.json shape](Advanced-Autograding#the-resultjson-contract)) — build
+  any custom report from it.
+- `gh teacher download` leaves `result.json` (latest attempt) and
+  `results.json` (all attempts, newest first) in each cloned repository, including
+  the per-test arrays.
+
+## Feedback pull requests
+
+The Feedback PR is **on by default** for assignments created with `gh teacher
+assignment add` (`--feedback-pr=false` to disable). When on, there is
+**one long-lived "Feedback" pull request per student repository** so you review
+cumulative work with inline comments alongside the scored Release.
+
+- **Frozen base branch.** Accept creates a `feedback` branch at the
+  student's baseline commit (the accept commit) and never advances it. The PR's
+  base is `feedback` and its head is the default branch, so it always shows the
+  full starter→latest diff.
+- **Opened at accept.** The PR is there before the first submission and exists even
+  when GitHub Actions is disabled for student repositories. The diff still starts at the
+  baseline, so the setup files never appear in it.
+- **One PR, reused** across submissions, labeled **Individual Assignment** or
+  **Group Assignment**. A student closing it reopens it; a teacher merge is left
+  alone.
+- **Default body.** The PR opens with Classroom 50's built-in "here is where your teacher leaves
+  feedback" text by default. Set `feedback_pr_template: true` (or check the box
+  on the web form) to use the template repository's own pull request template as
+  the body instead. Accept reads the first existing of
+  `.github/pull_request_template.md`, `pull_request_template.md`, or
+  `docs/pull_request_template.md` from the template and uses it verbatim. It
+  requires a template and the Feedback PR itself. The read is best-effort: a
+  missing, empty, oversized, or unreadable file falls back to the built-in body
+  and never blocks the PR. Keeping the template's contents correct is up to you.
+- **Maintained by the runner.** The runner adopts the PR by base and head and
+  maintains it from then on. If accept
+  could not open it (a permissions oddity, or a repository accepted before this
+  feature), the runner opens it on the first submission instead, and
+  re-accepting also retries, which is the only route with GitHub Actions off. On that
+  fallback open the runner honors the template too, best-effort: its GitHub Actions
+  token cannot always read a private or external template, so it uses the
+  built-in body and logs a warning when it has to.
+
+<details>
+<summary>Baseline resolution and prerequisites</summary>
+
+Both accept and the runner resolve the baseline as **the commit that introduced
+`.classroom50.yaml`** (a structural marker, not a commit subject) so they agree
+on where the base is frozen. The runner refuses to open or update the PR when
+the `feedback` branch sits at any other commit, since a student can create that
+branch themselves; an organization administrator deleting it lets the next submission re-freeze
+it correctly. If no marker commit is found, the runner opens the PR against the
+root commit and **warns** that the baseline is untrusted; if no baseline resolves
+at all, it **skips** with a warning.
+
+**Prerequisites (handled by `gh teacher init`):** the organization setting "Allow GitHub
+Actions to create and approve pull requests" must be on, and two organization rulesets
+protect submission history and the frozen `feedback` branch. If you enable
+feedback on an organization set up before this feature, **re-run `gh teacher init`**.
+
+**Student repositories accepted before this feature** use an older workflow and must
+be re-created (delete + re-accept) to pick up the new one.
+
+</details>

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -10,8 +10,6 @@ see [Managing Actions cost](Managing-Actions-Cost).
 
 ## How grading works
 
-The whole pipeline, end to end:
-
 1. You define tests on the assignment — usually
    [declarative tests](#declarative-tests) (input/output checks, run commands,
    or pytest), written in the web form or with `gh teacher assignment test add`.
@@ -335,9 +333,6 @@ To turn autograding off for an assignment, pause it over a break, or reduce
 what grading costs, see [Managing Actions cost](Managing-Actions-Cost).
 
 ## Reading results
-
-Where to find scores, per-test breakdowns, past attempts, and who submitted —
-and what each export contains.
 
 ### Where results live
 

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -357,7 +357,7 @@ shim). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | `--due <ISO-8601>` | Due date, e.g., `2026-09-15T23:59:00-04:00`. Stored as UTC; local timezone assumed if you omit the offset. A bare date with no time is rejected. |
 | `--mode individual\|group` | `individual` (default) or `group`. Group requires `--max-group-size`. |
 | `--max-group-size <N>` | Max collaborators on a group repo (2–100). Advisory, not hard-enforced. |
-| `--runtime <path>` | JSON describing the autograde environment (`runs-on`, language versions, `apt`, or a `container`). Omit for ubuntu-latest + Python 3.14. See [Autograders](Autograders). |
+| `--runtime <path>` | JSON describing the autograde environment (`runs-on`, language versions, `apt`, or a `container`). Omit for ubuntu-latest + Python 3.14. See [Advanced Autograding](Advanced-Autograding#the-runtime-block). |
 | `--autograder <name>` | Reserved for swapping the whole reusable workflow (rare). Use `--runtime` for language toolchains. |
 | `--submission-mode every-push\|tag` | When the autograder fires. `every-push` (default) grades every push; `tag` grades only on explicit submits (`gh student submit`, or a hand-pushed `submit/*` tag) — regular pushes cost no Actions minutes, the cost lever for large classrooms. |
 | `--submission-tag <pattern>` | Milestone tag (repeatable) that also triggers grading — e.g. `--submission-tag phase1 --submission-tag phase2`. Students grade a milestone with plain git: `git tag phase1 && git push origin phase1`. Works with either mode; the graded record still appears as a `submit/*` release. |
@@ -365,7 +365,7 @@ shim). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 > [!NOTE]
 > **Custom grading isn't registered here.** Drop an `autograder.py` at
 > `<classroom>/autograders/<slug>/` in the config repo, or set a classroom
-> default with `gh teacher autograder set-default`. See [Autograders](Autograders).
+> default with `gh teacher autograder set-default`. See [Advanced Autograding](Advanced-Autograding#classroom-default).
 
 Re-running with the same slug replaces the entry in place; new slugs append.
 
@@ -483,9 +483,9 @@ the `schedule:` block in `.github/workflows/collect-scores.yaml`.
 
 **Group assignments** are graded once, in the founder's repo. Collection reads
 that repo's collaborators, keeps those on the classroom team, and credits each
-with the same score. See [Autograders](Autograders#group-attribution-model) for
+with the same score. See [Autograders](Autograding-Basics#group-attribution-model) for
 the full attribution model — and
-[Reading results](Autograders#reading-results) in Autograders for where every
+[Reading results](Autograding-Basics#reading-results) in Autograding Basics for where every
 result lives, per-test breakdowns, and past attempts.
 
 ## 10. Download submissions
@@ -508,7 +508,7 @@ submission** (a student with several pushes contributes several lines), plus a
 blank-score line for each non-submitter, so you can sort by
 score to see who hasn't submitted. The column-by-column reference for
 `scores.csv` (and the per-repository `result.json` / `results.json` files) is in
-[Score exports](Autograders#score-exports) in Autograders.
+[Score exports](Autograding-Basics#score-exports) in Autograding Basics.
 
 Each run creates a fresh timestamped folder. Override the destination with `-d`:
 

--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -141,5 +141,5 @@ development resets and complete decommissioning.
 
 - [Can I turn autograding off, or reduce Actions usage?](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage)
   for pausing grading over a break.
-- [Which commits grade](Autograders#which-commits-grade) for submission modes
+- [Which commits grade](Autograding-Basics#which-commits-grade) for submission modes
   and milestone tags.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -192,7 +192,8 @@ they open their repository. See [Assignment Templates](Assignment-Templates).
 
 Yes. Use **declarative tests** (input/output, run-command, or pytest checks)
 defined right on the assignment. No grading script needed. For more control,
-write an `autograder.py`. See [Autograders](Autograders).
+write an `autograder.py`. See [Autograding Basics](Autograding-Basics#declarative-tests)
+and [Advanced Autograding](Advanced-Autograding).
 
 ### Can I turn autograding off, or reduce Actions usage?
 
@@ -205,7 +206,7 @@ Yes, several levers:
   saver for large classrooms, where every work-in-progress push would otherwise
   grade. You can also name **milestone tags** (`--submission-tag phase1`) so
   students grade specific checkpoints with plain git. See
-  [Which commits grade](Autograders#which-commits-grade) in Autograders.
+  [Which commits grade](Autograding-Basics#which-commits-grade) in Autograding Basics.
 - **Pause autograding for one assignment** (reversible) — **Pause autograding**
   in the submissions page's **Actions** menu disables the built-in
   `autograde.yaml` workflow in every student repository (via GitHub's
@@ -234,7 +235,7 @@ Yes. Set `runs-on` in the assignment's runtime to your self-hosted labels (for
 example `["self-hosted", "gpu"]`). Self-hosted runners keep their own
 toolchains, so Classroom 50 skips managed toolchain setup on them — provision
 what your assignments need in the runner image. See
-[Autograders](Autograders#the-runtime-block).
+[Autograders](Advanced-Autograding#the-runtime-block).
 
 ### Can the autograder show students *why* a test failed?
 
@@ -309,7 +310,7 @@ tooling locally — `gh teacher download` clones every submission repo and also
 writes a `scores.csv` summary at the destination root. The raw score data also
 lives in `scores.json` in your config repo, so you can build your own
 automations against it. The column-by-column reference for both CSVs is in
-[Score exports](Autograders#score-exports) in Autograders.
+[Score exports](Autograding-Basics#score-exports) in Autograding Basics.
 
 ### As a teacher, can I test an assignment as a student?
 

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -71,7 +71,7 @@ declarative tests (defined in the assignment) or a Python script you write.
 directly on an assignment, graded with no code to write. They fill the role
 of GitHub Classroom's `autograding.json` presets; an existing
 `autograding.json` workflow can be kept with a
-[custom runner workflow](Autograders#custom-runner-workflow-rare).
+[custom runner workflow](Advanced-Autograding#custom-runner-workflow-rare).
 
 **Runner** — The shared grading engine that runs in GitHub Actions on every
 submission.
@@ -86,7 +86,7 @@ repository for inline review of a student's work.
 (`score` out of `max-score`). The **collected scores** (`scores.json` in the
 `classroom50` repository) are the record of every submission, built by the
 score-collection workflow. Teachers can download them as CSV. See
-[Reading results](Autograders#reading-results) in Autograders.
+[Reading results](Autograding-Basics#reading-results) in Autograding Basics.
 
 **Score override** — A teacher-set score entered on the submissions page,
 stored with the collected scores and left untouched by autograding until

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -162,7 +162,7 @@ tool (or an org/enterprise policy) is changing it back.
 4. The **score-collection** workflow gathers those results into `scores.json`.
 
 Autograding is optional — an assignment with no tests still tags submissions and
-supports feedback. See [Autograders](Autograders) for the full pipeline.
+supports feedback. See [Autograding Basics](Autograding-Basics) for the full pipeline.
 
 ### The Feedback PR opens at accept, with the diff starting at the baseline
 
@@ -172,7 +172,7 @@ Actions is disabled for student repos. Its base is frozen at the accept commit,
 so the setup files (the accept marker and autograde workflow) stay out of the
 diff you review. Should accept not manage it, the autograde runner opens the same
 PR on the first submission instead. See
-[Autograders](Autograders#feedback-pull-requests).
+[Autograders](Autograding-Basics#feedback-pull-requests).
 
 ## Lifecycle: enroll, unenroll, and remove are separate
 

--- a/wiki/Managing-Actions-Cost.md
+++ b/wiki/Managing-Actions-Cost.md
@@ -1,0 +1,93 @@
+# Managing Actions cost
+
+Autograding runs in GitHub Actions in your organization, and GitHub bills the
+organization for those minutes, never the students. This page is the cost
+playbook: what grading spends, the levers that reduce it, and what happens
+when minutes run out.
+
+## What grading costs
+
+- **The organization pays.** GitHub Actions minutes are budgeted per
+  organization. Student repositories are private, so their workflow runs
+  count against the organization's included minutes.
+- **The Team plan includes 3,000 minutes per month.** Usage past that is
+  billed, up to the organization's Actions spending limit.
+- **Each run bills at least a minute.** GitHub rounds every job up to the
+  next minute, so even a near-empty grading run (a vacuous pass with no
+  tests) bills about a minute.
+- **In the default submission type, every push grades.** An assignment in
+  `every-push` mode grades each push to the default branch: five pushes in
+  ten minutes are five graded runs. Multiply by class size to estimate an
+  assignment's cost.
+
+## The levers, by impact
+
+1. **Grade on submit only.** Set the assignment's **Submission type** to
+   **A tagged commit** (`--submission-mode tag`). Regular pushes then run
+   nothing at all; grading happens only when a student submits. This is the
+   biggest saver for large classrooms. See
+   [Which commits grade](Autograding-Basics#which-commits-grade).
+2. **Skip the built-in autograder where you don't need it.** For assignments
+   graded by hand or by your own CI, pick **Do not use the built-in
+   autograder**; accept then installs no grading workflow at all. An
+   assignment with **no tests** still runs a lightweight workflow to tag
+   submissions, which uses far fewer minutes than grading.
+3. **Pause autograding over a break.** Per assignment, or organization-wide;
+   the next section covers both and how **Regrade all** behaves afterward.
+4. **Use self-hosted runners.** Grading on your own hardware costs no GitHub
+   Actions minutes. Set the assignment's `runs-on` to your runner labels;
+   see [The `runtime` block](Advanced-Autograding#the-runtime-block).
+5. **Ask GitHub Education.** Verified educators who need more minutes can
+   contact the GitHub Education team, which can often help with additional
+   credits.
+
+## Turning autograding off or pausing it
+
+Beyond choosing [when commits grade](Autograding-Basics#which-commits-grade),
+you can turn the pipeline off entirely:
+
+- **Per assignment, at creation** — pick **Do not use the built-in
+  autograder** (`no_autograder` in assignments.json). Accept installs no
+  autograding workflow at all; a templated assignment's own CI workflows run
+  instead, and score collection skips the assignment. Changeable later, but
+  only affects repositories accepted from then on (existing ones keep their
+  setup). See [`gh teacher` reference](gh-teacher#assignment-add).
+- **Per assignment, temporarily** — **Pause autograding** in the submissions
+  page's **Actions** menu disables the `autograde.yaml` workflow in every
+  student repository through GitHub's workflow-disable API. No files change, students'
+  other workflows keep running, and **Resume autograding** re-enables it.
+  Available on individual assignments using the built-in autograder (a single
+  repository can also be paused from its row). A student with admin on their own
+  repository can technically re-enable the workflow — a known limitation.
+- **Org-wide** — the organization settings' **Pause autograding for all
+  student repositories** toggle narrows the organization's GitHub Actions policy to the config
+  repository. **This stops all workflows in student repositories**, including any
+  course CI — prefer the per-assignment pause unless that's what you want.
+
+**Catching up after a pause.** Work pushed while autograding was off is not
+graded retroactively. After resuming, run **Regrade all** from the
+submissions page's **Actions** menu: it triggers one grading run per
+repository instead of one per missed push. Each repository's latest
+submission is re-run, and a never-graded repository is graded at its current
+state. See
+[Grading a specific commit](Autograding-Basics#grading-a-specific-commit)
+for the details of what a regrade re-runs.
+
+## The spending cap
+
+Setup creates a **$0 GitHub Actions spending cap**, but only when the
+organization has none yet, so a runaway workflow can't run up a bill. A cap
+you set yourself is never modified. When the included minutes are exhausted,
+workflow runs are blocked until the next billing month or until you raise
+the limit in the organization's billing settings.
+
+On enterprise-managed organizations, the cap often isn't readable and setup
+shows an advisory warning; see
+[Couldn't verify the Actions spending cap](Troubleshooting#couldnt-verify-the-actions-spending-cap).
+
+## Further reading
+
+- [Can I turn autograding off, or reduce Actions usage?](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage)
+  in the FAQ.
+- [Students can re-enable paused workflows](Known-Limitations#templates-and-student-repositories)
+  in Known limitations.

--- a/wiki/Migrating-from-GitHub-Classroom.md
+++ b/wiki/Migrating-from-GitHub-Classroom.md
@@ -49,7 +49,7 @@ starter repository as a template in your organization.
 
 ## Reusing your autograders
 
-Classroom 50's [declarative tests](Autograders#declarative-tests) fill the
+Classroom 50's [declarative tests](Autograding-Basics#declarative-tests) fill the
 role of GitHub Classroom's autograding presets: input/output, run-command,
 and pytest checks defined on the assignment, with no grading script to
 write. For most assignments, migrating the autograder means re-entering
@@ -57,7 +57,7 @@ those tests on the imported assignment.
 
 If you've invested in a working `autograding.json` workflow, you can keep it
 and skip Classroom 50's grading pipeline for that assignment; see
-[Bringing a GitHub Classroom autograder along](Autograders#bringing-a-github-classroom-autograder-along).
+[Bringing a GitHub Classroom autograder along](Advanced-Autograding#bringing-a-github-classroom-autograder-along).
 
 ## What behaves differently
 

--- a/wiki/Staff-TAs-and-Multiple-Teachers.md
+++ b/wiki/Staff-TAs-and-Multiple-Teachers.md
@@ -68,7 +68,7 @@ assignments, submissions, and scores. The differences:
   yet, which is expected; it appears after the next collection run.
 
 With read access, TAs can open each student's work and leave reviews on the
-[feedback pull request](Autograders#feedback-pull-requests). There is no
+[feedback pull request](Autograding-Basics#feedback-pull-requests). There is no
 automatic reviewer assignment yet; TAs pick up repositories from the
 submissions page (**Open all Feedback PRs** steps through them).
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -255,11 +255,11 @@ form, holds optional settings for customizing the autograding environment:
 > Existing organizations must refresh the shared workflow files (re-run
 > setup) before using submission release files. Submission publishing doesn't
 > support GitHub Immutable Releases. See
-> [Autograders](Autograders#attaching-files-to-submission-releases)
+> [Autograders](Advanced-Autograding#attaching-files-to-submission-releases)
 > for path rules and limits.
 
 Commands run in separate shell processes. See
-[Autograders](Autograders#setup-commands-dependencies-and-environment-variables)
+[Autograders](Autograding-Basics#setup-commands-dependencies-and-environment-variables)
 for dependency installation and environment-variable guidance.
 
 ### Autograding tests
@@ -445,7 +445,7 @@ and links to the repository, the commit, the feedback pull request
 (**Review**), and the Release (**View autograder details**). For where every
 result lives — per-test breakdowns, past attempts, grading a specific commit,
 and who submitted — see
-[Reading results](Autograders#reading-results) in Autograders.
+[Reading results](Autograding-Basics#reading-results) in Autograding Basics.
 
 ### Scores and overrides
 
@@ -509,7 +509,7 @@ assignment:
 
 Click **Download scores (CSV)** to export all submissions as a CSV for a
 spreadsheet or external tool. The column-by-column reference is in
-[Score exports](Autograders#score-exports) in Autograders.
+[Score exports](Autograding-Basics#score-exports) in Autograding Basics.
 
 ## Edit assignments and classrooms
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -16,9 +16,13 @@
   - [Staff, TAs, and Multiple Teachers](Staff-TAs-and-Multiple-Teachers)
   - [Migrating from GitHub Classroom](Migrating-from-GitHub-Classroom)
   - [Course Lifecycle and End of Term](Course-Lifecycle-and-End-of-Term)
+- **Autograding**
+  - [Autograding Basics](Autograding-Basics)
+  - [Autograder Recipes](Autograder-Recipes)
+  - [Advanced Autograding](Advanced-Autograding)
+  - [Managing Actions Cost](Managing-Actions-Cost)
 - **Reference**
   - [Assignment Templates](Assignment-Templates)
-  - [Autograders](Autograders)
   - [GitHub Integration](GitHub-Integration)
   - [Known Limitations](Known-Limitations)
   - [Troubleshooting](Troubleshooting)

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -410,7 +410,7 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | `--due <ISO-8601>` | Due date; timezone required. Stored verbatim. |
 | `--mode individual\|group` | `individual` (default) or `group` (requires `--max-group-size`). |
 | `--max-group-size <N>` | Max group collaborators (2–100). Advisory. |
-| `--runtime <path>` | JSON runtime (`runs-on`, toolchains, `apt`, `container`). See [Autograders](Autograders). |
+| `--runtime <path>` | JSON runtime (`runs-on`, toolchains, `apt`, `container`). See [Advanced Autograding](Advanced-Autograding#the-runtime-block). |
 | `--tests <path>` | JSON array of declarative tests. Mutually exclusive with a per-assignment `autograder.py`. |
 | `--autograder <name>` | Swap the reusable workflow (rare). Default `default`. |
 | `--feedback-pr` | One review PR per student repo. **On by default**; `--feedback-pr=false` disables. |
@@ -421,7 +421,9 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 
 **Where grading logic lives** (increasing effort): declarative `--tests` → a
 per-assignment `<classroom>/autograders/<slug>/autograder.py` → a classroom
-default via `gh teacher autograder set-default`. See [Autograders](Autograders).
+default via `gh teacher autograder set-default`. See
+[Autograding Basics](Autograding-Basics#declarative-tests) and
+[Advanced Autograding](Advanced-Autograding#writing-an-autograderpy).
 
 **No built-in autograder (teacher-supplied CI).** A **templated** assignment can
 carry `no_autograder: true` in `assignments.json` to opt out of the built-in
@@ -576,7 +578,7 @@ gh teacher assignment test remove <org> <classroom> <slug> <test-name>
 Manage the declarative `tests` block — GitHub Classroom-style io/run/python
 checks graded with no `autograder.py`. `add` upserts by `--name`; it's refused
 while a per-assignment `autograder.py` exists. See
-[Autograders](Autograders#declarative-tests) for fields and semantics. For bulk
+[Autograders](Autograding-Basics#declarative-tests) for fields and semantics. For bulk
 edits, use `assignment add --tests <file.json>`.
 
 ## `autograder`
@@ -604,7 +606,8 @@ gh teacher autograder remove <org> <classroom> [--yes]
   Prompts unless `--yes`. Idempotent.
 
 Named shims and per-assignment `autograder.py` overrides are **read-only from the
-CLI** — author them with ordinary git operations. See [Autograders](Autograders).
+CLI** — author them with ordinary git operations. See
+[Advanced Autograding](Advanced-Autograding).
 
 ## `invite`
 


### PR DESCRIPTION
PR 2 of the wiki reorganization plan (follows #619 and #620): the 1,000-line Autograders page mixed first-day setup, per-language specifics, contract-level internals, and cost management, forcing every reader to scan all four. This splits it by task.

## New pages

- **Autograding Basics** — how grading works, grading modes, declarative tests, setup commands, which commits grade, reading results, score exports, and feedback pull requests. Content moved verbatim from Autograders, with cross-page links retargeted.
- **Autograder Recipes** — new content: working declarative-test setups for Python, Java, C#, C and C++, and Rust (template layout, tests, common failures), plus the bring-your-own-CI options.
- **Advanced Autograding** — writing an `autograder.py`, the `result.json` contract, the `runtime` block (self-hosted runners, containers), `allowed_files`, release assets, custom runner workflows, failure paths, and operational notes. Moved verbatim, with headings promoted one level.
- **Managing Actions Cost** — new cost playbook: what grading costs (per-org billing, per-job minute rounding, 3,000 included Team-plan minutes), the levers by impact (tag mode, skipping the built-in autograder, pausing, self-hosted runners, GitHub Education credits), the moved "Turning autograding off or pausing it" section with post-pause **Regrade all** guidance (per the maintainer answer in #347), and the spending cap.

## Compatibility

- `Autograders.md` is now a stub: every former H2/H3 heading remains as an anchor target with a one-line link to its new home, so existing external links (README, CLI docs, old discussions) keep resolving. No anchor-level (`Autograders#...`) references exist outside the wiki; verified by repo-wide search.
- All 30+ intra-wiki links into the old page were retargeted to the new homes; a full-wiki link and anchor check passes.
- Sidebar gains an **Autograding** group with the four pages; the stub is no longer listed.

Moved prose also picks up two settled vocabulary fixes ("collected scores" instead of "gradebook", "the `classroom50` repository" instead of "config repository") since these pages are new files; the remaining wiki-wide sweep stays in PR 4.

## Review notes

Basics and Advanced are mostly verbatim moves; the genuinely new writing to review closely is Autograder-Recipes.md, Managing-Actions-Cost.md, the page intros, and the stub.