### PR TITLE
docs(wiki): move scattered guidance to canonical pages and de-duplicate

### DIFF
--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -6,14 +6,40 @@ for each student; `gh student submit` re-fetches a couple of files from it on
 every submission. This page describes the expected layout.
 
 > [!NOTE]
-> **Templates are optional.** Register an assignment without `--template` and
-> students get an *empty* repo containing only the autograder shim — good for
-> write-from-scratch or short-answer work. For repos with *nothing at all* (no
-> shim, no autograding), use `--empty-repo` instead. The rest of this page
-> applies only to assignments that ship a template.
+> **Templates are optional.** An assignment without a template gives each
+> student an initialized repository with a README and the autograding setup —
+> good for write-from-scratch or short-answer work. See
+> [Repository shapes](#repository-shapes) for every option. The rest of this
+> page applies to assignments that ship a template.
 
 A worked example lives at
 [`templates/example-assignment/`](https://github.com/foundation50/classroom50/tree/main/templates/example-assignment).
+
+## Repository shapes
+
+What accept creates is a per-assignment choice. All five shapes:
+
+| Shape | Set with | Students get | Autogrades? |
+| --- | --- | --- | --- |
+| **Template** | `--template` (or the web form's template field) | A copy of the template plus the control files | Yes |
+| **Template, own CI** | `no_autograder: true` (web: **Do not use the built-in autograder**) | A copy of the template with no autograding workflow; the template's own CI runs instead | No; score collection skips it |
+| **Template-less with a README** | Omit `--template` (web: **No template**, **Add a README** on) | An initialized repository: README plus the control files | Yes |
+| **Template-less, no README** | `init_shim: true` (web: **No template**, **Add a README** off) | An initialized repository carrying only the control files | Yes |
+| **Empty repository** | `--empty-repo` (web: **Empty repository**) | A completely bare repository: no commits, no control files, and no feedback pull request, ever | Never |
+
+Two rules apply across all of them:
+
+- **Shape changes affect future accepts only.** Every shape can be changed
+  after creation, but repositories students already accepted keep their
+  original setup; nothing is retrofitted. (**Assignment type** — individual
+  or group — is the exception: it stays locked once set.)
+- **A template brings only its default branch** unless the assignment turns
+  on **Include all branches** (`include_all_branches: true`), which copies
+  every branch into each generated repository. Template-only; it has no
+  effect on the other shapes.
+
+For the flag-level details (mutual exclusions and `assignments.json` fields),
+see [`gh teacher assignment add`](gh-teacher#assignment-add).
 
 ## Structure
 
@@ -72,13 +98,18 @@ gh student accept <org> <classroom> <slug>
 …which creates `<org>/<classroom>-<slug>-<username>` (lowercased) from your
 template.
 
+## Template visibility
+
+A **public** template always works. A **private** template works only if it's
+**inside your organization** — registering the assignment grants the
+classroom's team read access to it. A private template **outside** your
+organization is rejected (students can't be granted access, so accept would
+404). Enterprise Cloud's "internal" visibility also works.
+
 > [!NOTE]
-> **Template visibility.** A **public** template always works. A **private**
-> template works only if it's **inside your organization** — `gh teacher
-> assignment add` grants the classroom team read access to it. A private
-> template **outside** your organization is rejected (students can't be granted
-> access, so accept would 404). Enterprise Cloud's "internal" visibility also
-> works.
+> The team read grant happens when you **create** the assignment. If you
+> create the assignment first and add a private template later by editing it,
+> the grant isn't re-applied and students may get a 404 on accept.
 
 ## Template requirements and gotchas
 

--- a/wiki/CLI-Student-Guide.md
+++ b/wiki/CLI-Student-Guide.md
@@ -63,14 +63,9 @@ an empty repo if it's template-less), then prints a `git clone` command.
 Already accepted? The command reports `Assignment already accepted` and leaves
 your existing repo (and your work) alone.
 
-**Common errors:**
-
-| Message | What it means |
-| --- | --- |
-| "the classroom may not exist yet, or `publish-pages.yaml` may not have run" | Setup isn't finished or Pages hasn't deployed. Wait a few minutes, or ask your teacher. |
-| "assignment X is not registered" | A typo, or your teacher hasn't added the assignment yet. |
-| "autograder `<name>` not published yet" | The autograder's YAML isn't on the Pages site. Ask your teacher to confirm it exists and that Pages has deployed. |
-| "template `<owner>/<repo>` is not accessible to you" | The template is private and not shared with you. Ask your teacher to make it public or grant access. |
+If accept fails, see
+[Common `gh student accept` errors](Troubleshooting#common-gh-student-accept-errors)
+in Troubleshooting.
 
 ## 3. Clone and work
 

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -28,11 +28,8 @@ The CLI doesn't create the organization for you. Do this once on github.com:
    [Assignment Templates](Assignment-Templates) for the expected layout.
 
 > [!NOTE]
-> **Template visibility.** A **public** template always works. A **private**
-> template works only if it's **inside your organization** — `gh teacher
-> assignment add` grants the classroom's team read access to it. A private
-> template **outside** your organization is rejected. (Enterprise Cloud's
-> "internal" visibility also works.)
+> A private template must live **inside your organization**; see
+> [Template visibility](Assignment-Templates#template-visibility).
 
 `gh teacher init` (step 3) locks down organization member privileges for you.
 Four settings have no API and are listed as a manual checklist in that step.
@@ -308,8 +305,10 @@ gh teacher roster import <org> <classroom> <path-to-csv>
 
 Accepts a header of `username,first_name,last_name,email,section` (a trailing
 `github_id` column is accepted but ignored, since the CLI re-resolves each ID
-from GitHub). Every username is resolved up front; one typo aborts the whole
-import before any commit. New students are invited.
+from GitHub). The column-by-column reference is in
+[Roster CSV fields](Web-Teacher-Guide#roster-csv-fields) — the web app and the
+CLI read the same format. Every username is resolved up front; one typo aborts
+the whole import before any commit. New students are invited.
 
 **View the roster:**
 

--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -139,7 +139,7 @@ development resets and complete decommissioning.
 
 ## Further reading
 
-- [Can I turn autograding off, or reduce Actions usage?](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage)
-  for pausing grading over a break.
+- [Managing Actions cost](Managing-Actions-Cost) for pausing grading over a
+  break.
 - [Which commits grade](Autograding-Basics#which-commits-grade) for submission modes
   and milestone tags.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -50,14 +50,12 @@ course, section, or term. Add each with **Create classroom** in the web app or
 
 ### Should I create one organization per course, like GitHub Classroom?
 
-You don't have to. Because one organization holds many classrooms, a single,
-stable teaching team running one course (across terms or sections) works well
-with **one organization** and a classroom per term or section. Prefer
-**separate organizations** when many teachers run very different classes (e.g.
-school-wide adoption) — each teacher then manages their own org — or when a
-large course would otherwise accumulate hundreds of assignment repositories
-per year; in that case, one org per academic year keeps things tidy. Each
-organization needs its own one-time setup.
+You don't have to: one organization can hold many classrooms, so a stable
+teaching team usually keeps one organization with a classroom per term or
+section. Separate organizations fit school-wide adoption or very large
+courses. See
+[One organization or several?](Staff-TAs-and-Multiple-Teachers#one-organization-or-several)
+for how to choose.
 
 ### Can a classroom have multiple teachers or TAs?
 
@@ -105,17 +103,12 @@ See [How Classroom 50 Works](How-Classroom-50-Works#lifecycle-enroll-unenroll-an
 
 ### Can I use a private repository as an assignment template?
 
-Yes, if the template lives **inside your organization**. When you register the
-assignment, Classroom 50 automatically grants the classroom's team read access
-so students can copy it. A **public** template works from anywhere. A private
-template **outside** your organization can't be shared with students — copy it
-into your organization or make it public. See
-[Assignment Templates](Assignment-Templates).
-
-> [!NOTE]
-> Grant the template when you **create** the assignment. If you create the
-> assignment first and add a private template later by editing it, the team
-> read grant isn't re-applied and students may get a 404 on accept.
+Yes, if the template lives **inside your organization** — registering the
+assignment grants the classroom's team read access to it. A private template
+outside your organization can't be shared with students; a public one works
+from anywhere. See
+[Template visibility](Assignment-Templates#template-visibility), including
+why a private template added to an existing assignment can 404 on accept.
 
 ### Can I customize the Feedback PR's first comment?
 
@@ -142,12 +135,9 @@ blocked automatically.
 ### Does the due date cut off student access?
 
 No — there is no cutoff date; the due date only marks later submissions late.
-To actually end an assignment, use **Close submission** in the submissions
-page's **Actions** menu: it blocks new accepts and sets every student's
-repository to read-only (work is preserved). **Reopen submission** restores
-write access — useful when a project continues in a follow-up course. **Update
-student repo access** in the same menu gives finer control over the role
-students hold on their repositories.
+To actually end an assignment, use **Close submission**, which blocks new
+accepts and sets every student's repository to read-only. See
+[Due dates mark late; closing enforces](Course-Lifecycle-and-End-of-Term#due-dates-mark-late-closing-enforces).
 
 ### What's the difference between "template-less" and "empty repository"?
 
@@ -169,7 +159,8 @@ only affects repositories accepted from then on** — repositories students
 already accepted aren't retrofitted, so they keep their original shape. The web
 edit form asks you to confirm when students have already accepted. (**Assignment
 type** — Individual vs. Group — is the exception and stays locked, since
-switching it would invalidate existing submissions.)
+switching it would invalidate existing submissions.) For every shape in one
+table, see [Repository shapes](Assignment-Templates#repository-shapes).
 
 ### How do group assignments work?
 
@@ -197,37 +188,11 @@ and [Advanced Autograding](Advanced-Autograding).
 
 ### Can I turn autograding off, or reduce Actions usage?
 
-Yes, several levers:
-
-- **Grade on submit only** — set the assignment's **Submission type** to **A
-  tagged commit** (`--submission-mode tag` in the CLI). Students' regular
-  pushes then run nothing at all; grading happens only when they submit
-  (`gh student submit` or a hand-pushed `submit/*` tag). This is the biggest
-  saver for large classrooms, where every work-in-progress push would otherwise
-  grade. You can also name **milestone tags** (`--submission-tag phase1`) so
-  students grade specific checkpoints with plain git. See
-  [Which commits grade](Autograding-Basics#which-commits-grade) in Autograding Basics.
-- **Pause autograding for one assignment** (reversible) — **Pause autograding**
-  in the submissions page's **Actions** menu disables the built-in
-  `autograde.yaml` workflow in every student repository (via GitHub's
-  workflow-disable API — no files change). Students' other workflows keep
-  running, and **Resume autograding** re-enables it. Offered on individual
-  assignments that use the built-in autograder, once students have accepted.
-- Create an assignment with **no autograding tests**, and no grading runs
-  (Classroom 50 still uses a lightweight workflow to tag submissions and
-  support written feedback, which uses far fewer Actions minutes).
-- **Don't use the built-in autograder at all** — when creating an
-  assignment, pick **Do not use the built-in autograder**. Accept then installs
-  no autograding workflow: a templated assignment runs only your template's own
-  CI (if any), and score collection skips the assignment. The right choice for
-  project-shaped assignments graded by hand or by your own CI. Can be changed
-  after creation, but only affects repositories accepted from then on (existing
-  ones keep their original setup).
-- **Pause autograding org-wide** — the organization's Actions settings in the
-  web app. **Caution:** this stops **all** workflows in student repositories,
-  not just autograding — any CI your students run stops too. Setup also creates
-  a **$0 Actions spending cap** (only when the organization has none) so a
-  runaway workflow can't run up a bill.
+Yes. Grade only on explicit submits (**Submission type: A tagged commit**),
+skip the built-in autograder for assignments graded elsewhere, pause
+autograding per assignment or organization-wide, or grade on self-hosted
+runners. [Managing Actions cost](Managing-Actions-Cost) covers every lever
+and what each one trades away.
 
 ### Can I use my own (self-hosted) runners?
 
@@ -317,10 +282,9 @@ automations against it. The column-by-column reference for both CSVs is in
 You can — Classroom 50 doesn't currently disallow one account holding both a
 staff and a student role. Add yourself to the roster with `gh teacher roster
 add` (or the web app) while remaining on a staff team; you'll then show **both**
-roles and be graded as a student. (Your in-app access stays at your highest
-role, and the `roster.csv` `role` column records that highest role — an
-automatic sync may rewrite it, which doesn't affect your student enrollment. See
-[Dual roles](gh-teacher#dual-roles-staff-who-are-also-students).)
+roles and be graded as a student. For how the app behaves with a dual-role
+account, see
+[Staff who are also students](Staff-TAs-and-Multiple-Teachers#staff-who-are-also-students-dual-roles).
 
 One caveat: as an **organization owner** you keep `admin` on your own assignment
 repo (GitHub won't let an owner reduce their own access to `write`), so it won't
@@ -358,13 +322,11 @@ though Classroom 50 only acts on classroom ones. This matches the CLI's behavior
 
 ### Why does signing in ask for permission to "Delete repositories"?
 
-One feature uses it: **Tear down organization** (org settings → Danger zone),
-which resets an organization by deleting the repositories Classroom 50 manages
-— and only after you type an explicit confirmation. Nothing else ever deletes a
-repository, and because there's no Classroom 50 server, the token stays in your
-browser. The CLIs don't request it at all unless you opt in
-(`gh teacher login -s delete_repo`). Details:
-[GitHub Integration](GitHub-Integration#2-teacher-authentication).
+One feature uses it: **Tear down organization**, which resets an organization
+by deleting the repositories Classroom 50 manages, and only after you type an
+explicit confirmation. Nothing else ever deletes a repository. See
+[the full explanation](GitHub-Integration#2-teacher-authentication) in GitHub
+Integration.
 
 ### Can I edit the config files in the `classroom50` repo by hand?
 
@@ -388,7 +350,7 @@ need one per organization. See
 
 Some capabilities from GitHub Classroom aren't available today, including
 **LTI / LMS grade passback**, in-app **grade visibility for students**, and
-**roster self-selection** (students picking their own roster entry when
-accepting). Classroom 50 is open source and actively developed — share ideas
-or track direction in
+**roster self-selection**. See
+[Requested, but architecturally hard](Known-Limitations#requested-but-architecturally-hard)
+in Known limitations for why, and share your use case in
 [Discussions](https://github.com/foundation50/classroom50/discussions).

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -16,10 +16,8 @@ The CLI never creates the organization. Before running any CLI command:
    repository**.
 
 > [!NOTE]
-> **Template visibility.** Public works on any plan. A private template works
-> only if it's **inside your org** (`gh teacher assignment add` grants the
-> classroom team read). A private template **outside** your org is rejected.
-> Enterprise Cloud's "internal" visibility also works.
+> A private template must live **inside your org**; see
+> [Template visibility](Assignment-Templates#template-visibility).
 
 `gh teacher init` locks organization member privileges to least-privilege
 automatically. After it runs, a member can only create a **private** repository
@@ -40,16 +38,10 @@ rest.
 
 </details>
 
-**Four member-privilege settings have no API** — apply them once at
-`https://github.com/organizations/<org>/settings/member_privileges` (`init`
-prints this reminder):
-
-- [ ] **App access requests** → "Members only" (or disable).
-- [ ] **Uncheck** "Allow repository admins to install GitHub Apps for their
-      repositories".
-- [ ] **Projects base permissions** → "No access".
-- [ ] **Uncheck** "Allow repository administrators to rename branches protected
-      by organization rules".
+**Four member-privilege settings have no API**, so `init` can't set them and
+`audit` can't read them. Apply them once by hand; the checklist is in
+[Manual organization hardening](CLI-Teacher-Guide#manual-organization-hardening-one-time)
+in the CLI Teacher Guide.
 
 ### 2. Teacher authentication
 

--- a/wiki/Managing-Actions-Cost.md
+++ b/wiki/Managing-Actions-Cost.md
@@ -87,7 +87,7 @@ shows an advisory warning; see
 
 ## Further reading
 
-- [Can I turn autograding off, or reduce Actions usage?](FAQ#can-i-turn-autograding-off-or-reduce-actions-usage)
-  in the FAQ.
+- [Which commits grade](Autograding-Basics#which-commits-grade) for the full
+  submission-type semantics.
 - [Students can re-enable paused workflows](Known-Limitations#templates-and-student-repositories)
   in Known limitations.

--- a/wiki/Staff-TAs-and-Multiple-Teachers.md
+++ b/wiki/Staff-TAs-and-Multiple-Teachers.md
@@ -122,9 +122,7 @@ people, not courses:
   can be archived wholesale.
 
 Each organization needs its own one-time setup (plan upgrade, setup run, and
-service token). See
-[Should I create one organization per course?](FAQ#should-i-create-one-organization-per-course-like-github-classroom)
-for the short version.
+service token).
 
 ## Further reading
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -206,6 +206,17 @@ the student side. `roster add` prints a note when the target is already staff.
 See [Dual roles](gh-teacher#dual-roles-staff-who-are-also-students). For a
 "pure" student, use a separate GitHub account.
 
+## Common `gh student accept` errors
+
+| Message | What it means |
+| --- | --- |
+| "the classroom may not exist yet, or `publish-pages.yaml` may not have run" | Setup isn't finished or Pages hasn't deployed. Wait a few minutes, or ask your teacher. |
+| "assignment X is not registered" | A typo, or your teacher hasn't added the assignment yet. |
+| "autograder `<name>` not published yet" / "is malformed YAML" | The autograder's YAML is missing or broken; see [below](#autograder-name-not-published-yet-on-gh-student-accept). |
+| "template `<owner>/<repo>` is not accessible to you" | The template is private and not shared with you; see ["Template not found"](#template-not-found--404-on-gh-student-accept). |
+| "assignment `<X>` has unsupported mode `<mode>`" | The manifest's `mode` is neither `individual` nor `group` (likely hand-edited). Ask your teacher. |
+| "Assignment already accepted" | Not an error — your repository already exists and your work is untouched. |
+
 ## "Assignment already accepted" on `gh student accept`
 
 You've already accepted; the repo is at
@@ -217,11 +228,12 @@ have it locally.
 
 Only applies to assignments with a template. Check, in order:
 
-1. **The template is readable by the student.** Public always works. A private
-   template works only if it's inside your org (the classroom team is granted
-   read). A private template outside your org can't be shared — re-add the
-   assignment with an in-org copy or a public template. If a student still 404s,
-   confirm they're on the roster (so they're in the team).
+1. **The template is readable by the student.** Public always works; a
+   private template must be inside your org (see
+   [Template visibility](Assignment-Templates#template-visibility)). If it's
+   outside, re-add the assignment with an in-org copy or a public template.
+   If a student still 404s, confirm they're on the roster (so they're in the
+   team).
 2. **The repo is flagged as a template** in Settings → Template repository.
 3. **The `<assignment>` argument matches the registered slug** (case is
    normalized; spelling must be exact).

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -77,10 +77,9 @@ When step 1 is complete, continue to step 2 to add your service token.
 
 The **service token** is a fine-grained personal access token (PAT) scoped to
 your organization, used by the score-collection and regrade workflows to read
-student repositories (and push regrade tags) across the org. It needs
-**Contents**, **Actions**, and **Administration** read/write plus
-**Organization → Members** read — the form and the pre-filled GitHub page set
-these up for you; the full permission table is in
+student repositories (and push regrade tags) across the org. The form and the
+pre-filled GitHub page set up the required permissions for you; the full
+permission table is in
 [GitHub Integration](GitHub-Integration#4-fine-grained-pat-for-score-collection).
 Classroom 50 stores it as the `CLASSROOM50_SERVICE_TOKEN` secret in your config
 repo, where the daily score-collection workflow uses it.

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -59,15 +59,9 @@ a `git clone` command.
 Already accepted? The command reports `Assignment already accepted: <org>/<repo>`
 and leaves your repo alone.
 
-**Common errors:**
-
-| Message | What it means |
-| --- | --- |
-| "the classroom may not exist yet, or `publish-pages.yaml` may not have run" | Setup isn't finished or Pages hasn't deployed. Wait, or ask your teacher. |
-| "assignment X is not registered" | A typo, or your teacher hasn't added the assignment. |
-| "autograder `<name>` not published yet" / "is malformed YAML" | The autograder's YAML is missing or broken. Ask your teacher. |
-| "template `<owner>/<repo>` is not accessible to you" | The template is private and not shared with you. Ask your teacher to make it public or grant access. |
-| "assignment `<X>` has unsupported mode `<mode>`" | The manifest's `mode` is neither `individual` nor `group` (likely hand-edited). Ask your teacher. |
+If accept fails, see
+[Common `gh student accept` errors](Troubleshooting#common-gh-student-accept-errors)
+in Troubleshooting.
 
 ## `invite`
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -81,12 +81,12 @@ stale skeleton files (after a confirmation prompt).
 
 </details>
 
-**Service token requirements:** a fine-grained PAT with **Contents: Read and
-write**, **Actions: Read and write**, **Administration: Read and write** (repo),
-and **Members: Read** (organization). Scope it to **All repositories** — student
-repos are created on demand, so "Only select repositories" misses them. See the
-[CLI Teacher Guide](CLI-Teacher-Guide#create-the-service-token) for the full
-walkthrough.
+**Service token:** a fine-grained PAT `init` validates and uploads as the
+`CLASSROOM50_SERVICE_TOKEN` secret. See the
+[walkthrough](CLI-Teacher-Guide#create-the-service-token) in the CLI Teacher
+Guide and the
+[permission table](GitHub-Integration#4-fine-grained-pat-for-score-collection)
+in GitHub Integration.
 
 <details>
 <summary>Skeleton files shipped into the config repo</summary>
@@ -324,8 +324,10 @@ gh teacher roster import <org> <classroom> <path-to-csv>
 
 Bulk upsert. Accepts a 5-column header
 (`username,first_name,last_name,email,section`) or 6-column with a trailing
-`github_id` (which is ignored and re-resolved). Every username is resolved up
-front — one typo aborts before any commit. New students are invited.
+`github_id` (which is ignored and re-resolved). The field reference is in
+[Roster CSV fields](Web-Teacher-Guide#roster-csv-fields). Every username is
+resolved up front — one typo aborts before any commit. New students are
+invited.
 
 **Errors common to roster commands:** missing config repo → `run gh teacher init
 <org> first`; missing `roster.csv` → points at `classroom add`; bad header →
@@ -351,34 +353,21 @@ membership and is idempotent.
 
 ### Dual roles (staff who are also students)
 
-Classroom 50 does not currently disallow a single account holding more than one
-role in a classroom — most commonly a teacher or TA who also adds themselves to
-the roster to preview the student experience. In practice this only arises on
-the teacher's side: `staff add` and `roster add` each manage their own GitHub
-team, so running both for one account leaves it on both teams. There's no guard
-against it, so it's worth knowing how the app behaves.
+Nothing stops one account from being on a staff team and the roster at once
+(`staff add` and `roster add` each manage their own GitHub team). How a
+dual-role account behaves in the app is covered in
+[Staff who are also students](Staff-TAs-and-Multiple-Teachers#staff-who-are-also-students-dual-roles).
+The CLI-visible effects:
 
-The classroom's GitHub teams are the authority for enrollment and role; the
-`role` column in `roster.csv` is only a display snapshot. With that in mind:
-
-- **Roster view** — team memberships are unioned, so the account shows **all**
-  its role badges and appears under each role's filter.
-- **In-app access** — the **highest** role wins (`teacher > hta > ta > student`),
-  so a teacher-who-is-also-a-student keeps teacher-level access. "View as" only
-  downgrades the preview locally; it never grants access.
-- **`role` column / `roster list`** — records the single **highest** role. The
-  automatic sync refreshes it, so you may see a commit rewrite an empty/`""`
-  role to `teacher` shortly after `roster add`. That's the snapshot updating,
-  not a change to enrollment — nothing reads this column to decide access.
-- **Scores & submissions** — an account with a student enrollment is always
-  listed as a student. (A pure-staff account only appears in submissions once it
-  has actually accepted an assignment repo.)
-- **Unenroll** — drops only the student side (the roster row and student-team
-  membership); any staff role stays intact.
-
-`roster add` prints a note when the target is already staff, so the later
-`role`-column rewrite isn't a surprise. If you want a "pure" student view with no
-staff access, use a separate GitHub account for student testing.
+- **`roster list` and the `role` column** record the single **highest** role
+  (`teacher > hta > ta > student`). The automatic sync refreshes the column,
+  so you may see a commit rewrite an empty role to `teacher` shortly after
+  `roster add` — the snapshot updating, not a change to enrollment; nothing
+  reads this column to decide access.
+- **`roster add` prints a note** when the target is already staff, so the
+  later `role`-column rewrite isn't a surprise.
+- **`roster remove` (unenroll) drops only the student side** — the roster row
+  and student-team membership; any staff role stays intact.
 
 ## `assignment`
 
@@ -425,54 +414,32 @@ default via `gh teacher autograder set-default`. See
 [Autograding Basics](Autograding-Basics#declarative-tests) and
 [Advanced Autograding](Advanced-Autograding#writing-an-autograderpy).
 
-**No built-in autograder (teacher-supplied CI).** A **templated** assignment can
-carry `no_autograder: true` in `assignments.json` to opt out of the built-in
-autograder entirely: accept commits the `.classroom50.yaml` marker and the
-template's content but **no** `.github/workflows/autograde.yaml` shim, so the
-teacher's own CI inside the template runs instead. It **requires** a template
-(the template carries the workflows — use `--empty-repo` for a bare repo with no
-CI). Unlike `--empty-repo` it keeps the template and the Feedback PR (a
-templated repo has a baseline commit); it is mutually exclusive with
-`empty_repo`, a non-default `--autograder`, and the grading-adjacent fields
-(tests/allowed-files/release-assets/pass-threshold/submission-mode/
-submission-tag). It can be changed later, but only affects repositories accepted
-from then on (already-accepted repos aren't retrofitted). Score collection and
-regrade skip it (no `submit/*` releases are produced). Set it in the web app's
-assignment form — choose **"Do not use the built-in autograder"** under
-**Built-in autograder** — or by writing `no_autograder: true` into
-`assignments.json`; there is no `assignment add` flag.
+**Repository shapes.** Three more provisioning settings live in
+`assignments.json` only — there is no `assignment add` flag for them; set them
+in the web assignment form or by editing the file. All three are mutable but
+affect only repositories accepted from then on. The concept-level comparison
+of every shape is in
+[Repository shapes](Assignment-Templates#repository-shapes).
 
-**Built-in autograder on an otherwise-empty repo (`init_shim`).** A
-**template-less** assignment can carry `init_shim: true` in `assignments.json`
-to get an initialized-but-README-less repo carrying **only** the control files:
-accept creates the repo with an initial commit and lands the `.classroom50.yaml`
-marker + the universal default autograde shim — but no README and no other
-starter content. Unlike `--empty-repo` (a bare repo with no commit that **never**
-autogrades), an `init_shim` repo **does** autograde: it commits the default
-shim, produces `submit/*` releases, and is collected/regraded like any built-in
-assignment (the grading pipeline does **not** skip it). It **requires** the
-default autograder and **no** template (a template provides its own starter
-content); it is mutually exclusive with `empty_repo`, `template`,
-`no_autograder`, and a non-default `--autograder`, and it **permits** the
-grading-adjacent fields (it autogrades). It can be changed later, but only
-affects repositories accepted from then on (already-accepted repos aren't
-retrofitted). Set it in the web app's assignment form — pick **"No template"**,
-leave **"Add a README"** off, and keep **"Use the built-in autograder"** — or by
-writing `init_shim: true` into `assignments.json`; there is no `assignment add`
-flag.
-
-**Include all branches (`include_all_branches`).** A **templated** assignment can
-carry `include_all_branches: true` in `assignments.json` to copy **all** of the
-template's branches (not just the default) when each student repo is generated:
-accept passes `include_all_branches` to GitHub's `POST /repos/{template}/generate`.
-It **requires** a template (it only affects the generate call) and is mutually
-exclusive with `empty_repo` and `init_shim` (both template-less, never
-generated); it is **compatible** with everything else, including `no_autograder`
-and the grading-adjacent fields (branches don't affect grading). Like the other
-provisioning settings it is **mutable**, and being **accept-time only** it
-affects only repos generated from now on (already-accepted repos are never
-re-generated). Set it with the web assignment form's **"Include all branches"**
-toggle or via `assignments.json`; there is no `assignment add` flag.
+- **`no_autograder: true`** (web: **Do not use the built-in autograder**) —
+  accept commits the `.classroom50.yaml` marker and the template's content but
+  no autograde workflow, so the template's own CI runs instead. Requires a
+  template (it carries the workflows); keeps the Feedback PR. Score collection
+  and regrade skip it (no `submit/*` releases). Mutually exclusive with
+  `empty_repo`, a non-default `--autograder`, and the grading-adjacent fields
+  (tests/allowed-files/release-assets/pass-threshold/submission-mode/
+  submission-tag).
+- **`init_shim: true`** (web: **No template**, **Add a README** off, built-in
+  autograder on) — an initialized but README-less repo carrying only the
+  control files, which autogrades and is collected like any built-in
+  assignment. Requires the default autograder and no template; mutually
+  exclusive with `empty_repo`, `template`, `no_autograder`, and a non-default
+  `--autograder`; permits the grading-adjacent fields.
+- **`include_all_branches: true`** (web: **Include all branches**) — accept
+  passes `include_all_branches` to GitHub's generate call, so each student
+  repo gets **all** of the template's branches. Requires a template; mutually
+  exclusive with `empty_repo` and `init_shim`; compatible with everything
+  else.
 
 <details>
 <summary>Errors</summary>


### PR DESCRIPTION
PR 3 of the wiki reorganization plan (follows #620 and #621): several topics lived in two to five near-verbatim copies that drifted independently. This gives each topic exactly one canonical anchor and turns every other copy into a sentence plus a link. No content is lost: every fact removed from a page exists at the link target.

## Content moves (FAQ and gh-teacher slim down)

- **FAQ answers now defer to the guides**: org structuring → Staff, TAs, and Multiple Teachers; due-date/close semantics → Course Lifecycle; the five-bullet Actions-usage answer → Managing Actions Cost; the Roadmap section → Known Limitations; testing-as-a-student → the Staff page's dual-roles section.
- **gh-teacher.md keeps reference material only**: the dual-roles section shrinks to CLI-visible effects (role-column snapshot, `roster add` note, unenroll scope) plus a link; the three ~15-line `no_autograder` / `init_shim` / `include_all_branches` paragraphs compress to flag-level notes.
- **New canonical section: [Repository shapes](../wiki/Assignment-Templates#repository-shapes)** in Assignment Templates — all five accept-time shapes in one table with the two cross-cutting rules (changes affect future accepts only; include-all-branches is template-only). FAQ's template-less-vs-empty answer and gh-teacher both link to it.

## De-duplication (§5 of the plan)

- **Template visibility** (5 copies): canonical section in Assignment Templates, now including the grant-at-creation 404 gotcha from the FAQ; CLI Teacher Guide, GitHub Integration, FAQ, and Troubleshooting become one-liners with links.
- **Service token**: the CLI Teacher Guide walkthrough and the GitHub Integration permission table stay canonical; gh-teacher's init section and the Web Teacher Guide drop their hand-synced permission summaries and link both.
- **Manual hardening checklist**: canonical in CLI Teacher Guide; GitHub Integration's full copy becomes a link.
- **Roster CSV spec**: canonical at Web-Teacher-Guide#roster-csv-fields; the CLI guide and gh-teacher `roster import` link it.
- **`gh student accept` errors**: new canonical table in Troubleshooting (superset of both copies, rows linking to the detailed sections); CLI Student Guide and gh-student link it.
- **`delete_repo`**: GitHub Integration keeps the full explanation; the FAQ copy slims to a link.

Backlinks that became circular after the moves were retargeted (Course Lifecycle and the cost page no longer point at the slimmed FAQ answer; the Staff page drops its "see FAQ for the short version" note). Full-wiki link and anchor check passes; per the plan's §6 list, no externally cited anchor was touched.

Net: −220 / +169 lines across 12 pages.