### PR TITLE
docs(wiki): restructure sidebar around the teacher journey and sweep terminology

### DIFF
--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -73,7 +73,7 @@ see [`gh teacher assignment add`](gh-teacher#assignment-add).
 > shim is written by `gh student accept` (it's embedded in `gh-student`) and
 > never changes after accept. A copy in the template would be clobbered by
 > submit's `.github/` re-fetch and double-grade or break grading. Autograding
-> logic lives in your config repo, not the template — see [Autograding Basics](Autograding-Basics).
+> logic lives in your `classroom50` repository, not the template — see [Autograding Basics](Autograding-Basics).
 
 ## Set it up
 
@@ -140,7 +140,7 @@ organization is rejected (students can't be granted access, so accept would
     assignment's Repository features settings — by default each **inherits the
     template's current setting**; you can force any of them on or off per
     assignment. This applies on both the web and CLI accept paths. Repos
-    accepted before a change can be reconciled with the submissions page's
+    accepted before a change can be updated with the submissions page's
     **Update repository features** action.
 
 ## Reusing one template across assignments

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -54,7 +54,7 @@ CLIs.
 
 ## 3. Set up the organization
 
-Run once per organization to create `<org>/classroom50`, the private config repo
+Run once per organization to create `<org>/classroom50`, the private repository
 that holds classroom metadata, published assignment manifests, and collected
 scores:
 
@@ -69,8 +69,8 @@ gh teacher init <org>
 ```
 
 `init` is **idempotent** — re-running picks up where a prior run left off. It
-also offers to refresh the **skeleton files** — the workflow and script files
-Classroom 50 commits to the config repository — when the CLI ships newer versions
+also offers to refresh the **workflow files** (the workflow and script files
+Classroom 50 commits to the `classroom50` repository) when the CLI ships newer versions
 (this is how an existing organization gains new features); it asks before
 overwriting, so your edits are safe. Use `--yes` to skip the prompt in scripts.
 
@@ -78,19 +78,19 @@ overwriting, so your edits are safe. Use `--yes` to skip the prompt in scripts.
 
 | Flag | Purpose |
 | --- | --- |
-| `--dry-run` | Run read-only preflight checks and list planned steps without changing anything. Run this once first to catch problems early. |
+| `--dry-run` | Run read-only setup checks and list planned steps without changing anything. Run this once first to catch problems early. |
 | `--json` | Emit a machine-readable summary (implies `--quiet`). Lets a script check "any manual steps pending?" and "is the org ready?". |
 | `--quiet` / `-q` | Drop per-step progress; keep warnings and the final summary. |
-| `--yes` | Skip the skeleton-refresh confirmation. |
+| `--yes` | Skip the workflow-refresh confirmation. |
 
 <details>
 <summary>What <code>init</code> configures</summary>
 
 `init` applies a least-privilege lockdown of organization member privileges (the
 only member capabilities left on are private-repo creation, so `gh student
-accept` works, and public Pages creation, so the config repo can publish),
+accept` works, and public Pages creation, so the `classroom50` repository can publish),
 enables GitHub Actions, creates the private `classroom50` repo, commits the
-skeleton workflows and scripts, enables GitHub Pages (public, so students and
+workflow and script files, enables GitHub Pages (public, so students and
 the autograder can fetch published files), protects the default branch, raises
 workflow token permissions, allows reusable-workflow access, and uploads the
 service token secret.
@@ -171,7 +171,7 @@ prints this same reminder). Apply them once at
       repositories".
 - [ ] **Projects base permissions** → "No access".
 - [ ] **Uncheck** "Allow repository administrators to rename branches protected
-      by organization rules". (Defense-in-depth; the config repo's rulesets
+      by organization rules". (Defense-in-depth; the `classroom50` repository's rulesets
       already protect submission history.)
 
 > [!NOTE]
@@ -187,7 +187,8 @@ gh teacher audit <org>
 ```
 
 It's **read-only** and reports, per setting, whether the least-privilege value is
-in effect: **Verified** (read from the API), **Action required** (drifted), and
+in effect: **Verified** (read from the API), **Action required** (changed outside
+Classroom 50), and
 **Confirm by hand** (the four API-less settings above). It exits non-zero when a
 critical field is unenforced, so it's scriptable; add `--json` for a
 machine-readable report.
@@ -363,7 +364,7 @@ shim). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 
 > [!NOTE]
 > **Custom grading isn't registered here.** Drop an `autograder.py` at
-> `<classroom>/autograders/<slug>/` in the config repo, or set a classroom
+> `<classroom>/autograders/<slug>/` in the `classroom50` repository, or set a classroom
 > default with `gh teacher autograder set-default`. See [Advanced Autograding](Advanced-Autograding#classroom-default).
 
 Re-running with the same slug replaces the entry in place; new slugs append.
@@ -422,7 +423,7 @@ gh teacher member list <org>/<repo>  # repo collaborators
 Every submission publishes a GitHub Release carrying a `result.json`. The
 `collect-scores` workflow walks each `(member, assignment)` pair in scope,
 collects each repo's submissions, and aggregates them into
-`<classroom>/scores.json` — the classroom's authoritative gradebook. By default the
+`<classroom>/scores.json` — the classroom's authoritative score record. By default the
 scope is every classroom and every assignment; you can narrow it to one
 classroom, or to a single assignment (see below). Members are the union of the
 student team and the staff teams (teacher/hta/ta), so a staff member who
@@ -516,7 +517,7 @@ gh teacher download -d <dir> <org> <classroom> <assignment>
 ```
 
 > [!NOTE]
-> **Unconfigured classrooms.** If the config repo isn't bootstrapped, or you
+> **Unconfigured classrooms.** If the `classroom50` repository isn't bootstrapped, or you
 > want every matching repo regardless of the roster, pass `--by-pattern`. It
 > clones every repo whose name starts with `<classroom>-<assignment>-` and skips
 > the `result.json` refresh and `scores.csv` summary.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -20,7 +20,7 @@ The teaching model is familiar — you create assignments (optionally with
 starter code), students accept to get their own repository, and submissions are
 auto-graded — but Classroom 50 has no server or database of its own. Your
 classroom settings, roster, assignments, and scores are stored in a private
-`classroom50` config repo in your organization, and grading runs in GitHub
+`classroom50` repository in your organization, and grading runs in GitHub
 Actions. See [How Classroom 50 Works](How-Classroom-50-Works) for the full
 model, or the [Glossary](Glossary) for the core concepts.
 
@@ -260,7 +260,7 @@ Overridden scores show a **Manual** badge and aren't changed by autograding
 until you clear the override. Use **Clear override** in the dialog to revert.
 
 This editor appears only for organization owners (writing a score writes the
-config repo). Under the hood, an override is just an entry in the classroom's
+`classroom50` repository). Under the hood, an override is just an entry in the classroom's
 `scores.json` with `"override": true`, which collection leaves untouched on
 future runs — so you can still edit it by hand if you prefer (see
 [Collect scores](CLI-Teacher-Guide#9-collect-scores)).
@@ -273,7 +273,7 @@ in the same **Actions** menu bundles every repository's latest submission into
 a single zip (built in your browser). For real clones — e.g. to run your own
 tooling locally — `gh teacher download` clones every submission repo and also
 writes a `scores.csv` summary at the destination root. The raw score data also
-lives in `scores.json` in your config repo, so you can build your own
+lives in `scores.json` in your `classroom50` repository, so you can build your own
 automations against it. The column-by-column reference for both CSVs is in
 [Score exports](Autograding-Basics#score-exports) in Autograding Basics.
 
@@ -297,7 +297,7 @@ student.
 ### Can I import my existing GitHub Classroom?
 
 Yes. `gh teacher classroom migrate` imports a GitHub Classroom into your
-`classroom50` config repo — it copies each starter repo into your organization
+`classroom50` repository — it copies each starter repo into your organization
 as a fresh template and recreates the assignments. Rosters, scores, and past
 student repositories are **not** migrated; you re-onboard students for the new
 term. See [`gh teacher classroom migrate`](gh-teacher#classroom-migrate), and
@@ -331,8 +331,8 @@ Integration.
 ### Can I edit the config files in the `classroom50` repo by hand?
 
 It's not recommended. Some state is derived from both the config files and the
-live state on GitHub.com, and the app's reconciliation process updates the
-files automatically to keep them in sync — a hand-edit can create a state the
+live state on GitHub.com, and the app updates the files automatically to keep
+them in sync; a hand-edit can create a state the
 tools don't know how to handle (and makes problems much harder to
 troubleshoot). Manage the classroom through the web app or the `gh teacher`
 CLI instead; the one documented exception is a `scores.json` score override
@@ -341,7 +341,7 @@ CLI instead; the one documented exception is a `scores.json` score override
 ### What is the service token, and is it the same one the web app set up?
 
 The **service token** is a fine-grained personal access token stored as a secret
-in your config repo; the score-collection and regrade workflows use it. It's the
+in your `classroom50` repository; the score-collection and regrade workflows use it. It's the
 **same** token whether you set it up through the web app or the CLI — you only
 need one per organization. See
 [the service-token setup](CLI-Teacher-Guide#create-the-service-token).

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -11,7 +11,7 @@ The CLI never creates the organization. Before running any CLI command:
 
 1. **Create the organization** at <https://github.com/account/organizations/new>.
    Free orgs work for public templates; Team or Enterprise Cloud is required for
-   Pages from the private `classroom50` config repo.
+   Pages from the private `classroom50` repository.
 2. **Flag your template repositories** under **Settings → General → Template
    repository**.
 
@@ -69,7 +69,7 @@ warns and asks for confirmation before proceeding. See
 | `admin:org` | Org invitations, reading and removing memberships (implies `read:org`). |
 | `read:org` | Checking org membership. |
 | `repo` | Repo creation, contents writes, collaborators. |
-| `workflow` | Committing the config repo's workflow files during `init` (GitHub 404s the write without it). |
+| `workflow` | Committing the `classroom50` repository's workflow files during `init` (GitHub 404s the write without it). |
 
 > [!NOTE]
 > **Why the web app's sign-in asks for "Delete repositories".** Signing in at
@@ -254,11 +254,11 @@ The CLIs call GitHub through [`go-gh`](https://github.com/cli/go-gh);
 | GET | `/orgs/{org}` | Check org plan. |
 | PATCH | `/orgs/{org}` | Lock down member privileges at `init`. |
 | GET / PUT | `/orgs/{org}/actions/permissions` | Read/enable org Actions. |
-| POST | `/orgs/{org}/repos` | Create the `classroom50` config repo. |
-| GET | `/repos/{owner}/{repo}` | Check the config repo / validate a template. |
+| POST | `/orgs/{org}/repos` | Create the `classroom50` repository. |
+| GET | `/repos/{owner}/{repo}` | Check the `classroom50` repository / validate a template. |
 | POST / PUT | `/repos/{owner}/{repo}/pages` | Enable Pages and set it public. |
-| PUT | `/repos/{owner}/{repo}/branches/{branch}/protection` | Protect the config repo branch. |
-| GET / PUT | `/repos/{owner}/{repo}/actions/permissions` | Read/re-enable Actions on the config repo. |
+| PUT | `/repos/{owner}/{repo}/branches/{branch}/protection` | Protect the `classroom50` repository branch. |
+| GET / PUT | `/repos/{owner}/{repo}/actions/permissions` | Read/re-enable Actions on the `classroom50` repository. |
 | GET / PUT | `/repos/{owner}/{repo}/actions/permissions/workflow` | Read/set `GITHUB_TOKEN` permissions. |
 | PUT | `/repos/{owner}/{repo}/actions/permissions/access` | Allow same-org reusable workflows. |
 | GET / PUT | `/repos/{owner}/{repo}/actions/secrets/...` | Upload the encrypted service PAT. |

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -56,17 +56,17 @@ served from **GitHub Pages** — all inside your own organization.
 
 ## Get started
 
-**Web app** — no installation required:
-
-1. Teachers: [Web Teacher Guide](Web-Teacher-Guide).
-2. Students: [Web Student Guide](Web-Student-Guide).
-
-**Command line** — needs the [GitHub CLI (`gh`)](https://cli.github.com/) and
-[Go](https://go.dev/):
-
-1. [Install the CLI](Installation).
-2. Teachers: [CLI Teacher Guide](CLI-Teacher-Guide).
-3. Students: [CLI Student Guide](CLI-Student-Guide).
+1. Check the [prerequisites](Prerequisites-and-GitHub-Education): a GitHub
+   organization on the Team or Enterprise plan, free for verified teachers
+   through GitHub Education.
+2. Follow the [Quickstart](Quickstart) from empty organization to a graded
+   assignment. Every step works from the web app (no installation) or the
+   [command-line tools](Installation).
+3. Go deeper with the full walkthroughs: the
+   [Web Teacher Guide](Web-Teacher-Guide) or the
+   [CLI Teacher Guide](CLI-Teacher-Guide), and for students the
+   [Web Student Guide](Web-Student-Guide) or
+   [CLI Student Guide](CLI-Student-Guide).
 
 New to the terminology? See the [Glossary](Glossary). Curious how it all fits
 together? Read [How Classroom 50 Works](How-Classroom-50-Works). Have a question?

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -35,16 +35,16 @@ from this.
 ## Why teachers stay involved
 
 Because there is no always-on server, the app does not change state on its own
-while you are signed out. It cannot reconcile state in the background the way a
+while you are signed out. It cannot sync state in the background the way a
 hosted service can. As a result:
 
 - **Interactive work runs as you.** Creating a classroom, adding a student,
   saving an assignment, or inviting a TA runs at the moment you do it, using
   your signed-in GitHub token. These changes happen only when you make them.
-- **Signing in can trigger reconciliation.** Opening a classroom lets the app
-  correct things that have drifted — for example, migrating an old team name or
-  re-checking organization settings. Some upkeep occurs only after an owner
-  signs in and loads the page.
+- **Signing in can trigger a sync.** Opening a classroom lets the app
+  correct things that have fallen out of date — for example, migrating an old
+  team name or re-checking organization settings. Some upkeep occurs only
+  after an owner signs in and loads the page.
 - **Background jobs require setup.** Score collection and regrading run as
   GitHub Actions on a schedule, but only after you provision the
   [service token](#the-service-token) that lets them act while you are offline.
@@ -59,17 +59,17 @@ read it:
 
 - **Web app** — loading a page reads the current GitHub state (so opening
   classroom50.org effectively refreshes the roster, teams, and config), and
-  signing in as an owner can additionally run reconciliation upkeep. One
+  signing in as an owner can additionally run sync upkeep. One
   exception: the **organization list** is cached for ten minutes — use
   **Refresh list** to force it. If a view looks out of date, reopening the page
   usually updates it.
 - **CLI reads** (`roster list`, `classroom list`, `member list`, …) report
   what's committed and on GitHub **at that moment**; they never write or
-  reconcile. If the web app shows a newer roster than `roster list` did a
-  minute earlier, someone (or a sign-in reconciliation) committed in between.
+  sync. If the web app shows a newer roster than `roster list` did a
+  minute earlier, someone (or a sign-in sync) committed in between.
 - **CLI writes** (`roster add`, `staff add`, `assignment add`, …) update the
-  config repo and GitHub teams immediately, but only for the thing they
-  change — they don't run the web app's broader reconciliation.
+  `classroom50` repository and GitHub teams immediately, but only for the thing they
+  change — they don't run the web app's broader sync.
 - **Scores** refresh only when collection runs: nightly, or on demand with
   **Sync now** / `collect-scores.yaml`.
 
@@ -104,8 +104,8 @@ Classroom 50 has four roles, and each maps directly onto a GitHub construct:
 | Role | On GitHub | Can |
 | --- | --- | --- |
 | **Teacher** | Organization **owner**, on the `-teacher` team | Everything, including org + classroom settings |
-| **Head TA** | Org **member**, on the `-hta` team | Write the config repo; manage the classroom; not an owner |
-| **TA** | Org **member**, on the `-ta` team | Read the config repo; view submissions |
+| **Head TA** | Org **member**, on the `-hta` team | Write the `classroom50` repository; manage the classroom; not an owner |
+| **TA** | Org **member**, on the `-ta` team | Read the `classroom50` repository; view submissions |
 | **Student** | Org **member**, on the classroom team | Accept and submit assignments |
 
 Every classroom has a set of `secret` GitHub teams
@@ -143,11 +143,12 @@ per-repo access and the strict org policy work together.
 > score-collection workflow, not at accept time. A newly accepted repo
 > therefore has no staff team attached to it, which is expected.
 
-## Why org policies sometimes "drift"
+## Why organization settings sometimes change back
 
 If you run both Classroom 50 and GitHub Classroom in the same organization, they
 can disagree on a setting and flip it back and forth, most notably private-repo
-forking. That tug-of-war shows up as "policy drift" in the setup/audit check.
+forking. That tug-of-war shows up in the setup and audit checks as settings that
+changed outside Classroom 50.
 Classroom 50 no longer enforces the forking setting for this reason; private
 templates work either way. If you see a setting you fixed revert later, another
 tool (or an org/enterprise policy) is changing it back.
@@ -157,7 +158,7 @@ tool (or an org/enterprise policy) is changing it back.
 1. A student pushes to their repository (via `gh student submit` or a plain
    `git push`).
 2. A small workflow in their repo calls the shared **autograde runner** in your
-   config repo, which fetches the grading logic from Pages and runs it.
+   `classroom50` repository, which fetches the grading logic from Pages and runs it.
 3. The result is published as a **GitHub Release** on the student's repo.
 4. The **score-collection** workflow gathers those results into `scores.json`.
 
@@ -210,7 +211,7 @@ against them generally work the same as they did with GitHub Classroom.
 ## The service token
 
 The **service token** is a fine-grained personal access token stored as a secret
-in your config repo. The background workflows (score collection, regrade) use it
+in your `classroom50` repository. The background workflows (score collection, regrade) use it
 to read and update student repositories across the org — work that can't run as
 "you" because it happens on a schedule when you're not online. It's the same
 token whether you set it up in the web app or the CLI, and you need only one per
@@ -221,11 +222,11 @@ organization. See [the service-token setup](CLI-Teacher-Guide#create-the-service
 | | GitHub Classroom | Classroom 50 |
 | --- | --- | --- |
 | Backend | Hosted service | None (GitHub repos + Actions) |
-| Classroom ↔ org | Classrooms managed in the hosted dashboard | A folder in your organization's config repository, plus GitHub teams |
+| Classroom ↔ org | Classrooms managed in the hosted dashboard | A folder in your organization's `classroom50` repository, plus GitHub teams |
 | Grading | Hosted autograder | GitHub Actions in each repo |
 | Joining | Students self-select their roster entry from an invite link | The owner invites students; accept links work once they've joined the org |
 | Group naming | Team names | Founder's username |
-| Data | In the service | In your `classroom50` config repo (yours to keep) |
+| Data | In the service | In your `classroom50` repository (yours to keep) |
 
 For a term-by-term mapping of GitHub Classroom vocabulary (cutoff date,
 Download grades, roster identifiers, teams) to Classroom 50's, see

--- a/wiki/Managing-Actions-Cost.md
+++ b/wiki/Managing-Actions-Cost.md
@@ -17,7 +17,7 @@ when minutes run out.
   tests) bills about a minute.
 - **In the default submission type, every push grades.** An assignment in
   `every-push` mode grades each push to the default branch: five pushes in
-  ten minutes are five graded runs. Multiply by class size to estimate an
+  ten minutes are five graded runs. Multiply by roster size to estimate an
   assignment's cost.
 
 ## The levers, by impact

--- a/wiki/Migrating-from-GitHub-Classroom.md
+++ b/wiki/Migrating-from-GitHub-Classroom.md
@@ -95,7 +95,7 @@ with Classroom 50. The two tools disagree about the private-repository
 forking policy, and each keeps flipping the setting back, which shows up as
 recurring settings warnings. Archive the old GitHub Classroom classrooms
 once you've migrated. See
-[Why org policies sometimes "drift"](How-Classroom-50-Works#why-org-policies-sometimes-drift).
+[Why organization settings sometimes change back](How-Classroom-50-Works#why-organization-settings-sometimes-change-back).
 
 ## Your existing scripts still work
 

--- a/wiki/Quickstart.md
+++ b/wiki/Quickstart.md
@@ -1,0 +1,75 @@
+# Quickstart: your first classroom
+
+The path from nothing to a graded assignment, with each step linking into
+the right guide. Every step works from the web app or the CLI: the web app
+at [classroom50.org](https://classroom50.org) needs no installation, and the
+command-line tools need a one-time [install](Installation).
+
+Before you start, make sure you have a GitHub organization on the Team or
+Enterprise plan; see
+[Prerequisites and GitHub Education](Prerequisites-and-GitHub-Education) for
+the free upgrade through GitHub Education. New to the model? Skim
+[How Classroom 50 Works](How-Classroom-50-Works) first.
+
+## 1. Set up the organization (one time)
+
+Run the one-time setup, which creates the `classroom50` repository in your
+organization and adds a service token for the grading workflows.
+
+- Web: [Set up an organization](Web-Teacher-Guide#set-up-an-organization-one-time)
+- CLI: [Set up the organization](CLI-Teacher-Guide#3-set-up-the-organization)
+
+## 2. Create a classroom
+
+A classroom holds one course offering's roster, assignments, and scores; an
+organization can hold several.
+
+- Web: [Create a classroom](Web-Teacher-Guide#create-a-classroom)
+- CLI: [Add a classroom](CLI-Teacher-Guide#4-add-a-classroom)
+
+## 3. Add staff (optional)
+
+Co-teachers, head TAs, and TAs each get a role with matching access.
+
+- Web and CLI: [Adding staff](Staff-TAs-and-Multiple-Teachers#adding-staff)
+
+## 4. Add students
+
+Adding a student to the roster invites them to your organization; once
+they've joined, assignment accept links work.
+
+- Web: [Add students](Web-Teacher-Guide#add-students)
+- CLI: [Invite students](CLI-Teacher-Guide#5-invite-students) and
+  [Track students in the roster](CLI-Teacher-Guide#6-track-students-in-the-roster)
+
+## 5. Create an assignment
+
+Register an assignment, optionally with a
+[template repository](Assignment-Templates) for starter code and
+[autograding tests](Autograding-Basics#declarative-tests).
+
+- Web: [Create an assignment](Web-Teacher-Guide#create-an-assignment)
+- CLI: [Add assignments](CLI-Teacher-Guide#7-add-assignments)
+
+## 6. Students accept and submit
+
+Share the assignment's accept link (or the CLI commands) with your students.
+
+- Web: [Web Student Guide](Web-Student-Guide)
+- CLI: [CLI Student Guide](CLI-Student-Guide)
+
+## 7. Collect scores
+
+Grading runs on each submission; collection gathers the results so you can
+review them on the submissions page and download a CSV.
+
+- Web: [Collect submissions](Web-Teacher-Guide#collect-submissions)
+- CLI: [Collect scores](CLI-Teacher-Guide#9-collect-scores)
+
+## Where next
+
+- [Course Lifecycle and End of Term](Course-Lifecycle-and-End-of-Term) for
+  due dates, closing an assignment, and wrapping up the term.
+- [Managing Actions Cost](Managing-Actions-Cost) if your roster is large.
+- [FAQ](FAQ) and [Troubleshooting](Troubleshooting) when something looks
+  wrong.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -254,7 +254,7 @@ Fix it in the org, under Settings → Member privileges → Repository creation:
 
 Re-running **organization setup** in Classroom 50 (Organization settings →
 Re-run setup) applies this along with the rest of the audited lockdown, so it's
-the better fix if the org has drifted in other ways too.
+the better fix if other settings have changed too.
 
 If an enterprise policy pins repository creation at the enterprise level, the
 org-level toggle is ignored and only an enterprise owner can change it. In that
@@ -321,7 +321,7 @@ Teachers: if a repo you *expected* to grade on push shows that status, the
 repo's shim is still on the every-push trigger while the assignment is
 tag-mode (or vice versa) — run
 `gh teacher assignment submission-mode <org> <classroom> <slug> --tag` (or
-`--every-push`) or the web bulk action to reconcile, and have students
+`--every-push`) or the web bulk action to update the repositories, and have students
 `git pull` afterward.
 
 ## `gh teacher download` clones nothing
@@ -335,13 +335,13 @@ By default `download` is team-driven. If you get zero clones:
   `https://github.com/orgs/<org>/repositories?q=<classroom>-<assignment>`.
 - Re-run with `-v` to see which members were probed.
 
-If the config repo isn't bootstrapped, or you want every matching repo regardless
+If the `classroom50` repository isn't bootstrapped, or you want every matching repo regardless
 of the roster, pass `--by-pattern`.
 
 ## `collect-scores` warns "collected 0 submissions"
 
 Almost always means the `CLASSROOM50_SERVICE_TOKEN` can't read the student repos
-— not that the class submitted nothing. (A fine-grained PAT returns 404 for
+— not that no one submitted. (A fine-grained PAT returns 404 for
 out-of-scope repos, indistinguishable from "no release yet".)
 
 - Confirm the token has **Contents: Read and write on all org repos** (not "Only

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -138,7 +138,7 @@ On the classroom page, click **+ Assignment**. Fill in:
 - **Name** — the assignment's name.
 - **Description** (optional) — details for students.
 - **Due date** (optional) — a date and time in your local timezone. A due date
-  marks later submissions **late** in the gradebook; it does not block pushes
+  marks later submissions **late** in the collected scores; it does not block pushes
   or revoke access. To actually close an assignment, use the **Close
   submission** action (see below).
 - **Assignment type** — **Individual** (one repository per student) or **Group
@@ -190,7 +190,7 @@ section — most assignments never need them:
   **Inherit from template**, re-applies the template's current setting at
   accept time (again, GitHub's generate doesn't copy these); you can force any
   feature **On** or **Off** instead. Template-less assignments default to
-  GitHub's own defaults. To reconcile repositories that already exist, use the
+  GitHub's own defaults. To update repositories that already exist, use the
   **Update repository features** action on the submissions page.
 
 > [!NOTE]
@@ -198,7 +198,7 @@ section — most assignments never need them:
 > accepted from now on** — repositories students already accepted aren't
 > retrofitted, so they keep their original starter code and setup. When at least
 > one student has already accepted, the edit form asks you to confirm and warns
-> that you'll need to reconcile the existing repositories yourself. (**Assignment
+> that you'll need to update the existing repositories yourself. (**Assignment
 > type** — Individual vs. Group — is the exception: it stays locked on edit,
 > because switching it would invalidate every existing submission.)
 
@@ -217,7 +217,7 @@ section — most assignments never need them:
   choice sticks — leaving Autograded and coming back won't reset it. Can be
   changed after creation (edits only affect repositories accepted from now on;
   turning autograding off later makes already-accepted repositories' autograde
-  runs fail and drop out of the gradebook).
+  runs fail and drop out of the collected scores).
 - **Submission type** — when the autograder runs. **Every push to the default
   branch** (the default) grades each push. **A tagged commit** grades only
   when a student submits (`gh student submit`) or pushes a `submit/*` tag —
@@ -410,7 +410,7 @@ taken to the accept page:
 Accepting creates a repository named `<CLASSROOM>-<ASSIGNMENT>-<USERNAME>`.
 Pushing to it triggers autograding, which builds a Release containing a
 `result.json` file. The score-collection workflow (which runs daily, or on
-demand) aggregates those results into the classroom's gradebook.
+demand) aggregates those results into the classroom's scores.
 
 ![Accept success](images/web_accept_assignment_success.png)
 
@@ -418,12 +418,12 @@ demand) aggregates those results into the classroom's gradebook.
 
 ![Assignment with submissions](images/web_viewing_assignment_submissions.png)
 
-Scores flow into the gradebook when collection runs: the nightly workflow
+Scores update when collection runs: the nightly workflow
 covers every classroom, or click **Sync now** in the freshness strip at the top
 of the submissions page (also **Collect now** in the **Actions** menu). Both
 are **scoped to the current assignment** — they walk only this assignment's
 repositories, so a sync is fast even in a large classroom and doesn't rebuild
-other assignments' gradebooks. The strip shows when this assignment's data was
+other assignments' scores. The strip shows when this assignment's data was
 last synced (a per-assignment `collected_at` stamp in `scores.json`). Click
 **View workflow** to see the Actions run.
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,18 +1,11 @@
-- [Home](Home)
-- [Prerequisites and GitHub Education](Prerequisites-and-GitHub-Education)
-- [How Classroom 50 Works](How-Classroom-50-Works)
-- [Glossary](Glossary)
-- [FAQ](FAQ)
-- **Web app**
+- **Start here**
+  - [Home](Home)
+  - [Prerequisites and GitHub Education](Prerequisites-and-GitHub-Education)
+  - [How Classroom 50 Works](How-Classroom-50-Works)
+  - [Quickstart: Your First Classroom](Quickstart)
+- **Teacher guides**
   - [Web Teacher Guide](Web-Teacher-Guide)
-  - [Web Student Guide](Web-Student-Guide)
-- **Command line**
-  - [Installation](Installation)
   - [CLI Teacher Guide](CLI-Teacher-Guide)
-  - [CLI Student Guide](CLI-Student-Guide)
-  - [gh teacher](gh-teacher)
-  - [gh student](gh-student)
-- **Guides**
   - [Staff, TAs, and Multiple Teachers](Staff-TAs-and-Multiple-Teachers)
   - [Migrating from GitHub Classroom](Migrating-from-GitHub-Classroom)
   - [Course Lifecycle and End of Term](Course-Lifecycle-and-End-of-Term)
@@ -21,8 +14,16 @@
   - [Autograder Recipes](Autograder-Recipes)
   - [Advanced Autograding](Advanced-Autograding)
   - [Managing Actions Cost](Managing-Actions-Cost)
+- **Students**
+  - [Web Student Guide](Web-Student-Guide)
+  - [CLI Student Guide](CLI-Student-Guide)
 - **Reference**
+  - [gh teacher](gh-teacher)
+  - [gh student](gh-student)
+  - [Installation (CLI)](Installation)
   - [Assignment Templates](Assignment-Templates)
   - [GitHub Integration](GitHub-Integration)
   - [Known Limitations](Known-Limitations)
+  - [FAQ](FAQ)
   - [Troubleshooting](Troubleshooting)
+  - [Glossary](Glossary)

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -14,7 +14,7 @@ output, or `--verbose` / `-v` for per-step detail.
 | `whoami` | Print the authenticated GitHub user. |
 | `login` | Log in with the Classroom 50 scopes (`admin:org`, `read:org`, `repo`, `workflow`). Add scopes with `-s` (e.g., `delete_repo`). |
 | `logout` | Log out via `gh auth logout`. |
-| `init <org>` | Set up `<org>/classroom50` (org lockdown, config repo, Pages, branch protection, service token). Idempotent. |
+| `init <org>` | Set up `<org>/classroom50` (org lockdown, repository, Pages, branch protection, service token). Idempotent. |
 | `audit <org>` | Read-only audit of the org member-privilege lockdown. |
 | `rotate-service-token <org>` | Replace the `CLASSROOM50_SERVICE_TOKEN` secret. |
 | `classroom add <org> <short-name>` | Add a classroom. Flags: `--name`, `--term`, `--unlisted`, `--key`. |
@@ -45,7 +45,7 @@ output, or `--verbose` / `-v` for per-step detail.
 
 ## `init`
 
-One-time bootstrap for the per-org `classroom50` config repo. See the
+One-time bootstrap for the per-org `classroom50` repository. See the
 [CLI Teacher Guide](CLI-Teacher-Guide#3-set-up-the-organization) for when to run
 it.
 
@@ -54,11 +54,11 @@ CLASSROOM50_SERVICE_TOKEN=github_pat_... gh teacher init <org>
 gh teacher init <org>              # interactive token prompt
 gh teacher init <org> --dry-run    # preview, no changes
 gh teacher init <org> --json       # machine-readable summary
-gh teacher init <org> --yes        # skip the skeleton-refresh prompt
+gh teacher init <org> --yes        # skip the workflow-refresh prompt
 ```
 
 Idempotent: re-running resumes where a prior run stopped and offers to refresh
-stale skeleton files (after a confirmation prompt).
+stale workflow files (after a confirmation prompt).
 
 <details>
 <summary>Steps <code>init</code> performs, in order</summary>
@@ -69,9 +69,9 @@ stale skeleton files (after a confirmation prompt).
    private-repo creation enabled so `gh student accept` works. On a plan-gated
    rejection it retries per policy and warns per field.
 3. **Enable org Actions** — turns Actions on if it's off org-wide.
-4. **Create or fetch the config repo** — `classroom50`, with `auto_init`.
-5. **Skeleton drop / refresh** — commits the embedded workflows and scripts; on
-   re-runs, refreshes stale files after confirmation (`--yes` skips).
+4. **Create or fetch the `classroom50` repository** — private, with `auto_init`.
+5. **Commit or refresh workflow files** — commits the embedded workflows and
+   scripts; on re-runs, refreshes stale files after confirmation (`--yes` skips).
 6. **Enable Pages** — public, so students and the runner can fetch published
    files unauthenticated.
 7. **Branch protection** — no force-push or deletion on the default branch.
@@ -89,7 +89,7 @@ Guide and the
 in GitHub Integration.
 
 <details>
-<summary>Skeleton files shipped into the config repo</summary>
+<summary>Workflow and script files shipped into the <code>classroom50</code> repository</summary>
 
 | Path | Purpose |
 | --- | --- |
@@ -100,7 +100,7 @@ in GitHub Integration.
 | `.github/scripts/runner.py` | Grading bootstrap fetched from Pages each submission. |
 | `.github/scripts/collect_scores.py` | Team-driven score collector. |
 | `.github/scripts/probe_token.py` | Service-token scope probe. |
-| `README.md` | Describes the config repo layout. |
+| `README.md` | Describes the `classroom50` repository layout. |
 
 Both collection and regrade are **team-driven**: the classroom GitHub teams are
 the source of truth for enrollment. Collection polls the student team plus the
@@ -120,7 +120,7 @@ gh teacher audit <org> --json
 ```
 
 Classifies each in-scope setting as **Verified** (API value matches the
-lockdown), **Action required** (drifted, with the fix), or **Confirm by hand**
+lockdown), **Action required** (changed outside Classroom 50, with the fix), or **Confirm by hand**
 (the four settings GitHub exposes no API to read). Exits non-zero when any
 API-readable field is unenforced, so `gh teacher audit <org> && …` is safe in
 scripts. `--json` emits `{org, plan, read_ok, lockdown_complete, enforced,
@@ -181,7 +181,7 @@ accept).
 
 </details>
 
-**Errors:** missing config repo → `run gh teacher init <org> first`; existing
+**Errors:** missing `classroom50` repository → `run gh teacher init <org> first`; existing
 classroom directory → refuses to overwrite; bad short-name → prints the rule.
 
 ### `classroom list`
@@ -329,7 +329,7 @@ Bulk upsert. Accepts a 5-column header
 resolved up front — one typo aborts before any commit. New students are
 invited.
 
-**Errors common to roster commands:** missing config repo → `run gh teacher init
+**Errors common to roster commands:** missing `classroom50` repository → `run gh teacher init
 <org> first`; missing `roster.csv` → points at `classroom add`; bad header →
 prints the offending header; unknown GitHub user → prints the username; repeated
 rebase failures → `lost the rebase race`, retry.
@@ -337,7 +337,7 @@ rebase failures → `lost the rebase race`, retry.
 ## `staff`
 
 Manage a classroom's **staff teams** — `classroom50-<classroom>-{teacher,hta,ta}`.
-The `teacher` and `hta` (head TA) teams get write on the config repo; `ta` gets
+The `teacher` and `hta` (head TA) teams get write on the `classroom50` repository; `ta` gets
 read-only. The classroom's GitHub teams — not the `role` column in `roster.csv` —
 are the role authority, so a classroom's staff is the same from the CLI or the
 web app.
@@ -404,7 +404,7 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | `--autograder <name>` | Swap the reusable workflow (rare). Default `default`. |
 | `--feedback-pr` | One review PR per student repo. **On by default**; `--feedback-pr=false` disables. |
 | `--empty-repo` | Truly bare repos (no README/marker/shim); autograding and feedback PR disabled; changeable on a same-slug re-add (warns; only affects future accepts); mutually exclusive with template/tests/feedback-pr/allowed-files/pass-threshold/submission-mode/submission-tag/no-autograder/init-shim. |
-| `--pass-threshold <0–100>` | Advisory passing bar shown by gradebook clients. Off when omitted (distinct from `0`). |
+| `--pass-threshold <0–100>` | Advisory passing bar shown on the submissions page. Off when omitted (distinct from `0`). |
 | `--submission-mode every-push\|tag` | When the autograder fires: `every-push` (default) grades every push; `tag` grades only `submit/*` tag pushes (the submit clients push the tag — plain `git push` costs no Actions minutes). Change it later with `assignment submission-mode`. |
 | `--submission-tag <pattern>` | Milestone tag (repeatable) that also triggers grading: `git tag phase1 && git push origin phase1` grades that commit. Simple globs (`v*`) work; exact names are safer. The record still lives at the canonical `submit/*` tag. Mutually exclusive with `--empty-repo`. |
 
@@ -444,7 +444,7 @@ of every shape is in
 <details>
 <summary>Errors</summary>
 
-- Missing config repo / `assignments.json` → points at `init` / `classroom add`.
+- Missing `classroom50` repository / `assignments.json` → points at `init` / `classroom add`.
 - Template 404 → make it public or copy it into the org.
 - Template private and outside `<org>` → rejected (students can't be granted
   access).
@@ -610,7 +610,7 @@ gh teacher member list <org> --quiet
 ```
 
 Shows *actual* GitHub membership (the roster is the *intended* list), so you can
-reconcile drift — e.g., a student who never accepted their invite. Default is an
+spot mismatches — e.g., a student who never accepted their invite. Default is an
 aligned table; `--json` emits `{login, kind, role, github_id}`; `--quiet` prints
 one login per line. Reading org invitations needs `admin:org`. Read-only.
 
@@ -634,7 +634,7 @@ dirs are skipped on clone but still get `result.json` refreshed.
 
 **`--by-pattern`** pages through the org's repos and clones every one whose name
 starts with `<classroom>-<assignment>-`, skipping the team lookup, the
-`result.json` refresh, and the `scores.csv` summary. Use it when the config repo
+`result.json` refresh, and the `scores.csv` summary. Use it when the `classroom50` repository
 isn't bootstrapped, or to grab every matching repo regardless of the roster.
 
 ## `teardown`
@@ -646,7 +646,7 @@ gh teacher teardown --yes <org>    # skip the prompt (scripts only)
 
 Deletes **every** repository in `<org>` — a development reset. It confirms the
 `classroom50` marker repo exists (refusing otherwise), lists all repos, prompts
-for the typed org name, then deletes each (the config repo last, so an
+for the typed org name, then deletes each (the `classroom50` repository last, so an
 interrupted run stays safe to re-run).
 
 > [!WARNING]


### PR DESCRIPTION
## Summary

PR 4 of the wiki reorganization plan (sidebar and Home restructure, plus the wiki-wide terminology sweep).

- **Journey-based sidebar**: regroups the wiki into Start here → Teacher guides → Autograding → Students → Reference, with a visible onboarding spine (Prerequisites → How it works → Quickstart). The Installation entry is labeled "Installation (CLI)"; the page name is unchanged for link stability.
- **New Quickstart page**: a thin hub from empty organization to a graded assignment, one paragraph per step, each step linking into the web and CLI guide sections (the guides remain the canonical walkthroughs). States that the web app needs no installation.
- **Home "Get started" rewrite**: three steps (prerequisites → Quickstart → full guides) instead of two parallel tool-first lists.
- **Terminology sweep** against the Glossary canon, across all pages: "config repo/repository" → "`classroom50` repository" (37×), "skeleton" → "workflow files", "preflight" → "setup checks", "drift"/"reconcile" → plain phrasing ("changed outside Classroom 50", "sync"/"update"), "gradebook" → "scores"/"collected scores" (kept once where it means an external gradebook tool), "class size" → "roster size". Renamed the How-It-Works heading "Why org policies sometimes \"drift\"" to "Why organization settings sometimes change back" and updated its one inbound link.

The matching sweeps of the web app copy (`en.json`) and CLI output strings are separate follow-up PRs per the plan; until the CLI one lands, the CLI still prints "skeleton" in the init prompt while the wiki uses "workflow files".

## Test plan

- [x] Script-checked every intra-wiki link and anchor across all pages (all resolve; the renamed heading's inbound link updated)
- [x] Denylist grep for swept terms returns no hits ("preflight", "drift", "skeleton", "reconcile", "config repo", "instructor", "deadline", "gradebook")
- [ ] Preview the sidebar and Quickstart rendering on the published wiki after merge