### PR TITLE
fix(cli): sweep engineering jargon from help text and output

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -48,7 +48,7 @@ var embeddedShimContent string
 // each student repo's shim references the correct org's reusable
 // autograde-runner workflow. shimBranchPlaceholder is the student repo's
 // default branch (the shim's push trigger); shimConfigBranchPlaceholder is the
-// config repo's default branch (the reusable-workflow ref), which may not be
+// classroom50 repository's default branch (the reusable-workflow ref), which may not be
 // `main` if a config-repo rename could not land.
 const (
 	shimOrgPlaceholder          = "{{ORG}}"
@@ -137,7 +137,7 @@ func acceptCmd() *cobra.Command {
 			"`gh teacher assignment add --autograder <name>`) the shim is\n" +
 			"fetched from Pages instead. The shim is intentionally inert —\n" +
 			"it `uses:` the reusable autograde-runner workflow in the\n" +
-			"teacher's config repo, and that workflow fetches the\n" +
+			"teacher's classroom50 repository, and that workflow fetches the\n" +
 			"runner-side bootstrap and the autograder at workflow runtime.\n" +
 			"Teacher edits to runtime, dependencies, or grading logic\n" +
 			"propagate on the next submission without ever touching the\n" +
@@ -150,7 +150,7 @@ func acceptCmd() *cobra.Command {
 			"single Tree commit, then verified.\n\n" +
 			"Re-running is safe and self-healing: an already-accepted repo\n" +
 			"that is fully provisioned is left in place (its founder role is\n" +
-			"reconciled best-effort), but one whose setup never finished (a\n" +
+			"updated best-effort), but one whose setup never finished (a\n" +
 			"prior run interrupted after the repo was created but before the\n" +
 			"control files landed) is repaired by re-running the idempotent\n" +
 			"provisioning. accept only reports\n" +
@@ -393,7 +393,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	//    The entry carries the template ref, mode, and autograder ref.
 	//    `secret` (the --key value) selects the `<classroom>/<secret>/...`
 	//    path for a protected classroom, else "" — it must arrive via --key
-	//    since students can't read the config repo.
+	//    since students can't read the classroom50 repository.
 	lookup := u.Spinner(fmt.Sprintf("Looking up %s in %s/%s", assignment, org, classroom))
 	lookup.Start()
 	entry, err := assignments.FetchEntry(cmd.Context(), org, classroom, secret, assignment)
@@ -460,7 +460,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	//    leave a half-baked repo. The default (embedded) shim is rendered AFTER
 	//    the repo is created, because its `on: push: branches` must match the
 	//    assignment repo's actual default branch (which GitHub, not the template,
-	//    decides) and its `uses:` ref must match the config repo's branch. An
+	//    decides) and its `uses:` ref must match the classroom50 repository's branch. An
 	//    empty_repo assignment never carries the shim (nothing is committed at
 	//    all), so skip resolution entirely.
 	autograderName := entry.ResolveAutograder()
@@ -522,7 +522,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 
 	// Render the default shim now that the assignment repo's default branch is
 	// known: `on: push: branches` targets commitBranch, and the reusable-workflow
-	// `uses:` ref targets the config repo's actual default branch. On a read
+	// `uses:` ref targets the classroom50 repository's actual default branch. On a read
 	// failure, fall back to the assignment repo's own branch (commitBranch), not
 	// a hardcoded `main` — a wrong `@main` ref would 404 the runner and silently
 	// skip grading on a master-default org. A no-shim assignment (empty_repo or
@@ -631,7 +631,7 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			// already healthy, so a transient/SSO-403/left-org failure must not
 			// fail a re-run that previously always succeeded — warn and report.
 			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission)); err != nil && verbose {
-				u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
+				u.Detail("could not update %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 			}
 			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
 			// Ensure the Feedback PR exists even on the healthy path: repos
@@ -703,7 +703,7 @@ func acceptIntoBareRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.
 		// (its only provisioning is this grant), so a transient/SSO-403/
 		// left-org failure must not fail a re-run that previously succeeded.
 		if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission)); err != nil && verbose {
-			u.Detail("could not reconcile %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
+			u.Detail("could not update %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 		}
 		return reportAlreadyAccepted(u, out, p.fullName, p.htmlURL)
 	}
@@ -1370,7 +1370,7 @@ func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, ve
 	return htmlURL, fullName, defaultBranch, false, nil
 }
 
-// resolveConfigRepoBranch returns the org's classroom50 config repo default
+// resolveConfigRepoBranch returns the org's classroom50 repository default
 // branch for the shim's reusable-workflow `uses:` ref. A read failure is
 // returned as an error so the caller can fall back to the assignment repo's own
 // branch rather than a wrong `@main` ref that would 404 the runner; an empty

--- a/cli/gh-student/internal/assignments/assignments.go
+++ b/cli/gh-student/internal/assignments/assignments.go
@@ -340,7 +340,7 @@ func IsNotFound(err error) bool {
 // AutogradeWorkflow is the result of a Pages autograder fetch. Content is the
 // raw workflow shim body dropped at `.github/workflows/autograde.yaml`. The
 // shim is intentionally stable — it `uses:` the reusable autograde-runner
-// workflow in the config repo, which fetches the runner-side bootstrap
+// workflow in the classroom50 repository, which fetches the runner-side bootstrap
 // (runner.py) and the autograder fresh on every submission, so a stale shim
 // still grades against the latest teacher-side logic.
 type AutogradeWorkflow struct {
@@ -373,7 +373,7 @@ func fetchAutograderWorkflowFromURL(ctx context.Context, rawURL, name string) (A
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return AutogradeWorkflow{}, fmt.Errorf("autograder %q not published yet (%s returned 404) — ask your teacher to confirm that file exists in the config repo and that `publish-pages.yaml` has run", name, rawURL)
+		return AutogradeWorkflow{}, fmt.Errorf("autograder %q not published yet (%s returned 404) — ask your teacher to confirm that file exists in the classroom50 repository and that `publish-pages.yaml` has run", name, rawURL)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return AutogradeWorkflow{}, fmt.Errorf("GET %s: unexpected status %d", rawURL, resp.StatusCode)
@@ -393,7 +393,7 @@ func fetchAutograderWorkflowFromURL(ctx context.Context, rawURL, name string) (A
 	// release asset, `classroom50/autograde` commit status).
 	var sink any
 	if err := yaml.Unmarshal(body, &sink); err != nil {
-		return AutogradeWorkflow{}, fmt.Errorf("autograder %q is malformed YAML (parsed from %s) — ask your teacher to check the file in the config repo: %w", name, rawURL, err)
+		return AutogradeWorkflow{}, fmt.Errorf("autograder %q is malformed YAML (parsed from %s) — ask your teacher to check the file in the classroom50 repository: %w", name, rawURL, err)
 	}
 
 	return AutogradeWorkflow{Content: string(body)}, nil

--- a/cli/gh-teacher/autograder_cmd.go
+++ b/cli/gh-teacher/autograder_cmd.go
@@ -55,7 +55,7 @@ func autograderCmd() *cobra.Command {
 			"per-assignment overrides (<classroom>/autograders/<slug>/\n" +
 			"autograder.py) are read-only from the CLI — `list` shows what\n" +
 			"is present; author or delete them via ordinary git operations\n" +
-			"against the config repo.",
+			"against the classroom50 repository.",
 	}
 	cmd.AddCommand(autograderSetDefaultCmd())
 	cmd.AddCommand(autograderShowCmd())
@@ -75,7 +75,7 @@ func autograderSetDefaultCmd() *cobra.Command {
 		Long: "Replace `<classroom>/autograder.py` in <org>/classroom50\n" +
 			"with the contents of --from <path>. Pass `--from -` to\n" +
 			"read from stdin (one-shot agent flows). Lands as a single\n" +
-			"Tree commit on the config repo's default branch and is\n" +
+			"Tree commit on the classroom50 repository's default branch and is\n" +
 			"picked up by every subsequent submission once the next\n" +
 			"`publish-pages.yaml` run deploys (~30s).\n\n" +
 			"When --from is omitted, writes the diagnostic stub shipped\n" +

--- a/cli/gh-teacher/autograder_crud.go
+++ b/cli/gh-teacher/autograder_crud.go
@@ -196,7 +196,7 @@ func autograderListCmd() *cobra.Command {
 			"The classroom DEFAULT autograder (<classroom>/autograder.py)\n" +
 			"is not listed here -- inspect it with `gh teacher autograder\n" +
 			"show`. Named shims and per-assignment overrides are authored\n" +
-			"via ordinary git operations against the config repo; this\n" +
+			"via ordinary git operations against the classroom50 repository; this\n" +
 			"command is read-only and lists what is present.",
 		Example: "  gh teacher autograder list cs50-fall-2026 cs-principles\n" +
 			"  gh teacher autograder list cs50-fall-2026 cs-principles --json",

--- a/cli/gh-teacher/init.go
+++ b/cli/gh-teacher/init.go
@@ -67,17 +67,17 @@ func initCmd() *cobra.Command {
 			"an already-configured token untouched; replace it with\n" +
 			"`gh teacher rotate-service-token <org>`).\n\n" +
 			"Re-running is safe: init picks up where a prior run left off and\n" +
-			"refreshes workflow files that differ from this CLI's embedded\n" +
-			"version (so orgs gain new features) after a confirmation prompt;\n" +
-			"--yes skips that prompt for scripted runs.\n\n" +
+			"refreshes workflow and script files that differ from this CLI's\n" +
+			"embedded version (so orgs gain new features) after a confirmation\n" +
+			"prompt; --yes skips that prompt for scripted runs.\n\n" +
 			"Four org member-privilege settings have no REST API; init reports\n" +
 			"them as a manual checklist (and in --json's\n" +
 			"manual_hardening_required). See the CLI Teacher Guide for the full\n" +
 			"hardening context.\n\n" +
 			"Flags: --dry-run (setup checks + planned steps, no changes),\n" +
 			"--json (machine-readable summary on stdout, implies --quiet),\n" +
-			"--quiet/-q (suppress progress chatter), --yes (skip workflow-\n" +
-			"refresh prompt).",
+			"--quiet/-q (suppress progress chatter), --yes (skip the refresh\n" +
+			"prompt).",
 		Example: "  CLASSROOM50_SERVICE_TOKEN=github_pat_xxx gh teacher init cs50-fall-2026\n" +
 			"  gh teacher init cs50-fall-2026              # interactive prompt for the token\n" +
 			"  gh teacher init cs50-fall-2026 --dry-run    # preview without changes\n" +
@@ -339,7 +339,7 @@ func initCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&skipConfirm, "yes", false, "Skip the workflow-refresh confirmation prompt (scripted runs only)")
+	cmd.Flags().BoolVar(&skipConfirm, "yes", false, "Skip the refresh confirmation prompt (scripted runs only)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Run read-only setup checks and list the steps init would perform, without making any changes")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit a machine-readable JSON summary on stdout (implies --quiet); suppresses human output")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress per-step progress and success chatter; keep warnings and the final summary")

--- a/cli/gh-teacher/init.go
+++ b/cli/gh-teacher/init.go
@@ -25,8 +25,8 @@ func initCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init <org>",
-		Short: "Bootstrap the classroom50 config repo in an organization",
-		Long: "Bootstrap the classroom50 config repo for a teaching organization.\n" +
+		Short: "Bootstrap the classroom50 repository in an organization",
+		Long: "Bootstrap the classroom50 repository for a teaching organization.\n" +
 			"Run once per org; safe to re-run (idempotent).\n\n" +
 			"What it sets up (in order):\n" +
 			"  1.  Org member-privilege lockdown (least-privilege: the only\n" +
@@ -37,15 +37,15 @@ func initCmd() *cobra.Command {
 			"      an existing teacher-set budget is left untouched).\n" +
 			"  4.  Actions allowed to create pull requests (for Feedback PRs).\n" +
 			"  5.  Branch rulesets protecting submission history + Feedback base.\n" +
-			"  6.  The private classroom50 config repo (auto-initialized).\n" +
+			"  6.  The private classroom50 repository (auto-initialized).\n" +
 			"  7.  Repo-level Actions re-enabled.\n" +
-			"  8.  The embedded skeleton workflows/scripts (single commit).\n" +
+			"  8.  The embedded workflow and script files (single commit).\n" +
 			"  9.  GitHub Pages (workflow build, visibility public).\n" +
 			"  10. Branch protection on the default branch.\n" +
 			"  11. Workflow GITHUB_TOKEN permissions.\n" +
 			"  12. Reusable-workflow access for the org.\n" +
 			"  13. The repo-level CLASSROOM50_SERVICE_TOKEN secret.\n\n" +
-			"Preflight: before any change, init verifies your OAuth scopes,\n" +
+			"Setup checks: before any change, init verifies your OAuth scopes,\n" +
 			"org access and ownership, the org plan, and that a service token\n" +
 			"is available — and stops without mutating if a hard check fails.\n\n" +
 			"Service token: read from the CLASSROOM50_SERVICE_TOKEN environment\n" +
@@ -67,16 +67,16 @@ func initCmd() *cobra.Command {
 			"an already-configured token untouched; replace it with\n" +
 			"`gh teacher rotate-service-token <org>`).\n\n" +
 			"Re-running is safe: init picks up where a prior run left off and\n" +
-			"refreshes skeleton files that differ from this CLI's embedded\n" +
+			"refreshes workflow files that differ from this CLI's embedded\n" +
 			"version (so orgs gain new features) after a confirmation prompt;\n" +
 			"--yes skips that prompt for scripted runs.\n\n" +
 			"Four org member-privilege settings have no REST API; init reports\n" +
 			"them as a manual checklist (and in --json's\n" +
 			"manual_hardening_required). See the CLI Teacher Guide for the full\n" +
 			"hardening context.\n\n" +
-			"Flags: --dry-run (preflight + planned steps, no changes),\n" +
+			"Flags: --dry-run (setup checks + planned steps, no changes),\n" +
 			"--json (machine-readable summary on stdout, implies --quiet),\n" +
-			"--quiet/-q (suppress progress chatter), --yes (skip skeleton-\n" +
+			"--quiet/-q (suppress progress chatter), --yes (skip workflow-\n" +
 			"refresh prompt).",
 		Example: "  CLASSROOM50_SERVICE_TOKEN=github_pat_xxx gh teacher init cs50-fall-2026\n" +
 			"  gh teacher init cs50-fall-2026              # interactive prompt for the token\n" +
@@ -339,8 +339,8 @@ func initCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&skipConfirm, "yes", false, "Skip the skeleton-refresh confirmation prompt (scripted runs only)")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Run read-only preflight checks and list the steps init would perform, without making any changes")
+	cmd.Flags().BoolVar(&skipConfirm, "yes", false, "Skip the workflow-refresh confirmation prompt (scripted runs only)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Run read-only setup checks and list the steps init would perform, without making any changes")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit a machine-readable JSON summary on stdout (implies --quiet); suppresses human output")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress per-step progress and success chatter; keep warnings and the final summary")
 	return cmd

--- a/cli/gh-teacher/init_preflight.go
+++ b/cli/gh-teacher/init_preflight.go
@@ -199,7 +199,7 @@ func checkOwnership(client githubapi.Client, org, login string) preflightCheck {
 	}
 	if resp.Role != "admin" {
 		c.Status = preflightFail
-		c.Detail = fmt.Sprintf("you are a %q of %q, not an owner; `gh teacher init` needs org-owner rights to lock down member privileges and create the config repo", resp.Role, org)
+		c.Detail = fmt.Sprintf("you are a %q of %q, not an owner; `gh teacher init` needs org-owner rights to lock down member privileges and create the classroom50 repository", resp.Role, org)
 		return c
 	}
 	c.Status = preflightOK
@@ -250,7 +250,7 @@ func currentTokenSource() tokenSource {
 // suppresses per-check lines but always prints failures.
 func renderPreflight(u *ui.UI, res preflightResult, quiet bool) {
 	if !quiet {
-		u.Section("Preflight checks")
+		u.Section("Setup checks")
 	}
 	for _, c := range res.Checks {
 		switch c.Status {
@@ -275,7 +275,7 @@ func preflightFailError(res preflightResult) error {
 			failed = append(failed, fmt.Sprintf("%s (%s)", c.Name, c.Detail))
 		}
 	}
-	return fmt.Errorf("preflight failed — fix before re-running: %s", strings.Join(failed, "; "))
+	return fmt.Errorf("setup checks failed — fix before re-running: %s", strings.Join(failed, "; "))
 }
 
 // initStepLabels are init's phase labels in order — used by --dry-run and the
@@ -286,9 +286,9 @@ var initStepLabels = []string{
 	"Setting the $0 Actions budget cap",
 	"Allowing Actions to create pull requests (org)",
 	"Installing branch rulesets (Feedback PR protections)",
-	"Creating the config repo",
+	"Creating the classroom50 repository",
 	"Enabling repo-level Actions",
-	"Committing the skeleton workflows",
+	"Committing the workflow files",
 	"Enabling GitHub Pages",
 	"Protecting the default branch",
 	"Setting workflow permissions",

--- a/cli/gh-teacher/init_preflight.go
+++ b/cli/gh-teacher/init_preflight.go
@@ -288,7 +288,7 @@ var initStepLabels = []string{
 	"Installing branch rulesets (Feedback PR protections)",
 	"Creating the classroom50 repository",
 	"Enabling repo-level Actions",
-	"Committing the workflow files",
+	"Committing the workflow and script files",
 	"Enabling GitHub Pages",
 	"Protecting the default branch",
 	"Setting workflow permissions",

--- a/cli/gh-teacher/init_repo.go
+++ b/cli/gh-teacher/init_repo.go
@@ -319,7 +319,7 @@ func ensureOrgActionsEnabled(client githubapi.Client, out, errOut io.Writer, org
 		_, _ = fmt.Fprintf(out, "%s: Actions already enabled (all repositories)\n", org)
 		return nil
 	case "selected":
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: Actions is enabled only for selected repositories; ensure the classroom50 config repo and the <classroom>-* student repos are included (or switch to All repositories) at https://github.com/organizations/%s/settings/actions — Classroom50's autograde, publish-pages, and collect-scores workflows won't run in any repo left out.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: Actions is enabled only for selected repositories; ensure the classroom50 repository and the <classroom>-* student repos are included (or switch to All repositories) at https://github.com/organizations/%s/settings/actions — Classroom50's autograde, publish-pages, and collect-scores workflows won't run in any repo left out.\n",
 			org, org)
 		return nil
 	case "none":
@@ -375,7 +375,7 @@ type orgWorkflowPermissions struct {
 //
 // Trade-off: GitHub's single field couples "create" and "approve" — no
 // create-only toggle, so this also lets Actions *approve* PRs org-wide. Safe as
-// shipped: neither the config repo's default branch nor student repos have a
+// shipped: neither the classroom50 repository's default branch nor student repos have a
 // required-review gate, so a self-approval grants no merge a student couldn't
 // already do. Residual: if a teacher later adds a required-review rule, a
 // student-controlled token could satisfy it via self-approval (documented in
@@ -879,14 +879,14 @@ func reportOrgWorkflowPermissions(client githubapi.Client, out io.Writer, owner,
 		DefaultWorkflowPermissions string `json:"default_workflow_permissions"`
 	}
 	if err := client.Get(path, &resp); err != nil {
-		_, _ = fmt.Fprintf(out, "%s/%s: workflow permissions are managed by an org policy (HTTP 409 on PUT); skeleton workflows grant workflow-level permissions, so this is OK.\n", owner, repo)
+		_, _ = fmt.Fprintf(out, "%s/%s: workflow permissions are managed by an org policy (HTTP 409 on PUT); workflow files grant workflow-level permissions, so this is OK.\n", owner, repo)
 		return nil
 	}
 	if resp.DefaultWorkflowPermissions == "write" {
 		_, _ = fmt.Fprintf(out, "%s/%s: workflow permissions already write (set at org level)\n", owner, repo)
 		return nil
 	}
-	_, _ = fmt.Fprintf(out, "%s/%s: org default workflow permissions are %q; skeleton workflows grant workflow-level write where needed. To raise the org default: gh api -X PUT /orgs/%s/actions/permissions/workflow -F default_workflow_permissions=write\n",
+	_, _ = fmt.Fprintf(out, "%s/%s: org default workflow permissions are %q; workflow files grant workflow-level write where needed. To raise the org default: gh api -X PUT /orgs/%s/actions/permissions/workflow -F default_workflow_permissions=write\n",
 		owner, repo, resp.DefaultWorkflowPermissions, owner)
 	return nil
 }

--- a/cli/gh-teacher/init_skeleton.go
+++ b/cli/gh-teacher/init_skeleton.go
@@ -27,7 +27,7 @@ import (
 var skeletonFS embed.FS
 
 // skeletonProbePath detects "already committed" on re-runs.
-// publish-pages.yaml is unique to the config repo; README.md isn't reliable
+// publish-pages.yaml is unique to the classroom50 repository; README.md isn't reliable
 // (auto_init creates one).
 const skeletonProbePath = ".github/workflows/publish-pages.yaml"
 
@@ -75,7 +75,7 @@ func skeletonFiles(defaultBranch string) (map[string]string, error) {
 }
 
 // skeletonCommitMessage is the single bootstrap commit's message.
-var skeletonCommitMessage = contract.PrefixCommit("Bootstrap classroom50 config repo (gh teacher init)")
+var skeletonCommitMessage = contract.PrefixCommit("Bootstrap classroom50 repository (gh teacher init)")
 
 // skeletonCommitAttempts: read-parent + build-tree retries at 200ms×2^n backoff
 // (~3s) to ride out a fresh repo's git-data lag.
@@ -125,11 +125,11 @@ func commitSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Writer
 		return err
 	}
 
-	_, _ = fmt.Fprintf(out, "%s/%s: skeleton committed (%d files)\n", owner, repo, len(entries))
+	_, _ = fmt.Fprintf(out, "%s/%s: workflow files committed (%d files)\n", owner, repo, len(entries))
 	return nil
 }
 
-// refreshSkeleton brings an already-bootstrapped config repo's skeleton up to
+// refreshSkeleton brings an already-bootstrapped classroom50 repository's skeleton up to
 // date: diff embedded vs repo, confirm (skeleton files are user-editable, so an
 // overwrite resets customizations), then commit only the stale paths. Declining
 // is not an error.
@@ -139,11 +139,11 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 		return err
 	}
 	if len(stale) == 0 {
-		_, _ = fmt.Fprintf(out, "%s/%s: skeleton up to date\n", owner, repo)
+		_, _ = fmt.Fprintf(out, "%s/%s: workflow files up to date\n", owner, repo)
 		return nil
 	}
 
-	_, _ = fmt.Fprintf(errOut, "%s/%s: %d skeleton file(s) differ from this CLI's embedded version:\n", owner, repo, len(stale))
+	_, _ = fmt.Fprintf(errOut, "%s/%s: %d workflow file(s) differ from this CLI's embedded version:\n", owner, repo, len(stale))
 	for _, p := range stale {
 		_, _ = fmt.Fprintf(errOut, "  %s\n", p)
 	}
@@ -153,7 +153,7 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 			return err
 		}
 		if !ok {
-			_, _ = fmt.Fprintf(out, "%s/%s: skeleton refresh declined, files left untouched (re-run with --yes to skip the prompt)\n", owner, repo)
+			_, _ = fmt.Fprintf(out, "%s/%s: workflow-file refresh declined, files left untouched (re-run with --yes to skip the prompt)\n", owner, repo)
 			return nil
 		}
 	}
@@ -175,17 +175,17 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 		refreshed = len(changed)
 		return updates, nil
 	}
-	commitSHA, err := configwrite.CommitTree(client, owner, repo, branch, contract.PrefixCommit("Refresh classroom50 skeleton (gh teacher init)"), build)
+	commitSHA, err := configwrite.CommitTree(client, owner, repo, branch, contract.PrefixCommit("Refresh classroom50 workflow files (gh teacher init)"), build)
 	if err != nil {
 		return err
 	}
 	if commitSHA == "" {
 		// A concurrent writer refreshed the same files between the diff and
 		// the commit; nothing left to land.
-		_, _ = fmt.Fprintf(out, "%s/%s: skeleton already refreshed by a concurrent writer, nothing to commit\n", owner, repo)
+		_, _ = fmt.Fprintf(out, "%s/%s: workflow files already refreshed by a concurrent writer, nothing to commit\n", owner, repo)
 		return nil
 	}
-	_, _ = fmt.Fprintf(out, "%s/%s: skeleton refreshed (%d file(s))\n", owner, repo, refreshed)
+	_, _ = fmt.Fprintf(out, "%s/%s: workflow files refreshed (%d file(s))\n", owner, repo, refreshed)
 	return nil
 }
 

--- a/cli/gh-teacher/init_skeleton.go
+++ b/cli/gh-teacher/init_skeleton.go
@@ -125,7 +125,7 @@ func commitSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Writer
 		return err
 	}
 
-	_, _ = fmt.Fprintf(out, "%s/%s: workflow files committed (%d files)\n", owner, repo, len(entries))
+	_, _ = fmt.Fprintf(out, "%s/%s: workflow and script files committed (%d files)\n", owner, repo, len(entries))
 	return nil
 }
 
@@ -139,11 +139,11 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 		return err
 	}
 	if len(stale) == 0 {
-		_, _ = fmt.Fprintf(out, "%s/%s: workflow files up to date\n", owner, repo)
+		_, _ = fmt.Fprintf(out, "%s/%s: workflow and script files up to date\n", owner, repo)
 		return nil
 	}
 
-	_, _ = fmt.Fprintf(errOut, "%s/%s: %d workflow file(s) differ from this CLI's embedded version:\n", owner, repo, len(stale))
+	_, _ = fmt.Fprintf(errOut, "%s/%s: %d workflow and script file(s) differ from this CLI's embedded version:\n", owner, repo, len(stale))
 	for _, p := range stale {
 		_, _ = fmt.Fprintf(errOut, "  %s\n", p)
 	}
@@ -153,7 +153,7 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 			return err
 		}
 		if !ok {
-			_, _ = fmt.Fprintf(out, "%s/%s: workflow-file refresh declined, files left untouched (re-run with --yes to skip the prompt)\n", owner, repo)
+			_, _ = fmt.Fprintf(out, "%s/%s: refresh declined, files left untouched (re-run with --yes to skip the prompt)\n", owner, repo)
 			return nil
 		}
 	}
@@ -175,17 +175,17 @@ func refreshSkeleton(client githubapi.Client, in io.Reader, out, errOut io.Write
 		refreshed = len(changed)
 		return updates, nil
 	}
-	commitSHA, err := configwrite.CommitTree(client, owner, repo, branch, contract.PrefixCommit("Refresh classroom50 workflow files (gh teacher init)"), build)
+	commitSHA, err := configwrite.CommitTree(client, owner, repo, branch, contract.PrefixCommit("Refresh classroom50 workflow and script files (gh teacher init)"), build)
 	if err != nil {
 		return err
 	}
 	if commitSHA == "" {
 		// A concurrent writer refreshed the same files between the diff and
 		// the commit; nothing left to land.
-		_, _ = fmt.Fprintf(out, "%s/%s: workflow files already refreshed by a concurrent writer, nothing to commit\n", owner, repo)
+		_, _ = fmt.Fprintf(out, "%s/%s: workflow and script files already refreshed by a concurrent writer, nothing to commit\n", owner, repo)
 		return nil
 	}
-	_, _ = fmt.Fprintf(out, "%s/%s: workflow files refreshed (%d file(s))\n", owner, repo, refreshed)
+	_, _ = fmt.Fprintf(out, "%s/%s: workflow and script files refreshed (%d file(s))\n", owner, repo, refreshed)
 	return nil
 }
 

--- a/cli/gh-teacher/init_skeleton_commit_test.go
+++ b/cli/gh-teacher/init_skeleton_commit_test.go
@@ -181,7 +181,7 @@ func TestCommitSkeleton_UpToDateSkeletonNoOps(t *testing.T) {
 	if err := commitSkeleton(client, strings.NewReader(""), &out, io.Discard, "o", "r", "main", false); err != nil {
 		t.Fatalf("commitSkeleton returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "skeleton up to date") {
+	if !strings.Contains(out.String(), "workflow files up to date") {
 		t.Errorf("out = %q, want up-to-date note", out.String())
 	}
 	mu.Lock()
@@ -263,7 +263,7 @@ func TestCommitSkeleton_RefreshesStaleFiles(t *testing.T) {
 	if !*patched {
 		t.Error("ref was never PATCHed; the refresh never landed")
 	}
-	if !strings.Contains(out.String(), "skeleton refreshed (1 file(s))") {
+	if !strings.Contains(out.String(), "workflow files refreshed (1 file(s))") {
 		t.Errorf("out = %q, want refreshed note", out.String())
 	}
 	if !strings.Contains(errOut.String(), ".github/scripts/runner.py") {
@@ -307,7 +307,7 @@ func TestCommitSkeleton_RefreshReportsLandedCount(t *testing.T) {
 	if !*patched {
 		t.Error("ref was never PATCHed")
 	}
-	if !strings.Contains(out.String(), "skeleton refreshed (1 file(s))") {
+	if !strings.Contains(out.String(), "workflow files refreshed (1 file(s))") {
 		t.Errorf("out = %q, want the landed count (1), not the initial diff (2)", out.String())
 	}
 }

--- a/cli/gh-teacher/init_skeleton_commit_test.go
+++ b/cli/gh-teacher/init_skeleton_commit_test.go
@@ -181,7 +181,7 @@ func TestCommitSkeleton_UpToDateSkeletonNoOps(t *testing.T) {
 	if err := commitSkeleton(client, strings.NewReader(""), &out, io.Discard, "o", "r", "main", false); err != nil {
 		t.Fatalf("commitSkeleton returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "workflow files up to date") {
+	if !strings.Contains(out.String(), "workflow and script files up to date") {
 		t.Errorf("out = %q, want up-to-date note", out.String())
 	}
 	mu.Lock()
@@ -263,7 +263,7 @@ func TestCommitSkeleton_RefreshesStaleFiles(t *testing.T) {
 	if !*patched {
 		t.Error("ref was never PATCHed; the refresh never landed")
 	}
-	if !strings.Contains(out.String(), "workflow files refreshed (1 file(s))") {
+	if !strings.Contains(out.String(), "workflow and script files refreshed (1 file(s))") {
 		t.Errorf("out = %q, want refreshed note", out.String())
 	}
 	if !strings.Contains(errOut.String(), ".github/scripts/runner.py") {
@@ -307,7 +307,7 @@ func TestCommitSkeleton_RefreshReportsLandedCount(t *testing.T) {
 	if !*patched {
 		t.Error("ref was never PATCHed")
 	}
-	if !strings.Contains(out.String(), "workflow files refreshed (1 file(s))") {
+	if !strings.Contains(out.String(), "workflow and script files refreshed (1 file(s))") {
 		t.Errorf("out = %q, want the landed count (1), not the initial diff (2)", out.String())
 	}
 }

--- a/cli/gh-teacher/init_summary.go
+++ b/cli/gh-teacher/init_summary.go
@@ -117,7 +117,7 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 		if s.ConfigRepo.Created {
 			verb = "created"
 		}
-		u.Item("config repo (%s): %s", verb, s.ConfigRepo.URL)
+		u.Item("classroom50 repository (%s): %s", verb, s.ConfigRepo.URL)
 	}
 	if s.PagesURL != "" {
 		u.Item("pages (after first publish-pages run): %s", s.PagesURL)

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -31,7 +31,7 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "assignment",
-		Short: "Manage assignments inside the config repo",
+		Short: "Manage assignments inside the classroom50 repository",
 		Long: "Manage assignment entries in <org>/classroom50/<classroom>/assignments.json.\n\n" +
 			"Subcommands:\n" +
 			"  add     register or upsert an assignment\n" +
@@ -131,13 +131,13 @@ func assignmentAddCmd() *cobra.Command {
 			"referenced file must exist at write time. The default is\n" +
 			"`default`, which uses the universal shim embedded in\n" +
 			"gh-student — that shim `uses:` the autograde-runner workflow\n" +
-			"in the config repo.\n\n" +
+			"in the classroom50 repository.\n\n" +
 			"There are three ways to grade. (1) Declarative tests: pass\n" +
 			"--tests <file.json> here (or use `gh teacher assignment test\n" +
 			"add`) to describe io/run/python checks that the runner grades\n" +
 			"with no autograder.py. (2) A per-assignment autograder.py: drop\n" +
 			"an entrypoint plus any sibling fixtures at\n" +
-			"<classroom>/autograders/<slug>/ in the config repo (mutually\n" +
+			"<classroom>/autograders/<slug>/ in the classroom50 repository (mutually\n" +
 			"exclusive with --tests). (3) A classroom default: run\n" +
 			"`gh teacher autograder set-default <org> <classroom>` to install\n" +
 			"<classroom>/autograder.py for every assignment. See the\n" +
@@ -299,13 +299,13 @@ func assignmentAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&availableFrom, "available-from", "", "Optional release date (e.g., 2026-09-15T00:00:00-04:00); stored as UTC. Assignments are hidden from the student list by default (invite-link accept only); set this to list it for everyone once the date passes. Students who already accepted always see it (listing-only, not access control). Omit the offset to use the machine's local timezone.")
 	cmd.Flags().StringVar(&mode, "mode", assignment.ModeIndividual, "Assignment mode: `individual` (default) or `group`. Group mode requires --max-group-size.")
 	cmd.Flags().IntVar(&maxGroupSize, "max-group-size", 0, "Maximum collaborators on a group repo (>= 2; required with --mode group). Enforced within the CLI when students join; direct GitHub-UI invites can bypass it.")
-	cmd.Flags().StringVar(&autograder, "autograder", contract.DefaultAutograderName, "Autograder workflow shim this assignment opts into; resolves to <classroom>/autograders/<name>.yaml in the config repo")
+	cmd.Flags().StringVar(&autograder, "autograder", contract.DefaultAutograderName, "Autograder workflow shim this assignment opts into; resolves to <classroom>/autograders/<name>.yaml in the classroom50 repository")
 	cmd.Flags().StringVar(&runtimeFile, "runtime", "", "Path to a JSON file describing the runtime environment (runs-on as a single label or an array of labels for self-hosted runners, python/node/java/go/rust versions, apt packages, or container image), or `-` to read from stdin. Omit for ubuntu-latest + Python 3.14.")
 	cmd.Flags().StringVar(&testsFile, "tests", "", "Path to a JSON file with a bare array of declarative test specs (io/run/python), or `-` to read from stdin. Sets the assignment's `tests` block; mutually exclusive with a per-assignment autograder.py. See `gh teacher assignment test --help`.")
 	cmd.Flags().BoolVar(&feedbackPR, "feedback-pr", true, "Open one long-lived Feedback pull request per student repo so you can leave inline review comments on the full starter→submission diff. Accept freezes a base branch at the baseline commit and opens the PR right away, so it exists even with GitHub Actions disabled; the autograde runner then adopts and maintains it (and opens it on the first submission if accept could not). Default on; pass --feedback-pr=false to disable. Requires `gh teacher init` to have set up the org prerequisites.")
 	cmd.Flags().BoolVar(&emptyRepo, "empty-repo", false, "Create truly bare student repos: no README/initial commit, no .classroom50.yaml marker, no autograde workflow — for assignments where students build the repo (including their own GitHub Actions) from scratch. Autograding and the Feedback PR are disabled. Changing this on a same-slug re-add applies only to accepts from now on (repositories students already accepted are not retrofitted; a warning is printed). Mutually exclusive with --template, --tests, --feedback-pr, --allowed-files, --pass-threshold, --submission-mode, and --submission-tag.")
 	cmd.Flags().StringArrayVar(&allowedFiles, "allowed-files", nil, "Ordered .gitignore-style pattern (repeatable, order preserved) defining which files belong to the submission. Last match wins; `!` re-includes. Pass `--allowed-files '*' --allowed-files '!hello.py'` to allow only hello.py. The autograde runner removes disallowed files before grading (control files are always kept); `gh student submit` filters them too. Omit to allow every file.")
-	cmd.Flags().IntVar(&passThreshold, "pass-threshold", 0, "Opt-in passing bar as a percentage of max score (0–100): at/above it a gradebook client shows a submission as passing. Advisory/display-only — it does not change a student's score. Omit to leave it off (no passing concept); pass --pass-threshold 0 for an explicit 0%.")
+	cmd.Flags().IntVar(&passThreshold, "pass-threshold", 0, "Opt-in passing bar as a percentage of max score (0–100): at/above it the submissions page shows a submission as passing. Advisory/display-only — it does not change a student's score. Omit to leave it off (no passing concept); pass --pass-threshold 0 for an explicit 0%.")
 	cmd.Flags().StringVar(&studentPerm, "student-permission", "", "Optional collaborator role each student gets on their OWN assignment repo at accept time: one of pull, triage, push, maintain, admin. Omit for the default (push for individual, admin for group). Choose admin to let students manage repo settings and enable GitHub Pages. Applies to students who accept from now on; existing repos are unchanged. Caution: admin on a private repo also lets the student change its visibility.")
 	cmd.Flags().StringVar(&submissionMd, "submission-mode", contract.SubmissionModeEveryPush, "When the autograder fires: `every-push` (default; every push to the default branch grades) or `tag` (only submit/* tag pushes grade — `gh student submit` pushes the tag, or push any submit/* tag by hand; plain `git push` costs no Actions minutes). Baked into each student repo's shim at accept time; change it later with `gh teacher assignment submission-mode`, which also retrofits existing repos. Mutually exclusive with --empty-repo.")
 	cmd.Flags().StringArrayVar(&submissionTags, "submission-tag", nil, "Milestone tag pattern (repeatable) that ALSO triggers grading — e.g. --submission-tag phase1 --submission-tag phase2, or a glob like 'v*'. A student pushing a matching tag (`git tag phase1 && git push origin phase1`) gets that commit graded; the grading record still lives at the canonical submit/* tag the runner mints, so history and collection are unchanged. The canonical submit/* namespace always triggers too. Baked into the shim at accept time like --submission-mode (same retrofit to change later). Caution: a broad glob like 'v*' grades every matching tag a student pushes. Mutually exclusive with --empty-repo.")
@@ -330,7 +330,7 @@ func assignmentRemoveCmd() *cobra.Command {
 			"clean reset: an --empty-repo flag that differs from the removed\n" +
 			"entry leaves already-accepted repos on the old behavior — the\n" +
 			"change applies only to accepts from now on (a warning is printed;\n" +
-			"reconcile existing repositories yourself).",
+			"update existing repositories yourself).",
 		Example: "  gh teacher assignment remove cs50-fall-2026 cs-principles hello",
 		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -820,7 +820,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		if hasPrev && entry.PassThreshold == nil && file.Assignments[prevIdx].PassThreshold != nil {
 			droppedPassThreshold = file.Assignments[prevIdx].PassThreshold
 		}
-		// Same footgun for student_permission (often set in the gradebook GUI):
+		// Same footgun for student_permission (often set in the web app):
 		// re-running add without --student-permission drops a prior value back
 		// to the mode default. Empty = omitted (warn if the prior entry set one).
 		if hasPrev && entry.StudentPermission == "" && file.Assignments[prevIdx].StudentPermission != "" {
@@ -958,7 +958,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	}
 	if droppedPassThreshold != nil {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q dropped its pass_threshold (%d%%) — `assignment add` rewrites the whole entry, and you re-ran it without --pass-threshold. The passing bar (often set in the gradebook GUI) is now off. Pass --pass-threshold %d to keep it.\n",
+			"Warning: replacing %q dropped its pass_threshold (%d%%) — `assignment add` rewrites the whole entry, and you re-ran it without --pass-threshold. The passing bar (often set in the web app) is now off. Pass --pass-threshold %d to keep it.\n",
 			slug, *droppedPassThreshold, *droppedPassThreshold)
 	}
 	if droppedStudentPerm != "" {
@@ -972,7 +972,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	// reconciling any resulting inconsistency (mirrors the web app's confirm).
 	if changedEmptyRepo {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q changed its empty_repo setting. Repositories students already accepted are not retrofitted — they keep their original setup, and if autograding is now off their autograde runs start failing and drop out of the gradebook. The new setting applies only to accepts from now on; reconcile existing repositories yourself.\n",
+			"Warning: replacing %q changed its empty_repo setting. Repositories students already accepted are not retrofitted — they keep their original setup, and if autograding is now off their autograde runs start failing and drop out of the collected scores. The new setting applies only to accepts from now on; update existing repositories yourself.\n",
 			slug)
 	}
 	// Heads-up if the encoded file nears GitHub's ~1 MiB contents-API limit

--- a/cli/gh-teacher/internal/assignmentcmd/lock.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock.go
@@ -132,7 +132,7 @@ func runAssignmentLock(client githubapi.Client, out, errOut io.Writer, org, clas
 		_, _ = fmt.Fprintf(out, "%s/%s/%s: %sed %s\n",
 			org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), verb, slug)
 	} else {
-		_, _ = fmt.Fprintf(out, "%s/%s/%s: %s was already %sed, reconciling template access\n",
+		_, _ = fmt.Fprintf(out, "%s/%s/%s: %s was already %sed, re-checking template access\n",
 			org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), slug, verb)
 	}
 
@@ -144,7 +144,7 @@ func runAssignmentLock(client githubapi.Client, out, errOut io.Writer, org, clas
 	}
 	private, ok, err := templateVisibility(client, template.Owner, template.Repo)
 	if err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: %sed %q, but checking the template %s/%s failed (%v); its student-team access was not reconciled.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %sed %q, but checking the template %s/%s failed (%v); its student-team access was not updated.\n",
 			verb, slug, template.Owner, template.Repo, err)
 		return nil
 	}

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
@@ -74,7 +74,7 @@ func assignmentTestAddCmd() *cobra.Command {
 			"  cases at grade time.\n\n" +
 			"--input-file / --expected-file name a fixture file the teacher\n" +
 			"has committed alongside the assignment at\n" +
-			"<classroom>/autograders/<slug>/ in the config repo; it is bundled\n" +
+			"<classroom>/autograders/<slug>/ in the classroom50 repository; it is bundled\n" +
 			"and read at grade time. Fails if the assignment slug isn't\n" +
 			"registered yet, or if the assignment already has a hand-written\n" +
 			"per-assignment autograder.py (the two are mutually exclusive).",
@@ -387,7 +387,7 @@ func ensureDeclarativeTestsSupported(client githubapi.Client, org, ref string) e
 		return fmt.Errorf("check %s/%s/%s: %w", org, configrepo.ConfigRepoName, materializeScriptPath, err)
 	}
 	if !exists {
-		return fmt.Errorf("%s/%s is missing %s, so declarative tests would never run — re-run `gh teacher init %s` to update the skeleton, then retry",
+		return fmt.Errorf("%s/%s is missing %s, so declarative tests would never run — re-run `gh teacher init %s` to update the workflow files, then retry",
 			org, configrepo.ConfigRepoName, materializeScriptPath, org)
 	}
 	return nil

--- a/cli/gh-teacher/internal/audit/audit.go
+++ b/cli/gh-teacher/internal/audit/audit.go
@@ -134,7 +134,7 @@ type auditReport struct {
 	// repo's default branch (this value) isn't `main`; recommended, never a
 	// failure. Renameable in the web app; hand-fix link here.
 	ConfigRepoBranchRec string `json:"config_repo_branch_recommendation,omitempty"`
-	// ConfigRepoBranchesURL is the config repo's branches settings page.
+	// ConfigRepoBranchesURL is the classroom50 repository's branches settings page.
 	ConfigRepoBranchesURL string `json:"config_repo_branches_url,omitempty"`
 	// SettingsURL is the org member-privileges page every item lives on.
 	SettingsURL string `json:"settings_url"`
@@ -231,7 +231,7 @@ func buildAuditReport(client githubapi.Client, org, plan string) auditReport {
 		report.RepositoryDefaultsURL = orgpolicy.OrgRepositoryDefaultsURL(org)
 	}
 
-	// Advisory-only: the classroom50 config repo drifted off `main`. Renameable
+	// Advisory-only: the classroom50 repository drifted off `main`. Renameable
 	// in the web app; here we only recommend + link. A read failure (e.g., repo
 	// not yet initialized) simply omits the recommendation — it never gates the
 	// verdict.
@@ -361,7 +361,7 @@ func (r *auditReport) renderHuman(u *ui.UI) {
 		u.Detail("Change it at %s", r.RepositoryDefaultsURL)
 	}
 	if r.ConfigRepoBranchRec != "" {
-		u.Detail("The classroom50 config repo's default branch is %q, not %q; everything still works (reads/writes target the real branch), but renaming it matches Classroom 50's convention. The web app can rename it for you.",
+		u.Detail("The classroom50 repository's default branch is %q, not %q; everything still works (reads/writes target the real branch), but renaming it matches Classroom 50's convention. The web app can rename it for you.",
 			r.ConfigRepoBranchRec, orgpolicy.RecommendedOrgDefaultBranch)
 		u.Detail("Rename it at %s", r.ConfigRepoBranchesURL)
 	}

--- a/cli/gh-teacher/internal/auth/login.go
+++ b/cli/gh-teacher/internal/auth/login.go
@@ -21,7 +21,7 @@ func NewLoginCmd() *cobra.Command {
 			"gh-student request the same set so a single sign-in covers\n" +
 			"both CLIs. admin:org is required by GitHub's org-membership\n" +
 			"endpoints (`gh teacher invite`), and workflow lets `gh teacher\n" +
-			"init` commit the config repo's `.github/workflows/` files\n" +
+			"init` commit the classroom50 repository's `.github/workflows/` files\n" +
 			"(GitHub 404s that Git Data API write without it).\n\n" +
 			"delete_repo is NOT requested by default — opt in with\n" +
 			"`gh teacher login -s delete_repo` for `gh teacher teardown`.\n\n" +

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -237,7 +237,7 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	// is load-bearing — see GrantStaffTeamsConfigRepoAccess). Best-effort,
 	// mirroring the web: a failure warns but doesn't fail creation.
 	if err := configrepo.GrantStaffTeamsConfigRepoAccess(client, org, staffTeams); err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: couldn't grant staff teams config-repo access (%v); staff may lack write until re-affirmed.\n", err)
+		_, _ = fmt.Fprintf(errOut, "Warning: couldn't grant staff teams access to the classroom50 repository (%v); staff may lack write until re-affirmed.\n", err)
 	}
 
 	files, err := classroomScaffold(org, shortName, name, term, secret, nil, nil, &team, staffTeams)

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -1,5 +1,5 @@
 // Package classroom implements the `gh teacher classroom` command group:
-// managing classroom directories inside the <org>/classroom50 config repo
+// managing classroom directories inside the <org>/classroom50 repository
 // (add/list/edit/remove) plus `classroom migrate` (imports an existing GitHub
 // Classroom). Only NewCmd is exported. The four-file scaffold lands through the
 // race-safe internal/configwrite seam.
@@ -45,8 +45,8 @@ const defaultAutograderName = contract.DefaultAutograderName
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "classroom",
-		Short: "Manage classroom directories inside the config repo",
-		Long: "Manage classrooms within an org's classroom50 config repo.\n\n" +
+		Short: "Manage classroom directories inside the classroom50 repository",
+		Long: "Manage classrooms within an org's classroom50 repository.\n\n" +
 			"A classroom is a directory at the root of <org>/classroom50,\n" +
 			"named by its short-name (e.g., cs-principles). Each classroom\n" +
 			"holds four files: classroom.json (metadata), assignments.json\n" +
@@ -81,7 +81,7 @@ func classroomAddCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "add <org> <short-name>",
-		Short: "Add a new classroom directory inside the config repo",
+		Short: "Add a new classroom directory inside the classroom50 repository",
 		Long: "Create the directory <short-name>/ inside <org>/classroom50\n" +
 			"and populate it with a four-file scaffold: classroom.json,\n" +
 			"assignments.json, roster.csv, and scores.json.\n\n" +
@@ -373,7 +373,7 @@ func classroomListCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "list <org>",
-		Short: "List the classrooms registered in the config repo",
+		Short: "List the classrooms registered in the classroom50 repository",
 		Long: "List every classroom registered in <org>/classroom50.\n\n" +
 			"A classroom is a root-level directory holding a classroom.json;\n" +
 			"directories without one (e.g., .github) are skipped.\n\n" +
@@ -500,7 +500,7 @@ func classroomEditCmd() *cobra.Command {
 			"The short-name itself is immutable — it flows into student\n" +
 			"repo names (`<short-name>-<assignment>-<username>`), so renaming\n" +
 			"would orphan existing repos. To rename, add a new classroom.\n\n" +
-			"Lands as a single Tree commit on the config repo. Re-running\n" +
+			"Lands as a single Tree commit on the classroom50 repository. Re-running\n" +
 			"with values that already match the file is a no-op.",
 		Example: "  gh teacher classroom edit cs50-fall-2026 cs-principles --name \"CS Principles\"\n" +
 			"  gh teacher classroom edit cs50-fall-2026 cs-principles --term Fall-2026",
@@ -729,7 +729,7 @@ func classroomRemoveCmd() *cobra.Command {
 	var skipConfirm bool
 	cmd := &cobra.Command{
 		Use:   "remove <org> <short-name>",
-		Short: "Remove a classroom directory from the config repo",
+		Short: "Remove a classroom directory from the classroom50 repository",
 		Long: "Delete the <short-name>/ directory (classroom.json,\n" +
 			"assignments.json, roster.csv, scores.json, and any\n" +
 			"autograders/) from <org>/classroom50 in a single commit.\n\n" +

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -42,7 +42,7 @@ func classroomMigrateCmd() *cobra.Command {
 			"`gh teacher roster add|import`.\n\n" +
 			"GitHub Classroom is 1:1 with orgs (the org IS the classroom\n" +
 			"container) while Classroom 50 hosts multiple classrooms per\n" +
-			"org under one classroom50 config repo. Migrating N legacy\n" +
+			"org under one classroom50 repository. Migrating N legacy\n" +
 			"classrooms into one target org means running this command N\n" +
 			"times, once per source classroom.\n\n" +
 			"--source accepts a numeric GitHub Classroom ID (e.g., 95884) or\n" +
@@ -78,7 +78,7 @@ func classroomMigrateCmd() *cobra.Command {
 				return errors.New("--source is required (numeric classroom ID or org login)")
 			}
 			if targetVal == "" {
-				return errors.New("--target is required (destination org owning the classroom50 config repo)")
+				return errors.New("--target is required (destination org owning the classroom50 repository)")
 			}
 
 			client, err := githubapi.RequireAuthClient(cmd)
@@ -98,7 +98,7 @@ func classroomMigrateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&source, "source", "", "Source classroom — numeric ID or org login (required)")
-	cmd.Flags().StringVar(&target, "target", "", "Destination org owning the classroom50 config repo (required)")
+	cmd.Flags().StringVar(&target, "target", "", "Destination org owning the classroom50 repository (required)")
 	cmd.Flags().StringVar(&shortName, "short-name", "", "Override the auto-derived classroom directory name")
 	cmd.Flags().StringVar(&term, "term", "", "Set classroom.json.term (e.g., Spring-2026)")
 	cmd.Flags().StringVar(&templateSuffix, "template-suffix", "", "Suffix appended to every target template repo name (e.g., --template-suffix migrated → readability-migrated)")

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -33,7 +33,7 @@ func classroomMigrateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "migrate --source <id-or-org> --target <org>",
-		Short: "Migrate a classroom from GitHub Classroom into the target org's classroom50 repo",
+		Short: "Migrate a classroom from GitHub Classroom into the target org's classroom50 repository",
 		Long: "Migrate a classroom from the legacy GitHub Classroom product into\n" +
 			"<target>/classroom50 — copies each starter repo as a fresh template\n" +
 			"in the target org and registers a matching entry in\n" +
@@ -51,9 +51,9 @@ func classroomMigrateCmd() *cobra.Command {
 			"Archived classrooms resolve when looked up by numeric ID; they\n" +
 			"are skipped during org-name resolution unless --include-archived\n" +
 			"is passed.\n\n" +
-			"--target is the destination org where the classroom50 config\n" +
-			"repo lives. Run `gh teacher init <target>` first if it doesn't\n" +
-			"yet exist.\n\n" +
+			"--target is the destination org where the classroom50\n" +
+			"repository lives. Run `gh teacher init <target>` first if it\n" +
+			"doesn't yet exist.\n\n" +
 			"--short-name overrides the auto-derived classroom directory\n" +
 			"name. Migrate slugifies the source classroom name (lowercase,\n" +
 			"non-alnum → '-', collapsed, trimmed) and validates against\n" +
@@ -254,7 +254,7 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// Grant staff-team config-repo access AFTER the drop (order is load-bearing —
 	// see EnsureStaffTeams), same as `classroom add`. Best-effort.
 	if err := configrepo.GrantStaffTeamsConfigRepoAccess(client, plan.TargetOrg, staffTeams); err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: couldn't grant staff teams config-repo access (%v); staff may lack write until re-affirmed.\n", err)
+		_, _ = fmt.Fprintf(errOut, "Warning: couldn't grant staff teams access to the classroom50 repository (%v); staff may lack write until re-affirmed.\n", err)
 	}
 
 	build := func(parentSHA string) (map[string]string, error) {

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -39,7 +39,7 @@ type TeamRef struct {
 
 // StaffRole is a per-classroom staff role backing the web GUI's in-app
 // roles. Each maps to a `secret` GitHub team named
-// `classroom50-<short>-<role>` granted write on the config repo.
+// `classroom50-<short>-<role>` granted write on the classroom50 repository.
 type StaffRole string
 
 const (
@@ -94,7 +94,7 @@ var TemplateReadStaffRoles = []StaffRole{RoleHeadTA, RoleTA}
 // `push`; a plain TA is read-only → `pull`.
 // This is a SEPARATE axis from StaffTeamRepoPermissions above, which governs
 // student assignment repos and private templates. A role absent here is granted
-// nothing on the config repo.
+// nothing on the classroom50 repository.
 var ConfigRepoPermission = map[StaffRole]string{
 	RoleTeacher: "push",
 	RoleHeadTA:  "push",
@@ -327,7 +327,7 @@ func ReconcileClassroomTeamDescription(client githubapi.Client, org, shortName, 
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
 			return false, nil
 		}
-		return false, fmt.Errorf("GET %s (reconcile team description): %w", getPath, err)
+		return false, fmt.Errorf("GET %s (update team description): %w", getPath, err)
 	}
 
 	// Only ever write the record (which may carry the capability secret) onto a
@@ -344,7 +344,7 @@ func ReconcileClassroomTeamDescription(client githubapi.Client, org, shortName, 
 	patchPath := fmt.Sprintf("orgs/%s/teams/%s", url.PathEscape(org), url.PathEscape(existing.Slug))
 	resp, err := client.Request(http.MethodPatch, patchPath, bytes.NewReader(patch))
 	if err != nil {
-		return false, fmt.Errorf("PATCH %s (reconcile team description): %w", patchPath, err)
+		return false, fmt.Errorf("PATCH %s (update team description): %w", patchPath, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -437,7 +437,7 @@ func adoptSecretTeamByName(client githubapi.Client, org, name, description, noti
 		patchPath := fmt.Sprintf("orgs/%s/teams/%s", url.PathEscape(org), url.PathEscape(existing.Slug))
 		resp, err := client.Request(http.MethodPatch, patchPath, bytes.NewReader(body))
 		if err != nil {
-			return TeamRef{}, fmt.Errorf("PATCH %s (reconcile team): %w", patchPath, err)
+			return TeamRef{}, fmt.Errorf("PATCH %s (update team): %w", patchPath, err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 		_, _ = io.Copy(io.Discard, resp.Body)
@@ -663,7 +663,7 @@ func GrantTeamRepoRead(client githubapi.Client, org, slug, repoOwner, repo strin
 }
 
 // GrantTeamRepoWrite grants the team `push` on <repoOwner>/<repo> — the access
-// a staff team needs on the config repo to author assignments. Idempotent;
+// a staff team needs on the classroom50 repository to author assignments. Idempotent;
 // returns whether a new grant was applied. Mirrors the web's
 // grantTeamConfigRepoWrite.
 func GrantTeamRepoWrite(client githubapi.Client, org, slug, repoOwner, repo string) (granted bool, err error) {

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -221,7 +221,7 @@ func EnsureClassroomTeam(client githubapi.Client, org, shortName, description st
 // (#335).
 func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, role StaffRole) (TeamRef, error) {
 	if !CanonicalTeamSlugShortName(shortName) {
-		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking staff membership and config-repo grants)", shortName)
+		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking staff membership and classroom50 repository access)", shortName)
 	}
 	// Staff teams carry no bootstrap description: staff read the authoritative
 	// classroom.json directly, and the secret belongs only on the student team.
@@ -274,7 +274,7 @@ func GrantStaffTeamsConfigRepoAccess(client githubapi.Client, org string, refs *
 			continue
 		}
 		if _, err := GrantTeamConfigRepoAccess(client, org, ref.Slug, role); err != nil {
-			return fmt.Errorf("grant %s staff team config-repo access: %w", role, err)
+			return fmt.Errorf("grant %s staff team access to the classroom50 repository: %w", role, err)
 		}
 	}
 	return nil
@@ -650,7 +650,7 @@ func GrantTeamConfigRepoAccess(client githubapi.Client, org, slug string, role S
 		return false, nil
 	}
 	if err := putTeamRepoPermission(client, org, slug, org, ConfigRepoName, want); err != nil {
-		return false, fmt.Errorf("grant %s config-repo %s: %w", role, want, err)
+		return false, fmt.Errorf("grant %s %s access on the classroom50 repository: %w", role, want, err)
 	}
 	return true, nil
 }

--- a/cli/gh-teacher/internal/configwrite/workflowscope.go
+++ b/cli/gh-teacher/internal/configwrite/workflowscope.go
@@ -8,9 +8,9 @@ import (
 )
 
 // ErrMissingWorkflowScope: no `workflow` OAuth scope, so GitHub 404s the
-// Tree write of the skeleton's .github/workflows files. The guidance steers
+// Tree write of the .github/workflows files. The guidance steers
 // the teacher to re-authenticate with the scope granted.
-var ErrMissingWorkflowScope = errors.New("auth token is missing the `workflow` OAuth scope, so init can't commit the skeleton's .github/workflows files; re-run `gh teacher login` (or `gh auth refresh -s admin:org,workflow`), then run init again")
+var ErrMissingWorkflowScope = errors.New("auth token is missing the `workflow` OAuth scope, so init can't commit the .github/workflows files; re-run `gh teacher login` (or `gh auth refresh -s admin:org,workflow`), then run init again")
 
 // tokenLacksWorkflowScope reports whether err's X-OAuth-Scopes header is
 // present but missing `workflow`. An absent header (a fine-grained PAT

--- a/cli/gh-teacher/internal/download/download.go
+++ b/cli/gh-teacher/internal/download/download.go
@@ -2,7 +2,7 @@
 // student submission repo for an assignment under <org>/classroom50
 // (team-driven or --by-pattern), refreshing each repo's
 // result.json/results.json from its submit-tag releases, and writing a
-// scores.csv summary. Read-only consumer of the config repo; only NewCmd is
+// scores.csv summary. Read-only consumer of the classroom50 repository; only NewCmd is
 // exported.
 package download
 
@@ -114,7 +114,7 @@ func NewCmd() *cobra.Command {
 			"cloned.\n\n" +
 			"Pass --by-pattern to skip the team lookup and clone every <org> repo\n" +
 			"whose name starts with <classroom>-<assignment>-. No result.json fetch,\n" +
-			"no scores.csv summary — useful when the config repo isn't bootstrapped\n" +
+			"no scores.csv summary — useful when the classroom50 repository isn't bootstrapped\n" +
 			"yet or when you want every matching repo regardless of the roster.\n\n" +
 			"Clones go through `gh repo clone`, so authentication flows through the\n" +
 			"current gh session. The default destination is\n" +
@@ -380,7 +380,7 @@ func matchesAssignmentPrefix(name, classroom, assignment string) bool {
 
 // downloadByPattern: page through <org>'s repos and clone every one whose
 // name starts with <classroom>-<assignment>-. Skips the team lookup,
-// result.json refresh, and scores.csv summary (all depend on the config repo).
+// result.json refresh, and scores.csv summary (all depend on the classroom50 repository).
 func downloadByPattern(client githubapi.Client, out, errOut io.Writer, org, classroom, assignment, dir string, quiet, verbose bool) error {
 	prefix := contract.AssignmentRepoPrefix(classroom, assignment)
 

--- a/cli/gh-teacher/internal/member/member_list.go
+++ b/cli/gh-teacher/internal/member/member_list.go
@@ -55,8 +55,8 @@ func NewCmd() *cobra.Command {
 			"collaborator on a repo -- the counterpart to `gh teacher\n" +
 			"invite` / `gh teacher remove`.\n\n" +
 			"The roster (roster.csv) is the INTENDED membership; this\n" +
-			"command shows ACTUAL GitHub membership, so the two can be\n" +
-			"reconciled when they drift (a student on the roster who never\n" +
+			"command shows ACTUAL GitHub membership, so you can spot\n" +
+			"mismatches (a student on the roster who never\n" +
 			"accepted their invite, or a collaborator added out of band).\n\n" +
 			"Subcommands:\n" +
 			"  list   list org members + pending invitations, or repo collaborators",

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -183,7 +183,7 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 			// on re-run so a teacher can't accidentally break the student flow.
 			Field:     "members_can_create_pages",
 			Value:     true,
-			Desc:      "Pages creation enabled (required for the public config-repo site)",
+			Desc:      "Pages creation enabled (required for the classroom50 repository's public site)",
 			ManualFix: `check "Allow members to publish Pages sites"`,
 		},
 		{
@@ -192,7 +192,7 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 			// doesn't exist and the field is rejected (the fallback warns).
 			Field:     "members_can_create_public_pages",
 			Value:     true,
-			Desc:      "public Pages creation enabled (required for the public config-repo site)",
+			Desc:      "public Pages creation enabled (required for the classroom50 repository's public site)",
 			ManualFix: `under "Pages creation", select "Public"`,
 		},
 		{

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -178,7 +178,7 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 			enterpriseOnly: true,
 		},
 		{
-			// Enforced TRUE: the config repo publishes a public Pages site
+			// Enforced TRUE: the classroom50 repository publishes a public Pages site
 			// (the unauthenticated assignments.json fetch). init resets this
 			// on re-run so a teacher can't accidentally break the student flow.
 			Field:     "members_can_create_pages",
@@ -316,7 +316,7 @@ func OrgDefaultBranchRecommendation(live map[string]any) string {
 	return branch
 }
 
-// ConfigRepoDefaultBranchRecommendation returns the config repo's current
+// ConfigRepoDefaultBranchRecommendation returns the classroom50 repository's current
 // default branch when it differs from RecommendedOrgDefaultBranch (so callers
 // can advise renaming it), or "" when it already matches / is unset / couldn't
 // be read. Unlike the org-default recommendation this branch IS API-renameable,
@@ -328,7 +328,7 @@ func ConfigRepoDefaultBranchRecommendation(branch string) string {
 	return branch
 }
 
-// ConfigRepoBranchesURL is the config repo's branches settings page where a
+// ConfigRepoBranchesURL is the classroom50 repository's branches settings page where a
 // teacher can rename the default branch to `main`.
 func ConfigRepoBranchesURL(org string) string {
 	return fmt.Sprintf("https://github.com/%s/classroom50/settings/branches", org)

--- a/cli/gh-teacher/internal/roster/list.go
+++ b/cli/gh-teacher/internal/roster/list.go
@@ -88,7 +88,7 @@ func rosterListCmd() *cobra.Command {
 	return cmd
 }
 
-// runRosterList reads the roster at the config repo's default branch
+// runRosterList reads the roster at the classroom50 repository's default branch
 // and renders it as a table (default), a JSON array (--json), or
 // username-only lines (--quiet). Read-only; no commit.
 func runRosterList(client githubapi.Client, out, errOut io.Writer, org, classroom string, asJSON, quiet bool) error {

--- a/cli/gh-teacher/internal/staff/staff.go
+++ b/cli/gh-teacher/internal/staff/staff.go
@@ -69,14 +69,16 @@ func staffAddCmd() *cobra.Command {
 		Use:   "add <org> <classroom> <username>",
 		Short: "Add a user to a classroom's staff team",
 		Long: "Add <username> to the classroom's teacher (default), hta, or\n" +
-			"ta staff team. Teacher and hta members get write on the config\n" +
-			"repo (so they can author assignments); ta members get read-only.\n\n" +
+			"ta staff team. Teacher and hta members get write on the\n" +
+			"classroom50 repository (so they can author assignments); ta\n" +
+			"members get read-only.\n\n" +
 			"If the user isn't yet an org member the membership goes pending\n" +
 			"until they accept the org invitation (same as roster add).\n\n" +
 			"If the classroom predates the staff-teams feature (or its\n" +
 			"`teams` block is partial), this self-heals: it creates/adopts\n" +
-			"the missing team, grants it the role's config-repo access, and\n" +
-			"records the ref in classroom.json before adding the user.\n\n" +
+			"the missing team, grants it the role's access on the\n" +
+			"classroom50 repository, and records the ref in classroom.json\n" +
+			"before adding the user.\n\n" +
 			"Returns non-zero on: classroom not found, or GitHub user not\n" +
 			"found.",
 		Example: "  gh teacher staff add cs50-fall-2026 cs-principles alice\n" +
@@ -200,7 +202,7 @@ func ensureStaffTeamRecorded(client githubapi.Client, out io.Writer, org, classr
 		return configrepo.TeamRef{}, err
 	}
 	if _, err := configrepo.GrantTeamConfigRepoAccess(client, org, team.Slug, role); err != nil {
-		return configrepo.TeamRef{}, fmt.Errorf("grant %s staff team config-repo access: %w", role, err)
+		return configrepo.TeamRef{}, fmt.Errorf("grant %s staff team access to the classroom50 repository: %w", role, err)
 	}
 	// Persist the ref so future resolves and the delete/teardown sweeps find
 	// it. RMW classroom.json in one commit.

--- a/cli/gh-teacher/internal/staff/staff.go
+++ b/cli/gh-teacher/internal/staff/staff.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 		Long: "Add or remove teachers, head TAs, and teaching assistants on a\n" +
 			"classroom's staff teams (classroom50-<classroom>-{teacher,hta,ta}).\n\n" +
 			"Staff roles are GitHub Teams. The teacher and head-TA (hta) teams\n" +
-			"get write on the config repo so members can author assignments; the\n" +
+			"get write on the classroom50 repository so members can author assignments; the\n" +
 			"ta team gets read-only. Head TAs are org members, never org owners.\n" +
 			"This mirrors the web GUI's \"Staff & roles\" section — a classroom\n" +
 			"managed from either surface has the same staff.\n\n" +

--- a/cli/gh-teacher/internal/teardown/teardown.go
+++ b/cli/gh-teacher/internal/teardown/teardown.go
@@ -88,7 +88,7 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 	}
 
 	// Snapshot the classroom team refs (students + staff) BEFORE the repo
-	// deletions remove the config repo that records them, so we can sweep the
+	// deletions remove the classroom50 repository that records them, so we can sweep the
 	// teams afterward. Best-effort: a read failure shouldn't block teardown.
 	teams := collectClassroomTeams(client, org, errOut)
 
@@ -190,7 +190,7 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 func collectClassroomTeams(client githubapi.Client, org string, errOut io.Writer) []configrepo.TeamRef {
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
 	if err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: could not resolve the config repo branch to sweep classroom teams (%v); delete any lingering classroom50-* teams by hand.\n", org, err)
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: could not resolve the classroom50 repository branch to sweep classroom teams (%v); delete any lingering classroom50-* teams by hand.\n", org, err)
 		return nil
 	}
 	entries, _, err := configrepo.ListDirContents(client, org, configrepo.ConfigRepoName, "", branch)

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -99,7 +99,7 @@ const (
 	// contract_test.go pins the Go half.
 	RosterFilename = "roster.csv"
 
-	// ServiceTokenSecretName is the repo-level Actions secret on the config repo
+	// ServiceTokenSecretName is the repo-level Actions secret on the classroom50 repository
 	// holding the fine-grained PAT that collect-scores.yaml / regrade.yaml
 	// consume. Hand-mirrored with NO compile-time link in the collect-scores /
 	// regrade workflow YAML, the gh-teacher servicetoken package (SecretName),

--- a/cli/shared/gittree/gittree.go
+++ b/cli/shared/gittree/gittree.go
@@ -8,7 +8,7 @@
 //
 //   - CommitWithRebase — optimistic update with non-fast-forward retry, for
 //     writes to a repo with *concurrent writers* (the teacher's
-//     <org>/classroom50 config repo).
+//     <org>/classroom50 repository).
 //   - CommitWithFreshRepoRetry — retry the tree+commit build against a
 //     *freshly-created* repo whose ref/git-data APIs briefly 404/409 until they
 //     propagate (the teacher's first skeleton land; the student's accept-time


### PR DESCRIPTION
## Summary

The CLI string sweep from the wiki reorganization plan (§8), matching the wiki (#623) and web app (#624) sweeps. User-facing strings only: help text, flag descriptions, printed output, prompts, error messages, and the two bootstrap commit messages.

- "config repo" → "classroom50 repository" across `gh teacher` and `gh student` help and output (init, audit, classroom, assignment, autograder, staff, download, migrate, teardown, login, accept).
- "skeleton" → "workflow files" in init's help, progress output, refresh prompt copy, flag descriptions, and the `assignment test` hint.
- "preflight" → "setup checks" in init's help, the progress section header, and the failure error.
- "reconcile"/"drift" → plain phrasing ("update", "spot mismatches") in accept, assignment, lock, and `member` help.
- "gradebook" → "the submissions page" / "the collected scores" in the `--pass-threshold` help and `assignment add` warnings.

Not changed: Go identifiers, the `--json` summary field names (machine-readable contract), the embedded `skeleton/` directory name, and the GHC migration source's `deadline` field (it names the legacy system's data).

The wiki's CLI reference already uses the new wording, so this closes the temporary wiki/CLI mismatch noted in #623.

## Test plan

- [x] `go build ./...` and `go test ./...` pass in `cli/gh-teacher`, `cli/gh-student`, `cli/shared` (3 output assertions updated to the new strings)
- [x] `golangci-lint run` and `golangci-lint fmt --diff` clean on all three modules
- [x] Grep confirms no user-facing "config repo", "skeleton", "preflight", "drift", "reconcile", or "gradebook" strings remain