### PR TITLE
feat(web): retain invited emails and recover them on acceptance

### DIFF
--- a/schemas/invite-v1.schema.json
+++ b/schemas/invite-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/foundation50/classroom50/main/schemas/invite-v1.schema.json",
   "title": "classroom50/invite/v1",
-  "description": "Compact record stored in the DESCRIPTION of a per-invite `secret` team (`invite-<hash>`, where <hash> is a 16-hex-char SHA-256 prefix of `<classroom>\\u0000<lowercased-email>`) created when a teacher invites a student to a classroom by email. The team is attached to the org invitation's team_ids alongside the classroom team, so on acceptance the invitee becomes a member of BOTH. On the teacher's next visit a reconcile pass finds the team's single non-owner member (the accepted invitee), pairs their login/id with the `email` recorded here, backfills roster.csv, and deletes the team. This exists only to bridge the ONE moment nothing else can: after acceptance GitHub reports the login but no longer the invited email. Readable only by team members and org owners (the team is secret), so an invitee's email is never exposed to other students. The record is temporary storage, never a source of truth — enrollment and role stay team-driven, and teacher-entered roster.csv values win on conflict. Because the accepted invitee can edit their own team's description, a reader treats it as UNTRUSTED input: schema-validate it, require `email` to match the team-name hash, and treat name/section as best-effort display values. Keep the encoded JSON well under ~250 chars (GitHub's team-description limit): a writer over budget drops the optional display fields first, always preserving `schema`, `email`, and `classroom`. `additionalProperties` is true only to TOLERATE a field a newer binary adds; unknown fields are not preserved on a rewrite. Web-only today (email invites exist only in the web app); no Go/Python mirror yet.",
+  "description": "Compact record stored in the DESCRIPTION of a per-invite `secret` team (`invite-<hash>`, where <hash> is a 16-hex-char SHA-256 prefix of `<classroom>\\u0000<lowercased-email>`) created when a teacher invites a student to a classroom by email. The team is attached to the org invitation's team_ids alongside the classroom team, so on acceptance the invitee becomes a member of BOTH. On the teacher's next visit a reconcile pass finds the team's single regular-role member (the accepted invitee), pairs their login/id with the `email` recorded here, backfills roster.csv, and deletes the team. This exists only to bridge the ONE moment nothing else can: after acceptance GitHub reports the login but no longer the invited email. Deliberately PII-minimal — the email is the only personal datum stored (names/sections belong in roster.csv, supplied by the teacher and joined by email); the encoded JSON stays far under GitHub's ~250-char team-description limit. Readable only by team members and org owners (the team is secret), so an invitee's email is never exposed to other students. The record is temporary storage, never a source of truth — enrollment and role stay team-driven, and teacher-entered roster.csv values win on conflict. Because the accepted invitee can edit their own team's description, a reader treats it as UNTRUSTED input: schema-validate it and require `email` to match the team-name hash before acting on it. `additionalProperties` is true only to TOLERATE a field a newer binary adds; unknown fields are not preserved on a rewrite. Web-only today (email invites exist only in the web app); no Go/Python mirror yet.",
   "type": "object",
   "additionalProperties": true,
   "required": ["schema", "email", "classroom"],
@@ -15,18 +15,6 @@
     "classroom": {
       "type": "string",
       "description": "Short name of the classroom this invite belongs to. Scopes the team-name hash so the same email invited to two classrooms in one org gets two distinct teams (rather than colliding onto one name and overwriting the first's record), and lets a reconcile pass attribute the recovered mapping to the right classroom."
-    },
-    "first_name": {
-      "type": "string",
-      "description": "Optional first name the teacher supplied when inviting, backfilled onto roster.csv as a best-effort display value. Omitted when empty. Untrusted (invitee-editable); never authoritative."
-    },
-    "last_name": {
-      "type": "string",
-      "description": "Optional last name the teacher supplied when inviting, backfilled onto roster.csv as a best-effort display value. Omitted when empty. Untrusted (invitee-editable); never authoritative."
-    },
-    "section": {
-      "type": "string",
-      "description": "Optional section label the teacher supplied when inviting, backfilled onto roster.csv as a best-effort display value. Omitted when empty. Untrusted (invitee-editable); never authoritative."
     }
   }
 }

--- a/schemas/invite-v1.schema.json
+++ b/schemas/invite-v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/foundation50/classroom50/main/schemas/invite-v1.schema.json",
+  "title": "classroom50/invite/v1",
+  "description": "Compact record stored in the DESCRIPTION of a per-invite `secret` team (`invite-<hash>`, where <hash> is a 16-hex-char SHA-256 prefix of `<classroom>\\u0000<lowercased-email>`) created when a teacher invites a student to a classroom by email. The team is attached to the org invitation's team_ids alongside the classroom team, so on acceptance the invitee becomes a member of BOTH. On the teacher's next visit a reconcile pass finds the team's single non-owner member (the accepted invitee), pairs their login/id with the `email` recorded here, backfills roster.csv, and deletes the team. This exists only to bridge the ONE moment nothing else can: after acceptance GitHub reports the login but no longer the invited email. Readable only by team members and org owners (the team is secret), so an invitee's email is never exposed to other students. The record is temporary storage, never a source of truth — enrollment and role stay team-driven, and teacher-entered roster.csv values win on conflict. Because the accepted invitee can edit their own team's description, a reader treats it as UNTRUSTED input: schema-validate it, require `email` to match the team-name hash, and treat name/section as best-effort display values. Keep the encoded JSON well under ~250 chars (GitHub's team-description limit): a writer over budget drops the optional display fields first, always preserving `schema`, `email`, and `classroom`. `additionalProperties` is true only to TOLERATE a field a newer binary adds; unknown fields are not preserved on a rewrite. Web-only today (email invites exist only in the web app); no Go/Python mirror yet.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema", "email", "classroom"],
+  "properties": {
+    "schema": { "const": "classroom50/invite/v1" },
+    "email": {
+      "type": "string",
+      "description": "The email address the teacher sent the invitation to (normalized: trimmed, lowercased). The value the whole record exists to retain — after acceptance it is written onto the accepted student's roster.csv row so a GitHub account maps back to the person. This is the INVITED address, not necessarily the address the account is registered under."
+    },
+    "classroom": {
+      "type": "string",
+      "description": "Short name of the classroom this invite belongs to. Scopes the team-name hash so the same email invited to two classrooms in one org gets two distinct teams (rather than colliding onto one name and overwriting the first's record), and lets a reconcile pass attribute the recovered mapping to the right classroom."
+    },
+    "first_name": {
+      "type": "string",
+      "description": "Optional first name the teacher supplied when inviting, backfilled onto roster.csv as a best-effort display value. Omitted when empty. Untrusted (invitee-editable); never authoritative."
+    },
+    "last_name": {
+      "type": "string",
+      "description": "Optional last name the teacher supplied when inviting, backfilled onto roster.csv as a best-effort display value. Omitted when empty. Untrusted (invitee-editable); never authoritative."
+    },
+    "section": {
+      "type": "string",
+      "description": "Optional section label the teacher supplied when inviting, backfilled onto roster.csv as a best-effort display value. Omitted when empty. Untrusted (invitee-editable); never authoritative."
+    }
+  }
+}

--- a/web/src/domain/reconcileClassroom.test.ts
+++ b/web/src/domain/reconcileClassroom.test.ts
@@ -19,6 +19,12 @@ vi.mock("@/github-core/mutations", () => ({
     reconcileDescription(...a),
   removeUserFromTeam: (...a: unknown[]) => removeUserFromTeam(...a),
 }))
+// The invite-metadata backfill is exercised in inviteBackfill.test.ts; here it's
+// a no-op so these tests assert only the team/description reconcile.
+vi.mock("./students/inviteBackfill", () => ({
+  backfillInviteMetadata: () =>
+    Promise.resolve({ backfilled: [], deletedStale: 0 }),
+}))
 
 import { reconcileClassroom } from "./reconcileClassroom"
 import { ClassroomReconcilePermanentError } from "./reconcileClassroom"
@@ -77,6 +83,7 @@ describe("reconcileClassroom", () => {
       skipped: false,
       description: { changed: false },
       staffCreated: [],
+      invitesBackfilled: [],
     })
     expect(ensureStaffTeams).toHaveBeenCalledWith(client, "org", "cs101")
     expect(ensureClassroomTeam).toHaveBeenCalledWith(client, "org", "cs101")
@@ -142,6 +149,7 @@ describe("reconcileClassroom", () => {
       skipped: true,
       description: { changed: false },
       staffCreated: [],
+      invitesBackfilled: [],
     })
     expect(ensureClassroomTeam).not.toHaveBeenCalled()
     expect(ensureStaffTeams).not.toHaveBeenCalled()

--- a/web/src/domain/reconcileClassroom.test.ts
+++ b/web/src/domain/reconcileClassroom.test.ts
@@ -19,11 +19,17 @@ vi.mock("@/github-core/mutations", () => ({
     reconcileDescription(...a),
   removeUserFromTeam: (...a: unknown[]) => removeUserFromTeam(...a),
 }))
-// The invite-metadata backfill is exercised in inviteBackfill.test.ts; here it's
+// The roster reconciliation is exercised in reconcileRoster.test.ts; here it's
 // a no-op so these tests assert only the team/description reconcile.
-vi.mock("./students/inviteBackfill", () => ({
-  backfillInviteMetadata: () =>
-    Promise.resolve({ backfilled: [], deletedStale: 0 }),
+vi.mock("./students/reconcileRoster", () => ({
+  reconcileRoster: () =>
+    Promise.resolve({
+      addedUsernames: [],
+      recoveredEmails: [],
+      removedEmails: [],
+      noop: true,
+      deletedStaleTeams: 0,
+    }),
 }))
 
 import { reconcileClassroom } from "./reconcileClassroom"
@@ -84,6 +90,7 @@ describe("reconcileClassroom", () => {
       description: { changed: false },
       staffCreated: [],
       invitesBackfilled: [],
+      rosterChanged: false,
     })
     expect(ensureStaffTeams).toHaveBeenCalledWith(client, "org", "cs101")
     expect(ensureClassroomTeam).toHaveBeenCalledWith(client, "org", "cs101")
@@ -150,6 +157,7 @@ describe("reconcileClassroom", () => {
       description: { changed: false },
       staffCreated: [],
       invitesBackfilled: [],
+      rosterChanged: false,
     })
     expect(ensureClassroomTeam).not.toHaveBeenCalled()
     expect(ensureStaffTeams).not.toHaveBeenCalled()

--- a/web/src/domain/reconcileClassroom.ts
+++ b/web/src/domain/reconcileClassroom.ts
@@ -10,7 +10,7 @@ import {
   removeUserFromTeam,
   type TeamDescriptionReconcileResult,
 } from "@/github-core/mutations"
-import { backfillInviteMetadata } from "./students/inviteBackfill"
+import { reconcileRoster } from "./students/reconcileRoster"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("domain:reconcileClassroom")
@@ -25,6 +25,9 @@ export type ClassroomReconcileResult = {
   // Invited emails recovered from per-invite metadata teams and folded into
   // roster.csv this pass (their teams were then deleted). Empty when none.
   invitesBackfilled: string[]
+  // The consolidated roster reconciliation committed a change (recovered
+  // fold, dead-row removal, member append, or role/id refresh).
+  rosterChanged: boolean
 }
 
 // A 404 on the student-team read (a derived/wrong slug that never converges) is
@@ -46,6 +49,7 @@ const NOOP_RESULT: ClassroomReconcileResult = {
   description: { changed: false },
   staffCreated: [],
   invitesBackfilled: [],
+  rosterChanged: false,
 }
 
 // Verify (and self-heal) every classroom-scoped GitHub resource a teacher/owner
@@ -121,29 +125,43 @@ export async function reconcileClassroom(
     throw err
   }
 
-  // Recover any invited-email metadata for students who have accepted since the
-  // last visit, folding it into roster.csv and deleting the per-invite teams.
-  // backfillInviteMetadata never throws (best-effort by contract), so a failure
-  // inside it can't latch the classroom heal off.
-  const invitesBackfilled = (
-    await backfillInviteMetadata(client, { org, classroom })
-  ).backfilled
+  // The consolidated roster reconciliation: recover accepted email invites,
+  // drop dead email-only rows, and sync identity/role rows from the teams — at
+  // most one commit (see reconcileRoster). Best-effort here: unlike the
+  // never-throw collect half, the sync half can throw (a transient write
+  // failure), and that must not latch the classroom heal off.
+  let rosterChanged = false
+  let invitesBackfilled: string[] = []
+  try {
+    const roster = await reconcileRoster(client, { org, classroom })
+    rosterChanged = !roster.noop
+    invitesBackfilled = roster.recoveredEmails
+  } catch (err) {
+    log.warn("classroom reconcile: roster reconciliation failed", {
+      org,
+      classroom,
+      err,
+    })
+  }
 
-  if (
-    description.changed ||
-    staffCreated.length > 0 ||
-    invitesBackfilled.length > 0
-  ) {
+  if (description.changed || staffCreated.length > 0 || rosterChanged) {
     log.info("classroom reconcile: healed drift", {
       org,
       classroom,
       descriptionChanged: description.changed,
       staffCreated,
+      rosterChanged,
       invitesBackfilled: invitesBackfilled.length,
     })
   }
 
-  return { skipped: false, description, staffCreated, invitesBackfilled }
+  return {
+    skipped: false,
+    description,
+    staffCreated,
+    invitesBackfilled,
+    rosterChanged,
+  }
 }
 
 // Drop the acting owner from the given non-teacher team slugs (never teacher).

--- a/web/src/domain/reconcileClassroom.ts
+++ b/web/src/domain/reconcileClassroom.ts
@@ -10,6 +10,7 @@ import {
   removeUserFromTeam,
   type TeamDescriptionReconcileResult,
 } from "@/github-core/mutations"
+import { backfillInviteMetadata } from "./students/inviteBackfill"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("domain:reconcileClassroom")
@@ -21,6 +22,9 @@ export type ClassroomReconcileResult = {
   description: TeamDescriptionReconcileResult
   // Staff roles this run newly created (existing teams adopt as no-ops).
   staffCreated: StaffRole[]
+  // Invited emails recovered from per-invite metadata teams and folded into
+  // roster.csv this pass (their teams were then deleted). Empty when none.
+  invitesBackfilled: string[]
 }
 
 // A 404 on the student-team read (a derived/wrong slug that never converges) is
@@ -41,6 +45,7 @@ const NOOP_RESULT: ClassroomReconcileResult = {
   skipped: true,
   description: { changed: false },
   staffCreated: [],
+  invitesBackfilled: [],
 }
 
 // Verify (and self-heal) every classroom-scoped GitHub resource a teacher/owner
@@ -116,16 +121,37 @@ export async function reconcileClassroom(
     throw err
   }
 
-  if (description.changed || staffCreated.length > 0) {
+  // Recover any invited-email metadata for students who have accepted since the
+  // last visit, folding it into roster.csv and deleting the per-invite teams.
+  // Best-effort: a failure here must never latch the classroom heal off (mirrors
+  // grantStaffTeamsConfigRepoAccess), so it's caught and logged, not rethrown.
+  let invitesBackfilled: string[] = []
+  try {
+    const result = await backfillInviteMetadata(client, { org, classroom })
+    invitesBackfilled = result.backfilled
+  } catch (err) {
+    log.warn("classroom reconcile: invite metadata backfill failed", {
+      org,
+      classroom,
+      err,
+    })
+  }
+
+  if (
+    description.changed ||
+    staffCreated.length > 0 ||
+    invitesBackfilled.length > 0
+  ) {
     log.info("classroom reconcile: healed drift", {
       org,
       classroom,
       descriptionChanged: description.changed,
       staffCreated,
+      invitesBackfilled: invitesBackfilled.length,
     })
   }
 
-  return { skipped: false, description, staffCreated }
+  return { skipped: false, description, staffCreated, invitesBackfilled }
 }
 
 // Drop the acting owner from the given non-teacher team slugs (never teacher).

--- a/web/src/domain/reconcileClassroom.ts
+++ b/web/src/domain/reconcileClassroom.ts
@@ -123,19 +123,11 @@ export async function reconcileClassroom(
 
   // Recover any invited-email metadata for students who have accepted since the
   // last visit, folding it into roster.csv and deleting the per-invite teams.
-  // Best-effort: a failure here must never latch the classroom heal off (mirrors
-  // grantStaffTeamsConfigRepoAccess), so it's caught and logged, not rethrown.
-  let invitesBackfilled: string[] = []
-  try {
-    const result = await backfillInviteMetadata(client, { org, classroom })
-    invitesBackfilled = result.backfilled
-  } catch (err) {
-    log.warn("classroom reconcile: invite metadata backfill failed", {
-      org,
-      classroom,
-      err,
-    })
-  }
+  // backfillInviteMetadata never throws (best-effort by contract), so a failure
+  // inside it can't latch the classroom heal off.
+  const invitesBackfilled = (
+    await backfillInviteMetadata(client, { org, classroom })
+  ).backfilled
 
   if (
     description.changed ||

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -289,6 +289,7 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
       csvWritten: false,
       inviteAttempted: false,
       inviteBody: null as unknown,
+      inviteTeamCreated: false,
     }
 
     const requestRaw = vi.fn().mockImplementation((path: string) => {
@@ -317,6 +318,19 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
           }
           return Promise.reject(apiError422())
         }
+        // The per-invite metadata team create (POST /orgs/{org}/teams). Return
+        // it as a secret team carrying the exact description the caller wrote,
+        // so ensureInviteTeam's fail-closed read-back is a no-op (no PATCH/GET).
+        if (path.endsWith("/teams")) {
+          const body = options?.body as { name?: string; description?: string }
+          state.inviteTeamCreated = true
+          return Promise.resolve({
+            id: 9001,
+            slug: body?.name,
+            privacy: "secret",
+            description: body?.description,
+          })
+        }
         return Promise.reject(new Error(`unexpected request: ${path}`))
       })
 
@@ -337,10 +351,13 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
 
     expect(result.inviteWarning).toBeUndefined()
     expect(state.csvWritten).toBe(false)
-    // The classroom team id is attached so acceptance activates team membership.
+    // Both the classroom team and the per-invite metadata team are attached, so
+    // acceptance activates classroom membership AND lands the invitee on the
+    // metadata team the reconcile later reads to recover the email.
+    expect(state.inviteTeamCreated).toBe(true)
     expect(state.inviteBody).toMatchObject({
       email: "new@x.edu",
-      team_ids: [4242],
+      team_ids: [4242, 9001],
     })
   })
 

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -2187,6 +2187,11 @@ const makeTeamClient = (opts: {
   teacherInvites?: { login?: string; email?: string }[]
   htaInvites?: { login?: string; email?: string }[]
   taInvites?: { login?: string; email?: string }[]
+  // Pending ORG invitations (GET /orgs/{org}/invitations) — the liveness the
+  // dead-row removal confirms against. Emails listed here are still pending.
+  orgInviteEmails?: string[]
+  // When set, the org-invitations read rejects, so removal fails closed.
+  orgInvitesReject?: boolean
   // When set, a members read for the teacher/ta team rejects with this
   // non-404 status (to exercise the best-effort staff-read degradation).
   staffReadRejects?: { role: "teacher" | "ta"; status: number }
@@ -2242,6 +2247,22 @@ const makeTeamClient = (opts: {
               : (opts.teamInvites ?? [])
         return Promise.resolve(
           seed.map((i) => ({ login: i.login ?? null, email: i.email ?? null })),
+        )
+      }
+      // Pending ORG invitations (GET /orgs/{org}/invitations), read by the
+      // dead-row removal's liveness confirmation. Must be matched BEFORE the
+      // team-scoped invitations branch would see it (different path shape) and
+      // returns email-only invitees (login: null), as GitHub does.
+      if (/\/orgs\/[^/]+\/invitations(\?|$)/.test(path)) {
+        if (opts.orgInvitesReject) {
+          return Promise.reject(new Error("org invitations read failed"))
+        }
+        return Promise.resolve(
+          (opts.orgInviteEmails ?? []).map((email, i) => ({
+            id: 900 + i,
+            login: null,
+            email,
+          })),
         )
       }
       // Team members list (syncRosterFromTeam): GET .../teams/{slug}/members
@@ -3015,8 +3036,10 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
         HEADER + ",,,dead@x.edu,,,student\n" + ",,,live@x.edu,,,student\n",
       users: {},
       teamHas: [],
-      // The live invitee's pending invitation preserves their recorded role.
+      // The live invitee's pending invitation preserves their recorded role...
       teamInvites: [{ email: "live@x.edu" }],
+      // ...and the org-level pending list is what removal confirms against.
+      orgInviteEmails: ["live@x.edu"],
     })
 
     const result = await syncRosterFromTeam(client, {
@@ -3029,6 +3052,49 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
     const rows = rowsFromCsv(committed.content!)
     expect(rows).toHaveLength(1)
     expect(rows[0].email).toBe("live@x.edu")
+  })
+
+  it("keeps a row whose invite was sent after the invite snapshot was taken", async () => {
+    // The race: collect enumerated teams BEFORE this CSV read, so a brand-new
+    // invite's row is present but absent from liveInviteEmails. GitHub's current
+    // pending list still shows it, so the row must survive.
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + ",,,fresh@x.edu,,,student\n",
+      users: {},
+      teamHas: [],
+      teamInvites: [{ email: "fresh@x.edu" }],
+      orgInviteEmails: ["fresh@x.edu"],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      // Snapshot predates the invite: nothing live, nothing recovered.
+      invites: inviteState(),
+    })
+
+    expect(result.removedEmails).toEqual([])
+    expect(result.noop).toBe(true)
+    expect(committed.content).toBeNull()
+  })
+
+  it("keeps every email row when the pending-invitation read fails (fail closed)", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + ",,,dead@x.edu,,,student\n",
+      users: {},
+      teamHas: [],
+      teamInvites: [{ email: "dead@x.edu" }],
+      orgInvitesReject: true,
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState(),
+    })
+
+    expect(result.removedEmails).toEqual([])
+    expect(committed.content).toBeNull()
   })
 
   it("never removes an email row when the reconcile state is untrusted", async () => {

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -261,7 +261,7 @@ describe("enrollStudentInClassroom — already-member writes the row directly", 
   })
 })
 
-describe("inviteByEmail — org invite only, no CSV write", () => {
+describe("inviteByEmail — org invite plus a pending email row", () => {
   const apiError422 = () =>
     new GitHubAPIError({
       status: 422,
@@ -444,7 +444,7 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
   })
 })
 
-describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => {
+describe("bulkInviteByEmail — bulk org invites by email, one batch row write", () => {
   const apiError = (status: number, message: string) =>
     new GitHubAPIError({
       status,
@@ -2910,6 +2910,103 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
       (r) => r.username === "bob",
     )
     expect(bob).toMatchObject({ github_id: "7", email: "bob@x.edu" })
+  })
+
+  it("upgrades a row matched by github_id when its email differs from the invited one", async () => {
+    // The teacher had already added an identity row (id only). The recovery
+    // matches by id via recById, not email, and fills the invited address onto
+    // the blank email cell — no duplicate append.
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + ",,,,,42,student\n",
+      users: {},
+      teamHas: [{ login: "alice", id: 42 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState({
+        recovered: [
+          {
+            email: "alice@x.edu",
+            invitee: { id: 42, login: "alice" },
+            slug: "invite-aa",
+          },
+        ],
+      }),
+    })
+
+    expect(result.recoveredEmails).toEqual(["alice@x.edu"])
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      username: "alice",
+      github_id: "42",
+      email: "alice@x.edu",
+    })
+  })
+
+  it("upgrades a row matched by username (case-insensitive) with no email on file", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + "ALICE,,,,,,student\n",
+      users: {},
+      teamHas: [{ login: "alice", id: 42 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState({
+        recovered: [
+          {
+            email: "alice@x.edu",
+            invitee: { id: 42, login: "alice" },
+            slug: "invite-aa",
+          },
+        ],
+      }),
+    })
+
+    expect(result.recoveredEmails).toEqual(["alice@x.edu"])
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      // The teacher's casing is preserved; only blank cells are borrowed.
+      username: "ALICE",
+      github_id: "42",
+      email: "alice@x.edu",
+    })
+  })
+
+  it("claims one recovery at most once when two rows both match it", async () => {
+    // An email-only invite row AND a separate teacher-added identity row for the
+    // same person: the recovery claims the first match only, so the second row is
+    // left untouched rather than being upgraded (or appended) twice.
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + ",,,alice@x.edu,,,student\n" + "alice,,,,,,\n",
+      users: {},
+      teamHas: [{ login: "alice", id: 42 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState({
+        recovered: [
+          {
+            email: "alice@x.edu",
+            invitee: { id: 42, login: "alice" },
+            slug: "invite-aa",
+          },
+        ],
+      }),
+    })
+
+    // Reported once, not twice, and no third row appended.
+    expect(result.recoveredEmails).toEqual(["alice@x.edu"])
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows).toHaveLength(2)
+    expect(rows.filter((r) => r.email === "alice@x.edu")).toHaveLength(1)
   })
 
   it("removes a dead email-only row and keeps one a live invite team backs", async () => {

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -279,14 +279,14 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
     })
 
   // inviteSucceeds=false makes POST /invitations 422 (the already-member
-  // signal). Records whether any git tree write (a CSV commit) happened so we
-  // can assert email invites never touch roster.csv.
+  // signal). Tracks the roster.csv content committed by the pending-row write
+  // (null = no roster write happened).
   const makeEmailClient = (opts: {
     inviteSucceeds: boolean
     noTeamBlock?: boolean
   }) => {
     const state = {
-      csvWritten: false,
+      committed: null as string | null,
       inviteAttempted: false,
       inviteBody: null as unknown,
       inviteTeamCreated: false,
@@ -307,10 +307,34 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
       .mockImplementation((path: string, options?: { body?: unknown }) => {
         if (/\/repos\/[^/]+\/classroom50$/.test(path))
           return { default_branch: "main" }
+        // The pending-row write's conflict-retried read-modify-write chain.
+        if (path.includes("/contents/") && path.includes("roster.csv")) {
+          const csv =
+            state.committed ??
+            "username,first_name,last_name,email,section,github_id,role\n"
+          return Promise.resolve({
+            type: "file",
+            encoding: "base64",
+            content: Buffer.from(csv, "utf-8").toString("base64"),
+          })
+        }
+        if (path.includes("/git/ref/"))
+          return Promise.resolve({ object: { sha: "base-sha" } })
+        if (path.includes("/git/commits/"))
+          return Promise.resolve({ tree: { sha: "base-tree-sha" } })
         if (path.endsWith("/git/trees")) {
-          state.csvWritten = true
+          const tree = (
+            options as {
+              body?: { tree?: { path: string; content?: string }[] }
+            }
+          )?.body?.tree
+          const entry = tree?.find((t) => t.path.includes("roster.csv"))
+          if (entry?.content != null) state.committed = entry.content
           return Promise.resolve({ sha: "tree-sha" })
         }
+        if (path.endsWith("/git/commits"))
+          return Promise.resolve({ sha: "new-commit-sha" })
+        if (path.endsWith("/git/refs/heads/main")) return Promise.resolve({})
         if (path.endsWith("/invitations")) {
           state.inviteAttempted = true
           if (opts.inviteSucceeds) {
@@ -349,7 +373,7 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
     }
   }
 
-  it("sends the org invite (with team) and writes NO roster.csv row", async () => {
+  it("sends the org invite (with team) and retains the email as a pending row", async () => {
     const { client, state } = makeEmailClient({ inviteSucceeds: true })
 
     const result = await inviteByEmail(client, {
@@ -359,7 +383,6 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
     })
 
     expect(result.inviteWarning).toBeUndefined()
-    expect(state.csvWritten).toBe(false)
     // Both the classroom team and the per-invite metadata team are attached, so
     // acceptance activates classroom membership AND lands the invitee on the
     // metadata team the reconcile later reads to recover the email.
@@ -367,6 +390,16 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
     expect(state.inviteBody).toMatchObject({
       email: "new@x.edu",
       team_ids: [4242, 9001],
+    })
+    // The invited email is retained on the roster right away, as an
+    // email-only pending row (identity arrives via the acceptance reconcile).
+    const rows = rowsFromCsv(state.committed!)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      username: "",
+      github_id: "",
+      email: "new@x.edu",
+      role: "student",
     })
   })
 
@@ -389,7 +422,7 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
 
     // Nothing was sent and nothing was written.
     expect(state.inviteAttempted).toBe(false)
-    expect(state.csvWritten).toBe(false)
+    expect(state.committed).toBeNull()
   })
 
   it("422 already-member -> warns to add by username, writes no row", async () => {
@@ -403,9 +436,9 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
 
     expect(result.inviteWarning).toMatch(/already belongs to a member/i)
     expect(result.inviteWarning).toMatch(/by github username/i)
-    expect(state.csvWritten).toBe(false)
-    // The doomed invite's freshly created metadata team was cleaned up rather
-    // than left as a member-less orphan holding the email.
+    // A doomed invite retains nothing: no roster row, and its freshly created
+    // metadata team is cleaned up rather than left as a member-less orphan.
+    expect(state.committed).toBeNull()
     expect(state.inviteTeamCreated).toBe(true)
     expect(state.inviteTeamDeleted).toBe(true)
   })
@@ -466,7 +499,10 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     const failEmails = new Set(opts?.failEmails ?? [])
     let inviteAttempts = 0
     const state = {
-      csvWritten: false,
+      // roster.csv content committed by the batch pending-row write (null =
+      // no roster write happened).
+      committed: null as string | null,
+      rosterCommits: 0,
       inviteBodies: [] as {
         email: string
         role: string
@@ -492,10 +528,37 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
         (path: string, options?: { body?: unknown; method?: string }) => {
           if (/\/repos\/[^/]+\/classroom50$/.test(path))
             return { default_branch: "main" }
+          // The batch pending-row write's read-modify-write chain.
+          if (path.includes("/contents/") && path.includes("roster.csv")) {
+            const csv =
+              state.committed ??
+              "username,first_name,last_name,email,section,github_id,role\n"
+            return Promise.resolve({
+              type: "file",
+              encoding: "base64",
+              content: Buffer.from(csv, "utf-8").toString("base64"),
+            })
+          }
+          if (path.includes("/git/ref/"))
+            return Promise.resolve({ object: { sha: "base-sha" } })
+          if (path.includes("/git/commits/"))
+            return Promise.resolve({ tree: { sha: "base-tree-sha" } })
           if (path.endsWith("/git/trees")) {
-            state.csvWritten = true
+            const tree = (
+              options as {
+                body?: { tree?: { path: string; content?: string }[] }
+              }
+            )?.body?.tree
+            const entry = tree?.find((t) => t.path.includes("roster.csv"))
+            if (entry?.content != null) {
+              state.committed = entry.content
+              state.rosterCommits += 1
+            }
             return Promise.resolve({ sha: "tree-sha" })
           }
+          if (path.endsWith("/git/commits"))
+            return Promise.resolve({ sha: "new-commit-sha" })
+          if (path.endsWith("/git/refs/heads/main")) return Promise.resolve({})
           // Staff-team ensure (teacher/ta role -> resolveTeamIdByRole) AND the
           // per-invite metadata team create. An invite- name echoes back the
           // exact description (secret) so ensureInviteTeam's fail-closed
@@ -577,7 +640,6 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     ])
     expect(result.skipped).toEqual([])
     expect(result.failed).toEqual([])
-    expect(state.csvWritten).toBe(false)
     // Every invite carried the classroom team AND its per-invite metadata team
     // as a plain member (default role).
     expect(state.inviteTeamNames).toHaveLength(2)
@@ -585,9 +647,21 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
       expect(body.team_ids).toEqual([4242, 9001])
       expect(body.role).toBe("direct_member")
     }
+    // Both invited emails were retained on the roster in ONE batch commit, as
+    // email-only pending rows.
+    expect(state.rosterCommits).toBe(1)
+    const rows = rowsFromCsv(state.committed!)
+    expect(rows.map((r) => r.email).sort()).toEqual(["a@x.edu", "b@x.edu"])
+    for (const row of rows) {
+      expect(row).toMatchObject({
+        username: "",
+        github_id: "",
+        role: "student",
+      })
+    }
   })
 
-  it("still invites (classroom team only) when the metadata team create fails", async () => {
+  it("still invites (classroom team only, no roster row) when the metadata team create fails", async () => {
     const { client, state } = makeClient({ failInviteTeams: true })
 
     const result = await bulkInviteByEmail(client, {
@@ -600,6 +674,9 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     expect(result.invited.map((i) => i.email)).toEqual(["a@x.edu"])
     expect(result.failed).toEqual([])
     expect(state.inviteBodies[0].team_ids).toEqual([4242])
+    // No metadata team -> no roster row: the reconcile would just remove an
+    // email-only row nothing backs.
+    expect(state.committed).toBeNull()
   })
 
   it("invites a teacher as an org OWNER (admin role) with no metadata team", async () => {
@@ -616,8 +693,10 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
       role: "admin",
     })
     // An accepting owner is auto-promoted to team maintainer, so the backfill's
-    // role=member read would never see them — no metadata team is created.
+    // role=member read would never see them — no metadata team is created, and
+    // therefore no roster row either.
     expect(state.inviteTeamNames).toEqual([])
+    expect(state.committed).toBeNull()
   })
 
   it("routes a 422 already-member into skipped and deletes its fresh metadata team", async () => {
@@ -636,6 +715,9 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     // successful invite's team survives.
     expect(state.teamDeletes).toHaveLength(1)
     expect(state.inviteTeamNames).toContain(state.teamDeletes[0])
+    // Only the successfully sent invite's email is retained on the roster.
+    const rows = rowsFromCsv(state.committed!)
+    expect(rows.map((r) => r.email)).toEqual(["fresh@x.edu"])
   })
 
   it("reports progress and returns early for an empty invite list", async () => {
@@ -669,7 +751,7 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     ).rejects.toThrow(/couldn't resolve the classroom team/i)
 
     expect(state.inviteBodies).toEqual([])
-    expect(state.csvWritten).toBe(false)
+    expect(state.committed).toBeNull()
   })
 
   it("routes a non-422, non-rate-limit error into failed (not skipped)", async () => {
@@ -849,6 +931,14 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
       role: "admin",
       team_ids: [5000],
     })
+    // Only the metadata-team-carrying invites get pending roster rows, with
+    // the invited role recorded, in one batch commit.
+    expect(state.rosterCommits).toBe(1)
+    const rows = rowsFromCsv(state.committed!)
+    const roleByEmail = new Map(rows.map((r) => [r.email, r.role]))
+    expect(roleByEmail.get("stu@x.edu")).toBe("student")
+    expect(roleByEmail.get("ta@x.edu")).toBe("ta")
+    expect(roleByEmail.has("prof@x.edu")).toBe(false)
   })
 })
 
@@ -2737,6 +2827,150 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
     // octocat/torvalds are matched by id, so nothing is backfilled and the
     // short rows parsed without error.
     expect(result.addedUsernames).toEqual([])
+  })
+
+  // --- the consolidated invite fold/removal (reconcileRoster's sync half) ---
+
+  const inviteState = (
+    over: Partial<{
+      recovered: {
+        email: string
+        invitee: { id: number; login: string }
+        slug: string
+      }[]
+      liveInviteEmails: Set<string>
+      trusted: boolean
+    }> = {},
+  ) => ({
+    recovered: [],
+    liveInviteEmails: new Set<string>(),
+    trusted: true,
+    deletedStale: 0,
+    ...over,
+  })
+
+  it("upgrades the invite-time email row with the recovered identity (no duplicate)", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + ",,,alice@x.edu,,,student\n",
+      users: {},
+      teamHas: [{ login: "alice", id: 42 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState({
+        recovered: [
+          {
+            email: "alice@x.edu",
+            invitee: { id: 42, login: "alice" },
+            slug: "invite-aa",
+          },
+        ],
+      }),
+    })
+
+    expect(result.recoveredEmails).toEqual(["alice@x.edu"])
+    const rows = rowsFromCsv(committed.content!)
+    // The email row was upgraded in place — NOT duplicated by the member
+    // append (the upgraded row claims the id/login before "missing" runs).
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      username: "alice",
+      github_id: "42",
+      email: "alice@x.edu",
+      role: "student",
+    })
+  })
+
+  it("appends the recovered member WITH their invited email when no row matches", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER,
+      users: {},
+      teamHas: [{ login: "bob", id: 7 }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState({
+        recovered: [
+          {
+            email: "bob@x.edu",
+            invitee: { id: 7, login: "bob" },
+            slug: "invite-bb",
+          },
+        ],
+      }),
+    })
+
+    expect(result.addedUsernames).toEqual(["bob"])
+    expect(result.recoveredEmails).toEqual(["bob@x.edu"])
+    const bob = rowsFromCsv(committed.content!).find(
+      (r) => r.username === "bob",
+    )
+    expect(bob).toMatchObject({ github_id: "7", email: "bob@x.edu" })
+  })
+
+  it("removes a dead email-only row and keeps one a live invite team backs", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv:
+        HEADER + ",,,dead@x.edu,,,student\n" + ",,,live@x.edu,,,student\n",
+      users: {},
+      teamHas: [],
+      // The live invitee's pending invitation preserves their recorded role.
+      teamInvites: [{ email: "live@x.edu" }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState({ liveInviteEmails: new Set(["live@x.edu"]) }),
+    })
+
+    expect(result.removedEmails).toEqual(["dead@x.edu"])
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].email).toBe("live@x.edu")
+  })
+
+  it("never removes an email row when the reconcile state is untrusted", async () => {
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + ",,,dead@x.edu,,,student\n",
+      users: {},
+      teamHas: [],
+      teamInvites: [{ email: "dead@x.edu" }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState({ trusted: false }),
+    })
+
+    expect(result.removedEmails).toEqual([])
+    expect(result.noop).toBe(true)
+    expect(committed.content).toBeNull()
+  })
+
+  it("never removes an identity row, even with no live invite team", async () => {
+    const { client, committed } = makeTeamClient({
+      // A username row and an id-only row: both are identity rows, not
+      // email-only, so the removal pass must not touch them.
+      startingCsv: HEADER + "carol,,,c@x.edu,,,\n" + ",,,d@x.edu,,55,\n",
+      users: {},
+      teamHas: [],
+      teamInvites: [{ login: "carol" }, { email: "d@x.edu" }],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: inviteState(),
+    })
+
+    expect(result.removedEmails).toEqual([])
+    expect(committed.content).toBeNull()
   })
 })
 

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -290,6 +290,7 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
       inviteAttempted: false,
       inviteBody: null as unknown,
       inviteTeamCreated: false,
+      inviteTeamDeleted: false,
     }
 
     const requestRaw = vi.fn().mockImplementation((path: string) => {
@@ -330,6 +331,14 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
             privacy: "secret",
             description: body?.description,
           })
+        }
+        // The doomed-invite cleanup deletes the fresh metadata team.
+        if (
+          path.includes("/teams/invite-") &&
+          (options as { method?: string } | undefined)?.method === "DELETE"
+        ) {
+          state.inviteTeamDeleted = true
+          return Promise.resolve({})
         }
         return Promise.reject(new Error(`unexpected request: ${path}`))
       })
@@ -395,6 +404,10 @@ describe("inviteByEmail — org invite only, no CSV write", () => {
     expect(result.inviteWarning).toMatch(/already belongs to a member/i)
     expect(result.inviteWarning).toMatch(/by github username/i)
     expect(state.csvWritten).toBe(false)
+    // The doomed invite's freshly created metadata team was cleaned up rather
+    // than left as a member-less orphan holding the email.
+    expect(state.inviteTeamCreated).toBe(true)
+    expect(state.inviteTeamDeleted).toBe(true)
   })
 })
 
@@ -444,6 +457,9 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     // 429 (with Retry-After) the first N POST /invitations attempts, then let
     // later attempts through — exercises the Retry-After-backed retry pass.
     rateLimitFirstN?: number
+    // 500 every per-invite metadata team create — exercises the graceful
+    // degradation (invite still sent with the classroom team alone).
+    failInviteTeams?: boolean
   }) => {
     const memberEmails = new Set(opts?.memberEmails ?? [])
     const rateLimitEmails = new Set(opts?.rateLimitEmails ?? [])
@@ -456,6 +472,9 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
         role: string
         team_ids?: number[]
       }[],
+      // Names of per-invite metadata teams created / slugs deleted.
+      inviteTeamNames: [] as string[],
+      teamDeletes: [] as string[],
     }
 
     const requestRaw = vi.fn().mockImplementation((path: string) => {
@@ -477,15 +496,36 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
             state.csvWritten = true
             return Promise.resolve({ sha: "tree-sha" })
           }
-          // Staff-team ensure (teacher/ta role -> resolveTeamIdByRole): create
-          // returns a fresh team; the config-repo write grant is a no-op PUT.
+          // Staff-team ensure (teacher/ta role -> resolveTeamIdByRole) AND the
+          // per-invite metadata team create. An invite- name echoes back the
+          // exact description (secret) so ensureInviteTeam's fail-closed
+          // read-back is a no-op; a staff name returns a fresh team.
           if (path.endsWith("/teams") && options?.method === "POST") {
-            const body = (options as { body?: { name?: string } }).body
+            const body = (
+              options as { body?: { name?: string; description?: string } }
+            ).body
+            if (body?.name?.startsWith("invite-")) {
+              if (opts?.failInviteTeams) {
+                return Promise.reject(apiError(500, "team create failed"))
+              }
+              state.inviteTeamNames.push(body.name)
+              return Promise.resolve({
+                id: 9001,
+                slug: body.name,
+                privacy: "secret",
+                description: body.description,
+              })
+            }
             return Promise.resolve({
               id: 5000,
               slug: body?.name ?? "team",
               privacy: "secret",
             })
+          }
+          // The doomed-invite cleanup deletes the fresh metadata team.
+          if (path.includes("/teams/invite-") && options?.method === "DELETE") {
+            state.teamDeletes.push(path.split("/teams/")[1])
+            return Promise.resolve({})
           }
           if (path.includes("/teams/") && path.includes("/repos/")) {
             return Promise.resolve({})
@@ -538,14 +578,31 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     expect(result.skipped).toEqual([])
     expect(result.failed).toEqual([])
     expect(state.csvWritten).toBe(false)
-    // Every invite carried the classroom team as a plain member (default role).
+    // Every invite carried the classroom team AND its per-invite metadata team
+    // as a plain member (default role).
+    expect(state.inviteTeamNames).toHaveLength(2)
     for (const body of state.inviteBodies) {
-      expect(body.team_ids).toEqual([4242])
+      expect(body.team_ids).toEqual([4242, 9001])
       expect(body.role).toBe("direct_member")
     }
   })
 
-  it("invites a teacher as an org OWNER (admin role)", async () => {
+  it("still invites (classroom team only) when the metadata team create fails", async () => {
+    const { client, state } = makeClient({ failInviteTeams: true })
+
+    const result = await bulkInviteByEmail(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: [{ email: "a@x.edu" }],
+    })
+
+    // Graceful degradation: only email retention is lost, never the invite.
+    expect(result.invited.map((i) => i.email)).toEqual(["a@x.edu"])
+    expect(result.failed).toEqual([])
+    expect(state.inviteBodies[0].team_ids).toEqual([4242])
+  })
+
+  it("invites a teacher as an org OWNER (admin role) with no metadata team", async () => {
     const { client, state } = makeClient()
 
     await bulkInviteByEmail(client, {
@@ -558,10 +615,13 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
       email: "prof@x.edu",
       role: "admin",
     })
+    // An accepting owner is auto-promoted to team maintainer, so the backfill's
+    // role=member read would never see them — no metadata team is created.
+    expect(state.inviteTeamNames).toEqual([])
   })
 
-  it("routes a 422 already-member into skipped, not failed", async () => {
-    const { client } = makeClient({ memberEmails: ["member@x.edu"] })
+  it("routes a 422 already-member into skipped and deletes its fresh metadata team", async () => {
+    const { client, state } = makeClient({ memberEmails: ["member@x.edu"] })
 
     const result = await bulkInviteByEmail(client, {
       org: "acme",
@@ -572,6 +632,10 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     expect(result.skipped).toEqual([{ email: "member@x.edu" }])
     expect(result.invited.map((i) => i.email)).toEqual(["fresh@x.edu"])
     expect(result.failed).toEqual([])
+    // The doomed invite's freshly created metadata team was cleaned up; the
+    // successful invite's team survives.
+    expect(state.teamDeletes).toHaveLength(1)
+    expect(state.inviteTeamNames).toContain(state.teamDeletes[0])
   })
 
   it("reports progress and returns early for an empty invite list", async () => {
@@ -611,7 +675,7 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
   it("routes a non-422, non-rate-limit error into failed (not skipped)", async () => {
     // A 500 (or any non-422/non-throttle error) must land in `failed` with its
     // message surfaced, while the rest of the batch still invites.
-    const { client } = makeClient({ failEmails: ["broken@x.edu"] })
+    const { client, state } = makeClient({ failEmails: ["broken@x.edu"] })
 
     const result = await bulkInviteByEmail(client, {
       org: "acme",
@@ -625,6 +689,8 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     expect(result.invited.map((i) => i.email)).toEqual(["ok@x.edu"])
     expect(result.skipped).toEqual([])
     expect(result.deferred).toEqual([])
+    // The failed invite's fresh metadata team was deleted, not orphaned.
+    expect(state.teamDeletes).toHaveLength(1)
   })
 
   it("defers the rest once a mid-batch rate limit hits, sending no new invites", async () => {
@@ -767,17 +833,18 @@ describe("bulkInviteByEmail — bulk org invites by email, no CSV write", () => 
     })
 
     const byEmail = new Map(state.inviteBodies.map((b) => [b.email, b]))
-    // Student rides the classroom team (id 4242) as a plain member.
+    // Student rides the classroom team (id 4242) plus their metadata team.
     expect(byEmail.get("stu@x.edu")).toMatchObject({
       role: "direct_member",
-      team_ids: [4242],
+      team_ids: [4242, 9001],
     })
-    // TA rides the ensured staff team (id 5000) as a plain member.
+    // TA rides the ensured staff team (id 5000) plus their metadata team.
     expect(byEmail.get("ta@x.edu")).toMatchObject({
       role: "direct_member",
-      team_ids: [5000],
+      team_ids: [5000, 9001],
     })
-    // Teacher becomes an org OWNER on the ensured staff team.
+    // Teacher becomes an org OWNER on the ensured staff team; no metadata team
+    // (an owner would be a maintainer the backfill can never see).
     expect(byEmail.get("prof@x.edu")).toMatchObject({
       role: "admin",
       team_ids: [5000],

--- a/web/src/domain/students.ts
+++ b/web/src/domain/students.ts
@@ -40,6 +40,10 @@ export {
   type SyncRosterFromTeamResult,
 } from "./students/rosterSync"
 export {
+  backfillInviteMetadata,
+  type BackfillInviteMetadataResult,
+} from "./students/inviteBackfill"
+export {
   writeClassroomRoles,
   updateClassroomMetadata,
   applyClassroomRoleChange,

--- a/web/src/domain/students.ts
+++ b/web/src/domain/students.ts
@@ -41,7 +41,9 @@ export {
 } from "./students/rosterSync"
 export {
   backfillInviteMetadata,
+  purgeInviteTeams,
   type BackfillInviteMetadataResult,
+  type PurgeInviteTeamsResult,
 } from "./students/inviteBackfill"
 export {
   writeClassroomRoles,

--- a/web/src/domain/students.ts
+++ b/web/src/domain/students.ts
@@ -40,11 +40,11 @@ export {
   type SyncRosterFromTeamResult,
 } from "./students/rosterSync"
 export {
-  backfillInviteMetadata,
+  reconcileRoster,
   purgeInviteTeams,
-  type BackfillInviteMetadataResult,
+  type ReconcileRosterResult,
   type PurgeInviteTeamsResult,
-} from "./students/inviteBackfill"
+} from "./students/reconcileRoster"
 export {
   writeClassroomRoles,
   updateClassroomMetadata,

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -3,10 +3,12 @@ import {
   createGitCommit,
   createGitTree,
   createOrgInvitation,
+  deleteInviteTeam,
   ensureInviteTeam,
   ensureOrgMembership,
   isActiveMember,
   updateRef,
+  type InviteTeamRef,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import {
@@ -39,6 +41,7 @@ import {
   tryAddUserToTeam,
   StudentAlreadyEnrolledError,
 } from "./rosterPrimitives"
+import i18n from "@/i18n"
 
 export type AddStudentToClassroomResult = CreateClassroomResult & {
   student: StudentCsvRow
@@ -203,9 +206,10 @@ export async function inviteByEmail(
   // failure here must NOT block the invite (the invitee stays collectable via
   // the classroom team) — only email retention is lost, surfaced as a warning.
   const teamIds = [teamId]
+  let inviteTeam: InviteTeamRef | null = null
   let metadataWarning = ""
   try {
-    const inviteTeam = await ensureInviteTeam(client, org, {
+    inviteTeam = await ensureInviteTeam(client, org, {
       email: normalizedEmail,
       classroom,
       first_name: input.first_name,
@@ -215,10 +219,24 @@ export async function inviteByEmail(
     teamIds.push(inviteTeam.id)
   } catch (err) {
     log.error("invite metadata team create failed", { err })
-    metadataWarning =
-      `${normalizedEmail} was invited, but saving their email for later ` +
-      `matching failed (${getErrorMessage(err)}); their email won't be ` +
-      `retained automatically. You can add it after they accept.`
+    metadataWarning = i18n.t("students.inviteMetadataFailed", {
+      email: normalizedEmail,
+      message: getErrorMessage(err),
+    })
+  }
+
+  // A doomed invite must not leave a fresh, member-less metadata team behind
+  // (an orphan holding an email GC can't yet reap). Only a team THIS call
+  // created is deleted — an adopted one may hold a prior accepted invite's
+  // still-unrecovered record.
+  const cleanupInviteTeam = async () => {
+    if (!inviteTeam?.created) return
+    try {
+      await deleteInviteTeam(client, org, inviteTeam.slug)
+    } catch (err) {
+      // Best-effort: a leftover team is only an orphan awaiting GC.
+      log.error("invite metadata team cleanup failed", { err })
+    }
   }
 
   try {
@@ -232,6 +250,7 @@ export async function inviteByEmail(
     // There's no reliable identity to persist, so just tell the teacher to add
     // them by username (which resolves the immutable github_id).
     if (err instanceof GitHubAPIError && err.status === 422) {
+      await cleanupInviteTeam()
       return {
         inviteWarning:
           `${normalizedEmail} already belongs to a member of the ${org} ` +
@@ -240,6 +259,7 @@ export async function inviteByEmail(
       }
     }
     log.error("org email invite failed", { err })
+    await cleanupInviteTeam()
     return {
       inviteWarning:
         `Sending the organization invite to ${normalizedEmail} failed ` +

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -157,16 +157,20 @@ export type InviteByEmailResult = {
 // Send a GitHub org invite for an email, attaching the classroom team so the
 // student lands in it on acceptance, PLUS a per-invite secret metadata team
 // (invite-<hash(classroom,email)>) whose description retains the invited email
-// (PII-minimal: email only). Writes NOTHING to roster.csv: the team is the source
-// of truth for enrollment, and an email carries no reliable GitHub identity
-// until accepted. On acceptance the invitee lands on both teams; a later
-// reconcile pass recovers the email <-> account mapping from the metadata team
-// and backfills roster.csv. The invite shows up in the roster's `pending`
-// section via the org pending-invitations list. If the classroom team can't be
-// resolved, the invite is BLOCKED (throws) rather than sent team-less. If the
-// metadata team can't be created, the invite still goes out with the classroom
-// team alone (the invitee stays collectable; only email retention is lost) and
-// a non-fatal warning is returned.
+// (PII-minimal: email only). On success it also retains the address on the
+// roster as an email-only PENDING row (no username/github_id yet) — that row
+// lives exactly as long as its invite team does: the reconcile fills in the
+// account identity on acceptance and removes the row once the invite is
+// cancelled, expired, or GC'd. A row is written only when the metadata team was
+// attached, since the reconcile would otherwise reap an unbacked row.
+// On acceptance the invitee lands on both teams; a later reconcile pass recovers
+// the email <-> account mapping from the metadata team and folds it into
+// roster.csv. The invite also shows up in the roster's `pending` section via the
+// org pending-invitations list. If the classroom team can't be resolved, the
+// invite is BLOCKED (throws) rather than sent team-less. If the metadata team
+// can't be created, the invite still goes out with the classroom team alone (the
+// invitee stays collectable; only email retention is lost) and a non-fatal
+// warning is returned.
 export async function inviteByEmail(
   client: GitHubClient,
   input: AddEmailInviteToClassroomInput,
@@ -181,8 +185,9 @@ export async function inviteByEmail(
 
   // Resolve the classroom team id up front: in a team-authoritative model, an
   // invite that can't carry the team is broken — the accepted student would land
-  // in the org with no team and (since we write no CSV row) no roster row,
-  // silently uncollected. So block the invite unless we can attach the team.
+  // in the org with no team and, since the pending row carries no identity
+  // until acceptance, no collectable roster row either. So block the invite
+  // unless we can attach the team.
   // resolveClassroomTeamWithRetry returns id: undefined only for a genuine
   // missing team block (no throw); a TRANSIENT read failure is retried and then
   // propagates as its own error, so a brief GitHub blip surfaces "try again"

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -34,6 +34,7 @@ import {
 import { rosterPath } from "@/util/rosterPath"
 import { resolveGitHubId } from "@/util/students"
 import {
+  appendEmailInviteRows,
   log,
   rosterWriteTree,
   resolveClassroomTeam,
@@ -256,6 +257,17 @@ export async function inviteByEmail(
         `Sending the organization invite to ${normalizedEmail} failed ` +
         `(${getErrorMessage(err)}); try again.`,
     }
+  }
+
+  // Retain the invited email on the roster right away — but only when the
+  // metadata team is attached: the reconcile keeps an email-only row exactly
+  // as long as a live invite team backs it, so a team-less row would just be
+  // removed on the next pass. Best-effort (never throws); on a miss the
+  // accepted invite's reconcile fold appends the row instead.
+  if (inviteTeam) {
+    await appendEmailInviteRows(client, { org, classroom }, [
+      { email: normalizedEmail, role: "student" },
+    ])
   }
 
   return metadataWarning ? { inviteWarning: metadataWarning } : {}

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -145,12 +145,6 @@ type AddEmailInviteToClassroomInput = {
   org: string
   classroom: string
   email: string
-  // Optional display metadata the teacher typed in the Add-member dialog. Stored
-  // in the invite team's description and backfilled onto roster.csv on
-  // acceptance; best-effort, never authoritative.
-  first_name?: string
-  last_name?: string
-  section?: string
 }
 
 export type InviteByEmailResult = {
@@ -162,7 +156,7 @@ export type InviteByEmailResult = {
 // Send a GitHub org invite for an email, attaching the classroom team so the
 // student lands in it on acceptance, PLUS a per-invite secret metadata team
 // (invite-<hash(classroom,email)>) whose description retains the invited email
-// (and any name/section). Writes NOTHING to roster.csv: the team is the source
+// (PII-minimal: email only). Writes NOTHING to roster.csv: the team is the source
 // of truth for enrollment, and an email carries no reliable GitHub identity
 // until accepted. On acceptance the invitee lands on both teams; a later
 // reconcile pass recovers the email <-> account mapping from the metadata team
@@ -212,9 +206,6 @@ export async function inviteByEmail(
     inviteTeam = await ensureInviteTeam(client, org, {
       email: normalizedEmail,
       classroom,
-      first_name: input.first_name,
-      last_name: input.last_name,
-      section: input.section,
     })
     teamIds.push(inviteTeam.id)
   } catch (err) {

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -3,6 +3,7 @@ import {
   createGitCommit,
   createGitTree,
   createOrgInvitation,
+  ensureInviteTeam,
   ensureOrgMembership,
   isActiveMember,
   updateRef,
@@ -141,6 +142,12 @@ type AddEmailInviteToClassroomInput = {
   org: string
   classroom: string
   email: string
+  // Optional display metadata the teacher typed in the Add-member dialog. Stored
+  // in the invite team's description and backfilled onto roster.csv on
+  // acceptance; best-effort, never authoritative.
+  first_name?: string
+  last_name?: string
+  section?: string
 }
 
 export type InviteByEmailResult = {
@@ -150,13 +157,18 @@ export type InviteByEmailResult = {
 }
 
 // Send a GitHub org invite for an email, attaching the classroom team so the
-// student lands in it on acceptance. Writes NOTHING to roster.csv: the team
-// is the source of truth for enrollment, and an email carries no reliable
-// GitHub identity (it changes to a login only once accepted). The invite shows
-// up in the roster's `pending` section via the org pending-invitations list; to
-// capture name/section metadata, add the student by GitHub username or upload a
-// roster CSV once they've joined. If the classroom team can't be resolved, the
-// invite is BLOCKED (throws) rather than sent team-less — see below.
+// student lands in it on acceptance, PLUS a per-invite secret metadata team
+// (invite-<hash(classroom,email)>) whose description retains the invited email
+// (and any name/section). Writes NOTHING to roster.csv: the team is the source
+// of truth for enrollment, and an email carries no reliable GitHub identity
+// until accepted. On acceptance the invitee lands on both teams; a later
+// reconcile pass recovers the email <-> account mapping from the metadata team
+// and backfills roster.csv. The invite shows up in the roster's `pending`
+// section via the org pending-invitations list. If the classroom team can't be
+// resolved, the invite is BLOCKED (throws) rather than sent team-less. If the
+// metadata team can't be created, the invite still goes out with the classroom
+// team alone (the invitee stays collectable; only email retention is lost) and
+// a non-fatal warning is returned.
 export async function inviteByEmail(
   client: GitHubClient,
   input: AddEmailInviteToClassroomInput,
@@ -187,11 +199,33 @@ export async function inviteByEmail(
     )
   }
 
+  // Best-effort: create the per-invite metadata team and attach it too. A
+  // failure here must NOT block the invite (the invitee stays collectable via
+  // the classroom team) — only email retention is lost, surfaced as a warning.
+  const teamIds = [teamId]
+  let metadataWarning = ""
+  try {
+    const inviteTeam = await ensureInviteTeam(client, org, {
+      email: normalizedEmail,
+      classroom,
+      first_name: input.first_name,
+      last_name: input.last_name,
+      section: input.section,
+    })
+    teamIds.push(inviteTeam.id)
+  } catch (err) {
+    log.error("invite metadata team create failed", { err })
+    metadataWarning =
+      `${normalizedEmail} was invited, but saving their email for later ` +
+      `matching failed (${getErrorMessage(err)}); their email won't be ` +
+      `retained automatically. You can add it after they accept.`
+  }
+
   try {
     await createOrgInvitation(client, {
       org,
       email: normalizedEmail,
-      team_ids: [teamId],
+      team_ids: teamIds,
     })
   } catch (err) {
     // A 422 means the email already belongs to a member or is already invited.
@@ -213,7 +247,7 @@ export async function inviteByEmail(
     }
   }
 
-  return {}
+  return metadataWarning ? { inviteWarning: metadataWarning } : {}
 }
 
 export type AddStudentToClassroomInput = {

--- a/web/src/domain/students/inviteBackfill.test.ts
+++ b/web/src/domain/students/inviteBackfill.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it, vi, beforeEach } from "vitest"
 const listInviteTeams = vi.fn()
 const readInviteTeam = vi.fn()
 const deleteInviteTeam = vi.fn()
-const listOrgAdmins = vi.fn()
+const listTeamMembers = vi.fn()
+const assertClassroomNotArchived = vi.fn()
 const withRosterRewrite = vi.fn()
 
 vi.mock("@/github-core/mutations", () => ({
@@ -13,7 +14,11 @@ vi.mock("@/github-core/mutations", () => ({
   deleteInviteTeam: (...a: unknown[]) => deleteInviteTeam(...a),
 }))
 vi.mock("@/github-core/queries", () => ({
-  listOrgAdmins: (...a: unknown[]) => listOrgAdmins(...a),
+  listTeamMembers: (...a: unknown[]) => listTeamMembers(...a),
+}))
+vi.mock("../classrooms", () => ({
+  assertClassroomNotArchived: (...a: unknown[]) =>
+    assertClassroomNotArchived(...a),
 }))
 vi.mock("./rosterPrimitives", () => ({
   withRosterRewrite: (...a: unknown[]) => withRosterRewrite(...a),
@@ -22,12 +27,31 @@ vi.mock("./rosterPrimitives", () => ({
 
 import { backfillInviteMetadata } from "./inviteBackfill"
 import { inviteTeamName } from "@/util/inviteTeam"
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 
 const client = {} as never
-const OWNER = { id: 1, login: "prof" }
+
+const emptyRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const rateLimitError = () =>
+  new GitHubAPIError({
+    status: 429,
+    url: "https://api.github.com/x",
+    message: "rate limited",
+    body: null,
+    rateLimit: emptyRateLimit,
+  })
 
 // Build a valid invite-team state for (classroom, email) with the given
-// non-owner members, so the description's email hashes back to the slug.
+// regular-role members (readInviteTeam already excludes maintainers, i.e. the
+// auto-added owner), so the description's email hashes back to the slug.
 async function inviteState(
   classroom: string,
   email: string,
@@ -43,14 +67,19 @@ async function inviteState(
       classroom,
       ...extra,
     },
-    members: [OWNER, ...members],
+    members,
   }
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  listOrgAdmins.mockResolvedValue([OWNER])
+  assertClassroomNotArchived.mockResolvedValue(undefined)
   deleteInviteTeam.mockResolvedValue(undefined)
+  // Default: every accepted invitee used below is still on a classroom team.
+  listTeamMembers.mockResolvedValue([
+    { id: 2, login: "member2" },
+    { id: 3, login: "member3" },
+  ])
   // Default rewrite: run the mutate fn against an empty roster and report change.
   withRosterRewrite.mockImplementation(
     async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
@@ -68,9 +97,10 @@ describe("backfillInviteMetadata", () => {
     expect(result.backfilled).toEqual([])
     expect(withRosterRewrite).not.toHaveBeenCalled()
     expect(deleteInviteTeam).not.toHaveBeenCalled()
+    expect(listTeamMembers).not.toHaveBeenCalled()
   })
 
-  it("backfills the one non-owner member (excluding the owner) and deletes the team", async () => {
+  it("backfills the one accepted member and deletes the team", async () => {
     const state = await inviteState("cs101", "alice@example.com", [
       { id: 2, login: "alice" },
     ])
@@ -94,7 +124,7 @@ describe("backfillInviteMetadata", () => {
     })
   })
 
-  it("skips a still-pending team (owner-only membership) without deleting", async () => {
+  it("skips a still-pending team (no regular members) without deleting", async () => {
     const state = await inviteState("cs101", "bob@example.com", [])
     listInviteTeams.mockResolvedValue([{ slug: state.slug }])
     readInviteTeam.mockResolvedValue(state)
@@ -107,7 +137,7 @@ describe("backfillInviteMetadata", () => {
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("skips a team with >1 non-owner member (anomaly)", async () => {
+  it("skips a team with >1 regular member (anomaly)", async () => {
     const state = await inviteState("cs101", "carol@example.com", [
       { id: 2, login: "carol" },
       { id: 3, login: "intruder" },
@@ -153,6 +183,58 @@ describe("backfillInviteMetadata", () => {
     })
     expect(result.backfilled).toEqual([])
     expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("deletes without a roster write when the invitee is off every classroom team (unenrolled)", async () => {
+    const state = await inviteState("cs101", "gone@example.com", [
+      { id: 99, login: "gone" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+    listTeamMembers.mockResolvedValue([]) // on no classroom team
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(result.deletedStale).toBe(1)
+    expect(withRosterRewrite).not.toHaveBeenCalled()
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
+  })
+
+  it("skips a team (no delete) when the enrollment read fails", async () => {
+    const state = await inviteState("cs101", "held@example.com", [
+      { id: 2, login: "held" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+    listTeamMembers.mockRejectedValue(new Error("boom"))
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(result.deletedStale).toBe(0)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("does nothing on an archived classroom", async () => {
+    assertClassroomNotArchived.mockRejectedValue(new Error("archived"))
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(listInviteTeams).not.toHaveBeenCalled()
+  })
+
+  it("never throws: a failing team list yields an empty result", async () => {
+    listInviteTeams.mockRejectedValue(new Error("boom"))
+    await expect(
+      backfillInviteMetadata(client, { org: "org", classroom: "cs101" }),
+    ).resolves.toEqual({ backfilled: [], deletedStale: 0 })
   })
 
   it("teacher-entered roster values win over the recovered record", async () => {
@@ -209,5 +291,37 @@ describe("backfillInviteMetadata", () => {
       classroom: "cs101",
     })
     expect(result.backfilled).toEqual(["grace@example.com"])
+  })
+
+  it("a rate limit stops the pass instead of hammering the remaining teams", async () => {
+    listInviteTeams.mockResolvedValue([
+      { slug: "invite-aaaaaaaaaaaaaaaa" },
+      { slug: "invite-bbbbbbbbbbbbbbbb" },
+    ])
+    readInviteTeam.mockRejectedValue(rateLimitError())
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(readInviteTeam).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports a completed backfill even when the team delete fails", async () => {
+    const state = await inviteState("cs101", "kept@example.com", [
+      { id: 2, login: "kept" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+    deleteInviteTeam.mockRejectedValue(new Error("boom"))
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    // The roster write completed, so the caller must still invalidate; the
+    // leftover team is retried (idempotently) on the next pass.
+    expect(result.backfilled).toEqual(["kept@example.com"])
   })
 })

--- a/web/src/domain/students/inviteBackfill.test.ts
+++ b/web/src/domain/students/inviteBackfill.test.ts
@@ -27,7 +27,7 @@ vi.mock("./rosterPrimitives", () => ({
   log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }))
 
-import { backfillInviteMetadata } from "./inviteBackfill"
+import { backfillInviteMetadata, purgeInviteTeams } from "./inviteBackfill"
 import { inviteTeamName } from "@/util/inviteTeam"
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 
@@ -59,24 +59,17 @@ async function inviteState(
   classroom: string,
   email: string,
   members: { id: number; login: string }[],
-  extra: {
-    first_name?: string
-    last_name?: string
-    section?: string
-    createdAt?: string
-  } = {},
+  extra: { createdAt?: string } = {},
 ) {
   const slug = await inviteTeamName(classroom, email)
-  const { createdAt, ...fields } = extra
   return {
     slug,
     description: {
       schema: "classroom50/invite/v1",
       email,
       classroom,
-      ...fields,
     },
-    createdAt: createdAt ?? new Date().toISOString(),
+    createdAt: extra.createdAt ?? new Date().toISOString(),
     members,
   }
 }
@@ -318,15 +311,13 @@ describe("backfillInviteMetadata", () => {
   })
 
   it("teacher-entered roster values win over the recovered record", async () => {
-    const state = await inviteState(
-      "cs101",
-      "frank@example.com",
-      [{ id: 2, login: "frank" }],
-      { first_name: "RecordFirst", section: "RecordSec" },
-    )
+    const state = await inviteState("cs101", "frank@example.com", [
+      { id: 2, login: "frank" },
+    ])
     listInviteTeams.mockResolvedValue([{ slug: state.slug }])
     readInviteTeam.mockResolvedValue(state)
-    // Existing row already has a teacher-set first_name and section.
+    // Existing row already has a teacher-set email (and display metadata the
+    // record never carries — it's PII-minimal, email only).
     withRosterRewrite.mockImplementation(
       async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
         mutate([
@@ -335,8 +326,45 @@ describe("backfillInviteMetadata", () => {
             github_id: "2",
             first_name: "TeacherFirst",
             last_name: "",
-            email: "",
+            email: "teacher-set@example.com",
             section: "TeacherSec",
+            role: "",
+          },
+        ]),
+    )
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    const rewriteResult = await withRosterRewrite.mock.results[0].value
+    const row = rewriteResult.nextStudents[0]
+    // Teacher values kept everywhere; nothing to borrow -> no CSV change, but
+    // the team is still cleaned up.
+    expect(row.first_name).toBe("TeacherFirst")
+    expect(row.section).toBe("TeacherSec")
+    expect(row.email).toBe("teacher-set@example.com")
+    expect(rewriteResult.changed).toBe(0)
+    expect(result.backfilled).toEqual(["frank@example.com"])
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
+  })
+
+  it("borrows the recovered email onto a matching row with a blank email", async () => {
+    const state = await inviteState("cs101", "hana@example.com", [
+      { id: 2, login: "hana" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+    withRosterRewrite.mockImplementation(
+      async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
+        mutate([
+          {
+            username: "hana",
+            github_id: "",
+            first_name: "",
+            last_name: "",
+            email: "",
+            section: "",
             role: "",
           },
         ]),
@@ -345,10 +373,9 @@ describe("backfillInviteMetadata", () => {
     await backfillInviteMetadata(client, { org: "org", classroom: "cs101" })
     const rewriteResult = await withRosterRewrite.mock.results[0].value
     const row = rewriteResult.nextStudents[0]
-    // Teacher values kept; only the blank email borrowed from the record.
-    expect(row.first_name).toBe("TeacherFirst")
-    expect(row.section).toBe("TeacherSec")
-    expect(row.email).toBe("frank@example.com")
+    expect(row.email).toBe("hana@example.com")
+    expect(row.github_id).toBe("2")
+    expect(rewriteResult.changed).toBe(1)
   })
 
   it("one bad team never blocks the rest", async () => {
@@ -403,5 +430,73 @@ describe("backfillInviteMetadata", () => {
     // The roster write completed, so the caller must still invalidate; the
     // leftover team is retried (idempotently) on the next pass.
     expect(result.backfilled).toEqual(["kept@example.com"])
+  })
+})
+
+describe("purgeInviteTeams", () => {
+  it("recovers what it can, then purges the rest of this classroom's teams", async () => {
+    const recoverable = await inviteState("cs101", "alice@example.com", [
+      { id: 2, login: "alice" },
+    ])
+    // Tampered record: the claim says cs101, but the email no longer hashes to
+    // the slug — the backfill skips it, so only the purge can remove it.
+    const tampered = await inviteState("cs101", "bob@example.com", [])
+    tampered.description.email = "tampered@example.com"
+    // Another classroom's team must never be touched.
+    const other = await inviteState("cs202", "eve@example.com", [])
+
+    listInviteTeams.mockResolvedValue([
+      { slug: recoverable.slug },
+      { slug: tampered.slug },
+      { slug: other.slug },
+    ])
+    const deleted = new Set<string>()
+    deleteInviteTeam.mockImplementation(
+      async (_c: unknown, _o: unknown, slug: string) => {
+        deleted.add(slug)
+      },
+    )
+    readInviteTeam.mockImplementation(
+      async (_c: unknown, _o: unknown, slug: string) => {
+        if (deleted.has(slug)) return null
+        if (slug === recoverable.slug) return recoverable
+        if (slug === tampered.slug) return tampered
+        return other
+      },
+    )
+
+    const result = await purgeInviteTeams(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.recovered).toEqual(["alice@example.com"])
+    expect(result.purged).toBe(1)
+    expect(deleted.has(tampered.slug)).toBe(true)
+    expect(deleted.has(other.slug)).toBe(false)
+  })
+
+  it("throws on a purge-phase failure (an explicit action surfaces errors)", async () => {
+    listInviteTeams
+      .mockResolvedValueOnce([]) // the backfill run sees nothing
+      .mockRejectedValueOnce(new Error("boom")) // the purge listing fails
+    await expect(
+      purgeInviteTeams(client, { org: "org", classroom: "cs101" }),
+    ).rejects.toThrow("boom")
+  })
+
+  it("still purges when the classroom is archived (backfill no-ops, deletes proceed)", async () => {
+    assertClassroomNotArchived.mockRejectedValue(new Error("archived"))
+    const leftover = await inviteState("cs101", "left@example.com", [])
+    listInviteTeams.mockResolvedValue([{ slug: leftover.slug }])
+    readInviteTeam.mockResolvedValue(leftover)
+
+    const result = await purgeInviteTeams(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.recovered).toEqual([])
+    expect(result.purged).toBe(1)
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", leftover.slug)
+    expect(withRosterRewrite).not.toHaveBeenCalled()
   })
 })

--- a/web/src/domain/students/inviteBackfill.test.ts
+++ b/web/src/domain/students/inviteBackfill.test.ts
@@ -5,6 +5,7 @@ const listInviteTeams = vi.fn()
 const readInviteTeam = vi.fn()
 const deleteInviteTeam = vi.fn()
 const listTeamMembers = vi.fn()
+const listOrgInvitations = vi.fn()
 const assertClassroomNotArchived = vi.fn()
 const withRosterRewrite = vi.fn()
 
@@ -15,6 +16,7 @@ vi.mock("@/github-core/mutations", () => ({
 }))
 vi.mock("@/github-core/queries", () => ({
   listTeamMembers: (...a: unknown[]) => listTeamMembers(...a),
+  listOrgInvitations: (...a: unknown[]) => listOrgInvitations(...a),
 }))
 vi.mock("../classrooms", () => ({
   assertClassroomNotArchived: (...a: unknown[]) =>
@@ -52,29 +54,41 @@ const rateLimitError = () =>
 // Build a valid invite-team state for (classroom, email) with the given
 // regular-role members (readInviteTeam already excludes maintainers, i.e. the
 // auto-added owner), so the description's email hashes back to the slug.
+// createdAt defaults to "just now" (never a GC candidate).
 async function inviteState(
   classroom: string,
   email: string,
   members: { id: number; login: string }[],
-  extra: { first_name?: string; last_name?: string; section?: string } = {},
+  extra: {
+    first_name?: string
+    last_name?: string
+    section?: string
+    createdAt?: string
+  } = {},
 ) {
   const slug = await inviteTeamName(classroom, email)
+  const { createdAt, ...fields } = extra
   return {
     slug,
     description: {
       schema: "classroom50/invite/v1",
       email,
       classroom,
-      ...extra,
+      ...fields,
     },
+    createdAt: createdAt ?? new Date().toISOString(),
     members,
   }
 }
+
+// Older than the 24h GC age guard.
+const OLD_ENOUGH = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
 
 beforeEach(() => {
   vi.clearAllMocks()
   assertClassroomNotArchived.mockResolvedValue(undefined)
   deleteInviteTeam.mockResolvedValue(undefined)
+  listOrgInvitations.mockResolvedValue([])
   // Default: every accepted invitee used below is still on a classroom team.
   listTeamMembers.mockResolvedValue([
     { id: 2, login: "member2" },
@@ -124,7 +138,7 @@ describe("backfillInviteMetadata", () => {
     })
   })
 
-  it("skips a still-pending team (no regular members) without deleting", async () => {
+  it("keeps a still-pending team (no regular members, younger than the GC age)", async () => {
     const state = await inviteState("cs101", "bob@example.com", [])
     listInviteTeams.mockResolvedValue([{ slug: state.slug }])
     readInviteTeam.mockResolvedValue(state)
@@ -134,6 +148,72 @@ describe("backfillInviteMetadata", () => {
       classroom: "cs101",
     })
     expect(result.backfilled).toEqual([])
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+    // Too young to be a GC candidate — the invitations list isn't even read.
+    expect(listOrgInvitations).not.toHaveBeenCalled()
+  })
+
+  it("GCs an aged member-less team whose org invitation is gone (cancelled/expired)", async () => {
+    const state = await inviteState("cs101", "gone@example.com", [], {
+      createdAt: OLD_ENOUGH,
+    })
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.deletedStale).toBe(1)
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
+    expect(withRosterRewrite).not.toHaveBeenCalled()
+  })
+
+  it("keeps an aged member-less team whose org invitation is still pending", async () => {
+    const state = await inviteState("cs101", "waiting@example.com", [], {
+      createdAt: OLD_ENOUGH,
+    })
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+    listOrgInvitations.mockResolvedValue([
+      { id: 1, login: null, email: "waiting@example.com" },
+    ])
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.deletedStale).toBe(0)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("keeps an aged member-less team when the invitations read fails (fail-safe)", async () => {
+    const state = await inviteState("cs101", "held@example.com", [], {
+      createdAt: OLD_ENOUGH,
+    })
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+    listOrgInvitations.mockRejectedValue(new Error("boom"))
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.deletedStale).toBe(0)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("keeps an aged member-less team with no created_at (never reap on uncertainty)", async () => {
+    const state = await inviteState("cs101", "unknown@example.com", [])
+    state.createdAt = null as unknown as string
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.deletedStale).toBe(0)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 

--- a/web/src/domain/students/inviteBackfill.test.ts
+++ b/web/src/domain/students/inviteBackfill.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment node
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const listInviteTeams = vi.fn()
+const readInviteTeam = vi.fn()
+const deleteInviteTeam = vi.fn()
+const listOrgAdmins = vi.fn()
+const withRosterRewrite = vi.fn()
+
+vi.mock("@/github-core/mutations", () => ({
+  listInviteTeams: (...a: unknown[]) => listInviteTeams(...a),
+  readInviteTeam: (...a: unknown[]) => readInviteTeam(...a),
+  deleteInviteTeam: (...a: unknown[]) => deleteInviteTeam(...a),
+}))
+vi.mock("@/github-core/queries", () => ({
+  listOrgAdmins: (...a: unknown[]) => listOrgAdmins(...a),
+}))
+vi.mock("./rosterPrimitives", () => ({
+  withRosterRewrite: (...a: unknown[]) => withRosterRewrite(...a),
+  log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+import { backfillInviteMetadata } from "./inviteBackfill"
+import { inviteTeamName } from "@/util/inviteTeam"
+
+const client = {} as never
+const OWNER = { id: 1, login: "prof" }
+
+// Build a valid invite-team state for (classroom, email) with the given
+// non-owner members, so the description's email hashes back to the slug.
+async function inviteState(
+  classroom: string,
+  email: string,
+  members: { id: number; login: string }[],
+  extra: { first_name?: string; last_name?: string; section?: string } = {},
+) {
+  const slug = await inviteTeamName(classroom, email)
+  return {
+    slug,
+    description: {
+      schema: "classroom50/invite/v1",
+      email,
+      classroom,
+      ...extra,
+    },
+    members: [OWNER, ...members],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  listOrgAdmins.mockResolvedValue([OWNER])
+  deleteInviteTeam.mockResolvedValue(undefined)
+  // Default rewrite: run the mutate fn against an empty roster and report change.
+  withRosterRewrite.mockImplementation(
+    async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
+      mutate([]),
+  )
+})
+
+describe("backfillInviteMetadata", () => {
+  it("no invite teams -> no-op", async () => {
+    listInviteTeams.mockResolvedValue([])
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(withRosterRewrite).not.toHaveBeenCalled()
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("backfills the one non-owner member (excluding the owner) and deletes the team", async () => {
+    const state = await inviteState("cs101", "alice@example.com", [
+      { id: 2, login: "alice" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+
+    expect(result.backfilled).toEqual(["alice@example.com"])
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
+    // The rewrite appended an identity row carrying the recovered email.
+    const rewriteResult = await withRosterRewrite.mock.results[0].value
+    expect(rewriteResult.changed).toBe(1)
+    expect(rewriteResult.nextStudents[0]).toMatchObject({
+      username: "alice",
+      github_id: "2",
+      email: "alice@example.com",
+    })
+  })
+
+  it("skips a still-pending team (owner-only membership) without deleting", async () => {
+    const state = await inviteState("cs101", "bob@example.com", [])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("skips a team with >1 non-owner member (anomaly)", async () => {
+    const state = await inviteState("cs101", "carol@example.com", [
+      { id: 2, login: "carol" },
+      { id: 3, login: "intruder" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("ignores a team whose description email doesn't hash to its name (tampered)", async () => {
+    const state = await inviteState("cs101", "dan@example.com", [
+      { id: 2, login: "dan" },
+    ])
+    // Tamper: keep the slug, change the recorded email to a different address.
+    state.description.email = "attacker@example.com"
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("ignores a team belonging to another classroom", async () => {
+    const state = await inviteState("cs102", "eve@example.com", [
+      { id: 2, login: "eve" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual([])
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("teacher-entered roster values win over the recovered record", async () => {
+    const state = await inviteState(
+      "cs101",
+      "frank@example.com",
+      [{ id: 2, login: "frank" }],
+      { first_name: "RecordFirst", section: "RecordSec" },
+    )
+    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
+    readInviteTeam.mockResolvedValue(state)
+    // Existing row already has a teacher-set first_name and section.
+    withRosterRewrite.mockImplementation(
+      async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
+        mutate([
+          {
+            username: "frank",
+            github_id: "2",
+            first_name: "TeacherFirst",
+            last_name: "",
+            email: "",
+            section: "TeacherSec",
+            role: "",
+          },
+        ]),
+    )
+
+    await backfillInviteMetadata(client, { org: "org", classroom: "cs101" })
+    const rewriteResult = await withRosterRewrite.mock.results[0].value
+    const row = rewriteResult.nextStudents[0]
+    // Teacher values kept; only the blank email borrowed from the record.
+    expect(row.first_name).toBe("TeacherFirst")
+    expect(row.section).toBe("TeacherSec")
+    expect(row.email).toBe("frank@example.com")
+  })
+
+  it("one bad team never blocks the rest", async () => {
+    const good = await inviteState("cs101", "grace@example.com", [
+      { id: 3, login: "grace" },
+    ])
+    listInviteTeams.mockResolvedValue([
+      { slug: "invite-bad" },
+      { slug: good.slug },
+    ])
+    readInviteTeam.mockImplementation(
+      async (_c: unknown, _o: unknown, slug: string) => {
+        if (slug === "invite-bad") throw new Error("boom")
+        return good
+      },
+    )
+
+    const result = await backfillInviteMetadata(client, {
+      org: "org",
+      classroom: "cs101",
+    })
+    expect(result.backfilled).toEqual(["grace@example.com"])
+  })
+})

--- a/web/src/domain/students/inviteBackfill.test.ts
+++ b/web/src/domain/students/inviteBackfill.test.ts
@@ -6,8 +6,6 @@ const readInviteTeam = vi.fn()
 const deleteInviteTeam = vi.fn()
 const listTeamMembers = vi.fn()
 const listOrgInvitations = vi.fn()
-const assertClassroomNotArchived = vi.fn()
-const withRosterRewrite = vi.fn()
 
 vi.mock("@/github-core/mutations", () => ({
   listInviteTeams: (...a: unknown[]) => listInviteTeams(...a),
@@ -18,20 +16,19 @@ vi.mock("@/github-core/queries", () => ({
   listTeamMembers: (...a: unknown[]) => listTeamMembers(...a),
   listOrgInvitations: (...a: unknown[]) => listOrgInvitations(...a),
 }))
-vi.mock("../classrooms", () => ({
-  assertClassroomNotArchived: (...a: unknown[]) =>
-    assertClassroomNotArchived(...a),
-}))
 vi.mock("./rosterPrimitives", () => ({
-  withRosterRewrite: (...a: unknown[]) => withRosterRewrite(...a),
   log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }))
 
-import { backfillInviteMetadata, purgeInviteTeams } from "./inviteBackfill"
+import {
+  collectInviteRecoveries,
+  finalizeInviteRecoveries,
+} from "./inviteBackfill"
 import { inviteTeamName } from "@/util/inviteTeam"
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 
 const client = {} as never
+const INPUT = { org: "org", classroom: "cs101" }
 
 const emptyRateLimit: GitHubRateLimit = {
   limit: null,
@@ -79,7 +76,6 @@ const OLD_ENOUGH = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
 
 beforeEach(() => {
   vi.clearAllMocks()
-  assertClassroomNotArchived.mockResolvedValue(undefined)
   deleteInviteTeam.mockResolvedValue(undefined)
   listOrgInvitations.mockResolvedValue([])
   // Default: every accepted invitee used below is still on a classroom team.
@@ -87,298 +83,183 @@ beforeEach(() => {
     { id: 2, login: "member2" },
     { id: 3, login: "member3" },
   ])
-  // Default rewrite: run the mutate fn against an empty roster and report change.
-  withRosterRewrite.mockImplementation(
-    async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
-      mutate([]),
-  )
 })
 
-describe("backfillInviteMetadata", () => {
-  it("no invite teams -> no-op", async () => {
+describe("collectInviteRecoveries", () => {
+  it("no invite teams -> empty, trusted state", async () => {
     listInviteTeams.mockResolvedValue([])
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
-    expect(withRosterRewrite).not.toHaveBeenCalled()
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([])
+    expect(state.trusted).toBe(true)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
-    expect(listTeamMembers).not.toHaveBeenCalled()
   })
 
-  it("backfills the one accepted member and deletes the team", async () => {
-    const state = await inviteState("cs101", "alice@example.com", [
+  it("classifies an accepted, enrolled member as recovered WITHOUT deleting the team", async () => {
+    const team = await inviteState("cs101", "alice@example.com", [
       { id: 2, login: "alice" },
     ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-
-    expect(result.backfilled).toEqual(["alice@example.com"])
-    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
-    // The rewrite appended an identity row carrying the recovered email.
-    const rewriteResult = await withRosterRewrite.mock.results[0].value
-    expect(rewriteResult.changed).toBe(1)
-    expect(rewriteResult.nextStudents[0]).toMatchObject({
-      username: "alice",
-      github_id: "2",
-      email: "alice@example.com",
-    })
-  })
-
-  it("keeps a still-pending team (no regular members, younger than the GC age)", async () => {
-    const state = await inviteState("cs101", "bob@example.com", [])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
-
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([
+      {
+        email: "alice@example.com",
+        invitee: { id: 2, login: "alice" },
+        slug: team.slug,
+      },
+    ])
+    expect(state.trusted).toBe(true)
+    // Push-before-delete: the caller deletes AFTER the roster commit lands.
     expect(deleteInviteTeam).not.toHaveBeenCalled()
-    // Too young to be a GC candidate — the invitations list isn't even read.
+  })
+
+  it("counts a young pending team's email as live without reading invitations", async () => {
+    const team = await inviteState("cs101", "bob@example.com", [])
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.liveInviteEmails.has("bob@example.com")).toBe(true)
+    expect(state.trusted).toBe(true)
     expect(listOrgInvitations).not.toHaveBeenCalled()
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("GCs an aged member-less team whose org invitation is gone (cancelled/expired)", async () => {
-    const state = await inviteState("cs101", "gone@example.com", [], {
+  it("GCs an aged member-less team whose org invitation is gone (not live)", async () => {
+    const team = await inviteState("cs101", "gone@example.com", [], {
       createdAt: OLD_ENOUGH,
     })
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.deletedStale).toBe(1)
-    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
-    expect(withRosterRewrite).not.toHaveBeenCalled()
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.deletedStale).toBe(1)
+    expect(state.liveInviteEmails.has("gone@example.com")).toBe(false)
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", team.slug)
   })
 
-  it("keeps an aged member-less team whose org invitation is still pending", async () => {
-    const state = await inviteState("cs101", "waiting@example.com", [], {
+  it("keeps an aged member-less team whose org invitation is still pending (live)", async () => {
+    const team = await inviteState("cs101", "waiting@example.com", [], {
       createdAt: OLD_ENOUGH,
     })
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
     listOrgInvitations.mockResolvedValue([
       { id: 1, login: null, email: "waiting@example.com" },
     ])
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.deletedStale).toBe(0)
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.deletedStale).toBe(0)
+    expect(state.liveInviteEmails.has("waiting@example.com")).toBe(true)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("keeps an aged member-less team when the invitations read fails (fail-safe)", async () => {
-    const state = await inviteState("cs101", "held@example.com", [], {
+  it("flips trusted off when the invitations read fails (fail-safe)", async () => {
+    const team = await inviteState("cs101", "held@example.com", [], {
       createdAt: OLD_ENOUGH,
     })
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
     listOrgInvitations.mockRejectedValue(new Error("boom"))
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.deletedStale).toBe(0)
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.trusted).toBe(false)
+    expect(state.deletedStale).toBe(0)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("keeps an aged member-less team with no created_at (never reap on uncertainty)", async () => {
-    const state = await inviteState("cs101", "unknown@example.com", [])
-    state.createdAt = null as unknown as string
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+  it("keeps an aged member-less team with no created_at as live (never reap on uncertainty)", async () => {
+    const team = await inviteState("cs101", "unknown@example.com", [])
+    team.createdAt = null as unknown as string
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.deletedStale).toBe(0)
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.deletedStale).toBe(0)
+    expect(state.liveInviteEmails.has("unknown@example.com")).toBe(true)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("skips a team with >1 regular member (anomaly)", async () => {
-    const state = await inviteState("cs101", "carol@example.com", [
+  it("treats a >1-member anomaly as live and never guesses", async () => {
+    const team = await inviteState("cs101", "carol@example.com", [
       { id: 2, login: "carol" },
       { id: 3, login: "intruder" },
     ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([])
+    expect(state.liveInviteEmails.has("carol@example.com")).toBe(true)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("ignores a team whose description email doesn't hash to its name (tampered)", async () => {
-    const state = await inviteState("cs101", "dan@example.com", [
+  it("treats a tampered description (hash mismatch) as live, never recovered", async () => {
+    const team = await inviteState("cs101", "dan@example.com", [
       { id: 2, login: "dan" },
     ])
     // Tamper: keep the slug, change the recorded email to a different address.
-    state.description.email = "attacker@example.com"
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    team.description.email = "attacker@example.com"
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([])
+    expect(state.liveInviteEmails.has("attacker@example.com")).toBe(true)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
   it("ignores a team belonging to another classroom", async () => {
-    const state = await inviteState("cs102", "eve@example.com", [
+    const team = await inviteState("cs102", "eve@example.com", [
       { id: 2, login: "eve" },
     ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([])
+    expect(state.liveInviteEmails.size).toBe(0)
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("deletes without a roster write when the invitee is off every classroom team (unenrolled)", async () => {
-    const state = await inviteState("cs101", "gone@example.com", [
-      { id: 99, login: "gone" },
+  it("deletes the team of an accepted invitee who is off every classroom team (unenrolled)", async () => {
+    const team = await inviteState("cs101", "left@example.com", [
+      { id: 99, login: "left" },
     ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
     listTeamMembers.mockResolvedValue([]) // on no classroom team
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
-    expect(result.deletedStale).toBe(1)
-    expect(withRosterRewrite).not.toHaveBeenCalled()
-    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([])
+    expect(state.deletedStale).toBe(1)
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", team.slug)
   })
 
-  it("skips a team (no delete) when the enrollment read fails", async () => {
-    const state = await inviteState("cs101", "held@example.com", [
-      { id: 2, login: "held" },
+  it("flips trusted off when the enrollment read fails, keeping the team", async () => {
+    const team = await inviteState("cs101", "held2@example.com", [
+      { id: 2, login: "held2" },
     ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
     listTeamMembers.mockRejectedValue(new Error("boom"))
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
-    expect(result.deletedStale).toBe(0)
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.trusted).toBe(false)
+    expect(state.recovered).toEqual([])
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
-  it("does nothing on an archived classroom", async () => {
-    assertClassroomNotArchived.mockRejectedValue(new Error("archived"))
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
-    expect(listInviteTeams).not.toHaveBeenCalled()
-  })
-
-  it("never throws: a failing team list yields an empty result", async () => {
+  it("never throws: a failing team listing yields an untrusted empty state", async () => {
     listInviteTeams.mockRejectedValue(new Error("boom"))
-    await expect(
-      backfillInviteMetadata(client, { org: "org", classroom: "cs101" }),
-    ).resolves.toEqual({ backfilled: [], deletedStale: 0 })
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.trusted).toBe(false)
+    expect(state.recovered).toEqual([])
+    expect(state.deletedStale).toBe(0)
   })
 
-  it("teacher-entered roster values win over the recovered record", async () => {
-    const state = await inviteState("cs101", "frank@example.com", [
-      { id: 2, login: "frank" },
-    ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
-    // Existing row already has a teacher-set email (and display metadata the
-    // record never carries — it's PII-minimal, email only).
-    withRosterRewrite.mockImplementation(
-      async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
-        mutate([
-          {
-            username: "frank",
-            github_id: "2",
-            first_name: "TeacherFirst",
-            last_name: "",
-            email: "teacher-set@example.com",
-            section: "TeacherSec",
-            role: "",
-          },
-        ]),
-    )
-
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    const rewriteResult = await withRosterRewrite.mock.results[0].value
-    const row = rewriteResult.nextStudents[0]
-    // Teacher values kept everywhere; nothing to borrow -> no CSV change, but
-    // the team is still cleaned up.
-    expect(row.first_name).toBe("TeacherFirst")
-    expect(row.section).toBe("TeacherSec")
-    expect(row.email).toBe("teacher-set@example.com")
-    expect(rewriteResult.changed).toBe(0)
-    expect(result.backfilled).toEqual(["frank@example.com"])
-    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", state.slug)
-  })
-
-  it("borrows the recovered email onto a matching row with a blank email", async () => {
-    const state = await inviteState("cs101", "hana@example.com", [
-      { id: 2, login: "hana" },
-    ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
-    withRosterRewrite.mockImplementation(
-      async (_c: unknown, _i: unknown, mutate: (rows: unknown[]) => unknown) =>
-        mutate([
-          {
-            username: "hana",
-            github_id: "",
-            first_name: "",
-            last_name: "",
-            email: "",
-            section: "",
-            role: "",
-          },
-        ]),
-    )
-
-    await backfillInviteMetadata(client, { org: "org", classroom: "cs101" })
-    const rewriteResult = await withRosterRewrite.mock.results[0].value
-    const row = rewriteResult.nextStudents[0]
-    expect(row.email).toBe("hana@example.com")
-    expect(row.github_id).toBe("2")
-    expect(rewriteResult.changed).toBe(1)
-  })
-
-  it("one bad team never blocks the rest", async () => {
+  it("one bad team never blocks the rest, but flips trusted off", async () => {
     const good = await inviteState("cs101", "grace@example.com", [
       { id: 3, login: "grace" },
     ])
@@ -393,110 +274,40 @@ describe("backfillInviteMetadata", () => {
       },
     )
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual(["grace@example.com"])
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered.map((r) => r.email)).toEqual(["grace@example.com"])
+    expect(state.trusted).toBe(false)
   })
 
-  it("a rate limit stops the pass instead of hammering the remaining teams", async () => {
+  it("a rate limit stops the pass and flips trusted off", async () => {
     listInviteTeams.mockResolvedValue([
       { slug: "invite-aaaaaaaaaaaaaaaa" },
       { slug: "invite-bbbbbbbbbbbbbbbb" },
     ])
     readInviteTeam.mockRejectedValue(rateLimitError())
 
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.backfilled).toEqual([])
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.trusted).toBe(false)
     expect(readInviteTeam).toHaveBeenCalledTimes(1)
-  })
-
-  it("reports a completed backfill even when the team delete fails", async () => {
-    const state = await inviteState("cs101", "kept@example.com", [
-      { id: 2, login: "kept" },
-    ])
-    listInviteTeams.mockResolvedValue([{ slug: state.slug }])
-    readInviteTeam.mockResolvedValue(state)
-    deleteInviteTeam.mockRejectedValue(new Error("boom"))
-
-    const result = await backfillInviteMetadata(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    // The roster write completed, so the caller must still invalidate; the
-    // leftover team is retried (idempotently) on the next pass.
-    expect(result.backfilled).toEqual(["kept@example.com"])
   })
 })
 
-describe("purgeInviteTeams", () => {
-  it("recovers what it can, then purges the rest of this classroom's teams", async () => {
-    const recoverable = await inviteState("cs101", "alice@example.com", [
-      { id: 2, login: "alice" },
-    ])
-    // Tampered record: the claim says cs101, but the email no longer hashes to
-    // the slug — the backfill skips it, so only the purge can remove it.
-    const tampered = await inviteState("cs101", "bob@example.com", [])
-    tampered.description.email = "tampered@example.com"
-    // Another classroom's team must never be touched.
-    const other = await inviteState("cs202", "eve@example.com", [])
-
-    listInviteTeams.mockResolvedValue([
-      { slug: recoverable.slug },
-      { slug: tampered.slug },
-      { slug: other.slug },
-    ])
-    const deleted = new Set<string>()
-    deleteInviteTeam.mockImplementation(
-      async (_c: unknown, _o: unknown, slug: string) => {
-        deleted.add(slug)
-      },
-    )
-    readInviteTeam.mockImplementation(
-      async (_c: unknown, _o: unknown, slug: string) => {
-        if (deleted.has(slug)) return null
-        if (slug === recoverable.slug) return recoverable
-        if (slug === tampered.slug) return tampered
-        return other
-      },
-    )
-
-    const result = await purgeInviteTeams(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.recovered).toEqual(["alice@example.com"])
-    expect(result.purged).toBe(1)
-    expect(deleted.has(tampered.slug)).toBe(true)
-    expect(deleted.has(other.slug)).toBe(false)
-  })
-
-  it("throws on a purge-phase failure (an explicit action surfaces errors)", async () => {
-    listInviteTeams
-      .mockResolvedValueOnce([]) // the backfill run sees nothing
-      .mockRejectedValueOnce(new Error("boom")) // the purge listing fails
+describe("finalizeInviteRecoveries", () => {
+  it("deletes every recovered mapping's team, tolerating per-team failures", async () => {
+    deleteInviteTeam
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined)
     await expect(
-      purgeInviteTeams(client, { org: "org", classroom: "cs101" }),
-    ).rejects.toThrow("boom")
-  })
-
-  it("still purges when the classroom is archived (backfill no-ops, deletes proceed)", async () => {
-    assertClassroomNotArchived.mockRejectedValue(new Error("archived"))
-    const leftover = await inviteState("cs101", "left@example.com", [])
-    listInviteTeams.mockResolvedValue([{ slug: leftover.slug }])
-    readInviteTeam.mockResolvedValue(leftover)
-
-    const result = await purgeInviteTeams(client, {
-      org: "org",
-      classroom: "cs101",
-    })
-    expect(result.recovered).toEqual([])
-    expect(result.purged).toBe(1)
-    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", leftover.slug)
-    expect(withRosterRewrite).not.toHaveBeenCalled()
+      finalizeInviteRecoveries(client, "org", [
+        { email: "a@x", invitee: { id: 1, login: "a" }, slug: "invite-aa" },
+        { email: "b@x", invitee: { id: 2, login: "b" }, slug: "invite-bb" },
+      ]),
+    ).resolves.toBeUndefined()
+    expect(deleteInviteTeam).toHaveBeenCalledTimes(2)
+    expect(deleteInviteTeam).toHaveBeenLastCalledWith(
+      client,
+      "org",
+      "invite-bb",
+    )
   })
 })

--- a/web/src/domain/students/inviteBackfill.ts
+++ b/web/src/domain/students/inviteBackfill.ts
@@ -6,22 +6,42 @@ import {
 } from "@/github-core/mutations"
 import { listOrgInvitations, listTeamMembers } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
-import { inviteTeamName, type InviteDescription } from "@/util/inviteTeam"
+import { inviteTeamName } from "@/util/inviteTeam"
 import { classroomTeamSlugs } from "@/util/teamSlug"
-import { normalizeStudentRow, type StudentCsvRow } from "@/util/rosterCsv"
-import { parseGitHubId } from "@/util/identity"
-import { assertClassroomNotArchived } from "../classrooms"
-import { withRosterRewrite, log } from "./rosterPrimitives"
+import { log } from "./rosterPrimitives"
 
-export type BackfillInviteMetadataResult = {
-  // Emails whose invite team was reconciled into roster.csv and then deleted.
-  backfilled: string[]
-  // Invite teams deleted without a backfill: the accepted invitee is no longer
-  // on any classroom team (unenrolled — their mapping must not resurrect a
-  // roster row), or a member-less team whose org invitation is gone
-  // (cancelled/expired/failed) aged past the GC guard.
+// One accepted invite whose email <-> account mapping was recovered from its
+// metadata team. The roster sync folds it into roster.csv; the team at `slug`
+// is deleted only AFTER that commit lands (push-before-delete).
+export type RecoveredInvite = {
+  email: string
+  invitee: { id: number; login: string }
+  slug: string
+}
+
+export type InviteReconcileState = {
+  recovered: RecoveredInvite[]
+  // Normalized emails whose invite team is still live (invite pending, or an
+  // anomaly we refuse to touch). An email-only roster row backed by one of
+  // these must be KEPT by the sync's removal pass.
+  liveInviteEmails: Set<string>
+  // True only when the invite-team enumeration AND every per-team read
+  // completed. When false the sync must not remove email-only rows — an
+  // unreadable team can't prove its row is dead.
+  trusted: boolean
+  // Teams deleted without a recovery: an accepted invitee no longer on any
+  // classroom team (unenrolled — must not resurrect a row), or a member-less
+  // team whose org invitation is gone (cancelled/expired) aged past the GC
+  // guard.
   deletedStale: number
 }
+
+const emptyState = (): InviteReconcileState => ({
+  recovered: [],
+  liveInviteEmails: new Set(),
+  trusted: false,
+  deletedStale: 0,
+})
 
 // A member-less invite team is only GC'd once it's older than this, so a team
 // created moments before its org invitation lands (or read mid-creation) can
@@ -29,167 +49,168 @@ export type BackfillInviteMetadataResult = {
 // down immediately by the cancel path; this pass is the backstop.
 const INVITE_TEAM_GC_MIN_AGE_MS = 24 * 60 * 60 * 1000
 
-// Recover the invited-email <-> GitHub-account mapping that only the per-invite
-// metadata teams retain, and fold it into roster.csv. For each invite-<hash>
-// team in the org that belongs to THIS classroom:
-//   - read its description (the invited email) and regular-role
-//     members (GitHub keeps org owners as maintainers, so `role=member` is the
-//     accepted-invitee set);
+// Read-only-on-CSV half of the invite reconcile: enumerate this classroom's
+// invite-<hash> teams and classify each one, WITHOUT writing roster.csv (the
+// roster sync folds the result into its single commit). For each team that
+// belongs to THIS classroom (by its validated description):
 //   - verify the description's email hashes back to the team name (the team is
-//     invitee-editable after acceptance, so this is the trust boundary — a
-//     tampered email that no longer matches the slug is ignored);
-//   - with exactly one member, require them to still be on one of the
-//     classroom's teams: backfill their email onto that account's
-//     roster.csv row (creating an identity row if absent; teacher-entered
-//     values always win), then delete the team. A member on NO classroom team
-//     was unenrolled after accepting — delete the team without a roster write
-//     so the backfill can't resurrect a removed student;
-//   - with zero members the invite is pending — keep the team, unless it's
-//     older than the GC age guard AND no pending org invitation still maps to
-//     its (classroom, email): then the invite was cancelled, expired, or
-//     failed, and the team (holding a PII email) is deleted;
-//   - with more than one, skip and warn (an anomaly — a hash collision or a
-//     manually-added member) rather than guess which is the invitee.
+//     invitee-editable after acceptance, so this is the trust boundary);
+//   - with exactly one regular-role member (GitHub keeps org owners as team
+//     maintainers, so role=member is the accepted-invitee set) who is still on
+//     a classroom team -> a RECOVERED mapping. The team is left in place for
+//     the caller to delete after the roster commit lands;
+//   - one member on NO classroom team -> unenrolled after accepting; delete the
+//     team now so the mapping can't resurrect a removed student;
+//   - zero members -> the invite is live (row kept), unless the team aged past
+//     the GC guard AND no pending org invitation still maps to it (cancelled/
+//     expired) -> delete;
+//   - anomalies (tampered hash, >1 member) -> keep the team, count its email
+//     as live, and warn — never guess.
 //
-// Never throws: it runs piggybacked on reconcile/sync flows that must not fail
-// because of it. A per-team failure is logged and skipped; a rate limit stops
-// the pass (returning what completed) rather than hammering the API; any other
-// unexpected failure is logged and yields an empty result. Refuses to run on an
-// archived classroom (roster.csv is frozen there, like every sibling writer).
-// Scoped to one classroom via the description's `classroom` field, so a shared
-// org running several classrooms only touches its own invite teams.
-export async function backfillInviteMetadata(
+// Never throws. Fail-safe: any read failure (enumeration, a team, the org
+// invitation list) flips `trusted` off so the sync skips row removals; a rate
+// limit stops the pass early the same way.
+export async function collectInviteRecoveries(
   client: GitHubClient,
   input: { org: string; classroom: string },
-): Promise<BackfillInviteMetadataResult> {
+): Promise<InviteReconcileState> {
   const { org, classroom } = input
-  const backfilled: string[] = []
+  const recovered: RecoveredInvite[] = []
+  const liveInviteEmails = new Set<string>()
+  let trusted = true
   let deletedStale = 0
 
+  let inviteTeams
   try {
-    await assertClassroomNotArchived(client, org, classroom)
-
-    const inviteTeams = await listInviteTeams(client, org)
-    if (inviteTeams.length === 0) {
-      return { backfilled, deletedStale }
-    }
-
-    // The invitee must still be on a classroom team (student or staff) for a
-    // backfill to write; fetched lazily once, only when a team has an accepted
-    // member. A read failure here propagates to the per-team catch (skip),
-    // never silently reads as "member of nothing".
-    let enrolledIds: Set<number> | null = null
-    const loadEnrolledIds = async (): Promise<Set<number>> => {
-      if (enrolledIds) return enrolledIds
-      const rosters = await Promise.all(
-        classroomTeamSlugs(classroom).map((slug) =>
-          listTeamMembers(client, org, slug),
-        ),
-      )
-      enrolledIds = new Set(rosters.flat().map((m) => m.id))
-      return enrolledIds
-    }
-
-    // The still-live invite-team slugs for this classroom, derived by hashing
-    // every pending email invitation's address; fetched lazily once, only when
-    // a member-less team is old enough to be a GC candidate. listOrgInvitations
-    // is NOT error-tolerated, so a degraded read propagates to the per-team
-    // catch (skip) rather than reading as "nothing is live" and deleting every
-    // pending team.
-    let liveInviteSlugs: Set<string> | null = null
-    const loadLiveInviteSlugs = async (): Promise<Set<string>> => {
-      if (liveInviteSlugs) return liveInviteSlugs
-      const pending = await listOrgInvitations(client, org)
-      const slugs = await Promise.all(
-        pending
-          .filter((inv) => !inv.login && inv.email)
-          .map((inv) => inviteTeamName(classroom, inv.email as string)),
-      )
-      liveInviteSlugs = new Set(slugs)
-      return liveInviteSlugs
-    }
-
-    for (const team of inviteTeams) {
-      const slug = team.slug
-      if (!slug) continue
-      try {
-        const state = await readInviteTeam(client, org, slug)
-        if (!state) continue // already deleted
-        const record = state.description
-        // Not a valid v1 record, or belongs to another classroom — leave it for
-        // that classroom's own reconcile (or manual cleanup); never touch it
-        // here.
-        if (!record || record.classroom !== classroom) continue
-
-        // Trust boundary: the description is invitee-editable after
-        // acceptance, so only act on it when the recorded email still hashes
-        // back to this team's name. A tampered email can't redirect a backfill
-        // onto someone else.
-        const expected = await inviteTeamName(classroom, record.email)
-        if (expected !== slug) {
-          log.error(
-            "invite team email does not match its name hash; skipping",
-            {
-              slug,
-            },
-          )
-          continue
-        }
-
-        const invitees = state.members
-        if (invitees.length === 0) {
-          // Pending — or abandoned. Reap only when BOTH hold: the team is old
-          // enough that a mid-creation race is impossible, and no pending org
-          // invitation still maps to this slug (the invite was cancelled,
-          // expired, or failed). Uncertainty (missing created_at, unreadable
-          // invitation list) always keeps the team.
-          if (!isPastGcAge(state.createdAt)) continue
-          if ((await loadLiveInviteSlugs()).has(slug)) continue
-          await deleteInviteTeam(client, org, slug)
-          deletedStale += 1
-          continue
-        }
-        if (invitees.length > 1) {
-          log.error("invite team has multiple regular members; skipping", {
-            slug,
-            count: invitees.length,
-          })
-          continue
-        }
-
-        const invitee = invitees[0]
-        if (!(await loadEnrolledIds()).has(invitee.id)) {
-          // Accepted, then removed from the classroom: the invite lifecycle is
-          // over. Delete the team so its record can't resurrect the row later.
-          await deleteInviteTeam(client, org, slug)
-          deletedStale += 1
-          continue
-        }
-
-        await backfillRow(client, { org, classroom }, invitee, record)
-        // Record the recovery before the delete: if the delete fails, the next
-        // pass redoes an idempotent rewrite, whereas the reverse order could
-        // report nothing after a completed roster write.
-        backfilled.push(record.email)
-        await deleteInviteTeam(client, org, slug)
-      } catch (err) {
-        if (err instanceof GitHubAPIError && err.isRateLimited) {
-          // Every remaining team would hit the same limit — stop the pass and
-          // let the next reconcile pick up where this one left off.
-          log.error("invite metadata backfill rate-limited; stopping pass", {
-            slug,
-          })
-          break
-        }
-        // One bad team must never block the rest or the enclosing reconcile.
-        log.error("invite metadata backfill failed for team", { slug, err })
-      }
-    }
+    inviteTeams = await listInviteTeams(client, org)
   } catch (err) {
-    log.error("invite metadata backfill failed", { org, classroom, err })
+    log.error("invite reconcile: team listing failed", { org, err })
+    return emptyState()
   }
 
-  return { backfilled, deletedStale }
+  // The invitee must still be on a classroom team (student or staff) for a
+  // recovery to count; fetched lazily once. A read failure propagates to the
+  // per-team catch, never silently reads as "member of nothing".
+  let enrolledIds: Set<number> | null = null
+  const loadEnrolledIds = async (): Promise<Set<number>> => {
+    if (enrolledIds) return enrolledIds
+    const rosters = await Promise.all(
+      classroomTeamSlugs(classroom).map((slug) =>
+        listTeamMembers(client, org, slug),
+      ),
+    )
+    enrolledIds = new Set(rosters.flat().map((m) => m.id))
+    return enrolledIds
+  }
+
+  // Live invite-team slugs derived by hashing every pending email invitation's
+  // address; fetched lazily, only when a member-less team is old enough to be
+  // a GC candidate. NOT error-tolerated — a degraded read propagates (skip).
+  let liveInviteSlugs: Set<string> | null = null
+  const loadLiveInviteSlugs = async (): Promise<Set<string>> => {
+    if (liveInviteSlugs) return liveInviteSlugs
+    const pending = await listOrgInvitations(client, org)
+    const slugs = await Promise.all(
+      pending
+        .filter((inv) => !inv.login && inv.email)
+        .map((inv) => inviteTeamName(classroom, inv.email as string)),
+    )
+    liveInviteSlugs = new Set(slugs)
+    return liveInviteSlugs
+  }
+
+  for (const team of inviteTeams) {
+    const slug = team.slug
+    if (!slug) continue
+    try {
+      const state = await readInviteTeam(client, org, slug)
+      if (!state) continue // already deleted
+      const record = state.description
+      // Not a valid v1 record, or belongs to another classroom — leave it for
+      // that classroom's own reconcile (or manual cleanup); never touch it.
+      if (!record || record.classroom !== classroom) continue
+
+      // Trust boundary: only act on a description whose recorded email still
+      // hashes back to this team's name. A tampered team is kept (and its
+      // email treated as live) rather than acted on.
+      const expected = await inviteTeamName(classroom, record.email)
+      if (expected !== slug) {
+        log.error("invite team email does not match its name hash; skipping", {
+          slug,
+        })
+        liveInviteEmails.add(record.email)
+        continue
+      }
+
+      const invitees = state.members
+      if (invitees.length === 0) {
+        // Pending — or abandoned. Reap only when BOTH hold: old enough that a
+        // mid-creation race is impossible, and no pending org invitation still
+        // maps to this slug. Uncertainty always keeps the team (and the row).
+        if (
+          isPastGcAge(state.createdAt) &&
+          !(await loadLiveInviteSlugs()).has(slug)
+        ) {
+          await deleteInviteTeam(client, org, slug)
+          deletedStale += 1
+        } else {
+          liveInviteEmails.add(record.email)
+        }
+        continue
+      }
+      if (invitees.length > 1) {
+        log.error("invite team has multiple regular members; skipping", {
+          slug,
+          count: invitees.length,
+        })
+        liveInviteEmails.add(record.email)
+        continue
+      }
+
+      const invitee = invitees[0]
+      if (!(await loadEnrolledIds()).has(invitee.id)) {
+        // Accepted, then removed from the classroom: the invite lifecycle is
+        // over. Delete the team so its record can't resurrect the row later.
+        await deleteInviteTeam(client, org, slug)
+        deletedStale += 1
+        continue
+      }
+
+      recovered.push({
+        email: record.email,
+        invitee: { id: invitee.id, login: invitee.login },
+        slug,
+      })
+    } catch (err) {
+      // An unreadable team can't prove its row is dead — removals are off for
+      // this pass either way.
+      trusted = false
+      if (err instanceof GitHubAPIError && err.isRateLimited) {
+        log.error("invite reconcile rate-limited; stopping pass", { slug })
+        break
+      }
+      log.error("invite reconcile failed for team", { slug, err })
+    }
+  }
+
+  return { recovered, liveInviteEmails, trusted, deletedStale }
+}
+
+// Post-commit teardown: delete each recovered mapping's invite team, AFTER the
+// roster commit folding it has landed (a failed delete just means the next
+// pass re-recovers idempotently). Best-effort; never throws.
+export async function finalizeInviteRecoveries(
+  client: GitHubClient,
+  org: string,
+  recovered: RecoveredInvite[],
+): Promise<void> {
+  for (const r of recovered) {
+    try {
+      await deleteInviteTeam(client, org, r.slug)
+    } catch (err) {
+      log.error("invite team post-commit delete failed", { slug: r.slug, err })
+    }
+  }
 }
 
 // Whether a team's created_at is older than the GC age guard. Unparseable or
@@ -199,116 +220,4 @@ function isPastGcAge(createdAt: string | null): boolean {
   const created = Date.parse(createdAt)
   if (Number.isNaN(created)) return false
   return Date.now() - created > INVITE_TEAM_GC_MIN_AGE_MS
-}
-
-export type PurgeInviteTeamsResult = {
-  // Emails recovered into roster.csv by the backfill run first.
-  recovered: string[]
-  // Remaining invite teams for this classroom deleted afterwards.
-  purged: number
-}
-
-// Teacher-triggered cleanup for the invite teams the automatic pass cannot or
-// will not touch: tampered (hash-mismatched) records, multi-member anomalies,
-// still-pending invites the teacher wants forgotten, and an archived
-// classroom's leftovers. Runs the normal backfill first so anything
-// recoverable lands in roster.csv (a no-op on an archived classroom), then
-// deletes EVERY remaining team whose record claims this classroom — the claim
-// alone suffices here (a tamperer can at worst get their own team deleted).
-// Deliberately no archived guard on the deletes: purging stored emails writes
-// nothing to the frozen roster. Throws on failure (an explicit action the
-// teacher should see fail), except that already-gone teams read as done.
-export async function purgeInviteTeams(
-  client: GitHubClient,
-  input: { org: string; classroom: string },
-): Promise<PurgeInviteTeamsResult> {
-  const { org, classroom } = input
-  const { backfilled } = await backfillInviteMetadata(client, input)
-
-  let purged = 0
-  const teams = await listInviteTeams(client, org)
-  for (const team of teams) {
-    const slug = team.slug
-    if (!slug) continue
-    const state = await readInviteTeam(client, org, slug)
-    if (!state) continue // already gone
-    if (state.description?.classroom !== classroom) continue
-    await deleteInviteTeam(client, org, slug)
-    purged += 1
-  }
-  return { recovered: backfilled, purged }
-}
-
-// Write the invited email onto the accepted invitee's roster.csv row in one
-// conflict-retried rewrite. Ensures an identity row exists (email invites write
-// no row, so the accepted member may have none yet), then fills a blank email —
-// a teacher-entered value always wins (borrow-only). Never changes
-// role/enrollment (team-driven). Matches the row by github_id, then login (the
-// same identity join the roster view uses).
-async function backfillRow(
-  client: GitHubClient,
-  input: { org: string; classroom: string },
-  invitee: { id: number; login: string },
-  record: InviteDescription,
-): Promise<void> {
-  const { org, classroom } = input
-  const inviteeId = String(invitee.id)
-  const loginKey = invitee.login.toLowerCase()
-
-  await withRosterRewrite(client, { org, classroom }, (rows) => {
-    const matches = (row: StudentCsvRow) => {
-      const rowId = parseGitHubId(row.github_id)
-      if (rowId !== null && String(rowId) === inviteeId) return true
-      return row.username.trim().toLowerCase() === loginKey
-    }
-    const existing = rows.find(matches)
-
-    if (!existing) {
-      // No row yet (the common email-invite case): append an identity row
-      // carrying the recovered email. Names/sections arrive via roster.csv
-      // edits or uploads, joined by this email.
-      const added = normalizeStudentRow({
-        username: invitee.login,
-        github_id: inviteeId,
-        first_name: "",
-        last_name: "",
-        email: record.email,
-        section: "",
-      })
-      return {
-        nextStudents: [...rows, added],
-        changed: 1,
-        message: `Backfill invited email for ${classroom}/${invitee.login}`,
-      }
-    }
-
-    let changed = 0
-    const nextStudents = rows.map((row) => {
-      if (row !== existing) return row
-      // Borrow-only: fill blank identity/email fields; teacher values win.
-      const filled = normalizeStudentRow({
-        ...row,
-        username: row.username || invitee.login,
-        github_id: row.github_id || inviteeId,
-        email: row.email?.trim() || record.email,
-      })
-      // Only count a change when a field actually differs (avoid an empty commit
-      // when the teacher already provided everything).
-      if (
-        filled.username !== row.username ||
-        filled.github_id !== row.github_id ||
-        filled.email !== row.email
-      ) {
-        changed = 1
-        return filled
-      }
-      return row
-    })
-
-    return {
-      nextStudents,
-      changed,
-      message: `Backfill invited email for ${classroom}/${invitee.login}`,
-    }
-  })
 }

--- a/web/src/domain/students/inviteBackfill.ts
+++ b/web/src/domain/students/inviteBackfill.ts
@@ -4,7 +4,7 @@ import {
   listInviteTeams,
   readInviteTeam,
 } from "@/github-core/mutations"
-import { listTeamMembers } from "@/github-core/queries"
+import { listOrgInvitations, listTeamMembers } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { inviteTeamName, type InviteDescription } from "@/util/inviteTeam"
 import { classroomTeamSlugs } from "@/util/teamSlug"
@@ -16,11 +16,18 @@ import { withRosterRewrite, log } from "./rosterPrimitives"
 export type BackfillInviteMetadataResult = {
   // Emails whose invite team was reconciled into roster.csv and then deleted.
   backfilled: string[]
-  // Invite teams deleted without a backfill (the accepted invitee is no longer
-  // on any classroom team — an unenrolled/removed student whose mapping must
-  // not resurrect a roster row).
+  // Invite teams deleted without a backfill: the accepted invitee is no longer
+  // on any classroom team (unenrolled — their mapping must not resurrect a
+  // roster row), or a member-less team whose org invitation is gone
+  // (cancelled/expired/failed) aged past the GC guard.
   deletedStale: number
 }
+
+// A member-less invite team is only GC'd once it's older than this, so a team
+// created moments before its org invitation lands (or read mid-creation) can
+// never be reaped by a racing reconcile. Cancelled invites are usually torn
+// down immediately by the cancel path; this pass is the backstop.
+const INVITE_TEAM_GC_MIN_AGE_MS = 24 * 60 * 60 * 1000
 
 // Recover the invited-email <-> GitHub-account mapping that only the per-invite
 // metadata teams retain, and fold it into roster.csv. For each invite-<hash>
@@ -37,7 +44,10 @@ export type BackfillInviteMetadataResult = {
 //     values always win), then delete the team. A member on NO classroom team
 //     was unenrolled after accepting — delete the team without a roster write
 //     so the backfill can't resurrect a removed student;
-//   - with zero members the invite is still pending — leave the team;
+//   - with zero members the invite is pending — keep the team, unless it's
+//     older than the GC age guard AND no pending org invitation still maps to
+//     its (classroom, email): then the invite was cancelled, expired, or
+//     failed, and the team (holding a PII email) is deleted;
 //   - with more than one, skip and warn (an anomaly — a hash collision or a
 //     manually-added member) rather than guess which is the invitee.
 //
@@ -80,6 +90,25 @@ export async function backfillInviteMetadata(
       return enrolledIds
     }
 
+    // The still-live invite-team slugs for this classroom, derived by hashing
+    // every pending email invitation's address; fetched lazily once, only when
+    // a member-less team is old enough to be a GC candidate. listOrgInvitations
+    // is NOT error-tolerated, so a degraded read propagates to the per-team
+    // catch (skip) rather than reading as "nothing is live" and deleting every
+    // pending team.
+    let liveInviteSlugs: Set<string> | null = null
+    const loadLiveInviteSlugs = async (): Promise<Set<string>> => {
+      if (liveInviteSlugs) return liveInviteSlugs
+      const pending = await listOrgInvitations(client, org)
+      const slugs = await Promise.all(
+        pending
+          .filter((inv) => !inv.login && inv.email)
+          .map((inv) => inviteTeamName(classroom, inv.email as string)),
+      )
+      liveInviteSlugs = new Set(slugs)
+      return liveInviteSlugs
+    }
+
     for (const team of inviteTeams) {
       const slug = team.slug
       if (!slug) continue
@@ -108,7 +137,18 @@ export async function backfillInviteMetadata(
         }
 
         const invitees = state.members
-        if (invitees.length === 0) continue // still pending — keep the team
+        if (invitees.length === 0) {
+          // Pending — or abandoned. Reap only when BOTH hold: the team is old
+          // enough that a mid-creation race is impossible, and no pending org
+          // invitation still maps to this slug (the invite was cancelled,
+          // expired, or failed). Uncertainty (missing created_at, unreadable
+          // invitation list) always keeps the team.
+          if (!isPastGcAge(state.createdAt)) continue
+          if ((await loadLiveInviteSlugs()).has(slug)) continue
+          await deleteInviteTeam(client, org, slug)
+          deletedStale += 1
+          continue
+        }
         if (invitees.length > 1) {
           log.error("invite team has multiple regular members; skipping", {
             slug,
@@ -150,6 +190,15 @@ export async function backfillInviteMetadata(
   }
 
   return { backfilled, deletedStale }
+}
+
+// Whether a team's created_at is older than the GC age guard. Unparseable or
+// missing timestamps read as "not old enough" — never reap on uncertainty.
+function isPastGcAge(createdAt: string | null): boolean {
+  if (!createdAt) return false
+  const created = Date.parse(createdAt)
+  if (Number.isNaN(created)) return false
+  return Date.now() - created > INVITE_TEAM_GC_MIN_AGE_MS
 }
 
 // Write the invited email/name/section onto the accepted invitee's roster.csv

--- a/web/src/domain/students/inviteBackfill.ts
+++ b/web/src/domain/students/inviteBackfill.ts
@@ -32,14 +32,14 @@ const INVITE_TEAM_GC_MIN_AGE_MS = 24 * 60 * 60 * 1000
 // Recover the invited-email <-> GitHub-account mapping that only the per-invite
 // metadata teams retain, and fold it into roster.csv. For each invite-<hash>
 // team in the org that belongs to THIS classroom:
-//   - read its description (the invited email/name/section) and regular-role
+//   - read its description (the invited email) and regular-role
 //     members (GitHub keeps org owners as maintainers, so `role=member` is the
 //     accepted-invitee set);
 //   - verify the description's email hashes back to the team name (the team is
 //     invitee-editable after acceptance, so this is the trust boundary — a
 //     tampered email that no longer matches the slug is ignored);
 //   - with exactly one member, require them to still be on one of the
-//     classroom's teams: backfill their email/name/section onto that account's
+//     classroom's teams: backfill their email onto that account's
 //     roster.csv row (creating an identity row if absent; teacher-entered
 //     values always win), then delete the team. A member on NO classroom team
 //     was unenrolled after accepting — delete the team without a roster write
@@ -201,12 +201,50 @@ function isPastGcAge(createdAt: string | null): boolean {
   return Date.now() - created > INVITE_TEAM_GC_MIN_AGE_MS
 }
 
-// Write the invited email/name/section onto the accepted invitee's roster.csv
-// row in one conflict-retried rewrite. Ensures an identity row exists (email
-// invites write no row, so the accepted member may have none yet), then fills
-// blank metadata fields — teacher-entered values always win (borrow-only). Never
-// changes role/enrollment (team-driven). Matches the row by github_id, then
-// login (the same identity join the roster view uses).
+export type PurgeInviteTeamsResult = {
+  // Emails recovered into roster.csv by the backfill run first.
+  recovered: string[]
+  // Remaining invite teams for this classroom deleted afterwards.
+  purged: number
+}
+
+// Teacher-triggered cleanup for the invite teams the automatic pass cannot or
+// will not touch: tampered (hash-mismatched) records, multi-member anomalies,
+// still-pending invites the teacher wants forgotten, and an archived
+// classroom's leftovers. Runs the normal backfill first so anything
+// recoverable lands in roster.csv (a no-op on an archived classroom), then
+// deletes EVERY remaining team whose record claims this classroom — the claim
+// alone suffices here (a tamperer can at worst get their own team deleted).
+// Deliberately no archived guard on the deletes: purging stored emails writes
+// nothing to the frozen roster. Throws on failure (an explicit action the
+// teacher should see fail), except that already-gone teams read as done.
+export async function purgeInviteTeams(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+): Promise<PurgeInviteTeamsResult> {
+  const { org, classroom } = input
+  const { backfilled } = await backfillInviteMetadata(client, input)
+
+  let purged = 0
+  const teams = await listInviteTeams(client, org)
+  for (const team of teams) {
+    const slug = team.slug
+    if (!slug) continue
+    const state = await readInviteTeam(client, org, slug)
+    if (!state) continue // already gone
+    if (state.description?.classroom !== classroom) continue
+    await deleteInviteTeam(client, org, slug)
+    purged += 1
+  }
+  return { recovered: backfilled, purged }
+}
+
+// Write the invited email onto the accepted invitee's roster.csv row in one
+// conflict-retried rewrite. Ensures an identity row exists (email invites write
+// no row, so the accepted member may have none yet), then fills a blank email —
+// a teacher-entered value always wins (borrow-only). Never changes
+// role/enrollment (team-driven). Matches the row by github_id, then login (the
+// same identity join the roster view uses).
 async function backfillRow(
   client: GitHubClient,
   input: { org: string; classroom: string },
@@ -225,28 +263,17 @@ async function backfillRow(
     }
     const existing = rows.find(matches)
 
-    // Borrow a blank field from the record; a teacher-set value always wins.
-    const fill = (row: StudentCsvRow): StudentCsvRow =>
-      normalizeStudentRow({
-        ...row,
-        username: row.username || invitee.login,
-        github_id: row.github_id || inviteeId,
-        first_name: row.first_name?.trim() || record.first_name || "",
-        last_name: row.last_name?.trim() || record.last_name || "",
-        email: row.email?.trim() || record.email,
-        section: row.section?.trim() || record.section || "",
-      })
-
     if (!existing) {
       // No row yet (the common email-invite case): append an identity row
-      // carrying the recovered metadata.
+      // carrying the recovered email. Names/sections arrive via roster.csv
+      // edits or uploads, joined by this email.
       const added = normalizeStudentRow({
         username: invitee.login,
         github_id: inviteeId,
-        first_name: record.first_name || "",
-        last_name: record.last_name || "",
+        first_name: "",
+        last_name: "",
         email: record.email,
-        section: record.section || "",
+        section: "",
       })
       return {
         nextStudents: [...rows, added],
@@ -258,16 +285,19 @@ async function backfillRow(
     let changed = 0
     const nextStudents = rows.map((row) => {
       if (row !== existing) return row
-      const filled = fill(row)
+      // Borrow-only: fill blank identity/email fields; teacher values win.
+      const filled = normalizeStudentRow({
+        ...row,
+        username: row.username || invitee.login,
+        github_id: row.github_id || inviteeId,
+        email: row.email?.trim() || record.email,
+      })
       // Only count a change when a field actually differs (avoid an empty commit
       // when the teacher already provided everything).
       if (
         filled.username !== row.username ||
         filled.github_id !== row.github_id ||
-        filled.first_name !== row.first_name ||
-        filled.last_name !== row.last_name ||
-        filled.email !== row.email ||
-        filled.section !== row.section
+        filled.email !== row.email
       ) {
         changed = 1
         return filled

--- a/web/src/domain/students/inviteBackfill.ts
+++ b/web/src/domain/students/inviteBackfill.ts
@@ -1,0 +1,188 @@
+import type { GitHubClient } from "@/github-core/client"
+import {
+  deleteInviteTeam,
+  listInviteTeams,
+  readInviteTeam,
+} from "@/github-core/mutations"
+import { listOrgAdmins } from "@/github-core/queries"
+import { inviteTeamName, type InviteDescription } from "@/util/inviteTeam"
+import { normalizeStudentRow, type StudentCsvRow } from "@/util/rosterCsv"
+import { parseGitHubId } from "@/util/identity"
+import { withRosterRewrite, log } from "./rosterPrimitives"
+
+export type BackfillInviteMetadataResult = {
+  // Emails whose invite team was reconciled into roster.csv and then deleted.
+  backfilled: string[]
+  // Invite teams deleted without a backfill (stale: no accepted member and the
+  // team's classroom matches — a cancelled/expired invite left the team behind).
+  // Not currently distinguished from backfilled at the call site; kept for logs.
+  deletedStale: number
+}
+
+// Recover the invited-email <-> GitHub-account mapping that only the per-invite
+// metadata teams retain, and fold it into roster.csv. For each invite-<hash>
+// team in the org that belongs to THIS classroom:
+//   - read its description (the invited email/name/section) and members;
+//   - verify the description's email hashes back to the team name (the team is
+//     invitee-editable after acceptance, so this is the trust boundary — a
+//     tampered email that no longer matches the slug is ignored);
+//   - drop org owners (GitHub auto-adds the team creator as a maintainer), so
+//     the remaining members are the accepted invitee(s);
+//   - with exactly one non-owner member, backfill their email/name/section onto
+//     that account's roster.csv row (creating an identity row if absent;
+//     teacher-entered values always win), then delete the team;
+//   - with zero non-owner members the invite is still pending — leave the team;
+//   - with more than one, skip and warn (an anomaly — a hash collision or a
+//     manually-added member) rather than guess which is the invitee.
+//
+// Best-effort and idempotent: a per-team failure is logged and skipped so one
+// bad team never blocks the rest (or the enclosing reconcile). Scoped to one
+// classroom via the description's `classroom` field, so a shared org running
+// several classrooms only touches its own invite teams.
+export async function backfillInviteMetadata(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+): Promise<BackfillInviteMetadataResult> {
+  const { org, classroom } = input
+  const backfilled: string[] = []
+  const deletedStale = 0
+
+  const [inviteTeams, admins] = await Promise.all([
+    listInviteTeams(client, org),
+    listOrgAdmins(client, org),
+  ])
+  if (inviteTeams.length === 0) {
+    return { backfilled, deletedStale }
+  }
+  const adminIds = new Set(admins.map((a) => a.id))
+  const adminLogins = new Set(admins.map((a) => a.login.toLowerCase()))
+
+  for (const team of inviteTeams) {
+    const slug = team.slug
+    if (!slug) continue
+    try {
+      const state = await readInviteTeam(client, org, slug)
+      if (!state) continue // already deleted
+      const record = state.description
+      // Not a valid v1 record, or belongs to another classroom — leave it for
+      // that classroom's own reconcile (or manual cleanup); never touch it here.
+      if (!record || record.classroom !== classroom) continue
+
+      // Trust boundary: the description is invitee-editable after acceptance, so
+      // only act on it when the recorded email still hashes back to this team's
+      // name. A tampered email can't redirect a backfill onto someone else.
+      const expected = await inviteTeamName(classroom, record.email)
+      if (expected !== slug) {
+        log.error("invite team email does not match its name hash; skipping", {
+          slug,
+        })
+        continue
+      }
+
+      // Accepted invitee(s) = members minus org owners (the auto-added creator).
+      const invitees = state.members.filter(
+        (m) => !adminIds.has(m.id) && !adminLogins.has(m.login.toLowerCase()),
+      )
+      if (invitees.length === 0) continue // still pending — keep the team
+      if (invitees.length > 1) {
+        log.error("invite team has multiple non-owner members; skipping", {
+          slug,
+          count: invitees.length,
+        })
+        continue
+      }
+
+      const invitee = invitees[0]
+      await backfillRow(client, { org, classroom }, invitee, record)
+      await deleteInviteTeam(client, org, slug)
+      backfilled.push(record.email)
+    } catch (err) {
+      // One bad team must never block the rest or the enclosing reconcile.
+      log.error("invite metadata backfill failed for team", { slug, err })
+    }
+  }
+
+  return { backfilled, deletedStale }
+}
+
+// Write the invited email/name/section onto the accepted invitee's roster.csv
+// row in one conflict-retried rewrite. Ensures an identity row exists (email
+// invites write no row, so the accepted member may have none yet), then fills
+// blank metadata fields — teacher-entered values always win (borrow-only). Never
+// changes role/enrollment (team-driven). Matches the row by github_id, then
+// login (the same identity join the roster view uses).
+async function backfillRow(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+  invitee: { id: number; login: string },
+  record: InviteDescription,
+): Promise<void> {
+  const { org, classroom } = input
+  const inviteeId = String(invitee.id)
+  const loginKey = invitee.login.toLowerCase()
+
+  await withRosterRewrite(client, { org, classroom }, (rows) => {
+    const matches = (row: StudentCsvRow) => {
+      const rowId = parseGitHubId(row.github_id)
+      if (rowId !== null && String(rowId) === inviteeId) return true
+      return row.username.trim().toLowerCase() === loginKey
+    }
+    const existing = rows.find(matches)
+
+    // Borrow a blank field from the record; a teacher-set value always wins.
+    const fill = (row: StudentCsvRow): StudentCsvRow =>
+      normalizeStudentRow({
+        ...row,
+        username: row.username || invitee.login,
+        github_id: row.github_id || inviteeId,
+        first_name: row.first_name?.trim() || record.first_name || "",
+        last_name: row.last_name?.trim() || record.last_name || "",
+        email: row.email?.trim() || record.email,
+        section: row.section?.trim() || record.section || "",
+      })
+
+    if (!existing) {
+      // No row yet (the common email-invite case): append an identity row
+      // carrying the recovered metadata.
+      const added = normalizeStudentRow({
+        username: invitee.login,
+        github_id: inviteeId,
+        first_name: record.first_name || "",
+        last_name: record.last_name || "",
+        email: record.email,
+        section: record.section || "",
+      })
+      return {
+        nextStudents: [...rows, added],
+        changed: 1,
+        message: `Backfill invited email for ${classroom}/${invitee.login}`,
+      }
+    }
+
+    let changed = 0
+    const nextStudents = rows.map((row) => {
+      if (row !== existing) return row
+      const filled = fill(row)
+      // Only count a change when a field actually differs (avoid an empty commit
+      // when the teacher already provided everything).
+      if (
+        filled.username !== row.username ||
+        filled.github_id !== row.github_id ||
+        filled.first_name !== row.first_name ||
+        filled.last_name !== row.last_name ||
+        filled.email !== row.email ||
+        filled.section !== row.section
+      ) {
+        changed = 1
+        return filled
+      }
+      return row
+    })
+
+    return {
+      nextStudents,
+      changed,
+      message: `Backfill invited email for ${classroom}/${invitee.login}`,
+    }
+  })
+}

--- a/web/src/domain/students/inviteBackfill.ts
+++ b/web/src/domain/students/inviteBackfill.ts
@@ -4,102 +4,149 @@ import {
   listInviteTeams,
   readInviteTeam,
 } from "@/github-core/mutations"
-import { listOrgAdmins } from "@/github-core/queries"
+import { listTeamMembers } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
 import { inviteTeamName, type InviteDescription } from "@/util/inviteTeam"
+import { classroomTeamSlugs } from "@/util/teamSlug"
 import { normalizeStudentRow, type StudentCsvRow } from "@/util/rosterCsv"
 import { parseGitHubId } from "@/util/identity"
+import { assertClassroomNotArchived } from "../classrooms"
 import { withRosterRewrite, log } from "./rosterPrimitives"
 
 export type BackfillInviteMetadataResult = {
   // Emails whose invite team was reconciled into roster.csv and then deleted.
   backfilled: string[]
-  // Invite teams deleted without a backfill (stale: no accepted member and the
-  // team's classroom matches — a cancelled/expired invite left the team behind).
-  // Not currently distinguished from backfilled at the call site; kept for logs.
+  // Invite teams deleted without a backfill (the accepted invitee is no longer
+  // on any classroom team — an unenrolled/removed student whose mapping must
+  // not resurrect a roster row).
   deletedStale: number
 }
 
 // Recover the invited-email <-> GitHub-account mapping that only the per-invite
 // metadata teams retain, and fold it into roster.csv. For each invite-<hash>
 // team in the org that belongs to THIS classroom:
-//   - read its description (the invited email/name/section) and members;
+//   - read its description (the invited email/name/section) and regular-role
+//     members (GitHub keeps org owners as maintainers, so `role=member` is the
+//     accepted-invitee set);
 //   - verify the description's email hashes back to the team name (the team is
 //     invitee-editable after acceptance, so this is the trust boundary — a
 //     tampered email that no longer matches the slug is ignored);
-//   - drop org owners (GitHub auto-adds the team creator as a maintainer), so
-//     the remaining members are the accepted invitee(s);
-//   - with exactly one non-owner member, backfill their email/name/section onto
-//     that account's roster.csv row (creating an identity row if absent;
-//     teacher-entered values always win), then delete the team;
-//   - with zero non-owner members the invite is still pending — leave the team;
+//   - with exactly one member, require them to still be on one of the
+//     classroom's teams: backfill their email/name/section onto that account's
+//     roster.csv row (creating an identity row if absent; teacher-entered
+//     values always win), then delete the team. A member on NO classroom team
+//     was unenrolled after accepting — delete the team without a roster write
+//     so the backfill can't resurrect a removed student;
+//   - with zero members the invite is still pending — leave the team;
 //   - with more than one, skip and warn (an anomaly — a hash collision or a
 //     manually-added member) rather than guess which is the invitee.
 //
-// Best-effort and idempotent: a per-team failure is logged and skipped so one
-// bad team never blocks the rest (or the enclosing reconcile). Scoped to one
-// classroom via the description's `classroom` field, so a shared org running
-// several classrooms only touches its own invite teams.
+// Never throws: it runs piggybacked on reconcile/sync flows that must not fail
+// because of it. A per-team failure is logged and skipped; a rate limit stops
+// the pass (returning what completed) rather than hammering the API; any other
+// unexpected failure is logged and yields an empty result. Refuses to run on an
+// archived classroom (roster.csv is frozen there, like every sibling writer).
+// Scoped to one classroom via the description's `classroom` field, so a shared
+// org running several classrooms only touches its own invite teams.
 export async function backfillInviteMetadata(
   client: GitHubClient,
   input: { org: string; classroom: string },
 ): Promise<BackfillInviteMetadataResult> {
   const { org, classroom } = input
   const backfilled: string[] = []
-  const deletedStale = 0
+  let deletedStale = 0
 
-  const [inviteTeams, admins] = await Promise.all([
-    listInviteTeams(client, org),
-    listOrgAdmins(client, org),
-  ])
-  if (inviteTeams.length === 0) {
-    return { backfilled, deletedStale }
-  }
-  const adminIds = new Set(admins.map((a) => a.id))
-  const adminLogins = new Set(admins.map((a) => a.login.toLowerCase()))
+  try {
+    await assertClassroomNotArchived(client, org, classroom)
 
-  for (const team of inviteTeams) {
-    const slug = team.slug
-    if (!slug) continue
-    try {
-      const state = await readInviteTeam(client, org, slug)
-      if (!state) continue // already deleted
-      const record = state.description
-      // Not a valid v1 record, or belongs to another classroom — leave it for
-      // that classroom's own reconcile (or manual cleanup); never touch it here.
-      if (!record || record.classroom !== classroom) continue
-
-      // Trust boundary: the description is invitee-editable after acceptance, so
-      // only act on it when the recorded email still hashes back to this team's
-      // name. A tampered email can't redirect a backfill onto someone else.
-      const expected = await inviteTeamName(classroom, record.email)
-      if (expected !== slug) {
-        log.error("invite team email does not match its name hash; skipping", {
-          slug,
-        })
-        continue
-      }
-
-      // Accepted invitee(s) = members minus org owners (the auto-added creator).
-      const invitees = state.members.filter(
-        (m) => !adminIds.has(m.id) && !adminLogins.has(m.login.toLowerCase()),
-      )
-      if (invitees.length === 0) continue // still pending — keep the team
-      if (invitees.length > 1) {
-        log.error("invite team has multiple non-owner members; skipping", {
-          slug,
-          count: invitees.length,
-        })
-        continue
-      }
-
-      const invitee = invitees[0]
-      await backfillRow(client, { org, classroom }, invitee, record)
-      await deleteInviteTeam(client, org, slug)
-      backfilled.push(record.email)
-    } catch (err) {
-      // One bad team must never block the rest or the enclosing reconcile.
-      log.error("invite metadata backfill failed for team", { slug, err })
+    const inviteTeams = await listInviteTeams(client, org)
+    if (inviteTeams.length === 0) {
+      return { backfilled, deletedStale }
     }
+
+    // The invitee must still be on a classroom team (student or staff) for a
+    // backfill to write; fetched lazily once, only when a team has an accepted
+    // member. A read failure here propagates to the per-team catch (skip),
+    // never silently reads as "member of nothing".
+    let enrolledIds: Set<number> | null = null
+    const loadEnrolledIds = async (): Promise<Set<number>> => {
+      if (enrolledIds) return enrolledIds
+      const rosters = await Promise.all(
+        classroomTeamSlugs(classroom).map((slug) =>
+          listTeamMembers(client, org, slug),
+        ),
+      )
+      enrolledIds = new Set(rosters.flat().map((m) => m.id))
+      return enrolledIds
+    }
+
+    for (const team of inviteTeams) {
+      const slug = team.slug
+      if (!slug) continue
+      try {
+        const state = await readInviteTeam(client, org, slug)
+        if (!state) continue // already deleted
+        const record = state.description
+        // Not a valid v1 record, or belongs to another classroom — leave it for
+        // that classroom's own reconcile (or manual cleanup); never touch it
+        // here.
+        if (!record || record.classroom !== classroom) continue
+
+        // Trust boundary: the description is invitee-editable after
+        // acceptance, so only act on it when the recorded email still hashes
+        // back to this team's name. A tampered email can't redirect a backfill
+        // onto someone else.
+        const expected = await inviteTeamName(classroom, record.email)
+        if (expected !== slug) {
+          log.error(
+            "invite team email does not match its name hash; skipping",
+            {
+              slug,
+            },
+          )
+          continue
+        }
+
+        const invitees = state.members
+        if (invitees.length === 0) continue // still pending — keep the team
+        if (invitees.length > 1) {
+          log.error("invite team has multiple regular members; skipping", {
+            slug,
+            count: invitees.length,
+          })
+          continue
+        }
+
+        const invitee = invitees[0]
+        if (!(await loadEnrolledIds()).has(invitee.id)) {
+          // Accepted, then removed from the classroom: the invite lifecycle is
+          // over. Delete the team so its record can't resurrect the row later.
+          await deleteInviteTeam(client, org, slug)
+          deletedStale += 1
+          continue
+        }
+
+        await backfillRow(client, { org, classroom }, invitee, record)
+        // Record the recovery before the delete: if the delete fails, the next
+        // pass redoes an idempotent rewrite, whereas the reverse order could
+        // report nothing after a completed roster write.
+        backfilled.push(record.email)
+        await deleteInviteTeam(client, org, slug)
+      } catch (err) {
+        if (err instanceof GitHubAPIError && err.isRateLimited) {
+          // Every remaining team would hit the same limit — stop the pass and
+          // let the next reconcile pick up where this one left off.
+          log.error("invite metadata backfill rate-limited; stopping pass", {
+            slug,
+          })
+          break
+        }
+        // One bad team must never block the rest or the enclosing reconcile.
+        log.error("invite metadata backfill failed for team", { slug, err })
+      }
+    }
+  } catch (err) {
+    log.error("invite metadata backfill failed", { org, classroom, err })
   }
 
   return { backfilled, deletedStale }

--- a/web/src/domain/students/inviteRecoveries.test.ts
+++ b/web/src/domain/students/inviteRecoveries.test.ts
@@ -6,6 +6,7 @@ const readInviteTeam = vi.fn()
 const deleteInviteTeam = vi.fn()
 const listTeamMembers = vi.fn()
 const listOrgInvitations = vi.fn()
+const resolveClassroomTeamSlugs = vi.fn()
 
 vi.mock("@/github-core/mutations", () => ({
   listInviteTeams: (...a: unknown[]) => listInviteTeams(...a),
@@ -17,13 +18,15 @@ vi.mock("@/github-core/queries", () => ({
   listOrgInvitations: (...a: unknown[]) => listOrgInvitations(...a),
 }))
 vi.mock("./rosterPrimitives", () => ({
+  resolveClassroomTeamSlugs: (...a: unknown[]) =>
+    resolveClassroomTeamSlugs(...a),
   log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }))
 
 import {
   collectInviteRecoveries,
   finalizeInviteRecoveries,
-} from "./inviteBackfill"
+} from "./inviteRecoveries"
 import { inviteTeamName } from "@/util/inviteTeam"
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 
@@ -78,6 +81,15 @@ beforeEach(() => {
   vi.clearAllMocks()
   deleteInviteTeam.mockResolvedValue(undefined)
   listOrgInvitations.mockResolvedValue([])
+  // Authoritative slugs (classroom.json-backed), as the collector resolves them.
+  resolveClassroomTeamSlugs.mockResolvedValue({
+    student: "classroom50-cs101",
+    staff: {
+      teacher: "classroom50-cs101-teacher",
+      hta: "classroom50-cs101-hta",
+      ta: "classroom50-cs101-ta",
+    },
+  })
   // Default: every accepted invitee used below is still on a classroom team.
   listTeamMembers.mockResolvedValue([
     { id: 2, login: "member2" },
@@ -229,12 +241,55 @@ describe("collectInviteRecoveries", () => {
     ])
     listInviteTeams.mockResolvedValue([{ slug: team.slug }])
     readInviteTeam.mockResolvedValue(team)
-    listTeamMembers.mockResolvedValue([]) // on no classroom team
+    // Other members are visible, so the read is trustworthy — this account
+    // genuinely isn't on any classroom team.
+    listTeamMembers.mockResolvedValue([{ id: 2, login: "someone-else" }])
 
     const state = await collectInviteRecoveries(client, INPUT)
     expect(state.recovered).toEqual([])
     expect(state.deletedStale).toBe(1)
     expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", team.slug)
+  })
+
+  it("keeps the team (untrusted) when NO classroom member is visible at all", async () => {
+    // The invitee accepted an invite carrying the classroom team, so an empty
+    // membership read is a degraded read, not proof of unenrollment.
+    const team = await inviteState("cs101", "held3@example.com", [
+      { id: 2, login: "held3" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+    listTeamMembers.mockResolvedValue([])
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([])
+    expect(state.deletedStale).toBe(0)
+    expect(state.trusted).toBe(false)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("reads enrollment from the AUTHORITATIVE slugs, not derived ones", async () => {
+    // GitHub rewrote the team slug on a name collision; classroom.json holds the
+    // real one. Reading a derived slug would 404 -> [] and look like "unenrolled".
+    resolveClassroomTeamSlugs.mockResolvedValue({
+      student: "classroom50-cs101-2",
+      staff: {
+        teacher: "classroom50-cs101-teacher",
+        hta: "classroom50-cs101-hta",
+        ta: "classroom50-cs101-ta",
+      },
+    })
+    const team = await inviteState("cs101", "renamed@example.com", [
+      { id: 2, login: "renamed" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered.map((r) => r.email)).toEqual(["renamed@example.com"])
+    const readSlugs = listTeamMembers.mock.calls.map((c) => c[2])
+    expect(readSlugs).toContain("classroom50-cs101-2")
+    expect(readSlugs).not.toContain("classroom50-cs101")
   })
 
   it("flips trusted off when the enrollment read fails, keeping the team", async () => {
@@ -293,15 +348,17 @@ describe("collectInviteRecoveries", () => {
 })
 
 describe("finalizeInviteRecoveries", () => {
+  const RECOVERED = [
+    { email: "a@x", invitee: { id: 1, login: "a" }, slug: "invite-aa" },
+    { email: "b@x", invitee: { id: 2, login: "b" }, slug: "invite-bb" },
+  ]
+
   it("deletes every recovered mapping's team, tolerating per-team failures", async () => {
     deleteInviteTeam
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce(undefined)
     await expect(
-      finalizeInviteRecoveries(client, "org", [
-        { email: "a@x", invitee: { id: 1, login: "a" }, slug: "invite-aa" },
-        { email: "b@x", invitee: { id: 2, login: "b" }, slug: "invite-bb" },
-      ]),
+      finalizeInviteRecoveries(client, INPUT, RECOVERED),
     ).resolves.toBeUndefined()
     expect(deleteInviteTeam).toHaveBeenCalledTimes(2)
     expect(deleteInviteTeam).toHaveBeenLastCalledWith(
@@ -309,5 +366,34 @@ describe("finalizeInviteRecoveries", () => {
       "org",
       "invite-bb",
     )
+  })
+
+  it("skips a slug a fresh pending invitation now maps to (same-email re-invite)", async () => {
+    // The re-invite adopted the same deterministic slug; deleting it would tear
+    // the metadata team off a brand-new live invitation.
+    const reInvited = await inviteTeamName("cs101", "a@x")
+    listOrgInvitations.mockResolvedValue([{ id: 7, login: null, email: "a@x" }])
+
+    await finalizeInviteRecoveries(client, INPUT, [
+      { email: "a@x", invitee: { id: 1, login: "a" }, slug: reInvited },
+      RECOVERED[1],
+    ])
+
+    expect(deleteInviteTeam).toHaveBeenCalledTimes(1)
+    expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", "invite-bb")
+  })
+
+  it("keeps every team when the liveness read fails (a leftover beats a wrong delete)", async () => {
+    listOrgInvitations.mockRejectedValue(new Error("boom"))
+    await expect(
+      finalizeInviteRecoveries(client, INPUT, RECOVERED),
+    ).resolves.toBeUndefined()
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("does nothing (and reads nothing) with no recoveries", async () => {
+    await finalizeInviteRecoveries(client, INPUT, [])
+    expect(listOrgInvitations).not.toHaveBeenCalled()
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 })

--- a/web/src/domain/students/inviteRecoveries.ts
+++ b/web/src/domain/students/inviteRecoveries.ts
@@ -7,8 +7,7 @@ import {
 import { listOrgInvitations, listTeamMembers } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { inviteTeamName } from "@/util/inviteTeam"
-import { classroomTeamSlugs } from "@/util/teamSlug"
-import { log } from "./rosterPrimitives"
+import { log, resolveClassroomTeamSlugs } from "./rosterPrimitives"
 
 // One accepted invite whose email <-> account mapping was recovered from its
 // metadata team. The roster sync folds it into roster.csv; the team at `slug`
@@ -89,13 +88,17 @@ export async function collectInviteRecoveries(
   }
 
   // The invitee must still be on a classroom team (student or staff) for a
-  // recovery to count; fetched lazily once. A read failure propagates to the
-  // per-team catch, never silently reads as "member of nothing".
+  // recovery to count; fetched lazily once. Reads the AUTHORITATIVE slugs from
+  // classroom.json (GitHub can rewrite a team slug on name collision, so a
+  // derived slug would 404 -> [] and make an enrolled invitee look unenrolled).
+  // A read failure propagates to the per-team catch, never silently reads as
+  // "member of nothing".
   let enrolledIds: Set<number> | null = null
   const loadEnrolledIds = async (): Promise<Set<number>> => {
     if (enrolledIds) return enrolledIds
+    const slugs = await resolveClassroomTeamSlugs(client, org, classroom)
     const rosters = await Promise.all(
-      classroomTeamSlugs(classroom).map((slug) =>
+      [slugs.student, ...Object.values(slugs.staff)].map((slug) =>
         listTeamMembers(client, org, slug),
       ),
     )
@@ -103,20 +106,14 @@ export async function collectInviteRecoveries(
     return enrolledIds
   }
 
-  // Live invite-team slugs derived by hashing every pending email invitation's
-  // address; fetched lazily, only when a member-less team is old enough to be
-  // a GC candidate. NOT error-tolerated — a degraded read propagates (skip).
-  let liveInviteSlugs: Set<string> | null = null
+  // Live invite-team slugs, fetched lazily only when a member-less team is old
+  // enough to be a GC candidate. NOT error-tolerated — a degraded read
+  // propagates (skip).
+  let liveSlugs: Set<string> | null = null
   const loadLiveInviteSlugs = async (): Promise<Set<string>> => {
-    if (liveInviteSlugs) return liveInviteSlugs
-    const pending = await listOrgInvitations(client, org)
-    const slugs = await Promise.all(
-      pending
-        .filter((inv) => !inv.login && inv.email)
-        .map((inv) => inviteTeamName(classroom, inv.email as string)),
-    )
-    liveInviteSlugs = new Set(slugs)
-    return liveInviteSlugs
+    if (liveSlugs) return liveSlugs
+    liveSlugs = await liveInviteSlugsFor(client, org, classroom)
+    return liveSlugs
   }
 
   for (const team of inviteTeams) {
@@ -168,7 +165,18 @@ export async function collectInviteRecoveries(
       }
 
       const invitee = invitees[0]
-      if (!(await loadEnrolledIds()).has(invitee.id)) {
+      const enrolled = await loadEnrolledIds()
+      if (enrolled.size === 0) {
+        // This member accepted an invite carrying a classroom team, so a
+        // classroom with zero visible members means the read was degraded, not
+        // that they were unenrolled. Can't prove either state: keep the team.
+        trusted = false
+        log.error("invite reconcile: no classroom members visible; skipping", {
+          slug,
+        })
+        continue
+      }
+      if (!enrolled.has(invitee.id)) {
         // Accepted, then removed from the classroom: the invite lifecycle is
         // over. Delete the team so its record can't resurrect the row later.
         await deleteInviteTeam(client, org, slug)
@@ -199,18 +207,57 @@ export async function collectInviteRecoveries(
 // Post-commit teardown: delete each recovered mapping's invite team, AFTER the
 // roster commit folding it has landed (a failed delete just means the next
 // pass re-recovers idempotently). Best-effort; never throws.
+//
+// Skips any slug a pending invitation now maps to: the slug is a deterministic
+// hash, so a same-email RE-INVITE in the window since collect adopts this very
+// team, and deleting it would tear the metadata team off a brand-new live
+// invitation. An unreadable invitation list keeps every team — a leftover is
+// re-recovered next pass, whereas a wrong delete loses the email for good.
 export async function finalizeInviteRecoveries(
   client: GitHubClient,
-  org: string,
+  input: { org: string; classroom: string },
   recovered: RecoveredInvite[],
 ): Promise<void> {
+  if (recovered.length === 0) return
+  const { org, classroom } = input
+
+  let live: Set<string>
+  try {
+    live = await liveInviteSlugsFor(client, org, classroom)
+  } catch (err) {
+    log.error("invite teardown: liveness read failed; keeping teams", {
+      org,
+      err,
+    })
+    return
+  }
+
   for (const r of recovered) {
+    if (live.has(r.slug)) continue
     try {
       await deleteInviteTeam(client, org, r.slug)
     } catch (err) {
       log.error("invite team post-commit delete failed", { slug: r.slug, err })
     }
   }
+}
+
+// Invite-team slugs a pending EMAIL invitation still maps to. Hashing each
+// pending address reproduces its team's slug, so this is the liveness signal
+// both the GC guard and the post-commit teardown consult. Strict: a failed read
+// propagates so a caller fails closed rather than reading as "nothing is live".
+async function liveInviteSlugsFor(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+): Promise<Set<string>> {
+  const pending = await listOrgInvitations(client, org)
+  const slugs = await Promise.all(
+    pending
+      .filter((inv) => !inv.login && inv.email)
+      .map((inv) => inviteTeamName(classroom, inv.email as string)),
+  )
+  return new Set(slugs)
 }
 
 // Whether a team's created_at is older than the GC age guard. Unparseable or

--- a/web/src/domain/students/inviteRecoveries.ts
+++ b/web/src/domain/students/inviteRecoveries.ts
@@ -6,7 +6,7 @@ import {
 } from "@/github-core/mutations"
 import { listOrgInvitations, listTeamMembers } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
-import { inviteTeamName } from "@/util/inviteTeam"
+import { inviteTeamName, normalizeInviteEmail } from "@/util/inviteTeam"
 import { log, resolveClassroomTeamSlugs } from "./rosterPrimitives"
 
 // One accepted invite whose email <-> account mapping was recovered from its
@@ -239,6 +239,32 @@ export async function finalizeInviteRecoveries(
     } catch (err) {
       log.error("invite team post-commit delete failed", { slug: r.slug, err })
     }
+  }
+}
+
+// Emails with a still-pending EMAIL invitation, normalized for roster-row
+// comparison. The liveness signal the sync's dead-row removal confirms against
+// at commit time: collect's team snapshot is taken BEFORE the sync reads
+// roster.csv, so an invite sent in between has a row but no snapshot entry.
+// Returns null when the read fails, so a caller can fail closed rather than
+// reap rows on a blind guess.
+export async function pendingInviteEmails(
+  client: GitHubClient,
+  org: string,
+): Promise<Set<string> | null> {
+  try {
+    const pending = await listOrgInvitations(client, org)
+    return new Set(
+      pending
+        .filter((inv) => !inv.login && inv.email)
+        .map((inv) => normalizeInviteEmail(inv.email as string)),
+    )
+  } catch (err) {
+    log.error("pending invitation read failed; keeping email rows", {
+      org,
+      err,
+    })
+    return null
   }
 }
 

--- a/web/src/domain/students/inviteRoster.ts
+++ b/web/src/domain/students/inviteRoster.ts
@@ -1,8 +1,10 @@
 import type { GitHubClient } from "@/github-core/client"
 import {
   createOrgInvitation,
+  deleteInviteTeam,
   ensureInviteTeam,
   ensureOrgMembership,
+  type InviteTeamRef,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { assertClassroomNotArchived } from "../classrooms"
@@ -304,26 +306,52 @@ export async function bulkInviteByEmail(
   const inviteOne = async (target: EmailTarget) => {
     const teamId = teamIdByRole[target.role]
     const teamIds = teamId ? [teamId] : []
-    try {
-      const inviteTeam = await ensureInviteTeam(client, org, {
-        email: target.email,
-        classroom,
-      })
-      teamIds.push(inviteTeam.id)
-    } catch (err) {
-      if (err instanceof GitHubAPIError && err.isRateLimited) throw err
-      log.error("bulk invite metadata team create failed", {
-        email: target.email,
-        err,
-      })
-      // Non-rate-limit failure: proceed with the classroom team only.
+    let inviteTeam: InviteTeamRef | null = null
+    // Skip the metadata team for admin-role (teacher) invites: an accepting
+    // owner is auto-promoted to team maintainer, so the backfill's role=member
+    // read would never see them and the team would sit forever as a "pending"
+    // orphan holding their email.
+    if (githubOrgRoleForRole(target.role) !== "admin") {
+      try {
+        inviteTeam = await ensureInviteTeam(client, org, {
+          email: target.email,
+          classroom,
+        })
+        teamIds.push(inviteTeam.id)
+      } catch (err) {
+        if (err instanceof GitHubAPIError && err.isRateLimited) throw err
+        log.error("bulk invite metadata team create failed", {
+          email: target.email,
+          err,
+        })
+        // Non-rate-limit failure: proceed with the classroom team only.
+      }
     }
-    return createOrgInvitation(client, {
-      org,
-      email: target.email,
-      team_ids: teamIds.length > 0 ? teamIds : undefined,
-      role: githubOrgRoleForRole(target.role),
-    })
+    try {
+      return await createOrgInvitation(client, {
+        org,
+        email: target.email,
+        team_ids: teamIds.length > 0 ? teamIds : undefined,
+        role: githubOrgRoleForRole(target.role),
+      })
+    } catch (err) {
+      // A doomed invite (422 already-member/-invited, or a hard failure) must
+      // not leave a fresh, member-less metadata team behind for GC to reap.
+      // Keep it on a rate limit (the deferred retry re-adopts it) and keep an
+      // adopted team (it may hold a prior invite's still-unrecovered record).
+      const rateLimited = err instanceof GitHubAPIError && err.isRateLimited
+      if (!rateLimited && inviteTeam?.created) {
+        try {
+          await deleteInviteTeam(client, org, inviteTeam.slug)
+        } catch (cleanupErr) {
+          log.error("bulk invite metadata team cleanup failed", {
+            email: target.email,
+            err: cleanupErr,
+          })
+        }
+      }
+      throw err
+    }
   }
 
   let rateLimited = false

--- a/web/src/domain/students/inviteRoster.ts
+++ b/web/src/domain/students/inviteRoster.ts
@@ -1,6 +1,7 @@
 import type { GitHubClient } from "@/github-core/client"
 import {
   createOrgInvitation,
+  ensureInviteTeam,
   ensureOrgMembership,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
@@ -10,7 +11,7 @@ import { GitHubAPIError } from "@/github-core/errors"
 import { resolveGitHubId } from "@/util/students"
 import { mapWithConcurrency } from "@/util/concurrency"
 import { githubOrgRoleForRole, type ClassroomRole } from "@/util/teamRoster"
-import { retryDeferred, resolveTeamIdByRole } from "./rosterPrimitives"
+import { retryDeferred, resolveTeamIdByRole, log } from "./rosterPrimitives"
 import i18n from "@/i18n"
 
 export type InviteRosterStudentsInput = {
@@ -295,12 +296,32 @@ export async function bulkInviteByEmail(
 
   type EmailTarget = (typeof targets)[number]
   // Invite one email; throws on error so the caller classifies rate-limit/422.
-  const inviteOne = (target: EmailTarget) => {
+  // Best-effort per-invite metadata team: on create failure the invite still
+  // goes out with the classroom team alone (the invitee stays collectable; only
+  // email retention is lost). A rate-limit error from the team create surfaces
+  // as a thrown GitHubAPIError so the caller defers the whole target — retrying
+  // later recreates the team too, rather than sending a metadata-less invite.
+  const inviteOne = async (target: EmailTarget) => {
     const teamId = teamIdByRole[target.role]
+    const teamIds = teamId ? [teamId] : []
+    try {
+      const inviteTeam = await ensureInviteTeam(client, org, {
+        email: target.email,
+        classroom,
+      })
+      teamIds.push(inviteTeam.id)
+    } catch (err) {
+      if (err instanceof GitHubAPIError && err.isRateLimited) throw err
+      log.error("bulk invite metadata team create failed", {
+        email: target.email,
+        err,
+      })
+      // Non-rate-limit failure: proceed with the classroom team only.
+    }
     return createOrgInvitation(client, {
       org,
       email: target.email,
-      team_ids: teamId ? [teamId] : undefined,
+      team_ids: teamIds.length > 0 ? teamIds : undefined,
       role: githubOrgRoleForRole(target.role),
     })
   }

--- a/web/src/domain/students/inviteRoster.ts
+++ b/web/src/domain/students/inviteRoster.ts
@@ -13,7 +13,12 @@ import { GitHubAPIError } from "@/github-core/errors"
 import { resolveGitHubId } from "@/util/students"
 import { mapWithConcurrency } from "@/util/concurrency"
 import { githubOrgRoleForRole, type ClassroomRole } from "@/util/teamRoster"
-import { retryDeferred, resolveTeamIdByRole, log } from "./rosterPrimitives"
+import {
+  retryDeferred,
+  resolveTeamIdByRole,
+  appendEmailInviteRows,
+  log,
+} from "./rosterPrimitives"
 import i18n from "@/i18n"
 
 export type InviteRosterStudentsInput = {
@@ -298,12 +303,17 @@ export async function bulkInviteByEmail(
 
   type EmailTarget = (typeof targets)[number]
   // Invite one email; throws on error so the caller classifies rate-limit/422.
-  // Best-effort per-invite metadata team: on create failure the invite still
-  // goes out with the classroom team alone (the invitee stays collectable; only
-  // email retention is lost). A rate-limit error from the team create surfaces
-  // as a thrown GitHubAPIError so the caller defers the whole target — retrying
-  // later recreates the team too, rather than sending a metadata-less invite.
-  const inviteOne = async (target: EmailTarget) => {
+  // Returns whether the metadata team rode along, so the caller knows which
+  // invited emails to retain on the roster (a team-less invite must not get a
+  // row — the reconcile would just remove it). Best-effort per-invite metadata
+  // team: on create failure the invite still goes out with the classroom team
+  // alone (the invitee stays collectable; only email retention is lost). A
+  // rate-limit error from the team create surfaces as a thrown GitHubAPIError
+  // so the caller defers the whole target — retrying later recreates the team
+  // too, rather than sending a metadata-less invite.
+  const inviteOne = async (
+    target: EmailTarget,
+  ): Promise<{ hadInviteTeam: boolean }> => {
     const teamId = teamIdByRole[target.role]
     const teamIds = teamId ? [teamId] : []
     let inviteTeam: InviteTeamRef | null = null
@@ -328,12 +338,13 @@ export async function bulkInviteByEmail(
       }
     }
     try {
-      return await createOrgInvitation(client, {
+      await createOrgInvitation(client, {
         org,
         email: target.email,
         team_ids: teamIds.length > 0 ? teamIds : undefined,
         role: githubOrgRoleForRole(target.role),
       })
+      return { hadInviteTeam: inviteTeam !== null }
     } catch (err) {
       // A doomed invite (422 already-member/-invited, or a hard failure) must
       // not leave a fresh, member-less metadata team behind for GC to reap.
@@ -357,6 +368,9 @@ export async function bulkInviteByEmail(
   let rateLimited = false
   let retryAfterMs = 0
   const deferredTargets: EmailTarget[] = []
+  // Invited emails whose metadata team rode along — retained on the roster in
+  // ONE batch write below.
+  const rowsToRetain: { email: string; role: ClassroomRole }[] = []
 
   await mapWithConcurrency(targets, REPO_READ_CONCURRENCY, async (target) => {
     const { email } = target
@@ -366,8 +380,9 @@ export async function bulkInviteByEmail(
       return
     }
     try {
-      await inviteOne(target)
+      const { hadInviteTeam } = await inviteOne(target)
       invited.push({ email, role: target.role })
+      if (hadInviteTeam) rowsToRetain.push({ email, role: target.role })
     } catch (err) {
       if (err instanceof GitHubAPIError && err.isRateLimited) {
         rateLimited = true
@@ -392,8 +407,10 @@ export async function bulkInviteByEmail(
     sleepFn,
     initialRetryAfterMs: retryAfterMs,
     attempt: async (target) => {
-      await inviteOne(target)
+      const { hadInviteTeam } = await inviteOne(target)
       invited.push({ email: target.email, role: target.role })
+      if (hadInviteTeam)
+        rowsToRetain.push({ email: target.email, role: target.role })
     },
     onError: (target, err) => {
       // A 422 on retry means already-member/already-invited, not a failure.
@@ -403,6 +420,10 @@ export async function bulkInviteByEmail(
     },
   })
   for (const target of stillDeferred) deferred.push(target.email)
+
+  // Retain the successfully invited emails on the roster, one commit for the
+  // whole batch (best-effort; a miss is appended by the acceptance reconcile).
+  await appendEmailInviteRows(client, { org, classroom }, rowsToRetain)
 
   return { invited, skipped, failed, deferred }
 }

--- a/web/src/domain/students/inviteRoster.ts
+++ b/web/src/domain/students/inviteRoster.ts
@@ -240,12 +240,15 @@ export type BulkInviteByEmailResult = {
 // Bulk-invite a list of EMAIL addresses to the org, carrying the role's team so
 // accepting the single invite activates the right membership: student ->
 // classroom team, ta -> TA team, teacher -> the teacher team AND org
-// OWNER (role "admin"). Writes NOTHING to roster.csv — an email carries no
-// reliable GitHub identity until accepted; the invite surfaces as a `pending`
-// row via the org pending-invitations list. Mirrors inviteRosterStudents'
-// rate-limit handling (stop issuing new invites once throttled; defer the rest),
-// and the same team resolution (resolveTeamIdByRole ensures the staff team for
-// a teacher/ta invite, students-only never creates empty staff teams).
+// OWNER (role "admin"). Every successfully sent invite that carried a per-invite
+// metadata team is then retained on the roster as an email-only PENDING row, all
+// in ONE commit for the batch (see appendEmailInviteRows); each row lives exactly
+// as long as its invite team does, so an invite sent without a metadata team
+// gets no row. The invite also surfaces as a `pending` row via the org
+// pending-invitations list. Mirrors inviteRosterStudents' rate-limit handling
+// (stop issuing new invites once throttled; defer the rest), and the same team
+// resolution (resolveTeamIdByRole ensures the staff team for a teacher/ta
+// invite, students-only never creates empty staff teams).
 export async function bulkInviteByEmail(
   client: GitHubClient,
   input: BulkInviteByEmailInput,

--- a/web/src/domain/students/reconcileRoster.test.ts
+++ b/web/src/domain/students/reconcileRoster.test.ts
@@ -8,7 +8,7 @@ const listInviteTeams = vi.fn()
 const readInviteTeam = vi.fn()
 const deleteInviteTeam = vi.fn()
 
-vi.mock("./inviteBackfill", () => ({
+vi.mock("./inviteRecoveries", () => ({
   collectInviteRecoveries: (...a: unknown[]) => collectInviteRecoveries(...a),
   finalizeInviteRecoveries: (...a: unknown[]) => finalizeInviteRecoveries(...a),
 }))
@@ -87,9 +87,11 @@ describe("reconcileRoster", () => {
       }),
     )
     // ...and the recovered teams are deleted only after it.
-    expect(finalizeInviteRecoveries).toHaveBeenCalledWith(client, "org", [
-      RECOVERED,
-    ])
+    expect(finalizeInviteRecoveries).toHaveBeenCalledWith(
+      client,
+      { org: "org", classroom: "cs101" },
+      [RECOVERED],
+    )
     expect(result).toEqual({
       addedUsernames: ["alice"],
       recoveredEmails: ["alice@example.com"],

--- a/web/src/domain/students/reconcileRoster.test.ts
+++ b/web/src/domain/students/reconcileRoster.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const collectInviteRecoveries = vi.fn()
+const finalizeInviteRecoveries = vi.fn()
+const syncRosterFromTeam = vi.fn()
+const listInviteTeams = vi.fn()
+const readInviteTeam = vi.fn()
+const deleteInviteTeam = vi.fn()
+
+vi.mock("./inviteBackfill", () => ({
+  collectInviteRecoveries: (...a: unknown[]) => collectInviteRecoveries(...a),
+  finalizeInviteRecoveries: (...a: unknown[]) => finalizeInviteRecoveries(...a),
+}))
+vi.mock("./rosterSync", () => ({
+  syncRosterFromTeam: (...a: unknown[]) => syncRosterFromTeam(...a),
+}))
+vi.mock("@/github-core/mutations", () => ({
+  listInviteTeams: (...a: unknown[]) => listInviteTeams(...a),
+  readInviteTeam: (...a: unknown[]) => readInviteTeam(...a),
+  deleteInviteTeam: (...a: unknown[]) => deleteInviteTeam(...a),
+}))
+
+import { reconcileRoster, purgeInviteTeams } from "./reconcileRoster"
+
+const client = {} as never
+const INPUT = { org: "org", classroom: "cs101" }
+
+const RECOVERED = {
+  email: "alice@example.com",
+  invitee: { id: 2, login: "alice" },
+  slug: "invite-aaaaaaaaaaaaaaaa",
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  collectInviteRecoveries.mockResolvedValue({
+    recovered: [RECOVERED],
+    liveInviteEmails: new Set(),
+    trusted: true,
+    deletedStale: 1,
+  })
+  syncRosterFromTeam.mockResolvedValue({
+    addedUsernames: [],
+    recoveredEmails: ["alice@example.com"],
+    removedEmails: [],
+    noop: false,
+  })
+  finalizeInviteRecoveries.mockResolvedValue(undefined)
+  deleteInviteTeam.mockResolvedValue(undefined)
+})
+
+describe("reconcileRoster", () => {
+  it("collects, syncs with the collected state, then finalizes deletes — in order", async () => {
+    const order: string[] = []
+    collectInviteRecoveries.mockImplementation(async () => {
+      order.push("collect")
+      return {
+        recovered: [RECOVERED],
+        liveInviteEmails: new Set(["b@x"]),
+        trusted: true,
+        deletedStale: 1,
+      }
+    })
+    syncRosterFromTeam.mockImplementation(async () => {
+      order.push("sync")
+      return {
+        addedUsernames: ["alice"],
+        recoveredEmails: ["alice@example.com"],
+        removedEmails: ["dead@x"],
+        noop: false,
+      }
+    })
+    finalizeInviteRecoveries.mockImplementation(async () => {
+      order.push("finalize")
+    })
+
+    const result = await reconcileRoster(client, INPUT)
+    expect(order).toEqual(["collect", "sync", "finalize"])
+    // The collected state rides into the sync call...
+    expect(syncRosterFromTeam).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        org: "org",
+        classroom: "cs101",
+        invites: expect.objectContaining({ trusted: true }),
+      }),
+    )
+    // ...and the recovered teams are deleted only after it.
+    expect(finalizeInviteRecoveries).toHaveBeenCalledWith(client, "org", [
+      RECOVERED,
+    ])
+    expect(result).toEqual({
+      addedUsernames: ["alice"],
+      recoveredEmails: ["alice@example.com"],
+      removedEmails: ["dead@x"],
+      noop: false,
+      deletedStaleTeams: 1,
+    })
+  })
+
+  it("does NOT delete recovered teams when the sync throws (re-recovered next pass)", async () => {
+    syncRosterFromTeam.mockRejectedValue(new Error("archived"))
+    await expect(reconcileRoster(client, INPUT)).rejects.toThrow("archived")
+    expect(finalizeInviteRecoveries).not.toHaveBeenCalled()
+  })
+})
+
+describe("purgeInviteTeams", () => {
+  it("recovers via the reconcile, then purges the rest of this classroom's teams", async () => {
+    listInviteTeams.mockResolvedValue([
+      { slug: "invite-tampered" },
+      { slug: "invite-other" },
+    ])
+    readInviteTeam.mockImplementation(
+      async (_c: unknown, _o: unknown, slug: string) => {
+        if (slug === "invite-tampered") {
+          return {
+            slug,
+            description: { schema: "x", email: "t@x", classroom: "cs101" },
+            createdAt: null,
+            members: [],
+          }
+        }
+        return {
+          slug,
+          description: { schema: "x", email: "e@x", classroom: "cs202" },
+          createdAt: null,
+          members: [],
+        }
+      },
+    )
+
+    const result = await purgeInviteTeams(client, INPUT)
+    expect(result.recovered).toEqual(["alice@example.com"])
+    // Only the team claiming THIS classroom is purged.
+    expect(result.purged).toBe(1)
+    expect(deleteInviteTeam).toHaveBeenCalledWith(
+      client,
+      "org",
+      "invite-tampered",
+    )
+  })
+
+  it("still purges when the reconcile throws (archived classroom)", async () => {
+    syncRosterFromTeam.mockRejectedValue(new Error("archived"))
+    listInviteTeams.mockResolvedValue([{ slug: "invite-left" }])
+    readInviteTeam.mockResolvedValue({
+      slug: "invite-left",
+      description: { schema: "x", email: "l@x", classroom: "cs101" },
+      createdAt: null,
+      members: [],
+    })
+
+    const result = await purgeInviteTeams(client, INPUT)
+    expect(result.recovered).toEqual([])
+    expect(result.purged).toBe(1)
+  })
+
+  it("throws on a purge-phase failure (an explicit action surfaces errors)", async () => {
+    listInviteTeams.mockRejectedValue(new Error("boom"))
+    await expect(purgeInviteTeams(client, INPUT)).rejects.toThrow("boom")
+  })
+})

--- a/web/src/domain/students/reconcileRoster.ts
+++ b/web/src/domain/students/reconcileRoster.ts
@@ -7,7 +7,7 @@ import {
 import {
   collectInviteRecoveries,
   finalizeInviteRecoveries,
-} from "./inviteBackfill"
+} from "./inviteRecoveries"
 import { syncRosterFromTeam, type SyncRosterFromTeamResult } from "./rosterSync"
 
 export type ReconcileRosterResult = SyncRosterFromTeamResult & {
@@ -25,7 +25,8 @@ export type ReconcileRosterResult = SyncRosterFromTeamResult & {
 //      onto their rows, removes email-only rows no live invite team backs,
 //      appends missing team members, and reconciles roles/ids.
 //   3. finalize: delete the recovered mappings' teams only AFTER that commit
-//      landed (a failed delete is re-recovered idempotently next pass).
+//      landed, skipping any slug a fresh pending invitation now maps to (a
+//      same-email re-invite adopts the same deterministic slug).
 // Throws what syncRosterFromTeam throws (archived classroom, malformed CSV,
 // transient write failures); the collect half is never-throw by contract.
 export async function reconcileRoster(
@@ -35,7 +36,7 @@ export async function reconcileRoster(
   const { org, classroom } = input
   const invites = await collectInviteRecoveries(client, { org, classroom })
   const sync = await syncRosterFromTeam(client, { org, classroom, invites })
-  await finalizeInviteRecoveries(client, org, invites.recovered)
+  await finalizeInviteRecoveries(client, { org, classroom }, invites.recovered)
   return { ...sync, deletedStaleTeams: invites.deletedStale }
 }
 

--- a/web/src/domain/students/reconcileRoster.ts
+++ b/web/src/domain/students/reconcileRoster.ts
@@ -1,0 +1,84 @@
+import type { GitHubClient } from "@/github-core/client"
+import {
+  deleteInviteTeam,
+  listInviteTeams,
+  readInviteTeam,
+} from "@/github-core/mutations"
+import {
+  collectInviteRecoveries,
+  finalizeInviteRecoveries,
+} from "./inviteBackfill"
+import { syncRosterFromTeam, type SyncRosterFromTeamResult } from "./rosterSync"
+
+export type ReconcileRosterResult = SyncRosterFromTeamResult & {
+  // Invite teams deleted without a recovery (unenrolled invitee, or an aged
+  // team whose org invitation is gone).
+  deletedStaleTeams: number
+}
+
+// THE consolidated roster reconciliation — the single writer both the roster
+// page's "Sync roster" and the owner-visit classroom reconcile call, so
+// roster.csv converges in at most ONE commit per pass:
+//   1. collect: classify this classroom's invite teams (accepted -> recovered
+//      mappings, pending -> live emails) and GC the stale ones. No CSV writes.
+//   2. sync: one conflict-retried commit that folds the recovered mappings
+//      onto their rows, removes email-only rows no live invite team backs,
+//      appends missing team members, and reconciles roles/ids.
+//   3. finalize: delete the recovered mappings' teams only AFTER that commit
+//      landed (a failed delete is re-recovered idempotently next pass).
+// Throws what syncRosterFromTeam throws (archived classroom, malformed CSV,
+// transient write failures); the collect half is never-throw by contract.
+export async function reconcileRoster(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+): Promise<ReconcileRosterResult> {
+  const { org, classroom } = input
+  const invites = await collectInviteRecoveries(client, { org, classroom })
+  const sync = await syncRosterFromTeam(client, { org, classroom, invites })
+  await finalizeInviteRecoveries(client, org, invites.recovered)
+  return { ...sync, deletedStaleTeams: invites.deletedStale }
+}
+
+export type PurgeInviteTeamsResult = {
+  // Emails recovered into roster.csv by the reconcile run first.
+  recovered: string[]
+  // Remaining invite teams for this classroom deleted afterwards.
+  purged: number
+}
+
+// Teacher-triggered cleanup for the invite teams the automatic pass cannot or
+// will not touch: tampered (hash-mismatched) records, multi-member anomalies,
+// still-pending invites the teacher wants forgotten, and an archived
+// classroom's leftovers. Runs the consolidated reconcile first so anything
+// recoverable lands in roster.csv (skipped on an archived classroom, whose
+// roster is frozen), then deletes EVERY remaining team whose record claims
+// this classroom — the claim alone suffices here (a tamperer can at worst get
+// their own team deleted). Throws on failure (an explicit action the teacher
+// should see fail), except that already-gone teams read as done.
+export async function purgeInviteTeams(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+): Promise<PurgeInviteTeamsResult> {
+  const { org, classroom } = input
+  let recovered: string[] = []
+  try {
+    recovered = (await reconcileRoster(client, input)).recoveredEmails
+  } catch {
+    // Archived classroom (or an unwritable roster): recovery is off the
+    // table, but purging the stored emails is exactly why the teacher is
+    // here — proceed to the deletes.
+  }
+
+  let purged = 0
+  const teams = await listInviteTeams(client, org)
+  for (const team of teams) {
+    const slug = team.slug
+    if (!slug) continue
+    const state = await readInviteTeam(client, org, slug)
+    if (!state) continue // already gone
+    if (state.description?.classroom !== classroom) continue
+    await deleteInviteTeam(client, org, slug)
+    purged += 1
+  }
+  return { recovered, purged }
+}

--- a/web/src/domain/students/rosterPrimitives.ts
+++ b/web/src/domain/students/rosterPrimitives.ts
@@ -32,10 +32,12 @@ import { rosterPath } from "@/util/rosterPath"
 import { prefixCommit } from "@/util/commit"
 import {
   formatRosterProblems,
+  normalizeStudentRow,
   parseRosterCsv,
   stringifyStudentsCsv,
   type StudentCsvRow,
 } from "@/util/rosterCsv"
+import { normalizeInviteEmail } from "@/util/inviteTeam"
 import { withGitConflictRetry } from "../classrooms"
 import {
   ROLE_RANK,
@@ -114,6 +116,60 @@ export async function withRosterRewrite(
     await updateRef(client, org, newCommit.sha, configBranch)
     return { changed }
   })
+}
+
+// Append email-only pending rows for freshly sent email invites, one commit
+// for the whole batch. Only invites that carry a metadata team should be
+// passed in — the reconcile keeps an email-only row exactly as long as a live
+// invite team backs it, so a team-less row would be removed on the next pass.
+// Emails already claimed by any row are skipped (a resend must not duplicate).
+// Best-effort and never throws: a missed row simply appears later, when the
+// accepted invite's reconcile fold appends it.
+export async function appendEmailInviteRows(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+  invites: { email: string; role: ClassroomRole }[],
+): Promise<void> {
+  if (invites.length === 0) return
+  try {
+    await withRosterRewrite(client, input, (rows) => {
+      const claimed = new Set(
+        rows
+          .map((r) => r.email?.trim().toLowerCase())
+          .filter((e): e is string => Boolean(e)),
+      )
+      const added: StudentCsvRow[] = []
+      for (const invite of invites) {
+        const email = normalizeInviteEmail(invite.email)
+        if (!email || claimed.has(email)) continue
+        claimed.add(email)
+        added.push(
+          normalizeStudentRow({
+            username: "",
+            github_id: "",
+            first_name: "",
+            last_name: "",
+            email,
+            section: "",
+            role: invite.role,
+          }),
+        )
+      }
+      return {
+        nextStudents: [...rows, ...added],
+        changed: added.length,
+        message: `Add ${added.length} invited email${
+          added.length === 1 ? "" : "s"
+        } to roster: ${input.classroom}`,
+      }
+    })
+  } catch (err) {
+    log.error("email invite roster row write failed", {
+      org: input.org,
+      classroom: input.classroom,
+      err,
+    })
+  }
 }
 
 // Slug is authoritative in classroom.json: GitHub may assign a non-derived slug

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -19,6 +19,7 @@ import {
   normalizeStudentRow,
   parseStudentsCsv,
   stringifyStudentsCsv,
+  type StudentCsvRow,
 } from "@/util/rosterCsv"
 import { rosterPath } from "@/util/rosterPath"
 import {
@@ -28,6 +29,7 @@ import {
   listClassroomMembersWithRoles,
 } from "./rosterPrimitives"
 import type { InviteReconcileState } from "./inviteRecoveries"
+import { pendingInviteEmails } from "./inviteRecoveries"
 
 export type SyncRosterFromTeamResult = {
   // Team members newly appended to roster.csv as metadata rows.
@@ -46,8 +48,11 @@ export type SyncRosterFromTeamResult = {
 //   1. upgrade rows matched by a recovered invite (fill username/github_id
 //      onto the email row written at invite time);
 //   2. remove email-only rows (no username, no valid github_id) that no live
-//      invite team backs — the invite was cancelled, expired, or GC'd. Gated
-//      on `invites.trusted` so a degraded read can never wipe pending rows;
+//      invite backs — the invite was cancelled, expired, or GC'd. Gated on
+//      `invites.trusted` so a degraded read can never wipe pending rows, and
+//      every candidate is re-confirmed against GitHub's current pending
+//      invitations inside this closure (collect's snapshot predates the CSV
+//      read, so an invite sent in between must not be reaped);
 //   3. the pre-existing team sync: ensure every active member has an IDENTITY
 //      row (username + github_id) carrying their team-derived `role`, refresh
 //      changed roles, and backfill resolvable ids.
@@ -142,19 +147,36 @@ export async function syncRosterFromTeam(
 
     // --- Dead email-row removal ---------------------------------------------
     // An email-ONLY row (no username, no valid github_id) exists on the roster
-    // only while a live invite team backs it; once the invite is cancelled,
-    // expired, or GC'd, the row goes too — in this same commit. Gated on the
-    // reconcile state being trustworthy: a degraded invite-team read must
-    // never masquerade as "no live invites" and wipe pending rows.
+    // only while a live invite backs it; once the invite is cancelled, expired,
+    // or GC'd, the row goes too — in this same commit. Two gates keep that from
+    // eating a legitimate row: the invite-reconcile state must be trustworthy
+    // (a degraded invite-team read must never masquerade as "no live invites"),
+    // and every candidate is confirmed against GitHub's CURRENT pending
+    // invitations. That confirmation is read HERE, inside the retried closure,
+    // because the collect pass snapshotted teams BEFORE this CSV read — an
+    // invite sent in between has its fresh row in `currentStudents` but no
+    // entry in the snapshot, and must not be reaped for it.
+    const deadRows = new Set<StudentCsvRow>()
+    if (invites?.trusted) {
+      for (const s of foldedStudents) {
+        if (s.username.trim()) continue
+        if (resolveGitHubId(s.github_id) !== null) continue
+        const emailKey = normalizeInviteEmail(s.email ?? "")
+        if (!emailKey) continue // a blank junk row is not this pass's call
+        if (invites.liveInviteEmails.has(emailKey)) continue
+        if (recByEmail.has(emailKey)) continue
+        deadRows.add(s)
+      }
+    }
+    // Only pay for the confirmation read when something is actually up for
+    // removal. A failed read yields null and keeps every row (fail closed).
+    const stillPending =
+      deadRows.size > 0 ? await pendingInviteEmails(client, org) : null
     const removedEmails: string[] = []
     const keptStudents = foldedStudents.filter((s) => {
-      if (!invites?.trusted) return true
-      if (s.username.trim()) return true
-      if (resolveGitHubId(s.github_id) !== null) return true
+      if (!deadRows.has(s)) return true
       const emailKey = normalizeInviteEmail(s.email ?? "")
-      if (!emailKey) return true // a blank junk row is not this pass's call
-      if (invites.liveInviteEmails.has(emailKey)) return true
-      if (recByEmail.has(emailKey)) return true
+      if (!stillPending || stillPending.has(emailKey)) return true
       removedEmails.push(emailKey)
       return false
     })

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -13,6 +13,7 @@ import {
 } from "@/github-core/configRepoReads"
 import { rosterClaimSet } from "@/util/identity"
 import { parseGitHubId, resolveGitHubId } from "@/util/students"
+import { normalizeInviteEmail } from "@/util/inviteTeam"
 import { prefixCommit } from "@/util/commit"
 import {
   normalizeStudentRow,
@@ -26,23 +27,35 @@ import {
   resolveClassroomTeamSlugs,
   listClassroomMembersWithRoles,
 } from "./rosterPrimitives"
+import type { InviteReconcileState } from "./inviteBackfill"
 
 export type SyncRosterFromTeamResult = {
   // Team members newly appended to roster.csv as metadata rows.
   addedUsernames: string[]
-  // No missing members and no role changes — nothing was committed.
+  // Recovered invited emails folded onto rows (identity filled or appended).
+  recoveredEmails: string[]
+  // Email-only rows removed because no live invite team backs them.
+  removedEmails: string[]
+  // No missing members, no role changes, no invite fold — nothing committed.
   noop: boolean
 }
 
-// Sync roster.csv from the classroom's GitHub teams: ensure every active member
-// of the student team plus every staff team (teacher, hta, ta) has an IDENTITY
-// row (username +
-// github_id) carrying their recorded `role`, and refresh the role on rows whose
-// team-derived role has changed — all in ONE commit. The teams are the source
-// of truth for enrollment and role; the CSV holds teacher-supplied metadata
-// plus this best-effort role snapshot, so this writes identity + role only and
-// never fabricates name/email/section from the GitHub profile. Never removes
-// rows (CSV-only rows are drift, not deletions).
+// Sync roster.csv from the classroom's GitHub teams — plus, when the caller
+// passes the invite-reconcile state, fold the email-invite lifecycle into the
+// SAME single commit (see reconcileRoster):
+//   1. upgrade rows matched by a recovered invite (fill username/github_id
+//      onto the email row written at invite time);
+//   2. remove email-only rows (no username, no valid github_id) that no live
+//      invite team backs — the invite was cancelled, expired, or GC'd. Gated
+//      on `invites.trusted` so a degraded read can never wipe pending rows;
+//   3. the pre-existing team sync: ensure every active member has an IDENTITY
+//      row (username + github_id) carrying their team-derived `role`, refresh
+//      changed roles, and backfill resolvable ids.
+// The teams are the source of truth for enrollment and role; the CSV holds
+// teacher-supplied metadata plus this best-effort snapshot, so identity, role,
+// and the recovered email are the only fields written — never name/section
+// fabricated from a GitHub profile. Identity rows are never removed (CSV-only
+// identity rows are drift, not deletions); only dead email-ONLY rows are.
 //
 // The diff is recomputed INSIDE the retried closure (re-reading both teams and
 // CSV each attempt) so a 409 retry or concurrent edit can't reintroduce or
@@ -51,9 +64,15 @@ export type SyncRosterFromTeamResult = {
 // empty github_id isn't treated as missing (which would append a duplicate).
 export async function syncRosterFromTeam(
   client: GitHubClient,
-  input: { org: string; classroom: string },
+  input: {
+    org: string
+    classroom: string
+    // Invite-reconcile state from collectInviteRecoveries. Omitted = plain
+    // team sync (no fold, no removals).
+    invites?: InviteReconcileState
+  },
 ): Promise<SyncRosterFromTeamResult> {
-  const { org, classroom } = input
+  const { org, classroom, invites } = input
   log.info("sync roster from team: started", { org, classroom })
   await assertClassroomNotArchived(client, org, classroom)
 
@@ -78,14 +97,76 @@ export async function syncRosterFromTeam(
     })
     const currentStudents = parseStudentsCsv(currentCsv)
 
-    const { ids, logins } = rosterClaimSet(currentStudents)
+    // --- Invite fold: claim each recovered mapping onto its row -------------
+    // Match by the invited email first (the row written at invite time), then
+    // by id/login (a teacher may have added an identity row separately). Each
+    // mapping claims at most one row; borrow-only writes (blank fields filled,
+    // teacher values win). A mapping with no row at all is appended below with
+    // its email attached.
+    const recovered = invites?.recovered ?? []
+    const recByEmail = new Map(recovered.map((r) => [r.email, r]))
+    const recById = new Map(recovered.map((r) => [String(r.invitee.id), r]))
+    const recByLogin = new Map(
+      recovered.map((r) => [r.invitee.login.toLowerCase(), r]),
+    )
+    const claimed = new Set<(typeof recovered)[number]>()
+    const recoveredEmails: string[] = []
+    let inviteFolds = 0
+    const foldedStudents = currentStudents.map((s) => {
+      const emailKey = normalizeInviteEmail(s.email ?? "")
+      const idKey = parseGitHubId(s.github_id)
+      const match =
+        (emailKey ? recByEmail.get(emailKey) : undefined) ??
+        (idKey !== null ? recById.get(String(idKey)) : undefined) ??
+        recByLogin.get(s.username.trim().toLowerCase())
+      if (!match || claimed.has(match)) return s
+      claimed.add(match)
+      const next = normalizeStudentRow({
+        ...s,
+        username: s.username || match.invitee.login,
+        github_id: s.github_id || String(match.invitee.id),
+        email: s.email?.trim() || match.email,
+      })
+      if (
+        next.username !== s.username ||
+        next.github_id !== s.github_id ||
+        next.email !== s.email
+      ) {
+        inviteFolds++
+        recoveredEmails.push(match.email)
+        return next
+      }
+      return s
+    })
+    const unclaimed = recovered.filter((r) => !claimed.has(r))
+
+    // --- Dead email-row removal ---------------------------------------------
+    // An email-ONLY row (no username, no valid github_id) exists on the roster
+    // only while a live invite team backs it; once the invite is cancelled,
+    // expired, or GC'd, the row goes too — in this same commit. Gated on the
+    // reconcile state being trustworthy: a degraded invite-team read must
+    // never masquerade as "no live invites" and wipe pending rows.
+    const removedEmails: string[] = []
+    const keptStudents = foldedStudents.filter((s) => {
+      if (!invites?.trusted) return true
+      if (s.username.trim()) return true
+      if (resolveGitHubId(s.github_id) !== null) return true
+      const emailKey = normalizeInviteEmail(s.email ?? "")
+      if (!emailKey) return true // a blank junk row is not this pass's call
+      if (invites.liveInviteEmails.has(emailKey)) return true
+      if (recByEmail.has(emailKey)) return true
+      removedEmails.push(emailKey)
+      return false
+    })
+
+    const { ids, logins } = rosterClaimSet(keptStudents)
     // Email set mirrors buildTeamRoster's indexCsv.byEmail fold: a member whose
     // GitHub email matches an existing (e.g., pre-resolution, id/login-less) CSV
     // row is the SAME person the view folds by email, so appending would create
     // a duplicate email-colliding row the view masks but that breaks email-keyed
     // logic (match-by-email, invite dedupe).
     const emails = new Set(
-      currentStudents
+      keptStudents
         .map((s) => s.email?.trim().toLowerCase())
         .filter((e): e is string => Boolean(e)),
     )
@@ -136,7 +217,7 @@ export async function syncRosterFromTeam(
     )
     let roleChanges = 0
     let idBackfills = 0
-    const reconciledStudents = currentStudents.map((s) => {
+    const reconciledStudents = keptStudents.map((s) => {
       const loginKey = s.username.trim().toLowerCase()
       const emailKey = s.email?.trim().toLowerCase()
       const teamRole =
@@ -174,30 +255,46 @@ export async function syncRosterFromTeam(
       return next
     })
 
-    if (missing.length === 0 && roleChanges === 0 && idBackfills === 0) {
+    if (
+      missing.length === 0 &&
+      roleChanges === 0 &&
+      idBackfills === 0 &&
+      inviteFolds === 0 &&
+      removedEmails.length === 0
+    ) {
       log.info("sync roster from team: completed (up to date)", {
         org,
         classroom,
       })
-      return { addedUsernames: [], noop: true }
+      return {
+        addedUsernames: [],
+        recoveredEmails: [],
+        removedEmails: [],
+        noop: true,
+      }
     }
 
-    // Identity + role rows: username + github_id + role. Name/email/section are
-    // left blank for the teacher to provide (via Edit or a roster upload). The
-    // teams decide enrollment and role; the CSV holds only teacher-supplied
-    // metadata plus this role snapshot, so we never fabricate profile fields
-    // from the GitHub account here.
-    const addedRows = missing.map((m) =>
-      normalizeStudentRow({
+    // Identity + role rows: username + github_id + role, plus the recovered
+    // invited email when this member arrived via an email invite whose row is
+    // gone (the common case leaves the invite-time row in place and upgrades
+    // it above). Name/section are left for the teacher (via Edit or a roster
+    // upload); we never fabricate profile fields from the GitHub account here.
+    const emailByMemberId = new Map(
+      unclaimed.map((r) => [String(r.invitee.id), r.email]),
+    )
+    const addedRows = missing.map((m) => {
+      const recoveredEmail = emailByMemberId.get(String(m.id))
+      if (recoveredEmail) recoveredEmails.push(recoveredEmail)
+      return normalizeStudentRow({
         username: m.login,
         first_name: "",
         last_name: "",
-        email: "",
+        email: recoveredEmail ?? "",
         section: "",
         github_id: String(m.id),
         role: m.role,
-      }),
-    )
+      })
+    })
 
     const nextCsv = stringifyStudentsCsv([...reconciledStudents, ...addedRows])
 
@@ -209,11 +306,7 @@ export async function syncRosterFromTeam(
 
     const newCommit = await createGitCommit(client, {
       org,
-      message: prefixCommit(
-        `Sync ${addedRows.length} member${
-          addedRows.length === 1 ? "" : "s"
-        } into roster: ${classroom}`,
-      ),
+      message: prefixCommit(`Sync roster from teams: ${classroom}`),
       tree_sha: tree.sha,
       parents: [ref.object.sha],
     })
@@ -226,9 +319,13 @@ export async function syncRosterFromTeam(
       added: addedRows.length,
       roleChanges,
       idBackfills,
+      inviteFolds,
+      removedEmails: removedEmails.length,
     })
     return {
       addedUsernames: addedRows.map((r) => r.username),
+      recoveredEmails,
+      removedEmails,
       noop: false,
     }
   })

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -27,7 +27,7 @@ import {
   resolveClassroomTeamSlugs,
   listClassroomMembersWithRoles,
 } from "./rosterPrimitives"
-import type { InviteReconcileState } from "./inviteBackfill"
+import type { InviteReconcileState } from "./inviteRecoveries"
 
 export type SyncRosterFromTeamResult = {
   // Team members newly appended to roster.csv as metadata rows.

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -145,6 +145,7 @@ export {
   readInviteTeam,
   listInviteTeams,
   deleteInviteTeam,
+  deleteInviteTeamForEmail,
   InviteTeamNotSecretError,
   type InviteTeamRef,
   type InviteTeamState,

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -140,4 +140,13 @@ export {
   ClassroomSourceReadError,
   type TeamDescriptionReconcileResult,
 } from "./mutations/teamDescription"
+export {
+  ensureInviteTeam,
+  readInviteTeam,
+  listInviteTeams,
+  deleteInviteTeam,
+  InviteTeamNotSecretError,
+  type InviteTeamRef,
+  type InviteTeamState,
+} from "./mutations/inviteTeams"
 export { updateOrgProfile, type OrgProfileUpdate } from "./mutations/orgProfile"

--- a/web/src/github-core/mutations/inviteTeams.test.ts
+++ b/web/src/github-core/mutations/inviteTeams.test.ts
@@ -191,11 +191,13 @@ describe("listInviteTeams", () => {
     expect(teams.map((t) => t.slug)).toEqual(["invite-aaaa"])
   })
 
-  it("degrades to [] when the org team list is unreadable (404)", async () => {
+  it("throws when the org team list is unreadable (strict: rows depend on it)", async () => {
     const { client } = makeClient(() => {
       throw apiError(404)
     })
-    await expect(listInviteTeams(client, "acme")).resolves.toEqual([])
+    await expect(listInviteTeams(client, "acme")).rejects.toMatchObject({
+      status: 404,
+    })
   })
 })
 

--- a/web/src/github-core/mutations/inviteTeams.test.ts
+++ b/web/src/github-core/mutations/inviteTeams.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest"
+import {
+  ensureInviteTeam,
+  InviteTeamNotSecretError,
+  readInviteTeam,
+  listInviteTeams,
+  deleteInviteTeam,
+} from "./inviteTeams"
+import type { GitHubClient } from "../client"
+import { GitHubAPIError, type GitHubRateLimit } from "../errors"
+import { inviteTeamName, marshalInviteDescription } from "@/util/inviteTeam"
+
+const emptyRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const apiError = (status: number, message = `boom ${status}`) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/x",
+    message,
+    body: null,
+    rateLimit: emptyRateLimit,
+  })
+
+const METADATA = { email: "alice@example.com", classroom: "cs101" }
+const DESCRIPTION = marshalInviteDescription(METADATA)
+
+type Call = { url: string; options?: { method?: string; body?: unknown } }
+
+// A request mock that dispatches on method+url, recording every call.
+function makeClient(
+  handler: (url: string, options?: Call["options"]) => unknown,
+) {
+  const calls: Call[] = []
+  const request = vi.fn(async (url: string, options?: Call["options"]) => {
+    calls.push({ url, options })
+    return handler(url, options)
+  })
+  return { client: { request } as unknown as GitHubClient, request, calls }
+}
+
+describe("ensureInviteTeam", () => {
+  it("creates a fresh secret team and reports created: true (no PATCH)", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const { client, calls } = makeClient((url, options) => {
+      if (options?.method === "POST" && url === "/orgs/acme/teams") {
+        const body = options.body as Record<string, unknown>
+        expect(body.privacy).toBe("secret")
+        expect(body.description).toBe(DESCRIPTION)
+        expect(body.name).toBe(name)
+        return {
+          id: 7,
+          slug: name,
+          privacy: "secret",
+          description: DESCRIPTION,
+        }
+      }
+      throw new Error(`unexpected ${url}`)
+    })
+
+    const ref = await ensureInviteTeam(client, "acme", METADATA)
+    expect(ref).toEqual({ id: 7, slug: name, created: true })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("adopts an existing team on 422, forcing secret + description via PATCH (created: false)", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const { client, calls } = makeClient((_url, options) => {
+      if (options?.method === "POST") throw apiError(422)
+      if (options?.method === "PATCH") {
+        expect(options.body).toEqual({
+          privacy: "secret",
+          description: DESCRIPTION,
+        })
+        return {
+          id: 7,
+          slug: name,
+          privacy: "secret",
+          description: DESCRIPTION,
+        }
+      }
+      // The adopt read: a pre-existing CLOSED team with a stale description.
+      return { id: 7, slug: name, privacy: "closed", description: "old" }
+    })
+    const ref = await ensureInviteTeam(client, "acme", METADATA)
+    expect(ref).toEqual({ id: 7, slug: name, created: false })
+    expect(calls.map((c) => c.options?.method ?? "GET")).toEqual([
+      "POST",
+      "GET",
+      "PATCH",
+    ])
+  })
+
+  it("skips the PATCH when the adopted team is already secret with the same description", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const { client, calls } = makeClient((_url, options) => {
+      if (options?.method === "POST") throw apiError(422)
+      return { id: 7, slug: name, privacy: "secret", description: DESCRIPTION }
+    })
+
+    const ref = await ensureInviteTeam(client, "acme", METADATA)
+    expect(ref.created).toBe(false)
+    expect(calls.map((c) => c.options?.method ?? "GET")).toEqual([
+      "POST",
+      "GET",
+    ])
+  })
+
+  it("fails closed when the team can't be made secret", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const { client } = makeClient((_url, options) => {
+      if (options?.method === "POST") throw apiError(422)
+      // Both the adopt read and the PATCH report a stubbornly closed team.
+      return { id: 7, slug: name, privacy: "closed", description: DESCRIPTION }
+    })
+
+    await expect(ensureInviteTeam(client, "acme", METADATA)).rejects.toThrow(
+      InviteTeamNotSecretError,
+    )
+  })
+
+  it("rethrows a non-422 create failure", async () => {
+    const { client } = makeClient(() => {
+      throw apiError(500)
+    })
+    await expect(
+      ensureInviteTeam(client, "acme", METADATA),
+    ).rejects.toMatchObject({ status: 500 })
+  })
+})
+
+describe("readInviteTeam", () => {
+  it("returns null when the team is already gone (404)", async () => {
+    const { client } = makeClient(() => {
+      throw apiError(404)
+    })
+    await expect(readInviteTeam(client, "acme", "invite-abc")).resolves.toBe(
+      null,
+    )
+  })
+
+  it("parses the description and lists regular-role members only", async () => {
+    const { client, calls } = makeClient((url) => {
+      if (url.includes("/members")) return [{ id: 2, login: "alice" }]
+      return { slug: "invite-abc", description: DESCRIPTION }
+    })
+
+    const state = await readInviteTeam(client, "acme", "invite-abc")
+    expect(state?.description).toMatchObject({
+      email: "alice@example.com",
+      classroom: "cs101",
+    })
+    expect(state?.members).toEqual([{ id: 2, login: "alice" }])
+    // The maintainer-excluding filter is what keeps the auto-added owner (and
+    // any org owner) out of the invitee set.
+    const memberCall = calls.find((c) => c.url.includes("/members"))
+    expect(memberCall?.url).toContain("role=member")
+  })
+
+  it("yields a null description for a non-v1 record (hand-edited team)", async () => {
+    const { client } = makeClient((url) => {
+      if (url.includes("/members")) return []
+      return { slug: "invite-abc", description: "just some text" }
+    })
+    const state = await readInviteTeam(client, "acme", "invite-abc")
+    expect(state).not.toBeNull()
+    expect(state?.description).toBeNull()
+  })
+})
+
+describe("listInviteTeams", () => {
+  it("returns only invite- teams", async () => {
+    const { client } = makeClient(() => [
+      { id: 1, slug: "invite-aaaa" },
+      { id: 2, slug: "classroom50-cs101" },
+    ])
+    const teams = await listInviteTeams(client, "acme")
+    expect(teams.map((t) => t.slug)).toEqual(["invite-aaaa"])
+  })
+
+  it("degrades to [] when the org team list is unreadable (404)", async () => {
+    const { client } = makeClient(() => {
+      throw apiError(404)
+    })
+    await expect(listInviteTeams(client, "acme")).resolves.toEqual([])
+  })
+})
+
+describe("deleteInviteTeam", () => {
+  it("refuses to delete a slug outside the invite- namespace", async () => {
+    const { client, request } = makeClient(() => undefined)
+    await deleteInviteTeam(client, "acme", "classroom50-cs101")
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it("deletes an invite team and tolerates 404 (already gone)", async () => {
+    const { client, calls } = makeClient(() => {
+      throw apiError(404)
+    })
+    await expect(
+      deleteInviteTeam(client, "acme", "invite-abc"),
+    ).resolves.toBeUndefined()
+    expect(calls[0]).toMatchObject({
+      url: "/orgs/acme/teams/invite-abc",
+      options: { method: "DELETE" },
+    })
+  })
+})

--- a/web/src/github-core/mutations/inviteTeams.test.ts
+++ b/web/src/github-core/mutations/inviteTeams.test.ts
@@ -6,6 +6,7 @@ import {
   readInviteTeam,
   listInviteTeams,
   deleteInviteTeam,
+  deleteInviteTeamForEmail,
 } from "./inviteTeams"
 import type { GitHubClient } from "../client"
 import { GitHubAPIError, type GitHubRateLimit } from "../errors"
@@ -149,7 +150,11 @@ describe("readInviteTeam", () => {
   it("parses the description and lists regular-role members only", async () => {
     const { client, calls } = makeClient((url) => {
       if (url.includes("/members")) return [{ id: 2, login: "alice" }]
-      return { slug: "invite-abc", description: DESCRIPTION }
+      return {
+        slug: "invite-abc",
+        description: DESCRIPTION,
+        created_at: "2026-08-01T00:00:00Z",
+      }
     })
 
     const state = await readInviteTeam(client, "acme", "invite-abc")
@@ -157,6 +162,7 @@ describe("readInviteTeam", () => {
       email: "alice@example.com",
       classroom: "cs101",
     })
+    expect(state?.createdAt).toBe("2026-08-01T00:00:00Z")
     expect(state?.members).toEqual([{ id: 2, login: "alice" }])
     // The maintainer-excluding filter is what keeps the auto-added owner (and
     // any org owner) out of the invitee set.
@@ -211,5 +217,32 @@ describe("deleteInviteTeam", () => {
       url: "/orgs/acme/teams/invite-abc",
       options: { method: "DELETE" },
     })
+  })
+})
+
+describe("deleteInviteTeamForEmail", () => {
+  it("hashes (classroom, email) to the slug and deletes that team", async () => {
+    const slug = await inviteTeamName("cs101", "alice@example.com")
+    const { client, calls } = makeClient(() => undefined)
+    await deleteInviteTeamForEmail(client, "acme", {
+      classroom: "cs101",
+      email: "alice@example.com",
+    })
+    expect(calls[0]).toMatchObject({
+      url: `/orgs/acme/teams/${slug}`,
+      options: { method: "DELETE" },
+    })
+  })
+
+  it("never throws (best-effort cancel-side teardown)", async () => {
+    const { client } = makeClient(() => {
+      throw apiError(500)
+    })
+    await expect(
+      deleteInviteTeamForEmail(client, "acme", {
+        classroom: "cs101",
+        email: "alice@example.com",
+      }),
+    ).resolves.toBeUndefined()
   })
 })

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -12,7 +12,6 @@ import {
   type InviteDescription,
   type InviteMetadata,
 } from "@/util/inviteTeam"
-import { listTeamMembers } from "../queries/teamReads"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("mutations:inviteTeams")
@@ -32,7 +31,11 @@ export class InviteTeamNotSecretError extends Error {
   }
 }
 
-export type InviteTeamRef = { id: number; slug: string }
+// `created` distinguishes a team this call freshly created from an adopted
+// pre-existing one, so a caller whose org invite then fails can safely delete
+// only what it created (an adopted team may hold a still-unrecovered record
+// from an earlier accepted invite).
+export type InviteTeamRef = { id: number; slug: string; created: boolean }
 
 // Create (or adopt) the per-invite SECRET team for (classroom, email) and write
 // the classroom50/invite/v1 record into its description. The team name is the
@@ -51,6 +54,7 @@ export async function ensureInviteTeam(
   const description = marshalInviteDescription(metadata)
 
   let team: GitHubTeam
+  let created = true
   try {
     team = await createTeam(client, {
       org,
@@ -64,6 +68,7 @@ export async function ensureInviteTeam(
       // A same-named team already exists (a resend, a retry, or a prior invite
       // to the same email+classroom): adopt it, forcing secret + refreshing the
       // description. Name is slug-safe, so it doubles as the lookup slug.
+      created = false
       team = await client.request<GitHubTeam>(
         `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(name)}`,
       )
@@ -88,14 +93,17 @@ export async function ensureInviteTeam(
     throw new InviteTeamNotSecretError(team.slug)
   }
 
-  return { id: team.id, slug: team.slug }
+  return { id: team.id, slug: team.slug, created }
 }
 
 export type InviteTeamState = {
   slug: string
   description: InviteDescription | null
-  // Members of the team, EXCLUDING no one here — the caller filters out org
-  // owners (the auto-added creator/maintainer) to find the accepted invitee.
+  // Regular-role members only (?role=member). GitHub auto-promotes the
+  // creating owner — and any org owner — to team maintainer, so the invitee
+  // (added via the invitation's team_ids as a plain member) is exactly what's
+  // left; no org-admin subtraction needed. 404 (team vanished mid-read) yields
+  // [] so the team simply looks pending; other errors propagate.
   members: GitHubUser[]
 }
 
@@ -116,7 +124,17 @@ export async function readInviteTeam(
     null,
   )
   if (!team) return null
-  const members = await listTeamMembers(client, org, slug)
+  const members = await tolerateGitHubError(
+    () =>
+      paginateAll<GitHubUser>(
+        client,
+        (page) =>
+          `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+            slug,
+          )}/members?role=member&per_page=100&page=${page}`,
+      ),
+    [],
+  )
   return {
     slug: team.slug,
     description: parseInviteDescription(team.description),

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -99,6 +99,9 @@ export async function ensureInviteTeam(
 export type InviteTeamState = {
   slug: string
   description: InviteDescription | null
+  // From the full-team read; null when GitHub omits it. Drives the GC age
+  // guard (a team too young to judge is never reaped).
+  createdAt: string | null
   // Regular-role members only (?role=member). GitHub auto-promotes the
   // creating owner — and any org owner — to team maintainer, so the invitee
   // (added via the invitation's team_ids as a plain member) is exactly what's
@@ -138,6 +141,7 @@ export async function readInviteTeam(
   return {
     slug: team.slug,
     description: parseInviteDescription(team.description),
+    createdAt: team.created_at ?? null,
     members,
   }
 }
@@ -182,6 +186,24 @@ export async function deleteInviteTeam(
       ),
     undefined,
   )
+}
+
+// Best-effort delete of the (classroom, email) invite team — the cancel-side
+// teardown: when a teacher cancels or dismisses an email invitation, the
+// stored email should go with it rather than wait for the next GC pass. Never
+// throws (the cancel already succeeded; a leftover team is only a GC-pending
+// orphan). Safe to call for an email with no team (404 = already gone).
+export async function deleteInviteTeamForEmail(
+  client: GitHubClient,
+  org: string,
+  input: { classroom: string; email: string },
+): Promise<void> {
+  try {
+    const slug = await inviteTeamName(input.classroom, input.email)
+    await deleteInviteTeam(client, org, slug)
+  } catch (err) {
+    log.error("invite team cancel-cleanup failed", { org, err })
+  }
 }
 
 export { INVITE_TEAM_PREFIX }

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -147,21 +147,19 @@ export async function readInviteTeam(
 }
 
 // Enumerate the org's invite-<hash> teams (secret teams this feature owns),
-// filtering the org team list by the invite- prefix. Owner/member visibility
-// applies; a non-owner who can't list teams degrades to [] (tolerated upstream),
-// so GC/backfill simply do nothing rather than erroring.
+// filtering the org team list by the invite- prefix. STRICT: a failed listing
+// throws rather than degrading to [] — the reconcile uses this list to decide
+// which email-only roster rows are still backed by a live invite, and a
+// degraded read must never masquerade as "no invite teams" (which would wipe
+// every pending email row). Owner/member visibility still applies.
 export async function listInviteTeams(
   client: GitHubClient,
   org: string,
 ): Promise<GitHubTeam[]> {
-  const teams = await tolerateGitHubError(
-    () =>
-      paginateAll<GitHubTeam>(
-        client,
-        (page) =>
-          `/orgs/${encodeURIComponent(org)}/teams?per_page=100&page=${page}`,
-      ),
-    [],
+  const teams = await paginateAll<GitHubTeam>(
+    client,
+    (page) =>
+      `/orgs/${encodeURIComponent(org)}/teams?per_page=100&page=${page}`,
   )
   return teams.filter((t) => t.slug && isInviteTeamSlug(t.slug))
 }

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -1,0 +1,169 @@
+import type { GitHubClient } from "../client"
+import type { GitHubTeam, GitHubUser } from "../types"
+import { GitHubAPIError, tolerateGitHubError } from "../errors"
+import { createTeam } from "../teamWrites"
+import { paginateAll } from "../paginate"
+import {
+  INVITE_TEAM_PREFIX,
+  inviteTeamName,
+  isInviteTeamSlug,
+  marshalInviteDescription,
+  parseInviteDescription,
+  type InviteDescription,
+  type InviteMetadata,
+} from "@/util/inviteTeam"
+import { listTeamMembers } from "../queries/teamReads"
+import { logger } from "@/lib/logger"
+
+const log = logger.scope("mutations:inviteTeams")
+
+// Thrown by ensureInviteTeam when a pre-existing same-named team is NOT secret
+// and can't be made secret. The invite team stores a plaintext email in its
+// description; a closed/visible team would expose it to every org member, so we
+// fail closed rather than write PII onto a team students could read.
+export class InviteTeamNotSecretError extends Error {
+  slug: string
+  constructor(slug: string) {
+    super(
+      `Invite team "${slug}" is not secret; refusing to store an invited email on a team other org members could read.`,
+    )
+    this.name = "InviteTeamNotSecretError"
+    this.slug = slug
+  }
+}
+
+export type InviteTeamRef = { id: number; slug: string }
+
+// Create (or adopt) the per-invite SECRET team for (classroom, email) and write
+// the classroom50/invite/v1 record into its description. The team name is the
+// deterministic invite-<hash(classroom,email)> so a later reconcile can find it
+// from the roster row's email. Fail-closed on privacy: after create/adopt, the
+// team's privacy is confirmed to be `secret` (an adopted non-secret team is
+// PATCHed to secret; if that can't be confirmed, throw InviteTeamNotSecretError
+// rather than store the email where students could read it). Returns the ref so
+// the caller can attach its id to the org invitation's team_ids.
+export async function ensureInviteTeam(
+  client: GitHubClient,
+  org: string,
+  metadata: InviteMetadata,
+): Promise<InviteTeamRef> {
+  const name = await inviteTeamName(metadata.classroom, metadata.email)
+  const description = marshalInviteDescription(metadata)
+
+  let team: GitHubTeam
+  try {
+    team = await createTeam(client, {
+      org,
+      name,
+      description,
+      privacy: "secret",
+      notification_setting: "notifications_disabled",
+    })
+  } catch (err) {
+    if (err instanceof GitHubAPIError && err.status === 422) {
+      // A same-named team already exists (a resend, a retry, or a prior invite
+      // to the same email+classroom): adopt it, forcing secret + refreshing the
+      // description. Name is slug-safe, so it doubles as the lookup slug.
+      team = await client.request<GitHubTeam>(
+        `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(name)}`,
+      )
+    } else {
+      throw err
+    }
+  }
+
+  // Fail-closed secret invariant. On a fresh create GitHub honors privacy:
+  // "secret", but an adopted team may be closed; PATCH it and re-read. Never
+  // leave the email description on a non-secret team.
+  if (team.privacy !== "secret" || team.description !== description) {
+    team = await client.request<GitHubTeam>(
+      `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(team.slug)}`,
+      {
+        method: "PATCH",
+        body: { privacy: "secret", description },
+      },
+    )
+  }
+  if (team.privacy !== "secret") {
+    throw new InviteTeamNotSecretError(team.slug)
+  }
+
+  return { id: team.id, slug: team.slug }
+}
+
+export type InviteTeamState = {
+  slug: string
+  description: InviteDescription | null
+  // Members of the team, EXCLUDING no one here — the caller filters out org
+  // owners (the auto-added creator/maintainer) to find the accepted invitee.
+  members: GitHubUser[]
+}
+
+// Read one invite team's parsed description + members, for the reconcile pass.
+// 404 (team already deleted) -> null. `description` is null when the team's
+// description isn't a valid v1 record (hand-edited, or a slug collision with a
+// non-invite team); the caller skips such a team rather than acting on garbage.
+export async function readInviteTeam(
+  client: GitHubClient,
+  org: string,
+  slug: string,
+): Promise<InviteTeamState | null> {
+  const team = await tolerateGitHubError(
+    () =>
+      client.request<GitHubTeam>(
+        `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}`,
+      ),
+    null,
+  )
+  if (!team) return null
+  const members = await listTeamMembers(client, org, slug)
+  return {
+    slug: team.slug,
+    description: parseInviteDescription(team.description),
+    members,
+  }
+}
+
+// Enumerate the org's invite-<hash> teams (secret teams this feature owns),
+// filtering the org team list by the invite- prefix. Owner/member visibility
+// applies; a non-owner who can't list teams degrades to [] (tolerated upstream),
+// so GC/backfill simply do nothing rather than erroring.
+export async function listInviteTeams(
+  client: GitHubClient,
+  org: string,
+): Promise<GitHubTeam[]> {
+  const teams = await tolerateGitHubError(
+    () =>
+      paginateAll<GitHubTeam>(
+        client,
+        (page) =>
+          `/orgs/${encodeURIComponent(org)}/teams?per_page=100&page=${page}`,
+      ),
+    [],
+  )
+  return teams.filter((t) => t.slug && isInviteTeamSlug(t.slug))
+}
+
+// Delete an invite team by slug. Fail-closed: refuses any slug outside the
+// invite- namespace so a caller can't steer a delete into an unrelated team.
+// 404 = already gone (success), so teardown is idempotent.
+export async function deleteInviteTeam(
+  client: GitHubClient,
+  org: string,
+  slug: string,
+): Promise<void> {
+  if (!isInviteTeamSlug(slug)) {
+    log.error("refusing to delete non-invite team", { slug })
+    return
+  }
+  await tolerateGitHubError(
+    () =>
+      client.request(
+        `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}`,
+        { method: "DELETE" },
+      ),
+    undefined,
+  )
+}
+
+export { INVITE_TEAM_PREFIX }

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -83,6 +83,7 @@ export {
 export {
   getOrgFailedInvitations,
   getOrgFailedInvitationsForTeam,
+  listOrgInvitations,
   listTeamInvitations,
   teamInvitationsQuery,
   teamFailedInvitationsQuery,

--- a/web/src/github-core/queries/invitationReads.ts
+++ b/web/src/github-core/queries/invitationReads.ts
@@ -21,6 +21,23 @@ export async function getOrgFailedInvitations(
   )
 }
 
+// PENDING org invitations across all pages (GET /orgs/{org}/invitations).
+// Owner-only. The liveness source for the invite-team GC: a member-less
+// invite team whose (classroom, email) no longer matches any pending
+// invitation is stale (cancelled/expired). NOT error-tolerated — a degraded
+// read must fail the GC pass closed rather than read as "no live invites"
+// and delete every pending team.
+export async function listOrgInvitations(
+  client: GitHubClient,
+  org: string,
+): Promise<GitHubOrgInvitation[]> {
+  return paginateAll<GitHubOrgInvitation>(
+    client,
+    (page) =>
+      `/orgs/${encodeURIComponent(org)}/invitations?per_page=100&page=${page}`,
+  )
+}
+
 // Failed org invitations scoped to ONE classroom team. GitHub has no
 // team-scoped failed endpoint, so this reads the org-wide failed list and keeps
 // only invites whose team set (resolved per invite from invitation_teams_url)

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -189,6 +189,9 @@ export type GitHubTeam = {
   // Only returned by GET/POST/PATCH .../teams to org members; read defensively.
   notification_setting?: TeamNotificationSetting
   description: string | null
+  // Only on the full-team reads (GET/POST/PATCH .../teams/{slug}), not the org
+  // team list. Drives the invite-team GC age guard; read defensively.
+  created_at?: string | null
 }
 
 // A team as returned by GET /repos/{owner}/{repo}/teams — GitHubTeam plus the

--- a/web/src/hooks/mutations/orgSetupMutations.test.ts
+++ b/web/src/hooks/mutations/orgSetupMutations.test.ts
@@ -14,6 +14,9 @@ const renameConfigRepoToMain = vi.fn<(...args: unknown[]) => Promise<void>>(
 const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
   Promise.resolve(),
 )
+const deleteInviteTeamForEmail = vi.fn<(...args: unknown[]) => Promise<void>>(
+  () => Promise.resolve(),
+)
 const repairConcern = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve({}),
 )
@@ -36,6 +39,8 @@ vi.mock("@/github-core/mutations", () => ({
     renameConfigRepoToMain(client, org),
   cancelOrgInvitation: (client: unknown, input: unknown) =>
     cancelOrgInvitation(client, input),
+  deleteInviteTeamForEmail: (client: unknown, org: unknown, input: unknown) =>
+    deleteInviteTeamForEmail(client, org, input),
   initClassroom50: (params: unknown) => initClassroom50(params),
 }))
 vi.mock("@/github-core/queries", async (importOriginal) => ({
@@ -131,21 +136,39 @@ describe("useCancelClassroomInvite", () => {
   it("cancels the invite and invalidates the bound team's queries", async () => {
     const queryClient = freshClient()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
-    const { result } = renderHook(() => useCancelClassroomInvite(ORG, TEAM), {
-      wrapper: wrapperWith(queryClient),
-    })
-    result.current.mutate(99)
+    const { result } = renderHook(
+      () => useCancelClassroomInvite(ORG, CLASSROOM, TEAM),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate({ invitationId: 99 })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(cancelOrgInvitation).toHaveBeenCalledWith(expect.anything(), {
       org: ORG,
       invitationId: 99,
     })
+    // A username invitation has no metadata team to tear down.
+    expect(deleteInviteTeamForEmail).not.toHaveBeenCalled()
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.teamInvitations(ORG, TEAM),
     })
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.teamMembers(ORG, TEAM),
     })
+  })
+
+  it("tears down the metadata team when cancelling an email-only invite", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(
+      () => useCancelClassroomInvite(ORG, CLASSROOM, TEAM),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate({ invitationId: 99, inviteEmail: "ta@x.edu" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(deleteInviteTeamForEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG,
+      { classroom: CLASSROOM, email: "ta@x.edu" },
+    )
   })
 })
 

--- a/web/src/hooks/mutations/studentMutations.test.ts
+++ b/web/src/hooks/mutations/studentMutations.test.ts
@@ -13,6 +13,9 @@ import { githubKeys } from "@/github-core/queries"
 const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
   Promise.resolve(),
 )
+const deleteInviteTeamForEmail = vi.fn<(...args: unknown[]) => Promise<void>>(
+  () => Promise.resolve(),
+)
 const acceptAssignment = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve({ status: "created", repo: {}, cloneCommand: "" }),
 )
@@ -30,6 +33,8 @@ const invalidateInviteQueries = vi.fn<(...args: unknown[]) => void>(() => {})
 vi.mock("@/github-core/mutations", () => ({
   cancelOrgInvitation: (client: unknown, input: unknown) =>
     cancelOrgInvitation(client, input),
+  deleteInviteTeamForEmail: (client: unknown, org: unknown, input: unknown) =>
+    deleteInviteTeamForEmail(client, org, input),
 }))
 vi.mock("@/domain/assignments", () => ({
   acceptAssignment: (params: unknown) => acceptAssignment(params),
@@ -81,18 +86,42 @@ beforeEach(() => {
 describe("useDismissFailedInvite", () => {
   it("cancels the invite and invalidates the invite queries on success", async () => {
     const queryClient = freshClient()
-    const { result } = renderHook(() => useDismissFailedInvite(ORG), {
-      wrapper: wrapperWith(queryClient),
-    })
+    const { result } = renderHook(
+      () => useDismissFailedInvite(ORG, CLASSROOM),
+      {
+        wrapper: wrapperWith(queryClient),
+      },
+    )
 
-    result.current.mutate(42)
+    result.current.mutate({ invitationId: 42 })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(cancelOrgInvitation).toHaveBeenCalledWith(expect.anything(), {
       org: ORG,
       invitationId: 42,
     })
+    // A username invitation has no metadata team to tear down.
+    expect(deleteInviteTeamForEmail).not.toHaveBeenCalled()
     expect(invalidateInviteQueries).toHaveBeenCalledWith(queryClient, ORG)
+  })
+
+  it("tears down the metadata team when dismissing an email-only invite", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(
+      () => useDismissFailedInvite(ORG, CLASSROOM),
+      {
+        wrapper: wrapperWith(queryClient),
+      },
+    )
+
+    result.current.mutate({ invitationId: 42, inviteEmail: "gone@x.edu" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(deleteInviteTeamForEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG,
+      { classroom: CLASSROOM, email: "gone@x.edu" },
+    )
   })
 })
 

--- a/web/src/hooks/mutations/useCancelClassroomInvite.ts
+++ b/web/src/hooks/mutations/useCancelClassroomInvite.ts
@@ -1,5 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { cancelOrgInvitation } from "@/github-core/mutations"
+import {
+  cancelOrgInvitation,
+  deleteInviteTeamForEmail,
+} from "@/github-core/mutations"
 import { invalidateClassroomTeam } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
@@ -8,13 +11,35 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 // site (see ./README.md). Shared by the Settings staff section and the roster
 // member modal. Returns the raw cancel outcome so a caller can distinguish a
 // real cancellation from a stale (already-gone) invite id.
-export function useCancelClassroomInvite(org: string, teamSlug: string) {
+//
+// For an email-only invitation (no login), pass `inviteEmail` so the per-invite
+// metadata team holding that address is torn down with the invite (best-effort;
+// the GC pass is the backstop). A username invitation has no such team.
+export function useCancelClassroomInvite(
+  org: string,
+  classroom: string,
+  teamSlug: string,
+) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (invitationId: number) =>
-      cancelOrgInvitation(client, { org, invitationId }),
+    mutationFn: async (input: {
+      invitationId: number
+      inviteEmail?: string | null
+    }) => {
+      const result = await cancelOrgInvitation(client, {
+        org,
+        invitationId: input.invitationId,
+      })
+      if (input.inviteEmail) {
+        await deleteInviteTeamForEmail(client, org, {
+          classroom,
+          email: input.inviteEmail,
+        })
+      }
+      return result
+    },
     onSuccess: () => invalidateClassroomTeam(queryClient, org, teamSlug),
   })
 }

--- a/web/src/hooks/mutations/useDismissFailedInvite.ts
+++ b/web/src/hooks/mutations/useDismissFailedInvite.ts
@@ -1,5 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { cancelOrgInvitation } from "@/github-core/mutations"
+import {
+  cancelOrgInvitation,
+  deleteInviteTeamForEmail,
+} from "@/github-core/mutations"
 import { invalidateInviteQueries } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
@@ -7,13 +10,31 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 // the failed list; the mutation treats a 404 as success) and refresh the
 // invite-status queries. Hook owns the invalidation; the error toast stays at
 // the call site (see ./README.md). Sibling of useReinviteFailedInvite.
-export function useDismissFailedInvite(org: string) {
+//
+// For an email-only invitation (no login), pass `inviteEmail` so the per-invite
+// metadata team holding that address is torn down with the dismissal
+// (best-effort; the GC pass is the backstop).
+export function useDismissFailedInvite(org: string, classroom: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (invitationId: number) =>
-      cancelOrgInvitation(client, { org, invitationId }),
+    mutationFn: async (input: {
+      invitationId: number
+      inviteEmail?: string | null
+    }) => {
+      const result = await cancelOrgInvitation(client, {
+        org,
+        invitationId: input.invitationId,
+      })
+      if (input.inviteEmail) {
+        await deleteInviteTeamForEmail(client, org, {
+          classroom,
+          email: input.inviteEmail,
+        })
+      }
+      return result
+    },
     onSuccess: () => invalidateInviteQueries(queryClient, org),
   })
 }

--- a/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
+++ b/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { invalidateInviteQueries } from "@/github-core/queries"
+import { githubKeys, invalidateInviteQueries } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useUpdateRosterCache } from "@/hooks/useGetStudents"
 import {
@@ -8,6 +8,8 @@ import {
 } from "@/hooks/useTeamRoster"
 import { enrollStudentInClassroom, inviteByEmail } from "@/domain/students"
 import { splitName, toStudent } from "@/util/roster"
+import { CONFIG_REPO } from "@/util/configRepo"
+import { rosterPath } from "@/util/rosterPath"
 
 export type EnrollOrInviteFormValues = {
   name: string
@@ -70,14 +72,12 @@ export function useEnrollOrInviteStudent(
         }
       }
 
-      // Email-only -> a pure GitHub org invite (carrying the classroom team +
-      // a per-invite metadata team that retains the email) and NO roster.csv
-      // write: the team is the enrollment source of truth and an email carries
-      // no reliable identity. The record is PII-minimal (email only) — the
-      // typed name/section can be supplied via roster.csv, joined by email,
-      // once the row exists. The invite surfaces in the roster's "pending"
-      // section via the org pending-invitations list; on acceptance a
-      // reconcile pass recovers the email<->account mapping and backfills the row.
+      // Email-only -> a GitHub org invite (carrying the classroom team + a
+      // per-invite metadata team that retains the email) plus a pending
+      // email-only roster row. The row lives exactly as long as the invite
+      // does: on acceptance the reconcile fills in the account identity; a
+      // cancelled/expired invite's row is removed by the same reconcile. The
+      // typed name/section can be supplied via roster.csv, joined by email.
       const result = await inviteByEmail(githubClient, {
         org,
         classroom,
@@ -106,9 +106,12 @@ export function useEnrollOrInviteStudent(
           invalidateTeamRoster()
         }
       } else {
-        // Email invite writes no CSV row; just refresh so the new pending
-        // org-invitation shows in the roster.
+        // Email invite: refresh the pending-invitation view AND the roster
+        // file (the invite retains the email as a pending email-only row).
         invalidateTeamRoster()
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.csvFile(org, CONFIG_REPO, rosterPath(classroom)),
+        })
       }
     },
   })

--- a/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
+++ b/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
@@ -70,15 +70,19 @@ export function useEnrollOrInviteStudent(
         }
       }
 
-      // Email-only -> a pure GitHub org invite (carrying the classroom team) and
-      // NO roster.csv write: the team is the enrollment source of truth and an
+      // Email-only -> a pure GitHub org invite (carrying the classroom team +
+      // a per-invite metadata team that retains the email/name/section) and NO
+      // roster.csv write: the team is the enrollment source of truth and an
       // email carries no reliable identity. The invite surfaces in the roster's
-      // "pending" section via the org pending-invitations list; name/section are
-      // captured later by adding the student by username or uploading a roster.
+      // "pending" section via the org pending-invitations list; on acceptance a
+      // reconcile pass recovers the email<->account mapping and backfills the row.
       const result = await inviteByEmail(githubClient, {
         org,
         classroom,
         email,
+        first_name: first_name || undefined,
+        last_name: last_name || undefined,
+        section: section || undefined,
       })
       return {
         kind: "email" as const,

--- a/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
+++ b/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
@@ -71,18 +71,17 @@ export function useEnrollOrInviteStudent(
       }
 
       // Email-only -> a pure GitHub org invite (carrying the classroom team +
-      // a per-invite metadata team that retains the email/name/section) and NO
-      // roster.csv write: the team is the enrollment source of truth and an
-      // email carries no reliable identity. The invite surfaces in the roster's
-      // "pending" section via the org pending-invitations list; on acceptance a
+      // a per-invite metadata team that retains the email) and NO roster.csv
+      // write: the team is the enrollment source of truth and an email carries
+      // no reliable identity. The record is PII-minimal (email only) — the
+      // typed name/section can be supplied via roster.csv, joined by email,
+      // once the row exists. The invite surfaces in the roster's "pending"
+      // section via the org pending-invitations list; on acceptance a
       // reconcile pass recovers the email<->account mapping and backfills the row.
       const result = await inviteByEmail(githubClient, {
         org,
         classroom,
         email,
-        first_name: first_name || undefined,
-        last_name: last_name || undefined,
-        section: section || undefined,
       })
       return {
         kind: "email" as const,

--- a/web/src/hooks/mutations/usePurgeInviteTeams.ts
+++ b/web/src/hooks/mutations/usePurgeInviteTeams.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { purgeInviteTeams } from "@/domain/students"
+import { githubKeys } from "@/github-core/queries"
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { CONFIG_REPO } from "@/util/configRepo"
+import { rosterPath } from "@/util/rosterPath"
+
+// Teacher-triggered invite-data cleanup: recover what the backfill still can
+// into roster.csv, then delete every remaining stored invite email (hidden
+// invite team) for the classroom. Hook owns the roster-file invalidation (the
+// recovery may have written rows); the result/error toasts stay at the call
+// site (see ./README.md).
+export function usePurgeInviteTeams(org: string, classroom: string) {
+  const client = useGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => purgeInviteTeams(client, { org, classroom }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.csvFile(org, CONFIG_REPO, rosterPath(classroom)),
+      })
+    },
+  })
+}
+
+export default usePurgeInviteTeams

--- a/web/src/hooks/mutations/useSyncRoster.ts
+++ b/web/src/hooks/mutations/useSyncRoster.ts
@@ -1,27 +1,22 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { backfillInviteMetadata, syncRosterFromTeam } from "@/domain/students"
+import { reconcileRoster } from "@/domain/students"
 import { githubKeys } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { rosterPath } from "@/util/rosterPath"
 
-// Backfill roster.csv from team membership (teacher-triggered and auto-run on
-// open). First recovers any invited-email metadata from per-invite teams for
-// accepted students (deleting those teams), then syncs identity/role rows from
-// the classroom teams. Hook owns the roster-file invalidation; the
-// up-to-date/added/failed toasts stay at the call site (see ./README.md).
+// The teacher-triggered (and auto-run on open) roster reconciliation: one
+// consolidated pass that recovers accepted email invites, drops dead
+// email-only rows, and syncs identity/role rows from the classroom teams — at
+// most one commit (see reconcileRoster). Hook owns the roster-file
+// invalidation; the up-to-date/added/failed toasts stay at the call site (see
+// ./README.md).
 export function useSyncRoster(org: string, classroom: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async () => {
-      // Best-effort by contract (backfillInviteMetadata never throws): a
-      // metadata-recovery hiccup can't block the team sync the teacher asked
-      // for.
-      await backfillInviteMetadata(client, { org, classroom })
-      return syncRosterFromTeam(client, { org, classroom })
-    },
+    mutationFn: () => reconcileRoster(client, { org, classroom }),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: githubKeys.csvFile(org, CONFIG_REPO, rosterPath(classroom)),

--- a/web/src/hooks/mutations/useSyncRoster.ts
+++ b/web/src/hooks/mutations/useSyncRoster.ts
@@ -1,19 +1,26 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { syncRosterFromTeam } from "@/domain/students"
+import { backfillInviteMetadata, syncRosterFromTeam } from "@/domain/students"
 import { githubKeys } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { rosterPath } from "@/util/rosterPath"
 
 // Backfill roster.csv from team membership (teacher-triggered and auto-run on
-// open). Hook owns the roster-file invalidation; the up-to-date/added/failed
-// toasts stay at the call site (see ./README.md).
+// open). First recovers any invited-email metadata from per-invite teams for
+// accepted students (deleting those teams), then syncs identity/role rows from
+// the classroom teams. Hook owns the roster-file invalidation; the
+// up-to-date/added/failed toasts stay at the call site (see ./README.md).
 export function useSyncRoster(org: string, classroom: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: () => syncRosterFromTeam(client, { org, classroom }),
+    mutationFn: async () => {
+      // Best-effort: never let a metadata-recovery hiccup block the team sync
+      // the teacher explicitly asked for.
+      await backfillInviteMetadata(client, { org, classroom }).catch(() => {})
+      return syncRosterFromTeam(client, { org, classroom })
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: githubKeys.csvFile(org, CONFIG_REPO, rosterPath(classroom)),

--- a/web/src/hooks/mutations/useSyncRoster.ts
+++ b/web/src/hooks/mutations/useSyncRoster.ts
@@ -16,9 +16,10 @@ export function useSyncRoster(org: string, classroom: string) {
 
   return useMutation({
     mutationFn: async () => {
-      // Best-effort: never let a metadata-recovery hiccup block the team sync
-      // the teacher explicitly asked for.
-      await backfillInviteMetadata(client, { org, classroom }).catch(() => {})
+      // Best-effort by contract (backfillInviteMetadata never throws): a
+      // metadata-recovery hiccup can't block the team sync the teacher asked
+      // for.
+      await backfillInviteMetadata(client, { org, classroom })
       return syncRosterFromTeam(client, { org, classroom })
     },
     onSuccess: () => {

--- a/web/src/hooks/useClassroomReconcile.test.tsx
+++ b/web/src/hooks/useClassroomReconcile.test.tsx
@@ -36,12 +36,14 @@ const healthy: ClassroomReconcileResult = {
   skipped: false,
   description: { changed: false },
   staffCreated: [],
+  invitesBackfilled: [],
 }
 
 const archived: ClassroomReconcileResult = {
   skipped: true,
   description: { changed: false },
   staffCreated: [],
+  invitesBackfilled: [],
 }
 
 function githubAPIError(status: number): GitHubAPIError {

--- a/web/src/hooks/useClassroomReconcile.test.tsx
+++ b/web/src/hooks/useClassroomReconcile.test.tsx
@@ -37,6 +37,7 @@ const healthy: ClassroomReconcileResult = {
   description: { changed: false },
   staffCreated: [],
   invitesBackfilled: [],
+  rosterChanged: false,
 }
 
 const archived: ClassroomReconcileResult = {
@@ -44,6 +45,7 @@ const archived: ClassroomReconcileResult = {
   description: { changed: false },
   staffCreated: [],
   invitesBackfilled: [],
+  rosterChanged: false,
 }
 
 function githubAPIError(status: number): GitHubAPIError {

--- a/web/src/hooks/useClassroomReconcile.ts
+++ b/web/src/hooks/useClassroomReconcile.ts
@@ -58,6 +58,17 @@ export function useClassroomReconcile(
         // previewing as a student picks up the rewritten description.
         void queryClient.invalidateQueries({ queryKey: githubKeys.myTeams() })
       }
+      if (result.invitesBackfilled.length > 0) {
+        // Recovered invited emails were written into roster.csv; refresh it so
+        // the roster shows the backfilled name/email/section.
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.csvFile(
+            org,
+            CONFIG_REPO,
+            `${classroom}/roster.csv`,
+          ),
+        })
+      }
     },
     // Latch as permanent only a 403 the viewer can't fix or the description
     // step's wrong-slug team 404 (a derived slug that never converges). Every

--- a/web/src/hooks/useClassroomReconcile.ts
+++ b/web/src/hooks/useClassroomReconcile.ts
@@ -9,6 +9,7 @@ import {
 import { githubKeys } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { CONFIG_REPO } from "@/util/configRepo"
+import { rosterPath } from "@/util/rosterPath"
 import { logger } from "@/lib/logger"
 import { useBestEffortOwnerReconcile } from "@/hooks/useBestEffortOwnerReconcile"
 
@@ -62,11 +63,7 @@ export function useClassroomReconcile(
         // Recovered invited emails were written into roster.csv; refresh it so
         // the roster shows the backfilled name/email/section.
         void queryClient.invalidateQueries({
-          queryKey: githubKeys.csvFile(
-            org,
-            CONFIG_REPO,
-            `${classroom}/roster.csv`,
-          ),
+          queryKey: githubKeys.csvFile(org, CONFIG_REPO, rosterPath(classroom)),
         })
       }
     },

--- a/web/src/hooks/useClassroomReconcile.ts
+++ b/web/src/hooks/useClassroomReconcile.ts
@@ -59,9 +59,10 @@ export function useClassroomReconcile(
         // previewing as a student picks up the rewritten description.
         void queryClient.invalidateQueries({ queryKey: githubKeys.myTeams() })
       }
-      if (result.invitesBackfilled.length > 0) {
-        // Recovered invited emails were written into roster.csv; refresh it so
-        // the roster shows the backfilled name/email/section.
+      if (result.rosterChanged) {
+        // The consolidated reconcile committed roster.csv (recovered emails,
+        // removed dead rows, appended members, or refreshed roles) — refresh
+        // the view.
         void queryClient.invalidateQueries({
           queryKey: githubKeys.csvFile(org, CONFIG_REPO, rosterPath(classroom)),
         })

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -509,6 +509,7 @@
     "unenrollStudent": "Unenroll student",
     "added": "Added {{label}}.",
     "invited": "Sent an organization invite to {{label}}.",
+    "inviteMetadataFailed": "{{email}} was invited, but saving their email for later matching failed ({{message}}); their email won't be retained automatically. You can add it after they accept.",
     "alreadyEnrolled": "{{label}} is already enrolled in this classroom.",
     "addFailed": "Couldn't add {{label}}: {{message}}",
     "membersEnrolledCount_one": "{{count}} member enrolled",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -509,6 +509,7 @@
     "unenrollStudent": "Unenroll student",
     "added": "Added {{label}}.",
     "invited": "Sent an organization invite to {{label}}.",
+    "emailInviteHint": "Inviting by email only? The invited address is remembered and written to the roster when the student joins — note it's the address you invited, not necessarily the email on their GitHub account.",
     "inviteMetadataFailed": "{{email}} was invited, but saving their email for later matching failed ({{message}}); their email won't be retained automatically. You can add it after they accept.",
     "alreadyEnrolled": "{{label}} is already enrolled in this classroom.",
     "addFailed": "Couldn't add {{label}}: {{message}}",
@@ -1988,6 +1989,15 @@
     "deleteClassroomCancel": "Keep classroom",
     "archive": "Archive",
     "unarchive": "Unarchive",
+    "inviteCleanup": {
+      "button": "Clean up invite data",
+      "buttonTitle": "Recover and remove the invite emails stored for this classroom",
+      "confirmTitle": "Clean up stored invite emails?",
+      "body": "Email invitations keep each invited address in a hidden team so it can be written to the roster when the student joins. This first recovers anything still recoverable into <classroom>{{classroom}}</classroom>'s roster, then removes every remaining stored address. Pending invitations stay valid, but an address removed here won't be recorded automatically when its invite is accepted.",
+      "confirm": "Clean up",
+      "done": "Invite data cleaned up: {{recovered}} recovered to the roster, {{purged}} removed.",
+      "failed": "Couldn't clean up invite data: {{error}}"
+    },
     "archiveTitle": "Archive classroom",
     "unarchiveTitle": "Unarchive classroom",
     "archiveConfirmTitle": "Archive classroom?",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -509,7 +509,7 @@
     "unenrollStudent": "Unenroll student",
     "added": "Added {{label}}.",
     "invited": "Sent an organization invite to {{label}}.",
-    "emailInviteHint": "Inviting by email only? The invited address is remembered and written to the roster when the student joins — note it's the address you invited, not necessarily the email on their GitHub account.",
+    "emailInviteHint": "Inviting by email only? The address goes onto the roster right away and is matched to the student's GitHub account when they join — note it's the address you invited, not necessarily the email on their GitHub account.",
     "inviteMetadataFailed": "{{email}} was invited, but saving their email for later matching failed ({{message}}); their email won't be retained automatically. You can add it after they accept.",
     "alreadyEnrolled": "{{label}} is already enrolled in this classroom.",
     "addFailed": "Couldn't add {{label}}: {{message}}",

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -461,7 +461,7 @@ const PendingStaffRow = ({
     role,
     teamSlug,
   )
-  const cancelMutation = useCancelClassroomInvite(org, teamSlug)
+  const cancelMutation = useCancelClassroomInvite(org, classroom, teamSlug)
 
   // One latch per row so a same-tick double-click, or resend racing cancel on
   // the same invite, can't start two overlapping writes before isPending flips.
@@ -537,25 +537,32 @@ const PendingStaffRow = ({
           disabled={disabled || busy}
           onClick={() =>
             void submit(() =>
-              cancelMutation.mutateAsync(invite.id, {
-                onSuccess: () =>
-                  notify({
-                    tone: "success",
-                    durationMs: 4000,
-                    message: t("classes.staff.cancelledToast", { who }),
-                  }),
-                onError: (err) =>
-                  notify({
-                    tone: "error",
-                    message: t("classes.staff.cancelFailed", {
-                      who,
-                      error:
-                        err instanceof Error
-                          ? err.message
-                          : t("classes.somethingWentWrong"),
+              cancelMutation.mutateAsync(
+                {
+                  invitationId: invite.id,
+                  // Only an email-only invite has a metadata team to tear down.
+                  inviteEmail: invite.login ? undefined : invite.email,
+                },
+                {
+                  onSuccess: () =>
+                    notify({
+                      tone: "success",
+                      durationMs: 4000,
+                      message: t("classes.staff.cancelledToast", { who }),
                     }),
-                  }),
-              }),
+                  onError: (err) =>
+                    notify({
+                      tone: "error",
+                      message: t("classes.staff.cancelFailed", {
+                        who,
+                        error:
+                          err instanceof Error
+                            ? err.message
+                            : t("classes.somethingWentWrong"),
+                      }),
+                    }),
+                },
+              ),
             )
           }
         >

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -3,6 +3,7 @@ import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useArchiveClassroom } from "@/hooks/mutations/useArchiveClassroom"
 import { useDeleteClassroom } from "@/hooks/mutations/useDeleteClassroom"
+import { usePurgeInviteTeams } from "@/hooks/mutations/usePurgeInviteTeams"
 import { useForm } from "@tanstack/react-form"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { Trash2 } from "lucide-react"
@@ -190,6 +191,84 @@ const ArchiveClassroomButton = ({
   )
 }
 
+// One-shot cleanup of the classroom's stored invite emails (the hidden
+// per-invite teams): recover anything still recoverable into roster.csv, then
+// delete the rest. Kept OUTSIDE the archived-disabled fieldset — an archived
+// classroom's leftover invite teams are exactly what this exists to clear
+// (the automatic reconcile refuses to run there).
+const CleanupInviteDataButton = ({
+  org,
+  classroom,
+}: {
+  org: string
+  classroom: string
+}) => {
+  const { t } = useTranslation()
+  const { notify } = useToast()
+  const [open, setOpen] = useState(false)
+  const purgeMutation = usePurgeInviteTeams(org, classroom)
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        loading={purgeMutation.isPending}
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen(true)
+        }}
+        title={t("classes.inviteCleanup.buttonTitle")}
+      >
+        {t("classes.inviteCleanup.button")}
+      </Button>
+
+      <ConfirmModal
+        open={open}
+        title={t("classes.inviteCleanup.confirmTitle")}
+        description={
+          <Trans
+            i18nKey="classes.inviteCleanup.body"
+            values={{ classroom }}
+            components={{
+              classroom: <EmphasisLtr className="text-base-content" />,
+            }}
+          />
+        }
+        confirmLabel={t("classes.inviteCleanup.confirm")}
+        cancelLabel={t("common.cancel")}
+        confirmText=""
+        needsConfirm={false}
+        dangerous={false}
+        onConfirm={async () => {
+          try {
+            const result = await purgeMutation.mutateAsync()
+            notify({
+              tone: "success",
+              durationMs: 6000,
+              message: t("classes.inviteCleanup.done", {
+                recovered: result.recovered.length,
+                purged: result.purged,
+              }),
+            })
+          } catch (err) {
+            notify({
+              tone: "error",
+              message: t("classes.inviteCleanup.failed", {
+                error:
+                  err instanceof Error
+                    ? err.message
+                    : t("classes.somethingWentWrong"),
+              }),
+            })
+          }
+        }}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  )
+}
+
 const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -252,6 +331,7 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
             />
           </div>
           <div className="flex items-center gap-2">
+            <CleanupInviteDataButton org={org} classroom={classroom} />
             <ArchiveClassroomButton
               org={org}
               classroom={classroom}

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -339,6 +339,9 @@ const AddStudent = ({
                       {String(field.state.meta.errors[0] ?? "")}
                     </p>
                   )}
+                  <p className="text-base-content/60 text-xs mt-1">
+                    {t("students.emailInviteHint")}
+                  </p>
                 </div>
               )}
             </form.Field>

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -155,7 +155,7 @@ const EnrolledStudents = ({
   // Dismiss a failed/expired invitation: cancel it on GitHub (removes it from
   // the failed list) and refresh. The hook owns the invite-query invalidation;
   // the error toast stays here so it skips on unmount.
-  const dismissFailedInvite = useDismissFailedInvite(org)
+  const dismissFailedInvite = useDismissFailedInvite(org, classroom)
 
   // Re-invite a failed/expired invitation: dismiss the dead one, then re-issue
   // an equivalent fresh invite — same classroom role (teacher -> org OWNER),
@@ -517,15 +517,22 @@ const EnrolledStudents = ({
           }
           onReinvite={reinvite}
           onDismiss={(inv) =>
-            dismissFailedInvite.mutate(inv.id, {
-              onError: (err) =>
-                notify({
-                  tone: "error",
-                  message: t("students.failedInviteDismissError", {
-                    error: getErrorMessage(err),
+            dismissFailedInvite.mutate(
+              {
+                invitationId: inv.id,
+                // Only an email-only invite has a metadata team to tear down.
+                inviteEmail: inv.login ? undefined : inv.email,
+              },
+              {
+                onError: (err) =>
+                  notify({
+                    tone: "error",
+                    message: t("students.failedInviteDismissError", {
+                      error: getErrorMessage(err),
+                    }),
                   }),
-                }),
-            })
+              },
+            )
           }
         />
       ) : null}

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -6,7 +6,10 @@ import type { GitHubClient } from "@/github-core/client"
 import { ConfirmModal } from "@/components/modals"
 import { Alert, Button, Modal, Toolbar } from "@/components/ui"
 import { GitHubAPIError } from "@/github-core/errors"
-import { cancelOrgInvitation } from "@/github-core/mutations"
+import {
+  cancelOrgInvitation,
+  deleteInviteTeamForEmail,
+} from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import {
   bulkUnenrollRoster,
@@ -331,6 +334,14 @@ const RosterBulkActionsBar = ({
         // report it as "already gone" rather than a phantom cancellation.
         if (didCancel) cancelled.push({ key: row.key, label })
         else alreadyGone.push({ key: row.key, label })
+        if (!row.username && row.email) {
+          // An email-only invite carries a metadata team holding the address;
+          // tear it down with the invite (never throws; GC is the backstop).
+          await deleteInviteTeamForEmail(client, org, {
+            classroom,
+            email: row.email,
+          })
+        }
       } catch (err) {
         log.debug("bulk cancel: per-row cancel failed", { err })
         failed.push({ key: row.key, label, detail: getErrorMessage(err) })

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -14,7 +14,10 @@ import {
   resendClassroomInvite,
   type StudentCsvRow,
 } from "@/domain/students"
-import { cancelOrgInvitation } from "@/github-core/mutations"
+import {
+  cancelOrgInvitation,
+  deleteInviteTeamForEmail,
+} from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import {
   isMalformedGitHubId,
@@ -369,6 +372,14 @@ const RosterMemberModal = ({
     setCancelling(true)
     try {
       await cancelOrgInvitation(client, { org, invitationId })
+      if (!row.username && row.email) {
+        // An email-only invite carries a metadata team holding the address;
+        // tear it down with the invite (never throws; GC is the backstop).
+        await deleteInviteTeamForEmail(client, org, {
+          classroom,
+          email: row.email,
+        })
+      }
       onCanceled(row.key)
       onClose()
     } catch (err) {

--- a/web/src/util/goJsonEscape.ts
+++ b/web/src/util/goJsonEscape.ts
@@ -1,0 +1,14 @@
+// Match Go's json.Marshal, which HTML-escapes <, >, & AND the U+2028/U+2029
+// line/paragraph separators by default (no SetEscapeHTML(false) on the CLI
+// writers). JSON.stringify escapes none of these, so a TS writer that skips
+// this would produce different bytes than a Go writer for the same record and
+// perpetually overwrite it (description reconciles compare strings for exact
+// equality). One source for every description marshaller.
+export function escapeForGoJsonParity(json: string): string {
+  return json
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029")
+}

--- a/web/src/util/inviteTeam.test.ts
+++ b/web/src/util/inviteTeam.test.ts
@@ -64,17 +64,11 @@ describe("parseInviteDescription", () => {
       schema: INVITE_DESCRIPTION_SCHEMA,
       email: "alice@example.com",
       classroom: "cs101",
-      first_name: "Alice",
-      last_name: "Ng",
-      section: "S1",
     })
     expect(parseInviteDescription(desc)).toEqual({
       schema: INVITE_DESCRIPTION_SCHEMA,
       email: "alice@example.com",
       classroom: "cs101",
-      first_name: "Alice",
-      last_name: "Ng",
-      section: "S1",
     })
   })
 
@@ -91,14 +85,21 @@ describe("parseInviteDescription", () => {
     ).toBeNull()
   })
 
-  it("ignores unknown future fields (additive evolution)", () => {
+  it("tolerates unknown fields, including a legacy record's name/section", () => {
+    // Additive evolution AND backwards compatibility: an earlier release wrote
+    // first_name/last_name/section; the slimmed reader ignores them but still
+    // recovers the email.
     const desc = JSON.stringify({
       schema: INVITE_DESCRIPTION_SCHEMA,
       email: "a@b",
       classroom: "cs",
+      first_name: "Alice",
+      section: "S1",
       futureField: "x",
     })
-    expect(parseInviteDescription(desc)?.email).toBe("a@b")
+    const parsed = parseInviteDescription(desc)
+    expect(parsed?.email).toBe("a@b")
+    expect(parsed?.classroom).toBe("cs")
   })
 
   it("returns null for wrong schema, plain text, non-JSON, null/empty", () => {
@@ -116,92 +117,66 @@ describe("parseInviteDescription", () => {
 })
 
 describe("marshalInviteDescription", () => {
-  it("encodes required fields plus non-empty display fields", () => {
+  it("encodes exactly schema + email + classroom (PII-minimal)", () => {
     const out = marshalInviteDescription({
       email: "alice@example.com",
       classroom: "cs101",
-      first_name: "Alice",
-      last_name: "Ng",
-      section: "S1",
     })
     expect(JSON.parse(out)).toEqual({
       schema: INVITE_DESCRIPTION_SCHEMA,
       email: "alice@example.com",
       classroom: "cs101",
-      first_name: "Alice",
-      last_name: "Ng",
-      section: "S1",
     })
   })
 
-  it("normalizes the stored email and omits empty display fields", () => {
+  it("normalizes the stored email", () => {
     const out = marshalInviteDescription({
       email: "  ALICE@Example.com ",
       classroom: "cs101",
-      first_name: "  ",
     })
-    expect(JSON.parse(out)).toEqual({
-      schema: INVITE_DESCRIPTION_SCHEMA,
-      email: "alice@example.com",
-      classroom: "cs101",
-    })
+    expect(JSON.parse(out).email).toBe("alice@example.com")
   })
 
   it("round-trips through parseInviteDescription", () => {
     const out = marshalInviteDescription({
       email: "alice@example.com",
       classroom: "cs101",
-      first_name: "Alice",
     })
     expect(parseInviteDescription(out)).toEqual({
       schema: INVITE_DESCRIPTION_SCHEMA,
       email: "alice@example.com",
       classroom: "cs101",
-      first_name: "Alice",
     })
   })
 
-  it("drops display fields to fit the byte budget, preserving email/classroom", () => {
-    const longName = "x".repeat(300)
+  it("stays far under GitHub's ~250-char description cap for a long email", () => {
     const out = marshalInviteDescription({
-      email: "alice@example.com",
-      classroom: "cs101",
-      first_name: longName,
-      last_name: longName,
-      section: longName,
+      email: `${"x".repeat(64)}@${"y".repeat(60)}.example.com`,
+      classroom: "a-fairly-long-classroom-name",
     })
-    const parsed = parseInviteDescription(out)
-    expect(parsed?.email).toBe("alice@example.com")
-    expect(parsed?.classroom).toBe("cs101")
-    // The oversized display fields were dropped to stay within budget.
-    expect(parsed?.first_name).toBeUndefined()
-    expect(parsed?.last_name).toBeUndefined()
-    expect(parsed?.section).toBeUndefined()
     expect(out.length).toBeLessThanOrEqual(240)
   })
 
   it("escapes <, >, & (Go json.Marshal parity)", () => {
     const out = marshalInviteDescription({
-      email: "a@b",
+      email: "a&b<c>@x",
       classroom: "cs",
-      first_name: "C++ & <Data>",
     })
     expect(out).toContain("\\u0026")
     expect(out).toContain("\\u003c")
     expect(out).toContain("\\u003e")
     expect(out).not.toMatch(/[<>&]/)
-    expect(parseInviteDescription(out)?.first_name).toBe("C++ & <Data>")
+    expect(parseInviteDescription(out)?.email).toBe("a&b<c>@x")
   })
 
   it("escapes U+2028/U+2029 line/paragraph separators (Go parity)", () => {
     const out = marshalInviteDescription({
       email: "a@b",
-      classroom: "cs",
-      first_name: "a\u2028b\u2029c",
+      classroom: "cs\u2028x\u2029y",
     })
     expect(out).toContain("\\u2028")
     expect(out).toContain("\\u2029")
     expect(out).not.toMatch(/[\u2028\u2029]/)
-    expect(parseInviteDescription(out)?.first_name).toBe("a\u2028b\u2029c")
+    expect(parseInviteDescription(out)?.classroom).toBe("cs\u2028x\u2029y")
   })
 })

--- a/web/src/util/inviteTeam.test.ts
+++ b/web/src/util/inviteTeam.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import {
   INVITE_DESCRIPTION_SCHEMA,
   INVITE_TEAM_PREFIX,
@@ -8,6 +10,54 @@ import {
   normalizeInviteEmail,
   parseInviteDescription,
 } from "./inviteTeam"
+
+// schemas/invite-v1.schema.json is the source of truth for the record this
+// module hand-mirrors, with no compile-time link between them. Assert the two
+// agree so a schema edit that isn't mirrored here (or vice versa) fails CI
+// instead of silently drifting — same lockstep guard as submissionTags.test.ts.
+describe("classroom50/invite/v1 — schema/mirror parity", () => {
+  const schemaUrl = new URL(
+    "../../../schemas/invite-v1.schema.json",
+    import.meta.url,
+  )
+  const schema = JSON.parse(readFileSync(fileURLToPath(schemaUrl), "utf8")) as {
+    required: string[]
+    properties: Record<string, { const?: string }>
+  }
+
+  it("matches the schema sentinel", () => {
+    expect(schema.properties.schema.const).toBe(INVITE_DESCRIPTION_SCHEMA)
+  })
+
+  it("marshals exactly the schema's property set, and all of its required ones", () => {
+    const marshaled = JSON.parse(
+      marshalInviteDescription({
+        email: "alice@example.com",
+        classroom: "cs101",
+      }),
+    ) as Record<string, unknown>
+    const marshaledKeys = Object.keys(marshaled).sort()
+    // Every declared property is written, and nothing beyond them.
+    expect(marshaledKeys).toEqual(Object.keys(schema.properties).sort())
+    // Every required field is present in the encoded record.
+    for (const key of schema.required) {
+      expect(marshaled[key]).toBeTruthy()
+    }
+  })
+
+  it("parses back a record that satisfies the schema's required set", () => {
+    const record = parseInviteDescription(
+      marshalInviteDescription({
+        email: "alice@example.com",
+        classroom: "cs101",
+      }),
+    )
+    expect(record).not.toBeNull()
+    for (const key of schema.required) {
+      expect(record).toHaveProperty(key)
+    }
+  })
+})
 
 describe("normalizeInviteEmail", () => {
   it("trims and lowercases", () => {

--- a/web/src/util/inviteTeam.test.ts
+++ b/web/src/util/inviteTeam.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest"
+import {
+  INVITE_DESCRIPTION_SCHEMA,
+  INVITE_TEAM_PREFIX,
+  inviteTeamName,
+  isInviteTeamSlug,
+  marshalInviteDescription,
+  normalizeInviteEmail,
+  parseInviteDescription,
+} from "./inviteTeam"
+
+describe("normalizeInviteEmail", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeInviteEmail("  Alice@Example.COM ")).toBe(
+      "alice@example.com",
+    )
+  })
+})
+
+describe("inviteTeamName", () => {
+  it("is deterministic, slug-safe, and 23 chars (invite- + 16 hex)", async () => {
+    const name = await inviteTeamName("cs101", "alice@example.com")
+    expect(name).toMatch(/^invite-[0-9a-f]{16}$/)
+    expect(name).toHaveLength(INVITE_TEAM_PREFIX.length + 16)
+    // Slug-safe: GitHub derives the slug unchanged (lowercase, hyphen, no
+    // special chars), so name === slug.
+    expect(name).toBe(name.toLowerCase())
+    const again = await inviteTeamName("cs101", "alice@example.com")
+    expect(again).toBe(name)
+  })
+
+  it("normalizes the email before hashing (case/whitespace insensitive)", async () => {
+    const a = await inviteTeamName("cs101", "alice@example.com")
+    const b = await inviteTeamName("cs101", "  ALICE@Example.com  ")
+    expect(b).toBe(a)
+  })
+
+  it("scopes by classroom: same email in two classrooms -> distinct names", async () => {
+    const a = await inviteTeamName("cs101", "alice@example.com")
+    const b = await inviteTeamName("cs102", "alice@example.com")
+    expect(a).not.toBe(b)
+  })
+
+  it("does not collide on the classroom/email boundary", async () => {
+    // Without a separator byte, ("ab","c") and ("a","bc") would hash the same
+    // input. The \u0000 separator prevents this.
+    const a = await inviteTeamName("ab", "c@x")
+    const b = await inviteTeamName("a", "bc@x")
+    expect(a).not.toBe(b)
+  })
+})
+
+describe("isInviteTeamSlug", () => {
+  it("recognizes invite- teams and rejects others", () => {
+    expect(isInviteTeamSlug("invite-0123456789abcdef")).toBe(true)
+    expect(isInviteTeamSlug("classroom50-cs101")).toBe(false)
+    expect(isInviteTeamSlug("classroom50-cs101-teacher")).toBe(false)
+  })
+})
+
+describe("parseInviteDescription", () => {
+  it("parses a valid v1 record", () => {
+    const desc = JSON.stringify({
+      schema: INVITE_DESCRIPTION_SCHEMA,
+      email: "alice@example.com",
+      classroom: "cs101",
+      first_name: "Alice",
+      last_name: "Ng",
+      section: "S1",
+    })
+    expect(parseInviteDescription(desc)).toEqual({
+      schema: INVITE_DESCRIPTION_SCHEMA,
+      email: "alice@example.com",
+      classroom: "cs101",
+      first_name: "Alice",
+      last_name: "Ng",
+      section: "S1",
+    })
+  })
+
+  it("requires email and classroom", () => {
+    expect(
+      parseInviteDescription(
+        JSON.stringify({ schema: INVITE_DESCRIPTION_SCHEMA, email: "a@b" }),
+      ),
+    ).toBeNull()
+    expect(
+      parseInviteDescription(
+        JSON.stringify({ schema: INVITE_DESCRIPTION_SCHEMA, classroom: "cs" }),
+      ),
+    ).toBeNull()
+  })
+
+  it("ignores unknown future fields (additive evolution)", () => {
+    const desc = JSON.stringify({
+      schema: INVITE_DESCRIPTION_SCHEMA,
+      email: "a@b",
+      classroom: "cs",
+      futureField: "x",
+    })
+    expect(parseInviteDescription(desc)?.email).toBe("a@b")
+  })
+
+  it("returns null for wrong schema, plain text, non-JSON, null/empty", () => {
+    expect(
+      parseInviteDescription(
+        JSON.stringify({ schema: "other", email: "a@b", classroom: "cs" }),
+      ),
+    ).toBeNull()
+    expect(parseInviteDescription("just a team")).toBeNull()
+    expect(parseInviteDescription("{not json")).toBeNull()
+    expect(parseInviteDescription(null)).toBeNull()
+    expect(parseInviteDescription(undefined)).toBeNull()
+    expect(parseInviteDescription("")).toBeNull()
+  })
+})
+
+describe("marshalInviteDescription", () => {
+  it("encodes required fields plus non-empty display fields", () => {
+    const out = marshalInviteDescription({
+      email: "alice@example.com",
+      classroom: "cs101",
+      first_name: "Alice",
+      last_name: "Ng",
+      section: "S1",
+    })
+    expect(JSON.parse(out)).toEqual({
+      schema: INVITE_DESCRIPTION_SCHEMA,
+      email: "alice@example.com",
+      classroom: "cs101",
+      first_name: "Alice",
+      last_name: "Ng",
+      section: "S1",
+    })
+  })
+
+  it("normalizes the stored email and omits empty display fields", () => {
+    const out = marshalInviteDescription({
+      email: "  ALICE@Example.com ",
+      classroom: "cs101",
+      first_name: "  ",
+    })
+    expect(JSON.parse(out)).toEqual({
+      schema: INVITE_DESCRIPTION_SCHEMA,
+      email: "alice@example.com",
+      classroom: "cs101",
+    })
+  })
+
+  it("round-trips through parseInviteDescription", () => {
+    const out = marshalInviteDescription({
+      email: "alice@example.com",
+      classroom: "cs101",
+      first_name: "Alice",
+    })
+    expect(parseInviteDescription(out)).toEqual({
+      schema: INVITE_DESCRIPTION_SCHEMA,
+      email: "alice@example.com",
+      classroom: "cs101",
+      first_name: "Alice",
+    })
+  })
+
+  it("drops display fields to fit the byte budget, preserving email/classroom", () => {
+    const longName = "x".repeat(300)
+    const out = marshalInviteDescription({
+      email: "alice@example.com",
+      classroom: "cs101",
+      first_name: longName,
+      last_name: longName,
+      section: longName,
+    })
+    const parsed = parseInviteDescription(out)
+    expect(parsed?.email).toBe("alice@example.com")
+    expect(parsed?.classroom).toBe("cs101")
+    // The oversized display fields were dropped to stay within budget.
+    expect(parsed?.first_name).toBeUndefined()
+    expect(parsed?.last_name).toBeUndefined()
+    expect(parsed?.section).toBeUndefined()
+    expect(out.length).toBeLessThanOrEqual(240)
+  })
+
+  it("escapes <, >, & (Go json.Marshal parity)", () => {
+    const out = marshalInviteDescription({
+      email: "a@b",
+      classroom: "cs",
+      first_name: "C++ & <Data>",
+    })
+    expect(out).toContain("\\u0026")
+    expect(out).toContain("\\u003c")
+    expect(out).toContain("\\u003e")
+    expect(out).not.toMatch(/[<>&]/)
+    expect(parseInviteDescription(out)?.first_name).toBe("C++ & <Data>")
+  })
+
+  it("escapes U+2028/U+2029 line/paragraph separators (Go parity)", () => {
+    const out = marshalInviteDescription({
+      email: "a@b",
+      classroom: "cs",
+      first_name: "a\u2028b\u2029c",
+    })
+    expect(out).toContain("\\u2028")
+    expect(out).toContain("\\u2029")
+    expect(out).not.toMatch(/[\u2028\u2029]/)
+    expect(parseInviteDescription(out)?.first_name).toBe("a\u2028b\u2029c")
+  })
+})

--- a/web/src/util/inviteTeam.ts
+++ b/web/src/util/inviteTeam.ts
@@ -20,23 +20,19 @@ export const INVITE_TEAM_PREFIX = "invite-"
 // `invite-` (7) + 16 = 23 chars, well within GitHub's limit.
 const INVITE_HASH_HEX_LEN = 16
 
-// Byte budget for the encoded description. GitHub caps a team description near
-// 250 chars; a writer over budget drops the optional display fields
-// (first_name/last_name/section) first, always preserving schema/email/classroom
-// (the fields recovery depends on). Kept below the hard cap for safety margin.
-const INVITE_DESCRIPTION_BUDGET = 240
+// The email-only record stays far under GitHub's ~250-char team-description
+// cap for any RFC-length email; there is no drop-fields fallback because there
+// is nothing optional left to drop (PII-minimal by design).
 
-// The invite record. `email` and `classroom` are required (the recovery join and
-// per-classroom scoping); the display fields are optional and best-effort.
-// Unknown fields are ignored (tolerate-only, additive evolution) — the record is
+// The invite record: `email` (the value the record exists to retain) and
+// `classroom` (the recovery scope). Deliberately PII-minimal — display metadata
+// (names/sections) belongs in roster.csv, joined by email, never here. Unknown
+// fields are ignored (tolerate-only, additive evolution) — the record is
 // re-derived on write, never read-modify-written.
 const InviteDescriptionSchema = z.object({
   schema: z.literal(INVITE_DESCRIPTION_SCHEMA),
   email: z.string(),
   classroom: z.string(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  section: z.string().optional(),
 })
 
 export type InviteDescription = z.infer<typeof InviteDescriptionSchema>
@@ -44,9 +40,6 @@ export type InviteDescription = z.infer<typeof InviteDescriptionSchema>
 export type InviteMetadata = {
   email: string
   classroom: string
-  first_name?: string
-  last_name?: string
-  section?: string
 }
 
 // Normalize an email for hashing and storage: trim + lowercase. A single source
@@ -101,41 +94,15 @@ export function parseInviteDescription(
 }
 
 // marshalInviteDescription encodes the classroom50/invite/v1 record for a team
-// description — the inverse of parseInviteDescription. Compact JSON, empty
-// display fields omitted. When the full record would exceed the byte budget, the
-// optional display fields are dropped (section, then last_name, then first_name)
-// until it fits, always preserving schema/email/classroom so recovery still
-// works. Applies the same escaping as marshalTeamDescription so the bytes would
-// match a Go json.Marshal writer if one is ever added.
+// description — the inverse of parseInviteDescription. Compact JSON with the
+// same escaping as marshalTeamDescription so the bytes would match a Go
+// json.Marshal writer if one is ever added.
 export function marshalInviteDescription(input: InviteMetadata): string {
-  const email = normalizeInviteEmail(input.email)
-  const base: Record<string, unknown> = {
-    schema: INVITE_DESCRIPTION_SCHEMA,
-    email,
-    classroom: input.classroom,
-  }
-  const first = input.first_name?.trim()
-  const last = input.last_name?.trim()
-  const section = input.section?.trim()
-
-  // Try full, then progressively drop optional display fields to fit the budget.
-  const candidates: Array<Record<string, unknown>> = [
-    { ...base, first_name: first, last_name: last, section },
-    { ...base, first_name: first, last_name: last },
-    { ...base, first_name: first },
-    { ...base },
-  ]
-  for (const candidate of candidates) {
-    // Drop undefined/empty optional fields so they never serialize.
-    const record: Record<string, unknown> = { ...base }
-    if (candidate.first_name) record.first_name = candidate.first_name
-    if (candidate.last_name) record.last_name = candidate.last_name
-    if (candidate.section) record.section = candidate.section
-    const encoded = escapeForGoJsonParity(JSON.stringify(record))
-    if (encoded.length <= INVITE_DESCRIPTION_BUDGET) return encoded
-  }
-  // Even the minimal record exceeds the budget (a pathological email/classroom);
-  // return it anyway — a too-long description is GitHub's error to surface, and
-  // the minimal record is still the most useful thing to attempt.
-  return escapeForGoJsonParity(JSON.stringify(base))
+  return escapeForGoJsonParity(
+    JSON.stringify({
+      schema: INVITE_DESCRIPTION_SCHEMA,
+      email: normalizeInviteEmail(input.email),
+      classroom: input.classroom,
+    }),
+  )
 }

--- a/web/src/util/inviteTeam.ts
+++ b/web/src/util/inviteTeam.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { escapeForGoJsonParity } from "./goJsonEscape"
 
 // Schema sentinel for the classroom50/invite/v1 record stored in a per-invite
 // secret team's description. Byte-mirror of schemas/invite-v1.schema.json.
@@ -130,23 +131,11 @@ export function marshalInviteDescription(input: InviteMetadata): string {
     if (candidate.first_name) record.first_name = candidate.first_name
     if (candidate.last_name) record.last_name = candidate.last_name
     if (candidate.section) record.section = candidate.section
-    const encoded = escapeForGoParity(JSON.stringify(record))
+    const encoded = escapeForGoJsonParity(JSON.stringify(record))
     if (encoded.length <= INVITE_DESCRIPTION_BUDGET) return encoded
   }
   // Even the minimal record exceeds the budget (a pathological email/classroom);
   // return it anyway — a too-long description is GitHub's error to surface, and
   // the minimal record is still the most useful thing to attempt.
-  return escapeForGoParity(JSON.stringify(base))
-}
-
-// Match Go's json.Marshal, which HTML-escapes <, >, & and the U+2028/U+2029
-// line/paragraph separators by default. JSON.stringify escapes none; matching
-// keeps the bytes identical to a future Go writer (see marshalTeamDescription).
-function escapeForGoParity(json: string): string {
-  return json
-    .replaceAll("<", "\\u003c")
-    .replaceAll(">", "\\u003e")
-    .replaceAll("&", "\\u0026")
-    .replaceAll("\u2028", "\\u2028")
-    .replaceAll("\u2029", "\\u2029")
+  return escapeForGoJsonParity(JSON.stringify(base))
 }

--- a/web/src/util/inviteTeam.ts
+++ b/web/src/util/inviteTeam.ts
@@ -1,0 +1,152 @@
+import { z } from "zod"
+
+// Schema sentinel for the classroom50/invite/v1 record stored in a per-invite
+// secret team's description. Byte-mirror of schemas/invite-v1.schema.json.
+// Web-only today (email invites exist only in the web app), so there is no Go
+// contract constant yet; if a CLI email-invite path is added, this becomes a
+// cross-tool contract and must be kept in lockstep.
+export const INVITE_DESCRIPTION_SCHEMA = "classroom50/invite/v1"
+
+// Team-name prefix for a per-invite metadata team. GitHub derives a team's slug
+// from its name (lowercase, hyphenated, special chars stripped); an
+// `invite-<hex>` name is already slug-safe, so name === slug and the team is
+// locatable by prefix (GET /orgs/{org}/teams filtered on this) as well as by
+// recomputing the hash from a roster row's classroom + email.
+export const INVITE_TEAM_PREFIX = "invite-"
+
+// SHA-256 prefix length (hex chars) used in the team name. 16 hex = 64 bits —
+// ample collision resistance for a class-sized roster; total name length is
+// `invite-` (7) + 16 = 23 chars, well within GitHub's limit.
+const INVITE_HASH_HEX_LEN = 16
+
+// Byte budget for the encoded description. GitHub caps a team description near
+// 250 chars; a writer over budget drops the optional display fields
+// (first_name/last_name/section) first, always preserving schema/email/classroom
+// (the fields recovery depends on). Kept below the hard cap for safety margin.
+const INVITE_DESCRIPTION_BUDGET = 240
+
+// The invite record. `email` and `classroom` are required (the recovery join and
+// per-classroom scoping); the display fields are optional and best-effort.
+// Unknown fields are ignored (tolerate-only, additive evolution) — the record is
+// re-derived on write, never read-modify-written.
+const InviteDescriptionSchema = z.object({
+  schema: z.literal(INVITE_DESCRIPTION_SCHEMA),
+  email: z.string(),
+  classroom: z.string(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  section: z.string().optional(),
+})
+
+export type InviteDescription = z.infer<typeof InviteDescriptionSchema>
+
+export type InviteMetadata = {
+  email: string
+  classroom: string
+  first_name?: string
+  last_name?: string
+  section?: string
+}
+
+// Normalize an email for hashing and storage: trim + lowercase. A single source
+// so the name-hash and the stored `email` can't diverge (a mismatch would make
+// the team unlocatable from the roster row).
+export function normalizeInviteEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+// The deterministic team name for an (classroom, email) invite:
+// `invite-<sha256(classroom \0 email)[:16 hex]>`. Scoping by classroom keeps the
+// same email invited to two classrooms in one org on two distinct teams. Async
+// because it uses the Web Crypto digest (mirrors auth/pkce deriveChallenge);
+// the separator byte prevents ("ab","c") and ("a","bc") colliding.
+export async function inviteTeamName(
+  classroom: string,
+  email: string,
+): Promise<string> {
+  const normalized = normalizeInviteEmail(email)
+  const encoded = new TextEncoder().encode(`${classroom}\u0000${normalized}`)
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  const hex = [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+  return `${INVITE_TEAM_PREFIX}${hex.slice(0, INVITE_HASH_HEX_LEN)}`
+}
+
+// True when a team slug is one this feature owns (an `invite-` metadata team),
+// so a GC/enumeration pass can filter org teams to only the ones it may touch.
+export function isInviteTeamSlug(slug: string): boolean {
+  return slug.startsWith(INVITE_TEAM_PREFIX)
+}
+
+// parseInviteDescription reads a team description string into the invite record,
+// or null when absent, non-JSON, or not a valid v1 record. Never throws — a
+// team with a hand-edited or empty description simply yields no record, and the
+// caller skips it rather than crashing the reconcile pass. Because the accepted
+// invitee can edit their own team's description, this is the trust boundary:
+// callers additionally verify `email` hashes back to the team name before use.
+export function parseInviteDescription(
+  description: string | null | undefined,
+): InviteDescription | null {
+  if (!description) return null
+  let raw: unknown
+  try {
+    raw = JSON.parse(description)
+  } catch {
+    return null
+  }
+  const parsed = InviteDescriptionSchema.safeParse(raw)
+  return parsed.success ? parsed.data : null
+}
+
+// marshalInviteDescription encodes the classroom50/invite/v1 record for a team
+// description — the inverse of parseInviteDescription. Compact JSON, empty
+// display fields omitted. When the full record would exceed the byte budget, the
+// optional display fields are dropped (section, then last_name, then first_name)
+// until it fits, always preserving schema/email/classroom so recovery still
+// works. Applies the same escaping as marshalTeamDescription so the bytes would
+// match a Go json.Marshal writer if one is ever added.
+export function marshalInviteDescription(input: InviteMetadata): string {
+  const email = normalizeInviteEmail(input.email)
+  const base: Record<string, unknown> = {
+    schema: INVITE_DESCRIPTION_SCHEMA,
+    email,
+    classroom: input.classroom,
+  }
+  const first = input.first_name?.trim()
+  const last = input.last_name?.trim()
+  const section = input.section?.trim()
+
+  // Try full, then progressively drop optional display fields to fit the budget.
+  const candidates: Array<Record<string, unknown>> = [
+    { ...base, first_name: first, last_name: last, section },
+    { ...base, first_name: first, last_name: last },
+    { ...base, first_name: first },
+    { ...base },
+  ]
+  for (const candidate of candidates) {
+    // Drop undefined/empty optional fields so they never serialize.
+    const record: Record<string, unknown> = { ...base }
+    if (candidate.first_name) record.first_name = candidate.first_name
+    if (candidate.last_name) record.last_name = candidate.last_name
+    if (candidate.section) record.section = candidate.section
+    const encoded = escapeForGoParity(JSON.stringify(record))
+    if (encoded.length <= INVITE_DESCRIPTION_BUDGET) return encoded
+  }
+  // Even the minimal record exceeds the budget (a pathological email/classroom);
+  // return it anyway — a too-long description is GitHub's error to surface, and
+  // the minimal record is still the most useful thing to attempt.
+  return escapeForGoParity(JSON.stringify(base))
+}
+
+// Match Go's json.Marshal, which HTML-escapes <, >, & and the U+2028/U+2029
+// line/paragraph separators by default. JSON.stringify escapes none; matching
+// keeps the bytes identical to a future Go writer (see marshalTeamDescription).
+function escapeForGoParity(json: string): string {
+  return json
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029")
+}

--- a/web/src/util/teamDescription.ts
+++ b/web/src/util/teamDescription.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { SECRET_PATTERN, isValidSecret } from "./secret"
+import { escapeForGoJsonParity } from "./goJsonEscape"
 
 // Schema sentinel for the classroom50/team/v1 bootstrap record stored in a
 // classroom's secret student-team description. Byte-mirror of the CLI's
@@ -64,16 +65,5 @@ export function marshalTeamDescription(input: {
   if (input.term) record.term = input.term
   if (input.secret && isValidSecret(input.secret)) record.secret = input.secret
   if (!input.active) record.active = false
-  // Match Go's json.Marshal, which HTML-escapes <, >, & AND the U+2028/U+2029
-  // line/paragraph separators by default (no SetEscapeHTML(false) on the CLI
-  // writer). JSON.stringify escapes none of these, so without this the two tools
-  // would produce different bytes for a name/term containing them and perpetually
-  // overwrite each other's description (the reconcile compares strings for exact
-  // equality).
-  return JSON.stringify(record)
-    .replaceAll("<", "\\u003c")
-    .replaceAll(">", "\\u003e")
-    .replaceAll("&", "\\u0026")
-    .replaceAll("\u2028", "\\u2028")
-    .replaceAll("\u2029", "\\u2029")
+  return escapeForGoJsonParity(JSON.stringify(record))
 }

--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -83,6 +83,12 @@ Wrap up a finished course in this order:
    (after the next publish run), and refuses new assignments; student
    repositories are untouched, and `unarchive` reverses it. See
    [`gh teacher classroom archive`](gh-teacher#classroom-archive--unarchive).
+
+   If you invited students by email, also use **Clean up invite data** on the
+   classroom's Settings page. Email invitations store each invited address in
+   a hidden GitHub team until the student joins; the cleanup writes anything
+   still recoverable onto the roster and removes the rest, so no invited
+   address lingers in an archived classroom.
 4. Optionally, archive the student repositories on GitHub. Archiving a
    repository makes it read-only for everyone while preserving it. Classroom
    50 has no bulk action for this yet, but the GitHub CLI handles it. List

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -390,7 +390,12 @@ octofez
 > A username list or roster CSV both invites students **and** adds them to the
 > roster. An email list only sends invitations. An email carries no GitHub
 > identity until the student onboards, so those students appear under **pending
-> invitations**, not on the roster, until they accept.
+> invitations**, not on the roster, until they accept. When a student accepts,
+> Classroom 50 remembers which address was invited and writes it onto their new
+> roster row, so you can match the GitHub account back to your class list. Keep
+> in mind this is the address **you invited** — not necessarily the email on
+> the student's GitHub account. Names and sections can be filled in afterwards
+> by editing the roster or uploading a roster CSV.
 
 > [!TIP]
 > Adding students who are **already in your organization** (for example, from a

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -388,14 +388,13 @@ octofez
 
 > [!NOTE]
 > A username list or roster CSV both invites students **and** adds them to the
-> roster. An email list only sends invitations. An email carries no GitHub
-> identity until the student onboards, so those students appear under **pending
-> invitations**, not on the roster, until they accept. When a student accepts,
-> Classroom 50 remembers which address was invited and writes it onto their new
-> roster row, so you can match the GitHub account back to your class list. Keep
-> in mind this is the address **you invited** — not necessarily the email on
-> the student's GitHub account. Names and sections can be filled in afterwards
-> by editing the roster or uploading a roster CSV.
+> roster. An email list sends invitations and records each address as a
+> pending roster row. The row is matched to the student's GitHub account when
+> they accept; if the invitation is cancelled or expires, the row is removed
+> again on the next roster sync. Keep in mind the recorded address is the one
+> **you invited** — not necessarily the email on the student's GitHub account.
+> Names and sections can be filled in afterwards by editing the roster or
+> uploading a roster CSV.
 
 > [!TIP]
 > Adding students who are **already in your organization** (for example, from a


### PR DESCRIPTION
## The problem

A GitHub org invitation sent to an email address does not retain that address. Once the student accepts, the API reports their login but no longer the email they were invited with, so the teacher has no way to map the new GitHub account back to the person on their class list. There is exactly one moment where that mapping exists and nothing persists it.

## The approach

Each email invite creates a per-invite **secret** GitHub team named `invite-<sha256(classroom \0 email)[:16]>`, whose description holds a PII-minimal `classroom50/invite/v1` record (`{schema, email, classroom}` — nothing else; names and sections belong in `roster.csv`). The invitation carries this team alongside the classroom team, so accepting lands the student on both. A later reconcile finds the team's one regular-role member, pairs their account with the recorded email, writes it to `roster.csv`, and deletes the team. The team is `secret` and the write is fail-closed, so an invited email is never exposed to other org members.

The invited address is also written to `roster.csv` immediately as an email-only pending row, so it is retained from the moment the invite is sent rather than only on acceptance. That row lives exactly as long as its invite does: the reconcile fills in the account identity when the student accepts, and removes the row if the invite is cancelled, expires, or is garbage-collected.

## One reconcile, one commit

`reconcileRoster` is now the single roster writer, shared by the roster page's Sync action and the owner-visit classroom reconcile: **collect** classifies the invite teams (read-only), then **one commit** folds recovered identities, drops dead email rows, appends missing members and reconciles roles/ids, then **finalize** deletes the recovered teams only after that commit lands. This replaces the previous per-invitee backfill commits plus a separate sync commit.

Destructive steps are gated so a degraded read can never be mistaken for absence: row removal requires a trustworthy invite-team pass **and** confirmation against GitHub's current pending invitations, read inside the retried commit closure (the collect snapshot predates the roster read, so an invite sent in between must not be reaped). An unreadable invitation list keeps every row. Teams are reaped only behind a 24h age guard when no pending invitation maps to them, and cancel/dismiss tears a team down immediately.

## Limitations

The retained address is the one the teacher **invited**, not necessarily the email registered on the student's GitHub account. Surfaced in the invite form's helper text and the teacher guide.

## Follow-up required before or with this merge

The Go teacher CLI's strict roster reader rejects a row with an empty `username` and aborts the whole parse, so `gh teacher roster list` errors while an email invite is pending. Aligning the CLI reader (mirroring the web keep-rule `username || github_id || email`, plus a parity test) is a separate PR and should land first or together.

## Test plan

- [x] `npm run check` green — tsc, eslint, prettier, dependency-cruiser, 3865 unit tests
- [x] Verified live on a real org (`classroom50-summer-dev`): invite writes `,,,student@example.edu,,,student`; on acceptance the same row upgrades in place to `rliu50,,,student@example.edu,,127826836,student` with no duplicate; the metadata team is deleted; two commits total for the whole lifecycle
- [x] Verified the mechanism directly: GitHub adds the invitee to a freshly created secret team via `team_ids`, and keeps org owners as team maintainers (hence the `role=member` read)
- [ ] Browser accessibility suites (`*.browser.test.tsx`) run in CI only — need `npx playwright install chromium` locally; no layout changes in this branch

Towards #414. Also removes the need for #456 — teachers can reconcile GitHub accounts against their SIS by email, so students never need to self-select a roster entry.