### PR TITLE
fix(web): purge invite teams on classroom delete and retire a dead action

### DIFF
--- a/web/src/domain/classrooms.test.ts
+++ b/web/src/domain/classrooms.test.ts
@@ -371,10 +371,12 @@ describe("deleteClassroom invite-team purge", () => {
     })
 
     await deleteClassroom(client, { org: "acme", classroom: "cs101" })
-    expect(deleted).not.toContain(`/orgs/acme/teams/${inviteSlug}`)
+    // Nothing at all was deleted — the only team in the listing belongs to
+    // another classroom (the test above is the positive control).
+    expect(deleted).toEqual([])
   })
 
-  it("still reports the deletion when the purge can't list teams", async () => {
+  it("warns that invitation records went unchecked when the listing fails", async () => {
     const deleted: string[] = []
     const client = deleteFlowClient({
       onDelete: (p) => deleted.push(p),
@@ -385,6 +387,11 @@ describe("deleteClassroom invite-team purge", () => {
       org: "acme",
       classroom: "cs101",
     })
+
+    // The config deletion still succeeded, but the teacher must learn that a
+    // stored email address may be left behind — this is the silent-failure case.
     expect(result.deleted).toBe(true)
+    expect(result.teamDeleteWarning).toMatch(/invitation records/i)
+    expect(result.teamDeleteWarning).toMatch(/email address/i)
   })
 })

--- a/web/src/domain/classrooms.test.ts
+++ b/web/src/domain/classrooms.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { assertClassroomNotArchived, createClassroomFiles } from "./classrooms"
+import {
+  assertClassroomNotArchived,
+  createClassroomFiles,
+  deleteClassroom,
+} from "./classrooms"
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 import type { GitHubClient, GitHubRequestOptions } from "@/github-core/client"
 
@@ -256,5 +260,131 @@ describe("createClassroomFiles creator team cleanup", () => {
     expect(deleted).toContain(
       "/orgs/acme/teams/classroom50-cs101-ta/memberships/prof",
     )
+  })
+})
+
+// Deleting a classroom is the last moment its per-invite metadata teams are
+// findable: they're recorded nowhere in the config repo, so once the classroom
+// directory is gone nothing can enumerate them per-classroom again — and each
+// holds an invited student's email address in its description.
+describe("deleteClassroom invite-team purge", () => {
+  const inviteSlug = "invite-0123456789abcdef"
+
+  // A routing client covering the whole delete flow: classroom.json read, tree
+  // read, commit/ref writes, then the org-teams listing + per-team read the
+  // purge performs. Records every DELETE path.
+  const deleteFlowClient = (opts: {
+    onDelete: (path: string) => void
+    inviteClassroom?: string
+    listThrows?: boolean
+  }): GitHubClient => {
+    const request = vi.fn(
+      async (path: string, options?: GitHubRequestOptions) => {
+        const method = options?.method ?? "GET"
+
+        if (method === "DELETE") {
+          opts.onDelete(path)
+          return undefined
+        }
+        if (method === "GET" && /\/repos\/[^/]+\/classroom50$/.test(path)) {
+          return { default_branch: "main" }
+        }
+        if (path.includes("/git/ref/heads/")) {
+          return { object: { sha: "base-sha" } }
+        }
+        if (path.includes("/git/commits/")) {
+          return { tree: { sha: "tree-sha" }, sha: "base-sha" }
+        }
+        if (path.includes("/git/trees/")) {
+          return {
+            tree: [
+              {
+                path: "cs101/classroom.json",
+                mode: "100644",
+                type: "blob",
+                sha: "a",
+              },
+            ],
+            truncated: false,
+          }
+        }
+        if (path.endsWith("/git/trees")) return { sha: "new-tree" }
+        if (path.endsWith("/git/commits")) return { sha: "new-commit" }
+        if (path.includes("/git/refs/heads/")) return {}
+        // The purge's org-teams listing.
+        if (/\/orgs\/[^/]+\/teams\?/.test(path)) {
+          if (opts.listThrows) throw apiError(500)
+          return [{ id: 9, slug: inviteSlug }]
+        }
+        // The purge's per-team read (description carries the claimed classroom).
+        if (
+          path.includes(`/teams/${inviteSlug}`) &&
+          path.includes("/members")
+        ) {
+          return []
+        }
+        if (path.includes(`/teams/${inviteSlug}`)) {
+          return {
+            slug: inviteSlug,
+            description: JSON.stringify({
+              schema: "classroom50/invite/v1",
+              email: "pending@x.edu",
+              classroom: opts.inviteClassroom ?? "cs101",
+            }),
+          }
+        }
+        // Classroom team refs come from classroom.json (requestRaw below).
+        return undefined
+      },
+    )
+    return {
+      request,
+      requestRaw: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          schema: "classroom50/classroom/v1",
+          short_name: "cs101",
+        }),
+      ),
+      fetchArchive: vi.fn(),
+    } as unknown as GitHubClient
+  }
+
+  it("deletes the classroom's invite teams so no invited email is stranded", async () => {
+    const deleted: string[] = []
+    const client = deleteFlowClient({ onDelete: (p) => deleted.push(p) })
+
+    const result = await deleteClassroom(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+
+    expect(result.deleted).toBe(true)
+    expect(deleted).toContain(`/orgs/acme/teams/${inviteSlug}`)
+    expect(result.teamDeleteWarning).toBeUndefined()
+  })
+
+  it("leaves another classroom's invite team alone", async () => {
+    const deleted: string[] = []
+    const client = deleteFlowClient({
+      onDelete: (p) => deleted.push(p),
+      inviteClassroom: "cs202",
+    })
+
+    await deleteClassroom(client, { org: "acme", classroom: "cs101" })
+    expect(deleted).not.toContain(`/orgs/acme/teams/${inviteSlug}`)
+  })
+
+  it("still reports the deletion when the purge can't list teams", async () => {
+    const deleted: string[] = []
+    const client = deleteFlowClient({
+      onDelete: (p) => deleted.push(p),
+      listThrows: true,
+    })
+
+    const result = await deleteClassroom(client, {
+      org: "acme",
+      classroom: "cs101",
+    })
+    expect(result.deleted).toBe(true)
   })
 })

--- a/web/src/domain/classrooms.ts
+++ b/web/src/domain/classrooms.ts
@@ -22,6 +22,7 @@ import {
   removeUserFromTeam,
   isDeletableClassroomTeamRef,
   isNonFastForward,
+  purgeClassroomInviteTeams,
   updateRef,
   type ClassroomTeamRef,
   type EditClassroomInput,
@@ -515,11 +516,18 @@ export async function deleteClassroom(
       failedTeamSlugs.push(teamRef.slug)
     }
   }
+  // Purge this classroom's per-invite metadata teams. They're recorded nowhere
+  // in the config repo, so with the classroom directory now gone nothing else
+  // can ever find them — each holds an invited student's email address in its
+  // description. Runs after the commit (like the team deletes) and never throws.
+  const invitePurge = await purgeClassroomInviteTeams(client, org, classroom)
+
+  const lingeringSlugs = [...failedTeamSlugs, ...invitePurge.failedSlugs]
   const teamDeleteWarning =
-    failedTeamSlugs.length > 0
+    lingeringSlugs.length > 0
       ? `Removed the classroom config but could not delete ${
-          failedTeamSlugs.length === 1 ? "its team" : "its teams"
-        } ${failedTeamSlugs
+          lingeringSlugs.length === 1 ? "its team" : "its teams"
+        } ${lingeringSlugs
           .map((s) => `"${s}"`)
           .join(
             ", ",
@@ -531,6 +539,8 @@ export async function deleteClassroom(
     classroom,
     deletedPaths: entriesToDelete.length,
     teamsFailed: failedTeamSlugs.length,
+    inviteTeamsPurged: invitePurge.purged,
+    inviteTeamsFailed: invitePurge.failedSlugs.length,
   })
 
   return {

--- a/web/src/domain/classrooms.ts
+++ b/web/src/domain/classrooms.ts
@@ -522,16 +522,29 @@ export async function deleteClassroom(
   // description. Runs after the commit (like the team deletes) and never throws.
   const invitePurge = await purgeClassroomInviteTeams(client, org, classroom)
 
-  const lingeringSlugs = [...failedTeamSlugs, ...invitePurge.failedSlugs]
+  // Two warnings, because they ask for different actions. Named slugs are teams
+  // we know belong to this classroom; a failed listing or an unreadable team
+  // can't be named (it might belong to a live classroom), so that case points
+  // the teacher at the teams page instead of at a specific slug.
+  const namedSlugs = [...failedTeamSlugs, ...invitePurge.failedSlugs]
+  const warnings: string[] = []
+  if (namedSlugs.length > 0) {
+    warnings.push(
+      `couldn't delete ${namedSlugs.length === 1 ? "its team" : "its teams"} ${namedSlugs
+        .map((s) => `"${s}"`)
+        .join(", ")}`,
+    )
+  }
+  if (invitePurge.listFailed || invitePurge.unreadable > 0) {
+    warnings.push(
+      "couldn't check for leftover invitation records (each stores an invited student's email address)",
+    )
+  }
   const teamDeleteWarning =
-    lingeringSlugs.length > 0
-      ? `Removed the classroom config but could not delete ${
-          lingeringSlugs.length === 1 ? "its team" : "its teams"
-        } ${lingeringSlugs
-          .map((s) => `"${s}"`)
-          .join(
-            ", ",
-          )}; delete by hand at https://github.com/orgs/${org}/teams if they linger.`
+    warnings.length > 0
+      ? `Removed the classroom config but ${warnings.join(
+          " and ",
+        )}; review https://github.com/orgs/${org}/teams and delete anything that lingers.`
       : undefined
 
   log.info("delete classroom: completed", {
@@ -541,6 +554,8 @@ export async function deleteClassroom(
     teamsFailed: failedTeamSlugs.length,
     inviteTeamsPurged: invitePurge.purged,
     inviteTeamsFailed: invitePurge.failedSlugs.length,
+    inviteTeamsUnreadable: invitePurge.unreadable,
+    inviteListFailed: invitePurge.listFailed,
   })
 
   return {

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -146,6 +146,7 @@ export {
   listInviteTeams,
   deleteInviteTeam,
   deleteInviteTeamForEmail,
+  purgeClassroomInviteTeams,
   InviteTeamNotSecretError,
   type InviteTeamRef,
   type InviteTeamState,

--- a/web/src/github-core/mutations/inviteTeams.test.ts
+++ b/web/src/github-core/mutations/inviteTeams.test.ts
@@ -7,6 +7,7 @@ import {
   listInviteTeams,
   deleteInviteTeam,
   deleteInviteTeamForEmail,
+  purgeClassroomInviteTeams,
 } from "./inviteTeams"
 import type { GitHubClient } from "../client"
 import { GitHubAPIError, type GitHubRateLimit } from "../errors"
@@ -246,5 +247,91 @@ describe("deleteInviteTeamForEmail", () => {
         email: "alice@example.com",
       }),
     ).resolves.toBeUndefined()
+  })
+})
+
+// Deleting a classroom is the last moment these teams are findable: they're
+// recorded nowhere in the config repo, so once its directory is gone nothing can
+// enumerate them per-classroom again. Each holds an invited student's email.
+describe("purgeClassroomInviteTeams", () => {
+  const teamFor = async (classroom: string, email: string) => ({
+    slug: await inviteTeamName(classroom, email),
+    description: marshalInviteDescription({ classroom, email }),
+  })
+
+  it("deletes only the teams whose record claims this classroom", async () => {
+    const mine = await teamFor("cs101", "mine@x.edu")
+    const other = await teamFor("cs202", "other@x.edu")
+    const deleted: string[] = []
+    const { client } = makeClient((url, options) => {
+      if (url.includes("/teams?")) {
+        return [
+          { id: 1, slug: mine.slug },
+          { id: 2, slug: other.slug },
+        ]
+      }
+      if (options?.method === "DELETE") {
+        deleted.push(url.split("/teams/")[1])
+        return undefined
+      }
+      if (url.includes("/members")) return []
+      const slug = url.split("/teams/")[1]
+      return slug === mine.slug
+        ? { slug: mine.slug, description: mine.description }
+        : { slug: other.slug, description: other.description }
+    })
+
+    const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
+    expect(result).toEqual({ purged: 1, failedSlugs: [] })
+    expect(deleted).toEqual([mine.slug])
+  })
+
+  it("deletes a team whose record was tampered into claiming this classroom", async () => {
+    // The purge only ever deletes, so the claim alone is enough — a tamperer can
+    // at worst get their own team removed. (The reconcile, which writes a roster
+    // row, does verify the email hashes back to the slug.)
+    const foreign = await inviteTeamName("cs999", "someone@x.edu")
+    const deleted: string[] = []
+    const { client } = makeClient((url, options) => {
+      if (url.includes("/teams?")) return [{ id: 1, slug: foreign }]
+      if (options?.method === "DELETE") {
+        deleted.push(url.split("/teams/")[1])
+        return undefined
+      }
+      if (url.includes("/members")) return []
+      return {
+        slug: foreign,
+        description: marshalInviteDescription({
+          classroom: "cs101",
+          email: "someone@x.edu",
+        }),
+      }
+    })
+
+    const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
+    expect(result.purged).toBe(1)
+    expect(deleted).toEqual([foreign])
+  })
+
+  it("reports a per-team delete failure instead of throwing", async () => {
+    const mine = await teamFor("cs101", "mine@x.edu")
+    const { client } = makeClient((url, options) => {
+      if (url.includes("/teams?")) return [{ id: 1, slug: mine.slug }]
+      if (options?.method === "DELETE") throw apiError(500)
+      if (url.includes("/members")) return []
+      return { slug: mine.slug, description: mine.description }
+    })
+
+    const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
+    expect(result).toEqual({ purged: 0, failedSlugs: [mine.slug] })
+  })
+
+  it("never throws when the team listing fails (the config commit already landed)", async () => {
+    const { client } = makeClient(() => {
+      throw apiError(500)
+    })
+    await expect(
+      purgeClassroomInviteTeams(client, "acme", "cs101"),
+    ).resolves.toEqual({ purged: 0, failedSlugs: [] })
   })
 })

--- a/web/src/github-core/mutations/inviteTeams.test.ts
+++ b/web/src/github-core/mutations/inviteTeams.test.ts
@@ -31,6 +31,15 @@ const apiError = (status: number, message = `boom ${status}`) =>
     rateLimit: emptyRateLimit,
   })
 
+const rateLimitError = () =>
+  new GitHubAPIError({
+    status: 429,
+    url: "https://api.github.com/x",
+    message: "rate limited",
+    body: null,
+    rateLimit: emptyRateLimit,
+  })
+
 const METADATA = { email: "alice@example.com", classroom: "cs101" }
 const DESCRIPTION = marshalInviteDescription(METADATA)
 
@@ -282,14 +291,18 @@ describe("purgeClassroomInviteTeams", () => {
     })
 
     const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
-    expect(result).toEqual({ purged: 1, failedSlugs: [] })
+    expect(result).toEqual({
+      purged: 1,
+      failedSlugs: [],
+      unreadable: 0,
+      listFailed: false,
+    })
     expect(deleted).toEqual([mine.slug])
   })
 
   it("deletes a team whose record was tampered into claiming this classroom", async () => {
-    // The purge only ever deletes, so the claim alone is enough — a tamperer can
-    // at worst get their own team removed. (The reconcile, which writes a roster
-    // row, does verify the email hashes back to the slug.)
+    // The purge only ever deletes, so it takes the claim at face value (the
+    // reconcile, which writes a roster row, does verify the hash).
     const foreign = await inviteTeamName("cs999", "someone@x.edu")
     const deleted: string[] = []
     const { client } = makeClient((url, options) => {
@@ -323,15 +336,55 @@ describe("purgeClassroomInviteTeams", () => {
     })
 
     const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
-    expect(result).toEqual({ purged: 0, failedSlugs: [mine.slug] })
+    expect(result.purged).toBe(0)
+    expect(result.failedSlugs).toEqual([mine.slug])
+    expect(result.listFailed).toBe(false)
   })
 
-  it("never throws when the team listing fails (the config commit already landed)", async () => {
+  // A team we couldn't READ has an unknown classroom, so naming it to the
+  // teacher could send them to delete a live classroom's invite record.
+  it("counts an unreadable team without naming it as this classroom's", async () => {
+    const { client } = makeClient((url) => {
+      if (url.includes("/teams?"))
+        return [{ id: 1, slug: "invite-aaaaaaaaaaaaaaaa" }]
+      throw apiError(403)
+    })
+
+    const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
+    expect(result.unreadable).toBe(1)
+    expect(result.failedSlugs).toEqual([])
+    expect(result.purged).toBe(0)
+  })
+
+  it("stops the pass on a rate limit rather than hammering", async () => {
+    const reads: string[] = []
+    const { client } = makeClient((url) => {
+      if (url.includes("/teams?")) {
+        return [
+          { id: 1, slug: "invite-aaaaaaaaaaaaaaaa" },
+          { id: 2, slug: "invite-bbbbbbbbbbbbbbbb" },
+          { id: 3, slug: "invite-cccccccccccccccc" },
+        ]
+      }
+      reads.push(url)
+      throw rateLimitError()
+    })
+
+    const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
+    expect(reads).toHaveLength(1)
+    expect(result.unreadable).toBe(1)
+  })
+
+  it("flags a failed listing so the caller can still warn (nothing was checked)", async () => {
     const { client } = makeClient(() => {
       throw apiError(500)
     })
-    await expect(
-      purgeClassroomInviteTeams(client, "acme", "cs101"),
-    ).resolves.toEqual({ purged: 0, failedSlugs: [] })
+    const result = await purgeClassroomInviteTeams(client, "acme", "cs101")
+    expect(result).toEqual({
+      purged: 0,
+      failedSlugs: [],
+      unreadable: 0,
+      listFailed: true,
+    })
   })
 })

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -207,10 +207,13 @@ export async function deleteInviteTeamForEmail(
 export { INVITE_TEAM_PREFIX }
 
 // Delete every invite team whose stored record claims `classroom`, for the
-// teardown of that classroom itself. The record's claim is enough here: unlike
-// the reconcile (which folds an email onto a roster row and so must verify the
-// email hashes back to the slug), this only ever deletes, and a tampered record
-// can at worst get its own team deleted.
+// teardown of that classroom itself. The claim is taken at face value: this path
+// only ever deletes, never writes a roster row, so it doesn't need the
+// reconcile's hash verification. Note the consequence — a record hand-edited to
+// claim this classroom is deleted with it, which for a tampered team belonging
+// to another classroom costs that classroom its email<->account mapping. The
+// namespace fence in deleteInviteTeam still applies, so nothing outside the
+// invite- namespace can ever be deleted.
 //
 // Exists because these teams are recorded nowhere in the config repo, so once a
 // classroom's directory is gone nothing can find them again — the reconcile is
@@ -219,35 +222,67 @@ export { INVITE_TEAM_PREFIX }
 // strand that student's address in a secret team forever.
 //
 // Best-effort and never throws: the caller has already committed the deletion,
-// so a failure here is a leftover team to report, not a reason to fail. Returns
-// the slugs it could not delete.
+// so a failure here is a leftover team to report, not a reason to fail.
+// `failedSlugs` names only teams confirmed to belong to THIS classroom whose
+// delete failed — safe to show a teacher as "delete by hand". A team we could
+// not read is counted in `unreadable` instead: its classroom is unknown, so
+// naming it could send the teacher to delete a live classroom's invite record.
+// `listFailed` means the enumeration itself failed, so nothing was checked at
+// all — the caller must still warn, since this is exactly the case where an
+// invited email would otherwise be stranded silently.
 export async function purgeClassroomInviteTeams(
   client: GitHubClient,
   org: string,
   classroom: string,
-): Promise<{ purged: number; failedSlugs: string[] }> {
+): Promise<{
+  purged: number
+  failedSlugs: string[]
+  unreadable: number
+  listFailed: boolean
+}> {
   const failedSlugs: string[] = []
   let purged = 0
+  let unreadable = 0
   let teams: GitHubTeam[]
   try {
     teams = await listInviteTeams(client, org)
   } catch (err) {
     log.error("invite team purge: listing failed", { org, classroom, err })
-    return { purged, failedSlugs }
+    return { purged, failedSlugs, unreadable, listFailed: true }
   }
 
   for (const team of teams) {
     const slug = team.slug
     if (!slug) continue
+
+    // Read and delete are separate failure classes. Until the read succeeds we
+    // don't know which classroom the team belongs to, so a read failure must
+    // never reach the teacher-facing slug list.
+    let state: Awaited<ReturnType<typeof readInviteTeam>>
     try {
-      const state = await readInviteTeam(client, org, slug)
-      if (!state || state.description?.classroom !== classroom) continue
+      state = await readInviteTeam(client, org, slug)
+    } catch (err) {
+      unreadable += 1
+      log.error("invite team purge: read failed; scope unknown", {
+        org,
+        slug,
+        err,
+      })
+      if (err instanceof GitHubAPIError && err.isRateLimited) break
+      continue
+    }
+    if (!state || state.description?.classroom !== classroom) continue
+
+    try {
       await deleteInviteTeam(client, org, slug)
       purged += 1
     } catch (err) {
       log.error("invite team purge: delete failed", { org, slug, err })
       failedSlugs.push(slug)
+      // Every remaining delete would hit the same limit; stop rather than
+      // hammering a throttled endpoint and reporting every team as lingering.
+      if (err instanceof GitHubAPIError && err.isRateLimited) break
     }
   }
-  return { purged, failedSlugs }
+  return { purged, failedSlugs, unreadable, listFailed: false }
 }

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -205,3 +205,49 @@ export async function deleteInviteTeamForEmail(
 }
 
 export { INVITE_TEAM_PREFIX }
+
+// Delete every invite team whose stored record claims `classroom`, for the
+// teardown of that classroom itself. The record's claim is enough here: unlike
+// the reconcile (which folds an email onto a roster row and so must verify the
+// email hashes back to the slug), this only ever deletes, and a tampered record
+// can at worst get its own team deleted.
+//
+// Exists because these teams are recorded nowhere in the config repo, so once a
+// classroom's directory is gone nothing can find them again — the reconcile is
+// classroom-scoped and its settings page (with the manual cleanup action) is
+// gone too. A classroom deleted with a pending email invite would otherwise
+// strand that student's address in a secret team forever.
+//
+// Best-effort and never throws: the caller has already committed the deletion,
+// so a failure here is a leftover team to report, not a reason to fail. Returns
+// the slugs it could not delete.
+export async function purgeClassroomInviteTeams(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+): Promise<{ purged: number; failedSlugs: string[] }> {
+  const failedSlugs: string[] = []
+  let purged = 0
+  let teams: GitHubTeam[]
+  try {
+    teams = await listInviteTeams(client, org)
+  } catch (err) {
+    log.error("invite team purge: listing failed", { org, classroom, err })
+    return { purged, failedSlugs }
+  }
+
+  for (const team of teams) {
+    const slug = team.slug
+    if (!slug) continue
+    try {
+      const state = await readInviteTeam(client, org, slug)
+      if (!state || state.description?.classroom !== classroom) continue
+      await deleteInviteTeam(client, org, slug)
+      purged += 1
+    } catch (err) {
+      log.error("invite team purge: delete failed", { org, slug, err })
+      failedSlugs.push(slug)
+    }
+  }
+  return { purged, failedSlugs }
+}

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -28,7 +28,11 @@ import type { SuppressedLogins } from "@/hooks/useSuppressedLogins"
 import type { TeamRosterRow, ClassroomRole } from "@/util/teamRoster"
 import { sortTeamRosterRows } from "@/util/teamRoster"
 import { STAFF_ROLES } from "@/types/classroom"
-import { ROLE_LABEL_KEY, hasStudentEnrollment } from "@/util/classroomRoleUI"
+import {
+  ROLE_LABEL_KEY,
+  canTargetForUnenroll,
+  hasStudentEnrollment,
+} from "@/util/classroomRoleUI"
 import {
   filterRosterRows,
   NO_SECTION,
@@ -185,16 +189,23 @@ const EnrolledStudents = ({
   // + student-team membership, so it only applies to rows with a student
   // enrollment. A student who is ALSO staff IS selectable — unenroll drops only
   // their student side and leaves the staff role intact — matching the row
-  // modal's unenroll gate (both use hasStudentEnrollment) so the two never
-  // diverge (previously a student+teacher was removable in the modal but
-  // silently skipped by select-all).
+  // modal's unenroll gate (both use hasStudentEnrollment AND
+  // canTargetForUnenroll) so the two never diverge (previously a
+  // student+teacher was removable in the modal but silently skipped by
+  // select-all).
   const isSelf = (row: TeamRosterRow) =>
     isSameGitHubUser(viewer ?? null, {
       github_id: row.github_id,
       username: row.username,
     })
+  // Selectable for the bulk actions bar, whose destructive action is unenroll.
+  // A pending email invite is excluded for the same reason the row modal hides
+  // Remove (canTargetForUnenroll): the roster matcher keys on username/github_id,
+  // so unenroll can't match that row — it would silently report "already
+  // removed" while the row AND the live invitation survive. Cancel the
+  // invitation instead (offered per row in the modal).
   const isSelectable = (row: TeamRosterRow) =>
-    !isSelf(row) && hasStudentEnrollment(row)
+    !isSelf(row) && hasStudentEnrollment(row) && canTargetForUnenroll(row)
 
   // Distinct sections present across all rows (status-independent so switching
   // status never empties the section dropdown), sorted with "No section" last.

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -33,6 +33,7 @@ import {
   type TeamRosterRow,
 } from "@/util/teamRoster"
 import {
+  canTargetForUnenroll,
   hasStudentEnrollment,
   STATE_BADGE_TONE,
   STATE_LABEL_KEY,
@@ -211,8 +212,12 @@ const RosterMemberModal = ({
   const needsRole = canManage && row.state === "needs_attention_in_org"
   const needsInvite = canManage && row.state === "needs_attention_not_in_org"
   // Unenroll drops a roster.csv row + student-team membership — a student-only
-  // action. Hidden for a staff-only row (nothing to unenroll from the roster).
-  const canUnenroll = canManage && !staffOnly
+  // action. Hidden for a staff-only row (nothing to unenroll from the roster),
+  // and for a row unenroll could never match: a pending email invite carries
+  // only the address, and the shared matcher keys on username/github_id (see
+  // canTargetForUnenroll). Cancel invite is the right action there — it revokes
+  // the invitation, so the student can't still accept, and drops the row.
+  const canUnenroll = canManage && !staffOnly && canTargetForUnenroll(row)
   // Per-member role change is offered for an ENROLLED (active-team) member with
   // a resolvable username — but NOT for the viewer's own row: demoting yourself
   // off teacher revokes your own org-owner access mid-change (the mutation

--- a/web/src/util/classroomRoleUI.test.ts
+++ b/web/src/util/classroomRoleUI.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  canTargetForUnenroll,
   countByRole,
   enrolledCountsByRole,
   hasStudentEnrollment,
@@ -38,6 +39,21 @@ describe("hasStudentEnrollment", () => {
   })
   it("is true for a student who is also staff (unenroll drops only the student side)", () => {
     expect(hasStudentEnrollment(row(["teacher", "student"]))).toBe(true)
+  })
+})
+
+// A pending email invite's row carries only the invited address, and the shared
+// roster matcher keys on username/github_id — so offering unenroll for it would
+// be a dead action ("does not exist in roster"). Cancel invite retires it.
+describe("canTargetForUnenroll", () => {
+  it("is false for a pending email-only row (nothing for the matcher to key on)", () => {
+    expect(canTargetForUnenroll({ username: "", github_id: "" })).toBe(false)
+  })
+  it("is true once the row carries a username or an id", () => {
+    expect(canTargetForUnenroll({ username: "alice", github_id: "" })).toBe(
+      true,
+    )
+    expect(canTargetForUnenroll({ username: "", github_id: "4242" })).toBe(true)
   })
 })
 

--- a/web/src/util/classroomRoleUI.ts
+++ b/web/src/util/classroomRoleUI.ts
@@ -86,6 +86,22 @@ export function hasStudentEnrollment(
   return row.roles.includes("student")
 }
 
+// Whether unenroll can actually target this row's roster entry. The shared
+// roster-row matcher identifies a row by username or github_id only (a shared
+// email must never widen a removal), so a row carrying NEITHER — a pending
+// email invite, whose address is all we know until the student accepts — has
+// nothing for unenroll to match and would fail with "does not exist in roster".
+//
+// Such a row is retired by CANCELLING the invitation instead, which is also the
+// only correct action: dropping the roster row alone would leave the invitation
+// live, so the student could still accept and land in the classroom. Cancelling
+// revokes it, deletes the stored email, and the reconcile then drops the row.
+export function canTargetForUnenroll(
+  row: Pick<TeamRosterRow, "username" | "github_id">,
+): boolean {
+  return Boolean(row.username || row.github_id)
+}
+
 // Per-role head counts across the roster. `student` counts every row carrying
 // the student role (a student who is also staff still counts as a student);
 // `teacher`/`hta`/`ta` count every row holding that staff role. A person on two


### PR DESCRIPTION
Closes the two P1 lifecycle gaps left after #631 and #632. Both concern the per-invite teams that hold an invited student's email address until they accept.

## Deleting a classroom stranded invited emails

`deleteClassroom` removed the classroom directory and its four classroom teams, but not its `invite-*` teams — and afterwards nothing could: they are recorded nowhere in the config repo, the reconcile that finds them is classroom-scoped, and the settings page carrying the manual cleanup action was just deleted. Each of those teams holds a student's email address, so deleting a classroom with a pending email invite left that address in the org indefinitely.

The delete now purges them. It runs after the config commit, like the existing team deletes, so a purge failure can never undo a landed deletion; it never throws for the same reason.

Failures are reported by class, because they need different actions. Teams confirmed to belong to this classroom are named for hand-deletion. A team that could not be **read** is only counted — its classroom is unknown, so naming it could send a teacher to delete a live classroom's invite record. A failed listing means nothing was checked at all, which is precisely when an email is silently stranded, so that warns too. A rate limit stops the pass rather than hammering a throttled endpoint.

## Remove was a dead button on a pending invite

The roster modal offered **Remove** for a pending email invite, but it always failed with "does not exist in roster": the shared roster matcher identifies rows by username or `github_id`, and that row has neither until the student accepts. Bulk unenroll was worse — it accepted such a row and reported "Already removed" while the row *and* the live invitation both survived, so the student could still accept.

Both surfaces now share one predicate (`canTargetForUnenroll`) and exclude those rows. **Cancel invite** is the correct action and was already offered in the same modal: dropping the roster row alone would leave the invitation live, whereas cancelling revokes it, deletes the stored email, and lets the reconcile drop the row.

## Still open (separate issues)

Archiving a classroom also leaves invite teams behind — the automatic reconcile refuses to run on an archived classroom, so the manual "Clean up invite data" button is the only reaper and nothing prompts for it. Nothing cancels the org's pending email invitations on delete/archive/teardown (GitHub expires them on its own). And a student promoted to org owner before recovery reads as zero team members, so their mapping is lost and the row is dropped after the 24h GC.

## Test plan

- [x] `npm run check` green — tsc, eslint, prettier, dependency-cruiser, 3887 tests
- [x] Purge behavior pinned: deletes only teams claiming this classroom, counts an unreadable team without naming it, reports a delete failure, stops on a rate limit, flags a failed listing
- [x] `deleteClassroom` pinned end to end: purges its own invite team, leaves another classroom's alone, and warns about unchecked invitation records when the listing fails
- [x] `canTargetForUnenroll` pinned for the email-only row and for rows carrying a username or an id
- [ ] Browser accessibility suites run in CI only (need `npx playwright install chromium` locally); untouched here