### PR TITLE
fix(web): keep an invite record an org owner accepted

### DIFF
--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -2867,6 +2867,7 @@ describe("syncRosterFromTeam — identity-only backfill", () => {
     liveInviteEmails: new Set<string>(),
     trusted: true,
     deletedStale: 0,
+    ownerAccepted: [],
     ...over,
   })
 

--- a/web/src/domain/students/inviteRecoveries.test.ts
+++ b/web/src/domain/students/inviteRecoveries.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest"
 const listInviteTeams = vi.fn()
 const readInviteTeam = vi.fn()
 const deleteInviteTeam = vi.fn()
+const listInviteTeamMaintainers = vi.fn()
 const listTeamMembers = vi.fn()
 const listOrgInvitations = vi.fn()
 const resolveClassroomTeamSlugs = vi.fn()
@@ -12,6 +13,8 @@ vi.mock("@/github-core/mutations", () => ({
   listInviteTeams: (...a: unknown[]) => listInviteTeams(...a),
   readInviteTeam: (...a: unknown[]) => readInviteTeam(...a),
   deleteInviteTeam: (...a: unknown[]) => deleteInviteTeam(...a),
+  listInviteTeamMaintainers: (...a: unknown[]) =>
+    listInviteTeamMaintainers(...a),
 }))
 vi.mock("@/github-core/queries", () => ({
   listTeamMembers: (...a: unknown[]) => listTeamMembers(...a),
@@ -81,6 +84,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   deleteInviteTeam.mockResolvedValue(undefined)
   listOrgInvitations.mockResolvedValue([])
+  // One maintainer = just the creating teacher, i.e. nobody accepted.
+  listInviteTeamMaintainers.mockResolvedValue([{ id: 1, login: "prof" }])
   // Authoritative slugs (classroom.json-backed), as the collector resolves them.
   resolveClassroomTeamSlugs.mockResolvedValue({
     student: "classroom50-cs101",
@@ -135,6 +140,9 @@ describe("collectInviteRecoveries", () => {
     expect(state.liveInviteEmails.has("bob@example.com")).toBe(true)
     expect(state.trusted).toBe(true)
     expect(listOrgInvitations).not.toHaveBeenCalled()
+    // The maintainer read is a GC-path cost only; a young pending team never
+    // reaches the reap decision, so the common pass must not pay for it.
+    expect(listInviteTeamMaintainers).not.toHaveBeenCalled()
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
@@ -149,6 +157,44 @@ describe("collectInviteRecoveries", () => {
     expect(state.deletedStale).toBe(1)
     expect(state.liveInviteEmails.has("gone@example.com")).toBe(false)
     expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", team.slug)
+  })
+
+  // GitHub auto-promotes an org owner to team maintainer, so an owner who
+  // accepts never appears in the role=member read — the team looks abandoned.
+  // Reaping it would discard a real invited address (and the sync would then
+  // drop its roster row as dead), so the record is kept instead.
+  it("keeps an aged member-less team a second maintainer proves was accepted", async () => {
+    const team = await inviteState("cs101", "owner@example.com", [], {
+      createdAt: OLD_ENOUGH,
+    })
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+    // The creating teacher plus the accepted invitee, both maintainers.
+    listInviteTeamMaintainers.mockResolvedValue([
+      { id: 1, login: "prof" },
+      { id: 2, login: "promoted-student" },
+    ])
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.deletedStale).toBe(0)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+    // Reported so a caller can surface it, and kept live so the sync's removal
+    // pass leaves the roster row (and its address) in place.
+    expect(state.ownerAccepted).toEqual(["owner@example.com"])
+    expect(state.liveInviteEmails.has("owner@example.com")).toBe(true)
+  })
+
+  it("still reaps when the maintainer read shows only the creating teacher", async () => {
+    const team = await inviteState("cs101", "abandoned@example.com", [], {
+      createdAt: OLD_ENOUGH,
+    })
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+    listInviteTeamMaintainers.mockResolvedValue([{ id: 1, login: "prof" }])
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.deletedStale).toBe(1)
+    expect(state.ownerAccepted).toEqual([])
   })
 
   it("keeps an aged member-less team whose org invitation is still pending (live)", async () => {

--- a/web/src/domain/students/inviteRecoveries.ts
+++ b/web/src/domain/students/inviteRecoveries.ts
@@ -1,6 +1,7 @@
 import type { GitHubClient } from "@/github-core/client"
 import {
   deleteInviteTeam,
+  listInviteTeamMaintainers,
   listInviteTeams,
   readInviteTeam,
 } from "@/github-core/mutations"
@@ -33,6 +34,12 @@ export type InviteReconcileState = {
   // team whose org invitation is gone (cancelled/expired) aged past the GC
   // guard.
   deletedStale: number
+  // Emails whose invite was accepted by an ORG OWNER — auto-promoted to team
+  // maintainer, so invisible to the regular-member read the recovery uses. The
+  // mapping can't be recovered from team membership, so the team and its roster
+  // row are KEPT rather than reaped: the teacher keeps seeing the address and
+  // can finish the row by hand or cancel it.
+  ownerAccepted: string[]
 }
 
 const emptyState = (): InviteReconcileState => ({
@@ -40,6 +47,7 @@ const emptyState = (): InviteReconcileState => ({
   liveInviteEmails: new Set(),
   trusted: false,
   deletedStale: 0,
+  ownerAccepted: [],
 })
 
 // A member-less invite team is only GC'd once it's older than this, so a team
@@ -78,6 +86,7 @@ export async function collectInviteRecoveries(
   const liveInviteEmails = new Set<string>()
   let trusted = true
   let deletedStale = 0
+  const ownerAccepted: string[] = []
 
   let inviteTeams
   try {
@@ -141,13 +150,35 @@ export async function collectInviteRecoveries(
 
       const invitees = state.members
       if (invitees.length === 0) {
-        // Pending — or abandoned. Reap only when BOTH hold: old enough that a
-        // mid-creation race is impossible, and no pending org invitation still
-        // maps to this slug. Uncertainty always keeps the team (and the row).
+        // Pending — or abandoned — or accepted by an ORG OWNER. GitHub
+        // auto-promotes an owner to team maintainer, so an owner invitee never
+        // shows up in the `role=member` list this reads; a student promoted to
+        // teacher (org admin) between invite and reconcile lands exactly here.
+        // Reap only when BOTH hold: old enough that a mid-creation race is
+        // impossible, and no pending org invitation still maps to this slug.
+        // Uncertainty always keeps the team (and the row).
         if (
           isPastGcAge(state.createdAt) &&
           !(await loadLiveInviteSlugs()).has(slug)
         ) {
+          // Before reaping, check for the owner case: the creating teacher is a
+          // maintainer, so a SECOND maintainer means somebody accepted and was
+          // auto-promoted. Their address is real and its mapping is not
+          // recoverable from here (an owner-invitee is indistinguishable from
+          // the inviting teacher by team membership alone), so keep the team and
+          // its roster row rather than silently discarding the email the invite
+          // was sent to. A teacher can retire it with Cancel invite, or by
+          // filling in the row's username by hand.
+          const maintainers = await listInviteTeamMaintainers(client, org, slug)
+          if (maintainers.length > 1) {
+            log.error(
+              "invite accepted by an org owner; mapping unrecoverable, keeping the record",
+              { slug, maintainers: maintainers.length },
+            )
+            ownerAccepted.push(record.email)
+            liveInviteEmails.add(record.email)
+            continue
+          }
           await deleteInviteTeam(client, org, slug)
           deletedStale += 1
         } else {
@@ -201,7 +232,7 @@ export async function collectInviteRecoveries(
     }
   }
 
-  return { recovered, liveInviteEmails, trusted, deletedStale }
+  return { recovered, liveInviteEmails, trusted, deletedStale, ownerAccepted }
 }
 
 // Post-commit teardown: delete each recovered mapping's invite team, AFTER the

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -146,6 +146,7 @@ export {
   listInviteTeams,
   deleteInviteTeam,
   deleteInviteTeamForEmail,
+  listInviteTeamMaintainers,
   purgeClassroomInviteTeams,
   InviteTeamNotSecretError,
   type InviteTeamRef,

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -111,6 +111,37 @@ export type InviteTeamState = {
 }
 
 // Read one invite team's parsed description + members, for the reconcile pass.
+// The team's MAINTAINERS, read separately from readInviteTeam's regular-member
+// list because GitHub's member listing doesn't report each member's role.
+//
+// Needed to tell two states apart that both look member-less through the
+// `role=member` lens: a cancelled/expired invite nobody accepted, and an invite
+// accepted by an ORG OWNER — GitHub auto-promotes an owner to team maintainer,
+// so an owner invitee never appears as a regular member. The creating teacher is
+// also a maintainer, so more than one maintainer means somebody joined.
+//
+// Only called on the GC decision path, so the common reconcile pass doesn't pay
+// for it. 404 (team gone) -> [].
+export async function listInviteTeamMaintainers(
+  client: GitHubClient,
+  org: string,
+  slug: string,
+): Promise<GitHubUser[]> {
+  return tolerateGitHubError(
+    () =>
+      paginateAll<GitHubUser>(
+        client,
+        (page) =>
+          `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+            slug,
+          )}/members?role=maintainer&per_page=100&page=${page}`,
+      ),
+    [],
+  )
+}
+
+// The team's description plus its regular-role members. Reads the full team
+// record so `created_at` is available for the GC age guard.
 // 404 (team already deleted) -> null. `description` is null when the team's
 // description isn't a valid v1 record (hand-edited, or a slug collision with a
 // non-invite team); the caller skips such a team rather than acting on garbage.


### PR DESCRIPTION
The last silent data loss in the email-invite feature (the remaining P2s are hygiene). Follow-up to #631, #632, #634.

## What was lost

Recovery reads an invite team's members with `?role=member`, because GitHub keeps the creating teacher — and every org owner — on the team as a *maintainer*, and the accepted invitee is a plain member. That works until the invitee **is** an owner: GitHub auto-promotes them, so they never appear in that read and the team looks like nobody ever accepted.

The consequences chained: the 24h GC reaped the team as abandoned, and the next sync then dropped its roster row as dead — so the invited address disappeared with no trace, for someone who really had joined. The bulk path already avoids creating a metadata team for teacher-role invites, but that doesn't help a student promoted to teacher between invite and reconcile, which is the realistic path into this.

## What changed

Before reaping, the pass reads the team's maintainers. The creating teacher is one, so a **second** maintainer means somebody accepted. The mapping still can't be recovered — an owner-invitee is indistinguishable from the inviting teacher by team membership alone — so rather than guess an identity, the record is kept: the team survives, its email counts as live so the sync leaves the roster row alone, and the address is returned in a new `ownerAccepted` list for a caller to surface. The teacher keeps seeing the address and can finish the row by hand or cancel the invite.

The extra read is on the GC decision path only, so an ordinary reconcile pass doesn't pay for it (pinned by a test).

## Why not recover it properly

Two ways were considered and rejected. Reading maintainers and taking the non-teacher one breaks as soon as a classroom has more than one owner, and would happily map an address onto the wrong account — worse than keeping the row. Skipping the metadata team for anyone who *might* become an owner isn't knowable at invite time. Keeping the record is the honest outcome: no data is destroyed, and the one thing the automation can't determine is left to the teacher.

## Still open (hygiene, not loss)

Archiving a classroom leaves invite teams behind — deliberately not auto-purged, since archive is reversible and unarchive would want them back; it wants a notice plus the existing cleanup button. Nothing cancels the org's pending email invitations on delete/archive/teardown (GitHub expires them). The CLI can read a pending row but not remove/update it. And `matchesRosterRow`'s comment still claims "there are no username-less rows", which this feature falsified.

## Test plan

- [x] `npm run check` green — tsc, eslint, prettier, dependency-cruiser, 3889 tests
- [x] A second maintainer keeps the team, reports the email in `ownerAccepted`, and keeps it live so the row survives
- [x] Only the creating teacher as maintainer still reaps, as before
- [x] A young pending team pays for neither the invitation read nor the maintainer read
- [ ] Browser accessibility suites run in CI only (need `npx playwright install chromium` locally); untouched here