### PR TITLE
fix(web): recover an invited email even when an org owner accepts it

### DIFF
--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -292,6 +292,8 @@ describe("inviteByEmail — org invite plus a pending email row", () => {
       inviteTeamCreated: false,
       inviteTeamDeleted: false,
       actorDroppedFrom: null as string | null,
+      inviteRecordWritten: null as string | null,
+      inviteTeamCreateDescription: null as string | null,
     }
 
     const requestRaw = vi.fn().mockImplementation((path: string) => {
@@ -352,12 +354,31 @@ describe("inviteByEmail — org invite plus a pending email row", () => {
           state.actorDroppedFrom = path
           return Promise.resolve({})
         }
+        // The read-back proving no teacher remains, then the PATCH that writes
+        // the invite record now that it's safe to store the email.
+        if (path.includes("/teams/invite-") && path.includes("/members")) {
+          return Promise.resolve([])
+        }
+        if (
+          path.includes("/teams/invite-") &&
+          (options as { method?: string } | undefined)?.method === "PATCH"
+        ) {
+          const body = options?.body as { description?: string }
+          state.inviteRecordWritten = body?.description ?? null
+          return Promise.resolve({
+            id: 9001,
+            slug: path.split("/teams/")[1],
+            privacy: "secret",
+            description: body?.description,
+          })
+        }
         // The per-invite metadata team create (POST /orgs/{org}/teams). Return
         // it as a secret team carrying the exact description the caller wrote,
         // so ensureInviteTeam's fail-closed read-back is a no-op (no PATCH/GET).
         if (path.endsWith("/teams")) {
           const body = options?.body as { name?: string; description?: string }
           state.inviteTeamCreated = true
+          state.inviteTeamCreateDescription = body?.description ?? null
           return Promise.resolve({
             id: 9001,
             slug: body?.name,
@@ -401,8 +422,12 @@ describe("inviteByEmail — org invite plus a pending email row", () => {
       team_ids: [4242, 9001],
     })
     // The metadata team is left holding NO teacher, so the reconcile can read
-    // whoever accepts as the invitee regardless of their org role.
+    // whoever accepts as the invitee regardless of their org role. The email is
+    // written only after that's settled, so an interrupted run strands a team
+    // holding no address.
     expect(state.actorDroppedFrom).toMatch(/\/memberships\/teacher$/)
+    expect(state.inviteTeamCreateDescription).not.toContain("new@x.edu")
+    expect(state.inviteRecordWritten).toContain("new@x.edu")
     // The invited email is retained on the roster right away, as an
     // email-only pending row (identity arrives via the acceptance reconcile).
     const rows = rowsFromCsv(state.committed!)
@@ -544,6 +569,20 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
           if (path.includes("/memberships/")) {
             state.actorDrops.push(path)
             return Promise.resolve({})
+          }
+          // The read-back proving the invite team is teacher-free, then the
+          // PATCH writing its record once that's settled.
+          if (path.includes("/teams/invite-") && path.includes("/members")) {
+            return Promise.resolve([])
+          }
+          if (path.includes("/teams/invite-") && options?.method === "PATCH") {
+            const body = options.body as { description?: string }
+            return Promise.resolve({
+              id: 9001,
+              slug: path.split("/teams/")[1],
+              privacy: "secret",
+              description: body?.description,
+            })
           }
           if (/\/repos\/[^/]+\/classroom50$/.test(path))
             return { default_branch: "main" }

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -291,6 +291,7 @@ describe("inviteByEmail — org invite plus a pending email row", () => {
       inviteBody: null as unknown,
       inviteTeamCreated: false,
       inviteTeamDeleted: false,
+      actorDroppedFrom: null as string | null,
     }
 
     const requestRaw = vi.fn().mockImplementation((path: string) => {
@@ -343,6 +344,14 @@ describe("inviteByEmail — org invite plus a pending email row", () => {
           }
           return Promise.reject(apiError422())
         }
+        // The acting teacher's identity, so the invite team can be cleared of
+        // them (GitHub auto-adds the creator as a maintainer).
+        if (path === "/user") return Promise.resolve({ login: "teacher" })
+        // Dropping the acting teacher from the freshly created invite team.
+        if (path.includes("/memberships/")) {
+          state.actorDroppedFrom = path
+          return Promise.resolve({})
+        }
         // The per-invite metadata team create (POST /orgs/{org}/teams). Return
         // it as a secret team carrying the exact description the caller wrote,
         // so ensureInviteTeam's fail-closed read-back is a no-op (no PATCH/GET).
@@ -391,6 +400,9 @@ describe("inviteByEmail — org invite plus a pending email row", () => {
       email: "new@x.edu",
       team_ids: [4242, 9001],
     })
+    // The metadata team is left holding NO teacher, so the reconcile can read
+    // whoever accepts as the invitee regardless of their org role.
+    expect(state.actorDroppedFrom).toMatch(/\/memberships\/teacher$/)
     // The invited email is retained on the roster right away, as an
     // email-only pending row (identity arrives via the acceptance reconcile).
     const rows = rowsFromCsv(state.committed!)
@@ -490,8 +502,8 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
     // 429 (with Retry-After) the first N POST /invitations attempts, then let
     // later attempts through — exercises the Retry-After-backed retry pass.
     rateLimitFirstN?: number
-    // 500 every per-invite metadata team create — exercises the graceful
-    // degradation (invite still sent with the classroom team alone).
+    // 500 every per-invite metadata team create — the invite must then be
+    // reported as failed rather than sent without email retention.
     failInviteTeams?: boolean
   }) => {
     const memberEmails = new Set(opts?.memberEmails ?? [])
@@ -511,6 +523,8 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
       // Names of per-invite metadata teams created / slugs deleted.
       inviteTeamNames: [] as string[],
       teamDeletes: [] as string[],
+      // Invite teams the acting teacher was dropped from.
+      actorDrops: [] as string[],
     }
 
     const requestRaw = vi.fn().mockImplementation((path: string) => {
@@ -526,6 +540,11 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
       .fn()
       .mockImplementation(
         (path: string, options?: { body?: unknown; method?: string }) => {
+          if (path === "/user") return Promise.resolve({ login: "teacher" })
+          if (path.includes("/memberships/")) {
+            state.actorDrops.push(path)
+            return Promise.resolve({})
+          }
           if (/\/repos\/[^/]+\/classroom50$/.test(path))
             return { default_branch: "main" }
           // The batch pending-row write's read-modify-write chain.
@@ -661,7 +680,7 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
     }
   })
 
-  it("still invites (classroom team only, no roster row) when the metadata team create fails", async () => {
+  it("reports the target as FAILED (sending nothing) when the metadata team can't be prepared", async () => {
     const { client, state } = makeClient({ failInviteTeams: true })
 
     const result = await bulkInviteByEmail(client, {
@@ -670,16 +689,16 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
       invites: [{ email: "a@x.edu" }],
     })
 
-    // Graceful degradation: only email retention is lost, never the invite.
-    expect(result.invited.map((i) => i.email)).toEqual(["a@x.edu"])
-    expect(result.failed).toEqual([])
-    expect(state.inviteBodies[0].team_ids).toEqual([4242])
-    // No metadata team -> no roster row: the reconcile would just remove an
-    // email-only row nothing backs.
+    // The metadata team is the only thing retaining the address, so an invite
+    // without it would silently drop the email. Nothing is sent, and the
+    // teacher can retry cleanly.
+    expect(result.invited).toEqual([])
+    expect(result.failed.map((f) => f.email)).toEqual(["a@x.edu"])
+    expect(state.inviteBodies).toEqual([])
     expect(state.committed).toBeNull()
   })
 
-  it("invites a teacher as an org OWNER (admin role) with no metadata team", async () => {
+  it("invites a teacher as an org OWNER (admin role), retaining their email too", async () => {
     const { client, state } = makeClient()
 
     await bulkInviteByEmail(client, {
@@ -692,11 +711,14 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
       email: "prof@x.edu",
       role: "admin",
     })
-    // An accepting owner is auto-promoted to team maintainer, so the backfill's
-    // role=member read would never see them — no metadata team is created, and
-    // therefore no roster row either.
-    expect(state.inviteTeamNames).toEqual([])
-    expect(state.committed).toBeNull()
+    // An accepting owner is auto-promoted to team maintainer, but the invite
+    // team holds no teacher and the reconcile reads members of every role, so a
+    // teacher-role invite gets a metadata team and its email retained like any
+    // other.
+    expect(state.inviteTeamNames).toHaveLength(1)
+    expect(rowsFromCsv(state.committed!).map((r) => r.email)).toEqual([
+      "prof@x.edu",
+    ])
   })
 
   it("routes a 422 already-member into skipped and deletes its fresh metadata team", async () => {
@@ -925,20 +947,22 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
       role: "direct_member",
       team_ids: [5000, 9001],
     })
-    // Teacher becomes an org OWNER on the ensured staff team; no metadata team
-    // (an owner would be a maintainer the backfill can never see).
+    // Teacher becomes an org OWNER on the ensured staff team, and carries a
+    // metadata team like everyone else: the team holds no teacher, so the
+    // reconcile sees an accepting owner even though GitHub makes them a
+    // maintainer.
     expect(byEmail.get("prof@x.edu")).toMatchObject({
       role: "admin",
-      team_ids: [5000],
+      team_ids: [5000, 9001],
     })
-    // Only the metadata-team-carrying invites get pending roster rows, with
-    // the invited role recorded, in one batch commit.
+    // Every invited email gets a pending roster row recording its invited role,
+    // in one batch commit.
     expect(state.rosterCommits).toBe(1)
     const rows = rowsFromCsv(state.committed!)
     const roleByEmail = new Map(rows.map((r) => [r.email, r.role]))
     expect(roleByEmail.get("stu@x.edu")).toBe("student")
     expect(roleByEmail.get("ta@x.edu")).toBe("ta")
-    expect(roleByEmail.has("prof@x.edu")).toBe(false)
+    expect(roleByEmail.get("prof@x.edu")).toBe("teacher")
   })
 })
 

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -17,6 +17,7 @@ import {
   type CreateClassroomResult,
 } from "../classrooms"
 import { getRawFile, getUser } from "@/github-core/queries"
+import { getAuthenticatedUser } from "../queries/users"
 import {
   getBranchRef,
   getCommit,
@@ -161,16 +162,15 @@ export type InviteByEmailResult = {
 // roster as an email-only PENDING row (no username/github_id yet) — that row
 // lives exactly as long as its invite team does: the reconcile fills in the
 // account identity on acceptance and removes the row once the invite is
-// cancelled, expired, or GC'd. A row is written only when the metadata team was
-// attached, since the reconcile would otherwise reap an unbacked row.
+// cancelled, expired, or GC'd.
 // On acceptance the invitee lands on both teams; a later reconcile pass recovers
 // the email <-> account mapping from the metadata team and folds it into
 // roster.csv. The invite also shows up in the roster's `pending` section via the
-// org pending-invitations list. If the classroom team can't be resolved, the
-// invite is BLOCKED (throws) rather than sent team-less. If the metadata team
-// can't be created, the invite still goes out with the classroom team alone (the
-// invitee stays collectable; only email retention is lost) and a non-fatal
-// warning is returned.
+// org pending-invitations list. The invite is BLOCKED (throws) unless BOTH teams
+// are ready: an invite that can't carry the classroom team would land the
+// student in the org with nothing to collect them, and one without its metadata
+// team would silently lose the address it was sent to. Nothing has been sent at
+// that point, so the teacher just retries.
 export async function inviteByEmail(
   client: GitHubClient,
   input: AddEmailInviteToClassroomInput,
@@ -202,32 +202,37 @@ export async function inviteByEmail(
     )
   }
 
-  // Best-effort: create the per-invite metadata team and attach it too. A
-  // failure here must NOT block the invite (the invitee stays collectable via
-  // the classroom team) — only email retention is lost, surfaced as a warning.
-  const teamIds = [teamId]
-  let inviteTeam: InviteTeamRef | null = null
-  let metadataWarning = ""
+  // The metadata team is a precondition, not a nicety: it's the only thing that
+  // retains the invited address, so an invite without it would go out with the
+  // email silently dropped. Nothing has been sent yet, so failing here costs a
+  // retry rather than a stranded invitation.
+  const actor = await getAuthenticatedUser(client)
+  let inviteTeam: InviteTeamRef
   try {
-    inviteTeam = await ensureInviteTeam(client, org, {
-      email: normalizedEmail,
-      classroom,
-    })
-    teamIds.push(inviteTeam.id)
+    inviteTeam = await ensureInviteTeam(
+      client,
+      org,
+      { email: normalizedEmail, classroom },
+      actor.login,
+    )
   } catch (err) {
     log.error("invite metadata team create failed", { err })
-    metadataWarning = i18n.t("students.inviteMetadataFailed", {
-      email: normalizedEmail,
-      message: getErrorMessage(err),
-    })
+    throw new Error(
+      i18n.t("students.inviteMetadataFailed", {
+        email: normalizedEmail,
+        message: getErrorMessage(err),
+      }),
+      { cause: err },
+    )
   }
+  const teamIds = [teamId, inviteTeam.id]
 
   // A doomed invite must not leave a fresh, member-less metadata team behind
   // (an orphan holding an email GC can't yet reap). Only a team THIS call
   // created is deleted — an adopted one may hold a prior accepted invite's
   // still-unrecovered record.
   const cleanupInviteTeam = async () => {
-    if (!inviteTeam?.created) return
+    if (!inviteTeam.created) return
     try {
       await deleteInviteTeam(client, org, inviteTeam.slug)
     } catch (err) {
@@ -264,18 +269,14 @@ export async function inviteByEmail(
     }
   }
 
-  // Retain the invited email on the roster right away — but only when the
-  // metadata team is attached: the reconcile keeps an email-only row exactly
-  // as long as a live invite team backs it, so a team-less row would just be
-  // removed on the next pass. Best-effort (never throws); on a miss the
-  // accepted invite's reconcile fold appends the row instead.
-  if (inviteTeam) {
-    await appendEmailInviteRows(client, { org, classroom }, [
-      { email: normalizedEmail, role: "student" },
-    ])
-  }
+  // Retain the invited email on the roster right away. Best-effort (never
+  // throws); on a miss the accepted invite's reconcile fold appends the row
+  // instead.
+  await appendEmailInviteRows(client, { org, classroom }, [
+    { email: normalizedEmail, role: "student" },
+  ])
 
-  return metadataWarning ? { inviteWarning: metadataWarning } : {}
+  return {}
 }
 
 export type AddStudentToClassroomInput = {

--- a/web/src/domain/students/inviteRecoveries.test.ts
+++ b/web/src/domain/students/inviteRecoveries.test.ts
@@ -126,6 +126,28 @@ describe("collectInviteRecoveries", () => {
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
+  // The case the zero-member invariant exists for: GitHub auto-promotes an org
+  // owner to team maintainer, so an owner invitee is invisible to a role=member
+  // read. Since the team carries no teacher, the unfiltered read sees them and
+  // the mapping recovers like any other.
+  it("recovers an ORG OWNER invitee (present only as a maintainer)", async () => {
+    const team = await inviteState("cs101", "dean@example.com", [
+      { id: 3, login: "dean" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([
+      {
+        email: "dean@example.com",
+        invitee: { id: 3, login: "dean" },
+        slug: team.slug,
+      },
+    ])
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
   it("counts a young pending team's email as live without reading invitations", async () => {
     const team = await inviteState("cs101", "bob@example.com", [])
     listInviteTeams.mockResolvedValue([{ slug: team.slug }])

--- a/web/src/domain/students/inviteRecoveries.test.ts
+++ b/web/src/domain/students/inviteRecoveries.test.ts
@@ -51,10 +51,10 @@ const rateLimitError = () =>
     rateLimit: emptyRateLimit,
   })
 
-// Build a valid invite-team state for (classroom, email) with the given
-// regular-role members (readInviteTeam already excludes maintainers, i.e. the
-// auto-added owner), so the description's email hashes back to the slug.
-// createdAt defaults to "just now" (never a GC candidate).
+// Build a valid invite-team state for (classroom, email) with the given members
+// (readInviteTeam lists EVERY role — the team is left teacher-free at creation,
+// so whoever is on it accepted), so the description's email hashes back to the
+// slug. createdAt defaults to "just now" (never a GC candidate).
 async function inviteState(
   classroom: string,
   email: string,

--- a/web/src/domain/students/inviteRecoveries.ts
+++ b/web/src/domain/students/inviteRecoveries.ts
@@ -54,10 +54,11 @@ const INVITE_TEAM_GC_MIN_AGE_MS = 24 * 60 * 60 * 1000
 // belongs to THIS classroom (by its validated description):
 //   - verify the description's email hashes back to the team name (the team is
 //     invitee-editable after acceptance, so this is the trust boundary);
-//   - with exactly one regular-role member (GitHub keeps org owners as team
-//     maintainers, so role=member is the accepted-invitee set) who is still on
-//     a classroom team -> a RECOVERED mapping. The team is left in place for
-//     the caller to delete after the roster commit lands;
+//   - with exactly one member (of any role — the team holds no teacher, so
+//     whoever is on it accepted, including an org owner GitHub auto-promoted to
+//     maintainer) who is still on a classroom team -> a RECOVERED mapping. The
+//     team is left in place for the caller to delete after the roster commit
+//     lands;
 //   - one member on NO classroom team -> unenrolled after accepting; delete the
 //     team now so the mapping can't resurrect a removed student;
 //   - zero members -> the invite is live (row kept), unless the team aged past
@@ -156,7 +157,7 @@ export async function collectInviteRecoveries(
         continue
       }
       if (invitees.length > 1) {
-        log.error("invite team has multiple regular members; skipping", {
+        log.error("invite team has multiple members; skipping", {
           slug,
           count: invitees.length,
         })

--- a/web/src/domain/students/inviteRoster.ts
+++ b/web/src/domain/students/inviteRoster.ts
@@ -4,10 +4,10 @@ import {
   deleteInviteTeam,
   ensureInviteTeam,
   ensureOrgMembership,
-  type InviteTeamRef,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { assertClassroomNotArchived } from "../classrooms"
+import { getAuthenticatedUser } from "../queries/users"
 import { getUser, sleep, REPO_READ_CONCURRENCY } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { resolveGitHubId } from "@/util/students"
@@ -240,15 +240,16 @@ export type BulkInviteByEmailResult = {
 // Bulk-invite a list of EMAIL addresses to the org, carrying the role's team so
 // accepting the single invite activates the right membership: student ->
 // classroom team, ta -> TA team, teacher -> the teacher team AND org
-// OWNER (role "admin"). Every successfully sent invite that carried a per-invite
-// metadata team is then retained on the roster as an email-only PENDING row, all
+// OWNER (role "admin"). Every successfully sent invite carries a per-invite
+// metadata team and is retained on the roster as an email-only PENDING row, all
 // in ONE commit for the batch (see appendEmailInviteRows); each row lives exactly
-// as long as its invite team does, so an invite sent without a metadata team
-// gets no row. The invite also surfaces as a `pending` row via the org
-// pending-invitations list. Mirrors inviteRosterStudents' rate-limit handling
-// (stop issuing new invites once throttled; defer the rest), and the same team
-// resolution (resolveTeamIdByRole ensures the staff team for a teacher/ta
-// invite, students-only never creates empty staff teams).
+// as long as its invite team does. A target whose metadata team can't be
+// prepared is reported as FAILED rather than invited without email retention.
+// The invite also surfaces as a `pending` row via the org pending-invitations
+// list. Mirrors inviteRosterStudents' rate-limit handling (stop issuing new
+// invites once throttled; defer the rest), and the same team resolution
+// (resolveTeamIdByRole ensures the staff team for a teacher/ta invite,
+// students-only never creates empty staff teams).
 export async function bulkInviteByEmail(
   client: GitHubClient,
   input: BulkInviteByEmailInput,
@@ -298,6 +299,10 @@ export async function bulkInviteByEmail(
     )
   }
 
+  // Resolved once for the whole batch: every invite team must be cleared of the
+  // acting teacher, and the identity is the same for all of them.
+  const actor = await getAuthenticatedUser(client)
+
   let processed = 0
   const bump = (email: string) => {
     processed += 1
@@ -306,40 +311,20 @@ export async function bulkInviteByEmail(
 
   type EmailTarget = (typeof targets)[number]
   // Invite one email; throws on error so the caller classifies rate-limit/422.
-  // Returns whether the metadata team rode along, so the caller knows which
-  // invited emails to retain on the roster (a team-less invite must not get a
-  // row — the reconcile would just remove it). Best-effort per-invite metadata
-  // team: on create failure the invite still goes out with the classroom team
-  // alone (the invitee stays collectable; only email retention is lost). A
-  // rate-limit error from the team create surfaces as a thrown GitHubAPIError
-  // so the caller defers the whole target — retrying later recreates the team
-  // too, rather than sending a metadata-less invite.
-  const inviteOne = async (
-    target: EmailTarget,
-  ): Promise<{ hadInviteTeam: boolean }> => {
+  // The metadata team is a precondition, not a nicety: it's the only thing that
+  // retains the invited address, so a failure to prepare it throws and the
+  // target lands in `failed` rather than sending an invite whose email is
+  // silently dropped. Nothing has been sent at that point, so a retry is clean.
+  const inviteOne = async (target: EmailTarget): Promise<void> => {
     const teamId = teamIdByRole[target.role]
     const teamIds = teamId ? [teamId] : []
-    let inviteTeam: InviteTeamRef | null = null
-    // Skip the metadata team for admin-role (teacher) invites: an accepting
-    // owner is auto-promoted to team maintainer, so the backfill's role=member
-    // read would never see them and the team would sit forever as a "pending"
-    // orphan holding their email.
-    if (githubOrgRoleForRole(target.role) !== "admin") {
-      try {
-        inviteTeam = await ensureInviteTeam(client, org, {
-          email: target.email,
-          classroom,
-        })
-        teamIds.push(inviteTeam.id)
-      } catch (err) {
-        if (err instanceof GitHubAPIError && err.isRateLimited) throw err
-        log.error("bulk invite metadata team create failed", {
-          email: target.email,
-          err,
-        })
-        // Non-rate-limit failure: proceed with the classroom team only.
-      }
-    }
+    const inviteTeam = await ensureInviteTeam(
+      client,
+      org,
+      { email: target.email, classroom },
+      actor.login,
+    )
+    teamIds.push(inviteTeam.id)
     try {
       await createOrgInvitation(client, {
         org,
@@ -347,14 +332,13 @@ export async function bulkInviteByEmail(
         team_ids: teamIds.length > 0 ? teamIds : undefined,
         role: githubOrgRoleForRole(target.role),
       })
-      return { hadInviteTeam: inviteTeam !== null }
     } catch (err) {
       // A doomed invite (422 already-member/-invited, or a hard failure) must
       // not leave a fresh, member-less metadata team behind for GC to reap.
       // Keep it on a rate limit (the deferred retry re-adopts it) and keep an
       // adopted team (it may hold a prior invite's still-unrecovered record).
       const rateLimited = err instanceof GitHubAPIError && err.isRateLimited
-      if (!rateLimited && inviteTeam?.created) {
+      if (!rateLimited && inviteTeam.created) {
         try {
           await deleteInviteTeam(client, org, inviteTeam.slug)
         } catch (cleanupErr) {
@@ -371,9 +355,6 @@ export async function bulkInviteByEmail(
   let rateLimited = false
   let retryAfterMs = 0
   const deferredTargets: EmailTarget[] = []
-  // Invited emails whose metadata team rode along — retained on the roster in
-  // ONE batch write below.
-  const rowsToRetain: { email: string; role: ClassroomRole }[] = []
 
   await mapWithConcurrency(targets, REPO_READ_CONCURRENCY, async (target) => {
     const { email } = target
@@ -383,9 +364,8 @@ export async function bulkInviteByEmail(
       return
     }
     try {
-      const { hadInviteTeam } = await inviteOne(target)
+      await inviteOne(target)
       invited.push({ email, role: target.role })
-      if (hadInviteTeam) rowsToRetain.push({ email, role: target.role })
     } catch (err) {
       if (err instanceof GitHubAPIError && err.isRateLimited) {
         rateLimited = true
@@ -410,10 +390,8 @@ export async function bulkInviteByEmail(
     sleepFn,
     initialRetryAfterMs: retryAfterMs,
     attempt: async (target) => {
-      const { hadInviteTeam } = await inviteOne(target)
+      await inviteOne(target)
       invited.push({ email: target.email, role: target.role })
-      if (hadInviteTeam)
-        rowsToRetain.push({ email: target.email, role: target.role })
     },
     onError: (target, err) => {
       // A 422 on retry means already-member/already-invited, not a failure.
@@ -424,9 +402,10 @@ export async function bulkInviteByEmail(
   })
   for (const target of stillDeferred) deferred.push(target.email)
 
-  // Retain the successfully invited emails on the roster, one commit for the
-  // whole batch (best-effort; a miss is appended by the acceptance reconcile).
-  await appendEmailInviteRows(client, { org, classroom }, rowsToRetain)
+  // Retain the invited emails on the roster, one commit for the whole batch
+  // (best-effort; a miss is appended by the acceptance reconcile). Every
+  // successful invite carries its metadata team, so `invited` is the row set.
+  await appendEmailInviteRows(client, { org, classroom }, invited)
 
   return { invited, skipped, failed, deferred }
 }

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -148,6 +148,7 @@ export {
   deleteInviteTeamForEmail,
   purgeClassroomInviteTeams,
   InviteTeamNotSecretError,
+  InviteTeamNotEmptyError,
   type InviteTeamRef,
   type InviteTeamState,
 } from "./mutations/inviteTeams"

--- a/web/src/github-core/mutations/inviteTeams.test.ts
+++ b/web/src/github-core/mutations/inviteTeams.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   ensureInviteTeam,
   InviteTeamNotSecretError,
+  InviteTeamNotEmptyError,
   readInviteTeam,
   listInviteTeams,
   deleteInviteTeam,
@@ -11,7 +12,11 @@ import {
 } from "./inviteTeams"
 import type { GitHubClient } from "../client"
 import { GitHubAPIError, type GitHubRateLimit } from "../errors"
-import { inviteTeamName, marshalInviteDescription } from "@/util/inviteTeam"
+import {
+  inviteTeamName,
+  marshalInviteDescription,
+  parseInviteDescription,
+} from "@/util/inviteTeam"
 
 const emptyRateLimit: GitHubRateLimit = {
   limit: null,
@@ -71,40 +76,23 @@ describe("ensureInviteTeam", () => {
   const isMembershipDelete = (c: Call) =>
     c.options?.method === "DELETE" && c.url.includes("/memberships/")
 
-  it("creates a fresh secret team and drops the acting teacher (no PATCH)", async () => {
+  it("creates a fresh secret team, drops the acting teacher, then writes the email", async () => {
     const name = await inviteTeamName(METADATA.classroom, METADATA.email)
     const { client, calls } = makeClient((url, options) => {
       if (options?.method === "POST" && url === "/orgs/acme/teams") {
         const body = options.body as Record<string, unknown>
         expect(body.privacy).toBe("secret")
-        expect(body.description).toBe(DESCRIPTION)
         expect(body.name).toBe(name)
         return {
           id: 7,
           slug: name,
           privacy: "secret",
-          description: DESCRIPTION,
+          description: body.description,
         }
       }
       if (options?.method === "DELETE") return undefined
-      throw new Error(`unexpected ${url}`)
-    })
-
-    const ref = await ensureInviteTeam(client, "acme", METADATA, ACTOR)
-    expect(ref).toEqual({ id: 7, slug: name, created: true })
-    expect(methodsOf(calls)).toEqual(["POST", "DELETE"])
-    expect(calls[1].url).toBe(`/orgs/acme/teams/${name}/memberships/${ACTOR}`)
-  })
-
-  it("adopts an existing team on 422, forcing secret + description via PATCH (created: false)", async () => {
-    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
-    const { client, calls } = makeClient((_url, options) => {
-      if (options?.method === "POST") throw apiError(422)
+      if (url.includes("/members")) return []
       if (options?.method === "PATCH") {
-        expect(options.body).toEqual({
-          privacy: "secret",
-          description: DESCRIPTION,
-        })
         return {
           id: 7,
           slug: name,
@@ -112,13 +100,51 @@ describe("ensureInviteTeam", () => {
           description: DESCRIPTION,
         }
       }
+      throw new Error(`unexpected ${url}`)
+    })
+
+    const ref = await ensureInviteTeam(client, "acme", METADATA, ACTOR)
+    expect(ref).toEqual({ id: 7, slug: name, created: true })
+    // Create (no email) -> drop the teacher -> prove empty -> write the email.
+    expect(methodsOf(calls)).toEqual(["POST", "DELETE", "GET", "PATCH"])
+    expect(calls[1].url).toBe(`/orgs/acme/teams/${name}/memberships/${ACTOR}`)
+  })
+
+  it("adopts an existing team on 422, forcing secret before writing the email", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const privacyPatches: unknown[] = []
+    const { client, calls } = makeClient((url, options) => {
+      if (options?.method === "POST") throw apiError(422)
       if (options?.method === "DELETE") return undefined
+      if (url.includes("/members")) return []
+      if (options?.method === "PATCH") {
+        privacyPatches.push(options.body)
+        return {
+          id: 7,
+          slug: name,
+          privacy: "secret",
+          description: DESCRIPTION,
+        }
+      }
       // The adopt read: a pre-existing CLOSED team with a stale description.
       return { id: 7, slug: name, privacy: "closed", description: "old" }
     })
     const ref = await ensureInviteTeam(client, "acme", METADATA, ACTOR)
     expect(ref).toEqual({ id: 7, slug: name, created: false })
-    expect(methodsOf(calls)).toEqual(["POST", "GET", "PATCH", "DELETE"])
+    expect(methodsOf(calls)).toEqual([
+      "POST",
+      "GET",
+      "PATCH",
+      "DELETE",
+      "GET",
+      "PATCH",
+    ])
+    // Privacy is fixed first, on its own — the email rides only the last PATCH.
+    expect(privacyPatches[0]).toEqual({ privacy: "secret" })
+    expect(privacyPatches[1]).toEqual({
+      privacy: "secret",
+      description: DESCRIPTION,
+    })
   })
 
   // Not gated on created-vs-adopted: a team that already exists may still carry
@@ -126,15 +152,16 @@ describe("ensureInviteTeam", () => {
   // reconcile read the teacher as the accepted invitee.
   it("drops the acting teacher from an ADOPTED team too", async () => {
     const name = await inviteTeamName(METADATA.classroom, METADATA.email)
-    const { client, calls } = makeClient((_url, options) => {
+    const { client, calls } = makeClient((url, options) => {
       if (options?.method === "POST") throw apiError(422)
       if (options?.method === "DELETE") return undefined
+      if (url.includes("/members")) return []
       return { id: 7, slug: name, privacy: "secret", description: DESCRIPTION }
     })
 
     const ref = await ensureInviteTeam(client, "acme", METADATA, ACTOR)
     expect(ref.created).toBe(false)
-    expect(methodsOf(calls)).toEqual(["POST", "GET", "DELETE"])
+    expect(methodsOf(calls)).toEqual(["POST", "GET", "DELETE", "GET", "PATCH"])
     expect(calls[2].url).toBe(`/orgs/acme/teams/${name}/memberships/${ACTOR}`)
   })
 
@@ -152,6 +179,77 @@ describe("ensureInviteTeam", () => {
     expect(calls.filter(isMembershipDelete)).toEqual([])
   })
 
+  it("writes the email only AFTER the team is confirmed teacher-free", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const bodies: { method: string; description?: string }[] = []
+    const { client } = makeClient((url, options) => {
+      const method = options?.method ?? "GET"
+      const body = options?.body as { description?: string } | undefined
+      if (method === "POST" || method === "PATCH") {
+        bodies.push({ method, description: body?.description })
+      }
+      if (method === "POST") {
+        return {
+          id: 7,
+          slug: name,
+          privacy: "secret",
+          description: body?.description,
+        }
+      }
+      if (method === "DELETE") return undefined
+      if (url.includes("/members")) return []
+      if (method === "PATCH") {
+        return {
+          id: 7,
+          slug: name,
+          privacy: "secret",
+          description: DESCRIPTION,
+        }
+      }
+      throw new Error(`unexpected ${url}`)
+    })
+
+    await ensureInviteTeam(client, "acme", METADATA, ACTOR)
+
+    // The create must not carry the invited address: if the run dies before the
+    // actor is dropped, the leftover team holds a teacher but NO email, so the
+    // reconcile can't misread it as an accepted invite.
+    expect(bodies[0].method).toBe("POST")
+    expect(bodies[0].description).not.toContain(METADATA.email)
+    // And whatever it does carry must not parse as an invite record.
+    expect(parseInviteDescription(bodies[0].description ?? null)).toBeNull()
+    // The real record lands last, after the membership DELETE.
+    expect(bodies.at(-1)).toMatchObject({
+      method: "PATCH",
+      description: DESCRIPTION,
+    })
+  })
+
+  // An adopted team may still carry a DIFFERENT teacher stranded by an earlier
+  // run, and dropping `actor` alone wouldn't clear them. Nobody has accepted yet
+  // (the invitation isn't sent until this returns), so any member is a stray.
+  it("fails closed when an ADOPTED team still has a member, writing no email", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const patched: unknown[] = []
+    const { client } = makeClient((_url, options) => {
+      if (options?.method === "POST") throw apiError(422)
+      if (options?.method === "PATCH") {
+        patched.push(options.body)
+        return { id: 7, slug: name, privacy: "secret", description: "x" }
+      }
+      if (options?.method === "DELETE") return undefined
+      if (_url.includes("/members")) return [{ id: 99, login: "other-teacher" }]
+      return { id: 7, slug: name, privacy: "secret", description: "x" }
+    })
+
+    await expect(
+      ensureInviteTeam(client, "acme", METADATA, ACTOR),
+    ).rejects.toThrow(InviteTeamNotEmptyError)
+    expect(
+      patched.filter((b) => JSON.stringify(b).includes(METADATA.email)),
+    ).toEqual([])
+  })
+
   it("rethrows a non-422 create failure", async () => {
     const { client } = makeClient(() => {
       throw apiError(500)
@@ -161,56 +259,54 @@ describe("ensureInviteTeam", () => {
     ).rejects.toMatchObject({ status: 500 })
   })
 
-  // A team we created but couldn't clear must not survive: it holds a student's
-  // email AND a teacher, which the reconcile would read as "the teacher
-  // accepted this invite" and write onto the roster.
-  it("deletes the team it created when the acting teacher can't be dropped", async () => {
+  // A run that dies between the create and the membership drop is unavoidable
+  // (GitHub adds the creator during the create itself), so the leftover team is
+  // made harmless rather than cleaned up: it holds a teacher but no email, and
+  // no parseable record, so the reconcile skips it entirely.
+  it("leaves no email behind when the acting teacher can't be dropped", async () => {
     const name = await inviteTeamName(METADATA.classroom, METADATA.email)
-    const { client, calls } = makeClient((url, options) => {
+    const descriptions: (string | undefined)[] = []
+    const { client } = makeClient((url, options) => {
+      const body = options?.body as { description?: string } | undefined
       if (options?.method === "POST") {
+        descriptions.push(body?.description)
         return {
           id: 7,
           slug: name,
           privacy: "secret",
-          description: DESCRIPTION,
+          description: body?.description,
         }
       }
+      if (options?.method === "PATCH") descriptions.push(body?.description)
       if (options?.method === "DELETE" && url.includes("/memberships/")) {
         throw apiError(500)
       }
-      if (options?.method === "DELETE") return undefined
       throw new Error(`unexpected ${url}`)
     })
 
     await expect(
       ensureInviteTeam(client, "acme", METADATA, ACTOR),
     ).rejects.toMatchObject({ status: 500 })
-    expect(calls.at(-1)).toMatchObject({
-      url: `/orgs/acme/teams/${name}`,
-      options: { method: "DELETE" },
-    })
+    for (const d of descriptions) expect(d ?? "").not.toContain(METADATA.email)
   })
 
-  // The mirror case: an ADOPTED team may hold an earlier accepted invite's
-  // still-unrecovered record, so a failure must never delete it.
-  it("keeps an ADOPTED team when the acting teacher can't be dropped", async () => {
+  // The membership read-back is the proof, so a degraded read must not pass as
+  // "empty" and let the email be written onto a team holding a teacher.
+  it("fails closed when the membership read-back fails", async () => {
     const name = await inviteTeamName(METADATA.classroom, METADATA.email)
     const { client, calls } = makeClient((url, options) => {
-      if (options?.method === "POST") throw apiError(422)
-      if (options?.method === "DELETE" && url.includes("/memberships/")) {
-        throw apiError(500)
+      if (options?.method === "POST") {
+        return { id: 7, slug: name, privacy: "secret", description: "x" }
       }
-      return { id: 7, slug: name, privacy: "secret", description: DESCRIPTION }
+      if (options?.method === "DELETE") return undefined
+      if (url.includes("/members")) throw apiError(500)
+      throw new Error(`unexpected ${url}`)
     })
 
     await expect(
       ensureInviteTeam(client, "acme", METADATA, ACTOR),
     ).rejects.toMatchObject({ status: 500 })
-    expect(
-      calls.filter(
-        (c) => c.options?.method === "DELETE" && !isMembershipDelete(c),
-      ),
-    ).toEqual([])
+    expect(calls.filter((c) => c.options?.method === "PATCH")).toEqual([])
   })
 })
 

--- a/web/src/github-core/mutations/inviteTeams.test.ts
+++ b/web/src/github-core/mutations/inviteTeams.test.ts
@@ -42,6 +42,9 @@ const rateLimitError = () =>
 
 const METADATA = { email: "alice@example.com", classroom: "cs101" }
 const DESCRIPTION = marshalInviteDescription(METADATA)
+// The teacher performing the invite. GitHub auto-adds them as a maintainer of
+// the team they create, so ensureInviteTeam drops them again.
+const ACTOR = "ms-frizzle"
 
 type Call = { url: string; options?: { method?: string; body?: unknown } }
 
@@ -57,8 +60,18 @@ function makeClient(
   return { client: { request } as unknown as GitHubClient, request, calls }
 }
 
+// The invite team must hold NO teacher: GitHub auto-adds the creator as a
+// maintainer, and a teacher sitting on the team is indistinguishable from an
+// invitee who accepted (an org-owner invitee is auto-promoted to maintainer
+// too). Dropping the actor is what lets the reconcile treat any member of any
+// role as the accepted invitee.
 describe("ensureInviteTeam", () => {
-  it("creates a fresh secret team and reports created: true (no PATCH)", async () => {
+  const methodsOf = (calls: Call[]) =>
+    calls.map((c) => c.options?.method ?? "GET")
+  const isMembershipDelete = (c: Call) =>
+    c.options?.method === "DELETE" && c.url.includes("/memberships/")
+
+  it("creates a fresh secret team and drops the acting teacher (no PATCH)", async () => {
     const name = await inviteTeamName(METADATA.classroom, METADATA.email)
     const { client, calls } = makeClient((url, options) => {
       if (options?.method === "POST" && url === "/orgs/acme/teams") {
@@ -73,12 +86,14 @@ describe("ensureInviteTeam", () => {
           description: DESCRIPTION,
         }
       }
+      if (options?.method === "DELETE") return undefined
       throw new Error(`unexpected ${url}`)
     })
 
-    const ref = await ensureInviteTeam(client, "acme", METADATA)
+    const ref = await ensureInviteTeam(client, "acme", METADATA, ACTOR)
     expect(ref).toEqual({ id: 7, slug: name, created: true })
-    expect(calls).toHaveLength(1)
+    expect(methodsOf(calls)).toEqual(["POST", "DELETE"])
+    expect(calls[1].url).toBe(`/orgs/acme/teams/${name}/memberships/${ACTOR}`)
   })
 
   it("adopts an existing team on 422, forcing secret + description via PATCH (created: false)", async () => {
@@ -97,44 +112,44 @@ describe("ensureInviteTeam", () => {
           description: DESCRIPTION,
         }
       }
+      if (options?.method === "DELETE") return undefined
       // The adopt read: a pre-existing CLOSED team with a stale description.
       return { id: 7, slug: name, privacy: "closed", description: "old" }
     })
-    const ref = await ensureInviteTeam(client, "acme", METADATA)
+    const ref = await ensureInviteTeam(client, "acme", METADATA, ACTOR)
     expect(ref).toEqual({ id: 7, slug: name, created: false })
-    expect(calls.map((c) => c.options?.method ?? "GET")).toEqual([
-      "POST",
-      "GET",
-      "PATCH",
-    ])
+    expect(methodsOf(calls)).toEqual(["POST", "GET", "PATCH", "DELETE"])
   })
 
-  it("skips the PATCH when the adopted team is already secret with the same description", async () => {
+  // Not gated on created-vs-adopted: a team that already exists may still carry
+  // a teacher from an earlier run, and leaving them there would make the next
+  // reconcile read the teacher as the accepted invitee.
+  it("drops the acting teacher from an ADOPTED team too", async () => {
     const name = await inviteTeamName(METADATA.classroom, METADATA.email)
     const { client, calls } = makeClient((_url, options) => {
       if (options?.method === "POST") throw apiError(422)
+      if (options?.method === "DELETE") return undefined
       return { id: 7, slug: name, privacy: "secret", description: DESCRIPTION }
     })
 
-    const ref = await ensureInviteTeam(client, "acme", METADATA)
+    const ref = await ensureInviteTeam(client, "acme", METADATA, ACTOR)
     expect(ref.created).toBe(false)
-    expect(calls.map((c) => c.options?.method ?? "GET")).toEqual([
-      "POST",
-      "GET",
-    ])
+    expect(methodsOf(calls)).toEqual(["POST", "GET", "DELETE"])
+    expect(calls[2].url).toBe(`/orgs/acme/teams/${name}/memberships/${ACTOR}`)
   })
 
-  it("fails closed when the team can't be made secret", async () => {
+  it("fails closed when the team can't be made secret, before touching membership", async () => {
     const name = await inviteTeamName(METADATA.classroom, METADATA.email)
-    const { client } = makeClient((_url, options) => {
+    const { client, calls } = makeClient((_url, options) => {
       if (options?.method === "POST") throw apiError(422)
       // Both the adopt read and the PATCH report a stubbornly closed team.
       return { id: 7, slug: name, privacy: "closed", description: DESCRIPTION }
     })
 
-    await expect(ensureInviteTeam(client, "acme", METADATA)).rejects.toThrow(
-      InviteTeamNotSecretError,
-    )
+    await expect(
+      ensureInviteTeam(client, "acme", METADATA, ACTOR),
+    ).rejects.toThrow(InviteTeamNotSecretError)
+    expect(calls.filter(isMembershipDelete)).toEqual([])
   })
 
   it("rethrows a non-422 create failure", async () => {
@@ -142,8 +157,60 @@ describe("ensureInviteTeam", () => {
       throw apiError(500)
     })
     await expect(
-      ensureInviteTeam(client, "acme", METADATA),
+      ensureInviteTeam(client, "acme", METADATA, ACTOR),
     ).rejects.toMatchObject({ status: 500 })
+  })
+
+  // A team we created but couldn't clear must not survive: it holds a student's
+  // email AND a teacher, which the reconcile would read as "the teacher
+  // accepted this invite" and write onto the roster.
+  it("deletes the team it created when the acting teacher can't be dropped", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const { client, calls } = makeClient((url, options) => {
+      if (options?.method === "POST") {
+        return {
+          id: 7,
+          slug: name,
+          privacy: "secret",
+          description: DESCRIPTION,
+        }
+      }
+      if (options?.method === "DELETE" && url.includes("/memberships/")) {
+        throw apiError(500)
+      }
+      if (options?.method === "DELETE") return undefined
+      throw new Error(`unexpected ${url}`)
+    })
+
+    await expect(
+      ensureInviteTeam(client, "acme", METADATA, ACTOR),
+    ).rejects.toMatchObject({ status: 500 })
+    expect(calls.at(-1)).toMatchObject({
+      url: `/orgs/acme/teams/${name}`,
+      options: { method: "DELETE" },
+    })
+  })
+
+  // The mirror case: an ADOPTED team may hold an earlier accepted invite's
+  // still-unrecovered record, so a failure must never delete it.
+  it("keeps an ADOPTED team when the acting teacher can't be dropped", async () => {
+    const name = await inviteTeamName(METADATA.classroom, METADATA.email)
+    const { client, calls } = makeClient((url, options) => {
+      if (options?.method === "POST") throw apiError(422)
+      if (options?.method === "DELETE" && url.includes("/memberships/")) {
+        throw apiError(500)
+      }
+      return { id: 7, slug: name, privacy: "secret", description: DESCRIPTION }
+    })
+
+    await expect(
+      ensureInviteTeam(client, "acme", METADATA, ACTOR),
+    ).rejects.toMatchObject({ status: 500 })
+    expect(
+      calls.filter(
+        (c) => c.options?.method === "DELETE" && !isMembershipDelete(c),
+      ),
+    ).toEqual([])
   })
 })
 
@@ -157,7 +224,7 @@ describe("readInviteTeam", () => {
     )
   })
 
-  it("parses the description and lists regular-role members only", async () => {
+  it("parses the description and lists members of EVERY role", async () => {
     const { client, calls } = makeClient((url) => {
       if (url.includes("/members")) return [{ id: 2, login: "alice" }]
       return {
@@ -174,10 +241,11 @@ describe("readInviteTeam", () => {
     })
     expect(state?.createdAt).toBe("2026-08-01T00:00:00Z")
     expect(state?.members).toEqual([{ id: 2, login: "alice" }])
-    // The maintainer-excluding filter is what keeps the auto-added owner (and
-    // any org owner) out of the invitee set.
+    // Unfiltered on purpose: the team holds no teacher, so every member is the
+    // invitee — including an org owner, whom GitHub auto-promotes to maintainer
+    // and a role=member filter would hide.
     const memberCall = calls.find((c) => c.url.includes("/members"))
-    expect(memberCall?.url).toContain("role=member")
+    expect(memberCall?.url).not.toContain("role=")
   })
 
   it("yields a null description for a non-v1 record (hand-edited team)", async () => {

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -2,6 +2,7 @@ import type { GitHubClient } from "../client"
 import type { GitHubTeam, GitHubUser } from "../types"
 import { GitHubAPIError, tolerateGitHubError } from "../errors"
 import { createTeam } from "../teamWrites"
+import { removeUserFromTeam } from "./teams"
 import { paginateAll } from "../paginate"
 import {
   INVITE_TEAM_PREFIX,
@@ -37,18 +38,32 @@ export class InviteTeamNotSecretError extends Error {
 // from an earlier accepted invite).
 export type InviteTeamRef = { id: number; slug: string; created: boolean }
 
-// Create (or adopt) the per-invite SECRET team for (classroom, email) and write
-// the classroom50/invite/v1 record into its description. The team name is the
-// deterministic invite-<hash(classroom,email)> so a later reconcile can find it
-// from the roster row's email. Fail-closed on privacy: after create/adopt, the
-// team's privacy is confirmed to be `secret` (an adopted non-secret team is
-// PATCHed to secret; if that can't be confirmed, throw InviteTeamNotSecretError
-// rather than store the email where students could read it). Returns the ref so
-// the caller can attach its id to the org invitation's team_ids.
+// Create (or adopt) the per-invite SECRET team for (classroom, email), write the
+// classroom50/invite/v1 record into its description, and leave NO teacher on it.
+// The team name is the deterministic invite-<hash(classroom,email)> so a later
+// reconcile can find it from the roster row's email.
+//
+// Two fail-closed invariants, both of which throw rather than return a team that
+// would leak or mislead:
+//   - SECRET: an adopted team is PATCHed to secret, and if that can't be
+//     confirmed, InviteTeamNotSecretError — never store the email where students
+//     could read it.
+//   - NO TEACHER: GitHub silently adds the creator as a maintainer, and any org
+//     owner it holds is auto-promoted to maintainer too, so a teacher on the team
+//     is indistinguishable from an invitee who accepted. `actor` is dropped
+//     unconditionally (an adopted team may carry one from an earlier run). This is
+//     what lets the reconcile treat any member of any role as the invitee, so a
+//     failure here is fatal: a team created by this call is deleted again, while
+//     an adopted one is left alone (it may hold an earlier accepted invite's
+//     still-unrecovered record).
+//
+// Returns the ref so the caller can attach its id to the org invitation's
+// team_ids.
 export async function ensureInviteTeam(
   client: GitHubClient,
   org: string,
   metadata: InviteMetadata,
+  actor: string,
 ): Promise<InviteTeamRef> {
   const name = await inviteTeamName(metadata.classroom, metadata.email)
   const description = marshalInviteDescription(metadata)
@@ -93,6 +108,31 @@ export async function ensureInviteTeam(
     throw new InviteTeamNotSecretError(team.slug)
   }
 
+  // removeUserFromTeam treats 404 as success (not a member), so returning
+  // without throwing is itself the proof that no teacher remains — no
+  // verification read needed.
+  try {
+    await removeUserFromTeam(client, {
+      org,
+      teamSlug: team.slug,
+      username: actor,
+    })
+  } catch (err) {
+    if (created) {
+      // Best-effort: a leftover team is a GC-pending orphan, which is strictly
+      // better than one the reconcile would misread.
+      try {
+        await deleteInviteTeam(client, org, team.slug)
+      } catch (cleanupErr) {
+        log.error("invite team cleanup after a failed actor drop failed", {
+          slug: team.slug,
+          err: cleanupErr,
+        })
+      }
+    }
+    throw err
+  }
+
   return { id: team.id, slug: team.slug, created }
 }
 
@@ -102,11 +142,11 @@ export type InviteTeamState = {
   // From the full-team read; null when GitHub omits it. Drives the GC age
   // guard (a team too young to judge is never reaped).
   createdAt: string | null
-  // Regular-role members only (?role=member). GitHub auto-promotes the
-  // creating owner — and any org owner — to team maintainer, so the invitee
-  // (added via the invitation's team_ids as a plain member) is exactly what's
-  // left; no org-admin subtraction needed. 404 (team vanished mid-read) yields
-  // [] so the team simply looks pending; other errors propagate.
+  // Members of EVERY role. ensureInviteTeam leaves no teacher on the team, so
+  // whoever is here accepted the invitation — including an org owner, whom
+  // GitHub auto-promotes to maintainer and a role=member filter would hide.
+  // 404 (team vanished mid-read) yields [] so the team simply looks pending;
+  // other errors propagate.
   members: GitHubUser[]
 }
 
@@ -134,7 +174,7 @@ export async function readInviteTeam(
         (page) =>
           `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
             slug,
-          )}/members?role=member&per_page=100&page=${page}`,
+          )}/members?per_page=100&page=${page}`,
       ),
     [],
   )

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -32,30 +32,59 @@ export class InviteTeamNotSecretError extends Error {
   }
 }
 
+// Thrown by ensureInviteTeam when the team still has a member after the acting
+// teacher was dropped. Nobody can legitimately be on it yet (the invitation
+// isn't sent until this returns), so a member is a teacher stranded by an
+// earlier interrupted run — and with the role filter gone, a teacher on the team
+// is exactly what the reconcile would misread as the accepted invitee. Fail
+// closed BEFORE the email is written, leaving a team that holds no PII.
+export class InviteTeamNotEmptyError extends Error {
+  slug: string
+  constructor(slug: string) {
+    super(
+      `Invite team "${slug}" still has a member after dropping the acting user; refusing to store an invited email on a team whose membership would be misread as the invitee.`,
+    )
+    this.name = "InviteTeamNotEmptyError"
+    this.slug = slug
+  }
+}
+
 // `created` distinguishes a team this call freshly created from an adopted
 // pre-existing one, so a caller whose org invite then fails can safely delete
 // only what it created (an adopted team may hold a still-unrecovered record
 // from an earlier accepted invite).
 export type InviteTeamRef = { id: number; slug: string; created: boolean }
 
-// Create (or adopt) the per-invite SECRET team for (classroom, email), write the
-// classroom50/invite/v1 record into its description, and leave NO teacher on it.
-// The team name is the deterministic invite-<hash(classroom,email)> so a later
-// reconcile can find it from the roster row's email.
+// Placeholder description a team is created with, so a run that dies before the
+// membership drop leaves a team holding NO email. It deliberately does not parse
+// as a v1 record, which is what makes the reconcile skip such a team.
+const PROVISIONAL_DESCRIPTION = "classroom50: preparing invite"
+
+// Create (or adopt) the per-invite SECRET team for (classroom, email) and write
+// the classroom50/invite/v1 record into its description. The team name is the
+// deterministic invite-<hash(classroom,email)> so a later reconcile can find it
+// from the roster row's email.
 //
-// Two fail-closed invariants, both of which throw rather than return a team that
-// would leak or mislead:
+// Three fail-closed invariants, all of which throw rather than return a team
+// that would leak PII or mislead the reconcile:
 //   - SECRET: an adopted team is PATCHed to secret, and if that can't be
 //     confirmed, InviteTeamNotSecretError — never store the email where students
 //     could read it.
 //   - NO TEACHER: GitHub silently adds the creator as a maintainer, and any org
 //     owner it holds is auto-promoted to maintainer too, so a teacher on the team
 //     is indistinguishable from an invitee who accepted. `actor` is dropped
-//     unconditionally (an adopted team may carry one from an earlier run). This is
-//     what lets the reconcile treat any member of any role as the invitee, so a
-//     failure here is fatal: a team created by this call is deleted again, while
-//     an adopted one is left alone (it may hold an earlier accepted invite's
-//     still-unrecovered record).
+//     unconditionally (an adopted team may carry one from an earlier run) and the
+//     membership is then read back; a survivor throws InviteTeamNotEmptyError.
+//     This is what lets the reconcile treat any member of any role as the
+//     invitee.
+//   - EMAIL LAST: the create carries only PROVISIONAL_DESCRIPTION, and the real
+//     record is written only once the team is confirmed empty. GitHub adds the
+//     creator during the create itself, so the drop is necessarily a second
+//     request — an interrupted run (or a rate limit that throttles both the drop
+//     and any compensating delete) can always strand a team with a teacher on it.
+//     Ordering the email last makes that leftover harmless: it holds no address
+//     and no valid record, so the reconcile skips it, and the next invite to the
+//     same address adopts and heals it.
 //
 // Returns the ref so the caller can attach its id to the org invitation's
 // team_ids.
@@ -74,15 +103,15 @@ export async function ensureInviteTeam(
     team = await createTeam(client, {
       org,
       name,
-      description,
+      description: PROVISIONAL_DESCRIPTION,
       privacy: "secret",
       notification_setting: "notifications_disabled",
     })
   } catch (err) {
     if (err instanceof GitHubAPIError && err.status === 422) {
       // A same-named team already exists (a resend, a retry, or a prior invite
-      // to the same email+classroom): adopt it, forcing secret + refreshing the
-      // description. Name is slug-safe, so it doubles as the lookup slug.
+      // to the same email+classroom): adopt it, forcing secret below. Name is
+      // slug-safe, so it doubles as the lookup slug.
       created = false
       team = await client.request<GitHubTeam>(
         `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(name)}`,
@@ -92,48 +121,59 @@ export async function ensureInviteTeam(
     }
   }
 
-  // Fail-closed secret invariant. On a fresh create GitHub honors privacy:
-  // "secret", but an adopted team may be closed; PATCH it and re-read. Never
-  // leave the email description on a non-secret team.
-  if (team.privacy !== "secret" || team.description !== description) {
+  // Fail-closed secret invariant, settled BEFORE the email is written: an
+  // adopted team may be closed. Never let the email description land on a
+  // non-secret team.
+  if (team.privacy !== "secret") {
     team = await client.request<GitHubTeam>(
       `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(team.slug)}`,
-      {
-        method: "PATCH",
-        body: { privacy: "secret", description },
-      },
+      { method: "PATCH", body: { privacy: "secret" } },
     )
   }
   if (team.privacy !== "secret") {
     throw new InviteTeamNotSecretError(team.slug)
   }
 
-  // removeUserFromTeam treats 404 as success (not a member), so returning
-  // without throwing is itself the proof that no teacher remains — no
-  // verification read needed.
-  try {
-    await removeUserFromTeam(client, {
-      org,
-      teamSlug: team.slug,
-      username: actor,
-    })
-  } catch (err) {
-    if (created) {
-      // Best-effort: a leftover team is a GC-pending orphan, which is strictly
-      // better than one the reconcile would misread.
-      try {
-        await deleteInviteTeam(client, org, team.slug)
-      } catch (cleanupErr) {
-        log.error("invite team cleanup after a failed actor drop failed", {
-          slug: team.slug,
-          err: cleanupErr,
-        })
-      }
-    }
-    throw err
+  await requireTeacherFreeTeam(client, org, team.slug, actor)
+
+  // Only now is it safe to store the invited address.
+  const withRecord = await client.request<GitHubTeam>(
+    `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(team.slug)}`,
+    { method: "PATCH", body: { privacy: "secret", description } },
+  )
+  if (withRecord.privacy !== "secret") {
+    throw new InviteTeamNotSecretError(withRecord.slug)
   }
 
-  return { id: team.id, slug: team.slug, created }
+  return { id: withRecord.id, slug: withRecord.slug, created }
+}
+
+// Drop `actor` from the team, then PROVE no member remains. GitHub adds the
+// creator during the create, so the drop can't be atomic with it; the read-back
+// is what turns the invariant from an assumption into a checked fact, and it also
+// catches a DIFFERENT teacher stranded by an earlier run (whom dropping `actor`
+// alone would miss). A degraded read throws rather than reading as "empty".
+async function requireTeacherFreeTeam(
+  client: GitHubClient,
+  org: string,
+  slug: string,
+  actor: string,
+): Promise<void> {
+  await removeUserFromTeam(client, { org, teamSlug: slug, username: actor })
+  const remaining = await paginateAll<GitHubUser>(
+    client,
+    (page) =>
+      `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+        slug,
+      )}/members?per_page=100&page=${page}`,
+  )
+  if (remaining.length > 0) {
+    log.error("invite team still has a member after dropping the actor", {
+      slug,
+      remaining: remaining.length,
+    })
+    throw new InviteTeamNotEmptyError(slug)
+  }
 }
 
 export type InviteTeamState = {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -510,7 +510,7 @@
     "added": "Added {{label}}.",
     "invited": "Sent an organization invite to {{label}}.",
     "emailInviteHint": "Inviting by email only? The address goes onto the roster right away and is matched to the student's GitHub account when they join — note it's the address you invited, not necessarily the email on their GitHub account.",
-    "inviteMetadataFailed": "{{email}} was invited, but saving their email for later matching failed ({{message}}); their email won't be retained automatically. You can add it after they accept.",
+    "inviteMetadataFailed": "Couldn't prepare the invite for {{email}} ({{message}}), so no invite was sent. Try again.",
     "alreadyEnrolled": "{{label}} is already enrolled in this classroom.",
     "addFailed": "Couldn't add {{label}}: {{message}}",
     "membersEnrolledCount_one": "{{count}} member enrolled",


### PR DESCRIPTION
## Problem

GitHub silently adds the creating teacher to each per-invite metadata team as a **maintainer**, and auto-promotes any org owner on a team to maintainer too. So a teacher sitting on an invite team was indistinguishable from an invitee who had accepted. The recovery worked around that by reading only `?role=member`, which meant an invitee who is (or becomes) an org owner never appeared at all: their team looked abandoned, the 24h GC reaped it, and the roster sync then dropped the email-only row as dead — losing the address the invite was sent to.

Supersedes #635, which detected that case with a maintainer-count heuristic and kept the record as unrecoverable. Removing the ambiguity at the source is better: the mapping now recovers fully instead of merely avoiding data loss.

## Approach

`ensureInviteTeam` drops the acting teacher unconditionally (an adopted team may carry one from an earlier run), so an invite team holds no teacher and **any member of any role is the invitee**.

That invariant can't be established by the drop alone, though. GitHub adds the creator during the create itself, so the drop is necessarily a second request, and both it and any compensating delete can fail together — a secondary rate limit throttles the pair, and an interrupted run (closed tab, lost connectivity) never reaches the compensation. The leftover would then be a team holding a student's email plus one member, the teacher, which the reconcile would recover as the accepted invitee: it writes the teacher's account onto the student's row and deletes the team, losing the real mapping for good.

Ordering fixes what compensation cannot. The team is created with a placeholder description that deliberately does not parse as a v1 record, and the invited address is written only after a membership read-back proves nobody is on it. An interrupted run now strands a team holding no email and no record, so the reconcile skips it and the next invite to that address adopts and heals it. The read-back also catches a *different* teacher stranded by an earlier run, and fails closed on a degraded read rather than mistaking it for an empty team.

## Consequences

- The `?role=member` filter and the maintainer-probing helper are gone; a single member of any role is the invitee.
- The bulk path's admin-role skip is gone, so **teacher-role email invites now retain their address** — previously they got no metadata team and therefore no email retention at all.
- The metadata team is now a **precondition** rather than best-effort: it is the only thing retaining the invited address, so a failure blocks the invite instead of sending one whose email is silently dropped. The team is prepared before the invitation, so nothing is sent and a retry is clean.
- No schema, contract, or CLI change — the record shape is untouched and the CLI only knows the `invite-` prefix.

## Verification

Verified against a live org (`classroom50-summer-dev`) rather than only against mocks, since the design rests on GitHub's actual behavior:

- An org owner **can** delete their own team membership: `204`, after which the team reads as genuinely 0-member and the delete is idempotent.
- A non-member owner can still read, PATCH, delete, and enumerate the secret team, so the reconcile keeps working from a team the teacher isn't on.
- A **pending** invitee appears in no member read at all (only in `/teams/{slug}/invitations`), so the unfiltered read can't mistake a pending invite for an accepted one.
- Passing `maintainers: []` to the create does **not** avoid the auto-add, confirming the create/drop window is unavoidable and must be made harmless rather than eliminated.
- Simulated an interrupted run: the leftover team reads as one member with a non-v1 description, so the reconcile short-circuits before ever reading its membership, and adoption heals it.

Also purged a pre-invariant invite team left in the dev org by the shipped release; it carried a real invited address plus me as maintainer, which is exactly the case the new reader would have misread.

## Test plan

- [x] `tsc -b`, `eslint .`, `prettier --check .`, `arch:validate` clean
- [x] `vitest run --project=node` — 3892 passing
- [x] Go CLI builds and its roster/teardown/configrepo tests pass (unaffected)
- [ ] Send a fresh email invite in the dev org and confirm the address lands on the roster immediately
- [ ] Accept as a non-owner and confirm the row is completed with the account identity
- [ ] Accept as an **org owner** and confirm the row is completed (the case this PR fixes)
- [ ] Cancel an invite and confirm the pending row is removed on the next roster sync