### PR TITLE
fix(web): retire a pending roster row when its invitation is cancelled

### DIFF
--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -7,6 +7,8 @@ import {
   bulkInviteByEmail,
   unenrollStudent,
   bulkUnenrollStudents,
+  removeEmailInviteRow,
+  retireEmailInvite,
   resolveClassroomPendingInvite,
   resendClassroomInvite,
   bulkEnrollStudentsInClassroom,
@@ -2172,10 +2174,11 @@ describe("bulkUnenrollStudents — single-commit batch removal", () => {
     expect(committed.content).toBeNull()
   })
 
-  it("an email-only target matches nothing (identity is username/github_id only)", async () => {
-    // Every roster row now carries a GitHub identity, so removal targets match
-    // by username/github_id only. An email-only target (no username, no id)
-    // matches no row — it can't silently unenroll a same-email sibling.
+  it("rejects an email-only target rather than reporting it as notFound", async () => {
+    // Removal matches by username/github_id only, so an email-only target could
+    // never match a row. Reporting it as notFound would read as "already
+    // removed" while both the row and its live invitation survived — cancel the
+    // invitation instead (retireEmailInvite).
     const startingCsv = HEADER + "sam,,,sam@x.edu,,100\n"
     const { client, committed } = makeClient({ startingCsv })
 
@@ -2195,10 +2198,33 @@ describe("bulkUnenrollStudents — single-commit batch removal", () => {
       ],
     })
 
-    // Nothing matched: the identified row survives, target reported notFound.
+    // Filtered out up front: nothing committed, and it is NOT reported as a
+    // row that was already gone.
     expect(committed.content).toBeNull()
     expect(result.removed).toHaveLength(0)
-    expect(result.notFound).toHaveLength(1)
+    expect(result.notFound).toHaveLength(0)
+  })
+
+  it("unenrollStudent rejects an email-only target without implying email works", async () => {
+    const startingCsv = HEADER + "sam,,,sam@x.edu,,100\n"
+    const { client, committed } = makeClient({ startingCsv })
+
+    await expect(
+      unenrollStudent(client, {
+        org: "acme",
+        classroom: "cs101",
+        student: {
+          username: "",
+          first_name: "",
+          last_name: "",
+          email: "sam@x.edu",
+          section: "",
+          github_id: "",
+          role: "",
+        },
+      }),
+    ).rejects.toThrow(/username or ID is required/)
+    expect(committed.content).toBeNull()
   })
 
   // Regression (#130): removing the LAST student must not commit a header-less
@@ -2220,6 +2246,127 @@ describe("bulkUnenrollStudents — single-commit batch removal", () => {
     const csv = committed.content!
     expect(csv.split("\n")[0]).toBe(STUDENT_CSV_FIELDS.join(","))
     expect(parseStudentsCsv(csv)).toEqual([])
+  })
+})
+
+describe("removeEmailInviteRow — retiring a cancelled invite's pending row", () => {
+  it("drops the identity-less row for that address", async () => {
+    const { client, committed } = makeClient({
+      startingCsv: HEADER + ",,,sam@x.edu,,,student\n",
+    })
+
+    await removeEmailInviteRow(
+      client,
+      { org: "acme", classroom: "cs101" },
+      "sam@x.edu",
+    )
+
+    expect(parseStudentsCsv(committed.content!)).toEqual([])
+  })
+
+  it("matches case-insensitively and ignores surrounding whitespace", async () => {
+    const { client, committed } = makeClient({
+      startingCsv: HEADER + ",,,Sam@X.edu,,,student\n",
+    })
+
+    await removeEmailInviteRow(
+      client,
+      { org: "acme", classroom: "cs101" },
+      "  sam@x.edu  ",
+    )
+
+    expect(parseStudentsCsv(committed.content!)).toEqual([])
+  })
+
+  it("keeps a row for the same address that carries a username", async () => {
+    // A shared contact address must never let a cancellation drop an enrolled
+    // student — the whole reason the guard is identity-less-only.
+    const startingCsv = HEADER + "sam,,,shared@x.edu,,100,student\n"
+    const { client, committed } = makeClient({ startingCsv })
+
+    await removeEmailInviteRow(
+      client,
+      { org: "acme", classroom: "cs101" },
+      "shared@x.edu",
+    )
+
+    // changed === 0, so withRosterRewrite commits nothing at all.
+    expect(committed.content).toBeNull()
+  })
+
+  it("treats a present-but-unusable github_id as identity-less", async () => {
+    // An Excel-mangled id addresses no account, so the row is still the pending
+    // one the invite wrote.
+    const { client, committed } = makeClient({
+      startingCsv: HEADER + ",,,sam@x.edu,,5.83231E+05,student\n",
+    })
+
+    await removeEmailInviteRow(
+      client,
+      { org: "acme", classroom: "cs101" },
+      "sam@x.edu",
+    )
+
+    expect(parseStudentsCsv(committed.content!)).toEqual([])
+  })
+
+  it("keeps a row whose github_id resolves, even with a blank username", async () => {
+    const startingCsv = HEADER + ",,,sam@x.edu,,0583231,student\n"
+    const { client, committed } = makeClient({ startingCsv })
+
+    await removeEmailInviteRow(
+      client,
+      { org: "acme", classroom: "cs101" },
+      "sam@x.edu",
+    )
+
+    expect(committed.content).toBeNull()
+  })
+
+  it("never throws on a malformed roster — the cancel already succeeded", async () => {
+    const { client, committed } = makeClient({
+      startingCsv: "username,first_name\nbroken,row,too,many,fields\n",
+    })
+
+    await expect(
+      removeEmailInviteRow(
+        client,
+        { org: "acme", classroom: "cs101" },
+        "sam@x.edu",
+      ),
+    ).resolves.toBeUndefined()
+    expect(committed.content).toBeNull()
+  })
+
+  it("commits nothing for a blank address", async () => {
+    const { client, committed } = makeClient({
+      startingCsv: HEADER + ",,,sam@x.edu,,,student\n",
+    })
+
+    await removeEmailInviteRow(
+      client,
+      { org: "acme", classroom: "cs101" },
+      "   ",
+    )
+
+    expect(committed.content).toBeNull()
+  })
+
+  it("retireEmailInvite clears BOTH the invite team and the pending row", async () => {
+    // The two artifacts an email invitation leaves behind. Clearing only the
+    // team would strand the row invisibly on roster.csv — an email-only row
+    // never renders on its own, so a teacher could neither see nor remove it.
+    const { client, committed } = makeClient({
+      startingCsv: HEADER + ",,,sam@x.edu,,,student\n",
+    })
+
+    await retireEmailInvite(client, {
+      org: "acme",
+      classroom: "cs101",
+      email: "sam@x.edu",
+    })
+
+    expect(parseStudentsCsv(committed.content!)).toEqual([])
   })
 })
 

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -9,6 +9,7 @@ import {
   bulkUnenrollStudents,
   removeEmailInviteRow,
   retireEmailInvite,
+  retireEmailInvites,
   resolveClassroomPendingInvite,
   resendClassroomInvite,
   bulkEnrollStudentsInClassroom,
@@ -2367,6 +2368,34 @@ describe("removeEmailInviteRow — retiring a cancelled invite's pending row", (
     })
 
     expect(parseStudentsCsv(committed.content!)).toEqual([])
+  })
+
+  it("retireEmailInvites clears a batch of rows in ONE commit", async () => {
+    // A read-modify-write per row would push a class-sized bulk cancel into
+    // GitHub's content-creation secondary rate limit partway through, failing the
+    // cancellations that hadn't run yet.
+    let treeWrites = 0
+    const { client, committed } = makeClient({
+      startingCsv:
+        HEADER +
+        ",,,a@x.edu,,,student\n" +
+        ",,,b@x.edu,,,student\n" +
+        "keep,,,keep@x.edu,,100,student\n",
+      onTree: () => {
+        treeWrites += 1
+      },
+    })
+
+    await retireEmailInvites(client, {
+      org: "acme",
+      classroom: "cs101",
+      emails: ["a@x.edu", "b@x.edu"],
+    })
+
+    expect(treeWrites).toBe(1)
+    expect(parseStudentsCsv(committed.content!)).toEqual([
+      expect.objectContaining({ username: "keep" }),
+    ])
   })
 })
 

--- a/web/src/domain/students.ts
+++ b/web/src/domain/students.ts
@@ -17,6 +17,8 @@ export {
   RosterCsvMalformedError,
   type ClassroomPendingInvite,
 } from "./students/rosterPrimitives"
+export { removeEmailInviteRow } from "./students/rosterPrimitives"
+export { retireEmailInvite } from "./students/retireEmailInvite"
 export {
   addStudentToClassroom,
   addStudentToClassroomWithConflictRetry,

--- a/web/src/domain/students.ts
+++ b/web/src/domain/students.ts
@@ -17,8 +17,14 @@ export {
   RosterCsvMalformedError,
   type ClassroomPendingInvite,
 } from "./students/rosterPrimitives"
-export { removeEmailInviteRow } from "./students/rosterPrimitives"
-export { retireEmailInvite } from "./students/retireEmailInvite"
+export {
+  removeEmailInviteRow,
+  removeEmailInviteRows,
+} from "./students/rosterPrimitives"
+export {
+  retireEmailInvite,
+  retireEmailInvites,
+} from "./students/retireEmailInvite"
 export {
   addStudentToClassroom,
   addStudentToClassroomWithConflictRetry,

--- a/web/src/domain/students/retireEmailInvite.ts
+++ b/web/src/domain/students/retireEmailInvite.ts
@@ -1,0 +1,24 @@
+import type { GitHubClient } from "@/github-core/client"
+import { deleteInviteTeamForEmail } from "@/github-core/mutations"
+import { removeEmailInviteRow } from "./rosterPrimitives"
+
+// Everything an email invitation leaves behind, cleared in one call: the secret
+// invite team holding the address, and the pending roster.csv row.
+//
+// One helper because four call sites need this after cancelling or dismissing an
+// invitation (the two invite hooks, the roster member modal, the bulk actions
+// bar), and a hand-synced copy in each is how one of them silently stops doing
+// half the job. Callers pass the address they cancelled; a username invitation
+// has neither artifact, so callers skip this entirely for those.
+//
+// Never throws — both steps are best-effort by design. The cancellation itself
+// has already succeeded, so a leftover team (GC reaps it) or a leftover row (the
+// reconcile reaps it) must not be reported to the teacher as a failed cancel.
+export async function retireEmailInvite(
+  client: GitHubClient,
+  input: { org: string; classroom: string; email: string },
+): Promise<void> {
+  const { org, classroom, email } = input
+  await deleteInviteTeamForEmail(client, org, { classroom, email })
+  await removeEmailInviteRow(client, { org, classroom }, email)
+}

--- a/web/src/domain/students/retireEmailInvite.ts
+++ b/web/src/domain/students/retireEmailInvite.ts
@@ -1,6 +1,6 @@
 import type { GitHubClient } from "@/github-core/client"
 import { deleteInviteTeamForEmail } from "@/github-core/mutations"
-import { removeEmailInviteRow } from "./rosterPrimitives"
+import { removeEmailInviteRow, removeEmailInviteRows } from "./rosterPrimitives"
 
 // Everything an email invitation leaves behind, cleared in one call: the secret
 // invite team holding the address, and the pending roster.csv row.
@@ -21,4 +21,23 @@ export async function retireEmailInvite(
   const { org, classroom, email } = input
   await deleteInviteTeamForEmail(client, org, { classroom, email })
   await removeEmailInviteRow(client, { org, classroom }, email)
+}
+
+// The batch form, for a bulk cancel. Each invite team is its own GitHub resource
+// so those deletes stay per-address, but the roster rows are dropped in ONE
+// commit — a read-modify-write per row would push a class-sized selection into
+// GitHub's content-creation secondary rate limit partway through, failing the
+// cancellations that had not run yet.
+//
+// Never throws, for the same reason as the single form.
+export async function retireEmailInvites(
+  client: GitHubClient,
+  input: { org: string; classroom: string; emails: string[] },
+): Promise<void> {
+  const { org, classroom, emails } = input
+  if (emails.length === 0) return
+  for (const email of emails) {
+    await deleteInviteTeamForEmail(client, org, { classroom, email })
+  }
+  await removeEmailInviteRows(client, { org, classroom }, emails)
 }

--- a/web/src/domain/students/roleWrites.ts
+++ b/web/src/domain/students/roleWrites.ts
@@ -24,6 +24,7 @@ import {
 import { isSameGitHubUser } from "@/util/students"
 import { parseRosterCsv } from "@/util/rosterCsv"
 import { rosterPath } from "@/util/rosterPath"
+import { normalizeInviteEmail } from "@/util/inviteTeam"
 import { type ClassroomRole } from "@/util/teamRoster"
 import { isTeacherRole } from "@/authz"
 import { memberIdentitySets } from "@/util/identity"
@@ -231,6 +232,10 @@ export type RosterUploadContext = {
   // BLANK username). Seeding it from there would resolve a renamed student to
   // their old handle and silently defeat the point of reading the id.
   loginById: ReadonlyMap<number, string>
+  // Addresses already claimed by a stored roster row. An uploaded email-only row
+  // whose address is in here would be skipped by appendEmailInviteRows, so the
+  // preview marks it a no-op instead of counting it as an invitation to send.
+  claimedEmails: ReadonlySet<string>
 }
 
 // Read the classroom's CURRENT GitHub membership + stored roster.csv metadata
@@ -249,7 +254,7 @@ export async function resolveRosterUploadContext(
   // run it in the same wave rather than as a serial second stage.
   const [
     [orgMembers, studentMembers, teacherMembers, htaMembers, taMembers],
-    storedByIdentity,
+    { storedByIdentity, claimedEmails },
   ] = await Promise.all([
     Promise.all([
       listAllOrgMembers(client, org),
@@ -288,7 +293,12 @@ export async function resolveRosterUploadContext(
     orgMembers.map((member) => [member.id, member.login]),
   )
 
-  return { lookup: membershipLookup(resolved), storedByIdentity, loginById }
+  return {
+    lookup: membershipLookup(resolved),
+    storedByIdentity,
+    loginById,
+    claimedEmails,
+  }
 }
 
 // Convenience wrapper: read the context (see resolveRosterUploadContext) and
@@ -318,9 +328,13 @@ async function resolveStoredRosterLookup(
   client: GitHubClient,
   org: string,
   classroom: string,
-): Promise<(row: PreflightRow) => StoredRosterRow | undefined> {
+): Promise<{
+  storedByIdentity: (row: PreflightRow) => StoredRosterRow | undefined
+  claimedEmails: ReadonlySet<string>
+}> {
   const byId = new Map<string, StoredRosterRow>()
   const byLogin = new Map<string, StoredRosterRow>()
+  const claimedEmails = new Set<string>()
   try {
     const configBranch = await getConfigRepoBranch(client, org)
     const ref = await getBranchRef(client, org, configBranch)
@@ -339,17 +353,25 @@ async function resolveStoredRosterLookup(
       }
       if (s.github_id) byId.set(s.github_id.trim(), metadata)
       if (s.username) byLogin.set(s.username.trim().toLowerCase(), metadata)
+      // Same normalization appendEmailInviteRows uses for its `claimed` set, so
+      // the preview's "already on the roster" verdict matches what the write
+      // would actually skip.
+      const email = normalizeInviteEmail(s.email ?? "")
+      if (email) claimedEmails.add(email)
     }
   } catch (err) {
     log.warn("roster upload preflight: stored-roster read failed", { err })
-    return () => undefined
+    return { storedByIdentity: () => undefined, claimedEmails: new Set() }
   }
-  return (row: PreflightRow) => {
-    const id = row.github_id?.trim()
-    return (
-      (id ? byId.get(id) : undefined) ??
-      byLogin.get(row.username.trim().toLowerCase())
-    )
+  return {
+    storedByIdentity: (row: PreflightRow) => {
+      const id = row.github_id?.trim()
+      return (
+        (id ? byId.get(id) : undefined) ??
+        byLogin.get(row.username.trim().toLowerCase())
+      )
+    },
+    claimedEmails,
   }
 }
 

--- a/web/src/domain/students/rosterPrimitives.ts
+++ b/web/src/domain/students/rosterPrimitives.ts
@@ -181,33 +181,34 @@ export async function appendEmailInviteRows(
   }
 }
 
-// Drop the pending row an email invite left on the roster, for when that invite
-// is cancelled or dismissed. Without this the row survives the cancel and is
-// INVISIBLE: an email-only row never renders on its own (see teamRoster's
-// legacyByEmail donors), so a teacher can neither see nor clear it until some
-// unrelated reconcile happens to run.
+// Drop the pending rows a set of email invites left on the roster, in ONE commit
+// for the batch — the plural sibling of the single-address path, and what a bulk
+// cancel must use so a class-sized selection doesn't spend a read-modify-write
+// per row and walk into GitHub's content-creation secondary rate limit.
 //
-// Only an identity-less row is removed — no username and no usable github_id.
+// Only identity-less rows are removed — no username and no usable github_id.
 // That is the row an unaccepted invite writes, and the narrow guard is what
 // keeps an enrolled student who merely shares a contact address from being
 // dropped. Mirrors the Go reader's UpsertRosterRow claim rule.
 //
-// Best-effort and never throws: the cancel has already succeeded by the time
-// this runs, so a malformed roster must not surface as a failed cancellation.
-// The reconcile's dead-row reap remains the backstop.
-export async function removeEmailInviteRow(
+// Best-effort and never throws: the cancellations have already succeeded by the
+// time this runs, so a malformed roster must not surface as a failed cancel. The
+// reconcile's dead-row reap remains the backstop.
+export async function removeEmailInviteRows(
   client: GitHubClient,
   input: { org: string; classroom: string },
-  email: string,
+  emails: string[],
 ): Promise<void> {
-  const target = normalizeInviteEmail(email)
-  if (!target) return
+  const targets = new Set(
+    emails.map((e) => normalizeInviteEmail(e)).filter(Boolean),
+  )
+  if (targets.size === 0) return
   try {
     await withRosterRewrite(client, input, (rows) => {
       const nextStudents = rows.filter(
         (row) =>
           !(
-            normalizeInviteEmail(row.email ?? "") === target &&
+            targets.has(normalizeInviteEmail(row.email ?? "")) &&
             !row.username.trim() &&
             resolveGitHubId(row.github_id) === null
           ),
@@ -216,7 +217,9 @@ export async function removeEmailInviteRow(
       return {
         nextStudents,
         changed,
-        message: `Remove invited email from roster: ${input.classroom}`,
+        message: `Remove ${changed} invited email${
+          changed === 1 ? "" : "s"
+        } from roster: ${input.classroom}`,
       }
     })
   } catch (err) {
@@ -226,6 +229,16 @@ export async function removeEmailInviteRow(
       err,
     })
   }
+}
+
+// Single-address convenience over removeEmailInviteRows, for the one-at-a-time
+// cancel paths. Same guard, same never-throws contract.
+export async function removeEmailInviteRow(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+  email: string,
+): Promise<void> {
+  await removeEmailInviteRows(client, input, [email])
 }
 
 // Slug is authoritative in classroom.json: GitHub may assign a non-derived slug

--- a/web/src/domain/students/rosterPrimitives.ts
+++ b/web/src/domain/students/rosterPrimitives.ts
@@ -38,6 +38,7 @@ import {
   type StudentCsvRow,
 } from "@/util/rosterCsv"
 import { normalizeInviteEmail } from "@/util/inviteTeam"
+import { resolveGitHubId } from "@/util/students"
 import { withGitConflictRetry } from "../classrooms"
 import {
   ROLE_RANK,
@@ -173,6 +174,53 @@ export async function appendEmailInviteRows(
     })
   } catch (err) {
     log.error("email invite roster row write failed", {
+      org: input.org,
+      classroom: input.classroom,
+      err,
+    })
+  }
+}
+
+// Drop the pending row an email invite left on the roster, for when that invite
+// is cancelled or dismissed. Without this the row survives the cancel and is
+// INVISIBLE: an email-only row never renders on its own (see teamRoster's
+// legacyByEmail donors), so a teacher can neither see nor clear it until some
+// unrelated reconcile happens to run.
+//
+// Only an identity-less row is removed — no username and no usable github_id.
+// That is the row an unaccepted invite writes, and the narrow guard is what
+// keeps an enrolled student who merely shares a contact address from being
+// dropped. Mirrors the Go reader's UpsertRosterRow claim rule.
+//
+// Best-effort and never throws: the cancel has already succeeded by the time
+// this runs, so a malformed roster must not surface as a failed cancellation.
+// The reconcile's dead-row reap remains the backstop.
+export async function removeEmailInviteRow(
+  client: GitHubClient,
+  input: { org: string; classroom: string },
+  email: string,
+): Promise<void> {
+  const target = normalizeInviteEmail(email)
+  if (!target) return
+  try {
+    await withRosterRewrite(client, input, (rows) => {
+      const nextStudents = rows.filter(
+        (row) =>
+          !(
+            normalizeInviteEmail(row.email ?? "") === target &&
+            !row.username.trim() &&
+            resolveGitHubId(row.github_id) === null
+          ),
+      )
+      const changed = rows.length - nextStudents.length
+      return {
+        nextStudents,
+        changed,
+        message: `Remove invited email from roster: ${input.classroom}`,
+      }
+    })
+  } catch (err) {
+    log.error("email invite roster row removal failed", {
       org: input.org,
       classroom: input.classroom,
       err,
@@ -713,9 +761,15 @@ export async function resolveTeamIdByRole(
 // authority for matching a removal target to a roster row, shared by
 // unenrollStudent and bulkUnenrollStudents so the two can't drift.
 //
-// Identity is username/github_id only: every roster row now carries a GitHub
-// identity, so email is never a match key (a shared email must not widen the
-// match, and there are no username-less rows to target by email).
+// Identity is username/github_id only, and email is deliberately NOT a key: a
+// contact address can be shared (a parent's, a shared lab account), and widening
+// the match here would let one removal drop someone else's row.
+//
+// So an email-only row — the pending row an unaccepted email invitation writes —
+// is not removable through unenroll. It is retired by CANCELLING the invitation,
+// which is also the only correct action: dropping the row alone would leave the
+// invitation live, so the student could still accept into a classroom whose
+// roster no longer lists them. See retireEmailInvite.
 export function matchesRosterRow(row: StudentCsvRow, target: Student): boolean {
   const username = target.username?.trim()
   const githubId = target.github_id?.trim()

--- a/web/src/domain/students/unenroll.ts
+++ b/web/src/domain/students/unenroll.ts
@@ -45,12 +45,17 @@ export async function unenrollStudent(
   log.info("unenroll student: started", { org, classroom })
   await assertClassroomNotArchived(client, org, classroom)
   const normalizedUsername = toRemoveStudent?.username.trim()
-  const normalizedEmail = toRemoveStudent?.email?.trim()
+  const normalizedGithubId = toRemoveStudent?.github_id?.trim()
 
-  // An email-invited row not yet claimed has no username, so accept email too.
-  // One of the two must be present to target a row.
-  if (!normalizedUsername && !normalizedEmail) {
-    throw new Error("Student's GitHub username or email is required")
+  // Unenroll targets a roster row by GitHub identity, because matchesRosterRow
+  // deliberately won't key on email (a shared address must never widen a
+  // removal). An email-only row — an unaccepted email invitation — is retired by
+  // CANCELLING the invitation instead, which also revokes it and drops the row:
+  // see retireEmailInvite. Rejecting it here rather than downstream keeps the
+  // failure honest; accepting it would throw "does not exist in roster" after
+  // the caller had every reason to think email was a supported key.
+  if (!normalizedUsername && !normalizedGithubId) {
+    throw new Error("Student's GitHub username or ID is required")
   }
 
   // Resolve the slug concurrently with the commit. Can reject on a transient
@@ -90,7 +95,7 @@ export async function unenrollStudent(
 
   if (!exists) {
     throw new Error(
-      `Student ${toRemoveStudent.username || normalizedEmail} does not exist in roster!`,
+      `Student ${normalizedUsername || normalizedGithubId} does not exist in roster!`,
     )
   }
 
@@ -106,7 +111,7 @@ export async function unenrollStudent(
   const newCommit = await createGitCommit(client, {
     org,
     message: prefixCommit(
-      `Remove student: ${classroom}/${toRemoveStudent.username || normalizedEmail}`,
+      `Remove student: ${classroom}/${normalizedUsername || normalizedGithubId}`,
     ),
     tree_sha: tree.sha,
     parents: [ref.object.sha],
@@ -230,8 +235,12 @@ export async function bulkUnenrollStudents(
   const { org, classroom, students, onProgress } = input
   await assertClassroomNotArchived(client, org, classroom)
 
+  // Identity only, matching matchesRosterRow: an email-only target could never
+  // match a row, so accepting one here would silently report it as `notFound`
+  // ("already removed") while both the row and its live invitation survived.
+  // Cancel the invitation instead — see retireEmailInvite.
   const targets = students.filter(
-    (s) => s.username?.trim() || s.email?.trim() || s.github_id?.trim(),
+    (s) => s.username?.trim() || s.github_id?.trim(),
   )
   if (targets.length === 0) {
     return { removed: [], notFound: [], warnings: [] }

--- a/web/src/hooks/mutations/orgSetupMutations.test.ts
+++ b/web/src/hooks/mutations/orgSetupMutations.test.ts
@@ -14,6 +14,9 @@ const renameConfigRepoToMain = vi.fn<(...args: unknown[]) => Promise<void>>(
 const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
   Promise.resolve(),
 )
+const retireEmailInvite = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+)
 const deleteInviteTeamForEmail = vi.fn<(...args: unknown[]) => Promise<void>>(
   () => Promise.resolve(),
 )
@@ -53,6 +56,7 @@ vi.mock("@/domain/students", () => ({
   resendClassroomInvite: (...a: unknown[]) => resendClassroomInvite(...a),
   removeClassroomStaffMember: (...a: unknown[]) =>
     removeClassroomStaffMember(...a),
+  retireEmailInvite: (...a: unknown[]) => retireEmailInvite(...a),
 }))
 vi.mock("@/orgPolicy/repair", () => ({
   repairConcern: (client: unknown, org: unknown, id: unknown, plan: unknown) =>
@@ -146,8 +150,8 @@ describe("useCancelClassroomInvite", () => {
       org: ORG,
       invitationId: 99,
     })
-    // A username invitation has no metadata team to tear down.
-    expect(deleteInviteTeamForEmail).not.toHaveBeenCalled()
+    // A username invitation leaves neither a metadata team nor a pending row.
+    expect(retireEmailInvite).not.toHaveBeenCalled()
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.teamInvitations(ORG, TEAM),
     })
@@ -156,7 +160,7 @@ describe("useCancelClassroomInvite", () => {
     })
   })
 
-  it("tears down the metadata team when cancelling an email-only invite", async () => {
+  it("retires the invite team AND its pending roster row when cancelling an email-only invite", async () => {
     const queryClient = freshClient()
     const { result } = renderHook(
       () => useCancelClassroomInvite(ORG, CLASSROOM, TEAM),
@@ -164,11 +168,13 @@ describe("useCancelClassroomInvite", () => {
     )
     result.current.mutate({ invitationId: 99, inviteEmail: "ta@x.edu" })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(deleteInviteTeamForEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      ORG,
-      { classroom: CLASSROOM, email: "ta@x.edu" },
-    )
+    // One helper clears both the metadata team and the roster row; leaving the
+    // row behind would strand it invisibly on roster.csv.
+    expect(retireEmailInvite).toHaveBeenCalledWith(expect.anything(), {
+      org: ORG,
+      classroom: CLASSROOM,
+      email: "ta@x.edu",
+    })
   })
 })
 

--- a/web/src/hooks/mutations/orgSetupMutations.test.ts
+++ b/web/src/hooks/mutations/orgSetupMutations.test.ts
@@ -11,9 +11,9 @@ import type { ConcernId } from "@/orgPolicy/audit"
 const renameConfigRepoToMain = vi.fn<(...args: unknown[]) => Promise<void>>(
   () => Promise.resolve(),
 )
-const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
-  Promise.resolve(),
-)
+const cancelOrgInvitation = vi.fn<
+  (...args: unknown[]) => Promise<{ cancelled: boolean }>
+>(() => Promise.resolve({ cancelled: true }))
 const retireEmailInvite = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
   Promise.resolve(),
 )
@@ -158,6 +158,22 @@ describe("useCancelClassroomInvite", () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.teamMembers(ORG, TEAM),
     })
+  })
+
+  it("does NOT retire anything when the invitation id was already stale", async () => {
+    // A 404 (cancelled: false) does not mean the person has no live invitation —
+    // resendOrgInvitation recreates before cancelling, so an unrefreshed view
+    // holds an old id while a fresh invite is still pending. Dropping the row
+    // there would delete the invite-time details of someone who can still accept.
+    cancelOrgInvitation.mockResolvedValueOnce({ cancelled: false })
+    const queryClient = freshClient()
+    const { result } = renderHook(
+      () => useCancelClassroomInvite(ORG, CLASSROOM, TEAM),
+      { wrapper: wrapperWith(queryClient) },
+    )
+    result.current.mutate({ invitationId: 99, inviteEmail: "ta@x.edu" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(retireEmailInvite).not.toHaveBeenCalled()
   })
 
   it("retires the invite team AND its pending roster row when cancelling an email-only invite", async () => {

--- a/web/src/hooks/mutations/studentMutations.test.ts
+++ b/web/src/hooks/mutations/studentMutations.test.ts
@@ -10,9 +10,9 @@ import { githubKeys } from "@/github-core/queries"
 // Domain/github-core writes are mocked so each hook test asserts only the
 // hook's own responsibility: that it delegates to the right fn and (where it
 // owns cache reconcile) invalidates the right keys.
-const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
-  Promise.resolve(),
-)
+const cancelOrgInvitation = vi.fn<
+  (...args: unknown[]) => Promise<{ cancelled: boolean }>
+>(() => Promise.resolve({ cancelled: true }))
 const retireEmailInvite = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
   Promise.resolve(),
 )

--- a/web/src/hooks/mutations/studentMutations.test.ts
+++ b/web/src/hooks/mutations/studentMutations.test.ts
@@ -13,6 +13,9 @@ import { githubKeys } from "@/github-core/queries"
 const cancelOrgInvitation = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
   Promise.resolve(),
 )
+const retireEmailInvite = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+)
 const deleteInviteTeamForEmail = vi.fn<(...args: unknown[]) => Promise<void>>(
   () => Promise.resolve(),
 )
@@ -46,6 +49,8 @@ vi.mock("@/domain/students", () => ({
     unenrollStudent(client, input),
   updateStudentWithConflictRetry: (client: unknown, input: unknown) =>
     updateStudentWithConflictRetry(client, input),
+  retireEmailInvite: (client: unknown, input: unknown) =>
+    retireEmailInvite(client, input),
 }))
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({ request: vi.fn() }),
@@ -105,7 +110,7 @@ describe("useDismissFailedInvite", () => {
     expect(invalidateInviteQueries).toHaveBeenCalledWith(queryClient, ORG)
   })
 
-  it("tears down the metadata team when dismissing an email-only invite", async () => {
+  it("retires the invite team AND its pending roster row when dismissing an email-only invite", async () => {
     const queryClient = freshClient()
     const { result } = renderHook(
       () => useDismissFailedInvite(ORG, CLASSROOM),
@@ -117,11 +122,13 @@ describe("useDismissFailedInvite", () => {
     result.current.mutate({ invitationId: 42, inviteEmail: "gone@x.edu" })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-    expect(deleteInviteTeamForEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      ORG,
-      { classroom: CLASSROOM, email: "gone@x.edu" },
-    )
+    // One helper clears both the metadata team and the roster row; leaving the
+    // row behind would strand it invisibly on roster.csv.
+    expect(retireEmailInvite).toHaveBeenCalledWith(expect.anything(), {
+      org: ORG,
+      classroom: CLASSROOM,
+      email: "gone@x.edu",
+    })
   })
 })
 

--- a/web/src/hooks/mutations/useCancelClassroomInvite.ts
+++ b/web/src/hooks/mutations/useCancelClassroomInvite.ts
@@ -31,7 +31,12 @@ export function useCancelClassroomInvite(
         org,
         invitationId: input.invitationId,
       })
-      if (input.inviteEmail) {
+      // Only retire on a real cancellation: a stale id 404s (cancelled: false)
+      // while a live invitation for the same address may still exist —
+      // resendOrgInvitation recreates before cancelling — and dropping the row
+      // there would delete the invite-time details of someone who can still
+      // accept.
+      if (result.cancelled && input.inviteEmail) {
         await retireEmailInvite(client, {
           org,
           classroom,

--- a/web/src/hooks/mutations/useCancelClassroomInvite.ts
+++ b/web/src/hooks/mutations/useCancelClassroomInvite.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import {
-  cancelOrgInvitation,
-  deleteInviteTeamForEmail,
-} from "@/github-core/mutations"
+import { cancelOrgInvitation } from "@/github-core/mutations"
+import { retireEmailInvite } from "@/domain/students"
 import { invalidateClassroomTeam } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
@@ -12,9 +10,10 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 // member modal. Returns the raw cancel outcome so a caller can distinguish a
 // real cancellation from a stale (already-gone) invite id.
 //
-// For an email-only invitation (no login), pass `inviteEmail` so the per-invite
-// metadata team holding that address is torn down with the invite (best-effort;
-// the GC pass is the backstop). A username invitation has no such team.
+// For an email-only invitation (no login), pass `inviteEmail` so everything the
+// invite left behind is retired with it: the per-invite metadata team holding
+// that address, and its pending roster.csv row (best-effort; the GC and
+// reconcile passes are the backstops). A username invitation has neither.
 export function useCancelClassroomInvite(
   org: string,
   classroom: string,
@@ -33,7 +32,8 @@ export function useCancelClassroomInvite(
         invitationId: input.invitationId,
       })
       if (input.inviteEmail) {
-        await deleteInviteTeamForEmail(client, org, {
+        await retireEmailInvite(client, {
+          org,
           classroom,
           email: input.inviteEmail,
         })

--- a/web/src/hooks/mutations/useDismissFailedInvite.ts
+++ b/web/src/hooks/mutations/useDismissFailedInvite.ts
@@ -26,7 +26,12 @@ export function useDismissFailedInvite(org: string, classroom: string) {
         org,
         invitationId: input.invitationId,
       })
-      if (input.inviteEmail) {
+      // Only retire on a real cancellation: a stale id 404s (cancelled: false)
+      // while a live invitation for the same address may still exist —
+      // resendOrgInvitation recreates before cancelling — and dropping the row
+      // there would delete the invite-time details of someone who can still
+      // accept.
+      if (result.cancelled && input.inviteEmail) {
         await retireEmailInvite(client, {
           org,
           classroom,

--- a/web/src/hooks/mutations/useDismissFailedInvite.ts
+++ b/web/src/hooks/mutations/useDismissFailedInvite.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import {
-  cancelOrgInvitation,
-  deleteInviteTeamForEmail,
-} from "@/github-core/mutations"
+import { cancelOrgInvitation } from "@/github-core/mutations"
+import { retireEmailInvite } from "@/domain/students"
 import { invalidateInviteQueries } from "@/github-core/queries"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 
@@ -11,9 +9,10 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 // invite-status queries. Hook owns the invalidation; the error toast stays at
 // the call site (see ./README.md). Sibling of useReinviteFailedInvite.
 //
-// For an email-only invitation (no login), pass `inviteEmail` so the per-invite
-// metadata team holding that address is torn down with the dismissal
-// (best-effort; the GC pass is the backstop).
+// For an email-only invitation (no login), pass `inviteEmail` so everything the
+// invite left behind is retired with the dismissal: the per-invite metadata team
+// holding that address, and its pending roster.csv row (best-effort; the GC and
+// reconcile passes are the backstops).
 export function useDismissFailedInvite(org: string, classroom: string) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
@@ -28,7 +27,8 @@ export function useDismissFailedInvite(org: string, classroom: string) {
         invitationId: input.invitationId,
       })
       if (input.inviteEmail) {
-        await deleteInviteTeamForEmail(client, org, {
+        await retireEmailInvite(client, {
+          org,
           classroom,
           email: input.inviteEmail,
         })

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -748,6 +748,7 @@
     "droppedRows_one": "{{count}} row was skipped because it had no usable GitHub username or email address.",
     "droppedRows_other": "{{count}} rows were skipped because they had no usable GitHub username or email address.",
     "previewInviteByEmail": "Invite by email",
+    "previewAlreadyOnRoster": "Already on the roster",
     "previewPreviousUsernameHint": "file said {{username}}",
     "preflightIdentityConfirmTitle": "Check these accounts before importing",
     "preflightIdentityHint": "The github_id in these rows belongs to a different account than the username next to it — usually because the student renamed their GitHub account. We'll use the account the id belongs to, and correct the username on the roster.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -748,7 +748,7 @@
     "droppedRows_one": "{{count}} row was skipped because it had no usable GitHub username or email address.",
     "droppedRows_other": "{{count}} rows were skipped because they had no usable GitHub username or email address.",
     "previewInviteByEmail": "Invite by email",
-    "previewAlreadyOnRoster": "Already on the roster",
+    "previewEmailOnRoster": "Invite by email — already on the roster",
     "previewPreviousUsernameHint": "file said {{username}}",
     "preflightIdentityConfirmTitle": "Check these accounts before importing",
     "preflightIdentityHint": "The github_id in these rows belongs to a different account than the username next to it — usually because the student renamed their GitHub account. We'll use the account the id belongs to, and correct the username on the roster.",

--- a/web/src/pages/students/PreflightSummary.tsx
+++ b/web/src/pages/students/PreflightSummary.tsx
@@ -16,15 +16,18 @@ export type SummaryCategory = {
 //  - add:    a membership will be created/activated (invite + enroll), plus any
 //            email-identity row, each of which sends an invitation of its own
 //  - update: an existing member's details or role change (metadata + role_change)
-//  - skip:   already correct, nothing to do (no_action)
+//  - skip:   already correct, nothing to do (no_action), plus any email row whose
+//            address the roster already claims — that invite would be skipped
 //
-// `emailInviteCount` is passed in rather than read off the preflight because
-// email rows never enter the classification — they have no GitHub account to
-// classify against — but they are still work the summary must account for, or the
-// pills would under-report the visible row count.
+// `emailInviteCount` and `emailNoopCount` are passed in rather than read off the
+// preflight because email rows never enter the classification — they have no
+// GitHub account to classify against — but they are still work (or explicitly
+// not work) the summary must account for, or the pills would under-report the
+// visible row count.
 export function summarizePreflight(
   preflight: PreflightResult,
   emailInviteCount = 0,
+  emailNoopCount = 0,
 ): {
   categories: SummaryCategory[]
   addCount: number
@@ -35,7 +38,7 @@ export function summarizePreflight(
     preflight.needsInvite.length + preflight.enroll.length + emailInviteCount
   const updateCount =
     preflight.metadataUpdate.length + preflight.roleChanges.length
-  const skipCount = preflight.noAction.length
+  const skipCount = preflight.noAction.length + emailNoopCount
   const categories: SummaryCategory[] = [
     { key: "add", count: addCount, pillClass: "badge-success" },
     { key: "update", count: updateCount, pillClass: "badge-warning" },
@@ -51,12 +54,14 @@ export function summarizePreflight(
 export const PreflightSummary = ({
   preflight,
   emailInviteCount = 0,
+  emailNoopCount = 0,
   detailsOpen,
   onToggleDetails,
   canToggle = true,
 }: {
   preflight: PreflightResult
   emailInviteCount?: number
+  emailNoopCount?: number
   detailsOpen: boolean
   onToggleDetails: () => void
   // Whether the details toggle is meaningful. False when the table is force-open
@@ -65,7 +70,11 @@ export const PreflightSummary = ({
   canToggle?: boolean
 }) => {
   const { t } = useTranslation()
-  const { categories } = summarizePreflight(preflight, emailInviteCount)
+  const { categories } = summarizePreflight(
+    preflight,
+    emailInviteCount,
+    emailNoopCount,
+  )
   const active = categories.filter((c) => c.count > 0)
 
   return (

--- a/web/src/pages/students/PreflightSummary.tsx
+++ b/web/src/pages/students/PreflightSummary.tsx
@@ -16,18 +16,15 @@ export type SummaryCategory = {
 //  - add:    a membership will be created/activated (invite + enroll), plus any
 //            email-identity row, each of which sends an invitation of its own
 //  - update: an existing member's details or role change (metadata + role_change)
-//  - skip:   already correct, nothing to do (no_action), plus any email row whose
-//            address the roster already claims — that invite would be skipped
+//  - skip:   already correct, nothing to do (no_action)
 //
-// `emailInviteCount` and `emailNoopCount` are passed in rather than read off the
-// preflight because email rows never enter the classification — they have no
-// GitHub account to classify against — but they are still work (or explicitly
-// not work) the summary must account for, or the pills would under-report the
-// visible row count.
+// `emailInviteCount` is passed in rather than read off the preflight because
+// email rows never enter the classification — they have no GitHub account to
+// classify against — but they are still work the summary must account for, or the
+// pills would under-report the visible row count.
 export function summarizePreflight(
   preflight: PreflightResult,
   emailInviteCount = 0,
-  emailNoopCount = 0,
 ): {
   categories: SummaryCategory[]
   addCount: number
@@ -38,7 +35,7 @@ export function summarizePreflight(
     preflight.needsInvite.length + preflight.enroll.length + emailInviteCount
   const updateCount =
     preflight.metadataUpdate.length + preflight.roleChanges.length
-  const skipCount = preflight.noAction.length + emailNoopCount
+  const skipCount = preflight.noAction.length
   const categories: SummaryCategory[] = [
     { key: "add", count: addCount, pillClass: "badge-success" },
     { key: "update", count: updateCount, pillClass: "badge-warning" },
@@ -54,14 +51,12 @@ export function summarizePreflight(
 export const PreflightSummary = ({
   preflight,
   emailInviteCount = 0,
-  emailNoopCount = 0,
   detailsOpen,
   onToggleDetails,
   canToggle = true,
 }: {
   preflight: PreflightResult
   emailInviteCount?: number
-  emailNoopCount?: number
   detailsOpen: boolean
   onToggleDetails: () => void
   // Whether the details toggle is meaningful. False when the table is force-open
@@ -70,11 +65,7 @@ export const PreflightSummary = ({
   canToggle?: boolean
 }) => {
   const { t } = useTranslation()
-  const { categories } = summarizePreflight(
-    preflight,
-    emailInviteCount,
-    emailNoopCount,
-  )
+  const { categories } = summarizePreflight(preflight, emailInviteCount)
   const active = categories.filter((c) => c.count > 0)
 
   return (

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -6,16 +6,13 @@ import type { GitHubClient } from "@/github-core/client"
 import { ConfirmModal } from "@/components/modals"
 import { Alert, Button, Modal, Toolbar } from "@/components/ui"
 import { GitHubAPIError } from "@/github-core/errors"
-import {
-  cancelOrgInvitation,
-  deleteInviteTeamForEmail,
-} from "@/github-core/mutations"
+import { cancelOrgInvitation } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import {
   bulkUnenrollRoster,
   type BulkUnenrollRosterResult,
 } from "@/domain/roster/bulkUnenrollRoster"
-import { resendClassroomInvite } from "@/domain/students"
+import { resendClassroomInvite, retireEmailInvite } from "@/domain/students"
 import { isMalformedGitHubId, resolveGitHubId } from "@/util/students"
 import { sortRolesByRank } from "@/util/teamRoster"
 import {
@@ -335,12 +332,10 @@ const RosterBulkActionsBar = ({
         if (didCancel) cancelled.push({ key: row.key, label })
         else alreadyGone.push({ key: row.key, label })
         if (!row.username && row.email) {
-          // An email-only invite carries a metadata team holding the address;
-          // tear it down with the invite (never throws; GC is the backstop).
-          await deleteInviteTeamForEmail(client, org, {
-            classroom,
-            email: row.email,
-          })
+          // An email-only invite leaves a metadata team holding the address and a
+          // pending roster row; retire both with the invite (never throws — the
+          // GC and reconcile passes are the backstops).
+          await retireEmailInvite(client, { org, classroom, email: row.email })
         }
       } catch (err) {
         log.debug("bulk cancel: per-row cancel failed", { err })

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -318,9 +318,13 @@ const RosterBulkActionsBar = ({
     const cancelled: { key: string; label: string }[] = []
     const alreadyGone: { key: string; label: string }[] = []
     const failed: { key: string; label: string; detail?: string }[] = []
-    // Addresses whose invitations we cancelled; their invite teams and pending
-    // roster rows are retired together after the loop, so the batch makes ONE
-    // roster commit instead of one per row.
+    // Addresses whose invitation this pass actually revoked. A stale id (404 ->
+    // `alreadyGone`) is deliberately excluded: it does NOT mean the person has no
+    // live invitation. resendOrgInvitation recreates before cancelling, so a view
+    // that hasn't refetched — or another teacher's session — holds an old id
+    // while a fresh invitation for the same address is still pending. Retiring
+    // the row there would delete the invite-time name/section for someone who can
+    // still accept, leaving them to land as a blank identity row.
     const retiredEmails: string[] = []
     let processed = 0
     for (const row of cancellableSelected) {
@@ -335,7 +339,9 @@ const RosterBulkActionsBar = ({
         // report it as "already gone" rather than a phantom cancellation.
         if (didCancel) cancelled.push({ key: row.key, label })
         else alreadyGone.push({ key: row.key, label })
-        if (!row.username && row.email) retiredEmails.push(row.email)
+        if (didCancel && !row.username && row.email) {
+          retiredEmails.push(row.email)
+        }
       } catch (err) {
         log.debug("bulk cancel: per-row cancel failed", { err })
         failed.push({ key: row.key, label, detail: getErrorMessage(err) })
@@ -345,8 +351,9 @@ const RosterBulkActionsBar = ({
     }
 
     // An email-only invite leaves a metadata team holding the address and a
-    // pending roster row; retire both (never throws — the GC and reconcile
-    // passes are the backstops).
+    // pending roster row; retire both for the ones actually revoked. Runs after
+    // the loop so the batch makes ONE roster commit (never throws — the GC and
+    // reconcile passes are the backstops).
     await retireEmailInvites(client, {
       org,
       classroom,

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -12,7 +12,7 @@ import {
   bulkUnenrollRoster,
   type BulkUnenrollRosterResult,
 } from "@/domain/roster/bulkUnenrollRoster"
-import { resendClassroomInvite, retireEmailInvite } from "@/domain/students"
+import { resendClassroomInvite, retireEmailInvites } from "@/domain/students"
 import { isMalformedGitHubId, resolveGitHubId } from "@/util/students"
 import { sortRolesByRank } from "@/util/teamRoster"
 import {
@@ -318,6 +318,10 @@ const RosterBulkActionsBar = ({
     const cancelled: { key: string; label: string }[] = []
     const alreadyGone: { key: string; label: string }[] = []
     const failed: { key: string; label: string; detail?: string }[] = []
+    // Addresses whose invitations we cancelled; their invite teams and pending
+    // roster rows are retired together after the loop, so the batch makes ONE
+    // roster commit instead of one per row.
+    const retiredEmails: string[] = []
     let processed = 0
     for (const row of cancellableSelected) {
       const label = row.username || row.email
@@ -331,12 +335,7 @@ const RosterBulkActionsBar = ({
         // report it as "already gone" rather than a phantom cancellation.
         if (didCancel) cancelled.push({ key: row.key, label })
         else alreadyGone.push({ key: row.key, label })
-        if (!row.username && row.email) {
-          // An email-only invite leaves a metadata team holding the address and a
-          // pending roster row; retire both with the invite (never throws — the
-          // GC and reconcile passes are the backstops).
-          await retireEmailInvite(client, { org, classroom, email: row.email })
-        }
+        if (!row.username && row.email) retiredEmails.push(row.email)
       } catch (err) {
         log.debug("bulk cancel: per-row cancel failed", { err })
         failed.push({ key: row.key, label, detail: getErrorMessage(err) })
@@ -344,6 +343,15 @@ const RosterBulkActionsBar = ({
       processed += 1
       setProgress({ processed, total, message: label })
     }
+
+    // An email-only invite leaves a metadata team holding the address and a
+    // pending roster row; retire both (never throws — the GC and reconcile
+    // passes are the backstops).
+    await retireEmailInvites(client, {
+      org,
+      classroom,
+      emails: retiredEmails,
+    })
 
     const sections: BulkResultView["sections"] = []
     if (alreadyGone.length > 0)

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -374,11 +374,19 @@ const RosterMemberModal = ({
     }
     setCancelling(true)
     try {
-      await cancelOrgInvitation(client, { org, invitationId })
-      if (!row.username && row.email) {
+      const { cancelled: didCancel } = await cancelOrgInvitation(client, {
+        org,
+        invitationId,
+      })
+      if (didCancel && !row.username && row.email) {
         // An email-only invite leaves a metadata team holding the address and a
         // pending roster row; retire both with the invite (never throws — the GC
         // and reconcile passes are the backstops).
+        //
+        // Only on a real cancellation: a stale id 404s while a live invitation
+        // for the same address may still exist (resendOrgInvitation recreates
+        // before cancelling), and dropping the row there would delete the
+        // invite-time details of someone who can still accept.
         await retireEmailInvite(client, { org, classroom, email: row.email })
       }
       onCanceled(row.key)

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -12,12 +12,10 @@ import {
   applyClassroomRoleChange,
   inviteRosterStudents,
   resendClassroomInvite,
+  retireEmailInvite,
   type StudentCsvRow,
 } from "@/domain/students"
-import {
-  cancelOrgInvitation,
-  deleteInviteTeamForEmail,
-} from "@/github-core/mutations"
+import { cancelOrgInvitation } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import {
   isMalformedGitHubId,
@@ -378,12 +376,10 @@ const RosterMemberModal = ({
     try {
       await cancelOrgInvitation(client, { org, invitationId })
       if (!row.username && row.email) {
-        // An email-only invite carries a metadata team holding the address;
-        // tear it down with the invite (never throws; GC is the backstop).
-        await deleteInviteTeamForEmail(client, org, {
-          classroom,
-          email: row.email,
-        })
+        // An email-only invite leaves a metadata team holding the address and a
+        // pending roster row; retire both with the invite (never throws — the GC
+        // and reconcile passes are the backstops).
+        await retireEmailInvite(client, { org, classroom, email: row.email })
       }
       onCanceled(row.key)
       onClose()

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -104,14 +104,16 @@ const IdentityCell = ({
 }) => {
   const { t } = useTranslation()
   if (row.identity.kind === "email") {
-    // An address the roster already carries would be skipped on process, so say
-    // so rather than promising an invitation this row won't send.
+    // The address is invited either way; a roster row already carrying it just
+    // means no second row is written, and GitHub may answer the invite with a
+    // 422 if that person is already a member. Say that rather than implying the
+    // row is either a fresh invite or no action at all.
     return (
       <td>
         <Badge tone={alreadyOnRoster ? "neutral" : "info"} size="sm">
           {t(
             alreadyOnRoster
-              ? "students.previewAlreadyOnRoster"
+              ? "students.previewEmailOnRoster"
               : "students.previewInviteByEmail",
           )}
         </Badge>
@@ -156,9 +158,9 @@ export const RosterPreviewTable = ({
   changes?: RowChanges
   roleChanges?: RowRoleChanges
   identityChanges?: RowIdentityChanges
-  // Rows the import will skip (an email address the roster already claims), so
-  // the identity cell can say "already on the roster" instead of promising an
-  // invitation that won't be sent.
+  // Rows the roster already carries the address for. The import still invites
+  // them (GitHub decides whether that is redundant), but no second roster row is
+  // written, so the identity cell says so instead of implying a fresh invite.
   noopRowKeys?: ReadonlySet<string>
   // While the preflight resolves, the per-cell changes aren't known yet: render
   // the change-bearing columns as skeletons to signal "computing changes" in

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -96,16 +96,24 @@ const PreviewCell = ({
 const IdentityCell = ({
   row,
   declaredUsername,
+  alreadyOnRoster,
 }: {
   row: ResolvedImportRow
   declaredUsername?: string
+  alreadyOnRoster?: boolean
 }) => {
   const { t } = useTranslation()
   if (row.identity.kind === "email") {
+    // An address the roster already carries would be skipped on process, so say
+    // so rather than promising an invitation this row won't send.
     return (
       <td>
-        <Badge tone="info" size="sm">
-          {t("students.previewInviteByEmail")}
+        <Badge tone={alreadyOnRoster ? "neutral" : "info"} size="sm">
+          {t(
+            alreadyOnRoster
+              ? "students.previewAlreadyOnRoster"
+              : "students.previewInviteByEmail",
+          )}
         </Badge>
       </td>
     )
@@ -138,6 +146,7 @@ export const RosterPreviewTable = ({
   changes = {},
   roleChanges = {},
   identityChanges = {},
+  noopRowKeys,
   loading = false,
   skeletonRowCount,
 }: {
@@ -147,6 +156,10 @@ export const RosterPreviewTable = ({
   changes?: RowChanges
   roleChanges?: RowRoleChanges
   identityChanges?: RowIdentityChanges
+  // Rows the import will skip (an email address the roster already claims), so
+  // the identity cell can say "already on the roster" instead of promising an
+  // invitation that won't be sent.
+  noopRowKeys?: ReadonlySet<string>
   // While the preflight resolves, the per-cell changes aren't known yet: render
   // the change-bearing columns as skeletons to signal "computing changes" in
   // place, rather than briefly showing static values that then sprout highlights.
@@ -205,6 +218,7 @@ export const RosterPreviewTable = ({
                     <IdentityCell
                       row={row}
                       declaredUsername={identityChange?.declaredUsername}
+                      alreadyOnRoster={noopRowKeys?.has(key)}
                     />
                     <PreviewCell
                       value={[row.first_name, row.last_name]

--- a/web/src/pages/students/UploadRoster.test.tsx
+++ b/web/src/pages/students/UploadRoster.test.tsx
@@ -649,10 +649,14 @@ describe("UploadRoster email-identity rows in a roster CSV", () => {
     await waitFor(() => expect(button.disabled).toBe(false))
   })
 
-  it("marks an already-claimed email as a no-op and excludes it from the counts", async () => {
+  it("labels an email the roster already carries, but still invites it", async () => {
     const user = userEvent.setup()
-    // The roster already carries zoe@x.edu, so appendEmailInviteRows would skip
-    // that address. The preview must say so rather than promising an invitation.
+    // A roster row already carries zoe@x.edu, so appendEmailInviteRows will skip
+    // writing a SECOND row for it. The invitation still goes out — GitHub is the
+    // authority on whether it's redundant, and answers with a 422 that lands in
+    // the skipped bucket. Suppressing the send here would silently drop a person
+    // the teacher listed: the address could belong to a shared contact, or to a
+    // pending row whose invitation has since died.
     resolveRosterUploadContext.mockResolvedValue({
       ...stubContext,
       claimedEmails: new Set(["zoe@x.edu"]),
@@ -675,21 +679,19 @@ describe("UploadRoster email-identity rows in a roster CSV", () => {
       file("roster.csv", "email\nzoe@x.edu\nnewbie@x.edu\n"),
     )
 
-    // Two email rows, but only one is a real invitation.
+    // Both rows are invitations, so the counts say 2 — not 1.
     await waitFor(() =>
       expect(
         screen.getByRole("button", {
-          name: "students.importAndInviteMembers:1",
+          name: "students.importAndInviteMembers:2",
         }),
       ).toBeTruthy(),
     )
-    expect(screen.getByText("students.uploadInviteNotice:1")).toBeTruthy()
-    // The summary accounts for both rows: one to add, one to skip.
-    expect(screen.getByText("students.summary_add:1")).toBeTruthy()
-    expect(screen.getByText("students.summary_skip:1")).toBeTruthy()
-    // The skipped row is still shown, labelled for what it is.
+    expect(screen.getByText("students.uploadInviteNotice:2")).toBeTruthy()
+
+    // The already-carried row is distinguished in the preview.
     await user.click(screen.getByText("students.summaryViewDetails"))
-    expect(screen.getByText("students.previewAlreadyOnRoster")).toBeTruthy()
+    expect(screen.getByText("students.previewEmailOnRoster")).toBeTruthy()
     expect(screen.getByText("students.previewInviteByEmail")).toBeTruthy()
 
     bulkEnrollStudentsInClassroom.mockResolvedValue({
@@ -698,20 +700,20 @@ describe("UploadRoster email-identity rows in a roster CSV", () => {
     })
     bulkInviteByEmail.mockResolvedValue({
       invited: [{ email: "newbie@x.edu", role: "student" }],
-      skipped: [],
+      skipped: [{ email: "zoe@x.edu" }],
       failed: [],
       deferred: [],
     })
     await user.click(
       screen.getByRole("button", {
-        name: "students.importAndInviteMembers:1",
+        name: "students.importAndInviteMembers:2",
       }),
     )
 
-    // Only the unclaimed address is actually sent.
+    // BOTH addresses are sent; GitHub decides which is redundant.
     await waitFor(() => expect(bulkInviteByEmail).toHaveBeenCalledTimes(1))
     expect(bulkInviteByEmail.mock.calls[0][1]).toMatchObject({
-      invites: [{ email: "newbie@x.edu" }],
+      invites: [{ email: "zoe@x.edu" }, { email: "newbie@x.edu" }],
     })
   })
 

--- a/web/src/pages/students/UploadRoster.test.tsx
+++ b/web/src/pages/students/UploadRoster.test.tsx
@@ -83,6 +83,7 @@ const stubContext = {
   lookup: () => undefined,
   storedByIdentity: () => undefined,
   loginById: new Map<number, string>(),
+  claimedEmails: new Set<string>(),
 }
 beforeEach(() => {
   resolveRosterUploadContext.mockResolvedValue(stubContext)
@@ -646,6 +647,72 @@ describe("UploadRoster email-identity rows in a roster CSV", () => {
       .querySelector("input[type=checkbox]") as HTMLInputElement
     await user.click(confirm)
     await waitFor(() => expect(button.disabled).toBe(false))
+  })
+
+  it("marks an already-claimed email as a no-op and excludes it from the counts", async () => {
+    const user = userEvent.setup()
+    // The roster already carries zoe@x.edu, so appendEmailInviteRows would skip
+    // that address. The preview must say so rather than promising an invitation.
+    resolveRosterUploadContext.mockResolvedValue({
+      ...stubContext,
+      claimedEmails: new Set(["zoe@x.edu"]),
+    })
+    classifyRosterUpload.mockReturnValue({
+      noAction: [],
+      needsInvite: [],
+      enroll: [],
+      roleChanges: [],
+      metadataUpdate: [],
+      identityMismatches: [],
+      allAlreadyMembers: true,
+    })
+    renderModal(
+      <UploadRoster org="acme" classroom="cs50" client={client} open={true} />,
+    )
+
+    await uploadFile(
+      user,
+      file("roster.csv", "email\nzoe@x.edu\nnewbie@x.edu\n"),
+    )
+
+    // Two email rows, but only one is a real invitation.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "students.importAndInviteMembers:1",
+        }),
+      ).toBeTruthy(),
+    )
+    expect(screen.getByText("students.uploadInviteNotice:1")).toBeTruthy()
+    // The summary accounts for both rows: one to add, one to skip.
+    expect(screen.getByText("students.summary_add:1")).toBeTruthy()
+    expect(screen.getByText("students.summary_skip:1")).toBeTruthy()
+    // The skipped row is still shown, labelled for what it is.
+    await user.click(screen.getByText("students.summaryViewDetails"))
+    expect(screen.getByText("students.previewAlreadyOnRoster")).toBeTruthy()
+    expect(screen.getByText("students.previewInviteByEmail")).toBeTruthy()
+
+    bulkEnrollStudentsInClassroom.mockResolvedValue({
+      addedStudents: [],
+      skippedStudents: [],
+    })
+    bulkInviteByEmail.mockResolvedValue({
+      invited: [{ email: "newbie@x.edu", role: "student" }],
+      skipped: [],
+      failed: [],
+      deferred: [],
+    })
+    await user.click(
+      screen.getByRole("button", {
+        name: "students.importAndInviteMembers:1",
+      }),
+    )
+
+    // Only the unclaimed address is actually sent.
+    await waitFor(() => expect(bulkInviteByEmail).toHaveBeenCalledTimes(1))
+    expect(bulkInviteByEmail.mock.calls[0][1]).toMatchObject({
+      invites: [{ email: "newbie@x.edu" }],
+    })
   })
 
   it("counts invitations, not rows, in the primary button and notice", async () => {

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -318,6 +318,27 @@ const UploadRoster = ({
     () => resolvedRows.filter(isEmailRow),
     [resolvedRows],
   )
+  // Split the email rows by what processing will actually do. An address a
+  // stored roster row already claims is skipped by appendEmailInviteRows, so
+  // counting it as an invitation would overstate the batch — the same class of
+  // error as counting rows instead of invitations. The row still renders, marked
+  // as needing no action, so the teacher can see it was read.
+  const claimedEmails = preflightContext?.claimedEmails
+  const emailRowsToInvite = useMemo(
+    () =>
+      claimedEmails
+        ? emailRows.filter((r) => !claimedEmails.has(r.identity.email))
+        : emailRows,
+    [emailRows, claimedEmails],
+  )
+  const noopEmailKeys = useMemo(() => {
+    const keys = new Set<string>()
+    if (!claimedEmails) return keys
+    for (const r of emailRows) {
+      if (claimedEmails.has(r.identity.email)) keys.add(identityKey(r.identity))
+    }
+    return keys
+  }, [emailRows, claimedEmails])
   // The role the teacher assigned a row, defaulting to student.
   const roleFor = (identity: ImportIdentity): ClassroomRole =>
     rolesByUser[identityKey(identity)] ?? "student"
@@ -423,9 +444,9 @@ const UploadRoster = ({
   // fold them into the same gate rather than letting a roster CSV do silently
   // what the dedicated email upload requires a checkbox for.
   const teacherEmailRows = useMemo(
-    () => emailRows.filter((r) => isTeacherRole(roleFor(r.identity))),
+    () => emailRowsToInvite.filter((r) => isTeacherRole(roleFor(r.identity))),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [emailRows, rolesByUser],
+    [emailRowsToInvite, rolesByUser],
   )
   const mismatches = useMemo(
     () => preflight?.identityMismatches ?? [],
@@ -457,7 +478,7 @@ const UploadRoster = ({
   // org invitation and lands a pending roster row. So is a confirmed identity
   // mismatch — it repairs the stored username. Counting only the preflight
   // buckets would leave either kind of file on a disabled "No changes to apply".
-  const emailRowCount = emailRows.length
+  const emailRowCount = emailRowsToInvite.length
   // How many people this upload will actually invite: non-members it will invite
   // by username, plus every email-identity row. ONE source, so the notice, the
   // summary, and the primary button can't disagree — a row that's already a
@@ -675,7 +696,7 @@ const UploadRoster = ({
       section: r.section,
       role: roleFor(r.identity),
     }))
-    const emailInvites = emailRows.map((r) => ({
+    const emailInvites = emailRowsToInvite.map((r) => ({
       email: r.identity.email,
       role: roleFor(r.identity),
       first_name: r.first_name,
@@ -859,6 +880,7 @@ const UploadRoster = ({
                 <PreflightSummary
                   preflight={preflight}
                   emailInviteCount={emailRowCount}
+                  emailNoopCount={noopEmailKeys.size}
                   detailsOpen={detailsOpen}
                   onToggleDetails={() => setDetailsOpen((v) => !v)}
                   canToggle={!forceDetails}
@@ -927,6 +949,7 @@ const UploadRoster = ({
                   changes={rowChanges}
                   roleChanges={roleChangeByUser}
                   identityChanges={identityChangeByUser}
+                  noopRowKeys={noopEmailKeys}
                   loading={preflighting}
                   onRoleChange={(key, role) =>
                     setRolesByUser((prev) => ({ ...prev, [key]: role }))

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -318,19 +318,17 @@ const UploadRoster = ({
     () => resolvedRows.filter(isEmailRow),
     [resolvedRows],
   )
-  // Split the email rows by what processing will actually do. An address a
-  // stored roster row already claims is skipped by appendEmailInviteRows, so
-  // counting it as an invitation would overstate the batch — the same class of
-  // error as counting rows instead of invitations. The row still renders, marked
-  // as needing no action, so the teacher can see it was read.
+  // Addresses a stored roster row already carries. These still get an invitation
+  // — GitHub is the authority on whether one is redundant, and answers with a
+  // 422 that lands in bulkInviteByEmail's `skipped` bucket. What the roster claim
+  // predicts is only that appendEmailInviteRows will skip writing a SECOND row
+  // for the address, so the preview labels the row rather than dropping it.
+  //
+  // Deliberately not used to filter the send list: an address can be claimed by
+  // someone else's row (a shared parent or lab contact), or by a pending row
+  // whose invitation has since died, and in both cases a real person the teacher
+  // listed still needs inviting.
   const claimedEmails = preflightContext?.claimedEmails
-  const emailRowsToInvite = useMemo(
-    () =>
-      claimedEmails
-        ? emailRows.filter((r) => !claimedEmails.has(r.identity.email))
-        : emailRows,
-    [emailRows, claimedEmails],
-  )
   const noopEmailKeys = useMemo(() => {
     const keys = new Set<string>()
     if (!claimedEmails) return keys
@@ -444,9 +442,9 @@ const UploadRoster = ({
   // fold them into the same gate rather than letting a roster CSV do silently
   // what the dedicated email upload requires a checkbox for.
   const teacherEmailRows = useMemo(
-    () => emailRowsToInvite.filter((r) => isTeacherRole(roleFor(r.identity))),
+    () => emailRows.filter((r) => isTeacherRole(roleFor(r.identity))),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [emailRowsToInvite, rolesByUser],
+    [emailRows, rolesByUser],
   )
   const mismatches = useMemo(
     () => preflight?.identityMismatches ?? [],
@@ -478,7 +476,7 @@ const UploadRoster = ({
   // org invitation and lands a pending roster row. So is a confirmed identity
   // mismatch — it repairs the stored username. Counting only the preflight
   // buckets would leave either kind of file on a disabled "No changes to apply".
-  const emailRowCount = emailRowsToInvite.length
+  const emailRowCount = emailRows.length
   // How many people this upload will actually invite: non-members it will invite
   // by username, plus every email-identity row. ONE source, so the notice, the
   // summary, and the primary button can't disagree — a row that's already a
@@ -696,7 +694,7 @@ const UploadRoster = ({
       section: r.section,
       role: roleFor(r.identity),
     }))
-    const emailInvites = emailRowsToInvite.map((r) => ({
+    const emailInvites = emailRows.map((r) => ({
       email: r.identity.email,
       role: roleFor(r.identity),
       first_name: r.first_name,
@@ -880,7 +878,6 @@ const UploadRoster = ({
                 <PreflightSummary
                   preflight={preflight}
                   emailInviteCount={emailRowCount}
-                  emailNoopCount={noopEmailKeys.size}
                   detailsOpen={detailsOpen}
                   onToggleDetails={() => setDetailsOpen((v) => !v)}
                   canToggle={!forceDetails}


### PR DESCRIPTION
Follow-up to [#639](https://github.com/foundation50/classroom50/pull/639), which made email-only `roster.csv` rows a normal outcome of a CSV import rather than a rarity. Three defects follow from that. Web-side only — the CLI's `ParseImportCSV` convergence is a separate PR.

## 1. Cancelling an email invitation orphaned an invisible row

The cancel revoked the invitation and tore down the invite team but never wrote `roster.csv`. `syncRosterFromTeam` reaps such a row, but nothing triggers a reconcile for this case: the Sync button only renders when `csvMissingCount > 0`, and auto-sync fires on member/backfill drift. Meanwhile the row is **invisible** — an email-only row never renders on its own — so a teacher could neither see it nor clear it.

New `retireEmailInvite` clears both artifacts, replacing **four hand-synced copies** of the teardown (two invite hooks, the roster member modal, the bulk actions bar). Two guards keep it narrow:

- **Identity-less rows only** — blank username *and* no resolvable `github_id`. An enrolled student who merely shares a contact address is never dropped.
- **Only on a real cancellation.** A 404 means the id was stale, not that the person has no live invitation: `resendOrgInvitation` recreates *before* cancelling, so an unrefreshed view holds an old id while a fresh invite is pending. Retiring there would delete the invite-time name and section of someone who can still accept.

The bulk path removes all rows in **one commit** — a read-modify-write per row would walk a class-sized selection into GitHub's content-creation secondary rate limit partway through, failing the cancellations that hadn't run yet.

## 2. `unenroll` contradicted itself about email

It accepted an email-only target and named the email in its failure message, but `matchesRosterRow` keys on username/`github_id` — so `unenrollStudent` threw a confusing error while `bulkUnenrollStudents` silently reported `notFound` ("already removed") with the row and invitation both intact. Both now require an identity, and `matchesRosterRow`'s doc comment no longer claims "there are no username-less rows to target by email" — which #639 made false.

Deliberately narrowing, not widening: email stays out of the matcher because a shared address must never widen a removal. `canTargetForUnenroll` and the two UI gates are unchanged; they already encoded the right behavior.

## 3. The preview labels an already-carried address

`resolveStoredRosterLookup` gained a `claimedEmails` set built in its existing loop — **zero extra requests**. A row whose address the roster already carries now reads "Invite by email — already on the roster".

It is still **invited**. `appendEmailInviteRows`' claim set only governs whether a *second row* is written; the invitation goes out either way and GitHub is the authority on redundancy, answering with a 422 that lands in the `skipped` bucket. Suppressing the send would silently drop a person the teacher listed — the address could belong to a shared contact, or to a pending row whose invitation has since died.

## Test plan

- [x] `npm run check` in `web/` — 3926 tests, 0 lint errors, Prettier clean, no dependency violations (the new domain module passes the layer check)
- [x] `removeEmailInviteRow`: drops the pending row; keeps a row with a username for the same address; treats an Excel-mangled `github_id` as identity-less but keeps one that resolves; case- and whitespace-insensitive, matching `appendEmailInviteRows`; never throws on a malformed roster
- [x] `retireEmailInvite` clears both artifacts; `retireEmailInvites` clears a batch in one commit
- [x] A stale invitation id retires nothing
- [x] `unenroll` rejects an email-only target in both the single and bulk paths
- [x] An already-carried address is labelled but still sent, and the counts say 2 for a two-row file
- [x] Every new test verified to fail against the unfixed code before being kept
- [ ] Manual pass: cancel an email invitation and confirm the row leaves `roster.csv` without running Sync

## Follow-ups

- `cli/gh-teacher`'s `ParseImportCSV` should converge on the same identity precedence (next PR).
- The three open questions from #639's review remain open; none is a defect.