### PR TITLE
fix(web): stop reporting a pending email invite as an org discrepancy

### DIFF
--- a/web/src/domain/orgMembers/bulkRemoveFromClassroom.test.ts
+++ b/web/src/domain/orgMembers/bulkRemoveFromClassroom.test.ts
@@ -178,4 +178,46 @@ describe("bulkRemoveFromClassroom", () => {
     expect(res.outcomes.every((o) => o.status === "failed")).toBe(true)
     expect(res.outcomes[0].detail).toMatch(/409/)
   })
+
+  it("skips a pending email invite instead of reporting 'already removed'", async () => {
+    // The roster matcher keys on username/github_id, so bulkUnenrollStudents
+    // drops an identity-less target. Without this pre-filter the row reconciles
+    // to "already removed" while both the row AND the live invitation survive —
+    // the teacher is told the work is done when nothing happened.
+    bulkUnenrollMock.mockReset().mockImplementation((_c, input) =>
+      Promise.resolve({
+        removed: input.students as Student[],
+        notFound: [],
+        warnings: [],
+      }),
+    )
+
+    const res = await bulkRemoveFromClassroom(client, {
+      org: "acme",
+      classroom: "cs101",
+      rows: [
+        row({
+          key: "ada@uni.edu",
+          username: "",
+          github_id: "",
+          email: "ada@uni.edu",
+          isMember: false,
+          classification: "invitation-pending",
+          classrooms: [access("cs101")],
+        }),
+      ],
+    })
+
+    expect(res.removedCount).toBe(0)
+    expect(res.outcomes).toEqual([
+      {
+        key: "ada@uni.edu",
+        label: "ada@uni.edu",
+        status: "skipped",
+        detail: "pending-email-invite",
+      },
+    ])
+    // And it never reaches the writer, so no roster commit is spent on it.
+    expect(bulkUnenrollMock).not.toHaveBeenCalled()
+  })
 })

--- a/web/src/domain/orgMembers/bulkRemoveFromClassroom.ts
+++ b/web/src/domain/orgMembers/bulkRemoveFromClassroom.ts
@@ -2,6 +2,7 @@ import type { GitHubClient } from "@/github-core/client"
 import { bulkUnenrollStudents } from "@/domain/students"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { studentKey } from "@/util/identity"
+import { canTargetForUnenroll } from "@/util/classroomRoleUI"
 import type { Student } from "@/types/classroom"
 import type { OrgMemberRow } from "@/util/orgMembers"
 import { logger } from "@/lib/logger"
@@ -55,6 +56,11 @@ const rowToStudent = (row: OrgMemberRow): Student => ({
 // This layer owns the per-row PRE-filtering the members view needs:
 //   - rows not on the target classroom (nothing to remove) -> skipped
 //   - rows on an ARCHIVED instance -> skipped (read-only; the write would throw)
+//   - rows with NO GitHub identity — an unaccepted email invite — -> skipped.
+//     The roster matcher keys on username/github_id (a shared address must never
+//     widen a removal), so bulkUnenrollStudents drops such a target and it would
+//     otherwise reconcile to "already removed" while both the row AND the live
+//     invitation survived. Cancelling the invitation is the action that retires it.
 // so only removable rows reach the batch writer. Per-row outcomes are
 // reconciled from the batch result (removed / not-found).
 export async function bulkRemoveFromClassroom(
@@ -88,6 +94,15 @@ export async function bulkRemoveFromClassroom(
         label: labelFor(row),
         status: "skipped",
         detail: "archived",
+      })
+      continue
+    }
+    if (!canTargetForUnenroll(row)) {
+      outcomes.push({
+        key: row.key,
+        label: labelFor(row),
+        status: "skipped",
+        detail: "pending-email-invite",
       })
       continue
     }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -3004,6 +3004,7 @@
     "classroomCount_one": "{{count}} classroom",
     "classroomCount_other": "{{count}} classrooms",
     "badgeNotMember": "Not an org member",
+    "badgeInvitePending": "Invitation pending",
     "badgeNoClassroom": "No classroom",
     "badgeMember": "Member",
     "badgeOwner": "Owner",
@@ -3025,6 +3026,7 @@
     "inviteToOrg": "Invite to organization",
     "confirmInviteBody": "Send an organization invitation to {{label}}? The invite is sent to their GitHub account by id and they'll rejoin {{org}} with their prior classroom access once they accept.",
     "notMemberNoId": "This student is on a roster but is not an organization member. They have no GitHub id on file yet, so invite them from their classroom's Roster page.",
+    "invitePendingNotice": "This student was invited by email and hasn't accepted yet, so they have no GitHub account on file. Nothing is wrong — their details fill in automatically when they join. You can cancel the invitation from their classroom's Roster page.",
     "confirmUnenroll_one": "{{label}} will first be unenrolled from <count>{{count}} classroom</count> ({{classrooms}}), then removed from the <org>{{org}}</org> organization. Their assignment repositories are not deleted.",
     "confirmUnenroll_other": "{{label}} will first be unenrolled from <count>{{count}} classrooms</count> ({{classrooms}}), then removed from the <org>{{org}}</org> organization. Their assignment repositories are not deleted.",
     "confirmRemove": "{{label}} will be removed from the <org>{{org}}</org> organization.",
@@ -3083,6 +3085,7 @@
         "already-on-classroom": "Already on this classroom.",
         "not-on-classroom": "Not on this classroom.",
         "already-removed": "Already removed from this classroom.",
+        "pending-email-invite": "Invited by email and not accepted yet — cancel the invitation from the classroom's Roster page instead.",
         "archived": "Classroom is archived — unarchive it to change membership.",
         "resolve-failed": "Couldn't resolve their current GitHub account."
       }

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -279,7 +279,11 @@ const MemberDetailModal = ({
             </div>
           ) : (
             <div className="rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
-              {t("orgMembers.notMemberNoId")}
+              {t(
+                row.classification === "invitation-pending"
+                  ? "orgMembers.invitePendingNotice"
+                  : "orgMembers.notMemberNoId",
+              )}
             </div>
           )
         ) : confirming ? (

--- a/web/src/pages/orgMembers/memberPresentation.tsx
+++ b/web/src/pages/orgMembers/memberPresentation.tsx
@@ -1,6 +1,6 @@
 import type { TFunction } from "i18next"
 import { useTranslation } from "react-i18next"
-import { AlertTriangle, Info, ShieldCheck } from "lucide-react"
+import { AlertTriangle, Info, MailCheck, ShieldCheck } from "lucide-react"
 
 import { Badge } from "@/components/ui"
 import type { GitHubClient } from "@/github-core/client"
@@ -32,6 +32,16 @@ export const ClassificationBadge = ({
       <Badge tone="error" className="gap-1">
         <AlertTriangle aria-hidden="true" className="size-3" />{" "}
         {t("orgMembers.badgeNotMember")}
+      </Badge>
+    )
+  }
+  // An unaccepted email invite. Informational, not a discrepancy: there is no
+  // account yet to be missing from the org.
+  if (row.classification === "invitation-pending") {
+    return (
+      <Badge tone="info" className="gap-1">
+        <MailCheck aria-hidden="true" className="size-3" />{" "}
+        {t("orgMembers.badgeInvitePending")}
       </Badge>
     )
   }

--- a/web/src/util/orgMembers.test.ts
+++ b/web/src/util/orgMembers.test.ts
@@ -79,7 +79,7 @@ describe("aggregateOrgMembers", () => {
     expect(rows[0].username).toBe("teacher")
   })
 
-  it("dedupes an email-only student by email and marks them not-a-member", () => {
+  it("dedupes an email-only student by email across rosters", () => {
     const rows = aggregateOrgMembers(
       [],
       [
@@ -88,7 +88,9 @@ describe("aggregateOrgMembers", () => {
       ],
     )
     expect(rows).toHaveLength(1)
-    expect(rows[0].classification).toBe("on-roster-not-member")
+    // An identity-less row is an unaccepted email invite, not a departed member.
+    expect(rows[0].classification).toBe("invitation-pending")
+    expect(rows[0].isMember).toBe(false)
     expect(rows[0].classrooms).toHaveLength(2)
   })
 
@@ -235,5 +237,36 @@ describe("aggregateOrgMembers — team-verified membership / unprovisioned", () 
     expect(rows[0].unprovisionedClassrooms).toEqual(["cs201"])
     const cs201 = rows[0].classrooms.find((c) => c.classroom === "cs201")
     expect(cs201?.state).toBe("unprovisioned")
+  })
+
+  it("classifies an unaccepted email invite as pending, not a discrepancy", () => {
+    // The row an email invite writes: an address and nothing else. It is NOT a
+    // person who left the org — there is no account yet — so counting it in the
+    // "on a roster but not a member" tally cries wolf on a healthy invitation.
+    const rows = aggregateOrgMembers(
+      [],
+      [roster("cs101", [student({ email: "ada@uni.edu", first_name: "Ada" })])],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].classification).toBe("invitation-pending")
+    expect(rows[0].isMember).toBe(false)
+  })
+
+  it("sorts a pending invitation below healthy members", () => {
+    // A pending row is informational; ordering it above members would bury the
+    // rows a teacher can actually act on.
+    const rows = aggregateOrgMembers(
+      [member(42, "alice")],
+      [
+        roster("cs101", [
+          student({ email: "ada@uni.edu" }),
+          student({ username: "alice", github_id: "42" }),
+        ]),
+      ],
+    )
+    expect(rows.map((r) => r.classification)).toEqual([
+      "member-on-roster",
+      "invitation-pending",
+    ])
   })
 })

--- a/web/src/util/orgMembers.ts
+++ b/web/src/util/orgMembers.ts
@@ -23,10 +23,17 @@ export type ClassroomAccess = {
 //  - member-on-roster: a healthy member on >=1 roster.
 //  - on-roster-not-member: the target discrepancy — on a roster but no longer
 //    (or never) an org member.
+//  - invitation-pending: on a roster with NO GitHub identity at all, which is
+//    what an unaccepted email invite's row looks like. Not a discrepancy: the
+//    invitation is live and the account simply doesn't exist here yet, so it must
+//    not land in the count that asks the teacher to act.
 //  - member-no-roster: an org member on no roster (e.g., co-teacher, or a
 //    leftover after an unenroll).
 export type MemberClassification =
-  "member-on-roster" | "on-roster-not-member" | "member-no-roster"
+  | "member-on-roster"
+  | "on-roster-not-member"
+  | "invitation-pending"
+  | "member-no-roster"
 
 export type OrgMemberRow = {
   // Stable identity, mirroring studentKey (github_id || username || email).
@@ -172,7 +179,14 @@ export function aggregateOrgMembers(
       email: acc.email,
       isMember,
       classrooms,
-      classification: isMember ? "member-on-roster" : "on-roster-not-member",
+      // An identity-less roster row is an unaccepted email invite, not a person
+      // who left the org — there is no account to have left. Classify it as
+      // pending so it stays visible without being counted as a discrepancy.
+      classification: isMember
+        ? "member-on-roster"
+        : acc.username || acc.github_id
+          ? "on-roster-not-member"
+          : "invitation-pending",
       unprovisionedClassrooms,
     })
   }
@@ -195,10 +209,13 @@ export function aggregateOrgMembers(
   }
 
   // Discrepancies first (the actionable rows), then members, then by login/name.
+  // A pending invitation sorts after healthy members: it is informational, and
+  // putting it above them would bury the rows a teacher can act on.
   const order: Record<MemberClassification, number> = {
     "on-roster-not-member": 0,
     "member-on-roster": 1,
-    "member-no-roster": 2,
+    "invitation-pending": 2,
+    "member-no-roster": 3,
   }
   rows.sort((a, b) => {
     const byClass = order[a.classification] - order[b.classification]


### PR DESCRIPTION
## What

An email-invited student sits on the roster carrying only an address until they accept. The **Org Members** page treated that row as a discrepancy — "on a roster but not an organization member" — and bulk **Remove from classroom** told the teacher those rows were "Already removed" when nothing had happened.

Pending invitations are now their own classification: still listed, badged **Invitation pending** in an info tone, sorted below healthy members, and excluded from the discrepancy count. Bulk remove skips them with a reason that points at the action that does work.

## Why it happened

`studentKey` falls back to `email`, so an identity-less row survives into the Org Members aggregate. It then matches no member, and the classification was a plain binary:

```ts
classification: isMember ? "member-on-roster" : "on-roster-not-member"
```

That bucket is the page's *actionable* one and sorts first, so email-inviting thirty students produced a red banner claiming thirty were missing from the org — every one a healthy pending invitation.

The bulk-remove half is worse than cosmetic. `bulkUnenrollStudents` deliberately drops an identity-less target, with a comment saying why:

> Identity only, matching matchesRosterRow: an email-only target could never match a row, so accepting one here would silently report it as `notFound` ("already removed") while both the row and its live invitation survived.

The roster page is protected by `canTargetForUnenroll`; `bulkRemoveFromClassroom` never got the equivalent guard, so it re-created exactly the reported failure the domain layer was avoiding.

## Scope

This is the first of four PRs from a sweep for places the email-invite feature never reached. Deliberately **not** in here:

- the phantom checkbox selection, unreachable bulk cancel-invite, and missing resend-by-email (PR 2)
- a pending row's name/section being uneditable (PR 3)
- stale "legacy email-only row" comments and three wiki claims (PR 4)

The new `invitePendingNotice` copy says *cancel* only, not "resend" — resend for an email-only invite doesn't exist until PR 2, and promising it here would be a dead end.

## Testing

`npm run check` green: 3967 tests, 0 typecheck/lint errors, prettier clean, no dependency-cruiser violations, i18n audit PASS.

Both fixes mutation-checked — reverting the classification fails 3 tests, removing the bulk-remove guard fails 1. One existing test was updated: its subject was deduping an email-only student across two rosters, and the classification assertion was incidental to that.