### PR TITLE
fix(web): make a pending email invite's row and bulk actions work

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -558,6 +558,7 @@
       "colName": "Name",
       "colSection": "Section",
       "colRole": "Role",
+      "invitePending": "Invited by email — hasn't joined yet",
       "empty": "No one is listed in roster.csv yet."
     },
     "classroomTeamLabel": "Classroom team",

--- a/web/src/pages/orgMembers/shiftClickRange.test.tsx
+++ b/web/src/pages/orgMembers/shiftClickRange.test.tsx
@@ -16,9 +16,13 @@ type Row = { key: string }
 function Harness({
   rows,
   selectable = () => true,
+  // Real callers disable a non-selectable checkbox. A test can turn that off to
+  // exercise the hook's own gate rather than the DOM's.
+  disableUnselectable = true,
 }: {
   rows: Row[]
   selectable?: (row: Row) => boolean
+  disableUnselectable?: boolean
 }) {
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
   const { handleToggleRow, handleRowCheckboxClick } = useRangeSelection(
@@ -35,7 +39,7 @@ function Harness({
           <input
             type="checkbox"
             aria-label={row.key}
-            disabled={!selectable(row)}
+            disabled={disableUnselectable && !selectable(row)}
             checked={selectedKeys.has(row.key)}
             onClick={(e) => handleRowCheckboxClick(e, row.key)}
             onChange={() => handleToggleRow(row.key)}
@@ -104,5 +108,28 @@ describe("shift-click range selection (useRangeSelection wiring)", () => {
     await shiftClick(user, "d")
 
     expect(screen.getByTestId("selected").textContent).toBe("a,c,d")
+  })
+
+  it("refuses a plain click on a non-selectable row", async () => {
+    // The single-click path must honour `selectable` as selectRange does. A caller
+    // that doesn't also disable the input (or a click reaching it another way)
+    // would otherwise add the key, render the box CHECKED, and then have
+    // resolveSelectedRows filter it out — a ticked box that selects nothing.
+    // Rendered enabled on purpose: a disabled input would mask the hook's own gate.
+    const user = userEvent.setup()
+    render(
+      <Harness
+        rows={[{ key: "a" }, { key: "pending" }]}
+        selectable={(row) => row.key !== "pending"}
+        disableUnselectable={false}
+      />,
+    )
+
+    await user.click(screen.getByLabelText("pending"))
+    expect(screen.getByTestId("selected").textContent).toBe("")
+
+    // And a selectable row still toggles normally.
+    await user.click(screen.getByLabelText("a"))
+    expect(screen.getByTestId("selected").textContent).toBe("a")
   })
 })

--- a/web/src/pages/orgMembers/useRangeSelection.ts
+++ b/web/src/pages/orgMembers/useRangeSelection.ts
@@ -40,6 +40,12 @@ export function useRangeSelection<T extends Keyed>(
       rangeHandledRef.current = false
       return
     }
+    // Honour `selectable` here as selectRange already does. Without it a row the
+    // bulk bar can't act on still enters the set, so its checkbox renders checked
+    // while resolveSelectedRows filters it back out — a ticked box that does
+    // nothing, and a selection count that disagrees with the toolbar.
+    const row = order.find((r) => r.key === key)
+    if (row && !selectable(row)) return
     setSelectedKeys((prev) => toggleRow(prev, key))
     rangeAnchorKey.current = key
   }

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -7,6 +7,7 @@ import { RoleBadges } from "./RoleBadges"
 import { StudentSortSelect } from "./StudentSortSelect"
 import { coerceImportRole } from "./rosterImportParse"
 import type { Student } from "@/types/classroom"
+import { studentKey } from "@/util/identity"
 import {
   DEFAULT_STUDENT_SORT,
   sortStudentsByName,
@@ -15,7 +16,9 @@ import {
 
 function displayName(student: Student): string {
   const full = `${student.first_name} ${student.last_name}`.trim()
-  return full || student.username
+  // Fall back to the address for a pending email invite: it carries no username,
+  // and without this the row renders completely blank.
+  return full || student.username || student.email
 }
 
 // The read-only "CSV roster" for a non-owner staffer (TA / head TA), sourced
@@ -67,12 +70,18 @@ const CsvRosterView = ({ students }: { students: Student[] }) => {
               </tr>
             ) : (
               rows.map((student) => (
-                <tr key={student.username || student.github_id}>
+                // studentKey falls back to the email, so two pending invites
+                // don't collide on an empty key.
+                <tr key={studentKey(student)}>
                   <td>
                     <div className="font-bold">{displayName(student)}</div>
                     {student.username ? (
                       <div className="font-mono text-xs text-base-content/70">
                         {student.username}
+                      </div>
+                    ) : student.email ? (
+                      <div className="text-xs text-base-content/70">
+                        {t("students.csvRoster.invitePending")}
                       </div>
                     ) : null}
                   </td>

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -30,6 +30,7 @@ import { sortTeamRosterRows } from "@/util/teamRoster"
 import { STAFF_ROLES } from "@/types/classroom"
 import {
   ROLE_LABEL_KEY,
+  canCancelInviteFor,
   canTargetForUnenroll,
   hasStudentEnrollment,
 } from "@/util/classroomRoleUI"
@@ -199,14 +200,17 @@ const EnrolledStudents = ({
       github_id: row.github_id,
       username: row.username,
     })
-  // Selectable for the bulk actions bar, whose destructive action is unenroll.
-  // A pending email invite is excluded for the same reason the row modal hides
-  // Remove (canTargetForUnenroll): the roster matcher keys on username/github_id,
-  // so unenroll can't match that row — it would silently report "already
-  // removed" while the row AND the live invitation survive. Cancel the
-  // invitation instead (offered per row in the modal).
+  // Selectable for the bulk actions bar. The bar offers THREE actions (unenroll,
+  // role change, cancel invite), so eligibility is per-action rather than one
+  // unenroll-shaped gate: a pending email invite can't be unenrolled (the roster
+  // matcher keys on username/github_id, so it would report "already removed"
+  // while the row and the live invitation survive) but cancelling its invitation
+  // is exactly the right bulk action. Gating selection on unenroll alone made
+  // that path unreachable — and a class-sized email invite un-bulk-cancellable.
   const isSelectable = (row: TeamRosterRow) =>
-    !isSelf(row) && hasStudentEnrollment(row) && canTargetForUnenroll(row)
+    !isSelf(row) &&
+    hasStudentEnrollment(row) &&
+    (canTargetForUnenroll(row) || canCancelInviteFor(row))
 
   // Distinct sections present across all rows (status-independent so switching
   // status never empties the section dropdown), sorted with "No section" last.
@@ -453,6 +457,7 @@ const EnrolledStudents = ({
       key={row.key}
       row={row}
       selfRow={isSelf(row)}
+      selectable={isSelectable(row)}
       checked={selectedKeys.has(row.key)}
       onOpen={setSelectedKey}
       onCheckboxClick={handleRowCheckboxClick}

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -22,6 +22,7 @@ import {
   type BulkResultView,
 } from "@/components/bulk/resultView"
 import type { TeamRosterRow } from "@/util/teamRoster"
+import { canTargetForUnenroll } from "@/util/classroomRoleUI"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("students:RosterBulkActionsBar")
@@ -157,6 +158,11 @@ const RosterBulkActionsBar = ({
   const cancellableSelected = pendingSelected.filter(
     (r) => typeof r.invitation_id === "number",
   )
+  // Unenroll can only target a row the roster matcher can find. A selection may
+  // now mix an email-only pending invite (cancellable, not unenrollable) with
+  // ordinary rows, so filter rather than sending the whole selection and letting
+  // the writer silently report the pending ones as "already removed".
+  const unenrollableSelected = selectedRows.filter(canTargetForUnenroll)
 
   const isOpen = phase !== "idle"
 
@@ -169,21 +175,21 @@ const RosterBulkActionsBar = ({
   }
 
   const runUnenroll = async () => {
-    if (selectedRows.length === 0) return
+    if (unenrollableSelected.length === 0) return
     setAction("unenroll")
     setPhase("working")
     setError(null)
     setResult(null)
     setProgress({
       processed: 0,
-      total: selectedRows.length,
+      total: unenrollableSelected.length,
       message: t("students.bulk.starting"),
     })
     try {
       const res = await bulkUnenrollRoster(client, {
         org,
         classroom,
-        rows: selectedRows,
+        rows: unenrollableSelected,
         onProgress: setProgress,
       })
       setResult(buildUnenrollResult(res, t))
@@ -197,7 +203,7 @@ const RosterBulkActionsBar = ({
       )
       onDone(
         "unenroll",
-        selectedRows
+        unenrollableSelected
           .filter((r) => removedKeys.has(r.key))
           .map((r) => ({ username: r.username })),
       )
@@ -485,11 +491,12 @@ const RosterBulkActionsBar = ({
                   size="sm"
                   className="join-item text-error hover:bg-error/10"
                   aria-label={t("students.bulk.unenrollSelected", {
-                    count: selectedRows.length,
+                    count: unenrollableSelected.length,
                   })}
                   title={t("students.bulk.unenrollSelected", {
-                    count: selectedRows.length,
+                    count: unenrollableSelected.length,
                   })}
+                  disabled={unenrollableSelected.length === 0}
                   onClick={() => setConfirmingUnenroll(true)}
                 >
                   {t("students.bulk.unenroll")}
@@ -516,10 +523,10 @@ const RosterBulkActionsBar = ({
         dangerous
         needsConfirm={false}
         title={t("students.bulk.confirmUnenrollTitle", {
-          count: selectedRows.length,
+          count: unenrollableSelected.length,
         })}
         description={t("students.bulk.confirmUnenrollBody", {
-          count: selectedRows.length,
+          count: unenrollableSelected.length,
         })}
         confirmLabel={t("students.bulk.unenroll")}
         onConfirm={async () => {

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -11,6 +11,7 @@ import {
   assignRosterMemberRole,
   applyClassroomRoleChange,
   inviteRosterStudents,
+  bulkInviteByEmail,
   resendClassroomInvite,
   retireEmailInvite,
   type StudentCsvRow,
@@ -198,8 +199,13 @@ const RosterMemberModal = ({
     nameFromParts(row.first_name, row.last_name) || row.username || row.email
   const displayInitials = rosterRowInitials(row)
   const label = row.username || row.email
+  // Re-sending needs SOMETHING to address the invitation to: an account (id), or
+  // an address for an email-only pending invite. Excluding the latter left a
+  // student whose invitation went to spam with no option but Cancel.
   const canResend =
-    canManage && row.state === "pending" && Boolean(row.github_id)
+    canManage &&
+    row.state === "pending" &&
+    Boolean(row.github_id || (!row.username && row.email))
   // Cancelling a pending invite needs its org-invitation id (set on pending
   // rows). Available even for an email-only pending invite (no github_id), so
   // gate on the id, not github_id.
@@ -322,6 +328,38 @@ const RosterMemberModal = ({
 
   const handleResend = async () => {
     if (resending) return
+    // An email-only pending invite has no account to re-invite by id, so re-send
+    // by address instead — bulkInviteByEmail recreates the invitation and its
+    // invite team, the same recipe useReinviteFailedInvite uses for a failed one.
+    // appendEmailInviteRows skips the already-claimed address, so no second row.
+    if (!row.username && row.email) {
+      setResending(true)
+      try {
+        const role = sortRolesByRank(row.roles)[0] ?? "student"
+        const res = await bulkInviteByEmail(client, {
+          org,
+          classroom,
+          invites: [{ email: row.email, role }],
+        })
+        if (res.failed.length > 0) {
+          throw new Error(res.failed[0]!.message)
+        }
+        onResent(row.key)
+        onClose()
+      } catch (err) {
+        onError(
+          row.key,
+          t("students.resendFailed", {
+            username: row.email,
+            error: getErrorMessage(err),
+          }),
+        )
+      } finally {
+        setResending(false)
+        setConfirmingResend(false)
+      }
+      return
+    }
     const inviteeId = resolveGitHubId(row.github_id)
     if (inviteeId === null || !row.username) {
       const username = row.username || row.email

--- a/web/src/pages/students/RosterRow.tsx
+++ b/web/src/pages/students/RosterRow.tsx
@@ -19,9 +19,13 @@ export const RosterRow = ({
   onOpen,
   onCheckboxClick,
   onToggle,
+  selectable = true,
 }: {
   row: TeamRosterRow
   selfRow: boolean
+  // False when the bulk bar can't act on this row. Rendered as a disabled
+  // checkbox so it reads as unavailable rather than silently ignoring the click.
+  selectable?: boolean
   checked: boolean
   onOpen: (key: string) => void
   onCheckboxClick: (
@@ -49,7 +53,7 @@ export const RosterRow = ({
             ? t("students.bulk.selfNotSelectable")
             : t("students.bulk.selectRow", { label: displayHandle })
         }
-        disabled={selfRow}
+        disabled={selfRow || !selectable}
         title={selfRow ? t("students.bulk.selfNotSelectable") : undefined}
         checked={checked}
         onClick={(e) => {

--- a/web/src/util/classroomRoleUI.test.ts
+++ b/web/src/util/classroomRoleUI.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  canCancelInviteFor,
   canTargetForUnenroll,
   countByRole,
   enrolledCountsByRole,
@@ -54,6 +55,27 @@ describe("canTargetForUnenroll", () => {
       true,
     )
     expect(canTargetForUnenroll({ username: "", github_id: "4242" })).toBe(true)
+  })
+})
+
+// The complement of canTargetForUnenroll: the action that CAN retire a pending
+// email invite. Selection keys on both, so the bulk bar's three actions aren't
+// gated by whichever one happens to be the most restrictive.
+describe("canCancelInviteFor", () => {
+  it("is true for a pending row with an invitation id, identity or not", () => {
+    expect(canCancelInviteFor({ state: "pending", invitation_id: 7 })).toBe(
+      true,
+    )
+  })
+  it("is false for an enrolled row", () => {
+    expect(canCancelInviteFor({ state: "enrolled", invitation_id: 7 })).toBe(
+      false,
+    )
+  })
+  it("is false for a pending row with no invitation id to cancel", () => {
+    expect(
+      canCancelInviteFor({ state: "pending", invitation_id: undefined }),
+    ).toBe(false)
   })
 })
 

--- a/web/src/util/classroomRoleUI.ts
+++ b/web/src/util/classroomRoleUI.ts
@@ -102,6 +102,16 @@ export function canTargetForUnenroll(
   return Boolean(row.username || row.github_id)
 }
 
+// Whether this row's invitation can be cancelled — the action that retires a
+// pending row unenroll can't target. Keyed on the org-invitation id rather than
+// an identity, because that id is what cancelOrgInvitation needs and it is
+// present on a pending row even when no GitHub account exists yet.
+export function canCancelInviteFor(
+  row: Pick<TeamRosterRow, "state" | "invitation_id">,
+): boolean {
+  return row.state === "pending" && typeof row.invitation_id === "number"
+}
+
 // Per-role head counts across the roster. `student` counts every row carrying
 // the student role (a student who is also staff still counts as a student);
 // `teacher`/`hta`/`ta` count every row holding that staff role. A person on two

--- a/web/src/util/teamRoster.test.ts
+++ b/web/src/util/teamRoster.test.ts
@@ -154,6 +154,39 @@ describe("buildTeamRoster", () => {
     expect(rows[0].invitation_id).toBe(3)
   })
 
+  it("does not give a login-less invite an id borrowed via a shared address", () => {
+    // A returning student's old row carries their id AND their address. An email
+    // invite matched to it by address would otherwise produce a login-less row
+    // carrying that id — enough to pass the identity guards, so Resend offers a
+    // button that always errors and unenroll matches (and removes) the OTHER row.
+    const rows = buildTeamRoster({
+      members: [],
+      invitations: [invite({ id: 4, email: "shared@uni.edu" })],
+      students: [
+        csvRow({
+          github_id: "909",
+          username: "returning",
+          email: "shared@uni.edu",
+        }),
+      ],
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      state: "pending",
+      username: "",
+      github_id: "",
+    })
+  })
+
+  it("still carries the id when the invitation names a login", () => {
+    const rows = buildTeamRoster({
+      members: [],
+      invitations: [invite({ id: 5, login: "ada" })],
+      students: [csvRow({ github_id: "101", username: "ada" })],
+    })
+    expect(rows[0]).toMatchObject({ username: "ada", github_id: "101" })
+  })
+
   it("does NOT emit a row for a CSV person not on any team or invite", () => {
     const rows = buildTeamRoster({
       members: [member(101, "ada")],

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -298,7 +298,12 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
       state: "pending",
       roles: [role],
       username: login,
-      github_id: own?.github_id?.trim() ?? "",
+      // Only inherit an id when the invitation names a login. An email invite
+      // matched to an identity-bearing row by a SHARED address (a returning
+      // student's old row) would otherwise get a login-less row carrying someone's
+      // id: enough to pass the identity guards, so Resend would offer a button
+      // that always errors and unenroll would match — and remove — the OTHER row.
+      github_id: login ? (own?.github_id?.trim() ?? "") : "",
       avatar_url: "",
       invitation_id: invite.id,
       ...metadataFrom(own, legacyFor(emailKey || own?.email)),


### PR DESCRIPTION
> Stacked on #645 — review that first. The base will retarget to `main` once #645 merges.

## What

Four things a teacher can't do to an email-invited student who hasn't accepted yet, plus one that would have done the wrong thing.

| Symptom | Cause |
|---|---|
| Ticking the row's checkbox checks the box but selects nothing | the single-click path ignored the `selectable` predicate `selectRange` already honours |
| A class-sized email invite can't be bulk-cancelled | one unenroll-shaped gate decided selection for a bar with three actions |
| No **Resend** for a pending email invite | `canResend` gated on `github_id` |
| The TA/HTA CSV roster shows them as blank rows | `displayName` fell back to `username`; the React key was `""`, so two collided |
| Unenroll could remove **the wrong row** | a login-less invite inherited a `github_id` via a shared address |

## The two worth reading closely

**Selection was gated on the most restrictive action.** `isSelectable` required `canTargetForUnenroll`, so a pending email invite — which genuinely can't be unenrolled — could never be selected at all. But the bulk bar offers *three* actions, and cancel-invite is exactly right for that row. The bar even had a branch for it:

```ts
if (didCancel && !row.username && row.email) {
  retiredEmails.push(row.email)
}
```

`retiredEmails` was provably always empty, so `retireEmailInvites` was unreachable dead code. Selecting those rows instead produced a toast about staff management. Eligibility is now per-action, and `runUnenroll` filters the selection it acts on rather than trusting the gate — with its counts and disabled state following, so the confirm dialog can't promise more than it will do.

**A shared address leaked an identity.** A returning student's roster row carries both their id and their address. An email invite matched to it by address produced a *login-less* row carrying that id — enough to pass the identity guards, so `canResend` became true (and `handleResend` then failed on `!row.username`, showing "missing GitHub id. Re-add them to the roster"), and `canTargetForUnenroll` became true, at which point `matchesRosterRow` would match the **other** row by id. Unenrolling the pending row would have removed someone else's.

## Scope

PR 2 of 4 from the email-invite sweep. Not here: a pending row's name/section still can't be edited (PR 3), and the stale "legacy email-only row" comments (PR 4).

## Testing

`npm run check` green: 3973 tests, 0 typecheck/lint errors, prettier clean, no dependency-cruiser violations, i18n PASS.

Mutation-checked: reverting the single-click guard fails the new selection test, and restoring the inherited id fails the new `teamRoster` test. The existing shift-click harness disabled non-selectable checkboxes, which masked the hook's own gate — it now takes a flag so the new test exercises the hook rather than the DOM.