### PR TITLE
docs: correct comments the email-invite work falsified

### DIFF
--- a/web/src/domain/students/roleWrites.ts
+++ b/web/src/domain/students/roleWrites.ts
@@ -210,9 +210,9 @@ export async function updateClassroomMetadata(
 export type ResolveRosterUploadPreflightInput = {
   org: string
   classroom: string
-  // The uploaded rows reduced to identity + intended role. github_id is
-  // optional (threaded when the enroll pass has resolved it) and anchors the
-  // membership lookup across a login rename.
+  // The uploaded rows reduced to identity + intended role. github_id is set for
+  // any row the preview resolved from a github_id column, and anchors the
+  // membership lookup across a login rename; a username-only row joins by login.
   rows: PreflightRow[]
 }
 

--- a/web/src/pages/students/runRosterImport.ts
+++ b/web/src/pages/students/runRosterImport.ts
@@ -195,8 +195,8 @@ export async function runRosterImport(
   //    newly-added rows): inviteRosterStudents no-ops anyone already
   //    active/pending, so a re-run after a rate limit still re-invites a student
   //    whose first invite was deferred (their CSV row already exists, so they'd
-  //    otherwise be skipped as a duplicate and, since CSV-only rows don't
-  //    render, silently lost). Thread the github_id — the one the preview
+  //    otherwise be skipped as a duplicate and left sitting as a needs-attention
+  //    row with no invitation). Thread the github_id — the one the preview
   //    resolved, else the one the enroll pass just captured — so the invite
   //    targets the immutable account rather than re-resolving a possibly
   //    recycled/renamed login. Their roster.csv row enriches the pending row;

--- a/web/src/pages/students/uploadClassify.ts
+++ b/web/src/pages/students/uploadClassify.ts
@@ -11,10 +11,10 @@
 //
 // There is deliberately no content classifier: Roster CSV is ALWAYS the kind an
 // upload opens as, because its parser already handles all three shapes. Guessing
-// `email-list` from content would route a bare address list to the email-only
-// branch, where the roster parser's per-line detection never runs and the file's
-// name/section columns are discarded. The other two kinds are reachable only by
-// the teacher's explicit override.
+// `email-list` from content would read a bare address list through the flat
+// address reader, where per-line shape detection never runs and any columns the
+// file carried are discarded. The other two kinds are reachable only by the
+// teacher's explicit override.
 export type UploadKind = "roster-csv" | "username-list" | "email-list"
 
 export const DEFAULT_UPLOAD_KIND: UploadKind = "roster-csv"

--- a/web/src/util/rosterUploadPreflight.ts
+++ b/web/src/util/rosterUploadPreflight.ts
@@ -49,10 +49,10 @@ export type CurrentMembership = {
 
 // The uploaded row reduced to what the classifier needs: an identity + intended
 // role, plus the optional CSV metadata used to detect a metadata_update against
-// the stored roster. `username` is the normalized login; `github_id` (when the
-// enroll pass resolved it) anchors membership lookup across a rename. NOTE: at
-// preflight time github_id is typically absent (it's resolved later, in the
-// enroll pass), so the stored-roster metadata join is effectively login-only.
+// the stored roster. `username` is the normalized login; `github_id` is set for
+// any row the preview resolved from a github_id column (resolveImportIdentities
+// runs BEFORE the preflight), and anchors the membership + stored-roster join
+// across a rename. A username-only row still joins by login.
 export type PreflightRow = StudentMetadata & {
   username: string
   github_id?: string

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -118,16 +118,16 @@ export function csvForMember(
   )
 }
 
-// Metadata for a row, merging the row's own CSV student with an optional legacy
-// (email-only) fallback per field: the row's own value wins; a blank field
-// borrows from the legacy row. email is always the row's own (never borrowed).
+// Metadata for a row, merging the row's own CSV student with an optional
+// email-only donor per field: the row's own value wins; a blank field borrows
+// from the donor. email is always the row's own (never borrowed).
 const metadataFrom = (
   student: Student | undefined,
-  legacy?: Student | undefined,
+  donor?: Student | undefined,
 ) => ({
-  first_name: (student?.first_name?.trim() || legacy?.first_name?.trim()) ?? "",
-  last_name: (student?.last_name?.trim() || legacy?.last_name?.trim()) ?? "",
-  section: (student?.section?.trim() || legacy?.section?.trim()) ?? "",
+  first_name: (student?.first_name?.trim() || donor?.first_name?.trim()) ?? "",
+  last_name: (student?.last_name?.trim() || donor?.last_name?.trim()) ?? "",
+  section: (student?.section?.trim() || donor?.section?.trim()) ?? "",
   email: student?.email?.trim() ?? "",
 })
 
@@ -186,21 +186,26 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
   } = input
   const csv = indexCsv(students)
 
-  // Legacy username-less rows indexed by email, to enrich a real (username or
-  // id-carrying) row that shares the email. This is the ONLY use of email-only
-  // rows — they never render on their own.
-  const legacyByEmail = new Map<string, Student>()
+  // Identity-less rows (an unaccepted email invite's pending row) indexed by
+  // email, so a row that shares the address can borrow the name/section captured
+  // at invite time. Such a row never renders on its own — see the
+  // needs-attention pass below — but it IS read elsewhere: csv.byEmail is what
+  // gives a pending invite its own metadata.
+  const donorByEmail = new Map<string, Student>()
   for (const s of students) {
     const hasIdentity = Boolean(s.github_id?.trim() || s.username?.trim())
     const email = s.email?.trim().toLowerCase()
-    if (!hasIdentity && email && !legacyByEmail.has(email)) {
-      legacyByEmail.set(email, s)
+    if (!hasIdentity && email && !donorByEmail.has(email)) {
+      donorByEmail.set(email, s)
     }
   }
 
-  // A legacy email-only row (name/section donor) for a given email, if any.
-  const legacyFor = (email: string | undefined): Student | undefined =>
-    email ? legacyByEmail.get(email.toLowerCase()) : undefined
+  // The email-only row donating name/section for a given address, if any. Still
+  // load-bearing on the ENROLLED path, where `own` is resolved by id/login and so
+  // can never be the donor itself: it is how a just-accepted student keeps the
+  // name and section captured before the reconcile folded their row.
+  const donorFor = (email: string | undefined): Student | undefined =>
+    email ? donorByEmail.get(email.toLowerCase()) : undefined
 
   const rows: TeamRosterRow[] = []
   // Logins of ACTIVE members only. A pending invite for one of these is stale
@@ -245,7 +250,7 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
       username: member.login,
       github_id: id,
       avatar_url: member.avatar_url,
-      ...metadataFrom(own, legacyFor(email)),
+      ...metadataFrom(own, donorFor(email)),
     }
     enrolledById.set(id, row)
     rows.push(row)
@@ -306,7 +311,7 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
       github_id: login ? (own?.github_id?.trim() ?? "") : "",
       avatar_url: "",
       invitation_id: invite.id,
-      ...metadataFrom(own, legacyFor(emailKey || own?.email)),
+      ...metadataFrom(own, donorFor(emailKey || own?.email)),
       // Prefer the row's own email; fall back to the invite's target email.
       email: own?.email?.trim() || email,
     }
@@ -338,8 +343,10 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
       const login = student.username?.trim() ?? ""
       const loginKey = login.toLowerCase()
       const email = student.email?.trim().toLowerCase() ?? ""
-      // A row must carry a GitHub identity to appear on its own; a legacy
-      // email-only row only enriches (handled above).
+      // A row must carry a GitHub identity to appear on its own; an email-only
+      // row only donates metadata (handled above). Note the consequence: an
+      // email-only row whose invitation has died is invisible here until the
+      // reconcile's dead-row reap removes it.
       if (!id && !loginKey) continue
       // Already an enrolled member or a pending invite?
       if (id && enrolledById.has(id)) continue
@@ -363,7 +370,7 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
         username: login,
         github_id: id,
         avatar_url: "",
-        ...metadataFrom(student, legacyFor(email)),
+        ...metadataFrom(student, donorFor(email)),
       })
     }
   }

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -35,8 +35,9 @@ self-linking.
 **Pending row** — A `roster.csv` row for someone invited by email who hasn't
 accepted yet. It holds the invited address and role, with no username or
 `github_id`, because GitHub offers no way to look up an account from an email
-address. Accepting fills in the account on the next roster sync; a cancelled or
-expired invitation removes the row instead.
+address. Accepting fills in the account on the next roster sync; cancelling the
+invitation removes the row immediately, and an expired one is cleared by the next
+sync.
 
 **Invite team** — A `secret` GitHub team, named `invite-<hash>`, that holds one
 invited address until that person joins. It is how an email invitation is

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -158,10 +158,11 @@ account. Classroom 50 bridges that gap with an **invite team**.
    sync fills their account into the pending row and then deletes the invite team.
 
 An outstanding invitation keeps its team and its pending row, so a teacher can see
-who was invited. Cancelling one deletes its invite team at once, and the pending
-row goes away on the next roster sync. A team left by an expired invitation is
-cleaned up the same way, once it is more than 24 hours old and GitHub no longer
-lists the invitation as pending; a still-pending invitation is never touched.
+who was invited. Cancelling one deletes its invite team and its pending row right
+away; if either write fails, the next roster sync clears whatever is left. A team
+left by an expired invitation is cleaned up the same way, once it is more than 24
+hours old and GitHub no longer lists the invitation as pending; a still-pending
+invitation is never touched.
 To clear stored addresses early, use **Clean up invite data** on the classroom's
 **Settings** page; deleting a classroom removes its invite teams too.
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -426,8 +426,9 @@ Here `octocat` is found by id (even after a rename), `hubot` by username, and
 > A row identified by account (`github_id` or `username`) is both invited **and**
 > added to the roster. A row identified only by an email address is invited by
 > email, and the address is recorded as a pending roster row. That row is matched
-> to the student's GitHub account when they accept; if the invitation is
-> cancelled or expires, the row is removed again on the next roster sync. Keep in
+> to the student's GitHub account when they accept; if you cancel the invitation
+> the row is removed with it, and an expired one is cleared by the next roster
+> sync. Keep in
 > mind the recorded address is the one **you invited** — not necessarily the email
 > on the student's GitHub account. A name and section supplied in the CSV are kept
 > on the pending row, so they're already there when the student joins.


### PR DESCRIPTION
## What

No behaviour change. Seven source comments and three wiki claims whose premise moved under them as email invitations were added and hardened across #639, #640 and #643 — plus one rename, because the false claim was in an identifier, not just a comment.

## The rename

`web/src/util/teamRoster.ts` predates email invitations entirely, so it describes the row an invite now *deliberately* writes as "legacy" — in a map name, a helper name, a parameter, and three comments:

```ts
// Legacy username-less rows indexed by email, to enrich a real (username or
// id-carrying) row that shares the email. This is the ONLY use of email-only
// rows — they never render on their own.
const legacyByEmail = new Map<string, Student>()
```

Two of those three claims are false:

- **"Legacy"** — `appendEmailInviteRows` writes exactly this shape at invite time, with the teacher's name and section.
- **"the ONLY use"** — `csv.byEmail` is a second, load-bearing consumer: it is what gives a pending invite its own `github_id`, name, section and email.
- **"never render on their own"** — still true, and still enforced at the needs-attention guard.

Renamed `legacyByEmail`/`legacyFor` → `donorByEmail`/`donorFor`. I checked whether `donorFor` is redundant now that `own` can come from `byEmail`, and it isn't: on the **enrolled** path `own` is resolved by id/login, so it can never be the donor itself — that helper is how a just-accepted student keeps the name and section captured before the reconcile folded their row. Noted in the comment so the next reader doesn't re-derive it.

## The rest

| Where | Claim | Reality |
|---|---|---|
| `uploadClassify.ts` | routes to "the email-only branch" | #643 deleted that branch; `email-list` is a reader inside the one parser |
| `rosterUploadPreflight.ts` | `github_id` "resolved later, in the enroll pass", so the join is "effectively login-only" | #639 moved resolution *ahead* of the preflight; the join is id-first |
| `roleWrites.ts` | same "when the enroll pass has resolved it" | same |
| `runRosterImport.ts` | "CSV-only rows don't render, silently lost" | they surface as needs-attention rows for an org owner |
| `teamRoster.ts` needs-attention guard | "a legacy email-only row only enriches" | reworded, plus the consequence worth knowing: a dead invite's row is invisible until the reap |
| `wiki/How-Classroom-50-Works.md`, `wiki/Glossary.md`, `wiki/Web-Teacher-Guide.md` | a cancelled invitation's row "goes away on the next roster sync" | since #640 the cancel removes it; the sync is the backstop |

## Also checked and left alone

- **Every cancel-path comment #640 added** — all ten correctly present the reconcile as the backstop.
- **Every "never throws" contract in `domain/students/`** — verified in both directions. `appendEmailInviteRows`, `removeEmailInviteRows`, `deleteInviteTeamForEmail`, `resolveClassroomPendingInvite` and `cancelSoleClassroomInviteOnUnenroll` all genuinely swallow, and no caller redundantly re-wraps one that does. (This is the check that caught a false-positive review finding earlier in this series — a reviewer flagged an unwrapped `await` without reading the callee.)
- **Comments about the `role` column and org-OWNER grants** — accurate.
- **The rest of the wiki's email-invite and CSV-import prose** — consistent.

## Scope

PR 4 of 4 from the email-invite sweep (#645, #646, #648). Independent of the others — based on `main`, touches no behaviour, so it can merge in any order.

## Testing

`npm run check` green: 3973 tests, 0 typecheck/lint errors, prettier clean, no dependency-cruiser violations, i18n PASS. The rename is compiler-checked, and `teamRoster`'s existing suite covers both the enrolled donor path and the pending `byEmail` join.